### PR TITLE
fix: activity detection improvements for claude-code plugin

### DIFF
--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -202,7 +202,7 @@ describe("spawn command", () => {
 
     const content = readFileSync(metaFile, "utf-8");
     expect(content).toContain("branch=feat/INT-100");
-    expect(content).toContain("status=spawning");
+    expect(content).toContain("status=working");
     expect(content).toContain("project=my-app");
     expect(content).toContain("issue=INT-100");
   });

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -164,7 +164,8 @@ async function spawnSession(
     writeMetadata(join(sessionDir, sessionName), {
       worktree: worktreePath,
       branch: liveBranch || branch || "detached",
-      status: "spawning",
+      status: "working",
+      runtimeHandle: JSON.stringify({ id: sessionName, runtimeName: "tmux" }),
       project: projectId,
       ...(issueId ? { issue: issueId } : {}),
       createdAt: new Date().toISOString(),

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -201,6 +201,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         // empty output means the runtime probe failed, not that the agent exited.
         if (terminalOutput) {
           const activity = agent.detectActivity(terminalOutput);
+          // Persist detected activity to metadata so the API can serve it
+          updateMetadata(config.dataDir, session.id, { activity });
           if (activity === "waiting_input") return "needs_input";
 
           // Check whether the agent process is still alive. Some agents

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -19,6 +19,7 @@ import type {
   SessionId,
   SessionSpawnConfig,
   SessionStatus,
+  ActivityState,
   CleanupResult,
   OrchestratorConfig,
   ProjectConfig,
@@ -106,7 +107,7 @@ function metadataToSession(
     id: sessionId,
     projectId: meta["project"] ?? "",
     status: validateStatus(meta["status"]),
-    activity: "idle",
+    activity: (meta["activity"] as ActivityState) || "idle",
     branch: meta["branch"] || null,
     issueId: meta["issue"] || null,
     pr: meta["pr"]


### PR DESCRIPTION
## Summary

Fixes idle/stuck detection issues in `classifyTerminalOutput()` and persists activity state to metadata for the API to serve real-time activity.

Applied on top of feat/ACTIVITY (PR #45) which adds the `getActivityState()` agent-native mechanism. These fixes improve the terminal-output-based `detectActivity()` fallback that the lifecycle manager still uses.

## Changes

### Claude Code plugin (`agent-claude-code/src/index.ts`)
- **Strip TUI decorations** before classifying: status bar lines (⏵ prefix), separator lines (────), and trailing empty lines are removed bottom-up
- **Use "esc to interrupt" as authoritative signal**: present in status bar = active, absent = idle
- **Handle inline suggestions**: `❯ check CI status` with no esc-to-interrupt = idle (not active)
- **Fix false positive**: status bar text `bypass permissions on` no longer triggers `waiting_input`

### Lifecycle manager (`lifecycle-manager.ts`)
- Persist detected activity to session metadata via `updateMetadata()` on each poll cycle

### Session manager (`session-manager.ts`)
- Read `activity` from metadata instead of hardcoding `"idle"`, so the API serves real-time state

### CLI spawn (`spawn.ts`)
- Write `runtimeHandle` with `runtimeName:"tmux"` to metadata so lifecycle manager can resolve sessions
- Set initial status to `"working"` instead of `"spawning"`

## Testing

- 93 claude-code plugin tests passing (8 new regression tests for status bar detection)
- 127 core tests passing
- 138 CLI tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)