### PR TITLE
fix: merge defaults.agentConfig into project config

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -85,6 +85,7 @@ const DefaultPluginsSchema = z.object({
   agent: z.string().default("claude-code"),
   workspace: z.string().default("worktree"),
   notifiers: z.array(z.string()).default(["composio", "desktop"]),
+  agentConfig: AgentSpecificConfigSchema.optional(),
 });
 
 const OrchestratorConfigSchema = z.object({
@@ -149,6 +150,14 @@ function applyProjectDefaults(config: OrchestratorConfig): OrchestratorConfig {
     // Infer tracker from repo if not set (default to github issues)
     if (!project.tracker) {
       project.tracker = { plugin: "github" };
+    }
+
+    // Merge defaults.agentConfig into project.agentConfig
+    if (config.defaults.agentConfig || project.agentConfig) {
+      project.agentConfig = {
+        ...config.defaults.agentConfig,
+        ...project.agentConfig,
+      };
     }
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -735,6 +735,7 @@ export interface DefaultPlugins {
   agent: string;
   workspace: string;
   notifiers: string[];
+  agentConfig?: AgentSpecificConfig;
 }
 
 export interface ProjectConfig {


### PR DESCRIPTION
## Summary
- Adds `agentConfig` to `DefaultPluginsSchema` in config.ts, allowing users to specify agent settings in the defaults block
- Adds `agentConfig` to `DefaultPlugins` interface in types.ts for type safety
- Updates `applyProjectDefaults()` to deep-merge `defaults.agentConfig` into `project.agentConfig`, with project-level settings taking precedence

## Problem
`spawn.ts` and `start.ts` read `project.agentConfig?.permissions` directly without merging `defaults.agentConfig`. When users specify `agentConfig.permissions: skip` in the defaults block (as documented in the README), agents still block at the Claude trust dialog.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (all 746 tests)
- [x] `pnpm lint` passes (no new errors)
- [ ] Manual test: configure `defaults.agentConfig.permissions: skip` and verify agents spawn without blocking

Fixes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)