### PR TITLE
fix: start lifecycle manager in web dashboard to update session status

### DIFF
--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -14,9 +14,11 @@ import {
   loadConfig,
   createPluginRegistry,
   createSessionManager,
+  createLifecycleManager,
   type OrchestratorConfig,
   type PluginRegistry,
   type SessionManager,
+  type LifecycleManager,
   type SCM,
   type Tracker,
   type ProjectConfig,
@@ -34,6 +36,7 @@ export interface Services {
   config: OrchestratorConfig;
   registry: PluginRegistry;
   sessionManager: SessionManager;
+  lifecycleManager: LifecycleManager;
 }
 
 // Cache in globalThis for Next.js HMR stability
@@ -72,7 +75,13 @@ async function initServices(): Promise<Services> {
 
   const sessionManager = createSessionManager({ config, registry });
 
-  const services = { config, registry, sessionManager };
+  // Create and start the lifecycle manager to poll session status
+  // This runs a background loop that detects state transitions:
+  // spawning → working → pr_open → ci_failed/review_pending → etc.
+  const lifecycleManager = createLifecycleManager({ config, registry, sessionManager });
+  lifecycleManager.start(); // Start polling (default: every 30 seconds)
+
+  const services = { config, registry, sessionManager, lifecycleManager };
   globalForServices._aoServices = services;
   return services;
 }


### PR DESCRIPTION
## Summary
- Integrates the lifecycle manager into the web dashboard's service initialization
- Lifecycle manager now starts automatically when the dashboard loads, polling session status every 30 seconds
- Fixes the root cause: session status was never updated after `ao spawn` because nothing was calling the lifecycle manager's polling loop

## Problem
`ao spawn` writes `status=spawning` to the metadata file, but nothing ever updates it afterward. The dashboard shows all sessions as "spawning" indefinitely—even sessions where the agent has been working for hours, created PRs, and gone idle.

## Solution
The lifecycle manager already existed in `packages/core/src/lifecycle-manager.ts` with full logic for:
- Checking if tmux session is alive → `status=killed` if dead
- Checking agent process activity → `status=working`
- Checking PR state via SCM plugin → `status=pr_open`, `ci_failed`, `review_pending`, etc.

The fix simply creates and starts the lifecycle manager in `packages/web/src/lib/services.ts` when services are initialized.

## Test plan
- [ ] Start the dashboard with `ao start`
- [ ] Spawn a session with `ao spawn`
- [ ] Verify session transitions from "spawning" to "working" within 30 seconds
- [ ] Create a PR and verify status updates to "pr_open"
- [ ] CI checks should reflect in dashboard status

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)