### PR TITLE
fix: extract session summaries from Claude JSONL files

### DIFF
--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -498,6 +498,25 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       // No transition but track current state
       states.set(session.id, newStatus);
     }
+
+    // Update agent summary in metadata (persists across restarts).
+    // Only for active sessions — skip terminal states to avoid unnecessary I/O.
+    if (newStatus !== "merged" && newStatus !== "killed") {
+      const project = config.projects[session.projectId];
+      if (project) {
+        const agent = registry.get<Agent>("agent", project.agent ?? config.defaults.agent);
+        if (agent) {
+          try {
+            const info = await agent.getSessionInfo(session);
+            if (info?.summary && info.summary !== session.metadata?.["summary"]) {
+              updateMetadata(config.dataDir, session.id, { summary: info.summary });
+            }
+          } catch {
+            // Agent info extraction failed — non-fatal, skip
+          }
+        }
+      }
+    }
   }
 
   /** Run one polling cycle across all sessions. */

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -509,7 +509,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           try {
             const info = await agent.getSessionInfo(session);
             if (info?.summary && info.summary !== session.metadata?.["summary"]) {
-              updateMetadata(config.dataDir, session.id, { summary: info.summary });
+              const sessionsDir = getSessionsDir(config.configPath, project.path);
+              updateMetadata(sessionsDir, session.id, { summary: info.summary });
             }
           } catch {
             // Agent info extraction failed — non-fatal, skip

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -185,9 +185,9 @@ export const manifest = {
  * Convert a workspace path to Claude's project directory path.
  * Claude stores sessions at ~/.claude/projects/{encoded-path}/
  *
- * Verified against Claude Code's actual encoding (as of v1.x):
- * the path has its leading / stripped, then all / and . are replaced with -.
- * e.g. /Users/dev/.worktrees/ao → Users-dev--worktrees-ao
+ * Claude Code's encoding simply replaces all / and . with -.
+ * The leading / becomes a leading - in the directory name.
+ * e.g. /Users/dev/.worktrees/ao → -Users-dev--worktrees-ao
  *
  * If Claude Code changes its encoding scheme this will silently break
  * introspection. The path can be validated at runtime by checking whether


### PR DESCRIPTION
## Summary

- **Fix `toClaudeProjectPath()` encoding bug** — the function stripped the leading `/` before encoding, producing `Users-equinox-...` while Claude's actual project directories are `-Users-equinox-...`. This was the root cause of `getSessionInfo()` never finding JSONL files.
- **Add live agent info enrichment** in session manager's `enrichSessionWithRuntimeState()` so the dashboard gets summaries, cost estimates, and agent session IDs on every refresh.
- **Add background summary persistence** in lifecycle manager polling — writes summary to metadata files so they survive dashboard restarts.

## Before/After

**Before:** Sessions without PRs show generic info:
```
💤 ao-37
spawning
terminal
detached
```

**After:** Sessions show actual agent summaries:
```
💤 Better Agent-to-Agent Communication Architecture
ao-37 • spawning • detached
terminal
```

## Test plan

- [x] All existing tests updated and passing (85 agent-claude-code tests, 131 core tests)
- [x] `pnpm build` succeeds
- [x] Path encoding verified against actual `~/.claude/projects/` directories
- [ ] Manual verification: start dashboard, confirm sessions display summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)