### PR TITLE
feat: add 'ready' activity state for live session detection

### DIFF
--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -519,7 +519,7 @@ describe("status command", () => {
     expect(parsed[0].activity).toBe("active");
   });
 
-  it("treats assistant lastMessageType as idle, not active", async () => {
+  it("treats assistant lastMessageType as ready, not active", async () => {
     const sessionDir = join(tmpDir, "my-app-sessions");
     mkdirSync(sessionDir, { recursive: true });
     writeFileSync(
@@ -544,6 +544,6 @@ describe("status command", () => {
 
     const jsonCalls = consoleSpy.mock.calls.map((c) => c[0]).join("");
     const parsed = JSON.parse(jsonCalls);
-    expect(parsed[0].activity).toBe("idle");
+    expect(parsed[0].activity).toBe("ready");
   });
 });

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -114,7 +114,7 @@ async function gatherSessionInfo(
     // Detect activity from agent's last message type
     const msgType = introspection?.lastMessageType;
     if (msgType === "summary" || msgType === "assistant" || msgType === "result") {
-      activity = "idle";
+      activity = "ready";
     } else if (msgType === "tool_use" || msgType === "user") {
       activity = "active";
     }
@@ -126,7 +126,7 @@ async function gatherSessionInfo(
   if (activity === null && status) {
     const statusToActivity: Record<string, ActivityState> = {
       working: "active",
-      idle: "idle",
+      idle: "ready",
       stuck: "blocked",
       errored: "blocked",
     };

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -89,6 +89,8 @@ export function activityIcon(activity: ActivityState | null): string {
   switch (activity) {
     case "active":
       return chalk.green("working");
+    case "ready":
+      return chalk.cyan("ready");
     case "idle":
       return chalk.yellow("idle");
     case "waiting_input":

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -458,8 +458,8 @@ describe("list", () => {
     const sm = createSessionManager({ config, registry: registryWithError });
     const sessions = await sm.list();
 
-    // Should fall back to idle when getActivityState fails
-    expect(sessions[0].activity).toBe("idle");
+    // Should fall back to ready when getActivityState fails (runtime is alive)
+    expect(sessions[0].activity).toBe("ready");
   });
 });
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -188,8 +188,8 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
           try {
             session.activity = await plugins.agent.getActivityState(session);
           } catch {
-            // Can't detect activity — explicitly set to idle
-            session.activity = "idle";
+            // Can't detect activity — runtime is alive so assume ready
+            session.activity = "ready";
           }
         }
       } catch {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -44,7 +44,8 @@ export type SessionStatus =
 /** Activity state as detected by the agent plugin */
 export type ActivityState =
   | "active" // agent is processing (thinking, writing code)
-  | "idle" // agent is at prompt, waiting for input
+  | "ready" // agent finished its turn, process alive, waiting for input (recent)
+  | "idle" // agent process alive but no activity for >5 minutes (stale)
   | "waiting_input" // agent is asking a question / permission prompt
   | "blocked" // agent hit an error or is stuck
   | "exited"; // agent process is no longer running
@@ -52,6 +53,7 @@ export type ActivityState =
 /** Activity state constants */
 export const ACTIVITY_STATE = {
   ACTIVE: "active" as const,
+  READY: "ready" as const,
   IDLE: "idle" as const,
   WAITING_INPUT: "waiting_input" as const,
   BLOCKED: "blocked" as const,

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -17,7 +17,8 @@ interface SessionCardProps {
 
 const activityIcon: Record<string, string> = {
   active: "\u26A1",
-  idle: "\uD83D\uDCA4",
+  ready: "\uD83D\uDFE2",
+  idle: "\uD83D\uDFE1",
   waiting_input: "\u2753",
   blocked: "\uD83D\uDEA7",
   exited: "\uD83D\uDC80",


### PR DESCRIPTION
## Summary

- Adds a new **"ready"** activity state (🟢) to distinguish sessions that finished their turn and are waiting for input from truly stale sessions
- Sessions where Claude finished responding were shown as "idle" (💤) — indistinguishable from abandoned sessions. Users couldn't tell if ao-38 was alive and ready vs dead.
- **ready** (🟢) = process alive, finished turn, <5min since last activity
- **idle** (🟡) = process alive but no activity for >5min (stale/dormant)

## Changes

| File | Change |
|------|--------|
| `packages/core/src/types.ts` | Added `"ready"` to `ActivityState` union + `ACTIVITY_STATE.READY` |
| `packages/plugins/agent-claude-code/src/index.ts` | Rewrote `getActivityState()` with ready/idle split at 5min threshold |
| `packages/core/src/session-manager.ts` | Fallback on detection error → `"ready"` (runtime is known alive) |
| `packages/web/src/components/SessionCard.tsx` | Added 🟢 ready icon, changed idle to 🟡 |
| `packages/cli/src/lib/format.ts` | Added cyan "ready" display in CLI |
| `packages/cli/src/commands/status.ts` | Map assistant/system → "ready" instead of "idle" |
| Tests (2 files) | Updated expectations for new semantics |

## Activity state semantics

| State | Icon | Meaning |
|-------|------|---------|
| active | ⚡ | Processing (thinking, running tools) |
| **ready** | 🟢 | Finished turn, alive, waiting for input (<5min) |
| idle | 🟡 | Process alive but stale (>5min) |
| waiting_input | ❓ | Permission prompt |
| blocked | 🚧 | Error |
| exited | 💀 | Process terminated |

## Test plan

- [x] All 131 core tests pass
- [x] All 138 CLI tests pass
- [x] All plugin tests pass
- [x] Typecheck clean across all 22 packages
- [x] Lint clean (no new issues)
- [x] Build succeeds including Next.js web package
- [ ] Verify ao-38 (alive, waiting) shows 🟢 ready on dashboard
- [ ] Verify actively processing sessions show ⚡ active
- [ ] Verify old stale sessions show 🟡 idle
- [ ] Verify killed sessions show 💀 exited

🤖 Generated with [Claude Code](https://claude.com/claude-code)