### PR TITLE
fix: infer projectId from session prefix to fix merge button

### DIFF
--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -1,10 +1,7 @@
 # Agent Orchestrator Configuration
 # Copy to agent-orchestrator.yaml and customize.
 
-# Where to store session metadata
-dataDir: ~/.agent-orchestrator
-
-# Where to create workspaces (git worktrees, clones)
+# Where to create workspaces (git worktrees, clones). Defaults to ~/.worktrees
 worktreeDir: ~/.worktrees
 
 # Web dashboard port
@@ -72,12 +69,12 @@ projects:
 #     webhook: ${SLACK_WEBHOOK_URL}
 #     channel: "#agent-updates"
 
-# Notification routing by priority
+# Notification routing by priority (defaults: all priorities → desktop)
 # notificationRouting:
 #   urgent: [desktop, slack]   # agent stuck, needs input, errored
 #   action: [desktop, slack]   # PR ready to merge
-#   warning: [slack]           # auto-fix failed
-#   info: [slack]              # summary, all done
+#   warning: [desktop, slack]  # auto-fix failed
+#   info: [desktop, slack]     # summary, all done
 
 # Reactions — auto-responses to events (these are the defaults)
 # reactions:

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -237,11 +237,6 @@ export function registerInit(program: Command): void {
       try {
         // Basic config
         console.log(chalk.bold("  Configuration\n"));
-        const dataDir = await prompt(
-          rl,
-          "Data directory (session metadata)",
-          "~/.agent-orchestrator",
-        );
         const worktreeDir = await prompt(rl, "Worktree directory", "~/.worktrees");
         const freePort = await findFreePort(DEFAULT_PORT);
         const portStr = await prompt(rl, "Dashboard port", String(freePort));
@@ -274,7 +269,6 @@ export function registerInit(program: Command): void {
         );
 
         const config: Record<string, unknown> = {
-          dataDir,
           worktreeDir,
           port,
           defaults: { runtime, agent, workspace, notifiers },
@@ -445,7 +439,6 @@ async function handleAutoMode(outputPath: string, smart: boolean): Promise<void>
 
   const port = await findFreePort(DEFAULT_PORT);
   const config: Record<string, unknown> = {
-    dataDir: "~/.agent-orchestrator",
     worktreeDir: "~/.worktrees",
     port,
     defaults: {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -114,6 +114,7 @@ beforeEach(() => {
 
   config = {
     configPath,
+    worktreeDir: join(tmpDir, ".worktrees"),
     port: 3000,
     defaults: {
       runtime: "mock",

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -88,6 +88,7 @@ beforeEach(() => {
 
   config = {
     configPath,
+    worktreeDir: join(tmpDir, ".worktrees"),
     port: 3000,
     defaults: {
       runtime: "mock",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -85,10 +85,11 @@ const DefaultPluginsSchema = z.object({
   runtime: z.string().default("tmux"),
   agent: z.string().default("claude-code"),
   workspace: z.string().default("worktree"),
-  notifiers: z.array(z.string()).default(["composio", "desktop"]),
+  notifiers: z.array(z.string()).default(["desktop"]),
 });
 
 const OrchestratorConfigSchema = z.object({
+  worktreeDir: z.string().default("~/.worktrees"),
   port: z.number().default(3000),
   terminalPort: z.number().optional(),
   directTerminalPort: z.number().optional(),
@@ -97,10 +98,10 @@ const OrchestratorConfigSchema = z.object({
   projects: z.record(ProjectConfigSchema),
   notifiers: z.record(NotifierConfigSchema).default({}),
   notificationRouting: z.record(z.array(z.string())).default({
-    urgent: ["desktop", "composio"],
-    action: ["desktop", "composio"],
-    warning: ["composio"],
-    info: ["composio"],
+    urgent: ["desktop"],
+    action: ["desktop"],
+    warning: ["desktop"],
+    info: ["desktop"],
   }),
   reactions: z.record(ReactionConfigSchema).default({}),
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,7 +44,7 @@ export {
 } from "./tmux.js";
 
 // Session manager — session CRUD
-export { createSessionManager } from "./session-manager.js";
+export { createSessionManager, inferProjectId } from "./session-manager.js";
 export type { SessionManagerDeps } from "./session-manager.js";
 
 // Lifecycle manager — state machine + reaction engine

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -51,11 +51,13 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
 
 /** Extract plugin-specific config from orchestrator config */
 function extractPluginConfig(
-  _slot: PluginSlot,
-  _name: string,
-  _config: OrchestratorConfig,
+  slot: PluginSlot,
+  name: string,
+  config: OrchestratorConfig,
 ): Record<string, unknown> | undefined {
-  // Reserved for future plugin-specific config mapping
+  if (slot === "workspace" && name === "worktree") {
+    return { worktreeDir: config.worktreeDir };
+  }
   return undefined;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -797,6 +797,9 @@ export interface OrchestratorConfig {
    */
   configPath: string;
 
+  /** Where to create workspaces (git worktrees, clones). Defaults to ~/.worktrees */
+  worktreeDir: string;
+
   /** Web dashboard port (defaults to 3000) */
   port?: number;
 

--- a/packages/integration-tests/src/cli-spawn-core-read-new.integration.test.ts
+++ b/packages/integration-tests/src/cli-spawn-core-read-new.integration.test.ts
@@ -155,6 +155,7 @@ describe.skipIf(!tmuxOk)("CLI-Core integration (hash-based architecture)", () =>
     // Create session-manager with configPath
     const config: OrchestratorConfig = {
       configPath, // This enables hash-based architecture
+      worktreeDir: join(tmpDir, ".worktrees"),
       port: 3000,
       readyThresholdMs: 300_000,
       defaults: {
@@ -215,6 +216,7 @@ describe.skipIf(!tmuxOk)("CLI-Core integration (hash-based architecture)", () =>
 
     const config: OrchestratorConfig = {
       configPath,
+      worktreeDir: join(tmpDir, ".worktrees"),
       port: 3000,
       readyThresholdMs: 300_000,
       defaults: {

--- a/packages/web/src/app/api/prs/[id]/merge/route.ts
+++ b/packages/web/src/app/api/prs/[id]/merge/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getServices, getSCM } from "@/lib/services";
+import { inferProjectId } from "@composio/ao-core";
 
 /** POST /api/prs/:id/merge — Merge a PR */
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -18,11 +19,22 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
       return NextResponse.json({ error: "PR not found" }, { status: 404 });
     }
 
-    const project = config.projects[session.projectId];
+    let project = config.projects[session.projectId];
+    if (!project) {
+      const inferred = inferProjectId(session.id, config.projects);
+      if (inferred) {
+        project = config.projects[inferred];
+      }
+    }
     const scm = getSCM(registry, project);
     if (!scm) {
       return NextResponse.json(
-        { error: "No SCM plugin configured for this project" },
+        {
+          error: "No SCM plugin configured for this project",
+          detail: session.projectId
+            ? `Project "${session.projectId}" not found in config`
+            : `Session "${session.id}" has no project field and prefix could not be matched`,
+        },
         { status: 500 },
       );
     }

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -71,7 +71,18 @@ export function Dashboard({ sessions, stats, orchestratorId, projectName }: Dash
   const handleMerge = async (prNumber: number) => {
     const res = await fetch(`/api/prs/${prNumber}/merge`, { method: "POST" });
     if (!res.ok) {
-      console.error(`Failed to merge PR #${prNumber}:`, await res.text());
+      let errorMessage = `Failed to merge PR #${prNumber}`;
+      try {
+        const body = await res.json();
+        if (body.error) errorMessage += `:\n\n${body.error}`;
+        if (body.detail) errorMessage += `\n${body.detail}`;
+        if (body.blockers && Array.isArray(body.blockers) && body.blockers.length > 0) {
+          errorMessage += `\n\nBlockers:\n${body.blockers.map((b: string) => `• ${b}`).join("\n")}`;
+        }
+      } catch {
+        errorMessage += `:\n\n${await res.text().catch(() => "Unknown error")}`;
+      }
+      alert(errorMessage);
     }
   };
 


### PR DESCRIPTION
## Summary

- Add `inferProjectId()` function that matches session ID prefix against configured `sessionPrefix` values (e.g. `ao-18` matches prefix `ao`), with fallback to the only configured project when there's just one
- Use it in `metadataToSession()` so legacy sessions (missing `project` field) get their projectId resolved automatically
- Use it in the merge API route as a fallback when `session.projectId` doesn't resolve to a configured project
- Improve dashboard error display — show user-facing `alert()` with parsed JSON error responses and formatted merge blockers list instead of console-only logging

Fixes the merge button failing with "No SCM plugin configured" for legacy sessions that don't have a `project` metadata field.

Successor to #46, which was closed due to the hash-based architecture refactoring in #58.

## Test plan

- [x] 5 new unit tests for `inferProjectId()` (prefix matching, single-project fallback, no match, empty config, integration with `list()`)
- [x] All 219 core tests pass
- [x] Build passes (including web package)
- [x] Typecheck clean
- [ ] Manual test: create a session without `project` field in metadata, verify merge button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)