### PR TITLE
fix: transition session status from spawning to working after launch

### DIFF
--- a/packages/cli/__tests__/commands/session.test.ts
+++ b/packages/cli/__tests__/commands/session.test.ts
@@ -499,7 +499,7 @@ describe("session table", () => {
     expect(output).toContain("app-1");
     expect(output).toContain("working");
     expect(output).toContain("active");
-    expect(output).toContain("http://localhost:3000/sessions/app-1");
+    expect(output).toContain("/sessions/app-1");
   });
 
   it("shows PR, CI, and bugbot data from SCM", async () => {
@@ -575,7 +575,7 @@ describe("session table", () => {
     expect(parsed[0].activity).toBe("idle");
     expect(parsed[0].ci).toBe("-");
     expect(parsed[0].bugbot).toBe(0);
-    expect(parsed[0].sessionUrl).toBe("http://localhost:3000/sessions/app-1");
+    expect(parsed[0].sessionUrl).toContain("/sessions/app-1");
     expect(parsed[0].prUrl).toBe("");
   });
 

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -615,51 +615,6 @@ describe("status command", () => {
     expect(parsed[0].activity).toBeNull();
   });
 
-  it("shows null activity when session activity is null", async () => {
-    writeFileSync(
-      join(sessionsDir, "app-1"),
-      "worktree=/tmp/wt\nbranch=feat/err\nstatus=working\n",
-    );
-
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1";
-      if (args[0] === "display-message") return String(Math.floor(Date.now() / 1000));
-      return null;
-    });
-    mockGit.mockResolvedValue("feat/err");
-
-    // Session has activity: null (default from buildSessionsFromDir)
-    await program.parseAsync(["node", "test", "status", "--json"]);
-
-    const jsonCalls = consoleSpy.mock.calls.map((c) => c[0]).join("");
-    const parsed = JSON.parse(jsonCalls);
-    expect(parsed[0].activity).toBeNull();
-  });
-
-  it("shows null activity when session activity is explicitly null", async () => {
-    writeFileSync(
-      join(sessionsDir, "app-1"),
-      "worktree=/tmp/wt\nbranch=feat/null\nstatus=working\n",
-    );
-
-    mockSessionManager.list.mockImplementation(async () => {
-      return buildSessionsFromDir(sessionsDirRef.current, "my-app", null);
-    });
-
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1";
-      if (args[0] === "display-message") return String(Math.floor(Date.now() / 1000));
-      return null;
-    });
-    mockGit.mockResolvedValue("feat/null");
-
-    await program.parseAsync(["node", "test", "status", "--json"]);
-
-    const jsonCalls = consoleSpy.mock.calls.map((c) => c[0]).join("");
-    const parsed = JSON.parse(jsonCalls);
-    expect(parsed[0].activity).toBeNull();
-  });
-
   it("shows exited activity from session manager", async () => {
     writeFileSync(
       join(sessionsDir, "app-1"),

--- a/packages/cli/__tests__/lib/scm-data.test.ts
+++ b/packages/cli/__tests__/lib/scm-data.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Session, SCM, ProjectConfig, PRInfo } from "@composio/ao-core";
+import { detectSessionPR } from "../../src/lib/scm-data.js";
+
+/** Build a minimal Session for testing. */
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "app-1",
+    projectId: "my-app",
+    status: "working",
+    activity: "active",
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: null,
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+/** Build a minimal ProjectConfig for testing. */
+function makeProject(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    name: "My App",
+    repo: "org/my-app",
+    path: "/tmp/my-app",
+    defaultBranch: "main",
+    sessionPrefix: "app",
+    ...overrides,
+  };
+}
+
+/** Build a mock SCM with configurable detectPR behavior. */
+function makeSCM(detectPR: SCM["detectPR"]): SCM {
+  return {
+    name: "github",
+    detectPR,
+    getCISummary: vi.fn(),
+    getReviewDecision: vi.fn(),
+    getPendingComments: vi.fn(),
+    getAutomatedComments: vi.fn(),
+    getCIChecks: vi.fn(),
+    getReviews: vi.fn(),
+    getMergeability: vi.fn(),
+    getPRState: vi.fn(),
+    mergePR: vi.fn(),
+    closePR: vi.fn(),
+  } as unknown as SCM;
+}
+
+const PR_URL = "https://github.com/org/my-app/pull/42";
+
+const mockPRInfo: PRInfo = {
+  number: 42,
+  url: PR_URL,
+  title: "Test PR",
+  owner: "org",
+  repo: "my-app",
+  branch: "feat/test",
+  baseBranch: "main",
+  isDraft: false,
+};
+
+describe("detectSessionPR", () => {
+  it("returns nulls when no metadata URL and no SCM", async () => {
+    const session = makeSession();
+    const result = await detectSessionPR(session, null, undefined);
+
+    expect(result.prNumber).toBeNull();
+    expect(result.prUrl).toBe("");
+    expect(result.prInfo).toBeNull();
+  });
+
+  it("extracts PR number from metadata URL when no SCM provided", async () => {
+    const session = makeSession({ metadata: { pr: PR_URL } });
+    const result = await detectSessionPR(session, null, undefined);
+
+    expect(result.prNumber).toBe(42);
+    expect(result.prUrl).toBe(PR_URL);
+    expect(result.prInfo).toBeNull();
+  });
+
+  it("extracts PR number from metadata URL when SCM provided but project undefined", async () => {
+    const scm = makeSCM(vi.fn());
+    const session = makeSession({ metadata: { pr: PR_URL } });
+    const result = await detectSessionPR(session, scm, undefined);
+
+    expect(result.prNumber).toBe(42);
+    expect(result.prUrl).toBe(PR_URL);
+    expect(result.prInfo).toBeNull();
+    // SCM should NOT be called when project is undefined
+    expect(scm.detectPR).not.toHaveBeenCalled();
+  });
+
+  it("uses SCM detectPR result when available", async () => {
+    const detectPR = vi.fn().mockResolvedValue(mockPRInfo);
+    const scm = makeSCM(detectPR);
+    const session = makeSession();
+    const project = makeProject();
+
+    const result = await detectSessionPR(session, scm, project);
+
+    expect(result.prNumber).toBe(42);
+    expect(result.prUrl).toBe(PR_URL);
+    expect(result.prInfo).toBe(mockPRInfo);
+    expect(detectPR).toHaveBeenCalledWith(session, project);
+  });
+
+  it("SCM result overrides metadata URL fallback", async () => {
+    const scmPR: PRInfo = { ...mockPRInfo, number: 99, url: "https://github.com/org/my-app/pull/99" };
+    const detectPR = vi.fn().mockResolvedValue(scmPR);
+    const scm = makeSCM(detectPR);
+    const session = makeSession({ metadata: { pr: PR_URL } });
+    const project = makeProject();
+
+    const result = await detectSessionPR(session, scm, project);
+
+    // SCM result should override the metadata URL
+    expect(result.prNumber).toBe(99);
+    expect(result.prUrl).toBe("https://github.com/org/my-app/pull/99");
+    expect(result.prInfo).toBe(scmPR);
+  });
+
+  it("falls back to metadata URL when SCM detectPR throws", async () => {
+    const detectPR = vi.fn().mockRejectedValue(new Error("gh failed"));
+    const scm = makeSCM(detectPR);
+    const session = makeSession({ metadata: { pr: PR_URL } });
+    const project = makeProject();
+
+    const result = await detectSessionPR(session, scm, project);
+
+    expect(result.prNumber).toBe(42);
+    expect(result.prUrl).toBe(PR_URL);
+    expect(result.prInfo).toBeNull();
+  });
+
+  it("returns nulls when SCM detectPR throws and no metadata URL", async () => {
+    const detectPR = vi.fn().mockRejectedValue(new Error("gh failed"));
+    const scm = makeSCM(detectPR);
+    const session = makeSession();
+    const project = makeProject();
+
+    const result = await detectSessionPR(session, scm, project);
+
+    expect(result.prNumber).toBeNull();
+    expect(result.prUrl).toBe("");
+    expect(result.prInfo).toBeNull();
+  });
+
+  it("returns nulls when SCM detectPR returns null", async () => {
+    const detectPR = vi.fn().mockResolvedValue(null);
+    const scm = makeSCM(detectPR);
+    const session = makeSession();
+    const project = makeProject();
+
+    const result = await detectSessionPR(session, scm, project);
+
+    expect(result.prNumber).toBeNull();
+    expect(result.prUrl).toBe("");
+    expect(result.prInfo).toBeNull();
+  });
+
+  it("keeps metadata URL when SCM detectPR returns null", async () => {
+    const detectPR = vi.fn().mockResolvedValue(null);
+    const scm = makeSCM(detectPR);
+    const session = makeSession({ metadata: { pr: PR_URL } });
+    const project = makeProject();
+
+    const result = await detectSessionPR(session, scm, project);
+
+    // Metadata fallback preserved when SCM returns null (no PR detected)
+    expect(result.prNumber).toBe(42);
+    expect(result.prUrl).toBe(PR_URL);
+    expect(result.prInfo).toBeNull();
+  });
+
+  it("handles metadata URL without /pull/ pattern gracefully", async () => {
+    const session = makeSession({ metadata: { pr: "https://github.com/org/my-app/issues/10" } });
+    const result = await detectSessionPR(session, null, undefined);
+
+    // URL doesn't match /pull/N pattern — no PR number extracted
+    expect(result.prNumber).toBeNull();
+    expect(result.prUrl).toBe("");
+    expect(result.prInfo).toBeNull();
+  });
+
+  it("works with session that has no branch", async () => {
+    const detectPR = vi.fn().mockResolvedValue(null);
+    const scm = makeSCM(detectPR);
+    const session = makeSession({ branch: null });
+    const project = makeProject();
+
+    const result = await detectSessionPR(session, scm, project);
+
+    // Should still call detectPR — the shared helper doesn't gate on branch
+    expect(detectPR).toHaveBeenCalledWith(session, project);
+    expect(result.prNumber).toBeNull();
+    expect(result.prInfo).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -1,9 +1,18 @@
 import chalk from "chalk";
 import type { Command } from "commander";
-import { loadConfig, SessionNotRestorableError, WorkspaceMissingError } from "@composio/ao-core";
+import {
+  type Session,
+  type CIStatus,
+  type OrchestratorConfig,
+  loadConfig,
+  SessionNotRestorableError,
+  WorkspaceMissingError,
+} from "@composio/ao-core";
 import { git, getTmuxActivity } from "../lib/shell.js";
 import { formatAge } from "../lib/format.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
+import { getSCM } from "../lib/plugins.js";
+import { detectSessionPR } from "../lib/scm-data.js";
 
 export function registerSession(program: Command): void {
   const session = program.command("session").description("Session management (ls, kill, cleanup)");
@@ -181,4 +190,145 @@ export function registerSession(program: Command): void {
         process.exit(1);
       }
     });
+
+  session
+    .command("table")
+    .description("Print structured table of all sessions with PR/CI/bugbot data")
+    .option("-p, --project <id>", "Filter by project ID")
+    .option("--json", "Output as JSON instead of table")
+    .action(async (opts: { project?: string; json?: boolean }) => {
+      const config = loadConfig();
+      if (opts.project && !config.projects[opts.project]) {
+        console.error(`Unknown project: ${opts.project}`);
+        process.exit(1);
+      }
+
+      const sm = await getSessionManager(config);
+      const sessions = await sm.list(opts.project);
+      const port = config.port ?? 3000;
+
+      // Gather enriched data for each session in parallel
+      const rows = await Promise.all(
+        sessions
+          .sort((a, b) => a.id.localeCompare(b.id))
+          .map((s) => gatherTableRow(s, config, port)),
+      );
+
+      if (opts.json) {
+        console.log(JSON.stringify(rows, null, 2));
+        return;
+      }
+
+      // Compute column widths from data
+      const cols = computeColumnWidths(rows);
+
+      // Print header
+      const hdr =
+        pad("SESSION", cols.session) +
+        pad("STATUS", cols.status) +
+        pad("ACTIVITY", cols.activity) +
+        pad("PR", cols.pr) +
+        pad("CI", cols.ci) +
+        pad("BUGBOT", cols.bugbot) +
+        pad("SESSION_URL", cols.sessionUrl) +
+        "PR_URL";
+      console.log(hdr);
+
+      // Print rows
+      for (const row of rows) {
+        const line =
+          pad(row.session, cols.session) +
+          pad(row.status, cols.status) +
+          pad(row.activity, cols.activity) +
+          pad(row.pr, cols.pr) +
+          pad(row.ci, cols.ci) +
+          pad(String(row.bugbot), cols.bugbot) +
+          pad(row.sessionUrl, cols.sessionUrl) +
+          row.prUrl;
+        console.log(line);
+      }
+    });
+}
+
+interface TableRow {
+  session: string;
+  status: string;
+  activity: string;
+  pr: string;
+  ci: string;
+  bugbot: number;
+  sessionUrl: string;
+  prUrl: string;
+}
+
+async function gatherTableRow(
+  session: Session,
+  config: OrchestratorConfig,
+  port: number,
+): Promise<TableRow> {
+  const project = config.projects[session.projectId];
+  const scm = project ? getSCM(config, session.projectId) : null;
+
+  const { prNumber, prUrl, prInfo } = await detectSessionPR(session, scm, project);
+  const prLabel = prNumber ? `#${prNumber}` : "-";
+  let ciStatus: CIStatus | null = null;
+  let bugbotCount = 0;
+
+  if (prInfo && scm) {
+    const [ci, automated] = await Promise.all([
+      scm.getCISummary(prInfo).catch(() => null),
+      scm.getAutomatedComments(prInfo).catch(() => []),
+    ]);
+    ciStatus = ci;
+    bugbotCount = automated.length;
+  }
+
+  // Map CI status to display value
+  let ciDisplay: string;
+  switch (ciStatus) {
+    case "passing":
+      ciDisplay = "green";
+      break;
+    case "failing":
+      ciDisplay = "red";
+      break;
+    case "pending":
+      ciDisplay = "pending";
+      break;
+    default:
+      ciDisplay = "-";
+  }
+
+  const sessionUrl = `http://localhost:${port}/sessions/${session.id}`;
+
+  return {
+    session: session.id,
+    status: session.status,
+    activity: session.activity ?? "unknown",
+    pr: prLabel,
+    ci: ciDisplay,
+    bugbot: bugbotCount,
+    sessionUrl,
+    prUrl,
+  };
+}
+
+function computeColumnWidths(rows: TableRow[]): Record<string, number> {
+  const min = (key: keyof TableRow, header: string) => {
+    const max = Math.max(header.length, ...rows.map((r) => String(r[key]).length));
+    return max + 2; // 2-char padding
+  };
+  return {
+    session: min("session", "SESSION"),
+    status: min("status", "STATUS"),
+    activity: min("activity", "ACTIVITY"),
+    pr: min("pr", "PR"),
+    ci: min("ci", "CI"),
+    bugbot: min("bugbot", "BUGBOT"),
+    sessionUrl: min("sessionUrl", "SESSION_URL"),
+  };
+}
+
+function pad(str: string, width: number): string {
+  return str.padEnd(width);
 }

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -3,6 +3,7 @@ import type { Command } from "commander";
 import {
   type Session,
   type CIStatus,
+  type SCM,
   type OrchestratorConfig,
   loadConfig,
   SessionNotRestorableError,
@@ -267,7 +268,14 @@ async function gatherTableRow(
   port: number,
 ): Promise<TableRow> {
   const project = config.projects[session.projectId];
-  const scm = project ? getSCM(config, session.projectId) : null;
+  let scm: SCM | null = null;
+  if (project) {
+    try {
+      scm = getSCM(config, session.projectId);
+    } catch {
+      // Unknown/misconfigured SCM plugin — proceed without SCM data
+    }
+  }
 
   const { prNumber, prUrl, prInfo } = await detectSessionPR(session, scm, project);
   const prLabel = prNumber ? `#${prNumber}` : "-";

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -4,7 +4,6 @@ import {
   type Agent,
   type SCM,
   type Session,
-  type PRInfo,
   type CIStatus,
   type ReviewDecision,
   type ActivityState,
@@ -22,6 +21,7 @@ import {
 } from "../lib/format.js";
 import { getAgentByName, getSCM } from "../lib/plugins.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
+import { detectSessionPR } from "../lib/scm-data.js";
 
 interface SessionInfo {
   name: string;
@@ -76,41 +76,22 @@ async function gatherSessionInfo(
   const activity = session.activity;
 
   // Fetch PR, CI, and review data from SCM
-  let prNumber: number | null = null;
+  const project = projectConfig.projects[session.projectId];
+  const { prNumber, prInfo } = await detectSessionPR(session, scm, project);
   let ciStatus: CIStatus | null = null;
   let reviewDecision: ReviewDecision | null = null;
   let pendingThreads: number | null = null;
 
-  // Extract PR number from metadata URL as fallback
-  if (prUrl) {
-    const prMatch = /\/pull\/(\d+)/.exec(prUrl);
-    if (prMatch) {
-      prNumber = parseInt(prMatch[1], 10);
-    }
-  }
+  if (prInfo) {
+    const [ci, review, threads] = await Promise.all([
+      scm.getCISummary(prInfo).catch(() => null),
+      scm.getReviewDecision(prInfo).catch(() => null),
+      scm.getPendingComments(prInfo).catch(() => null),
+    ]);
 
-  if (branch) {
-    try {
-      const project = projectConfig.projects[session.projectId];
-      if (project) {
-        const prInfo: PRInfo | null = await scm.detectPR(session, project);
-        if (prInfo) {
-          prNumber = prInfo.number;
-
-          const [ci, review, threads] = await Promise.all([
-            scm.getCISummary(prInfo).catch(() => null),
-            scm.getReviewDecision(prInfo).catch(() => null),
-            scm.getPendingComments(prInfo).catch(() => null),
-          ]);
-
-          ciStatus = ci;
-          reviewDecision = review;
-          pendingThreads = threads !== null ? threads.length : null;
-        }
-      }
-    } catch {
-      // SCM lookup failed — not critical
-    }
+    ciStatus = ci;
+    reviewDecision = review;
+    pendingThreads = threads !== null ? threads.length : null;
   }
 
   return {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -49,7 +49,6 @@ async function gatherSessionInfo(
   let branch = session.branch;
   const status = session.status;
   const summary = session.metadata["summary"] ?? null;
-  const prUrl = session.metadata["pr"] ?? null;
   const issue = session.issueId;
 
   // Get live branch from worktree if available
@@ -77,7 +76,7 @@ async function gatherSessionInfo(
 
   // Fetch PR, CI, and review data from SCM
   const project = projectConfig.projects[session.projectId];
-  const { prNumber, prInfo } = await detectSessionPR(session, scm, project);
+  const { prNumber, prUrl, prInfo } = await detectSessionPR(session, scm, project);
   let ciStatus: CIStatus | null = null;
   let reviewDecision: ReviewDecision | null = null;
   let pendingThreads: number | null = null;
@@ -100,7 +99,7 @@ async function gatherSessionInfo(
     status,
     summary,
     claudeSummary,
-    pr: prUrl,
+    pr: prUrl || null,
     prNumber,
     issue,
     lastActivity,

--- a/packages/cli/src/lib/scm-data.ts
+++ b/packages/cli/src/lib/scm-data.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared SCM data-fetching helpers.
+ *
+ * Extracts the common PR detection pattern used by both `status.ts` and
+ * `session.ts` (table command): metadata URL fallback → SCM detectPR.
+ */
+
+import type { Session, ProjectConfig, SCM, PRInfo } from "@composio/ao-core";
+
+export interface PRDetectionResult {
+  prNumber: number | null;
+  prUrl: string;
+  prInfo: PRInfo | null;
+}
+
+/**
+ * Detect PR for a session using SCM plugin with metadata URL fallback.
+ *
+ * 1. Extracts PR number from metadata `pr` URL (e.g. `/pull/42`)
+ * 2. Attempts live PR detection via SCM plugin (overwrites if found)
+ * 3. Returns prInfo so callers can fetch additional data (CI, reviews, etc.)
+ */
+export async function detectSessionPR(
+  session: Session,
+  scm: SCM | null,
+  project: ProjectConfig | undefined,
+): Promise<PRDetectionResult> {
+  let prNumber: number | null = null;
+  let prUrl = "";
+  let prInfo: PRInfo | null = null;
+
+  // Extract PR number from metadata URL as fallback
+  const prMetaUrl = session.metadata["pr"];
+  if (prMetaUrl) {
+    const match = /\/pull\/(\d+)/.exec(prMetaUrl);
+    if (match) {
+      prNumber = parseInt(match[1], 10);
+      prUrl = prMetaUrl;
+    }
+  }
+
+  // Try to detect PR via SCM
+  if (scm && project) {
+    try {
+      prInfo = await scm.detectPR(session, project);
+      if (prInfo) {
+        prNumber = prInfo.number;
+        prUrl = prInfo.url;
+      }
+    } catch {
+      // SCM lookup failed — use metadata fallback
+    }
+  }
+
+  return { prNumber, prUrl, prInfo };
+}

--- a/packages/core/src/orchestrator-prompt.ts
+++ b/packages/core/src/orchestrator-prompt.ts
@@ -77,7 +77,22 @@ ao open ${projectId}
 | \`ao session cleanup [-p project]\` | Kill completed/merged sessions |
 | \`ao send <session> <message>\` | Send a message to a running session |
 | \`ao dashboard\` | Start the web dashboard (http://localhost:${config.port ?? 3000}) |
-| \`ao open <project>\` | Open all project sessions in terminal tabs |`);
+| \`ao open <project>\` | Open all project sessions in terminal tabs |
+| \`ao session table [-p project]\` | Print structured table of all sessions (deterministic, machine-readable) |
+| \`ao session table --json [-p project]\` | Same as above but JSON output |`);
+
+  // Session Table
+  sections.push(`## Session Table (Deterministic Data Source)
+
+Before generating any status response, run \`ao session table\` to get accurate, structured data:
+
+\`\`\`bash
+ao session table -p ${projectId}
+\`\`\`
+
+Output columns: SESSION, STATUS, ACTIVITY, PR, CI, BUGBOT, SESSION_URL, PR_URL
+
+This gives you deterministic data to base your responses on rather than guessing. Always run this command first when asked about session status.`);
 
   // Session Management
   sections.push(`## Session Management
@@ -198,7 +213,9 @@ When an agent needs human judgment:
 
 7. **Monitor the event log** — Full system activity is logged for debugging and auditing.
 
-8. **Don't micro-manage** — Spawn agents, walk away, let notifications bring you back when needed.`);
+8. **Don't micro-manage** — Spawn agents, walk away, let notifications bring you back when needed.
+
+9. **You are running in a terminal — do NOT use markdown links like \`[text](url)\`.** URLs must be printed as plain text so they are clickable in the terminal. Example: \`http://localhost:3000/sessions/ao-1\` not \`[ao-1](http://localhost:3000/sessions/ao-1)\``);
 
   // Project-specific rules (if any)
   if (project.orchestratorRules) {

--- a/packages/core/src/orchestrator-prompt.ts
+++ b/packages/core/src/orchestrator-prompt.ts
@@ -76,7 +76,7 @@ ao open ${projectId}
 | \`ao session kill <session>\` | Kill a specific session |
 | \`ao session cleanup [-p project]\` | Kill completed/merged sessions |
 | \`ao send <session> <message>\` | Send a message to a running session |
-| \`ao dashboard\` | Start the web dashboard (http://localhost:${config.port ?? 3000}) |
+| \`ao dashboard\` | Start the web dashboard (http://localhost:${config.port}) |
 | \`ao open <project>\` | Open all project sessions in terminal tabs |
 | \`ao session table [-p project]\` | Print structured table of all sessions (deterministic, machine-readable) |
 | \`ao session table --json [-p project]\` | Same as above but JSON output |`);
@@ -215,7 +215,7 @@ When an agent needs human judgment:
 
 8. **Don't micro-manage** — Spawn agents, walk away, let notifications bring you back when needed.
 
-9. **You are running in a terminal — do NOT use markdown links like \`[text](url)\`.** URLs must be printed as plain text so they are clickable in the terminal. Example: \`http://localhost:3000/sessions/ao-1\` not \`[ao-1](http://localhost:3000/sessions/ao-1)\``);
+9. **You are running in a terminal — do NOT use markdown links like \`[text](url)\`.** URLs must be printed as plain text so they are clickable in the terminal. Example: \`http://localhost:${config.port}/sessions/ao-1\` not \`[ao-1](http://localhost:${config.port}/sessions/ao-1)\``);
 
   // Project-specific rules (if any)
   if (project.orchestratorRules) {

--- a/packages/integration-tests/src/spawn-stays-alive.integration.test.ts
+++ b/packages/integration-tests/src/spawn-stays-alive.integration.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration test: spawn pipeline keeps agent alive.
+ *
+ * Validates the fix for the `-p` (one-shot exit) bug. Uses a stub agent
+ * (simple shell script) wired through real tmux runtime, verifying the
+ * spawned process stays alive instead of exiting immediately.
+ *
+ * Requires: tmux installed and running.
+ * Does NOT require: Claude Code binary, API keys, or git repos.
+ */
+
+import { mkdtemp, rm, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import tmuxPlugin from "@composio/ao-plugin-runtime-tmux";
+import type { RuntimeHandle, Agent, AgentLaunchConfig } from "@composio/ao-core";
+import { isTmuxAvailable, killSessionsByPrefix } from "./helpers/tmux.js";
+import { sleep } from "./helpers/polling.js";
+
+const tmuxOk = await isTmuxAvailable();
+const SESSION_PREFIX = "ao-inttest-spawn-alive-";
+
+/**
+ * Stub agent that stays alive. Returns a simple bash loop as the launch
+ * command — this replaces Claude Code for testing the spawn pipeline.
+ */
+function createStubAgent(): Agent {
+  return {
+    name: "stub",
+    processName: "bash",
+
+    getLaunchCommand(_config: AgentLaunchConfig): string {
+      // Simple loop that stays alive — the key property being tested
+      return "bash -c 'while true; do sleep 1; done'";
+    },
+
+    getEnvironment(): Record<string, string> {
+      return {};
+    },
+
+    detectActivity(): "active" {
+      return "active";
+    },
+
+    async getActivityState(): Promise<"active"> {
+      return "active";
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      const runtime = tmuxPlugin.create();
+      return runtime.isAlive(handle);
+    },
+
+    async getSessionInfo(): Promise<null> {
+      return null;
+    },
+  } as Agent;
+}
+
+describe.skipIf(!tmuxOk)("spawn pipeline keeps agent alive (integration)", () => {
+  const runtime = tmuxPlugin.create();
+  const sessionName = `${SESSION_PREFIX}${Date.now()}`;
+  let tmpDir: string;
+  let handle: RuntimeHandle;
+
+  beforeAll(async () => {
+    await killSessionsByPrefix(SESSION_PREFIX);
+    const raw = await mkdtemp(join(tmpdir(), "ao-inttest-spawn-alive-"));
+    tmpDir = await realpath(raw);
+  }, 30_000);
+
+  afterAll(async () => {
+    try {
+      if (handle) await runtime.destroy(handle);
+    } catch {
+      /* best-effort */
+    }
+    await killSessionsByPrefix(SESSION_PREFIX);
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 30_000);
+
+  it("stub agent launch command keeps process alive in tmux", async () => {
+    const agent = createStubAgent();
+
+    // Get the launch command (same as session-manager does)
+    const launchCommand = agent.getLaunchCommand({
+      sessionId: sessionName,
+      projectConfig: {
+        name: "test",
+        repo: "test/test",
+        path: tmpDir,
+        defaultBranch: "main",
+        sessionPrefix: "test",
+      },
+    });
+
+    // Create tmux session with the launch command (same as runtime.create)
+    handle = await runtime.create({
+      sessionId: sessionName,
+      workspacePath: tmpDir,
+      launchCommand,
+      environment: {},
+    });
+
+    expect(handle.id).toBe(sessionName);
+    expect(handle.runtimeName).toBe("tmux");
+  });
+
+  it("process is alive immediately after spawn", async () => {
+    expect(await runtime.isAlive(handle)).toBe(true);
+  });
+
+  it("process stays alive after 3 seconds (not one-shot exit)", async () => {
+    await sleep(3_000);
+    expect(await runtime.isAlive(handle)).toBe(true);
+  });
+
+  it("session can be destroyed cleanly", async () => {
+    await runtime.destroy(handle);
+    expect(await runtime.isAlive(handle)).toBe(false);
+  });
+});

--- a/packages/integration-tests/src/spawn-stays-alive.integration.test.ts
+++ b/packages/integration-tests/src/spawn-stays-alive.integration.test.ts
@@ -1,20 +1,35 @@
 /**
  * Integration test: spawn pipeline keeps agent alive.
  *
- * Validates the fix for the `-p` (one-shot exit) bug. Uses a stub agent
- * (simple shell script) wired through real tmux runtime, verifying the
- * spawned process stays alive instead of exiting immediately.
+ * Validates the fix for the `-p` (one-shot exit) bug. Wires a stub agent
+ * through the REAL sessionManager.spawn() → tmux runtime pipeline, verifying:
+ *   1. The spawned process stays alive (not one-shot exit)
+ *   2. Metadata is written with status=working
+ *   3. Session can be killed and cleaned up
  *
  * Requires: tmux installed and running.
  * Does NOT require: Claude Code binary, API keys, or git repos.
  */
 
-import { mkdtemp, rm, realpath } from "node:fs/promises";
+import { mkdtemp, rm, realpath, readFile } from "node:fs/promises";
+import { writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import tmuxPlugin from "@composio/ao-plugin-runtime-tmux";
-import type { RuntimeHandle, Agent, AgentLaunchConfig } from "@composio/ao-core";
+import {
+  type Agent,
+  type AgentLaunchConfig,
+  type OrchestratorConfig,
+  type PluginModule,
+  type RuntimeHandle,
+  type Session,
+  type SessionManager,
+  createSessionManager,
+  createPluginRegistry,
+  getProjectBaseDir,
+  getSessionsDir,
+} from "@composio/ao-core";
 import { isTmuxAvailable, killSessionsByPrefix } from "./helpers/tmux.js";
 import { sleep } from "./helpers/polling.js";
 
@@ -22,104 +37,173 @@ const tmuxOk = await isTmuxAvailable();
 const SESSION_PREFIX = "ao-inttest-spawn-alive-";
 
 /**
- * Stub agent that stays alive. Returns a simple bash loop as the launch
- * command — this replaces Claude Code for testing the spawn pipeline.
+ * Stub agent plugin that stays alive. Returns a simple bash loop as the
+ * launch command — this replaces Claude Code for testing the spawn pipeline.
  */
-function createStubAgent(): Agent {
+function createStubAgentPlugin(): PluginModule<Agent> {
   return {
-    name: "stub",
-    processName: "bash",
-
-    getLaunchCommand(_config: AgentLaunchConfig): string {
-      // Simple loop that stays alive — the key property being tested
-      return "bash -c 'while true; do sleep 1; done'";
+    manifest: {
+      name: "stub",
+      slot: "agent" as const,
+      description: "Stub agent for integration tests",
+      version: "0.1.0",
     },
+    create(): Agent {
+      return {
+        name: "stub",
+        processName: "bash",
 
-    getEnvironment(): Record<string, string> {
-      return {};
-    },
+        getLaunchCommand(_config: AgentLaunchConfig): string {
+          // Simple loop that stays alive — the key property being tested
+          return "bash -c 'while true; do sleep 1; done'";
+        },
 
-    detectActivity(): "active" {
-      return "active";
-    },
+        getEnvironment(): Record<string, string> {
+          return {};
+        },
 
-    async getActivityState(): Promise<"active"> {
-      return "active";
-    },
+        detectActivity(): "active" {
+          return "active";
+        },
 
-    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
-      const runtime = tmuxPlugin.create();
-      return runtime.isAlive(handle);
-    },
+        async getActivityState(): Promise<"active"> {
+          return "active";
+        },
 
-    async getSessionInfo(): Promise<null> {
-      return null;
+        async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+          const runtime = tmuxPlugin.create();
+          return runtime.isAlive(handle);
+        },
+
+        async getSessionInfo(): Promise<null> {
+          return null;
+        },
+      } as Agent;
     },
-  } as Agent;
+  };
 }
 
-describe.skipIf(!tmuxOk)("spawn pipeline keeps agent alive (integration)", () => {
-  const runtime = tmuxPlugin.create();
-  const sessionName = `${SESSION_PREFIX}${Date.now()}`;
+describe.skipIf(!tmuxOk)("sessionManager.spawn() pipeline (integration)", () => {
   let tmpDir: string;
-  let handle: RuntimeHandle;
+  let configPath: string;
+  let sm: SessionManager;
+  let session: Session | null = null;
+  let projectBaseDir: string;
 
   beforeAll(async () => {
     await killSessionsByPrefix(SESSION_PREFIX);
+
     const raw = await mkdtemp(join(tmpdir(), "ao-inttest-spawn-alive-"));
     tmpDir = await realpath(raw);
+
+    // Write a real config file on disk (required by validateAndStoreOrigin)
+    configPath = join(tmpDir, "agent-orchestrator.yaml");
+    writeFileSync(configPath, "# integration test config\n");
+
+    // Build config object
+    const config: OrchestratorConfig = {
+      configPath,
+      readyThresholdMs: 300_000,
+      defaults: {
+        runtime: "tmux",
+        agent: "stub",
+        workspace: "worktree", // Not registered → null → skip workspace creation
+        notifiers: [],
+      },
+      projects: {
+        test: {
+          name: "test-project",
+          repo: "test/test",
+          path: tmpDir,
+          defaultBranch: "main",
+          sessionPrefix: SESSION_PREFIX.slice(0, -1), // Remove trailing dash
+        },
+      },
+      notifiers: {},
+      notificationRouting: {} as OrchestratorConfig["notificationRouting"],
+      reactions: {},
+    };
+
+    // Build plugin registry with stub agent + real tmux
+    const registry = createPluginRegistry();
+    registry.register(tmuxPlugin);
+    registry.register(createStubAgentPlugin());
+
+    sm = createSessionManager({ config, registry });
+
+    // Track the project base dir for cleanup
+    projectBaseDir = getProjectBaseDir(configPath, tmpDir);
   }, 30_000);
 
   afterAll(async () => {
-    try {
-      if (handle) await runtime.destroy(handle);
-    } catch {
-      /* best-effort */
+    // Kill spawned session via runtime
+    if (session?.runtimeHandle) {
+      try {
+        const runtime = tmuxPlugin.create();
+        await runtime.destroy(session.runtimeHandle);
+      } catch {
+        /* best-effort */
+      }
     }
+
+    // Clean up any leftover tmux sessions with our prefix
     await killSessionsByPrefix(SESSION_PREFIX);
+
+    // Clean up metadata directory
+    if (projectBaseDir && existsSync(projectBaseDir)) {
+      await rm(projectBaseDir, { recursive: true, force: true }).catch(() => {});
+    }
+
+    // Clean up temp dir
     if (tmpDir) {
       await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 30_000);
 
-  it("stub agent launch command keeps process alive in tmux", async () => {
-    const agent = createStubAgent();
+  it("spawn() creates a session with working status", async () => {
+    session = await sm.spawn({ projectId: "test" });
 
-    // Get the launch command (same as session-manager does)
-    const launchCommand = agent.getLaunchCommand({
-      sessionId: sessionName,
-      projectConfig: {
-        name: "test",
-        repo: "test/test",
-        path: tmpDir,
-        defaultBranch: "main",
-        sessionPrefix: "test",
-      },
-    });
+    expect(session).toBeTruthy();
+    expect(session.id).toMatch(/^ao-inttest-spawn-alive-\d+$/);
+    expect(session.projectId).toBe("test");
+    expect(session.status).toBe("working");
+    expect(session.runtimeHandle).toBeTruthy();
+    expect(session.runtimeHandle!.runtimeName).toBe("tmux");
+  });
 
-    // Create tmux session with the launch command (same as runtime.create)
-    handle = await runtime.create({
-      sessionId: sessionName,
-      workspacePath: tmpDir,
-      launchCommand,
-      environment: {},
-    });
+  it("metadata file exists with correct status", async () => {
+    expect(session).toBeTruthy();
 
-    expect(handle.id).toBe(sessionName);
-    expect(handle.runtimeName).toBe("tmux");
+    const sessionsDir = getSessionsDir(configPath, tmpDir);
+    const metaPath = join(sessionsDir, session!.id);
+    expect(existsSync(metaPath)).toBe(true);
+
+    const content = await readFile(metaPath, "utf-8");
+    expect(content).toContain("status=working");
+    expect(content).toContain(`project=test`);
   });
 
   it("process is alive immediately after spawn", async () => {
-    expect(await runtime.isAlive(handle)).toBe(true);
+    expect(session?.runtimeHandle).toBeTruthy();
+    const runtime = tmuxPlugin.create();
+    expect(await runtime.isAlive(session!.runtimeHandle!)).toBe(true);
   });
 
   it("process stays alive after 3 seconds (not one-shot exit)", async () => {
     await sleep(3_000);
-    expect(await runtime.isAlive(handle)).toBe(true);
+    expect(session?.runtimeHandle).toBeTruthy();
+    const runtime = tmuxPlugin.create();
+    expect(await runtime.isAlive(session!.runtimeHandle!)).toBe(true);
   });
 
-  it("session can be destroyed cleanly", async () => {
-    await runtime.destroy(handle);
-    expect(await runtime.isAlive(handle)).toBe(false);
+  it("session can be killed via session manager", async () => {
+    expect(session).toBeTruthy();
+    await sm.kill(session!.id);
+
+    const runtime = tmuxPlugin.create();
+    expect(await runtime.isAlive(session!.runtimeHandle!)).toBe(false);
+
+    // Clear session so afterAll doesn't try to destroy it again
+    session = null;
   });
 });

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -605,8 +605,12 @@ function createClaudeCodeAgent(): Agent {
         parts.push("--append-system-prompt", shellEscape(config.systemPrompt));
       }
 
+      // Deliver config.prompt via --append-system-prompt (NOT `-p`).
+      // Claude Code's `-p` flag is one-shot/print mode — the agent would
+      // exit after generating a single response. Using --append-system-prompt
+      // keeps the agent in interactive mode with the prompt as context.
       if (config.prompt) {
-        parts.push("-p", shellEscape(config.prompt));
+        parts.push("--append-system-prompt", shellEscape(config.prompt));
       }
 
       return parts.join(" ");


### PR DESCRIPTION
## Summary

- **Primary fix**: `spawn()` in `session-manager.ts` now calls `updateMetadata()` after `postLaunchSetup()` succeeds, immediately persisting `status: "working"` (and updating the returned `Session` object). Previously, sessions were written with `status: "spawning"` and only the lifecycle manager's polling loop would transition them — causing the "stuck in Spawning" bug when the lifecycle manager wasn't running or hadn't polled yet.
- **Safety-net fix**: `enrichSessionWithRuntimeState()` now auto-transitions `spawning → working` when the agent is detected as `active` via JSONL activity detection. This covers sessions created before this fix and races where the lifecycle manager hasn't fired.
- **Web page verification**: Confirmed `page.tsx` and `SessionDetail.tsx` both use the correct relative `/api/sessions/{id}` endpoint. No changes needed.

## Test plan

- [x] Updated 2 existing tests that asserted `status: "spawning"` from `spawn()` — now correctly expect `"working"`
- [x] Added test: `"transitions status from spawning to working after successful launch"` — verifies both returned session and persisted metadata
- [x] Added test: `"auto-transitions spawning → working when agent is detected as active"` — verifies the safety-net in `enrichSessionWithRuntimeState()`
- [x] All 227 core tests pass
- [x] All 129 CLI tests pass
- [x] Typecheck clean across all packages
- [x] Lint: 0 errors (pre-existing warnings only)

Fixes the "Sessions stuck in Spawning phase after ao spawn" bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)