### PR TITLE
feat: self-improvement system — logging, perf monitoring, retrospectives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,13 @@ packages/
 ## Key Files (Read These First)
 
 1. `packages/core/src/types.ts` — all interfaces (Runtime, Agent, Workspace, Tracker, SCM, Notifier, Terminal)
-2. `agent-orchestrator.yaml.example` — config format
-3. Plugin examples:
+2. `packages/core/src/session-manager.ts` — session CRUD (spawn, kill, list, get, restore)
+3. `packages/core/src/lifecycle-manager.ts` — state machine + reaction engine + event persistence
+4. `agent-orchestrator.yaml.example` — config format
+5. Plugin examples:
    - `packages/plugins/runtime-tmux/src/index.ts` — Runtime implementation
    - `packages/plugins/agent-claude-code/src/index.ts` — Agent implementation
-4. This file (CLAUDE.md) — code conventions
+6. This file (CLAUDE.md) — code conventions
 
 ## TypeScript Conventions (MUST follow)
 
@@ -145,6 +147,17 @@ pnpm test              # run tests
 
 # Before committing
 pnpm lint && pnpm typecheck
+
+# Logging & debugging (ao CLI)
+ao logs dashboard [--since T] [--level L] [--tail N]   # query dashboard logs
+ao logs events [--session S] [--type T]                # lifecycle event logs
+ao perf routes                                         # API response times p50/p95/p99
+ao perf slow [--limit N]                               # slowest requests with timing breakdown
+ao perf cache                                          # cache hit rates
+ao retro list [--project P]                            # session retrospectives
+ao retro show <session>                                # view retrospective
+ao dashboard restart [--clean] [--wait]                # restart dashboard (clean .next if needed)
+ao dashboard status                                    # dashboard process status
 ```
 
 ## Development Workflow
@@ -212,6 +225,66 @@ Then use `browser_navigate` as normal. If Playwright was previously used in the 
 
 Config loaded from `agent-orchestrator.yaml` (see `agent-orchestrator.yaml.example`). Paths support `~` expansion. Validated with Zod at load time. Per-project overrides for plugins and reactions.
 
+## Logging & Observability
+
+All system activity is logged to structured JSONL files for querying, debugging, and learning.
+
+### Log Files
+
+| File | Location | Content |
+|------|----------|---------|
+| `dashboard.jsonl` | `{logDir}/` | Dashboard stdout/stderr output |
+| `events.jsonl` | `{logDir}/` | Lifecycle state transitions (session spawned, CI failed, PR merged, etc.) |
+| `api.jsonl` | `{logDir}/` | API request timing with performance breakdowns |
+| `browser.jsonl` | `{logDir}/` | Client-side errors, web vitals, fetch timing |
+
+Log dir is at `~/.agent-orchestrator/{configHash}/{projectHash}/logs/`.
+
+### Key Modules
+
+| Module | Path | Purpose |
+|--------|------|---------|
+| `LogWriter` | `packages/core/src/log-writer.ts` | JSONL writer with size-based rotation |
+| `readLogs` / `tailLogs` | `packages/core/src/log-reader.ts` | Query/filter log files |
+| `generateReportCard` | `packages/core/src/session-report-card.ts` | Per-session metrics from event log |
+| `generateRetrospective` | `packages/core/src/retrospective.ts` | Post-session analysis and lessons |
+| `restartDashboard` | `packages/core/src/dashboard-manager.ts` | Programmatic dashboard process control |
+| `request-logger` | `packages/web/src/lib/request-logger.ts` | API request timing |
+| `client-logger` | `packages/web/src/lib/client-logger.ts` | Browser error/perf capture |
+| `cache.getStats()` | `packages/web/src/lib/cache.ts` | Cache hit/miss tracking |
+
+### LogEntry Format
+
+Every JSONL line follows this schema:
+
+```typescript
+interface LogEntry {
+  ts: string;       // ISO 8601
+  level: "stdout" | "stderr" | "info" | "warn" | "error";
+  source: "dashboard" | "lifecycle" | "cli" | "api" | "browser";
+  sessionId: string | null;
+  message: string;
+  data?: Record<string, unknown>;
+}
+```
+
+### Dashboard Pages
+
+- `/logs` — filterable log viewer (source, level, time range, session)
+- `/perf` — API performance dashboard (route stats, slow requests, cache hit rates, PR enrichment timing)
+
+### Environment Variables (in spawned sessions)
+
+- `AO_PROJECT_ID` — project identifier for this session
+- `AO_LOG_DIR` — path to the project's log directory
+
+### Debugging Tips for ao Development
+
+- **Dashboard not loading?** `ao dashboard status` then `ao dashboard restart --clean --wait`
+- **Slow API responses?** `ao perf routes` to find bottleneck, `ao perf slow` for details. PR enrichment in `packages/web/src/lib/serialize.ts` is the #1 bottleneck.
+- **Lifecycle events missing?** Check `ao logs events --since 1h` and verify `logDir` is set in `LifecycleManagerDeps`
+- **Session stuck?** `ao logs events --session <id>` to see state transitions, check if reaction fired
+
 ## Design Decisions
 
 1. **Stateless orchestrator** — no database, flat metadata files + event log
@@ -220,3 +293,5 @@ Config loaded from `agent-orchestrator.yaml` (see `agent-orchestrator.yaml.examp
 4. **Two-tier event handling** — auto-handle routine issues, notify human when judgment needed
 5. **Backwards-compatible metadata** — flat key=value files
 6. **Security first** — `execFile` not `exec`, validate all external input
+7. **Structured JSONL logging** — crash-safe append, size-based rotation, queryable
+8. **Auto-retrospectives** — generated on session merge/kill for learning from past sessions

--- a/packages/cli/__tests__/commands/logs.test.ts
+++ b/packages/cli/__tests__/commands/logs.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockReadLogs, mockReadLogsFromDir, mockTailLogs, mockResolveLogDir } = vi.hoisted(() => ({
+  mockReadLogs: vi.fn(),
+  mockReadLogsFromDir: vi.fn(),
+  mockTailLogs: vi.fn(),
+  mockResolveLogDir: vi.fn(),
+}));
+
+vi.mock("@composio/ao-core", () => ({
+  readLogs: mockReadLogs,
+  readLogsFromDir: mockReadLogsFromDir,
+  tailLogs: mockTailLogs,
+}));
+
+vi.mock("../../src/lib/perf-utils.js", () => ({
+  resolveLogDir: mockResolveLogDir,
+}));
+
+vi.mock("../../src/lib/format.js", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importOriginal<typeof import("../../src/lib/format.js")>();
+  return { ...actual };
+});
+
+import { Command } from "commander";
+import { registerLogs } from "../../src/commands/logs.js";
+
+let program: Command;
+let logs: string[];
+
+beforeEach(() => {
+  program = new Command();
+  program.exitOverride();
+  registerLogs(program);
+
+  logs = [];
+  vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(" "));
+  });
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new Error(`process.exit(${code})`);
+  });
+
+  mockReadLogs.mockReset();
+  mockReadLogsFromDir.mockReset();
+  mockTailLogs.mockReset();
+  mockResolveLogDir.mockReset();
+  mockResolveLogDir.mockReturnValue("/tmp/logs");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("logs dashboard", () => {
+  it("calls tailLogs with correct args when using --tail", async () => {
+    mockTailLogs.mockReturnValue([
+      {
+        ts: "2025-01-01T12:00:00Z",
+        level: "info",
+        source: "dashboard",
+        sessionId: null,
+        message: "Server started",
+      },
+    ]);
+
+    await program.parseAsync(["node", "test", "logs", "dashboard", "--tail", "20"]);
+
+    expect(mockTailLogs).toHaveBeenCalledWith(
+      expect.stringContaining("dashboard.jsonl"),
+      20,
+    );
+    const output = logs.join("\n");
+    expect(output).toContain("Server started");
+  });
+
+  it("calls readLogs with a since Date when using --since", async () => {
+    mockReadLogs.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "logs", "dashboard", "--since", "1h"]);
+
+    expect(mockReadLogs).toHaveBeenCalledWith(
+      expect.stringContaining("dashboard.jsonl"),
+      expect.objectContaining({
+        since: expect.any(Date),
+      }),
+    );
+  });
+
+  it("shows 'No log entries found.' when empty", async () => {
+    mockTailLogs.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "logs", "dashboard"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("No log entries found.");
+  });
+
+  it("outputs JSON with --json flag", async () => {
+    const entries = [
+      {
+        ts: "2025-01-01T12:00:00Z",
+        level: "info" as const,
+        source: "dashboard" as const,
+        sessionId: null,
+        message: "test entry",
+      },
+    ];
+    mockTailLogs.mockReturnValue(entries);
+
+    await program.parseAsync(["node", "test", "logs", "dashboard", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].message).toBe("test entry");
+  });
+});
+
+describe("logs events", () => {
+  it("calls readLogsFromDir with 'events' prefix", async () => {
+    mockReadLogsFromDir.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "logs", "events"]);
+
+    expect(mockReadLogsFromDir).toHaveBeenCalledWith(
+      "/tmp/logs",
+      "events",
+      expect.objectContaining({ source: "lifecycle" }),
+    );
+  });
+
+  it("passes sessionId filter with --session", async () => {
+    mockReadLogsFromDir.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "logs", "events", "--session", "sess-1"]);
+
+    expect(mockReadLogsFromDir).toHaveBeenCalledWith(
+      "/tmp/logs",
+      "events",
+      expect.objectContaining({ sessionId: "sess-1", source: "lifecycle" }),
+    );
+  });
+
+  it("shows empty message when no events found", async () => {
+    mockReadLogsFromDir.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "logs", "events"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("No log entries found.");
+  });
+
+  it("outputs JSON with --json flag", async () => {
+    const entries = [
+      {
+        ts: "2025-01-01T12:00:00Z",
+        level: "info" as const,
+        source: "lifecycle" as const,
+        sessionId: "sess-1",
+        message: "state changed",
+      },
+    ];
+    mockReadLogsFromDir.mockReturnValue(entries);
+
+    await program.parseAsync(["node", "test", "logs", "events", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].sessionId).toBe("sess-1");
+  });
+});
+
+describe("logs session", () => {
+  it("calls readLogsFromDir with sessionId", async () => {
+    mockReadLogsFromDir.mockReturnValue([
+      {
+        ts: "2025-01-01T12:00:00Z",
+        level: "info",
+        source: "lifecycle",
+        sessionId: "myid",
+        message: "spawned",
+      },
+    ]);
+
+    await program.parseAsync(["node", "test", "logs", "session", "myid"]);
+
+    expect(mockReadLogsFromDir).toHaveBeenCalledWith(
+      "/tmp/logs",
+      "events",
+      expect.objectContaining({ sessionId: "myid" }),
+    );
+  });
+
+  it("shows message when no events found for session", async () => {
+    mockReadLogsFromDir.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "logs", "session", "unknown-id"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain('No events found for session "unknown-id"');
+  });
+
+  it("outputs JSON with --json flag", async () => {
+    const entries = [
+      {
+        ts: "2025-01-01T12:00:00Z",
+        level: "info" as const,
+        source: "lifecycle" as const,
+        sessionId: "myid",
+        message: "spawned",
+      },
+    ];
+    mockReadLogsFromDir.mockReturnValue(entries);
+
+    await program.parseAsync(["node", "test", "logs", "session", "myid", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].sessionId).toBe("myid");
+  });
+});

--- a/packages/cli/__tests__/commands/logs.test.ts
+++ b/packages/cli/__tests__/commands/logs.test.ts
@@ -201,7 +201,7 @@ describe("logs session", () => {
     await program.parseAsync(["node", "test", "logs", "session", "unknown-id"]);
 
     const output = logs.join("\n");
-    expect(output).toContain('No events found for session "unknown-id"');
+    expect(output).toContain("No log entries found.");
   });
 
   it("outputs JSON with --json flag", async () => {

--- a/packages/cli/__tests__/commands/perf.test.ts
+++ b/packages/cli/__tests__/commands/perf.test.ts
@@ -1,68 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { ParsedRequest } from "../../src/lib/perf-utils.js";
 
-const { mockPercentile, mockResolveLogDir, mockLoadRequests, mockComputeApiStats } =
-  vi.hoisted(() => {
-    const mockPercentile = vi.fn((sorted: number[], p: number) => {
-      if (sorted.length === 0) return 0;
-      const idx = Math.ceil((p / 100) * sorted.length) - 1;
-      return sorted[Math.max(0, idx)];
-    });
-    const mockNormalizeRoutePath = vi.fn(
-      (path: string) =>
-        path
-          .replace(/\/sessions\/[^/]+/g, "/sessions/:id")
-          .replace(/\/prs\/[^/]+/g, "/prs/:id"),
-    );
-
-    // Inline implementation that mirrors computeApiStats in core.
-    // Needed because perf.ts delegates route grouping to computeApiStats.
-    const mockComputeApiStats = vi.fn(
-      (entries: { method: string; path: string; statusCode: number; durationMs: number; error?: string; cacheStats?: unknown }[]) => {
-        const byRoute = new Map<string, typeof entries>();
-        for (const e of entries) {
-          const key = `${e.method} ${mockNormalizeRoutePath(e.path)}`;
-          const arr = byRoute.get(key) ?? [];
-          arr.push(e);
-          byRoute.set(key, arr);
-        }
-        const routes: Record<string, { count: number; avgMs: number; p50Ms: number; p95Ms: number; p99Ms: number; errors: number }> = {};
-        for (const [route, logs] of byRoute) {
-          const durations = logs.map((l) => l.durationMs).sort((a, b) => a - b);
-          routes[route] = {
-            count: logs.length,
-            avgMs: Math.round(durations.reduce((s, d) => s + d, 0) / durations.length),
-            p50Ms: mockPercentile(durations, 50),
-            p95Ms: mockPercentile(durations, 95),
-            p99Ms: mockPercentile(durations, 99),
-            errors: logs.filter((l) => l.error !== undefined || l.statusCode >= 400).length,
-          };
-        }
-        const slowest = [...entries].sort((a, b) => b.durationMs - a.durationMs).slice(0, 10);
-        let latestCacheStats = null;
-        for (let i = entries.length - 1; i >= 0; i--) {
-          if ((entries[i] as { cacheStats?: unknown }).cacheStats) {
-            latestCacheStats = (entries[i] as { cacheStats?: unknown }).cacheStats;
-            break;
-          }
-        }
-        return { routes, slowest, latestCacheStats };
-      },
-    );
-
-    return {
-      mockPercentile,
-      mockComputeApiStats,
-      mockResolveLogDir: vi.fn(() => "/tmp/logs"),
-      mockLoadRequests: vi.fn(),
-    };
-  });
-
-vi.mock("@composio/ao-core", () => ({
-  percentile: mockPercentile,
-  computeApiStats: mockComputeApiStats,
+const { mockResolveLogDir, mockLoadRequests } = vi.hoisted(() => ({
+  mockResolveLogDir: vi.fn(() => "/tmp/logs"),
+  mockLoadRequests: vi.fn(),
 }));
 
+// computeApiStats and percentile are pure functions — use real implementations.
+// Only mock file I/O (perf-utils.js).
 vi.mock("../../src/lib/perf-utils.js", () => ({
   resolveLogDir: mockResolveLogDir,
   loadRequests: mockLoadRequests,

--- a/packages/cli/__tests__/commands/perf.test.ts
+++ b/packages/cli/__tests__/commands/perf.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ParsedRequest } from "../../src/lib/perf-utils.js";
+
+const { mockPercentile, mockNormalizeRoutePath, mockResolveLogDir, mockLoadRequests } = vi.hoisted(
+  () => ({
+    mockPercentile: vi.fn((sorted: number[], p: number) => {
+      if (sorted.length === 0) return 0;
+      const idx = Math.ceil((p / 100) * sorted.length) - 1;
+      return sorted[Math.max(0, idx)];
+    }),
+    mockNormalizeRoutePath: vi.fn(
+      (path: string) =>
+        path
+          .replace(/\/sessions\/[^/]+/g, "/sessions/:id")
+          .replace(/\/prs\/[^/]+/g, "/prs/:id"),
+    ),
+    mockResolveLogDir: vi.fn(() => "/tmp/logs"),
+    mockLoadRequests: vi.fn(),
+  }),
+);
+
+vi.mock("@composio/ao-core", () => ({
+  percentile: mockPercentile,
+  normalizeRoutePath: mockNormalizeRoutePath,
+}));
+
+vi.mock("../../src/lib/perf-utils.js", () => ({
+  resolveLogDir: mockResolveLogDir,
+  loadRequests: mockLoadRequests,
+}));
+
+vi.mock("../../src/lib/format.js", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importOriginal<typeof import("../../src/lib/format.js")>();
+  return { ...actual };
+});
+
+import { Command } from "commander";
+import { registerPerf } from "../../src/commands/perf.js";
+
+let program: Command;
+let logs: string[];
+
+beforeEach(() => {
+  program = new Command();
+  program.exitOverride();
+  registerPerf(program);
+
+  logs = [];
+  vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(" "));
+  });
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new Error(`process.exit(${code})`);
+  });
+
+  mockLoadRequests.mockReset();
+  mockResolveLogDir.mockReturnValue("/tmp/logs");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeRequest(overrides: Partial<ParsedRequest> = {}): ParsedRequest {
+  return {
+    ts: "2025-01-01T12:00:00Z",
+    method: "GET",
+    path: "/api/sessions",
+    statusCode: 200,
+    durationMs: 50,
+    ...overrides,
+  };
+}
+
+describe("perf routes", () => {
+  it("outputs grouped route stats with --json", async () => {
+    mockLoadRequests.mockReturnValue([
+      makeRequest({ path: "/api/sessions/abc", durationMs: 100 }),
+      makeRequest({ path: "/api/sessions/def", durationMs: 200 }),
+      makeRequest({ path: "/api/health", durationMs: 5 }),
+    ]);
+
+    await program.parseAsync(["node", "test", "perf", "routes", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed["GET /api/sessions/:id"]).toBeDefined();
+    expect(parsed["GET /api/sessions/:id"].count).toBe(2);
+    expect(parsed["GET /api/health"]).toBeDefined();
+    expect(parsed["GET /api/health"].count).toBe(1);
+  });
+
+  it("shows empty message when no data", async () => {
+    mockLoadRequests.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "perf", "routes"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("No API request logs found.");
+  });
+
+  it("tracks errors per route in JSON output", async () => {
+    mockLoadRequests.mockReturnValue([
+      makeRequest({ statusCode: 200 }),
+      makeRequest({ statusCode: 500, error: "server error" }),
+    ]);
+
+    await program.parseAsync(["node", "test", "perf", "routes", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    const routeKey = Object.keys(parsed)[0];
+    expect(parsed[routeKey].errors).toBe(1);
+  });
+
+  it("displays table format without --json", async () => {
+    mockLoadRequests.mockReturnValue([
+      makeRequest({ durationMs: 100 }),
+      makeRequest({ durationMs: 200 }),
+    ]);
+
+    await program.parseAsync(["node", "test", "perf", "routes"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("Route");
+    expect(output).toContain("Count");
+    expect(output).toContain("total requests");
+  });
+});
+
+describe("perf slow", () => {
+  it("outputs slowest requests with --json --limit 2", async () => {
+    mockLoadRequests.mockReturnValue([
+      makeRequest({ durationMs: 500, path: "/api/slow" }),
+      makeRequest({ durationMs: 300, path: "/api/medium" }),
+      makeRequest({ durationMs: 100, path: "/api/fast" }),
+    ]);
+
+    await program.parseAsync(["node", "test", "perf", "slow", "--json", "--limit", "2"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].durationMs).toBe(500);
+    expect(parsed[1].durationMs).toBe(300);
+  });
+
+  it("shows empty message when no data without --json", async () => {
+    mockLoadRequests.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "perf", "slow"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("No API request logs found.");
+  });
+
+  it("outputs empty array as JSON when no data", async () => {
+    mockLoadRequests.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "perf", "slow", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed).toEqual([]);
+  });
+});
+
+describe("perf cache", () => {
+  it("outputs cache stats with --json", async () => {
+    mockLoadRequests.mockReturnValue([
+      makeRequest({
+        cacheStats: { hits: 15, misses: 5, hitRate: 0.75, size: 20 },
+      }),
+    ]);
+
+    await program.parseAsync(["node", "test", "perf", "cache", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed.hits).toBe(15);
+    expect(parsed.misses).toBe(5);
+    expect(parsed.hitRate).toBe(0.75);
+    expect(parsed.size).toBe(20);
+  });
+
+  it("outputs empty object as JSON when no cache stats", async () => {
+    mockLoadRequests.mockReturnValue([makeRequest()]);
+
+    await program.parseAsync(["node", "test", "perf", "cache", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed).toEqual({});
+  });
+
+  it("shows human-readable output without --json", async () => {
+    mockLoadRequests.mockReturnValue([
+      makeRequest({
+        cacheStats: { hits: 10, misses: 2, hitRate: 0.83, size: 12 },
+      }),
+    ]);
+
+    await program.parseAsync(["node", "test", "perf", "cache"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("Cache Statistics");
+    expect(output).toContain("83.0%");
+  });
+
+  it("uses the most recent cache stats entry", async () => {
+    mockLoadRequests.mockReturnValue([
+      makeRequest({
+        cacheStats: { hits: 1, misses: 1, hitRate: 0.5, size: 2 },
+      }),
+      makeRequest(),
+      makeRequest({
+        cacheStats: { hits: 20, misses: 5, hitRate: 0.8, size: 25 },
+      }),
+    ]);
+
+    await program.parseAsync(["node", "test", "perf", "cache", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed.hits).toBe(20);
+  });
+});
+
+describe("perf enrichment", () => {
+  it("outputs timing data with --json", async () => {
+    mockLoadRequests.mockReturnValue([
+      makeRequest({
+        path: "/api/sessions",
+        timings: { prEnrichment: 120, sessionList: 30 },
+      }),
+      makeRequest({
+        path: "/api/sessions/abc",
+        timings: { prEnrichment: 80, sessionList: 20 },
+      }),
+    ]);
+
+    await program.parseAsync(["node", "test", "perf", "enrichment", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed.enrichTimes).toEqual([120, 80]);
+    expect(parsed.listTimes).toEqual([30, 20]);
+  });
+
+  it("outputs empty arrays as JSON when no enrichment data", async () => {
+    mockLoadRequests.mockReturnValue([
+      makeRequest({ path: "/api/sessions" }),
+    ]);
+
+    await program.parseAsync(["node", "test", "perf", "enrichment", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed.enrichTimes).toEqual([]);
+    expect(parsed.listTimes).toEqual([]);
+  });
+
+  it("shows human-readable output without --json", async () => {
+    mockLoadRequests.mockReturnValue([
+      makeRequest({
+        path: "/api/sessions",
+        timings: { prEnrichment: 150, sessionList: 40 },
+      }),
+    ]);
+
+    await program.parseAsync(["node", "test", "perf", "enrichment"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("PR Enrichment Performance");
+    expect(output).toContain("Samples");
+  });
+});

--- a/packages/cli/__tests__/commands/perf.test.ts
+++ b/packages/cli/__tests__/commands/perf.test.ts
@@ -68,6 +68,7 @@ function makeRequest(overrides: Partial<ParsedRequest> = {}): ParsedRequest {
     ts: "2025-01-01T12:00:00Z",
     method: "GET",
     path: "/api/sessions",
+    sessionId: null,
     statusCode: 200,
     durationMs: 50,
     ...overrides,
@@ -99,6 +100,16 @@ describe("perf routes", () => {
 
     const output = logs.join("\n");
     expect(output).toContain("No API request logs found.");
+  });
+
+  it("outputs empty object as JSON when no data with --json", async () => {
+    mockLoadRequests.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "perf", "routes", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed).toEqual({});
   });
 
   it("tracks errors per route in JSON output", async () => {

--- a/packages/cli/__tests__/commands/retrospective.test.ts
+++ b/packages/cli/__tests__/commands/retrospective.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Retrospective } from "@composio/ao-core";
+
+const {
+  mockLoadConfig,
+  mockResolveProjectRetroDir,
+  mockLoadRetrospectives,
+  mockGenerateRetrospective,
+  mockSaveRetrospective,
+} = vi.hoisted(() => ({
+  mockLoadConfig: vi.fn(),
+  mockResolveProjectRetroDir: vi.fn(),
+  mockLoadRetrospectives: vi.fn(),
+  mockGenerateRetrospective: vi.fn(),
+  mockSaveRetrospective: vi.fn(),
+}));
+
+vi.mock("@composio/ao-core", () => ({
+  loadConfig: mockLoadConfig,
+  resolveProjectRetroDir: mockResolveProjectRetroDir,
+  loadRetrospectives: mockLoadRetrospectives,
+  generateRetrospective: mockGenerateRetrospective,
+  saveRetrospective: mockSaveRetrospective,
+}));
+
+import { Command } from "commander";
+import { registerRetrospective } from "../../src/commands/retrospective.js";
+
+let program: Command;
+let logs: string[];
+
+function makeRetro(overrides: Partial<Retrospective> = {}): Retrospective {
+  return {
+    sessionId: "sess-1",
+    projectId: "my-app",
+    generatedAt: "2025-01-15T12:00:00Z",
+    outcome: "success",
+    timeline: [
+      { event: "spawned", at: "2025-01-15T10:00:00Z", detail: "Session created" },
+      { event: "pr_opened", at: "2025-01-15T11:00:00Z", detail: "PR #42 opened" },
+    ],
+    metrics: {
+      totalDurationMs: 7200000,
+      ciFailures: 1,
+      reviewRounds: 2,
+    },
+    lessons: ["Always run tests before pushing"],
+    reportCard: {
+      sessionId: "sess-1",
+      projectId: "my-app",
+      duration: {
+        startedAt: "2025-01-15T10:00:00Z",
+        endedAt: "2025-01-15T12:00:00Z",
+        totalMs: 7200000,
+      },
+      stateTransitions: [],
+      ciAttempts: 2,
+      reviewRounds: 2,
+      outcome: "merged",
+      prUrl: "https://github.com/org/repo/pull/42",
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  program = new Command();
+  program.exitOverride();
+  registerRetrospective(program);
+
+  logs = [];
+  vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(String).join(" "));
+  });
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new Error(`process.exit(${code})`);
+  });
+
+  mockLoadConfig.mockReset();
+  mockResolveProjectRetroDir.mockReset();
+  mockLoadRetrospectives.mockReset();
+  mockGenerateRetrospective.mockReset();
+  mockSaveRetrospective.mockReset();
+
+  mockLoadConfig.mockReturnValue({ projects: { "my-app": { name: "My App" } } });
+  mockResolveProjectRetroDir.mockReturnValue("/tmp/retros");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("retro list", () => {
+  it("shows retrospectives table", async () => {
+    mockLoadRetrospectives.mockReturnValue([
+      makeRetro(),
+      makeRetro({ sessionId: "sess-2", outcome: "failure" }),
+    ]);
+
+    await program.parseAsync(["node", "test", "retro", "list"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("Session");
+    expect(output).toContain("Outcome");
+    expect(output).toContain("sess-1");
+    expect(output).toContain("sess-2");
+    expect(output).toContain("2 retrospectives");
+  });
+
+  it("outputs JSON with --json flag", async () => {
+    const retros = [makeRetro(), makeRetro({ sessionId: "sess-2" })];
+    mockLoadRetrospectives.mockReturnValue(retros);
+
+    await program.parseAsync(["node", "test", "retro", "list", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].sessionId).toBe("sess-1");
+    expect(parsed[1].sessionId).toBe("sess-2");
+  });
+
+  it("shows empty message when none found", async () => {
+    mockLoadRetrospectives.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "retro", "list"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("No retrospectives found.");
+  });
+
+  it("passes limit option to loadRetrospectives", async () => {
+    mockLoadRetrospectives.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "retro", "list", "-n", "5"]);
+
+    expect(mockLoadRetrospectives).toHaveBeenCalledWith(
+      "/tmp/retros",
+      expect.objectContaining({ limit: 5 }),
+    );
+  });
+
+  it("passes project filter to loadRetrospectives", async () => {
+    mockLoadRetrospectives.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "retro", "list", "-p", "my-app"]);
+
+    expect(mockLoadRetrospectives).toHaveBeenCalledWith(
+      "/tmp/retros",
+      expect.objectContaining({ projectId: "my-app" }),
+    );
+  });
+});
+
+describe("retro show", () => {
+  it("shows retrospective detail", async () => {
+    mockLoadRetrospectives.mockReturnValue([makeRetro()]);
+
+    await program.parseAsync(["node", "test", "retro", "show", "sess-1"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("Retrospective:");
+    expect(output).toContain("sess-1");
+    expect(output).toContain("Duration:");
+    expect(output).toContain("CI failures:");
+    expect(output).toContain("Review rounds:");
+    expect(output).toContain("Timeline:");
+    expect(output).toContain("Session created");
+    expect(output).toContain("Lessons:");
+    expect(output).toContain("Always run tests before pushing");
+  });
+
+  it("outputs JSON with --json flag", async () => {
+    const retro = makeRetro();
+    mockLoadRetrospectives.mockReturnValue([retro]);
+
+    await program.parseAsync(["node", "test", "retro", "show", "sess-1", "--json"]);
+
+    const output = logs.join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed.sessionId).toBe("sess-1");
+    expect(parsed.outcome).toBe("success");
+    expect(parsed.metrics.ciFailures).toBe(1);
+  });
+
+  it("shows message when no retrospective found", async () => {
+    mockLoadRetrospectives.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "retro", "show", "nonexistent"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain('No retrospective found for session "nonexistent"');
+  });
+
+  it("shows PR URL when present", async () => {
+    mockLoadRetrospectives.mockReturnValue([makeRetro()]);
+
+    await program.parseAsync(["node", "test", "retro", "show", "sess-1"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("https://github.com/org/repo/pull/42");
+  });
+
+  it("passes sessionId and limit to loadRetrospectives", async () => {
+    mockLoadRetrospectives.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "retro", "show", "sess-1"]);
+
+    expect(mockLoadRetrospectives).toHaveBeenCalledWith(
+      "/tmp/retros",
+      expect.objectContaining({ sessionId: "sess-1", limit: 1 }),
+    );
+  });
+});
+
+describe("retro generate", () => {
+  it("calls generateRetrospective and saves", async () => {
+    const retro = makeRetro();
+    mockGenerateRetrospective.mockReturnValue(retro);
+
+    await program.parseAsync(["node", "test", "retro", "generate", "sess-1"]);
+
+    expect(mockGenerateRetrospective).toHaveBeenCalledWith(
+      "sess-1",
+      expect.objectContaining({ projects: expect.any(Object) }),
+      "my-app",
+    );
+    expect(mockSaveRetrospective).toHaveBeenCalledWith(retro, "/tmp/retros");
+
+    const output = logs.join("\n");
+    expect(output).toContain("Retrospective generated for sess-1");
+    expect(output).toContain("Saved to:");
+  });
+
+  it("shows message when generate returns null", async () => {
+    mockGenerateRetrospective.mockReturnValue(null);
+
+    await program.parseAsync(["node", "test", "retro", "generate", "sess-1"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain('Could not generate retrospective for "sess-1"');
+    expect(mockSaveRetrospective).not.toHaveBeenCalled();
+  });
+
+  it("throws when no projects configured", async () => {
+    mockLoadConfig.mockReturnValue({ projects: {} });
+
+    await expect(
+      program.parseAsync(["node", "test", "retro", "generate", "sess-1"]),
+    ).rejects.toThrow("process.exit");
+  });
+
+  it("displays outcome and duration after generating", async () => {
+    const retro = makeRetro({ outcome: "partial", metrics: { totalDurationMs: 3600000, ciFailures: 0, reviewRounds: 1 } });
+    mockGenerateRetrospective.mockReturnValue(retro);
+
+    await program.parseAsync(["node", "test", "retro", "generate", "sess-1"]);
+
+    const output = logs.join("\n");
+    expect(output).toContain("partial");
+    expect(output).toContain("1.0h");
+  });
+});

--- a/packages/cli/__tests__/commands/review-check.test.ts
+++ b/packages/cli/__tests__/commands/review-check.test.ts
@@ -18,6 +18,7 @@ const { mockTmux, mockExec, mockGh, mockConfigRef, mockSessionManager, sessionsD
       spawn: vi.fn(),
       spawnOrchestrator: vi.fn(),
       send: vi.fn(),
+      getAttachInfo: vi.fn().mockResolvedValue(null),
     },
     sessionsDirRef: { current: "" },
   }));

--- a/packages/cli/__tests__/commands/session.test.ts
+++ b/packages/cli/__tests__/commands/session.test.ts
@@ -33,6 +33,7 @@ const { mockTmux, mockGit, mockGh, mockExec, mockConfigRef, mockSessionManager, 
       spawn: vi.fn(),
       spawnOrchestrator: vi.fn(),
       send: vi.fn(),
+      getAttachInfo: vi.fn().mockResolvedValue(null),
     },
     sessionsDirRef: { current: "" },
   }));

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -15,6 +15,7 @@ const { mockExec, mockConfigRef, mockSessionManager } = vi.hoisted(() => ({
     spawn: vi.fn(),
     spawnOrchestrator: vi.fn(),
     send: vi.fn(),
+    getAttachInfo: vi.fn().mockResolvedValue(null),
   },
 }));
 

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -39,6 +39,7 @@ const {
     spawn: vi.fn(),
     spawnOrchestrator: vi.fn(),
     send: vi.fn(),
+    getAttachInfo: vi.fn().mockResolvedValue(null),
   },
   sessionsDirRef: { current: "" },
 }));

--- a/packages/cli/__tests__/lib/format.test.ts
+++ b/packages/cli/__tests__/lib/format.test.ts
@@ -255,6 +255,7 @@ describe("padCol", () => {
     const result = padCol(colored, 10);
     // Visible content is "green" (5 chars) + 5 spaces = 10 visible chars
     // But actual string is longer due to ANSI codes
+    // eslint-disable-next-line no-control-regex
     const stripped = result.replace(/\u001b\[[0-9;]*m/g, "");
     expect(stripped.length).toBe(10);
   });

--- a/packages/cli/__tests__/lib/format.test.ts
+++ b/packages/cli/__tests__/lib/format.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { formatAge, statusColor, header, banner } from "../../src/lib/format.js";
+import {
+  formatAge,
+  statusColor,
+  header,
+  banner,
+  formatMs,
+  parseSinceArg,
+  colorLevel,
+  formatLogEntry,
+  padCol,
+  ciStatusIcon,
+  reviewDecisionIcon,
+  activityIcon,
+} from "../../src/lib/format.js";
+import type { LogEntry } from "@composio/ao-core";
 
 describe("formatAge", () => {
   beforeEach(() => {
@@ -73,5 +87,255 @@ describe("banner", () => {
     expect(result).toContain("STATUS");
     const lines = result.split("\n");
     expect(lines.length).toBe(3);
+  });
+});
+
+describe("formatMs", () => {
+  it("formats sub-second durations with ms suffix", () => {
+    expect(formatMs(0)).toBe("0ms");
+    expect(formatMs(1)).toBe("1ms");
+    expect(formatMs(500)).toBe("500ms");
+    expect(formatMs(999)).toBe("999ms");
+  });
+
+  it("formats 1 second exactly as seconds", () => {
+    expect(formatMs(1000)).toBe("1.0s");
+  });
+
+  it("formats multi-second durations with one decimal", () => {
+    expect(formatMs(1500)).toBe("1.5s");
+    expect(formatMs(2000)).toBe("2.0s");
+    expect(formatMs(12345)).toBe("12.3s");
+  });
+});
+
+describe("parseSinceArg", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("parses seconds suffix", () => {
+    const result = parseSinceArg("30s");
+    const expectedMs = Date.now() - 30 * 1000;
+    expect(result.getTime()).toBe(expectedMs);
+  });
+
+  it("parses minutes suffix", () => {
+    const result = parseSinceArg("5m");
+    const expectedMs = Date.now() - 5 * 60_000;
+    expect(result.getTime()).toBe(expectedMs);
+  });
+
+  it("parses hours suffix", () => {
+    const result = parseSinceArg("2h");
+    const expectedMs = Date.now() - 2 * 3_600_000;
+    expect(result.getTime()).toBe(expectedMs);
+  });
+
+  it("parses days suffix", () => {
+    const result = parseSinceArg("3d");
+    const expectedMs = Date.now() - 3 * 86_400_000;
+    expect(result.getTime()).toBe(expectedMs);
+  });
+
+  it("parses ISO 8601 date string", () => {
+    const iso = "2026-01-01T00:00:00Z";
+    const result = parseSinceArg(iso);
+    expect(result).toEqual(new Date(iso));
+  });
+
+  it("throws on invalid format", () => {
+    expect(() => parseSinceArg("bad")).toThrow(/Invalid time format/);
+    expect(() => parseSinceArg("5x")).toThrow(/Invalid time format/);
+    expect(() => parseSinceArg("not-a-date")).toThrow(/Invalid time format/);
+  });
+});
+
+describe("colorLevel", () => {
+  it("returns non-empty string for each level", () => {
+    const levels: LogEntry["level"][] = ["error", "warn", "stderr", "stdout", "info"];
+    for (const level of levels) {
+      expect(colorLevel(level)).toBeTruthy();
+    }
+  });
+
+  it("error level contains ERR", () => {
+    expect(colorLevel("error")).toContain("ERR");
+  });
+
+  it("warn level contains WRN", () => {
+    expect(colorLevel("warn")).toContain("WRN");
+  });
+
+  it("stderr level contains err", () => {
+    expect(colorLevel("stderr")).toContain("err");
+  });
+
+  it("stdout level contains out", () => {
+    expect(colorLevel("stdout")).toContain("out");
+  });
+
+  it("info level contains inf", () => {
+    expect(colorLevel("info")).toContain("inf");
+  });
+});
+
+describe("formatLogEntry", () => {
+  const baseEntry: LogEntry = {
+    ts: "2026-01-15T12:00:00Z",
+    level: "info",
+    source: "lifecycle",
+    sessionId: null,
+    message: "session spawned",
+  };
+
+  it("includes the message text", () => {
+    const result = formatLogEntry(baseEntry);
+    expect(result).toContain("session spawned");
+  });
+
+  it("includes the level indicator", () => {
+    const result = formatLogEntry(baseEntry);
+    expect(result).toContain("inf");
+  });
+
+  it("includes the formatted timestamp", () => {
+    const result = formatLogEntry(baseEntry);
+    // toLocaleTimeString output varies by locale but should be non-empty
+    expect(result.length).toBeGreaterThan("inf session spawned".length);
+  });
+
+  it("includes sessionId when present", () => {
+    const entry = { ...baseEntry, sessionId: "sess-abc" };
+    const result = formatLogEntry(entry);
+    expect(result).toContain("sess-abc");
+  });
+
+  it("omits sessionId prefix when null", () => {
+    const result = formatLogEntry(baseEntry);
+    // No extra whitespace from sessionId prefix
+    expect(result).not.toContain("null");
+  });
+
+  it("formats error entries with ERR indicator", () => {
+    const entry = { ...baseEntry, level: "error" as const, message: "something failed" };
+    const result = formatLogEntry(entry);
+    expect(result).toContain("ERR");
+    expect(result).toContain("something failed");
+  });
+});
+
+describe("padCol", () => {
+  it("pads short strings to the target width", () => {
+    const result = padCol("hi", 10);
+    expect(result.length).toBe(10);
+    expect(result).toContain("hi");
+  });
+
+  it("returns string unchanged when exactly at width", () => {
+    const result = padCol("hello", 5);
+    expect(result.length).toBe(5);
+    expect(result).toBe("hello");
+  });
+
+  it("truncates long strings with ellipsis", () => {
+    const result = padCol("abcdefghij", 5);
+    expect(result.length).toBe(5);
+    expect(result).toContain("…");
+  });
+
+  it("handles ANSI escape codes correctly (visible width)", () => {
+    // A chalk-colored string: ANSI codes are invisible characters
+    const colored = "\u001b[32mgreen\u001b[0m"; // visible: "green" (5 chars)
+    const result = padCol(colored, 10);
+    // Visible content is "green" (5 chars) + 5 spaces = 10 visible chars
+    // But actual string is longer due to ANSI codes
+    const stripped = result.replace(/\u001b\[[0-9;]*m/g, "");
+    expect(stripped.length).toBe(10);
+  });
+
+  it("handles empty string", () => {
+    const result = padCol("", 5);
+    expect(result.length).toBe(5);
+    expect(result.trim()).toBe("");
+  });
+});
+
+describe("ciStatusIcon", () => {
+  it("returns pass for passing", () => {
+    expect(ciStatusIcon("passing")).toContain("pass");
+  });
+
+  it("returns fail for failing", () => {
+    expect(ciStatusIcon("failing")).toContain("fail");
+  });
+
+  it("returns pend for pending", () => {
+    expect(ciStatusIcon("pending")).toContain("pend");
+  });
+
+  it("returns dash for none", () => {
+    expect(ciStatusIcon("none")).toContain("-");
+  });
+
+  it("returns dash for null", () => {
+    expect(ciStatusIcon(null)).toContain("-");
+  });
+});
+
+describe("reviewDecisionIcon", () => {
+  it("returns ok for approved", () => {
+    expect(reviewDecisionIcon("approved")).toContain("ok");
+  });
+
+  it("returns change indicator for changes_requested", () => {
+    expect(reviewDecisionIcon("changes_requested")).toContain("chg!");
+  });
+
+  it("returns review indicator for pending", () => {
+    expect(reviewDecisionIcon("pending")).toContain("rev?");
+  });
+
+  it("returns dash for none", () => {
+    expect(reviewDecisionIcon("none")).toContain("-");
+  });
+
+  it("returns dash for null", () => {
+    expect(reviewDecisionIcon(null)).toContain("-");
+  });
+});
+
+describe("activityIcon", () => {
+  it("returns working for active", () => {
+    expect(activityIcon("active")).toContain("working");
+  });
+
+  it("returns ready for ready", () => {
+    expect(activityIcon("ready")).toContain("ready");
+  });
+
+  it("returns idle for idle", () => {
+    expect(activityIcon("idle")).toContain("idle");
+  });
+
+  it("returns waiting for waiting_input", () => {
+    expect(activityIcon("waiting_input")).toContain("waiting");
+  });
+
+  it("returns blocked for blocked", () => {
+    expect(activityIcon("blocked")).toContain("blocked");
+  });
+
+  it("returns exited for exited", () => {
+    expect(activityIcon("exited")).toContain("exited");
+  });
+
+  it("returns unknown for null", () => {
+    expect(activityIcon(null)).toContain("unknown");
   });
 });

--- a/packages/cli/__tests__/lib/perf-utils.test.ts
+++ b/packages/cli/__tests__/lib/perf-utils.test.ts
@@ -12,8 +12,7 @@ vi.mock("@composio/ao-core", () => ({
   readLogsFromDir: mockReadLogsFromDir,
 }));
 
-import { resolveLogDir, loadRequests } from "../../src/lib/perf-utils.js";
-import type { ParsedRequest } from "../../src/lib/perf-utils.js";
+import { resolveLogDir, loadRequests, type ParsedRequest } from "../../src/lib/perf-utils.js";
 
 beforeEach(() => {
   mockLoadConfig.mockReset();

--- a/packages/cli/__tests__/lib/perf-utils.test.ts
+++ b/packages/cli/__tests__/lib/perf-utils.test.ts
@@ -10,6 +10,33 @@ vi.mock("@composio/ao-core", () => ({
   loadConfig: mockLoadConfig,
   resolveProjectLogDir: mockResolveProjectLogDir,
   readLogsFromDir: mockReadLogsFromDir,
+  // parseApiLogs delegates to mockReadLogsFromDir so tests can control entries
+  parseApiLogs: (logDir: string, opts?: { since?: Date; route?: string }) => {
+    const entries = (mockReadLogsFromDir(logDir, "api", { source: "api", since: opts?.since }) ?? []) as Array<{
+      ts: string;
+      sessionId: string | null;
+      data?: Record<string, unknown>;
+    }>;
+    const results = [];
+    for (const entry of entries) {
+      const data = entry.data ?? {};
+      if (!data["method"] || !data["path"]) continue;
+      const req = {
+        ts: entry.ts,
+        method: String(data["method"]),
+        path: String(data["path"]),
+        sessionId: entry.sessionId,
+        statusCode: Number(data["statusCode"]) || 0,
+        durationMs: Number(data["durationMs"]) || 0,
+        error: data["error"] ? String(data["error"]) : undefined,
+        timings: data["timings"] as Record<string, number> | undefined,
+        cacheStats: data["cacheStats"] as { hits: number; misses: number; hitRate: number; size: number } | undefined,
+      };
+      if (opts?.route && !req.path.includes(opts.route)) continue;
+      results.push(req);
+    }
+    return results;
+  },
 }));
 
 import { resolveLogDir, loadRequests, type ParsedRequest } from "../../src/lib/perf-utils.js";
@@ -65,6 +92,7 @@ describe("loadRequests", () => {
       ts: "2025-01-01T00:00:00Z",
       method: "GET",
       path: "/api/sessions",
+      sessionId: null,
       statusCode: 200,
       durationMs: 45,
       error: undefined,

--- a/packages/cli/__tests__/lib/perf-utils.test.ts
+++ b/packages/cli/__tests__/lib/perf-utils.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockLoadConfig, mockResolveProjectLogDir, mockReadLogsFromDir } = vi.hoisted(() => ({
+  mockLoadConfig: vi.fn(),
+  mockResolveProjectLogDir: vi.fn(),
+  mockReadLogsFromDir: vi.fn(),
+}));
+
+vi.mock("@composio/ao-core", () => ({
+  loadConfig: mockLoadConfig,
+  resolveProjectLogDir: mockResolveProjectLogDir,
+  readLogsFromDir: mockReadLogsFromDir,
+}));
+
+import { resolveLogDir, loadRequests } from "../../src/lib/perf-utils.js";
+import type { ParsedRequest } from "../../src/lib/perf-utils.js";
+
+beforeEach(() => {
+  mockLoadConfig.mockReset();
+  mockResolveProjectLogDir.mockReset();
+  mockReadLogsFromDir.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolveLogDir", () => {
+  it("throws when no projects configured (resolveProjectLogDir returns null)", () => {
+    mockLoadConfig.mockReturnValue({ projects: {} });
+    mockResolveProjectLogDir.mockReturnValue(null);
+
+    expect(() => resolveLogDir()).toThrow("No projects configured");
+  });
+
+  it("returns directory path when configured", () => {
+    mockLoadConfig.mockReturnValue({ projects: { app: {} } });
+    mockResolveProjectLogDir.mockReturnValue("/tmp/logs");
+
+    expect(resolveLogDir()).toBe("/tmp/logs");
+  });
+});
+
+describe("loadRequests", () => {
+  it("parses log entries into ParsedRequest objects", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      {
+        ts: "2025-01-01T00:00:00Z",
+        level: "info",
+        source: "api",
+        sessionId: null,
+        message: "request",
+        data: {
+          method: "GET",
+          path: "/api/sessions",
+          statusCode: 200,
+          durationMs: 45,
+        },
+      },
+    ]);
+
+    const result = loadRequests("/tmp/logs");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual<ParsedRequest>({
+      ts: "2025-01-01T00:00:00Z",
+      method: "GET",
+      path: "/api/sessions",
+      statusCode: 200,
+      durationMs: 45,
+      error: undefined,
+      timings: undefined,
+      cacheStats: undefined,
+    });
+  });
+
+  it("skips entries without method/path", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      {
+        ts: "2025-01-01T00:00:00Z",
+        level: "info",
+        source: "api",
+        sessionId: null,
+        message: "startup",
+        data: { msg: "server ready" },
+      },
+      {
+        ts: "2025-01-01T00:00:01Z",
+        level: "info",
+        source: "api",
+        sessionId: null,
+        message: "request",
+        data: {
+          method: "POST",
+          path: "/api/sessions",
+          statusCode: 201,
+          durationMs: 120,
+        },
+      },
+    ]);
+
+    const result = loadRequests("/tmp/logs");
+    expect(result).toHaveLength(1);
+    expect(result[0].method).toBe("POST");
+  });
+
+  it("filters by route when opts.route is set", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      {
+        ts: "2025-01-01T00:00:00Z",
+        level: "info",
+        source: "api",
+        sessionId: null,
+        message: "request",
+        data: { method: "GET", path: "/api/sessions", statusCode: 200, durationMs: 10 },
+      },
+      {
+        ts: "2025-01-01T00:00:01Z",
+        level: "info",
+        source: "api",
+        sessionId: null,
+        message: "request",
+        data: { method: "GET", path: "/api/health", statusCode: 200, durationMs: 5 },
+      },
+    ]);
+
+    const result = loadRequests("/tmp/logs", { route: "/api/sessions" });
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe("/api/sessions");
+  });
+
+  it("returns empty array when no matching entries", () => {
+    mockReadLogsFromDir.mockReturnValue([]);
+
+    const result = loadRequests("/tmp/logs");
+    expect(result).toEqual([]);
+  });
+
+  it("includes timings and cacheStats when present", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      {
+        ts: "2025-01-01T00:00:00Z",
+        level: "info",
+        source: "api",
+        sessionId: null,
+        message: "request",
+        data: {
+          method: "GET",
+          path: "/api/sessions",
+          statusCode: 200,
+          durationMs: 100,
+          timings: { prEnrichment: 50, sessionList: 30 },
+          cacheStats: { hits: 10, misses: 2, hitRate: 0.83, size: 12 },
+        },
+      },
+    ]);
+
+    const result = loadRequests("/tmp/logs");
+    expect(result[0].timings).toEqual({ prEnrichment: 50, sessionList: 30 });
+    expect(result[0].cacheStats).toEqual({ hits: 10, misses: 2, hitRate: 0.83, size: 12 });
+  });
+
+  it("includes error field when present", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      {
+        ts: "2025-01-01T00:00:00Z",
+        level: "error",
+        source: "api",
+        sessionId: null,
+        message: "request failed",
+        data: {
+          method: "GET",
+          path: "/api/sessions",
+          statusCode: 500,
+          durationMs: 200,
+          error: "Internal Server Error",
+        },
+      },
+    ]);
+
+    const result = loadRequests("/tmp/logs");
+    expect(result[0].error).toBe("Internal Server Error");
+    expect(result[0].statusCode).toBe(500);
+  });
+});

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -15,7 +15,7 @@ import chalk from "chalk";
 import type { Command } from "commander";
 import {
   loadConfig,
-  getLogsDir,
+  resolveProjectLogDir,
   LogWriter,
   readLogs,
   tailLogs,
@@ -33,14 +33,9 @@ import {
 } from "../lib/dashboard-rebuild.js";
 import { formatAge, parseSinceArg } from "../lib/format.js";
 
-/** Resolve the log directory for the first configured project. */
 function resolveLogDir(): string | null {
   try {
-    const config = loadConfig();
-    const projectId = Object.keys(config.projects)[0];
-    if (!projectId) return null;
-    const project = config.projects[projectId];
-    return getLogsDir(config.configPath, project.path);
+    return resolveProjectLogDir(loadConfig());
   } catch {
     return null;
   }

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -15,7 +15,6 @@ import chalk from "chalk";
 import type { Command } from "commander";
 import {
   loadConfig,
-  resolveProjectLogDir,
   LogWriter,
   readLogs,
   tailLogs,
@@ -32,10 +31,12 @@ import {
   waitForPortFree,
 } from "../lib/dashboard-rebuild.js";
 import { formatAge, parseSinceArg } from "../lib/format.js";
+import { resolveLogDir as resolveLogDirStrict } from "../lib/perf-utils.js";
 
+/** Nullable variant — dashboard degrades gracefully when no project is configured. */
 function resolveLogDir(): string | null {
   try {
-    return resolveProjectLogDir(loadConfig());
+    return resolveLogDirStrict();
   } catch {
     return null;
   }

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -348,6 +348,8 @@ export function registerDashboard(program: Command): void {
               `  Process:  ${chalk.yellow("conflict")} ` +
                 `(PID file: ${pid}, but port ${port} held by PID ${portPid})`,
             );
+            running = false;
+            pid = null;
           }
           // else: PID file matches port process — both agree, fall through to "running"
         } else if (running) {

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -12,7 +12,7 @@ import chalk from "chalk";
 import type { Command } from "commander";
 import {
   loadConfig,
-  getLogsDir,
+  resolveProjectLogDir,
   readLogs,
   readLogsFromDir,
   tailLogs,
@@ -40,13 +40,11 @@ function colorLevel(level: LogEntry["level"]): string {
   }
 }
 
-/** Resolve log directory from config, first project. */
 function resolveLogDir(): string {
   const config = loadConfig();
-  const projectId = Object.keys(config.projects)[0];
-  if (!projectId) throw new Error("No projects configured.");
-  const project = config.projects[projectId];
-  return getLogsDir(config.configPath, project.path);
+  const dir = resolveProjectLogDir(config);
+  if (!dir) throw new Error("No projects configured.");
+  return dir;
 }
 
 export function registerLogs(program: Command): void {

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -1,0 +1,164 @@
+/**
+ * `ao logs` — query structured logs from the orchestrator.
+ *
+ * Subcommands:
+ *   ao logs dashboard  — dashboard process stdout/stderr
+ *   ao logs events     — lifecycle state transitions
+ *   ao logs session <id> — events for a specific session
+ */
+
+import { join } from "node:path";
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  loadConfig,
+  getLogsDir,
+  readLogs,
+  readLogsFromDir,
+  tailLogs,
+  type LogEntry,
+  type LogQueryOptions,
+} from "@composio/ao-core";
+
+/** Parse a relative time string like "5m", "1h", "30s" into a Date. */
+function parseSinceArg(since: string): Date {
+  const match = since.match(/^(\d+)(s|m|h|d)$/);
+  if (!match) {
+    // Try ISO 8601
+    const d = new Date(since);
+    if (!isNaN(d.getTime())) return d;
+    throw new Error(`Invalid time format: "${since}". Use "5m", "1h", "30s", or ISO 8601.`);
+  }
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+  const ms =
+    unit === "s" ? value * 1000 :
+    unit === "m" ? value * 60_000 :
+    unit === "h" ? value * 3_600_000 :
+    value * 86_400_000;
+  return new Date(Date.now() - ms);
+}
+
+/** Format a log entry for terminal display. */
+function formatLogEntry(entry: LogEntry): string {
+  const ts = new Date(entry.ts).toLocaleTimeString();
+  const level = colorLevel(entry.level);
+  const session = entry.sessionId ? chalk.cyan(entry.sessionId) + " " : "";
+  return `${chalk.dim(ts)} ${level} ${session}${entry.message}`;
+}
+
+/** Color-code log level. */
+function colorLevel(level: LogEntry["level"]): string {
+  switch (level) {
+    case "error": return chalk.red("ERR");
+    case "warn": return chalk.yellow("WRN");
+    case "stderr": return chalk.red("err");
+    case "stdout": return chalk.dim("out");
+    case "info": return chalk.blue("inf");
+  }
+}
+
+/** Resolve log directory from config, first project. */
+function resolveLogDir(): string {
+  const config = loadConfig();
+  const projectId = Object.keys(config.projects)[0];
+  if (!projectId) throw new Error("No projects configured.");
+  const project = config.projects[projectId];
+  return getLogsDir(config.configPath, project.path);
+}
+
+export function registerLogs(program: Command): void {
+  const logsCmd = program
+    .command("logs")
+    .description("Query structured logs from the orchestrator");
+
+  logsCmd
+    .command("dashboard")
+    .description("Show dashboard process logs")
+    .option("--since <time>", "Show logs since (e.g., 5m, 1h, 2024-01-01)")
+    .option("--level <level>", "Filter by level (stdout, stderr, info, warn, error)")
+    .option("--tail <n>", "Show last N entries", "50")
+    .option("--json", "Output as JSON")
+    .action((opts: { since?: string; level?: string; tail?: string; json?: boolean }) => {
+      try {
+        const logDir = resolveLogDir();
+        const logPath = join(logDir, "dashboard.jsonl");
+
+        if (opts.since) {
+          const queryOpts: LogQueryOptions = {
+            since: parseSinceArg(opts.since),
+            level: opts.level ? [opts.level as LogEntry["level"]] : undefined,
+          };
+          const entries = readLogs(logPath, queryOpts);
+          printEntries(entries, opts.json);
+        } else {
+          const n = parseInt(opts.tail ?? "50", 10);
+          let entries = tailLogs(logPath, n);
+          if (opts.level) {
+            entries = entries.filter((e) => e.level === opts.level);
+          }
+          printEntries(entries, opts.json);
+        }
+      } catch (err) {
+        console.error(chalk.red("Error:"), err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  logsCmd
+    .command("events")
+    .description("Show lifecycle event logs (state transitions)")
+    .option("--since <time>", "Show events since (e.g., 5m, 1h)")
+    .option("--session <id>", "Filter by session ID")
+    .option("--type <type>", "Filter by event type pattern")
+    .option("--json", "Output as JSON")
+    .action((opts: { since?: string; session?: string; type?: string; json?: boolean }) => {
+      try {
+        const logDir = resolveLogDir();
+
+        const queryOpts: LogQueryOptions = {
+          source: "lifecycle",
+          ...(opts.since && { since: parseSinceArg(opts.since) }),
+          ...(opts.session && { sessionId: opts.session }),
+          ...(opts.type && { pattern: opts.type }),
+        };
+        const entries = readLogsFromDir(logDir, "events", queryOpts);
+        printEntries(entries, opts.json);
+      } catch (err) {
+        console.error(chalk.red("Error:"), err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  logsCmd
+    .command("session <id>")
+    .description("Show all events for a specific session")
+    .option("--json", "Output as JSON")
+    .action((sessionId: string, opts: { json?: boolean }) => {
+      try {
+        const logDir = resolveLogDir();
+        const entries = readLogsFromDir(logDir, "events", { sessionId });
+        if (entries.length === 0) {
+          console.log(chalk.yellow(`No events found for session "${sessionId}"`));
+          return;
+        }
+        printEntries(entries, opts.json);
+      } catch (err) {
+        console.error(chalk.red("Error:"), err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+}
+
+function printEntries(entries: LogEntry[], json?: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(entries, null, 2));
+  } else if (entries.length === 0) {
+    console.log(chalk.dim("No log entries found."));
+  } else {
+    for (const entry of entries) {
+      console.log(formatLogEntry(entry));
+    }
+    console.log(chalk.dim(`\n${entries.length} entries`));
+  }
+}

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -19,25 +19,7 @@ import {
   type LogEntry,
   type LogQueryOptions,
 } from "@composio/ao-core";
-
-/** Parse a relative time string like "5m", "1h", "30s" into a Date. */
-function parseSinceArg(since: string): Date {
-  const match = since.match(/^(\d+)(s|m|h|d)$/);
-  if (!match) {
-    // Try ISO 8601
-    const d = new Date(since);
-    if (!isNaN(d.getTime())) return d;
-    throw new Error(`Invalid time format: "${since}". Use "5m", "1h", "30s", or ISO 8601.`);
-  }
-  const value = parseInt(match[1], 10);
-  const unit = match[2];
-  const ms =
-    unit === "s" ? value * 1000 :
-    unit === "m" ? value * 60_000 :
-    unit === "h" ? value * 3_600_000 :
-    value * 86_400_000;
-  return new Date(Date.now() - ms);
-}
+import { parseSinceArg } from "../lib/format.js";
 
 /** Format a log entry for terminal display. */
 function formatLogEntry(entry: LogEntry): string {

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -91,10 +91,6 @@ export function registerLogs(program: Command): void {
       try {
         const logDir = resolveLogDir();
         const entries = readLogsFromDir(logDir, "events", { sessionId });
-        if (entries.length === 0) {
-          console.log(chalk.yellow(`No events found for session "${sessionId}"`));
-          return;
-        }
         printEntries(entries, opts.json);
       } catch (err) {
         console.error(chalk.red("Error:"), err instanceof Error ? err.message : String(err));

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -11,8 +11,6 @@ import { join } from "node:path";
 import chalk from "chalk";
 import type { Command } from "commander";
 import {
-  loadConfig,
-  resolveProjectLogDir,
   readLogs,
   readLogsFromDir,
   tailLogs,
@@ -20,6 +18,7 @@ import {
   type LogQueryOptions,
 } from "@composio/ao-core";
 import { parseSinceArg } from "../lib/format.js";
+import { resolveLogDir } from "../lib/perf-utils.js";
 
 /** Format a log entry for terminal display. */
 function formatLogEntry(entry: LogEntry): string {
@@ -38,13 +37,6 @@ function colorLevel(level: LogEntry["level"]): string {
     case "stdout": return chalk.dim("out");
     case "info": return chalk.blue("inf");
   }
-}
-
-function resolveLogDir(): string {
-  const config = loadConfig();
-  const dir = resolveProjectLogDir(config);
-  if (!dir) throw new Error("No projects configured.");
-  return dir;
 }
 
 export function registerLogs(program: Command): void {

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -17,27 +17,8 @@ import {
   type LogEntry,
   type LogQueryOptions,
 } from "@composio/ao-core";
-import { parseSinceArg } from "../lib/format.js";
+import { formatLogEntry, parseSinceArg } from "../lib/format.js";
 import { resolveLogDir } from "../lib/perf-utils.js";
-
-/** Format a log entry for terminal display. */
-function formatLogEntry(entry: LogEntry): string {
-  const ts = new Date(entry.ts).toLocaleTimeString();
-  const level = colorLevel(entry.level);
-  const session = entry.sessionId ? chalk.cyan(entry.sessionId) + " " : "";
-  return `${chalk.dim(ts)} ${level} ${session}${entry.message}`;
-}
-
-/** Color-code log level. */
-function colorLevel(level: LogEntry["level"]): string {
-  switch (level) {
-    case "error": return chalk.red("ERR");
-    case "warn": return chalk.yellow("WRN");
-    case "stderr": return chalk.red("err");
-    case "stdout": return chalk.dim("out");
-    case "info": return chalk.blue("inf");
-  }
-}
 
 export function registerLogs(program: Command): void {
   const logsCmd = program

--- a/packages/cli/src/commands/perf.ts
+++ b/packages/cli/src/commands/perf.ts
@@ -11,15 +11,14 @@
 
 import chalk from "chalk";
 import type { Command } from "commander";
-import { loadConfig, getLogsDir, readLogsFromDir } from "@composio/ao-core";
+import { loadConfig, resolveProjectLogDir, readLogsFromDir } from "@composio/ao-core";
 import { padCol, parseSinceArg } from "../lib/format.js";
 
 function resolveLogDir(): string {
   const config = loadConfig();
-  const projectId = Object.keys(config.projects)[0];
-  if (!projectId) throw new Error("No projects configured.");
-  const project = config.projects[projectId];
-  return getLogsDir(config.configPath, project.path);
+  const dir = resolveProjectLogDir(config);
+  if (!dir) throw new Error("No projects configured.");
+  return dir;
 }
 
 interface ParsedRequest {

--- a/packages/cli/src/commands/perf.ts
+++ b/packages/cli/src/commands/perf.ts
@@ -1,0 +1,332 @@
+/**
+ * `ao perf` — API performance analysis from request logs.
+ *
+ * Subcommands:
+ *   ao perf              — overview of route performance
+ *   ao perf routes       — per-route p50/p95/p99 stats
+ *   ao perf slow         — slowest recent requests
+ *   ao perf cache        — cache hit rates
+ *   ao perf enrichment   — PR enrichment timing breakdown
+ */
+
+import chalk from "chalk";
+import type { Command } from "commander";
+import { loadConfig, getLogsDir, readLogsFromDir } from "@composio/ao-core";
+import { padCol } from "../lib/format.js";
+
+/** Parse a relative time string into a Date. */
+function parseSinceArg(since: string): Date {
+  const match = since.match(/^(\d+)(s|m|h|d)$/);
+  if (!match) {
+    const d = new Date(since);
+    if (!isNaN(d.getTime())) return d;
+    throw new Error(`Invalid time format: "${since}". Use "5m", "1h", "30s", or ISO 8601.`);
+  }
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+  const ms =
+    unit === "s" ? value * 1000 :
+    unit === "m" ? value * 60_000 :
+    unit === "h" ? value * 3_600_000 :
+    value * 86_400_000;
+  return new Date(Date.now() - ms);
+}
+
+function resolveLogDir(): string {
+  const config = loadConfig();
+  const projectId = Object.keys(config.projects)[0];
+  if (!projectId) throw new Error("No projects configured.");
+  const project = config.projects[projectId];
+  return getLogsDir(config.configPath, project.path);
+}
+
+interface ParsedRequest {
+  ts: string;
+  method: string;
+  path: string;
+  statusCode: number;
+  durationMs: number;
+  error?: string;
+  timings?: Record<string, number>;
+  cacheStats?: { hits: number; misses: number; hitRate: number; size: number };
+}
+
+function loadRequests(logDir: string, opts?: { since?: Date; route?: string }): ParsedRequest[] {
+  const entries = readLogsFromDir(logDir, "api", {
+    source: "api",
+    since: opts?.since,
+  });
+
+  const requests: ParsedRequest[] = [];
+  for (const entry of entries) {
+    const data = entry.data ?? {};
+    if (!data["method"] || !data["path"]) continue;
+
+    const req: ParsedRequest = {
+      ts: entry.ts,
+      method: String(data["method"]),
+      path: String(data["path"]),
+      statusCode: Number(data["statusCode"]) || 0,
+      durationMs: Number(data["durationMs"]) || 0,
+      error: data["error"] ? String(data["error"]) : undefined,
+      timings: data["timings"] as Record<string, number> | undefined,
+      cacheStats: data["cacheStats"] as ParsedRequest["cacheStats"] | undefined,
+    };
+
+    if (opts?.route && !req.path.includes(opts.route)) continue;
+    requests.push(req);
+  }
+
+  return requests;
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+function normalizePath(path: string): string {
+  return path
+    .replace(/\/sessions\/[^/]+/g, "/sessions/:id")
+    .replace(/\/prs\/[^/]+/g, "/prs/:id");
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function registerPerf(program: Command): void {
+  const perfCmd = program
+    .command("perf")
+    .description("API performance analysis from request logs");
+
+  perfCmd
+    .command("routes")
+    .description("Per-route p50/p95/p99 response time stats")
+    .option("--since <time>", "Analyze requests since (e.g., 1h, 1d)")
+    .option("--route <pattern>", "Filter by route pattern")
+    .option("--json", "Output as JSON")
+    .action((opts: { since?: string; route?: string; json?: boolean }) => {
+      try {
+        const logDir = resolveLogDir();
+        const since = opts.since ? parseSinceArg(opts.since) : undefined;
+        const requests = loadRequests(logDir, { since, route: opts.route });
+
+        if (requests.length === 0) {
+          console.log(chalk.dim("No API request logs found."));
+          return;
+        }
+
+        // Group by normalized route
+        const byRoute = new Map<string, number[]>();
+        const errorsByRoute = new Map<string, number>();
+        for (const req of requests) {
+          const key = `${req.method} ${normalizePath(req.path)}`;
+          const durations = byRoute.get(key) ?? [];
+          durations.push(req.durationMs);
+          byRoute.set(key, durations);
+          if (req.error || req.statusCode >= 400) {
+            errorsByRoute.set(key, (errorsByRoute.get(key) ?? 0) + 1);
+          }
+        }
+
+        if (opts.json) {
+          const result: Record<string, unknown> = {};
+          for (const [route, durations] of byRoute) {
+            durations.sort((a, b) => a - b);
+            result[route] = {
+              count: durations.length,
+              p50: percentile(durations, 50),
+              p95: percentile(durations, 95),
+              p99: percentile(durations, 99),
+              errors: errorsByRoute.get(route) ?? 0,
+            };
+          }
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+
+        // Table
+        const COL = { route: 32, count: 7, p50: 8, p95: 8, p99: 8, errors: 7 };
+        console.log(
+          chalk.dim(
+            "  " +
+            padCol("Route", COL.route) +
+            padCol("Count", COL.count) +
+            padCol("p50", COL.p50) +
+            padCol("p95", COL.p95) +
+            padCol("p99", COL.p99) +
+            "Errors",
+          ),
+        );
+        console.log(chalk.dim("  " + "─".repeat(70)));
+
+        const sorted = [...byRoute.entries()].sort((a, b) => {
+          const medA = percentile(a[1].sort((x, y) => x - y), 95);
+          const medB = percentile(b[1].sort((x, y) => x - y), 95);
+          return medB - medA;
+        });
+
+        for (const [route, durations] of sorted) {
+          durations.sort((a, b) => a - b);
+          const errors = errorsByRoute.get(route) ?? 0;
+          console.log(
+            "  " +
+            padCol(chalk.cyan(route), COL.route) +
+            padCol(String(durations.length), COL.count) +
+            padCol(formatMs(percentile(durations, 50)), COL.p50) +
+            padCol(formatMs(percentile(durations, 95)), COL.p95) +
+            padCol(formatMs(percentile(durations, 99)), COL.p99) +
+            (errors > 0 ? chalk.red(String(errors)) : chalk.dim("0")),
+          );
+        }
+        console.log(chalk.dim(`\n  ${requests.length} total requests`));
+      } catch (err) {
+        console.error(chalk.red("Error:"), err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  perfCmd
+    .command("slow")
+    .description("Show slowest recent requests")
+    .option("--limit <n>", "Number of requests to show", "10")
+    .option("--since <time>", "Analyze requests since")
+    .option("--json", "Output as JSON")
+    .action((opts: { limit?: string; since?: string; json?: boolean }) => {
+      try {
+        const logDir = resolveLogDir();
+        const since = opts.since ? parseSinceArg(opts.since) : undefined;
+        const requests = loadRequests(logDir, { since });
+        const limit = parseInt(opts.limit ?? "10", 10);
+
+        const slowest = requests
+          .sort((a, b) => b.durationMs - a.durationMs)
+          .slice(0, limit);
+
+        if (opts.json) {
+          console.log(JSON.stringify(slowest, null, 2));
+          return;
+        }
+
+        if (slowest.length === 0) {
+          console.log(chalk.dim("No API request logs found."));
+          return;
+        }
+
+        console.log(chalk.bold("\nSlowest Requests:\n"));
+        for (const req of slowest) {
+          const time = new Date(req.ts).toLocaleTimeString();
+          const timingDetail = req.timings
+            ? Object.entries(req.timings)
+                .map(([k, v]) => `${k}: ${formatMs(v)}`)
+                .join(", ")
+            : "";
+          console.log(
+            `  ${chalk.yellow(formatMs(req.durationMs).padEnd(7))} ` +
+            `${req.method} ${chalk.cyan(req.path)}  ` +
+            chalk.dim(time),
+          );
+          if (timingDetail) {
+            console.log(`           ${chalk.dim(`(${timingDetail})`)}`);
+          }
+        }
+        console.log();
+      } catch (err) {
+        console.error(chalk.red("Error:"), err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  perfCmd
+    .command("cache")
+    .description("Show cache hit rates")
+    .option("--json", "Output as JSON")
+    .action((opts: { json?: boolean }) => {
+      try {
+        const logDir = resolveLogDir();
+        const requests = loadRequests(logDir);
+
+        // Find the most recent cache stats from request logs
+        let latestStats: ParsedRequest["cacheStats"] | undefined;
+        for (let i = requests.length - 1; i >= 0; i--) {
+          if (requests[i].cacheStats) {
+            latestStats = requests[i].cacheStats;
+            break;
+          }
+        }
+
+        if (opts.json) {
+          console.log(JSON.stringify(latestStats ?? {}, null, 2));
+          return;
+        }
+
+        if (!latestStats) {
+          console.log(chalk.dim("No cache stats available yet. Hit the dashboard a few times first."));
+          return;
+        }
+
+        const rate = (latestStats.hitRate * 100).toFixed(1);
+        console.log(chalk.bold("\nCache Statistics:\n"));
+        console.log(`  Hit rate:   ${chalk.green(rate + "%")} (${latestStats.hits} hits / ${latestStats.misses} misses)`);
+        console.log(`  Cache size: ${latestStats.size} entries`);
+        console.log();
+      } catch (err) {
+        console.error(chalk.red("Error:"), err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  perfCmd
+    .command("enrichment")
+    .description("PR enrichment timing breakdown")
+    .option("--since <time>", "Analyze since")
+    .option("--json", "Output as JSON")
+    .action((opts: { since?: string; json?: boolean }) => {
+      try {
+        const logDir = resolveLogDir();
+        const since = opts.since ? parseSinceArg(opts.since) : undefined;
+        const requests = loadRequests(logDir, { since, route: "/api/sessions" });
+
+        // Collect enrichment timings
+        const enrichTimes: number[] = [];
+        const listTimes: number[] = [];
+        for (const req of requests) {
+          if (req.timings?.["prEnrichment"]) enrichTimes.push(req.timings["prEnrichment"]);
+          if (req.timings?.["sessionList"]) listTimes.push(req.timings["sessionList"]);
+        }
+
+        if (opts.json) {
+          console.log(JSON.stringify({ enrichTimes, listTimes }, null, 2));
+          return;
+        }
+
+        if (enrichTimes.length === 0) {
+          console.log(chalk.dim("No enrichment timing data found. Hit the dashboard a few times first."));
+          return;
+        }
+
+        enrichTimes.sort((a, b) => a - b);
+        listTimes.sort((a, b) => a - b);
+
+        console.log(chalk.bold("\nPR Enrichment Performance:\n"));
+        console.log(`  Samples:    ${enrichTimes.length}`);
+        console.log(`  p50:        ${formatMs(percentile(enrichTimes, 50))}`);
+        console.log(`  p95:        ${formatMs(percentile(enrichTimes, 95))}`);
+        console.log(`  p99:        ${formatMs(percentile(enrichTimes, 99))}`);
+
+        if (listTimes.length > 0) {
+          console.log(chalk.bold("\nSession List Performance:\n"));
+          console.log(`  Samples:    ${listTimes.length}`);
+          console.log(`  p50:        ${formatMs(percentile(listTimes, 50))}`);
+          console.log(`  p95:        ${formatMs(percentile(listTimes, 95))}`);
+        }
+        console.log();
+      } catch (err) {
+        console.error(chalk.red("Error:"), err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/commands/perf.ts
+++ b/packages/cli/src/commands/perf.ts
@@ -33,7 +33,11 @@ export function registerPerf(program: Command): void {
         const requests = loadRequests(logDir, { since, route: opts.route });
 
         if (requests.length === 0) {
-          console.log(chalk.dim("No API request logs found."));
+          if (opts.json) {
+            console.log(JSON.stringify({}, null, 2));
+          } else {
+            console.log(chalk.dim("No API request logs found."));
+          }
           return;
         }
 

--- a/packages/cli/src/commands/perf.ts
+++ b/packages/cli/src/commands/perf.ts
@@ -12,25 +12,7 @@
 import chalk from "chalk";
 import type { Command } from "commander";
 import { loadConfig, getLogsDir, readLogsFromDir } from "@composio/ao-core";
-import { padCol } from "../lib/format.js";
-
-/** Parse a relative time string into a Date. */
-function parseSinceArg(since: string): Date {
-  const match = since.match(/^(\d+)(s|m|h|d)$/);
-  if (!match) {
-    const d = new Date(since);
-    if (!isNaN(d.getTime())) return d;
-    throw new Error(`Invalid time format: "${since}". Use "5m", "1h", "30s", or ISO 8601.`);
-  }
-  const value = parseInt(match[1], 10);
-  const unit = match[2];
-  const ms =
-    unit === "s" ? value * 1000 :
-    unit === "m" ? value * 60_000 :
-    unit === "h" ? value * 3_600_000 :
-    value * 86_400_000;
-  return new Date(Date.now() - ms);
-}
+import { padCol, parseSinceArg } from "../lib/format.js";
 
 function resolveLogDir(): string {
   const config = loadConfig();

--- a/packages/cli/src/commands/retrospective.ts
+++ b/packages/cli/src/commands/retrospective.ts
@@ -1,0 +1,187 @@
+/**
+ * `ao retro` — view and generate session retrospectives.
+ *
+ * Subcommands:
+ *   ao retro list      — list all retrospectives
+ *   ao retro show <id> — show retrospective for a session
+ *   ao retro generate <id> — manually generate a retrospective
+ */
+
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  loadConfig,
+  getRetrospectivesDir,
+  loadRetrospectives,
+  generateRetrospective,
+  saveRetrospective,
+  type Retrospective,
+} from "@composio/ao-core";
+
+function resolveRetroDir(): string {
+  const config = loadConfig();
+  const projectId = Object.keys(config.projects)[0];
+  if (!projectId) throw new Error("No projects configured.");
+  const project = config.projects[projectId];
+  return getRetrospectivesDir(config.configPath, project.path);
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+  if (ms < 86_400_000) return `${(ms / 3_600_000).toFixed(1)}h`;
+  return `${(ms / 86_400_000).toFixed(1)}d`;
+}
+
+function outcomeColor(outcome: Retrospective["outcome"]): string {
+  switch (outcome) {
+    case "success": return chalk.green(outcome);
+    case "failure": return chalk.red(outcome);
+    case "partial": return chalk.yellow(outcome);
+  }
+}
+
+export function registerRetrospective(program: Command): void {
+  const retroCmd = program
+    .command("retro")
+    .description("View and generate session retrospectives");
+
+  retroCmd
+    .command("list")
+    .description("List all retrospectives")
+    .option("-p, --project <id>", "Filter by project ID")
+    .option("-n, --limit <n>", "Limit results", "20")
+    .option("--json", "Output as JSON")
+    .action((opts: { project?: string; limit?: string; json?: boolean }) => {
+      try {
+        const retroDir = resolveRetroDir();
+        const retros = loadRetrospectives(retroDir, {
+          projectId: opts.project,
+          limit: parseInt(opts.limit ?? "20", 10),
+        });
+
+        if (opts.json) {
+          console.log(JSON.stringify(retros, null, 2));
+          return;
+        }
+
+        if (retros.length === 0) {
+          console.log(chalk.dim("No retrospectives found."));
+          return;
+        }
+
+        // Table header
+        console.log(
+          chalk.dim(
+            "  " +
+            "Session".padEnd(18) +
+            "Outcome".padEnd(10) +
+            "Duration".padEnd(10) +
+            "CI".padEnd(5) +
+            "Rev".padEnd(5) +
+            "Date",
+          ),
+        );
+        console.log(chalk.dim("  " + "─".repeat(65)));
+
+        for (const retro of retros) {
+          const date = new Date(retro.generatedAt).toLocaleDateString();
+          console.log(
+            "  " +
+            chalk.cyan(retro.sessionId.padEnd(18)) +
+            outcomeColor(retro.outcome).padEnd(10 + 10) + // extra for ANSI
+            formatDuration(retro.metrics.totalDurationMs).padEnd(10) +
+            String(retro.metrics.ciFailures).padEnd(5) +
+            String(retro.metrics.reviewRounds).padEnd(5) +
+            chalk.dim(date),
+          );
+        }
+        console.log(chalk.dim(`\n  ${retros.length} retrospectives`));
+      } catch (err) {
+        console.error(chalk.red("Error:"), err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  retroCmd
+    .command("show <session-id>")
+    .description("Show detailed retrospective for a session")
+    .option("--json", "Output as JSON")
+    .action((sessionId: string, opts: { json?: boolean }) => {
+      try {
+        const retroDir = resolveRetroDir();
+        const retros = loadRetrospectives(retroDir, { sessionId, limit: 1 });
+
+        if (retros.length === 0) {
+          console.log(chalk.yellow(`No retrospective found for session "${sessionId}"`));
+          return;
+        }
+
+        const retro = retros[0];
+
+        if (opts.json) {
+          console.log(JSON.stringify(retro, null, 2));
+          return;
+        }
+
+        console.log(chalk.bold(`\nRetrospective: ${chalk.cyan(retro.sessionId)}\n`));
+        console.log(`  Outcome:  ${outcomeColor(retro.outcome)}`);
+        console.log(`  Duration: ${formatDuration(retro.metrics.totalDurationMs)}`);
+        console.log(`  CI failures: ${retro.metrics.ciFailures}`);
+        console.log(`  Review rounds: ${retro.metrics.reviewRounds}`);
+        if (retro.reportCard.prUrl) {
+          console.log(`  PR: ${chalk.blue(retro.reportCard.prUrl)}`);
+        }
+
+        if (retro.timeline.length > 0) {
+          console.log(chalk.bold("\n  Timeline:"));
+          for (const event of retro.timeline.slice(0, 20)) {
+            const time = new Date(event.at).toLocaleTimeString();
+            console.log(`    ${chalk.dim(time)} ${event.detail}`);
+          }
+          if (retro.timeline.length > 20) {
+            console.log(chalk.dim(`    ... ${retro.timeline.length - 20} more events`));
+          }
+        }
+
+        if (retro.lessons.length > 0) {
+          console.log(chalk.bold("\n  Lessons:"));
+          for (const lesson of retro.lessons) {
+            console.log(`    ${chalk.yellow("*")} ${lesson}`);
+          }
+        }
+        console.log();
+      } catch (err) {
+        console.error(chalk.red("Error:"), err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  retroCmd
+    .command("generate <session-id>")
+    .description("Manually generate a retrospective for a session")
+    .action((sessionId: string) => {
+      try {
+        const config = loadConfig();
+        const projectId = Object.keys(config.projects)[0];
+        if (!projectId) throw new Error("No projects configured.");
+
+        const retro = generateRetrospective(sessionId, config, projectId);
+        if (!retro) {
+          console.log(chalk.yellow(`Could not generate retrospective for "${sessionId}"`));
+          return;
+        }
+
+        const retroDir = resolveRetroDir();
+        saveRetrospective(retro, retroDir);
+
+        console.log(chalk.green(`Retrospective generated for ${sessionId}`));
+        console.log(`  Outcome: ${outcomeColor(retro.outcome)}`);
+        console.log(`  Duration: ${formatDuration(retro.metrics.totalDurationMs)}`);
+        console.log(`  Saved to: ${chalk.dim(retroDir)}`);
+      } catch (err) {
+        console.error(chalk.red("Error:"), err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/commands/retrospective.ts
+++ b/packages/cli/src/commands/retrospective.ts
@@ -11,7 +11,7 @@ import chalk from "chalk";
 import type { Command } from "commander";
 import {
   loadConfig,
-  getRetrospectivesDir,
+  resolveProjectRetroDir,
   loadRetrospectives,
   generateRetrospective,
   saveRetrospective,
@@ -20,10 +20,9 @@ import {
 
 function resolveRetroDir(): string {
   const config = loadConfig();
-  const projectId = Object.keys(config.projects)[0];
-  if (!projectId) throw new Error("No projects configured.");
-  const project = config.projects[projectId];
-  return getRetrospectivesDir(config.configPath, project.path);
+  const dir = resolveProjectRetroDir(config);
+  if (!dir) throw new Error("No projects configured.");
+  return dir;
 }
 
 function formatDuration(ms: number): string {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,9 @@ import { registerReviewCheck } from "./commands/review-check.js";
 import { registerDashboard } from "./commands/dashboard.js";
 import { registerOpen } from "./commands/open.js";
 import { registerStart, registerStop } from "./commands/start.js";
+import { registerLogs } from "./commands/logs.js";
+import { registerRetrospective } from "./commands/retrospective.js";
+import { registerPerf } from "./commands/perf.js";
 
 const program = new Command();
 
@@ -29,5 +32,8 @@ registerSend(program);
 registerReviewCheck(program);
 registerDashboard(program);
 registerOpen(program);
+registerLogs(program);
+registerRetrospective(program);
+registerPerf(program);
 
 program.parse();

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -104,6 +104,12 @@ export function activityIcon(activity: ActivityState | null): string {
   }
 }
 
+/** Format milliseconds as human-readable duration. */
+export function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
 /** Parse a relative time string like "5m", "1h", "30s", "2d" into a Date. Also accepts ISO 8601. */
 export function parseSinceArg(since: string): Date {
   const match = since.match(/^(\d+)(s|m|h|d)$/);

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -104,6 +104,24 @@ export function activityIcon(activity: ActivityState | null): string {
   }
 }
 
+/** Parse a relative time string like "5m", "1h", "30s", "2d" into a Date. Also accepts ISO 8601. */
+export function parseSinceArg(since: string): Date {
+  const match = since.match(/^(\d+)(s|m|h|d)$/);
+  if (!match) {
+    const d = new Date(since);
+    if (!isNaN(d.getTime())) return d;
+    throw new Error(`Invalid time format: "${since}". Use "5m", "1h", "30s", or ISO 8601.`);
+  }
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+  const ms =
+    unit === "s" ? value * 1000 :
+    unit === "m" ? value * 60_000 :
+    unit === "h" ? value * 3_600_000 :
+    value * 86_400_000;
+  return new Date(Date.now() - ms);
+}
+
 // eslint-disable-next-line no-control-regex
 const ANSI_RE = /\u001b\[[0-9;]*m/g;
 

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import type { CIStatus, ReviewDecision, ActivityState } from "@composio/ao-core";
+import type { CIStatus, ReviewDecision, ActivityState, LogEntry } from "@composio/ao-core";
 
 export function header(title: string): string {
   const line = "─".repeat(76);
@@ -126,6 +126,25 @@ export function parseSinceArg(since: string): Date {
     unit === "h" ? value * 3_600_000 :
     value * 86_400_000;
   return new Date(Date.now() - ms);
+}
+
+/** Color-code log level for terminal display. */
+export function colorLevel(level: LogEntry["level"]): string {
+  switch (level) {
+    case "error": return chalk.red("ERR");
+    case "warn": return chalk.yellow("WRN");
+    case "stderr": return chalk.red("err");
+    case "stdout": return chalk.dim("out");
+    case "info": return chalk.blue("inf");
+  }
+}
+
+/** Format a log entry for terminal display. */
+export function formatLogEntry(entry: LogEntry): string {
+  const ts = new Date(entry.ts).toLocaleTimeString();
+  const level = colorLevel(entry.level);
+  const session = entry.sessionId ? chalk.cyan(entry.sessionId) + " " : "";
+  return `${chalk.dim(ts)} ${level} ${session}${entry.message}`;
 }
 
 // eslint-disable-next-line no-control-regex

--- a/packages/cli/src/lib/perf-utils.ts
+++ b/packages/cli/src/lib/perf-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared helpers for performance analysis commands.
+ * Used by `ao perf` and potentially other CLI commands that read API logs.
+ */
+
+import { loadConfig, resolveProjectLogDir, readLogsFromDir } from "@composio/ao-core";
+
+export interface ParsedRequest {
+  ts: string;
+  method: string;
+  path: string;
+  statusCode: number;
+  durationMs: number;
+  error?: string;
+  timings?: Record<string, number>;
+  cacheStats?: { hits: number; misses: number; hitRate: number; size: number };
+}
+
+/** Resolve the log directory from config. Throws if no projects configured. */
+export function resolveLogDir(): string {
+  const config = loadConfig();
+  const dir = resolveProjectLogDir(config);
+  if (!dir) throw new Error("No projects configured. Run `ao init` first.");
+  return dir;
+}
+
+/** Parse API log entries into typed request objects. */
+export function loadRequests(logDir: string, opts?: { since?: Date; route?: string }): ParsedRequest[] {
+  const entries = readLogsFromDir(logDir, "api", {
+    source: "api",
+    since: opts?.since,
+  });
+
+  const requests: ParsedRequest[] = [];
+  for (const entry of entries) {
+    const data = entry.data ?? {};
+    if (!data["method"] || !data["path"]) continue;
+
+    const req: ParsedRequest = {
+      ts: entry.ts,
+      method: String(data["method"]),
+      path: String(data["path"]),
+      statusCode: Number(data["statusCode"]) || 0,
+      durationMs: Number(data["durationMs"]) || 0,
+      error: data["error"] ? String(data["error"]) : undefined,
+      timings: data["timings"] as Record<string, number> | undefined,
+      cacheStats: data["cacheStats"] as ParsedRequest["cacheStats"] | undefined,
+    };
+
+    if (opts?.route && !req.path.includes(opts.route)) continue;
+    requests.push(req);
+  }
+
+  return requests;
+}

--- a/packages/cli/src/lib/perf-utils.ts
+++ b/packages/cli/src/lib/perf-utils.ts
@@ -3,18 +3,8 @@
  * Used by `ao perf` and potentially other CLI commands that read API logs.
  */
 
-import { loadConfig, resolveProjectLogDir, readLogsFromDir } from "@composio/ao-core";
-
-export interface ParsedRequest {
-  ts: string;
-  method: string;
-  path: string;
-  statusCode: number;
-  durationMs: number;
-  error?: string;
-  timings?: Record<string, number>;
-  cacheStats?: { hits: number; misses: number; hitRate: number; size: number };
-}
+import { loadConfig, resolveProjectLogDir, parseApiLogs } from "@composio/ao-core";
+export type { ApiLogEntry as ParsedRequest } from "@composio/ao-core";
 
 /** Resolve the log directory from config. Throws if no projects configured. */
 export function resolveLogDir(): string {
@@ -25,31 +15,6 @@ export function resolveLogDir(): string {
 }
 
 /** Parse API log entries into typed request objects. */
-export function loadRequests(logDir: string, opts?: { since?: Date; route?: string }): ParsedRequest[] {
-  const entries = readLogsFromDir(logDir, "api", {
-    source: "api",
-    since: opts?.since,
-  });
-
-  const requests: ParsedRequest[] = [];
-  for (const entry of entries) {
-    const data = entry.data ?? {};
-    if (!data["method"] || !data["path"]) continue;
-
-    const req: ParsedRequest = {
-      ts: entry.ts,
-      method: String(data["method"]),
-      path: String(data["path"]),
-      statusCode: Number(data["statusCode"]) || 0,
-      durationMs: Number(data["durationMs"]) || 0,
-      error: data["error"] ? String(data["error"]) : undefined,
-      timings: data["timings"] as Record<string, number> | undefined,
-      cacheStats: data["cacheStats"] as ParsedRequest["cacheStats"] | undefined,
-    };
-
-    if (opts?.route && !req.path.includes(opts.route)) continue;
-    requests.push(req);
-  }
-
-  return requests;
+export function loadRequests(logDir: string, opts?: { since?: Date; route?: string }) {
+  return parseApiLogs(logDir, opts);
 }

--- a/packages/core/src/__tests__/dashboard-manager.test.ts
+++ b/packages/core/src/__tests__/dashboard-manager.test.ts
@@ -1,0 +1,967 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import type { DashboardRestartOpts } from "../dashboard-manager.js";
+
+// ---------------------------------------------------------------------------
+// Hoisted mock functions — vi.hoisted() runs before vi.mock factories
+// ---------------------------------------------------------------------------
+const {
+  mockExecFile,
+  mockSpawn,
+  mockExistsSync,
+  mockReadFileSync,
+  mockWriteFileSync,
+  mockUnlinkSync,
+  mockRmSync,
+  mockMkdirSync,
+  mockOpenSync,
+  mockCloseSync,
+  mockFetch,
+} = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+  mockSpawn: vi.fn(),
+  mockExistsSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+  mockUnlinkSync: vi.fn(),
+  mockRmSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockOpenSync: vi.fn(),
+  mockCloseSync: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock node:child_process
+// ---------------------------------------------------------------------------
+vi.mock("node:child_process", () => ({
+  execFile: mockExecFile,
+  spawn: mockSpawn,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock node:fs
+// ---------------------------------------------------------------------------
+vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+  unlinkSync: mockUnlinkSync,
+  rmSync: mockRmSync,
+  mkdirSync: mockMkdirSync,
+  openSync: mockOpenSync,
+  closeSync: mockCloseSync,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock node:util — promisify wraps our mock execFile as a promise-returning fn
+// ---------------------------------------------------------------------------
+vi.mock("node:util", () => ({
+  promisify: (fn: unknown) => {
+    if (fn === mockExecFile) {
+      return (...args: unknown[]) => {
+        return new Promise((resolve, reject) => {
+          (fn as Function)(...args, (err: Error | null, stdout: string, stderr: string) => {
+            if (err) reject(err);
+            else resolve({ stdout, stderr });
+          });
+        });
+      };
+    }
+    throw new Error("promisify called with unexpected function");
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock global fetch for waitForHealthy
+// ---------------------------------------------------------------------------
+vi.stubGlobal("fetch", mockFetch);
+
+// ---------------------------------------------------------------------------
+// Import the module under test (after all mocks are wired)
+// ---------------------------------------------------------------------------
+import {
+  readPidFile,
+  writePidFile,
+  removePidFile,
+  waitForHealthy,
+  getDashboardStatus,
+  stopDashboard,
+  restartDashboard,
+} from "../dashboard-manager.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Simulate a successful `lsof` call returning a PID. */
+function mockLsofReturnsPid(pid: number): void {
+  mockExecFile.mockImplementation(
+    (
+      cmd: string,
+      _args: string[],
+      _opts: unknown,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      if (cmd === "lsof") {
+        cb(null, `${pid}\n`, "");
+      } else {
+        cb(new Error("unknown command"), "", "");
+      }
+    },
+  );
+}
+
+/** Simulate `lsof` finding nothing (exit code 1). */
+function mockLsofReturnsEmpty(): void {
+  mockExecFile.mockImplementation(
+    (
+      cmd: string,
+      _args: string[],
+      _opts: unknown,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      if (cmd === "lsof") {
+        cb(new Error("exit code 1"), "", "");
+      } else {
+        cb(new Error("unknown command"), "", "");
+      }
+    },
+  );
+}
+
+/** Create a fake ChildProcess-like object from spawn. */
+function makeFakeChild(pid: number | undefined): Partial<ChildProcess> {
+  return {
+    pid,
+    unref: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  // Reset all mocks individually so implementations are cleared
+  mockExecFile.mockReset();
+  mockSpawn.mockReset();
+  mockExistsSync.mockReset();
+  mockReadFileSync.mockReset();
+  mockWriteFileSync.mockReset();
+  mockUnlinkSync.mockReset();
+  mockRmSync.mockReset();
+  mockMkdirSync.mockReset();
+  mockOpenSync.mockReset();
+  mockCloseSync.mockReset();
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// =========================================================================
+// readPidFile
+// =========================================================================
+describe("readPidFile", () => {
+  it("returns null when PID file does not exist", () => {
+    mockExistsSync.mockReturnValue(false);
+
+    expect(readPidFile("/tmp/logs")).toBeNull();
+    expect(mockExistsSync).toHaveBeenCalledWith("/tmp/logs/dashboard.pid");
+  });
+
+  it("returns PID when file exists and process is alive", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("42\n");
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = readPidFile("/tmp/logs");
+
+    expect(result).toBe(42);
+    expect(killSpy).toHaveBeenCalledWith(42, 0);
+  });
+
+  it("returns null and cleans up when PID file contains NaN", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("not-a-number\n");
+
+    const result = readPidFile("/tmp/logs");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null and removes stale PID file when process is dead", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("99999\n");
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+
+    const result = readPidFile("/tmp/logs");
+
+    expect(result).toBeNull();
+    expect(killSpy).toHaveBeenCalledWith(99999, 0);
+    // Should attempt to remove the stale PID file
+    expect(mockUnlinkSync).toHaveBeenCalledWith("/tmp/logs/dashboard.pid");
+  });
+
+  it("handles unlink failure gracefully when cleaning stale PID", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("99999\n");
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    mockUnlinkSync.mockImplementation(() => {
+      throw new Error("EACCES");
+    });
+
+    // Should not throw even if unlink fails
+    expect(() => readPidFile("/tmp/logs")).not.toThrow();
+    expect(readPidFile("/tmp/logs")).toBeNull();
+  });
+});
+
+// =========================================================================
+// writePidFile
+// =========================================================================
+describe("writePidFile", () => {
+  it("writes the PID as a string to the correct path", () => {
+    writePidFile("/tmp/logs", 1234);
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      "/tmp/logs/dashboard.pid",
+      "1234",
+      "utf-8",
+    );
+  });
+
+  it("handles large PIDs", () => {
+    writePidFile("/var/ao", 4294967295);
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      "/var/ao/dashboard.pid",
+      "4294967295",
+      "utf-8",
+    );
+  });
+});
+
+// =========================================================================
+// removePidFile
+// =========================================================================
+describe("removePidFile", () => {
+  it("removes the PID file when it exists", () => {
+    mockExistsSync.mockReturnValue(true);
+
+    removePidFile("/tmp/logs");
+
+    expect(mockUnlinkSync).toHaveBeenCalledWith("/tmp/logs/dashboard.pid");
+  });
+
+  it("does nothing when PID file does not exist", () => {
+    mockExistsSync.mockReturnValue(false);
+
+    removePidFile("/tmp/logs");
+
+    expect(mockUnlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when unlink fails", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockUnlinkSync.mockImplementation(() => {
+      throw new Error("EACCES");
+    });
+
+    expect(() => removePidFile("/tmp/logs")).not.toThrow();
+  });
+
+  it("does not throw when existsSync fails", () => {
+    mockExistsSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    expect(() => removePidFile("/tmp/logs")).not.toThrow();
+  });
+});
+
+// =========================================================================
+// waitForHealthy
+// =========================================================================
+describe("waitForHealthy", () => {
+  it("returns true when fetch succeeds with 200", async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    const result = await waitForHealthy(3000, 5000);
+
+    expect(result).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:3000",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("returns true when server responds with 404", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404 });
+
+    const result = await waitForHealthy(3000, 5000);
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false on timeout when fetch keeps failing", async () => {
+    vi.useFakeTimers();
+
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const resultPromise = waitForHealthy(3000, 3000);
+
+    // The function polls every 1000ms. Advance past the deadline.
+    // First attempt: immediate, fails -> waits 1000ms
+    await vi.advanceTimersByTimeAsync(1000);
+    // Second attempt: fails -> waits 1000ms
+    await vi.advanceTimersByTimeAsync(1000);
+    // Third attempt: fails -> waits 1000ms
+    await vi.advanceTimersByTimeAsync(1000);
+    // Past deadline, should exit loop
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await resultPromise;
+    expect(result).toBe(false);
+  });
+
+  it("succeeds after initial failures when server eventually responds", async () => {
+    vi.useFakeTimers();
+
+    let callCount = 0;
+    mockFetch.mockImplementation(() => {
+      callCount++;
+      if (callCount < 3) {
+        return Promise.reject(new Error("ECONNREFUSED"));
+      }
+      return Promise.resolve({ ok: true, status: 200 });
+    });
+
+    const resultPromise = waitForHealthy(3000, 10_000);
+
+    // First call fails immediately, then waits 1000ms
+    await vi.advanceTimersByTimeAsync(1000);
+    // Second call fails, waits 1000ms
+    await vi.advanceTimersByTimeAsync(1000);
+    // Third call succeeds (callCount === 3)
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await resultPromise;
+    expect(result).toBe(true);
+  });
+
+  it("handles 500 server error (not ok, not 404) and retries", async () => {
+    vi.useFakeTimers();
+
+    let callCount = 0;
+    mockFetch.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // Server error — not ok and not 404
+        return Promise.resolve({ ok: false, status: 500 });
+      }
+      return Promise.resolve({ ok: true, status: 200 });
+    });
+
+    const resultPromise = waitForHealthy(3000, 10_000);
+
+    // First attempt returns 500, but res.ok is false and status != 404, so no early return.
+    // Wait for poll interval
+    await vi.advanceTimersByTimeAsync(1000);
+    // Second attempt returns 200
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await resultPromise;
+    expect(result).toBe(true);
+  });
+
+  it("uses default timeout of 30000ms", async () => {
+    vi.useFakeTimers();
+
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const resultPromise = waitForHealthy(3000);
+
+    // Advance 30 seconds + a bit to exceed the deadline
+    for (let i = 0; i < 32; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+
+    const result = await resultPromise;
+    expect(result).toBe(false);
+  });
+});
+
+// =========================================================================
+// getDashboardStatus
+// =========================================================================
+describe("getDashboardStatus", () => {
+  it('returns pid_file source when PID file has a live process', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("1234\n");
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    mockLsofReturnsEmpty(); // port scan would find nothing
+
+    const status = await getDashboardStatus("/tmp/logs", 3000);
+
+    expect(status).toEqual({ running: true, pid: 1234, source: "pid_file" });
+  });
+
+  it('returns port_scan source when no PID file but port is occupied', async () => {
+    // PID file does not exist
+    mockExistsSync.mockReturnValue(false);
+    // lsof finds a process on the port
+    mockLsofReturnsPid(5678);
+
+    const status = await getDashboardStatus("/tmp/logs", 3000);
+
+    expect(status).toEqual({ running: true, pid: 5678, source: "port_scan" });
+  });
+
+  it("returns not running when neither PID file nor port scan finds a process", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockLsofReturnsEmpty();
+
+    const status = await getDashboardStatus("/tmp/logs", 3000);
+
+    expect(status).toEqual({ running: false, pid: null, source: null });
+  });
+
+  it("prefers PID file over port scan when both would find a process", async () => {
+    // PID file exists and is alive
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("1111\n");
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    // Port scan would also find something
+    mockLsofReturnsPid(2222);
+
+    const status = await getDashboardStatus("/tmp/logs", 3000);
+
+    // Should return the PID from the file, not from port scan
+    expect(status).toEqual({ running: true, pid: 1111, source: "pid_file" });
+  });
+
+  it("falls back to port scan when PID file has stale process", async () => {
+    // First call to existsSync (in readPidFile) returns true for PID file
+    // but process.kill throws (stale PID)
+    mockExistsSync.mockImplementation((path: string) => {
+      return (path as string).endsWith("dashboard.pid");
+    });
+    mockReadFileSync.mockReturnValue("9999\n");
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    mockLsofReturnsPid(5555);
+
+    const status = await getDashboardStatus("/tmp/logs", 3000);
+
+    // readPidFile returns null (stale), falls through to port scan
+    expect(status).toEqual({ running: true, pid: 5555, source: "port_scan" });
+  });
+});
+
+// =========================================================================
+// stopDashboard
+// =========================================================================
+describe("stopDashboard", () => {
+  it("returns false when no process is found", async () => {
+    // No PID file
+    mockExistsSync.mockReturnValue(false);
+    // No process on port
+    mockLsofReturnsEmpty();
+
+    const result = await stopDashboard("/tmp/logs", 3000);
+
+    expect(result).toBe(false);
+  });
+
+  it("kills process found via PID file and returns true", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("1234\n");
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    // After kill, lsof should find nothing (port released)
+    let lsofCallCount = 0;
+    mockExecFile.mockImplementation(
+      (
+        cmd: string,
+        _args: string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        if (cmd === "lsof") {
+          lsofCallCount++;
+          // First call in findPidOnPort from stopDashboard returns the PID,
+          // subsequent calls from waitForPortFree return nothing (port freed)
+          if (lsofCallCount <= 1) {
+            cb(null, "1234\n", "");
+          } else {
+            cb(new Error("exit code 1"), "", "");
+          }
+        }
+      },
+    );
+
+    const result = await stopDashboard("/tmp/logs", 3000);
+
+    expect(result).toBe(true);
+    // Check that SIGTERM was sent (call 0 is the kill(pid,0) check, call 1 is SIGTERM)
+    expect(killSpy).toHaveBeenCalledWith(1234, "SIGTERM");
+  });
+
+  it("kills process found via port scan when no PID file", async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    let lsofCallCount = 0;
+    mockExecFile.mockImplementation(
+      (
+        cmd: string,
+        _args: string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        if (cmd === "lsof") {
+          lsofCallCount++;
+          // First call finds the PID, second call in waitForPortFree finds nothing
+          if (lsofCallCount <= 1) {
+            cb(null, "5678\n", "");
+          } else {
+            cb(new Error("exit code 1"), "", "");
+          }
+        }
+      },
+    );
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await stopDashboard("/tmp/logs", 3000);
+
+    expect(result).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(5678, "SIGTERM");
+  });
+
+  it("handles process already exited when sending SIGTERM", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("1234\n");
+
+    let killCallCount = 0;
+    vi.spyOn(process, "kill").mockImplementation((...args: unknown[]) => {
+      killCallCount++;
+      if (killCallCount === 1) {
+        // kill(pid, 0) — alive check succeeds
+        return true;
+      }
+      // kill(pid, SIGTERM) — process already gone
+      throw new Error("ESRCH");
+    });
+
+    // Port is already free (process already exited)
+    mockLsofReturnsEmpty();
+
+    const result = await stopDashboard("/tmp/logs", 3000);
+
+    expect(result).toBe(true);
+  });
+
+  it("removes PID file after stopping", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue("1234\n");
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    mockLsofReturnsEmpty();
+
+    await stopDashboard("/tmp/logs", 3000);
+
+    // removePidFile checks existsSync and calls unlinkSync
+    expect(mockUnlinkSync).toHaveBeenCalled();
+  });
+});
+
+// =========================================================================
+// restartDashboard
+// =========================================================================
+describe("restartDashboard", () => {
+  function makeOpts(overrides: Partial<DashboardRestartOpts> = {}): DashboardRestartOpts {
+    return {
+      webDir: "/app/packages/web",
+      logDir: "/tmp/ao-logs",
+      ...overrides,
+    };
+  }
+
+  /** Set up mocks for a fresh start (no existing process). */
+  function setupFreshStart(spawnPid: number = 12345): void {
+    // No PID file
+    mockExistsSync.mockReturnValue(false);
+    // No process on port
+    mockLsofReturnsEmpty();
+    // openSync returns file descriptors
+    mockOpenSync.mockReturnValueOnce(10).mockReturnValueOnce(11);
+    // spawn returns a child with a PID
+    mockSpawn.mockReturnValue(makeFakeChild(spawnPid));
+  }
+
+  it("spawns a new process when no existing process is running", async () => {
+    setupFreshStart(42);
+
+    const result = await restartDashboard(makeOpts());
+
+    expect(result).toEqual({ pid: 42, killed: false, cleaned: false });
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "npx",
+      ["next", "dev", "-p", "3000"],
+      expect.objectContaining({
+        cwd: "/app/packages/web",
+        detached: true,
+      }),
+    );
+  });
+
+  it("uses specified port instead of default 3000", async () => {
+    setupFreshStart(100);
+
+    const result = await restartDashboard(makeOpts({ port: 8080 }));
+
+    expect(result.pid).toBe(100);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "npx",
+      ["next", "dev", "-p", "8080"],
+      expect.objectContaining({
+        cwd: "/app/packages/web",
+      }),
+    );
+  });
+
+  it("kills existing process found via PID file", async () => {
+    // PID file says process 999 is running
+    const existsSyncImpl = (path: string) => {
+      if ((path as string).endsWith("dashboard.pid")) return true;
+      if ((path as string).endsWith(".next")) return false;
+      return false;
+    };
+    mockExistsSync.mockImplementation(existsSyncImpl);
+    mockReadFileSync.mockReturnValue("999\n");
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    // lsof: first call for initial findPidOnPort (in restartDashboard),
+    // subsequent calls for waitForPortFree should find nothing
+    let lsofCallCount = 0;
+    mockExecFile.mockImplementation(
+      (
+        cmd: string,
+        _args: string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        if (cmd === "lsof") {
+          lsofCallCount++;
+          if (lsofCallCount <= 1) {
+            cb(null, "999\n", "");
+          } else {
+            cb(new Error("exit code 1"), "", "");
+          }
+        }
+      },
+    );
+
+    mockOpenSync.mockReturnValueOnce(10).mockReturnValueOnce(11);
+    mockSpawn.mockReturnValue(makeFakeChild(1000));
+
+    const result = await restartDashboard(makeOpts());
+
+    expect(result.killed).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(999, "SIGTERM");
+  });
+
+  it("kills existing process found via port scan when no PID file", async () => {
+    mockExistsSync.mockImplementation((path: string) => {
+      if ((path as string).endsWith("dashboard.pid")) return false;
+      return false;
+    });
+
+    let lsofCallCount = 0;
+    mockExecFile.mockImplementation(
+      (
+        cmd: string,
+        _args: string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        if (cmd === "lsof") {
+          lsofCallCount++;
+          if (lsofCallCount <= 1) {
+            cb(null, "888\n", "");
+          } else {
+            cb(new Error("exit code 1"), "", "");
+          }
+        }
+      },
+    );
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    mockOpenSync.mockReturnValueOnce(10).mockReturnValueOnce(11);
+    mockSpawn.mockReturnValue(makeFakeChild(2000));
+
+    const result = await restartDashboard(makeOpts());
+
+    expect(result.killed).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(888, "SIGTERM");
+    expect(result.pid).toBe(2000);
+  });
+
+  it("cleans .next directory when clean: true and .next exists", async () => {
+    mockExistsSync.mockImplementation((path: string) => {
+      if ((path as string).endsWith("dashboard.pid")) return false;
+      if ((path as string).endsWith(".next")) return true;
+      // logDir exists
+      return true;
+    });
+    mockLsofReturnsEmpty();
+    mockOpenSync.mockReturnValueOnce(10).mockReturnValueOnce(11);
+    mockSpawn.mockReturnValue(makeFakeChild(500));
+
+    const result = await restartDashboard(makeOpts({ clean: true }));
+
+    expect(result.cleaned).toBe(true);
+    expect(mockRmSync).toHaveBeenCalledWith(
+      expect.stringContaining(".next"),
+      { recursive: true, force: true },
+    );
+  });
+
+  it("does not clean when clean: true but .next does not exist", async () => {
+    // All existsSync calls return false (no PID, no .next)
+    mockExistsSync.mockReturnValue(false);
+    mockLsofReturnsEmpty();
+    mockOpenSync.mockReturnValueOnce(10).mockReturnValueOnce(11);
+    mockSpawn.mockReturnValue(makeFakeChild(500));
+
+    const result = await restartDashboard(makeOpts({ clean: true }));
+
+    expect(result.cleaned).toBe(false);
+    expect(mockRmSync).not.toHaveBeenCalled();
+  });
+
+  it("does not clean when clean option is not set", async () => {
+    setupFreshStart(500);
+
+    const result = await restartDashboard(makeOpts());
+
+    expect(result.cleaned).toBe(false);
+    expect(mockRmSync).not.toHaveBeenCalled();
+  });
+
+  it("creates log directory if it does not exist", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockLsofReturnsEmpty();
+    mockOpenSync.mockReturnValueOnce(10).mockReturnValueOnce(11);
+    mockSpawn.mockReturnValue(makeFakeChild(123));
+
+    await restartDashboard(makeOpts({ logDir: "/new/logs" }));
+
+    expect(mockMkdirSync).toHaveBeenCalledWith("/new/logs", { recursive: true });
+  });
+
+  it("opens log files for stdout and stderr", async () => {
+    setupFreshStart(123);
+
+    await restartDashboard(makeOpts({ logDir: "/tmp/ao-logs" }));
+
+    expect(mockOpenSync).toHaveBeenCalledWith("/tmp/ao-logs/dashboard.out.log", "a");
+    expect(mockOpenSync).toHaveBeenCalledWith("/tmp/ao-logs/dashboard.err.log", "a");
+  });
+
+  it("closes file descriptors after spawn", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockLsofReturnsEmpty();
+    mockOpenSync.mockReturnValueOnce(42).mockReturnValueOnce(43);
+    mockSpawn.mockReturnValue(makeFakeChild(100));
+
+    await restartDashboard(makeOpts());
+
+    expect(mockCloseSync).toHaveBeenCalledWith(42);
+    expect(mockCloseSync).toHaveBeenCalledWith(43);
+  });
+
+  it("unrefs the child process so parent can exit", async () => {
+    setupFreshStart(100);
+    const fakeChild = makeFakeChild(100);
+    mockSpawn.mockReturnValue(fakeChild);
+
+    await restartDashboard(makeOpts());
+
+    expect(fakeChild.unref).toHaveBeenCalled();
+  });
+
+  it("writes PID file after successful spawn", async () => {
+    setupFreshStart(7777);
+
+    await restartDashboard(makeOpts({ logDir: "/tmp/ao-logs" }));
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      "/tmp/ao-logs/dashboard.pid",
+      "7777",
+      "utf-8",
+    );
+  });
+
+  it("does not write PID file when spawn returns no PID", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockLsofReturnsEmpty();
+    mockOpenSync.mockReturnValueOnce(10).mockReturnValueOnce(11);
+    mockSpawn.mockReturnValue(makeFakeChild(undefined));
+
+    const result = await restartDashboard(makeOpts());
+
+    expect(result.pid).toBeNull();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it("calls onStatus with progress messages for fresh start", async () => {
+    setupFreshStart(555);
+    const messages: string[] = [];
+
+    await restartDashboard(
+      makeOpts({ onStatus: (msg) => messages.push(msg) }),
+    );
+
+    // Fresh start: only "Dashboard started" message
+    expect(messages.some((m) => m.includes("Dashboard started"))).toBe(true);
+    expect(messages.some((m) => m.includes("555"))).toBe(true);
+  });
+
+  it("calls onStatus with stop and start messages when killing existing", async () => {
+    mockExistsSync.mockImplementation((path: string) => {
+      if ((path as string).endsWith("dashboard.pid")) return true;
+      return false;
+    });
+    mockReadFileSync.mockReturnValue("100\n");
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    let lsofCallCount = 0;
+    mockExecFile.mockImplementation(
+      (
+        cmd: string,
+        _args: string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        if (cmd === "lsof") {
+          lsofCallCount++;
+          if (lsofCallCount <= 1) {
+            cb(null, "100\n", "");
+          } else {
+            cb(new Error("exit code 1"), "", "");
+          }
+        }
+      },
+    );
+    mockOpenSync.mockReturnValueOnce(10).mockReturnValueOnce(11);
+    mockSpawn.mockReturnValue(makeFakeChild(200));
+
+    const messages: string[] = [];
+
+    await restartDashboard(
+      makeOpts({ onStatus: (msg) => messages.push(msg) }),
+    );
+
+    expect(messages.some((m) => m.includes("Stopping"))).toBe(true);
+    expect(messages.some((m) => m.includes("stopped"))).toBe(true);
+    expect(messages.some((m) => m.includes("started"))).toBe(true);
+  });
+
+  it("calls onStatus with clean messages when cleaning", async () => {
+    mockExistsSync.mockImplementation((path: string) => {
+      if ((path as string).endsWith("dashboard.pid")) return false;
+      if ((path as string).endsWith(".next")) return true;
+      return true;
+    });
+    mockLsofReturnsEmpty();
+    mockOpenSync.mockReturnValueOnce(10).mockReturnValueOnce(11);
+    mockSpawn.mockReturnValue(makeFakeChild(300));
+
+    const messages: string[] = [];
+
+    await restartDashboard(
+      makeOpts({ clean: true, onStatus: (msg) => messages.push(msg) }),
+    );
+
+    expect(messages.some((m) => m.includes("Cleaning"))).toBe(true);
+    expect(messages.some((m) => m.includes("cleaned"))).toBe(true);
+  });
+
+  it("passes AO_CONFIG_PATH to the spawned process env", async () => {
+    setupFreshStart(100);
+
+    await restartDashboard(
+      makeOpts({ configPath: "/path/to/config.yaml" }),
+    );
+
+    const spawnCall = mockSpawn.mock.calls[0];
+    const spawnOpts = spawnCall[2];
+    expect(spawnOpts.env["AO_CONFIG_PATH"]).toBe("/path/to/config.yaml");
+  });
+
+  it("sets PORT in spawned process env", async () => {
+    setupFreshStart(100);
+
+    await restartDashboard(makeOpts({ port: 9999 }));
+
+    const spawnCall = mockSpawn.mock.calls[0];
+    const spawnOpts = spawnCall[2];
+    expect(spawnOpts.env["PORT"]).toBe("9999");
+  });
+
+  it("spawns process with stdio pointing to file descriptors", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockLsofReturnsEmpty();
+    mockOpenSync.mockReturnValueOnce(77).mockReturnValueOnce(88);
+    mockSpawn.mockReturnValue(makeFakeChild(100));
+
+    await restartDashboard(makeOpts());
+
+    const spawnCall = mockSpawn.mock.calls[0];
+    const spawnOpts = spawnCall[2];
+    expect(spawnOpts.stdio).toEqual(["ignore", 77, 88]);
+  });
+
+  it("returns full result with killed, cleaned, and pid", async () => {
+    // Existing process to kill
+    mockExistsSync.mockImplementation((path: string) => {
+      if ((path as string).endsWith("dashboard.pid")) return true;
+      if ((path as string).endsWith(".next")) return true;
+      return true;
+    });
+    mockReadFileSync.mockReturnValue("111\n");
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    let lsofCallCount = 0;
+    mockExecFile.mockImplementation(
+      (
+        cmd: string,
+        _args: string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        if (cmd === "lsof") {
+          lsofCallCount++;
+          if (lsofCallCount <= 1) {
+            cb(null, "111\n", "");
+          } else {
+            cb(new Error("exit code 1"), "", "");
+          }
+        }
+      },
+    );
+    mockOpenSync.mockReturnValueOnce(10).mockReturnValueOnce(11);
+    mockSpawn.mockReturnValue(makeFakeChild(222));
+
+    const result = await restartDashboard(
+      makeOpts({ clean: true }),
+    );
+
+    expect(result).toEqual({ pid: 222, killed: true, cleaned: true });
+  });
+});

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -866,3 +866,2036 @@ describe("getStates", () => {
     expect(lm.getStates().get("app-1")).toBe("working");
   });
 });
+
+// =============================================================================
+// Helper functions tested indirectly through the public API
+// =============================================================================
+
+describe("inferPriority (tested indirectly via notification routing)", () => {
+  /**
+   * inferPriority maps event types to priorities:
+   *   - "stuck"/"needs_input"/"errored" → "urgent"
+   *   - "approved"/"ready"/"merged"/"completed" → "action"
+   *   - "fail"/"changes_requested"/"conflicts" → "warning"
+   *   - "summary.*" → "info"
+   *   - everything else → "info"
+   *
+   * We test this by observing which notifiers get called based on
+   * notificationRouting config for different priority levels.
+   */
+
+  it("routes 'urgent' priority for stuck transitions", async () => {
+    const urgentNotifier: Notifier = {
+      name: "urgent-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "urgent-channel") return urgentNotifier;
+        return null;
+      }),
+    };
+
+    // Configure: only "urgent-channel" receives "urgent" priority
+    const urgentConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["urgent-channel"],
+        action: [],
+        warning: [],
+        info: [],
+      },
+      reactions: {},
+    };
+
+    // session.stuck has no reaction key mapping, so it should hit notifyHuman
+    // inferPriority("session.stuck") → "urgent"
+    // The session needs_input → stuck transition won't happen directly,
+    // but working → needs_input triggers "session.needs_input" → "urgent"
+    vi.mocked(mockAgent.detectActivity).mockReturnValue("waiting_input");
+
+    const session = makeSession({ status: "working" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: urgentConfig,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("needs_input");
+    // session.needs_input maps to "agent-needs-input" reaction key,
+    // but there's no reaction configured, so it should notify.
+    // inferPriority("session.needs_input") includes "needs_input" → "urgent"
+    expect(urgentNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session.needs_input",
+        priority: "urgent",
+      }),
+    );
+  });
+
+  it("routes 'warning' priority for ci.failing (no reaction configured)", async () => {
+    const warningNotifier: Notifier = {
+      name: "warning-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "warning-channel") return warningNotifier;
+        return null;
+      }),
+    };
+
+    const warningConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: [],
+        action: [],
+        warning: ["warning-channel"],
+        info: [],
+      },
+      reactions: {}, // No reaction for ci-failed, so it falls through to notifyHuman
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: warningConfig,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+    // inferPriority("ci.failing") includes "fail" → "warning"
+    expect(warningNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "ci.failing",
+        priority: "warning",
+      }),
+    );
+  });
+
+  it("routes 'action' priority for merge.completed", async () => {
+    const actionNotifier: Notifier = {
+      name: "action-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "action-channel") return actionNotifier;
+        return null;
+      }),
+    };
+
+    const actionConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: [],
+        action: ["action-channel"],
+        warning: [],
+        info: [],
+      },
+      reactions: {},
+    };
+
+    const session = makeSession({ status: "approved", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: actionConfig,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("merged");
+    // inferPriority("merge.completed") includes "completed" → "action"
+    expect(actionNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "merge.completed",
+        priority: "action",
+      }),
+    );
+  });
+
+  it("does not notify for 'info' priority transitions when no notifiers configured for info", async () => {
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    // session.working → inferPriority("session.working") = "info" (no special keywords)
+    const session = makeSession({ status: "spawning" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "spawning",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config, // default config has info: []
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("working");
+    // "session.working" → "info" priority → should NOT notify (info is not > info)
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+  });
+});
+
+describe("statusToEventType (tested indirectly via check transitions)", () => {
+  /**
+   * statusToEventType maps session status to event types.
+   * We verify by checking which event type reaches the notifier.
+   */
+
+  it("maps 'review_pending' status to 'review.pending' event (info priority, not notified)", async () => {
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("pending"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithAll: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const notifyConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: notifyConfig,
+      registry: registryWithAll,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    // pr_open → review_pending correctly maps to "review.pending" event type
+    expect(lm.getStates().get("app-1")).toBe("review_pending");
+    // inferPriority("review.pending") = "info" (no special keywords matched)
+    // The code only calls notifyHuman when priority !== "info", so no notification fires.
+    // This verifies that review.pending is correctly classified as info-level.
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+  });
+
+  it("maps 'changes_requested' status to 'review.changes_requested' event", async () => {
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("changes_requested"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithAll: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const notifyConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+      // No reaction for changes-requested, so notification will fire directly
+      reactions: {},
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: notifyConfig,
+      registry: registryWithAll,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("changes_requested");
+    // review.changes_requested has reaction key "changes-requested", but no reaction
+    // configured, so notifyHuman fires directly.
+    // inferPriority("review.changes_requested") → "warning" (contains "changes_requested")
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "review.changes_requested",
+        priority: "warning",
+      }),
+    );
+  });
+
+  it("returns null event type for 'spawning' status (no notification)", async () => {
+    // When a session remains in "spawning" status, statusToEventType returns null for
+    // spawning, so no event or notification is fired.
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    // For spawning → working, the event type is "session.working" (the TO status).
+    // But if we have a status that maps to null... that's only "spawning" as the TO value,
+    // which doesn't happen in normal flow. Instead, verify spawning → working produces
+    // session.working (not null), confirming the switch on the TO status.
+    const session = makeSession({ status: "spawning" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "spawning",
+      project: "my-app",
+    });
+
+    const notifyConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+    };
+
+    const lm = createLifecycleManager({
+      config: notifyConfig,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    // spawning → working; "session.working" → inferPriority = "info"
+    // info priority is not > info, so no notification is sent
+    expect(lm.getStates().get("app-1")).toBe("working");
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+  });
+});
+
+describe("eventToReactionKey (tested indirectly via reaction triggering)", () => {
+  /**
+   * eventToReactionKey maps event types to reaction config keys.
+   * We verify by configuring reactions with specific keys and
+   * checking they fire on the correct transitions.
+   */
+
+  it("maps review.changes_requested to 'changes-requested' reaction key", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("changes_requested"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const reactionConfig: OrchestratorConfig = {
+      ...config,
+      reactions: {
+        "changes-requested": {
+          auto: true,
+          action: "send-to-agent",
+          message: "Address the review feedback.",
+          retries: 3,
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: reactionConfig,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("changes_requested");
+    expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "Address the review feedback.");
+  });
+
+  it("maps merge.ready to 'approved-and-green' reaction key", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      }),
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const reactionConfig: OrchestratorConfig = {
+      ...config,
+      reactions: {
+        "approved-and-green": {
+          auto: true,
+          action: "auto-merge",
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: reactionConfig,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("mergeable");
+    // auto-merge reaction calls notifyHuman internally with "action" priority
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "reaction.triggered",
+        priority: "action",
+      }),
+    );
+  });
+
+  it("maps session.killed to 'agent-exited' reaction key", async () => {
+    vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const reactionConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+      reactions: {
+        "agent-exited": {
+          auto: true,
+          action: "notify",
+          priority: "warning",
+        },
+      },
+    };
+
+    const session = makeSession({ status: "working" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: reactionConfig,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("killed");
+    // agent-exited reaction with action="notify" calls notifyHuman with
+    // the configured priority ("warning")
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "reaction.triggered",
+        priority: "warning",
+      }),
+    );
+  });
+
+  it("falls through to direct notification for events without reaction keys", async () => {
+    // "review.approved" maps to "approved" status, event type "review.approved"
+    // eventToReactionKey does NOT have a mapping for "review.approved"
+    // (only "merge.ready" → "approved-and-green")
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: false,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: ["branch protection"],
+      }),
+    };
+
+    const registryWithAll: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const notifyConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: notifyConfig,
+      registry: registryWithAll,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    // Approved but not mergeable → "approved" status
+    expect(lm.getStates().get("app-1")).toBe("approved");
+    // review.approved has no reaction key → falls to notifyHuman
+    // inferPriority("review.approved") → "action" (contains "approved")
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "review.approved",
+        priority: "action",
+      }),
+    );
+  });
+});
+
+describe("createEvent (tested indirectly via notifier arguments)", () => {
+  it("populates all event fields including auto-inferred priority", async () => {
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithAll: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const notifyConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+    };
+
+    const session = makeSession({ status: "approved", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: notifyConfig,
+      registry: registryWithAll,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+    const event = vi.mocked(mockNotifier.notify).mock.calls[0][0];
+
+    // Verify all createEvent fields are populated
+    expect(event.id).toBeDefined();
+    expect(typeof event.id).toBe("string");
+    expect(event.id.length).toBeGreaterThan(0);
+    expect(event.type).toBe("merge.completed");
+    expect(event.priority).toBe("action"); // auto-inferred: "completed" → "action"
+    expect(event.sessionId).toBe("app-1");
+    expect(event.projectId).toBe("my-app");
+    expect(event.timestamp).toBeInstanceOf(Date);
+    expect(event.message).toContain("app-1");
+    expect(event.message).toContain("approved");
+    expect(event.message).toContain("merged");
+    expect(event.data).toEqual(
+      expect.objectContaining({
+        oldStatus: "approved",
+        newStatus: "merged",
+      }),
+    );
+  });
+});
+
+describe("parseDuration (tested indirectly via escalation logic)", () => {
+  /**
+   * parseDuration is used in executeReaction to compare escalateAfter
+   * duration strings against elapsed time. We test it by configuring
+   * escalateAfter with various duration strings and checking escalation.
+   */
+
+  it("does not time-escalate on first attempt even with short duration (tracker is fresh)", async () => {
+    // parseDuration("1h") = 3_600_000ms. Even with escalateAfter="1h",
+    // the first attempt won't trigger time-based escalation because no time
+    // has elapsed since firstTriggered. This verifies parseDuration("1h") is
+    // parsed correctly and the elapsed time comparison works.
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithAll: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const escalationConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent",
+          message: "Fix CI",
+          retries: 100,
+          escalateAfter: "1h", // 3_600_000ms — won't be exceeded on first attempt
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: escalationConfig,
+      registry: registryWithAll,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    // Should send to agent normally, no escalation
+    expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "Fix CI");
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+  });
+
+  it("parses '30s' duration correctly (escalation not triggered within 30s)", async () => {
+    // Verifies parseDuration("30s") = 30_000ms by configuring escalateAfter="30s"
+    // and confirming no escalation on the first attempt (elapsed time ~ 0ms < 30_000ms)
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithAll: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const escalationConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent",
+          message: "Fix CI",
+          retries: 100,
+          escalateAfter: "30s", // 30_000ms
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: escalationConfig,
+      registry: registryWithAll,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    // First attempt, no time elapsed: should send to agent, not escalate
+    expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "Fix CI");
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+  });
+
+  it("does not escalate when duration has not elapsed", async () => {
+    vi.useFakeTimers();
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithAll: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const escalationConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent",
+          message: "Fix CI",
+          retries: 100,
+          escalateAfter: "10m", // 10 minutes — won't elapse in this test
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: escalationConfig,
+      registry: registryWithAll,
+      sessionManager: mockSessionManager,
+    });
+
+    // Trigger first check: pr_open → ci_failed
+    await lm.check("app-1");
+
+    expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "Fix CI");
+    // Should NOT have escalated — only 0ms elapsed vs 10m threshold
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("treats invalid duration format as 0 (no time-based escalation)", async () => {
+    // parseDuration returns 0 for invalid formats. When escalateAfter = "invalid",
+    // durationMs = 0, and the condition `durationMs > 0` prevents time-based escalation.
+    // Only numeric retry-based escalation applies.
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithAll: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const invalidDurationConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent",
+          message: "Fix CI",
+          retries: 100,
+          escalateAfter: "invalid", // parseDuration returns 0 → durationMs > 0 is false
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: invalidDurationConfig,
+      registry: registryWithAll,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    // Should send to agent (not escalate), because invalid duration = 0 = no time escalation
+    expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "Fix CI");
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+  });
+});
+
+describe("pollAll (tested via start/stop with fake timers)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("polls all active sessions on each interval tick", async () => {
+    const sessions = [
+      makeSession({ id: "app-1", status: "working" }),
+      makeSession({ id: "app-2", status: "spawning" }),
+    ];
+
+    vi.mocked(mockSessionManager.list).mockResolvedValue(sessions);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+    writeMetadata(sessionsDir, "app-2", {
+      worktree: "/tmp",
+      branch: "feat/new",
+      status: "spawning",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(5000);
+
+    // Wait for initial pollAll to complete
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockSessionManager.list).toHaveBeenCalledTimes(1);
+
+    // After one interval
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockSessionManager.list).toHaveBeenCalledTimes(2);
+
+    // After another interval
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockSessionManager.list).toHaveBeenCalledTimes(3);
+
+    lm.stop();
+  });
+
+  it("skips terminal sessions (merged, killed) unless state changed from tracked", async () => {
+    const sessions = [
+      makeSession({ id: "app-1", status: "merged" }),
+      makeSession({ id: "app-2", status: "killed" }),
+      makeSession({ id: "app-3", status: "working" }),
+    ];
+
+    vi.mocked(mockSessionManager.list).mockResolvedValue(sessions);
+
+    writeMetadata(sessionsDir, "app-3", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(5000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const states = lm.getStates();
+    // app-3 is working and should have been polled
+    expect(states.get("app-3")).toBe("working");
+    // app-1 and app-2 are terminal with no tracked state diff, so they were skipped.
+    // They may or may not appear in states depending on the filter, but they should not
+    // have caused determineStatus calls. Since they're filtered out, they shouldn't
+    // appear in states at all (checkSession is never called for them).
+    expect(states.has("app-1")).toBe(false);
+    expect(states.has("app-2")).toBe(false);
+
+    lm.stop();
+  });
+
+  it("processes terminal sessions when tracked state differs from list() status", async () => {
+    // Simulate: session was previously tracked as "working" but list() now returns "killed"
+    // (e.g., runtime died and list() detected it)
+    const session = makeSession({ id: "app-1", status: "working" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    // First: track the session as "working" via check
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("working");
+
+    // Now list() returns it as "killed" — the session filter should include it
+    // because tracked state ("working") differs from list status ("killed")
+    const killedSession = makeSession({ id: "app-1", status: "killed" });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([killedSession]);
+    vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+
+    lm.start(5000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The session should now be tracked as "killed" after poll
+    expect(lm.getStates().get("app-1")).toBe("killed");
+
+    lm.stop();
+  });
+
+  it("handles errors in individual sessions without stopping the poll", async () => {
+    // Set up two sessions: app-1 will have an error config, app-2 should still be processed
+    const session1 = makeSession({
+      id: "app-1",
+      status: "working",
+      runtimeHandle: { id: "rt-err", runtimeName: "mock", data: {} },
+    });
+    const session2 = makeSession({
+      id: "app-2",
+      status: "spawning",
+      runtimeHandle: { id: "rt-ok", runtimeName: "mock", data: {} },
+    });
+
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session1, session2]);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+    writeMetadata(sessionsDir, "app-2", {
+      worktree: "/tmp",
+      branch: "feat/new",
+      status: "spawning",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(5000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // app-2 should have been polled successfully even if app-1 had issues
+    // (pollAll uses Promise.allSettled)
+    const states = lm.getStates();
+    expect(states.get("app-2")).toBe("working"); // spawning → working
+
+    lm.stop();
+  });
+
+  it("prunes stale entries from states map for removed sessions", async () => {
+    const session = makeSession({ id: "app-1", status: "working" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    // Track a session via check()
+    await lm.check("app-1");
+    expect(lm.getStates().has("app-1")).toBe(true);
+
+    // Now list returns no sessions (session was cleaned up externally)
+    vi.mocked(mockSessionManager.list).mockResolvedValue([]);
+
+    lm.start(5000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The stale entry should be pruned
+    expect(lm.getStates().has("app-1")).toBe(false);
+
+    lm.stop();
+  });
+
+  it("emits all-complete reaction when all sessions become terminal", async () => {
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const allCompleteConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+      reactions: {
+        "all-complete": {
+          auto: true,
+          action: "notify",
+          priority: "action",
+        },
+      },
+    };
+
+    // All sessions are terminal
+    const sessions = [
+      makeSession({ id: "app-1", status: "merged" }),
+      makeSession({ id: "app-2", status: "killed" }),
+    ];
+
+    vi.mocked(mockSessionManager.list).mockResolvedValue(sessions);
+
+    const lm = createLifecycleManager({
+      config: allCompleteConfig,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(5000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // all-complete reaction should have been triggered
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "reaction.triggered",
+      }),
+    );
+
+    lm.stop();
+  });
+
+  it("does not emit all-complete twice for the same terminal state", async () => {
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const allCompleteConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+      reactions: {
+        "all-complete": {
+          auto: true,
+          action: "notify",
+          priority: "action",
+        },
+      },
+    };
+
+    const sessions = [makeSession({ id: "app-1", status: "merged" })];
+    vi.mocked(mockSessionManager.list).mockResolvedValue(sessions);
+
+    const lm = createLifecycleManager({
+      config: allCompleteConfig,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(5000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const callCount = vi.mocked(mockNotifier.notify).mock.calls.length;
+
+    // Second poll tick
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // Should not have been called again
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(callCount);
+
+    lm.stop();
+  });
+
+  it("does not emit all-complete when there are no sessions at all", async () => {
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const allCompleteConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+      reactions: {
+        "all-complete": {
+          auto: true,
+          action: "notify",
+          priority: "action",
+        },
+      },
+    };
+
+    vi.mocked(mockSessionManager.list).mockResolvedValue([]);
+
+    const lm = createLifecycleManager({
+      config: allCompleteConfig,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(5000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // sessions.length === 0, so all-complete should NOT fire
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+
+    lm.stop();
+  });
+});
+
+describe("reaction tracking and escalation", () => {
+  it("escalates after exceeding retry count (numeric escalateAfter)", async () => {
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithAll: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const escalationConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent",
+          message: "Fix CI",
+          retries: 1, // will escalate on attempt 2
+          escalateAfter: 1, // numeric: escalate after 1 attempt
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: escalationConfig,
+      registry: registryWithAll,
+      sessionManager: mockSessionManager,
+    });
+
+    // First check: pr_open → ci_failed (attempt 1)
+    await lm.check("app-1");
+
+    // Attempt 1 should send to agent, not escalate yet
+    expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "Fix CI");
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+
+    // Simulate: CI still failing, but we need a status transition to trigger reaction again.
+    // Reset state to pr_open, then back to ci_failed.
+    vi.mocked(mockSCM.getCISummary).mockResolvedValueOnce("passing");
+    vi.mocked(mockSCM.getReviewDecision).mockResolvedValueOnce("none");
+    await lm.check("app-1"); // ci_failed → pr_open
+
+    vi.mocked(mockSCM.getCISummary).mockResolvedValue("failing");
+    vi.mocked(mockSCM.getReviewDecision).mockResolvedValue("none");
+
+    // Note: the transition from ci_failed to pr_open clears the reaction tracker
+    // for the old "ci-failed" key (line 449-455 in source). So each ci_failed transition
+    // starts with a fresh tracker. With retries=1, the first attempt (attempt 1)
+    // doesn't exceed maxRetries, so it sends to agent.
+    // With numeric escalateAfter=1, attempt 1 doesn't exceed 1 either.
+    // Attempt 2 would exceed both, but the tracker resets on state change.
+    // This tests that the numeric escalateAfter path is exercised.
+    await lm.check("app-1"); // pr_open → ci_failed (new tracker, attempt 1)
+
+    // With fresh tracker, attempt 1 <= retries(1) and attempt 1 <= escalateAfter(1),
+    // so it should still send to agent
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("escalates when retries exceeded (without state transition resetting tracker)", async () => {
+    // To test escalation properly, we need repeated reactions on the SAME transition
+    // without the tracker being cleared. This happens when the same event type
+    // keeps firing. However, the lifecycle manager only triggers reactions on
+    // state *transitions*. To get multiple triggers without reset, we'd need
+    // the session to remain in ci_failed and the reaction to fire again.
+    //
+    // Looking at the code: reactions only fire when oldStatus !== newStatus.
+    // So the tracker can only accumulate across separate transitions to the same state.
+    // But each transition from ci_failed to something else clears the tracker.
+    //
+    // This means: with retries=1 and the tracker resetting on each state change,
+    // we can never actually reach attempt > 1 for the same tracker key
+    // through the public API. The escalation is designed to work across
+    // persistent ci_failed states polled repeatedly — but pollAll only triggers
+    // reactions on transitions.
+    //
+    // However: if retries = 0, then attempt 1 > maxRetries(0), so it escalates immediately.
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithAll: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const escalationConfig: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: ["desktop"],
+        info: ["desktop"],
+      },
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent",
+          message: "Fix CI",
+          retries: 0, // escalate immediately on first attempt (1 > 0)
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: escalationConfig,
+      registry: registryWithAll,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+    // With retries=0, attempt 1 > 0, so escalation fires immediately
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "reaction.escalated",
+        priority: "urgent", // default escalation priority
+      }),
+    );
+    // send-to-agent should NOT have been called (escalation path returns early)
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
+  });
+
+  it("clears reaction tracker when state transitions away from the triggering status", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const reactionConfig: OrchestratorConfig = {
+      ...config,
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent",
+          message: "Fix CI",
+          retries: 100,
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: reactionConfig,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    // First transition: pr_open → ci_failed
+    await lm.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+
+    // Transition away: ci_failed → pr_open (CI passes)
+    vi.mocked(mockSCM.getCISummary).mockResolvedValueOnce("passing");
+    vi.mocked(mockSCM.getReviewDecision).mockResolvedValueOnce("none");
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("pr_open");
+
+    // Transition back: pr_open → ci_failed
+    vi.mocked(mockSCM.getCISummary).mockResolvedValue("failing");
+    vi.mocked(mockSCM.getReviewDecision).mockResolvedValue("none");
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+
+    // The tracker should have been cleared when state changed from ci_failed,
+    // so this is treated as a fresh first attempt (not attempt 2)
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(2);
+    expect(mockSessionManager.send).toHaveBeenLastCalledWith("app-1", "Fix CI");
+  });
+
+  it("uses project-specific reaction overrides when configured", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    // Global reaction has one message, project override has another
+    const projectOverrideConfig: OrchestratorConfig = {
+      ...config,
+      projects: {
+        "my-app": {
+          ...config.projects["my-app"],
+          reactions: {
+            "ci-failed": {
+              message: "Project-specific: fix the CI please!",
+            },
+          },
+        },
+      },
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent",
+          message: "Global: fix CI",
+          retries: 3,
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: projectOverrideConfig,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    // Project-specific message should override global
+    expect(mockSessionManager.send).toHaveBeenCalledWith(
+      "app-1",
+      "Project-specific: fix the CI please!",
+    );
+  });
+
+  it("handles send-to-agent failure gracefully (returns success=false)", async () => {
+    vi.mocked(mockSessionManager.send).mockRejectedValue(new Error("tmux send failed"));
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const reactionConfig: OrchestratorConfig = {
+      ...config,
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent",
+          message: "Fix CI",
+          retries: 3,
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: reactionConfig,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    // Should not throw — the reaction catches the send error
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+    expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "Fix CI");
+  });
+});
+
+describe("event logging", () => {
+  it("logs state transitions when eventLogger is provided", async () => {
+    const mockEventLogger = {
+      append: vi.fn(),
+      appendLine: vi.fn(),
+      close: vi.fn(),
+    };
+
+    const session = makeSession({ status: "spawning" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "spawning",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      eventLogger: mockEventLogger,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockEventLogger.append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "info",
+        source: "lifecycle",
+        sessionId: "app-1",
+        message: expect.stringContaining("spawning"),
+      }),
+    );
+    expect(mockEventLogger.append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("working"),
+      }),
+    );
+  });
+
+  it("closes eventLogger on stop", () => {
+    const mockEventLogger = {
+      append: vi.fn(),
+      appendLine: vi.fn(),
+      close: vi.fn(),
+    };
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      eventLogger: mockEventLogger,
+    });
+
+    lm.stop();
+
+    expect(mockEventLogger.close).toHaveBeenCalled();
+  });
+
+  it("does not log when eventLogger is not provided", async () => {
+    const session = makeSession({ status: "spawning" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "spawning",
+      project: "my-app",
+    });
+
+    // No eventLogger passed — should not throw
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("working");
+  });
+});

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -110,6 +110,7 @@ beforeEach(() => {
     kill: vi.fn().mockResolvedValue(undefined),
     cleanup: vi.fn(),
     send: vi.fn().mockResolvedValue(undefined),
+    getAttachInfo: vi.fn().mockResolvedValue(null),
   };
 
   config = {

--- a/packages/core/src/__tests__/log-reader.test.ts
+++ b/packages/core/src/__tests__/log-reader.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
-import type { LogEntry } from "../log-writer.js";
+import type { LogEntry } from "../types.js";
 import { readLogs, readLogsFromDir, tailLogs } from "../log-reader.js";
 
 let testDir: string;

--- a/packages/core/src/__tests__/log-reader.test.ts
+++ b/packages/core/src/__tests__/log-reader.test.ts
@@ -1,0 +1,698 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import type { LogEntry } from "../log-writer.js";
+import { readLogs, readLogsFromDir, tailLogs } from "../log-reader.js";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `ao-test-log-reader-${randomUUID()}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+/** Helper: create a LogEntry with sensible defaults. */
+function makeEntry(overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    ts: overrides.ts ?? new Date().toISOString(),
+    level: overrides.level ?? "info",
+    source: overrides.source ?? "lifecycle",
+    sessionId: overrides.sessionId ?? null,
+    message: overrides.message ?? "test message",
+    ...(overrides.data !== undefined ? { data: overrides.data } : {}),
+  };
+}
+
+/** Helper: write an array of LogEntry objects to a JSONL file. */
+function writeJsonl(filePath: string, entries: LogEntry[]): void {
+  const content = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  writeFileSync(filePath, content, "utf-8");
+}
+
+describe("readLogs", () => {
+  it("reads all entries from a JSONL file", () => {
+    const entries = [
+      makeEntry({ message: "first" }),
+      makeEntry({ message: "second" }),
+      makeEntry({ message: "third" }),
+    ];
+    const filePath = join(testDir, "test.jsonl");
+    writeJsonl(filePath, entries);
+
+    const result = readLogs(filePath);
+    expect(result).toHaveLength(3);
+    expect(result[0].message).toBe("first");
+    expect(result[1].message).toBe("second");
+    expect(result[2].message).toBe("third");
+  });
+
+  it("returns empty array for non-existent file", () => {
+    const result = readLogs(join(testDir, "nonexistent.jsonl"));
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array with no options (all entries returned)", () => {
+    const entries = [makeEntry({ message: "a" }), makeEntry({ message: "b" })];
+    const filePath = join(testDir, "test.jsonl");
+    writeJsonl(filePath, entries);
+
+    const result = readLogs(filePath);
+    expect(result).toHaveLength(2);
+  });
+
+  describe("since filter", () => {
+    it("returns only entries after the since date", () => {
+      const entries = [
+        makeEntry({ ts: "2025-01-01T00:00:00.000Z", message: "old" }),
+        makeEntry({ ts: "2025-06-15T12:00:00.000Z", message: "mid" }),
+        makeEntry({ ts: "2025-12-31T23:59:59.000Z", message: "new" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, {
+        since: new Date("2025-06-01T00:00:00.000Z"),
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("mid");
+      expect(result[1].message).toBe("new");
+    });
+
+    it("excludes entries exactly before the since date", () => {
+      const entries = [
+        makeEntry({ ts: "2025-01-01T00:00:00.000Z", message: "before" }),
+        makeEntry({ ts: "2025-01-02T00:00:00.000Z", message: "exact" }),
+        makeEntry({ ts: "2025-01-03T00:00:00.000Z", message: "after" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, {
+        since: new Date("2025-01-02T00:00:00.000Z"),
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("exact");
+      expect(result[1].message).toBe("after");
+    });
+  });
+
+  describe("until filter", () => {
+    it("returns only entries before or equal to the until date", () => {
+      const entries = [
+        makeEntry({ ts: "2025-01-01T00:00:00.000Z", message: "old" }),
+        makeEntry({ ts: "2025-06-15T12:00:00.000Z", message: "mid" }),
+        makeEntry({ ts: "2025-12-31T23:59:59.000Z", message: "new" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, {
+        until: new Date("2025-06-30T00:00:00.000Z"),
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("old");
+      expect(result[1].message).toBe("mid");
+    });
+
+    it("excludes entries exactly after the until date", () => {
+      const entries = [
+        makeEntry({ ts: "2025-01-01T00:00:00.000Z", message: "before" }),
+        makeEntry({ ts: "2025-01-02T00:00:00.000Z", message: "exact" }),
+        makeEntry({ ts: "2025-01-03T00:00:00.000Z", message: "after" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, {
+        until: new Date("2025-01-02T00:00:00.000Z"),
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("before");
+      expect(result[1].message).toBe("exact");
+    });
+  });
+
+  describe("since + until combined", () => {
+    it("returns entries within the date range", () => {
+      const entries = [
+        makeEntry({ ts: "2025-01-01T00:00:00.000Z", message: "too early" }),
+        makeEntry({ ts: "2025-03-15T00:00:00.000Z", message: "in range" }),
+        makeEntry({ ts: "2025-06-15T00:00:00.000Z", message: "also in range" }),
+        makeEntry({ ts: "2025-12-31T00:00:00.000Z", message: "too late" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, {
+        since: new Date("2025-02-01T00:00:00.000Z"),
+        until: new Date("2025-09-01T00:00:00.000Z"),
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("in range");
+      expect(result[1].message).toBe("also in range");
+    });
+  });
+
+  describe("level filter", () => {
+    it("returns only entries matching specified levels", () => {
+      const entries = [
+        makeEntry({ level: "info", message: "info msg" }),
+        makeEntry({ level: "warn", message: "warn msg" }),
+        makeEntry({ level: "error", message: "error msg" }),
+        makeEntry({ level: "stdout", message: "stdout msg" }),
+        makeEntry({ level: "stderr", message: "stderr msg" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { level: ["warn", "error"] });
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("warn msg");
+      expect(result[1].message).toBe("error msg");
+    });
+
+    it("returns all entries when level array is empty", () => {
+      const entries = [
+        makeEntry({ level: "info", message: "a" }),
+        makeEntry({ level: "warn", message: "b" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { level: [] });
+      expect(result).toHaveLength(2);
+    });
+
+    it("filters to a single level", () => {
+      const entries = [
+        makeEntry({ level: "info", message: "info1" }),
+        makeEntry({ level: "error", message: "error1" }),
+        makeEntry({ level: "info", message: "info2" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { level: ["error"] });
+      expect(result).toHaveLength(1);
+      expect(result[0].message).toBe("error1");
+    });
+  });
+
+  describe("sessionId filter", () => {
+    it("returns only entries matching the sessionId", () => {
+      const entries = [
+        makeEntry({ sessionId: "sess-1", message: "from sess-1" }),
+        makeEntry({ sessionId: "sess-2", message: "from sess-2" }),
+        makeEntry({ sessionId: "sess-1", message: "from sess-1 again" }),
+        makeEntry({ sessionId: null, message: "no session" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { sessionId: "sess-1" });
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("from sess-1");
+      expect(result[1].message).toBe("from sess-1 again");
+    });
+
+    it("returns entries with null sessionId when filtering for null", () => {
+      const entries = [
+        makeEntry({ sessionId: "sess-1", message: "has session" }),
+        makeEntry({ sessionId: null, message: "no session" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      // The filter does strict equality: entry.sessionId !== opts.sessionId
+      // Passing undefined means the filter is not applied (sessionId is optional)
+      const result = readLogs(filePath);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("source filter", () => {
+    it("returns only entries matching the source", () => {
+      const entries = [
+        makeEntry({ source: "dashboard", message: "from dashboard" }),
+        makeEntry({ source: "lifecycle", message: "from lifecycle" }),
+        makeEntry({ source: "cli", message: "from cli" }),
+        makeEntry({ source: "api", message: "from api" }),
+        makeEntry({ source: "browser", message: "from browser" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { source: "cli" });
+      expect(result).toHaveLength(1);
+      expect(result[0].message).toBe("from cli");
+    });
+
+    it("returns multiple entries matching the same source", () => {
+      const entries = [
+        makeEntry({ source: "lifecycle", message: "lc1" }),
+        makeEntry({ source: "api", message: "api1" }),
+        makeEntry({ source: "lifecycle", message: "lc2" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { source: "lifecycle" });
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("lc1");
+      expect(result[1].message).toBe("lc2");
+    });
+  });
+
+  describe("limit option", () => {
+    it("stops after N entries", () => {
+      const entries = [
+        makeEntry({ message: "one" }),
+        makeEntry({ message: "two" }),
+        makeEntry({ message: "three" }),
+        makeEntry({ message: "four" }),
+        makeEntry({ message: "five" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { limit: 3 });
+      expect(result).toHaveLength(3);
+      expect(result[0].message).toBe("one");
+      expect(result[1].message).toBe("two");
+      expect(result[2].message).toBe("three");
+    });
+
+    it("returns all entries when limit exceeds total", () => {
+      const entries = [
+        makeEntry({ message: "one" }),
+        makeEntry({ message: "two" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { limit: 100 });
+      expect(result).toHaveLength(2);
+    });
+
+    it("returns one entry when limit is 1", () => {
+      const entries = [
+        makeEntry({ message: "first" }),
+        makeEntry({ message: "second" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { limit: 1 });
+      expect(result).toHaveLength(1);
+      expect(result[0].message).toBe("first");
+    });
+  });
+
+  describe("pattern filter", () => {
+    it("returns entries where message contains the pattern", () => {
+      const entries = [
+        makeEntry({ message: "session started for user-1" }),
+        makeEntry({ message: "error in handler" }),
+        makeEntry({ message: "session ended for user-1" }),
+        makeEntry({ message: "unrelated log line" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { pattern: "session" });
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("session started for user-1");
+      expect(result[1].message).toBe("session ended for user-1");
+    });
+
+    it("is case-sensitive", () => {
+      const entries = [
+        makeEntry({ message: "Error occurred" }),
+        makeEntry({ message: "error occurred" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { pattern: "Error" });
+      expect(result).toHaveLength(1);
+      expect(result[0].message).toBe("Error occurred");
+    });
+
+    it("matches partial words", () => {
+      const entries = [
+        makeEntry({ message: "processing complete" }),
+        makeEntry({ message: "preprocess data" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { pattern: "process" });
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("corrupted/invalid JSON lines", () => {
+    it("skips corrupted lines and returns valid entries", () => {
+      const content = [
+        JSON.stringify(makeEntry({ message: "valid-1" })),
+        "this is not json",
+        JSON.stringify(makeEntry({ message: "valid-2" })),
+        "{broken json",
+        JSON.stringify(makeEntry({ message: "valid-3" })),
+      ].join("\n") + "\n";
+
+      const filePath = join(testDir, "test.jsonl");
+      writeFileSync(filePath, content, "utf-8");
+
+      const result = readLogs(filePath);
+      expect(result).toHaveLength(3);
+      expect(result[0].message).toBe("valid-1");
+      expect(result[1].message).toBe("valid-2");
+      expect(result[2].message).toBe("valid-3");
+    });
+
+    it("skips empty lines gracefully", () => {
+      const content = [
+        JSON.stringify(makeEntry({ message: "a" })),
+        "",
+        "  ",
+        JSON.stringify(makeEntry({ message: "b" })),
+        "",
+      ].join("\n");
+
+      const filePath = join(testDir, "test.jsonl");
+      writeFileSync(filePath, content, "utf-8");
+
+      const result = readLogs(filePath);
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("a");
+      expect(result[1].message).toBe("b");
+    });
+
+    it("returns empty array when all lines are corrupted", () => {
+      const content = "not json\nalso not json\n{broken\n";
+      const filePath = join(testDir, "test.jsonl");
+      writeFileSync(filePath, content, "utf-8");
+
+      const result = readLogs(filePath);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("combined filters", () => {
+    it("applies multiple filters simultaneously", () => {
+      const entries = [
+        makeEntry({ ts: "2025-01-01T00:00:00.000Z", level: "info", sessionId: "s1", source: "lifecycle", message: "lifecycle info s1 old" }),
+        makeEntry({ ts: "2025-06-15T00:00:00.000Z", level: "error", sessionId: "s1", source: "lifecycle", message: "lifecycle error s1 mid" }),
+        makeEntry({ ts: "2025-06-15T00:00:00.000Z", level: "info", sessionId: "s2", source: "lifecycle", message: "lifecycle info s2 mid" }),
+        makeEntry({ ts: "2025-06-15T00:00:00.000Z", level: "error", sessionId: "s1", source: "api", message: "api error s1 mid" }),
+        makeEntry({ ts: "2025-12-31T00:00:00.000Z", level: "error", sessionId: "s1", source: "lifecycle", message: "lifecycle error s1 new" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, {
+        since: new Date("2025-03-01T00:00:00.000Z"),
+        level: ["error"],
+        sessionId: "s1",
+        source: "lifecycle",
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("lifecycle error s1 mid");
+      expect(result[1].message).toBe("lifecycle error s1 new");
+    });
+
+    it("applies pattern filter with limit", () => {
+      const entries = [
+        makeEntry({ message: "match one" }),
+        makeEntry({ message: "no hit" }),
+        makeEntry({ message: "match two" }),
+        makeEntry({ message: "match three" }),
+      ];
+      const filePath = join(testDir, "test.jsonl");
+      writeJsonl(filePath, entries);
+
+      const result = readLogs(filePath, { pattern: "match", limit: 2 });
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe("match one");
+      expect(result[1].message).toBe("match two");
+    });
+  });
+});
+
+describe("readLogsFromDir", () => {
+  it("reads current + rotated files in chronological order", () => {
+    // Rotated files: highest number = oldest. Current file (no number) = newest.
+    // The sort puts highest-numbered first (oldest), current file last (newest).
+    const logDir = join(testDir, "logs");
+    mkdirSync(logDir, { recursive: true });
+
+    // Oldest backup (highest number)
+    writeJsonl(join(logDir, "app.3.jsonl"), [
+      makeEntry({ ts: "2025-01-01T00:00:00.000Z", message: "oldest" }),
+    ]);
+    // Middle backup
+    writeJsonl(join(logDir, "app.2.jsonl"), [
+      makeEntry({ ts: "2025-03-01T00:00:00.000Z", message: "older" }),
+    ]);
+    // Newest backup
+    writeJsonl(join(logDir, "app.1.jsonl"), [
+      makeEntry({ ts: "2025-06-01T00:00:00.000Z", message: "recent backup" }),
+    ]);
+    // Current file (newest)
+    writeJsonl(join(logDir, "app.jsonl"), [
+      makeEntry({ ts: "2025-09-01T00:00:00.000Z", message: "current" }),
+    ]);
+
+    const result = readLogsFromDir(logDir, "app");
+    expect(result).toHaveLength(4);
+    expect(result[0].message).toBe("oldest");
+    expect(result[1].message).toBe("older");
+    expect(result[2].message).toBe("recent backup");
+    expect(result[3].message).toBe("current");
+  });
+
+  it("returns empty array for non-existent directory", () => {
+    const result = readLogsFromDir(join(testDir, "nonexistent"), "app");
+    expect(result).toEqual([]);
+  });
+
+  it("reads only the current file when no backups exist", () => {
+    const logDir = join(testDir, "logs");
+    mkdirSync(logDir, { recursive: true });
+
+    writeJsonl(join(logDir, "app.jsonl"), [
+      makeEntry({ message: "only entry" }),
+    ]);
+
+    const result = readLogsFromDir(logDir, "app");
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe("only entry");
+  });
+
+  it("ignores files that do not match the prefix", () => {
+    const logDir = join(testDir, "logs");
+    mkdirSync(logDir, { recursive: true });
+
+    writeJsonl(join(logDir, "app.jsonl"), [
+      makeEntry({ message: "app entry" }),
+    ]);
+    writeJsonl(join(logDir, "other.jsonl"), [
+      makeEntry({ message: "other entry" }),
+    ]);
+    writeJsonl(join(logDir, "app-extra.jsonl"), [
+      makeEntry({ message: "extra entry" }),
+    ]);
+
+    const result = readLogsFromDir(logDir, "app");
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe("app entry");
+  });
+
+  it("applies filters across all files", () => {
+    const logDir = join(testDir, "logs");
+    mkdirSync(logDir, { recursive: true });
+
+    writeJsonl(join(logDir, "app.1.jsonl"), [
+      makeEntry({ level: "info", message: "backup info" }),
+      makeEntry({ level: "error", message: "backup error" }),
+    ]);
+    writeJsonl(join(logDir, "app.jsonl"), [
+      makeEntry({ level: "info", message: "current info" }),
+      makeEntry({ level: "error", message: "current error" }),
+    ]);
+
+    const result = readLogsFromDir(logDir, "app", { level: ["error"] });
+    expect(result).toHaveLength(2);
+    expect(result[0].message).toBe("backup error");
+    expect(result[1].message).toBe("current error");
+  });
+
+  it("respects limit across multiple files", () => {
+    const logDir = join(testDir, "logs");
+    mkdirSync(logDir, { recursive: true });
+
+    writeJsonl(join(logDir, "app.2.jsonl"), [
+      makeEntry({ message: "backup-2 entry 1" }),
+      makeEntry({ message: "backup-2 entry 2" }),
+    ]);
+    writeJsonl(join(logDir, "app.1.jsonl"), [
+      makeEntry({ message: "backup-1 entry 1" }),
+      makeEntry({ message: "backup-1 entry 2" }),
+    ]);
+    writeJsonl(join(logDir, "app.jsonl"), [
+      makeEntry({ message: "current entry 1" }),
+      makeEntry({ message: "current entry 2" }),
+    ]);
+
+    const result = readLogsFromDir(logDir, "app", { limit: 3 });
+    expect(result).toHaveLength(3);
+    // Should get entries from oldest files first
+    expect(result[0].message).toBe("backup-2 entry 1");
+    expect(result[1].message).toBe("backup-2 entry 2");
+    expect(result[2].message).toBe("backup-1 entry 1");
+  });
+
+  it("returns empty array when directory has no matching files", () => {
+    const logDir = join(testDir, "logs");
+    mkdirSync(logDir, { recursive: true });
+
+    writeJsonl(join(logDir, "other.jsonl"), [
+      makeEntry({ message: "irrelevant" }),
+    ]);
+
+    const result = readLogsFromDir(logDir, "app");
+    expect(result).toEqual([]);
+  });
+
+  it("handles prefix with regex metacharacters", () => {
+    const logDir = join(testDir, "logs");
+    mkdirSync(logDir, { recursive: true });
+
+    // The prefix "app.v2" contains a dot which is a regex metacharacter
+    writeJsonl(join(logDir, "app.v2.jsonl"), [
+      makeEntry({ message: "correct" }),
+    ]);
+    // This should NOT match because "appXv2" is not "app.v2"
+    writeJsonl(join(logDir, "appXv2.jsonl"), [
+      makeEntry({ message: "wrong" }),
+    ]);
+
+    const result = readLogsFromDir(logDir, "app.v2");
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe("correct");
+  });
+});
+
+describe("tailLogs", () => {
+  it("returns last N entries from a log file", () => {
+    const entries = [
+      makeEntry({ message: "one" }),
+      makeEntry({ message: "two" }),
+      makeEntry({ message: "three" }),
+      makeEntry({ message: "four" }),
+      makeEntry({ message: "five" }),
+    ];
+    const filePath = join(testDir, "test.jsonl");
+    writeJsonl(filePath, entries);
+
+    const result = tailLogs(filePath, 3);
+    expect(result).toHaveLength(3);
+    expect(result[0].message).toBe("three");
+    expect(result[1].message).toBe("four");
+    expect(result[2].message).toBe("five");
+  });
+
+  it("returns all entries when N exceeds total", () => {
+    const entries = [
+      makeEntry({ message: "one" }),
+      makeEntry({ message: "two" }),
+    ];
+    const filePath = join(testDir, "test.jsonl");
+    writeJsonl(filePath, entries);
+
+    const result = tailLogs(filePath, 100);
+    expect(result).toHaveLength(2);
+    expect(result[0].message).toBe("one");
+    expect(result[1].message).toBe("two");
+  });
+
+  it("returns empty array for non-existent file", () => {
+    const result = tailLogs(join(testDir, "nonexistent.jsonl"), 5);
+    expect(result).toEqual([]);
+  });
+
+  it("returns exactly all entries when N equals total", () => {
+    const entries = [
+      makeEntry({ message: "a" }),
+      makeEntry({ message: "b" }),
+      makeEntry({ message: "c" }),
+    ];
+    const filePath = join(testDir, "test.jsonl");
+    writeJsonl(filePath, entries);
+
+    const result = tailLogs(filePath, 3);
+    expect(result).toHaveLength(3);
+    expect(result[0].message).toBe("a");
+    expect(result[1].message).toBe("b");
+    expect(result[2].message).toBe("c");
+  });
+
+  it("returns single entry when N is 1", () => {
+    const entries = [
+      makeEntry({ message: "first" }),
+      makeEntry({ message: "second" }),
+      makeEntry({ message: "last" }),
+    ];
+    const filePath = join(testDir, "test.jsonl");
+    writeJsonl(filePath, entries);
+
+    const result = tailLogs(filePath, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe("last");
+  });
+
+  it("skips corrupted lines in the tail region", () => {
+    const content = [
+      JSON.stringify(makeEntry({ message: "early" })),
+      JSON.stringify(makeEntry({ message: "valid-1" })),
+      "not valid json",
+      JSON.stringify(makeEntry({ message: "valid-2" })),
+    ].join("\n") + "\n";
+
+    const filePath = join(testDir, "test.jsonl");
+    writeFileSync(filePath, content, "utf-8");
+
+    // Tail 3: gets "valid-1", "not valid json" (skipped), "valid-2"
+    const result = tailLogs(filePath, 3);
+    expect(result).toHaveLength(2);
+    expect(result[0].message).toBe("valid-1");
+    expect(result[1].message).toBe("valid-2");
+  });
+
+  it("returns empty array for file with only empty lines", () => {
+    const filePath = join(testDir, "test.jsonl");
+    writeFileSync(filePath, "\n\n  \n\n", "utf-8");
+
+    const result = tailLogs(filePath, 5);
+    expect(result).toEqual([]);
+  });
+
+  it("preserves data field in entries", () => {
+    const entries = [
+      makeEntry({ message: "with data", data: { key: "value", count: 42 } }),
+    ];
+    const filePath = join(testDir, "test.jsonl");
+    writeJsonl(filePath, entries);
+
+    const result = tailLogs(filePath, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].data).toEqual({ key: "value", count: 42 });
+  });
+});

--- a/packages/core/src/__tests__/log-writer.test.ts
+++ b/packages/core/src/__tests__/log-writer.test.ts
@@ -3,7 +3,8 @@ import { mkdirSync, rmSync, readFileSync, existsSync, chmodSync } from "node:fs"
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
-import { LogWriter, type LogEntry } from "../log-writer.js";
+import type { LogEntry } from "../types.js";
+import { LogWriter } from "../log-writer.js";
 
 let testDir: string;
 

--- a/packages/core/src/__tests__/log-writer.test.ts
+++ b/packages/core/src/__tests__/log-writer.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, rmSync, readFileSync, existsSync, writeFileSync, chmodSync } from "node:fs";
+import { mkdirSync, rmSync, readFileSync, existsSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
-import { LogWriter } from "../log-writer.js";
-import type { LogEntry } from "../log-writer.js";
+import { LogWriter, type LogEntry } from "../log-writer.js";
 
 let testDir: string;
 

--- a/packages/core/src/__tests__/log-writer.test.ts
+++ b/packages/core/src/__tests__/log-writer.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, rmSync, readFileSync, existsSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { LogWriter } from "../log-writer.js";
+import type { LogEntry } from "../log-writer.js";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `ao-test-log-writer-${randomUUID()}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+function makeEntry(overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    ts: "2026-01-15T12:00:00.000Z",
+    level: "info",
+    source: "cli",
+    sessionId: null,
+    message: "test message",
+    ...overrides,
+  };
+}
+
+describe("append", () => {
+  it("writes valid JSONL lines", () => {
+    const filePath = join(testDir, "test.jsonl");
+    const writer = new LogWriter({ filePath });
+
+    const entry = makeEntry({ message: "hello world" });
+    writer.append(entry);
+
+    const content = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(content.trim());
+    expect(parsed).toEqual(entry);
+  });
+
+  it("each line is valid JSON", () => {
+    const filePath = join(testDir, "test.jsonl");
+    const writer = new LogWriter({ filePath });
+
+    const entry1 = makeEntry({ message: "first" });
+    const entry2 = makeEntry({ message: "second", level: "error", sessionId: "sess-1" });
+    writer.append(entry1);
+    writer.append(entry2);
+
+    const lines = readFileSync(filePath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0])).toEqual(entry1);
+    expect(JSON.parse(lines[1])).toEqual(entry2);
+  });
+
+  it("preserves optional data field", () => {
+    const filePath = join(testDir, "test.jsonl");
+    const writer = new LogWriter({ filePath });
+
+    const entry = makeEntry({
+      message: "with data",
+      data: { exitCode: 1, pid: 12345 },
+    });
+    writer.append(entry);
+
+    const content = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(content.trim());
+    expect(parsed.data).toEqual({ exitCode: 1, pid: 12345 });
+  });
+});
+
+describe("appendLine", () => {
+  it("creates a proper LogEntry with all fields", () => {
+    const filePath = join(testDir, "test.jsonl");
+    const writer = new LogWriter({ filePath });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-19T10:30:00.000Z"));
+
+    writer.appendLine("something happened", "warn", "dashboard", "sess-42");
+
+    vi.useRealTimers();
+
+    const content = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(content.trim());
+    expect(parsed.ts).toBe("2026-02-19T10:30:00.000Z");
+    expect(parsed.level).toBe("warn");
+    expect(parsed.source).toBe("dashboard");
+    expect(parsed.sessionId).toBe("sess-42");
+    expect(parsed.message).toBe("something happened");
+  });
+
+  it("defaults sessionId to null when omitted", () => {
+    const filePath = join(testDir, "test.jsonl");
+    const writer = new LogWriter({ filePath });
+
+    writer.appendLine("no session", "info", "lifecycle");
+
+    const content = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(content.trim());
+    expect(parsed.sessionId).toBeNull();
+  });
+});
+
+describe("multiple appends", () => {
+  it("creates one line per entry", () => {
+    const filePath = join(testDir, "test.jsonl");
+    const writer = new LogWriter({ filePath });
+
+    for (let i = 0; i < 5; i++) {
+      writer.append(makeEntry({ message: `line ${i}` }));
+    }
+
+    const lines = readFileSync(filePath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(5);
+
+    lines.forEach((line, i) => {
+      const parsed = JSON.parse(line);
+      expect(parsed.message).toBe(`line ${i}`);
+    });
+  });
+});
+
+describe("close", () => {
+  it("prevents further writes after close", () => {
+    const filePath = join(testDir, "test.jsonl");
+    const writer = new LogWriter({ filePath });
+
+    writer.append(makeEntry({ message: "before close" }));
+    writer.close();
+    writer.append(makeEntry({ message: "after close" }));
+
+    const lines = readFileSync(filePath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).message).toBe("before close");
+  });
+
+  it("appendLine is also blocked after close", () => {
+    const filePath = join(testDir, "test.jsonl");
+    const writer = new LogWriter({ filePath });
+
+    writer.appendLine("before", "info", "cli");
+    writer.close();
+    writer.appendLine("after", "info", "cli");
+
+    const lines = readFileSync(filePath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+  });
+});
+
+describe("rotation", () => {
+  it("rotates file to .1.jsonl when maxSizeBytes exceeded", () => {
+    const filePath = join(testDir, "app.jsonl");
+    const writer = new LogWriter({ filePath, maxSizeBytes: 100, maxBackups: 2 });
+
+    // Write enough data to exceed 100 bytes
+    const longEntry = makeEntry({ message: "A".repeat(80) });
+    writer.append(longEntry);
+
+    // File should exist and be over 100 bytes now
+    expect(existsSync(filePath)).toBe(true);
+    const sizeAfterFirst = readFileSync(filePath, "utf-8").length;
+    expect(sizeAfterFirst).toBeGreaterThan(100);
+
+    // Next append triggers rotation
+    const smallEntry = makeEntry({ message: "after rotation" });
+    writer.append(smallEntry);
+
+    // Original file should now contain only the new entry
+    const currentContent = readFileSync(filePath, "utf-8").trim();
+    const currentParsed = JSON.parse(currentContent);
+    expect(currentParsed.message).toBe("after rotation");
+
+    // Rotated file should contain the old entry
+    const rotatedPath = join(testDir, "app.1.jsonl");
+    expect(existsSync(rotatedPath)).toBe(true);
+    const rotatedContent = readFileSync(rotatedPath, "utf-8").trim();
+    const rotatedParsed = JSON.parse(rotatedContent);
+    expect(rotatedParsed.message).toBe("A".repeat(80));
+  });
+
+  it("shifts existing backups on rotation", () => {
+    const filePath = join(testDir, "app.jsonl");
+    const writer = new LogWriter({ filePath, maxSizeBytes: 100, maxBackups: 3 });
+
+    // Write first batch -> exceeds limit
+    writer.append(makeEntry({ message: "batch-1-" + "X".repeat(80) }));
+    // Trigger rotation with second append
+    writer.append(makeEntry({ message: "batch-2-" + "Y".repeat(80) }));
+    // batch-1 is now in .1.jsonl, batch-2 is in app.jsonl
+    // Trigger another rotation
+    writer.append(makeEntry({ message: "batch-3" }));
+    // batch-1 -> .2.jsonl, batch-2 -> .1.jsonl, batch-3 -> app.jsonl
+
+    expect(existsSync(filePath)).toBe(true);
+    expect(existsSync(join(testDir, "app.1.jsonl"))).toBe(true);
+    expect(existsSync(join(testDir, "app.2.jsonl"))).toBe(true);
+
+    const current = JSON.parse(readFileSync(filePath, "utf-8").trim());
+    expect(current.message).toBe("batch-3");
+
+    const backup1 = JSON.parse(readFileSync(join(testDir, "app.1.jsonl"), "utf-8").trim());
+    expect(backup1.message).toContain("batch-2-");
+
+    const backup2 = JSON.parse(readFileSync(join(testDir, "app.2.jsonl"), "utf-8").trim());
+    expect(backup2.message).toContain("batch-1-");
+  });
+
+  it("deletes oldest backup when maxBackups exceeded", () => {
+    const filePath = join(testDir, "app.jsonl");
+    const writer = new LogWriter({ filePath, maxSizeBytes: 100, maxBackups: 2 });
+
+    // Rotation 1: batch-1 -> .1.jsonl
+    writer.append(makeEntry({ message: "batch-1-" + "A".repeat(80) }));
+    writer.append(makeEntry({ message: "batch-2-" + "B".repeat(80) }));
+    // Now: app.jsonl=batch-2, app.1.jsonl=batch-1
+
+    // Rotation 2: batch-1 -> .2.jsonl, batch-2 -> .1.jsonl
+    writer.append(makeEntry({ message: "batch-3-" + "C".repeat(80) }));
+    // Now: app.jsonl=batch-3, app.1.jsonl=batch-2, app.2.jsonl=batch-1
+
+    // Rotation 3: .2 is deleted (maxBackups=2), batch-2 -> .2, batch-3 -> .1
+    writer.append(makeEntry({ message: "batch-4" }));
+    // Now: app.jsonl=batch-4, app.1.jsonl=batch-3, app.2.jsonl=batch-2
+    // batch-1 should be gone
+
+    expect(existsSync(filePath)).toBe(true);
+    expect(existsSync(join(testDir, "app.1.jsonl"))).toBe(true);
+    expect(existsSync(join(testDir, "app.2.jsonl"))).toBe(true);
+
+    // Verify batch-1 is gone — none of the remaining files should contain it
+    const currentMsg = JSON.parse(readFileSync(filePath, "utf-8").trim()).message;
+    const backup1Msg = JSON.parse(
+      readFileSync(join(testDir, "app.1.jsonl"), "utf-8").trim(),
+    ).message;
+    const backup2Msg = JSON.parse(
+      readFileSync(join(testDir, "app.2.jsonl"), "utf-8").trim(),
+    ).message;
+
+    expect(currentMsg).toBe("batch-4");
+    expect(backup1Msg).toContain("batch-3-");
+    expect(backup2Msg).toContain("batch-2-");
+    // batch-1 content should not appear in any file
+    expect(currentMsg).not.toContain("batch-1-");
+    expect(backup1Msg).not.toContain("batch-1-");
+    expect(backup2Msg).not.toContain("batch-1-");
+  });
+});
+
+describe("auto-create directory", () => {
+  it("creates parent directories if they do not exist", () => {
+    const nestedDir = join(testDir, "a", "b", "c");
+    const filePath = join(nestedDir, "test.jsonl");
+
+    expect(existsSync(nestedDir)).toBe(false);
+
+    const writer = new LogWriter({ filePath });
+    writer.append(makeEntry({ message: "in nested dir" }));
+
+    expect(existsSync(nestedDir)).toBe(true);
+    const content = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(content.trim());
+    expect(parsed.message).toBe("in nested dir");
+  });
+});
+
+describe("write failure", () => {
+  it("does not throw on write failure", () => {
+    // Create a read-only directory so writes fail
+    const readOnlyDir = join(testDir, "readonly");
+    mkdirSync(readOnlyDir, { recursive: true });
+    const filePath = join(readOnlyDir, "test.jsonl");
+
+    const writer = new LogWriter({ filePath });
+
+    // Make directory read-only after construction (so mkdirSync in constructor succeeds)
+    chmodSync(readOnlyDir, 0o444);
+
+    expect(() => {
+      writer.append(makeEntry({ message: "should not throw" }));
+    }).not.toThrow();
+
+    // Restore permissions for cleanup
+    chmodSync(readOnlyDir, 0o755);
+  });
+});

--- a/packages/core/src/__tests__/plugin-integration.test.ts
+++ b/packages/core/src/__tests__/plugin-integration.test.ts
@@ -444,6 +444,7 @@ describe("plugin integration", () => {
         get: vi.fn().mockResolvedValue(makeSession({ status: "pr_open", pr })),
         kill: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue(undefined),
+        getAttachInfo: vi.fn().mockResolvedValue(null),
         spawnOrchestrator: vi.fn(),
       };
 
@@ -474,6 +475,7 @@ describe("plugin integration", () => {
         get: vi.fn().mockResolvedValue(makeSession({ status: "pr_open", pr })),
         kill: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue(undefined),
+        getAttachInfo: vi.fn().mockResolvedValue(null),
         spawnOrchestrator: vi.fn(),
       };
 
@@ -501,6 +503,7 @@ describe("plugin integration", () => {
         get: vi.fn().mockResolvedValue(makeSession({ status: "pr_open", pr })),
         kill: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue(undefined),
+        getAttachInfo: vi.fn().mockResolvedValue(null),
         spawnOrchestrator: vi.fn(),
       };
 

--- a/packages/core/src/__tests__/retrospective.test.ts
+++ b/packages/core/src/__tests__/retrospective.test.ts
@@ -1,10 +1,45 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
-import type { Retrospective } from "../types.js";
-import { saveRetrospective, loadRetrospectives } from "../retrospective.js";
+import type { Retrospective, SessionReportCard, LogEntry } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks for generateRetrospective dependencies (hoisted before imports)
+// ---------------------------------------------------------------------------
+
+const { mockReadMetadataRaw, mockGenerateReportCard, mockReadLogs, mockGetSessionsDir, mockGetLogsDir } =
+  vi.hoisted(() => ({
+    mockReadMetadataRaw: vi.fn(),
+    mockGenerateReportCard: vi.fn(),
+    mockReadLogs: vi.fn(),
+    mockGetSessionsDir: vi.fn(),
+    mockGetLogsDir: vi.fn(),
+  }));
+
+vi.mock("../metadata.js", () => ({
+  readMetadataRaw: mockReadMetadataRaw,
+}));
+
+vi.mock("../session-report-card.js", () => ({
+  generateReportCard: mockGenerateReportCard,
+}));
+
+vi.mock("../log-reader.js", () => ({
+  readLogs: mockReadLogs,
+}));
+
+vi.mock("../paths.js", () => ({
+  getSessionsDir: mockGetSessionsDir,
+  getLogsDir: mockGetLogsDir,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — after mocks so they resolve the mocked modules
+// ---------------------------------------------------------------------------
+
+import { saveRetrospective, loadRetrospectives, generateRetrospective } from "../retrospective.js";
 
 let tmpDir: string;
 let retroDir: string;
@@ -307,5 +342,713 @@ describe("loadRetrospectives", () => {
     expect(loaded.metrics.totalDurationMs).toBe(50_000_000);
     expect(loaded.reportCard.sessionId).toBe("test-1"); // from default makeRetro
     expect(loaded.timeline).toHaveLength(2);
+  });
+});
+
+// ===========================================================================
+// generateRetrospective + extractLessons (via mocked dependencies)
+// ===========================================================================
+
+/** Helper to build a SessionReportCard with sensible defaults. */
+function makeReportCard(overrides: Partial<SessionReportCard> = {}): SessionReportCard {
+  return {
+    sessionId: "test-1",
+    projectId: "my-project",
+    duration: {
+      startedAt: "2025-06-01T10:00:00.000Z",
+      endedAt: "2025-06-01T12:00:00.000Z",
+      totalMs: 7_200_000, // 2 hours
+    },
+    stateTransitions: [],
+    ciAttempts: 0,
+    reviewRounds: 0,
+    outcome: "merged",
+    prUrl: "https://github.com/org/repo/pull/42",
+    ...overrides,
+  };
+}
+
+/** Helper to build a LogEntry with sensible defaults. */
+function makeLogEntry(overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    ts: "2025-06-01T10:00:00.000Z",
+    level: "info",
+    source: "lifecycle",
+    sessionId: "test-1",
+    message: "event",
+    ...overrides,
+  };
+}
+
+/** Config fixture for generateRetrospective. */
+function makeConfig(): {
+  config: { configPath: string; projects: Record<string, { path: string }> };
+} {
+  return {
+    config: {
+      configPath: "/tmp/agent-orchestrator.yaml",
+      projects: {
+        "my-project": { path: "/tmp/repos/my-project" },
+      },
+    },
+  };
+}
+
+/**
+ * Set up standard mocks for generateRetrospective.
+ * Returns the default report card so tests can override fields.
+ */
+function setupGenerateMocks(opts?: {
+  metadata?: Record<string, string> | null;
+  archiveMetadata?: Record<string, string> | null;
+  reportCard?: Partial<SessionReportCard>;
+  logEntries?: LogEntry[];
+}): SessionReportCard {
+  mockGetSessionsDir.mockReturnValue("/tmp/sessions");
+  mockGetLogsDir.mockReturnValue("/tmp/logs");
+
+  // First call: live metadata. Second call: archive metadata.
+  if (opts?.metadata !== undefined) {
+    mockReadMetadataRaw.mockReturnValueOnce(opts.metadata);
+  } else {
+    mockReadMetadataRaw.mockReturnValueOnce({ project: "my-project" });
+  }
+  if (opts?.archiveMetadata !== undefined) {
+    mockReadMetadataRaw.mockReturnValueOnce(opts.archiveMetadata);
+  }
+
+  const card = makeReportCard(opts?.reportCard);
+  mockGenerateReportCard.mockReturnValue(card);
+
+  const entries = opts?.logEntries ?? [];
+  mockReadLogs.mockReturnValue(entries);
+
+  return card;
+}
+
+describe("generateRetrospective", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null for unknown project", () => {
+    const { config } = makeConfig();
+
+    const result = generateRetrospective("test-1", config as never, "nonexistent");
+
+    expect(result).toBeNull();
+  });
+
+  it("generates a retrospective for a successful session (merged PR)", () => {
+    const { config } = makeConfig();
+    const entries = [
+      makeLogEntry({ ts: "2025-06-01T10:00:00.000Z", message: "session spawned", data: { type: "spawned" } }),
+      makeLogEntry({ ts: "2025-06-01T10:30:00.000Z", message: "PR opened", data: { type: "pr.opened" } }),
+      makeLogEntry({ ts: "2025-06-01T11:00:00.000Z", message: "PR merged", data: { type: "pr.merged" } }),
+    ];
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 0,
+        reviewRounds: 0,
+        prUrl: "https://github.com/org/repo/pull/42",
+        duration: {
+          startedAt: "2025-06-01T10:00:00.000Z",
+          endedAt: "2025-06-01T11:00:00.000Z",
+          totalMs: 3_600_000, // 1 hour
+        },
+      },
+      logEntries: entries,
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result).not.toBeNull();
+    expect(result!.sessionId).toBe("test-1");
+    expect(result!.projectId).toBe("my-project");
+    expect(result!.outcome).toBe("success");
+    expect(result!.timeline).toHaveLength(3);
+    expect(result!.metrics.totalDurationMs).toBe(3_600_000);
+    expect(result!.metrics.ciFailures).toBe(0);
+    expect(result!.metrics.reviewRounds).toBe(0);
+    expect(result!.reportCard.outcome).toBe("merged");
+    expect(result!.lessons).toContain(
+      "Clean execution: merged quickly with minimal CI/review iterations.",
+    );
+  });
+
+  it("generates a retrospective for a failed session (killed, no PR)", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "killed",
+        prUrl: null,
+        ciAttempts: 0,
+        reviewRounds: 0,
+        duration: {
+          startedAt: "2025-06-01T10:00:00.000Z",
+          endedAt: "2025-06-01T11:00:00.000Z",
+          totalMs: 3_600_000,
+        },
+      },
+      logEntries: [
+        makeLogEntry({ ts: "2025-06-01T10:00:00.000Z", message: "session spawned" }),
+        makeLogEntry({ ts: "2025-06-01T11:00:00.000Z", message: "session killed" }),
+      ],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result).not.toBeNull();
+    expect(result!.outcome).toBe("failure");
+    expect(result!.lessons).toContain(
+      "Session was killed without creating a PR. May indicate a stuck or misdirected session.",
+    );
+  });
+
+  it("generates a retrospective for partial success (PR open but killed)", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "active",
+        prUrl: "https://github.com/org/repo/pull/99",
+        ciAttempts: 1,
+        reviewRounds: 0,
+        duration: {
+          startedAt: "2025-06-01T10:00:00.000Z",
+          endedAt: "2025-06-01T14:00:00.000Z",
+          totalMs: 14_400_000, // 4 hours
+        },
+      },
+      logEntries: [
+        makeLogEntry({ ts: "2025-06-01T10:00:00.000Z", message: "session spawned" }),
+      ],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result).not.toBeNull();
+    expect(result!.outcome).toBe("partial");
+  });
+
+  it("maps abandoned outcome to failure", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "abandoned",
+        prUrl: null,
+        ciAttempts: 0,
+        reviewRounds: 0,
+      },
+      logEntries: [],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result).not.toBeNull();
+    expect(result!.outcome).toBe("failure");
+  });
+
+  it("extracts timeline events from log entries", () => {
+    const { config } = makeConfig();
+    const entries = [
+      makeLogEntry({
+        ts: "2025-06-01T10:00:00.000Z",
+        message: "session spawned",
+        data: { type: "spawned" },
+      }),
+      makeLogEntry({
+        ts: "2025-06-01T10:30:00.000Z",
+        message: "CI passed",
+        data: { type: "ci.passing" },
+      }),
+      makeLogEntry({
+        ts: "2025-06-01T11:00:00.000Z",
+        level: "warn",
+        message: "warning event",
+      }),
+    ];
+    setupGenerateMocks({
+      reportCard: { outcome: "merged" },
+      logEntries: entries,
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.timeline).toHaveLength(3);
+    expect(result!.timeline[0]).toEqual({
+      event: "spawned",
+      at: "2025-06-01T10:00:00.000Z",
+      detail: "session spawned",
+    });
+    expect(result!.timeline[1]).toEqual({
+      event: "ci.passing",
+      at: "2025-06-01T10:30:00.000Z",
+      detail: "CI passed",
+    });
+    // When data.type is absent, falls back to entry.level
+    expect(result!.timeline[2]).toEqual({
+      event: "warn",
+      at: "2025-06-01T11:00:00.000Z",
+      detail: "warning event",
+    });
+  });
+
+  it("falls back to level when data.type is missing in timeline", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: { outcome: "merged" },
+      logEntries: [
+        makeLogEntry({ level: "error", message: "something broke" }),
+      ],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.timeline[0].event).toBe("error");
+  });
+
+  it("falls back to archive dir when live metadata is missing", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      metadata: null,
+      archiveMetadata: { project: "my-project", branch: "feat/old" },
+      reportCard: { outcome: "merged" },
+      logEntries: [],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result).not.toBeNull();
+    // readMetadataRaw called twice: once for live, once for archive
+    expect(mockReadMetadataRaw).toHaveBeenCalledTimes(2);
+    expect(mockReadMetadataRaw).toHaveBeenNthCalledWith(1, "/tmp/sessions", "test-1");
+    expect(mockReadMetadataRaw).toHaveBeenNthCalledWith(
+      2,
+      join("/tmp/sessions", "archive"),
+      "test-1",
+    );
+  });
+
+  it("uses fallback metadata when no files found (live or archive)", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      metadata: null,
+      archiveMetadata: null,
+      reportCard: { outcome: "active" },
+      logEntries: [],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result).not.toBeNull();
+    // generateReportCard receives { project: projectId } as fallback
+    expect(mockGenerateReportCard).toHaveBeenCalledWith(
+      "test-1",
+      join("/tmp/logs", "events.jsonl"),
+      { project: "my-project" },
+    );
+  });
+
+  it("passes the correct eventsLogPath to generateReportCard and readLogs", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: { outcome: "merged" },
+      logEntries: [],
+    });
+
+    generateRetrospective("test-1", config as never, "my-project");
+
+    const expectedPath = join("/tmp/logs", "events.jsonl");
+    expect(mockGenerateReportCard).toHaveBeenCalledWith("test-1", expectedPath, expect.any(Object));
+    expect(mockReadLogs).toHaveBeenCalledWith(expectedPath, { sessionId: "test-1" });
+  });
+
+  it("includes generatedAt timestamp", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: { outcome: "merged" },
+      logEntries: [],
+    });
+
+    const before = new Date().toISOString();
+    const result = generateRetrospective("test-1", config as never, "my-project");
+    const after = new Date().toISOString();
+
+    expect(result!.generatedAt).toBeDefined();
+    expect(result!.generatedAt >= before).toBe(true);
+    expect(result!.generatedAt <= after).toBe(true);
+  });
+});
+
+// ===========================================================================
+// extractLessons — exercised through generateRetrospective
+// ===========================================================================
+
+describe("extractLessons (via generateRetrospective)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flags high CI failure count (>3 failures)", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 5,
+        reviewRounds: 0,
+        duration: { startedAt: "2025-06-01T10:00:00.000Z", endedAt: "2025-06-01T14:00:00.000Z", totalMs: 14_400_000 },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons).toContain(
+      "High CI failure count (5 failures). Consider running tests locally before pushing.",
+    );
+  });
+
+  it("flags moderate CI failures (>1 but <=3)", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 2,
+        reviewRounds: 0,
+        duration: { startedAt: "2025-06-01T10:00:00.000Z", endedAt: "2025-06-01T14:00:00.000Z", totalMs: 14_400_000 },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons).toContain("CI failed 2 times before passing.");
+    // Should NOT contain the "High CI failure count" message
+    expect(result!.lessons.some((l) => l.includes("High CI failure count"))).toBe(false);
+  });
+
+  it("flags exactly 3 CI failures with moderate message (not high)", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 3,
+        reviewRounds: 0,
+        duration: { startedAt: "2025-06-01T10:00:00.000Z", endedAt: "2025-06-01T14:00:00.000Z", totalMs: 14_400_000 },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons).toContain("CI failed 3 times before passing.");
+    expect(result!.lessons.some((l) => l.includes("High CI failure count"))).toBe(false);
+  });
+
+  it("flags multiple review rounds (>2)", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 0,
+        reviewRounds: 3,
+        duration: { startedAt: "2025-06-01T10:00:00.000Z", endedAt: "2025-06-01T14:00:00.000Z", totalMs: 14_400_000 },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons).toContain(
+      "Multiple review rounds (3). Breaking changes into smaller PRs may help.",
+    );
+  });
+
+  it("does not flag review rounds when <=2", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 0,
+        reviewRounds: 2,
+        duration: { startedAt: "2025-06-01T10:00:00.000Z", endedAt: "2025-06-01T14:00:00.000Z", totalMs: 14_400_000 },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons.some((l) => l.includes("Multiple review rounds"))).toBe(false);
+  });
+
+  it("flags long-running sessions (>24 hours)", () => {
+    const { config } = makeConfig();
+    const thirtyHoursMs = 30 * 3_600_000;
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 0,
+        reviewRounds: 0,
+        duration: {
+          startedAt: "2025-06-01T00:00:00.000Z",
+          endedAt: "2025-06-02T06:00:00.000Z",
+          totalMs: thirtyHoursMs,
+        },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons).toContain(
+      "Session ran for 30 hours. Long-running sessions may indicate complexity or blocking.",
+    );
+  });
+
+  it("does not flag sessions under 24 hours for duration", () => {
+    const { config } = makeConfig();
+    const twentyHoursMs = 20 * 3_600_000;
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 0,
+        reviewRounds: 0,
+        duration: {
+          startedAt: "2025-06-01T00:00:00.000Z",
+          endedAt: "2025-06-01T20:00:00.000Z",
+          totalMs: twentyHoursMs,
+        },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons.some((l) => l.includes("Long-running sessions"))).toBe(false);
+  });
+
+  it("flags quick success (<1 hour, merged, no CI or review issues)", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 0,
+        reviewRounds: 0,
+        duration: {
+          startedAt: "2025-06-01T10:00:00.000Z",
+          endedAt: "2025-06-01T10:30:00.000Z",
+          totalMs: 1_800_000, // 30 minutes
+        },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons).toContain(
+      "Clean execution: merged quickly with minimal CI/review iterations.",
+    );
+  });
+
+  it("does not flag quick success when CI failed once", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 2,
+        reviewRounds: 0,
+        duration: {
+          startedAt: "2025-06-01T10:00:00.000Z",
+          endedAt: "2025-06-01T10:30:00.000Z",
+          totalMs: 1_800_000,
+        },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons.some((l) => l.includes("Clean execution"))).toBe(false);
+  });
+
+  it("does not flag quick success when not merged", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "active",
+        ciAttempts: 0,
+        reviewRounds: 0,
+        duration: {
+          startedAt: "2025-06-01T10:00:00.000Z",
+          endedAt: "2025-06-01T10:30:00.000Z",
+          totalMs: 1_800_000,
+        },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons.some((l) => l.includes("Clean execution"))).toBe(false);
+  });
+
+  it("flags quick success under 2 hours threshold", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 1,
+        reviewRounds: 1,
+        duration: {
+          startedAt: "2025-06-01T10:00:00.000Z",
+          endedAt: "2025-06-01T11:30:00.000Z",
+          totalMs: 5_400_000, // 1.5 hours
+        },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons).toContain(
+      "Clean execution: merged quickly with minimal CI/review iterations.",
+    );
+  });
+
+  it("does not flag quick success at exactly 2 hours", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        ciAttempts: 0,
+        reviewRounds: 0,
+        duration: {
+          startedAt: "2025-06-01T10:00:00.000Z",
+          endedAt: "2025-06-01T12:00:00.000Z",
+          totalMs: 7_200_000, // exactly 2 hours
+        },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons.some((l) => l.includes("Clean execution"))).toBe(false);
+  });
+
+  it("flags killed without PR", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "killed",
+        prUrl: null,
+        ciAttempts: 0,
+        reviewRounds: 0,
+        duration: { startedAt: "2025-06-01T10:00:00.000Z", endedAt: "2025-06-01T11:00:00.000Z", totalMs: 3_600_000 },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons).toContain(
+      "Session was killed without creating a PR. May indicate a stuck or misdirected session.",
+    );
+  });
+
+  it("does not flag killed with PR", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "killed",
+        prUrl: "https://github.com/org/repo/pull/42",
+        ciAttempts: 0,
+        reviewRounds: 0,
+        duration: { startedAt: "2025-06-01T10:00:00.000Z", endedAt: "2025-06-01T11:00:00.000Z", totalMs: 3_600_000 },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons.some((l) => l.includes("killed without creating a PR"))).toBe(false);
+  });
+
+  it("flags no events recorded (empty timeline)", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "active",
+        ciAttempts: 0,
+        reviewRounds: 0,
+        duration: { startedAt: "2025-06-01T10:00:00.000Z", endedAt: null, totalMs: 1_000 },
+      },
+      logEntries: [],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons).toContain(
+      "No lifecycle events recorded. Session may have been very short-lived or logging was not active.",
+    );
+  });
+
+  it("returns multiple lessons when multiple patterns match", () => {
+    const { config } = makeConfig();
+    const fiftyHoursMs = 50 * 3_600_000;
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "killed",
+        prUrl: null,
+        ciAttempts: 5,
+        reviewRounds: 4,
+        duration: {
+          startedAt: "2025-06-01T00:00:00.000Z",
+          endedAt: "2025-06-03T02:00:00.000Z",
+          totalMs: fiftyHoursMs,
+        },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    // Should have: high CI failure, multiple review rounds, long duration, killed without PR
+    expect(result!.lessons).toContain(
+      "High CI failure count (5 failures). Consider running tests locally before pushing.",
+    );
+    expect(result!.lessons).toContain(
+      "Multiple review rounds (4). Breaking changes into smaller PRs may help.",
+    );
+    expect(result!.lessons).toContain(
+      "Session ran for 50 hours. Long-running sessions may indicate complexity or blocking.",
+    );
+    expect(result!.lessons).toContain(
+      "Session was killed without creating a PR. May indicate a stuck or misdirected session.",
+    );
+    expect(result!.lessons).toHaveLength(4);
+  });
+
+  it("returns empty lessons for a clean session (no issues)", () => {
+    const { config } = makeConfig();
+    setupGenerateMocks({
+      reportCard: {
+        outcome: "merged",
+        prUrl: "https://github.com/org/repo/pull/42",
+        ciAttempts: 0,
+        reviewRounds: 0,
+        duration: {
+          startedAt: "2025-06-01T10:00:00.000Z",
+          endedAt: "2025-06-01T14:00:00.000Z",
+          totalMs: 14_400_000, // 4 hours (between 2h and 24h, so no quick success or duration flag)
+        },
+      },
+      logEntries: [makeLogEntry()],
+    });
+
+    const result = generateRetrospective("test-1", config as never, "my-project");
+
+    expect(result!.lessons).toEqual([]);
   });
 });

--- a/packages/core/src/__tests__/retrospective.test.ts
+++ b/packages/core/src/__tests__/retrospective.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import type { Retrospective } from "../retrospective.js";
+import { saveRetrospective, loadRetrospectives } from "../retrospective.js";
+
+let tmpDir: string;
+let retroDir: string;
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `ao-test-retrospective-${randomUUID()}`);
+  retroDir = join(tmpDir, "retrospectives");
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Helper to build a Retrospective object with sensible defaults. */
+function makeRetro(overrides: Partial<Retrospective> = {}): Retrospective {
+  return {
+    sessionId: "test-1",
+    projectId: "my-project",
+    generatedAt: "2025-06-01T12:00:00.000Z",
+    outcome: "success",
+    timeline: [
+      { event: "info", at: "2025-06-01T10:00:00.000Z", detail: "session started" },
+      { event: "info", at: "2025-06-01T12:00:00.000Z", detail: "session merged" },
+    ],
+    metrics: {
+      totalDurationMs: 7_200_000,
+      ciFailures: 0,
+      reviewRounds: 0,
+    },
+    lessons: ["Clean execution: merged quickly with minimal CI/review iterations."],
+    reportCard: {
+      sessionId: "test-1",
+      projectId: "my-project",
+      duration: {
+        startedAt: "2025-06-01T10:00:00.000Z",
+        endedAt: "2025-06-01T12:00:00.000Z",
+        totalMs: 7_200_000,
+      },
+      stateTransitions: [],
+      ciAttempts: 0,
+      reviewRounds: 0,
+      outcome: "merged",
+      prUrl: null,
+    },
+    ...overrides,
+  };
+}
+
+describe("saveRetrospective", () => {
+  it("creates the directory and writes a JSON file", () => {
+    const retro = makeRetro();
+
+    saveRetrospective(retro, retroDir);
+
+    const files = readdirSync(retroDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^test-1-.*\.json$/);
+
+    const content = readFileSync(join(retroDir, files[0]), "utf-8");
+    const parsed = JSON.parse(content) as Retrospective;
+    expect(parsed.sessionId).toBe("test-1");
+    expect(parsed.projectId).toBe("my-project");
+    expect(parsed.outcome).toBe("success");
+  });
+
+  it("writes to existing directory without error", () => {
+    mkdirSync(retroDir, { recursive: true });
+    const retro = makeRetro();
+
+    expect(() => saveRetrospective(retro, retroDir)).not.toThrow();
+
+    const files = readdirSync(retroDir);
+    expect(files).toHaveLength(1);
+  });
+
+  it("writes multiple retrospectives for different sessions", () => {
+    saveRetrospective(makeRetro({ sessionId: "test-1" }), retroDir);
+    saveRetrospective(makeRetro({ sessionId: "test-2" }), retroDir);
+    saveRetrospective(makeRetro({ sessionId: "test-3" }), retroDir);
+
+    const files = readdirSync(retroDir);
+    expect(files).toHaveLength(3);
+  });
+
+  it("preserves all fields in the written JSON", () => {
+    const retro = makeRetro({
+      lessons: ["Lesson 1", "Lesson 2"],
+      metrics: { totalDurationMs: 100_000, ciFailures: 3, reviewRounds: 2 },
+    });
+
+    saveRetrospective(retro, retroDir);
+
+    const files = readdirSync(retroDir);
+    const content = readFileSync(join(retroDir, files[0]), "utf-8");
+    const parsed = JSON.parse(content) as Retrospective;
+
+    expect(parsed.lessons).toEqual(["Lesson 1", "Lesson 2"]);
+    expect(parsed.metrics.ciFailures).toBe(3);
+    expect(parsed.metrics.reviewRounds).toBe(2);
+    expect(parsed.reportCard).toBeDefined();
+  });
+});
+
+describe("loadRetrospectives", () => {
+  it("returns empty array for non-existent directory", () => {
+    const result = loadRetrospectives(join(tmpDir, "nonexistent"));
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for empty directory", () => {
+    mkdirSync(retroDir, { recursive: true });
+
+    const result = loadRetrospectives(retroDir);
+    expect(result).toEqual([]);
+  });
+
+  it("loads saved retrospectives", () => {
+    const retro = makeRetro();
+    saveRetrospective(retro, retroDir);
+
+    const results = loadRetrospectives(retroDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].sessionId).toBe("test-1");
+    expect(results[0].projectId).toBe("my-project");
+    expect(results[0].outcome).toBe("success");
+  });
+
+  it("loads multiple retrospectives sorted newest first", () => {
+    // Manually write files with controlled names to verify sort order
+    mkdirSync(retroDir, { recursive: true });
+
+    writeFileSync(
+      join(retroDir, "test-1-2025-06-01T10-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "test-1", generatedAt: "2025-06-01T10:00:00.000Z" })),
+      "utf-8",
+    );
+    writeFileSync(
+      join(retroDir, "test-2-2025-06-02T10-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "test-2", generatedAt: "2025-06-02T10:00:00.000Z" })),
+      "utf-8",
+    );
+    writeFileSync(
+      join(retroDir, "test-3-2025-06-03T10-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "test-3", generatedAt: "2025-06-03T10:00:00.000Z" })),
+      "utf-8",
+    );
+
+    const results = loadRetrospectives(retroDir);
+    expect(results).toHaveLength(3);
+    // Sorted reverse alphabetically by filename, so newest first
+    expect(results[0].sessionId).toBe("test-3");
+    expect(results[1].sessionId).toBe("test-2");
+    expect(results[2].sessionId).toBe("test-1");
+  });
+
+  it("filters by sessionId", () => {
+    mkdirSync(retroDir, { recursive: true });
+
+    writeFileSync(
+      join(retroDir, "test-1-2025-06-01T10-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "test-1" })),
+      "utf-8",
+    );
+    writeFileSync(
+      join(retroDir, "test-2-2025-06-01T11-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "test-2" })),
+      "utf-8",
+    );
+    writeFileSync(
+      join(retroDir, "test-1-2025-06-02T10-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "test-1" })),
+      "utf-8",
+    );
+
+    const results = loadRetrospectives(retroDir, { sessionId: "test-1" });
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.sessionId === "test-1")).toBe(true);
+  });
+
+  it("filters by projectId", () => {
+    mkdirSync(retroDir, { recursive: true });
+
+    writeFileSync(
+      join(retroDir, "test-1-2025-06-01T10-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "test-1", projectId: "project-a" })),
+      "utf-8",
+    );
+    writeFileSync(
+      join(retroDir, "test-2-2025-06-01T11-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "test-2", projectId: "project-b" })),
+      "utf-8",
+    );
+    writeFileSync(
+      join(retroDir, "test-3-2025-06-01T12-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "test-3", projectId: "project-a" })),
+      "utf-8",
+    );
+
+    const results = loadRetrospectives(retroDir, { projectId: "project-a" });
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.projectId === "project-a")).toBe(true);
+  });
+
+  it("respects limit option", () => {
+    mkdirSync(retroDir, { recursive: true });
+
+    for (let i = 1; i <= 5; i++) {
+      writeFileSync(
+        join(retroDir, `test-${i}-2025-06-0${i}T10-00-00-000Z.json`),
+        JSON.stringify(makeRetro({ sessionId: `test-${i}` })),
+        "utf-8",
+      );
+    }
+
+    const results = loadRetrospectives(retroDir, { limit: 2 });
+    expect(results).toHaveLength(2);
+  });
+
+  it("combines sessionId filter with limit", () => {
+    mkdirSync(retroDir, { recursive: true });
+
+    for (let i = 1; i <= 5; i++) {
+      writeFileSync(
+        join(retroDir, `sess-a-2025-06-0${i}T10-00-00-000Z.json`),
+        JSON.stringify(makeRetro({ sessionId: "sess-a" })),
+        "utf-8",
+      );
+    }
+
+    const results = loadRetrospectives(retroDir, { sessionId: "sess-a", limit: 3 });
+    expect(results).toHaveLength(3);
+  });
+
+  it("skips corrupted JSON files", () => {
+    mkdirSync(retroDir, { recursive: true });
+
+    writeFileSync(
+      join(retroDir, "good-1-2025-06-01T10-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "good-1" })),
+      "utf-8",
+    );
+    writeFileSync(
+      join(retroDir, "bad-1-2025-06-02T10-00-00-000Z.json"),
+      "THIS IS NOT VALID JSON {{{",
+      "utf-8",
+    );
+    writeFileSync(
+      join(retroDir, "good-2-2025-06-03T10-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "good-2" })),
+      "utf-8",
+    );
+
+    const results = loadRetrospectives(retroDir);
+    expect(results).toHaveLength(2);
+    const sessionIds = results.map((r) => r.sessionId);
+    expect(sessionIds).toContain("good-1");
+    expect(sessionIds).toContain("good-2");
+  });
+
+  it("ignores non-JSON files", () => {
+    mkdirSync(retroDir, { recursive: true });
+
+    writeFileSync(
+      join(retroDir, "test-1-2025-06-01T10-00-00-000Z.json"),
+      JSON.stringify(makeRetro({ sessionId: "test-1" })),
+      "utf-8",
+    );
+    writeFileSync(join(retroDir, "readme.txt"), "not a retro", "utf-8");
+    writeFileSync(join(retroDir, ".hidden"), "hidden file", "utf-8");
+
+    const results = loadRetrospectives(retroDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].sessionId).toBe("test-1");
+  });
+
+  it("round-trips save and load", () => {
+    const retro = makeRetro({
+      sessionId: "roundtrip-1",
+      projectId: "proj-x",
+      outcome: "failure",
+      lessons: ["CI failed 4 times before passing.", "Multiple review rounds (3)."],
+      metrics: { totalDurationMs: 50_000_000, ciFailures: 4, reviewRounds: 3 },
+    });
+
+    saveRetrospective(retro, retroDir);
+    const results = loadRetrospectives(retroDir);
+
+    expect(results).toHaveLength(1);
+    const loaded = results[0];
+    expect(loaded.sessionId).toBe("roundtrip-1");
+    expect(loaded.projectId).toBe("proj-x");
+    expect(loaded.outcome).toBe("failure");
+    expect(loaded.lessons).toEqual([
+      "CI failed 4 times before passing.",
+      "Multiple review rounds (3).",
+    ]);
+    expect(loaded.metrics.ciFailures).toBe(4);
+    expect(loaded.metrics.reviewRounds).toBe(3);
+    expect(loaded.metrics.totalDurationMs).toBe(50_000_000);
+    expect(loaded.reportCard.sessionId).toBe("test-1"); // from default makeRetro
+    expect(loaded.timeline).toHaveLength(2);
+  });
+});

--- a/packages/core/src/__tests__/retrospective.test.ts
+++ b/packages/core/src/__tests__/retrospective.test.ts
@@ -3,8 +3,7 @@ import { mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync } from "nod
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
-import type { Retrospective } from "../retrospective.js";
-import { saveRetrospective, loadRetrospectives } from "../retrospective.js";
+import { saveRetrospective, loadRetrospectives, type Retrospective } from "../retrospective.js";
 
 let tmpDir: string;
 let retroDir: string;

--- a/packages/core/src/__tests__/retrospective.test.ts
+++ b/packages/core/src/__tests__/retrospective.test.ts
@@ -3,7 +3,8 @@ import { mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync } from "nod
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
-import { saveRetrospective, loadRetrospectives, type Retrospective } from "../retrospective.js";
+import type { Retrospective } from "../types.js";
+import { saveRetrospective, loadRetrospectives } from "../retrospective.js";
 
 let tmpDir: string;
 let retroDir: string;

--- a/packages/core/src/__tests__/session-report-card.test.ts
+++ b/packages/core/src/__tests__/session-report-card.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { generateReportCard } from "../session-report-card.js";
+
+let tmpDir: string;
+let eventsLogPath: string;
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `ao-test-report-card-${randomUUID()}`);
+  mkdirSync(tmpDir, { recursive: true });
+  eventsLogPath = join(tmpDir, "events.jsonl");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Helper to write JSONL lines to the events log file. */
+function writeEvents(entries: Array<Record<string, unknown>>): void {
+  const lines = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  writeFileSync(eventsLogPath, lines, "utf-8");
+}
+
+/** Helper to build a log entry with sensible defaults. */
+function makeEntry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ts: new Date().toISOString(),
+    level: "info",
+    source: "lifecycle",
+    sessionId: "test-1",
+    message: "event",
+    ...overrides,
+  };
+}
+
+describe("generateReportCard", () => {
+  it("returns defaults for empty events (no log file)", () => {
+    // eventsLogPath does not exist yet
+    const card = generateReportCard("test-1", eventsLogPath, {});
+
+    expect(card.sessionId).toBe("test-1");
+    expect(card.projectId).toBe("");
+    expect(card.stateTransitions).toEqual([]);
+    expect(card.ciAttempts).toBe(0);
+    expect(card.reviewRounds).toBe(0);
+    expect(card.outcome).toBe("active");
+    expect(card.prUrl).toBeNull();
+  });
+
+  it("returns defaults for empty events file", () => {
+    writeFileSync(eventsLogPath, "", "utf-8");
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+
+    expect(card.stateTransitions).toEqual([]);
+    expect(card.ciAttempts).toBe(0);
+    expect(card.reviewRounds).toBe(0);
+    expect(card.outcome).toBe("active");
+  });
+
+  it("tracks state transitions from oldStatus/newStatus in data", () => {
+    const t1 = "2025-06-01T10:00:00.000Z";
+    const t2 = "2025-06-01T10:05:00.000Z";
+    const t3 = "2025-06-01T10:10:00.000Z";
+
+    writeEvents([
+      makeEntry({ ts: t1, data: { oldStatus: "spawning", newStatus: "working" } }),
+      makeEntry({ ts: t2, data: { oldStatus: "working", newStatus: "pr_open" } }),
+      makeEntry({ ts: t3, data: { oldStatus: "pr_open", newStatus: "merged" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+
+    expect(card.stateTransitions).toHaveLength(3);
+    expect(card.stateTransitions[0]).toEqual({ from: "spawning", to: "working", at: t1 });
+    expect(card.stateTransitions[1]).toEqual({ from: "working", to: "pr_open", at: t2 });
+    expect(card.stateTransitions[2]).toEqual({ from: "pr_open", to: "merged", at: t3 });
+  });
+
+  it("counts CI attempts from data.type=ci.failing", () => {
+    writeEvents([
+      makeEntry({ data: { type: "ci.failing" } }),
+      makeEntry({ data: { type: "ci.failing" } }),
+      makeEntry({ data: { type: "ci.failing" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.ciAttempts).toBe(3);
+  });
+
+  it("counts CI attempts from data.newStatus=ci_failed", () => {
+    writeEvents([
+      makeEntry({ data: { oldStatus: "pr_open", newStatus: "ci_failed" } }),
+      makeEntry({ data: { oldStatus: "ci_failed", newStatus: "working" } }),
+      makeEntry({ data: { oldStatus: "working", newStatus: "ci_failed" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.ciAttempts).toBe(2);
+  });
+
+  it("counts both ci.failing type and ci_failed newStatus without double-counting different events", () => {
+    writeEvents([
+      makeEntry({ data: { type: "ci.failing" } }),
+      makeEntry({ data: { oldStatus: "pr_open", newStatus: "ci_failed" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.ciAttempts).toBe(2);
+  });
+
+  it("counts review rounds from data.type=review.changes_requested", () => {
+    writeEvents([
+      makeEntry({ data: { type: "review.changes_requested" } }),
+      makeEntry({ data: { type: "review.changes_requested" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.reviewRounds).toBe(2);
+  });
+
+  it("counts review rounds from data.newStatus=changes_requested", () => {
+    writeEvents([
+      makeEntry({ data: { oldStatus: "review_pending", newStatus: "changes_requested" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.reviewRounds).toBe(1);
+  });
+
+  it("determines outcome=merged from last transition", () => {
+    writeEvents([
+      makeEntry({ data: { oldStatus: "spawning", newStatus: "working" } }),
+      makeEntry({ data: { oldStatus: "working", newStatus: "merged" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.outcome).toBe("merged");
+  });
+
+  it("determines outcome=killed from last transition", () => {
+    writeEvents([
+      makeEntry({ data: { oldStatus: "spawning", newStatus: "working" } }),
+      makeEntry({ data: { oldStatus: "working", newStatus: "killed" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.outcome).toBe("killed");
+  });
+
+  it("determines outcome=abandoned from last transition", () => {
+    writeEvents([
+      makeEntry({ data: { oldStatus: "working", newStatus: "abandoned" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.outcome).toBe("abandoned");
+  });
+
+  it("determines outcome=active for unrecognized last status", () => {
+    writeEvents([
+      makeEntry({ data: { oldStatus: "spawning", newStatus: "working" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.outcome).toBe("active");
+  });
+
+  it("falls back to metadata status when there are no transitions", () => {
+    writeEvents([
+      makeEntry({ message: "session started" }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, { status: "merged" });
+    expect(card.outcome).toBe("merged");
+  });
+
+  it("falls back to active when no transitions and no metadata status", () => {
+    writeEvents([
+      makeEntry({ message: "session started" }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.outcome).toBe("active");
+  });
+
+  it("calculates duration from first to last event timestamps", () => {
+    const start = "2025-06-01T10:00:00.000Z";
+    const end = "2025-06-01T12:30:00.000Z";
+
+    writeEvents([
+      makeEntry({ ts: start, data: { oldStatus: "spawning", newStatus: "working" } }),
+      makeEntry({ ts: "2025-06-01T11:00:00.000Z", message: "doing work" }),
+      makeEntry({ ts: end, data: { oldStatus: "working", newStatus: "merged" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+
+    expect(card.duration.startedAt).toBe(start);
+    expect(card.duration.endedAt).toBe(end);
+    // 2.5 hours = 9,000,000 ms
+    expect(card.duration.totalMs).toBe(9_000_000);
+  });
+
+  it("endedAt is null for active sessions", () => {
+    const start = "2025-06-01T10:00:00.000Z";
+
+    writeEvents([
+      makeEntry({ ts: start, data: { oldStatus: "spawning", newStatus: "working" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+
+    expect(card.duration.startedAt).toBe(start);
+    expect(card.duration.endedAt).toBeNull();
+    // totalMs should be positive (now minus start)
+    expect(card.duration.totalMs).toBeGreaterThan(0);
+  });
+
+  it("uses metadata createdAt when no events present", () => {
+    const createdAt = "2025-06-01T08:00:00.000Z";
+
+    // No events file at all
+    const card = generateReportCard("test-1", eventsLogPath, { createdAt });
+
+    expect(card.duration.startedAt).toBe(createdAt);
+  });
+
+  it("reads PR URL from metadata", () => {
+    writeEvents([makeEntry({})]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {
+      pr: "https://github.com/org/repo/pull/42",
+    });
+
+    expect(card.prUrl).toBe("https://github.com/org/repo/pull/42");
+  });
+
+  it("prUrl is null when metadata has no pr field", () => {
+    writeEvents([makeEntry({})]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.prUrl).toBeNull();
+  });
+
+  it("reads projectId from metadata", () => {
+    writeEvents([makeEntry({})]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {
+      project: "my-project",
+    });
+
+    expect(card.projectId).toBe("my-project");
+  });
+
+  it("only includes events matching the given sessionId", () => {
+    writeEvents([
+      makeEntry({ sessionId: "test-1", data: { type: "ci.failing" } }),
+      makeEntry({ sessionId: "other-session", data: { type: "ci.failing" } }),
+      makeEntry({ sessionId: "test-1", data: { type: "ci.failing" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    expect(card.ciAttempts).toBe(2);
+  });
+
+  it("handles events without data gracefully", () => {
+    writeEvents([
+      makeEntry({ message: "plain event" }),
+      makeEntry({ message: "another event" }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+
+    expect(card.stateTransitions).toEqual([]);
+    expect(card.ciAttempts).toBe(0);
+    expect(card.reviewRounds).toBe(0);
+  });
+
+  it("handles corrupted JSONL lines gracefully", () => {
+    const content = [
+      JSON.stringify(makeEntry({ data: { type: "ci.failing" } })),
+      "THIS IS NOT VALID JSON",
+      JSON.stringify(makeEntry({ data: { type: "ci.failing" } })),
+    ].join("\n") + "\n";
+
+    writeFileSync(eventsLogPath, content, "utf-8");
+
+    const card = generateReportCard("test-1", eventsLogPath, {});
+    // Corrupted line is skipped, two valid ci.failing events counted
+    expect(card.ciAttempts).toBe(2);
+  });
+
+  it("full lifecycle scenario", () => {
+    const t1 = "2025-06-01T10:00:00.000Z";
+    const t2 = "2025-06-01T10:30:00.000Z";
+    const t3 = "2025-06-01T11:00:00.000Z";
+    const t4 = "2025-06-01T11:30:00.000Z";
+    const t5 = "2025-06-01T12:00:00.000Z";
+    const t6 = "2025-06-01T12:30:00.000Z";
+    const t7 = "2025-06-01T13:00:00.000Z";
+
+    writeEvents([
+      makeEntry({ ts: t1, data: { oldStatus: "spawning", newStatus: "working" } }),
+      makeEntry({ ts: t2, data: { oldStatus: "working", newStatus: "pr_open" } }),
+      makeEntry({ ts: t3, data: { oldStatus: "pr_open", newStatus: "ci_failed" } }),
+      makeEntry({ ts: t4, data: { oldStatus: "ci_failed", newStatus: "working" } }),
+      makeEntry({ ts: t5, data: { oldStatus: "working", newStatus: "pr_open" } }),
+      makeEntry({ ts: t6, data: { oldStatus: "pr_open", newStatus: "changes_requested" } }),
+      makeEntry({ ts: t7, data: { oldStatus: "changes_requested", newStatus: "merged" } }),
+    ]);
+
+    const card = generateReportCard("test-1", eventsLogPath, {
+      project: "my-app",
+      pr: "https://github.com/org/repo/pull/99",
+    });
+
+    expect(card.sessionId).toBe("test-1");
+    expect(card.projectId).toBe("my-app");
+    expect(card.stateTransitions).toHaveLength(7);
+    expect(card.ciAttempts).toBe(1);
+    expect(card.reviewRounds).toBe(1);
+    expect(card.outcome).toBe("merged");
+    expect(card.prUrl).toBe("https://github.com/org/repo/pull/99");
+    expect(card.duration.startedAt).toBe(t1);
+    expect(card.duration.endedAt).toBe(t7);
+    // 3 hours = 10,800,000 ms
+    expect(card.duration.totalMs).toBe(10_800_000);
+  });
+});

--- a/packages/core/src/__tests__/utils-perf.test.ts
+++ b/packages/core/src/__tests__/utils-perf.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { percentile, normalizeRoutePath } from "../utils.js";
+
+describe("percentile", () => {
+  it("returns 0 for empty array", () => {
+    expect(percentile([], 50)).toBe(0);
+  });
+
+  it("returns the single element for single-element array", () => {
+    expect(percentile([42], 50)).toBe(42);
+    expect(percentile([42], 95)).toBe(42);
+    expect(percentile([42], 99)).toBe(42);
+  });
+
+  it("returns correct p50 for odd-length array", () => {
+    expect(percentile([10, 20, 30, 40, 50], 50)).toBe(30);
+  });
+
+  it("returns correct p95 for larger array", () => {
+    // 20 elements, p95 = ceil(0.95 * 20) - 1 = ceil(19) - 1 = 18
+    const sorted = Array.from({ length: 20 }, (_, i) => (i + 1) * 10);
+    expect(percentile(sorted, 95)).toBe(190);
+  });
+
+  it("returns correct p99 for larger array", () => {
+    // 100 elements, p99 = ceil(0.99 * 100) - 1 = 99 - 1 = 98
+    const sorted = Array.from({ length: 100 }, (_, i) => i + 1);
+    expect(percentile(sorted, 99)).toBe(99);
+  });
+
+  it("handles p=0 by returning the first element", () => {
+    // p=0: idx = ceil(0) - 1 = -1, clamped to 0
+    expect(percentile([10, 20, 30], 0)).toBe(10);
+  });
+
+  it("handles p=100 by returning the last element", () => {
+    // p=100: idx = ceil(1 * 3) - 1 = 2
+    expect(percentile([10, 20, 30], 100)).toBe(30);
+  });
+
+  it("returns correct p50 for even-length array", () => {
+    // 4 elements, p50 = ceil(0.5 * 4) - 1 = ceil(2) - 1 = 1
+    expect(percentile([10, 20, 30, 40], 50)).toBe(20);
+  });
+});
+
+describe("normalizeRoutePath", () => {
+  it("replaces /sessions/<id> with /sessions/:id", () => {
+    expect(normalizeRoutePath("/sessions/abc123")).toBe("/sessions/:id");
+  });
+
+  it("replaces /prs/<id> with /prs/:id", () => {
+    expect(normalizeRoutePath("/prs/456")).toBe("/prs/:id");
+  });
+
+  it("handles paths with both sessions and prs segments", () => {
+    expect(normalizeRoutePath("/api/sessions/abc/prs/123")).toBe(
+      "/api/sessions/:id/prs/:id",
+    );
+  });
+
+  it("leaves paths without dynamic segments unchanged", () => {
+    expect(normalizeRoutePath("/api/health")).toBe("/api/health");
+    expect(normalizeRoutePath("/")).toBe("/");
+  });
+
+  it("handles multiple session segments", () => {
+    expect(normalizeRoutePath("/sessions/a/sessions/b")).toBe(
+      "/sessions/:id/sessions/:id",
+    );
+  });
+
+  it("preserves query strings and trailing slashes", () => {
+    // normalizeRoutePath only replaces path segments; everything else passes through
+    expect(normalizeRoutePath("/sessions/abc123/details")).toBe(
+      "/sessions/:id/details",
+    );
+  });
+});

--- a/packages/core/src/dashboard-manager.ts
+++ b/packages/core/src/dashboard-manager.ts
@@ -62,7 +62,7 @@ async function findPidOnPort(port: number): Promise<number | null> {
 }
 
 /** Read PID from dashboard.pid file, verify it's alive. */
-function readPidFile(logDir: string): number | null {
+export function readPidFile(logDir: string): number | null {
   const pidFile = join(logDir, "dashboard.pid");
   if (!existsSync(pidFile)) return null;
 
@@ -79,12 +79,12 @@ function readPidFile(logDir: string): number | null {
 }
 
 /** Write PID to dashboard.pid. */
-function writePidFile(logDir: string, pid: number): void {
+export function writePidFile(logDir: string, pid: number): void {
   writeFileSync(join(logDir, "dashboard.pid"), String(pid), "utf-8");
 }
 
 /** Remove dashboard.pid. */
-function removePidFile(logDir: string): void {
+export function removePidFile(logDir: string): void {
   try {
     const f = join(logDir, "dashboard.pid");
     if (existsSync(f)) unlinkSync(f);

--- a/packages/core/src/dashboard-manager.ts
+++ b/packages/core/src/dashboard-manager.ts
@@ -159,8 +159,8 @@ export async function restartDashboard(opts: DashboardRestartOpts): Promise<Dash
   if (opts.configPath) {
     env["AO_CONFIG_PATH"] = opts.configPath;
   }
-  env["NEXT_PUBLIC_TERMINAL_PORT"] = env["TERMINAL_PORT"] ?? "3001";
-  env["NEXT_PUBLIC_DIRECT_TERMINAL_PORT"] = env["DIRECT_TERMINAL_PORT"] ?? "3003";
+  env["NEXT_PUBLIC_TERMINAL_PORT"] = env["TERMINAL_PORT"] ?? "14800";
+  env["NEXT_PUBLIC_DIRECT_TERMINAL_PORT"] = env["DIRECT_TERMINAL_PORT"] ?? "14801";
 
   const child = spawn("npx", ["next", "dev", "-p", String(port)], {
     cwd: opts.webDir,

--- a/packages/core/src/dashboard-manager.ts
+++ b/packages/core/src/dashboard-manager.ts
@@ -17,6 +17,7 @@ import {
   rmSync,
   mkdirSync,
   openSync,
+  closeSync,
 } from "node:fs";
 
 const execFileAsync = promisify(execFileCb);
@@ -167,6 +168,10 @@ export async function restartDashboard(opts: DashboardRestartOpts): Promise<Dash
     detached: true,
     env,
   });
+
+  // Close FDs in the parent — the child has its own copies via dup2
+  closeSync(outFd);
+  closeSync(errFd);
 
   child.unref();
 

--- a/packages/core/src/dashboard-manager.ts
+++ b/packages/core/src/dashboard-manager.ts
@@ -1,0 +1,250 @@
+/**
+ * Dashboard process manager — programmatic control of the Next.js dev server.
+ *
+ * Provides `restartDashboard()` for use by the orchestrator agent, lifecycle
+ * manager, or any code that needs to kill/clean/restart the dashboard without
+ * going through the CLI.
+ */
+
+import { execFile as execFileCb, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { join, resolve } from "node:path";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+  rmSync,
+  mkdirSync,
+  openSync,
+} from "node:fs";
+
+const execFileAsync = promisify(execFileCb);
+
+export interface DashboardRestartOpts {
+  /** Wipe .next cache before restarting. */
+  clean?: boolean;
+  /** Port the dashboard listens on. Default 3000. */
+  port?: number;
+  /** Path to the @composio/ao-web package directory. */
+  webDir: string;
+  /** Log directory for PID file and output logs. */
+  logDir: string;
+  /** AO_CONFIG_PATH to pass to the dashboard. */
+  configPath?: string;
+  /** Max ms to wait for old process to release the port. Default 5000. */
+  killTimeoutMs?: number;
+  /** Called with status messages (for logging/display). */
+  onStatus?: (message: string) => void;
+}
+
+export interface DashboardRestartResult {
+  /** PID of the newly spawned dashboard process, or null if spawn failed. */
+  pid: number | null;
+  /** Whether an existing process was killed. */
+  killed: boolean;
+  /** Whether .next cache was cleaned. */
+  cleaned: boolean;
+}
+
+/** Find PID of a process listening on a TCP port via lsof. */
+async function findPidOnPort(port: number): Promise<number | null> {
+  try {
+    const { stdout } = await execFileAsync("lsof", ["-ti", `:${port}`, "-sTCP:LISTEN"], {
+      timeout: 5000,
+    });
+    const pid = parseInt(stdout.trim().split("\n")[0], 10);
+    return isNaN(pid) ? null : pid;
+  } catch {
+    return null;
+  }
+}
+
+/** Read PID from dashboard.pid file, verify it's alive. */
+function readPidFile(logDir: string): number | null {
+  const pidFile = join(logDir, "dashboard.pid");
+  if (!existsSync(pidFile)) return null;
+
+  try {
+    const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+    if (isNaN(pid)) return null;
+    process.kill(pid, 0); // test if alive
+    return pid;
+  } catch {
+    // stale — clean up
+    try { unlinkSync(pidFile); } catch { /* best effort */ }
+    return null;
+  }
+}
+
+/** Write PID to dashboard.pid. */
+function writePidFile(logDir: string, pid: number): void {
+  writeFileSync(join(logDir, "dashboard.pid"), String(pid), "utf-8");
+}
+
+/** Remove dashboard.pid. */
+function removePidFile(logDir: string): void {
+  try {
+    const f = join(logDir, "dashboard.pid");
+    if (existsSync(f)) unlinkSync(f);
+  } catch { /* best effort */ }
+}
+
+/** Wait for a port to become free. */
+async function waitForPortFree(port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const pid = await findPidOnPort(port);
+    if (!pid) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`Port ${port} still in use after ${timeoutMs}ms`);
+}
+
+/**
+ * Kill the running dashboard, optionally clean .next, and spawn a new one.
+ *
+ * The new process is spawned detached with stdout/stderr going to log files
+ * so it survives the caller exiting. Returns immediately after spawn — does
+ * NOT wait for the server to be healthy (use `waitForHealthy` for that).
+ */
+export async function restartDashboard(opts: DashboardRestartOpts): Promise<DashboardRestartResult> {
+  const port = opts.port ?? 3000;
+  const killTimeout = opts.killTimeoutMs ?? 5000;
+  const log = opts.onStatus ?? (() => {});
+
+  let killed = false;
+  let cleaned = false;
+
+  // 1. Find and kill existing dashboard
+  const filePid = readPidFile(opts.logDir);
+  const portPid = await findPidOnPort(port);
+  const targetPid = filePid ?? portPid;
+
+  if (targetPid) {
+    log(`Stopping dashboard (PID ${targetPid}) on port ${port}...`);
+    try {
+      process.kill(targetPid, "SIGTERM");
+    } catch {
+      // already exited
+    }
+    await waitForPortFree(port, killTimeout);
+    removePidFile(opts.logDir);
+    killed = true;
+    log("Dashboard stopped.");
+  }
+
+  // 2. Clean .next cache if requested
+  if (opts.clean) {
+    const nextDir = resolve(opts.webDir, ".next");
+    if (existsSync(nextDir)) {
+      log("Cleaning .next cache...");
+      rmSync(nextDir, { recursive: true, force: true });
+      cleaned = true;
+      log("Cache cleaned.");
+    }
+  }
+
+  // 3. Spawn new dashboard (detached, logs to files)
+  if (!existsSync(opts.logDir)) {
+    mkdirSync(opts.logDir, { recursive: true });
+  }
+
+  const outFd = openSync(join(opts.logDir, "dashboard.out.log"), "a");
+  const errFd = openSync(join(opts.logDir, "dashboard.err.log"), "a");
+
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  env["PORT"] = String(port);
+  if (opts.configPath) {
+    env["AO_CONFIG_PATH"] = opts.configPath;
+  }
+  env["NEXT_PUBLIC_TERMINAL_PORT"] = env["TERMINAL_PORT"] ?? "3001";
+  env["NEXT_PUBLIC_DIRECT_TERMINAL_PORT"] = env["DIRECT_TERMINAL_PORT"] ?? "3003";
+
+  const child = spawn("npx", ["next", "dev", "-p", String(port)], {
+    cwd: opts.webDir,
+    stdio: ["ignore", outFd, errFd],
+    detached: true,
+    env,
+  });
+
+  child.unref();
+
+  const pid = child.pid ?? null;
+  if (pid) {
+    writePidFile(opts.logDir, pid);
+    log(`Dashboard started (PID ${pid}) on port ${port}.`);
+  }
+
+  return { pid, killed, cleaned };
+}
+
+/**
+ * Wait for the dashboard to respond to HTTP requests.
+ * Polls `http://localhost:{port}` until it gets a response or times out.
+ */
+export async function waitForHealthy(port: number, timeoutMs = 30_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 2000);
+      const res = await fetch(`http://localhost:${port}`, { signal: controller.signal });
+      clearTimeout(timer);
+      if (res.ok || res.status === 404) return true; // 404 is fine, server is responding
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return false;
+}
+
+/**
+ * Get the status of the dashboard process.
+ */
+export async function getDashboardStatus(
+  logDir: string,
+  port: number,
+): Promise<{
+  running: boolean;
+  pid: number | null;
+  source: "pid_file" | "port_scan" | null;
+}> {
+  const filePid = readPidFile(logDir);
+  if (filePid) {
+    return { running: true, pid: filePid, source: "pid_file" };
+  }
+
+  const portPid = await findPidOnPort(port);
+  if (portPid) {
+    return { running: true, pid: portPid, source: "port_scan" };
+  }
+
+  return { running: false, pid: null, source: null };
+}
+
+/**
+ * Stop the dashboard without restarting.
+ */
+export async function stopDashboard(
+  logDir: string,
+  port: number,
+  timeoutMs = 5000,
+): Promise<boolean> {
+  const filePid = readPidFile(logDir);
+  const portPid = await findPidOnPort(port);
+  const targetPid = filePid ?? portPid;
+
+  if (!targetPid) return false;
+
+  try {
+    process.kill(targetPid, "SIGTERM");
+  } catch {
+    // already dead
+  }
+
+  await waitForPortFree(port, timeoutMs);
+  removePidFile(logDir);
+  return true;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,5 +98,5 @@ export { generateReportCard } from "./session-report-card.js";
 export { generateRetrospective, saveRetrospective, loadRetrospectives, JsonlRetrospectiveStore } from "./retrospective.js";
 
 // Dashboard manager — programmatic dashboard process control
-export { restartDashboard, waitForHealthy, getDashboardStatus, stopDashboard } from "./dashboard-manager.js";
+export { restartDashboard, waitForHealthy, getDashboardStatus, stopDashboard, readPidFile, writePidFile, removePidFile } from "./dashboard-manager.js";
 export type { DashboardRestartOpts, DashboardRestartResult } from "./dashboard-manager.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,8 @@ export {
   getSessionsDir,
   getWorktreesDir,
   getArchiveDir,
+  getLogsDir,
+  getRetrospectivesDir,
   getOriginFilePath,
   generateSessionName,
   generateTmuxName,
@@ -79,3 +81,19 @@ export {
   expandHome,
   validateAndStoreOrigin,
 } from "./paths.js";
+
+// Log writer — JSONL structured logging with rotation
+export { LogWriter } from "./log-writer.js";
+export type { LogEntry, LogWriterOptions } from "./log-writer.js";
+
+// Log reader — query and filter JSONL logs
+export { readLogs, readLogsFromDir, tailLogs } from "./log-reader.js";
+export type { LogQueryOptions } from "./log-reader.js";
+
+// Session report card — per-session metrics
+export { generateReportCard } from "./session-report-card.js";
+export type { SessionReportCard } from "./session-report-card.js";
+
+// Retrospective — session analysis
+export { generateRetrospective, saveRetrospective, loadRetrospectives } from "./retrospective.js";
+export type { Retrospective } from "./retrospective.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,8 @@ export {
   getArchiveDir,
   getLogsDir,
   getRetrospectivesDir,
+  resolveProjectLogDir,
+  resolveProjectRetroDir,
   getOriginFilePath,
   generateSessionName,
   generateTmuxName,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,7 +60,7 @@ export { generateOrchestratorPrompt } from "./orchestrator-prompt.js";
 export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";
 
 // Shared utilities
-export { shellEscape, escapeAppleScript, validateUrl, readLastJsonlEntry } from "./utils.js";
+export { shellEscape, escapeAppleScript, validateUrl, readLastJsonlEntry, percentile, normalizeRoutePath } from "./utils.js";
 
 // Path utilities — hash-based directory structure
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,7 +89,8 @@ export { LogWriter } from "./log-writer.js";
 export type { LogWriterOptions } from "./log-writer.js";
 
 // Log reader — query and filter JSONL logs
-export { readLogs, readLogsFromDir, tailLogs } from "./log-reader.js";
+export { readLogs, readLogsFromDir, tailLogs, parseApiLogs } from "./log-reader.js";
+export type { ApiLogEntry } from "./log-reader.js";
 
 // Session report card — per-session metrics
 export { generateReportCard } from "./session-report-card.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,3 +97,7 @@ export type { SessionReportCard } from "./session-report-card.js";
 // Retrospective — session analysis
 export { generateRetrospective, saveRetrospective, loadRetrospectives } from "./retrospective.js";
 export type { Retrospective } from "./retrospective.js";
+
+// Dashboard manager — programmatic dashboard process control
+export { restartDashboard, waitForHealthy, getDashboardStatus, stopDashboard } from "./dashboard-manager.js";
+export type { DashboardRestartOpts, DashboardRestartResult } from "./dashboard-manager.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,8 +89,8 @@ export { LogWriter } from "./log-writer.js";
 export type { LogWriterOptions } from "./log-writer.js";
 
 // Log reader — query and filter JSONL logs
-export { readLogs, readLogsFromDir, tailLogs, parseApiLogs } from "./log-reader.js";
-export type { ApiLogEntry } from "./log-reader.js";
+export { readLogs, readLogsFromDir, tailLogs, parseApiLogs, computeApiStats } from "./log-reader.js";
+export type { ApiLogEntry, RouteStats, ApiPerfResult } from "./log-reader.js";
 
 // Session report card — per-session metrics
 export { generateReportCard } from "./session-report-card.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,21 +82,18 @@ export {
   validateAndStoreOrigin,
 } from "./paths.js";
 
-// Log writer — JSONL structured logging with rotation
+// Log writer — JSONL structured logging with rotation (default EventLogger implementation)
 export { LogWriter } from "./log-writer.js";
-export type { LogEntry, LogWriterOptions } from "./log-writer.js";
+export type { LogWriterOptions } from "./log-writer.js";
 
 // Log reader — query and filter JSONL logs
 export { readLogs, readLogsFromDir, tailLogs } from "./log-reader.js";
-export type { LogQueryOptions } from "./log-reader.js";
 
 // Session report card — per-session metrics
 export { generateReportCard } from "./session-report-card.js";
-export type { SessionReportCard } from "./session-report-card.js";
 
-// Retrospective — session analysis
-export { generateRetrospective, saveRetrospective, loadRetrospectives } from "./retrospective.js";
-export type { Retrospective } from "./retrospective.js";
+// Retrospective — session analysis (includes default RetrospectiveStore implementation)
+export { generateRetrospective, saveRetrospective, loadRetrospectives, JsonlRetrospectiveStore } from "./retrospective.js";
 
 // Dashboard manager — programmatic dashboard process control
 export { restartDashboard, waitForHealthy, getDashboardStatus, stopDashboard } from "./dashboard-manager.js";

--- a/packages/core/src/log-reader.ts
+++ b/packages/core/src/log-reader.ts
@@ -1,0 +1,173 @@
+/**
+ * Log query and filter utilities for reading JSONL log files.
+ *
+ * Reads line-by-line, parses JSON (wrapped in try/catch per CLAUDE.md),
+ * and applies filters. Supports reading current + rotated files in order.
+ */
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join, basename } from "node:path";
+import type { LogEntry } from "./log-writer.js";
+
+export interface LogQueryOptions {
+  since?: Date;
+  until?: Date;
+  level?: LogEntry["level"][];
+  sessionId?: string;
+  source?: LogEntry["source"];
+  limit?: number;
+  pattern?: string;
+}
+
+/** Read and filter log entries from a single JSONL file. */
+export function readLogs(filePath: string, opts?: LogQueryOptions): LogEntry[] {
+  if (!existsSync(filePath)) return [];
+
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const entries: LogEntry[] = [];
+  const lines = content.split("\n");
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+
+    let entry: LogEntry;
+    try {
+      entry = JSON.parse(line) as LogEntry;
+    } catch {
+      // Corrupted line — skip (per CLAUDE.md: always wrap JSON.parse in try/catch)
+      continue;
+    }
+
+    if (!matchesFilter(entry, opts)) continue;
+    entries.push(entry);
+
+    if (opts?.limit && entries.length >= opts.limit) break;
+  }
+
+  return entries;
+}
+
+/**
+ * Read log entries from a directory, including rotated files.
+ * Reads in chronological order: oldest backup first, current file last.
+ */
+export function readLogsFromDir(
+  logDir: string,
+  prefix: string,
+  opts?: LogQueryOptions,
+): LogEntry[] {
+  if (!existsSync(logDir)) return [];
+
+  // Find all files matching the prefix pattern
+  const files: string[] = [];
+  try {
+    const dirEntries = readdirSync(logDir);
+    for (const entry of dirEntries) {
+      if (entry === `${prefix}.jsonl` || entry.match(new RegExp(`^${escapeRegex(prefix)}\\.\\d+\\.jsonl$`))) {
+        files.push(entry);
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  // Sort: highest numbered backup first (oldest), current file last
+  files.sort((a, b) => {
+    const numA = extractBackupNumber(a);
+    const numB = extractBackupNumber(b);
+    // Higher backup number = older file, should come first
+    return numB - numA;
+  });
+
+  const allEntries: LogEntry[] = [];
+  const remaining = opts?.limit;
+
+  for (const file of files) {
+    const fileOpts = remaining !== undefined
+      ? { ...opts, limit: remaining - allEntries.length }
+      : opts;
+
+    const entries = readLogs(join(logDir, file), fileOpts);
+    allEntries.push(...entries);
+
+    if (remaining !== undefined && allEntries.length >= remaining) break;
+  }
+
+  return allEntries;
+}
+
+/** Read the last N entries from a log file (most recent first). */
+export function tailLogs(filePath: string, lines: number): LogEntry[] {
+  if (!existsSync(filePath)) return [];
+
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const allLines = content.split("\n").filter((l) => l.trim());
+  const lastLines = allLines.slice(-lines);
+  const entries: LogEntry[] = [];
+
+  for (const line of lastLines) {
+    try {
+      entries.push(JSON.parse(line) as LogEntry);
+    } catch {
+      // Skip corrupted lines
+    }
+  }
+
+  return entries;
+}
+
+/** Check if a log entry matches the given filter options. */
+function matchesFilter(entry: LogEntry, opts?: LogQueryOptions): boolean {
+  if (!opts) return true;
+
+  if (opts.since) {
+    const entryTime = new Date(entry.ts);
+    if (entryTime < opts.since) return false;
+  }
+
+  if (opts.until) {
+    const entryTime = new Date(entry.ts);
+    if (entryTime > opts.until) return false;
+  }
+
+  if (opts.level && opts.level.length > 0) {
+    if (!opts.level.includes(entry.level)) return false;
+  }
+
+  if (opts.sessionId) {
+    if (entry.sessionId !== opts.sessionId) return false;
+  }
+
+  if (opts.source) {
+    if (entry.source !== opts.source) return false;
+  }
+
+  if (opts.pattern) {
+    if (!entry.message.includes(opts.pattern)) return false;
+  }
+
+  return true;
+}
+
+/** Extract backup number from filename (0 for current file). */
+function extractBackupNumber(filename: string): number {
+  const match = basename(filename).match(/\.(\d+)\.jsonl$/);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+/** Escape regex metacharacters in a string. */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/core/src/log-reader.ts
+++ b/packages/core/src/log-reader.ts
@@ -7,17 +7,7 @@
 
 import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { join, basename } from "node:path";
-import type { LogEntry } from "./log-writer.js";
-
-export interface LogQueryOptions {
-  since?: Date;
-  until?: Date;
-  level?: LogEntry["level"][];
-  sessionId?: string;
-  source?: LogEntry["source"];
-  limit?: number;
-  pattern?: string;
-}
+import type { LogEntry, LogQueryOptions } from "./types.js";
 
 /** Read and filter log entries from a single JSONL file. */
 export function readLogs(filePath: string, opts?: LogQueryOptions): LogEntry[] {

--- a/packages/core/src/log-reader.ts
+++ b/packages/core/src/log-reader.ts
@@ -261,8 +261,9 @@ export function computeApiStats(entries: ApiLogEntry[]): ApiPerfResult {
 
   let latestCacheStats: ApiLogEntry["cacheStats"] | null = null;
   for (let i = entries.length - 1; i >= 0; i--) {
-    if (entries[i].cacheStats) {
-      latestCacheStats = entries[i].cacheStats!;
+    const stats = entries[i].cacheStats;
+    if (stats) {
+      latestCacheStats = stats;
       break;
     }
   }

--- a/packages/core/src/log-writer.ts
+++ b/packages/core/src/log-writer.ts
@@ -1,0 +1,125 @@
+/**
+ * JSONL log writer with size-based rotation.
+ *
+ * Writes structured log entries to .jsonl files with automatic rotation
+ * when file size exceeds the configured limit. Crash-safe via appendFileSync.
+ */
+
+import { appendFileSync, statSync, renameSync, mkdirSync, existsSync, unlinkSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface LogEntry {
+  ts: string;
+  level: "stdout" | "stderr" | "info" | "warn" | "error";
+  source: "dashboard" | "lifecycle" | "cli" | "api" | "browser";
+  sessionId: string | null;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+export interface LogWriterOptions {
+  filePath: string;
+  maxSizeBytes?: number;
+  maxBackups?: number;
+}
+
+const DEFAULT_MAX_SIZE = 50 * 1024 * 1024; // 50MB
+const DEFAULT_MAX_BACKUPS = 5;
+
+export class LogWriter {
+  private readonly filePath: string;
+  private readonly maxSizeBytes: number;
+  private readonly maxBackups: number;
+  private closed = false;
+
+  constructor(opts: LogWriterOptions) {
+    this.filePath = opts.filePath;
+    this.maxSizeBytes = opts.maxSizeBytes ?? DEFAULT_MAX_SIZE;
+    this.maxBackups = opts.maxBackups ?? DEFAULT_MAX_BACKUPS;
+
+    // Ensure directory exists
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  /** Append a structured log entry. */
+  append(entry: LogEntry): void {
+    if (this.closed) return;
+    this.rotateIfNeeded();
+    try {
+      appendFileSync(this.filePath, JSON.stringify(entry) + "\n", "utf-8");
+    } catch {
+      // Write failed — best effort, don't crash the caller
+    }
+  }
+
+  /** Convenience: create and append a LogEntry from a raw line. */
+  appendLine(
+    line: string,
+    level: LogEntry["level"],
+    source: LogEntry["source"],
+    sessionId: string | null = null,
+  ): void {
+    this.append({
+      ts: new Date().toISOString(),
+      level,
+      source,
+      sessionId,
+      message: line,
+    });
+  }
+
+  /** Close the writer. Further appends are silently ignored. */
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Check file size and rotate if needed. */
+  private rotateIfNeeded(): void {
+    let size: number;
+    try {
+      size = statSync(this.filePath).size;
+    } catch {
+      // File doesn't exist yet — no rotation needed
+      return;
+    }
+
+    if (size < this.maxSizeBytes) return;
+
+    // Rotate: .jsonl -> .1.jsonl -> .2.jsonl -> ... -> .N.jsonl (deleted)
+    const base = this.filePath.replace(/\.jsonl$/, "");
+    const ext = ".jsonl";
+
+    // Delete the oldest backup if it exists
+    const oldestPath = `${base}.${this.maxBackups}${ext}`;
+    try {
+      if (existsSync(oldestPath)) {
+        unlinkSync(oldestPath);
+      }
+    } catch {
+      // best effort
+    }
+
+    // Shift existing backups: N-1 -> N, N-2 -> N-1, ..., 1 -> 2
+    for (let i = this.maxBackups - 1; i >= 1; i--) {
+      const from = `${base}.${i}${ext}`;
+      const to = `${base}.${i + 1}${ext}`;
+      try {
+        if (existsSync(from)) {
+          renameSync(from, to);
+        }
+      } catch {
+        // best effort
+      }
+    }
+
+    // Rename current file to .1.jsonl
+    try {
+      renameSync(this.filePath, `${base}.1${ext}`);
+    } catch {
+      // best effort
+    }
+  }
+}

--- a/packages/core/src/log-writer.ts
+++ b/packages/core/src/log-writer.ts
@@ -7,15 +7,7 @@
 
 import { appendFileSync, statSync, renameSync, mkdirSync, existsSync, unlinkSync } from "node:fs";
 import { dirname } from "node:path";
-
-export interface LogEntry {
-  ts: string;
-  level: "stdout" | "stderr" | "info" | "warn" | "error";
-  source: "dashboard" | "lifecycle" | "cli" | "api" | "browser";
-  sessionId: string | null;
-  message: string;
-  data?: Record<string, unknown>;
-}
+import type { LogEntry, EventLogger } from "./types.js";
 
 export interface LogWriterOptions {
   filePath: string;
@@ -26,7 +18,7 @@ export interface LogWriterOptions {
 const DEFAULT_MAX_SIZE = 50 * 1024 * 1024; // 50MB
 const DEFAULT_MAX_BACKUPS = 5;
 
-export class LogWriter {
+export class LogWriter implements EventLogger {
   private readonly filePath: string;
   private readonly maxSizeBytes: number;
   private readonly maxBackups: number;

--- a/packages/core/src/orchestrator-prompt.ts
+++ b/packages/core/src/orchestrator-prompt.ts
@@ -72,7 +72,7 @@ ao open ${projectId}
 | \`ao spawn <project> [issue]\` | Spawn a single worker agent session |
 | \`ao batch-spawn <project> <issues...>\` | Spawn multiple sessions in parallel |
 | \`ao session ls [-p project]\` | List all sessions (optionally filter by project) |
-| \`tmux attach -t <session>\` | Attach to a session's tmux window |
+| \`ao session attach <session>\` | Attach to a running session |
 | \`ao session kill <session>\` | Kill a specific session |
 | \`ao session cleanup [-p project]\` | Kill completed/merged sessions |
 | \`ao send <session> <message>\` | Send a message to a running session |
@@ -254,7 +254,7 @@ ${reactionLines.join("\n")}`);
 
 ### Handling Stuck Agents
 1. Check \`ao status\` for sessions in "stuck" or "needs_input" state
-2. Attach with \`tmux attach -t <session>\` to see what they're doing
+2. Attach with \`ao session attach <session>\` to see what they're doing
 3. Send clarification or instructions with \`ao send <session> '...'\`
 4. Or kill and respawn with fresh context if needed
 
@@ -269,7 +269,7 @@ ${reactionLines.join("\n")}`);
 When an agent needs human judgment:
 1. You'll get a notification (desktop/slack/webhook)
 2. Check the dashboard or \`ao status\` for details
-3. Attach to the session if needed: \`tmux attach -t <session>\`
+3. Attach to the session if needed: \`ao session attach <session>\`
 4. Send instructions: \`ao send <session> '...'\`
 5. Or handle it yourself (merge PR, close issue, etc.)
 
@@ -277,7 +277,7 @@ When an agent needs human judgment:
 1. Check logs: \`ao logs events --session <session-id>\` to see state transitions
 2. Look for CI failures: \`ao logs events --session <session-id>\` | grep ci
 3. Check the dashboard: \`ao logs dashboard --since 10m --level error\`
-4. Attach if needed: \`tmux attach -t <session>\`
+4. Attach if needed: \`ao session attach <session>\`
 
 ### Dashboard Not Loading
 1. Check status: \`ao dashboard status\`

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -111,6 +111,22 @@ export function getArchiveDir(configPath: string, projectPath: string): string {
 }
 
 /**
+ * Get the logs directory for a project.
+ * Format: ~/.agent-orchestrator/{hash}-{projectId}/logs
+ */
+export function getLogsDir(configPath: string, projectPath: string): string {
+  return join(getProjectBaseDir(configPath, projectPath), "logs");
+}
+
+/**
+ * Get the retrospectives directory for a project.
+ * Format: ~/.agent-orchestrator/{hash}-{projectId}/retrospectives
+ */
+export function getRetrospectivesDir(configPath: string, projectPath: string): string {
+  return join(getProjectBaseDir(configPath, projectPath), "retrospectives");
+}
+
+/**
  * Get the .origin file path for a project.
  * This file stores the config path for collision detection.
  */

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -12,6 +12,7 @@ import { createHash } from "node:crypto";
 import { dirname, basename, join } from "node:path";
 import { homedir } from "node:os";
 import { realpathSync, existsSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import type { OrchestratorConfig } from "./types.js";
 
 /**
  * Generate a 12-character hash from a config directory path.
@@ -124,6 +125,26 @@ export function getLogsDir(configPath: string, projectPath: string): string {
  */
 export function getRetrospectivesDir(configPath: string, projectPath: string): string {
   return join(getProjectBaseDir(configPath, projectPath), "retrospectives");
+}
+
+/**
+ * Resolve the log directory for the first configured project.
+ * Returns null if no projects are configured.
+ */
+export function resolveProjectLogDir(config: OrchestratorConfig): string | null {
+  const projectId = Object.keys(config.projects)[0];
+  if (!projectId) return null;
+  return getLogsDir(config.configPath, config.projects[projectId].path);
+}
+
+/**
+ * Resolve the retrospectives directory for the first configured project.
+ * Returns null if no projects are configured.
+ */
+export function resolveProjectRetroDir(config: OrchestratorConfig): string | null {
+  const projectId = Object.keys(config.projects)[0];
+  if (!projectId) return null;
+  return getRetrospectivesDir(config.configPath, config.projects[projectId].path);
 }
 
 /**

--- a/packages/core/src/prompt-builder.ts
+++ b/packages/core/src/prompt-builder.ts
@@ -37,7 +37,18 @@ export const BASE_AGENT_PROMPT = `You are an AI coding agent managed by the Agen
 - Write a clear PR title and description explaining what changed and why.
 - Link the issue in the PR description so it auto-closes when merged.
 - If the repo has CI checks, make sure they pass before requesting review.
-- Respond to every review comment, even if just to acknowledge it.`;
+- Respond to every review comment, even if just to acknowledge it.
+
+## Environment
+Your session has these environment variables available:
+- \`AO_PROJECT_ID\` — the project this session belongs to
+- \`AO_LOG_DIR\` — directory where structured logs are written (JSONL format)
+
+## Debugging
+If you're stuck or need to understand system behavior:
+- Check event logs: lifecycle events are written to \`$AO_LOG_DIR/events.jsonl\`
+- Check dashboard logs: \`$AO_LOG_DIR/dashboard.jsonl\` has dashboard output
+- These are JSONL files — each line is valid JSON with \`ts\`, \`level\`, \`source\`, \`sessionId\`, \`message\` fields`;
 
 // =============================================================================
 // TYPES

--- a/packages/core/src/retrospective.ts
+++ b/packages/core/src/retrospective.ts
@@ -1,0 +1,193 @@
+/**
+ * Retrospective — structured analysis of completed sessions.
+ *
+ * Generates retrospectives from event logs and session metadata,
+ * extracting timeline, metrics, and heuristic lessons learned.
+ * Saves to JSON files for later querying by agents and CLI.
+ */
+
+import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { generateReportCard, type SessionReportCard } from "./session-report-card.js";
+import { readLogs } from "./log-reader.js";
+import { readMetadataRaw } from "./metadata.js";
+import { getSessionsDir, getLogsDir } from "./paths.js";
+import type { OrchestratorConfig } from "./types.js";
+
+export interface Retrospective {
+  sessionId: string;
+  projectId: string;
+  generatedAt: string;
+  outcome: "success" | "failure" | "partial";
+  timeline: Array<{ event: string; at: string; detail: string }>;
+  metrics: {
+    totalDurationMs: number;
+    ciFailures: number;
+    reviewRounds: number;
+  };
+  lessons: string[];
+  reportCard: SessionReportCard;
+}
+
+/** Generate a retrospective for a completed session. */
+export function generateRetrospective(
+  sessionId: string,
+  config: OrchestratorConfig,
+  projectId: string,
+): Retrospective | null {
+  const project = config.projects[projectId];
+  if (!project) return null;
+
+  const sessionsDir = getSessionsDir(config.configPath, project.path);
+  const logsDir = getLogsDir(config.configPath, project.path);
+  const eventsLogPath = join(logsDir, "events.jsonl");
+
+  // Read metadata (try live, then archived)
+  let metadata = readMetadataRaw(sessionsDir, sessionId);
+  if (!metadata) {
+    metadata = readMetadataRaw(join(sessionsDir, "archive"), sessionId);
+  }
+  if (!metadata) {
+    metadata = { project: projectId };
+  }
+
+  const reportCard = generateReportCard(sessionId, eventsLogPath, metadata);
+
+  // Build timeline from events
+  const entries = readLogs(eventsLogPath, { sessionId });
+  const timeline: Retrospective["timeline"] = entries.map((e) => ({
+    event: String(e.data?.["type"] ?? e.level),
+    at: e.ts,
+    detail: e.message,
+  }));
+
+  // Determine outcome
+  let outcome: Retrospective["outcome"];
+  if (reportCard.outcome === "merged") {
+    outcome = "success";
+  } else if (reportCard.outcome === "killed" || reportCard.outcome === "abandoned") {
+    outcome = "failure";
+  } else {
+    outcome = "partial";
+  }
+
+  // Extract heuristic lessons
+  const lessons = extractLessons(reportCard, timeline);
+
+  return {
+    sessionId,
+    projectId,
+    generatedAt: new Date().toISOString(),
+    outcome,
+    timeline,
+    metrics: {
+      totalDurationMs: reportCard.duration.totalMs,
+      ciFailures: reportCard.ciAttempts,
+      reviewRounds: reportCard.reviewRounds,
+    },
+    lessons,
+    reportCard,
+  };
+}
+
+/** Save a retrospective to disk. */
+export function saveRetrospective(retro: Retrospective, retrospectivesDir: string): void {
+  if (!existsSync(retrospectivesDir)) {
+    mkdirSync(retrospectivesDir, { recursive: true });
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `${retro.sessionId}-${timestamp}.json`;
+  const filePath = join(retrospectivesDir, filename);
+
+  writeFileSync(filePath, JSON.stringify(retro, null, 2), "utf-8");
+}
+
+/** Load retrospectives from disk, optionally filtered. */
+export function loadRetrospectives(
+  retrospectivesDir: string,
+  opts?: { sessionId?: string; projectId?: string; limit?: number },
+): Retrospective[] {
+  if (!existsSync(retrospectivesDir)) return [];
+
+  let files: string[];
+  try {
+    files = readdirSync(retrospectivesDir)
+      .filter((f) => f.endsWith(".json"))
+      .sort()
+      .reverse(); // newest first
+  } catch {
+    return [];
+  }
+
+  // Filter by session ID prefix if specified
+  if (opts?.sessionId) {
+    files = files.filter((f) => f.startsWith(opts.sessionId!));
+  }
+
+  const results: Retrospective[] = [];
+  for (const file of files) {
+    if (opts?.limit && results.length >= opts.limit) break;
+
+    try {
+      const content = readFileSync(join(retrospectivesDir, file), "utf-8");
+      const retro = JSON.parse(content) as Retrospective;
+
+      if (opts?.projectId && retro.projectId !== opts.projectId) continue;
+      results.push(retro);
+    } catch {
+      // Corrupted file — skip
+    }
+  }
+
+  return results;
+}
+
+/** Extract heuristic lessons from session metrics. */
+function extractLessons(
+  card: SessionReportCard,
+  timeline: Retrospective["timeline"],
+): string[] {
+  const lessons: string[] = [];
+
+  // CI failure patterns
+  if (card.ciAttempts > 3) {
+    lessons.push(
+      `High CI failure count (${card.ciAttempts} failures). Consider running tests locally before pushing.`,
+    );
+  } else if (card.ciAttempts > 1) {
+    lessons.push(`CI failed ${card.ciAttempts} times before passing.`);
+  }
+
+  // Review round patterns
+  if (card.reviewRounds > 2) {
+    lessons.push(
+      `Multiple review rounds (${card.reviewRounds}). Breaking changes into smaller PRs may help.`,
+    );
+  }
+
+  // Duration anomalies
+  const hours = card.duration.totalMs / 3_600_000;
+  if (hours > 24) {
+    lessons.push(
+      `Session ran for ${Math.round(hours)} hours. Long-running sessions may indicate complexity or blocking.`,
+    );
+  }
+
+  // Quick success
+  if (card.outcome === "merged" && card.ciAttempts <= 1 && card.reviewRounds <= 1 && hours < 2) {
+    lessons.push("Clean execution: merged quickly with minimal CI/review iterations.");
+  }
+
+  // Killed without PR
+  if (card.outcome === "killed" && !card.prUrl) {
+    lessons.push("Session was killed without creating a PR. May indicate a stuck or misdirected session.");
+  }
+
+  // No events at all
+  if (timeline.length === 0) {
+    lessons.push("No lifecycle events recorded. Session may have been very short-lived or logging was not active.");
+  }
+
+  return lessons;
+}

--- a/packages/core/src/retrospective.ts
+++ b/packages/core/src/retrospective.ts
@@ -105,9 +105,9 @@ export function loadRetrospectives(
     return [];
   }
 
-  // Filter by session ID prefix if specified
+  // Filter by session ID — match exact session followed by timestamp delimiter
   if (opts?.sessionId) {
-    files = files.filter((f) => f.startsWith(opts.sessionId!));
+    files = files.filter((f) => f.startsWith(`${opts.sessionId!}-`));
   }
 
   const results: Retrospective[] = [];

--- a/packages/core/src/retrospective.ts
+++ b/packages/core/src/retrospective.ts
@@ -113,8 +113,9 @@ export function loadRetrospectives(
   }
 
   // Filter by session ID — match exact session followed by timestamp delimiter
-  if (opts?.sessionId) {
-    files = files.filter((f) => f.startsWith(`${opts.sessionId!}-`));
+  const sessionIdFilter = opts?.sessionId;
+  if (sessionIdFilter) {
+    files = files.filter((f) => f.startsWith(`${sessionIdFilter}-`));
   }
 
   const results: Retrospective[] = [];

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -51,6 +51,7 @@ import { buildPrompt } from "./prompt-builder.js";
 import {
   getSessionsDir,
   getProjectBaseDir,
+  getLogsDir,
   generateTmuxName,
   generateConfigHash,
   validateAndStoreOrigin,
@@ -461,6 +462,11 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);
       const environment = plugins.agent.getEnvironment(agentLaunchConfig);
 
+      // Resolve log directory for the project
+      const logDir = config.configPath
+        ? getLogsDir(config.configPath, project.path)
+        : undefined;
+
       handle = await plugins.runtime.create({
         sessionId: tmuxName ?? sessionId, // Use tmux name for runtime if available
         workspacePath,
@@ -470,6 +476,8 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
           AO_SESSION: sessionId,
           AO_DATA_DIR: sessionsDir, // Pass sessions directory (not root dataDir)
           AO_SESSION_NAME: sessionId, // User-facing session name
+          AO_PROJECT_ID: spawnConfig.projectId,
+          ...(logDir && { AO_LOG_DIR: logDir }),
           ...(tmuxName && { AO_TMUX_NAME: tmuxName }), // Tmux session name if using new arch
         },
       });

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1103,5 +1103,22 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     return restoredSession;
   }
 
-  return { spawn, spawnOrchestrator, restore, list, get, kill, cleanup, send };
+  async function getAttachInfo(sessionId: SessionId) {
+    const session = await get(sessionId);
+    if (!session || !session.runtimeHandle) return null;
+
+    const project = config.projects[session.projectId];
+    if (!project) return null;
+
+    const { runtime } = resolvePlugins(project);
+    if (!runtime?.getAttachInfo) return null;
+
+    try {
+      return await runtime.getAttachInfo(session.runtimeHandle);
+    } catch {
+      return null;
+    }
+  }
+
+  return { spawn, spawnOrchestrator, restore, list, get, kill, cleanup, send, getAttachInfo };
 }

--- a/packages/core/src/session-report-card.ts
+++ b/packages/core/src/session-report-card.ts
@@ -1,0 +1,96 @@
+/**
+ * Session Report Card — per-session metrics extracted from event logs.
+ *
+ * Generates a structured summary of a session's lifecycle: duration,
+ * state transitions, CI attempts, review rounds, and outcome.
+ */
+
+import { readLogs } from "./log-reader.js";
+
+export interface SessionReportCard {
+  sessionId: string;
+  projectId: string;
+  duration: {
+    startedAt: string;
+    endedAt: string | null;
+    totalMs: number;
+  };
+  stateTransitions: Array<{ from: string; to: string; at: string }>;
+  ciAttempts: number;
+  reviewRounds: number;
+  outcome: "merged" | "killed" | "abandoned" | "active";
+  prUrl: string | null;
+}
+
+/** Generate a report card for a session from its event log entries. */
+export function generateReportCard(
+  sessionId: string,
+  eventsLogPath: string,
+  metadata: Record<string, string>,
+): SessionReportCard {
+  const entries = readLogs(eventsLogPath, { sessionId });
+
+  const transitions: SessionReportCard["stateTransitions"] = [];
+  let ciAttempts = 0;
+  let reviewRounds = 0;
+  let startedAt: string | null = null;
+  let endedAt: string | null = null;
+
+  for (const entry of entries) {
+    if (!startedAt) {
+      startedAt = entry.ts;
+    }
+    endedAt = entry.ts;
+
+    const data = entry.data ?? {};
+
+    // Track state transitions
+    if (data["oldStatus"] && data["newStatus"]) {
+      transitions.push({
+        from: String(data["oldStatus"]),
+        to: String(data["newStatus"]),
+        at: entry.ts,
+      });
+    }
+
+    // Count CI attempts (transitions to ci_failed)
+    if (data["type"] === "ci.failing" || data["newStatus"] === "ci_failed") {
+      ciAttempts++;
+    }
+
+    // Count review rounds (transitions to changes_requested)
+    if (data["type"] === "review.changes_requested" || data["newStatus"] === "changes_requested") {
+      reviewRounds++;
+    }
+  }
+
+  // Determine outcome from last known status
+  const lastStatus = transitions.length > 0
+    ? transitions[transitions.length - 1].to
+    : metadata["status"] ?? "active";
+
+  let outcome: SessionReportCard["outcome"];
+  if (lastStatus === "merged") outcome = "merged";
+  else if (lastStatus === "killed") outcome = "killed";
+  else if (lastStatus === "abandoned") outcome = "abandoned";
+  else outcome = "active";
+
+  const now = new Date().toISOString();
+  const start = startedAt ?? metadata["createdAt"] ?? now;
+  const end = outcome !== "active" ? (endedAt ?? now) : null;
+
+  return {
+    sessionId,
+    projectId: metadata["project"] ?? "",
+    duration: {
+      startedAt: start,
+      endedAt: end,
+      totalMs: end ? new Date(end).getTime() - new Date(start).getTime() : Date.now() - new Date(start).getTime(),
+    },
+    stateTransitions: transitions,
+    ciAttempts,
+    reviewRounds,
+    outcome,
+    prUrl: metadata["pr"] ?? null,
+  };
+}

--- a/packages/core/src/session-report-card.ts
+++ b/packages/core/src/session-report-card.ts
@@ -6,21 +6,7 @@
  */
 
 import { readLogs } from "./log-reader.js";
-
-export interface SessionReportCard {
-  sessionId: string;
-  projectId: string;
-  duration: {
-    startedAt: string;
-    endedAt: string | null;
-    totalMs: number;
-  };
-  stateTransitions: Array<{ from: string; to: string; at: string }>;
-  ciAttempts: number;
-  reviewRounds: number;
-  outcome: "merged" | "killed" | "abandoned" | "active";
-  prUrl: string | null;
-}
+import type { SessionReportCard } from "./types.js";
 
 /** Generate a report card for a session from its event log entries. */
 export function generateReportCard(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1045,15 +1045,6 @@ export interface EventLogger {
 }
 
 /**
- * Event log reader — queries structured log entries.
- * Implement this interface to read logs from a custom backend.
- */
-export interface EventLogReader {
-  query(opts?: LogQueryOptions): LogEntry[];
-  tail(lines: number): LogEntry[];
-}
-
-/**
  * Retrospective store — saves and loads session retrospectives.
  * Implement this interface to store retrospectives in a database,
  * cloud storage, or other backend instead of the default JSON files.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -972,6 +972,98 @@ export interface SessionMetadata {
 }
 
 // =============================================================================
+// LOGGING & OBSERVABILITY
+// =============================================================================
+
+/** Structured log entry written by the system. */
+export interface LogEntry {
+  ts: string;
+  level: "stdout" | "stderr" | "info" | "warn" | "error";
+  source: "dashboard" | "lifecycle" | "cli" | "api" | "browser";
+  sessionId: string | null;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+/** Options for querying log entries. */
+export interface LogQueryOptions {
+  since?: Date;
+  until?: Date;
+  level?: LogEntry["level"][];
+  sessionId?: string;
+  source?: LogEntry["source"];
+  limit?: number;
+  pattern?: string;
+}
+
+/** Per-session metrics extracted from event logs. */
+export interface SessionReportCard {
+  sessionId: string;
+  projectId: string;
+  duration: {
+    startedAt: string;
+    endedAt: string | null;
+    totalMs: number;
+  };
+  stateTransitions: Array<{ from: string; to: string; at: string }>;
+  ciAttempts: number;
+  reviewRounds: number;
+  outcome: "merged" | "killed" | "abandoned" | "active";
+  prUrl: string | null;
+}
+
+/** Structured analysis of a completed session. */
+export interface Retrospective {
+  sessionId: string;
+  projectId: string;
+  generatedAt: string;
+  outcome: "success" | "failure" | "partial";
+  timeline: Array<{ event: string; at: string; detail: string }>;
+  metrics: {
+    totalDurationMs: number;
+    ciFailures: number;
+    reviewRounds: number;
+  };
+  lessons: string[];
+  reportCard: SessionReportCard;
+}
+
+/**
+ * Event logger — writes structured log entries.
+ * Implement this interface to send logs to a custom backend
+ * (database, cloud logging service, etc.) instead of the default JSONL files.
+ */
+export interface EventLogger {
+  append(entry: LogEntry): void;
+  appendLine(
+    line: string,
+    level: LogEntry["level"],
+    source: LogEntry["source"],
+    sessionId?: string | null,
+  ): void;
+  close(): void;
+}
+
+/**
+ * Event log reader — queries structured log entries.
+ * Implement this interface to read logs from a custom backend.
+ */
+export interface EventLogReader {
+  query(opts?: LogQueryOptions): LogEntry[];
+  tail(lines: number): LogEntry[];
+}
+
+/**
+ * Retrospective store — saves and loads session retrospectives.
+ * Implement this interface to store retrospectives in a database,
+ * cloud storage, or other backend instead of the default JSON files.
+ */
+export interface RetrospectiveStore {
+  save(retro: Retrospective): void;
+  load(opts?: { sessionId?: string; projectId?: string; limit?: number }): Retrospective[];
+}
+
+// =============================================================================
 // SERVICE INTERFACES (core, not pluggable)
 // =============================================================================
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -985,6 +985,7 @@ export interface SessionManager {
   kill(sessionId: SessionId): Promise<void>;
   cleanup(projectId?: string, options?: { dryRun?: boolean }): Promise<CleanupResult>;
   send(sessionId: SessionId, message: string): Promise<void>;
+  getAttachInfo(sessionId: SessionId): Promise<AttachInfo | null>;
 }
 
 export interface CleanupResult {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -33,6 +33,26 @@ export function validateUrl(url: string, label: string): void {
 }
 
 /**
+ * Compute a percentile value from a pre-sorted array of numbers.
+ * Returns 0 for empty arrays.
+ */
+export function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+/**
+ * Normalize an API route path by replacing dynamic segments with `:id` placeholders.
+ * e.g. `/api/sessions/abc123` → `/api/sessions/:id`
+ */
+export function normalizeRoutePath(path: string): string {
+  return path
+    .replace(/\/sessions\/[^/]+/g, "/sessions/:id")
+    .replace(/\/prs\/[^/]+/g, "/prs/:id");
+}
+
+/**
  * Read the last line from a file by reading backwards from the end.
  * Pure Node.js — no external binaries. Handles any file size.
  */

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -81,6 +81,7 @@ const mockSessionManager: SessionManager = {
       throw new Error(`Session ${id} not found`);
     }
   }),
+  getAttachInfo: vi.fn(async () => null),
   cleanup: vi.fn(async () => ({ killed: [], skipped: [], errors: [] })),
   spawnOrchestrator: vi.fn(),
   restore: vi.fn(async (id: string) => {

--- a/packages/web/src/__tests__/observability-routes.test.ts
+++ b/packages/web/src/__tests__/observability-routes.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock fns ────────────────────────────────────────────────────────────
+
+const mockReadLogsFromDir = vi.fn();
+const mockTailLogs = vi.fn();
+const mockResolveProjectLogDir = vi.fn();
+const mockLoadConfig = vi.fn();
+const mockLogWriterAppend = vi.fn();
+
+vi.mock("@composio/ao-core", () => ({
+  resolveProjectLogDir: (...args: unknown[]) => mockResolveProjectLogDir(...args),
+  readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
+  tailLogs: (...args: unknown[]) => mockTailLogs(...args),
+  loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+  percentile: (sorted: number[], p: number) => {
+    if (sorted.length === 0) return 0;
+    const idx = Math.ceil((p / 100) * sorted.length) - 1;
+    return sorted[Math.max(0, idx)];
+  },
+  normalizeRoutePath: (path: string) =>
+    path
+      .replace(/\/sessions\/[^/]+/g, "/sessions/:id")
+      .replace(/\/prs\/[^/]+/g, "/prs/:id"),
+  LogWriter: vi.fn().mockImplementation(() => ({
+    append: mockLogWriterAppend,
+    appendLine: vi.fn(),
+    close: vi.fn(),
+  })),
+}));
+
+// ── Import routes after mocking ─────────────────────────────────────────
+
+const { GET: logsGET } = await import("../app/api/logs/route.js");
+const { GET: perfGET } = await import("../app/api/perf/route.js");
+const { POST: clientLogsPost } = await import("../app/api/client-logs/route.js");
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLoadConfig.mockReturnValue({});
+  mockResolveProjectLogDir.mockReturnValue("/tmp/test-logs");
+});
+
+// ── GET /api/logs ───────────────────────────────────────────────────────
+
+describe("GET /api/logs", () => {
+  it("returns entries when logs exist", async () => {
+    const fakeEntries = [
+      {
+        ts: "2026-01-01T00:00:00Z",
+        level: "info",
+        source: "events",
+        sessionId: null,
+        message: "session spawned",
+      },
+      {
+        ts: "2026-01-01T00:01:00Z",
+        level: "warn",
+        source: "events",
+        sessionId: "s-1",
+        message: "timeout",
+      },
+    ];
+    mockReadLogsFromDir.mockReturnValue(fakeEntries);
+
+    const req = new Request("http://localhost:3000/api/logs?limit=100");
+    const res = await logsGET(req);
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.entries).toHaveLength(2);
+    expect(json.count).toBe(2);
+    expect(json.entries[0].message).toBe("session spawned");
+  });
+
+  it("applies source filter (maps to file prefix)", async () => {
+    mockReadLogsFromDir.mockReturnValue([]);
+
+    const req = new Request("http://localhost:3000/api/logs?source=api&limit=50");
+    await logsGET(req);
+
+    // readLogsFromDir should be called with the log dir and prefix "api"
+    expect(mockReadLogsFromDir).toHaveBeenCalledWith(
+      "/tmp/test-logs",
+      "api",
+      expect.objectContaining({ limit: 50 }),
+    );
+  });
+
+  it("defaults source to events when not specified", async () => {
+    mockReadLogsFromDir.mockReturnValue([]);
+
+    const req = new Request("http://localhost:3000/api/logs");
+    await logsGET(req);
+
+    expect(mockReadLogsFromDir).toHaveBeenCalledWith(
+      "/tmp/test-logs",
+      "events",
+      expect.any(Object),
+    );
+  });
+
+  it("applies tail parameter (calls tailLogs instead of readLogsFromDir)", async () => {
+    const tailEntries = [
+      {
+        ts: "2026-01-01T00:05:00Z",
+        level: "info",
+        source: "events",
+        sessionId: null,
+        message: "last line",
+      },
+    ];
+    mockTailLogs.mockReturnValue(tailEntries);
+
+    const req = new Request("http://localhost:3000/api/logs?tail=10");
+    const res = await logsGET(req);
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.entries).toHaveLength(1);
+    expect(json.entries[0].message).toBe("last line");
+
+    // tailLogs should be called, NOT readLogsFromDir
+    expect(mockTailLogs).toHaveBeenCalledWith("/tmp/test-logs/events.jsonl", 10);
+    expect(mockReadLogsFromDir).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when config has no projects", async () => {
+    mockResolveProjectLogDir.mockReturnValue(null);
+    // resolveLogDir() will throw "No projects configured."
+
+    const req = new Request("http://localhost:3000/api/logs");
+    const res = await logsGET(req);
+    expect(res.status).toBe(500);
+
+    const json = await res.json();
+    expect(json.error).toMatch(/No projects configured/);
+  });
+});
+
+// ── GET /api/perf ───────────────────────────────────────────────────────
+
+describe("GET /api/perf", () => {
+  const perfLogEntries = [
+    {
+      ts: "2026-01-01T00:00:00Z",
+      level: "info",
+      source: "api",
+      sessionId: null,
+      message: "req",
+      data: {
+        method: "GET",
+        path: "/api/sessions",
+        statusCode: 200,
+        durationMs: 150,
+      },
+    },
+    {
+      ts: "2026-01-01T00:01:00Z",
+      level: "info",
+      source: "api",
+      sessionId: null,
+      message: "req",
+      data: {
+        method: "GET",
+        path: "/api/sessions",
+        statusCode: 200,
+        durationMs: 250,
+      },
+    },
+    {
+      ts: "2026-01-01T00:02:00Z",
+      level: "info",
+      source: "api",
+      sessionId: null,
+      message: "req",
+      data: {
+        method: "POST",
+        path: "/api/spawn",
+        statusCode: 500,
+        durationMs: 3000,
+        error: "fail",
+      },
+    },
+  ];
+
+  it("returns route stats with count, avgMs, p50Ms, etc.", async () => {
+    mockReadLogsFromDir.mockReturnValue(perfLogEntries);
+
+    const req = new Request("http://localhost:3000/api/perf");
+    const res = await perfGET(req);
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.routes).toBeDefined();
+    expect(json.totalRequests).toBe(3);
+
+    // Two GET /api/sessions entries -> normalized to "GET /api/sessions"
+    const sessionRoute = json.routes["GET /api/sessions"];
+    expect(sessionRoute).toBeDefined();
+    expect(sessionRoute.count).toBe(2);
+    expect(sessionRoute.avgMs).toBe(200); // (150 + 250) / 2
+    expect(sessionRoute.p50Ms).toBeDefined();
+    expect(sessionRoute.p95Ms).toBeDefined();
+    expect(sessionRoute.p99Ms).toBeDefined();
+    expect(sessionRoute.errors).toBe(0);
+
+    // One POST /api/spawn with statusCode 500 and error
+    const spawnRoute = json.routes["POST /api/spawn"];
+    expect(spawnRoute).toBeDefined();
+    expect(spawnRoute.count).toBe(1);
+    expect(spawnRoute.avgMs).toBe(3000);
+    expect(spawnRoute.errors).toBe(1);
+  });
+
+  it("returns slowest requests sorted by duration", async () => {
+    mockReadLogsFromDir.mockReturnValue(perfLogEntries);
+
+    const req = new Request("http://localhost:3000/api/perf");
+    const res = await perfGET(req);
+    const json = await res.json();
+
+    expect(json.slowest).toBeDefined();
+    expect(Array.isArray(json.slowest)).toBe(true);
+    expect(json.slowest.length).toBe(3);
+    // Sorted descending by duration
+    expect(json.slowest[0].durationMs).toBe(3000);
+    expect(json.slowest[1].durationMs).toBe(250);
+    expect(json.slowest[2].durationMs).toBe(150);
+  });
+
+  it("normalizes route paths for grouping", async () => {
+    mockReadLogsFromDir.mockReturnValue([
+      {
+        ts: "2026-01-01T00:00:00Z",
+        level: "info",
+        source: "api",
+        sessionId: null,
+        message: "req",
+        data: {
+          method: "GET",
+          path: "/api/sessions/backend-3",
+          statusCode: 200,
+          durationMs: 100,
+        },
+      },
+      {
+        ts: "2026-01-01T00:01:00Z",
+        level: "info",
+        source: "api",
+        sessionId: null,
+        message: "req",
+        data: {
+          method: "GET",
+          path: "/api/sessions/frontend-1",
+          statusCode: 200,
+          durationMs: 200,
+        },
+      },
+    ]);
+
+    const req = new Request("http://localhost:3000/api/perf");
+    const res = await perfGET(req);
+    const json = await res.json();
+
+    // Both should be grouped under the normalized key
+    const normalized = json.routes["GET /api/sessions/:id"];
+    expect(normalized).toBeDefined();
+    expect(normalized.count).toBe(2);
+  });
+
+  it("returns 500 when no projects configured", async () => {
+    mockResolveProjectLogDir.mockReturnValue(null);
+
+    const req = new Request("http://localhost:3000/api/perf");
+    const res = await perfGET(req);
+    expect(res.status).toBe(500);
+
+    const json = await res.json();
+    expect(json.error).toMatch(/No projects configured/);
+  });
+});
+
+// ── POST /api/client-logs ───────────────────────────────────────────────
+
+describe("POST /api/client-logs", () => {
+  it("returns 400 when body has no entries array", async () => {
+    const req = new Request("http://localhost:3000/api/client-logs", {
+      method: "POST",
+      body: JSON.stringify({ something: "else" }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await clientLogsPost(req);
+    expect(res.status).toBe(400);
+
+    const json = await res.json();
+    expect(json.error).toMatch(/Missing entries/);
+  });
+
+  it("returns 400 when body is not an object", async () => {
+    const req = new Request("http://localhost:3000/api/client-logs", {
+      method: "POST",
+      body: JSON.stringify("just a string"),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await clientLogsPost(req);
+    expect(res.status).toBe(400);
+
+    const json = await res.json();
+    expect(json.error).toMatch(/Invalid request/);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new Request("http://localhost:3000/api/client-logs", {
+      method: "POST",
+      body: "not json at all",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await clientLogsPost(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("logs valid entries and skips invalid ones", async () => {
+    const req = new Request("http://localhost:3000/api/client-logs", {
+      method: "POST",
+      body: JSON.stringify({
+        entries: [
+          { level: "info", message: "page loaded", url: "/dashboard" },
+          { level: "error", message: "fetch failed", stack: "Error: 500\n  at ..." },
+          { level: "invalid-level", message: "bad level" }, // invalid: level not in set
+          { notAMessage: true }, // invalid: no message field
+          { level: "warn", message: "slow render", timing: { ttfb: 120 } },
+        ],
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await clientLogsPost(req);
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.logged).toBe(3); // info, error, warn are valid; 2 invalid skipped
+
+    // Verify append was called 3 times with correct structure
+    expect(mockLogWriterAppend).toHaveBeenCalledTimes(3);
+
+    // Check first call (info entry)
+    const firstCall = mockLogWriterAppend.mock.calls[0][0];
+    expect(firstCall.level).toBe("info");
+    expect(firstCall.source).toBe("browser");
+    expect(firstCall.message).toBe("page loaded");
+    expect(firstCall.data).toEqual({ url: "/dashboard" });
+
+    // Check second call (error entry with stack)
+    const secondCall = mockLogWriterAppend.mock.calls[1][0];
+    expect(secondCall.level).toBe("error");
+    expect(secondCall.message).toBe("fetch failed");
+    expect(secondCall.data).toHaveProperty("stack");
+
+    // Check third call (warn entry with timing)
+    const thirdCall = mockLogWriterAppend.mock.calls[2][0];
+    expect(thirdCall.level).toBe("warn");
+    expect(thirdCall.message).toBe("slow render");
+    expect(thirdCall.data).toEqual({ timing: { ttfb: 120 } });
+  });
+
+  it("returns logged: 0 when writer is unavailable", async () => {
+    mockResolveProjectLogDir.mockReturnValue(null);
+
+    // Force re-import to reset the cached logWriter
+    // Since logWriter is module-level, we need a fresh module
+    vi.resetModules();
+
+    // Re-apply the mock after resetModules
+    vi.doMock("@composio/ao-core", () => ({
+      resolveProjectLogDir: () => null,
+      loadConfig: () => ({}),
+      LogWriter: vi.fn().mockImplementation(() => ({
+        append: mockLogWriterAppend,
+        appendLine: vi.fn(),
+        close: vi.fn(),
+      })),
+    }));
+
+    const { POST: freshPost } = await import("../app/api/client-logs/route.js");
+
+    const req = new Request("http://localhost:3000/api/client-logs", {
+      method: "POST",
+      body: JSON.stringify({
+        entries: [{ level: "info", message: "test" }],
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await freshPost(req);
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.logged).toBe(0);
+  });
+
+  it("returns correct count for empty entries array", async () => {
+    const req = new Request("http://localhost:3000/api/client-logs", {
+      method: "POST",
+      body: JSON.stringify({ entries: [] }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await clientLogsPost(req);
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.logged).toBe(0);
+  });
+});

--- a/packages/web/src/app/api/client-logs/route.ts
+++ b/packages/web/src/app/api/client-logs/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { getLogsDir, LogWriter, loadConfig } from "@composio/ao-core";
+
+interface ClientLogEntry {
+  level: "info" | "warn" | "error";
+  message: string;
+  url?: string;
+  stack?: string;
+  timing?: Record<string, number>;
+}
+
+let logWriter: LogWriter | null = null;
+
+function getLogWriter(): LogWriter | null {
+  if (logWriter) return logWriter;
+
+  try {
+    const config = loadConfig();
+    const projectId = Object.keys(config.projects)[0];
+    if (!projectId) return null;
+    const project = config.projects[projectId];
+    const logDir = getLogsDir(config.configPath, project.path);
+    logWriter = new LogWriter({ filePath: `${logDir}/browser.jsonl` });
+    return logWriter;
+  } catch {
+    return null;
+  }
+}
+
+/** POST /api/client-logs — Ingest batched browser-side log entries. */
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as { entries?: ClientLogEntry[] };
+    if (!body.entries || !Array.isArray(body.entries)) {
+      return NextResponse.json({ error: "Missing entries array" }, { status: 400 });
+    }
+
+    const writer = getLogWriter();
+    if (!writer) {
+      return NextResponse.json({ ok: true, logged: 0 });
+    }
+
+    for (const entry of body.entries) {
+      const level = entry.level === "error" ? "error" : entry.level === "warn" ? "warn" : "info";
+      writer.append({
+        ts: new Date().toISOString(),
+        level,
+        source: "browser",
+        sessionId: null,
+        message: entry.message,
+        data: {
+          ...(entry.url && { url: entry.url }),
+          ...(entry.stack && { stack: entry.stack }),
+          ...(entry.timing && { timing: entry.timing }),
+        },
+      });
+    }
+
+    return NextResponse.json({ ok: true, logged: body.entries.length });
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+}

--- a/packages/web/src/app/api/logs/route.ts
+++ b/packages/web/src/app/api/logs/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import {
+  getLogsDir,
+  readLogsFromDir,
+  tailLogs,
+  loadConfig,
+  type LogQueryOptions,
+  type LogEntry,
+} from "@composio/ao-core";
+
+function resolveLogDir(): string {
+  const config = loadConfig();
+  const projectId = Object.keys(config.projects)[0];
+  if (!projectId) throw new Error("No projects configured.");
+  const project = config.projects[projectId];
+  return getLogsDir(config.configPath, project.path);
+}
+
+/**
+ * GET /api/logs — Query structured logs.
+ *
+ * Query params:
+ *   source     — "dashboard" | "events" | "api" | "browser"
+ *   since      — ISO 8601 timestamp
+ *   level      — comma-separated levels
+ *   sessionId  — filter by session
+ *   limit      — max entries (default 200)
+ *   tail       — return last N entries instead of filtering
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const source = searchParams.get("source") ?? "events";
+    const since = searchParams.get("since");
+    const level = searchParams.get("level");
+    const sessionId = searchParams.get("sessionId");
+    const limit = parseInt(searchParams.get("limit") ?? "200", 10);
+    const tail = searchParams.get("tail");
+
+    const logDir = resolveLogDir();
+
+    // Map source to file prefix
+    const prefixMap: Record<string, string> = {
+      dashboard: "dashboard",
+      events: "events",
+      api: "api",
+      browser: "browser",
+    };
+    const prefix = prefixMap[source] ?? "events";
+    const filePath = `${logDir}/${prefix}.jsonl`;
+
+    let entries: LogEntry[];
+
+    if (tail) {
+      entries = tailLogs(filePath, parseInt(tail, 10));
+    } else {
+      const opts: LogQueryOptions = {
+        ...(since && { since: new Date(since) }),
+        ...(level && { level: level.split(",") as LogEntry["level"][] }),
+        ...(sessionId && { sessionId }),
+        limit,
+      };
+      entries = readLogsFromDir(logDir, prefix, opts);
+    }
+
+    return NextResponse.json({ entries, count: entries.length });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to read logs" },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/src/app/api/logs/route.ts
+++ b/packages/web/src/app/api/logs/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import {
-  getLogsDir,
+  resolveProjectLogDir,
   readLogsFromDir,
   tailLogs,
   loadConfig,
@@ -9,11 +9,9 @@ import {
 } from "@composio/ao-core";
 
 function resolveLogDir(): string {
-  const config = loadConfig();
-  const projectId = Object.keys(config.projects)[0];
-  if (!projectId) throw new Error("No projects configured.");
-  const project = config.projects[projectId];
-  return getLogsDir(config.configPath, project.path);
+  const dir = resolveProjectLogDir(loadConfig());
+  if (!dir) throw new Error("No projects configured.");
+  return dir;
 }
 
 /**

--- a/packages/web/src/app/api/perf/route.ts
+++ b/packages/web/src/app/api/perf/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { resolveProjectLogDir, loadConfig } from "@composio/ao-core";
-import { getRequestStats } from "../../../lib/request-logger.js";
+import { getRequestStats } from "@/lib/request-logger";
 
 function resolveLogDir(): string {
   const dir = resolveProjectLogDir(loadConfig());

--- a/packages/web/src/app/api/perf/route.ts
+++ b/packages/web/src/app/api/perf/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse } from "next/server";
+import { getLogsDir, readLogsFromDir, loadConfig } from "@composio/ao-core";
+
+function resolveLogDir(): string {
+  const config = loadConfig();
+  const projectId = Object.keys(config.projects)[0];
+  if (!projectId) throw new Error("No projects configured.");
+  const project = config.projects[projectId];
+  return getLogsDir(config.configPath, project.path);
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+function normalizePath(path: string): string {
+  return path
+    .replace(/\/sessions\/[^/]+/g, "/sessions/:id")
+    .replace(/\/prs\/[^/]+/g, "/prs/:id");
+}
+
+/**
+ * GET /api/perf — Performance statistics from API request logs.
+ *
+ * Query params:
+ *   since — ISO 8601 timestamp
+ *   route — filter by route pattern
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const since = searchParams.get("since");
+    const route = searchParams.get("route");
+
+    const logDir = resolveLogDir();
+    const entries = readLogsFromDir(logDir, "api", {
+      source: "api",
+      ...(since && { since: new Date(since) }),
+    });
+
+    // Parse and group by route
+    const byRoute = new Map<string, number[]>();
+    const errorsByRoute = new Map<string, number>();
+    const slowest: Array<{
+      ts: string;
+      method: string;
+      path: string;
+      durationMs: number;
+      timings?: Record<string, number>;
+    }> = [];
+
+    let latestCacheStats: unknown = null;
+
+    for (const entry of entries) {
+      const data = entry.data ?? {};
+      if (!data["method"] || !data["path"]) continue;
+
+      const method = String(data["method"]);
+      const path = String(data["path"]);
+      const durationMs = Number(data["durationMs"]) || 0;
+
+      if (route && !path.includes(route)) continue;
+
+      const key = `${method} ${normalizePath(path)}`;
+      const durations = byRoute.get(key) ?? [];
+      durations.push(durationMs);
+      byRoute.set(key, durations);
+
+      if (data["error"] || (Number(data["statusCode"]) || 0) >= 400) {
+        errorsByRoute.set(key, (errorsByRoute.get(key) ?? 0) + 1);
+      }
+
+      if (data["cacheStats"]) {
+        latestCacheStats = data["cacheStats"];
+      }
+
+      slowest.push({
+        ts: entry.ts,
+        method,
+        path,
+        durationMs,
+        timings: data["timings"] as Record<string, number> | undefined,
+      });
+    }
+
+    // Build route stats
+    const routes: Record<string, unknown> = {};
+    for (const [routeKey, durations] of byRoute) {
+      durations.sort((a, b) => a - b);
+      routes[routeKey] = {
+        count: durations.length,
+        avgMs: Math.round(durations.reduce((s, d) => s + d, 0) / durations.length),
+        p50Ms: percentile(durations, 50),
+        p95Ms: percentile(durations, 95),
+        p99Ms: percentile(durations, 99),
+        errors: errorsByRoute.get(routeKey) ?? 0,
+      };
+    }
+
+    // Top 10 slowest
+    slowest.sort((a, b) => b.durationMs - a.durationMs);
+
+    return NextResponse.json({
+      routes,
+      slowest: slowest.slice(0, 10),
+      cacheStats: latestCacheStats,
+      totalRequests: entries.length,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to compute perf stats" },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/src/app/api/perf/route.ts
+++ b/packages/web/src/app/api/perf/route.ts
@@ -1,12 +1,10 @@
 import { NextResponse } from "next/server";
-import { getLogsDir, readLogsFromDir, loadConfig } from "@composio/ao-core";
+import { resolveProjectLogDir, readLogsFromDir, loadConfig } from "@composio/ao-core";
 
 function resolveLogDir(): string {
-  const config = loadConfig();
-  const projectId = Object.keys(config.projects)[0];
-  if (!projectId) throw new Error("No projects configured.");
-  const project = config.projects[projectId];
-  return getLogsDir(config.configPath, project.path);
+  const dir = resolveProjectLogDir(loadConfig());
+  if (!dir) throw new Error("No projects configured.");
+  return dir;
 }
 
 function percentile(sorted: number[], p: number): number {

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -8,18 +8,28 @@ import {
   enrichSessionsMetadata,
   computeStats,
 } from "@/lib/serialize";
+import { logApiRequest } from "@/lib/request-logger";
+import { prCache } from "@/lib/cache";
 
 /** GET /api/sessions — List all sessions with full state
  * Query params:
  * - active=true: Only return non-exited sessions
  */
 export async function GET(request: Request) {
+  const requestStart = Date.now();
+  const timings: Record<string, number> = {};
+
   try {
     const { searchParams } = new URL(request.url);
     const activeOnly = searchParams.get("active") === "true";
 
+    const serviceStart = Date.now();
     const { config, registry, sessionManager } = await getServices();
+    timings["serviceInit"] = Date.now() - serviceStart;
+
+    const listStart = Date.now();
     const coreSessions = await sessionManager.list();
+    timings["sessionList"] = Date.now() - listStart;
 
     // Filter out orchestrator sessions — they get their own button, not a card
     let workerSessions = coreSessions.filter((s) => !s.id.endsWith("-orchestrator"));
@@ -37,10 +47,13 @@ export async function GET(request: Request) {
     }
 
     // Enrich metadata (issue labels, agent summaries, issue titles) — cap at 3s
+    const issueStart = Date.now();
     const metaTimeout = new Promise<void>((resolve) => setTimeout(resolve, 3_000));
     await Promise.race([enrichSessionsMetadata(workerSessions, dashboardSessions, config, registry), metaTimeout]);
+    timings["issueEnrichment"] = Date.now() - issueStart;
 
     // Enrich sessions that have PRs with live SCM data (CI, reviews, mergeability)
+    const enrichStart = Date.now();
     const enrichPromises = workerSessions.map((core, i) => {
       if (!core.pr) return Promise.resolve();
       const project = resolveProject(core, config.projects);
@@ -50,12 +63,38 @@ export async function GET(request: Request) {
     });
     const enrichTimeout = new Promise<void>((resolve) => setTimeout(resolve, 4_000));
     await Promise.race([Promise.allSettled(enrichPromises), enrichTimeout]);
+    timings["prEnrichment"] = Date.now() - enrichStart;
+
+    const durationMs = Date.now() - requestStart;
+
+    logApiRequest({
+      ts: new Date().toISOString(),
+      method: "GET",
+      path: "/api/sessions",
+      sessionId: null,
+      statusCode: 200,
+      durationMs,
+      timings,
+      cacheStats: prCache.getStats(),
+    });
 
     return NextResponse.json({
       sessions: dashboardSessions,
       stats: computeStats(dashboardSessions),
     });
   } catch (err) {
+    const durationMs = Date.now() - requestStart;
+    logApiRequest({
+      ts: new Date().toISOString(),
+      method: "GET",
+      path: "/api/sessions",
+      sessionId: null,
+      statusCode: 500,
+      durationMs,
+      timings,
+      error: err instanceof Error ? err.message : "Failed to list sessions",
+    });
+
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Failed to list sessions" },
       { status: 500 },

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
 import { getProjectName } from "@/lib/project-name";
+import { ClientLogger } from "@/components/ClientLogger";
 import "./globals.css";
 
 const ibmPlexSans = IBM_Plex_Sans({
@@ -32,6 +33,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={`dark ${ibmPlexSans.variable} ${ibmPlexMono.variable}`}>
       <body className="bg-[var(--color-bg-base)] text-[var(--color-text-primary)] antialiased">
+        <ClientLogger />
         {children}
       </body>
     </html>

--- a/packages/web/src/app/logs/page.tsx
+++ b/packages/web/src/app/logs/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { LogViewer } from "@/components/LogViewer";
+
+export default function LogsPage() {
+  return (
+    <div className="mx-auto max-w-[1100px] px-8 py-8">
+      <div className="mb-7 flex items-baseline justify-between">
+        <h1 className="text-[22px] font-semibold tracking-tight">
+          <a href="/" className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]">
+            <span className="text-[#7c8aff]">Agent</span> Orchestrator
+          </a>
+          <span className="mx-2 text-[var(--color-text-muted)]">/</span>
+          Logs
+        </h1>
+        <div className="flex gap-3">
+          <a
+            href="/"
+            className="rounded-md border border-[var(--color-border-default)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-accent-blue)] hover:text-[var(--color-accent-blue)]"
+          >
+            dashboard
+          </a>
+          <a
+            href="/perf"
+            className="rounded-md border border-[var(--color-border-default)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-accent-blue)] hover:text-[var(--color-accent-blue)]"
+          >
+            perf
+          </a>
+        </div>
+      </div>
+
+      <LogViewer />
+    </div>
+  );
+}

--- a/packages/web/src/app/perf/page.tsx
+++ b/packages/web/src/app/perf/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { PerfDashboard } from "@/components/PerfDashboard";
+
+export default function PerfPage() {
+  return (
+    <div className="mx-auto max-w-[1100px] px-8 py-8">
+      <div className="mb-7 flex items-baseline justify-between">
+        <h1 className="text-[22px] font-semibold tracking-tight">
+          <a href="/" className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]">
+            <span className="text-[#7c8aff]">Agent</span> Orchestrator
+          </a>
+          <span className="mx-2 text-[var(--color-text-muted)]">/</span>
+          Performance
+        </h1>
+        <div className="flex gap-3">
+          <a
+            href="/"
+            className="rounded-md border border-[var(--color-border-default)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-accent-blue)] hover:text-[var(--color-accent-blue)]"
+          >
+            dashboard
+          </a>
+          <a
+            href="/logs"
+            className="rounded-md border border-[var(--color-border-default)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-accent-blue)] hover:text-[var(--color-accent-blue)]"
+          >
+            logs
+          </a>
+        </div>
+      </div>
+
+      <PerfDashboard />
+    </div>
+  );
+}

--- a/packages/web/src/components/ClientLogger.tsx
+++ b/packages/web/src/components/ClientLogger.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { initClientLogger } from "@/lib/client-logger";
+
+/** Invisible component that initializes browser-side error/perf capture. */
+export function ClientLogger() {
+  useEffect(() => {
+    const cleanup = initClientLogger();
+    return cleanup;
+  }, []);
+
+  return null;
+}

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -103,18 +103,32 @@ export function Dashboard({ sessions, stats, orchestratorId, projectName }: Dash
           </h1>
           <StatusLine stats={stats} />
         </div>
-        {orchestratorId && (
+        <div className="flex items-center gap-3">
           <a
-            href={`/sessions/${encodeURIComponent(orchestratorId)}`}
-            className="orchestrator-btn flex items-center gap-2 rounded-[7px] px-4 py-2 text-[12px] font-semibold hover:no-underline"
+            href="/logs"
+            className="rounded-md border border-[var(--color-border-default)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-accent-blue)] hover:text-[var(--color-accent-blue)]"
           >
-            <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)] opacity-80" />
-            orchestrator
-            <svg className="h-3 w-3 opacity-70" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3" />
-            </svg>
+            logs
           </a>
-        )}
+          <a
+            href="/perf"
+            className="rounded-md border border-[var(--color-border-default)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-accent-blue)] hover:text-[var(--color-accent-blue)]"
+          >
+            perf
+          </a>
+          {orchestratorId && (
+            <a
+              href={`/sessions/${encodeURIComponent(orchestratorId)}`}
+              className="orchestrator-btn flex items-center gap-2 rounded-[7px] px-4 py-2 text-[12px] font-semibold hover:no-underline"
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)] opacity-80" />
+              orchestrator
+              <svg className="h-3 w-3 opacity-70" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3" />
+              </svg>
+            </a>
+          )}
+        </div>
       </div>
 
       {/* Rate limit notice */}

--- a/packages/web/src/components/LogViewer.tsx
+++ b/packages/web/src/components/LogViewer.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface LogEntry {
+  ts: string;
+  level: "stdout" | "stderr" | "info" | "warn" | "error";
+  source: "dashboard" | "lifecycle" | "cli" | "api" | "browser";
+  sessionId: string | null;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+const LEVEL_COLORS: Record<string, string> = {
+  error: "text-red-400",
+  warn: "text-yellow-400",
+  stderr: "text-red-300",
+  stdout: "text-[var(--color-text-secondary)]",
+  info: "text-blue-400",
+};
+
+const SOURCE_OPTIONS = ["events", "dashboard", "api", "browser"] as const;
+const LEVEL_OPTIONS = ["stdout", "stderr", "info", "warn", "error"] as const;
+
+export function LogViewer() {
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [source, setSource] = useState<string>("events");
+  const [level, setLevel] = useState<string>("");
+  const [sessionId, setSessionId] = useState<string>("");
+  const [autoRefresh, setAutoRefresh] = useState(true);
+
+  const fetchLogs = useCallback(async () => {
+    try {
+      const params = new URLSearchParams({ source, limit: "200" });
+      if (level) params.set("level", level);
+      if (sessionId) params.set("sessionId", sessionId);
+
+      const res = await fetch(`/api/logs?${params}`);
+      if (!res.ok) return;
+      const data = (await res.json()) as { entries: LogEntry[] };
+      setEntries(data.entries);
+    } catch {
+      // Transient error — skip
+    } finally {
+      setLoading(false);
+    }
+  }, [source, level, sessionId]);
+
+  useEffect(() => {
+    void fetchLogs();
+  }, [fetchLogs]);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const interval = setInterval(() => void fetchLogs(), 5000);
+    return () => clearInterval(interval);
+  }, [autoRefresh, fetchLogs]);
+
+  return (
+    <div>
+      {/* Filters */}
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <select
+          value={source}
+          onChange={(e) => setSource(e.target.value)}
+          className="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-secondary)] px-2 py-1 text-xs text-[var(--color-text-primary)]"
+        >
+          {SOURCE_OPTIONS.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+
+        <select
+          value={level}
+          onChange={(e) => setLevel(e.target.value)}
+          className="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-secondary)] px-2 py-1 text-xs text-[var(--color-text-primary)]"
+        >
+          <option value="">all levels</option>
+          {LEVEL_OPTIONS.map((l) => (
+            <option key={l} value={l}>{l}</option>
+          ))}
+        </select>
+
+        <input
+          type="text"
+          placeholder="session ID"
+          value={sessionId}
+          onChange={(e) => setSessionId(e.target.value)}
+          className="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-secondary)] px-2 py-1 text-xs text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)]"
+        />
+
+        <label className="flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
+          <input
+            type="checkbox"
+            checked={autoRefresh}
+            onChange={(e) => setAutoRefresh(e.target.checked)}
+          />
+          auto-refresh
+        </label>
+      </div>
+
+      {/* Log table */}
+      <div className="overflow-hidden rounded-lg border border-[var(--color-border-default)]">
+        <table className="w-full border-collapse font-mono text-xs">
+          <thead>
+            <tr className="border-b border-[var(--color-border-muted)] bg-[var(--color-bg-secondary)]">
+              <th className="px-2 py-1.5 text-left font-semibold text-[var(--color-text-muted)]">Time</th>
+              <th className="px-2 py-1.5 text-left font-semibold text-[var(--color-text-muted)]">Level</th>
+              <th className="px-2 py-1.5 text-left font-semibold text-[var(--color-text-muted)]">Session</th>
+              <th className="px-2 py-1.5 text-left font-semibold text-[var(--color-text-muted)]">Message</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={4} className="px-2 py-4 text-center text-[var(--color-text-muted)]">
+                  Loading...
+                </td>
+              </tr>
+            ) : entries.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-2 py-4 text-center text-[var(--color-text-muted)]">
+                  No log entries found.
+                </td>
+              </tr>
+            ) : (
+              entries.map((entry, i) => (
+                <tr
+                  key={`${entry.ts}-${i}`}
+                  className="border-b border-[var(--color-border-muted)] last:border-0 hover:bg-[var(--color-bg-secondary)]"
+                >
+                  <td className="whitespace-nowrap px-2 py-1 text-[var(--color-text-muted)]">
+                    {new Date(entry.ts).toLocaleTimeString()}
+                  </td>
+                  <td className={`px-2 py-1 ${LEVEL_COLORS[entry.level] ?? ""}`}>
+                    {entry.level}
+                  </td>
+                  <td className="px-2 py-1">
+                    {entry.sessionId ? (
+                      <a
+                        href={`/sessions/${encodeURIComponent(entry.sessionId)}`}
+                        className="text-[var(--color-accent-blue)] hover:underline"
+                      >
+                        {entry.sessionId}
+                      </a>
+                    ) : (
+                      <span className="text-[var(--color-text-muted)]">—</span>
+                    )}
+                  </td>
+                  <td className="max-w-[600px] truncate px-2 py-1 text-[var(--color-text-primary)]">
+                    {entry.message}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-2 text-xs text-[var(--color-text-muted)]">
+        {entries.length} entries
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/PerfDashboard.tsx
+++ b/packages/web/src/components/PerfDashboard.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface RouteStats {
+  count: number;
+  avgMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  errors: number;
+}
+
+interface SlowRequest {
+  ts: string;
+  method: string;
+  path: string;
+  durationMs: number;
+  timings?: Record<string, number>;
+}
+
+interface PerfData {
+  routes: Record<string, RouteStats>;
+  slowest: SlowRequest[];
+  cacheStats: { hits: number; misses: number; hitRate: number; size: number } | null;
+  totalRequests: number;
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function PerfDashboard() {
+  const [data, setData] = useState<PerfData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchPerf = useCallback(async () => {
+    try {
+      const res = await fetch("/api/perf");
+      if (!res.ok) return;
+      setData((await res.json()) as PerfData);
+    } catch {
+      // Transient error
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchPerf();
+    const interval = setInterval(() => void fetchPerf(), 30_000);
+    return () => clearInterval(interval);
+  }, [fetchPerf]);
+
+  if (loading) {
+    return <div className="py-8 text-center text-[var(--color-text-muted)]">Loading performance data...</div>;
+  }
+
+  if (!data || Object.keys(data.routes).length === 0) {
+    return (
+      <div className="py-8 text-center text-[var(--color-text-muted)]">
+        No performance data yet. Hit the dashboard a few times to generate API request logs.
+      </div>
+    );
+  }
+
+  const sortedRoutes = Object.entries(data.routes).sort(
+    ([, a], [, b]) => b.p95Ms - a.p95Ms,
+  );
+
+  return (
+    <div className="space-y-8">
+      {/* Route Performance Table */}
+      <section>
+        <h2 className="mb-3 text-[13px] font-semibold uppercase tracking-widest text-[var(--color-text-muted)]">
+          Route Performance
+        </h2>
+        <div className="overflow-hidden rounded-lg border border-[var(--color-border-default)]">
+          <table className="w-full border-collapse font-mono text-xs">
+            <thead>
+              <tr className="border-b border-[var(--color-border-muted)] bg-[var(--color-bg-secondary)]">
+                <th className="px-3 py-2 text-left font-semibold text-[var(--color-text-muted)]">Route</th>
+                <th className="px-3 py-2 text-right font-semibold text-[var(--color-text-muted)]">Count</th>
+                <th className="px-3 py-2 text-right font-semibold text-[var(--color-text-muted)]">p50</th>
+                <th className="px-3 py-2 text-right font-semibold text-[var(--color-text-muted)]">p95</th>
+                <th className="px-3 py-2 text-right font-semibold text-[var(--color-text-muted)]">p99</th>
+                <th className="px-3 py-2 text-right font-semibold text-[var(--color-text-muted)]">Errors</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedRoutes.map(([route, stats]) => (
+                <tr
+                  key={route}
+                  className="border-b border-[var(--color-border-muted)] last:border-0 hover:bg-[var(--color-bg-secondary)]"
+                >
+                  <td className="px-3 py-1.5 text-[var(--color-accent-blue)]">{route}</td>
+                  <td className="px-3 py-1.5 text-right text-[var(--color-text-secondary)]">{stats.count}</td>
+                  <td className="px-3 py-1.5 text-right">{formatMs(stats.p50Ms)}</td>
+                  <td className={`px-3 py-1.5 text-right ${stats.p95Ms > 1000 ? "text-yellow-400" : ""}`}>
+                    {formatMs(stats.p95Ms)}
+                  </td>
+                  <td className={`px-3 py-1.5 text-right ${stats.p99Ms > 2000 ? "text-red-400" : ""}`}>
+                    {formatMs(stats.p99Ms)}
+                  </td>
+                  <td className={`px-3 py-1.5 text-right ${stats.errors > 0 ? "text-red-400" : "text-[var(--color-text-muted)]"}`}>
+                    {stats.errors}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Slowest Requests */}
+      {data.slowest.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-[13px] font-semibold uppercase tracking-widest text-[var(--color-text-muted)]">
+            Slowest Requests
+          </h2>
+          <div className="overflow-hidden rounded-lg border border-[var(--color-border-default)]">
+            <table className="w-full border-collapse font-mono text-xs">
+              <thead>
+                <tr className="border-b border-[var(--color-border-muted)] bg-[var(--color-bg-secondary)]">
+                  <th className="px-3 py-2 text-right font-semibold text-[var(--color-text-muted)]">Duration</th>
+                  <th className="px-3 py-2 text-left font-semibold text-[var(--color-text-muted)]">Request</th>
+                  <th className="px-3 py-2 text-left font-semibold text-[var(--color-text-muted)]">Time</th>
+                  <th className="px-3 py-2 text-left font-semibold text-[var(--color-text-muted)]">Breakdown</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.slowest.map((req, i) => (
+                  <tr
+                    key={`${req.ts}-${i}`}
+                    className="border-b border-[var(--color-border-muted)] last:border-0 hover:bg-[var(--color-bg-secondary)]"
+                  >
+                    <td className="whitespace-nowrap px-3 py-1.5 text-right text-yellow-400">
+                      {formatMs(req.durationMs)}
+                    </td>
+                    <td className="px-3 py-1.5 text-[var(--color-accent-blue)]">
+                      {req.method} {req.path}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-1.5 text-[var(--color-text-muted)]">
+                      {new Date(req.ts).toLocaleTimeString()}
+                    </td>
+                    <td className="px-3 py-1.5 text-[var(--color-text-muted)]">
+                      {req.timings
+                        ? Object.entries(req.timings)
+                            .map(([k, v]) => `${k}: ${formatMs(v)}`)
+                            .join(", ")
+                        : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* Cache Stats */}
+      {data.cacheStats && (
+        <section>
+          <h2 className="mb-3 text-[13px] font-semibold uppercase tracking-widest text-[var(--color-text-muted)]">
+            Cache
+          </h2>
+          <div className="flex gap-8 rounded-lg border border-[var(--color-border-default)] px-4 py-3">
+            <div>
+              <div className="text-2xl font-bold text-[var(--color-accent-green)]">
+                {(data.cacheStats.hitRate * 100).toFixed(1)}%
+              </div>
+              <div className="text-xs text-[var(--color-text-muted)]">hit rate</div>
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-[var(--color-text-primary)]">
+                {data.cacheStats.hits}
+              </div>
+              <div className="text-xs text-[var(--color-text-muted)]">hits</div>
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-[var(--color-text-primary)]">
+                {data.cacheStats.misses}
+              </div>
+              <div className="text-xs text-[var(--color-text-muted)]">misses</div>
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-[var(--color-text-primary)]">
+                {data.cacheStats.size}
+              </div>
+              <div className="text-xs text-[var(--color-text-muted)]">entries</div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <div className="text-xs text-[var(--color-text-muted)]">
+        {data.totalRequests} total requests logged
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/lib/__tests__/client-logger.test.ts
+++ b/packages/web/src/lib/__tests__/client-logger.test.ts
@@ -1,0 +1,977 @@
+/**
+ * Tests for browser-side client logger.
+ *
+ * Covers:
+ * - window.onerror / unhandledrejection capture
+ * - PerformanceObserver integration (LCP, FCP, navigation)
+ * - Batch flush via fetch POST to /api/client-logs
+ * - sendBeacon usage on flush, with fetch fallback
+ * - Periodic flush timer
+ * - Visibility change flush
+ * - beforeunload (pagehide) flush
+ * - Cleanup function behavior
+ * - Graceful degradation when PerformanceObserver is unavailable
+ *
+ * The module under test uses module-level state (buffer, flushTimer).
+ * We use vi.resetModules() + dynamic import to get fresh state per test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// PromiseRejectionEvent polyfill for jsdom (not available by default)
+// ---------------------------------------------------------------------------
+
+if (typeof globalThis.PromiseRejectionEvent === "undefined") {
+  // Minimal polyfill that satisfies the code under test
+  class PromiseRejectionEventPolyfill extends Event {
+    readonly promise: Promise<unknown>;
+    readonly reason: unknown;
+
+    constructor(
+      type: string,
+      init: { promise: Promise<unknown>; reason?: unknown },
+    ) {
+      super(type, { bubbles: false, cancelable: true });
+      this.promise = init.promise;
+      this.reason = init.reason;
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).PromiseRejectionEvent = PromiseRejectionEventPolyfill;
+}
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+/** Captured PerformanceObserver callback from the most recent instantiation. */
+let perfObserverCallback: ((list: { getEntries: () => unknown[] }) => void) | null = null;
+let perfObserverObservedTypes: string[] = [];
+let perfObserverDisconnected = false;
+
+class MockPerformanceObserver {
+  callback: (list: { getEntries: () => unknown[] }) => void;
+
+  constructor(cb: (list: { getEntries: () => unknown[] }) => void) {
+    this.callback = cb;
+    perfObserverCallback = cb;
+  }
+
+  observe(opts: { type: string; buffered?: boolean }): void {
+    perfObserverObservedTypes.push(opts.type);
+  }
+
+  disconnect(): void {
+    perfObserverDisconnected = true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup and teardown
+// ---------------------------------------------------------------------------
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+let sendBeaconSpy: ReturnType<typeof vi.fn>;
+let originalPerformanceObserver: typeof globalThis.PerformanceObserver | undefined;
+
+/** Dynamically imported initClientLogger — fresh module state each test. */
+let initClientLogger: () => () => void;
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+
+  // Reset PerformanceObserver tracking
+  perfObserverCallback = null;
+  perfObserverObservedTypes = [];
+  perfObserverDisconnected = false;
+
+  // Install mock PerformanceObserver
+  originalPerformanceObserver = globalThis.PerformanceObserver;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.PerformanceObserver = MockPerformanceObserver as any;
+
+  // Mock fetch
+  fetchSpy = vi.fn().mockResolvedValue({ ok: true });
+  globalThis.fetch = fetchSpy;
+
+  // Mock sendBeacon (returns true by default)
+  sendBeaconSpy = vi.fn().mockReturnValue(true);
+  Object.defineProperty(navigator, "sendBeacon", {
+    value: sendBeaconSpy,
+    writable: true,
+    configurable: true,
+  });
+
+  // Reset modules to get fresh module-level state (buffer, flushTimer)
+  vi.resetModules();
+  const mod = await import("../client-logger.js");
+  initClientLogger = mod.initClientLogger;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+
+  // Restore PerformanceObserver
+  if (originalPerformanceObserver) {
+    globalThis.PerformanceObserver = originalPerformanceObserver;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// initClientLogger — basic setup
+// ---------------------------------------------------------------------------
+
+describe("initClientLogger", () => {
+  it("returns a cleanup function", () => {
+    const cleanup = initClientLogger();
+    expect(typeof cleanup).toBe("function");
+    cleanup();
+  });
+
+  it("registers error event listener on window", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const cleanup = initClientLogger();
+
+    const errorCalls = addSpy.mock.calls.filter(([type]) => type === "error");
+    expect(errorCalls.length).toBe(1);
+
+    cleanup();
+  });
+
+  it("registers unhandledrejection event listener on window", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const cleanup = initClientLogger();
+
+    const rejectionCalls = addSpy.mock.calls.filter(
+      ([type]) => type === "unhandledrejection",
+    );
+    expect(rejectionCalls.length).toBe(1);
+
+    cleanup();
+  });
+
+  it("registers pagehide event listener on window", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const cleanup = initClientLogger();
+
+    const pageCalls = addSpy.mock.calls.filter(([type]) => type === "pagehide");
+    expect(pageCalls.length).toBe(1);
+
+    cleanup();
+  });
+
+  it("registers visibilitychange event listener on window", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const cleanup = initClientLogger();
+
+    const visCalls = addSpy.mock.calls.filter(
+      ([type]) => type === "visibilitychange",
+    );
+    expect(visCalls.length).toBe(1);
+
+    cleanup();
+  });
+
+  it("sets up a periodic flush interval", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const cleanup = initClientLogger();
+
+    // setInterval should have been called with 10_000 ms
+    const flushCalls = setIntervalSpy.mock.calls.filter(
+      ([, ms]) => ms === 10_000,
+    );
+    expect(flushCalls.length).toBe(1);
+
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error capture
+// ---------------------------------------------------------------------------
+
+describe("error capture", () => {
+  it("captures error events with message, filename, and stack", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    const errorEvent = new ErrorEvent("error", {
+      message: "Test error occurred",
+      filename: "https://example.com/app.js",
+      lineno: 42,
+      colno: 7,
+      error: new Error("Test error occurred"),
+    });
+
+    window.dispatchEvent(errorEvent);
+
+    // Advance timer to trigger flush
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].level).toBe("error");
+    expect(body.entries[0].message).toBe("Test error occurred");
+    expect(body.entries[0].url).toBe("https://example.com/app.js");
+    expect(body.entries[0].stack).toBeDefined();
+
+    cleanup();
+  });
+
+  it("captures error event with fallback message when message is empty", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    const errorEvent = new ErrorEvent("error", {
+      message: "",
+      filename: "app.js",
+    });
+    window.dispatchEvent(errorEvent);
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].message).toBe("Unknown error");
+    expect(body.entries[0].level).toBe("error");
+
+    cleanup();
+  });
+
+  it("captures unhandled promise rejections with Error reason", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    const reason = new Error("Promise failed");
+    const event = new PromiseRejectionEvent("unhandledrejection", {
+      reason,
+      promise: Promise.resolve(),
+    });
+    window.dispatchEvent(event);
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].message).toBe("Promise failed");
+    expect(body.entries[0].level).toBe("error");
+    expect(body.entries[0].stack).toBeDefined();
+
+    cleanup();
+  });
+
+  it("captures unhandled promise rejections with string reason", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    const event = new PromiseRejectionEvent("unhandledrejection", {
+      reason: "string rejection",
+      promise: Promise.resolve(),
+    });
+    window.dispatchEvent(event);
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].message).toBe("string rejection");
+    expect(body.entries[0].stack).toBeUndefined();
+
+    cleanup();
+  });
+
+  it("captures unhandled promise rejections with non-Error non-string reason", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    const event = new PromiseRejectionEvent("unhandledrejection", {
+      reason: 42,
+      promise: Promise.resolve(),
+    });
+    window.dispatchEvent(event);
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries[0].message).toBe("42");
+    expect(body.entries[0].stack).toBeUndefined();
+
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flush mechanism
+// ---------------------------------------------------------------------------
+
+describe("flush mechanism", () => {
+  it("skips fetch when buffer is empty", () => {
+    const cleanup = initClientLogger();
+
+    // Advance timer -- no errors were recorded
+    vi.advanceTimersByTime(10_000);
+
+    expect(sendBeaconSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("batches multiple entries into a single POST", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    // Dispatch two errors
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "Error 1", filename: "a.js" }),
+    );
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "Error 2", filename: "b.js" }),
+    );
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries).toHaveLength(2);
+    expect(body.entries[0].message).toBe("Error 1");
+    expect(body.entries[1].message).toBe("Error 2");
+
+    cleanup();
+  });
+
+  it("uses sendBeacon for flush and skips fetch when sendBeacon succeeds", () => {
+    sendBeaconSpy.mockReturnValue(true);
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "beacon test" }),
+    );
+    vi.advanceTimersByTime(10_000);
+
+    expect(sendBeaconSpy).toHaveBeenCalledTimes(1);
+    expect(sendBeaconSpy.mock.calls[0][0]).toBe("/api/client-logs");
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("falls back to fetch when sendBeacon returns false", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "fallback test" }),
+    );
+    vi.advanceTimersByTime(10_000);
+
+    expect(sendBeaconSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe("/api/client-logs");
+    expect(fetchSpy.mock.calls[0][1].method).toBe("POST");
+    expect(fetchSpy.mock.calls[0][1].keepalive).toBe(true);
+
+    cleanup();
+  });
+
+  it("falls back to fetch when sendBeacon is not available", () => {
+    // Remove sendBeacon
+    Object.defineProperty(navigator, "sendBeacon", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "no beacon" }),
+    );
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries[0].message).toBe("no beacon");
+
+    cleanup();
+  });
+
+  it("sends correct Content-Type header in fetch fallback", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "header check" }),
+    );
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy.mock.calls[0][1].headers).toEqual({
+      "Content-Type": "application/json",
+    });
+
+    cleanup();
+  });
+
+  it("does not crash when fetch rejects", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    fetchSpy.mockRejectedValue(new Error("network error"));
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "fetch will fail" }),
+    );
+
+    // Should not throw
+    expect(() => vi.advanceTimersByTime(10_000)).not.toThrow();
+
+    cleanup();
+  });
+
+  it("clears the buffer after flushing", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "first batch" }),
+    );
+    vi.advanceTimersByTime(10_000);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Second interval: nothing new was added, so flush should be skipped
+    vi.advanceTimersByTime(10_000);
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // Still 1
+
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Visibility change and pagehide
+// ---------------------------------------------------------------------------
+
+describe("visibility change and pagehide flush", () => {
+  it("flushes when document.visibilityState becomes hidden", () => {
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "visibility test" }),
+    );
+
+    // Simulate visibilitychange to hidden
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      writable: true,
+      configurable: true,
+    });
+    window.dispatchEvent(new Event("visibilitychange"));
+
+    expect(sendBeaconSpy).toHaveBeenCalledTimes(1);
+
+    // Restore visibilityState
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      writable: true,
+      configurable: true,
+    });
+
+    cleanup();
+  });
+
+  it("does not flush on visibilitychange when state is visible", () => {
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "visible test" }),
+    );
+
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      writable: true,
+      configurable: true,
+    });
+    window.dispatchEvent(new Event("visibilitychange"));
+
+    // Should NOT have flushed yet (only periodic timer would flush)
+    expect(sendBeaconSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("flushes on pagehide event", () => {
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "pagehide test" }),
+    );
+
+    window.dispatchEvent(new Event("pagehide"));
+
+    expect(sendBeaconSpy).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup function
+// ---------------------------------------------------------------------------
+
+describe("cleanup", () => {
+  it("removes error event listener", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const cleanup = initClientLogger();
+
+    cleanup();
+
+    const errorRemoves = removeSpy.mock.calls.filter(
+      ([type]) => type === "error",
+    );
+    expect(errorRemoves.length).toBe(1);
+  });
+
+  it("removes unhandledrejection event listener", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const cleanup = initClientLogger();
+
+    cleanup();
+
+    const rejectionRemoves = removeSpy.mock.calls.filter(
+      ([type]) => type === "unhandledrejection",
+    );
+    expect(rejectionRemoves.length).toBe(1);
+  });
+
+  it("removes pagehide event listener", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const cleanup = initClientLogger();
+
+    cleanup();
+
+    const pageRemoves = removeSpy.mock.calls.filter(
+      ([type]) => type === "pagehide",
+    );
+    expect(pageRemoves.length).toBe(1);
+  });
+
+  it("clears the flush interval", () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    const cleanup = initClientLogger();
+
+    cleanup();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+  });
+
+  it("flushes remaining entries on cleanup", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "leftover entry" }),
+    );
+
+    // No timer advance -- just call cleanup directly
+    cleanup();
+
+    // Cleanup calls flush() which tries sendBeacon (false) then fetch
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].message).toBe("leftover entry");
+  });
+
+  it("disconnects PerformanceObserver on cleanup", () => {
+    const cleanup = initClientLogger();
+    expect(perfObserverDisconnected).toBe(false);
+
+    cleanup();
+
+    expect(perfObserverDisconnected).toBe(true);
+  });
+
+  it("no longer captures errors after cleanup", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+    cleanup();
+
+    // Reset spies after cleanup flush
+    fetchSpy.mockClear();
+    sendBeaconSpy.mockClear();
+
+    // Dispatch error after cleanup
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "after cleanup" }),
+    );
+    vi.advanceTimersByTime(10_000);
+
+    // The interval was cleared, so no periodic flush. The event listener was
+    // removed, so the error was never captured. Nothing should have been sent.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(sendBeaconSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PerformanceObserver integration
+// ---------------------------------------------------------------------------
+
+describe("PerformanceObserver integration", () => {
+  it("observes largest-contentful-paint, paint, and navigation types", () => {
+    const cleanup = initClientLogger();
+
+    expect(perfObserverObservedTypes).toContain("largest-contentful-paint");
+    expect(perfObserverObservedTypes).toContain("paint");
+    expect(perfObserverObservedTypes).toContain("navigation");
+
+    cleanup();
+  });
+
+  it("captures LCP entries", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    // Simulate PerformanceObserver callback with LCP entry
+    perfObserverCallback!({
+      getEntries: () => [
+        {
+          entryType: "largest-contentful-paint",
+          startTime: 1234.5,
+          name: "largest-contentful-paint",
+        },
+      ],
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].level).toBe("info");
+    expect(body.entries[0].message).toBe("LCP: 1235ms");
+    expect(body.entries[0].timing.lcp).toBe(1234.5);
+
+    cleanup();
+  });
+
+  it("captures first-contentful-paint entries", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    perfObserverCallback!({
+      getEntries: () => [
+        {
+          entryType: "paint",
+          startTime: 567.8,
+          name: "first-contentful-paint",
+        },
+      ],
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].message).toBe("first-contentful-paint: 568ms");
+    expect(body.entries[0].timing.fcp).toBe(567.8);
+
+    cleanup();
+  });
+
+  it("captures first-paint entries with fp timing key", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    perfObserverCallback!({
+      getEntries: () => [
+        {
+          entryType: "paint",
+          startTime: 200.3,
+          name: "first-paint",
+        },
+      ],
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries[0].timing.fp).toBe(200.3);
+
+    cleanup();
+  });
+
+  it("captures navigation timing entries with TTFB, DOM, and load metrics", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    perfObserverCallback!({
+      getEntries: () => [
+        {
+          entryType: "navigation",
+          name: "navigation",
+          startTime: 0,
+          responseStart: 150.5,
+          domContentLoadedEventEnd: 450.2,
+          loadEventEnd: 800.7,
+        },
+      ],
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].message).toBe("Navigation: TTFB 151ms, DOM 450ms");
+    expect(body.entries[0].timing.ttfb).toBe(150.5);
+    expect(body.entries[0].timing.domContentLoaded).toBe(450.2);
+    expect(body.entries[0].timing.loadComplete).toBe(800.7);
+
+    cleanup();
+  });
+
+  it("handles multiple entries in a single observer callback", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    perfObserverCallback!({
+      getEntries: () => [
+        {
+          entryType: "paint",
+          startTime: 100,
+          name: "first-paint",
+        },
+        {
+          entryType: "paint",
+          startTime: 300,
+          name: "first-contentful-paint",
+        },
+      ],
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries).toHaveLength(2);
+    expect(body.entries[0].timing.fp).toBe(100);
+    expect(body.entries[1].timing.fcp).toBe(300);
+
+    cleanup();
+  });
+
+  it("gracefully handles PerformanceObserver not being available", () => {
+    // Remove PerformanceObserver from global scope
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).PerformanceObserver;
+
+    const cleanup = initClientLogger();
+
+    // Should still work without crashing
+    expect(typeof cleanup).toBe("function");
+
+    // No observer should have been created
+    expect(perfObserverCallback).toBeNull();
+
+    // Restore for subsequent tests
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.PerformanceObserver = MockPerformanceObserver as any;
+
+    cleanup();
+  });
+
+  it("gracefully handles PerformanceObserver.observe throwing", () => {
+    // Create a mock that throws on observe
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.PerformanceObserver = class ThrowingObserver {
+      observe(): void {
+        throw new Error("not supported");
+      }
+      disconnect(): void {
+        // noop
+      }
+    } as any;
+
+    // Should not throw
+    const cleanup = initClientLogger();
+    expect(typeof cleanup).toBe("function");
+
+    // Restore
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    globalThis.PerformanceObserver = MockPerformanceObserver as any;
+
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Periodic timer behavior
+// ---------------------------------------------------------------------------
+
+describe("periodic timer", () => {
+  it("flushes every 10 seconds", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    // Add entry and advance 10s
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "tick 1" }),
+    );
+    vi.advanceTimersByTime(10_000);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Add another entry and advance another 10s
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "tick 2" }),
+    );
+    vi.advanceTimersByTime(10_000);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    cleanup();
+  });
+
+  it("does not flush at 5 seconds", () => {
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "too early" }),
+    );
+    vi.advanceTimersByTime(5_000);
+
+    expect(sendBeaconSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSR safety
+// ---------------------------------------------------------------------------
+
+describe("SSR safety", () => {
+  it("returns noop cleanup when window is undefined", () => {
+    // The module checks `typeof window === "undefined"`. In jsdom, window
+    // always exists so we cannot truly remove it. Instead we verify that the
+    // function returns a callable cleanup even in the normal path. This test
+    // documents that the SSR guard exists in the source code.
+    const cleanup = initClientLogger();
+    expect(typeof cleanup).toBe("function");
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("edge cases", () => {
+  it("handles error event where error property is null", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    // ErrorEvent with no error object (just a message)
+    const event = new ErrorEvent("error", {
+      message: "Script error.",
+      filename: "",
+      lineno: 0,
+      colno: 0,
+      error: null,
+    });
+    window.dispatchEvent(event);
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries[0].message).toBe("Script error.");
+    expect(body.entries[0].stack).toBeUndefined();
+
+    cleanup();
+  });
+
+  it("handles rapid successive flushes without duplicating entries", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "only once" }),
+    );
+
+    // Trigger flush via pagehide
+    window.dispatchEvent(new Event("pagehide"));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Now the periodic timer fires -- buffer should be empty
+    vi.advanceTimersByTime(10_000);
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // Still 1
+
+    cleanup();
+  });
+
+  it("payload is valid JSON with entries array", () => {
+    sendBeaconSpy.mockReturnValue(false);
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "json check" }),
+    );
+    vi.advanceTimersByTime(10_000);
+
+    const rawBody = fetchSpy.mock.calls[0][1].body as string;
+    const parsed = JSON.parse(rawBody);
+    expect(parsed).toHaveProperty("entries");
+    expect(Array.isArray(parsed.entries)).toBe(true);
+
+    cleanup();
+  });
+
+  it("sendBeacon receives a Blob with application/json type", () => {
+    sendBeaconSpy.mockReturnValue(true);
+    const cleanup = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "blob check" }),
+    );
+    vi.advanceTimersByTime(10_000);
+
+    const blobArg = sendBeaconSpy.mock.calls[0][1];
+    expect(blobArg).toBeInstanceOf(Blob);
+    expect(blobArg.type).toBe("application/json");
+
+    cleanup();
+  });
+
+  it("multiple initClientLogger calls share module-level buffer", async () => {
+    // This test documents that calling initClientLogger multiple times
+    // accumulates entries into the same buffer. The second cleanup flushes
+    // entries captured by both instances.
+    sendBeaconSpy.mockReturnValue(false);
+
+    const cleanup1 = initClientLogger();
+    const cleanup2 = initClientLogger();
+
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "shared buffer test" }),
+    );
+
+    // Both error listeners fire, so we get 2 entries (one from each init)
+    vi.advanceTimersByTime(10_000);
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.entries).toHaveLength(2);
+
+    cleanup1();
+    cleanup2();
+  });
+});

--- a/packages/web/src/lib/__tests__/request-logger.test.ts
+++ b/packages/web/src/lib/__tests__/request-logger.test.ts
@@ -1,0 +1,666 @@
+/**
+ * Tests for request-logger: logApiRequest, getRequestStats, normalizePath, percentile.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { getRequestStats as GetRequestStatsFn } from "../request-logger.js";
+
+// ── Mock fns (hoisted) ────────────────────────────────────────────────
+
+const mockLoadConfig = vi.fn();
+const mockGetLogsDir = vi.fn();
+const mockReadLogsFromDir = vi.fn();
+const mockLogWriterAppend = vi.fn();
+const mockLogWriterClose = vi.fn();
+
+vi.mock("@composio/ao-core", () => ({
+  loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+  getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
+  readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
+  LogWriter: vi.fn().mockImplementation(() => ({
+    append: mockLogWriterAppend,
+    appendLine: vi.fn(),
+    close: mockLogWriterClose,
+  })),
+}));
+
+// ── Import after mocking ──────────────────────────────────────────────
+
+// We need a fresh module for each describe block that tests logApiRequest
+// because of the module-level logWriter cache. For getRequestStats tests,
+// we can reuse the same import since it doesn't depend on the cached writer.
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── logApiRequest ─────────────────────────────────────────────────────
+
+describe("logApiRequest", () => {
+  beforeEach(() => {
+    vi.resetModules();
+
+    // Re-apply mock after resetModules
+    vi.doMock("@composio/ao-core", () => ({
+      loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+      getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
+      readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
+      LogWriter: vi.fn().mockImplementation(() => ({
+        append: mockLogWriterAppend,
+        appendLine: vi.fn(),
+        close: mockLogWriterClose,
+      })),
+    }));
+  });
+
+  it("logs request with all required fields", async () => {
+    mockLoadConfig.mockReturnValue({
+      configPath: "/tmp/config.yaml",
+      projects: { myProject: { path: "/tmp/project" } },
+    });
+    mockGetLogsDir.mockReturnValue("/tmp/logs");
+
+    const { logApiRequest } = await import("../request-logger.js");
+
+    logApiRequest({
+      ts: "2026-01-15T10:00:00Z",
+      method: "GET",
+      path: "/api/sessions",
+      sessionId: null,
+      statusCode: 200,
+      durationMs: 42,
+    });
+
+    expect(mockLogWriterAppend).toHaveBeenCalledTimes(1);
+    const entry = mockLogWriterAppend.mock.calls[0][0];
+    expect(entry.ts).toBe("2026-01-15T10:00:00Z");
+    expect(entry.level).toBe("info");
+    expect(entry.source).toBe("api");
+    expect(entry.sessionId).toBeNull();
+    expect(entry.message).toBe("GET /api/sessions 200 42ms");
+    expect(entry.data.method).toBe("GET");
+    expect(entry.data.path).toBe("/api/sessions");
+    expect(entry.data.statusCode).toBe(200);
+    expect(entry.data.durationMs).toBe(42);
+  });
+
+  it("logs error level when error field is present", async () => {
+    mockLoadConfig.mockReturnValue({
+      configPath: "/tmp/config.yaml",
+      projects: { myProject: { path: "/tmp/project" } },
+    });
+    mockGetLogsDir.mockReturnValue("/tmp/logs");
+
+    const { logApiRequest } = await import("../request-logger.js");
+
+    logApiRequest({
+      ts: "2026-01-15T10:00:00Z",
+      method: "POST",
+      path: "/api/spawn",
+      sessionId: null,
+      statusCode: 500,
+      durationMs: 100,
+      error: "spawn failed",
+    });
+
+    const entry = mockLogWriterAppend.mock.calls[0][0];
+    expect(entry.level).toBe("error");
+    expect(entry.data.error).toBe("spawn failed");
+  });
+
+  it("includes optional timings field when provided", async () => {
+    mockLoadConfig.mockReturnValue({
+      configPath: "/tmp/config.yaml",
+      projects: { myProject: { path: "/tmp/project" } },
+    });
+    mockGetLogsDir.mockReturnValue("/tmp/logs");
+
+    const { logApiRequest } = await import("../request-logger.js");
+
+    const timings = {
+      serviceInit: 5,
+      sessionList: 20,
+      prEnrichment: 100,
+    };
+
+    logApiRequest({
+      ts: "2026-01-15T10:00:00Z",
+      method: "GET",
+      path: "/api/sessions",
+      sessionId: null,
+      statusCode: 200,
+      durationMs: 130,
+      timings,
+    });
+
+    const entry = mockLogWriterAppend.mock.calls[0][0];
+    expect(entry.data.timings).toEqual(timings);
+  });
+
+  it("includes optional cacheStats field when provided", async () => {
+    mockLoadConfig.mockReturnValue({
+      configPath: "/tmp/config.yaml",
+      projects: { myProject: { path: "/tmp/project" } },
+    });
+    mockGetLogsDir.mockReturnValue("/tmp/logs");
+
+    const { logApiRequest } = await import("../request-logger.js");
+
+    const cacheStats = { hits: 5, misses: 2, hitRate: 0.71, size: 10 };
+
+    logApiRequest({
+      ts: "2026-01-15T10:00:00Z",
+      method: "GET",
+      path: "/api/sessions",
+      sessionId: null,
+      statusCode: 200,
+      durationMs: 50,
+      cacheStats,
+    });
+
+    const entry = mockLogWriterAppend.mock.calls[0][0];
+    expect(entry.data.cacheStats).toEqual(cacheStats);
+  });
+
+  it("omits optional fields from data when not provided", async () => {
+    mockLoadConfig.mockReturnValue({
+      configPath: "/tmp/config.yaml",
+      projects: { myProject: { path: "/tmp/project" } },
+    });
+    mockGetLogsDir.mockReturnValue("/tmp/logs");
+
+    const { logApiRequest } = await import("../request-logger.js");
+
+    logApiRequest({
+      ts: "2026-01-15T10:00:00Z",
+      method: "GET",
+      path: "/api/sessions",
+      sessionId: null,
+      statusCode: 200,
+      durationMs: 42,
+    });
+
+    const entry = mockLogWriterAppend.mock.calls[0][0];
+    expect(entry.data).not.toHaveProperty("error");
+    expect(entry.data).not.toHaveProperty("timings");
+    expect(entry.data).not.toHaveProperty("cacheStats");
+  });
+
+  it("handles missing logDir gracefully (no projects)", async () => {
+    mockLoadConfig.mockReturnValue({
+      configPath: "/tmp/config.yaml",
+      projects: {},
+    });
+
+    const { logApiRequest } = await import("../request-logger.js");
+
+    // Should not throw
+    logApiRequest({
+      ts: "2026-01-15T10:00:00Z",
+      method: "GET",
+      path: "/api/sessions",
+      sessionId: null,
+      statusCode: 200,
+      durationMs: 42,
+    });
+
+    expect(mockLogWriterAppend).not.toHaveBeenCalled();
+  });
+
+  it("handles loadConfig throwing an error gracefully", async () => {
+    mockLoadConfig.mockImplementation(() => {
+      throw new Error("No config file found");
+    });
+
+    const { logApiRequest } = await import("../request-logger.js");
+
+    // Should not throw
+    logApiRequest({
+      ts: "2026-01-15T10:00:00Z",
+      method: "GET",
+      path: "/api/sessions",
+      sessionId: null,
+      statusCode: 200,
+      durationMs: 42,
+    });
+
+    expect(mockLogWriterAppend).not.toHaveBeenCalled();
+  });
+
+  it("caches the LogWriter after first successful initialization", async () => {
+    mockLoadConfig.mockReturnValue({
+      configPath: "/tmp/config.yaml",
+      projects: { myProject: { path: "/tmp/project" } },
+    });
+    mockGetLogsDir.mockReturnValue("/tmp/logs");
+
+    const { logApiRequest } = await import("../request-logger.js");
+
+    logApiRequest({
+      ts: "2026-01-15T10:00:00Z",
+      method: "GET",
+      path: "/api/sessions",
+      sessionId: null,
+      statusCode: 200,
+      durationMs: 42,
+    });
+
+    logApiRequest({
+      ts: "2026-01-15T10:01:00Z",
+      method: "GET",
+      path: "/api/sessions",
+      sessionId: null,
+      statusCode: 200,
+      durationMs: 55,
+    });
+
+    // loadConfig should only be called once (writer is cached)
+    expect(mockLoadConfig).toHaveBeenCalledTimes(1);
+    // But append should be called twice
+    expect(mockLogWriterAppend).toHaveBeenCalledTimes(2);
+  });
+
+  it("includes sessionId in log entry", async () => {
+    mockLoadConfig.mockReturnValue({
+      configPath: "/tmp/config.yaml",
+      projects: { myProject: { path: "/tmp/project" } },
+    });
+    mockGetLogsDir.mockReturnValue("/tmp/logs");
+
+    const { logApiRequest } = await import("../request-logger.js");
+
+    logApiRequest({
+      ts: "2026-01-15T10:00:00Z",
+      method: "GET",
+      path: "/api/sessions/ao-5",
+      sessionId: "ao-5",
+      statusCode: 200,
+      durationMs: 42,
+    });
+
+    const entry = mockLogWriterAppend.mock.calls[0][0];
+    expect(entry.sessionId).toBe("ao-5");
+  });
+});
+
+// ── getRequestStats ───────────────────────────────────────────────────
+
+describe("getRequestStats", () => {
+  // getRequestStats calls readLogsFromDir directly, no cached writer involved
+  let getRequestStats: GetRequestStatsFn;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock("@composio/ao-core", () => ({
+      loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+      getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
+      readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
+      LogWriter: vi.fn().mockImplementation(() => ({
+        append: mockLogWriterAppend,
+        appendLine: vi.fn(),
+        close: mockLogWriterClose,
+      })),
+    }));
+
+    const mod = await import("../request-logger.js");
+    getRequestStats = mod.getRequestStats;
+  });
+
+  it("computes per-route stats with count, avgMs, percentiles", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/sessions", 200, 100),
+      makeLogEntry("GET", "/api/sessions", 200, 200),
+      makeLogEntry("GET", "/api/sessions", 200, 300),
+      makeLogEntry("GET", "/api/sessions", 200, 400),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+
+    const route = result.routes["GET /api/sessions"];
+    expect(route).toBeDefined();
+    expect(route.count).toBe(4);
+    expect(route.avgMs).toBe(250); // (100+200+300+400)/4
+    expect(route.errors).toBe(0);
+  });
+
+  it("counts errors when statusCode >= 400", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/sessions", 200, 100),
+      makeLogEntry("GET", "/api/sessions", 400, 50),
+      makeLogEntry("GET", "/api/sessions", 500, 200),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+
+    const route = result.routes["GET /api/sessions"];
+    expect(route.errors).toBe(2);
+  });
+
+  it("counts errors when error field is present", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("POST", "/api/spawn", 200, 100, "something went wrong"),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+
+    const route = result.routes["POST /api/spawn"];
+    expect(route.errors).toBe(1);
+  });
+
+  it("groups by normalized path (dynamic segments replaced)", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/sessions/abc123", 200, 100),
+      makeLogEntry("GET", "/api/sessions/def456", 200, 200),
+      makeLogEntry("GET", "/api/prs/42/merge", 200, 50),
+      makeLogEntry("GET", "/api/prs/99/merge", 200, 150),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+
+    // Both session paths should be grouped under :id
+    expect(result.routes["GET /api/sessions/:id"]).toBeDefined();
+    expect(result.routes["GET /api/sessions/:id"].count).toBe(2);
+
+    // Both PR paths should be grouped under :id
+    expect(result.routes["GET /api/prs/:id/merge"]).toBeDefined();
+    expect(result.routes["GET /api/prs/:id/merge"].count).toBe(2);
+
+    // Original paths should NOT exist as separate routes
+    expect(result.routes["GET /api/sessions/abc123"]).toBeUndefined();
+    expect(result.routes["GET /api/prs/42/merge"]).toBeUndefined();
+  });
+
+  it("returns slowest requests sorted by duration (descending)", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/sessions", 200, 50),
+      makeLogEntry("GET", "/api/sessions", 200, 3000),
+      makeLogEntry("GET", "/api/sessions", 200, 500),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+
+    expect(result.slowest).toHaveLength(3);
+    expect(result.slowest[0].durationMs).toBe(3000);
+    expect(result.slowest[1].durationMs).toBe(500);
+    expect(result.slowest[2].durationMs).toBe(50);
+  });
+
+  it("limits slowest to 10 entries", () => {
+    const entries = [];
+    for (let i = 0; i < 15; i++) {
+      entries.push(makeLogEntry("GET", "/api/sessions", 200, (i + 1) * 10));
+    }
+    mockReadLogsFromDir.mockReturnValue(entries);
+
+    const result = getRequestStats("/tmp/logs");
+
+    expect(result.slowest).toHaveLength(10);
+    // The slowest should be 150ms (15*10), not 10ms (1*10)
+    expect(result.slowest[0].durationMs).toBe(150);
+  });
+
+  it("handles empty log directory (no entries)", () => {
+    mockReadLogsFromDir.mockReturnValue([]);
+
+    const result = getRequestStats("/tmp/logs");
+
+    expect(result.routes).toEqual({});
+    expect(result.slowest).toEqual([]);
+  });
+
+  it("passes since filter to readLogsFromDir", () => {
+    mockReadLogsFromDir.mockReturnValue([]);
+
+    const since = new Date("2026-01-15T00:00:00Z");
+    getRequestStats("/tmp/logs", { since });
+
+    expect(mockReadLogsFromDir).toHaveBeenCalledWith(
+      "/tmp/logs",
+      "api",
+      expect.objectContaining({ since }),
+    );
+  });
+
+  it("filters by route pattern", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/sessions", 200, 100),
+      makeLogEntry("GET", "/api/prs", 200, 200),
+      makeLogEntry("POST", "/api/sessions/abc/kill", 200, 50),
+    ]);
+
+    const result = getRequestStats("/tmp/logs", { route: "sessions" });
+
+    // Only routes containing "sessions" should be included
+    expect(Object.keys(result.routes)).toEqual(
+      expect.arrayContaining(["GET /api/sessions"]),
+    );
+    expect(result.routes["GET /api/prs"]).toBeUndefined();
+    expect(result.slowest.every((r) => r.path.includes("sessions"))).toBe(true);
+  });
+
+  it("skips entries without method or path in data", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      {
+        ts: "2026-01-15T10:00:00Z",
+        level: "info",
+        source: "api",
+        sessionId: null,
+        message: "some log without method/path",
+        data: { statusCode: 200, durationMs: 50 },
+      },
+      makeLogEntry("GET", "/api/sessions", 200, 100),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+
+    expect(Object.keys(result.routes)).toHaveLength(1);
+    expect(result.routes["GET /api/sessions"].count).toBe(1);
+  });
+
+  it("handles entries with missing data object", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      {
+        ts: "2026-01-15T10:00:00Z",
+        level: "info",
+        source: "api",
+        sessionId: null,
+        message: "bare entry",
+      },
+      makeLogEntry("GET", "/api/sessions", 200, 100),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+
+    expect(Object.keys(result.routes)).toHaveLength(1);
+  });
+
+  it("separates routes by HTTP method", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/sessions", 200, 100),
+      makeLogEntry("POST", "/api/sessions", 201, 200),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+
+    expect(result.routes["GET /api/sessions"]).toBeDefined();
+    expect(result.routes["POST /api/sessions"]).toBeDefined();
+    expect(result.routes["GET /api/sessions"].count).toBe(1);
+    expect(result.routes["POST /api/sessions"].count).toBe(1);
+  });
+});
+
+// ── normalizePath (tested indirectly via getRequestStats) ─────────────
+
+describe("normalizePath (indirect)", () => {
+  let getRequestStats: GetRequestStatsFn;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock("@composio/ao-core", () => ({
+      loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+      getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
+      readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
+      LogWriter: vi.fn().mockImplementation(() => ({
+        append: mockLogWriterAppend,
+        appendLine: vi.fn(),
+        close: mockLogWriterClose,
+      })),
+    }));
+
+    const mod = await import("../request-logger.js");
+    getRequestStats = mod.getRequestStats;
+  });
+
+  it("/api/sessions/abc123 normalizes to /api/sessions/:id", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/sessions/abc123", 200, 100),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+    expect(result.routes["GET /api/sessions/:id"]).toBeDefined();
+  });
+
+  it("/api/prs/42/merge normalizes to /api/prs/:id/merge", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/prs/42/merge", 200, 100),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+    expect(result.routes["GET /api/prs/:id/merge"]).toBeDefined();
+  });
+
+  it("/api/sessions remains unchanged (no dynamic segment)", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/sessions", 200, 100),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+    expect(result.routes["GET /api/sessions"]).toBeDefined();
+  });
+
+  it("normalizes multiple dynamic segments in one path", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/sessions/abc123/prs/42", 200, 100),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+    // sessions/:id and prs/:id should both be replaced
+    expect(result.routes["GET /api/sessions/:id/prs/:id"]).toBeDefined();
+  });
+
+  it("non-matching paths remain unchanged", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/config", 200, 100),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+    expect(result.routes["GET /api/config"]).toBeDefined();
+  });
+});
+
+// ── percentile (tested indirectly via getRequestStats) ────────────────
+
+describe("percentile (indirect)", () => {
+  let getRequestStats: GetRequestStatsFn;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock("@composio/ao-core", () => ({
+      loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+      getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
+      readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
+      LogWriter: vi.fn().mockImplementation(() => ({
+        append: mockLogWriterAppend,
+        appendLine: vi.fn(),
+        close: mockLogWriterClose,
+      })),
+    }));
+
+    const mod = await import("../request-logger.js");
+    getRequestStats = mod.getRequestStats;
+  });
+
+  it("returns 0 for empty array (no entries)", () => {
+    mockReadLogsFromDir.mockReturnValue([]);
+
+    const result = getRequestStats("/tmp/logs");
+
+    // No routes means no percentiles to check, but verify no crash
+    expect(result.routes).toEqual({});
+  });
+
+  it("returns the single element for single-entry route", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/sessions", 200, 42),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+    const route = result.routes["GET /api/sessions"];
+    expect(route.p50Ms).toBe(42);
+    expect(route.p95Ms).toBe(42);
+    expect(route.p99Ms).toBe(42);
+  });
+
+  it("computes correct p50 for two elements", () => {
+    mockReadLogsFromDir.mockReturnValue([
+      makeLogEntry("GET", "/api/sessions", 200, 100),
+      makeLogEntry("GET", "/api/sessions", 200, 200),
+    ]);
+
+    const result = getRequestStats("/tmp/logs");
+    const route = result.routes["GET /api/sessions"];
+    // sorted: [100, 200]
+    // p50: ceil(50/100 * 2) - 1 = ceil(1) - 1 = 0 => sorted[0] = 100
+    expect(route.p50Ms).toBe(100);
+    // p95: ceil(95/100 * 2) - 1 = ceil(1.9) - 1 = 1 => sorted[1] = 200
+    expect(route.p95Ms).toBe(200);
+    // p99: ceil(99/100 * 2) - 1 = ceil(1.98) - 1 = 1 => sorted[1] = 200
+    expect(route.p99Ms).toBe(200);
+  });
+
+  it("computes correct percentiles for a larger dataset", () => {
+    // 100 entries with durations 1..100
+    const entries = [];
+    for (let i = 1; i <= 100; i++) {
+      entries.push(makeLogEntry("GET", "/api/sessions", 200, i));
+    }
+    mockReadLogsFromDir.mockReturnValue(entries);
+
+    const result = getRequestStats("/tmp/logs");
+    const route = result.routes["GET /api/sessions"];
+
+    expect(route.count).toBe(100);
+    // p50: ceil(50/100 * 100) - 1 = 50 - 1 = 49 => sorted[49] = 50
+    expect(route.p50Ms).toBe(50);
+    // p95: ceil(95/100 * 100) - 1 = 95 - 1 = 94 => sorted[94] = 95
+    expect(route.p95Ms).toBe(95);
+    // p99: ceil(99/100 * 100) - 1 = 99 - 1 = 98 => sorted[98] = 99
+    expect(route.p99Ms).toBe(99);
+    expect(route.avgMs).toBe(51); // Math.round(5050 / 100) = 51 (rounded up from 50.5)
+  });
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function makeLogEntry(
+  method: string,
+  path: string,
+  statusCode: number,
+  durationMs: number,
+  error?: string,
+) {
+  return {
+    ts: "2026-01-15T10:00:00Z",
+    level: error ? "error" : "info",
+    source: "api",
+    sessionId: null,
+    message: `${method} ${path} ${statusCode} ${durationMs}ms`,
+    data: {
+      method,
+      path,
+      statusCode,
+      durationMs,
+      ...(error && { error }),
+    },
+  };
+}

--- a/packages/web/src/lib/__tests__/request-logger.test.ts
+++ b/packages/web/src/lib/__tests__/request-logger.test.ts
@@ -1,38 +1,23 @@
 /**
- * Tests for request-logger: logApiRequest, getRequestStats, normalizePath, percentile.
+ * Tests for request-logger: logApiRequest (write path) and getRequestStats (delegation).
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { getRequestStats as GetRequestStatsFn } from "../request-logger.js";
 
 // ── Mock fns (hoisted) ────────────────────────────────────────────────
 
 const mockLoadConfig = vi.fn();
 const mockGetLogsDir = vi.fn();
-const mockReadLogsFromDir = vi.fn();
+const mockParseApiLogs = vi.fn();
+const mockComputeApiStats = vi.fn();
 const mockLogWriterAppend = vi.fn();
 const mockLogWriterClose = vi.fn();
-
-/** Inline percentile impl (matches core's implementation) used in every mock below. */
-function mockPercentileImpl(sorted: number[], p: number): number {
-  if (sorted.length === 0) return 0;
-  const idx = Math.ceil((p / 100) * sorted.length) - 1;
-  return sorted[Math.max(0, idx)];
-}
-
-/** Inline normalizeRoutePath impl (matches core's implementation) used in every mock below. */
-function mockNormalizeRoutePathImpl(path: string): string {
-  return path
-    .replace(/\/sessions\/[^/]+/g, "/sessions/:id")
-    .replace(/\/prs\/[^/]+/g, "/prs/:id");
-}
 
 vi.mock("@composio/ao-core", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
   getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
-  readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
-  percentile: mockPercentileImpl,
-  normalizeRoutePath: mockNormalizeRoutePathImpl,
+  parseApiLogs: (...args: unknown[]) => mockParseApiLogs(...args),
+  computeApiStats: (...args: unknown[]) => mockComputeApiStats(...args),
   LogWriter: vi.fn().mockImplementation(() => ({
     append: mockLogWriterAppend,
     appendLine: vi.fn(),
@@ -60,9 +45,8 @@ describe("logApiRequest", () => {
     vi.doMock("@composio/ao-core", () => ({
       loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
       getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
-      readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
-      percentile: mockPercentileImpl,
-      normalizeRoutePath: mockNormalizeRoutePathImpl,
+      parseApiLogs: (...args: unknown[]) => mockParseApiLogs(...args),
+      computeApiStats: (...args: unknown[]) => mockComputeApiStats(...args),
       LogWriter: vi.fn().mockImplementation(() => ({
         append: mockLogWriterAppend,
         appendLine: vi.fn(),
@@ -302,19 +286,21 @@ describe("logApiRequest", () => {
 });
 
 // ── getRequestStats ───────────────────────────────────────────────────
+//
+// getRequestStats is a thin delegation wrapper around parseApiLogs + computeApiStats.
+// The logic is tested in @composio/ao-core's log-reader.test.ts. Here we only
+// verify the delegation contract.
 
 describe("getRequestStats", () => {
-  // getRequestStats calls readLogsFromDir directly, no cached writer involved
-  let getRequestStats: GetRequestStatsFn;
+  let getRequestStats: (logDir: string, opts?: { since?: Date; route?: string }) => unknown;
 
   beforeEach(async () => {
     vi.resetModules();
     vi.doMock("@composio/ao-core", () => ({
       loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
       getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
-      readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
-      percentile: mockPercentileImpl,
-      normalizeRoutePath: mockNormalizeRoutePathImpl,
+      parseApiLogs: (...args: unknown[]) => mockParseApiLogs(...args),
+      computeApiStats: (...args: unknown[]) => mockComputeApiStats(...args),
       LogWriter: vi.fn().mockImplementation(() => ({
         append: mockLogWriterAppend,
         appendLine: vi.fn(),
@@ -326,365 +312,40 @@ describe("getRequestStats", () => {
     getRequestStats = mod.getRequestStats;
   });
 
-  it("computes per-route stats with count, avgMs, percentiles", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/sessions", 200, 100),
-      makeLogEntry("GET", "/api/sessions", 200, 200),
-      makeLogEntry("GET", "/api/sessions", 200, 300),
-      makeLogEntry("GET", "/api/sessions", 200, 400),
-    ]);
+  it("delegates: calls parseApiLogs then computeApiStats, returns result", () => {
+    const fakeEntries = [{ method: "GET", path: "/api/sessions", statusCode: 200, durationMs: 42 }];
+    const fakeResult = { routes: { "GET /api/sessions": { count: 1 } }, slowest: [], latestCacheStats: null };
+    mockParseApiLogs.mockReturnValue(fakeEntries);
+    mockComputeApiStats.mockReturnValue(fakeResult);
 
     const result = getRequestStats("/tmp/logs");
 
-    const route = result.routes["GET /api/sessions"];
-    expect(route).toBeDefined();
-    expect(route.count).toBe(4);
-    expect(route.avgMs).toBe(250); // (100+200+300+400)/4
-    expect(route.errors).toBe(0);
+    expect(mockParseApiLogs).toHaveBeenCalledWith("/tmp/logs", undefined);
+    expect(mockComputeApiStats).toHaveBeenCalledWith(fakeEntries);
+    expect(result).toBe(fakeResult);
   });
 
-  it("counts errors when statusCode >= 400", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/sessions", 200, 100),
-      makeLogEntry("GET", "/api/sessions", 400, 50),
-      makeLogEntry("GET", "/api/sessions", 500, 200),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-
-    const route = result.routes["GET /api/sessions"];
-    expect(route.errors).toBe(2);
-  });
-
-  it("counts errors when error field is present", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("POST", "/api/spawn", 200, 100, "something went wrong"),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-
-    const route = result.routes["POST /api/spawn"];
-    expect(route.errors).toBe(1);
-  });
-
-  it("groups by normalized path (dynamic segments replaced)", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/sessions/abc123", 200, 100),
-      makeLogEntry("GET", "/api/sessions/def456", 200, 200),
-      makeLogEntry("GET", "/api/prs/42/merge", 200, 50),
-      makeLogEntry("GET", "/api/prs/99/merge", 200, 150),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-
-    // Both session paths should be grouped under :id
-    expect(result.routes["GET /api/sessions/:id"]).toBeDefined();
-    expect(result.routes["GET /api/sessions/:id"].count).toBe(2);
-
-    // Both PR paths should be grouped under :id
-    expect(result.routes["GET /api/prs/:id/merge"]).toBeDefined();
-    expect(result.routes["GET /api/prs/:id/merge"].count).toBe(2);
-
-    // Original paths should NOT exist as separate routes
-    expect(result.routes["GET /api/sessions/abc123"]).toBeUndefined();
-    expect(result.routes["GET /api/prs/42/merge"]).toBeUndefined();
-  });
-
-  it("returns slowest requests sorted by duration (descending)", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/sessions", 200, 50),
-      makeLogEntry("GET", "/api/sessions", 200, 3000),
-      makeLogEntry("GET", "/api/sessions", 200, 500),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-
-    expect(result.slowest).toHaveLength(3);
-    expect(result.slowest[0].durationMs).toBe(3000);
-    expect(result.slowest[1].durationMs).toBe(500);
-    expect(result.slowest[2].durationMs).toBe(50);
-  });
-
-  it("limits slowest to 10 entries", () => {
-    const entries = [];
-    for (let i = 0; i < 15; i++) {
-      entries.push(makeLogEntry("GET", "/api/sessions", 200, (i + 1) * 10));
-    }
-    mockReadLogsFromDir.mockReturnValue(entries);
-
-    const result = getRequestStats("/tmp/logs");
-
-    expect(result.slowest).toHaveLength(10);
-    // The slowest should be 150ms (15*10), not 10ms (1*10)
-    expect(result.slowest[0].durationMs).toBe(150);
-  });
-
-  it("handles empty log directory (no entries)", () => {
-    mockReadLogsFromDir.mockReturnValue([]);
-
-    const result = getRequestStats("/tmp/logs");
-
-    expect(result.routes).toEqual({});
-    expect(result.slowest).toEqual([]);
-  });
-
-  it("passes since filter to readLogsFromDir", () => {
-    mockReadLogsFromDir.mockReturnValue([]);
+  it("forwards since and route options to parseApiLogs", () => {
+    mockParseApiLogs.mockReturnValue([]);
+    mockComputeApiStats.mockReturnValue({ routes: {}, slowest: [], latestCacheStats: null });
 
     const since = new Date("2026-01-15T00:00:00Z");
-    getRequestStats("/tmp/logs", { since });
+    getRequestStats("/tmp/logs", { since, route: "sessions" });
 
-    expect(mockReadLogsFromDir).toHaveBeenCalledWith(
-      "/tmp/logs",
-      "api",
-      expect.objectContaining({ since }),
-    );
+    expect(mockParseApiLogs).toHaveBeenCalledWith("/tmp/logs", { since, route: "sessions" });
   });
 
-  it("filters by route pattern", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/sessions", 200, 100),
-      makeLogEntry("GET", "/api/prs", 200, 200),
-      makeLogEntry("POST", "/api/sessions/abc/kill", 200, 50),
-    ]);
-
-    const result = getRequestStats("/tmp/logs", { route: "sessions" });
-
-    // Only routes containing "sessions" should be included
-    expect(Object.keys(result.routes)).toEqual(
-      expect.arrayContaining(["GET /api/sessions"]),
-    );
-    expect(result.routes["GET /api/prs"]).toBeUndefined();
-    expect(result.slowest.every((r) => r.path.includes("sessions"))).toBe(true);
-  });
-
-  it("skips entries without method or path in data", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      {
-        ts: "2026-01-15T10:00:00Z",
-        level: "info",
-        source: "api",
-        sessionId: null,
-        message: "some log without method/path",
-        data: { statusCode: 200, durationMs: 50 },
-      },
-      makeLogEntry("GET", "/api/sessions", 200, 100),
-    ]);
+  it("returns computeApiStats result unchanged", () => {
+    const expected = {
+      routes: { "GET /api/sessions": { count: 5, avgMs: 100, p50Ms: 90, p95Ms: 200, p99Ms: 300, errors: 0 } },
+      slowest: [],
+      latestCacheStats: { hits: 10, misses: 2, hitRate: 0.83, size: 12 },
+    };
+    mockParseApiLogs.mockReturnValue([]);
+    mockComputeApiStats.mockReturnValue(expected);
 
     const result = getRequestStats("/tmp/logs");
 
-    expect(Object.keys(result.routes)).toHaveLength(1);
-    expect(result.routes["GET /api/sessions"].count).toBe(1);
-  });
-
-  it("handles entries with missing data object", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      {
-        ts: "2026-01-15T10:00:00Z",
-        level: "info",
-        source: "api",
-        sessionId: null,
-        message: "bare entry",
-      },
-      makeLogEntry("GET", "/api/sessions", 200, 100),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-
-    expect(Object.keys(result.routes)).toHaveLength(1);
-  });
-
-  it("separates routes by HTTP method", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/sessions", 200, 100),
-      makeLogEntry("POST", "/api/sessions", 201, 200),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-
-    expect(result.routes["GET /api/sessions"]).toBeDefined();
-    expect(result.routes["POST /api/sessions"]).toBeDefined();
-    expect(result.routes["GET /api/sessions"].count).toBe(1);
-    expect(result.routes["POST /api/sessions"].count).toBe(1);
+    expect(result).toBe(expected);
   });
 });
-
-// ── normalizePath (tested indirectly via getRequestStats) ─────────────
-
-describe("normalizePath (indirect)", () => {
-  let getRequestStats: GetRequestStatsFn;
-
-  beforeEach(async () => {
-    vi.resetModules();
-    vi.doMock("@composio/ao-core", () => ({
-      loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
-      getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
-      readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
-      percentile: mockPercentileImpl,
-      normalizeRoutePath: mockNormalizeRoutePathImpl,
-      LogWriter: vi.fn().mockImplementation(() => ({
-        append: mockLogWriterAppend,
-        appendLine: vi.fn(),
-        close: mockLogWriterClose,
-      })),
-    }));
-
-    const mod = await import("../request-logger.js");
-    getRequestStats = mod.getRequestStats;
-  });
-
-  it("/api/sessions/abc123 normalizes to /api/sessions/:id", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/sessions/abc123", 200, 100),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-    expect(result.routes["GET /api/sessions/:id"]).toBeDefined();
-  });
-
-  it("/api/prs/42/merge normalizes to /api/prs/:id/merge", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/prs/42/merge", 200, 100),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-    expect(result.routes["GET /api/prs/:id/merge"]).toBeDefined();
-  });
-
-  it("/api/sessions remains unchanged (no dynamic segment)", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/sessions", 200, 100),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-    expect(result.routes["GET /api/sessions"]).toBeDefined();
-  });
-
-  it("normalizes multiple dynamic segments in one path", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/sessions/abc123/prs/42", 200, 100),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-    // sessions/:id and prs/:id should both be replaced
-    expect(result.routes["GET /api/sessions/:id/prs/:id"]).toBeDefined();
-  });
-
-  it("non-matching paths remain unchanged", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/config", 200, 100),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-    expect(result.routes["GET /api/config"]).toBeDefined();
-  });
-});
-
-// ── percentile (tested indirectly via getRequestStats) ────────────────
-
-describe("percentile (indirect)", () => {
-  let getRequestStats: GetRequestStatsFn;
-
-  beforeEach(async () => {
-    vi.resetModules();
-    vi.doMock("@composio/ao-core", () => ({
-      loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
-      getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
-      readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
-      percentile: mockPercentileImpl,
-      normalizeRoutePath: mockNormalizeRoutePathImpl,
-      LogWriter: vi.fn().mockImplementation(() => ({
-        append: mockLogWriterAppend,
-        appendLine: vi.fn(),
-        close: mockLogWriterClose,
-      })),
-    }));
-
-    const mod = await import("../request-logger.js");
-    getRequestStats = mod.getRequestStats;
-  });
-
-  it("returns 0 for empty array (no entries)", () => {
-    mockReadLogsFromDir.mockReturnValue([]);
-
-    const result = getRequestStats("/tmp/logs");
-
-    // No routes means no percentiles to check, but verify no crash
-    expect(result.routes).toEqual({});
-  });
-
-  it("returns the single element for single-entry route", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/sessions", 200, 42),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-    const route = result.routes["GET /api/sessions"];
-    expect(route.p50Ms).toBe(42);
-    expect(route.p95Ms).toBe(42);
-    expect(route.p99Ms).toBe(42);
-  });
-
-  it("computes correct p50 for two elements", () => {
-    mockReadLogsFromDir.mockReturnValue([
-      makeLogEntry("GET", "/api/sessions", 200, 100),
-      makeLogEntry("GET", "/api/sessions", 200, 200),
-    ]);
-
-    const result = getRequestStats("/tmp/logs");
-    const route = result.routes["GET /api/sessions"];
-    // sorted: [100, 200]
-    // p50: ceil(50/100 * 2) - 1 = ceil(1) - 1 = 0 => sorted[0] = 100
-    expect(route.p50Ms).toBe(100);
-    // p95: ceil(95/100 * 2) - 1 = ceil(1.9) - 1 = 1 => sorted[1] = 200
-    expect(route.p95Ms).toBe(200);
-    // p99: ceil(99/100 * 2) - 1 = ceil(1.98) - 1 = 1 => sorted[1] = 200
-    expect(route.p99Ms).toBe(200);
-  });
-
-  it("computes correct percentiles for a larger dataset", () => {
-    // 100 entries with durations 1..100
-    const entries = [];
-    for (let i = 1; i <= 100; i++) {
-      entries.push(makeLogEntry("GET", "/api/sessions", 200, i));
-    }
-    mockReadLogsFromDir.mockReturnValue(entries);
-
-    const result = getRequestStats("/tmp/logs");
-    const route = result.routes["GET /api/sessions"];
-
-    expect(route.count).toBe(100);
-    // p50: ceil(50/100 * 100) - 1 = 50 - 1 = 49 => sorted[49] = 50
-    expect(route.p50Ms).toBe(50);
-    // p95: ceil(95/100 * 100) - 1 = 95 - 1 = 94 => sorted[94] = 95
-    expect(route.p95Ms).toBe(95);
-    // p99: ceil(99/100 * 100) - 1 = 99 - 1 = 98 => sorted[98] = 99
-    expect(route.p99Ms).toBe(99);
-    expect(route.avgMs).toBe(51); // Math.round(5050 / 100) = 51 (rounded up from 50.5)
-  });
-});
-
-// ── Helpers ───────────────────────────────────────────────────────────
-
-function makeLogEntry(
-  method: string,
-  path: string,
-  statusCode: number,
-  durationMs: number,
-  error?: string,
-) {
-  return {
-    ts: "2026-01-15T10:00:00Z",
-    level: error ? "error" : "info",
-    source: "api",
-    sessionId: null,
-    message: `${method} ${path} ${statusCode} ${durationMs}ms`,
-    data: {
-      method,
-      path,
-      statusCode,
-      durationMs,
-      ...(error && { error }),
-    },
-  };
-}

--- a/packages/web/src/lib/__tests__/request-logger.test.ts
+++ b/packages/web/src/lib/__tests__/request-logger.test.ts
@@ -13,10 +13,26 @@ const mockReadLogsFromDir = vi.fn();
 const mockLogWriterAppend = vi.fn();
 const mockLogWriterClose = vi.fn();
 
+/** Inline percentile impl (matches core's implementation) used in every mock below. */
+function mockPercentileImpl(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+/** Inline normalizeRoutePath impl (matches core's implementation) used in every mock below. */
+function mockNormalizeRoutePathImpl(path: string): string {
+  return path
+    .replace(/\/sessions\/[^/]+/g, "/sessions/:id")
+    .replace(/\/prs\/[^/]+/g, "/prs/:id");
+}
+
 vi.mock("@composio/ao-core", () => ({
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
   getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
   readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
+  percentile: mockPercentileImpl,
+  normalizeRoutePath: mockNormalizeRoutePathImpl,
   LogWriter: vi.fn().mockImplementation(() => ({
     append: mockLogWriterAppend,
     appendLine: vi.fn(),
@@ -40,11 +56,13 @@ describe("logApiRequest", () => {
   beforeEach(() => {
     vi.resetModules();
 
-    // Re-apply mock after resetModules
+    // Re-apply mock after resetModules (must include all imports from @composio/ao-core)
     vi.doMock("@composio/ao-core", () => ({
       loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
       getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
       readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
+      percentile: mockPercentileImpl,
+      normalizeRoutePath: mockNormalizeRoutePathImpl,
       LogWriter: vi.fn().mockImplementation(() => ({
         append: mockLogWriterAppend,
         appendLine: vi.fn(),
@@ -295,6 +313,8 @@ describe("getRequestStats", () => {
       loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
       getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
       readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
+      percentile: mockPercentileImpl,
+      normalizeRoutePath: mockNormalizeRoutePathImpl,
       LogWriter: vi.fn().mockImplementation(() => ({
         append: mockLogWriterAppend,
         appendLine: vi.fn(),
@@ -500,6 +520,8 @@ describe("normalizePath (indirect)", () => {
       loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
       getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
       readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
+      percentile: mockPercentileImpl,
+      normalizeRoutePath: mockNormalizeRoutePathImpl,
       LogWriter: vi.fn().mockImplementation(() => ({
         append: mockLogWriterAppend,
         appendLine: vi.fn(),
@@ -569,6 +591,8 @@ describe("percentile (indirect)", () => {
       loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
       getLogsDir: (...args: unknown[]) => mockGetLogsDir(...args),
       readLogsFromDir: (...args: unknown[]) => mockReadLogsFromDir(...args),
+      percentile: mockPercentileImpl,
+      normalizeRoutePath: mockNormalizeRoutePathImpl,
       LogWriter: vi.fn().mockImplementation(() => ({
         append: mockLogWriterAppend,
         appendLine: vi.fn(),

--- a/packages/web/src/lib/__tests__/with-timing.test.ts
+++ b/packages/web/src/lib/__tests__/with-timing.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Tests for with-timing: withTiming, extractSessionId, createTimingContext.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock logApiRequest from request-logger ────────────────────────────
+
+const mockLogApiRequest = vi.fn();
+
+vi.mock("../request-logger.js", () => ({
+  logApiRequest: (...args: unknown[]) => mockLogApiRequest(...args),
+}));
+
+// ── Import after mocking ──────────────────────────────────────────────
+
+import { withTiming, createTimingContext } from "../with-timing.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── withTiming ────────────────────────────────────────────────────────
+
+describe("withTiming", () => {
+  it("wraps handler and calls it with the request", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions");
+    await wrapped(req);
+
+    expect(innerHandler).toHaveBeenCalledTimes(1);
+    expect(innerHandler).toHaveBeenCalledWith(req, undefined);
+  });
+
+  it("passes context argument through to handler", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response("ok", { status: 200 }),
+    );
+    const ctx = { params: { id: "abc" } };
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions/abc");
+    await wrapped(req, ctx);
+
+    expect(innerHandler).toHaveBeenCalledWith(req, ctx);
+  });
+
+  it("returns the original response unchanged on success", async () => {
+    const body = JSON.stringify({ sessions: [] });
+    const originalResponse = new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+    const innerHandler = vi.fn().mockResolvedValue(originalResponse);
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions");
+    const result = await wrapped(req);
+
+    expect(result).toBe(originalResponse);
+    expect(result.status).toBe(200);
+  });
+
+  it("calls logApiRequest with correct fields for successful response", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response("ok", { status: 200 }),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions");
+    await wrapped(req);
+
+    expect(mockLogApiRequest).toHaveBeenCalledTimes(1);
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.method).toBe("GET");
+    expect(log.path).toBe("/api/sessions");
+    expect(log.statusCode).toBe(200);
+    expect(typeof log.durationMs).toBe("number");
+    expect(log.durationMs).toBeGreaterThanOrEqual(0);
+    expect(log.error).toBeUndefined();
+    expect(log.ts).toBeDefined();
+    expect(typeof log.ts).toBe("string");
+  });
+
+  it("logs correct method for POST requests", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response("created", { status: 201 }),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/spawn", {
+      method: "POST",
+      body: JSON.stringify({ session: "ao-1" }),
+    });
+    await wrapped(req);
+
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.method).toBe("POST");
+    expect(log.statusCode).toBe(201);
+  });
+
+  it("logs error responses (4xx) without error field", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response("not found", { status: 404 }),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions/unknown");
+    await wrapped(req);
+
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.statusCode).toBe(404);
+    // error field is only set when the handler throws, not for error status codes
+    expect(log.error).toBeUndefined();
+  });
+
+  it("logs error responses (5xx) without error field when handler does not throw", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response("internal error", { status: 500 }),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions");
+    await wrapped(req);
+
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.statusCode).toBe(500);
+    expect(log.error).toBeUndefined();
+  });
+
+  it("catches thrown errors, logs them, and returns 500 response", async () => {
+    const innerHandler = vi.fn().mockRejectedValue(
+      new Error("database connection failed"),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions");
+    const result = await wrapped(req);
+
+    // Should return a 500 response with the error
+    expect(result.status).toBe(500);
+    const body = await result.json();
+    expect(body.error).toBe("database connection failed");
+
+    // Should have logged the error
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.statusCode).toBe(500);
+    expect(log.error).toBe("database connection failed");
+  });
+
+  it("handles non-Error thrown values", async () => {
+    const innerHandler = vi.fn().mockRejectedValue("string error");
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions");
+    const result = await wrapped(req);
+
+    expect(result.status).toBe(500);
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.error).toBe("string error");
+  });
+
+  it("measures duration (durationMs is non-negative)", async () => {
+    const innerHandler = vi.fn().mockImplementation(async () => {
+      // Simulate some work
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return new Response("ok", { status: 200 });
+    });
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions");
+    await wrapped(req);
+
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ── extractSessionId (tested indirectly via withTiming) ───────────────
+
+describe("extractSessionId (indirect via withTiming)", () => {
+  it("extracts sessionId from /api/sessions/abc123", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response("ok", { status: 200 }),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions/abc123");
+    await wrapped(req);
+
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.sessionId).toBe("abc123");
+  });
+
+  it("extracts sessionId from /api/sessions/ao-1/kill", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response("ok", { status: 200 }),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions/ao-1/kill");
+    await wrapped(req);
+
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.sessionId).toBe("ao-1");
+  });
+
+  it("returns null for /api/sessions (no ID segment)", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response("ok", { status: 200 }),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/sessions");
+    await wrapped(req);
+
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.sessionId).toBeNull();
+  });
+
+  it("returns null for /api/prs/42/merge (no sessions segment)", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response("ok", { status: 200 }),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/prs/42/merge");
+    await wrapped(req);
+
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.sessionId).toBeNull();
+  });
+
+  it("returns null for /api/config (no sessions segment)", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response("ok", { status: 200 }),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request("http://localhost:3000/api/config");
+    await wrapped(req);
+
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.sessionId).toBeNull();
+  });
+
+  it("decodes URL-encoded session IDs", async () => {
+    const innerHandler = vi.fn().mockResolvedValue(
+      new Response("ok", { status: 200 }),
+    );
+
+    const wrapped = withTiming(innerHandler, "test-route");
+    const req = new Request(
+      "http://localhost:3000/api/sessions/session%20with%20spaces",
+    );
+    await wrapped(req);
+
+    const log = mockLogApiRequest.mock.calls[0][0];
+    expect(log.sessionId).toBe("session with spaces");
+  });
+});
+
+// ── createTimingContext ───────────────────────────────────────────────
+
+describe("createTimingContext", () => {
+  it("creates context with empty timings object", () => {
+    const ctx = createTimingContext();
+    expect(ctx.timings).toEqual({});
+  });
+
+  it("creates context with a start timestamp", () => {
+    const before = Date.now();
+    const ctx = createTimingContext();
+    const after = Date.now();
+
+    expect(ctx.start).toBeGreaterThanOrEqual(before);
+    expect(ctx.start).toBeLessThanOrEqual(after);
+  });
+
+  it("has a mark function", () => {
+    const ctx = createTimingContext();
+    expect(typeof ctx.mark).toBe("function");
+  });
+
+  it("mark() records operation timing with name and duration", () => {
+    const ctx = createTimingContext();
+    const opStart = Date.now() - 50; // Simulate 50ms ago
+
+    ctx.mark("serviceInit", opStart);
+
+    expect(ctx.timings["serviceInit"]).toBeDefined();
+    expect(ctx.timings["serviceInit"]).toBeGreaterThanOrEqual(49); // allow 1ms slack
+  });
+
+  it("mark() can record multiple operations", () => {
+    const ctx = createTimingContext();
+
+    const start1 = Date.now() - 100;
+    ctx.mark("serviceInit", start1);
+
+    const start2 = Date.now() - 50;
+    ctx.mark("sessionList", start2);
+
+    const start3 = Date.now() - 25;
+    ctx.mark("prEnrichment", start3);
+
+    expect(Object.keys(ctx.timings)).toHaveLength(3);
+    expect(ctx.timings["serviceInit"]).toBeDefined();
+    expect(ctx.timings["sessionList"]).toBeDefined();
+    expect(ctx.timings["prEnrichment"]).toBeDefined();
+  });
+
+  it("mark() overwrites previous timing for same operation name", () => {
+    const ctx = createTimingContext();
+
+    const start1 = Date.now() - 100;
+    ctx.mark("serviceInit", start1);
+    const first = ctx.timings["serviceInit"];
+
+    const start2 = Date.now() - 10;
+    ctx.mark("serviceInit", start2);
+    const second = ctx.timings["serviceInit"];
+
+    // Second mark should record a shorter duration
+    expect(second).toBeLessThan(first);
+  });
+
+  it("mark() computes duration as Date.now() - startMs", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T10:00:00.100Z"));
+
+    const ctx = createTimingContext();
+
+    // Simulate an operation that started at T=0
+    const opStart = new Date("2026-01-15T10:00:00.000Z").getTime();
+
+    // Advance to T=100ms for mark
+    ctx.mark("serviceInit", opStart);
+
+    expect(ctx.timings["serviceInit"]).toBe(100);
+
+    vi.useRealTimers();
+  });
+});

--- a/packages/web/src/lib/__tests__/with-timing.test.ts
+++ b/packages/web/src/lib/__tests__/with-timing.test.ts
@@ -28,7 +28,7 @@ describe("withTiming", () => {
       new Response(JSON.stringify({ ok: true }), { status: 200 }),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions");
     await wrapped(req);
 
@@ -42,7 +42,7 @@ describe("withTiming", () => {
     );
     const ctx = { params: { id: "abc" } };
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions/abc");
     await wrapped(req, ctx);
 
@@ -57,7 +57,7 @@ describe("withTiming", () => {
     });
     const innerHandler = vi.fn().mockResolvedValue(originalResponse);
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions");
     const result = await wrapped(req);
 
@@ -70,7 +70,7 @@ describe("withTiming", () => {
       new Response("ok", { status: 200 }),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions");
     await wrapped(req);
 
@@ -91,7 +91,7 @@ describe("withTiming", () => {
       new Response("created", { status: 201 }),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/spawn", {
       method: "POST",
       body: JSON.stringify({ session: "ao-1" }),
@@ -108,7 +108,7 @@ describe("withTiming", () => {
       new Response("not found", { status: 404 }),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions/unknown");
     await wrapped(req);
 
@@ -123,7 +123,7 @@ describe("withTiming", () => {
       new Response("internal error", { status: 500 }),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions");
     await wrapped(req);
 
@@ -137,7 +137,7 @@ describe("withTiming", () => {
       new Error("database connection failed"),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions");
     const result = await wrapped(req);
 
@@ -155,7 +155,7 @@ describe("withTiming", () => {
   it("handles non-Error thrown values", async () => {
     const innerHandler = vi.fn().mockRejectedValue("string error");
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions");
     const result = await wrapped(req);
 
@@ -171,7 +171,7 @@ describe("withTiming", () => {
       return new Response("ok", { status: 200 });
     });
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions");
     await wrapped(req);
 
@@ -188,7 +188,7 @@ describe("extractSessionId (indirect via withTiming)", () => {
       new Response("ok", { status: 200 }),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions/abc123");
     await wrapped(req);
 
@@ -201,7 +201,7 @@ describe("extractSessionId (indirect via withTiming)", () => {
       new Response("ok", { status: 200 }),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions/ao-1/kill");
     await wrapped(req);
 
@@ -214,7 +214,7 @@ describe("extractSessionId (indirect via withTiming)", () => {
       new Response("ok", { status: 200 }),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/sessions");
     await wrapped(req);
 
@@ -227,7 +227,7 @@ describe("extractSessionId (indirect via withTiming)", () => {
       new Response("ok", { status: 200 }),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/prs/42/merge");
     await wrapped(req);
 
@@ -240,7 +240,7 @@ describe("extractSessionId (indirect via withTiming)", () => {
       new Response("ok", { status: 200 }),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request("http://localhost:3000/api/config");
     await wrapped(req);
 
@@ -253,7 +253,7 @@ describe("extractSessionId (indirect via withTiming)", () => {
       new Response("ok", { status: 200 }),
     );
 
-    const wrapped = withTiming(innerHandler, "test-route");
+    const wrapped = withTiming(innerHandler);
     const req = new Request(
       "http://localhost:3000/api/sessions/session%20with%20spaces",
     );

--- a/packages/web/src/lib/client-logger.ts
+++ b/packages/web/src/lib/client-logger.ts
@@ -1,0 +1,136 @@
+/**
+ * Browser-side error and performance capture.
+ *
+ * Captures:
+ * - window.onerror / unhandledrejection — JS runtime errors
+ * - PerformanceObserver — LCP, FCP, TTFB navigation timing
+ * - Fetch timing — API call durations from the browser side
+ *
+ * Batches entries and POSTs to /api/client-logs every 10 seconds
+ * (or on page unload via navigator.sendBeacon).
+ */
+
+interface ClientLogEntry {
+  level: "info" | "warn" | "error";
+  message: string;
+  url?: string;
+  stack?: string;
+  timing?: Record<string, number>;
+}
+
+let buffer: ClientLogEntry[] = [];
+let flushTimer: ReturnType<typeof setInterval> | null = null;
+
+function addEntry(entry: ClientLogEntry): void {
+  buffer.push(entry);
+}
+
+function flush(): void {
+  if (buffer.length === 0) return;
+
+  const entries = buffer;
+  buffer = [];
+
+  // Try sendBeacon first (works during unload), fall back to fetch
+  const payload = JSON.stringify({ entries });
+  if (typeof navigator !== "undefined" && navigator.sendBeacon) {
+    const sent = navigator.sendBeacon("/api/client-logs", new Blob([payload], { type: "application/json" }));
+    if (sent) return;
+  }
+
+  // Fallback: fire-and-forget fetch
+  fetch("/api/client-logs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+    keepalive: true,
+  }).catch(() => {
+    // best effort
+  });
+}
+
+export function initClientLogger(): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  // Capture JS errors
+  const onError = (event: ErrorEvent): void => {
+    addEntry({
+      level: "error",
+      message: event.message || "Unknown error",
+      url: event.filename,
+      stack: event.error?.stack,
+    });
+  };
+  window.addEventListener("error", onError);
+
+  // Capture unhandled promise rejections
+  const onRejection = (event: PromiseRejectionEvent): void => {
+    const reason = event.reason;
+    addEntry({
+      level: "error",
+      message: reason instanceof Error ? reason.message : String(reason),
+      stack: reason instanceof Error ? reason.stack : undefined,
+    });
+  };
+  window.addEventListener("unhandledrejection", onRejection);
+
+  // Performance observer for web vitals
+  let perfObserver: PerformanceObserver | null = null;
+  if (typeof PerformanceObserver !== "undefined") {
+    try {
+      perfObserver = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          if (entry.entryType === "largest-contentful-paint") {
+            addEntry({
+              level: "info",
+              message: `LCP: ${Math.round(entry.startTime)}ms`,
+              timing: { lcp: entry.startTime },
+            });
+          } else if (entry.entryType === "paint") {
+            addEntry({
+              level: "info",
+              message: `${entry.name}: ${Math.round(entry.startTime)}ms`,
+              timing: { [entry.name === "first-contentful-paint" ? "fcp" : "fp"]: entry.startTime },
+            });
+          } else if (entry.entryType === "navigation") {
+            const nav = entry as PerformanceNavigationTiming;
+            addEntry({
+              level: "info",
+              message: `Navigation: TTFB ${Math.round(nav.responseStart)}ms, DOM ${Math.round(nav.domContentLoadedEventEnd)}ms`,
+              timing: {
+                ttfb: nav.responseStart,
+                domContentLoaded: nav.domContentLoadedEventEnd,
+                loadComplete: nav.loadEventEnd,
+              },
+            });
+          }
+        }
+      });
+      perfObserver.observe({ type: "largest-contentful-paint", buffered: true });
+      perfObserver.observe({ type: "paint", buffered: true });
+      perfObserver.observe({ type: "navigation", buffered: true });
+    } catch {
+      // PerformanceObserver not supported for these types
+    }
+  }
+
+  // Flush periodically
+  flushTimer = setInterval(flush, 10_000);
+
+  // Flush on page unload
+  const onUnload = (): void => flush();
+  window.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") flush();
+  });
+  window.addEventListener("pagehide", onUnload);
+
+  // Return cleanup function
+  return () => {
+    flush();
+    window.removeEventListener("error", onError);
+    window.removeEventListener("unhandledrejection", onRejection);
+    window.removeEventListener("pagehide", onUnload);
+    if (flushTimer) clearInterval(flushTimer);
+    if (perfObserver) perfObserver.disconnect();
+  };
+}

--- a/packages/web/src/lib/client-logger.ts
+++ b/packages/web/src/lib/client-logger.ts
@@ -117,11 +117,12 @@ export function initClientLogger(): () => void {
   // Flush periodically
   flushTimer = setInterval(flush, 10_000);
 
-  // Flush on page unload
-  const onUnload = (): void => flush();
-  window.addEventListener("visibilitychange", () => {
+  // Flush on page hide / visibility change
+  const onVisibilityChange = (): void => {
     if (document.visibilityState === "hidden") flush();
-  });
+  };
+  const onUnload = (): void => flush();
+  window.addEventListener("visibilitychange", onVisibilityChange);
   window.addEventListener("pagehide", onUnload);
 
   // Return cleanup function
@@ -129,6 +130,7 @@ export function initClientLogger(): () => void {
     flush();
     window.removeEventListener("error", onError);
     window.removeEventListener("unhandledrejection", onRejection);
+    window.removeEventListener("visibilitychange", onVisibilityChange);
     window.removeEventListener("pagehide", onUnload);
     if (flushTimer) clearInterval(flushTimer);
     if (perfObserver) perfObserver.disconnect();

--- a/packages/web/src/lib/request-logger.ts
+++ b/packages/web/src/lib/request-logger.ts
@@ -1,0 +1,164 @@
+/**
+ * Structured API request logging with performance timing.
+ *
+ * Logs each API request to {logDir}/api.jsonl with timing breakdowns.
+ * Provides getRequestStats() for aggregated analysis used by CLI and dashboard.
+ */
+
+import { getLogsDir, LogWriter, loadConfig, readLogsFromDir } from "@composio/ao-core";
+
+export interface RequestLog {
+  ts: string;
+  method: string;
+  path: string;
+  sessionId: string | null;
+  statusCode: number;
+  durationMs: number;
+  error?: string;
+  timings?: {
+    serviceInit?: number;
+    sessionList?: number;
+    prEnrichment?: number;
+    issueEnrichment?: number;
+    serialization?: number;
+  };
+  cacheStats?: {
+    hits: number;
+    misses: number;
+    hitRate: number;
+    size: number;
+  };
+}
+
+export interface RouteStats {
+  count: number;
+  avgMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  errors: number;
+}
+
+export interface RequestStatsResult {
+  routes: Record<string, RouteStats>;
+  slowest: RequestLog[];
+}
+
+let logWriter: LogWriter | null = null;
+
+function getLogWriter(): LogWriter | null {
+  if (logWriter) return logWriter;
+
+  try {
+    const config = loadConfig();
+    const projectId = Object.keys(config.projects)[0];
+    if (!projectId) return null;
+    const project = config.projects[projectId];
+    const logDir = getLogsDir(config.configPath, project.path);
+    logWriter = new LogWriter({ filePath: `${logDir}/api.jsonl` });
+    return logWriter;
+  } catch {
+    return null;
+  }
+}
+
+/** Log an API request with timing data. */
+export function logApiRequest(log: RequestLog): void {
+  const writer = getLogWriter();
+  if (!writer) return;
+
+  writer.append({
+    ts: log.ts,
+    level: log.error ? "error" : "info",
+    source: "api",
+    sessionId: log.sessionId,
+    message: `${log.method} ${log.path} ${log.statusCode} ${log.durationMs}ms`,
+    data: {
+      method: log.method,
+      path: log.path,
+      statusCode: log.statusCode,
+      durationMs: log.durationMs,
+      ...(log.error && { error: log.error }),
+      ...(log.timings && { timings: log.timings }),
+      ...(log.cacheStats && { cacheStats: log.cacheStats }),
+    },
+  });
+}
+
+/** Compute aggregated request stats from api.jsonl logs. */
+export function getRequestStats(
+  logDir: string,
+  opts?: { since?: Date; route?: string },
+): RequestStatsResult {
+  const entries = readLogsFromDir(logDir, "api", {
+    source: "api",
+    since: opts?.since,
+  });
+
+  // Parse request logs from entries
+  const requestLogs: RequestLog[] = [];
+  for (const entry of entries) {
+    const data = entry.data ?? {};
+    if (!data["method"] || !data["path"]) continue;
+
+    const log: RequestLog = {
+      ts: entry.ts,
+      method: String(data["method"]),
+      path: String(data["path"]),
+      sessionId: entry.sessionId,
+      statusCode: Number(data["statusCode"]) || 0,
+      durationMs: Number(data["durationMs"]) || 0,
+      error: data["error"] ? String(data["error"]) : undefined,
+      timings: data["timings"] as RequestLog["timings"],
+      cacheStats: data["cacheStats"] as RequestLog["cacheStats"],
+    };
+
+    if (opts?.route && !log.path.includes(opts.route)) continue;
+    requestLogs.push(log);
+  }
+
+  // Group by route (normalize path params)
+  const byRoute = new Map<string, RequestLog[]>();
+  for (const log of requestLogs) {
+    const normalizedPath = normalizePath(log.path);
+    const key = `${log.method} ${normalizedPath}`;
+    const existing = byRoute.get(key) ?? [];
+    existing.push(log);
+    byRoute.set(key, existing);
+  }
+
+  // Compute per-route stats
+  const routes: Record<string, RouteStats> = {};
+  for (const [route, logs] of byRoute) {
+    const durations = logs.map((l) => l.durationMs).sort((a, b) => a - b);
+    routes[route] = {
+      count: logs.length,
+      avgMs: Math.round(durations.reduce((sum, d) => sum + d, 0) / durations.length),
+      p50Ms: percentile(durations, 50),
+      p95Ms: percentile(durations, 95),
+      p99Ms: percentile(durations, 99),
+      errors: logs.filter((l) => l.error || l.statusCode >= 400).length,
+    };
+  }
+
+  // Find slowest requests
+  const slowest = requestLogs
+    .sort((a, b) => b.durationMs - a.durationMs)
+    .slice(0, 10);
+
+  return { routes, slowest };
+}
+
+/** Normalize API path by replacing dynamic segments. */
+function normalizePath(path: string): string {
+  return path
+    .replace(/\/sessions\/[^/]+/g, "/sessions/:id")
+    .replace(/\/prs\/[^/]+/g, "/prs/:id");
+}
+
+/** Compute percentile from a sorted array. */
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}

--- a/packages/web/src/lib/request-logger.ts
+++ b/packages/web/src/lib/request-logger.ts
@@ -2,47 +2,23 @@
  * Structured API request logging with performance timing.
  *
  * Logs each API request to {logDir}/api.jsonl with timing breakdowns.
- * Provides getRequestStats() for aggregated analysis used by CLI and dashboard.
+ * For aggregated stats, use getRequestStats() which delegates to
+ * parseApiLogs + computeApiStats from @composio/ao-core.
  */
 
-import { getLogsDir, LogWriter, loadConfig, readLogsFromDir, percentile, normalizeRoutePath } from "@composio/ao-core";
+import {
+  getLogsDir,
+  LogWriter,
+  loadConfig,
+  parseApiLogs,
+  computeApiStats,
+  type ApiLogEntry,
+  type ApiPerfResult,
+} from "@composio/ao-core";
 
-export interface RequestLog {
-  ts: string;
-  method: string;
-  path: string;
-  sessionId: string | null;
-  statusCode: number;
-  durationMs: number;
-  error?: string;
-  timings?: {
-    serviceInit?: number;
-    sessionList?: number;
-    prEnrichment?: number;
-    issueEnrichment?: number;
-    serialization?: number;
-  };
-  cacheStats?: {
-    hits: number;
-    misses: number;
-    hitRate: number;
-    size: number;
-  };
-}
-
-export interface RouteStats {
-  count: number;
-  avgMs: number;
-  p50Ms: number;
-  p95Ms: number;
-  p99Ms: number;
-  errors: number;
-}
-
-export interface RequestStatsResult {
-  routes: Record<string, RouteStats>;
-  slowest: RequestLog[];
-}
+// Re-export core types so callers don't need to import from two packages.
+export type { ApiLogEntry as RequestLog, ApiPerfResult as RequestStatsResult } from "@composio/ao-core";
+export type { RouteStats } from "@composio/ao-core";
 
 let logWriter: LogWriter | null = null;
 
@@ -63,7 +39,7 @@ function getLogWriter(): LogWriter | null {
 }
 
 /** Log an API request with timing data. */
-export function logApiRequest(log: RequestLog): void {
+export function logApiRequest(log: ApiLogEntry): void {
   const writer = getLogWriter();
   if (!writer) return;
 
@@ -89,63 +65,7 @@ export function logApiRequest(log: RequestLog): void {
 export function getRequestStats(
   logDir: string,
   opts?: { since?: Date; route?: string },
-): RequestStatsResult {
-  const entries = readLogsFromDir(logDir, "api", {
-    source: "api",
-    since: opts?.since,
-  });
-
-  // Parse request logs from entries
-  const requestLogs: RequestLog[] = [];
-  for (const entry of entries) {
-    const data = entry.data ?? {};
-    if (!data["method"] || !data["path"]) continue;
-
-    const log: RequestLog = {
-      ts: entry.ts,
-      method: String(data["method"]),
-      path: String(data["path"]),
-      sessionId: entry.sessionId,
-      statusCode: Number(data["statusCode"]) || 0,
-      durationMs: Number(data["durationMs"]) || 0,
-      error: data["error"] ? String(data["error"]) : undefined,
-      timings: data["timings"] as RequestLog["timings"],
-      cacheStats: data["cacheStats"] as RequestLog["cacheStats"],
-    };
-
-    if (opts?.route && !log.path.includes(opts.route)) continue;
-    requestLogs.push(log);
-  }
-
-  // Group by route (normalize path params)
-  const byRoute = new Map<string, RequestLog[]>();
-  for (const log of requestLogs) {
-    const normalizedPath = normalizeRoutePath(log.path);
-    const key = `${log.method} ${normalizedPath}`;
-    const existing = byRoute.get(key) ?? [];
-    existing.push(log);
-    byRoute.set(key, existing);
-  }
-
-  // Compute per-route stats
-  const routes: Record<string, RouteStats> = {};
-  for (const [route, logs] of byRoute) {
-    const durations = logs.map((l) => l.durationMs).sort((a, b) => a - b);
-    routes[route] = {
-      count: logs.length,
-      avgMs: Math.round(durations.reduce((sum, d) => sum + d, 0) / durations.length),
-      p50Ms: percentile(durations, 50),
-      p95Ms: percentile(durations, 95),
-      p99Ms: percentile(durations, 99),
-      errors: logs.filter((l) => l.error || l.statusCode >= 400).length,
-    };
-  }
-
-  // Find slowest requests
-  const slowest = requestLogs
-    .sort((a, b) => b.durationMs - a.durationMs)
-    .slice(0, 10);
-
-  return { routes, slowest };
+): ApiPerfResult {
+  const entries = parseApiLogs(logDir, opts);
+  return computeApiStats(entries);
 }
-

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -131,7 +131,8 @@ export async function enrichSessionPR(
   // Cache miss — if cacheOnly, signal caller to refresh in background
   if (opts?.cacheOnly) return false;
 
-  // Fetch from SCM
+  // Fetch from SCM (with timing instrumentation)
+  const enrichStart = Date.now();
   const results = await Promise.allSettled([
     scm.getPRSummary
       ? scm.getPRSummary(pr)
@@ -142,6 +143,12 @@ export async function enrichSessionPR(
     scm.getMergeability(pr),
     scm.getPendingComments(pr),
   ]);
+  const enrichDurationMs = Date.now() - enrichStart;
+  if (enrichDurationMs > 1000) {
+    console.warn(
+      `[enrichSessionPR] Slow enrichment for PR #${pr.number}: ${enrichDurationMs}ms`,
+    );
+  }
 
   const [summaryR, checksR, ciR, reviewR, mergeR, commentsR] = results;
 

--- a/packages/web/src/lib/with-timing.ts
+++ b/packages/web/src/lib/with-timing.ts
@@ -1,0 +1,79 @@
+/**
+ * Route timing wrapper — higher-order function for API route instrumentation.
+ *
+ * Wraps Next.js API route handlers with timing instrumentation, logging
+ * each request's duration and status to the API request log.
+ */
+
+import { logApiRequest, type RequestLog } from "./request-logger.js";
+
+type RouteHandler = (req: Request, ctx?: unknown) => Promise<Response>;
+
+/** Extract session ID from URL path (e.g., /api/sessions/ao-1/kill -> ao-1). */
+function extractSessionId(path: string): string | null {
+  const match = path.match(/\/sessions\/([^/]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+/**
+ * Wrap a route handler with timing instrumentation.
+ * Logs method, path, status code, and duration for every request.
+ */
+export function withTiming(handler: RouteHandler, _routeName: string): RouteHandler {
+  return async (req: Request, ctx?: unknown) => {
+    const start = Date.now();
+    const url = new URL(req.url);
+    const path = url.pathname;
+    const method = req.method;
+    const sessionId = extractSessionId(path);
+
+    let response: Response;
+    let error: string | undefined;
+
+    try {
+      response = await handler(req, ctx);
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+      response = new Response(JSON.stringify({ error: error }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const durationMs = Date.now() - start;
+
+    const log: RequestLog = {
+      ts: new Date().toISOString(),
+      method,
+      path,
+      sessionId,
+      statusCode: response.status,
+      durationMs,
+      error,
+    };
+
+    logApiRequest(log);
+
+    return response;
+  };
+}
+
+/**
+ * Create a timing context for manual instrumentation within a route.
+ * Use when you need to log sub-operation timings (e.g., PR enrichment).
+ */
+export function createTimingContext(): TimingContext {
+  return {
+    timings: {},
+    start: Date.now(),
+    mark(name: string, startMs: number): void {
+      this.timings[name] = Date.now() - startMs;
+    },
+  };
+}
+
+export interface TimingContext {
+  timings: Record<string, number>;
+  start: number;
+  mark(name: string, startMs: number): void;
+}

--- a/packages/web/src/lib/with-timing.ts
+++ b/packages/web/src/lib/with-timing.ts
@@ -5,7 +5,8 @@
  * each request's duration and status to the API request log.
  */
 
-import { logApiRequest, type RequestLog } from "./request-logger.js";
+import type { ApiLogEntry } from "@composio/ao-core";
+import { logApiRequest } from "./request-logger.js";
 
 type RouteHandler = (req: Request, ctx?: unknown) => Promise<Response>;
 
@@ -42,7 +43,7 @@ export function withTiming(handler: RouteHandler, _routeName: string): RouteHand
 
     const durationMs = Date.now() - start;
 
-    const log: RequestLog = {
+    const log: ApiLogEntry = {
       ts: new Date().toISOString(),
       method,
       path,

--- a/packages/web/src/lib/with-timing.ts
+++ b/packages/web/src/lib/with-timing.ts
@@ -20,7 +20,7 @@ function extractSessionId(path: string): string | null {
  * Wrap a route handler with timing instrumentation.
  * Logs method, path, status code, and duration for every request.
  */
-export function withTiming(handler: RouteHandler, _routeName: string): RouteHandler {
+export function withTiming(handler: RouteHandler): RouteHandler {
   return async (req: Request, ctx?: unknown) => {
     const start = Date.now();
     const url = new URL(req.url);


### PR DESCRIPTION
## Summary

Full self-improvement system for ao: structured logging, API performance monitoring, session retrospectives, dashboard management, and comprehensive tests.

### Core Infrastructure
- **JSONL log writer** (`log-writer.ts`): size-based rotation, crash-safe `appendFileSync`, configurable backups
- **Log reader** (`log-reader.ts`): query/filter by time, level, source, session, pattern; reads across rotated files; tail support
- **Session report cards** (`session-report-card.ts`): per-session metrics (CI attempts, review rounds, outcome, duration)
- **Retrospectives** (`retrospective.ts`): post-session analysis with timeline, metrics, and heuristic lessons
- **Dashboard manager** (`dashboard-manager.ts`): programmatic `restartDashboard()` for orchestrator agent to kill/clean/restart Next.js without CLI
- **Path utilities**: `getLogsDir()`, `getRetrospectivesDir()`

### CLI Commands
- `ao logs dashboard|events|session` — query structured logs
- `ao perf routes|slow|cache|enrichment` — API performance analysis
- `ao retro list|show|generate` — session retrospective management  
- `ao dashboard restart|status|logs` — dashboard process management with PID tracking

### Dashboard (Web)
- `/logs` page with `LogViewer` component (filterable by source, level, time, session)
- `/perf` page with `PerfDashboard` component (route stats, slow requests, cache hit rates)
- `POST /api/client-logs` — browser-side error/perf ingestion
- `GET /api/logs`, `GET /api/perf` — log and performance query APIs
- `ClientLogger` component: captures `window.onerror`, `PerformanceObserver`, fetch timing
- Cache hit/miss tracking in `TTLCache.getStats()`
- API request timing in `/api/sessions` route
- PR enrichment timing in `serialize.ts`

### Event Persistence & Lifecycle
- Lifecycle manager writes events to `events.jsonl` with full state transition data
- Auto-generates retrospectives on session merge/kill
- Session manager passes `AO_PROJECT_ID` and `AO_LOG_DIR` env vars to spawned sessions

### Tests (101 new)
- `log-writer.test.ts` (13): append, rotation, close, auto-create dirs, write failure
- `log-reader.test.ts` (42): all filters, corrupted lines, readLogsFromDir, tailLogs
- `session-report-card.test.ts` (24): transitions, CI/review counting, outcomes, duration
- `retrospective.test.ts` (15): save/load, filters, corrupted JSON, round-trip
- `cache.test.ts` (7 new): getStats hit/miss tracking, hit rate, size

### Bugbot Fixes
- Background mode log capture uses file descriptors instead of pipes (survives parent exit)
- Fixed `visibilitychange` listener leak in client-logger
- Removed dead code (`with-timing.ts`, unused `getRequestStats`)
- Fixed port conflict detection logic in dashboard status
- Implemented `--since` option in dashboard logs subcommand

## Test plan
- [x] `pnpm test` — all 927 tests pass
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors
- [ ] `ao start` — dashboard logs captured to JSONL
- [ ] `ao logs dashboard --tail 20` — shows recent output
- [ ] `ao dashboard restart --clean --wait` — kills, cleans .next, restarts
- [ ] `ao perf routes` — per-route p50/p95/p99
- [ ] `ao retro list` — shows retrospectives
- [ ] Dashboard `/logs` and `/perf` pages render

🤖 Generated with [Claude Code](https://claude.com/claude-code)