### PR TITLE
fix: return ActivityDetection from getActivityState to fix stale lastActivityAt

### DIFF
--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -211,7 +211,7 @@ beforeEach(() => {
   mockIntrospect.mockReset();
   mockIntrospect.mockResolvedValue(null);
   mockGetActivityState.mockReset();
-  mockGetActivityState.mockResolvedValue("active");
+  mockGetActivityState.mockResolvedValue({ state: "active" });
   mockDetectPR.mockReset();
   mockDetectPR.mockResolvedValue(null);
   mockGetCISummary.mockReset();

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -84,7 +84,7 @@ beforeEach(() => {
     getLaunchCommand: vi.fn(),
     getEnvironment: vi.fn(),
     detectActivity: vi.fn().mockReturnValue("active" as ActivityState),
-    getActivityState: vi.fn().mockResolvedValue("active" as ActivityState),
+    getActivityState: vi.fn().mockResolvedValue({ state: "active" as ActivityState }),
     isProcessRunning: vi.fn().mockResolvedValue(true),
     getSessionInfo: vi.fn().mockResolvedValue(null),
   };

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -453,7 +453,8 @@ describe("list", () => {
   });
 
   it("updates lastActivityAt from agent session info", async () => {
-    const recentDate = new Date("2026-02-18T22:42:00Z");
+    // Far-future date ensures it's always newer than the metadata file's mtime
+    const recentDate = new Date("2099-01-01T00:00:00Z");
     const agentWithInfo: Agent = {
       ...mockAgent,
       getActivityState: vi.fn().mockResolvedValue("active"),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,7 +60,13 @@ export { generateOrchestratorPrompt } from "./orchestrator-prompt.js";
 export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";
 
 // Shared utilities
-export { shellEscape, escapeAppleScript, validateUrl, readLastJsonlEntry } from "./utils.js";
+export {
+  shellEscape,
+  escapeAppleScript,
+  validateUrl,
+  readLastJsonlEntry,
+  isAgentProcessRunning,
+} from "./utils.js";
 
 // Path utilities — hash-based directory structure
 export {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -285,6 +285,21 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       } catch {
         // Can't detect activity — keep existing value
       }
+
+      // Enrich with live agent session info (summary, cost, lastLogModified).
+      // This updates lastActivityAt from the agent's JSONL file mtime, which
+      // reflects actual agent activity rather than the metadata file mtime.
+      try {
+        const info = await plugins.agent.getSessionInfo(session);
+        if (info) {
+          session.agentInfo = info;
+          if (info.lastLogModified && info.lastLogModified > session.lastActivityAt) {
+            session.lastActivityAt = info.lastLogModified;
+          }
+        }
+      } catch {
+        // Can't get session info — keep existing values
+      }
     }
   }
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -280,22 +280,20 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       try {
         const detected = await plugins.agent.getActivityState(session, config.readyThresholdMs);
         if (detected !== null) {
-          session.activity = detected;
+          session.activity = detected.state;
+          if (detected.timestamp && detected.timestamp > session.lastActivityAt) {
+            session.lastActivityAt = detected.timestamp;
+          }
         }
       } catch {
         // Can't detect activity — keep existing value
       }
 
-      // Enrich with live agent session info (summary, cost, lastLogModified).
-      // This updates lastActivityAt from the agent's JSONL file mtime, which
-      // reflects actual agent activity rather than the metadata file mtime.
+      // Enrich with live agent session info (summary, cost).
       try {
         const info = await plugins.agent.getSessionInfo(session);
         if (info) {
           session.agentInfo = info;
-          if (info.lastLogModified && info.lastLogModified > session.lastActivityAt) {
-            session.lastActivityAt = info.lastLogModified;
-          }
         }
       } catch {
         // Can't get session info — keep existing values

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -357,10 +357,6 @@ export interface AgentSessionInfo {
   agentSessionId: string | null;
   /** Estimated cost so far */
   cost?: CostEstimate;
-  /** Last message type in agent's log */
-  lastMessageType?: string;
-  /** When agent's log was last modified */
-  lastLogModified?: Date;
 }
 
 export interface CostEstimate {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,6 +60,13 @@ export const ACTIVITY_STATE = {
   EXITED: "exited" as const,
 } satisfies Record<string, ActivityState>;
 
+/** Result of activity detection, carrying both the state and an optional timestamp. */
+export interface ActivityDetection {
+  state: ActivityState;
+  /** When activity was last observed (e.g., agent log file mtime) */
+  timestamp?: Date;
+}
+
 /** Default threshold (ms) before a "ready" session becomes "idle". */
 export const DEFAULT_READY_THRESHOLD_MS = 300_000; // 5 minutes
 
@@ -273,7 +280,7 @@ export interface Agent {
    * This is the preferred method for activity detection.
    * @param readyThresholdMs - ms before "ready" becomes "idle" (default: DEFAULT_READY_THRESHOLD_MS)
    */
-  getActivityState(session: Session, readyThresholdMs?: number): Promise<ActivityState | null>;
+  getActivityState(session: Session, readyThresholdMs?: number): Promise<ActivityDetection | null>;
 
   /** Check if agent process is running (given runtime handle) */
   isProcessRunning(handle: RuntimeHandle): Promise<boolean>;

--- a/packages/integration-tests/src/agent-aider.integration.test.ts
+++ b/packages/integration-tests/src/agent-aider.integration.test.ts
@@ -156,6 +156,11 @@ describe.skipIf(!canRun)("agent-aider (integration)", () => {
       expect(["active", "ready", "idle", "waiting_input", "blocked"]).toContain(
         aliveActivityState.state,
       );
+      // When activity is detected, timestamp should be present (feeds lastActivityAt).
+      // Exception: hasRecentCommits detection provides no timestamp.
+      if (aliveActivityState.timestamp !== undefined) {
+        expect(aliveActivityState.timestamp).toBeInstanceOf(Date);
+      }
     }
   });
 

--- a/packages/integration-tests/src/agent-aider.integration.test.ts
+++ b/packages/integration-tests/src/agent-aider.integration.test.ts
@@ -149,9 +149,13 @@ describe.skipIf(!canRun)("agent-aider (integration)", () => {
   });
 
   it("getActivityState → returns valid state while agent is running", () => {
-    // Aider checks git commits and chat history mtime for activity detection.
-    // May return null if no chat history exists yet.
-    if (aliveActivityState !== undefined && aliveActivityState !== null) {
+    // Polling must have captured an observation — undefined means the
+    // 30s polling window expired without ever seeing a non-exited state.
+    expect(aliveActivityState).not.toBeUndefined();
+    // May be null if no chat history exists yet and no recent commits.
+    // The undefined guard is redundant after the assertion above but required
+    // for TypeScript type narrowing.
+    if (aliveActivityState !== null && aliveActivityState !== undefined) {
       expect(aliveActivityState.state).not.toBe("exited");
       expect(["active", "ready", "idle", "waiting_input", "blocked"]).toContain(
         aliveActivityState.state,

--- a/packages/integration-tests/src/agent-aider.integration.test.ts
+++ b/packages/integration-tests/src/agent-aider.integration.test.ts
@@ -14,7 +14,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import type { ActivityState, AgentSessionInfo } from "@composio/ao-core";
+import type { ActivityDetection, AgentSessionInfo } from "@composio/ao-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import aiderPlugin from "@composio/ao-plugin-agent-aider";
 import {
@@ -93,11 +93,11 @@ describe.skipIf(!canRun)("agent-aider (integration)", () => {
 
   // Observations captured while the agent is alive
   let aliveRunning = false;
-  let aliveActivityState: ActivityState | null | undefined;
+  let aliveActivityState: ActivityDetection | null | undefined;
 
   // Observations captured after the agent exits
   let exitedRunning: boolean;
-  let exitedActivityState: ActivityState | null;
+  let exitedActivityState: ActivityDetection | null;
   let sessionInfo: AgentSessionInfo | null;
 
   beforeAll(async () => {
@@ -119,7 +119,7 @@ describe.skipIf(!canRun)("agent-aider (integration)", () => {
       if (running) {
         aliveRunning = true;
         const activityState = await agent.getActivityState(session);
-        if (activityState !== "exited") {
+        if (activityState?.state !== "exited") {
           aliveActivityState = activityState;
           break;
         }
@@ -151,10 +151,10 @@ describe.skipIf(!canRun)("agent-aider (integration)", () => {
   it("getActivityState → returns valid state while agent is running", () => {
     // Aider checks git commits and chat history mtime for activity detection.
     // May return null if no chat history exists yet.
-    if (aliveActivityState !== undefined) {
-      expect(aliveActivityState).not.toBe("exited");
-      expect([null, "active", "ready", "idle", "waiting_input", "blocked"]).toContain(
-        aliveActivityState,
+    if (aliveActivityState !== undefined && aliveActivityState !== null) {
+      expect(aliveActivityState.state).not.toBe("exited");
+      expect(["active", "ready", "idle", "waiting_input", "blocked"]).toContain(
+        aliveActivityState.state,
       );
     }
   });
@@ -164,7 +164,7 @@ describe.skipIf(!canRun)("agent-aider (integration)", () => {
   });
 
   it("getActivityState → returns exited after agent process terminates", () => {
-    expect(exitedActivityState).toBe("exited");
+    expect(exitedActivityState).toEqual({ state: "exited" });
   });
 
   it("getSessionInfo → null (not implemented for aider)", () => {

--- a/packages/integration-tests/src/agent-claude-code.integration.test.ts
+++ b/packages/integration-tests/src/agent-claude-code.integration.test.ts
@@ -252,6 +252,8 @@ describe.skipIf(!canRun)("agent-claude-code (integration)", () => {
       expect(["active", "ready", "idle", "waiting_input", "blocked"]).toContain(
         aliveActivityState.state,
       );
+      // Timestamp must be present — it feeds session.lastActivityAt
+      expect(aliveActivityState.timestamp).toBeInstanceOf(Date);
     }
   });
 

--- a/packages/integration-tests/src/agent-claude-code.integration.test.ts
+++ b/packages/integration-tests/src/agent-claude-code.integration.test.ts
@@ -245,8 +245,12 @@ describe.skipIf(!canRun)("agent-claude-code (integration)", () => {
   });
 
   it("getActivityState → returns valid non-exited state while agent is alive", () => {
-    expect(aliveActivityState).toBeDefined();
-    // May be null (no JSONL yet) or a concrete ActivityDetection
+    // Polling must have captured an observation — undefined means the
+    // 30s polling window expired without ever seeing a non-exited state.
+    expect(aliveActivityState).not.toBeUndefined();
+    // May be null (JSONL not created yet) or a concrete ActivityDetection.
+    // The undefined guard is redundant after the assertion above but required
+    // for TypeScript type narrowing.
     if (aliveActivityState !== null && aliveActivityState !== undefined) {
       expect(aliveActivityState.state).not.toBe("exited");
       expect(["active", "ready", "idle", "waiting_input", "blocked"]).toContain(

--- a/packages/integration-tests/src/agent-codex.integration.test.ts
+++ b/packages/integration-tests/src/agent-codex.integration.test.ts
@@ -116,11 +116,12 @@ describe.skipIf(!canRun)("agent-codex (integration)", () => {
   });
 
   it("getActivityState → returns null while agent is running (no per-session tracking)", () => {
+    // Polling must have captured an observation — undefined means the
+    // 15s polling window expired without ever seeing a non-exited state.
+    expect(aliveActivityState).not.toBeUndefined();
     // Codex uses global rollout file storage without per-session scoping,
     // so getActivityState honestly returns null instead of guessing.
-    if (aliveActivityState !== undefined) {
-      expect(aliveActivityState).toBeNull();
-    }
+    expect(aliveActivityState).toBeNull();
   });
 
   it("isProcessRunning → false after agent exits", () => {

--- a/packages/integration-tests/src/agent-codex.integration.test.ts
+++ b/packages/integration-tests/src/agent-codex.integration.test.ts
@@ -14,7 +14,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import type { ActivityState, AgentSessionInfo } from "@composio/ao-core";
+import type { ActivityDetection, AgentSessionInfo } from "@composio/ao-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import codexPlugin from "@composio/ao-plugin-agent-codex";
 import {
@@ -62,11 +62,11 @@ describe.skipIf(!canRun)("agent-codex (integration)", () => {
 
   // Observations captured while the agent is alive
   let aliveRunning = false;
-  let aliveActivityState: ActivityState | null | undefined;
+  let aliveActivityState: ActivityDetection | null | undefined;
 
   // Observations captured after the agent exits
   let exitedRunning: boolean;
-  let exitedActivityState: ActivityState | null;
+  let exitedActivityState: ActivityDetection | null;
   let sessionInfo: AgentSessionInfo | null;
 
   beforeAll(async () => {
@@ -86,7 +86,7 @@ describe.skipIf(!canRun)("agent-codex (integration)", () => {
       if (running) {
         aliveRunning = true;
         const activityState = await agent.getActivityState(session);
-        if (activityState !== "exited") {
+        if (activityState?.state !== "exited") {
           aliveActivityState = activityState;
           break;
         }
@@ -128,7 +128,7 @@ describe.skipIf(!canRun)("agent-codex (integration)", () => {
   });
 
   it("getActivityState → returns exited after agent process terminates", () => {
-    expect(exitedActivityState).toBe("exited");
+    expect(exitedActivityState).toEqual({ state: "exited" });
   });
 
   it("getSessionInfo → null (not implemented for codex)", () => {

--- a/packages/integration-tests/src/agent-opencode.integration.test.ts
+++ b/packages/integration-tests/src/agent-opencode.integration.test.ts
@@ -140,11 +140,12 @@ describe.skipIf(!canRun)("agent-opencode (integration)", () => {
   });
 
   it("getActivityState → returns null while agent is running (no per-session tracking)", () => {
+    // Polling must have captured an observation — undefined means the
+    // 15s polling window expired without ever seeing a non-exited state.
+    expect(aliveActivityState).not.toBeUndefined();
     // OpenCode uses a global SQLite database shared by all sessions,
     // so getActivityState honestly returns null instead of guessing.
-    if (aliveActivityState !== undefined) {
-      expect(aliveActivityState).toBeNull();
-    }
+    expect(aliveActivityState).toBeNull();
   });
 
   it("isProcessRunning → false after agent exits", () => {

--- a/packages/integration-tests/src/agent-opencode.integration.test.ts
+++ b/packages/integration-tests/src/agent-opencode.integration.test.ts
@@ -14,7 +14,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import type { ActivityState, AgentSessionInfo } from "@composio/ao-core";
+import type { ActivityDetection, AgentSessionInfo } from "@composio/ao-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import opencodePlugin from "@composio/ao-plugin-agent-opencode";
 import {
@@ -86,11 +86,11 @@ describe.skipIf(!canRun)("agent-opencode (integration)", () => {
 
   // Observations captured while the agent is alive
   let aliveRunning = false;
-  let aliveActivityState: ActivityState | null | undefined;
+  let aliveActivityState: ActivityDetection | null | undefined;
 
   // Observations captured after the agent exits
   let exitedRunning: boolean;
-  let exitedActivityState: ActivityState | null;
+  let exitedActivityState: ActivityDetection | null;
   let sessionInfo: AgentSessionInfo | null;
 
   beforeAll(async () => {
@@ -110,7 +110,7 @@ describe.skipIf(!canRun)("agent-opencode (integration)", () => {
       if (running) {
         aliveRunning = true;
         const activityState = await agent.getActivityState(session);
-        if (activityState !== "exited") {
+        if (activityState?.state !== "exited") {
           aliveActivityState = activityState;
           break;
         }
@@ -152,7 +152,7 @@ describe.skipIf(!canRun)("agent-opencode (integration)", () => {
   });
 
   it("getActivityState → returns exited after agent process terminates", () => {
-    expect(exitedActivityState).toBe("exited");
+    expect(exitedActivityState).toEqual({ state: "exited" });
   });
 
   it("getSessionInfo → null (not implemented for opencode)", () => {

--- a/packages/plugins/agent-claude-code/src/__tests__/activity-detection.test.ts
+++ b/packages/plugins/agent-claude-code/src/__tests__/activity-detection.test.ts
@@ -119,17 +119,19 @@ describe("Claude Code Activity Detection", () => {
     it("returns 'exited' when process is not running", async () => {
       vi.spyOn(agent, "isProcessRunning").mockResolvedValue(false);
       writeJsonl([{ type: "assistant" }]);
-      expect(await agent.getActivityState(makeSession())).toBe("exited");
+      expect(await agent.getActivityState(makeSession())).toEqual({ state: "exited" });
     });
 
     it("returns 'exited' when no runtimeHandle", async () => {
-      expect(await agent.getActivityState(makeSession({ runtimeHandle: undefined }))).toBe(
-        "exited",
-      );
+      expect(await agent.getActivityState(makeSession({ runtimeHandle: undefined }))).toEqual({
+        state: "exited",
+      });
     });
 
     it("returns 'exited' when runtimeHandle is null", async () => {
-      expect(await agent.getActivityState(makeSession({ runtimeHandle: null }))).toBe("exited");
+      expect(await agent.getActivityState(makeSession({ runtimeHandle: null }))).toEqual({
+        state: "exited",
+      });
     });
 
     // -----------------------------------------------------------------------
@@ -158,37 +160,58 @@ describe("Claude Code Activity Detection", () => {
     describe("real Claude Code entry types", () => {
       it("returns 'active' for recent 'progress' entry (streaming)", async () => {
         writeJsonl([{ type: "progress", status: "running tool" }]);
-        expect(await agent.getActivityState(makeSession())).toBe("active");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "active",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'active' for recent 'user' entry", async () => {
         writeJsonl([{ type: "user", message: { content: "fix the bug" } }]);
-        expect(await agent.getActivityState(makeSession())).toBe("active");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "active",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'ready' for recent 'assistant' entry", async () => {
         writeJsonl([{ type: "assistant", message: { content: "Done!" } }]);
-        expect(await agent.getActivityState(makeSession())).toBe("ready");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "ready",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'ready' for recent 'system' entry", async () => {
         writeJsonl([{ type: "system", summary: "session started" }]);
-        expect(await agent.getActivityState(makeSession())).toBe("ready");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "ready",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'active' for recent 'file-history-snapshot' (bookkeeping)", async () => {
         writeJsonl([{ type: "file-history-snapshot" }]);
-        expect(await agent.getActivityState(makeSession())).toBe("active");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "active",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'active' for recent 'queue-operation' (bookkeeping)", async () => {
         writeJsonl([{ type: "queue-operation" }]);
-        expect(await agent.getActivityState(makeSession())).toBe("active");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "active",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'active' for recent 'pr-link' (bookkeeping)", async () => {
         writeJsonl([{ type: "pr-link" }]);
-        expect(await agent.getActivityState(makeSession())).toBe("active");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "active",
+          timestamp: expect.any(Date),
+        });
       });
     });
 
@@ -199,27 +222,42 @@ describe("Claude Code Activity Detection", () => {
     describe("agent interface spec types", () => {
       it("returns 'active' for recent 'tool_use' entry", async () => {
         writeJsonl([{ type: "tool_use" }]);
-        expect(await agent.getActivityState(makeSession())).toBe("active");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "active",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'waiting_input' for 'permission_request'", async () => {
         writeJsonl([{ type: "permission_request" }]);
-        expect(await agent.getActivityState(makeSession())).toBe("waiting_input");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "waiting_input",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'blocked' for 'error'", async () => {
         writeJsonl([{ type: "error" }]);
-        expect(await agent.getActivityState(makeSession())).toBe("blocked");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "blocked",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'ready' for recent 'summary' entry", async () => {
         writeJsonl([{ type: "summary", summary: "Implemented login feature" }]);
-        expect(await agent.getActivityState(makeSession())).toBe("ready");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "ready",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'ready' for recent 'result' entry", async () => {
         writeJsonl([{ type: "result" }]);
-        expect(await agent.getActivityState(makeSession())).toBe("ready");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "ready",
+          timestamp: expect.any(Date),
+        });
       });
     });
 
@@ -230,48 +268,70 @@ describe("Claude Code Activity Detection", () => {
     describe("staleness threshold", () => {
       it("returns 'idle' for stale 'assistant' entry (> threshold)", async () => {
         writeJsonl([{ type: "assistant" }], 400_000); // 6+ min old
-        expect(await agent.getActivityState(makeSession())).toBe("idle");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "idle",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'idle' for stale 'user' entry (> threshold)", async () => {
         writeJsonl([{ type: "user" }], 400_000);
-        expect(await agent.getActivityState(makeSession())).toBe("idle");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "idle",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'idle' for stale 'progress' entry (> threshold)", async () => {
         writeJsonl([{ type: "progress" }], 400_000);
-        expect(await agent.getActivityState(makeSession())).toBe("idle");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "idle",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns 'idle' for stale bookkeeping entry (> threshold)", async () => {
         writeJsonl([{ type: "file-history-snapshot" }], 400_000);
-        expect(await agent.getActivityState(makeSession())).toBe("idle");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "idle",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("'permission_request' ignores staleness (always waiting_input)", async () => {
         writeJsonl([{ type: "permission_request" }], 400_000);
-        expect(await agent.getActivityState(makeSession())).toBe("waiting_input");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "waiting_input",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("'error' ignores staleness (always blocked)", async () => {
         writeJsonl([{ type: "error" }], 400_000);
-        expect(await agent.getActivityState(makeSession())).toBe("blocked");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "blocked",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("respects custom readyThresholdMs", async () => {
         // 2 minutes old — stale with 60s threshold, ready with default 5min
         writeJsonl([{ type: "assistant" }], 120_000);
 
-        expect(await agent.getActivityState(makeSession(), 60_000)).toBe("idle");
-        expect(await agent.getActivityState(makeSession(), 300_000)).toBe("ready");
+        const result60 = await agent.getActivityState(makeSession(), 60_000);
+        expect(result60).toEqual({ state: "idle", timestamp: expect.any(Date) });
+        const result300 = await agent.getActivityState(makeSession(), 300_000);
+        expect(result300).toEqual({ state: "ready", timestamp: expect.any(Date) });
       });
 
       it("custom threshold applies to active types too", async () => {
         // 2 minutes old
         writeJsonl([{ type: "user" }], 120_000);
 
-        expect(await agent.getActivityState(makeSession(), 60_000)).toBe("idle");
-        expect(await agent.getActivityState(makeSession(), 300_000)).toBe("active");
+        const result60 = await agent.getActivityState(makeSession(), 60_000);
+        expect(result60).toEqual({ state: "idle", timestamp: expect.any(Date) });
+        const result300 = await agent.getActivityState(makeSession(), 300_000);
+        expect(result300).toEqual({ state: "active", timestamp: expect.any(Date) });
       });
     });
 
@@ -285,7 +345,10 @@ describe("Claude Code Activity Detection", () => {
         writeJsonl([{ type: "assistant" }], 10_000, "old-session.jsonl");
         writeJsonl([{ type: "user" }], 0, "new-session.jsonl");
 
-        expect(await agent.getActivityState(makeSession())).toBe("active");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "active",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("ignores agent- prefixed JSONL files", async () => {
@@ -301,7 +364,10 @@ describe("Claude Code Activity Detection", () => {
           { type: "progress", status: "thinking" },
           { type: "assistant", message: { content: "Done!" } },
         ]);
-        expect(await agent.getActivityState(makeSession())).toBe("ready");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "ready",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("returns null for empty JSONL file", async () => {
@@ -321,7 +387,10 @@ describe("Claude Code Activity Detection", () => {
         writeFileSync(join(projectDir, "notes.txt"), "some notes");
         // Write actual JSONL
         writeJsonl([{ type: "assistant" }]);
-        expect(await agent.getActivityState(makeSession())).toBe("ready");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "ready",
+          timestamp: expect.any(Date),
+        });
       });
     });
 
@@ -338,7 +407,10 @@ describe("Claude Code Activity Detection", () => {
           { type: "progress", status: "Writing file" },
           { type: "progress", status: "Running tool" },
         ]);
-        expect(await agent.getActivityState(makeSession())).toBe("active");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "active",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("detects agent done and waiting (assistant is last entry)", async () => {
@@ -348,7 +420,10 @@ describe("Claude Code Activity Detection", () => {
           { type: "progress", status: "writing" },
           { type: "assistant", message: { content: "I've implemented the auth feature." } },
         ]);
-        expect(await agent.getActivityState(makeSession())).toBe("ready");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "ready",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("detects agent done with system summary", async () => {
@@ -358,7 +433,10 @@ describe("Claude Code Activity Detection", () => {
           { type: "assistant", message: { content: "Fixed!" } },
           { type: "system", summary: "Fixed failing tests" },
         ]);
-        expect(await agent.getActivityState(makeSession())).toBe("ready");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "ready",
+          timestamp: expect.any(Date),
+        });
       });
 
       it("detects stale finished session", async () => {
@@ -369,7 +447,10 @@ describe("Claude Code Activity Detection", () => {
           ],
           600_000, // 10 min old
         );
-        expect(await agent.getActivityState(makeSession())).toBe("idle");
+        expect(await agent.getActivityState(makeSession())).toEqual({
+          state: "idle",
+          timestamp: expect.any(Date),
+        });
       });
     });
   });

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -601,15 +601,6 @@ describe("getSessionInfo", () => {
     });
   });
 
-  describe("lastLogModified", () => {
-    it("returns file mtime as lastLogModified", async () => {
-      const mtime = new Date(1700000000000);
-      mockJsonlFiles('{"type":"user","message":{"content":"hi"}}', undefined, mtime);
-      const result = await agent.getSessionInfo(makeSession());
-      expect(result?.lastLogModified).toEqual(mtime);
-    });
-  });
-
   describe("malformed JSONL handling", () => {
     it("skips malformed lines and parses valid ones", async () => {
       const jsonl = [

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -701,15 +701,6 @@ function createClaudeCodeAgent(): Agent {
       const sessionFile = await findLatestSessionFile(projectDir);
       if (!sessionFile) return null;
 
-      // Get file modification time
-      let lastLogModified: Date | undefined;
-      try {
-        const fileStat = await stat(sessionFile);
-        lastLogModified = fileStat.mtime;
-      } catch {
-        // Ignore stat errors
-      }
-
       // Parse the JSONL
       const lines = await parseJsonlFile(sessionFile);
       if (lines.length === 0) return null;
@@ -721,7 +712,6 @@ function createClaudeCodeAgent(): Agent {
         summary: extractSummary(lines),
         agentSessionId,
         cost: extractCost(lines),
-        lastLogModified,
       };
     },
 

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -3,6 +3,7 @@ import {
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
+  type ActivityDetection,
   type ActivityState,
   type PluginModule,
   type RuntimeHandle,
@@ -75,11 +76,11 @@ function createCodexAgent(): Agent {
       return "active";
     },
 
-    async getActivityState(session: Session, _readyThresholdMs?: number): Promise<ActivityState | null> {
+    async getActivityState(session: Session, _readyThresholdMs?: number): Promise<ActivityDetection | null> {
       // Check if process is running first
-      if (!session.runtimeHandle) return "exited";
+      if (!session.runtimeHandle) return { state: "exited" };
       const running = await this.isProcessRunning(session.runtimeHandle);
-      if (!running) return "exited";
+      if (!running) return { state: "exited" };
 
       // NOTE: Codex stores rollout files in a global ~/.codex/sessions/ directory
       // without workspace-specific scoping. When multiple Codex sessions run in

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -3,6 +3,7 @@ import {
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
+  type ActivityDetection,
   type ActivityState,
   type PluginModule,
   type RuntimeHandle,
@@ -63,11 +64,11 @@ function createOpenCodeAgent(): Agent {
       return "active";
     },
 
-    async getActivityState(session: Session, _readyThresholdMs?: number): Promise<ActivityState | null> {
+    async getActivityState(session: Session, _readyThresholdMs?: number): Promise<ActivityDetection | null> {
       // Check if process is running first
-      if (!session.runtimeHandle) return "exited";
+      if (!session.runtimeHandle) return { state: "exited" };
       const running = await this.isProcessRunning(session.runtimeHandle);
-      if (!running) return "exited";
+      if (!running) return { state: "exited" };
 
       // NOTE: OpenCode stores all session data in a single global SQLite database
       // at ~/.local/share/opencode/opencode.db without per-workspace scoping. When

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -1,5 +1,6 @@
 import {
   shellEscape,
+  isAgentProcessRunning,
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
@@ -9,10 +10,6 @@ import {
   type RuntimeHandle,
   type Session,
 } from "@composio/ao-core";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
 
 // =============================================================================
 // Plugin Manifest
@@ -81,54 +78,7 @@ function createOpenCodeAgent(): Agent {
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
-      try {
-        if (handle.runtimeName === "tmux" && handle.id) {
-          const { stdout: ttyOut } = await execFileAsync(
-            "tmux",
-            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
-            { timeout: 30_000 },
-          );
-          const ttys = ttyOut
-            .trim()
-            .split("\n")
-            .map((t) => t.trim())
-            .filter(Boolean);
-          if (ttys.length === 0) return false;
-
-          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
-            timeout: 30_000,
-          });
-          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
-          const processRe = /(?:^|\/)opencode(?:\s|$)/;
-          for (const line of psOut.split("\n")) {
-            const cols = line.trimStart().split(/\s+/);
-            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
-            const args = cols.slice(2).join(" ");
-            if (processRe.test(args)) {
-              return true;
-            }
-          }
-          return false;
-        }
-
-        const rawPid = handle.data["pid"];
-        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
-        if (Number.isFinite(pid) && pid > 0) {
-          try {
-            process.kill(pid, 0);
-            return true;
-          } catch (err: unknown) {
-            if (err instanceof Error && "code" in err && err.code === "EPERM") {
-              return true;
-            }
-            return false;
-          }
-        }
-
-        return false;
-      } catch {
-        return false;
-      }
+      return isAgentProcessRunning(handle, "opencode");
     },
 
     async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {


### PR DESCRIPTION
## Summary

- Dashboard showed "Active 2h ago" even when agents were active minutes ago because `lastActivityAt` was sourced from the metadata file's mtime (only updates on PR creation, status changes), not during agent work
- `getActivityState()` now returns `ActivityDetection { state, timestamp? }` instead of a bare `ActivityState` string — the timestamp comes from data the plugin already had (JSONL file mtime), requiring zero additional I/O
- `enrichSessionWithRuntimeState()` uses `detected.timestamp` to update `lastActivityAt`, eliminating the separate `getSessionInfo()` call that was previously added for this purpose

## Changes

- **`packages/core/src/types.ts`** — new `ActivityDetection` interface, updated `Agent.getActivityState` return type
- **`packages/core/src/session-manager.ts`** — use `detected.state` + `detected.timestamp` from activity detection
- **4 agent plugins** (claude-code, aider, codex, opencode) — return `{ state, timestamp }` objects
- **Tests** — all activity-detection, session-manager, lifecycle-manager, status, and integration tests updated

## Test plan

- [x] New test: `updates lastActivityAt from ActivityDetection timestamp` — verifies JSONL mtime overwrites stale metadata mtime
- [x] New test: `keeps metadata lastActivityAt when ActivityDetection has no timestamp` — verifies we never regress
- [x] All 54 session-manager tests pass
- [x] All 42 activity-detection tests pass (updated assertions for `ActivityDetection` shape)
- [x] Full test suite passes (all 21 packages)
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)