### PR TITLE
fix: don't treat UNSTABLE merge state as blocker when CI is pending

### DIFF
--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -544,12 +544,14 @@ function createGitHubSCM(): SCM {
       } else if (mergeState === "BLOCKED") {
         blockers.push("Merge is blocked by branch protection");
       } else if (mergeState === "UNSTABLE") {
-        // UNSTABLE means required status checks exist but aren't all passing.
-        // Skip the blocker only when CI is pending (checks still running) —
-        // "Required checks are failing" would be misleading in that case.
-        // For all other ciStatus values (failing, none, passing) fail closed:
-        // GitHub says something's wrong, so report it.
-        if (ciStatus !== CI_STATUS.PENDING) {
+        // UNSTABLE means required status checks aren't all passing — could be
+        // pending or failing.  When !ciPassing the CI section above already
+        // added a specific blocker ("CI is failing" / "CI is pending"), so
+        // adding a second one here would be redundant or misleading.  Only
+        // add the UNSTABLE blocker when ciPassing is true — that's the
+        // fail-closed safety net for edge cases (e.g. all checks skipped but
+        // GitHub still reports UNSTABLE).
+        if (ciPassing) {
           blockers.push("Required checks are failing");
         }
       }

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -545,9 +545,11 @@ function createGitHubSCM(): SCM {
         blockers.push("Merge is blocked by branch protection");
       } else if (mergeState === "UNSTABLE") {
         // UNSTABLE means required status checks exist but aren't all passing.
-        // Only treat as a blocker when CI is actually failing — pending CI
-        // is still running and shouldn't block the mergeability assessment.
-        if (ciStatus === CI_STATUS.FAILING) {
+        // Skip the blocker only when CI is pending (checks still running) —
+        // "Required checks are failing" would be misleading in that case.
+        // For all other ciStatus values (failing, none, passing) fail closed:
+        // GitHub says something's wrong, so report it.
+        if (ciStatus !== CI_STATUS.PENDING) {
           blockers.push("Required checks are failing");
         }
       }

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -544,7 +544,12 @@ function createGitHubSCM(): SCM {
       } else if (mergeState === "BLOCKED") {
         blockers.push("Merge is blocked by branch protection");
       } else if (mergeState === "UNSTABLE") {
-        blockers.push("Required checks are failing");
+        // UNSTABLE means required status checks exist but aren't all passing.
+        // Only treat as a blocker when CI is actually failing — pending CI
+        // is still running and shouldn't block the mergeability assessment.
+        if (ciStatus === CI_STATUS.FAILING) {
+          blockers.push("Required checks are failing");
+        }
       }
 
       // Draft

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -544,13 +544,9 @@ function createGitHubSCM(): SCM {
       } else if (mergeState === "BLOCKED") {
         blockers.push("Merge is blocked by branch protection");
       } else if (mergeState === "UNSTABLE") {
-        // UNSTABLE means required status checks aren't all passing — could be
-        // pending or failing.  When !ciPassing the CI section above already
-        // added a specific blocker ("CI is failing" / "CI is pending"), so
-        // adding a second one here would be redundant or misleading.  Only
-        // add the UNSTABLE blocker when ciPassing is true — that's the
-        // fail-closed safety net for edge cases (e.g. all checks skipped but
-        // GitHub still reports UNSTABLE).
+        // When !ciPassing the CI section already added a blocker — don't
+        // duplicate.  When ciPassing (e.g. all checks skipped) this is the
+        // fail-closed safety net: GitHub says UNSTABLE but we saw nothing wrong.
         if (ciPassing) {
           blockers.push("Required checks are failing");
         }

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -753,10 +753,11 @@ describe("scm-github plugin", () => {
       expect(result.ciPassing).toBe(false);
       expect(result.mergeable).toBe(false);
       expect(result.blockers).toContain("CI is failing");
-      expect(result.blockers).toContain("Required checks are failing");
+      // No redundant "Required checks are failing" — the CI section covers it
+      expect(result.blockers).not.toContain("Required checks are failing");
     });
 
-    it("reports UNSTABLE merge state even when CI fetch fails", async () => {
+    it("falls back to CI failing when CI fetch fails with UNSTABLE merge state", async () => {
       mockGh({ state: "OPEN" }); // getPRState
       mockGh({
         mergeable: "MERGEABLE",
@@ -769,8 +770,9 @@ describe("scm-github plugin", () => {
       const result = await scm.getMergeability(pr);
       expect(result.ciPassing).toBe(false);
       expect(result.mergeable).toBe(false);
+      // getCISummary fail-closes to "failing", which the CI section reports
       expect(result.blockers).toContain("CI is failing");
-      expect(result.blockers).toContain("Required checks are failing");
+      expect(result.blockers).not.toContain("Required checks are failing");
     });
 
     it("does not treat UNSTABLE as a blocker when CI is pending", async () => {


### PR DESCRIPTION
## Summary

GitHub's `mergeStateStatus: UNSTABLE` means required status checks exist but aren't all passing. Previously we unconditionally added "Required checks are failing" as a blocker, which caused two problems:

1. **False alarm for pending CI** — dashboard showed "Required checks are failing" while CI was just running
2. **Redundant blockers for failing CI** — both "CI is failing" (from CI section) and "Required checks are failing" (from UNSTABLE section) appeared simultaneously

**Fix**: Gate the UNSTABLE blocker on `ciPassing` — it only fires when the CI section didn't already report the problem. This is also the fail-closed safety net for edge cases where our CI aggregation says "none" (all skipped) but GitHub still reports UNSTABLE.

### Blocker matrix after fix

| ciStatus | CI section blocker | UNSTABLE blocker | Notes |
|----------|-------------------|-----------------|-------|
| failing | "CI is failing" | *(none)* | CI section covers it |
| pending | "CI is pending" | *(none)* | Not failing, just running |
| none | *(none)* | "Required checks are failing" | Fail-closed safety net |
| passing | *(none)* | "Required checks are failing" | Fail-closed safety net |

## Test plan

- [x] `reports CI failures as blockers` — UNSTABLE + FAILURE: only "CI is failing", no duplicate
- [x] `falls back to CI failing when CI fetch fails` — UNSTABLE + error: only "CI is failing"
- [x] `does not treat UNSTABLE as a blocker when CI is pending` — UNSTABLE + PENDING: only "CI is pending"
- [x] `reports UNSTABLE as blocker when CI status is none (fail closed)` — UNSTABLE + SKIPPED: "Required checks are failing"
- [x] All 56 scm-github tests pass
- [x] Full suite: typecheck + lint + test all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)