### PR TITLE
test(web): add coverage for isPRRateLimited, computeStats, getAlerts, and Dashboard

### DIFF
--- a/packages/web/src/__tests__/components.test.tsx
+++ b/packages/web/src/__tests__/components.test.tsx
@@ -667,13 +667,13 @@ describe("Dashboard", () => {
     });
     const session = makeSession({ pr: rateLimitedPR });
     render(<Dashboard sessions={[session]} stats={makeStats({ totalSessions: 1 })} />);
-    expect(screen.getByText(/GitHub API rate limited/)).toBeInTheDocument();
+    expect(screen.getByText(/PR data may be unavailable/)).toBeInTheDocument();
   });
 
   it("hides rate limit banner when no sessions are rate-limited", () => {
     const session = makeSession({ pr: makePR() }); // clean PR
     render(<Dashboard sessions={[session]} stats={makeStats({ totalSessions: 1 })} />);
-    expect(screen.queryByText(/GitHub API rate limited/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/PR data may be unavailable/)).not.toBeInTheDocument();
   });
 
   it("dismisses rate limit banner when X is clicked", () => {
@@ -683,9 +683,9 @@ describe("Dashboard", () => {
     const session = makeSession({ pr: rateLimitedPR });
     render(<Dashboard sessions={[session]} stats={makeStats({ totalSessions: 1 })} />);
 
-    expect(screen.getByText(/GitHub API rate limited/)).toBeInTheDocument();
+    expect(screen.getByText(/PR data may be unavailable/)).toBeInTheDocument();
     fireEvent.click(screen.getByLabelText("Dismiss"));
-    expect(screen.queryByText(/GitHub API rate limited/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/PR data may be unavailable/)).not.toBeInTheDocument();
   });
 
   it("shows PR table for sessions with open PRs", () => {

--- a/packages/web/src/__tests__/helpers.ts
+++ b/packages/web/src/__tests__/helpers.ts
@@ -11,6 +11,7 @@ export function makeSession(overrides: Partial<DashboardSession> = {}): Dashboar
     issueId: "https://linear.app/test/issue/INT-100",
     issueUrl: "https://linear.app/test/issue/INT-100",
     issueLabel: "INT-100",
+    issueTitle: null,
     summary: "Test session",
     summaryIsFallback: false,
     createdAt: new Date().toISOString(),

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -125,7 +125,7 @@ export function Dashboard({ sessions, stats, orchestratorId, projectName }: Dash
             <path d="M12 8v4M12 16h.01" />
           </svg>
           <span className="flex-1">
-            GitHub API rate limited — PR data (CI status, review state, sizes) may be stale.
+            PR data may be unavailable — CI status, review state, and sizes may be stale (GitHub API rate limited or enrichment timed out).
             {" "}Will retry automatically on next refresh.
           </span>
           <button

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -980,7 +980,6 @@ describe("basicPRToDashboard defaults", () => {
 
 // ── computeStats ──────────────────────────────────────────────────────
 
-import { computeStats } from "../serialize";
 import { makeSession, makePR } from "../../__tests__/helpers";
 
 describe("computeStats", () => {

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -150,12 +150,16 @@ export interface SSEActivityEvent {
 }
 
 /**
- * Returns true when this PR's enrichment data couldn't be fetched due to
- * API rate limiting. When true, CI status / review decision / mergeability
- * may be stale defaults — don't make decisions based on them.
+ * Returns true when this PR's enrichment data is unavailable or stale.
+ * Covers both API rate-limiting and enrichment timeouts ("Data not loaded").
+ * When true, CI status / review decision / mergeability are unreliable defaults —
+ * don't make automated decisions based on them.
  */
 export function isPRRateLimited(pr: DashboardPR): boolean {
-  return pr.mergeability.blockers.includes("API rate limited or unavailable");
+  return (
+    pr.mergeability.blockers.includes("API rate limited or unavailable") ||
+    pr.mergeability.blockers.includes("Data not loaded")
+  );
 }
 
 /** Determines which attention zone a session belongs to */


### PR DESCRIPTION
## Summary

- **Bug fix**: `isPRRateLimited` now also returns `true` for the `"Data not loaded"` blocker, which is set when server-side PR enrichment times out (4s `Promise.race`). Without this, sessions with timed-out enrichment had their default `ciStatus=none`/`reviewDecision=none` treated as real data, causing `getAttentionLevel` to misclassify them as `"pending"` or `"review"` instead of `"working"`.
- **New tests**: Comprehensive unit tests for previously uncovered code paths.

## Test additions

| File | Tests added | Coverage target |
|------|------------|-----------------|
| `types.test.ts` | 7 | `isPRRateLimited` unit tests + `getAttentionLevel` integration |
| `serialize.test.ts` | 6 | `computeStats` (zero, total count, working count, open PRs, needsReview) |
| `components.test.tsx` | 7 | `getAlerts` edge cases (reviewDecision=none, draft bypass, merge conflict, rate-limited, closed/merged) |
| `components.test.tsx` | 11 | `Dashboard` component (empty state, session counts, attention zones, orchestrator link, rate-limit banner, PR table) |

## Test plan

- [x] `pnpm test` — all 367 tests pass
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm lint` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)