### PR TITLE
fix: persist session model/permissions in metadata for restore

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "pnpm -r typecheck",
+    "typecheck": "pnpm --filter @composio/ao-core build && pnpm -r typecheck",
     "test": "pnpm -r --filter '!@composio/ao-web' test",
     "test:integration": "pnpm --filter @composio/ao-integration-tests test:integration",
     "clean": "pnpm -r clean",

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -99,6 +99,9 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
     project: raw["project"],
     createdAt: raw["createdAt"],
     runtimeHandle: raw["runtimeHandle"],
+    permissions: raw["permissions"],
+    model: raw["model"],
+    restoredAt: raw["restoredAt"],
     dashboardPort: raw["dashboardPort"] ? Number(raw["dashboardPort"]) : undefined,
     terminalWsPort: raw["terminalWsPort"] ? Number(raw["terminalWsPort"]) : undefined,
     directTerminalWsPort: raw["directTerminalWsPort"] ? Number(raw["directTerminalWsPort"]) : undefined,
@@ -141,6 +144,9 @@ export function writeMetadata(
   if (metadata.project) data["project"] = metadata.project;
   if (metadata.createdAt) data["createdAt"] = metadata.createdAt;
   if (metadata.runtimeHandle) data["runtimeHandle"] = metadata.runtimeHandle;
+  if (metadata.permissions) data["permissions"] = metadata.permissions;
+  if (metadata.model) data["model"] = metadata.model;
+  if (metadata.restoredAt) data["restoredAt"] = metadata.restoredAt;
   if (metadata.dashboardPort !== undefined)
     data["dashboardPort"] = String(metadata.dashboardPort);
   if (metadata.terminalWsPort !== undefined)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -965,6 +965,8 @@ export interface SessionMetadata {
   project?: string;
   createdAt?: string;
   runtimeHandle?: string;
+  permissions?: string;
+  model?: string;
   restoredAt?: string;
   dashboardPort?: number;
   terminalWsPort?: number;

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -744,15 +744,19 @@ function createClaudeCodeAgent(): Agent {
       const sessionUuid = basename(sessionFile, ".jsonl");
       if (!sessionUuid) return null;
 
-      // Build resume command
+      // Build resume command with same config as original session
       const parts: string[] = ["claude", "--resume", shellEscape(sessionUuid)];
 
-      if (project.agentConfig?.permissions === "skip") {
+      // Check permissions: prefer metadata (persisted at spawn time), fall back to project config
+      const permissions = session.metadata?.["permissions"] ?? project.agentConfig?.permissions;
+      if (permissions === "skip") {
         parts.push("--dangerously-skip-permissions");
       }
 
-      if (project.agentConfig?.model) {
-        parts.push("--model", shellEscape(project.agentConfig.model as string));
+      // Check model: prefer metadata (persisted at spawn time), fall back to project config
+      const model = session.metadata?.["model"] ?? project.agentConfig?.model;
+      if (model) {
+        parts.push("--model", shellEscape(model as string));
       }
 
       return parts.join(" ");


### PR DESCRIPTION
## Summary

Fixes metadata serialization gaps in the session restore pipeline. Three issues addressed:

- **Metadata fields silently dropped**: `writeMetadata()` and `readMetadata()` didn't serialize `model`, `permissions`, or `restoredAt` fields, even though `SessionMetadata` defined them and `session-manager.ts` wrote them. Values were silently discarded.

- **Restore uses stale config**: `getRestoreCommand()` only read from `project.agentConfig` (current config), not from session metadata (config at spawn time). If the project config changed between spawn and restore, the session would be restored with wrong settings.

- **Typecheck CI failure**: `pnpm -r typecheck` ran all packages in parallel, but agent plugins depend on built type definitions from `@composio/ao-core`. Without building core first, TypeScript couldn't find new interface methods.

## Changes

1. **`packages/core/src/metadata.ts`** — Add `permissions`, `model`, `restoredAt` to both `readMetadata()` and `writeMetadata()`
2. **`packages/core/src/types.ts`** — Add `permissions` and `model` to `SessionMetadata` interface  
3. **`packages/plugins/agent-claude-code/src/index.ts`** — `getRestoreCommand()` now prefers persisted metadata over project config, with fallback for older sessions
4. **`package.json`** — Build core before running typecheck across workspace

## Test plan

- [x] Core unit tests pass (245/245)
- [x] Typecheck passes with new script
- [ ] CI: Lint, Test, Typecheck, Integration Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)