### PR TITLE
feat: wire lifecycle reactions to notifier for push-not-pull PR reviews

### DIFF
--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -1,0 +1,69 @@
+/**
+ * `ao lifecycle` command — manage lifecycle polling and reactions.
+ *
+ * Subcommands:
+ *   start  — run lifecycle polling loop in foreground
+ *   check  — run a single check for one session
+ */
+
+import chalk from "chalk";
+import type { Command } from "commander";
+import { loadConfig, createLifecycleManager } from "@composio/ao-core";
+import { getSessionManager, getRegistry } from "../lib/create-session-manager.js";
+
+export function registerLifecycle(program: Command): void {
+  const lifecycle = program
+    .command("lifecycle")
+    .description("Manage lifecycle polling and reactions");
+
+  lifecycle
+    .command("start")
+    .description("Start lifecycle polling loop (runs in foreground)")
+    .option("-i, --interval <ms>", "Polling interval in milliseconds", "30000")
+    .action(async (opts: { interval: string }) => {
+      const config = loadConfig();
+      const intervalMs = parseInt(opts.interval, 10);
+
+      if (isNaN(intervalMs) || intervalMs < 1000) {
+        console.error(chalk.red("Invalid interval. Must be >= 1000ms"));
+        process.exit(1);
+      }
+
+      const registry = await getRegistry(config);
+      const sessionManager = await getSessionManager(config);
+      const lifecycleManager = createLifecycleManager({
+        config,
+        registry,
+        sessionManager,
+      });
+
+      console.log(chalk.bold(`Starting lifecycle polling (interval: ${intervalMs}ms)\n`));
+      console.log(chalk.dim("Press Ctrl-C to stop\n"));
+
+      lifecycleManager.start(intervalMs);
+
+      process.on("SIGINT", () => {
+        console.log(chalk.yellow("\nStopping lifecycle manager..."));
+        lifecycleManager.stop();
+        process.exit(0);
+      });
+    });
+
+  lifecycle
+    .command("check")
+    .description("Run a single lifecycle check for a session")
+    .argument("<sessionId>", "Session ID to check")
+    .action(async (sessionId: string) => {
+      const config = loadConfig();
+      const registry = await getRegistry(config);
+      const sessionManager = await getSessionManager(config);
+      const lifecycleManager = createLifecycleManager({
+        config,
+        registry,
+        sessionManager,
+      });
+
+      await lifecycleManager.check(sessionId);
+      console.log(chalk.green(`Done: checked session ${sessionId}`));
+    });
+}

--- a/packages/cli/src/commands/review-check.ts
+++ b/packages/cli/src/commands/review-check.ts
@@ -65,6 +65,11 @@ export function registerReviewCheck(program: Command): void {
     .argument("[project]", "Project ID (checks all if omitted)")
     .option("--dry-run", "Show what would be done without sending messages")
     .action(async (projectId: string | undefined, opts: { dryRun?: boolean }) => {
+      console.log(
+        chalk.yellow(
+          "NOTE: 'ao review-check' is deprecated. Use 'ao lifecycle start' for automated polling.\n",
+        ),
+      );
       const config = loadConfig();
 
       if (projectId && !config.projects[projectId]) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import { registerReviewCheck } from "./commands/review-check.js";
 import { registerDashboard } from "./commands/dashboard.js";
 import { registerOpen } from "./commands/open.js";
 import { registerStart, registerStop } from "./commands/start.js";
+import { registerLifecycle } from "./commands/lifecycle.js";
 
 const program = new Command();
 
@@ -29,5 +30,6 @@ registerSend(program);
 registerReviewCheck(program);
 registerDashboard(program);
 registerOpen(program);
+registerLifecycle(program);
 
 program.parse();

--- a/packages/cli/src/lib/create-session-manager.ts
+++ b/packages/cli/src/lib/create-session-manager.ts
@@ -22,7 +22,7 @@ let registryPromise: Promise<PluginRegistry> | null = null;
  * Caches the Promise (not the resolved value) so concurrent callers
  * await the same initialization rather than racing.
  */
-async function getRegistry(config: OrchestratorConfig): Promise<PluginRegistry> {
+export async function getRegistry(config: OrchestratorConfig): Promise<PluginRegistry> {
   if (!registryPromise) {
     registryPromise = (async () => {
       const registry = createPluginRegistry();

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -418,7 +418,7 @@ describe("check (single session)", () => {
       getCISummary: vi.fn().mockResolvedValue("failing"),
       getReviews: vi.fn(),
       getReviewDecision: vi.fn().mockResolvedValue("none"),
-      getPendingComments: vi.fn(),
+      getPendingComments: vi.fn().mockResolvedValue([]),
       getAutomatedComments: vi.fn(),
       getMergeability: vi.fn(),
     };
@@ -465,7 +465,7 @@ describe("check (single session)", () => {
       getCISummary: vi.fn(),
       getReviews: vi.fn(),
       getReviewDecision: vi.fn(),
-      getPendingComments: vi.fn(),
+      getPendingComments: vi.fn().mockResolvedValue([]),
       getAutomatedComments: vi.fn(),
       getMergeability: vi.fn(),
     };
@@ -512,7 +512,7 @@ describe("check (single session)", () => {
       getCISummary: vi.fn().mockResolvedValue("passing"),
       getReviews: vi.fn(),
       getReviewDecision: vi.fn().mockResolvedValue("approved"),
-      getPendingComments: vi.fn(),
+      getPendingComments: vi.fn().mockResolvedValue([]),
       getAutomatedComments: vi.fn(),
       getMergeability: vi.fn().mockResolvedValue({
         mergeable: true,
@@ -614,7 +614,7 @@ describe("reactions", () => {
       getCISummary: vi.fn().mockResolvedValue("failing"),
       getReviews: vi.fn(),
       getReviewDecision: vi.fn().mockResolvedValue("none"),
-      getPendingComments: vi.fn(),
+      getPendingComments: vi.fn().mockResolvedValue([]),
       getAutomatedComments: vi.fn(),
       getMergeability: vi.fn(),
     };
@@ -669,7 +669,7 @@ describe("reactions", () => {
       getCISummary: vi.fn().mockResolvedValue("failing"),
       getReviews: vi.fn(),
       getReviewDecision: vi.fn().mockResolvedValue("none"),
-      getPendingComments: vi.fn(),
+      getPendingComments: vi.fn().mockResolvedValue([]),
       getAutomatedComments: vi.fn(),
       getMergeability: vi.fn(),
     };
@@ -720,7 +720,7 @@ describe("reactions", () => {
       getCISummary: vi.fn().mockResolvedValue("failing"),
       getReviews: vi.fn(),
       getReviewDecision: vi.fn(),
-      getPendingComments: vi.fn(),
+      getPendingComments: vi.fn().mockResolvedValue([]),
       getAutomatedComments: vi.fn(),
       getMergeability: vi.fn(),
     };
@@ -793,7 +793,7 @@ describe("reactions", () => {
       getCISummary: vi.fn(),
       getReviews: vi.fn(),
       getReviewDecision: vi.fn(),
-      getPendingComments: vi.fn(),
+      getPendingComments: vi.fn().mockResolvedValue([]),
       getAutomatedComments: vi.fn(),
       getMergeability: vi.fn(),
     };

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -229,6 +229,15 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
         "There are review comments on your PR. Check with `gh pr view --comments` and `gh api` for inline comments. Address each one, push fixes, and reply.",
       escalateAfter: "30m",
     },
+    "review-comments": {
+      auto: true,
+      action: "send-to-agent",
+      message:
+        "There are new review comments on your PR. Check with `gh pr view --comments` and fetch inline comments with `gh api`. Address each comment, push fixes, and reply to resolve threads.",
+      retries: 2,
+      escalateAfter: "30m",
+      priority: "warning",
+    },
     "bugbot-comments": {
       auto: true,
       action: "send-to-agent",

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -102,6 +102,7 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
     dashboardPort: raw["dashboardPort"] ? Number(raw["dashboardPort"]) : undefined,
     terminalWsPort: raw["terminalWsPort"] ? Number(raw["terminalWsPort"]) : undefined,
     directTerminalWsPort: raw["directTerminalWsPort"] ? Number(raw["directTerminalWsPort"]) : undefined,
+    reviewCommentsSeen: raw["reviewCommentsSeen"],
   };
 }
 
@@ -147,6 +148,7 @@ export function writeMetadata(
     data["terminalWsPort"] = String(metadata.terminalWsPort);
   if (metadata.directTerminalWsPort !== undefined)
     data["directTerminalWsPort"] = String(metadata.directTerminalWsPort);
+  if (metadata.reviewCommentsSeen) data["reviewCommentsSeen"] = metadata.reviewCommentsSeen;
 
   writeFileSync(path, serializeMetadata(data), "utf-8");
 }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -92,6 +92,7 @@ const VALID_STATUSES: ReadonlySet<string> = new Set([
   "ci_failed",
   "review_pending",
   "changes_requested",
+  "review_comments_unresolved",
   "approved",
   "mergeable",
   "merged",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,6 +30,7 @@ export type SessionStatus =
   | "ci_failed"
   | "review_pending"
   | "changes_requested"
+  | "review_comments_unresolved"
   | "approved"
   | "mergeable"
   | "merged"
@@ -78,6 +79,7 @@ export const SESSION_STATUS = {
   CI_FAILED: "ci_failed" as const,
   REVIEW_PENDING: "review_pending" as const,
   CHANGES_REQUESTED: "changes_requested" as const,
+  REVIEW_COMMENTS_UNRESOLVED: "review_comments_unresolved" as const,
   APPROVED: "approved" as const,
   MERGEABLE: "mergeable" as const,
   MERGED: "merged" as const,
@@ -969,6 +971,7 @@ export interface SessionMetadata {
   dashboardPort?: number;
   terminalWsPort?: number;
   directTerminalWsPort?: number;
+  reviewCommentsSeen?: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Adds automated review comment detection to the lifecycle polling loop
- When unresolved PR review comments are detected, transitions session to `review_comments_unresolved` status and triggers the `review-comments` reaction (sends fix instructions to the agent automatically)
- Prevents `mergeable` status when there are pending review comments
- New `ao lifecycle start/check` CLI commands replace manual `ao review-check` polling

## Changes

**Core types (`types.ts`):**
- New `review_comments_unresolved` session status
- New `reviewCommentsSeen` field on `SessionMetadata` for dedup tracking

**Lifecycle manager (`lifecycle-manager.ts`):**
- `determineStatus()` now calls `getPendingComments()` and tracks seen comment IDs
- `pendingCommentsCache` Map avoids redundant API calls within a single poll cycle
- Re-triggers reaction when new comments appear while already in `review_comments_unresolved`
- Blocks `mergeable` status when pending comments exist (approved + green CI but unresolved threads)

**Config (`config.ts`):**
- New `review-comments` default reaction: auto send-to-agent, 2 retries, escalates after 30m

**CLI:**
- New `ao lifecycle start` (foreground polling) and `ao lifecycle check <session>` commands
- Deprecation notice on `ao review-check` (still functional)

## Replaces

Replaces #63 (closed due to conflicts with #58 hash-based metadata architecture). Clean re-implementation on current main.

## Test plan

- [x] All 131 tests pass
- [x] Lint clean (0 errors)
- [x] Build passes (web typecheck failures are pre-existing)
- [ ] Manual: ao lifecycle start polls and detects review comments
- [ ] Manual: Agent receives fix instructions when comments appear
- [ ] Manual: Duplicate comments don't re-trigger reaction

Generated with Claude Code