### PR TITLE
feat(cli): add ao doctor command and Node.js version guard in ao init

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,351 @@
+import { existsSync, accessSync, constants } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import chalk from "chalk";
+import type { Command } from "commander";
+import { execSilent, git } from "../lib/shell.js";
+import { findConfigFile, loadConfig } from "@composio/ao-core";
+
+const MIN_NODE_MAJOR = 20;
+
+interface CheckResult {
+  name: string;
+  status: "pass" | "warn" | "fail";
+  message: string;
+  fix?: string;
+}
+
+function pass(name: string, message: string): CheckResult {
+  return { name, status: "pass", message };
+}
+
+function warn(name: string, message: string, fix?: string): CheckResult {
+  return { name, status: "warn", message, fix };
+}
+
+function fail(name: string, message: string, fix?: string): CheckResult {
+  return { name, status: "fail", message, fix };
+}
+
+function expandPath(p: string): string {
+  if (p.startsWith("~/")) return resolve(homedir(), p.slice(2));
+  return p;
+}
+
+function isDirectoryWritable(dirPath: string): boolean {
+  if (existsSync(dirPath)) {
+    try {
+      accessSync(dirPath, constants.W_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  // If it doesn't exist, check the parent directory
+  const parent = resolve(dirPath, "..");
+  if (existsSync(parent)) {
+    try {
+      accessSync(parent, constants.W_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+async function checkNodeVersion(): Promise<CheckResult> {
+  const [major] = process.versions.node.split(".").map(Number);
+  if (major >= MIN_NODE_MAJOR) {
+    return pass("Node.js", `v${process.versions.node} (>= ${MIN_NODE_MAJOR} required)`);
+  }
+  return fail(
+    "Node.js",
+    `v${process.versions.node} — requires Node ${MIN_NODE_MAJOR}+`,
+    `Install Node.js ${MIN_NODE_MAJOR}+ via: nvm install ${MIN_NODE_MAJOR} && nvm use ${MIN_NODE_MAJOR}`,
+  );
+}
+
+async function checkGit(): Promise<CheckResult> {
+  const output = await execSilent("git", ["--version"]);
+  if (!output) {
+    return fail("Git", "not found", "Install git: https://git-scm.com/downloads");
+  }
+  return pass("Git", output.replace("git version ", ""));
+}
+
+async function checkGitRepo(): Promise<CheckResult> {
+  const result = await git(["rev-parse", "--git-dir"]);
+  if (!result) {
+    return warn("Git repo", "not in a git repository — ao works best inside a git repo");
+  }
+  return pass("Git repo", "current directory is a git repository");
+}
+
+async function checkTmux(): Promise<CheckResult> {
+  const output = await execSilent("tmux", ["-V"]);
+  if (!output) {
+    return fail(
+      "tmux",
+      "not found (required for default tmux runtime)",
+      "Install with: brew install tmux  (or apt install tmux)",
+    );
+  }
+  return pass("tmux", output.trim());
+}
+
+async function checkGhCli(): Promise<CheckResult[]> {
+  const version = await execSilent("gh", ["--version"]);
+  if (!version) {
+    return [
+      warn(
+        "GitHub CLI",
+        "not found — required for GitHub tracker and SCM features",
+        "Install with: brew install gh",
+      ),
+    ];
+  }
+
+  const versionLine = version.split("\n")[0] ?? "gh";
+  const authOutput = await execSilent("gh", ["auth", "status"]);
+  if (authOutput === null) {
+    return [
+      pass("GitHub CLI", versionLine),
+      warn("GitHub CLI auth", "not authenticated", "Run: gh auth login"),
+    ];
+  }
+  return [
+    pass("GitHub CLI", versionLine),
+    pass("GitHub CLI auth", "authenticated"),
+  ];
+}
+
+async function checkAgentCli(): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  const claudeVersion = await execSilent("claude", ["--version"]);
+  if (claudeVersion) {
+    results.push(pass("claude-code", claudeVersion.split("\n")[0] ?? "installed"));
+  } else {
+    results.push(
+      warn(
+        "claude-code",
+        "not found — required if using the claude-code agent plugin",
+        "Install with: npm install -g @anthropic-ai/claude-code",
+      ),
+    );
+  }
+
+  const codexVersion = await execSilent("codex", ["--version"]);
+  if (codexVersion) {
+    results.push(pass("codex", codexVersion.split("\n")[0] ?? "installed"));
+  }
+
+  const aiderVersion = await execSilent("aider", ["--version"]);
+  if (aiderVersion) {
+    results.push(pass("aider", aiderVersion.split("\n")[0] ?? "installed"));
+  }
+
+  // At least one agent must be present
+  const hasAnyAgent = claudeVersion || codexVersion || aiderVersion;
+  if (!hasAnyAgent) {
+    // Already warned about claude-code above; no need to add another entry
+  }
+
+  return results;
+}
+
+async function checkConfig(): Promise<CheckResult[]> {
+  const configPath = findConfigFile();
+  if (!configPath) {
+    return [
+      warn(
+        "Config file",
+        "agent-orchestrator.yaml not found in current directory or parent directories",
+        "Run: ao init",
+      ),
+    ];
+  }
+
+  const results: CheckResult[] = [pass("Config file", configPath)];
+
+  try {
+    loadConfig(configPath);
+    results.push(pass("Config validation", "valid"));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    results.push(fail("Config validation", message, `Fix the errors in ${configPath}`));
+  }
+
+  return results;
+}
+
+async function checkDirectories(_configPath: string | null): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  const dataDir = "~/.agent-orchestrator";
+  const worktreeDir = "~/.worktrees";
+
+  const expandedDataDir = expandPath(dataDir);
+  const expandedWorktreeDir = expandPath(worktreeDir);
+
+  if (isDirectoryWritable(expandedDataDir)) {
+    results.push(
+      pass("dataDir", `${dataDir} — ${existsSync(expandedDataDir) ? "exists and writable" : "parent writable, will be created"}`),
+    );
+  } else {
+    results.push(
+      fail(
+        "dataDir",
+        `${dataDir} — not writable`,
+        `Run: mkdir -p ${expandedDataDir} && chmod 755 ${expandedDataDir}`,
+      ),
+    );
+  }
+
+  if (isDirectoryWritable(expandedWorktreeDir)) {
+    results.push(
+      pass("worktreeDir", `${worktreeDir} — ${existsSync(expandedWorktreeDir) ? "exists and writable" : "parent writable, will be created"}`),
+    );
+  } else {
+    results.push(
+      fail(
+        "worktreeDir",
+        `${worktreeDir} — not writable`,
+        `Run: mkdir -p ${expandedWorktreeDir} && chmod 755 ${expandedWorktreeDir}`,
+      ),
+    );
+  }
+
+  return results;
+}
+
+async function checkOptionalIntegrations(): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  if (process.env["LINEAR_API_KEY"]) {
+    results.push(pass("LINEAR_API_KEY", "set"));
+  } else {
+    results.push(
+      warn(
+        "LINEAR_API_KEY",
+        "not set — required for Linear tracker",
+        "Set in your shell profile: export LINEAR_API_KEY=lin_api_...",
+      ),
+    );
+  }
+
+  if (process.env["SLACK_WEBHOOK_URL"]) {
+    results.push(pass("SLACK_WEBHOOK_URL", "set"));
+  }
+
+  return results;
+}
+
+function printCheck(check: CheckResult): void {
+  const icon =
+    check.status === "pass" ? chalk.green("✓") :
+    check.status === "warn" ? chalk.yellow("⚠") :
+    chalk.red("✗");
+
+  const nameCol = chalk.bold(check.name.padEnd(22));
+  const messageColor =
+    check.status === "pass" ? chalk.dim :
+    check.status === "warn" ? chalk.yellow :
+    chalk.red;
+
+  console.log(`  ${icon} ${nameCol} ${messageColor(check.message)}`);
+  if (check.fix && check.status !== "pass") {
+    console.log(`    ${chalk.dim("→")} ${chalk.cyan(check.fix)}`);
+  }
+}
+
+export function registerDoctor(program: Command): void {
+  program
+    .command("doctor")
+    .description("Check system health — verify prerequisites and configuration")
+    .action(async () => {
+      console.log(chalk.bold.cyan("\n  ao doctor — System Health Check\n"));
+
+      const allChecks: CheckResult[] = [];
+
+      // --- Core prerequisites ---
+      console.log(chalk.bold("  Core prerequisites"));
+      const nodeCheck = await checkNodeVersion();
+      allChecks.push(nodeCheck);
+      printCheck(nodeCheck);
+
+      const gitCheck = await checkGit();
+      allChecks.push(gitCheck);
+      printCheck(gitCheck);
+
+      const gitRepoCheck = await checkGitRepo();
+      allChecks.push(gitRepoCheck);
+      printCheck(gitRepoCheck);
+
+      const tmuxCheck = await checkTmux();
+      allChecks.push(tmuxCheck);
+      printCheck(tmuxCheck);
+
+      // --- GitHub CLI ---
+      console.log(chalk.bold("\n  GitHub CLI"));
+      const ghChecks = await checkGhCli();
+      allChecks.push(...ghChecks);
+      ghChecks.forEach(printCheck);
+
+      // --- Agent CLIs ---
+      console.log(chalk.bold("\n  Agent CLIs"));
+      const agentChecks = await checkAgentCli();
+      allChecks.push(...agentChecks);
+      agentChecks.forEach(printCheck);
+
+      // --- Configuration ---
+      console.log(chalk.bold("\n  Configuration"));
+      const configChecks = await checkConfig();
+      allChecks.push(...configChecks);
+      configChecks.forEach(printCheck);
+
+      // --- Directories ---
+      const configPath = findConfigFile();
+      console.log(chalk.bold("\n  Directories"));
+      const dirChecks = await checkDirectories(configPath);
+      allChecks.push(...dirChecks);
+      dirChecks.forEach(printCheck);
+
+      // --- Optional integrations ---
+      console.log(chalk.bold("\n  Optional integrations"));
+      const optionalChecks = await checkOptionalIntegrations();
+      allChecks.push(...optionalChecks);
+      optionalChecks.forEach(printCheck);
+
+      // --- Summary ---
+      const failures = allChecks.filter((c) => c.status === "fail");
+      const warnings = allChecks.filter((c) => c.status === "warn");
+      const passes = allChecks.filter((c) => c.status === "pass");
+
+      console.log();
+      if (failures.length === 0 && warnings.length === 0) {
+        console.log(chalk.green.bold(`  ✓ All ${passes.length} checks passed — you're good to go!`));
+      } else if (failures.length === 0) {
+        console.log(
+          chalk.yellow.bold(
+            `  ⚠ ${passes.length} passed, ${warnings.length} warning${warnings.length !== 1 ? "s" : ""} — optional features may be unavailable`,
+          ),
+        );
+      } else {
+        console.log(
+          chalk.red.bold(
+            `  ✗ ${failures.length} critical issue${failures.length !== 1 ? "s" : ""} found (${warnings.length} warning${warnings.length !== 1 ? "s" : ""}, ${passes.length} passed)`,
+          ),
+        );
+        console.log(chalk.dim("\n  Fix the critical issues above before running ao start\n"));
+      }
+
+      console.log();
+
+      // Exit with non-zero code if there are critical failures
+      if (failures.length > 0) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -13,6 +13,7 @@ import {
   formatProjectTypeForDisplay,
 } from "../lib/project-detection.js";
 
+const MIN_NODE_MAJOR = 20;
 const DEFAULT_PORT = 3000;
 const MAX_PORT_SCAN = 100;
 
@@ -161,6 +162,18 @@ export function registerInit(program: Command): void {
     )
     .action(async (opts: { output: string; auto?: boolean; smart?: boolean }) => {
       const outputPath = resolve(opts.output);
+
+      // Check Node.js version requirement
+      const nodeMajor = parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+      if (nodeMajor < MIN_NODE_MAJOR) {
+        console.error(
+          chalk.red(`Error: Node.js ${MIN_NODE_MAJOR}+ is required (you have v${process.versions.node})`),
+        );
+        console.log(
+          chalk.dim(`  Upgrade with: nvm install ${MIN_NODE_MAJOR} && nvm use ${MIN_NODE_MAJOR}`),
+        );
+        process.exit(1);
+      }
 
       if (existsSync(outputPath)) {
         console.log(chalk.yellow(`Config already exists: ${outputPath}`));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from "commander";
 import { registerInit } from "./commands/init.js";
+import { registerDoctor } from "./commands/doctor.js";
 import { registerStatus } from "./commands/status.js";
 import { registerSpawn, registerBatchSpawn } from "./commands/spawn.js";
 import { registerSession } from "./commands/session.js";
@@ -19,6 +20,7 @@ program
   .version("0.1.0");
 
 registerInit(program);
+registerDoctor(program);
 registerStart(program);
 registerStop(program);
 registerStatus(program);


### PR DESCRIPTION
## Summary

Implements the prerequisite checking and health-check parts of the end-to-end install & setup experience (#15).

- **`ao doctor`** — new command that runs a comprehensive system health check before you start using ao:
  - Node.js version (≥ 20 required)
  - Git availability
  - Git repository detection
  - tmux availability (required for default runtime)
  - GitHub CLI presence and auth status
  - Agent CLI availability (claude-code, codex, aider — warns if none found)
  - Config file discovery and Zod validation
  - Write permissions for dataDir (`~/.agent-orchestrator`) and worktreeDir (`~/.worktrees`)
  - Optional integrations (LINEAR_API_KEY, SLACK_WEBHOOK_URL)
  - Each check shows ✓ / ⚠ / ✗ with an actionable fix instruction
  - Exits with non-zero if any critical checks fail

- **`ao init` Node.js guard** — fails fast with a clear message if the user is running Node < 20, before any interactive prompts

## Test plan

- [ ] Run `ao doctor` in a repo with all dependencies installed — all checks green
- [ ] Run `ao doctor` without tmux — shows ✗ with install instructions
- [ ] Run `ao doctor` without a config file — shows warning with `ao init` suggestion
- [ ] Run `ao doctor` with an invalid config — shows ✗ on config validation
- [ ] `ao init` on Node 18 exits with clear error message
- [ ] `pnpm build` and `pnpm lint` pass (verified locally)

Closes #15 (partial — implements prerequisite checks and `ao doctor`; npm publish and README quickstart are separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)