### PR TITLE
chore: disable release workflow until NPM_TOKEN is configured

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch: # Manual trigger only until NPM_TOKEN is configured
+  # push:
+  #   branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Switch release workflow from automatic (on push to main) to manual trigger (`workflow_dispatch`)
- The workflow fails on every push because `NPM_TOKEN` secret is not configured, causing a red X on main

## To re-enable
1. Add `NPM_TOKEN` secret in repo Settings → Secrets → Actions (generate from npmjs.com under `@composio` org)
2. Uncomment the `push` trigger in `.github/workflows/release.yml`

## Test plan
- [ ] Verify no release job runs on next push to main
- [ ] Verify workflow can still be triggered manually from Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)