### PR TITLE
fix(codex): support current Codex CLI flags for system prompt

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -323,7 +323,7 @@ export interface AgentLaunchConfig {
   /**
    * System prompt to pass to the agent for orchestrator context.
    * - Claude Code: --append-system-prompt
-   * - Codex: --system-prompt or AGENTS.md
+   * - Codex: -c developer_instructions=... or AGENTS.md
    * - Aider: --system-prompt flag
    * - OpenCode: equivalent mechanism
    *
@@ -338,7 +338,8 @@ export interface AgentLaunchConfig {
    *
    * When set, takes precedence over systemPrompt.
    * - Claude Code: --append-system-prompt "$(cat /path/to/file)"
-   * - Codex/Aider: similar shell substitution
+   * - Codex: -c "developer_instructions=$(cat /path/to/file)"
+   * - Aider: --system-prompt "$(cat /path/to/file)"
    */
   systemPromptFile?: string;
 }

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -38,7 +38,7 @@ function createCodexAgent(): Agent {
       const parts: string[] = ["codex"];
 
       if (config.permissions === "skip") {
-        parts.push("--approval-mode", "full-auto");
+        parts.push("--full-auto");
       }
 
       if (config.model) {
@@ -46,9 +46,9 @@ function createCodexAgent(): Agent {
       }
 
       if (config.systemPromptFile) {
-        parts.push("--system-prompt", `"$(cat ${shellEscape(config.systemPromptFile)})"`);
+        parts.push("-c", `"developer_instructions=$(cat ${shellEscape(config.systemPromptFile)})"`);
       } else if (config.systemPrompt) {
-        parts.push("--system-prompt", shellEscape(config.systemPrompt));
+        parts.push("-c", shellEscape(`developer_instructions=${config.systemPrompt}`));
       }
 
       if (config.prompt) {


### PR DESCRIPTION
## Summary
- replace deprecated Codex launch args in the `agent-codex` plugin: use `--full-auto` instead of `--approval-mode full-auto`
- pass orchestrator system prompt through supported Codex config override (`-c developer_instructions=...`) for both inline and file-based prompts
- add/update tests for the new command shape and refresh `AgentLaunchConfig` docs for Codex behavior

## Test Plan
- [x] `pnpm --filter @composio/ao-plugin-agent-codex test`
- [x] `pnpm --filter @composio/ao-plugin-agent-codex build`
- [x] `pnpm --filter @composio/ao-core typecheck`
- [x] manual verification: `ao start pain-radar --no-dashboard` launches Codex with `-c "developer_instructions=$(cat ...)"` and no `--system-prompt` error
