### PR TITLE
feat: ao status — support showing exited/historical sessions and search

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -333,9 +333,10 @@ export function registerStatus(program: Command): void {
 
         if (filteredInfos.length === 0) {
           if (!opts.json) {
-            const label = opts.search
-              ? "(no matching sessions)"
-              : "(no active sessions)";
+            let label = "(no active sessions)";
+            if (opts.search) label = "(no matching sessions)";
+            else if (opts.state === "exited") label = "(no exited sessions)";
+            else if (opts.state === "active") label = "(no active sessions)";
             console.log(chalk.dim(`  ${label}`));
             console.log();
           }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -159,13 +159,14 @@ function printTableHeader(): void {
   console.log(chalk.dim(`  ${"─".repeat(totalWidth)}`));
 }
 
-function printSessionRow(info: SessionInfo): void {
+function printSessionRow(info: SessionInfo, dimmed = false): void {
   const prStr = info.prNumber ? `#${info.prNumber}` : "-";
+  const nameStyle = dimmed ? chalk.dim : chalk.green;
 
   const row =
-    padCol(chalk.green(info.name), COL.session) +
-    padCol(info.branch ? chalk.cyan(info.branch) : chalk.dim("-"), COL.branch) +
-    padCol(info.prNumber ? chalk.blue(prStr) : chalk.dim(prStr), COL.pr) +
+    padCol(nameStyle(info.name), COL.session) +
+    padCol(info.branch ? (dimmed ? chalk.dim(info.branch) : chalk.cyan(info.branch)) : chalk.dim("-"), COL.branch) +
+    padCol(info.prNumber ? (dimmed ? chalk.dim(prStr) : chalk.blue(prStr)) : chalk.dim(prStr), COL.pr) +
     padCol(ciStatusIcon(info.ciStatus), COL.ci) +
     padCol(reviewDecisionIcon(info.reviewDecision), COL.review) +
     padCol(
@@ -186,13 +187,31 @@ function printSessionRow(info: SessionInfo): void {
   }
 }
 
+/** Check if a session matches a search query (case-insensitive). */
+function matchesSearch(info: SessionInfo, query: string): boolean {
+  const q = query.toLowerCase();
+  return (
+    info.name.toLowerCase().includes(q) ||
+    (info.branch?.toLowerCase().includes(q) ?? false) ||
+    (info.pr?.toLowerCase().includes(q) ?? false) ||
+    (info.prNumber !== null && String(info.prNumber).includes(q)) ||
+    (info.issue?.toLowerCase().includes(q) ?? false) ||
+    (info.summary?.toLowerCase().includes(q) ?? false) ||
+    (info.claudeSummary?.toLowerCase().includes(q) ?? false) ||
+    (info.project?.toLowerCase().includes(q) ?? false)
+  );
+}
+
 export function registerStatus(program: Command): void {
   program
     .command("status")
     .description("Show all sessions with branch, activity, PR, and CI status")
     .option("-p, --project <id>", "Filter by project ID")
     .option("--json", "Output as JSON")
-    .action(async (opts: { project?: string; json?: boolean }) => {
+    .option("-a, --all", "Include exited/archived sessions")
+    .option("--state <state>", "Filter by session state (active, exited)")
+    .option("-s, --search <query>", "Search sessions by PR, branch, issue, or summary")
+    .action(async (opts: { project?: string; json?: boolean; all?: boolean; state?: string; search?: string }) => {
       let config: ReturnType<typeof loadConfig>;
       try {
         config = loadConfig();
@@ -208,9 +227,14 @@ export function registerStatus(program: Command): void {
         process.exit(1);
       }
 
+      // Determine whether to include archived sessions
+      const includeArchived = opts.all || opts.state === "exited" || !!opts.search;
+
       // Use session manager to list sessions (metadata-based, not tmux-based)
       const sm = await getSessionManager(config);
-      const sessions = await sm.list(opts.project);
+      const sessions = includeArchived
+        ? await sm.listAll(opts.project)
+        : await sm.list(opts.project);
 
       if (!opts.json) {
         console.log(banner("AGENT ORCHESTRATOR STATUS"));
@@ -227,7 +251,8 @@ export function registerStatus(program: Command): void {
 
       // Show projects that have no sessions too (if not filtered)
       const projectIds = opts.project ? [opts.project] : Object.keys(config.projects);
-      let totalSessions = 0;
+      let totalActive = 0;
+      let totalExited = 0;
       const jsonOutput: SessionInfo[] = [];
 
       for (const projectId of projectIds) {
@@ -255,21 +280,74 @@ export function registerStatus(program: Command): void {
           continue;
         }
 
-        totalSessions += projectSessions.length;
-
-        if (!opts.json) {
-          printTableHeader();
-        }
-
         // Gather all session info in parallel
         const infoPromises = projectSessions.map((s) => gatherSessionInfo(s, agent, scm, config));
-        const sessionInfos = await Promise.all(infoPromises);
+        const allInfos = await Promise.all(infoPromises);
 
-        for (const info of sessionInfos) {
-          if (opts.json) {
-            jsonOutput.push(info);
-          } else {
-            printSessionRow(info);
+        // Apply search filter if specified
+        let filteredInfos = allInfos;
+        if (opts.search) {
+          filteredInfos = allInfos.filter((info) => matchesSearch(info, opts.search!));
+        }
+
+        // Apply state filter
+        if (opts.state === "exited") {
+          filteredInfos = filteredInfos.filter((info) => info.activity === "exited");
+        } else if (opts.state === "active") {
+          filteredInfos = filteredInfos.filter((info) => info.activity !== "exited");
+        }
+
+        // Separate active and exited sessions
+        const activeSessions = filteredInfos.filter((info) => info.activity !== "exited");
+        const exitedSessions = filteredInfos.filter((info) => info.activity === "exited");
+
+        totalActive += activeSessions.length;
+        totalExited += exitedSessions.length;
+
+        if (filteredInfos.length === 0) {
+          if (!opts.json) {
+            const label = opts.search
+              ? "(no matching sessions)"
+              : "(no active sessions)";
+            console.log(chalk.dim(`  ${label}`));
+            console.log();
+          }
+          continue;
+        }
+
+        // Print active sessions
+        if (activeSessions.length > 0) {
+          if (!opts.json) {
+            printTableHeader();
+          }
+          for (const info of activeSessions) {
+            if (opts.json) {
+              jsonOutput.push(info);
+            } else {
+              printSessionRow(info);
+            }
+          }
+          if (!opts.json && exitedSessions.length > 0) {
+            console.log();
+          }
+        }
+
+        // Print exited sessions with dimmed styling
+        if (exitedSessions.length > 0) {
+          if (!opts.json) {
+            if (activeSessions.length > 0 || includeArchived) {
+              console.log(chalk.dim(`  ── exited sessions ──`));
+            }
+            if (activeSessions.length === 0) {
+              printTableHeader();
+            }
+          }
+          for (const info of exitedSessions) {
+            if (opts.json) {
+              jsonOutput.push(info);
+            } else {
+              printSessionRow(info, true);
+            }
           }
         }
 
@@ -281,9 +359,17 @@ export function registerStatus(program: Command): void {
       if (opts.json) {
         console.log(JSON.stringify(jsonOutput, null, 2));
       } else {
+        const parts: string[] = [];
+        if (totalActive > 0 || !includeArchived) {
+          parts.push(`${totalActive} active session${totalActive !== 1 ? "s" : ""}`);
+        }
+        if (totalExited > 0) {
+          parts.push(`${totalExited} exited session${totalExited !== 1 ? "s" : ""}`);
+        }
+        const summary = parts.length > 0 ? parts.join(", ") : "0 sessions";
         console.log(
           chalk.dim(
-            `  ${totalSessions} active session${totalSessions !== 1 ? "s" : ""} across ${projectIds.length} project${projectIds.length !== 1 ? "s" : ""}`,
+            `  ${summary} across ${projectIds.length} project${projectIds.length !== 1 ? "s" : ""}`,
           ),
         );
         console.log();

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -106,6 +106,7 @@ beforeEach(() => {
     spawnOrchestrator: vi.fn(),
     restore: vi.fn(),
     list: vi.fn().mockResolvedValue([]),
+    listAll: vi.fn().mockResolvedValue([]),
     get: vi.fn().mockResolvedValue(null),
     kill: vi.fn().mockResolvedValue(undefined),
     cleanup: vi.fn(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,7 +29,6 @@ export {
   updateMetadata,
   deleteMetadata,
   listMetadata,
-  listArchivedMetadata,
   scanArchivedSessions,
 } from "./metadata.js";
 export type { ArchivedSessionEntry } from "./metadata.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export {
   updateMetadata,
   deleteMetadata,
   listMetadata,
+  listArchivedMetadata,
 } from "./metadata.js";
 
 // tmux — command wrappers

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,7 +30,9 @@ export {
   deleteMetadata,
   listMetadata,
   listArchivedMetadata,
+  scanArchivedSessions,
 } from "./metadata.js";
+export type { ArchivedSessionEntry } from "./metadata.js";
 
 // tmux — command wrappers
 export {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -280,6 +280,64 @@ export function listArchivedMetadata(dataDir: string): SessionId[] {
   return Array.from(seen);
 }
 
+export interface ArchivedSessionEntry {
+  sessionId: SessionId;
+  raw: Record<string, string>;
+  createdAt: Date | undefined;
+  modifiedAt: Date | undefined;
+}
+
+/**
+ * Scan the archive directory once and return metadata + file timestamps
+ * for each unique session. Reads the directory only once (O(F) where F is
+ * the total number of archive files), avoiding the O(N×F) cost of calling
+ * listArchivedMetadata + readArchivedMetadataRaw + statSync per session.
+ */
+export function scanArchivedSessions(dataDir: string): ArchivedSessionEntry[] {
+  const archiveDir = join(dataDir, "archive");
+  if (!existsSync(archiveDir)) return [];
+
+  // Single directory read — build a map of sessionId → latest filename
+  const latestFiles = new Map<string, string>();
+  for (const file of readdirSync(archiveDir)) {
+    if (file.startsWith(".")) continue;
+    const lastUnderscoreIdx = file.lastIndexOf("_");
+    if (lastUnderscoreIdx === -1) continue;
+    const sessionId = file.slice(0, lastUnderscoreIdx);
+    const charAfterSep = file[lastUnderscoreIdx + 1];
+    if (!charAfterSep || charAfterSep < "0" || charAfterSep > "9") continue;
+    if (!sessionId || !VALID_SESSION_ID.test(sessionId)) continue;
+
+    const existing = latestFiles.get(sessionId);
+    if (!existing || file > existing) {
+      latestFiles.set(sessionId, file);
+    }
+  }
+
+  // Read metadata + stats for the latest file of each session
+  const results: ArchivedSessionEntry[] = [];
+  for (const [sessionId, latestFile] of latestFiles) {
+    const filePath = join(archiveDir, latestFile);
+    try {
+      const raw = parseMetadataFile(readFileSync(filePath, "utf-8"));
+      let createdAt: Date | undefined;
+      let modifiedAt: Date | undefined;
+      try {
+        const stats = statSync(filePath);
+        createdAt = stats.birthtime;
+        modifiedAt = stats.mtime;
+      } catch {
+        // stat failed — timestamps will default in caller
+      }
+      results.push({ sessionId, raw, createdAt, modifiedAt });
+    } catch {
+      // File read failed — skip this session
+    }
+  }
+
+  return results;
+}
+
 /**
  * Atomically reserve a session ID by creating its metadata file with O_EXCL.
  * Returns true if the ID was successfully reserved, false if it already exists.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -981,6 +981,8 @@ export interface SessionManager {
   spawnOrchestrator(config: OrchestratorSpawnConfig): Promise<Session>;
   restore(sessionId: SessionId): Promise<Session>;
   list(projectId?: string): Promise<Session[]>;
+  /** List all sessions including archived/exited ones. */
+  listAll(projectId?: string): Promise<Session[]>;
   get(sessionId: SessionId): Promise<Session | null>;
   kill(sessionId: SessionId): Promise<void>;
   cleanup(projectId?: string, options?: { dryRun?: boolean }): Promise<CleanupResult>;


### PR DESCRIPTION
## Summary

Adds `--all`, `--state`, and `--search` flags to `ao status` so users can discover exited/archived sessions and search across all session metadata.

Closes #138

## Changes

### Core (`@composio/ao-core`)

- **`metadata.ts`**: New `listArchivedMetadata()` function that scans the `archive/` subdirectory for unique session IDs
- **`types.ts`**: Added `listAll()` to the `SessionManager` interface
- **`session-manager.ts`**: Implemented `listAll()` — combines active sessions (fully enriched) with archived sessions (skip expensive runtime enrichment, `activity: "exited"`)
- **`index.ts`**: Exported `listArchivedMetadata`

### CLI (`@composio/ao-cli`)

- **`status.ts`**: Three new options:
  - `-a, --all` — Include exited/archived sessions, displayed in a separate dimmed group
  - `--state <state>` — Filter by `active` or `exited` (implies `--all`)
  - `-s, --search <query>` — Case-insensitive search across name, branch, PR, issue, and summary (implies `--all`)
- Visual distinction: exited sessions shown with `chalk.dim()` styling and grouped under an `── exited sessions ──` separator
- Updated footer summary: shows `X active sessions, Y exited sessions` when `--all` is used

### Tests

- 7 new tests in `status.test.ts` covering:
  - `--all` shows archived + active with visual separator
  - `--all` footer summary counts
  - `--state exited` filters correctly
  - `--search` by branch name, issue ID
  - `--search` with no results shows graceful message
  - `--json --all` includes archived sessions
- All 25 CLI status tests pass ✅
- All 245 core tests pass ✅
- Full typecheck passes ✅

## Usage

```bash
# Show all sessions including historical ones
ao status --all

# Show only exited sessions
ao status --state exited

# Search for a specific PR or issue
ao status --search "#1189"
ao status --search "INT-100"

# Combine: search + JSON output
ao status --search login --json
```