### PR TITLE
feat: Add jira tracker plugin

### DIFF
--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -37,6 +37,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   // Trackers
   { slot: "tracker", name: "github", pkg: "@composio/ao-plugin-tracker-github" },
   { slot: "tracker", name: "linear", pkg: "@composio/ao-plugin-tracker-linear" },
+  { slot: "tracker", name: "jira", pkg: "@composio/ao-plugin-tracker-jira" },
   // SCM
   { slot: "scm", name: "github", pkg: "@composio/ao-plugin-scm-github" },
   // Notifiers

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -19,7 +19,8 @@
     "@composio/ao-plugin-runtime-process": "workspace:*",
     "@composio/ao-plugin-workspace-worktree": "workspace:*",
     "@composio/ao-plugin-workspace-clone": "workspace:*",
-    "@composio/ao-plugin-tracker-linear": "workspace:*"
+    "@composio/ao-plugin-tracker-linear": "workspace:*",
+    "@composio/ao-plugin-tracker-jira": "workspace:*"
   },
   "devDependencies": {
     "@composio/ao-plugin-notifier-desktop": "workspace:*",

--- a/packages/integration-tests/src/tracker-jira.integration.test.ts
+++ b/packages/integration-tests/src/tracker-jira.integration.test.ts
@@ -112,8 +112,8 @@ function jiraApi<T>(method: string, path: string, body?: unknown): Promise<T> {
 // ---------------------------------------------------------------------------
 
 describe.skipIf(!canRun)("tracker-jira (integration)", () => {
-  const transport = hasComposioCredentials ? "composio" : "direct";
-  const tracker = trackerJira.create({ transport });
+  // Auto-detects transport from env: COMPOSIO_API_KEY → Composio, else direct
+  const tracker = trackerJira.create();
 
   const project: ProjectConfig = {
     name: "test-project",
@@ -124,6 +124,7 @@ describe.skipIf(!canRun)("tracker-jira (integration)", () => {
     tracker: {
       plugin: "jira",
       projectKey: JIRA_PROJECT_KEY!,
+      host: JIRA_HOST!,
     },
   };
 

--- a/packages/integration-tests/src/tracker-jira.integration.test.ts
+++ b/packages/integration-tests/src/tracker-jira.integration.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Integration tests for the Jira tracker plugin.
+ *
+ * Requires one of:
+ *   - JIRA_HOST + JIRA_EMAIL + JIRA_API_TOKEN (direct Jira API access), or
+ *   - COMPOSIO_API_KEY + JIRA_HOST (via Composio SDK, optionally COMPOSIO_ENTITY_ID)
+ * Plus:
+ *   - JIRA_PROJECT_KEY (project to create test issues in, e.g. "PROJ")
+ *
+ * When using Composio, cleanup (issue deletion) still requires direct API
+ * credentials since deletion uses a direct REST call outside the plugin.
+ *
+ * Skipped automatically when prerequisites are missing.
+ *
+ * Each test run creates a real Jira issue, exercises the plugin methods
+ * against it, and deletes it in cleanup. This validates that our API
+ * calls, state mapping, and data parsing work against the real API —
+ * not just against mocked responses.
+ */
+
+import { request } from "node:https";
+import type { ProjectConfig } from "@composio/ao-core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import trackerJira from "@composio/ao-plugin-tracker-jira";
+import { pollUntilEqual } from "./helpers/polling.js";
+
+// ---------------------------------------------------------------------------
+// Prerequisites
+// ---------------------------------------------------------------------------
+
+const JIRA_HOST = process.env["JIRA_HOST"];
+const JIRA_EMAIL = process.env["JIRA_EMAIL"];
+const JIRA_API_TOKEN = process.env["JIRA_API_TOKEN"];
+const COMPOSIO_API_KEY = process.env["COMPOSIO_API_KEY"];
+const JIRA_PROJECT_KEY = process.env["JIRA_PROJECT_KEY"];
+
+const hasDirectCredentials = Boolean(JIRA_HOST && JIRA_EMAIL && JIRA_API_TOKEN);
+const hasComposioCredentials = Boolean(COMPOSIO_API_KEY && JIRA_HOST);
+const hasCredentials = hasDirectCredentials || hasComposioCredentials;
+const canRun = hasCredentials && Boolean(JIRA_PROJECT_KEY);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Direct Jira REST API call for test setup/cleanup.
+ * Only available when direct credentials are set.
+ */
+function jiraApi<T>(method: string, path: string, body?: unknown): Promise<T> {
+  if (!JIRA_HOST || !JIRA_EMAIL || !JIRA_API_TOKEN) {
+    throw new Error("jiraApi requires JIRA_HOST, JIRA_EMAIL, and JIRA_API_TOKEN");
+  }
+  const auth = Buffer.from(`${JIRA_EMAIL}:${JIRA_API_TOKEN}`).toString("base64");
+  const bodyStr = body !== undefined ? JSON.stringify(body) : undefined;
+
+  return new Promise<T>((resolve, reject) => {
+    const req = request(
+      {
+        hostname: JIRA_HOST,
+        path,
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          Authorization: `Basic ${auth}`,
+          ...(bodyStr ? { "Content-Length": Buffer.byteLength(bodyStr) } : {}),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          try {
+            const text = Buffer.concat(chunks).toString("utf-8");
+            const status = res.statusCode ?? 0;
+            if (status < 200 || status >= 300) {
+              reject(
+                new Error(
+                  `Jira API ${method} ${path} returned HTTP ${status}: ${text.slice(0, 200)}`,
+                ),
+              );
+              return;
+            }
+            if (!text || text.trim() === "") {
+              resolve(undefined as T);
+              return;
+            }
+            resolve(JSON.parse(text) as T);
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+
+    req.setTimeout(30_000, () => {
+      req.destroy();
+      reject(new Error("Jira API request timed out"));
+    });
+
+    req.on("error", (err) => reject(err));
+    if (bodyStr) {
+      req.write(bodyStr);
+    }
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!canRun)("tracker-jira (integration)", () => {
+  const tracker = trackerJira.create();
+
+  const project: ProjectConfig = {
+    name: "test-project",
+    repo: "test-org/test-repo",
+    path: "/tmp/test",
+    defaultBranch: "main",
+    sessionPrefix: "test",
+    tracker: {
+      plugin: "jira",
+      projectKey: JIRA_PROJECT_KEY!,
+    },
+  };
+
+  // Issue state tracked across tests (created in beforeAll, cleaned up in afterAll)
+  let issueKey: string; // e.g. "PROJ-123"
+
+  // -------------------------------------------------------------------------
+  // Setup — create a test issue
+  // -------------------------------------------------------------------------
+
+  beforeAll(async () => {
+    const result = await tracker.createIssue!(
+      {
+        title: `[AO Integration Test] ${new Date().toISOString()}`,
+        description: "Automated integration test issue. Safe to delete if found lingering.",
+        priority: 4, // Low
+      },
+      project,
+    );
+
+    issueKey = result.id;
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // Cleanup — delete the test issue.
+  // With direct credentials we can delete it directly. With Composio-only we
+  // close it via the plugin (can't delete through the plugin interface).
+  // -------------------------------------------------------------------------
+
+  afterAll(async () => {
+    if (!issueKey) return;
+
+    try {
+      if (hasDirectCredentials) {
+        await jiraApi("DELETE", `/rest/api/3/issue/${encodeURIComponent(issueKey)}`);
+      } else {
+        // Composio-only: best-effort close via plugin
+        await tracker.updateIssue!(issueKey, { state: "closed" }, project);
+      }
+    } catch {
+      // Best-effort cleanup
+    }
+  }, 15_000);
+
+  // -------------------------------------------------------------------------
+  // Test cases
+  // -------------------------------------------------------------------------
+
+  it("createIssue returns a well-shaped Issue", () => {
+    // Validating the result captured in beforeAll
+    expect(issueKey).toBeDefined();
+    expect(issueKey).toMatch(/^[A-Z][A-Z0-9_]+-\d+$/);
+  });
+
+  it("getIssue fetches the created issue with correct fields", async () => {
+    const issue = await tracker.getIssue(issueKey, project);
+
+    expect(issue.id).toBe(issueKey);
+    expect(issue.title).toContain("[AO Integration Test]");
+    expect(issue.description).toContain("Automated integration test");
+    expect(issue.url).toContain(issueKey);
+    expect(issue.state).toBe("open");
+    expect(Array.isArray(issue.labels)).toBe(true);
+  });
+
+  it("isCompleted returns false for an open issue", async () => {
+    const completed = await tracker.isCompleted(issueKey, project);
+    expect(completed).toBe(false);
+  });
+
+  it("issueUrl returns a valid Jira URL", () => {
+    const url = tracker.issueUrl(issueKey, project);
+    expect(url).toContain(issueKey);
+    expect(url).toMatch(/^https:\/\/.+\/browse\//);
+  });
+
+  it("issueLabel extracts the key from a Jira URL", () => {
+    const url = tracker.issueUrl(issueKey, project);
+    const label = tracker.issueLabel!(url, project);
+    expect(label).toBe(issueKey);
+  });
+
+  it("branchName returns conventional branch name", () => {
+    const branch = tracker.branchName(issueKey, project);
+    expect(branch).toBe(`feat/${issueKey}`);
+  });
+
+  it("generatePrompt includes issue details", async () => {
+    const prompt = await tracker.generatePrompt(issueKey, project);
+
+    expect(prompt).toContain(issueKey);
+    expect(prompt).toContain("[AO Integration Test]");
+    expect(prompt).toContain("implement the changes");
+  });
+
+  it("listIssues includes the created issue", async () => {
+    const issues = await tracker.listIssues!({ state: "open", limit: 50 }, project);
+
+    const found = issues.find((i: { id: string }) => i.id === issueKey);
+    expect(found).toBeDefined();
+    expect(found!.title).toContain("[AO Integration Test]");
+  });
+
+  it("updateIssue adds a comment", async () => {
+    await tracker.updateIssue!(issueKey, { comment: "Integration test comment" }, project);
+
+    // Verify the comment was added — use direct API if available,
+    // otherwise trust the plugin didn't throw
+    if (hasDirectCredentials) {
+      const data = await jiraApi<{
+        comments: Array<{ body: unknown }>;
+      }>("GET", `/rest/api/3/issue/${encodeURIComponent(issueKey)}/comment`);
+
+      const commentBodies = data.comments.map((c) => {
+        // Comments use ADF format — extract text from the first paragraph
+        const body = c.body as { content?: Array<{ content?: Array<{ text?: string }> }> };
+        return body?.content?.[0]?.content?.[0]?.text ?? "";
+      });
+      expect(commentBodies).toContain("Integration test comment");
+    }
+  });
+
+  it("updateIssue closes the issue and isCompleted reflects it", async () => {
+    await tracker.updateIssue!(issueKey, { state: "closed" }, project);
+
+    // Jira API may have eventual consistency — poll until the state propagates
+    const completed = await pollUntilEqual(() => tracker.isCompleted(issueKey, project), true, {
+      timeoutMs: 5_000,
+      intervalMs: 500,
+    });
+    expect(completed).toBe(true);
+
+    const issue = await tracker.getIssue(issueKey, project);
+    expect(issue.state).toBe("closed");
+  });
+
+  it("updateIssue reopens the issue", async () => {
+    await tracker.updateIssue!(issueKey, { state: "open" }, project);
+
+    // Jira API may have eventual consistency — poll until the state propagates
+    const completed = await pollUntilEqual(() => tracker.isCompleted(issueKey, project), false, {
+      timeoutMs: 5_000,
+      intervalMs: 500,
+    });
+    expect(completed).toBe(false);
+
+    const issue = await tracker.getIssue(issueKey, project);
+    expect(issue.state).toBe("open");
+  });
+});

--- a/packages/integration-tests/src/tracker-jira.integration.test.ts
+++ b/packages/integration-tests/src/tracker-jira.integration.test.ts
@@ -112,7 +112,8 @@ function jiraApi<T>(method: string, path: string, body?: unknown): Promise<T> {
 // ---------------------------------------------------------------------------
 
 describe.skipIf(!canRun)("tracker-jira (integration)", () => {
-  const tracker = trackerJira.create();
+  const transport = hasComposioCredentials ? "composio" : "direct";
+  const tracker = trackerJira.create({ transport });
 
   const project: ProjectConfig = {
     name: "test-project",

--- a/packages/plugins/tracker-jira/package.json
+++ b/packages/plugins/tracker-jira/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@composio/ao-plugin-tracker-jira",
+  "version": "0.1.0",
+  "description": "Tracker plugin: Jira",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/tracker-jira"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/tracker-jira/src/composio-core.d.ts
+++ b/packages/plugins/tracker-jira/src/composio-core.d.ts
@@ -1,0 +1,20 @@
+/**
+ * Minimal type declarations for @composio/core (optional peer dependency).
+ * Only the subset used by the Composio transport is declared here.
+ */
+declare module "@composio/core" {
+  interface ComposioExecuteResult {
+    data?: Record<string, unknown>;
+    error?: string;
+    successful?: boolean;
+  }
+
+  interface ComposioTools {
+    execute(action: string, params: Record<string, unknown>): Promise<ComposioExecuteResult>;
+  }
+
+  export class Composio {
+    constructor(opts: { apiKey: string });
+    tools: ComposioTools;
+  }
+}

--- a/packages/plugins/tracker-jira/src/index.ts
+++ b/packages/plugins/tracker-jira/src/index.ts
@@ -1,0 +1,702 @@
+/**
+ * tracker-jira plugin — Jira as an issue tracker.
+ *
+ * Supports two transports:
+ *   1. Direct Jira REST API v3 with Basic Auth
+ *      (JIRA_HOST, JIRA_EMAIL, JIRA_API_TOKEN)
+ *   2. Composio SDK (COMPOSIO_API_KEY, optional COMPOSIO_ENTITY_ID)
+ *      Still requires JIRA_HOST for URL construction.
+ *
+ * When COMPOSIO_API_KEY is set, the Composio transport is preferred.
+ */
+
+import { request } from "node:https";
+import type {
+  PluginModule,
+  Tracker,
+  Issue,
+  IssueFilters,
+  IssueUpdate,
+  CreateIssueInput,
+  ProjectConfig,
+} from "@composio/ao-core";
+import type { Composio } from "@composio/core";
+
+// ---------------------------------------------------------------------------
+// Types for Jira responses
+// ---------------------------------------------------------------------------
+
+interface JiraStatusCategory {
+  key: string; // "new" | "indeterminate" | "done" | "undefined"
+  name: string;
+}
+
+interface JiraStatus {
+  name: string;
+  statusCategory: JiraStatusCategory;
+}
+
+/** Atlassian Document Format node */
+interface AdfNode {
+  type: string;
+  text?: string;
+  content?: AdfNode[];
+}
+
+interface JiraIssueFields {
+  summary: string;
+  description: AdfNode | string | null;
+  status: JiraStatus;
+  labels: string[];
+  assignee: { displayName: string; emailAddress?: string } | null;
+  priority: { name: string; id: string } | null;
+  issuetype: { name: string } | null;
+  project: { key: string } | null;
+}
+
+interface JiraIssue {
+  id: string;
+  key: string;
+  self: string;
+  fields: JiraIssueFields;
+}
+
+interface JiraSearchResult {
+  issues: JiraIssue[];
+  total: number;
+  maxResults: number;
+  startAt: number;
+}
+
+interface JiraTransition {
+  id: string;
+  name: string;
+  to: {
+    statusCategory: JiraStatusCategory;
+  };
+}
+
+interface JiraTransitionsResponse {
+  transitions: JiraTransition[];
+}
+
+// ---------------------------------------------------------------------------
+// Transport abstraction — action-based interface
+// ---------------------------------------------------------------------------
+
+interface JiraTransportActions {
+  getIssue(key: string, fields?: string): Promise<JiraIssue>;
+  searchIssues(jql: string, maxResults: number, fields: string): Promise<JiraSearchResult>;
+  getTransitions(key: string): Promise<JiraTransitionsResponse>;
+  transitionIssue(key: string, transitionId: string): Promise<void>;
+  updateIssueFields(key: string, fields: Record<string, unknown>): Promise<void>;
+  addComment(key: string, body: unknown): Promise<void>;
+  createIssue(fields: Record<string, unknown>): Promise<JiraIssue>;
+}
+
+// ---------------------------------------------------------------------------
+// Direct Jira API transport
+// ---------------------------------------------------------------------------
+
+interface JiraCredentials {
+  host: string;
+  email: string;
+  apiToken: string;
+}
+
+function getJiraCredentials(): JiraCredentials {
+  const host = process.env["JIRA_HOST"];
+  const email = process.env["JIRA_EMAIL"];
+  const apiToken = process.env["JIRA_API_TOKEN"];
+  if (!host || !email || !apiToken) {
+    throw new Error(
+      "JIRA_HOST, JIRA_EMAIL, and JIRA_API_TOKEN environment variables are required for the Jira tracker plugin",
+    );
+  }
+  return { host, email, apiToken };
+}
+
+/** Low-level HTTPS request helper for the direct transport. */
+function jiraHttpRequest<T>(
+  creds: JiraCredentials,
+  auth: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const bodyStr = body !== undefined ? JSON.stringify(body) : undefined;
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (!settled) {
+        settled = true;
+        fn();
+      }
+    };
+
+    const req = request(
+      {
+        hostname: creds.host,
+        path,
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          Authorization: `Basic ${auth}`,
+          ...(bodyStr ? { "Content-Length": Buffer.byteLength(bodyStr) } : {}),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("error", (err: Error) => settle(() => reject(err)));
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          settle(() => {
+            try {
+              const text = Buffer.concat(chunks).toString("utf-8");
+              const status = res.statusCode ?? 0;
+              if (status < 200 || status >= 300) {
+                reject(new Error(`Jira API returned HTTP ${status}: ${text.slice(0, 200)}`));
+                return;
+              }
+              // Some Jira endpoints return 204 with no body
+              if (!text || text.trim() === "") {
+                resolve(undefined as T);
+                return;
+              }
+              resolve(JSON.parse(text) as T);
+            } catch (err) {
+              reject(err);
+            }
+          });
+        });
+      },
+    );
+
+    req.setTimeout(30_000, () => {
+      settle(() => {
+        req.destroy();
+        reject(new Error("Jira API request timed out after 30s"));
+      });
+    });
+
+    req.on("error", (err) => settle(() => reject(err)));
+    if (bodyStr) {
+      req.write(bodyStr);
+    }
+    req.end();
+  });
+}
+
+function createDirectTransport(): { actions: JiraTransportActions; host: string } {
+  const creds = getJiraCredentials();
+  const auth = Buffer.from(`${creds.email}:${creds.apiToken}`).toString("base64");
+
+  const http = <T>(method: string, path: string, body?: unknown): Promise<T> =>
+    jiraHttpRequest<T>(creds, auth, method, path, body);
+
+  const actions: JiraTransportActions = {
+    async getIssue(key, fields) {
+      const qs = fields ? `?fields=${encodeURIComponent(fields)}` : "";
+      return http<JiraIssue>("GET", `/rest/api/3/issue/${encodeURIComponent(key)}${qs}`);
+    },
+
+    async searchIssues(jql, maxResults, fields) {
+      const params = new URLSearchParams({
+        jql,
+        maxResults: String(maxResults),
+        fields,
+      });
+      return http<JiraSearchResult>("GET", `/rest/api/3/search/jql?${params.toString()}`);
+    },
+
+    async getTransitions(key) {
+      return http<JiraTransitionsResponse>(
+        "GET",
+        `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`,
+      );
+    },
+
+    async transitionIssue(key, transitionId) {
+      await http("POST", `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`, {
+        transition: { id: transitionId },
+      });
+    },
+
+    async updateIssueFields(key, fields) {
+      await http("PUT", `/rest/api/3/issue/${encodeURIComponent(key)}`, { fields });
+    },
+
+    async addComment(key, body) {
+      await http("POST", `/rest/api/3/issue/${encodeURIComponent(key)}/comment`, { body });
+    },
+
+    async createIssue(fields) {
+      return http<JiraIssue>("POST", "/rest/api/3/issue", { fields });
+    },
+  };
+
+  return { actions, host: creds.host };
+}
+
+// ---------------------------------------------------------------------------
+// Composio SDK transport
+// ---------------------------------------------------------------------------
+
+type ComposioTools = Composio["tools"];
+
+function createComposioTransport(apiKey: string, entityId: string): JiraTransportActions {
+  // Lazy-load the Composio client — cached as a promise so the constructor
+  // is called only once, even under concurrent requests.
+  let clientPromise: Promise<ComposioTools> | undefined;
+
+  function getClient(): Promise<ComposioTools> {
+    if (!clientPromise) {
+      clientPromise = (async () => {
+        try {
+          const { Composio } = await import("@composio/core");
+          const client = new Composio({ apiKey });
+          return client.tools;
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (
+            msg.includes("Cannot find module") ||
+            msg.includes("Cannot find package") ||
+            msg.includes("ERR_MODULE_NOT_FOUND")
+          ) {
+            throw new Error(
+              "Composio SDK (@composio/core) is not installed. " +
+                "Install it with: pnpm add @composio/core",
+              { cause: err },
+            );
+          }
+          throw err;
+        }
+      })();
+    }
+    return clientPromise;
+  }
+
+  async function exec<T>(action: string, args: Record<string, unknown>): Promise<T> {
+    const tools = await getClient();
+
+    const resultPromise = tools.execute(action, {
+      entityId,
+      arguments: args,
+    });
+
+    // Apply 30s timeout for parity with the direct transport
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error("Composio Jira API request timed out after 30s"));
+      }, 30_000);
+    });
+
+    // Attach no-op .catch() to both promises so the loser of the race
+    // doesn't trigger an unhandled promise rejection.
+    resultPromise.catch(() => {});
+    timeoutPromise.catch(() => {});
+
+    try {
+      const result = await Promise.race([resultPromise, timeoutPromise]);
+
+      if (!result.successful) {
+        throw new Error(`Composio Jira API error: ${result.error ?? "unknown error"}`);
+      }
+
+      if (!result.data) {
+        throw new Error("Composio Jira API returned no data");
+      }
+
+      return result.data as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  const actions: JiraTransportActions = {
+    async getIssue(key, fields) {
+      return exec<JiraIssue>("JIRA_GET_ISSUE", {
+        issue_id_or_key: key,
+        ...(fields ? { fields } : {}),
+      });
+    },
+
+    async searchIssues(jql, maxResults, fields) {
+      return exec<JiraSearchResult>("JIRA_SEARCH_ISSUES", {
+        jql,
+        max_results: maxResults,
+        fields,
+      });
+    },
+
+    async getTransitions(key) {
+      return exec<JiraTransitionsResponse>("JIRA_GET_TRANSITIONS", {
+        issue_id_or_key: key,
+      });
+    },
+
+    async transitionIssue(key, transitionId) {
+      await exec("JIRA_TRANSITION_ISSUE", {
+        issue_id_or_key: key,
+        transition_id: transitionId,
+      });
+    },
+
+    async updateIssueFields(key, fields) {
+      await exec("JIRA_UPDATE_ISSUE", {
+        issue_id_or_key: key,
+        fields: JSON.stringify(fields),
+      });
+    },
+
+    async addComment(key, body) {
+      await exec("JIRA_ADD_COMMENT", {
+        issue_id_or_key: key,
+        body: JSON.stringify(body),
+      });
+    },
+
+    async createIssue(fields) {
+      return exec<JiraIssue>("JIRA_CREATE_ISSUE", {
+        fields: JSON.stringify(fields),
+      });
+    },
+  };
+
+  return actions;
+}
+
+// ---------------------------------------------------------------------------
+// State mapping
+// ---------------------------------------------------------------------------
+
+function mapJiraState(statusCategory: JiraStatusCategory, statusName: string): Issue["state"] {
+  // Check for cancelled status by name
+  if (statusName.toLowerCase().includes("cancel")) {
+    return "cancelled";
+  }
+
+  switch (statusCategory.key) {
+    case "done":
+      return "closed";
+    case "indeterminate":
+      return "in_progress";
+    case "new":
+    default:
+      return "open";
+  }
+}
+
+/** Map priority name to a numeric value (1 = highest) */
+function mapJiraPriority(priority: { name: string; id: string } | null): number | undefined {
+  if (!priority) return undefined;
+  // Jira default priority IDs: 1=Highest, 2=High, 3=Medium, 4=Low, 5=Lowest
+  const id = parseInt(priority.id, 10);
+  if (!isNaN(id) && id >= 1 && id <= 5) return id;
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// ADF -> plain text
+// ---------------------------------------------------------------------------
+
+/** Recursively extract plain text from an Atlassian Document Format tree. */
+function adfToText(node: AdfNode): string {
+  if (node.type === "text") return node.text ?? "";
+  if (!node.content) return "";
+  const parts = node.content.map(adfToText);
+  // Add newlines between block-level nodes
+  if (
+    node.type === "doc" ||
+    node.type === "paragraph" ||
+    node.type === "bulletList" ||
+    node.type === "orderedList" ||
+    node.type === "listItem"
+  ) {
+    return parts.join("\n");
+  }
+  return parts.join("");
+}
+
+function extractDescription(desc: AdfNode | string | null): string {
+  if (desc === null || desc === undefined) return "";
+  if (typeof desc === "string") return desc;
+  return adfToText(desc).trim();
+}
+
+// ---------------------------------------------------------------------------
+// Helper: map JiraIssue to Issue
+// ---------------------------------------------------------------------------
+
+function mapIssue(jiraIssue: JiraIssue, host: string): Issue {
+  const fields = jiraIssue.fields;
+  return {
+    id: jiraIssue.key,
+    title: fields.summary,
+    description: extractDescription(fields.description),
+    url: `https://${host}/browse/${jiraIssue.key}`,
+    state: mapJiraState(fields.status.statusCategory, fields.status.name),
+    labels: fields.labels ?? [],
+    assignee: fields.assignee?.displayName,
+    priority: mapJiraPriority(fields.priority),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tracker implementation
+// ---------------------------------------------------------------------------
+
+function createJiraTracker(actions: JiraTransportActions, host: string): Tracker {
+  return {
+    name: "jira",
+
+    async getIssue(identifier: string, _project: ProjectConfig): Promise<Issue> {
+      const jiraIssue = await actions.getIssue(identifier);
+      return mapIssue(jiraIssue, host);
+    },
+
+    async isCompleted(identifier: string, _project: ProjectConfig): Promise<boolean> {
+      const jiraIssue = await actions.getIssue(identifier, "status");
+      const cat = jiraIssue.fields.status.statusCategory.key;
+      return cat === "done";
+    },
+
+    issueUrl(identifier: string, _project: ProjectConfig): string {
+      return `https://${host}/browse/${identifier}`;
+    },
+
+    issueLabel(url: string, _project: ProjectConfig): string {
+      // Extract issue key from Jira URL
+      // Examples:
+      //   https://mycompany.atlassian.net/browse/PROJ-123
+      //   https://mycompany.atlassian.net/browse/PROJ-123?focusedId=12345
+      const match = url.match(/\/browse\/([A-Z][A-Z0-9_]+-\d+)/);
+      if (match) {
+        return match[1];
+      }
+      // Fallback: return the last path segment
+      const parts = url.split("/");
+      return parts[parts.length - 1] || url;
+    },
+
+    branchName(identifier: string, _project: ProjectConfig): string {
+      return `feat/${identifier}`;
+    },
+
+    async generatePrompt(identifier: string, project: ProjectConfig): Promise<string> {
+      const issue = await this.getIssue(identifier, project);
+      const lines = [
+        `You are working on Jira ticket ${issue.id}: ${issue.title}`,
+        `Issue URL: ${issue.url}`,
+        "",
+      ];
+
+      if (issue.labels.length > 0) {
+        lines.push(`Labels: ${issue.labels.join(", ")}`);
+      }
+
+      if (issue.priority !== undefined) {
+        const priorityNames: Record<number, string> = {
+          1: "Highest",
+          2: "High",
+          3: "Medium",
+          4: "Low",
+          5: "Lowest",
+        };
+        lines.push(`Priority: ${priorityNames[issue.priority] ?? String(issue.priority)}`);
+      }
+
+      if (issue.description) {
+        lines.push("## Description", "", issue.description);
+      }
+
+      lines.push(
+        "",
+        "Please implement the changes described in this ticket. When done, commit and push your changes.",
+      );
+
+      return lines.join("\n");
+    },
+
+    async listIssues(filters: IssueFilters, project: ProjectConfig): Promise<Issue[]> {
+      const projectKey = project.tracker?.["projectKey"] as string | undefined;
+
+      // Build JQL clauses
+      const clauses: string[] = [];
+
+      if (projectKey) {
+        clauses.push(`project = "${projectKey}"`);
+      }
+
+      if (filters.state === "closed") {
+        clauses.push('statusCategory = "Done"');
+      } else if (filters.state !== "all") {
+        // Default to open (exclude done)
+        clauses.push('statusCategory != "Done"');
+      }
+
+      if (filters.assignee) {
+        clauses.push(`assignee = "${filters.assignee}"`);
+      }
+
+      if (filters.labels && filters.labels.length > 0) {
+        for (const label of filters.labels) {
+          clauses.push(`labels = "${label}"`);
+        }
+      }
+
+      const jql = clauses.length > 0 ? clauses.join(" AND ") : "ORDER BY created DESC";
+      const maxResults = filters.limit ?? 30;
+      const fields = "summary,status,labels,assignee,priority,issuetype,project,description";
+
+      const result = await actions.searchIssues(jql, maxResults, fields);
+      return result.issues.map((issue) => mapIssue(issue, host));
+    },
+
+    async updateIssue(
+      identifier: string,
+      update: IssueUpdate,
+      _project: ProjectConfig,
+    ): Promise<void> {
+      // Handle state change via transitions
+      if (update.state) {
+        const transitionsData = await actions.getTransitions(identifier);
+
+        let targetCategoryKey: string;
+        if (update.state === "closed") {
+          targetCategoryKey = "done";
+        } else if (update.state === "in_progress") {
+          targetCategoryKey = "indeterminate";
+        } else {
+          targetCategoryKey = "new";
+        }
+
+        const transition = transitionsData.transitions.find(
+          (t) => t.to.statusCategory.key === targetCategoryKey,
+        );
+
+        if (!transition) {
+          throw new Error(
+            `No transition found to status category "${targetCategoryKey}" for issue ${identifier}`,
+          );
+        }
+
+        await actions.transitionIssue(identifier, transition.id);
+      }
+
+      // Handle field updates (labels, assignee)
+      const fieldsUpdate: Record<string, unknown> = {};
+
+      if (update.labels && update.labels.length > 0) {
+        // Additive — fetch existing labels and merge
+        const existing = await actions.getIssue(identifier, "labels");
+        const existingLabels = new Set(existing.fields.labels ?? []);
+        for (const label of update.labels) {
+          existingLabels.add(label);
+        }
+        fieldsUpdate["labels"] = [...existingLabels];
+      }
+
+      if (update.assignee) {
+        // Jira assignee is set by accountId; use displayName search
+        // For simplicity, pass the name — works when assignee matches accountId or displayName
+        fieldsUpdate["assignee"] = { name: update.assignee };
+      }
+
+      if (Object.keys(fieldsUpdate).length > 0) {
+        await actions.updateIssueFields(identifier, fieldsUpdate);
+      }
+
+      // Handle comment
+      if (update.comment) {
+        await actions.addComment(identifier, {
+          type: "doc",
+          version: 1,
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: update.comment }],
+            },
+          ],
+        });
+      }
+    },
+
+    async createIssue(input: CreateIssueInput, project: ProjectConfig): Promise<Issue> {
+      const projectKey = project.tracker?.["projectKey"] as string | undefined;
+      if (!projectKey) {
+        throw new Error("Jira tracker requires 'projectKey' in project tracker config");
+      }
+
+      const fields: Record<string, unknown> = {
+        project: { key: projectKey },
+        summary: input.title,
+        issuetype: { name: "Task" },
+      };
+
+      if (input.description) {
+        fields["description"] = {
+          type: "doc",
+          version: 1,
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: input.description }],
+            },
+          ],
+        };
+      }
+
+      if (input.labels && input.labels.length > 0) {
+        fields["labels"] = input.labels;
+      }
+
+      if (input.assignee) {
+        fields["assignee"] = { name: input.assignee };
+      }
+
+      if (input.priority !== undefined) {
+        fields["priority"] = { id: String(input.priority) };
+      }
+
+      const created = await actions.createIssue(fields);
+
+      // Fetch full issue details since create response may be partial
+      const full = await actions.getIssue(created.key);
+
+      return mapIssue(full, host);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin module export
+// ---------------------------------------------------------------------------
+
+export const manifest = {
+  name: "jira",
+  slot: "tracker" as const,
+  description: "Tracker plugin: Jira issue tracker",
+  version: "0.1.0",
+};
+
+export function create(): Tracker {
+  const host = process.env["JIRA_HOST"];
+  if (!host) {
+    throw new Error("JIRA_HOST environment variable is required for the Jira tracker plugin");
+  }
+
+  const composioKey = process.env["COMPOSIO_API_KEY"];
+  if (composioKey) {
+    const entityId = process.env["COMPOSIO_ENTITY_ID"] ?? "default";
+    return createJiraTracker(createComposioTransport(composioKey, entityId), host);
+  }
+
+  const { actions } = createDirectTransport();
+  return createJiraTracker(actions, host);
+}
+
+export default { manifest, create } satisfies PluginModule<Tracker>;

--- a/packages/plugins/tracker-jira/test/composio-transport.test.ts
+++ b/packages/plugins/tracker-jira/test/composio-transport.test.ts
@@ -1,0 +1,454 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock @composio/core
+// ---------------------------------------------------------------------------
+
+const { mockExecute, MockComposio } = vi.hoisted(() => {
+  const mockExecute = vi.fn();
+  const MockComposio = vi.fn().mockImplementation(() => ({
+    tools: { execute: mockExecute },
+  }));
+  return { mockExecute, MockComposio };
+});
+
+vi.mock("@composio/core", () => ({
+  Composio: MockComposio,
+}));
+
+import { create } from "../src/index.js";
+import type { ProjectConfig } from "@composio/ao-core";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_HOST = "mycompany.atlassian.net";
+
+const project: ProjectConfig = {
+  name: "test",
+  repo: "acme/repo",
+  path: "/tmp/repo",
+  defaultBranch: "main",
+  sessionPrefix: "test",
+  tracker: { plugin: "jira", projectKey: "PROJ" },
+};
+
+const sampleJiraIssue = {
+  id: "10001",
+  key: "PROJ-123",
+  self: `https://${TEST_HOST}/rest/api/3/issue/10001`,
+  fields: {
+    summary: "Fix login bug",
+    description: "Users can't log in with SSO",
+    status: {
+      name: "To Do",
+      statusCategory: { key: "new", name: "To Do" },
+    },
+    labels: ["bug", "priority-high"],
+    assignee: { displayName: "Alice Smith", emailAddress: "alice@example.com" },
+    priority: { name: "High", id: "2" },
+    issuetype: { name: "Bug" },
+    project: { key: "PROJ" },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockComposioResponse(data: unknown) {
+  mockExecute.mockResolvedValueOnce({
+    data,
+    successful: true,
+  });
+}
+
+function mockComposioError(error: string) {
+  mockExecute.mockResolvedValueOnce({
+    error,
+    successful: false,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Environment helpers
+// ---------------------------------------------------------------------------
+
+let savedComposioKey: string | undefined;
+let savedEntityId: string | undefined;
+let savedJiraHost: string | undefined;
+let savedJiraEmail: string | undefined;
+let savedJiraToken: string | undefined;
+
+function saveEnv() {
+  savedComposioKey = process.env["COMPOSIO_API_KEY"];
+  savedEntityId = process.env["COMPOSIO_ENTITY_ID"];
+  savedJiraHost = process.env["JIRA_HOST"];
+  savedJiraEmail = process.env["JIRA_EMAIL"];
+  savedJiraToken = process.env["JIRA_API_TOKEN"];
+}
+
+function restoreEnv() {
+  if (savedComposioKey === undefined) {
+    delete process.env["COMPOSIO_API_KEY"];
+  } else {
+    process.env["COMPOSIO_API_KEY"] = savedComposioKey;
+  }
+  if (savedEntityId === undefined) {
+    delete process.env["COMPOSIO_ENTITY_ID"];
+  } else {
+    process.env["COMPOSIO_ENTITY_ID"] = savedEntityId;
+  }
+  if (savedJiraHost === undefined) {
+    delete process.env["JIRA_HOST"];
+  } else {
+    process.env["JIRA_HOST"] = savedJiraHost;
+  }
+  if (savedJiraEmail === undefined) {
+    delete process.env["JIRA_EMAIL"];
+  } else {
+    process.env["JIRA_EMAIL"] = savedJiraEmail;
+  }
+  if (savedJiraToken === undefined) {
+    delete process.env["JIRA_API_TOKEN"];
+  } else {
+    process.env["JIRA_API_TOKEN"] = savedJiraToken;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("tracker-jira Composio transport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveEnv();
+    // Set Composio key and JIRA_HOST, remove direct credentials
+    process.env["COMPOSIO_API_KEY"] = "composio_test_key";
+    process.env["JIRA_HOST"] = TEST_HOST;
+    delete process.env["JIRA_EMAIL"];
+    delete process.env["JIRA_API_TOKEN"];
+    delete process.env["COMPOSIO_ENTITY_ID"];
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  // ---- Auto-detection ---------------------------------------------------
+
+  describe("transport auto-detection", () => {
+    it("uses Composio transport when COMPOSIO_API_KEY is set", async () => {
+      mockComposioResponse(sampleJiraIssue);
+      const tracker = create();
+      const issue = await tracker.getIssue("PROJ-123", project);
+
+      expect(issue.id).toBe("PROJ-123");
+      expect(MockComposio).toHaveBeenCalledWith({ apiKey: "composio_test_key" });
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it("prefers COMPOSIO_API_KEY over direct credentials when both set", async () => {
+      process.env["JIRA_EMAIL"] = "test@example.com";
+      process.env["JIRA_API_TOKEN"] = "test-token";
+      mockComposioResponse(sampleJiraIssue);
+
+      const tracker = create();
+      await tracker.getIssue("PROJ-123", project);
+
+      // Should use Composio, not direct
+      expect(MockComposio).toHaveBeenCalled();
+      expect(mockExecute).toHaveBeenCalled();
+    });
+
+    it("throws when JIRA_HOST is missing", () => {
+      delete process.env["JIRA_HOST"];
+      expect(() => create()).toThrow("JIRA_HOST");
+    });
+  });
+
+  // ---- Entity ID --------------------------------------------------------
+
+  describe("entity ID", () => {
+    it("defaults entity ID to 'default'", async () => {
+      mockComposioResponse(sampleJiraIssue);
+      const tracker = create();
+      await tracker.getIssue("PROJ-123", project);
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        "JIRA_GET_ISSUE",
+        expect.objectContaining({ entityId: "default" }),
+      );
+    });
+
+    it("uses COMPOSIO_ENTITY_ID env var when set", async () => {
+      process.env["COMPOSIO_ENTITY_ID"] = "my-entity";
+      mockComposioResponse(sampleJiraIssue);
+
+      const tracker = create();
+      await tracker.getIssue("PROJ-123", project);
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        "JIRA_GET_ISSUE",
+        expect.objectContaining({ entityId: "my-entity" }),
+      );
+    });
+  });
+
+  // ---- Successful queries -----------------------------------------------
+
+  describe("successful queries", () => {
+    it("returns correct Issue from getIssue", async () => {
+      mockComposioResponse(sampleJiraIssue);
+      const tracker = create();
+      const issue = await tracker.getIssue("PROJ-123", project);
+
+      expect(issue).toEqual({
+        id: "PROJ-123",
+        title: "Fix login bug",
+        description: "Users can't log in with SSO",
+        url: `https://${TEST_HOST}/browse/PROJ-123`,
+        state: "open",
+        labels: ["bug", "priority-high"],
+        assignee: "Alice Smith",
+        priority: 2,
+      });
+    });
+
+    it("passes correct action and arguments for getIssue", async () => {
+      mockComposioResponse(sampleJiraIssue);
+      const tracker = create();
+      await tracker.getIssue("PROJ-123", project);
+
+      expect(mockExecute).toHaveBeenCalledWith("JIRA_GET_ISSUE", {
+        entityId: "default",
+        arguments: { issue_id_or_key: "PROJ-123" },
+      });
+    });
+
+    it("works with isCompleted", async () => {
+      const doneIssue = {
+        ...sampleJiraIssue,
+        fields: {
+          ...sampleJiraIssue.fields,
+          status: {
+            name: "Done",
+            statusCategory: { key: "done", name: "Done" },
+          },
+        },
+      };
+      mockComposioResponse(doneIssue);
+      const tracker = create();
+      const result = await tracker.isCompleted("PROJ-123", project);
+      expect(result).toBe(true);
+    });
+
+    it("passes fields parameter for isCompleted", async () => {
+      mockComposioResponse(sampleJiraIssue);
+      const tracker = create();
+      await tracker.isCompleted("PROJ-123", project);
+
+      expect(mockExecute).toHaveBeenCalledWith("JIRA_GET_ISSUE", {
+        entityId: "default",
+        arguments: { issue_id_or_key: "PROJ-123", fields: "status" },
+      });
+    });
+
+    it("works with listIssues", async () => {
+      mockComposioResponse({
+        issues: [sampleJiraIssue],
+        total: 1,
+        maxResults: 30,
+        startAt: 0,
+      });
+      const tracker = create();
+      const issues = await tracker.listIssues!({}, project);
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0].id).toBe("PROJ-123");
+    });
+
+    it("passes correct action for searchIssues", async () => {
+      mockComposioResponse({
+        issues: [],
+        total: 0,
+        maxResults: 30,
+        startAt: 0,
+      });
+      const tracker = create();
+      await tracker.listIssues!({}, project);
+
+      expect(mockExecute).toHaveBeenCalledWith("JIRA_SEARCH_ISSUES", {
+        entityId: "default",
+        arguments: expect.objectContaining({
+          jql: expect.stringContaining('project = "PROJ"'),
+          max_results: 30,
+        }),
+      });
+    });
+
+    it("creates an issue via JIRA_CREATE_ISSUE", async () => {
+      // First: create returns partial
+      mockComposioResponse({ id: "10002", key: "PROJ-456", self: "..." });
+      // Second: getIssue for full details
+      mockComposioResponse({
+        ...sampleJiraIssue,
+        id: "10002",
+        key: "PROJ-456",
+        fields: { ...sampleJiraIssue.fields, summary: "New issue" },
+      });
+
+      const tracker = create();
+      const issue = await tracker.createIssue!(
+        { title: "New issue", description: "Desc" },
+        project,
+      );
+
+      expect(issue.id).toBe("PROJ-456");
+      expect(mockExecute).toHaveBeenCalledWith(
+        "JIRA_CREATE_ISSUE",
+        expect.objectContaining({
+          arguments: expect.objectContaining({
+            fields: expect.stringContaining('"summary":"New issue"'),
+          }),
+        }),
+      );
+    });
+
+    it("transitions an issue via JIRA_GET_TRANSITIONS and JIRA_TRANSITION_ISSUE", async () => {
+      // First: get transitions
+      mockComposioResponse({
+        transitions: [{ id: "31", name: "Done", to: { statusCategory: { key: "done" } } }],
+      });
+      // Second: perform transition
+      mockComposioResponse({});
+
+      const tracker = create();
+      await tracker.updateIssue!("PROJ-123", { state: "closed" }, project);
+
+      expect(mockExecute).toHaveBeenCalledWith("JIRA_GET_TRANSITIONS", {
+        entityId: "default",
+        arguments: { issue_id_or_key: "PROJ-123" },
+      });
+      expect(mockExecute).toHaveBeenCalledWith("JIRA_TRANSITION_ISSUE", {
+        entityId: "default",
+        arguments: { issue_id_or_key: "PROJ-123", transition_id: "31" },
+      });
+    });
+
+    it("adds a comment via JIRA_ADD_COMMENT", async () => {
+      mockComposioResponse({});
+      const tracker = create();
+      await tracker.updateIssue!("PROJ-123", { comment: "Hello" }, project);
+
+      expect(mockExecute).toHaveBeenCalledWith("JIRA_ADD_COMMENT", {
+        entityId: "default",
+        arguments: expect.objectContaining({
+          issue_id_or_key: "PROJ-123",
+          body: expect.stringContaining("Hello"),
+        }),
+      });
+    });
+  });
+
+  // ---- Error handling ---------------------------------------------------
+
+  describe("error handling", () => {
+    it("throws on unsuccessful response", async () => {
+      mockComposioError("Authentication failed");
+      const tracker = create();
+
+      await expect(tracker.getIssue("PROJ-123", project)).rejects.toThrow(
+        "Composio Jira API error: Authentication failed",
+      );
+    });
+
+    it("throws with 'unknown error' when error field is missing", async () => {
+      mockExecute.mockResolvedValueOnce({
+        successful: false,
+      });
+      const tracker = create();
+
+      await expect(tracker.getIssue("PROJ-123", project)).rejects.toThrow(
+        "Composio Jira API error: unknown error",
+      );
+    });
+
+    it("throws when response has no data", async () => {
+      mockExecute.mockResolvedValueOnce({
+        successful: true,
+        data: undefined,
+      });
+      const tracker = create();
+
+      await expect(tracker.getIssue("PROJ-123", project)).rejects.toThrow(
+        "Composio Jira API returned no data",
+      );
+    });
+
+    it("propagates execute rejections", async () => {
+      mockExecute.mockRejectedValueOnce(new Error("Network error"));
+      const tracker = create();
+
+      await expect(tracker.getIssue("PROJ-123", project)).rejects.toThrow("Network error");
+    });
+  });
+
+  // ---- Client caching ---------------------------------------------------
+
+  describe("client caching", () => {
+    it("creates Composio client only once across multiple queries", async () => {
+      mockComposioResponse(sampleJiraIssue);
+      mockComposioResponse(sampleJiraIssue);
+
+      const tracker = create();
+      await tracker.getIssue("PROJ-123", project);
+      await tracker.isCompleted("PROJ-123", project);
+
+      // Composio constructor should be called exactly once
+      expect(MockComposio).toHaveBeenCalledTimes(1);
+      // But execute should be called twice
+      expect(mockExecute).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ---- Timeout ----------------------------------------------------------
+
+  describe("timeout", () => {
+    it("times out after 30s", async () => {
+      // Pre-warm the client so import() resolves before we switch to fake timers.
+      mockComposioResponse(sampleJiraIssue);
+      const tracker = create();
+      await tracker.getIssue("PROJ-123", project);
+
+      // Now switch to fake timers
+      vi.useFakeTimers();
+
+      // Suppress transient unhandled rejection from Promise.race timeout
+      const suppressed: unknown[] = [];
+      const handler = (reason: unknown) => {
+        suppressed.push(reason);
+      };
+      process.on("unhandledRejection", handler);
+
+      try {
+        // Make execute hang forever
+        mockExecute.mockImplementationOnce(
+          () => new Promise(() => {}), // never resolves
+        );
+
+        const promise = tracker.getIssue("PROJ-123", project);
+
+        // Advance timers past the 30s timeout
+        await vi.advanceTimersByTimeAsync(30_001);
+
+        await expect(promise).rejects.toThrow("Composio Jira API request timed out after 30s");
+      } finally {
+        process.removeListener("unhandledRejection", handler);
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/packages/plugins/tracker-jira/test/index.test.ts
+++ b/packages/plugins/tracker-jira/test/index.test.ts
@@ -1,0 +1,509 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { ProjectConfig } from "@composio/ao-core";
+
+import { manifest, create } from "../src/index.js";
+
+// Mock node:https request to capture calls
+const { requestMock } = vi.hoisted(() => ({ requestMock: vi.fn() }));
+
+vi.mock("node:https", () => ({
+  request: requestMock,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const project: ProjectConfig = {
+  name: "test",
+  repo: "acme/repo",
+  path: "/tmp/repo",
+  defaultBranch: "main",
+  sessionPrefix: "test",
+  tracker: { plugin: "jira", projectKey: "PROJ" },
+};
+
+const TEST_HOST = "mycompany.atlassian.net";
+
+/** Decode URL path, handling both %20 and + as spaces */
+function decodePath(path: string): string {
+  return decodeURIComponent(path.replaceAll("+", " "));
+}
+
+function mockJiraResponse(statusCode: number, body: unknown) {
+  const bodyStr = typeof body === "string" ? body : JSON.stringify(body);
+  requestMock.mockImplementationOnce((_opts: unknown, callback: (res: unknown) => void) => {
+    const res = {
+      statusCode,
+      on: vi.fn((event: string, handler: (data?: unknown) => void) => {
+        if (event === "data") {
+          handler(Buffer.from(bodyStr));
+        }
+        if (event === "end") {
+          handler();
+        }
+      }),
+    };
+    // Call callback synchronously for test simplicity
+    callback(res);
+    return {
+      setTimeout: vi.fn(),
+      on: vi.fn(),
+      write: vi.fn(),
+      end: vi.fn(),
+      destroy: vi.fn(),
+    };
+  });
+}
+
+const sampleJiraIssue = {
+  id: "10001",
+  key: "PROJ-123",
+  self: `https://${TEST_HOST}/rest/api/3/issue/10001`,
+  fields: {
+    summary: "Fix login bug",
+    description: "Users can't log in with SSO",
+    status: {
+      name: "To Do",
+      statusCategory: { key: "new", name: "To Do" },
+    },
+    labels: ["bug", "priority-high"],
+    assignee: { displayName: "Alice Smith", emailAddress: "alice@example.com" },
+    priority: { name: "High", id: "2" },
+    issuetype: { name: "Bug" },
+    project: { key: "PROJ" },
+  },
+};
+
+const inProgressIssue = {
+  ...sampleJiraIssue,
+  fields: {
+    ...sampleJiraIssue.fields,
+    status: {
+      name: "In Progress",
+      statusCategory: { key: "indeterminate", name: "In Progress" },
+    },
+  },
+};
+
+const doneIssue = {
+  ...sampleJiraIssue,
+  fields: {
+    ...sampleJiraIssue.fields,
+    status: {
+      name: "Done",
+      statusCategory: { key: "done", name: "Done" },
+    },
+  },
+};
+
+const cancelledIssue = {
+  ...sampleJiraIssue,
+  fields: {
+    ...sampleJiraIssue.fields,
+    status: {
+      name: "Cancelled",
+      statusCategory: { key: "done", name: "Done" },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("tracker-jira plugin", () => {
+  let tracker: ReturnType<typeof create>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Set env vars for direct transport
+    process.env["JIRA_HOST"] = TEST_HOST;
+    process.env["JIRA_EMAIL"] = "test@example.com";
+    process.env["JIRA_API_TOKEN"] = "test-token";
+    delete process.env["COMPOSIO_API_KEY"];
+
+    tracker = create();
+  });
+
+  // ---- manifest ----------------------------------------------------------
+
+  describe("manifest", () => {
+    it("has correct metadata", () => {
+      expect(manifest.name).toBe("jira");
+      expect(manifest.slot).toBe("tracker");
+      expect(manifest.version).toBe("0.1.0");
+    });
+  });
+
+  describe("create()", () => {
+    it("returns a Tracker with correct name", () => {
+      expect(tracker.name).toBe("jira");
+    });
+  });
+
+  // ---- getIssue ----------------------------------------------------------
+
+  describe("getIssue", () => {
+    it("returns Issue with correct fields", async () => {
+      mockJiraResponse(200, sampleJiraIssue);
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue).toEqual({
+        id: "PROJ-123",
+        title: "Fix login bug",
+        description: "Users can't log in with SSO",
+        url: `https://${TEST_HOST}/browse/PROJ-123`,
+        state: "open",
+        labels: ["bug", "priority-high"],
+        assignee: "Alice Smith",
+        priority: 2,
+      });
+    });
+
+    it("maps in_progress state", async () => {
+      mockJiraResponse(200, inProgressIssue);
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.state).toBe("in_progress");
+    });
+
+    it("maps done state to closed", async () => {
+      mockJiraResponse(200, doneIssue);
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.state).toBe("closed");
+    });
+
+    it("maps cancelled status name to cancelled", async () => {
+      mockJiraResponse(200, cancelledIssue);
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.state).toBe("cancelled");
+    });
+
+    it("handles missing description gracefully", async () => {
+      mockJiraResponse(200, {
+        ...sampleJiraIssue,
+        fields: { ...sampleJiraIssue.fields, description: null },
+      });
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.description).toBe("");
+    });
+
+    it("handles missing assignee", async () => {
+      mockJiraResponse(200, {
+        ...sampleJiraIssue,
+        fields: { ...sampleJiraIssue.fields, assignee: null },
+      });
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.assignee).toBeUndefined();
+    });
+
+    it("handles missing priority", async () => {
+      mockJiraResponse(200, {
+        ...sampleJiraIssue,
+        fields: { ...sampleJiraIssue.fields, priority: null },
+      });
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.priority).toBeUndefined();
+    });
+
+    it("propagates HTTP errors", async () => {
+      mockJiraResponse(404, { errorMessages: ["Issue does not exist"] });
+      await expect(tracker.getIssue("PROJ-999", project)).rejects.toThrow(
+        "Jira API returned HTTP 404",
+      );
+    });
+  });
+
+  // ---- isCompleted -------------------------------------------------------
+
+  describe("isCompleted", () => {
+    it("returns true for done issues", async () => {
+      mockJiraResponse(200, doneIssue);
+      expect(await tracker.isCompleted("PROJ-123", project)).toBe(true);
+    });
+
+    it("returns false for open issues", async () => {
+      mockJiraResponse(200, sampleJiraIssue);
+      expect(await tracker.isCompleted("PROJ-123", project)).toBe(false);
+    });
+
+    it("returns false for in-progress issues", async () => {
+      mockJiraResponse(200, inProgressIssue);
+      expect(await tracker.isCompleted("PROJ-123", project)).toBe(false);
+    });
+  });
+
+  // ---- issueUrl ----------------------------------------------------------
+
+  describe("issueUrl", () => {
+    it("generates correct URL", () => {
+      expect(tracker.issueUrl("PROJ-42", project)).toBe(`https://${TEST_HOST}/browse/PROJ-42`);
+    });
+  });
+
+  // ---- issueLabel --------------------------------------------------------
+
+  describe("issueLabel", () => {
+    it("extracts key from Jira URL", () => {
+      expect(tracker.issueLabel!(`https://${TEST_HOST}/browse/PROJ-123`, project)).toBe("PROJ-123");
+    });
+
+    it("handles URL with query params", () => {
+      expect(
+        tracker.issueLabel!(`https://${TEST_HOST}/browse/PROJ-123?focusedId=12345`, project),
+      ).toBe("PROJ-123");
+    });
+
+    it("falls back to last path segment", () => {
+      expect(tracker.issueLabel!(`https://${TEST_HOST}/something/else`, project)).toBe("else");
+    });
+  });
+
+  // ---- branchName --------------------------------------------------------
+
+  describe("branchName", () => {
+    it("generates feat/KEY format", () => {
+      expect(tracker.branchName("PROJ-123", project)).toBe("feat/PROJ-123");
+    });
+  });
+
+  // ---- generatePrompt ----------------------------------------------------
+
+  describe("generatePrompt", () => {
+    it("includes title and URL", async () => {
+      mockJiraResponse(200, sampleJiraIssue);
+      const prompt = await tracker.generatePrompt("PROJ-123", project);
+      expect(prompt).toContain("Fix login bug");
+      expect(prompt).toContain(`https://${TEST_HOST}/browse/PROJ-123`);
+      expect(prompt).toContain("Jira ticket PROJ-123");
+    });
+
+    it("includes labels when present", async () => {
+      mockJiraResponse(200, sampleJiraIssue);
+      const prompt = await tracker.generatePrompt("PROJ-123", project);
+      expect(prompt).toContain("bug, priority-high");
+    });
+
+    it("includes priority", async () => {
+      mockJiraResponse(200, sampleJiraIssue);
+      const prompt = await tracker.generatePrompt("PROJ-123", project);
+      expect(prompt).toContain("Priority: High");
+    });
+
+    it("includes description", async () => {
+      mockJiraResponse(200, sampleJiraIssue);
+      const prompt = await tracker.generatePrompt("PROJ-123", project);
+      expect(prompt).toContain("Users can't log in with SSO");
+    });
+
+    it("omits labels section when no labels", async () => {
+      mockJiraResponse(200, {
+        ...sampleJiraIssue,
+        fields: { ...sampleJiraIssue.fields, labels: [] },
+      });
+      const prompt = await tracker.generatePrompt("PROJ-123", project);
+      expect(prompt).not.toContain("Labels:");
+    });
+
+    it("omits description section when body is empty", async () => {
+      mockJiraResponse(200, {
+        ...sampleJiraIssue,
+        fields: { ...sampleJiraIssue.fields, description: null },
+      });
+      const prompt = await tracker.generatePrompt("PROJ-123", project);
+      expect(prompt).not.toContain("## Description");
+    });
+  });
+
+  // ---- listIssues --------------------------------------------------------
+
+  describe("listIssues", () => {
+    it("returns mapped issues", async () => {
+      const secondIssue = {
+        ...sampleJiraIssue,
+        key: "PROJ-456",
+        fields: { ...sampleJiraIssue.fields, summary: "Another issue" },
+      };
+      mockJiraResponse(200, {
+        issues: [sampleJiraIssue, secondIssue],
+        total: 2,
+        maxResults: 30,
+        startAt: 0,
+      });
+      const issues = await tracker.listIssues!({}, project);
+      expect(issues).toHaveLength(2);
+      expect(issues[0].id).toBe("PROJ-123");
+      expect(issues[1].id).toBe("PROJ-456");
+    });
+
+    it("passes project key in JQL", async () => {
+      mockJiraResponse(200, { issues: [], total: 0, maxResults: 30, startAt: 0 });
+      await tracker.listIssues!({}, project);
+      const callArgs = requestMock.mock.calls[0][0] as { path: string };
+      const decoded = decodePath(callArgs.path);
+      expect(decoded).toContain('project = "PROJ"');
+    });
+
+    it("filters closed issues", async () => {
+      mockJiraResponse(200, { issues: [], total: 0, maxResults: 30, startAt: 0 });
+      await tracker.listIssues!({ state: "closed" }, project);
+      const callArgs = requestMock.mock.calls[0][0] as { path: string };
+      const decoded = decodePath(callArgs.path);
+      expect(decoded).toContain('statusCategory = "Done"');
+    });
+
+    it("defaults to non-done state", async () => {
+      mockJiraResponse(200, { issues: [], total: 0, maxResults: 30, startAt: 0 });
+      await tracker.listIssues!({}, project);
+      const callArgs = requestMock.mock.calls[0][0] as { path: string };
+      const decoded = decodePath(callArgs.path);
+      expect(decoded).toContain('statusCategory != "Done"');
+    });
+
+    it("passes assignee filter", async () => {
+      mockJiraResponse(200, { issues: [], total: 0, maxResults: 30, startAt: 0 });
+      await tracker.listIssues!({ assignee: "alice" }, project);
+      const callArgs = requestMock.mock.calls[0][0] as { path: string };
+      const decoded = decodePath(callArgs.path);
+      expect(decoded).toContain('assignee = "alice"');
+    });
+
+    it("passes label filter", async () => {
+      mockJiraResponse(200, { issues: [], total: 0, maxResults: 30, startAt: 0 });
+      await tracker.listIssues!({ labels: ["bug", "urgent"] }, project);
+      const callArgs = requestMock.mock.calls[0][0] as { path: string };
+      const decoded = decodePath(callArgs.path);
+      expect(decoded).toContain('labels = "bug"');
+      expect(decoded).toContain('labels = "urgent"');
+    });
+
+    it("respects custom limit", async () => {
+      mockJiraResponse(200, { issues: [], total: 0, maxResults: 5, startAt: 0 });
+      await tracker.listIssues!({ limit: 5 }, project);
+      const callArgs = requestMock.mock.calls[0][0] as { path: string };
+      expect(callArgs.path).toContain("maxResults=5");
+    });
+  });
+
+  // ---- updateIssue -------------------------------------------------------
+
+  describe("updateIssue", () => {
+    it("transitions an issue to done", async () => {
+      // First: GET transitions
+      mockJiraResponse(200, {
+        transitions: [
+          { id: "31", name: "Done", to: { statusCategory: { key: "done" } } },
+          { id: "21", name: "In Progress", to: { statusCategory: { key: "indeterminate" } } },
+        ],
+      });
+      // Second: POST transition
+      mockJiraResponse(204, "");
+
+      await tracker.updateIssue!("PROJ-123", { state: "closed" }, project);
+      expect(requestMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws when no matching transition found", async () => {
+      mockJiraResponse(200, {
+        transitions: [
+          { id: "21", name: "In Progress", to: { statusCategory: { key: "indeterminate" } } },
+        ],
+      });
+
+      await expect(tracker.updateIssue!("PROJ-123", { state: "closed" }, project)).rejects.toThrow(
+        'No transition found to status category "done"',
+      );
+    });
+
+    it("adds a comment", async () => {
+      mockJiraResponse(201, { id: "10001" });
+      await tracker.updateIssue!("PROJ-123", { comment: "Working on this" }, project);
+      expect(requestMock).toHaveBeenCalledTimes(1);
+      const callArgs = requestMock.mock.calls[0][0] as { path: string; method: string };
+      expect(callArgs.method).toBe("POST");
+      expect(callArgs.path).toContain("/comment");
+    });
+
+    it("updates labels (additive)", async () => {
+      // First: GET existing labels
+      mockJiraResponse(200, {
+        ...sampleJiraIssue,
+        fields: { ...sampleJiraIssue.fields, labels: ["existing"] },
+      });
+      // Second: PUT update
+      mockJiraResponse(204, "");
+
+      await tracker.updateIssue!("PROJ-123", { labels: ["new-label"] }, project);
+      expect(requestMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ---- createIssue -------------------------------------------------------
+
+  describe("createIssue", () => {
+    it("creates an issue and fetches full details", async () => {
+      // First: POST create returns partial
+      mockJiraResponse(201, { id: "10002", key: "PROJ-456", self: "..." });
+      // Second: GET full issue
+      mockJiraResponse(200, {
+        ...sampleJiraIssue,
+        id: "10002",
+        key: "PROJ-456",
+        fields: { ...sampleJiraIssue.fields, summary: "New issue" },
+      });
+
+      const issue = await tracker.createIssue!(
+        { title: "New issue", description: "Description" },
+        project,
+      );
+      expect(issue).toMatchObject({
+        id: "PROJ-456",
+        title: "New issue",
+        state: "open",
+      });
+    });
+
+    it("throws when projectKey is missing", async () => {
+      const projectWithoutKey: ProjectConfig = {
+        ...project,
+        tracker: { plugin: "jira" },
+      };
+      await expect(
+        tracker.createIssue!({ title: "Test", description: "" }, projectWithoutKey),
+      ).rejects.toThrow("projectKey");
+    });
+  });
+
+  // ---- state mapping edge cases -------------------------------------------
+
+  describe("state mapping", () => {
+    it("maps unknown status category to open", async () => {
+      mockJiraResponse(200, {
+        ...sampleJiraIssue,
+        fields: {
+          ...sampleJiraIssue.fields,
+          status: {
+            name: "Unknown",
+            statusCategory: { key: "undefined", name: "Unknown" },
+          },
+        },
+      });
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.state).toBe("open");
+    });
+
+    it("detects cancelled by status name regardless of category", async () => {
+      mockJiraResponse(200, {
+        ...sampleJiraIssue,
+        fields: {
+          ...sampleJiraIssue.fields,
+          status: {
+            name: "Cancelled by Admin",
+            statusCategory: { key: "done", name: "Done" },
+          },
+        },
+      });
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.state).toBe("cancelled");
+    });
+  });
+});

--- a/packages/plugins/tracker-jira/test/index.test.ts
+++ b/packages/plugins/tracker-jira/test/index.test.ts
@@ -14,16 +14,16 @@ vi.mock("node:https", () => ({
 // Fixtures
 // ---------------------------------------------------------------------------
 
+const TEST_HOST = "mycompany.atlassian.net";
+
 const project: ProjectConfig = {
   name: "test",
   repo: "acme/repo",
   path: "/tmp/repo",
   defaultBranch: "main",
   sessionPrefix: "test",
-  tracker: { plugin: "jira", projectKey: "PROJ" },
+  tracker: { plugin: "jira", projectKey: "PROJ", host: TEST_HOST },
 };
-
-const TEST_HOST = "mycompany.atlassian.net";
 
 /** Decode URL path, handling both %20 and + as spaces */
 function decodePath(path: string): string {
@@ -118,7 +118,6 @@ describe("tracker-jira plugin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Set env vars for direct transport
-    process.env["JIRA_HOST"] = TEST_HOST;
     process.env["JIRA_EMAIL"] = "test@example.com";
     process.env["JIRA_API_TOKEN"] = "test-token";
     delete process.env["COMPOSIO_API_KEY"];
@@ -465,7 +464,7 @@ describe("tracker-jira plugin", () => {
     it("throws when projectKey is missing", async () => {
       const projectWithoutKey: ProjectConfig = {
         ...project,
-        tracker: { plugin: "jira" },
+        tracker: { plugin: "jira", host: TEST_HOST },
       };
       await expect(
         tracker.createIssue!({ title: "Test", description: "" }, projectWithoutKey),

--- a/packages/plugins/tracker-jira/test/smoke.ts
+++ b/packages/plugins/tracker-jira/test/smoke.ts
@@ -1,0 +1,57 @@
+/**
+ * Smoke test — hit real Jira API with env credentials.
+ *
+ * Direct transport:
+ *   JIRA_HOST=... JIRA_EMAIL=... JIRA_API_TOKEN=... npx tsx test/smoke.ts <ISSUE-KEY>
+ *
+ * Composio transport:
+ *   JIRA_HOST=... COMPOSIO_API_KEY=... npx tsx test/smoke.ts <ISSUE-KEY>
+ */
+
+import { create } from "../src/index.js";
+import type { ProjectConfig } from "@composio/ao-core";
+
+const issueKey = process.argv[2];
+if (!issueKey) {
+  console.error("Usage: npx tsx test/smoke.ts <ISSUE-KEY>");
+  process.exit(1);
+}
+
+const project: ProjectConfig = {
+  name: "smoke-test",
+  repo: "test/repo",
+  path: "/tmp",
+  defaultBranch: "main",
+  sessionPrefix: "test",
+  tracker: { plugin: "jira", projectKey: issueKey.split("-")[0] },
+};
+
+const tracker = create();
+
+console.log("--- getIssue ---");
+const issue = await tracker.getIssue(issueKey, project);
+console.log(issue);
+
+console.log("\n--- isCompleted ---");
+const completed = await tracker.isCompleted(issueKey, project);
+console.log("completed:", completed);
+
+console.log("\n--- issueUrl ---");
+console.log(tracker.issueUrl(issueKey, project));
+
+console.log("\n--- issueLabel ---");
+console.log(tracker.issueLabel?.(tracker.issueUrl(issueKey, project), project));
+
+console.log("\n--- branchName ---");
+console.log(tracker.branchName(issueKey, project));
+
+console.log("\n--- generatePrompt ---");
+const prompt = await tracker.generatePrompt(issueKey, project);
+console.log(prompt);
+
+console.log("\n--- listIssues (open) ---");
+const issues = await tracker.listIssues!({}, project);
+console.log(`Found ${issues.length} open issues:`);
+for (const i of issues) {
+  console.log(`  ${i.id}: ${i.title} [${i.state}]`);
+}

--- a/packages/plugins/tracker-jira/tsconfig.json
+++ b/packages/plugins/tracker-jira/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       '@composio/ao-plugin-runtime-tmux':
         specifier: workspace:*
         version: link:../plugins/runtime-tmux
+      '@composio/ao-plugin-tracker-jira':
+        specifier: workspace:*
+        version: link:../plugins/tracker-jira
       '@composio/ao-plugin-tracker-linear':
         specifier: workspace:*
         version: link:../plugins/tracker-linear
@@ -410,6 +413,22 @@ importers:
         version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugins/tracker-github:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/plugins/tracker-jira:
     dependencies:
       '@composio/ao-core':
         specifier: workspace:*


### PR DESCRIPTION
## Problem

AO had no Jira tracker plugin. Users with Jira-based workflows couldn't use AO to orchestrate agents against Jira issues. Issue #137 requested adding Jira support alongside the existing GitHub and Linear tracker plugins.

## Solution

Adds `@composio/ao-plugin-tracker-jira` — a full `Tracker` interface implementation with **two transports**:

1. **Direct transport** — HTTPS calls to the Jira REST API v3 using Basic Auth (`JIRA_EMAIL` + `JIRA_API_TOKEN`)
2. **Composio transport** — Uses the Composio SDK to call Jira actions (`JIRA_GET_ISSUE`, `JIRA_SEARCH_ISSUES`, etc.)

### Transport design

The original PR used a REST-based transport (`method, path, body`), but this didn't map cleanly to Composio's action-based API (as discussed in the PR comments). Instead of maintaining a fragile path-to-action mapping, the transport was refactored to an **action-based interface**:

```typescript
interface JiraTransportActions {
  getIssue(key: string, fields?: string): Promise<JiraIssue>;
  searchIssues(jql: string, maxResults: number, fields: string): Promise<JiraSearchResult>;
  getTransitions(key: string): Promise<JiraTransitionsResponse>;
  transitionIssue(key: string, transitionId: string): Promise<void>;
  updateIssueFields(key: string, fields: Record<string, unknown>): Promise<void>;
  addComment(key: string, body: unknown): Promise<void>;
  createIssue(fields: Record<string, unknown>): Promise<JiraIssue>;
}
```

Both transports implement this interface. The direct transport maps actions to HTTPS calls; the Composio transport maps them to Composio SDK `execute()` calls. No path-to-action resolution needed.

### Auto-detection

`create()` picks the transport automatically:
- If `COMPOSIO_API_KEY` is set → Composio transport (with optional `COMPOSIO_ENTITY_ID`)
- Otherwise falls back to direct transport (`JIRA_EMAIL` + `JIRA_API_TOKEN`)
- `JIRA_HOST` is always required

### State mapping

Jira status categories are mapped to standardized states:
- `new` → `open`
- `indeterminate` → `in_progress`
- `done` → `closed`
- Status names containing "cancel" → `cancelled`

## How it works

### Configuration

```yaml
# agent-orchestrator.yaml
projects:
  my-project:
    tracker:
      plugin: jira
      projectKey: PROJ
```

### Environment variables

**Option A — Composio (recommended):**
```bash
export JIRA_HOST=mycompany.atlassian.net
export COMPOSIO_API_KEY=your_composio_key
export COMPOSIO_ENTITY_ID=default  # optional
```

**Option B — Direct API:**
```bash
export JIRA_HOST=mycompany.atlassian.net
export JIRA_EMAIL=you@company.com
export JIRA_API_TOKEN=your_api_token
```

### Supported operations

All `Tracker` interface methods are implemented:
- `getIssue` — fetch issue by key (e.g. `PROJ-123`)
- `isCompleted` — check if issue is in a "done" status category
- `listIssues` — JQL search with state/assignee/label filters
- `createIssue` — create with summary, description, type, priority, labels
- `updateIssue` — transition state, add comments, update fields
- `issueUrl` / `issueLabel` / `branchName` / `generatePrompt` — URL generation, branch naming, prompt generation

## Files changed

| File | Description |
|------|-------------|
| `packages/plugins/tracker-jira/src/index.ts` | Main plugin implementation (both transports) |
| `packages/plugins/tracker-jira/src/composio-core.d.ts` | Ambient types for optional `@composio/core` peer dep |
| `packages/plugins/tracker-jira/test/index.test.ts` | 39 unit tests — direct transport |
| `packages/plugins/tracker-jira/test/composio-transport.test.ts` | 20 unit tests — Composio transport |
| `packages/plugins/tracker-jira/test/smoke.ts` | Manual smoke test script |
| `packages/integration-tests/src/tracker-jira.integration.test.ts` | Integration tests against real Jira API |
| `packages/core/src/plugin-registry.ts` | Register `jira` in builtin plugins |

## Testing done

- **59 unit tests passing** — 39 direct transport + 20 Composio transport
- **Build, typecheck, lint all pass** (`pnpm build && pnpm typecheck && pnpm lint`)
- **Integration tests** — exercise all plugin methods against real Jira API; auto-skipped when credentials are missing. Requires `JIRA_HOST` + credentials + `JIRA_PROJECT_KEY`.

Closes #137