### PR TITLE
refactor: preserve metadata on session kill instead of archiving

### DIFF
--- a/packages/cli/__tests__/commands/review-check.test.ts
+++ b/packages/cli/__tests__/commands/review-check.test.ts
@@ -70,7 +70,7 @@ function parseMetadata(content: string): Record<string, string> {
 /** Build Session objects from metadata files in sessionsDir. */
 function buildSessionsFromDir(dir: string, projectId: string): Session[] {
   if (!existsSync(dir)) return [];
-  const files = readdirSync(dir).filter((f) => !f.startsWith(".") && f !== "archive");
+  const files = readdirSync(dir).filter((f) => !f.startsWith("."));
   return files.map((name) => {
     const content = readFileSync(join(dir, name), "utf-8");
     const meta = parseMetadata(content);

--- a/packages/cli/__tests__/commands/session.test.ts
+++ b/packages/cli/__tests__/commands/session.test.ts
@@ -84,7 +84,7 @@ function parseMetadata(content: string): Record<string, string> {
 /** Build Session objects from metadata files in sessionsDir. */
 function buildSessionsFromDir(dir: string, projectId: string): Session[] {
   if (!existsSync(dir)) return [];
-  const files = readdirSync(dir).filter((f) => !f.startsWith(".") && f !== "archive");
+  const files = readdirSync(dir).filter((f) => !f.startsWith("."));
   return files.map((name) => {
     const content = readFileSync(join(dir, name), "utf-8");
     const meta = parseMetadata(content);

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -127,7 +127,7 @@ function buildSessionsFromDir(
   activityOverride?: ActivityState | null,
 ): Session[] {
   if (!existsSync(dir)) return [];
-  const files = readdirSync(dir).filter((f) => !f.startsWith(".") && f !== "archive");
+  const files = readdirSync(dir).filter((f) => !f.startsWith("."));
   return files.map((name) => {
     const content = readFileSync(join(dir, name), "utf-8");
     const meta = parseMetadata(content);

--- a/packages/core/src/__tests__/paths.test.ts
+++ b/packages/core/src/__tests__/paths.test.ts
@@ -23,7 +23,6 @@ import {
   getProjectBaseDir,
   getSessionsDir,
   getWorktreesDir,
-  getArchiveDir,
   getOriginFilePath,
   generateSessionName,
   generateTmuxName,
@@ -271,12 +270,6 @@ describe("Path Construction", () => {
     expect(worktreesDir).toMatch(/\.agent-orchestrator\/[a-f0-9]{12}-integrator\/worktrees$/);
   });
 
-  it("getArchiveDir returns {baseDir}/sessions/archive", () => {
-    const archiveDir = getArchiveDir(configPath, "/repos/integrator");
-
-    expect(archiveDir).toMatch(/\.agent-orchestrator\/[a-f0-9]{12}-integrator\/sessions\/archive$/);
-  });
-
   it("getOriginFilePath returns {baseDir}/.origin", () => {
     const originPath = getOriginFilePath(configPath, "/repos/integrator");
 
@@ -287,11 +280,9 @@ describe("Path Construction", () => {
     const baseDir = getProjectBaseDir(configPath, "/repos/integrator");
     const sessionsDir = getSessionsDir(configPath, "/repos/integrator");
     const worktreesDir = getWorktreesDir(configPath, "/repos/integrator");
-    const archiveDir = getArchiveDir(configPath, "/repos/integrator");
 
     expect(sessionsDir).toContain(baseDir);
     expect(worktreesDir).toContain(baseDir);
-    expect(archiveDir).toContain(baseDir);
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,7 +71,6 @@ export {
   getProjectBaseDir,
   getSessionsDir,
   getWorktreesDir,
-  getArchiveDir,
   getOriginFilePath,
   generateSessionName,
   generateTmuxName,

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -103,14 +103,6 @@ export function getWorktreesDir(configPath: string, projectPath: string): string
 }
 
 /**
- * Get the archive directory for a project.
- * Format: ~/.agent-orchestrator/{hash}-{projectId}/archive
- */
-export function getArchiveDir(configPath: string, projectPath: string): string {
-  return join(getSessionsDir(configPath, projectPath), "archive");
-}
-
-/**
  * Get the .origin file path for a project.
  * This file stores the config path for collision detection.
  */

--- a/packages/integration-tests/src/config-metadata-service.integration.test.ts
+++ b/packages/integration-tests/src/config-metadata-service.integration.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { mkdtemp, writeFile, rm } from "node:fs/promises";
-import { mkdirSync, existsSync, readdirSync } from "node:fs";
+import { mkdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -152,18 +152,12 @@ describe("config → metadata service integration (real filesystem)", () => {
     expect(ids).toContain("lifecycle-1");
     expect(ids).toContain("lifecycle-2");
 
-    // 5. Delete with archive
-    deleteMetadata(sessionsDir, "lifecycle-1", true);
+    // 5. Delete metadata
+    deleteMetadata(sessionsDir, "lifecycle-1");
     expect(readMetadata(sessionsDir, "lifecycle-1")).toBeNull();
 
-    // Verify archive exists
-    const archiveDir = join(sessionsDir, "archive");
-    expect(existsSync(archiveDir)).toBe(true);
-    const archived = readdirSync(archiveDir);
-    expect(archived.some((f) => f.startsWith("lifecycle-1_"))).toBe(true);
-
-    // 6. Delete without archive
-    deleteMetadata(sessionsDir, "lifecycle-2", false);
+    // 6. Delete second session
+    deleteMetadata(sessionsDir, "lifecycle-2");
     expect(readMetadata(sessionsDir, "lifecycle-2")).toBeNull();
   });
 
@@ -208,7 +202,7 @@ describe("config → metadata service integration (real filesystem)", () => {
     expect(listMetadata(dirB)).not.toContain("projA-session-1");
 
     // Cleanup
-    deleteMetadata(dirA, "projA-session-1", false);
-    deleteMetadata(dirB, "projB-session-1", false);
+    deleteMetadata(dirA, "projA-session-1");
+    deleteMetadata(dirB, "projB-session-1");
   });
 });


### PR DESCRIPTION
## Summary
- **kill() now sets `status=done`** instead of moving metadata to `archive/` directory — killed sessions remain visible in the dashboard
- **Removed archive dead code**: `readArchivedMetadataRaw()`, `getArchiveDir()`, archive parameter from `deleteMetadata()`, archive fallback in `restore()`
- **Simplified `listMetadata()`** and `listAllSessions()` — no longer need to skip `archive/` directory

## Test plan
- [x] All unit tests pass (`pnpm test` — 12 test files, 131+ tests)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint` — 0 errors)
- [x] Build succeeds (`pnpm build`)
- [ ] Verify killed sessions appear in dashboard done zone
- [ ] Verify `ao session kill` sets status=done in metadata file

🤖 Generated with [Claude Code](https://claude.com/claude-code)