### PR TITLE
fix: prevent cleanup from killing sessions with open PRs

### DIFF
--- a/packages/cli/__tests__/commands/session.test.ts
+++ b/packages/cli/__tests__/commands/session.test.ts
@@ -184,6 +184,7 @@ beforeEach(() => {
   mockSessionManager.cleanup.mockResolvedValue({
     killed: [],
     skipped: [],
+    warnings: [],
     errors: [],
   } satisfies CleanupResult);
 });
@@ -322,6 +323,7 @@ describe("session cleanup", () => {
     mockSessionManager.cleanup.mockResolvedValue({
       killed: ["app-1"],
       skipped: [],
+      warnings: [],
       errors: [],
     } satisfies CleanupResult);
 
@@ -341,6 +343,7 @@ describe("session cleanup", () => {
     mockSessionManager.cleanup.mockResolvedValue({
       killed: [],
       skipped: ["app-1"],
+      warnings: [],
       errors: [],
     } satisfies CleanupResult);
 
@@ -360,6 +363,7 @@ describe("session cleanup", () => {
     mockSessionManager.cleanup.mockResolvedValue({
       killed: ["app-1"],
       skipped: [],
+      warnings: [],
       errors: [],
     } satisfies CleanupResult);
 
@@ -388,6 +392,7 @@ describe("session cleanup", () => {
     mockSessionManager.cleanup.mockResolvedValue({
       killed: ["app-2"],
       skipped: [],
+      warnings: [],
       errors: [{ sessionId: "app-1", error: "tmux error" }],
     } satisfies CleanupResult);
 
@@ -409,6 +414,7 @@ describe("session cleanup", () => {
     mockSessionManager.cleanup.mockResolvedValue({
       killed: [],
       skipped: [],
+      warnings: [],
       errors: [],
     } satisfies CleanupResult);
 

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -122,6 +122,9 @@ export function registerSession(program: Command): void {
           for (const id of result.killed) {
             console.log(chalk.yellow(`  Would kill ${id}`));
           }
+          for (const { sessionId, message } of result.warnings) {
+            console.log(chalk.yellow(`  Warning (${sessionId}): ${message}`));
+          }
           if (result.killed.length > 0) {
             console.log(
               chalk.dim(
@@ -140,6 +143,9 @@ export function registerSession(program: Command): void {
             for (const id of result.killed) {
               console.log(chalk.green(`  Cleaned: ${id}`));
             }
+          }
+          for (const { sessionId, message } of result.warnings) {
+            console.log(chalk.yellow(`  Warning (${sessionId}): ${message}`));
           }
           if (result.errors.length > 0) {
             for (const { sessionId, error } of result.errors) {

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -116,7 +116,7 @@ export function registerSession(program: Command): void {
           }
         }
 
-        if (result.killed.length === 0 && result.errors.length === 0) {
+        if (result.killed.length === 0 && result.errors.length === 0 && result.warnings.length === 0) {
           console.log(chalk.dim("  No sessions to clean up."));
         } else {
           for (const id of result.killed) {
@@ -136,7 +136,7 @@ export function registerSession(program: Command): void {
       } else {
         const result = await sm.cleanup(opts.project);
 
-        if (result.killed.length === 0 && result.errors.length === 0) {
+        if (result.killed.length === 0 && result.errors.length === 0 && result.warnings.length === 0) {
           console.log(chalk.dim("  No sessions to clean up."));
         } else {
           if (result.killed.length > 0) {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -815,7 +815,12 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
         let shouldKill = false;
 
         // Check PR state first — open PR means never clean up
-        if (session.pr && plugins.scm) {
+        if (session.pr) {
+          if (!plugins.scm) {
+            // Has PR but no SCM plugin — can't verify state, skip to be safe
+            result.skipped.push(session.id);
+            continue;
+          }
           try {
             const prState = await plugins.scm.getPRState(session.pr);
             const isPrClosed = prState === PR_STATE.MERGED || prState === PR_STATE.CLOSED;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -990,6 +990,7 @@ export interface SessionManager {
 export interface CleanupResult {
   killed: string[];
   skipped: string[];
+  warnings: Array<{ sessionId: string; message: string }>;
   errors: Array<{ sessionId: string; error: string }>;
 }
 


### PR DESCRIPTION
## Problem

`ao session cleanup` removed sessions with dead runtimes even when those sessions had open, unmerged PRs. This orphaned the PRs — no active session owned them, the worktree was deleted, and users had to manually grep metadata files to discover which session previously owned a PR.

**Root cause:** The cleanup logic checked three conditions sequentially — (1) PR merged/closed, (2) issue completed, (3) runtime dead — and condition 3 would kill sessions without verifying whether an open PR existed. A session that failed to start (status `starting`, dead tmux) but had already pushed a PR would be killed by the dead-runtime check.

Closes #146

## Solution

Restructure the cleanup decision logic to **short-circuit on PR state**:

1. **PR gate first**: If a session has a PR, check its state immediately. Open PR → skip (never clean up). Merged/closed PR → mark for kill. PR check fails or no SCM plugin → skip to be safe.
2. **Issue check**: If no PR, check if the linked issue is completed.
3. **Runtime fallback**: Only if no prior check resolved, check if the runtime is dead. Emit a warning when killing via this fallback path (since there's no conclusive PR/issue status).
4. **Warning ordering**: Warnings are only emitted after `kill()` succeeds, avoiding contradictory state in `CleanupResult` if kill fails.

### Key behaviors

| Scenario | Result |
|----------|--------|
| PR merged/closed | Kill |
| PR open | Skip (protected) |
| PR exists, no SCM plugin | Skip (safe default) |
| PR check throws | Skip (safe default) |
| Issue completed | Kill |
| No PR, no issue, runtime dead | Kill + warning |
| Issue check fails, runtime dead | Kill + warning |

## Changes

- **`packages/core/src/session-manager.ts`** — Restructured `cleanup()` to gate on PR state first, added `warnings` field tracking, emit warnings only after successful kill
- **`packages/core/src/types.ts`** — Added `warnings: Array<{ sessionId: string; message: string }>` to `CleanupResult`
- **`packages/cli/src/commands/session.ts`** — Render warnings in CLI output for both dry-run and real cleanup; include warnings in the "no sessions" empty-state check
- **`packages/core/src/__tests__/session-manager.test.ts`** — Added 8 new cleanup tests covering: open PR skip, PR state short-circuit, SCM error handling, tracker error fallback, no-tracker fallback, open issue with dead runtime
- **`packages/cli/__tests__/commands/session.test.ts`** — Updated `CleanupResult` mocks to include `warnings` field

## Breaking changes

- `CleanupResult` now has a required `warnings` field. Any code that constructs `CleanupResult` literals (e.g., tests, custom callers) must include `warnings: []`.

## Test plan

- [x] Core tests pass (251 tests)
- [x] CLI tests pass (131 tests)
- [x] TypeScript typecheck passes
- [x] All 3 Cursor Bugbot review comments addressed
- [ ] CI checks pass after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)