### PR TITLE
fix(web): resolve missing @composio/core when bundling tracker-linear

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,4 +1,9 @@
-const path = require("path");
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 
 // Resolve @composio/core only when not installed, so COMPOSIO_API_KEY + real SDK work.
 let stubComposioCorePath = null;

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@composio/ao-core"],
+  webpack: (config, { isServer }) => {
+    // tracker-linear optionally uses @composio/core; stub so Next.js can resolve it
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@composio/core": require("path").resolve(__dirname, "stub-composio-core.js"),
+    };
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,12 +1,23 @@
+const path = require("path");
+
+// Resolve @composio/core only when not installed, so COMPOSIO_API_KEY + real SDK work.
+let stubComposioCorePath = null;
+try {
+  require.resolve("@composio/core");
+} catch {
+  stubComposioCorePath = path.resolve(__dirname, "stub-composio-core.js");
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@composio/ao-core"],
-  webpack: (config, { isServer }) => {
-    // tracker-linear optionally uses @composio/core; stub so Next.js can resolve it
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      "@composio/core": require("path").resolve(__dirname, "stub-composio-core.js"),
-    };
+  webpack: (config) => {
+    if (stubComposioCorePath) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        "@composio/core": stubComposioCorePath,
+      };
+    }
     return config;
   },
 };

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -23,6 +23,11 @@ const nextConfig = {
         "@composio/core": stubComposioCorePath,
       };
     }
+    // Core's plugin-registry uses dynamic import(pkg); webpack can't resolve it at build time.
+    config.ignoreWarnings = [
+      ...(config.ignoreWarnings ?? []),
+      { module: /plugin-registry\.js$/, message: /Critical dependency: the request of a dependency is an expression/ },
+    ];
     return config;
   },
 };

--- a/packages/web/stub-composio-core.js
+++ b/packages/web/stub-composio-core.js
@@ -1,0 +1,14 @@
+/**
+ * Stub for optional @composio/core (used by tracker-linear when COMPOSIO_API_KEY is set).
+ * Allows Next.js to resolve the module when bundling. Runtime use will throw.
+ */
+function throwNotInstalled() {
+  throw new Error(
+    "Composio SDK (@composio/core) is not installed. Install it with: pnpm add @composio/core"
+  );
+}
+module.exports = {
+  Composio: function Composio() {
+    throwNotInstalled();
+  },
+};

--- a/packages/web/stub-composio-core.js
+++ b/packages/web/stub-composio-core.js
@@ -1,14 +1,14 @@
 /**
  * Stub for optional @composio/core (used by tracker-linear when COMPOSIO_API_KEY is set).
  * Allows Next.js to resolve the module when bundling. Runtime use will throw.
+ * ESM export so import("@composio/core") works in type:module packages.
  */
 function throwNotInstalled() {
   throw new Error(
     "Composio SDK (@composio/core) is not installed. Install it with: pnpm add @composio/core"
   );
 }
-module.exports = {
-  Composio: function Composio() {
-    throwNotInstalled();
-  },
-};
+
+export function Composio() {
+  throwNotInstalled();
+}


### PR DESCRIPTION
## Problem
Next.js fails to build the web dashboard with:
`Module not found: Can't resolve '@composio/core' in '.../packages/plugins/tracker-linear/dist'`

tracker-linear optionally uses the Composio SDK (`@composio/core`) when `COMPOSIO_API_KEY` is set. The web package does not depend on it, so bundling the plugin causes resolution to fail even when only the direct Linear (or GitHub) tracker is used.

## Solution
- Add a stub module for `@composio/core` so webpack can resolve the dependency.
- Alias `@composio/core` to the stub in next.config.js.

If the Composio transport is ever used at runtime without the real package installed, the stub throws a clear error. No behavior change for users who install `@composio/core` or who only use LINEAR_API_KEY / GitHub tracker.

Made with [Cursor](https://cursor.com)