### PR TITLE
fix(agent-codex): forward OPENAI_API_KEY to session so Codex runs without login

### DIFF
--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -251,6 +251,29 @@ describe("getEnvironment", () => {
       process.env["PATH"] = originalPath;
     }
   });
+
+  it("forwards OPENAI_API_KEY when set in process.env", () => {
+    const original = process.env["OPENAI_API_KEY"];
+    process.env["OPENAI_API_KEY"] = "sk-test-key";
+    try {
+      const env = agent.getEnvironment(makeLaunchConfig());
+      expect(env["OPENAI_API_KEY"]).toBe("sk-test-key");
+    } finally {
+      if (original === undefined) delete process.env["OPENAI_API_KEY"];
+      else process.env["OPENAI_API_KEY"] = original;
+    }
+  });
+
+  it("omits OPENAI_API_KEY when not set in process.env", () => {
+    const original = process.env["OPENAI_API_KEY"];
+    delete process.env["OPENAI_API_KEY"];
+    try {
+      const env = agent.getEnvironment(makeLaunchConfig());
+      expect(env["OPENAI_API_KEY"]).toBeUndefined();
+    } finally {
+      if (original !== undefined) process.env["OPENAI_API_KEY"] = original;
+    }
+  });
 });
 
 // =========================================================================

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -315,6 +315,12 @@ function createCodexAgent(): Agent {
         env["AO_ISSUE_ID"] = config.issueId;
       }
 
+      // Forward OpenAI API key so Codex can run without interactive login.
+      const openaiKey = process.env["OPENAI_API_KEY"];
+      if (openaiKey) {
+        env["OPENAI_API_KEY"] = openaiKey;
+      }
+
       // Prepend ~/.ao/bin to PATH so our gh/git wrappers intercept commands.
       // The wrappers strip this directory from PATH before calling the real
       // binary, so there's no infinite recursion.


### PR DESCRIPTION
When the AO server is started with OPENAI_API_KEY in env (e.g. from .env.local), the codex plugin now passes it into the session environment. Codex can then use the key and skip the interactive sign-in prompt.

- getEnvironment() forwards process.env.OPENAI_API_KEY when set
- Added tests for presence/absence of OPENAI_API_KEY in session env

Made with [Cursor](https://cursor.com)