### PR TITLE
feat(cli): add --base-branch flag to spawn and batch-spawn

### DIFF
--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -290,6 +290,62 @@ describe("spawn command", () => {
     });
   });
 
+  it("passes --base-branch flag to sessionManager.spawn()", async () => {
+    const fakeSession: Session = {
+      id: "app-1",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: "feat/INT-50",
+      issueId: "INT-50",
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-app-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync(["node", "test", "spawn", "my-app", "INT-50", "--base-branch", "feat/existing-feature"]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: "INT-50",
+      baseBranch: "feat/existing-feature",
+    });
+  });
+
+  it("passes --base-branch without issue ID", async () => {
+    const fakeSession: Session = {
+      id: "app-1",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: "session/app-1",
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-app-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync(["node", "test", "spawn", "my-app", "--base-branch", "feat/existing-feature"]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: undefined,
+      baseBranch: "feat/existing-feature",
+    });
+  });
+
   it("rejects unknown project ID", async () => {
     await expect(
       program.parseAsync(["node", "test", "spawn", "nonexistent"]),

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -190,6 +190,32 @@ describe("spawn", () => {
     expect(session.branch).toBe("custom/INT-100-my-feature");
   });
 
+  it("passes baseBranch to workspace.create()", async () => {
+    const sm = createSessionManager({ config, registry: mockRegistry });
+
+    await sm.spawn({ projectId: "my-app", issueId: "INT-100", baseBranch: "feat/existing-feature" });
+
+    expect(mockWorkspace.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseBranch: "feat/existing-feature",
+        branch: "feat/INT-100",
+      }),
+    );
+  });
+
+  it("passes undefined baseBranch when not specified", async () => {
+    const sm = createSessionManager({ config, registry: mockRegistry });
+
+    await sm.spawn({ projectId: "my-app", issueId: "INT-100" });
+
+    expect(mockWorkspace.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseBranch: undefined,
+        branch: "feat/INT-100",
+      }),
+    );
+  });
+
   it("increments session numbers correctly", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -408,6 +408,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
           project,
           sessionId,
           branch,
+          baseBranch: spawnConfig.baseBranch,
         });
         workspacePath = wsInfo.path;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -175,6 +175,8 @@ export interface SessionSpawnConfig {
   projectId: string;
   issueId?: string;
   branch?: string;
+  /** Base branch to start from instead of project.defaultBranch (e.g. an existing feature branch) */
+  baseBranch?: string;
   prompt?: string;
   /** Override the agent plugin for this session (e.g. "codex", "claude-code") */
   agent?: string;
@@ -403,6 +405,8 @@ export interface WorkspaceCreateConfig {
   project: ProjectConfig;
   sessionId: SessionId;
   branch: string;
+  /** Base branch to start from instead of project.defaultBranch */
+  baseBranch?: string;
 }
 
 export interface WorkspaceInfo {

--- a/packages/plugins/workspace-worktree/src/index.ts
+++ b/packages/plugins/workspace-worktree/src/index.ts
@@ -71,7 +71,9 @@ export function create(config?: Record<string, unknown>): Workspace {
         // Fetch may fail if offline — continue anyway
       }
 
-      const baseRef = `origin/${cfg.project.defaultBranch}`;
+      const baseRef = cfg.baseBranch
+        ? `origin/${cfg.baseBranch}`
+        : `origin/${cfg.project.defaultBranch}`;
 
       // Create worktree with a new branch
       try {


### PR DESCRIPTION
## Summary

- Adds `--base-branch` option to `ao spawn` and `ao batch-spawn` commands, allowing agent sessions to branch from an existing feature branch instead of the project's `defaultBranch`
- Threads `baseBranch` through `SessionSpawnConfig` -> `WorkspaceCreateConfig` -> workspace-worktree plugin
- Useful for interrelated tasks where dependent issues need to start from a parent feature branch

## Usage

```bash
# Spawn from an existing feature branch
ao spawn my-app INT-456 --base-branch feat/INT-123

# Batch spawn multiple issues from the same base
ao batch-spawn my-app INT-456 INT-457 --base-branch feat/INT-123
```

## Changes

- `packages/core/src/types.ts` — Added `baseBranch?: string` to `SessionSpawnConfig` and `WorkspaceCreateConfig`
- `packages/core/src/session-manager.ts` — Passes `baseBranch` through to workspace plugin
- `packages/plugins/workspace-worktree/src/index.ts` — Uses `origin/{baseBranch}` when provided, falls back to `origin/{defaultBranch}`
- `packages/cli/src/commands/spawn.ts` — Added `--base-branch` flag to both `spawn` and `batch-spawn`

## Test plan

- [x] Added CLI tests for `--base-branch` with and without issue ID
- [x] Added session-manager tests for `baseBranch` passthrough
- [x] Added worktree plugin tests for `baseBranch` usage, fallback, and branch-exists path
- [x] All 901 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)