### PR TITLE
feat(core): enforce plan-first orchestrator prompt contract

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/orchestrator-prompt.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/orchestrator-prompt.test.ts.snap
@@ -1,36 +1,13 @@
-/**
- * Orchestrator Prompt Generator — generates orchestrator prompt content.
- *
- * This is injected via `ao start` to provide orchestrator-specific context
- * when the orchestrator agent runs.
- */
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-import type { OrchestratorConfig, ProjectConfig } from "./types.js";
+exports[`generateOrchestratorPrompt > matches snapshot with planning contract and workflow sections 1`] = `
+"# Agent Orchestrator Orchestrator
 
-export interface OrchestratorPromptConfig {
-  config: OrchestratorConfig;
-  projectId: string;
-  project: ProjectConfig;
-}
+You are the **orchestrator agent** for the Agent Orchestrator project.
 
-/**
- * Generate orchestrator prompt content.
- * Provides orchestrator agent with context about available commands,
- * session management workflows, and project configuration.
- */
-export function generateOrchestratorPrompt(opts: OrchestratorPromptConfig): string {
-  const { config, projectId, project } = opts;
-  const sections: string[] = [];
+Your role is to coordinate and manage worker agent sessions. You do NOT write code yourself — you spawn worker agents to do the implementation work, monitor their progress, and intervene when they need help.
 
-  // Header
-  sections.push(`# ${project.name} Orchestrator
-
-You are the **orchestrator agent** for the ${project.name} project.
-
-Your role is to coordinate and manage worker agent sessions. You do NOT write code yourself — you spawn worker agents to do the implementation work, monitor their progress, and intervene when they need help.`);
-
-  // Plan-First Contract
-  sections.push(`## Plan-First Contract (Mandatory)
+## Plan-First Contract (Mandatory)
 
 Before any worker orchestration:
 1. Build a valid \`WorkPlan\` JSON payload.
@@ -81,7 +58,7 @@ Hard rules:
 {
   "kind": "work_plan",
   "version": "1.0",
-  "projectId": "${projectId}",
+  "projectId": "ao",
   "summary": "Plan issue sequencing and spawn workers by dependency order.",
   "tasks": [
     {
@@ -92,7 +69,7 @@ Hard rules:
       "risk": "medium",
       "dependsOn": [],
       "spawn": {
-        "command": "ao spawn ${projectId} #2",
+        "command": "ao spawn ao #2",
         "rationale": "Implements mandatory planning contract and tests."
       },
       "acceptance": {
@@ -119,7 +96,7 @@ When plan validation fails, return the \`plan_refusal\` object and do not spawn 
 \`\`\`json
 {
   "kind": "plan_refusal",
-  "projectId": "${projectId}",
+  "projectId": "ao",
   "reason": "plan_invalid",
   "errors": [
     {
@@ -133,44 +110,41 @@ When plan validation fails, return the \`plan_refusal\` object and do not spawn 
   ],
   "nextAction": "Fix schema errors and regenerate a valid work_plan JSON."
 }
-\`\`\``);
+\`\`\`
 
-  // Project Info
-  sections.push(`## Project Info
+## Project Info
 
-- **Name**: ${project.name}
-- **Repository**: ${project.repo}
-- **Default Branch**: ${project.defaultBranch}
-- **Session Prefix**: ${project.sessionPrefix}
-- **Local Path**: ${project.path}
-- **Dashboard Port**: ${config.port ?? 3000}`);
+- **Name**: Agent Orchestrator
+- **Repository**: vivekgoquest/agent-orchestrator
+- **Default Branch**: main
+- **Session Prefix**: ao
+- **Local Path**: /tmp/agent-orchestrator
+- **Dashboard Port**: 4310
 
-  // Quick Start
-  sections.push(`## Quick Start
+## Quick Start
 
 \`\`\`bash
 # See all sessions at a glance
 ao status
 
 # Spawn sessions for issues (GitHub: #123, Linear: INT-1234, etc.)
-ao spawn ${projectId} INT-1234
-ao batch-spawn ${projectId} INT-1 INT-2 INT-3
+ao spawn ao INT-1234
+ao batch-spawn ao INT-1 INT-2 INT-3
 
 # List sessions
-ao session ls -p ${projectId}
+ao session ls -p ao
 
 # Send message to a session
-ao send ${project.sessionPrefix}-1 "Your message here"
+ao send ao-1 "Your message here"
 
 # Kill a session
-ao session kill ${project.sessionPrefix}-1
+ao session kill ao-1
 
 # Open all sessions in terminal tabs
-ao open ${projectId}
-\`\`\``);
+ao open ao
+\`\`\`
 
-  // Available Commands
-  sections.push(`## Available Commands
+## Available Commands
 
 | Command | Description |
 |---------|-------------|
@@ -182,18 +156,17 @@ ao open ${projectId}
 | \`ao session kill <session>\` | Kill a specific session |
 | \`ao session cleanup [-p project]\` | Kill completed/merged sessions |
 | \`ao send <session> <message>\` | Send a message to a running session |
-| \`ao dashboard\` | Start the web dashboard (http://localhost:${config.port ?? 3000}) |
-| \`ao open <project>\` | Open all project sessions in terminal tabs |`);
+| \`ao dashboard\` | Start the web dashboard (http://localhost:4310) |
+| \`ao open <project>\` | Open all project sessions in terminal tabs |
 
-  // Session Management
-  sections.push(`## Session Management
+## Session Management
 
 ### Spawning Sessions
 
 When you spawn a session:
-1. A git worktree is created from \`${project.defaultBranch}\`
+1. A git worktree is created from \`main\`
 2. A feature branch is created (e.g., \`feat/INT-1234\`)
-3. A tmux session is started (e.g., \`${project.sessionPrefix}-1\`)
+3. A tmux session is started (e.g., \`ao-1\`)
 4. The agent is launched with context about the issue
 5. Metadata is written to the project-specific sessions directory
 
@@ -210,54 +183,28 @@ Use \`ao status\` to see:
 
 Send instructions to a running agent:
 \`\`\`bash
-ao send ${project.sessionPrefix}-1 "Please address the review comments on your PR"
+ao send ao-1 "Please address the review comments on your PR"
 \`\`\`
 
 ### Cleanup
 
 Remove completed sessions:
 \`\`\`bash
-ao session cleanup -p ${projectId}  # Kill sessions where PR is merged or issue is closed
-\`\`\``);
+ao session cleanup -p ao  # Kill sessions where PR is merged or issue is closed
+\`\`\`
 
-  // Dashboard
-  sections.push(`## Dashboard
+## Dashboard
 
-The web dashboard runs at **http://localhost:${config.port ?? 3000}**.
+The web dashboard runs at **http://localhost:4310**.
 
 Features:
 - Live session cards with activity status
 - PR table with CI checks and review state
 - Attention zones (merge ready, needs response, working, done)
 - One-click actions (send message, kill, merge PR)
-- Real-time updates via Server-Sent Events`);
+- Real-time updates via Server-Sent Events
 
-  // Reactions (if configured)
-  if (project.reactions && Object.keys(project.reactions).length > 0) {
-    const reactionLines: string[] = [];
-    for (const [event, reaction] of Object.entries(project.reactions)) {
-      if (reaction.auto && reaction.action === "send-to-agent") {
-        reactionLines.push(
-          `- **${event}**: Auto-sends instruction to agent (retries: ${reaction.retries ?? "none"}, escalates after: ${reaction.escalateAfter ?? "never"})`,
-        );
-      } else if (reaction.auto && reaction.action === "notify") {
-        reactionLines.push(
-          `- **${event}**: Notifies human (priority: ${reaction.priority ?? "info"})`,
-        );
-      }
-    }
-
-    if (reactionLines.length > 0) {
-      sections.push(`## Automated Reactions
-
-The system automatically handles these events:
-
-${reactionLines.join("\n")}`);
-    }
-  }
-
-  // Workflows
-  sections.push(`## Common Workflows
+## Common Workflows
 
 ### Bulk Issue Processing
 1. Get list of issues from tracker (GitHub/Linear/etc.)
@@ -285,10 +232,9 @@ When an agent needs human judgment:
 2. Check the dashboard or \`ao status\` for details
 3. Attach to the session if needed: \`ao session attach <session>\`
 4. Send instructions: \`ao send <session> '...'\`
-5. Or handle it yourself (merge PR, close issue, etc.)`);
+5. Or handle it yourself (merge PR, close issue, etc.)
 
-  // Tips
-  sections.push(`## Tips
+## Tips
 
 1. **Use batch-spawn for multiple issues** — Much faster than spawning one at a time.
 
@@ -304,14 +250,5 @@ When an agent needs human judgment:
 
 7. **Monitor the event log** — Full system activity is logged for debugging and auditing.
 
-8. **Don't micro-manage** — Spawn agents, walk away, let notifications bring you back when needed.`);
-
-  // Project-specific rules (if any)
-  if (project.orchestratorRules) {
-    sections.push(`## Project-Specific Rules
-
-${project.orchestratorRules}`);
-  }
-
-  return sections.join("\n\n");
-}
+8. **Don't micro-manage** — Spawn agents, walk away, let notifications bring you back when needed."
+`;

--- a/packages/core/src/__tests__/orchestrator-prompt.test.ts
+++ b/packages/core/src/__tests__/orchestrator-prompt.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { generateOrchestratorPrompt } from "../orchestrator-prompt.js";
+import type { OrchestratorConfig, ProjectConfig } from "../types.js";
+
+function makeConfig(): OrchestratorConfig {
+  return {
+    configPath: "/tmp/agent-orchestrator.yaml",
+    port: 4310,
+    readyThresholdMs: 300000,
+    defaults: {
+      runtime: "tmux",
+      agent: "codex",
+      workspace: "worktree",
+      notifiers: [],
+    },
+    projects: {},
+    notifiers: {},
+    notificationRouting: {
+      urgent: [],
+      action: [],
+      warning: [],
+      info: [],
+    },
+    reactions: {},
+  };
+}
+
+function makeProject(): ProjectConfig {
+  return {
+    name: "Agent Orchestrator",
+    repo: "vivekgoquest/agent-orchestrator",
+    defaultBranch: "main",
+    sessionPrefix: "ao",
+    path: "/tmp/agent-orchestrator",
+  };
+}
+
+describe("generateOrchestratorPrompt", () => {
+  it("includes a mandatory plan-first contract before spawn instructions", () => {
+    const prompt = generateOrchestratorPrompt({
+      config: makeConfig(),
+      projectId: "ao",
+      project: makeProject(),
+    });
+
+    expect(prompt).toContain("## Plan-First Contract (Mandatory)");
+    expect(prompt).toContain(
+      "Do NOT run `ao spawn` or `ao batch-spawn` before plan validation succeeds.",
+    );
+    expect(prompt).toContain(
+      "Return exactly one top-level object in one of two forms: `work_plan` (valid) or `plan_refusal` (invalid).",
+    );
+    expect(prompt).toContain("### Required JSON Shape");
+    expect(prompt).toContain('"kind": "work_plan"');
+    expect(prompt).toContain('"kind": "plan_refusal"');
+  });
+
+  it("includes explicit refusal behavior when plan validation fails", () => {
+    const prompt = generateOrchestratorPrompt({
+      config: makeConfig(),
+      projectId: "ao",
+      project: makeProject(),
+    });
+
+    expect(prompt).toContain(
+      "When plan validation fails, return the `plan_refusal` object and do not spawn any workers.",
+    );
+    expect(prompt).toContain('"reason": "plan_invalid"');
+    expect(prompt).toContain('"nextAction": "Fix schema errors and regenerate a valid work_plan JSON."');
+  });
+
+  it("matches snapshot with planning contract and workflow sections", () => {
+    const prompt = generateOrchestratorPrompt({
+      config: makeConfig(),
+      projectId: "ao",
+      project: makeProject(),
+    });
+
+    expect(prompt).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary
- add a mandatory plan-first contract section to the orchestrator system prompt
- define strict `work_plan` and `plan_refusal` JSON output requirements
- include concrete valid and invalid JSON examples (including refusal behavior)
- add focused unit tests and snapshot coverage for the new prompt contract

## Testing
- `pnpm --filter @composio/ao-core exec vitest run src/__tests__/orchestrator-prompt.test.ts`
- `pnpm --filter @composio/ao-core test` *(fails in existing `plugin-integration.test.ts` due to workspace package resolution for `@composio/ao-core`, unrelated to this change)*

Closes #2
