### PR TITLE
Codex non-interactive when permissions=skip

### DIFF
--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -148,9 +148,11 @@ describe("getLaunchCommand", () => {
     expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("codex");
   });
 
-  it("includes --full-auto when permissions=skip", () => {
+  it("includes --full-auto and -a never when permissions=skip", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "skip" }));
     expect(cmd).toContain("--full-auto");
+    expect(cmd).toContain("-a");
+    expect(cmd).toContain("never");
   });
 
   it("includes --model with shell-escaped value", () => {
@@ -167,7 +169,7 @@ describe("getLaunchCommand", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ permissions: "skip", model: "o3", prompt: "Go" }),
     );
-    expect(cmd).toBe("codex --full-auto --model 'o3' -- 'Go'");
+    expect(cmd).toBe("codex --full-auto -a never --model 'o3' -- 'Go'");
   });
 
   it("escapes single quotes in prompt (POSIX shell escaping)", () => {

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -13,7 +13,7 @@ import {
 import { execFile } from "node:child_process";
 import { writeFile, mkdir, readFile, rename } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { promisify } from "node:util";
 import { randomBytes } from "node:crypto";
 
@@ -266,6 +266,7 @@ async function setupCodexWorkspace(workspacePath: string): Promise<void> {
     const content = existing
       ? existing.trimEnd() + "\n" + AO_AGENTS_MD_SECTION
       : AO_AGENTS_MD_SECTION.trimStart();
+    await mkdir(dirname(agentsMdPath), { recursive: true });
     await writeFile(agentsMdPath, content, "utf-8");
   }
 }
@@ -283,7 +284,7 @@ function createCodexAgent(): Agent {
       const parts: string[] = ["codex"];
 
       if (config.permissions === "skip") {
-        parts.push("--full-auto");
+        parts.push("--full-auto", "-a", "never");
       }
 
       if (config.model) {


### PR DESCRIPTION
## Summary

- **codex:** Pass `-a never` when `permissions: skip` so agents run non-interactively (no approval prompts for git/shell).
- **codex:** `mkdir` before writing AGENTS.md to avoid ENOENT when project path is missing.

Tests updated for new Codex launch args.