### PR TITLE
Fix button spacing — reduce gap between screenshots and CTAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Agent Orchestrator manages fleets of AI coding agents working in parallel on you
   <img src="docs/assets/demo-video-tweet.png" alt="Agent Orchestrator demo — AI agents building their own orchestrator" width="560">
 </a>
 
-<p>&nbsp;</p>
+<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" height="8">
 
 <a href="https://x.com/agent_wrapper/status/2026329204405723180"><img src="docs/assets/btn-watch-demo.png" alt="Watch the Demo on X" height="48"></a>
 
@@ -37,7 +37,7 @@ Agent Orchestrator manages fleets of AI coding agents working in parallel on you
   <img src="docs/assets/article-tweet.png" alt="The Self-Improving AI System That Built Itself" width="560">
 </a>
 
-<p>&nbsp;</p>
+<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" height="8">
 
 <a href="https://x.com/agent_wrapper/status/2025986105485733945"><img src="docs/assets/btn-read-article.png" alt="Read the Full Article on X" height="48"></a>
 


### PR DESCRIPTION
## Summary
- Replace `<p>&nbsp;</p>` with a 1px transparent GIF spacer at `height=8`
- Previous spacing was too large — button felt disconnected from its screenshot
- Inline data URI, no extra file needed

## Test plan
- [ ] Verify button sits close to its screenshot but with a subtle gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)