### PR TITLE
feat(config): add optional orchestratorModel for separate orchestrator agent model

### DIFF
--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -46,7 +46,8 @@ projects:
     # Agent-specific config
     # agentConfig:
     #   permissions: skip    # --dangerously-skip-permissions
-    #   model: opus
+    #   model: opus          # worker agents (e.g. gpt-4o, o3; agent plugin default if unset)
+    #   orchestratorModel: gpt-4o  # orchestrator session only (defaults to model if unset)
 
     # Inline rules included in every agent prompt for this project
     # agentRules: |

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -55,6 +55,7 @@ const AgentSpecificConfigSchema = z
   .object({
     permissions: z.enum(["skip", "default"]).optional(),
     model: z.string().optional(),
+    orchestratorModel: z.string().optional(),
   })
   .passthrough();
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1045,12 +1045,16 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
 
     // 7. Get launch command — try restore command first, fall back to fresh launch
     let launchCommand: string;
+    const isOrchestratorSession = sessionId.endsWith("-orchestrator");
+    const model = isOrchestratorSession
+      ? (project.agentConfig?.orchestratorModel ?? project.agentConfig?.model)
+      : project.agentConfig?.model;
     const agentLaunchConfig = {
       sessionId,
       projectConfig: project,
       issueId: session.issueId ?? undefined,
       permissions: project.agentConfig?.permissions,
-      model: project.agentConfig?.model,
+      model,
     };
 
     if (plugins.agent.getRestoreCommand) {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -610,7 +610,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       sessionId,
       projectConfig: project,
       permissions: project.agentConfig?.permissions,
-      model: project.agentConfig?.model,
+      model: project.agentConfig?.orchestratorModel ?? project.agentConfig?.model,
       systemPromptFile,
     };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -905,7 +905,10 @@ export interface NotifierConfig {
 
 export interface AgentSpecificConfig {
   permissions?: "skip" | "default";
+  /** Model for worker agents (e.g. "gpt-4o", "o3"). Agent plugin default if unset. */
   model?: string;
+  /** Model for the orchestrator agent session. Falls back to `model` if unset. */
+  orchestratorModel?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
Adds an optional `orchestratorModel` to `agentConfig`. When set, the orchestrator agent session uses it; otherwise it falls back to `model`. Workers always use `model`.

- **types**: `orchestratorModel?: string` on `AgentSpecificConfig`
- **config**: Zod schema + passthrough
- **session-manager**: orchestrator launch uses `orchestratorModel ?? model`
- **agent-orchestrator.yaml.example**: document `model` and `orchestratorModel`

Backward compatible; both fields remain optional.

Made with [Cursor](https://cursor.com)