### PR TITLE
fix(dashboard): PR state detection and merge race handling

### DIFF
--- a/packages/cli/__tests__/commands/review-check.test.ts
+++ b/packages/cli/__tests__/commands/review-check.test.ts
@@ -18,6 +18,7 @@ const { mockTmux, mockExec, mockGh, mockConfigRef, mockSessionManager, sessionsD
       spawn: vi.fn(),
       spawnOrchestrator: vi.fn(),
       send: vi.fn(),
+      ensurePRDetected: vi.fn().mockResolvedValue(null),
     },
     sessionsDirRef: { current: "" },
   }));

--- a/packages/cli/__tests__/commands/session.test.ts
+++ b/packages/cli/__tests__/commands/session.test.ts
@@ -33,6 +33,7 @@ const { mockTmux, mockGit, mockGh, mockExec, mockConfigRef, mockSessionManager, 
       spawn: vi.fn(),
       spawnOrchestrator: vi.fn(),
       send: vi.fn(),
+      ensurePRDetected: vi.fn().mockResolvedValue(null),
     },
     sessionsDirRef: { current: "" },
   }));

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -15,6 +15,7 @@ const { mockExec, mockConfigRef, mockSessionManager } = vi.hoisted(() => ({
     spawn: vi.fn(),
     spawnOrchestrator: vi.fn(),
     send: vi.fn(),
+    ensurePRDetected: vi.fn().mockResolvedValue(null),
   },
 }));
 

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -39,6 +39,7 @@ const {
     spawn: vi.fn(),
     spawnOrchestrator: vi.fn(),
     send: vi.fn(),
+    ensurePRDetected: vi.fn().mockResolvedValue(null),
   },
   sessionsDirRef: { current: "" },
 }));

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -110,6 +110,7 @@ beforeEach(() => {
     kill: vi.fn().mockResolvedValue(undefined),
     cleanup: vi.fn(),
     send: vi.fn().mockResolvedValue(undefined),
+    ensurePRDetected: vi.fn().mockResolvedValue(null),
   };
 
   config = {

--- a/packages/core/src/__tests__/plugin-integration.test.ts
+++ b/packages/core/src/__tests__/plugin-integration.test.ts
@@ -445,6 +445,7 @@ describe("plugin integration", () => {
         kill: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue(undefined),
         spawnOrchestrator: vi.fn(),
+        ensurePRDetected: vi.fn().mockResolvedValue(null),
       };
 
       const lm = createLifecycleManager({
@@ -475,6 +476,7 @@ describe("plugin integration", () => {
         kill: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue(undefined),
         spawnOrchestrator: vi.fn(),
+        ensurePRDetected: vi.fn().mockResolvedValue(null),
       };
 
       const lm = createLifecycleManager({
@@ -502,6 +504,7 @@ describe("plugin integration", () => {
         kill: vi.fn().mockResolvedValue(undefined),
         send: vi.fn().mockResolvedValue(undefined),
         spawnOrchestrator: vi.fn(),
+        ensurePRDetected: vi.fn().mockResolvedValue(null),
       };
 
       const lm = createLifecycleManager({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -905,7 +905,10 @@ export interface NotifierConfig {
 
 export interface AgentSpecificConfig {
   permissions?: "skip" | "default";
+  /** Model for worker agents (e.g. "gpt-4o", "o3"). Agent plugin default if unset. */
   model?: string;
+  /** Model for the orchestrator agent session. Falls back to `model` if unset. */
+  orchestratorModel?: string;
   [key: string]: unknown;
 }
 
@@ -988,6 +991,8 @@ export interface SessionManager {
   kill(sessionId: SessionId): Promise<void>;
   cleanup(projectId?: string, options?: { dryRun?: boolean }): Promise<CleanupResult>;
   send(sessionId: SessionId, message: string): Promise<void>;
+  /** If session has no pr but has branch or workspacePath, try to detect PR via SCM and persist. Returns session with pr set, or null. */
+  ensurePRDetected(session: Session, project: ProjectConfig): Promise<Session | null>;
 }
 
 export interface CleanupResult {

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -132,7 +132,11 @@ describe("scm-github plugin", () => {
     });
 
     it("returns null when session has no branch", async () => {
-      const result = await scm.detectPR(makeSession({ branch: null }), project);
+      // No branch and no workspacePath → cannot derive branch; return null without calling gh
+      const result = await scm.detectPR(
+        makeSession({ branch: null, workspacePath: null }),
+        project,
+      );
       expect(result).toBeNull();
       expect(ghMock).not.toHaveBeenCalled();
     });

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   enrichSessionPR,
   enrichSessionsMetadata,
 } from "@/lib/serialize";
+import { ensureSessionsHaveDetectedPRs } from "@/lib/session-pr-detection";
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -16,6 +17,12 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     if (!coreSession) {
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
+    await ensureSessionsHaveDetectedPRs({
+      sessions: [coreSession],
+      config,
+      registry,
+      sessionManager,
+    });
 
     const dashboardSession = sessionToDashboard(coreSession);
 

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -8,6 +8,7 @@ import {
   enrichSessionsMetadata,
   computeStats,
 } from "@/lib/serialize";
+import { ensureSessionsHaveDetectedPRs } from "@/lib/session-pr-detection";
 
 /** GET /api/sessions — List all sessions with full state
  * Query params:
@@ -20,6 +21,13 @@ export async function GET(request: Request) {
 
     const { config, registry, sessionManager } = await getServices();
     const coreSessions = await sessionManager.list();
+
+    await ensureSessionsHaveDetectedPRs({
+      sessions: coreSessions,
+      config,
+      registry,
+      sessionManager,
+    });
 
     // Filter out orchestrator sessions — they get their own button, not a card
     let workerSessions = coreSessions.filter((s) => !s.id.endsWith("-orchestrator"));

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/serialize";
 import { prCache, prCacheKey } from "@/lib/cache";
 import { getProjectName } from "@/lib/project-name";
+import { ensureSessionsHaveDetectedPRs } from "@/lib/session-pr-detection";
 
 export const dynamic = "force-dynamic";
 
@@ -27,6 +28,13 @@ export default async function Home() {
   try {
     const { config, registry, sessionManager } = await getServices();
     const allSessions = await sessionManager.list();
+
+    await ensureSessionsHaveDetectedPRs({
+      sessions: allSessions,
+      config,
+      registry,
+      sessionManager,
+    });
 
     // Find the orchestrator session (any session ending with -orchestrator)
     // Only set orchestratorId if an actual session exists (no fallback)

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -70,9 +70,23 @@ export function Dashboard({ sessions, stats, orchestratorId, projectName }: Dash
 
   const handleMerge = async (prNumber: number) => {
     const res = await fetch(`/api/prs/${prNumber}/merge`, { method: "POST" });
-    if (!res.ok) {
-      console.error(`Failed to merge PR #${prNumber}:`, await res.text());
+    if (res.ok) {
+      // Re-fetch server-rendered state (PR status/session attention) after merge action.
+      window.location.reload();
+      return;
     }
+    let message = `HTTP ${res.status}`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body.error) message = body.error;
+    } catch {
+      try {
+        message = await res.text();
+      } catch {
+        // ignore
+      }
+    }
+    console.error(`Failed to merge PR #${prNumber}:`, message);
   };
 
   const handleRestore = async (sessionId: string) => {

--- a/packages/web/src/lib/session-pr-detection.ts
+++ b/packages/web/src/lib/session-pr-detection.ts
@@ -1,0 +1,66 @@
+import type {
+  OrchestratorConfig,
+  PluginRegistry,
+  ProjectConfig,
+  Session,
+  SessionManager,
+  Tracker,
+} from "@composio/ao-core";
+
+/** Extract short issue id (e.g. CLA-5) from issueId which may be a URL or plain id. */
+function issueIdToShortId(issueId: string): string {
+  if (!issueId.includes("/") && !issueId.includes(".")) return issueId;
+  const segment = issueId.replace(/\/$/, "").split("/").pop();
+  return segment ?? issueId;
+}
+
+/**
+ * Ensure a session has branch/workspace context needed for PR detection.
+ * If missing, derive branch from tracker + issue id where possible.
+ */
+function ensureSessionBranchContext(
+  session: Session,
+  project: ProjectConfig,
+  registry: PluginRegistry,
+): void {
+  if (session.branch || session.workspacePath || !session.issueId || !project.tracker) return;
+  const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
+  if (!tracker?.branchName) return;
+  try {
+    const shortId = issueIdToShortId(session.issueId);
+    const derivedBranch = tracker.branchName(shortId, project);
+    if (derivedBranch) {
+      (session as { branch: string | null }).branch = derivedBranch;
+    }
+  } catch {
+    // best effort
+  }
+}
+
+/**
+ * Detect and persist missing PR metadata for sessions.
+ * Keeps heavy SCM calls out of SessionManager.list() while still allowing
+ * callers that render PR state to opt in.
+ */
+export async function ensureSessionsHaveDetectedPRs(args: {
+  sessions: Session[];
+  config: OrchestratorConfig;
+  registry: PluginRegistry;
+  sessionManager: SessionManager;
+}): Promise<void> {
+  const { sessions, config, registry, sessionManager } = args;
+  for (let i = 0; i < sessions.length; i++) {
+    const s = sessions[i];
+    if (s.pr) continue;
+    const project = config.projects[s.projectId];
+    if (!project?.scm) continue;
+    ensureSessionBranchContext(s, project, registry);
+    if (!s.branch && !s.workspacePath) continue;
+    try {
+      const updated = await sessionManager.ensurePRDetected(s, project);
+      if (updated) sessions[i] = updated;
+    } catch {
+      // Non-fatal; session can still render without PR.
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **PR state detection:** When a session has no `pr` in metadata but has a branch (or workspace path so we can derive branch), we now call SCM `detectPR` and persist `pr` (and `branch` when missing). The dashboard and session API routes use a shared `ensureSessionsHaveDetectedPRs()` helper so sessions show the correct PR instead of "No PR associated".
- **Merge race handling:** If the merge API fails with "merge already in progress" / "already merged" / "clean status", return 202 with `mergePending: true` instead of 500. Dashboard reloads on 200/202 so state stays in sync.

## Changes
- `SessionManager.ensurePRDetected()` (core) + SCM GitHub branch fallback when `session.branch` is missing
- `session-pr-detection.ts` helper used from `page.tsx` and `/api/sessions` + `/api/sessions/[id]`
- Merge route idempotent response; Dashboard success handling

Made with [Cursor](https://cursor.com)