### PR TITLE
feat(core): allow separate orchestrator and worker model config

### DIFF
--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -48,6 +48,10 @@ projects:
     #   permissions: skip    # --dangerously-skip-permissions
     #   model: opus
 
+    # Optional orchestrator-specific override (falls back to agentConfig)
+    # orchestratorAgentConfig:
+    #   model: sonnet
+
     # Inline rules included in every agent prompt for this project
     # agentRules: |
     #   Always run tests before pushing.

--- a/examples/codex-integration.yaml
+++ b/examples/codex-integration.yaml
@@ -17,8 +17,12 @@ projects:
 
     # Codex-specific configuration
     agentConfig:
-      model: gpt-4
+      model: gpt-5.3-codex-spark
       permissions: default
+
+    # Optional: separate model for the orchestrator session
+    orchestratorAgentConfig:
+      model: gpt-5.3-codex
 
     agentRules: |
       Write clean, well-documented code.

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -336,6 +336,28 @@ describe("Config Schema Validation", () => {
     expect(validated.projects.proj1.sessionPrefix).toBeDefined();
     expect(validated.projects.proj1.sessionPrefix).toBe("test"); // "test" is 4 chars, used as-is
   });
+
+  it("accepts orchestratorAgentConfig field", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          agentConfig: {
+            model: "gpt-5.3-codex-spark",
+          },
+          orchestratorAgentConfig: {
+            model: "gpt-5.3-codex",
+          },
+        },
+      },
+    };
+
+    const validated = validateConfig(config);
+    expect(validated.projects.proj1.agentConfig?.model).toBe("gpt-5.3-codex-spark");
+    expect(validated.projects.proj1.orchestratorAgentConfig?.model).toBe("gpt-5.3-codex");
+  });
 });
 
 describe("Config Defaults", () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -75,6 +75,7 @@ const ProjectConfigSchema = z.object({
   symlinks: z.array(z.string()).optional(),
   postCreate: z.array(z.string()).optional(),
   agentConfig: AgentSpecificConfigSchema.optional(),
+  orchestratorAgentConfig: AgentSpecificConfigSchema.optional(),
   reactions: z.record(ReactionConfigSchema.partial()).optional(),
   agentRules: z.string().optional(),
   agentRulesFile: z.string().optional(),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -874,6 +874,9 @@ export interface ProjectConfig {
   /** Agent-specific configuration */
   agentConfig?: AgentSpecificConfig;
 
+  /** Orchestrator-specific agent config (falls back to agentConfig when omitted) */
+  orchestratorAgentConfig?: AgentSpecificConfig;
+
   /** Per-project reaction overrides */
   reactions?: Record<string, Partial<ReactionConfig>>;
 


### PR DESCRIPTION
## Summary
- add `orchestratorAgentConfig` to project config schema/types
- use `orchestratorAgentConfig` for orchestrator sessions while keeping worker sessions on `agentConfig`
- keep fallback behavior: if orchestrator config is missing, use `agentConfig`
- add tests for spawn/restore behavior and config validation
- document the new key in config examples

## Verification
- `pnpm --filter @composio/ao-core test -- src/__tests__/config-validation.test.ts src/__tests__/session-manager.test.ts`
- `pnpm build`