### PR TITLE
fix: construct full issueUrl when GitHub tracker stores bare issue numbers

### DIFF
--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -260,6 +260,17 @@ export function enrichSessionIssue(
 ): void {
   if (!dashboard.issueUrl) return;
 
+  // If issueUrl is a bare ID (e.g. "42" or "#42") rather than a full URL,
+  // construct the full URL via the tracker plugin.
+  // GitHub tracker stores the raw issue number; Linear stores the full URL.
+  if (!dashboard.issueUrl.startsWith("http") && tracker.issueUrl) {
+    try {
+      dashboard.issueUrl = tracker.issueUrl(dashboard.issueUrl, project);
+    } catch {
+      // Leave as-is if construction fails
+    }
+  }
+
   // Use tracker plugin to extract human-readable label from URL
   if (tracker.issueLabel) {
     try {


### PR DESCRIPTION
## Problem

When spawning a session with a bare issue number:
```
ao spawn myproject 42
ao spawn myproject "#42"
```

The GitHub tracker plugin stores the raw number as `issueUrl` (e.g. `"42"`) rather than a full `https://` URL. `enrichSessionIssue()` then passes this value directly to `tracker.issueLabel()`, which tries to parse it as a URL — producing a broken label like `"42"` or splitting on `/` and returning the last segment, instead of `"#42"`.

The issue link in the dashboard SessionCard also renders broken (or missing) because the URL is not navigable.

## Fix

In `enrichSessionIssue()`, before calling `issueLabel`, check whether `issueUrl` starts with `"http"`. If not, use `tracker.issueUrl()` to construct the canonical URL first.

```ts
if (!dashboard.issueUrl.startsWith("http") && tracker.issueUrl) {
  try {
    dashboard.issueUrl = tracker.issueUrl(dashboard.issueUrl, project);
  } catch {
    // Leave as-is if construction fails
  }
}
```

This makes the GitHub tracker consistent with how the Linear tracker already works — Linear always stores full URLs, so it was never affected.

## Testing

- `ao spawn <project> 42` → issue link in dashboard shows `#42` and navigates correctly
- `ao spawn <project> "#42"` → same
- Linear sessions unaffected (their `issueUrl` already starts with `https://`)

## Scope

Single file, 11 lines added. No behavior change for sessions that already store full URLs.