### PR TITLE
feat: show archived/killed sessions in dashboard Done zone

### DIFF
--- a/packages/cli/__tests__/commands/review-check.test.ts
+++ b/packages/cli/__tests__/commands/review-check.test.ts
@@ -12,6 +12,7 @@ const { mockTmux, mockExec, mockGh, mockConfigRef, mockSessionManager, sessionsD
     mockConfigRef: { current: null as Record<string, unknown> | null },
     mockSessionManager: {
       list: vi.fn(),
+      listArchived: vi.fn(),
       kill: vi.fn(),
       cleanup: vi.fn(),
       get: vi.fn(),

--- a/packages/cli/__tests__/commands/session.test.ts
+++ b/packages/cli/__tests__/commands/session.test.ts
@@ -27,6 +27,7 @@ const { mockTmux, mockGit, mockGh, mockExec, mockConfigRef, mockSessionManager, 
     mockConfigRef: { current: null as Record<string, unknown> | null },
     mockSessionManager: {
       list: vi.fn(),
+      listArchived: vi.fn(),
       kill: vi.fn(),
       cleanup: vi.fn(),
       get: vi.fn(),

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -9,6 +9,7 @@ const { mockExec, mockConfigRef, mockSessionManager } = vi.hoisted(() => ({
   mockConfigRef: { current: null as Record<string, unknown> | null },
   mockSessionManager: {
     list: vi.fn(),
+    listArchived: vi.fn(),
     kill: vi.fn(),
     cleanup: vi.fn(),
     get: vi.fn(),

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -33,6 +33,7 @@ const {
   mockGetPendingComments: vi.fn(),
   mockSessionManager: {
     list: vi.fn(),
+    listArchived: vi.fn(),
     kill: vi.fn(),
     cleanup: vi.fn(),
     get: vi.fn(),

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -106,6 +106,7 @@ beforeEach(() => {
     spawnOrchestrator: vi.fn(),
     restore: vi.fn(),
     list: vi.fn().mockResolvedValue([]),
+    listArchived: vi.fn().mockResolvedValue([]),
     get: vi.fn().mockResolvedValue(null),
     kill: vi.fn().mockResolvedValue(undefined),
     cleanup: vi.fn(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export {
   updateMetadata,
   deleteMetadata,
   listMetadata,
+  listArchivedSessionIds,
 } from "./metadata.js";
 
 // tmux — command wrappers

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -242,6 +242,39 @@ export function readArchivedMetadataRaw(
 }
 
 /**
+ * List deduplicated session IDs from the archive directory.
+ * Returns one entry per session (the latest archive file wins).
+ * Uses the same `_` + digit separator detection as readArchivedMetadataRaw().
+ */
+export function listArchivedSessionIds(dataDir: string): SessionId[] {
+  const archiveDir = join(dataDir, "archive");
+  if (!existsSync(archiveDir)) return [];
+
+  const seen = new Set<string>();
+  for (const file of readdirSync(archiveDir)) {
+    // Find the last `_` followed by a digit (start of ISO timestamp)
+    // to split sessionId from timestamp suffix.
+    let splitIdx = -1;
+    for (let i = file.length - 1; i >= 0; i--) {
+      if (file[i] === "_") {
+        const next = file[i + 1];
+        if (next && next >= "0" && next <= "9") {
+          splitIdx = i;
+          break;
+        }
+      }
+    }
+    if (splitIdx === -1) continue;
+
+    const sessionId = file.slice(0, splitIdx);
+    if (!VALID_SESSION_ID.test(sessionId)) continue;
+    seen.add(sessionId);
+  }
+
+  return [...seen];
+}
+
+/**
  * List all session IDs that have metadata files.
  */
 export function listMetadata(dataDir: string): SessionId[] {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -45,6 +45,7 @@ import {
   updateMetadata,
   deleteMetadata,
   listMetadata,
+  listArchivedSessionIds,
   reserveSessionId,
 } from "./metadata.js";
 import { buildPrompt } from "./prompt-builder.js";
@@ -1147,5 +1148,36 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     return restoredSession;
   }
 
-  return { spawn, spawnOrchestrator, restore, list, get, kill, cleanup, send };
+  async function listArchived(projectId?: string): Promise<Session[]> {
+    const results: Session[] = [];
+
+    for (const [projectKey, project] of Object.entries(config.projects)) {
+      if (projectId && projectKey !== projectId) continue;
+
+      const sessionsDir = getProjectSessionsDir(project);
+      const archivedIds = listArchivedSessionIds(sessionsDir);
+
+      // Get active session IDs for this project to skip duplicates
+      const activeIds = new Set(listMetadata(sessionsDir));
+
+      for (const sessionId of archivedIds) {
+        if (activeIds.has(sessionId)) continue;
+
+        const raw = readArchivedMetadataRaw(sessionsDir, sessionId);
+        if (!raw) continue;
+
+        const session = metadataToSession(sessionId, raw);
+        session.activity = "exited";
+        if (!TERMINAL_SESSION_STATUSES.has(session.status)) {
+          session.status = "killed";
+        }
+
+        results.push(session);
+      }
+    }
+
+    return results;
+  }
+
+  return { spawn, spawnOrchestrator, restore, list, listArchived, get, kill, cleanup, send };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -994,6 +994,7 @@ export interface SessionManager {
   spawnOrchestrator(config: OrchestratorSpawnConfig): Promise<Session>;
   restore(sessionId: SessionId): Promise<Session>;
   list(projectId?: string): Promise<Session[]>;
+  listArchived(projectId?: string): Promise<Session[]>;
   get(sessionId: SessionId): Promise<Session | null>;
   kill(sessionId: SessionId): Promise<void>;
   cleanup(projectId?: string, options?: { dryRun?: boolean }): Promise<CleanupResult>;

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -62,6 +62,7 @@ const testSessions: Session[] = [
 
 const mockSessionManager: SessionManager = {
   list: vi.fn(async () => testSessions),
+  listArchived: vi.fn(async () => []),
   get: vi.fn(async (id: string) => testSessions.find((s) => s.id === id) ?? null),
   spawn: vi.fn(async (config) =>
     makeSession({


### PR DESCRIPTION
## Summary

- When `ao session kill` archives metadata, sessions previously vanished from the dashboard entirely. This surfaces them in the collapsed **Done** zone so users can see session history.
- Adds `listArchivedSessionIds()` to scan the archive directory and `listArchived()` to the `SessionManager` interface — reads archived metadata with no runtime enrichment (no subprocess calls, no API calls).
- SSR page always includes archived sessions in the initial render. API route supports `?include=archived` query param for client fetches.
- Dashboard stats (total, working, PRs, review) are computed from active sessions only — archived sessions don't inflate counts.

## Test plan

- [x] `pnpm typecheck` — no errors
- [x] `pnpm lint` — no errors (warnings only, pre-existing)
- [x] `pnpm test` — all 133 tests pass
- [ ] Manual: `ao session kill <id>`, reload dashboard, verify session appears in collapsed Done zone with branch/PR/summary
- [ ] Manual: `GET /api/sessions` returns only active sessions; `GET /api/sessions?include=archived` includes archived
- [ ] Manual: stats bar counts don't include archived sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)