### PR TITLE
fix: poll for agent ready indicator instead of fixed 5s sleep

### DIFF
--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -549,11 +549,16 @@ describe("spawn", () => {
     const postLaunchAgent = {
       ...mockAgent,
       promptDelivery: "post-launch" as const,
+      detectActivity: vi.fn().mockReturnValue("idle"),
+    };
+    const runtimeWithPrompt: Runtime = {
+      ...mockRuntime,
+      getOutput: vi.fn().mockResolvedValue("❯ "),
     };
     const registryWithPostLaunch: PluginRegistry = {
       ...mockRegistry,
       get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
+        if (slot === "runtime") return runtimeWithPrompt;
         if (slot === "agent") return postLaunchAgent;
         if (slot === "workspace") return mockWorkspace;
         return null;
@@ -562,11 +567,11 @@ describe("spawn", () => {
 
     const sm = createSessionManager({ config, registry: registryWithPostLaunch });
     const spawnPromise = sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
-    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(500);
     await spawnPromise;
 
     // Prompt should be sent via runtime.sendMessage, not included in launch command
-    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+    expect(runtimeWithPrompt.sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({ id: expect.any(String) }),
       expect.stringContaining("Fix the bug"),
     );
@@ -610,11 +615,13 @@ describe("spawn", () => {
     vi.useFakeTimers();
     const failingRuntime: Runtime = {
       ...mockRuntime,
+      getOutput: vi.fn().mockResolvedValue("❯ "),
       sendMessage: vi.fn().mockRejectedValue(new Error("tmux send failed")),
     };
     const postLaunchAgent = {
       ...mockAgent,
       promptDelivery: "post-launch" as const,
+      detectActivity: vi.fn().mockReturnValue("idle"),
     };
     const registryWithFailingSend: PluginRegistry = {
       ...mockRegistry,
@@ -628,7 +635,7 @@ describe("spawn", () => {
 
     const sm = createSessionManager({ config, registry: registryWithFailingSend });
     const spawnPromise = sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
-    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(500);
     const session = await spawnPromise;
 
     // Session should still be returned successfully despite sendMessage failure
@@ -639,33 +646,87 @@ describe("spawn", () => {
     vi.useRealTimers();
   });
 
-  it("waits before sending post-launch prompt", async () => {
+  it("waits until agent signals ready before sending post-launch prompt", async () => {
     vi.useFakeTimers();
+    // First 3 polls return empty output (agent still starting), 4th returns the prompt
+    const getOutput = vi
+      .fn()
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("")
+      .mockResolvedValue("❯ ");
+    const runtimeWithDelayedOutput: Runtime = {
+      ...mockRuntime,
+      getOutput,
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+    };
     const postLaunchAgent = {
       ...mockAgent,
       promptDelivery: "post-launch" as const,
+      detectActivity: vi.fn().mockReturnValue("idle"),
     };
-    const registryWithPostLaunch: PluginRegistry = {
+    const registry: PluginRegistry = {
       ...mockRegistry,
       get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
+        if (slot === "runtime") return runtimeWithDelayedOutput;
         if (slot === "agent") return postLaunchAgent;
         if (slot === "workspace") return mockWorkspace;
         return null;
       }),
     };
 
-    const sm = createSessionManager({ config, registry: registryWithPostLaunch });
+    const sm = createSessionManager({ config, registry });
     const spawnPromise = sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
 
-    // Advance only 4s — not enough, message should not have been sent yet
-    await vi.advanceTimersByTimeAsync(4_000);
-    expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
+    // After 3 poll cycles (1500ms) output is still empty — not sent yet
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(runtimeWithDelayedOutput.sendMessage).not.toHaveBeenCalled();
 
-    // Advance the remaining 1s — now it should fire
-    await vi.advanceTimersByTimeAsync(1_000);
+    // 4th poll (500ms more) returns the prompt — sends immediately
+    await vi.advanceTimersByTimeAsync(500);
     await spawnPromise;
-    expect(mockRuntime.sendMessage).toHaveBeenCalled();
+    expect(runtimeWithDelayedOutput.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.any(String) }),
+      expect.stringContaining("Fix the bug"),
+    );
+    vi.useRealTimers();
+  });
+
+  it("does not treat empty terminal output as agent ready", async () => {
+    vi.useFakeTimers();
+    // detectActivity returns "idle" even for empty strings (real behavior),
+    // but the output.trim() guard must prevent a false positive
+    const postLaunchAgent = {
+      ...mockAgent,
+      promptDelivery: "post-launch" as const,
+      detectActivity: vi.fn().mockReturnValue("idle"),
+    };
+    const runtimeAlwaysEmpty: Runtime = {
+      ...mockRuntime,
+      getOutput: vi.fn().mockResolvedValue(""),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return runtimeAlwaysEmpty;
+        if (slot === "agent") return postLaunchAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    const sm = createSessionManager({ config, registry });
+    const spawnPromise = sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
+
+    // Several poll cycles pass — empty output must not be treated as ready
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(runtimeAlwaysEmpty.sendMessage).not.toHaveBeenCalled();
+
+    // After the full 30s timeout the prompt is sent as best-effort fallback
+    await vi.advanceTimersByTimeAsync(28_500);
+    await spawnPromise;
+    expect(runtimeAlwaysEmpty.sendMessage).toHaveBeenCalled();
     vi.useRealTimers();
   });
 });

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -573,8 +573,23 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     // should NOT destroy the session. The agent is running; user can retry with `ao send`.
     if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt) {
       try {
-        // Wait for agent to start and be ready for input
-        await new Promise((resolve) => setTimeout(resolve, 5_000));
+        // Poll for the agent's ready indicator instead of a fixed sleep.
+        // Claude Code shows "❯" when it's ready for input.
+        const POLL_INTERVAL_MS = 500;
+        const TIMEOUT_MS = 30_000;
+        const deadline = Date.now() + TIMEOUT_MS;
+        let ready = false;
+        while (Date.now() < deadline) {
+          await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+          const output = await plugins.runtime.getOutput(handle, 10);
+          if (/[❯>]\s*$/.test(output.trimEnd())) {
+            ready = true;
+            break;
+          }
+        }
+        if (!ready) {
+          // Timed out waiting — agent may still be starting, send anyway as best-effort
+        }
         await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
       } catch {
         // Non-fatal: agent is running but didn't receive the initial prompt.

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -581,7 +581,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
         while (Date.now() < deadline) {
           await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
           const output = await plugins.runtime.getOutput(handle, 10);
-          if (plugins.agent.detectActivity(output) === "idle") {
+          if (output.trim() && plugins.agent.detectActivity(output) === "idle") {
             ready = true;
             break;
           }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -574,7 +574,6 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt) {
       try {
         // Poll for the agent's ready indicator instead of a fixed sleep.
-        // Claude Code shows "❯" when it's ready for input.
         const POLL_INTERVAL_MS = 500;
         const TIMEOUT_MS = 30_000;
         const deadline = Date.now() + TIMEOUT_MS;
@@ -582,7 +581,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
         while (Date.now() < deadline) {
           await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
           const output = await plugins.runtime.getOutput(handle, 10);
-          if (/[❯>]\s*$/.test(output.trimEnd())) {
+          if (plugins.agent.detectActivity(output) === "idle") {
             ready = true;
             break;
           }


### PR DESCRIPTION
Closes #257

## Problem

The current code uses a hardcoded `setTimeout(resolve, 5_000)` before sending the initial prompt to a `post-launch` agent. This has two failure modes:

1. **Too slow** — on fast machines, the agent is ready well before 5s, wasting time
2. **Too fast** — on slow machines or under load, 5s may not be enough and the prompt is sent before the agent is ready to receive it

## Solution

Replace the fixed sleep with a polling loop that delegates readiness detection to the agent plugin:

- Polls every **500ms**, timeout of **30 seconds** (sends anyway as best-effort if reached)
- Uses `plugins.agent.detectActivity(output)` — the existing `Agent` interface method — instead of an inline regex, so detection logic stays in one place (the plugin)
- Guards against empty output (`output.trim()`) since `detectActivity` returns `"idle"` for empty strings, which would otherwise trigger a false positive on the very first poll

```typescript
const POLL_INTERVAL_MS = 500;
const TIMEOUT_MS = 30_000;
const deadline = Date.now() + TIMEOUT_MS;
let ready = false;
while (Date.now() < deadline) {
  await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
  const output = await plugins.runtime.getOutput(handle, 10);
  if (output.trim() && plugins.agent.detectActivity(output) === "idle") {
    ready = true;
    break;
  }
}
await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
```

## Changes after review

- **Replaced inline regex** (`/[❯>]\s*$/` on full output) with `plugins.agent.detectActivity(output) === "idle"` — avoids duplicating the detection logic that already exists in the agent plugin, and uses the correct last-line-only check
- **Added empty output guard** — `detectActivity("")` returns `"idle"`, so without `output.trim()` the loop would exit after 500ms on an empty terminal buffer (worse than the original 5s sleep)
- **Updated tests** — fixed 3 tests written for the old 5s sleep, added 2 new regression tests:
  - _"waits until agent signals ready"_ — verifies empty polls are skipped, prompt sent on the poll that finds real output
  - _"does not treat empty terminal output as agent ready"_ — direct guard for the `output.trim()` fix

## Test plan

- [x] Existing post-launch prompt tests updated and passing (82/82)
- [ ] Spawn a new session with an initial prompt — verify the prompt is delivered promptly once the agent is ready
- [ ] Verify behaviour on a slow start (e.g. with a large project) — prompt should still be delivered within 30s
- [ ] Confirm no regression for sessions without an initial prompt (code path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)