### PR TITLE
feat: add --continue flag to ao start

### DIFF
--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -641,6 +641,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       permissions: "skip" as const,
       model: project.agentConfig?.model,
       systemPromptFile,
+      continue: orchestratorConfig.continue,
     };
 
     const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -184,6 +184,12 @@ export interface SessionSpawnConfig {
 export interface OrchestratorSpawnConfig {
   projectId: string;
   systemPrompt?: string;
+  /**
+   * Continue the most recent conversation in the project directory.
+   * When true, the agent is launched with --continue (or equivalent),
+   * preserving conversation history while loading fresh system prompts.
+   */
+  continue?: boolean;
 }
 
 // =============================================================================
@@ -352,6 +358,13 @@ export interface AgentLaunchConfig {
    * - Codex/Aider: similar shell substitution
    */
   systemPromptFile?: string;
+  /**
+   * Continue the most recent conversation in the project directory.
+   * Loads fresh system prompt while preserving conversation history.
+   * - Claude Code: --continue flag
+   * - Other agents: ignored if not supported
+   */
+  continue?: boolean;
 }
 
 export interface WorkspaceHooksConfig {

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -203,6 +203,24 @@ describe("getLaunchCommand", () => {
     expect(cmd).not.toMatch(/\s-p\s/);
     expect(cmd).not.toContain("Do the task");
   });
+
+  it("includes --continue when continue=true", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ continue: true }));
+    expect(cmd).toContain("--continue");
+    expect(cmd).toBe("claude --continue");
+  });
+
+  it("combines --continue with other flags", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ continue: true, permissions: "skip", model: "opus" }),
+    );
+    expect(cmd).toBe("claude --continue --dangerously-skip-permissions --model 'opus'");
+  });
+
+  it("omits --continue when continue is not set", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig());
+    expect(cmd).not.toContain("--continue");
+  });
 });
 
 // =========================================================================

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -635,6 +635,10 @@ function createClaudeCodeAgent(): Agent {
       // This command must be safe for both shell and execFile contexts.
       const parts: string[] = ["claude"];
 
+      if (config.continue) {
+        parts.push("--continue");
+      }
+
       if (config.permissions === "skip") {
         parts.push("--dangerously-skip-permissions");
       }


### PR DESCRIPTION
## Summary

- Adds `--continue` flag to `ao start` for orchestrator conversation continuity
- When the orchestrator needs a fresh system prompt (e.g. CLAUDE.local.md was updated), `ao start --continue` kills the existing session and respawns with `claude --continue`, preserving conversation history while reloading all system prompts
- Implemented at the interface level (`AgentLaunchConfig.continue`) so all agent plugins can support it

## Changes

- **`packages/core/src/types.ts`**: Add `continue?: boolean` to `AgentLaunchConfig` and `OrchestratorSpawnConfig`
- **`packages/plugins/agent-claude-code/src/index.ts`**: Pass `--continue` to Claude CLI when `continue` is set
- **`packages/core/src/session-manager.ts`**: Forward `continue` from orchestrator config to agent launch config
- **`packages/cli/src/commands/start.ts`**: Add `--continue` CLI option — kills existing session first, then respawns with continue flag
- **`packages/plugins/agent-claude-code/src/index.test.ts`**: 3 new tests for --continue flag behavior

## How it works

```bash
# Normal start (existing behavior unchanged)
ao start

# Continue with fresh system prompt + conversation history
ao start --continue
```

When `--continue` is used:
1. If an orchestrator session exists, it's killed first
2. A new session is spawned with `claude --continue`, which continues the most recent conversation in the project directory
3. Fresh system prompts are loaded (via `--append-system-prompt`)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes (all 156 CLI tests + 111 agent-claude-code tests)
- [x] No changes to other agent plugins needed (optional field, backwards-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)