### PR TITLE
fix: reduce PR cache staleness + live CI status updates

### DIFF
--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -1,8 +1,32 @@
 import { getServices } from "@/lib/services";
 import { sessionToDashboard } from "@/lib/serialize";
-import { getAttentionLevel } from "@/lib/types";
+import { getAttentionLevel, type DashboardSession } from "@/lib/types";
+import { prCache, prCacheKey } from "@/lib/cache";
 
 export const dynamic = "force-dynamic";
+
+/** Build a snapshot entry for a session, including cached PR status (no API calls). */
+function toSnapshotEntry(s: DashboardSession) {
+  const entry: Record<string, unknown> = {
+    id: s.id,
+    status: s.status,
+    activity: s.activity,
+    attentionLevel: getAttentionLevel(s),
+    lastActivityAt: s.lastActivityAt,
+  };
+
+  // Include cached PR status if available (cheap cache read, no API call)
+  if (s.pr) {
+    const cached = prCache.get(prCacheKey(s.pr.owner, s.pr.repo, s.pr.number));
+    if (cached) {
+      entry.prState = cached.state;
+      entry.ciStatus = cached.ciStatus;
+      entry.reviewDecision = cached.reviewDecision;
+    }
+  }
+
+  return entry;
+}
 
 /**
  * GET /api/events — SSE stream for real-time lifecycle events
@@ -26,13 +50,7 @@ export async function GET(): Promise<Response> {
 
           const initialEvent = {
             type: "snapshot",
-            sessions: dashboardSessions.map((s) => ({
-              id: s.id,
-              status: s.status,
-              activity: s.activity,
-              attentionLevel: getAttentionLevel(s),
-              lastActivityAt: s.lastActivityAt,
-            })),
+            sessions: dashboardSessions.map(toSnapshotEntry),
           };
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(initialEvent)}\n\n`));
         } catch {
@@ -69,13 +87,7 @@ export async function GET(): Promise<Response> {
           try {
             const event = {
               type: "snapshot",
-              sessions: dashboardSessions.map((s) => ({
-                id: s.id,
-                status: s.status,
-                activity: s.activity,
-                attentionLevel: getAttentionLevel(s),
-                lastActivityAt: s.lastActivityAt,
-              })),
+              sessions: dashboardSessions.map(toSnapshotEntry),
             };
             controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
           } catch {

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -7,9 +7,11 @@ import {
   enrichSessionsMetadata,
 } from "@/lib/serialize";
 
-export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
+    const { searchParams } = new URL(request.url);
+    const forceRefresh = searchParams.get("refresh") === "true";
     const { config, registry, sessionManager } = await getServices();
 
     const coreSession = await sessionManager.get(id);
@@ -27,10 +29,15 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       const project = resolveProject(coreSession, config.projects);
       const scm = getSCM(registry, project);
       if (scm) {
-        const cached = await enrichSessionPR(dashboardSession, scm, coreSession.pr, { cacheOnly: true });
-        if (!cached) {
-          // Nothing cached yet — block once to populate, then future calls use cache
-          await enrichSessionPR(dashboardSession, scm, coreSession.pr);
+        if (forceRefresh) {
+          // Force-refresh bypasses cache entirely
+          await enrichSessionPR(dashboardSession, scm, coreSession.pr, { forceRefresh: true });
+        } else {
+          const cached = await enrichSessionPR(dashboardSession, scm, coreSession.pr, { cacheOnly: true });
+          if (!cached) {
+            // Nothing cached yet — block once to populate, then future calls use cache
+            await enrichSessionPR(dashboardSession, scm, coreSession.pr);
+          }
         }
       }
     }

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -17,6 +17,7 @@ export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const activeOnly = searchParams.get("active") === "true";
+    const forceRefresh = searchParams.get("refresh") === "true";
 
     const { config, registry, sessionManager } = await getServices();
     const coreSessions = await sessionManager.list();
@@ -50,7 +51,7 @@ export async function GET(request: Request) {
       const project = resolveProject(core, config.projects);
       const scm = getSCM(registry, project);
       if (!scm) return Promise.resolve();
-      return enrichSessionPR(dashboardSessions[i], scm, core.pr);
+      return enrichSessionPR(dashboardSessions[i], scm, core.pr, { forceRefresh });
     });
     const enrichTimeout = new Promise<void>((resolve) => setTimeout(resolve, 4_000));
     await Promise.race([Promise.allSettled(enrichPromises), enrichTimeout]);

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -17,15 +17,38 @@ function reducer(state: DashboardSession[], action: Action): DashboardSession[] 
       const next = state.map((s) => {
         const patch = patchMap.get(s.id);
         if (!patch) return s;
-        if (
-          s.status === patch.status &&
-          s.activity === patch.activity &&
-          s.lastActivityAt === patch.lastActivityAt
-        ) {
-          return s;
-        }
+
+        // Check if basic session fields changed
+        const basicChanged =
+          s.status !== patch.status ||
+          s.activity !== patch.activity ||
+          s.lastActivityAt !== patch.lastActivityAt;
+
+        // Check if PR status fields changed (from cached PR data in SSE)
+        const prChanged =
+          s.pr !== null &&
+          patch.prState !== undefined &&
+          patch.prState !== null &&
+          (s.pr.state !== patch.prState ||
+            s.pr.ciStatus !== patch.ciStatus ||
+            s.pr.reviewDecision !== patch.reviewDecision);
+
+        if (!basicChanged && !prChanged) return s;
+
         changed = true;
-        return { ...s, status: patch.status, activity: patch.activity, lastActivityAt: patch.lastActivityAt };
+        const updated = { ...s, status: patch.status, activity: patch.activity, lastActivityAt: patch.lastActivityAt };
+
+        // Apply PR status patches if present
+        if (updated.pr && patch.prState !== undefined && patch.prState !== null) {
+          updated.pr = {
+            ...updated.pr,
+            state: patch.prState,
+            ...(patch.ciStatus !== undefined && patch.ciStatus !== null && { ciStatus: patch.ciStatus }),
+            ...(patch.reviewDecision !== undefined && patch.reviewDecision !== null && { reviewDecision: patch.reviewDecision }),
+          };
+        }
+
+        return updated;
       });
       return changed ? next : state;
     }

--- a/packages/web/src/lib/__tests__/cache.test.ts
+++ b/packages/web/src/lib/__tests__/cache.test.ts
@@ -96,11 +96,44 @@ describe("TTLCache", () => {
     shortCache.clear();
   });
 
+  it("should invalidate a specific key", () => {
+    cache.set("key1", "value1");
+    cache.set("key2", "value2");
+    expect(cache.get("key1")).toBe("value1");
+
+    const removed = cache.invalidate("key1");
+    expect(removed).toBe(true);
+    expect(cache.get("key1")).toBeNull();
+    expect(cache.get("key2")).toBe("value2"); // Other keys unaffected
+  });
+
+  it("should return false when invalidating non-existent key", () => {
+    const removed = cache.invalidate("nonexistent");
+    expect(removed).toBe(false);
+  });
+
   it("should not prevent process exit with unref", () => {
     // This test just verifies the cache can be created without throwing
     const testCache = new TTLCache<string>(1000);
     expect(testCache).toBeDefined();
     testCache.clear();
+  });
+
+  it("should use default TTL of 60 seconds", () => {
+    vi.useFakeTimers();
+    const defaultCache = new TTLCache<string>();
+    defaultCache.set("key1", "value1");
+
+    // Still valid at 59 seconds
+    vi.advanceTimersByTime(59_000);
+    expect(defaultCache.get("key1")).toBe("value1");
+
+    // Expired at 61 seconds
+    vi.advanceTimersByTime(2_000);
+    expect(defaultCache.get("key1")).toBeNull();
+
+    defaultCache.clear();
+    vi.useRealTimers();
   });
 });
 

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -415,6 +415,79 @@ describe("enrichSessionPR", () => {
     expect(scm.getPRSummary).not.toHaveBeenCalled();
   });
 
+  it("should bypass cache when forceRefresh is true", async () => {
+    const pr = createPRInfo();
+    const coreSession = createCoreSession({ pr });
+    const dashboard1 = sessionToDashboard(coreSession);
+    const dashboard2 = sessionToDashboard(coreSession);
+    const scm = createMockSCM();
+
+    // First call: populate cache
+    await enrichSessionPR(dashboard1, scm, pr);
+    expect(scm.getPRSummary).toHaveBeenCalledTimes(1);
+
+    // Second call with forceRefresh: should bypass cache and fetch again
+    await enrichSessionPR(dashboard2, scm, pr, { forceRefresh: true });
+    expect(scm.getPRSummary).toHaveBeenCalledTimes(2);
+    expect(dashboard2.pr?.additions).toBe(100);
+  });
+
+  it("should use shorter TTL for terminal PR states (merged/closed)", async () => {
+    vi.useFakeTimers();
+
+    const pr = createPRInfo();
+    const coreSession = createCoreSession({ pr });
+    const dashboard = sessionToDashboard(coreSession);
+
+    // SCM returns merged state
+    const scm: SCM = {
+      ...createMockSCM(),
+      getPRSummary: vi.fn().mockResolvedValue({
+        state: "merged",
+        title: "Test PR",
+        additions: 100,
+        deletions: 50,
+      }),
+    };
+
+    await enrichSessionPR(dashboard, scm, pr);
+    expect(dashboard.pr?.state).toBe("merged");
+
+    // Cache should still be valid at 4 minutes (terminal state TTL is 5 min)
+    vi.advanceTimersByTime(4 * 60_000);
+    const cacheKey = prCacheKey(pr.owner, pr.repo, pr.number);
+    expect(prCache.get(cacheKey)).not.toBeNull();
+
+    // Cache should expire after 5 minutes
+    vi.advanceTimersByTime(1 * 60_000 + 1);
+    expect(prCache.get(cacheKey)).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it("should cache rate-limited data for 10 minutes (not 60)", async () => {
+    vi.useFakeTimers();
+
+    const pr = createPRInfo();
+    const coreSession = createCoreSession({ pr });
+    const dashboard = sessionToDashboard(coreSession);
+    const scm = createFailingSCM();
+
+    await enrichSessionPR(dashboard, scm, pr);
+
+    const cacheKey = prCacheKey(pr.owner, pr.repo, pr.number);
+
+    // Cache should still be valid at 9 minutes
+    vi.advanceTimersByTime(9 * 60_000);
+    expect(prCache.get(cacheKey)).not.toBeNull();
+
+    // Cache should expire after 10 minutes
+    vi.advanceTimersByTime(1 * 60_000 + 1);
+    expect(prCache.get(cacheKey)).toBeNull();
+
+    vi.useRealTimers();
+  });
+
   it("should handle missing optional SCM methods", async () => {
     const pr = createPRInfo();
     const coreSession = createCoreSession({ pr });

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -488,6 +488,62 @@ describe("enrichSessionPR", () => {
     vi.useRealTimers();
   });
 
+  it("should use shorter TTL (15s) when CI checks are pending", async () => {
+    vi.useFakeTimers();
+
+    const pr = createPRInfo();
+    const coreSession = createCoreSession({ pr });
+    const dashboard = sessionToDashboard(coreSession);
+
+    // SCM returns pending CI status
+    const scm: SCM = {
+      ...createMockSCM(),
+      getCISummary: vi.fn().mockResolvedValue("pending"),
+      getCIChecks: vi.fn().mockResolvedValue([
+        { name: "build", status: "running", url: "https://example.com" },
+      ]),
+    };
+
+    await enrichSessionPR(dashboard, scm, pr);
+    expect(dashboard.pr?.ciStatus).toBe("pending");
+
+    const cacheKey = prCacheKey(pr.owner, pr.repo, pr.number);
+
+    // Cache should still be valid at 14 seconds
+    vi.advanceTimersByTime(14_000);
+    expect(prCache.get(cacheKey)).not.toBeNull();
+
+    // Cache should expire after 15 seconds
+    vi.advanceTimersByTime(1_001);
+    expect(prCache.get(cacheKey)).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it("should use default TTL (60s) when CI is stable (passing)", async () => {
+    vi.useFakeTimers();
+
+    const pr = createPRInfo();
+    const coreSession = createCoreSession({ pr });
+    const dashboard = sessionToDashboard(coreSession);
+    const scm = createMockSCM(); // Returns passing CI
+
+    await enrichSessionPR(dashboard, scm, pr);
+    expect(dashboard.pr?.ciStatus).toBe("passing");
+
+    const cacheKey = prCacheKey(pr.owner, pr.repo, pr.number);
+
+    // Cache should still be valid at 59 seconds
+    vi.advanceTimersByTime(59_000);
+    expect(prCache.get(cacheKey)).not.toBeNull();
+
+    // Cache should expire after 60 seconds
+    vi.advanceTimersByTime(1_001);
+    expect(prCache.get(cacheKey)).toBeNull();
+
+    vi.useRealTimers();
+  });
+
   it("should handle missing optional SCM methods", async () => {
     const pr = createPRInfo();
     const coreSession = createCoreSession({ pr });

--- a/packages/web/src/lib/cache.ts
+++ b/packages/web/src/lib/cache.ts
@@ -10,7 +10,7 @@ interface CacheEntry<T> {
   expiresAt: number;
 }
 
-const DEFAULT_TTL_MS = 5 * 60_000; // 5 minutes
+const DEFAULT_TTL_MS = 60_000; // 60 seconds
 
 /**
  * Simple TTL cache backed by a Map.
@@ -71,6 +71,11 @@ export class TTLCache<T> {
     }
   }
 
+  /** Remove a specific key from the cache */
+  invalidate(key: string): boolean {
+    return this.cache.delete(key);
+  }
+
   /** Get cache size (includes stale entries) */
   size(): number {
     return this.cache.size;
@@ -105,7 +110,7 @@ export interface PREnrichmentData {
   }>;
 }
 
-/** Global PR enrichment cache (60s TTL) */
+/** Global PR enrichment cache (default 60s TTL) */
 export const prCache = new TTLCache<PREnrichmentData>();
 
 /** Generate cache key for a PR: `owner/repo#123` */

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -106,26 +106,28 @@ export async function enrichSessionPR(
   dashboard: DashboardSession,
   scm: SCM,
   pr: PRInfo,
-  opts?: { cacheOnly?: boolean },
+  opts?: { cacheOnly?: boolean; forceRefresh?: boolean },
 ): Promise<boolean> {
   if (!dashboard.pr) return false;
 
   const cacheKey = prCacheKey(pr.owner, pr.repo, pr.number);
 
-  // Check cache first
-  const cached = prCache.get(cacheKey);
-  if (cached && dashboard.pr) {
-    dashboard.pr.state = cached.state;
-    dashboard.pr.title = cached.title;
-    dashboard.pr.additions = cached.additions;
-    dashboard.pr.deletions = cached.deletions;
-    dashboard.pr.ciStatus = cached.ciStatus;
-    dashboard.pr.ciChecks = cached.ciChecks;
-    dashboard.pr.reviewDecision = cached.reviewDecision;
-    dashboard.pr.mergeability = cached.mergeability;
-    dashboard.pr.unresolvedThreads = cached.unresolvedThreads;
-    dashboard.pr.unresolvedComments = cached.unresolvedComments;
-    return true;
+  // Check cache first (unless force-refresh requested)
+  if (!opts?.forceRefresh) {
+    const cached = prCache.get(cacheKey);
+    if (cached && dashboard.pr) {
+      dashboard.pr.state = cached.state;
+      dashboard.pr.title = cached.title;
+      dashboard.pr.additions = cached.additions;
+      dashboard.pr.deletions = cached.deletions;
+      dashboard.pr.ciStatus = cached.ciStatus;
+      dashboard.pr.ciChecks = cached.ciChecks;
+      dashboard.pr.reviewDecision = cached.reviewDecision;
+      dashboard.pr.mergeability = cached.mergeability;
+      dashboard.pr.unresolvedThreads = cached.unresolvedThreads;
+      dashboard.pr.unresolvedComments = cached.unresolvedComments;
+      return true;
+    }
   }
 
   // Cache miss — if cacheOnly, signal caller to refresh in background
@@ -216,7 +218,7 @@ export async function enrichSessionPR(
     dashboard.pr.mergeability.blockers.push("API rate limited or unavailable");
   }
 
-  // If rate limited, cache the partial data with a long TTL (5 min) so we stop
+  // If rate limited, cache partial data with a moderate TTL so we stop
   // hammering the API on every page load. The rate-limit blocker flag tells the
   // UI to show stale-data warnings instead of making decisions on bad data.
   if (mostFailed) {
@@ -232,7 +234,7 @@ export async function enrichSessionPR(
       unresolvedThreads: dashboard.pr.unresolvedThreads,
       unresolvedComments: dashboard.pr.unresolvedComments,
     };
-    prCache.set(cacheKey, rateLimitedData, 60 * 60_000); // 60 min — GitHub rate limit resets hourly
+    prCache.set(cacheKey, rateLimitedData, 10 * 60_000); // 10 min — retry sooner than hourly reset
     return true;
   }
 
@@ -248,7 +250,12 @@ export async function enrichSessionPR(
     unresolvedThreads: dashboard.pr.unresolvedThreads,
     unresolvedComments: dashboard.pr.unresolvedComments,
   };
-  prCache.set(cacheKey, cacheData);
+
+  // Use shorter TTL for terminal states (merged/closed) — no need to re-check often
+  const ttl = dashboard.pr.state === "merged" || dashboard.pr.state === "closed"
+    ? 5 * 60_000 // 5 min for terminal states
+    : undefined;  // default TTL for open PRs
+  prCache.set(cacheKey, cacheData, ttl);
   return true;
 }
 

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -251,10 +251,20 @@ export async function enrichSessionPR(
     unresolvedComments: dashboard.pr.unresolvedComments,
   };
 
-  // Use shorter TTL for terminal states (merged/closed) — no need to re-check often
-  const ttl = dashboard.pr.state === "merged" || dashboard.pr.state === "closed"
-    ? 5 * 60_000 // 5 min for terminal states
-    : undefined;  // default TTL for open PRs
+  // Adaptive TTL based on PR state:
+  // - Terminal states (merged/closed): 5 min (won't change)
+  // - Active CI (pending/running checks): 15s (changes rapidly)
+  // - Stable open PRs: default 60s
+  const hasActiveCI = dashboard.pr.ciStatus === "pending" ||
+    dashboard.pr.ciChecks.some((c) => c.status === "pending" || c.status === "running");
+  let ttl: number | undefined;
+  if (dashboard.pr.state === "merged" || dashboard.pr.state === "closed") {
+    ttl = 5 * 60_000; // 5 min for terminal states
+  } else if (hasActiveCI) {
+    ttl = 15_000; // 15s for active CI — changes rapidly
+  }
+  // else: undefined → default 60s TTL
+
   prCache.set(cacheKey, cacheData, ttl);
   return true;
 }

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -136,6 +136,10 @@ export interface SSESnapshotEvent {
     activity: ActivityState | null;
     attentionLevel: AttentionLevel;
     lastActivityAt: string;
+    /** PR status fields from cache (null when no PR or not cached) */
+    prState?: "open" | "merged" | "closed" | null;
+    ciStatus?: CIStatus | null;
+    reviewDecision?: ReviewDecision | null;
   }>;
 }
 


### PR DESCRIPTION
## Summary

Fixes stale PR state on dashboard (e.g. 'Ready to merge' badge showing for already-merged PRs) and adds live CI check status updates without manual refresh.

### Cache staleness fixes
- Reduced default PR enrichment cache TTL from **5 minutes → 60 seconds**
- Reduced rate-limit fallback cache TTL from **60 minutes → 10 minutes**
- Added `TTLCache.invalidate(key)` method for targeted cache busting
- Added `?refresh=true` query param to `/api/sessions` and `/api/sessions/[id]` that bypasses cache entirely
- Terminal PR states (merged/closed) use a longer 5-minute TTL since they won't change

### Live CI status updates
- **Adaptive cache TTL**: 15s when CI is pending/running (checks change rapidly), 60s default for stable open PRs
- **SSE PR patches**: Snapshots now include `prState`, `ciStatus`, `reviewDecision` from cache (cheap reads, no extra API calls)
- **Client-side merging**: `useSessionEvents` reducer applies PR status patches from SSE, so dashboard cards reflect CI changes in real-time

### How it works
1. Session detail page polls every 5s → hits cache (60s/15s TTL) → fresh data on expiry
2. When CI is running, cache expires in 15s → CI status updates within ~20s
3. SSE snapshots read cached PR data → dashboard cards update when any page fetches fresh data
4. Force-refresh (`?refresh=true`) bypasses cache entirely for manual refresh scenarios

## Test plan
- [x] `TTLCache.invalidate()` — removes specific key, returns false for missing
- [x] Default TTL is 60 seconds (not 5 minutes)
- [x] `forceRefresh` bypasses cache and re-fetches
- [x] Rate-limited data cached for 10 min (not 60)
- [x] Terminal states (merged/closed) use 5-min TTL
- [x] Pending CI uses 15s TTL
- [x] Stable CI (passing) uses default 60s TTL
- [x] All 360 web tests pass
- [x] Typecheck clean
- [x] Lint clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)