### PR TITLE
Add opencode agent support and light/dark theme toggle

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "@composio/ao-plugin-agent-aider": "workspace:*",
     "@composio/ao-plugin-agent-claude-code": "workspace:*",
     "@composio/ao-plugin-agent-codex": "workspace:*",
+    "@composio/ao-plugin-agent-opencode": "workspace:*",
     "@composio/ao-plugin-notifier-composio": "workspace:*",
     "@composio/ao-plugin-notifier-desktop": "workspace:*",
     "@composio/ao-plugin-notifier-slack": "workspace:*",

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -2,12 +2,14 @@ import type { Agent, OrchestratorConfig, SCM } from "@composio/ao-core";
 import claudeCodePlugin from "@composio/ao-plugin-agent-claude-code";
 import codexPlugin from "@composio/ao-plugin-agent-codex";
 import aiderPlugin from "@composio/ao-plugin-agent-aider";
+import opencodePlugin from "@composio/ao-plugin-agent-opencode";
 import githubSCMPlugin from "@composio/ao-plugin-scm-github";
 
 const agentPlugins: Record<string, { create(): Agent }> = {
   "claude-code": claudeCodePlugin,
   codex: codexPlugin,
   aider: aiderPlugin,
+  opencode: opencodePlugin,
 };
 
 const scmPlugins: Record<string, { create(): SCM }> = {

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -31,6 +31,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "claude-code", pkg: "@composio/ao-plugin-agent-claude-code" },
   { slot: "agent", name: "codex", pkg: "@composio/ao-plugin-agent-codex" },
   { slot: "agent", name: "aider", pkg: "@composio/ao-plugin-agent-aider" },
+  { slot: "agent", name: "opencode", pkg: "@composio/ao-plugin-agent-opencode" },
   // Workspaces
   { slot: "workspace", name: "worktree", pkg: "@composio/ao-plugin-workspace-worktree" },
   { slot: "workspace", name: "clone", pkg: "@composio/ao-plugin-workspace-clone" },

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -237,6 +237,21 @@ a:hover {
     inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
+.light .orchestrator-btn {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.1),
+    0 3px 8px rgba(0, 0, 0, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.light .orchestrator-btn:hover {
+  box-shadow:
+    0 2px 6px rgba(0, 0, 0, 0.12),
+    0 8px 20px rgba(0, 0, 0, 0.08),
+    0 0 20px rgba(88, 166, 255, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
 /* ── Glass nav ────────────────────────────────────────────────────────── */
 
 .nav-glass {

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -157,6 +157,16 @@ a:hover {
   background: rgba(255, 255, 255, 0.25);
 }
 
+.light ::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.15);
+}
+.light ::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.25);
+}
+.light ::-webkit-scrollbar-thumb:active {
+  background: rgba(0, 0, 0, 0.35);
+}
+
 /* ── Animations ──────────────────────────────────────────────────────── */
 
 @keyframes activity-pulse {

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1,68 +1,112 @@
 @import "tailwindcss";
 
 @theme {
-  /* ── Base surfaces ────────────────────────────────────────────────── */
-  --color-bg-base:      #0d1117;
-  --color-bg-surface:   rgba(22, 27, 34, 0.8);
-  --color-bg-elevated:  rgba(28, 33, 40, 0.9);
-  --color-bg-subtle:    rgba(33, 38, 45, 0.7);
+  /* ── Base surfaces (dark theme) ───────────────────────────────────────── */
+  --color-bg-base: #0d1117;
+  --color-bg-surface: rgba(22, 27, 34, 0.8);
+  --color-bg-elevated: rgba(28, 33, 40, 0.9);
+  --color-bg-subtle: rgba(33, 38, 45, 0.7);
 
   /* Backward-compat aliases */
-  --color-bg-primary:   var(--color-bg-base);
+  --color-bg-primary: var(--color-bg-base);
   --color-bg-secondary: var(--color-bg-surface);
-  --color-bg-tertiary:  var(--color-bg-elevated);
+  --color-bg-tertiary: var(--color-bg-elevated);
 
-  /* ── Borders ─────────────────────────────────────────────────────── */
-  --color-border-subtle:   rgba(48, 54, 61, 0.6);
-  --color-border-default:  rgba(48, 54, 61, 1);
-  --color-border-strong:   rgba(72, 79, 88, 1);
+  /* ── Borders (dark theme) ─────────────────────────────────────────────── */
+  --color-border-subtle: rgba(48, 54, 61, 0.6);
+  --color-border-default: rgba(48, 54, 61, 1);
+  --color-border-strong: rgba(72, 79, 88, 1);
 
   /* Backward-compat aliases */
-  --color-border-muted:    var(--color-border-subtle);
+  --color-border-muted: var(--color-border-subtle);
   --color-border-emphasis: var(--color-border-strong);
 
-  /* ── Text ─────────────────────────────────────────────────────────── */
-  --color-text-primary:   #e6edf3;
+  /* ── Text (dark theme) ───────────────────────────────────────────────── */
+  --color-text-primary: #e6edf3;
   --color-text-secondary: #7d8590;
-  --color-text-tertiary:  #484f58;
-  --color-text-muted:     #484f58;
-  --color-text-inverse:   #0d1117;
+  --color-text-tertiary: #484f58;
+  --color-text-muted: #484f58;
+  --color-text-inverse: #0d1117;
 
-  /* ── Interactive accent ──────────────────────────────────────────── */
-  --color-accent:         #58a6ff;
-  --color-accent-hover:   #79b8ff;
-  --color-accent-subtle:  rgba(88, 166, 255, 0.12);
+  /* ── Interactive accent (dark theme) ─────────────────────────────────── */
+  --color-accent: #58a6ff;
+  --color-accent-hover: #79b8ff;
+  --color-accent-subtle: rgba(88, 166, 255, 0.12);
 
-  /* ── Status / semantic colors ────────────────────────────────────── */
-  --color-status-working:   #58a6ff;
-  --color-status-ready:     #3fb950;
+  /* ── Status / semantic colors ───────────────────────────────────────── */
+  --color-status-working: #58a6ff;
+  --color-status-ready: #3fb950;
   --color-status-attention: #d29922;
-  --color-status-idle:      #484f58;
-  --color-status-done:      #30363d;
-  --color-status-error:     #f85149;
+  --color-status-idle: #484f58;
+  --color-status-done: #30363d;
+  --color-status-error: #f85149;
 
   /* Semantic aliases */
-  --color-accent-blue:    #58a6ff;
-  --color-accent-green:   #3fb950;
-  --color-accent-yellow:  #d29922;
-  --color-accent-orange:  #d18616;
-  --color-accent-red:     #f85149;
-  --color-accent-violet:  #a371f7;
-  --color-accent-purple:  #bc8cff;
+  --color-accent-blue: #58a6ff;
+  --color-accent-green: #3fb950;
+  --color-accent-yellow: #d29922;
+  --color-accent-orange: #d18616;
+  --color-accent-red: #f85149;
+  --color-accent-violet: #a371f7;
+  --color-accent-purple: #bc8cff;
 
-  /* ── Typography ──────────────────────────────────────────────────── */
+  /* ── Typography ─────────────────────────────────────────────────────── */
   --font-sans: var(--font-ibm-plex-sans), "SF Pro Text", -apple-system, system-ui, sans-serif;
   --font-mono: var(--font-ibm-plex-mono), "SF Mono", "Menlo", "Consolas", monospace;
 
-  /* ── Border radius ────────────────────────────────────────────────── */
+  /* ── Border radius ───────────────────────────────────────────────────── */
   --radius-sm: 4px;
   --radius-md: 6px;
   --radius-lg: 8px;
   --radius-xl: 12px;
 
-  /* ── Transitions ──────────────────────────────────────────────────── */
-  --transition-quick:   0.1s;
+  /* ── Transitions ─────────────────────────────────────────────────────── */
+  --transition-quick: 0.1s;
   --transition-regular: 0.25s;
+}
+
+/* ── Light theme ───────────────────────────────────────────────────────── */
+.light {
+  --color-bg-base: #ffffff;
+  --color-bg-surface: rgba(246, 248, 250, 0.8);
+  --color-bg-elevated: rgba(255, 255, 255, 0.95);
+  --color-bg-subtle: rgba(240, 242, 245, 0.7);
+
+  --color-bg-primary: var(--color-bg-base);
+  --color-bg-secondary: var(--color-bg-surface);
+  --color-bg-tertiary: var(--color-bg-elevated);
+
+  --color-border-subtle: rgba(27, 31, 36, 0.12);
+  --color-border-default: rgba(27, 31, 36, 0.2);
+  --color-border-strong: rgba(27, 31, 36, 0.35);
+
+  --color-border-muted: var(--color-border-subtle);
+  --color-border-emphasis: var(--color-border-strong);
+
+  --color-text-primary: #1f2328;
+  --color-text-secondary: #656d76;
+  --color-text-tertiary: #8b949e;
+  --color-text-muted: #8b949e;
+  --color-text-inverse: #ffffff;
+
+  --color-accent: #0969da;
+  --color-accent-hover: #0550ae;
+  --color-accent-subtle: rgba(9, 105, 218, 0.1);
+
+  --color-status-working: #0969da;
+  --color-status-ready: #1a7f37;
+  --color-status-attention: #9a6700;
+  --color-status-idle: #8b949e;
+  --color-status-done: #d0d7de;
+  --color-status-error: #cf222e;
+
+  --color-accent-blue: #0969da;
+  --color-accent-green: #1a7f37;
+  --color-accent-yellow: #9a6700;
+  --color-accent-orange: #bc4c00;
+  --color-accent-red: #cf222e;
+  --color-accent-violet: #8250df;
+  --color-accent-purple: #8957e5;
 }
 
 /* ── Base styles ─────────────────────────────────────────────────────── */
@@ -78,6 +122,13 @@ body {
   letter-spacing: -0.011em;
 }
 
+.light body {
+  background:
+    radial-gradient(ellipse 70% 40% at 15% 0%, rgba(9, 105, 218, 0.04) 0%, transparent 60%),
+    radial-gradient(ellipse 50% 30% at 85% 90%, rgba(130, 80, 223, 0.03) 0%, transparent 60%),
+    var(--color-bg-base);
+}
+
 a {
   color: var(--color-accent);
   text-decoration: none;
@@ -88,56 +139,92 @@ a:hover {
 
 /* ── Scrollbar ────────────────────────────────────────────────────────── */
 
-::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.15); }
-::-webkit-scrollbar-thumb:active { background: rgba(255,255,255,0.25); }
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+::-webkit-scrollbar-thumb:active {
+  background: rgba(255, 255, 255, 0.25);
+}
 
 /* ── Animations ──────────────────────────────────────────────────────── */
 
 @keyframes activity-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(88, 166, 255, 0.45); }
-  50%       { box-shadow: 0 0 0 4px rgba(88, 166, 255, 0); }
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(88, 166, 255, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(88, 166, 255, 0);
+  }
 }
 
 @keyframes spin {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.4; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
 @keyframes slide-up {
-  from { opacity: 0; transform: translateY(4px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ── Orchestrator button ──────────────────────────────────────────────── */
 
 .orchestrator-btn {
   color: var(--color-accent);
-  background: linear-gradient(175deg, rgba(88,166,255,0.12) 0%, rgba(88,166,255,0.06) 100%);
-  border: 1px solid rgba(88,166,255,0.25);
+  background: linear-gradient(175deg, rgba(88, 166, 255, 0.12) 0%, rgba(88, 166, 255, 0.06) 100%);
+  border: 1px solid rgba(88, 166, 255, 0.25);
   box-shadow:
-    0 1px 2px rgba(0,0,0,0.6),
-    0 3px 8px rgba(0,0,0,0.3),
-    inset 0 1px 0 rgba(255,255,255,0.08);
-  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+    0 1px 2px rgba(0, 0, 0, 0.6),
+    0 3px 8px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease,
+    background 0.12s ease,
+    border-color 0.12s ease;
 }
 
 .orchestrator-btn:hover {
   transform: translateY(-1px);
-  background: linear-gradient(175deg, rgba(88,166,255,0.18) 0%, rgba(88,166,255,0.1) 100%);
-  border-color: rgba(88,166,255,0.45);
+  background: linear-gradient(175deg, rgba(88, 166, 255, 0.18) 0%, rgba(88, 166, 255, 0.1) 100%);
+  border-color: rgba(88, 166, 255, 0.45);
   box-shadow:
-    0 2px 6px rgba(0,0,0,0.7),
-    0 8px 20px rgba(0,0,0,0.35),
-    0 0 20px rgba(88,166,255,0.12),
-    inset 0 1px 0 rgba(255,255,255,0.12);
+    0 2px 6px rgba(0, 0, 0, 0.7),
+    0 8px 20px rgba(0, 0, 0, 0.35),
+    0 0 20px rgba(88, 166, 255, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 /* ── Glass nav ────────────────────────────────────────────────────────── */
@@ -148,59 +235,113 @@ a:hover {
   -webkit-backdrop-filter: blur(16px);
 }
 
+.light .nav-glass {
+  background: rgba(255, 255, 255, 0.88);
+}
+
 /* ── Detail page cards — subtle depth, no hover lift ─────────────────── */
 
 .detail-card {
-  background: linear-gradient(175deg, rgba(24,31,40,1) 0%, rgba(17,22,29,1) 100%);
+  background: linear-gradient(175deg, rgba(24, 31, 40, 1) 0%, rgba(17, 22, 29, 1) 100%);
   box-shadow:
-    0 1px 3px rgba(0,0,0,0.6),
-    inset 0 1px 0 rgba(255,255,255,0.05);
+    0 1px 3px rgba(0, 0, 0, 0.6),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
   --color-text-secondary: #8b949e;
-  --color-text-muted:     #656d76;
-  --color-text-tertiary:  #656d76;
+  --color-text-muted: #656d76;
+  --color-text-tertiary: #656d76;
+}
+
+.light .detail-card {
+  background: linear-gradient(175deg, rgba(255, 255, 255, 1) 0%, rgba(246, 248, 250, 1) 100%);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  --color-text-secondary: #57606a;
+  --color-text-muted: #6e7781;
+  --color-text-tertiary: #8b949e;
 }
 
 /* ── Session cards ────────────────────────────────────────────────────── */
 
 .session-card {
-  background: linear-gradient(175deg, rgba(28,36,47,1) 0%, rgba(18,23,31,1) 100%);
+  background: linear-gradient(175deg, rgba(28, 36, 47, 1) 0%, rgba(18, 23, 31, 1) 100%);
   box-shadow:
-    0 1px 2px rgba(0,0,0,0.9),
-    0 3px 10px rgba(0,0,0,0.55),
-    inset 0 1px 0 rgba(255,255,255,0.07);
-  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+    0 1px 2px rgba(0, 0, 0, 0.9),
+    0 3px 10px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07);
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease,
+    border-color 0.12s ease;
 
   /* Bump dim text colors inside the card — the elevated surface is darker
      than the transparent bg these values were calibrated for */
   --color-text-secondary: #8b949e;
-  --color-text-muted:     #656d76;
-  --color-text-tertiary:  #656d76;
+  --color-text-muted: #656d76;
+  --color-text-tertiary: #656d76;
+}
+
+.light .session-card {
+  background: linear-gradient(175deg, rgba(255, 255, 255, 1) 0%, rgba(246, 248, 250, 1) 100%);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.08),
+    0 3px 10px rgba(0, 0, 0, 0.05),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  --color-text-secondary: #57606a;
+  --color-text-muted: #6e7781;
+  --color-text-tertiary: #8b949e;
 }
 
 .session-card:hover {
   transform: translateY(-2px);
   box-shadow:
-    0 4px 8px rgba(0,0,0,0.85),
-    0 14px 36px rgba(0,0,0,0.55),
-    inset 0 1px 0 rgba(255,255,255,0.1);
+    0 4px 8px rgba(0, 0, 0, 0.85),
+    0 14px 36px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.light .session-card:hover {
+  box-shadow:
+    0 4px 8px rgba(0, 0, 0, 0.12),
+    0 14px 36px rgba(0, 0, 0, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
 }
 
 .session-card.card-merge-ready {
-  background: linear-gradient(175deg, rgba(16,40,24,1) 0%, rgba(10,26,15,1) 100%);
+  background: linear-gradient(175deg, rgba(16, 40, 24, 1) 0%, rgba(10, 26, 15, 1) 100%);
   box-shadow:
-    0 0 0 1px rgba(63,185,80,0.22),
-    0 1px 2px rgba(0,0,0,0.9),
-    0 3px 10px rgba(0,0,0,0.55),
-    0 0 40px rgba(63,185,80,0.13),
-    inset 0 1px 0 rgba(255,255,255,0.07);
+    0 0 0 1px rgba(63, 185, 80, 0.22),
+    0 1px 2px rgba(0, 0, 0, 0.9),
+    0 3px 10px rgba(0, 0, 0, 0.55),
+    0 0 40px rgba(63, 185, 80, 0.13),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07);
+}
+
+.light .session-card.card-merge-ready {
+  background: linear-gradient(175deg, rgba(226, 244, 232, 1) 0%, rgba(209, 235, 217, 1) 100%);
+  box-shadow:
+    0 0 0 1px rgba(26, 127, 55, 0.22),
+    0 1px 2px rgba(0, 0, 0, 0.08),
+    0 3px 10px rgba(0, 0, 0, 0.05),
+    0 0 40px rgba(26, 127, 55, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
 }
 
 .session-card.card-merge-ready:hover {
   transform: translateY(-2px);
   box-shadow:
-    0 0 0 1px rgba(63,185,80,0.35),
-    0 4px 8px rgba(0,0,0,0.85),
-    0 14px 36px rgba(0,0,0,0.55),
-    0 0 60px rgba(63,185,80,0.2),
-    inset 0 1px 0 rgba(255,255,255,0.1);
+    0 0 0 1px rgba(63, 185, 80, 0.35),
+    0 4px 8px rgba(0, 0, 0, 0.85),
+    0 14px 36px rgba(0, 0, 0, 0.55),
+    0 0 60px rgba(63, 185, 80, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.light .session-card.card-merge-ready:hover {
+  box-shadow:
+    0 0 0 1px rgba(26, 127, 55, 0.35),
+    0 4px 8px rgba(0, 0, 0, 0.12),
+    0 14px 36px rgba(0, 0, 0, 0.08),
+    0 0 60px rgba(26, 127, 55, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
 }

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -36,6 +36,22 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       suppressHydrationWarning
       className={`${ibmPlexSans.variable} ${ibmPlexMono.variable}`}
     >
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                var theme = localStorage.getItem('theme');
+                if (theme === 'light') {
+                  document.documentElement.classList.add('light');
+                } else {
+                  document.documentElement.classList.add('dark');
+                }
+              })();
+            `,
+          }}
+        />
+      </head>
       <body className="bg-[var(--color-bg-base)] text-[var(--color-text-primary)] antialiased">
         <ThemeProvider>{children}</ThemeProvider>
       </body>

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
 import { getProjectName } from "@/lib/project-name";
+import { ThemeProvider } from "@/components/ThemeProvider";
 import "./globals.css";
 
 const ibmPlexSans = IBM_Plex_Sans({
@@ -30,9 +31,13 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`dark ${ibmPlexSans.variable} ${ibmPlexMono.variable}`}>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${ibmPlexSans.variable} ${ibmPlexMono.variable}`}
+    >
       <body className="bg-[var(--color-bg-base)] text-[var(--color-text-primary)] antialiased">
-        {children}
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -13,6 +13,7 @@ import { CI_STATUS } from "@composio/ao-core/types";
 import { AttentionZone } from "./AttentionZone";
 import { PRTableRow } from "./PRStatus";
 import { DynamicFavicon } from "./DynamicFavicon";
+import { ThemeToggle } from "./ThemeToggle";
 import { useSessionEvents } from "@/hooks/useSessionEvents";
 
 interface DashboardProps {
@@ -105,37 +106,58 @@ export function Dashboard({ initialSessions, stats, orchestratorId, projectName 
           </h1>
           <StatusLine stats={stats} />
         </div>
-        {orchestratorId && (
-          <a
-            href={`/sessions/${encodeURIComponent(orchestratorId)}`}
-            className="orchestrator-btn flex items-center gap-2 rounded-[7px] px-4 py-2 text-[12px] font-semibold hover:no-underline"
-          >
-            <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)] opacity-80" />
-            orchestrator
-            <svg className="h-3 w-3 opacity-70" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3" />
-            </svg>
-          </a>
-        )}
+        <div className="flex items-center gap-3">
+          {orchestratorId && (
+            <a
+              href={`/sessions/${encodeURIComponent(orchestratorId)}`}
+              className="orchestrator-btn flex items-center gap-2 rounded-[7px] px-4 py-2 text-[12px] font-semibold hover:no-underline"
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)] opacity-80" />
+              orchestrator
+              <svg
+                className="h-3 w-3 opacity-70"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+              >
+                <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3" />
+              </svg>
+            </a>
+          )}
+          <ThemeToggle />
+        </div>
       </div>
 
       {/* Rate limit notice */}
       {anyRateLimited && !rateLimitDismissed && (
         <div className="mb-6 flex items-center gap-2.5 rounded border border-[rgba(245,158,11,0.25)] bg-[rgba(245,158,11,0.05)] px-3.5 py-2.5 text-[11px] text-[var(--color-status-attention)]">
-          <svg className="h-3.5 w-3.5 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <svg
+            className="h-3.5 w-3.5 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+          >
             <circle cx="12" cy="12" r="10" />
             <path d="M12 8v4M12 16h.01" />
           </svg>
           <span className="flex-1">
-            GitHub API rate limited — PR data (CI status, review state, sizes) may be stale.
-            {" "}Will retry automatically on next refresh.
+            GitHub API rate limited — PR data (CI status, review state, sizes) may be stale. Will
+            retry automatically on next refresh.
           </span>
           <button
             onClick={() => setRateLimitDismissed(true)}
             className="ml-1 shrink-0 opacity-60 hover:opacity-100"
             aria-label="Dismiss"
           >
-            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <svg
+              className="h-3.5 w-3.5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+            >
               <path d="M18 6 6 18M6 6l12 12" />
             </svg>
           </button>
@@ -241,18 +263,14 @@ function StatusLine({ stats }: { stats: DashboardStats }) {
     <div className="flex items-baseline gap-0.5">
       {parts.map((p, i) => (
         <span key={p.label} className="flex items-baseline">
-          {i > 0 && (
-            <span className="mx-3 text-[11px] text-[var(--color-border-strong)]">·</span>
-          )}
+          {i > 0 && <span className="mx-3 text-[11px] text-[var(--color-border-strong)]">·</span>}
           <span
             className="text-[20px] font-bold tabular-nums tracking-tight"
             style={{ color: p.color ?? "var(--color-text-primary)" }}
           >
             {p.value}
           </span>
-          <span className="ml-1.5 text-[11px] text-[var(--color-text-muted)]">
-            {p.label}
-          </span>
+          <span className="ml-1.5 text-[11px] text-[var(--color-text-muted)]">{p.label}</span>
         </span>
       ))}
     </div>

--- a/packages/web/src/components/ThemeProvider.tsx
+++ b/packages/web/src/components/ThemeProvider.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+type Theme = "dark" | "light";
+
+type ThemeContextType = {
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("dark");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const stored = localStorage.getItem("theme") as Theme | null;
+    if (stored) {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (mounted) {
+      document.documentElement.classList.remove("dark", "light");
+      document.documentElement.classList.add(theme);
+      localStorage.setItem("theme", theme);
+    }
+  }, [theme, mounted]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  };
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+  return context;
+}

--- a/packages/web/src/components/ThemeProvider.tsx
+++ b/packages/web/src/components/ThemeProvider.tsx
@@ -12,12 +12,7 @@ type ThemeContextType = {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(() => {
-    if (typeof window !== "undefined") {
-      return (localStorage.getItem("theme") as Theme) || "dark";
-    }
-    return "dark";
-  });
+  const [theme, setTheme] = useState<Theme>("dark");
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {

--- a/packages/web/src/components/ThemeProvider.tsx
+++ b/packages/web/src/components/ThemeProvider.tsx
@@ -12,7 +12,12 @@ type ThemeContextType = {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>("dark");
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== "undefined") {
+      return (localStorage.getItem("theme") as Theme) || "dark";
+    }
+    return "dark";
+  });
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {

--- a/packages/web/src/components/ThemeToggle.tsx
+++ b/packages/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useTheme } from "./ThemeProvider";
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-md hover:bg-[var(--color-bg-surface)] transition-colors"
+      aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+    >
+      {theme === "dark" ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="5" />
+          <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+        </svg>
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@composio/ao-plugin-agent-codex':
         specifier: workspace:*
         version: link:../plugins/agent-codex
+      '@composio/ao-plugin-agent-opencode':
+        specifier: workspace:*
+        version: link:../plugins/agent-opencode
       '@composio/ao-plugin-notifier-composio':
         specifier: workspace:*
         version: link:../plugins/notifier-composio


### PR DESCRIPTION
## Summary

- Add support for opencode AI agent in the orchestrator
- Add light/dark theme support with toggle in the web dashboard

## Changes

### Opencode Agent Support
- Added `opencode` to the agent plugins list in `packages/cli/src/lib/plugins.ts`
- Registered `opencode` in the plugin registry at `packages/core/src/plugin-registry.ts`
- This enables users to use opencode as an AI coding agent alongside Claude Code, Codex, and Aider

### Theme Support
- Created `ThemeProvider.tsx` with React context for theme state management
- Created `ThemeToggle.tsx` component with sun/moon icons for toggling
- Added light theme CSS variables in `globals.css` (GitHub-inspired colors)
- Added light theme variants for cards, navigation, and gradients
- Added theme toggle button to the dashboard header

## Why

1. **Opencode agent**: The orchestrator aims to be agent-agnostic. Adding opencode support expands the choices available to users.

2. **Theme toggle**: Users have different preferences for light/dark themes. Having both options improves accessibility and user experience.

## Testing

- TypeScript compilation passes (`pnpm typecheck`)
- ESLint passes with no new errors (`pnpm lint`)
- Theme toggle can be tested by running the dev server and clicking the sun/moon icon in the dashboard header