### PR TITLE
feat(web): instant session tab titles via lightweight /meta endpoint

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/meta/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/meta/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getServices } from "@/lib/services";
+import { sessionToDashboard } from "@/lib/serialize";
+
+/**
+ * GET /api/sessions/[id]/meta — lightweight session metadata endpoint.
+ *
+ * Returns local metadata only (no SCM enrichment, no GitHub API calls).
+ * Responds in <50ms, suitable for instant tab title population.
+ */
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const { sessionManager } = await getServices();
+
+    const coreSession = await sessionManager.get(id);
+    if (!coreSession) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    // Convert to dashboard format without any enrichment
+    const dashboardSession = sessionToDashboard(coreSession);
+
+    return NextResponse.json(dashboardSession);
+  } catch (error) {
+    console.error("Failed to fetch session meta:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
 import { SessionDetail } from "@/components/SessionDetail";
 import { type DashboardSession, getAttentionLevel, type AttentionLevel } from "@/lib/types";
@@ -46,6 +46,7 @@ export default function SessionPage() {
   const isOrchestrator = id.endsWith("-orchestrator");
 
   const [session, setSession] = useState<DashboardSession | null>(null);
+  const sessionRef = useRef<DashboardSession | null>(null);
   const [zoneCounts, setZoneCounts] = useState<ZoneCounts | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -70,11 +71,16 @@ export default function SessionPage() {
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = (await res.json()) as DashboardSession;
+      sessionRef.current = data;
       setSession(data);
       setError(null);
     } catch (err) {
       console.error("Failed to fetch session:", err);
-      setError("Failed to load session");
+      // Only show error if we don't already have session data from Phase 1 (meta).
+      // When Phase 1 succeeded, keep showing the existing session instead of an error.
+      if (!sessionRef.current) {
+        setError("Failed to load session");
+      }
     } finally {
       setLoading(false);
     }
@@ -109,7 +115,10 @@ export default function SessionPage() {
         const res = await fetch(`/api/sessions/${encodeURIComponent(id)}/meta`);
         if (res.ok) {
           const meta = (await res.json()) as DashboardSession;
-          setSession((prev) => prev ?? meta);
+          setSession((prev) => {
+            if (!prev) sessionRef.current = meta;
+            return prev ?? meta;
+          });
           setLoading(false);
         }
       } catch {

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -99,13 +99,30 @@ export default function SessionPage() {
     }
   }, [isOrchestrator]);
 
-  // Initial fetch — session first, zone counts after (avoids blocking on slow /api/sessions)
+  // Two-phase initial fetch:
+  // 1. Fast /meta endpoint for instant tab title (local metadata only, <50ms)
+  // 2. Full enriched session data for PR/CI details
   useEffect(() => {
+    // Phase 1: instant meta (sets title immediately)
+    void (async () => {
+      try {
+        const res = await fetch(`/api/sessions/${encodeURIComponent(id)}/meta`);
+        if (res.ok) {
+          const meta = (await res.json()) as DashboardSession;
+          setSession((prev) => prev ?? meta);
+          setLoading(false);
+        }
+      } catch {
+        // Non-critical — full fetch will handle errors
+      }
+    })();
+
+    // Phase 2: full enriched data (may take seconds due to GitHub API)
     fetchSession();
     // Delay zone counts so the heavy /api/sessions call doesn't contend with session load
     const t = setTimeout(fetchZoneCounts, 2000);
     return () => clearTimeout(t);
-  }, [fetchSession, fetchZoneCounts]);
+  }, [fetchSession, fetchZoneCounts, id]);
 
   // Poll every 5s
   useEffect(() => {


### PR DESCRIPTION
Add /api/sessions/[id]/meta endpoint that returns local session metadata without SCM enrichment (no GitHub API calls). Responds in <50ms.

Session detail page now uses a two-phase fetch strategy:
1. Fast /meta fetch populates the tab title instantly (activity emoji, branch, session ID) — no waiting for GitHub API
2. Full /api/sessions/[id] fetch loads enriched PR/CI data for the detail view

The /meta endpoint returns the same DashboardSession shape but skips enrichSessionPR() and enrichSessionsMetadata(), making it suitable for any UI that only needs local metadata.

Closes #123