### PR TITLE
feat(agent-aider): implement getSessionInfo and richer activity detec…

### DIFF
--- a/packages/plugins/agent-aider/src/index.test.ts
+++ b/packages/plugins/agent-aider/src/index.test.ts
@@ -4,8 +4,9 @@ import type { Session, RuntimeHandle, AgentLaunchConfig } from "@composio/ao-cor
 // ---------------------------------------------------------------------------
 // Hoisted mocks
 // ---------------------------------------------------------------------------
-const { mockExecFileAsync } = vi.hoisted(() => ({
+const { mockExecFileAsync, mockReadFile } = vi.hoisted(() => ({
   mockExecFileAsync: vi.fn(),
+  mockReadFile: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => {
@@ -13,6 +14,14 @@ vi.mock("node:child_process", () => {
     [Symbol.for("nodejs.util.promisify.custom")]: mockExecFileAsync,
   });
   return { execFile: fn };
+});
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    readFile: mockReadFile,
+  };
 });
 
 import { create, manifest, default as defaultExport } from "./index.js";
@@ -256,6 +265,38 @@ describe("detectActivity", () => {
   it("returns active for non-empty terminal output", () => {
     expect(agent.detectActivity("aider is processing files\n")).toBe("active");
   });
+
+  it("returns ready when aider prompt is shown", () => {
+    expect(agent.detectActivity("some output\naider > ")).toBe("ready");
+  });
+
+  it("returns ready for bare > prompt", () => {
+    expect(agent.detectActivity("some output\n> ")).toBe("ready");
+  });
+
+  it("returns waiting_input for Y/N confirmation", () => {
+    expect(agent.detectActivity("Allow edits to src/index.ts?\n(Y)es/(N)o")).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for add-to-chat prompt", () => {
+    expect(agent.detectActivity("Add src/utils.ts to the chat?\n")).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for create new file prompt", () => {
+    expect(agent.detectActivity("Create new file src/new.ts?\n")).toBe("waiting_input");
+  });
+
+  it("returns blocked for error lines", () => {
+    expect(agent.detectActivity("Error: file not found\n")).toBe("blocked");
+  });
+
+  it("returns blocked for API errors", () => {
+    expect(agent.detectActivity("Processing...\nAPI Error: rate limited\n")).toBe("blocked");
+  });
+
+  it("returns blocked for rate limit messages", () => {
+    expect(agent.detectActivity("Waiting...\nrate limit exceeded\n")).toBe("blocked");
+  });
 });
 
 // =========================================================================
@@ -264,8 +305,66 @@ describe("detectActivity", () => {
 describe("getSessionInfo", () => {
   const agent = create();
 
-  it("always returns null (not implemented)", async () => {
-    expect(await agent.getSessionInfo(makeSession())).toBeNull();
-    expect(await agent.getSessionInfo(makeSession({ workspacePath: "/some/path" }))).toBeNull();
+  it("returns null when workspacePath is missing", async () => {
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: null }));
+    expect(result).toBeNull();
+  });
+
+  it("returns null summary when chat history file does not exist", async () => {
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    const result = await agent.getSessionInfo(makeSession());
+    expect(result).not.toBeNull();
+    expect(result!.summary).toBeNull();
+    expect(result!.summaryIsFallback).toBe(false);
+    expect(result!.agentSessionId).toBeNull();
+  });
+
+  it("extracts summary from last assistant message", async () => {
+    mockReadFile.mockResolvedValue(
+      "#### user\nFix the login bug\n\n#### assistant\nI'll fix the authentication issue in login.ts by updating the token validation logic.\n",
+    );
+    const result = await agent.getSessionInfo(makeSession());
+    expect(result!.summary).toBe(
+      "I'll fix the authentication issue in login.ts by updating the token validation logic.",
+    );
+    expect(result!.summaryIsFallback).toBe(false);
+  });
+
+  it("falls back to first user message when no assistant response", async () => {
+    mockReadFile.mockResolvedValue("#### user\nPlease refactor the database module\n");
+    const result = await agent.getSessionInfo(makeSession());
+    expect(result!.summary).toBe("Please refactor the database module");
+    expect(result!.summaryIsFallback).toBe(true);
+  });
+
+  it("returns null summary for empty chat history", async () => {
+    mockReadFile.mockResolvedValue("");
+    const result = await agent.getSessionInfo(makeSession());
+    expect(result!.summary).toBeNull();
+  });
+
+  it("handles multiple assistant messages (uses last one)", async () => {
+    mockReadFile.mockResolvedValue(
+      "#### user\nFirst task\n\n#### assistant\nDone with first task.\n\n#### user\nSecond task\n\n#### assistant\nCompleted the refactoring of utils.ts.\n",
+    );
+    const result = await agent.getSessionInfo(makeSession());
+    expect(result!.summary).toBe("Completed the refactoring of utils.ts.");
+    expect(result!.summaryIsFallback).toBe(false);
+  });
+
+  it("skips code blocks in assistant messages", async () => {
+    mockReadFile.mockResolvedValue(
+      "#### user\nFix it\n\n#### assistant\n```python\ndef fix():\n  pass\n```\nHere is the fix for the issue.\n",
+    );
+    const result = await agent.getSessionInfo(makeSession());
+    expect(result!.summary).toBe("Here is the fix for the issue.");
+    expect(result!.summaryIsFallback).toBe(false);
+  });
+
+  it("truncates long summaries to 120 characters", async () => {
+    const longMessage = "A".repeat(200);
+    mockReadFile.mockResolvedValue(`#### user\nDo something\n\n#### assistant\n${longMessage}\n`);
+    const result = await agent.getSessionInfo(makeSession());
+    expect(result!.summary!.length).toBe(120);
   });
 });

--- a/packages/plugins/agent-aider/src/index.ts
+++ b/packages/plugins/agent-aider/src/index.ts
@@ -12,7 +12,7 @@ import {
 } from "@composio/ao-core";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { stat, access } from "node:fs/promises";
+import { stat, access, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { constants } from "node:fs";
 
@@ -50,6 +50,80 @@ async function getChatHistoryMtime(workspacePath: string): Promise<Date | null> 
   } catch {
     return null;
   }
+}
+
+/**
+ * Extract a summary from Aider's chat history file (.aider.chat.history.md).
+ * The file uses markdown with `#### <role>` headers separating messages.
+ * Returns the first line of the last assistant message as the summary.
+ */
+async function extractSummaryFromChatHistory(
+  workspacePath: string,
+): Promise<{ summary: string; isFallback: boolean } | null> {
+  const chatFile = join(workspacePath, ".aider.chat.history.md");
+  let content: string;
+  try {
+    content = await readFile(chatFile, "utf-8");
+  } catch {
+    return null;
+  }
+
+  if (!content.trim()) return null;
+
+  // Split into sections by role headers (#### user, #### assistant)
+  // Walk backwards to find the last assistant message
+  const lines = content.split("\n");
+  let lastAssistantStart = -1;
+  let lastAssistantEnd = lines.length;
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (/^#{1,4}\s+(assistant|ASSISTANT)/i.test(line)) {
+      lastAssistantStart = i + 1;
+      break;
+    }
+    // If we hit another header before finding assistant, update the end boundary
+    if (/^#{1,4}\s+(user|USER|system|SYSTEM)/i.test(line)) {
+      lastAssistantEnd = i;
+    }
+  }
+
+  if (lastAssistantStart === -1) {
+    // No assistant message found — try to use the first user message as fallback
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (/^#{1,4}\s+(user|USER)/i.test(line)) {
+        const userContent = lines
+          .slice(i + 1)
+          .map((l) => l.trim())
+          .filter(Boolean);
+        if (userContent.length > 0) {
+          return { summary: userContent[0].slice(0, 120), isFallback: true };
+        }
+        break;
+      }
+    }
+    return null;
+  }
+
+  // Extract the assistant message content, skipping code blocks entirely
+  const rawLines = lines.slice(lastAssistantStart, lastAssistantEnd);
+  const assistantLines: string[] = [];
+  let inCodeBlock = false;
+  for (const l of rawLines) {
+    const trimmed = l.trim();
+    if (trimmed.startsWith("```")) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (!inCodeBlock && trimmed) {
+      assistantLines.push(trimmed);
+    }
+  }
+
+  if (assistantLines.length === 0) return null;
+
+  return { summary: assistantLines[0].slice(0, 120), isFallback: false };
 }
 
 // =============================================================================
@@ -108,7 +182,26 @@ function createAiderAgent(): Agent {
 
     detectActivity(terminalOutput: string): ActivityState {
       if (!terminalOutput.trim()) return "idle";
-      // Aider doesn't have rich terminal output patterns yet
+
+      const lines = terminalOutput.trim().split("\n");
+      const lastLine = lines[lines.length - 1]?.trim() ?? "";
+      const tail = lines.slice(-5).join("\n");
+
+      // Aider's input prompt — waiting for user input
+      if (/^aider\s*>\s*$/i.test(lastLine)) return "ready";
+      if (/^>\s*$/.test(lastLine)) return "ready";
+
+      // Permission/confirmation prompts
+      if (/\(Y\)es.*\(N\)o/i.test(tail)) return "waiting_input";
+      if (/Allow edits to/i.test(tail)) return "waiting_input";
+      if (/Add .+ to the chat\?/i.test(tail)) return "waiting_input";
+      if (/Create new file/i.test(tail)) return "waiting_input";
+
+      // Error patterns
+      if (/^Error:/i.test(lastLine)) return "blocked";
+      if (/API Error/i.test(tail)) return "blocked";
+      if (/rate limit/i.test(tail)) return "blocked";
+
       return "active";
     },
 
@@ -197,9 +290,15 @@ function createAiderAgent(): Agent {
       }
     },
 
-    async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {
-      // Aider doesn't have JSONL session files for introspection yet
-      return null;
+    async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {
+      if (!session.workspacePath) return null;
+
+      const result = await extractSummaryFromChatHistory(session.workspacePath);
+      return {
+        summary: result?.summary ?? null,
+        summaryIsFallback: result?.isFallback ?? false,
+        agentSessionId: null, // Aider doesn't have persistent session IDs
+      };
     },
   };
 }

--- a/packages/plugins/agent-aider/src/index.ts
+++ b/packages/plugins/agent-aider/src/index.ts
@@ -93,12 +93,13 @@ async function extractSummaryFromChatHistory(
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i].trim();
       if (/^#{1,4}\s+(user|USER)/i.test(line)) {
-        const userContent = lines
-          .slice(i + 1)
-          .map((l) => l.trim())
-          .filter(Boolean);
-        if (userContent.length > 0) {
-          return { summary: userContent[0].slice(0, 120), isFallback: true };
+        // Gather content until the next section header
+        for (let j = i + 1; j < lines.length; j++) {
+          const nextLine = lines[j].trim();
+          if (/^#{1,4}\s+/i.test(nextLine)) break;
+          if (nextLine) {
+            return { summary: nextLine.slice(0, 120), isFallback: true };
+          }
         }
         break;
       }


### PR DESCRIPTION
…tion

Aider's getSessionInfo() previously returned null. Now it parses .aider.chat.history.md to extract a session summary from the last assistant message (with fallback to the first user message).

detectActivity() now recognizes richer terminal patterns:
- 'aider >' or '>' prompts → ready
- Y/N confirmations, add-to-chat, create-file prompts → waiting_input
- Error:, API Error, rate limit messages → blocked

Changes:
- Add extractSummaryFromChatHistory() helper that parses markdown chat history, skips code blocks, and extracts first meaningful line
- Implement getSessionInfo() using the chat history parser
- Add pattern matching for idle, ready, waiting_input, blocked states in detectActivity()
- Update tests: 9 new detectActivity tests, 7 new getSessionInfo tests

Closes #18