### PR TITLE
feat(cli): add --all and --search flags to ao status

### DIFF
--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -33,11 +33,13 @@ const {
   mockGetPendingComments: vi.fn(),
   mockSessionManager: {
     list: vi.fn(),
+    listArchived: vi.fn().mockResolvedValue([]),
     kill: vi.fn(),
     cleanup: vi.fn(),
     get: vi.fn(),
     spawn: vi.fn(),
     spawnOrchestrator: vi.fn(),
+    restore: vi.fn(),
     send: vi.fn(),
   },
   sessionsDirRef: { current: "" },
@@ -304,7 +306,7 @@ describe("status command", () => {
     await program.parseAsync(["node", "test", "status"]);
 
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
-    expect(output).toContain("1 active session");
+    expect(output).toContain("1 session");
   });
 
   it("shows plural for multiple sessions", async () => {
@@ -321,7 +323,7 @@ describe("status command", () => {
     await program.parseAsync(["node", "test", "status"]);
 
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
-    expect(output).toContain("2 active sessions");
+    expect(output).toContain("2 sessions");
   });
 
   it("prefers live branch over metadata branch", async () => {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -191,8 +191,10 @@ export function registerStatus(program: Command): void {
     .command("status")
     .description("Show all sessions with branch, activity, PR, and CI status")
     .option("-p, --project <id>", "Filter by project ID")
+    .option("--all", "Include archived/exited sessions")
+    .option("--search <query>", "Filter sessions by text (branch, PR, issue, summary)")
     .option("--json", "Output as JSON")
-    .action(async (opts: { project?: string; json?: boolean }) => {
+    .action(async (opts: { project?: string; all?: boolean; search?: string; json?: boolean }) => {
       let config: ReturnType<typeof loadConfig>;
       try {
         config = loadConfig();
@@ -210,7 +212,30 @@ export function registerStatus(program: Command): void {
 
       // Use session manager to list sessions (metadata-based, not tmux-based)
       const sm = await getSessionManager(config);
-      const sessions = await sm.list(opts.project);
+      let sessions = await sm.list(opts.project);
+
+      // Include archived sessions if --all is set (fixes #138)
+      if (opts.all) {
+        const archived = await sm.listArchived(opts.project);
+        sessions = [...sessions, ...archived];
+      }
+
+      // Filter by search query across metadata fields
+      if (opts.search) {
+        const q = opts.search.toLowerCase();
+        sessions = sessions.filter((s) => {
+          const fields = [
+            s.id,
+            s.branch,
+            s.status,
+            s.issueId,
+            s.projectId,
+            s.metadata["pr"],
+            s.metadata["summary"],
+          ];
+          return fields.some((f) => f?.toLowerCase().includes(q));
+        });
+      }
 
       if (!opts.json) {
         console.log(banner("AGENT ORCHESTRATOR STATUS"));
@@ -283,7 +308,7 @@ export function registerStatus(program: Command): void {
       } else {
         console.log(
           chalk.dim(
-            `  ${totalSessions} active session${totalSessions !== 1 ? "s" : ""} across ${projectIds.length} project${projectIds.length !== 1 ? "s" : ""}`,
+            `  ${totalSessions} session${totalSessions !== 1 ? "s" : ""}${opts.all ? " (including archived)" : ""} across ${projectIds.length} project${projectIds.length !== 1 ? "s" : ""}`,
           ),
         );
         console.log();

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -106,6 +106,7 @@ beforeEach(() => {
     spawnOrchestrator: vi.fn(),
     restore: vi.fn(),
     list: vi.fn().mockResolvedValue([]),
+    listArchived: vi.fn().mockResolvedValue([]),
     get: vi.fn().mockResolvedValue(null),
     kill: vi.fn().mockResolvedValue(undefined),
     cleanup: vi.fn(),

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -255,6 +255,27 @@ export function readArchivedMetadataRaw(
 }
 
 /**
+ * List unique session IDs that have archived metadata files.
+ * Archive files are named `<sessionId>_<ISO-timestamp>`.
+ */
+export function listArchivedSessionIds(dataDir: string): SessionId[] {
+  const archiveDir = join(dataDir, "archive");
+  if (!existsSync(archiveDir)) return [];
+
+  const ids = new Set<string>();
+  for (const file of readdirSync(archiveDir)) {
+    // Extract session ID from `<sessionId>_<ISO-timestamp>` format
+    const lastUnderscore = file.lastIndexOf("_");
+    if (lastUnderscore === -1) continue;
+    const id = file.slice(0, lastUnderscore);
+    if (VALID_SESSION_ID.test(id)) {
+      ids.add(id);
+    }
+  }
+  return [...ids];
+}
+
+/**
  * List all session IDs that have metadata files.
  */
 export function listMetadata(dataDir: string): SessionId[] {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -45,6 +45,7 @@ import {
   updateMetadata,
   deleteMetadata,
   listMetadata,
+  listArchivedSessionIds,
   reserveSessionId,
 } from "./metadata.js";
 import { buildPrompt } from "./prompt-builder.js";
@@ -1148,5 +1149,36 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     return restoredSession;
   }
 
-  return { spawn, spawnOrchestrator, restore, list, get, kill, cleanup, send };
+  async function listArchived(projectId?: string): Promise<Session[]> {
+    const sessions: Session[] = [];
+
+    const projectEntries = projectId
+      ? [[projectId, config.projects[projectId]] as const].filter(([, p]) => p)
+      : Object.entries(config.projects);
+
+    for (const [, project] of projectEntries) {
+      if (!project) continue;
+      const sessionsDir = getProjectSessionsDir(project);
+      const activeIds = new Set(listMetadata(sessionsDir));
+      const archivedIds = listArchivedSessionIds(sessionsDir);
+
+      for (const sessionId of archivedIds) {
+        // Skip if the session is still active (not truly archived)
+        if (activeIds.has(sessionId)) continue;
+
+        const raw = readArchivedMetadataRaw(sessionsDir, sessionId);
+        if (!raw) continue;
+
+        // Archived sessions don't have live timestamps — use metadata
+        // createdAt if available, otherwise fall back to current time
+        const createdAt = raw["createdAt"] ? new Date(raw["createdAt"]) : undefined;
+        const session = metadataToSession(sessionId, raw, createdAt, createdAt);
+        sessions.push(session);
+      }
+    }
+
+    return sessions;
+  }
+
+  return { spawn, spawnOrchestrator, restore, list, listArchived, get, kill, cleanup, send };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -994,6 +994,8 @@ export interface SessionManager {
   spawnOrchestrator(config: OrchestratorSpawnConfig): Promise<Session>;
   restore(sessionId: SessionId): Promise<Session>;
   list(projectId?: string): Promise<Session[]>;
+  /** List archived (exited/cleaned-up) sessions from the archive directory. */
+  listArchived(projectId?: string): Promise<Session[]>;
   get(sessionId: SessionId): Promise<Session | null>;
   kill(sessionId: SessionId): Promise<void>;
   cleanup(projectId?: string, options?: { dryRun?: boolean }): Promise<CleanupResult>;


### PR DESCRIPTION
ao status only showed active sessions. Archived sessions (from cleanup or kill) were invisible even though their metadata persists in the archive directory.

Changes:
- Add listArchivedSessionIds() to metadata.ts for listing archived IDs
- Add listArchived() to SessionManager interface and implementation
- Add --all flag to ao status to include archived/exited sessions
- Add --search flag to filter sessions by text match across id, branch, status, issue, project, PR URL, and summary fields

This enables:
  ao status --all              # show all sessions including archived
  ao status --search '1189'    # find session by PR number
  ao status --all --search pr  # search across all sessions

Closes #138