### PR TITLE
fix: add session URL pattern and CLI flag docs to orchestrator prompt

### DIFF
--- a/packages/core/src/orchestrator-prompt.ts
+++ b/packages/core/src/orchestrator-prompt.ts
@@ -76,8 +76,10 @@ ao open ${projectId}
 | \`ao session kill <session>\` | Kill a specific session |
 | \`ao session cleanup [-p project]\` | Kill completed/merged sessions |
 | \`ao send <session> <message>\` | Send a message to a running session |
+| \`ao send -f <path> <session>\` | Send contents of a file (for long/multi-line prompts) |
 | \`ao dashboard\` | Start the web dashboard (http://localhost:${config.port ?? 3000}) |
-| \`ao open <project>\` | Open all project sessions in terminal tabs |`);
+| \`ao open <project>\` | Open all project sessions in terminal tabs |
+| \`ao open <session>\` | Open a single session in a terminal tab |`);
 
   // Session Management
   sections.push(`## Session Management
@@ -105,6 +107,9 @@ Use \`ao status\` to see:
 Send instructions to a running agent:
 \`\`\`bash
 ao send ${project.sessionPrefix}-1 "Please address the review comments on your PR"
+
+# For long/multi-line prompts, use -f to send from a file:
+ao send -f /tmp/prompt.txt ${project.sessionPrefix}-1
 \`\`\`
 
 ### Cleanup
@@ -118,6 +123,8 @@ ao session cleanup -p ${projectId}  # Kill sessions where PR is merged or issue 
   sections.push(`## Dashboard
 
 The web dashboard runs at **http://localhost:${config.port ?? 3000}**.
+
+Individual session pages are at \`http://localhost:${config.port ?? 3000}/sessions/{sessionId}\`.
 
 Features:
 - Live session cards with activity status


### PR DESCRIPTION
## Summary

- Adds individual session detail page URL pattern (`/sessions/{sessionId}`) to the Dashboard section of the orchestrator prompt, so orchestrators can link directly to session pages
- Documents `ao send -f <path> <session>` flag in both the command table and the Sending Messages example section (critical for long multi-line prompts that get truncated by shell)
- Documents `ao open <session>` for opening a single session's terminal tab (previously only showed project-level usage)

## Test plan

- [x] `pnpm typecheck` passes for `@composio/ao-core`
- [x] `pnpm lint` passes (0 errors)
- [ ] Verify generated prompt includes session URL pattern and new CLI flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)