### PR TITLE
Fix direct terminal PTY leaks, stale WS reconnect loops, and noisy WebSocket errors

### DIFF
--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -689,6 +689,27 @@ describe("connection lifecycle", () => {
     ws.close();
   });
 
+  it("replaces prior connection for the same session ID", async () => {
+    const ws1 = await connectWs(TEST_SESSION);
+    await waitForWsData(ws1);
+    const ws1Closed = waitForWsClose(ws1);
+
+    const ws2 = await connectWs(TEST_SESSION);
+    await waitForWsData(ws2);
+
+    const closeResult = await ws1Closed;
+    expect(closeResult.code).toBe(4009);
+    expect(terminal.activeSessions.size).toBe(1);
+    expect(terminal.activeSessions.has(TEST_SESSION)).toBe(true);
+
+    const marker = `REPLACE_OK_${Date.now()}`;
+    ws2.send(`echo ${marker}\n`);
+    const output = await waitForMarker(ws2, marker);
+    expect(output).toContain(marker);
+
+    ws2.close();
+  });
+
   it("handles rapid connect and disconnect", async () => {
     // Connect and immediately close multiple times
     for (let i = 0; i < 3; i++) {

--- a/packages/web/server/__tests__/direct-terminal-ws.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { replaceExistingSession, type TerminalSession } from "../direct-terminal-ws.js";
+
+function makeSession(sessionId: string): TerminalSession {
+  const ws = {
+    close: vi.fn(),
+  };
+  const pty = {
+    kill: vi.fn(),
+  };
+  return {
+    sessionId,
+    ws: ws as unknown as TerminalSession["ws"],
+    pty: pty as unknown as TerminalSession["pty"],
+  };
+}
+
+describe("replaceExistingSession", () => {
+  it("returns false when no session exists", () => {
+    const sessions = new Map<string, TerminalSession>();
+    expect(replaceExistingSession(sessions, "ao-1")).toBe(false);
+    expect(sessions.size).toBe(0);
+  });
+
+  it("kills PTY, closes websocket, and removes existing session", () => {
+    const sessions = new Map<string, TerminalSession>();
+    const session = makeSession("ao-1");
+    sessions.set("ao-1", session);
+
+    const replaced = replaceExistingSession(sessions, "ao-1");
+
+    expect(replaced).toBe(true);
+    expect(sessions.has("ao-1")).toBe(false);
+    expect((session.ws.close as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      4009,
+      "Replaced by newer connection",
+    );
+    expect((session.pty.kill as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles websocket close errors and still removes session", () => {
+    const sessions = new Map<string, TerminalSession>();
+    const session = makeSession("ao-2");
+    (session.ws.close as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("close failed");
+    });
+    sessions.set("ao-2", session);
+
+    const replaced = replaceExistingSession(sessions, "ao-2");
+
+    expect(replaced).toBe(true);
+    expect(sessions.has("ao-2")).toBe(false);
+    expect((session.pty.kill as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles PTY kill errors and still removes session", () => {
+    const sessions = new Map<string, TerminalSession>();
+    const session = makeSession("ao-3");
+    (session.pty.kill as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("kill failed");
+    });
+    sessions.set("ao-3", session);
+
+    const replaced = replaceExistingSession(sessions, "ao-3");
+
+    expect(replaced).toBe(true);
+    expect(sessions.has("ao-3")).toBe(false);
+    expect((session.ws.close as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -14,10 +14,35 @@ import { spawn as ptySpawn, type IPty } from "node-pty";
 import { homedir, userInfo } from "node:os";
 import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js";
 
-interface TerminalSession {
+export interface TerminalSession {
   sessionId: string;
   pty: IPty;
   ws: WebSocket;
+}
+
+/**
+ * Replace an existing terminal session for a user-facing session ID.
+ * Returns true when an existing session was found and terminated.
+ */
+export function replaceExistingSession(
+  sessions: Map<string, TerminalSession>,
+  sessionId: string,
+): boolean {
+  const previous = sessions.get(sessionId);
+  if (!previous) return false;
+
+  try {
+    previous.ws.close(4009, "Replaced by newer connection");
+  } catch {
+    // Ignore close errors if socket is already gone
+  }
+  try {
+    previous.pty.kill();
+  } catch {
+    // Ignore kill errors if PTY is already dead
+  }
+  sessions.delete(sessionId);
+  return true;
 }
 
 export interface DirectTerminalServer {
@@ -34,6 +59,8 @@ export interface DirectTerminalServer {
 export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalServer {
   const TMUX = tmuxPath ?? findTmux();
   const activeSessions = new Map<string, TerminalSession>();
+  const HEARTBEAT_INTERVAL_MS = 30_000;
+  const HEARTBEAT_TIMEOUT_MS = 90_000;
 
   const server = createServer((req, res) => {
     if (req.url === "/health") {
@@ -83,6 +110,13 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
     }
 
     console.log(`[DirectTerminal] New connection for session: ${tmuxSessionId}`);
+
+    // Enforce one active PTY per user-facing session ID.
+    // Reconnecting clients should replace stale sockets instead of accumulating
+    // multiple tmux attach processes for the same logical session.
+    if (replaceExistingSession(activeSessions, sessionId)) {
+      console.log(`[DirectTerminal] Replacing existing connection for ${sessionId}`);
+    }
 
     // Enable mouse mode for scrollback support
     const mouseProc = spawn(TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "on"]);
@@ -136,6 +170,22 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
 
     const session: TerminalSession = { sessionId, pty, ws };
     activeSessions.set(sessionId, session);
+    let cleanedUp = false;
+    let lastPongAt = Date.now();
+
+    const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      clearInterval(heartbeatTimer);
+      if (activeSessions.get(sessionId)?.pty === pty) {
+        activeSessions.delete(sessionId);
+      }
+      try {
+        pty.kill();
+      } catch {
+        // PTY may already be dead
+      }
+    };
 
     // PTY -> WebSocket
     pty.onData((data) => {
@@ -147,11 +197,7 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
     // PTY exit
     pty.onExit(({ exitCode }) => {
       console.log(`[DirectTerminal] PTY exited for ${sessionId} with code ${exitCode}`);
-      // Guard against stale exits: only delete if this pty is still the active one.
-      // A new connection may have already replaced this session entry.
-      if (activeSessions.get(sessionId)?.pty === pty) {
-        activeSessions.delete(sessionId);
-      }
+      cleanup();
       if (ws.readyState === WebSocket.OPEN) {
         ws.close(1000, "Terminal session ended");
       }
@@ -181,22 +227,35 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
     // WebSocket close
     ws.on("close", () => {
       console.log(`[DirectTerminal] WebSocket closed for ${sessionId}`);
-      // Guard against stale closes replacing a newer session's entry
-      if (activeSessions.get(sessionId)?.pty === pty) {
-        activeSessions.delete(sessionId);
-      }
-      pty.kill();
+      cleanup();
     });
 
     // WebSocket error
     ws.on("error", (err) => {
       console.error(`[DirectTerminal] WebSocket error for ${sessionId}:`, err.message);
-      // Guard against stale error handlers replacing a newer session's entry
-      if (activeSessions.get(sessionId)?.pty === pty) {
-        activeSessions.delete(sessionId);
-      }
-      pty.kill();
+      cleanup();
     });
+
+    ws.on("pong", () => {
+      lastPongAt = Date.now();
+    });
+
+    const heartbeatTimer = setInterval(() => {
+      if (ws.readyState !== WebSocket.OPEN) return;
+      if (Date.now() - lastPongAt > HEARTBEAT_TIMEOUT_MS) {
+        console.warn(`[DirectTerminal] Heartbeat timeout for ${sessionId}, terminating socket`);
+        ws.terminate();
+        cleanup();
+        return;
+      }
+      try {
+        ws.ping();
+      } catch {
+        ws.terminate();
+        cleanup();
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+    heartbeatTimer.unref();
   });
 
   function shutdown() {
@@ -211,9 +270,11 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
 }
 
 // --- Run as standalone script ---
-// Only start the server when executed directly (not imported by tests)
-const isMainModule = process.argv[1]?.endsWith("direct-terminal-ws.ts") ||
-  process.argv[1]?.endsWith("direct-terminal-ws.js");
+// Only start the server when executed directly (not imported by tests).
+// `tsx watch` sets argv[1] to its own CLI, so also check later args.
+const isMainModule = process.argv.some(
+  (arg) => arg.endsWith("direct-terminal-ws.ts") || arg.endsWith("direct-terminal-ws.js"),
+);
 
 if (isMainModule) {
   const TMUX = findTmux();

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -78,7 +78,11 @@ export function DirectTerminal({
     let cleanup: (() => void) | null = null;
     let inputDisposable: { dispose(): void } | null = null;
 
-    const PERMANENT_CLOSE_CODES = new Set([4001, 4004]); // auth failure, session not found
+    // Do not retry these close codes:
+    // 1008: policy/session errors from server
+    // 4001/4004: auth/session-not-found (custom app codes)
+    // 4009: this client was replaced by a newer connection for the same session
+    const PERMANENT_CLOSE_CODES = new Set([1008, 4001, 4004, 4009]);
     const MAX_RECONNECT_DELAY = 15_000;
 
     Promise.all([
@@ -309,8 +313,10 @@ export function DirectTerminal({
             }
           };
 
-          websocket.onerror = (event) => {
-            console.error("[DirectTerminal] WebSocket error:", event);
+          websocket.onerror = () => {
+            // Browser WebSocket error events are intentionally opaque.
+            // Actionable details are surfaced via the subsequent onclose event.
+            console.warn("[DirectTerminal] WebSocket transport error");
           };
 
           websocket.onclose = (event) => {


### PR DESCRIPTION
## Why
Direct terminal sessions were exhausting PTYs over time, causing local terminal tab failures (`forkpty: Device not configured`) and unstable dashboard terminal behavior.

## What
- enforce single active PTY per user-facing session ID in `direct-terminal-ws`
- replace stale session sockets with custom close code `4009` (newer connection wins)
- add heartbeat ping/pong cleanup to terminate dead sockets and free PTYs
- improve main-module detection under `tsx watch` so direct terminal server starts reliably
- stop noisy browser Console Error overlays for opaque WebSocket transport errors
- treat permanent close codes (`1008`, `4001`, `4004`, `4009`) as non-retry conditions in `DirectTerminal`

## Tests
- added unit test: `packages/web/server/__tests__/direct-terminal-ws.test.ts`
- added integration test for replacement behavior: `packages/web/server/__tests__/direct-terminal-ws.integration.test.ts`
- ran:
  - `pnpm --filter @composio/ao-web test -- server/__tests__/direct-terminal-ws.test.ts server/__tests__/direct-terminal-ws.integration.test.ts`

## Local verification
- confirmed direct terminal backend accepts websocket for `integrator-orchestrator` and executes command output successfully
