### PR TITLE
feat: show tracker issue link in `ao status` output

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -20,7 +20,7 @@ import {
   reviewDecisionIcon,
   padCol,
 } from "../lib/format.js";
-import { getAgentByName, getSCM } from "../lib/plugins.js";
+import { getAgentByName, getSCM, getTracker } from "../lib/plugins.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
 
 interface SessionInfo {
@@ -32,6 +32,7 @@ interface SessionInfo {
   pr: string | null;
   prNumber: number | null;
   issue: string | null;
+  issueUrl: string | null;
   lastActivity: string;
   project: string | null;
   ciStatus: CIStatus | null;
@@ -51,6 +52,20 @@ async function gatherSessionInfo(
   const summary = session.metadata["summary"] ?? null;
   const prUrl = session.metadata["pr"] ?? null;
   const issue = session.issueId;
+
+  // Resolve issue URL via tracker plugin
+  let issueUrl: string | null = null;
+  if (issue) {
+    try {
+      const tracker = getTracker(projectConfig, session.projectId);
+      const project = projectConfig.projects[session.projectId];
+      if (tracker && project) {
+        issueUrl = tracker.issueUrl(issue, project);
+      }
+    } catch {
+      // Tracker lookup failed — not critical
+    }
+  }
 
   // Get live branch from worktree if available
   if (session.workspacePath) {
@@ -122,6 +137,7 @@ async function gatherSessionInfo(
     pr: prUrl,
     prNumber,
     issue,
+    issueUrl,
     lastActivity,
     project: session.projectId,
     ciStatus,
@@ -134,6 +150,7 @@ async function gatherSessionInfo(
 // Column widths for the table
 const COL = {
   session: 14,
+  issue: 12,
   branch: 24,
   pr: 6,
   ci: 6,
@@ -146,6 +163,7 @@ const COL = {
 function printTableHeader(): void {
   const hdr =
     padCol("Session", COL.session) +
+    padCol("Issue", COL.issue) +
     padCol("Branch", COL.branch) +
     padCol("PR", COL.pr) +
     padCol("CI", COL.ci) +
@@ -155,15 +173,26 @@ function printTableHeader(): void {
     "Age";
   console.log(chalk.dim(`  ${hdr}`));
   const totalWidth =
-    COL.session + COL.branch + COL.pr + COL.ci + COL.review + COL.threads + COL.activity + 3;
+    COL.session + COL.issue + COL.branch + COL.pr + COL.ci + COL.review + COL.threads + COL.activity + 3;
   console.log(chalk.dim(`  ${"─".repeat(totalWidth)}`));
+}
+
+function terminalLink(text: string, url: string): string {
+  return `\u001b]8;;${url}\u0007${text}\u001b]8;;\u0007`;
 }
 
 function printSessionRow(info: SessionInfo): void {
   const prStr = info.prNumber ? `#${info.prNumber}` : "-";
 
+  const issueLabel = info.issue
+    ? info.issueUrl
+      ? chalk.magenta(terminalLink(info.issue, info.issueUrl))
+      : chalk.magenta(info.issue)
+    : chalk.dim("-");
+
   const row =
     padCol(chalk.green(info.name), COL.session) +
+    padCol(issueLabel, COL.issue) +
     padCol(info.branch ? chalk.cyan(info.branch) : chalk.dim("-"), COL.branch) +
     padCol(info.prNumber ? chalk.blue(prStr) : chalk.dim(prStr), COL.pr) +
     padCol(ciStatusIcon(info.ciStatus), COL.ci) +
@@ -182,7 +211,7 @@ function printSessionRow(info: SessionInfo): void {
   // Show summary on a second line if available
   const displaySummary = info.claudeSummary || info.summary;
   if (displaySummary) {
-    console.log(`  ${" ".repeat(COL.session)}${chalk.dim(displaySummary.slice(0, 60))}`);
+    console.log(`  ${" ".repeat(COL.session + COL.issue)}${chalk.dim(displaySummary.slice(0, 60))}`);
   }
 }
 

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -105,7 +105,7 @@ export function activityIcon(activity: ActivityState | null): string {
 }
 
 // eslint-disable-next-line no-control-regex
-const ANSI_RE = /\u001b\[[0-9;]*m/g;
+const ANSI_RE = /\u001b\[[0-9;]*m|\u001b\]8;;[^\u0007]*\u0007/g;
 
 /** Pad/truncate a string to exactly `width` visible characters */
 export function padCol(str: string, width: number): string {

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -1,8 +1,10 @@
-import type { Agent, OrchestratorConfig, SCM } from "@composio/ao-core";
+import type { Agent, OrchestratorConfig, SCM, Tracker } from "@composio/ao-core";
 import claudeCodePlugin from "@composio/ao-plugin-agent-claude-code";
 import codexPlugin from "@composio/ao-plugin-agent-codex";
 import aiderPlugin from "@composio/ao-plugin-agent-aider";
 import githubSCMPlugin from "@composio/ao-plugin-scm-github";
+import githubTrackerPlugin from "@composio/ao-plugin-tracker-github";
+import linearTrackerPlugin from "@composio/ao-plugin-tracker-linear";
 
 const agentPlugins: Record<string, { create(): Agent }> = {
   "claude-code": claudeCodePlugin,
@@ -12,6 +14,11 @@ const agentPlugins: Record<string, { create(): Agent }> = {
 
 const scmPlugins: Record<string, { create(): SCM }> = {
   github: githubSCMPlugin,
+};
+
+const trackerPlugins: Record<string, { create(): Tracker }> = {
+  github: githubTrackerPlugin,
+  linear: linearTrackerPlugin,
 };
 
 /**
@@ -46,5 +53,16 @@ export function getSCM(config: OrchestratorConfig, projectId: string): SCM {
   if (!plugin) {
     throw new Error(`Unknown SCM plugin: ${scmName}`);
   }
+  return plugin.create();
+}
+
+/**
+ * Resolve the Tracker plugin for a project, or return null if none configured.
+ */
+export function getTracker(config: OrchestratorConfig, projectId: string): Tracker | null {
+  const trackerName = config.projects[projectId]?.tracker?.plugin;
+  if (!trackerName) return null;
+  const plugin = trackerPlugins[trackerName];
+  if (!plugin) return null;
   return plugin.create();
 }


### PR DESCRIPTION
## Summary

- Add **Issue** column to `ao status` table between Session and Branch, displaying the tracker issue identifier (e.g. `ENG-1628`)
- Resolve issue URLs via tracker plugin (`issueUrl()`) and include `issueUrl` in `--json` output
- Render issue identifiers as clickable **OSC 8 terminal hyperlinks** for supported terminals
- Update `padCol`'s ANSI regex to strip OSC 8 sequences so column alignment stays correct
- Add `getTracker()` helper to CLI plugin resolver

Closes #303

## Changes

| File | What |
|------|------|
| `packages/cli/src/commands/status.ts` | Add `Issue` column to `COL`, `printTableHeader()`, `printSessionRow()`; resolve `issueUrl` in `gatherSessionInfo()` |
| `packages/cli/src/lib/plugins.ts` | Add `getTracker()` to load tracker plugins (linear, github) |
| `packages/cli/src/lib/format.ts` | Extend ANSI strip regex to handle OSC 8 hyperlink sequences |

## Test plan

- [ ] Run `ao status` with sessions that have tracker issues — verify Issue column appears with correct identifiers
- [ ] Run `ao status --json` — verify `issueUrl` field is present in output
- [ ] Run `ao status` with sessions that have no tracker issue — verify `-` placeholder
- [ ] Run `ao status` on a project with no tracker configured — verify graceful fallback
- [ ] Verify column alignment is correct with and without hyperlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)