### PR TITLE
fix(core): include ao CLI control-plane guidance in orchestrator prompt

### DIFF
--- a/packages/core/src/__tests__/orchestrator-prompt.test.ts
+++ b/packages/core/src/__tests__/orchestrator-prompt.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { generateOrchestratorPrompt } from "../orchestrator-prompt.js";
+import type { OrchestratorConfig, ProjectConfig } from "../types.js";
+
+const projectId = "integrator";
+
+const project: ProjectConfig = {
+  name: "Integrator",
+  repo: "org/integrator",
+  path: "/tmp/integrator",
+  defaultBranch: "main",
+  sessionPrefix: "int",
+};
+
+const config: OrchestratorConfig = {
+  configPath: "/tmp/agent-orchestrator.yaml",
+  port: 3000,
+  terminalPort: 3001,
+  directTerminalPort: 3003,
+  readyThresholdMs: 300_000,
+  defaults: {
+    runtime: "tmux",
+    agent: "claude-code",
+    workspace: "worktree",
+    notifiers: ["desktop"],
+  },
+  projects: {
+    [projectId]: project,
+  },
+  notifiers: {},
+  notificationRouting: {
+    urgent: ["desktop"],
+    action: ["desktop"],
+    warning: [],
+    info: [],
+  },
+  reactions: {},
+};
+
+describe("generateOrchestratorPrompt", () => {
+  it("includes ao CLI control-plane guidance and key commands", () => {
+    const prompt = generateOrchestratorPrompt({ config, projectId, project });
+
+    expect(prompt).toContain("## AO CLI Control Plane");
+    expect(prompt).toContain("Prefer `ao` commands over manual shell/tmux workflows");
+    expect(prompt).toContain("Do NOT manage sessions manually with raw `tmux` commands");
+
+    expect(prompt).toContain("ao status");
+    expect(prompt).toContain(`ao spawn ${projectId} INT-1234`);
+    expect(prompt).toContain(`ao batch-spawn ${projectId} INT-1 INT-2 INT-3`);
+    expect(prompt).toContain(`ao send ${project.sessionPrefix}-1 "Your message here"`);
+    expect(prompt).toContain(`ao review-check ${projectId}`);
+    expect(prompt).toContain("`ao review-check [project]`");
+  });
+});

--- a/packages/core/src/orchestrator-prompt.ts
+++ b/packages/core/src/orchestrator-prompt.ts
@@ -29,6 +29,15 @@ You are the **orchestrator agent** for the ${project.name} project.
 
 Your role is to coordinate and manage worker agent sessions. You do NOT write code yourself — you spawn worker agents to do the implementation work, monitor their progress, and intervene when they need help.`);
 
+  // AO CLI control plane
+  sections.push(`## AO CLI Control Plane
+
+Use the \`ao\` CLI as your control plane for managing sessions and workflow state.
+
+- Prefer \`ao\` commands over manual shell/tmux workflows.
+- Do NOT manage sessions manually with raw \`tmux\` commands, shell loops, or ad-hoc metadata edits when an \`ao\` command exists.
+- If a command fails, retry with the relevant \`ao\` command first before falling back to manual debugging.`);
+
   // Project Info
   sections.push(`## Project Info
 
@@ -57,6 +66,9 @@ ao session ls -p ${projectId}
 # Send message to a session
 ao send ${project.sessionPrefix}-1 "Your message here"
 
+# Scan PRs/reviews and route follow-up actions
+ao review-check ${projectId}
+
 # Claim an existing PR for a session
 ao session claim-pr 123 ${project.sessionPrefix}-1
 
@@ -81,6 +93,7 @@ ao open ${projectId}
 | \`ao session kill <session>\` | Kill a specific session |
 | \`ao session cleanup [-p project]\` | Kill completed/merged sessions |
 | \`ao send <session> <message>\` | Send a message to a running session |
+| \`ao review-check [project]\` | Scan PRs for CI/review updates and trigger follow-up actions |
 | \`ao dashboard\` | Start the web dashboard (http://localhost:${config.port ?? 3000}) |
 | \`ao open <project>\` | Open all project sessions in terminal tabs |`);
 


### PR DESCRIPTION
## Summary
- add an explicit **AO CLI Control Plane** section to the orchestrator system prompt generated during `ao start`
- instruct orchestrator agents to prefer `ao` commands over manual tmux/shell workflows
- add `ao review-check [project]` to the orchestrator quick-start and command reference table
- add a core unit test to lock in CLI guidance + key command coverage in the generated orchestrator prompt

## Why
Orchestrator sessions were not consistently using AO-native session management commands and could fall back to manual tmux workflows. This makes the expected control surface explicit in the injected system prompt.

Closes #328

## Validation
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
