### PR TITLE
fix(codex): prioritize /usr/local/bin in agent session PATH

### DIFF
--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -374,12 +374,36 @@ describe("getEnvironment", () => {
     expect(env["PATH"]?.startsWith("/mock/home/.ao/bin:")).toBe(true);
   });
 
+  it("prioritizes /usr/local/bin before linuxbrew paths", () => {
+    const originalPath = process.env["PATH"];
+    process.env["PATH"] = "/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin";
+    try {
+      const env = agent.getEnvironment(makeLaunchConfig());
+      expect(env["PATH"]).toBe(
+        "/mock/home/.ao/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin",
+      );
+    } finally {
+      process.env["PATH"] = originalPath;
+    }
+  });
+
+  it("does not duplicate /usr/local/bin when it is already in PATH", () => {
+    const originalPath = process.env["PATH"];
+    process.env["PATH"] = "/usr/local/bin:/usr/bin:/usr/local/bin:/bin";
+    try {
+      const env = agent.getEnvironment(makeLaunchConfig());
+      expect(env["PATH"]).toBe("/mock/home/.ao/bin:/usr/local/bin:/usr/bin:/bin");
+    } finally {
+      process.env["PATH"] = originalPath;
+    }
+  });
+
   it("falls back to /usr/bin:/bin when process.env.PATH is undefined", () => {
     const originalPath = process.env["PATH"];
     delete process.env["PATH"];
     try {
       const env = agent.getEnvironment(makeLaunchConfig());
-      expect(env["PATH"]).toContain("/usr/bin:/bin");
+      expect(env["PATH"]).toBe("/mock/home/.ao/bin:/usr/local/bin:/usr/bin:/bin");
     } finally {
       process.env["PATH"] = originalPath;
     }

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -26,6 +26,35 @@ const execFileAsync = promisify(execFile);
 
 /** Shared bin directory for ao shell wrappers (prepended to PATH) */
 const AO_BIN_DIR = join(homedir(), ".ao", "bin");
+const DEFAULT_PATH_FALLBACK = "/usr/bin:/bin";
+const PRIORITY_PATH_DIRS = ["/usr/local/bin"] as const;
+const PRIORITY_PATH_SET = new Set<string>(PRIORITY_PATH_DIRS);
+
+function buildAgentPath(basePath: string | undefined): string {
+  const segments = (basePath ?? DEFAULT_PATH_FALLBACK).split(":").filter(Boolean);
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+
+  const pushUnique = (segment: string) => {
+    if (seen.has(segment)) return;
+    seen.add(segment);
+    ordered.push(segment);
+  };
+
+  // Keep AO wrappers first, then prioritize user/system shim locations.
+  pushUnique(AO_BIN_DIR);
+  for (const dir of PRIORITY_PATH_DIRS) {
+    pushUnique(dir);
+  }
+
+  for (const segment of segments) {
+    if (segment === AO_BIN_DIR) continue;
+    if (PRIORITY_PATH_SET.has(segment)) continue;
+    pushUnique(segment);
+  }
+
+  return ordered.join(":");
+}
 
 // =============================================================================
 // Plugin Manifest
@@ -599,10 +628,9 @@ function createCodexAgent(): Agent {
         env["AO_ISSUE_ID"] = config.issueId;
       }
 
-      // Prepend ~/.ao/bin to PATH so our gh/git wrappers intercept commands.
-      // The wrappers strip this directory from PATH before calling the real
-      // binary, so there's no infinite recursion.
-      env["PATH"] = `${AO_BIN_DIR}:${process.env["PATH"] ?? "/usr/bin:/bin"}`;
+      // Ensure wrappers intercept first, while preferring /usr/local/bin over
+      // package-manager bins (e.g. Linuxbrew) for the real gh/git resolution.
+      env["PATH"] = buildAgentPath(process.env["PATH"]);
 
       return env;
     },


### PR DESCRIPTION
## Summary
- add deterministic PATH builder in codex agent `getEnvironment()`
- keep `~/.ao/bin` first for wrappers and prioritize `/usr/local/bin` next
- preserve remaining PATH order while removing duplicates
- add unit tests for linuxbrew ordering, de-duplication, and fallback behavior

## Testing
- pnpm build
- pnpm test

Fixes #341
