### PR TITLE
fix(tracker-linear): add webpackIgnore to optional @composio/core import

### DIFF
--- a/packages/plugins/tracker-linear/src/index.ts
+++ b/packages/plugins/tracker-linear/src/index.ts
@@ -137,7 +137,7 @@ function createComposioTransport(apiKey: string, entityId: string): GraphQLTrans
     if (!clientPromise) {
       clientPromise = (async () => {
         try {
-          const { Composio } = await import("@composio/core");
+          const { Composio } = await import(/* webpackIgnore: true */ "@composio/core");
           const client = new Composio({ apiKey });
           return client.tools;
         } catch (err: unknown) {


### PR DESCRIPTION
## Summary

- The dynamic `import("@composio/core")` in `tracker-linear`'s Composio transport path causes a `Module not found: Can't resolve '@composio/core'` warning when the web dashboard bundles via Next.js webpack
- The import is intentionally optional (only used when `COMPOSIO_API_KEY` is set), but webpack statically analyzes all `import()` calls and tries to resolve the module at build time
- Adding `/* webpackIgnore: true */` tells webpack to skip this import and let it resolve at runtime only when the code path is actually executed

## Reproduction

Start the web dashboard (`pnpm dev` in `packages/web`) — the following warning appears on every page load:

```
../plugins/tracker-linear/dist/index.js
Module not found: Can't resolve '@composio/core' in '.../packages/plugins/tracker-linear/dist'
```

## Fix

One-line change in `packages/plugins/tracker-linear/src/index.ts`:

```diff
- const { Composio } = await import("@composio/core");
+ const { Composio } = await import(/* webpackIgnore: true */ "@composio/core");
```