### PR TITLE
feat: default CI failure auto-injection with 5-retry escalation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+## Agent Orchestrator (ao) Session
+
+You are running inside an Agent Orchestrator managed workspace.
+Session metadata is updated automatically via shell wrappers.
+
+If automatic updates fail, you can manually update metadata:
+```bash
+~/.ao/bin/ao-metadata-helper.sh  # sourced automatically
+# Then call: update_ao_metadata <key> <value>
+```

--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -112,6 +112,48 @@ projects:
     it("should throw error if config not found", () => {
       expect(() => loadConfig()).toThrow("No agent-orchestrator.yaml found");
     });
+
+    it("applies default ci-failed reaction with 5 retries before escalation", () => {
+      const configPath = join(testDir, "defaults-config.yaml");
+      writeFileSync(
+        configPath,
+        `
+projects:
+  test-project:
+    repo: test/repo
+    path: ${testDir}
+`,
+      );
+
+      const config = loadConfig(configPath);
+      expect(config.reactions["ci-failed"]).toEqual(
+        expect.objectContaining({
+          auto: true,
+          action: "send-to-agent",
+          retries: 5,
+          escalateAfter: 5,
+        }),
+      );
+    });
+
+    it("preserves explicit ci-failed retry override", () => {
+      const configPath = join(testDir, "override-config.yaml");
+      writeFileSync(
+        configPath,
+        `
+projects:
+  test-project:
+    repo: test/repo
+    path: ${testDir}
+reactions:
+  ci-failed:
+    retries: 7
+`,
+      );
+
+      const config = loadConfig(configPath);
+      expect(config.reactions["ci-failed"]?.retries).toBe(7);
+    });
   });
 
   describe("Config Discovery Priority", () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -830,6 +830,93 @@ describe("reactions", () => {
     expect(mockNotifier.notify).not.toHaveBeenCalled();
   });
 
+  it("tracks CI retry escalation per CI run and resets on a new failing run", async () => {
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Fix CI failure.",
+        retries: 1,
+        escalateAfter: 1,
+      },
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    let ciChecksCall = 0;
+    const run1Time = new Date("2026-01-01T00:00:00.000Z");
+    const run2Time = new Date("2026-01-01T00:10:00.000Z");
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn().mockImplementation(async () => {
+        ciChecksCall++;
+        const startedAt = ciChecksCall <= 2 ? run1Time : run2Time;
+        return [{ name: "test", status: "failed", conclusion: "failure", startedAt }];
+      }),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCMAndNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.send).mockRejectedValue(new Error("send failed"));
+    const session = makeSession({ status: "ci_failed", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "ci_failed",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCMAndNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    // Run 1: first failed send (attempt 1), then escalation on next retry (attempt 2)
+    await lm.check("app-1");
+    await lm.check("app-1");
+
+    // Run 2: fingerprint changes, retries should reset (new send attempt, then escalation again)
+    await lm.check("app-1");
+    await lm.check("app-1");
+
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(2);
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(2);
+    expect(mockNotifier.notify).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ type: "reaction.escalated" }),
+    );
+    expect(mockNotifier.notify).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ type: "reaction.escalated" }),
+    );
+  });
+
   it("dispatches unresolved review comments even when reviewDecision stays unchanged", async () => {
     config.reactions = {
       "changes-requested": {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -224,8 +224,8 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
       action: "send-to-agent",
       message:
         "CI is failing on your PR. Run `gh pr checks` to see the failures, fix them, and push.",
-      retries: 2,
-      escalateAfter: 2,
+      retries: 5,
+      escalateAfter: 5,
     },
     "changes-requested": {
       auto: true,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -28,6 +28,7 @@ import {
   type Runtime,
   type Agent,
   type SCM,
+  type CICheck,
   type Notifier,
   type Session,
   type EventPriority,
@@ -463,6 +464,100 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return [...ids].sort().join(",");
   }
 
+  function makeCiRunFingerprint(checks: CICheck[] | null): string {
+    if (!checks || checks.length === 0) return "ci-failing";
+    return checks
+      .map((check) => {
+        const startedAt = check.startedAt ? check.startedAt.toISOString() : "";
+        const completedAt = check.completedAt ? check.completedAt.toISOString() : "";
+        const conclusion = check.conclusion ?? "";
+        const url = check.url ?? "";
+        return `${check.name}|${check.status}|${conclusion}|${startedAt}|${completedAt}|${url}`;
+      })
+      .sort()
+      .join(",");
+  }
+
+  async function maybeDispatchCiFailureBacklog(
+    session: Session,
+    oldStatus: SessionStatus,
+    newStatus: SessionStatus,
+    transitionReaction?: { key: string; result: ReactionResult | null },
+  ): Promise<void> {
+    const project = config.projects[session.projectId];
+    if (!project) return;
+
+    const ciReactionKey = "ci-failed";
+    if (newStatus !== "ci_failed" || !session.pr) {
+      clearReactionTracker(session.id, ciReactionKey);
+      updateSessionMetadata(session, {
+        lastCiFailureFingerprint: "",
+        lastCiFailureDispatchHash: "",
+        lastCiFailureDispatchAt: "",
+      });
+      return;
+    }
+
+    const reactionConfig = getReactionConfigForSession(session, ciReactionKey);
+    if (
+      !reactionConfig ||
+      !reactionConfig.action ||
+      (reactionConfig.auto === false && reactionConfig.action !== "notify")
+    ) {
+      return;
+    }
+
+    const scm = project.scm ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    if (!scm) return;
+
+    let checks: CICheck[] | null = null;
+    try {
+      checks = await scm.getCIChecks(session.pr);
+    } catch {
+      // Best effort fingerprinting. If checks can't be fetched, keep retrying
+      // against a stable fallback fingerprint for the currently failing run.
+    }
+
+    const ciFingerprint = makeCiRunFingerprint(checks);
+    const lastFingerprint = session.metadata["lastCiFailureFingerprint"] ?? "";
+    const lastDispatchHash = session.metadata["lastCiFailureDispatchHash"] ?? "";
+
+    if (ciFingerprint !== lastFingerprint) {
+      clearReactionTracker(session.id, ciReactionKey);
+      updateSessionMetadata(session, {
+        lastCiFailureFingerprint: ciFingerprint,
+      });
+    }
+
+    if (transitionReaction?.key === ciReactionKey && transitionReaction.result?.success) {
+      if (lastDispatchHash !== ciFingerprint) {
+        updateSessionMetadata(session, {
+          lastCiFailureDispatchHash: ciFingerprint,
+          lastCiFailureDispatchAt: new Date().toISOString(),
+        });
+      }
+      return;
+    }
+
+    if (
+      !(oldStatus !== newStatus && newStatus === "ci_failed") &&
+      ciFingerprint !== lastDispatchHash
+    ) {
+      const result = await executeReaction(
+        session.id,
+        session.projectId,
+        ciReactionKey,
+        reactionConfig,
+      );
+      if (result.success) {
+        updateSessionMetadata(session, {
+          lastCiFailureDispatchHash: ciFingerprint,
+          lastCiFailureDispatchAt: new Date().toISOString(),
+        });
+      }
+    }
+  }
+
   async function maybeDispatchReviewBacklog(
     session: Session,
     oldStatus: SessionStatus,
@@ -721,6 +816,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       states.set(session.id, newStatus);
     }
 
+    await maybeDispatchCiFailureBacklog(session, oldStatus, newStatus, transitionReaction);
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction);
   }
 

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -466,10 +466,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return checks
       .map((check) => {
         const startedAt = check.startedAt ? check.startedAt.toISOString() : "";
-        const completedAt = check.completedAt ? check.completedAt.toISOString() : "";
-        const conclusion = check.conclusion ?? "";
         const url = check.url ?? "";
-        return `${check.name}|${check.status}|${conclusion}|${startedAt}|${completedAt}|${url}`;
+        return `${check.name}|${startedAt}|${url}`;
       })
       .sort()
       .join(",");

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -437,10 +437,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return reactionConfig ? (reactionConfig as ReactionConfig) : null;
   }
 
-  function updateSessionMetadata(
-    session: Session,
-    updates: Partial<Record<string, string>>,
-  ): void {
+  function updateSessionMetadata(session: Session, updates: Partial<Record<string, string>>): void {
     const project = config.projects[session.projectId];
     if (!project) return;
 
@@ -490,11 +487,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const ciReactionKey = "ci-failed";
     if (newStatus !== "ci_failed" || !session.pr) {
       clearReactionTracker(session.id, ciReactionKey);
-      updateSessionMetadata(session, {
-        lastCiFailureFingerprint: "",
-        lastCiFailureDispatchHash: "",
-        lastCiFailureDispatchAt: "",
-      });
+      if (
+        session.metadata["lastCiFailureFingerprint"] !== undefined ||
+        session.metadata["lastCiFailureDispatchHash"] !== undefined ||
+        session.metadata["lastCiFailureDispatchAt"] !== undefined
+      ) {
+        updateSessionMetadata(session, {
+          lastCiFailureFingerprint: "",
+          lastCiFailureDispatchHash: "",
+          lastCiFailureDispatchAt: "",
+        });
+      }
       return;
     }
 
@@ -523,7 +526,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const lastDispatchHash = session.metadata["lastCiFailureDispatchHash"] ?? "";
 
     if (ciFingerprint !== lastFingerprint) {
-      clearReactionTracker(session.id, ciReactionKey);
+      if (transitionReaction?.key !== ciReactionKey) {
+        clearReactionTracker(session.id, ciReactionKey);
+      }
       updateSessionMetadata(session, {
         lastCiFailureFingerprint: ciFingerprint,
       });
@@ -677,12 +682,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       );
     }
     if (automatedComments !== null) {
-      const automatedFingerprint = makeFingerprint(
-        automatedComments.map((comment) => comment.id),
-      );
+      const automatedFingerprint = makeFingerprint(automatedComments.map((comment) => comment.id));
       const lastAutomatedFingerprint = session.metadata["lastAutomatedReviewFingerprint"] ?? "";
-      const lastAutomatedDispatchHash =
-        session.metadata["lastAutomatedReviewDispatchHash"] ?? "";
+      const lastAutomatedDispatchHash = session.metadata["lastAutomatedReviewDispatchHash"] ?? "";
 
       if (automatedFingerprint !== lastAutomatedFingerprint) {
         clearReactionTracker(session.id, automatedReactionKey);


### PR DESCRIPTION
Implements Tier 1 of the escalation architecture. CI failures are automatically injected back into agent sessions so they can self-heal.

- Default reaction: `send-to-agent` on CI failure with actionable error context
- Retry tracking per CI run ID (new run resets counter)
- After 5 retries, escalates to human via notifier plugins
- Ships as default behavior, configurable in YAML
- Tests for config defaults and retry-per-run logic

Closes #351 (partial — Tier 1 only)