### PR TITLE
Fix dashboard links behind /ao reverse proxy

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,32 +1,19 @@
 /** @type {import('next').NextConfig} */
 
-/**
- * Normalize and validate the basePath from NEXT_PUBLIC_BASE_PATH env var.
- *
- * - Empty string → no basePath (root deployment)
- * - "ao", "/ao", "/ao/" → "/ao"
- * - "/", "///" → throws error (Next.js rejects "/" as invalid)
- *
- * Next.js requires basePath to be a sub-path (e.g., "/ao"), not the root "/".
- * Raw fetch/EventSource calls need manual prepending of this basePath.
- */
-function normalizeBasePath(raw) {
-  if (!raw) return "";
+export function normalizeBasePath(raw) {
+  if (raw == null) return "";
 
-  // Strip leading/trailing slashes, then prepend one
-  const normalized = raw.replace(/^\/+|\/+$/g, "");
-  const basePath = normalized ? `/${normalized}` : "";
+  const trimmed = String(raw).trim();
+  if (!trimmed) return "";
 
-  // Next.js explicitly rejects basePath: "/" as invalid
-  if (basePath === "/") {
+  const stripped = trimmed.replace(/^\/+|\/+$/g, "");
+  if (!stripped) {
     throw new Error(
-      `Invalid NEXT_PUBLIC_BASE_PATH: "${raw}" normalizes to "/" which is not allowed. ` +
-        `basePath must be a sub-path like "/ao", not the root. ` +
-        `Set NEXT_PUBLIC_BASE_PATH to a non-empty value like "ao" or "/ao", or leave unset for root deployment.`,
+      `Invalid NEXT_PUBLIC_BASE_PATH: "${raw}" must include a non-root path segment like "ao" or "/ao".`,
     );
   }
 
-  return basePath;
+  return `/${stripped}`;
 }
 
 const normalizedBasePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH ?? "");

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,12 +1,39 @@
 /** @type {import('next').NextConfig} */
-const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
-const normalizedBasePath = rawBasePath
-  ? `/${rawBasePath.replace(/^\/+|\/+$/g, "")}`
-  : "";
+
+/**
+ * Normalize and validate the basePath from NEXT_PUBLIC_BASE_PATH env var.
+ *
+ * - Empty string → no basePath (root deployment)
+ * - "ao", "/ao", "/ao/" → "/ao"
+ * - "/", "///" → throws error (Next.js rejects "/" as invalid)
+ *
+ * Next.js requires basePath to be a sub-path (e.g., "/ao"), not the root "/".
+ * Raw fetch/EventSource calls need manual prepending of this basePath.
+ */
+function normalizeBasePath(raw) {
+  if (!raw) return "";
+
+  // Strip leading/trailing slashes, then prepend one
+  const normalized = raw.replace(/^\/+|\/+$/g, "");
+  const basePath = normalized ? `/${normalized}` : "";
+
+  // Next.js explicitly rejects basePath: "/" as invalid
+  if (basePath === "/") {
+    throw new Error(
+      `Invalid NEXT_PUBLIC_BASE_PATH: "${raw}" normalizes to "/" which is not allowed. ` +
+        `basePath must be a sub-path like "/ao", not the root. ` +
+        `Set NEXT_PUBLIC_BASE_PATH to a non-empty value like "ao" or "/ao", or leave unset for root deployment.`,
+    );
+  }
+
+  return basePath;
+}
+
+const normalizedBasePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH ?? "");
 
 const nextConfig = {
   transpilePackages: ["@composio/ao-core"],
-  basePath: normalizedBasePath,
+  basePath: normalizedBasePath || undefined,
 };
 
 export default nextConfig;

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,6 +1,12 @@
 /** @type {import('next').NextConfig} */
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+const normalizedBasePath = rawBasePath
+  ? `/${rawBasePath.replace(/^\/+|\/+$/g, "")}`
+  : "";
+
 const nextConfig = {
   transpilePackages: ["@composio/ao-core"],
+  basePath: normalizedBasePath,
 };
 
 export default nextConfig;

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,8 +1,8 @@
-/** @type {import('next').NextConfig} */
 import { normalizeBasePath } from "./src/lib/base-path.js";
 
 const normalizedBasePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH ?? "");
 
+/** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@composio/ao-core"],
   basePath: normalizedBasePath || undefined,

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,20 +1,7 @@
 /** @type {import('next').NextConfig} */
+import { normalizeBasePath } from "./src/lib/base-path.js";
 
-export function normalizeBasePath(raw) {
-  if (raw == null) return "";
-
-  const trimmed = String(raw).trim();
-  if (!trimmed) return "";
-
-  const stripped = trimmed.replace(/^\/+|\/+$/g, "");
-  if (!stripped) {
-    throw new Error(
-      `Invalid NEXT_PUBLIC_BASE_PATH: "${raw}" must include a non-root path segment like "ao" or "/ao".`,
-    );
-  }
-
-  return `/${stripped}`;
-}
+export { normalizeBasePath };
 
 const normalizedBasePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH ?? "");
 

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 import { normalizeBasePath } from "./src/lib/base-path.js";
 
-export { normalizeBasePath };
-
 const normalizedBasePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH ?? "");
 
 const nextConfig = {

--- a/packages/web/src/app/dev/terminal-test/page.tsx
+++ b/packages/web/src/app/dev/terminal-test/page.tsx
@@ -4,6 +4,7 @@ import { DirectTerminal } from "@/components/DirectTerminal";
 import { Terminal } from "@/components/Terminal";
 import { useSearchParams } from "next/navigation";
 import { useState, useEffect, Suspense } from "react";
+import { apiPath } from "@/lib/api-path";
 
 // Force dynamic rendering (required for useSearchParams)
 export const dynamic = "force-dynamic";
@@ -30,7 +31,7 @@ function TerminalTestPageContent() {
 
   // Fetch available sessions on mount (only active ones)
   useEffect(() => {
-    fetch("/api/sessions?active=true")
+    fetch(apiPath("/api/sessions?active=true"))
       .then((res) => res.json())
       .then((data) => {
         if (data.sessions && Array.isArray(data.sessions)) {

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
 import { useParams } from "next/navigation";
 import { isOrchestratorSession } from "@composio/ao-core/types";
 import { SessionDetail } from "@/components/SessionDetail";
 import { type DashboardSession, getAttentionLevel, type AttentionLevel } from "@/lib/types";
 import { activityIcon } from "@/lib/activity-icons";
+import { apiPath } from "@/lib/api-path";
 
 function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max) + "..." : s;
@@ -64,7 +66,7 @@ export default function SessionPage() {
   // Fetch session data (memoized to avoid recreating on every render)
   const fetchSession = useCallback(async () => {
     try {
-      const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`);
+      const res = await fetch(apiPath(`/api/sessions/${encodeURIComponent(id)}`));
       if (res.status === 404) {
         setError("Session not found");
         setLoading(false);
@@ -85,7 +87,7 @@ export default function SessionPage() {
   const fetchZoneCounts = useCallback(async () => {
     if (!sessionIsOrchestrator || !sessionProjectId) return;
     try {
-      const res = await fetch(`/api/sessions?project=${encodeURIComponent(sessionProjectId)}`);
+      const res = await fetch(apiPath(`/api/sessions?project=${encodeURIComponent(sessionProjectId)}`));
       if (!res.ok) return;
       const body = (await res.json()) as { sessions: DashboardSession[] };
       const sessions = body.sessions ?? [];
@@ -139,9 +141,9 @@ export default function SessionPage() {
         <div className="text-[13px] text-[var(--color-status-error)]">
           {error ?? "Session not found"}
         </div>
-        <a href="/" className="text-[12px] text-[var(--color-accent)] hover:underline">
+        <Link href="/" className="text-[12px] text-[var(--color-accent)] hover:underline">
           ← Back to dashboard
-        </a>
+        </Link>
       </div>
     );
   }

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -18,6 +18,7 @@ import { DynamicFavicon } from "./DynamicFavicon";
 import { useSessionEvents } from "@/hooks/useSessionEvents";
 import { ProjectSidebar } from "./ProjectSidebar";
 import type { ProjectInfo } from "@/lib/project-name";
+import { apiPath } from "@/lib/api-path";
 
 interface DashboardProps {
   initialSessions: DashboardSession[];
@@ -139,7 +140,7 @@ export function Dashboard({
   }, [activeOrchestrators, allProjectsView, projects, sessionsByProject]);
 
   const handleSend = useCallback(async (sessionId: string, message: string) => {
-    const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/send`, {
+    const res = await fetch(apiPath(`/api/sessions/${encodeURIComponent(sessionId)}/send`), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ message }),
@@ -151,7 +152,7 @@ export function Dashboard({
 
   const handleKill = useCallback(async (sessionId: string) => {
     if (!confirm(`Kill session ${sessionId}?`)) return;
-    const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/kill`, {
+    const res = await fetch(apiPath(`/api/sessions/${encodeURIComponent(sessionId)}/kill`), {
       method: "POST",
     });
     if (!res.ok) {
@@ -160,7 +161,7 @@ export function Dashboard({
   }, []);
 
   const handleMerge = useCallback(async (prNumber: number) => {
-    const res = await fetch(`/api/prs/${prNumber}/merge`, { method: "POST" });
+    const res = await fetch(apiPath(`/api/prs/${prNumber}/merge`), { method: "POST" });
     if (!res.ok) {
       console.error(`Failed to merge PR #${prNumber}:`, await res.text());
     }
@@ -168,7 +169,7 @@ export function Dashboard({
 
   const handleRestore = useCallback(async (sessionId: string) => {
     if (!confirm(`Restore session ${sessionId}?`)) return;
-    const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/restore`, {
+    const res = await fetch(apiPath(`/api/sessions/${encodeURIComponent(sessionId)}/restore`), {
       method: "POST",
     });
     if (!res.ok) {
@@ -183,7 +184,7 @@ export function Dashboard({
     setSpawnErrors(({ [project.id]: _ignored, ...current }) => current);
 
     try {
-      const res = await fetch("/api/orchestrators", {
+      const res = await fetch(apiPath("/api/orchestrators"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ projectId: project.id }),

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -19,6 +19,7 @@ import { useSessionEvents } from "@/hooks/useSessionEvents";
 import { ProjectSidebar } from "./ProjectSidebar";
 import type { ProjectInfo } from "@/lib/project-name";
 import { apiPath } from "@/lib/api-path";
+import Link from "next/link";
 
 interface DashboardProps {
   initialSessions: DashboardSession[];
@@ -425,7 +426,7 @@ function OrchestratorControl({ orchestrators }: { orchestrators: DashboardOrches
   if (orchestrators.length === 1) {
     const orchestrator = orchestrators[0];
     return (
-      <a
+      <Link
         href={`/sessions/${encodeURIComponent(orchestrator.id)}`}
         className="orchestrator-btn flex items-center gap-2 rounded-[7px] px-4 py-2 text-[12px] font-semibold hover:no-underline"
       >
@@ -440,7 +441,7 @@ function OrchestratorControl({ orchestrators }: { orchestrators: DashboardOrches
         >
           <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3" />
         </svg>
-      </a>
+      </Link>
     );
   }
 
@@ -461,7 +462,7 @@ function OrchestratorControl({ orchestrators }: { orchestrators: DashboardOrches
       </summary>
       <div className="absolute right-0 top-[calc(100%+0.5rem)] z-10 min-w-[220px] overflow-hidden rounded-[10px] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] shadow-[0_18px_40px_rgba(0,0,0,0.18)]">
         {orchestrators.map((orchestrator, index) => (
-          <a
+          <Link
             key={orchestrator.id}
             href={`/sessions/${encodeURIComponent(orchestrator.id)}`}
             className={`flex items-center justify-between gap-3 px-4 py-3 text-[12px] hover:bg-[var(--color-bg-hover)] hover:no-underline ${
@@ -481,7 +482,7 @@ function OrchestratorControl({ orchestrators }: { orchestrators: DashboardOrches
             >
               <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3" />
             </svg>
-          </a>
+          </Link>
         ))}
       </div>
     </details>
@@ -522,12 +523,12 @@ function ProjectOverviewGrid({
                 {openPRCount > 0 ? ` · ${openPRCount} open PR${openPRCount !== 1 ? "s" : ""}` : ""}
               </div>
             </div>
-            <a
+            <Link
               href={`/?project=${encodeURIComponent(project.id)}`}
               className="rounded-[7px] border border-[var(--color-border-default)] px-3 py-1.5 text-[11px] font-medium text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:no-underline"
             >
               Open project
-            </a>
+            </Link>
           </div>
 
           <div className="mb-4 flex flex-wrap gap-2">
@@ -556,13 +557,13 @@ function ProjectOverviewGrid({
                 {orchestrator ? "Per-project orchestrator available" : "No running orchestrator"}
               </div>
               {orchestrator ? (
-                <a
+                <Link
                   href={`/sessions/${encodeURIComponent(orchestrator.id)}`}
                   className="orchestrator-btn flex items-center gap-2 rounded-[7px] px-3 py-1.5 text-[11px] font-semibold hover:no-underline"
                 >
                   <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)] opacity-80" />
                   orchestrator
-                </a>
+                </Link>
               ) : (
                 <button
                   type="button"

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@/lib/cn";
+import { apiPath } from "@/lib/api-path";
 
 // Import xterm CSS (must be imported in client component)
 import "xterm/css/xterm.css";
@@ -114,9 +115,12 @@ export function DirectTerminal({
       let commandToSend = reloadCommand;
 
       if (!commandToSend) {
-        const remapRes = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/remap`, {
-          method: "POST",
-        });
+        const remapRes = await fetch(
+          apiPath(`/api/sessions/${encodeURIComponent(sessionId)}/remap`),
+          {
+            method: "POST",
+          },
+        );
         if (!remapRes.ok) {
           throw new Error(`Failed to remap OpenCode session: ${remapRes.status}`);
         }
@@ -130,7 +134,7 @@ export function DirectTerminal({
         commandToSend = `/exit\nopencode --session ${remapData.opencodeSessionId}\n`;
       }
 
-      const sendRes = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/send`, {
+      const sendRes = await fetch(apiPath(`/api/sessions/${encodeURIComponent(sessionId)}/send`), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: commandToSend }),

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo, useState, useEffect, useRef } from "react";
+import Link from "next/link";
 import {
   type DashboardSession,
   type AttentionLevel,
@@ -106,13 +107,13 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
           </button>
         )}
         {!isTerminal && (
-          <a
+          <Link
             href={`/sessions/${encodeURIComponent(session.id)}`}
             onClick={(e) => e.stopPropagation()}
             className="rounded border border-[var(--color-border-default)] bg-[var(--color-bg-subtle)] px-2.5 py-0.5 text-[11px] text-[var(--color-text-muted)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] hover:no-underline"
           >
             terminal
-          </a>
+          </Link>
         )}
       </div>
 

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { type DashboardSession, type DashboardPR, isPRMergeReady } from "@/lib/types";
 import { CI_STATUS } from "@composio/ao-core/types";
@@ -221,7 +222,7 @@ export function SessionDetail({
       {/* Nav bar — glass effect */}
       <nav className="nav-glass sticky top-0 z-10 border-b border-[var(--color-border-subtle)]">
         <div className="mx-auto flex max-w-[900px] items-center gap-2 px-8 py-2.5">
-          <a
+          <Link
             href="/"
             className="flex items-center gap-1 text-[11px] font-medium text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-text-primary)] hover:no-underline"
           >
@@ -235,7 +236,7 @@ export function SessionDetail({
               <path d="M15 18l-6-6 6-6" />
             </svg>
             Orchestrator
-          </a>
+          </Link>
           <span className="text-[var(--color-border-strong)]">/</span>
           <span className="font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
             {session.id}

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/cn";
 import { CICheckList } from "./CIBadge";
 import { DirectTerminal } from "./DirectTerminal";
 import { ActivityDot } from "./ActivityDot";
+import { apiPath } from "@/lib/api-path";
 
 interface OrchestratorZones {
   merge: number;
@@ -89,7 +90,7 @@ async function askAgentToFix(
   try {
     const { title, description } = cleanBugbotComment(comment.body);
     const message = `Please address this review comment:\n\nFile: ${comment.path}\nComment: ${title}\nDescription: ${description}\n\nComment URL: ${comment.url}\n\nAfter fixing, mark the comment as resolved at ${comment.url}`;
-    const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/message`, {
+    const res = await fetch(apiPath(`/api/sessions/${encodeURIComponent(sessionId)}/message`), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ message }),

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useReducer, useRef } from "react";
 import type { DashboardSession, GlobalPauseState, SSESnapshotEvent } from "@/lib/types";
+import { apiPath } from "@/lib/api-path";
 
 const MEMBERSHIP_REFRESH_DELAY_MS = 120;
 const STALE_REFRESH_INTERVAL_MS = 15000;
@@ -78,7 +79,9 @@ export function useSessionEvents(
   }, [initialSessions, initialGlobalPause]);
 
   useEffect(() => {
-    const url = project ? `/api/events?project=${encodeURIComponent(project)}` : "/api/events";
+    const url = project
+      ? apiPath(`/api/events?project=${encodeURIComponent(project)}`)
+      : apiPath("/api/events");
     const es = new EventSource(url);
     let disposed = false;
     let activeRefreshController: AbortController | null = null;
@@ -102,8 +105,8 @@ export function useSessionEvents(
         activeRefreshController = refreshController;
 
         const sessionsUrl = project
-          ? `/api/sessions?project=${encodeURIComponent(project)}`
-          : "/api/sessions";
+          ? apiPath(`/api/sessions?project=${encodeURIComponent(project)}`)
+          : apiPath("/api/sessions");
 
         void fetch(sessionsUrl, { signal: refreshController.signal })
           .then((res) => (res.ok ? res.json() : null))
@@ -149,10 +152,11 @@ export function useSessionEvents(
         const data = JSON.parse(event.data as string) as { type: string };
         if (data.type === "snapshot") {
           const snapshot = data as SSESnapshotEvent;
-          dispatch({ type: "snapshot", patches: snapshot.sessions });
+          const workerPatches = snapshot.sessions.filter((s) => !s.id.endsWith("-orchestrator"));
+          dispatch({ type: "snapshot", patches: workerPatches });
 
           const currentMembershipKey = createMembershipKey(sessionsRef.current);
-          const snapshotMembershipKey = createMembershipKey(snapshot.sessions);
+          const snapshotMembershipKey = createMembershipKey(workerPatches);
 
           if (currentMembershipKey !== snapshotMembershipKey) {
             pendingMembershipKeyRef.current = snapshotMembershipKey;

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -152,11 +152,10 @@ export function useSessionEvents(
         const data = JSON.parse(event.data as string) as { type: string };
         if (data.type === "snapshot") {
           const snapshot = data as SSESnapshotEvent;
-          const workerPatches = snapshot.sessions.filter((s) => !s.id.endsWith("-orchestrator"));
-          dispatch({ type: "snapshot", patches: workerPatches });
+          dispatch({ type: "snapshot", patches: snapshot.sessions });
 
           const currentMembershipKey = createMembershipKey(sessionsRef.current);
-          const snapshotMembershipKey = createMembershipKey(workerPatches);
+          const snapshotMembershipKey = createMembershipKey(snapshot.sessions);
 
           if (currentMembershipKey !== snapshotMembershipKey) {
             pendingMembershipKeyRef.current = snapshotMembershipKey;

--- a/packages/web/src/lib/__tests__/api-path.test.ts
+++ b/packages/web/src/lib/__tests__/api-path.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, from "vitest";
+import { getBasePath, from "../api-path";
+
+describe("getBasePath", () => {
+  it("returns empty string when env var is not set", () => {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    expect(getBasePath()).toBe("");
+  });
+
+  it("returns normalized path with leading slash when env var has leading slash", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/ao";
+    expect(getBasePath()).toBe("/ao");
+  });
+
+  it("returns normalized path when env var has trailing slash", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "ao/";
+    expect(getBasePath()).toBe("/ao");
+  });
+
+  it("returns normalized path when env var has both leading and trailing slashes", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "///ao///";
+    expect(getBasePath()).toBe("/ao");
+  });
+
+  it("returns empty string when env var is whitespace-only", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "   ";
+    expect(getBasePath()).toBe("");
+  });
+
+  it("returns normalized path when env var has surrounding whitespace", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "  ao  ";
+    expect(getBasePath()).toBe("/ao");
+  });
+});
+
+describe("apiPath", () => {
+  it("prepends basePath to path", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/ao";
+    expect(apiPath("/api/sessions")).toBe("/ao/api/sessions");
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+  });
+
+  it("handles path starting without slash", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/ao";
+    expect(apiPath("api/sessions")).toBe("/ao/api/sessions");
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+  });
+
+  it("handles path with multiple leading slashes", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/ao";
+    expect(apiPath("//api/events")).toBe("/ao//api/events");
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+  });
+
+  it("returns path unchanged when no basePath", () => {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    expect(apiPath("/api/sessions")).toBe("/api/sessions");
+  });
+});

--- a/packages/web/src/lib/__tests__/api-path.test.ts
+++ b/packages/web/src/lib/__tests__/api-path.test.ts
@@ -1,58 +1,51 @@
-import { describe, test, from "vitest";
-import { getBasePath, from "../api-path";
+import { afterEach, describe, expect, it } from "vitest";
+import { apiPath, getBasePath } from "../api-path";
+
+const originalBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
+
+afterEach(() => {
+  if (originalBasePath === undefined) {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_BASE_PATH = originalBasePath;
+});
 
 describe("getBasePath", () => {
-  it("returns empty string when env var is not set", () => {
+  it("returns an empty string when unset", () => {
     delete process.env.NEXT_PUBLIC_BASE_PATH;
     expect(getBasePath()).toBe("");
   });
 
-  it("returns normalized path with leading slash when env var has leading slash", () => {
-    process.env.NEXT_PUBLIC_BASE_PATH = "/ao";
-    expect(getBasePath()).toBe("/ao");
-  });
-
-  it("returns normalized path when env var has trailing slash", () => {
-    process.env.NEXT_PUBLIC_BASE_PATH = "ao/";
-    expect(getBasePath()).toBe("/ao");
-  });
-
-  it("returns normalized path when env var has both leading and trailing slashes", () => {
+  it("normalizes leading and trailing slashes", () => {
     process.env.NEXT_PUBLIC_BASE_PATH = "///ao///";
     expect(getBasePath()).toBe("/ao");
   });
 
-  it("returns empty string when env var is whitespace-only", () => {
-    process.env.NEXT_PUBLIC_BASE_PATH = "   ";
-    expect(getBasePath()).toBe("");
+  it("trims surrounding whitespace", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "  /ao/  ";
+    expect(getBasePath()).toBe("/ao");
   });
 
-  it("returns normalized path when env var has surrounding whitespace", () => {
-    process.env.NEXT_PUBLIC_BASE_PATH = "  ao  ";
-    expect(getBasePath()).toBe("/ao");
+  it("returns an empty string for whitespace-only input", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "   ";
+    expect(getBasePath()).toBe("");
   });
 });
 
 describe("apiPath", () => {
-  it("prepends basePath to path", () => {
+  it("prepends the normalized base path", () => {
     process.env.NEXT_PUBLIC_BASE_PATH = "/ao";
     expect(apiPath("/api/sessions")).toBe("/ao/api/sessions");
-    delete process.env.NEXT_PUBLIC_BASE_PATH;
   });
 
-  it("handles path starting without slash", () => {
+  it("adds a leading slash when the input path does not have one", () => {
     process.env.NEXT_PUBLIC_BASE_PATH = "/ao";
     expect(apiPath("api/sessions")).toBe("/ao/api/sessions");
-    delete process.env.NEXT_PUBLIC_BASE_PATH;
   });
 
-  it("handles path with multiple leading slashes", () => {
-    process.env.NEXT_PUBLIC_BASE_PATH = "/ao";
-    expect(apiPath("//api/events")).toBe("/ao//api/events");
-    delete process.env.NEXT_PUBLIC_BASE_PATH;
-  });
-
-  it("returns path unchanged when no basePath", () => {
+  it("returns the original path when no base path is set", () => {
     delete process.env.NEXT_PUBLIC_BASE_PATH;
     expect(apiPath("/api/sessions")).toBe("/api/sessions");
   });

--- a/packages/web/src/lib/__tests__/api-path.test.ts
+++ b/packages/web/src/lib/__tests__/api-path.test.ts
@@ -32,6 +32,11 @@ describe("getBasePath", () => {
     process.env.NEXT_PUBLIC_BASE_PATH = "   ";
     expect(getBasePath()).toBe("");
   });
+
+  it("rejects slash-only input to match next.config normalization", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "///";
+    expect(() => getBasePath()).toThrow(/NEXT_PUBLIC_BASE_PATH/);
+  });
 });
 
 describe("apiPath", () => {

--- a/packages/web/src/lib/__tests__/next-config.test.ts
+++ b/packages/web/src/lib/__tests__/next-config.test.ts
@@ -1,34 +1,27 @@
-import { describe, test, expect, from "vitest";
-import { normalizeBasePath } from "../next.config.js";
+import { describe, expect, it } from "vitest";
+import { normalizeBasePath } from "../../../next.config.js";
 
 describe("normalizeBasePath", () => {
-  it("returns empty string when input is empty", () => {
+  it("returns an empty string for empty input", () => {
     expect(normalizeBasePath("")).toBe("");
-  expect(normalizeBasePath(null)).toBe("");
     expect(normalizeBasePath(undefined)).toBe("");
+    expect(normalizeBasePath(null)).toBe("");
   });
 
-  it("returns normalized path for various slash formats", () => {
-    expect(normalizeBasePath("/ao")).toBe("/ao");
-    expect(normalizeBasePath("ao/")).toBe("/ao");
+  it("normalizes valid base paths", () => {
     expect(normalizeBasePath("ao")).toBe("/ao");
-    expect(normalizeBasePath("///ao")).toBe("/ao");
-    expect(normalizeBasePath("  ao  ")).toBe("/ao");
-    expect(normalizeBasePath("ao/  ")).toBe("/ao");
-    expect(normalizeBasePath("/ao/ ")).toBe("/ao");
+    expect(normalizeBasePath("/ao")).toBe("/ao");
+    expect(normalizeBasePath("/ao/")).toBe("/ao");
+    expect(normalizeBasePath("  /ao/  ")).toBe("/ao");
   });
 
-  it("returns empty string when input is whitespace", () => {
+  it("returns an empty string for whitespace-only input", () => {
     expect(normalizeBasePath("   ")).toBe("");
-    expect(normalizeBasePath("\t\t\t")).toBe("");
-    expect(normalizeBasePath("\n")).toBe("");
-    expect(normalizeBasePath("\n  ")).toBe("");
-    expect(normalizeBasePath("\n\n")).toBe("");
   });
 
-  it("throws error for slash-only input (Next.js rejects basePath: '/')", () => {
-    expect(() => normalizeBasePath("/")).toThrow(/Invalid NEXT_PUBLIC_BASE_PATH: "/" normalizes to "/" which is not allowed. Use --sub-path like "/ao", not the root.`);
-    expect(() => normalizeBasePath("//")).toThrow(/Invalid NEXT_PUBLIC_BASE_PATH: "/" normalizes to "/" which is not allowed. Use --sub-path like "/ao", not root.`);
-    });
+  it("rejects slash-only input", () => {
+    expect(() => normalizeBasePath("/")).toThrow(/NEXT_PUBLIC_BASE_PATH/);
+    expect(() => normalizeBasePath("///")).toThrow(/NEXT_PUBLIC_BASE_PATH/);
+    expect(() => normalizeBasePath("  //  ")).toThrow(/NEXT_PUBLIC_BASE_PATH/);
   });
 });

--- a/packages/web/src/lib/__tests__/next-config.test.ts
+++ b/packages/web/src/lib/__tests__/next-config.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect, from "vitest";
+import { normalizeBasePath } from "../next.config.js";
+
+describe("normalizeBasePath", () => {
+  it("returns empty string when input is empty", () => {
+    expect(normalizeBasePath("")).toBe("");
+  expect(normalizeBasePath(null)).toBe("");
+    expect(normalizeBasePath(undefined)).toBe("");
+  });
+
+  it("returns normalized path for various slash formats", () => {
+    expect(normalizeBasePath("/ao")).toBe("/ao");
+    expect(normalizeBasePath("ao/")).toBe("/ao");
+    expect(normalizeBasePath("ao")).toBe("/ao");
+    expect(normalizeBasePath("///ao")).toBe("/ao");
+    expect(normalizeBasePath("  ao  ")).toBe("/ao");
+    expect(normalizeBasePath("ao/  ")).toBe("/ao");
+    expect(normalizeBasePath("/ao/ ")).toBe("/ao");
+  });
+
+  it("returns empty string when input is whitespace", () => {
+    expect(normalizeBasePath("   ")).toBe("");
+    expect(normalizeBasePath("\t\t\t")).toBe("");
+    expect(normalizeBasePath("\n")).toBe("");
+    expect(normalizeBasePath("\n  ")).toBe("");
+    expect(normalizeBasePath("\n\n")).toBe("");
+  });
+
+  it("throws error for slash-only input (Next.js rejects basePath: '/')", () => {
+    expect(() => normalizeBasePath("/")).toThrow(/Invalid NEXT_PUBLIC_BASE_PATH: "/" normalizes to "/" which is not allowed. Use --sub-path like "/ao", not the root.`);
+    expect(() => normalizeBasePath("//")).toThrow(/Invalid NEXT_PUBLIC_BASE_PATH: "/" normalizes to "/" which is not allowed. Use --sub-path like "/ao", not root.`);
+    });
+  });
+});

--- a/packages/web/src/lib/__tests__/next-config.test.ts
+++ b/packages/web/src/lib/__tests__/next-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeBasePath } from "../../../next.config.js";
+import { normalizeBasePath } from "../base-path.js";
 
 describe("normalizeBasePath", () => {
   it("returns an empty string for empty input", () => {

--- a/packages/web/src/lib/api-path.ts
+++ b/packages/web/src/lib/api-path.ts
@@ -1,13 +1,7 @@
-/**
- * Utility for prepending basePath to API routes.
- *
- * Next.js only auto-prefixes basePath for next/link and next/router;
- * Raw `fetch()` and `EventSource` calls require manual prepending of this basePath.
- */
 export function getBasePath(): string {
   const raw = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
   if (!raw) return "";
-  const stripped = raw.replace(/^\/+|\/+$/g, "");
+  const stripped = raw.trim().replace(/^\/+|\/+$/g, "");
   return stripped ? `/${stripped}` : "";
 }
 

--- a/packages/web/src/lib/api-path.ts
+++ b/packages/web/src/lib/api-path.ts
@@ -1,0 +1,19 @@
+/**
+ * Utility for prepending basePath to API routes.
+ *
+ * Next.js only auto-prefixes basePath for next/link and next/router;
+ * Raw `fetch()` and `EventSource` calls require manual prepending of this basePath.
+ */
+export function getBasePath(): string {
+  const raw = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+  if (!raw) return "";
+  const stripped = raw.replace(/^\/+|\/+$/g, "");
+  return stripped ? `/${stripped}` : "";
+}
+
+export function apiPath(path: string): string {
+  const base = getBasePath();
+  if (!base) return path;
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${base}${normalizedPath}`;
+}

--- a/packages/web/src/lib/api-path.ts
+++ b/packages/web/src/lib/api-path.ts
@@ -1,8 +1,7 @@
+import { normalizeBasePath } from "./base-path.js";
+
 export function getBasePath(): string {
-  const raw = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
-  if (!raw) return "";
-  const stripped = raw.trim().replace(/^\/+|\/+$/g, "");
-  return stripped ? `/${stripped}` : "";
+  return normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH ?? "");
 }
 
 export function apiPath(path: string): string {

--- a/packages/web/src/lib/base-path.js
+++ b/packages/web/src/lib/base-path.js
@@ -6,7 +6,7 @@
  * @returns {string}
  */
 export function normalizeBasePath(raw) {
-  if (raw == null) return "";
+  if (raw === null || raw === undefined) return "";
 
   const trimmed = String(raw).trim();
   if (!trimmed) return "";

--- a/packages/web/src/lib/base-path.js
+++ b/packages/web/src/lib/base-path.js
@@ -1,0 +1,22 @@
+/**
+ * Normalize NEXT_PUBLIC_BASE_PATH to a Next.js-compatible basePath string.
+ * Returns "" when unset/blank, and throws for slash-only root input.
+ *
+ * @param {unknown} raw
+ * @returns {string}
+ */
+export function normalizeBasePath(raw) {
+  if (raw == null) return "";
+
+  const trimmed = String(raw).trim();
+  if (!trimmed) return "";
+
+  const stripped = trimmed.replace(/^\/+|\/+$/g, "");
+  if (!stripped) {
+    throw new Error(
+      `Invalid NEXT_PUBLIC_BASE_PATH: "${raw}" must include a non-root path segment like "ao" or "/ao".`,
+    );
+  }
+
+  return `/${stripped}`;
+}


### PR DESCRIPTION
## Summary
- add env-driven Next.js `basePath` in `packages/web/next.config.js` via `NEXT_PUBLIC_BASE_PATH`
- normalize values like `ao`, `/ao`, and `/ao/` to `/ao`
- replace internal root/session `<a>` links with `next/link` so navigation respects `basePath`

## Why
When the dashboard is served behind a reverse proxy at `/ao`, hardcoded root-relative links navigated to `/` instead of `/ao/...`.

## Validation
- attempted `pnpm build` in `packages/web`
- build currently fails in this environment due pre-existing module resolution issues (`@composio/ao-core` / `@composio/ao-core/types`), unrelated to this link/basePath change
