### PR TITLE
fix: reliable ao send delivery for long tmux paste-buffer messages

### DIFF
--- a/docs/reviews/pr-374-explainer.html
+++ b/docs/reviews/pr-374-explainer.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>PR #374 Explainer - Long Message Delivery Reliability</title>
+  <style>
+    :root {
+      --bg: #f6f7fb;
+      --card: #ffffff;
+      --text: #14213d;
+      --muted: #4a5568;
+      --accent: #0f766e;
+      --warn: #9a3412;
+      --ok: #166534;
+      --border: #d9e2ec;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "IBM Plex Sans", "Segoe UI", Tahoma, sans-serif;
+      background: linear-gradient(160deg, #f6f7fb 0%, #e8eef5 100%);
+      color: var(--text);
+      line-height: 1.55;
+    }
+    .wrap {
+      max-width: 980px;
+      margin: 28px auto;
+      padding: 0 16px 32px;
+    }
+    .hero {
+      background: linear-gradient(135deg, #0f766e, #115e59);
+      color: #fff;
+      border-radius: 14px;
+      padding: 22px;
+      box-shadow: 0 10px 24px rgba(17, 94, 89, 0.18);
+    }
+    .hero h1 { margin: 0 0 8px; font-size: 1.6rem; }
+    .hero p { margin: 0; opacity: 0.95; }
+    .grid {
+      margin-top: 16px;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 12px;
+    }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 14px;
+    }
+    h2 { margin: 0 0 8px; font-size: 1.12rem; }
+    h3 { margin: 10px 0 6px; font-size: 1rem; }
+    ul { margin: 8px 0 0 18px; }
+    code { background: #eef2ff; padding: 1px 5px; border-radius: 4px; }
+    .ok { color: var(--ok); font-weight: 700; }
+    .warn { color: var(--warn); font-weight: 700; }
+    .muted { color: var(--muted); }
+    .footer {
+      margin-top: 14px;
+      font-size: 0.92rem;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <section class="hero">
+      <h1>PR #374 Explainer: Reliable Long Message Delivery in tmux</h1>
+      <p>Issue #373 fix for swallowed Enter after paste-buffer in <code>ao send</code> paths, including multi-chunk paste and busy render races.</p>
+    </section>
+
+    <section class="grid">
+      <article class="card">
+        <h2>What This PR Does</h2>
+        <ul>
+          <li>Hardens long/multiline tmux send flow where messages are delivered through paste-buffer.</li>
+          <li>Adds adaptive wait + Enter retry behavior with pane-change confirmation in core tmux helper.</li>
+          <li>Hardens runtime-tmux plugin with paste-settle detection and submission verification heuristics.</li>
+          <li>Fixes review feedback issues: baseline timing bug, unbounded delay, and timer-flaky tests.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Architecture and Design Choices</h2>
+        <h3>Core tmux helper (<code>packages/core/src/tmux.ts</code>)</h3>
+        <ul>
+          <li>Capture pane baseline right before first Enter (not before adaptive delay).</li>
+          <li>Cap adaptive delay with <code>MAX_ADAPTIVE_PASTE_DELAY_MS = 15000</code>.</li>
+          <li>Retry Enter with staggered delays when output does not progress.</li>
+        </ul>
+        <h3>Runtime tmux plugin (<code>packages/plugins/runtime-tmux/src/index.ts</code>)</h3>
+        <ul>
+          <li>Waits for paste rendering to settle to handle chunked paste markers.</li>
+          <li>Detects submission start via draft marker disappearance / prompt transition.</li>
+          <li>Retries Enter if submission not confirmed.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Iterations and Feedback Addressed</h2>
+        <ul>
+          <li><strong>Iteration 1:</strong> initial adaptive delay + retry in core helper.</li>
+          <li><strong>Iteration 2:</strong> production path hardening in runtime-tmux plugin.</li>
+          <li><strong>Iteration 3:</strong> baseline capture ordering fix (Bugbot high severity).</li>
+          <li><strong>Iteration 4:</strong> capped adaptive delay + timer-mock tests (Bugbot medium findings).</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Testing Performed</h2>
+        <ul>
+          <li><code>pnpm -C packages/core test src/__tests__/tmux.test.ts</code> → <span class="ok">PASS (25/25)</span></li>
+          <li><code>pnpm -C packages/plugins/runtime-tmux test src/__tests__/index.test.ts</code> → <span class="ok">PASS (26/26)</span></li>
+          <li><code>ao review-check --dry-run</code> → cannot run in this workspace (missing <code>agent-orchestrator.yaml</code>); manual deep review fallback executed.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>CI and Bugbot Status</h2>
+        <p class="muted">Latest completed run before this pre-merge update was green across CI checks; Bugbot surfaced inline findings that have been addressed in follow-up commits.</p>
+        <ul>
+          <li>CI: Lint/Test/Typecheck/Integration/Security checks passing in latest completed run snapshot.</li>
+          <li>Bugbot: reported issues addressed with code and tests; replies posted on review threads.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Remaining Risks</h2>
+        <ul>
+          <li>Terminal output heuristics are inherently environment-sensitive (different prompts/agents).</li>
+          <li>Very large payload behavior remains bounded by delay cap; retries may still be needed in unusually slow terminals.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Merge Recommendation</h2>
+        <p><strong class="ok">Recommend MERGE</strong>, conditional on latest post-push CI remaining green.</p>
+        <p>Quality self-assessment:</p>
+        <ul>
+          <li>Satisfied with implementation quality: <strong>Yes</strong></li>
+          <li>Should be merged: <strong>Yes</strong></li>
+          <li>Proud of this PR: <strong>Yes</strong></li>
+        </ul>
+      </article>
+    </section>
+
+    <p class="footer">Generated for PR #374 pre-merge quality sweep.</p>
+  </main>
+</body>
+</html>

--- a/docs/reviews/pr-374-explainer.html
+++ b/docs/reviews/pr-374-explainer.html
@@ -118,7 +118,7 @@
 
       <article class="card">
         <h2>CI and Bugbot Status</h2>
-        <p class="muted">Latest completed run before this pre-merge update was green across CI checks; Bugbot surfaced inline findings that have been addressed in follow-up commits.</p>
+        <p class="muted">Post-push snapshot is green for CI checks; Cursor Bugbot is still processing at snapshot time, and previously reported inline findings are already addressed in follow-up commits.</p>
         <ul>
           <li>CI: Lint/Test/Typecheck/Integration/Security checks passing in latest completed run snapshot.</li>
           <li>Bugbot: reported issues addressed with code and tests; replies posted on review threads.</li>

--- a/docs/reviews/pr-374-premerge-status.md
+++ b/docs/reviews/pr-374-premerge-status.md
@@ -1,0 +1,78 @@
+# PR #374 Pre-Merge Status
+
+- PR: https://github.com/ComposioHQ/agent-orchestrator/pull/374
+- Branch: `feat/#373`
+- Last updated: 2026-03-10
+
+## CI/Bugbot Snapshot
+
+### GitHub checks (latest completed run before this pre-merge update)
+- `Dependency Review`: pass
+- `Integration Tests`: pass
+- `Lint`: pass
+- `NPM Audit`: pass
+- `Scan for Secrets`: pass
+- `Test`: pass
+- `Test (Web)`: pass
+- `Test Fresh Onboarding`: pass
+- `Typecheck`: pass
+- `Cursor Bugbot`: neutral/skipping (reported inline findings)
+
+### Bugbot findings status
+- Baseline-capture ordering issue in `packages/core/src/tmux.ts`: addressed in `dd17227` (baseline moved to immediately before first Enter)
+- Unbounded adaptive delay issue in `packages/core/src/tmux.ts`: addressed in current branch (adaptive delay now capped at `15_000ms`)
+- Core timer-flakiness in `packages/core/src/__tests__/tmux.test.ts`: addressed in current branch (mocked `node:timers/promises` sleep)
+
+## Feedback Addressed
+
+1. **Enter retry false-positive due to stale baseline**
+- Fix: baseline capture moved to after adaptive wait and right before first Enter.
+- File: `packages/core/src/tmux.ts`
+
+2. **Adaptive delay unbounded for huge payloads**
+- Fix: added `MAX_ADAPTIVE_PASTE_DELAY_MS = 15_000` and capped computed adaptive delay.
+- File: `packages/core/src/tmux.ts`
+
+3. **Potential test flakiness from real timers**
+- Fix: switched core tmux tests to mocked `node:timers/promises` sleep and added cap assertion.
+- File: `packages/core/src/__tests__/tmux.test.ts`
+
+## Review Step (Requested)
+
+### In-session review command check
+- Attempted `/review`: unavailable in this shell (`/bin/bash: /review: No such file or directory`)
+
+### Agent review command fallback
+- Ran `ao review-check --help`: command exists
+- Ran `ao review-check --dry-run`: failed due missing local config (`No agent-orchestrator.yaml found`)
+
+### Structured deep manual review (fallback executed)
+- Reviewed diff for all touched files against `origin/main`
+- Verified long-message delivery paths in both core tmux helper and runtime-tmux plugin
+- Verified retry signaling logic and boundary conditions (baseline timing, capped delays, retry loop exits)
+- Verified tests cover:
+  - short message path
+  - long/multiline paste path
+  - retry when unchanged pane persists
+  - delay cap behavior under very large payloads
+
+## Testing Performed (Exact Commands + Results)
+
+1. `pnpm -C packages/core test src/__tests__/tmux.test.ts`
+- Result: pass (`25 passed`)
+
+2. `pnpm -C packages/plugins/runtime-tmux test src/__tests__/index.test.ts`
+- Result: pass (`26 passed`)
+
+3. `ao review-check --dry-run`
+- Result: failed in this workspace due missing `agent-orchestrator.yaml`; documented fallback review completed instead
+
+## Quality Self-Assessment
+
+- **Am I satisfied with implementation quality?** Yes.
+- **Should this PR be merged?** Yes, after latest push CI is green.
+- **Am I proud of this PR?** Yes.
+
+## Final Verdict
+
+**MERGE** (conditional on latest post-push CI staying green).

--- a/docs/reviews/pr-374-premerge-status.md
+++ b/docs/reviews/pr-374-premerge-status.md
@@ -6,7 +6,7 @@
 
 ## CI/Bugbot Snapshot
 
-### GitHub checks (latest completed run before this pre-merge update)
+### GitHub checks (latest post-push snapshot for commit `69d6dbc`)
 - `Dependency Review`: pass
 - `Integration Tests`: pass
 - `Lint`: pass
@@ -16,7 +16,7 @@
 - `Test (Web)`: pass
 - `Test Fresh Onboarding`: pass
 - `Typecheck`: pass
-- `Cursor Bugbot`: neutral/skipping (reported inline findings)
+- `Cursor Bugbot`: in progress at snapshot time
 
 ### Bugbot findings status
 - Baseline-capture ordering issue in `packages/core/src/tmux.ts`: addressed in `dd17227` (baseline moved to immediately before first Enter)
@@ -75,4 +75,4 @@
 
 ## Final Verdict
 
-**MERGE** (conditional on latest post-push CI staying green).
+**MERGE** (all CI checks are green; Bugbot comments have been addressed with fixes + replies).

--- a/packages/core/src/__tests__/tmux.test.ts
+++ b/packages/core/src/__tests__/tmux.test.ts
@@ -209,17 +209,20 @@ describe("sendKeys", () => {
 
   it("uses load-buffer with named buffer for long text", async () => {
     const longText = "a".repeat(250);
-    // Calls: send-keys Escape, load-buffer -b name, paste-buffer -b name -d, send-keys Enter
+    // Calls: Escape, load-buffer, paste-buffer, capture-pane, Enter, capture-pane
     mockTmuxSequence([
       { stdout: "" }, // send-keys Escape
       { stdout: "" }, // load-buffer
       { stdout: "" }, // paste-buffer
+      { stdout: "before submit" }, // capture-pane baseline
       { stdout: "" }, // send-keys Enter
+      { stdout: "after submit" }, // capture-pane changed
+      { stdout: "" }, // optional fallback
     ]);
 
     await sendKeys("app-1", longText);
 
-    expect(mockExecFile).toHaveBeenCalledTimes(4);
+    expect(mockExecFile).toHaveBeenCalledTimes(6);
 
     // Call 0: Escape
     const escapeArgs = mockExecFile.mock.calls[0][1] as string[];
@@ -239,24 +242,55 @@ describe("sendKeys", () => {
     expect(pasteArgs).toContain("-d");
     expect(pasteArgs).toContain("-t");
     expect(pasteArgs).toContain("app-1");
+
+    // Call 3: baseline capture before Enter
+    const baselineCaptureArgs = mockExecFile.mock.calls[3][1] as string[];
+    expect(baselineCaptureArgs).toEqual(["capture-pane", "-t", "app-1", "-p", "-S", "-40"]);
   });
 
   it("uses load-buffer for multiline text", async () => {
-    // Calls: send-keys Escape, load-buffer, paste-buffer, send-keys Enter
+    // Calls: Escape, load-buffer, paste-buffer, capture-pane, Enter, capture-pane
     mockTmuxSequence([
       { stdout: "" }, // send-keys Escape
       { stdout: "" }, // load-buffer
       { stdout: "" }, // paste-buffer
+      { stdout: "before submit" }, // capture-pane baseline
       { stdout: "" }, // send-keys Enter
+      { stdout: "after submit" }, // capture-pane changed
+      { stdout: "" }, // optional fallback
     ]);
 
     await sendKeys("app-1", "line1\nline2");
 
-    expect(mockExecFile).toHaveBeenCalledTimes(4);
+    expect(mockExecFile).toHaveBeenCalledTimes(6);
     // Call 1 (after Escape) should be load-buffer
     const loadArgs = mockExecFile.mock.calls[1][1] as string[];
     expect(loadArgs[0]).toBe("load-buffer");
     expect(loadArgs[1]).toBe("-b"); // named buffer
+  });
+
+  it("retries Enter when pane output is unchanged after paste-buffer submit", async () => {
+    const longText = "a".repeat(4096);
+    mockTmuxSequence([
+      { stdout: "" }, // send-keys Escape
+      { stdout: "" }, // load-buffer
+      { stdout: "" }, // paste-buffer
+      { stdout: "unchanged pane" }, // capture-pane baseline
+      { stdout: "" }, // send-keys Enter (attempt 1)
+      { stdout: "unchanged pane" }, // capture-pane unchanged -> retry
+      { stdout: "" }, // send-keys Enter (attempt 2)
+      { stdout: "processing started" }, // capture-pane changed -> stop retries
+      { stdout: "" }, // optional fallback
+    ]);
+
+    await sendKeys("app-1", longText);
+
+    // Enter should be sent twice because first check remained unchanged
+    const enterCalls = mockExecFile.mock.calls.filter((call) => {
+      const args = call[1] as string[];
+      return args[0] === "send-keys" && args[args.length - 1] === "Enter";
+    });
+    expect(enterCalls).toHaveLength(2);
   });
 });
 

--- a/packages/core/src/__tests__/tmux.test.ts
+++ b/packages/core/src/__tests__/tmux.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as childProcess from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
 import {
   isTmuxAvailable,
   listSessions,
@@ -15,8 +16,12 @@ import {
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(),
 }));
+vi.mock("node:timers/promises", () => ({
+  setTimeout: vi.fn().mockResolvedValue(undefined),
+}));
 
 const mockExecFile = vi.mocked(childProcess.execFile);
+const mockSleep = vi.mocked(sleep);
 
 type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
 
@@ -53,6 +58,7 @@ function mockTmuxSequence(results: Array<{ stdout?: string; error?: string }>) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSleep.mockResolvedValue(undefined);
 });
 
 describe("isTmuxAvailable", () => {
@@ -291,6 +297,23 @@ describe("sendKeys", () => {
       return args[0] === "send-keys" && args[args.length - 1] === "Enter";
     });
     expect(enterCalls).toHaveLength(2);
+  });
+
+  it("caps adaptive paste delay for very large messages", async () => {
+    const hugeText = "x".repeat(1_000_000);
+    mockTmuxSequence([
+      { stdout: "" }, // send-keys Escape
+      { stdout: "" }, // load-buffer
+      { stdout: "" }, // paste-buffer
+      { stdout: "before submit" }, // capture-pane baseline
+      { stdout: "" }, // send-keys Enter
+      { stdout: "processing started" }, // capture-pane changed
+      { stdout: "" }, // optional fallback
+    ]);
+
+    await sendKeys("app-1", hugeText);
+
+    expect(mockSleep).toHaveBeenCalledWith(15_000);
   });
 });
 

--- a/packages/core/src/tmux.ts
+++ b/packages/core/src/tmux.ts
@@ -175,9 +175,11 @@ export async function sendKeys(
 
     // For large paste-buffer payloads, allow enough time for terminal input handling.
     const adaptivePasteDelayMs = BASE_PASTE_DELAY_MS + (text.length / 1000) * PASTE_DELAY_PER_1K_CHARS_MS;
-    const baselinePane = await capturePane(sessionName, CAPTURE_PANE_LINES).catch(() => "");
-
     await new Promise((resolve) => setTimeout(resolve, adaptivePasteDelayMs));
+
+    // Capture baseline immediately before Enter so retries compare against
+    // true pre-submit state (not intermediate paste rendering changes).
+    const baselinePane = await capturePane(sessionName, CAPTURE_PANE_LINES).catch(() => "");
     await tmux("send-keys", "-t", sessionName, "Enter");
 
     let previousPane = baselinePane;

--- a/packages/core/src/tmux.ts
+++ b/packages/core/src/tmux.ts
@@ -6,6 +6,12 @@
 
 import { execFile } from "node:child_process";
 
+const PASTE_BUFFER_THRESHOLD = 200;
+const BASE_PASTE_DELAY_MS = 1000;
+const PASTE_DELAY_PER_1K_CHARS_MS = 500;
+const ENTER_RETRY_DELAYS_MS = [500, 1000, 1500] as const;
+const CAPTURE_PANE_LINES = 40;
+
 /** Run a tmux command and return stdout. */
 function tmux(...args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -127,12 +133,14 @@ export async function sendKeys(
   text: string,
   pressEnter = true,
 ): Promise<void> {
+  const usesPasteBuffer = text.includes("\n") || text.length > PASTE_BUFFER_THRESHOLD;
+
   // Clear any partial input first (matches bash reference scripts)
   await tmux("send-keys", "-t", sessionName, "Escape");
   // Small delay to ensure Escape is processed before pasting
   await new Promise((resolve) => setTimeout(resolve, 100));
 
-  if (text.includes("\n") || text.length > 200) {
+  if (usesPasteBuffer) {
     // Use a named buffer to avoid global paste buffer race conditions
     const { writeFileSync, unlinkSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
@@ -160,13 +168,30 @@ export async function sendKeys(
   }
 
   if (pressEnter) {
-    // Delay for paste to complete before sending Enter
-    // Higher delay needed when using paste-buffer to ensure tmux processes the paste
-    // before receiving the Enter keystroke (especially with Claude permission prompts)
-    if (text.includes("\n") || text.length > 200) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+    if (!usesPasteBuffer) {
+      await tmux("send-keys", "-t", sessionName, "Enter");
+      return;
     }
+
+    // For large paste-buffer payloads, allow enough time for terminal input handling.
+    const adaptivePasteDelayMs = BASE_PASTE_DELAY_MS + (text.length / 1000) * PASTE_DELAY_PER_1K_CHARS_MS;
+    const baselinePane = await capturePane(sessionName, CAPTURE_PANE_LINES).catch(() => "");
+
+    await new Promise((resolve) => setTimeout(resolve, adaptivePasteDelayMs));
     await tmux("send-keys", "-t", sessionName, "Enter");
+
+    let previousPane = baselinePane;
+    for (const retryDelayMs of ENTER_RETRY_DELAYS_MS) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      const currentPane = await capturePane(sessionName, CAPTURE_PANE_LINES).catch(() => "");
+
+      if (currentPane.trim() !== previousPane.trim()) {
+        return;
+      }
+
+      await tmux("send-keys", "-t", sessionName, "Enter");
+      previousPane = currentPane;
+    }
   }
 }
 

--- a/packages/core/src/tmux.ts
+++ b/packages/core/src/tmux.ts
@@ -5,10 +5,12 @@
  */
 
 import { execFile } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
 
 const PASTE_BUFFER_THRESHOLD = 200;
 const BASE_PASTE_DELAY_MS = 1000;
 const PASTE_DELAY_PER_1K_CHARS_MS = 500;
+const MAX_ADAPTIVE_PASTE_DELAY_MS = 15_000;
 const ENTER_RETRY_DELAYS_MS = [500, 1000, 1500] as const;
 const CAPTURE_PANE_LINES = 40;
 
@@ -138,7 +140,7 @@ export async function sendKeys(
   // Clear any partial input first (matches bash reference scripts)
   await tmux("send-keys", "-t", sessionName, "Escape");
   // Small delay to ensure Escape is processed before pasting
-  await new Promise((resolve) => setTimeout(resolve, 100));
+  await sleep(100);
 
   if (usesPasteBuffer) {
     // Use a named buffer to avoid global paste buffer race conditions
@@ -174,8 +176,11 @@ export async function sendKeys(
     }
 
     // For large paste-buffer payloads, allow enough time for terminal input handling.
-    const adaptivePasteDelayMs = BASE_PASTE_DELAY_MS + (text.length / 1000) * PASTE_DELAY_PER_1K_CHARS_MS;
-    await new Promise((resolve) => setTimeout(resolve, adaptivePasteDelayMs));
+    const adaptivePasteDelayMs = Math.min(
+      MAX_ADAPTIVE_PASTE_DELAY_MS,
+      BASE_PASTE_DELAY_MS + (text.length / 1000) * PASTE_DELAY_PER_1K_CHARS_MS,
+    );
+    await sleep(adaptivePasteDelayMs);
 
     // Capture baseline immediately before Enter so retries compare against
     // true pre-submit state (not intermediate paste rendering changes).
@@ -184,7 +189,7 @@ export async function sendKeys(
 
     let previousPane = baselinePane;
     for (const retryDelayMs of ENTER_RETRY_DELAYS_MS) {
-      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      await sleep(retryDelayMs);
       const currentPane = await capturePane(sessionName, CAPTURE_PANE_LINES).catch(() => "");
 
       if (currentPane.trim() !== previousPane.trim()) {

--- a/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as childProcess from "node:child_process";
 import * as fs from "node:fs";
 import type { RuntimeHandle } from "@composio/ao-core";
+import { setTimeout as sleep } from "node:timers/promises";
 
 // Mock node:child_process with custom promisify support
 vi.mock("node:child_process", () => {
@@ -23,10 +24,16 @@ vi.mock("node:fs", () => ({
   unlinkSync: vi.fn(),
 }));
 
+// Mock node:timers/promises to avoid real waits in retry logic
+vi.mock("node:timers/promises", () => ({
+  setTimeout: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Get reference to the promisify-custom mock — this is what the plugin actually calls
 const mockExecFileCustom = (childProcess.execFile as any)[
   Symbol.for("nodejs.util.promisify.custom")
 ] as ReturnType<typeof vi.fn>;
+const mockSleep = vi.mocked(sleep);
 const expectedTmuxOptions = { timeout: 5_000 };
 
 /** Queue a successful tmux command with the given stdout. */
@@ -56,6 +63,7 @@ import tmuxPlugin, { manifest, create } from "../index.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSleep.mockResolvedValue(undefined);
 });
 
 describe("manifest", () => {
@@ -306,16 +314,20 @@ describe("runtime.sendMessage()", () => {
     const handle = makeHandle("msg-long");
     const longText = "x".repeat(250);
 
-    // 1: C-u, 2: load-buffer, 3: paste-buffer, 4: unlinkSync (sync), 5: delete-buffer, 6: Enter
+    // C-u, load-buffer, paste-buffer, delete-buffer, capture settle x3, Enter, capture confirm
     mockTmuxSuccess(); // C-u
     mockTmuxSuccess(); // load-buffer
     mockTmuxSuccess(); // paste-buffer
     mockTmuxSuccess(); // delete-buffer (finally block)
+    mockTmuxSuccess("> [Pasted Content 250 chars]"); // capture initial
+    mockTmuxSuccess("> [Pasted Content 250 chars]"); // capture stable #1
+    mockTmuxSuccess("> [Pasted Content 250 chars]"); // capture stable #2
     mockTmuxSuccess(); // Enter
+    mockTmuxSuccess("Working on it..."); // capture after Enter
 
     await runtime.sendMessage(handle, longText);
 
-    expect(mockExecFileCustom).toHaveBeenCalledTimes(5);
+    expect(mockExecFileCustom).toHaveBeenCalledTimes(9);
 
     // Call 0: clear
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
@@ -367,7 +379,11 @@ describe("runtime.sendMessage()", () => {
     mockTmuxSuccess(); // load-buffer
     mockTmuxSuccess(); // paste-buffer
     mockTmuxSuccess(); // delete-buffer (finally)
+    mockTmuxSuccess("> [Pasted Content 18 chars]"); // capture initial
+    mockTmuxSuccess("> [Pasted Content 18 chars]"); // capture stable #1
+    mockTmuxSuccess("> [Pasted Content 18 chars]"); // capture stable #2
     mockTmuxSuccess(); // Enter
+    mockTmuxSuccess("Working on multiline input..."); // capture after Enter
 
     await runtime.sendMessage(handle, "line1\nline2\nline3");
 
@@ -417,6 +433,33 @@ describe("runtime.sendMessage()", () => {
       ["delete-buffer", "-b", "ao-test-uuid-1234"],
       expectedTmuxOptions,
     );
+  });
+
+  it("retries Enter when pasted draft is still visible after first Enter", async () => {
+    const runtime = create();
+    const handle = makeHandle("msg-retry");
+    const longText = "z".repeat(4096);
+
+    mockTmuxSuccess(); // C-u
+    mockTmuxSuccess(); // load-buffer
+    mockTmuxSuccess(); // paste-buffer
+    mockTmuxSuccess(); // delete-buffer (finally)
+    mockTmuxSuccess("> [Pasted Content 4096 chars]"); // capture initial
+    mockTmuxSuccess("> [Pasted Content 4096 chars]"); // capture stable #1
+    mockTmuxSuccess("> [Pasted Content 4096 chars]"); // capture stable #2
+    mockTmuxSuccess(); // Enter attempt #1
+    mockTmuxSuccess("> [Pasted Content 4096 chars]"); // still draft -> retry
+    mockTmuxSuccess(); // Enter attempt #2
+    mockTmuxSuccess("Thinking..."); // draft gone -> confirmed
+
+    await runtime.sendMessage(handle, longText);
+
+    const enterCalls = mockExecFileCustom.mock.calls.filter(
+      (call) =>
+        call[0] === "tmux" &&
+        JSON.stringify(call[1]) === JSON.stringify(["send-keys", "-t", "msg-retry", "Enter"]),
+    );
+    expect(enterCalls).toHaveLength(2);
   });
 });
 

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -16,6 +16,10 @@ import type {
 
 const execFileAsync = promisify(execFile);
 const TMUX_COMMAND_TIMEOUT_MS = 5_000;
+const PASTE_BUFFER_THRESHOLD = 200;
+const CAPTURE_LINES = 40;
+const CAPTURE_POLL_MS = 250;
+const ENTER_RETRY_DELAYS_MS = [500, 1000, 1500, 2500] as const;
 
 export const manifest = {
   name: "tmux",
@@ -39,6 +43,76 @@ async function tmux(...args: string[]): Promise<string> {
     timeout: TMUX_COMMAND_TIMEOUT_MS,
   });
   return stdout.trimEnd();
+}
+
+function lastNonEmptyLine(output: string): string {
+  const lines = output.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]?.trim();
+    if (line) return line;
+  }
+  return "";
+}
+
+function isPromptLine(line: string): boolean {
+  return /^[>$#❯]\s*$/.test(line);
+}
+
+function hasPastedDraftMarker(output: string): boolean {
+  return /\[Pasted Content \d+ chars\](?:\s*#\d+)?/.test(output);
+}
+
+function likelyHasDraftInput(output: string, message: string): boolean {
+  if (hasPastedDraftMarker(output)) return true;
+
+  // Fallback for terminals that show raw text instead of paste markers.
+  const tail = message.slice(-Math.min(120, message.length)).trim();
+  if (!tail) return false;
+  return output.includes(tail);
+}
+
+async function capturePane(sessionName: string, lines = CAPTURE_LINES): Promise<string> {
+  try {
+    return await tmux("capture-pane", "-t", sessionName, "-p", "-S", `-${lines}`);
+  } catch {
+    return "";
+  }
+}
+
+async function waitForPasteToSettle(sessionName: string, messageLength: number): Promise<string> {
+  const settleBudgetMs = Math.min(15_000, 1_500 + Math.ceil(messageLength / 1000) * 600);
+  let snapshot = await capturePane(sessionName);
+  let stableCount = 0;
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < settleBudgetMs) {
+    await sleep(CAPTURE_POLL_MS);
+    const next = await capturePane(sessionName);
+    if (next === snapshot) {
+      stableCount++;
+      if (stableCount >= 2) return next;
+    } else {
+      stableCount = 0;
+      snapshot = next;
+    }
+  }
+
+  return snapshot;
+}
+
+function hasSubmissionStarted(opts: { before: string; after: string; message: string }): boolean {
+  const { before, after, message } = opts;
+  if (after === before) return false;
+
+  const beforeHasDraft = likelyHasDraftInput(before, message);
+  const afterHasDraft = likelyHasDraftInput(after, message);
+  if (beforeHasDraft && !afterHasDraft) return true;
+
+  const beforePrompt = isPromptLine(lastNonEmptyLine(before));
+  const afterPrompt = isPromptLine(lastNonEmptyLine(after));
+  if (beforePrompt && !afterPrompt) return true;
+
+  return false;
 }
 
 export function create(): Runtime {
@@ -117,7 +191,8 @@ export function create(): Runtime {
 
       // For long or multiline messages, use load-buffer + paste-buffer
       // Use randomUUID to avoid temp file collisions on concurrent sends
-      if (message.includes("\n") || message.length > 200) {
+      const usesPasteBuffer = message.includes("\n") || message.length > PASTE_BUFFER_THRESHOLD;
+      if (usesPasteBuffer) {
         const bufferName = `ao-${randomUUID()}`;
         const tmpPath = join(tmpdir(), `ao-send-${randomUUID()}.txt`);
         writeFileSync(tmpPath, message, { encoding: "utf-8", mode: 0o600 });
@@ -144,10 +219,25 @@ export function create(): Runtime {
         await tmux("send-keys", "-t", handle.id, "-l", message);
       }
 
-      // Small delay to let tmux process the pasted text before pressing Enter.
-      // Without this, Enter can arrive before the text is fully rendered.
-      await sleep(300);
+      if (!usesPasteBuffer) {
+        await tmux("send-keys", "-t", handle.id, "Enter");
+        return;
+      }
+
+      // Wait for multi-chunk paste rendering to settle before first Enter.
+      let baselinePane = await waitForPasteToSettle(handle.id, message.length);
       await tmux("send-keys", "-t", handle.id, "Enter");
+
+      for (const retryDelayMs of ENTER_RETRY_DELAYS_MS) {
+        await sleep(retryDelayMs);
+        const currentPane = await capturePane(handle.id);
+        if (hasSubmissionStarted({ before: baselinePane, after: currentPane, message })) {
+          return;
+        }
+
+        await tmux("send-keys", "-t", handle.id, "Enter");
+        baselinePane = currentPane;
+      }
     },
 
     async getOutput(handle: RuntimeHandle, lines = 50): Promise<string> {


### PR DESCRIPTION
## Summary
- fix long-message `ao send` delivery in tmux by replacing single fixed-delay Enter with adaptive delay and retry-on-no-change behavior in core tmux helpers
- harden the active runtime path (`packages/plugins/runtime-tmux`) with paste-settle waiting, draft-marker-aware submission confirmation, and Enter retries for multi-chunk paste-buffer sends
- add tests covering large/multiline sends plus retry behavior when pasted draft remains visible after first Enter

## Why
Long messages (paste-buffer path) could leave pasted content in the input without submitting when Enter arrived too early. This change makes submission robust for larger payloads and busy terminal render states.

Closes #373
