### PR TITLE
fix(agent-codex): fix session file matching for activity detection

### DIFF
--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -401,13 +401,13 @@ async function sessionFileMatchesCwd(
   workspacePath: string,
 ): Promise<boolean> {
   try {
-    // Read only the first 4 KB — session_meta is always in the first few lines.
-    // Avoids loading large rollout files (100 MB+) into memory.
+    // Read up to 32 KB — session_meta is always the first line but can be 20 KB+
+    // when it includes base_instructions. Avoids loading large rollout files (100 MB+).
     const handle = await open(filePath, "r");
     let content: string;
     try {
-      const buffer = Buffer.allocUnsafe(4096);
-      const { bytesRead } = await handle.read(buffer, 0, 4096, 0);
+      const buffer = Buffer.allocUnsafe(32_768);
+      const { bytesRead } = await handle.read(buffer, 0, 32_768, 0);
       content = buffer.subarray(0, bytesRead).toString("utf-8");
     } finally {
       await handle.close();
@@ -423,12 +423,25 @@ async function sessionFileMatchesCwd(
           parsed !== null &&
           !Array.isArray(parsed) &&
           (parsed as CodexJsonlLine).type === "session_meta" &&
-          (parsed as CodexJsonlLine).cwd === workspacePath
+          // cwd lives at top level in older Codex versions, inside payload in newer ones
+          ((parsed as CodexJsonlLine).cwd === workspacePath ||
+            (parsed as Record<string, unknown>).payload != null &&
+            typeof (parsed as Record<string, unknown>).payload === "object" &&
+            ((parsed as Record<string, Record<string, unknown>>).payload.cwd === workspacePath))
         ) {
           return true;
         }
       } catch {
-        // Skip malformed lines
+        // JSON parse failed (truncated line or malformed) — try raw text match.
+        // The session_meta line always contains a "cwd":"<path>" field, so a
+        // substring check is a reliable fallback when the line exceeds our buffer.
+        if (
+          trimmed.includes('"type":"session_meta"') &&
+          trimmed.includes(`"cwd":"${workspacePath}"`)
+        ) {
+          return true;
+        }
+        // Skip truly malformed lines
       }
     }
   } catch {


### PR DESCRIPTION
## Problem

The Codex plugin's `sessionFileMatchesCwd()` had two bugs that prevented `getActivityState()` from ever returning a result for Codex sessions. It always returned `null`, which broke all activity-based lifecycle transitions (stuck detection, idle detection, etc.).

### Bug 1: Read buffer too small (4 KB)

The `session_meta` entry is always the first line of a Codex rollout JSONL file. However, newer Codex CLI versions embed the full system prompt (`base_instructions`) in this line, making it **~21 KB**. The 4 KB read buffer truncated the JSON, causing `JSON.parse()` to fail on every session file.

### Bug 2: Wrong `cwd` nesting level

Newer Codex CLI versions store `cwd` inside `payload`:
```json
{"type": "session_meta", "payload": {"cwd": "/path/to/workspace", ...}}
```

But the code only checked for top-level `cwd`:
```typescript
(parsed as CodexJsonlLine).cwd === workspacePath  // always undefined
```

## Fix

1. **Increased read buffer from 4 KB to 32 KB** to accommodate the larger `session_meta` lines.
2. **Added raw text fallback** in the catch block: if the JSON line still exceeds the buffer, a substring match on `"type":"session_meta"` + `"cwd":"<path>"` reliably identifies the workspace.
3. **Check both top-level and `payload.cwd`** for backward compatibility with older Codex versions.

## Testing

- All 193 agent-codex plugin tests pass
- Verified end-to-end: `getActivityState()` now correctly returns `{state: "idle", timestamp: ...}` for a real Codex session that was previously returning `null`