### PR TITLE
feat: add OpenClaw phase 1 operational controls and health polling

### DIFF
--- a/packages/integration-tests/src/openclaw-ops.integration.test.ts
+++ b/packages/integration-tests/src/openclaw-ops.integration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Integration-style tests for OpenClaw phase-1 operational controls.
+ *
+ * Mocks CLI/network boundaries only.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import openClawPlugin, {
+  executeAoAutoReplyCommand,
+  type AoCliRunner,
+} from "@composio/ao-plugin-notifier-openclaw";
+import { makeEvent } from "./helpers/event-factory.js";
+
+describe("openclaw phase-1 operations integration", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.OPENCLAW_HOOKS_TOKEN;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("command success path: /ao status <session>", async () => {
+    const runner: AoCliRunner = async () => ({
+      ok: true,
+      stdout: JSON.stringify([
+        { name: "ao-18", status: "working", activity: "active", lastActivity: "2m" },
+      ]),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await executeAoAutoReplyCommand({ type: "status", sessionId: "ao-18" }, { runner });
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe("AO status session=ao-18 status=working activity=active last=2m");
+  });
+
+  it("AO CLI unavailable path returns deterministic failure code", async () => {
+    const runner: AoCliRunner = async () => ({
+      ok: false,
+      stdout: "",
+      stderr: "ao not found",
+      exitCode: 1,
+      errorCode: "ENOENT",
+    });
+
+    const result = await executeAoAutoReplyCommand({ type: "sessions" }, { runner });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("ao_unavailable");
+    expect(result.message).toBe("AO CLI unavailable");
+  });
+
+  it("burst escalation path reduces notification noise via batching", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const notifier = openClawPlugin.create({
+      token: "tok",
+      debounceWindowMs: 1,
+      batchTriggerCount: 2,
+      batchWindowMs: 75,
+      batchSessionKey: "hook:ao:ops",
+    });
+
+    await notifier.notify(
+      makeEvent({
+        type: "reaction.escalated",
+        priority: "urgent",
+        sessionId: "ao-1",
+        message: "Agent stalled",
+        data: { reason: "stale" },
+      }),
+    );
+    await notifier.notify(
+      makeEvent({
+        type: "reaction.escalated",
+        priority: "urgent",
+        sessionId: "ao-2",
+        message: "CI failed",
+        data: { reason: "ci_failed" },
+      }),
+    );
+    await notifier.notify(
+      makeEvent({
+        type: "reaction.escalated",
+        priority: "urgent",
+        sessionId: "ao-3",
+        message: "Send failed",
+        data: { reason: "send_failed" },
+      }),
+    );
+
+    // Only first event sent immediately; subsequent burst events are batched.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const summaryBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(summaryBody.sessionKey).toBe("hook:ao:ops");
+    expect(summaryBody.message).toContain("batched_escalations");
+  });
+});

--- a/packages/plugins/notifier-openclaw/README.md
+++ b/packages/plugins/notifier-openclaw/README.md
@@ -2,6 +2,8 @@
 
 OpenClaw notifier plugin for AO escalation events.
 
+Phase 1 adds operational controls for OpenClaw-side command adapters, AO health polling helpers, and anti-spam escalation guardrails.
+
 ## Required OpenClaw config (`openclaw.json`)
 
 ```json
@@ -30,6 +32,95 @@ notifiers:
 - Sends `POST /hooks/agent` payloads with per-session key `hook:ao:<sessionId>`.
 - Defaults `wakeMode: now` and `deliver: true`.
 - Retries on `429` and `5xx` responses with exponential backoff.
+- Debounces repeated escalations for the same `sessionId + type + reason` in a rolling window.
+- Batches burst escalations into a compact summary notification.
+
+## Phase 1 operational commands
+
+Use these helpers inside an OpenClaw plugin command handler (no AI turn required):
+
+- `/ao status <sessionId?>`
+- `/ao sessions`
+- `/ao retry <sessionId>`
+- `/ao kill <sessionId>`
+
+Programmatic API (from this package):
+
+```ts
+import {
+  parseAoAutoReplyCommand,
+  executeAoAutoReplyCommand,
+  createAoCliRunner,
+} from "@composio/ao-plugin-notifier-openclaw";
+
+const parsed = parseAoAutoReplyCommand("/ao status ao-7");
+if (parsed) {
+  const result = await executeAoAutoReplyCommand(parsed, {
+    runner: createAoCliRunner(),
+  });
+  // result.message is deterministic and compact
+}
+```
+
+Response format examples:
+
+- `AO status session=ao-7 status=working activity=active last=2m`
+- `AO sessions total=3 active=2 degraded=1 dead=0 ids=ao-1,ao-2,ao-7`
+- `Retry queued for ao-7`
+- `Session killed: ao-7`
+
+Error format examples:
+
+- `AO CLI unavailable` (`code=ao_unavailable`)
+- `AO CLI command failed (<exitCode>)` (`code=ao_command_failed`)
+
+## AO health polling helper
+
+Use `AoHealthPollingService` + `collectAoHealthSummary()` to publish periodic AO health snapshots:
+
+- active / degraded / dead session counts
+- stale session detection (`lastActivity >= staleAfterMinutes`)
+- failed `ao send` / spawn command counters (from shared metrics object)
+
+```ts
+import { AoHealthPollingService } from "@composio/ao-plugin-notifier-openclaw";
+
+const service = new AoHealthPollingService({
+  pollIntervalMs: 30000,
+  staleAfterMinutes: 15,
+  onSummary: async (summary) => {
+    // route to chat/logging
+  },
+});
+
+service.start();
+```
+
+## Permissions and runtime expectations
+
+- OpenClaw process needs permission to execute local `ao` CLI.
+- `ao` must be available in `PATH` for command adapters and health polling.
+- OpenClaw needs network access to AO-local resources only if your handlers call networked tools.
+- AO notifier requires permission to reach `http://127.0.0.1:18789/hooks/agent`.
+
+## Troubleshooting checklist
+
+1. `hooks.token` mismatch:
+   - Verify OpenClaw `hooks.token`.
+   - Verify AO `token` / `OPENCLAW_HOOKS_TOKEN`.
+   - Confirm webhook returns `200` (not `401`).
+2. Missing AO binary:
+   - Run `which ao` in OpenClaw runtime shell.
+   - Ensure `PATH` for service process includes AO install location.
+3. Commands failing intermittently:
+   - Check AO stderr in command adapter response (`ao_command_failed`).
+   - Increase CLI timeout (runner option `timeoutMs`) if needed.
+4. Escalation noise too high:
+   - Increase `debounceWindowMs`.
+   - Lower `batchTriggerCount` and tune `batchWindowMs`.
+5. No health summaries:
+   - Verify `AoHealthPollingService.start()` is invoked.
+   - Ensure `onSummary` handler does not throw.
 
 ## Token rotation
 
@@ -37,8 +128,6 @@ notifiers:
 2. Update `OPENCLAW_HOOKS_TOKEN` used by AO.
 3. Verify old token returns `401` and new token returns `200`.
 
-## Known limitation (Phase 0)
+## Known limitation
 
-- OpenClaw hook ingest is not idempotent by default. Replayed webhook payloads are processed as separate runs.
-- Owner: AO integration.
-- Follow-up: add stable event id/idempotency key support.
+- Webhook ingest is still text/webhook-first in Phase 1 (no dedicated AO reverse API).

--- a/packages/plugins/notifier-openclaw/src/ao-cli.ts
+++ b/packages/plugins/notifier-openclaw/src/ao-cli.ts
@@ -1,0 +1,64 @@
+import { execFile } from "node:child_process";
+
+export interface AoCliResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  errorCode?: string;
+}
+
+export type AoCliRunner = (args: string[]) => Promise<AoCliResult>;
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").trim();
+}
+
+export function createAoCliRunner(options?: {
+  binary?: string;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+}): AoCliRunner {
+  const binary = options?.binary ?? "ao";
+  const timeoutMs = options?.timeoutMs ?? 15_000;
+
+  return async (args: string[]): Promise<AoCliResult> => {
+    return await new Promise<AoCliResult>((resolve) => {
+      execFile(
+        binary,
+        args,
+        {
+          timeout: timeoutMs,
+          maxBuffer: 1024 * 1024,
+          env: { ...process.env, ...options?.env, FORCE_COLOR: "0" },
+        },
+        (error, stdout, stderr) => {
+          if (!error) {
+            resolve({
+              ok: true,
+              stdout: normalizeText(stdout),
+              stderr: normalizeText(stderr),
+              exitCode: 0,
+            });
+            return;
+          }
+
+          const errWithMeta = error as NodeJS.ErrnoException & {
+            code?: string | number | null;
+            signal?: string | null;
+          };
+          const code = typeof errWithMeta.code === "string" ? errWithMeta.code : undefined;
+          const exitCode = typeof errWithMeta.code === "number" ? errWithMeta.code : 1;
+
+          resolve({
+            ok: false,
+            stdout: normalizeText(stdout),
+            stderr: normalizeText(stderr) || normalizeText(error.message),
+            exitCode,
+            errorCode: code,
+          });
+        },
+      );
+    });
+  };
+}

--- a/packages/plugins/notifier-openclaw/src/commands.test.ts
+++ b/packages/plugins/notifier-openclaw/src/commands.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  executeAoAutoReplyCommand,
+  parseAoAutoReplyCommand,
+  type AoCliRunner,
+  type AoAutoReplyMetrics,
+} from "./index.js";
+
+function okJson(payload: unknown): ReturnType<AoCliRunner> {
+  return Promise.resolve({
+    ok: true,
+    stdout: JSON.stringify(payload),
+    stderr: "",
+    exitCode: 0,
+  });
+}
+
+describe("openclaw command parsing", () => {
+  it("parses supported /ao commands", () => {
+    expect(parseAoAutoReplyCommand("/ao sessions")).toEqual({ type: "sessions" });
+    expect(parseAoAutoReplyCommand("/ao status")).toEqual({ type: "status", sessionId: undefined });
+    expect(parseAoAutoReplyCommand("/ao status ao-2")).toEqual({ type: "status", sessionId: "ao-2" });
+    expect(parseAoAutoReplyCommand("/ao retry ao-2")).toEqual({ type: "retry", sessionId: "ao-2" });
+    expect(parseAoAutoReplyCommand("/ao kill ao-2")).toEqual({ type: "kill", sessionId: "ao-2" });
+  });
+
+  it("rejects invalid commands", () => {
+    expect(parseAoAutoReplyCommand("hello")).toBeNull();
+    expect(parseAoAutoReplyCommand("/ao retry")).toBeNull();
+    expect(parseAoAutoReplyCommand("/ao unknown")).toBeNull();
+  });
+});
+
+describe("openclaw command execution", () => {
+  it("returns deterministic summary for /ao sessions", async () => {
+    const runner: AoCliRunner = async () =>
+      await okJson([
+        { name: "ao-1", status: "working", activity: "active", lastActivity: "1m" },
+        { name: "ao-2", status: "stuck", activity: "inactive", lastActivity: "25m" },
+      ]);
+
+    const result = await executeAoAutoReplyCommand({ type: "sessions" }, { runner });
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("total=2");
+    expect(result.message).toContain("active=1");
+    expect(result.message).toContain("degraded=1");
+    expect(result.message).toContain("ids=ao-1,ao-2");
+  });
+
+  it("returns session-specific status for /ao status <id>", async () => {
+    const runner: AoCliRunner = async () =>
+      await okJson([
+        { name: "ao-4", status: "working", activity: "active", lastActivity: "3m" },
+      ]);
+
+    const result = await executeAoAutoReplyCommand({ type: "status", sessionId: "ao-4" }, { runner });
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe("AO status session=ao-4 status=working activity=active last=3m");
+  });
+
+  it("runs ao send for /ao retry and tracks failures", async () => {
+    const metrics: AoAutoReplyMetrics = { failedSendCommands: 0, failedSpawnCommands: 0 };
+    const runner: AoCliRunner = async (args) => {
+      expect(args[0]).toBe("send");
+      return { ok: false, stdout: "", stderr: "boom", exitCode: 1 };
+    };
+
+    const result = await executeAoAutoReplyCommand({ type: "retry", sessionId: "ao-8" }, { runner, metrics });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("ao_send_failed");
+    expect(metrics.failedSendCommands).toBe(1);
+  });
+
+  it("maps missing ao binary to ao_unavailable", async () => {
+    const runner: AoCliRunner = async () => ({
+      ok: false,
+      stdout: "",
+      stderr: "ao: not found",
+      exitCode: 1,
+      errorCode: "ENOENT",
+    });
+
+    const result = await executeAoAutoReplyCommand({ type: "sessions" }, { runner });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("ao_unavailable");
+    expect(result.message).toContain("AO CLI unavailable");
+  });
+});

--- a/packages/plugins/notifier-openclaw/src/commands.test.ts
+++ b/packages/plugins/notifier-openclaw/src/commands.test.ts
@@ -26,6 +26,7 @@ describe("openclaw command parsing", () => {
 
   it("rejects invalid commands", () => {
     expect(parseAoAutoReplyCommand("hello")).toBeNull();
+    expect(parseAoAutoReplyCommand("/aobot sessions")).toBeNull();
     expect(parseAoAutoReplyCommand("/ao retry")).toBeNull();
     expect(parseAoAutoReplyCommand("/ao unknown")).toBeNull();
   });

--- a/packages/plugins/notifier-openclaw/src/commands.ts
+++ b/packages/plugins/notifier-openclaw/src/commands.ts
@@ -1,0 +1,277 @@
+import type { AoCliRunner } from "./ao-cli.js";
+import { createAoCliRunner } from "./ao-cli.js";
+
+export type AoAutoReplyCommandType = "status" | "sessions" | "retry" | "kill";
+
+export interface AoAutoReplyCommand {
+  type: AoAutoReplyCommandType;
+  sessionId?: string;
+}
+
+export interface AoSessionInfo {
+  name: string;
+  status: string | null;
+  activity: string | null;
+  lastActivity: string;
+}
+
+export interface AoAutoReplyResult {
+  ok: boolean;
+  code: string;
+  message: string;
+  command: AoAutoReplyCommandType;
+}
+
+export interface AoAutoReplyMetrics {
+  failedSendCommands: number;
+  failedSpawnCommands: number;
+}
+
+export interface AoAutoReplyDeps {
+  runner?: AoCliRunner;
+  retryMessage?: string;
+  metrics?: AoAutoReplyMetrics;
+}
+
+const DEFAULT_RETRY_MESSAGE = "Please retry your current task and post a brief status update.";
+
+export function parseAoAutoReplyCommand(text: string): AoAutoReplyCommand | null {
+  const input = text.trim();
+  if (!input.startsWith("/ao")) return null;
+
+  const parts = input.split(/\s+/).filter(Boolean);
+  if (parts.length < 2) return null;
+
+  const command = parts[1]?.toLowerCase();
+
+  if (command === "sessions") {
+    return { type: "sessions" };
+  }
+
+  if (command === "status") {
+    return { type: "status", sessionId: parts[2] };
+  }
+
+  if (command === "retry") {
+    const sessionId = parts[2];
+    if (!sessionId) return null;
+    return { type: "retry", sessionId };
+  }
+
+  if (command === "kill") {
+    const sessionId = parts[2];
+    if (!sessionId) return null;
+    return { type: "kill", sessionId };
+  }
+
+  return null;
+}
+
+function summarizeSessions(sessions: AoSessionInfo[]): {
+  total: number;
+  active: number;
+  degraded: number;
+  dead: number;
+} {
+  let active = 0;
+  let degraded = 0;
+  let dead = 0;
+
+  for (const session of sessions) {
+    const status = (session.status ?? "").toLowerCase();
+    const activity = (session.activity ?? "").toLowerCase();
+
+    if (activity === "active" || status === "working") {
+      active += 1;
+      continue;
+    }
+
+    if (["killed", "dead", "crashed", "failed", "error"].includes(status)) {
+      dead += 1;
+      continue;
+    }
+
+    if (["blocked", "stuck", "unknown"].includes(status) || activity === "inactive") {
+      degraded += 1;
+    }
+  }
+
+  return {
+    total: sessions.length,
+    active,
+    degraded,
+    dead,
+  };
+}
+
+async function readSessions(runner: AoCliRunner): Promise<{
+  ok: boolean;
+  sessions?: AoSessionInfo[];
+  errorCode: string;
+  errorMessage: string;
+}> {
+  const result = await runner(["status", "--json"]);
+
+  if (!result.ok) {
+    const unavailable = result.errorCode === "ENOENT";
+    return {
+      ok: false,
+      errorCode: unavailable ? "ao_unavailable" : "ao_command_failed",
+      errorMessage: unavailable
+        ? "AO CLI unavailable"
+        : `AO CLI command failed (${result.exitCode})`,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout) as Array<Record<string, unknown>>;
+    const sessions: AoSessionInfo[] = parsed.map((row) => ({
+      name: String(row.name ?? ""),
+      status: (row.status as string | null | undefined) ?? null,
+      activity: (row.activity as string | null | undefined) ?? null,
+      lastActivity: String(row.lastActivity ?? "-"),
+    }));
+
+    return { ok: true, sessions, errorCode: "ok", errorMessage: "" };
+  } catch {
+    return {
+      ok: false,
+      errorCode: "ao_invalid_json",
+      errorMessage: "AO CLI returned invalid JSON",
+    };
+  }
+}
+
+function withMetrics(metrics: AoAutoReplyMetrics | undefined, key: keyof AoAutoReplyMetrics): void {
+  if (!metrics) return;
+  metrics[key] += 1;
+}
+
+export async function executeAoAutoReplyCommand(
+  command: AoAutoReplyCommand,
+  deps?: AoAutoReplyDeps,
+): Promise<AoAutoReplyResult> {
+  const runner = deps?.runner ?? createAoCliRunner();
+
+  if (command.type === "sessions") {
+    const sessionsResponse = await readSessions(runner);
+    if (!sessionsResponse.ok || !sessionsResponse.sessions) {
+      return {
+        ok: false,
+        code: sessionsResponse.errorCode,
+        message: sessionsResponse.errorMessage,
+        command: command.type,
+      };
+    }
+
+    const summary = summarizeSessions(sessionsResponse.sessions);
+    const ids = sessionsResponse.sessions.map((s) => s.name).join(",") || "none";
+
+    return {
+      ok: true,
+      code: "ok",
+      message: `AO sessions total=${summary.total} active=${summary.active} degraded=${summary.degraded} dead=${summary.dead} ids=${ids}`,
+      command: command.type,
+    };
+  }
+
+  if (command.type === "status") {
+    const sessionsResponse = await readSessions(runner);
+    if (!sessionsResponse.ok || !sessionsResponse.sessions) {
+      return {
+        ok: false,
+        code: sessionsResponse.errorCode,
+        message: sessionsResponse.errorMessage,
+        command: command.type,
+      };
+    }
+
+    if (!command.sessionId) {
+      const summary = summarizeSessions(sessionsResponse.sessions);
+      return {
+        ok: true,
+        code: "ok",
+        message: `AO status total=${summary.total} active=${summary.active} degraded=${summary.degraded} dead=${summary.dead}`,
+        command: command.type,
+      };
+    }
+
+    const session = sessionsResponse.sessions.find((s) => s.name === command.sessionId);
+    if (!session) {
+      return {
+        ok: false,
+        code: "session_not_found",
+        message: `Session not found: ${command.sessionId}`,
+        command: command.type,
+      };
+    }
+
+    return {
+      ok: true,
+      code: "ok",
+      message: `AO status session=${session.name} status=${session.status ?? "unknown"} activity=${session.activity ?? "unknown"} last=${session.lastActivity}`,
+      command: command.type,
+    };
+  }
+
+  if (command.type === "retry") {
+    const sessionId = command.sessionId;
+    if (!sessionId) {
+      return {
+        ok: false,
+        code: "invalid_command",
+        message: "Missing session id",
+        command: command.type,
+      };
+    }
+
+    const message = deps?.retryMessage?.trim() || DEFAULT_RETRY_MESSAGE;
+    const result = await runner(["send", sessionId, message]);
+
+    if (!result.ok) {
+      withMetrics(deps?.metrics, "failedSendCommands");
+      const code = result.errorCode === "ENOENT" ? "ao_unavailable" : "ao_send_failed";
+      return {
+        ok: false,
+        code,
+        message: code === "ao_unavailable" ? "AO CLI unavailable" : `ao send failed for ${sessionId}`,
+        command: command.type,
+      };
+    }
+
+    return {
+      ok: true,
+      code: "ok",
+      message: `Retry queued for ${sessionId}`,
+      command: command.type,
+    };
+  }
+
+  const sessionId = command.sessionId;
+  if (!sessionId) {
+    return {
+      ok: false,
+      code: "invalid_command",
+      message: "Missing session id",
+      command: command.type,
+    };
+  }
+
+  const result = await runner(["session", "kill", sessionId]);
+  if (!result.ok) {
+    const code = result.errorCode === "ENOENT" ? "ao_unavailable" : "ao_kill_failed";
+    return {
+      ok: false,
+      code,
+      message: code === "ao_unavailable" ? "AO CLI unavailable" : `ao session kill failed for ${sessionId}`,
+      command: command.type,
+    };
+  }
+
+  return {
+    ok: true,
+    code: "ok",
+    message: `Session killed: ${sessionId}`,
+    command: command.type,
+  };
+}

--- a/packages/plugins/notifier-openclaw/src/commands.ts
+++ b/packages/plugins/notifier-openclaw/src/commands.ts
@@ -1,5 +1,5 @@
-import type { AoCliRunner } from "./ao-cli.js";
-import { createAoCliRunner } from "./ao-cli.js";
+import { createAoCliRunner, type AoCliRunner } from "./ao-cli.js";
+import { summarizeSessionStates } from "./session-classification.js";
 
 export type AoAutoReplyCommandType = "status" | "sessions" | "retry" | "kill";
 
@@ -37,9 +37,8 @@ const DEFAULT_RETRY_MESSAGE = "Please retry your current task and post a brief s
 
 export function parseAoAutoReplyCommand(text: string): AoAutoReplyCommand | null {
   const input = text.trim();
-  if (!input.startsWith("/ao")) return null;
-
   const parts = input.split(/\s+/).filter(Boolean);
+  if (parts[0] !== "/ao") return null;
   if (parts.length < 2) return null;
 
   const command = parts[1]?.toLowerCase();
@@ -65,43 +64,6 @@ export function parseAoAutoReplyCommand(text: string): AoAutoReplyCommand | null
   }
 
   return null;
-}
-
-function summarizeSessions(sessions: AoSessionInfo[]): {
-  total: number;
-  active: number;
-  degraded: number;
-  dead: number;
-} {
-  let active = 0;
-  let degraded = 0;
-  let dead = 0;
-
-  for (const session of sessions) {
-    const status = (session.status ?? "").toLowerCase();
-    const activity = (session.activity ?? "").toLowerCase();
-
-    if (activity === "active" || status === "working") {
-      active += 1;
-      continue;
-    }
-
-    if (["killed", "dead", "crashed", "failed", "error"].includes(status)) {
-      dead += 1;
-      continue;
-    }
-
-    if (["blocked", "stuck", "unknown"].includes(status) || activity === "inactive") {
-      degraded += 1;
-    }
-  }
-
-  return {
-    total: sessions.length,
-    active,
-    degraded,
-    dead,
-  };
 }
 
 async function readSessions(runner: AoCliRunner): Promise<{
@@ -164,7 +126,7 @@ export async function executeAoAutoReplyCommand(
       };
     }
 
-    const summary = summarizeSessions(sessionsResponse.sessions);
+    const summary = summarizeSessionStates(sessionsResponse.sessions);
     const ids = sessionsResponse.sessions.map((s) => s.name).join(",") || "none";
 
     return {
@@ -187,7 +149,7 @@ export async function executeAoAutoReplyCommand(
     }
 
     if (!command.sessionId) {
-      const summary = summarizeSessions(sessionsResponse.sessions);
+      const summary = summarizeSessionStates(sessionsResponse.sessions);
       return {
         ok: true,
         code: "ok",

--- a/packages/plugins/notifier-openclaw/src/health.test.ts
+++ b/packages/plugins/notifier-openclaw/src/health.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AoHealthPollingService,
+  collectAoHealthSummary,
+  type AoCliRunner,
+  type AoAutoReplyMetrics,
+} from "./index.js";
+
+describe("health polling", () => {
+  it("computes active/degraded/dead/stale from ao status --json", async () => {
+    const runner: AoCliRunner = async () => ({
+      ok: true,
+      stdout: JSON.stringify([
+        { name: "ao-1", status: "working", activity: "active", lastActivity: "2m" },
+        { name: "ao-2", status: "stuck", activity: "inactive", lastActivity: "40m" },
+        { name: "ao-3", status: "dead", activity: "inactive", lastActivity: "1h" },
+      ]),
+      stderr: "",
+      exitCode: 0,
+    });
+    const metrics: AoAutoReplyMetrics = { failedSendCommands: 2, failedSpawnCommands: 1 };
+
+    const summary = await collectAoHealthSummary({ runner, staleAfterMinutes: 30, metrics });
+
+    expect(summary.source).toBe("ao-cli");
+    expect(summary.total).toBe(3);
+    expect(summary.active).toBe(1);
+    expect(summary.degraded).toBe(1);
+    expect(summary.dead).toBe(1);
+    expect(summary.stale).toBe(2);
+    expect(summary.staleSessions).toEqual(["ao-2", "ao-3"]);
+    expect(summary.failedSendCommands).toBe(2);
+    expect(summary.failedSpawnCommands).toBe(1);
+  });
+
+  it("returns ao_unavailable when binary is missing", async () => {
+    const runner: AoCliRunner = async () => ({
+      ok: false,
+      stdout: "",
+      stderr: "not found",
+      exitCode: 1,
+      errorCode: "ENOENT",
+    });
+
+    const summary = await collectAoHealthSummary({ runner });
+
+    expect(summary.source).toBe("error");
+    expect(summary.errorCode).toBe("ao_unavailable");
+    expect(summary.total).toBe(0);
+  });
+
+  it("publishes periodic summaries", async () => {
+    vi.useFakeTimers();
+
+    const runner: AoCliRunner = async () => ({
+      ok: true,
+      stdout: JSON.stringify([{ name: "ao-1", status: "working", activity: "active", lastActivity: "1m" }]),
+      stderr: "",
+      exitCode: 0,
+    });
+    const onSummary = vi.fn();
+
+    const service = new AoHealthPollingService({ runner, pollIntervalMs: 1000, onSummary });
+    service.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(onSummary).toHaveBeenCalledTimes(3);
+    service.stop();
+    vi.useRealTimers();
+  });
+});

--- a/packages/plugins/notifier-openclaw/src/health.test.ts
+++ b/packages/plugins/notifier-openclaw/src/health.test.ts
@@ -71,4 +71,32 @@ describe("health polling", () => {
     service.stop();
     vi.useRealTimers();
   });
+
+  it("catches onSummary errors and keeps polling", async () => {
+    vi.useFakeTimers();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const runner: AoCliRunner = async () => ({
+      ok: true,
+      stdout: JSON.stringify([{ name: "ao-1", status: "working", activity: "active", lastActivity: "1m" }]),
+      stderr: "",
+      exitCode: 0,
+    });
+    const onSummary = vi.fn().mockRejectedValue(new Error("sink failed"));
+
+    const service = new AoHealthPollingService({ runner, pollIntervalMs: 1000, onSummary });
+    service.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(onSummary).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[notifier-openclaw] AO health polling failed:",
+      expect.any(Error),
+    );
+
+    service.stop();
+    vi.useRealTimers();
+  });
 });

--- a/packages/plugins/notifier-openclaw/src/health.ts
+++ b/packages/plugins/notifier-openclaw/src/health.ts
@@ -1,0 +1,176 @@
+import type { AoCliRunner } from "./ao-cli.js";
+import { createAoCliRunner } from "./ao-cli.js";
+import type { AoAutoReplyMetrics, AoSessionInfo } from "./commands.js";
+
+export interface AoHealthSummary {
+  timestamp: string;
+  total: number;
+  active: number;
+  degraded: number;
+  dead: number;
+  stale: number;
+  staleSessions: string[];
+  failedSendCommands: number;
+  failedSpawnCommands: number;
+  source: "ao-cli" | "error";
+  errorCode?: string;
+  errorMessage?: string;
+}
+
+export interface AoHealthPollOptions {
+  staleAfterMinutes?: number;
+  runner?: AoCliRunner;
+  metrics?: AoAutoReplyMetrics;
+}
+
+export interface AoHealthServiceOptions extends AoHealthPollOptions {
+  pollIntervalMs?: number;
+  onSummary: (summary: AoHealthSummary) => void | Promise<void>;
+}
+
+function parseAgeToMinutes(age: string): number {
+  const trimmed = age.trim();
+  if (!trimmed || trimmed === "-") return Number.POSITIVE_INFINITY;
+
+  const match = /^(\d+)([smhd])$/.exec(trimmed);
+  if (!match) return Number.POSITIVE_INFINITY;
+
+  const value = Number.parseInt(match[1], 10);
+  const unit = match[2];
+
+  if (unit === "s") return value / 60;
+  if (unit === "m") return value;
+  if (unit === "h") return value * 60;
+  return value * 60 * 24;
+}
+
+function classify(sessions: AoSessionInfo[], staleAfterMinutes: number): Omit<AoHealthSummary, "timestamp" | "source" | "failedSendCommands" | "failedSpawnCommands"> {
+  let active = 0;
+  let degraded = 0;
+  let dead = 0;
+  let stale = 0;
+  const staleSessions: string[] = [];
+
+  for (const session of sessions) {
+    const status = (session.status ?? "").toLowerCase();
+    const activity = (session.activity ?? "").toLowerCase();
+
+    if (activity === "active" || status === "working") {
+      active += 1;
+    } else if (["killed", "dead", "crashed", "failed", "error"].includes(status)) {
+      dead += 1;
+    } else if (["blocked", "stuck", "unknown"].includes(status) || activity === "inactive") {
+      degraded += 1;
+    }
+
+    if (parseAgeToMinutes(session.lastActivity) >= staleAfterMinutes) {
+      stale += 1;
+      staleSessions.push(session.name);
+    }
+  }
+
+  return {
+    total: sessions.length,
+    active,
+    degraded,
+    dead,
+    stale,
+    staleSessions,
+  };
+}
+
+export async function collectAoHealthSummary(options?: AoHealthPollOptions): Promise<AoHealthSummary> {
+  const runner = options?.runner ?? createAoCliRunner();
+  const staleAfterMinutes = options?.staleAfterMinutes ?? 15;
+  const metrics = options?.metrics;
+
+  const response = await runner(["status", "--json"]);
+  const base = {
+    timestamp: new Date().toISOString(),
+    failedSendCommands: metrics?.failedSendCommands ?? 0,
+    failedSpawnCommands: metrics?.failedSpawnCommands ?? 0,
+  };
+
+  if (!response.ok) {
+    return {
+      ...base,
+      total: 0,
+      active: 0,
+      degraded: 0,
+      dead: 0,
+      stale: 0,
+      staleSessions: [],
+      source: "error",
+      errorCode: response.errorCode === "ENOENT" ? "ao_unavailable" : "ao_command_failed",
+      errorMessage: response.errorCode === "ENOENT" ? "AO CLI unavailable" : "AO CLI command failed",
+    };
+  }
+
+  try {
+    const rows = JSON.parse(response.stdout) as Array<Record<string, unknown>>;
+    const sessions: AoSessionInfo[] = rows.map((row) => ({
+      name: String(row.name ?? ""),
+      status: (row.status as string | null | undefined) ?? null,
+      activity: (row.activity as string | null | undefined) ?? null,
+      lastActivity: String(row.lastActivity ?? "-"),
+    }));
+
+    return {
+      ...base,
+      ...classify(sessions, staleAfterMinutes),
+      source: "ao-cli",
+    };
+  } catch {
+    return {
+      ...base,
+      total: 0,
+      active: 0,
+      degraded: 0,
+      dead: 0,
+      stale: 0,
+      staleSessions: [],
+      source: "error",
+      errorCode: "ao_invalid_json",
+      errorMessage: "AO CLI returned invalid JSON",
+    };
+  }
+}
+
+export class AoHealthPollingService {
+  private readonly onSummary: (summary: AoHealthSummary) => void | Promise<void>;
+  private readonly pollIntervalMs: number;
+  private readonly options: AoHealthPollOptions;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(options: AoHealthServiceOptions) {
+    this.onSummary = options.onSummary;
+    this.pollIntervalMs = options.pollIntervalMs ?? 30_000;
+    this.options = options;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.pollOnce();
+    }, this.pollIntervalMs);
+    void this.pollOnce();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async pollOnce(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    try {
+      const summary = await collectAoHealthSummary(this.options);
+      await this.onSummary(summary);
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/packages/plugins/notifier-openclaw/src/health.ts
+++ b/packages/plugins/notifier-openclaw/src/health.ts
@@ -1,6 +1,6 @@
-import type { AoCliRunner } from "./ao-cli.js";
-import { createAoCliRunner } from "./ao-cli.js";
+import { createAoCliRunner, type AoCliRunner } from "./ao-cli.js";
 import type { AoAutoReplyMetrics, AoSessionInfo } from "./commands.js";
+import { classifySessionState } from "./session-classification.js";
 
 export interface AoHealthSummary {
   timestamp: string;
@@ -52,14 +52,12 @@ function classify(sessions: AoSessionInfo[], staleAfterMinutes: number): Omit<Ao
   const staleSessions: string[] = [];
 
   for (const session of sessions) {
-    const status = (session.status ?? "").toLowerCase();
-    const activity = (session.activity ?? "").toLowerCase();
-
-    if (activity === "active" || status === "working") {
+    const sessionState = classifySessionState(session);
+    if (sessionState === "active") {
       active += 1;
-    } else if (["killed", "dead", "crashed", "failed", "error"].includes(status)) {
+    } else if (sessionState === "dead") {
       dead += 1;
-    } else if (["blocked", "stuck", "unknown"].includes(status) || activity === "inactive") {
+    } else if (sessionState === "degraded") {
       degraded += 1;
     }
 
@@ -152,9 +150,13 @@ export class AoHealthPollingService {
   start(): void {
     if (this.timer) return;
     this.timer = setInterval(() => {
-      void this.pollOnce();
+      this.pollOnce().catch((error) => {
+        console.error("[notifier-openclaw] AO health polling failed:", error);
+      });
     }, this.pollIntervalMs);
-    void this.pollOnce();
+    this.pollOnce().catch((error) => {
+      console.error("[notifier-openclaw] AO health polling failed:", error);
+    });
   }
 
   stop(): void {

--- a/packages/plugins/notifier-openclaw/src/index.test.ts
+++ b/packages/plugins/notifier-openclaw/src/index.test.ts
@@ -172,4 +172,47 @@ describe("notifier-openclaw", () => {
     await expect(notifier.notify(makeEvent())).rejects.toThrow("OpenClaw webhook failed (401)");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("debounces repeated escalations for same session+reason", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const notifier = create({ token: "tok", debounceWindowMs: 60_000, batchTriggerCount: 99 });
+    const event = makeEvent({ sessionId: "ao-12", data: { reason: "ci_failed" } });
+
+    await notifier.notify(event);
+    await notifier.notify(event);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining("Debounced repeated escalation"));
+  });
+
+  it("batches burst escalations into a summary payload", async () => {
+    vi.useFakeTimers();
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const notifier = create({
+      token: "tok",
+      debounceWindowMs: 1,
+      batchTriggerCount: 2,
+      batchWindowMs: 50,
+      batchSessionKey: "hook:ao:ops",
+    });
+
+    await notifier.notify(makeEvent({ sessionId: "ao-1", data: { reason: "ci_failed" } }));
+    await notifier.notify(makeEvent({ sessionId: "ao-2", data: { reason: "tests_failed" } }));
+    await notifier.notify(makeEvent({ sessionId: "ao-3", data: { reason: "tests_failed" } }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const summaryBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(summaryBody.sessionKey).toBe("hook:ao:ops");
+    expect(summaryBody.message).toContain("batched_escalations");
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining("Batched escalation"));
+  });
 });

--- a/packages/plugins/notifier-openclaw/src/index.ts
+++ b/packages/plugins/notifier-openclaw/src/index.ts
@@ -7,6 +7,27 @@ import {
   type PluginModule,
 } from "@composio/ao-core";
 import { isRetryableHttpStatus, normalizeRetryConfig, validateUrl } from "@composio/ao-core/utils";
+import { EscalationNoiseController, type OpenClawWebhookPayload } from "./noise-control.js";
+export {
+  createAoCliRunner,
+  type AoCliResult,
+  type AoCliRunner,
+} from "./ao-cli.js";
+export {
+  parseAoAutoReplyCommand,
+  executeAoAutoReplyCommand,
+  type AoAutoReplyCommand,
+  type AoAutoReplyCommandType,
+  type AoAutoReplyResult,
+  type AoAutoReplyMetrics,
+} from "./commands.js";
+export {
+  collectAoHealthSummary,
+  AoHealthPollingService,
+  type AoHealthSummary,
+  type AoHealthPollOptions,
+  type AoHealthServiceOptions,
+} from "./health.js";
 
 export const manifest = {
   name: "openclaw",
@@ -16,14 +37,6 @@ export const manifest = {
 };
 
 type WakeMode = "now" | "next-heartbeat";
-
-interface OpenClawWebhookPayload {
-  message: string;
-  name?: string;
-  sessionKey?: string;
-  wakeMode?: WakeMode;
-  deliver?: boolean;
-}
 
 async function postWithRetry(
   url: string,
@@ -120,6 +133,13 @@ export function create(config?: Record<string, unknown>): Notifier {
     typeof config?.sessionKeyPrefix === "string" ? config.sessionKeyPrefix : "hook:ao:";
   const wakeMode: WakeMode = config?.wakeMode === "next-heartbeat" ? "next-heartbeat" : "now";
   const deliver = typeof config?.deliver === "boolean" ? config.deliver : true;
+  const debounceWindowMs =
+    typeof config?.debounceWindowMs === "number" ? config.debounceWindowMs : 90_000;
+  const batchWindowMs = typeof config?.batchWindowMs === "number" ? config.batchWindowMs : 20_000;
+  const batchTriggerCount =
+    typeof config?.batchTriggerCount === "number" ? config.batchTriggerCount : 3;
+  const batchSessionKey =
+    typeof config?.batchSessionKey === "string" ? config.batchSessionKey : `${sessionKeyPrefix}ops`;
 
   const { retries, retryDelayMs } = normalizeRetryConfig(config);
 
@@ -142,10 +162,39 @@ export function create(config?: Record<string, unknown>): Notifier {
     await postWithRetry(url, payload, headers, retries, retryDelayMs, { sessionId });
   }
 
+  const noiseController = new EscalationNoiseController({
+    debounceWindowMs,
+    batchWindowMs,
+    batchTriggerCount,
+    batchSessionKey,
+    senderName,
+    wakeMode,
+    deliver,
+    onBatchReady: async (payload) => {
+      await sendPayload(payload);
+    },
+  });
+
+  async function shouldSendEvent(event: OrchestratorEvent): Promise<boolean> {
+    const decision = noiseController.evaluateEvent(event);
+    if (decision === "send") return true;
+    if (decision === "debounced") {
+      console.info(
+        `[notifier-openclaw] Debounced repeated escalation session=${event.sessionId} type=${event.type}`,
+      );
+      return false;
+    }
+    console.info(
+      `[notifier-openclaw] Batched escalation session=${event.sessionId} type=${event.type}`,
+    );
+    return false;
+  }
+
   return {
     name: "openclaw",
 
     async notify(event: OrchestratorEvent): Promise<void> {
+      if (!(await shouldSendEvent(event))) return;
       const sessionKey = `${sessionKeyPrefix}${sanitizeSessionId(event.sessionId)}`;
       await sendPayload({
         message: formatEscalationMessage(event),
@@ -157,6 +206,7 @@ export function create(config?: Record<string, unknown>): Notifier {
     },
 
     async notifyWithActions(event: OrchestratorEvent, actions: NotifyAction[]): Promise<void> {
+      if (!(await shouldSendEvent(event))) return;
       const sessionKey = `${sessionKeyPrefix}${sanitizeSessionId(event.sessionId)}`;
       const actionsLine = formatActionsLine(actions);
       const message = [formatEscalationMessage(event), actionsLine].filter(Boolean).join("\n");

--- a/packages/plugins/notifier-openclaw/src/noise-control.test.ts
+++ b/packages/plugins/notifier-openclaw/src/noise-control.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { EscalationNoiseController } from "./noise-control.js";
+import type { OrchestratorEvent } from "@composio/ao-core";
+
+function makeEvent(sessionId: string, reason: string): OrchestratorEvent {
+  return {
+    id: `evt-${sessionId}`,
+    type: "reaction.escalated",
+    priority: "urgent",
+    sessionId,
+    projectId: "ao",
+    timestamp: new Date("2026-03-10T12:00:00Z"),
+    message: "Escalated",
+    data: { reason },
+  };
+}
+
+describe("EscalationNoiseController", () => {
+  it("catches batch callback failures", async () => {
+    vi.useFakeTimers();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const onBatchReady = vi.fn().mockRejectedValue(new Error("batch sink failed"));
+    const controller = new EscalationNoiseController({
+      batchTriggerCount: 2,
+      batchWindowMs: 20,
+      debounceWindowMs: 1,
+      onBatchReady,
+    });
+
+    expect(controller.evaluateEvent(makeEvent("ao-1", "r1"))).toBe("send");
+    expect(controller.evaluateEvent(makeEvent("ao-2", "r2"))).toBe("batched");
+    expect(controller.evaluateEvent(makeEvent("ao-3", "r3"))).toBe("batched");
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(onBatchReady).toHaveBeenCalledOnce();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[notifier-openclaw] Failed to flush escalation batch:",
+      expect.any(Error),
+    );
+
+    vi.useRealTimers();
+  });
+});

--- a/packages/plugins/notifier-openclaw/src/noise-control.ts
+++ b/packages/plugins/notifier-openclaw/src/noise-control.ts
@@ -1,0 +1,156 @@
+import type { EventPriority, OrchestratorEvent } from "@composio/ao-core";
+
+export interface NoiseControlOptions {
+  debounceWindowMs?: number;
+  batchWindowMs?: number;
+  batchTriggerCount?: number;
+  batchSessionKey?: string;
+  senderName?: string;
+  wakeMode?: "now" | "next-heartbeat";
+  deliver?: boolean;
+  onBatchReady?: (payload: OpenClawWebhookPayload) => void | Promise<void>;
+}
+
+export interface OpenClawWebhookPayload {
+  message: string;
+  name?: string;
+  sessionKey?: string;
+  wakeMode?: "now" | "next-heartbeat";
+  deliver?: boolean;
+}
+
+interface PendingBatch {
+  events: OrchestratorEvent[];
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface BurstWindow {
+  recent: Array<{ ts: number; sessionId: string }>;
+  activeBatch: PendingBatch | null;
+}
+
+function reasonKey(event: OrchestratorEvent): string {
+  const reason =
+    typeof event.data["reason"] === "string"
+      ? event.data["reason"]
+      : typeof event.data["action"] === "string"
+        ? event.data["action"]
+        : "na";
+  return `${event.sessionId}|${event.type}|${reason}`;
+}
+
+function summarizePriority(events: OrchestratorEvent[]): EventPriority {
+  const priorities: EventPriority[] = ["urgent", "action", "warning", "info"];
+  for (const p of priorities) {
+    if (events.some((event) => event.priority === p)) return p;
+  }
+  return "info";
+}
+
+function summaryTag(priority: EventPriority): string {
+  return `[AO ${priority.toUpperCase()}]`;
+}
+
+function buildBatchSummary(events: OrchestratorEvent[]): string {
+  const sessionSet = new Set(events.map((e) => e.sessionId));
+  const reasonCounts = new Map<string, number>();
+
+  for (const event of events) {
+    const reason =
+      typeof event.data["reason"] === "string" ? event.data["reason"] : event.type;
+    reasonCounts.set(reason, (reasonCounts.get(reason) ?? 0) + 1);
+  }
+
+  const reasonSummary = [...reasonCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([reason, count]) => `${reason}:${count}`)
+    .join(",");
+
+  const ids = [...sessionSet].sort().join(",");
+  return `${summaryTag(summarizePriority(events))} batched_escalations count=${events.length} sessions=${sessionSet.size} ids=${ids} reasons=${reasonSummary}`;
+}
+
+export class EscalationNoiseController {
+  private readonly debounceWindowMs: number;
+  private readonly batchWindowMs: number;
+  private readonly batchTriggerCount: number;
+  private readonly batchSessionKey: string;
+  private readonly senderName: string;
+  private readonly wakeMode: "now" | "next-heartbeat";
+  private readonly deliver: boolean;
+  private readonly onBatchReady?: (payload: OpenClawWebhookPayload) => void | Promise<void>;
+  private readonly debouncedAt = new Map<string, number>();
+  private readonly burstState: BurstWindow = { recent: [], activeBatch: null };
+
+  constructor(options?: NoiseControlOptions) {
+    this.debounceWindowMs = options?.debounceWindowMs ?? 90_000;
+    this.batchWindowMs = options?.batchWindowMs ?? 20_000;
+    this.batchTriggerCount = options?.batchTriggerCount ?? 3;
+    this.batchSessionKey = options?.batchSessionKey ?? "hook:ao:ops";
+    this.senderName = options?.senderName ?? "AO";
+    this.wakeMode = options?.wakeMode ?? "now";
+    this.deliver = options?.deliver ?? true;
+    this.onBatchReady = options?.onBatchReady;
+  }
+
+  evaluateEvent(event: OrchestratorEvent): "send" | "debounced" | "batched" {
+    const now = Date.now();
+    const key = reasonKey(event);
+    const last = this.debouncedAt.get(key);
+    if (last && now - last < this.debounceWindowMs) {
+      return "debounced";
+    }
+    this.debouncedAt.set(key, now);
+
+    this.burstState.recent = this.burstState.recent.filter((r) => now - r.ts <= this.batchWindowMs);
+    this.burstState.recent.push({ ts: now, sessionId: event.sessionId });
+
+    if (this.burstState.activeBatch) {
+      this.burstState.activeBatch.events.push(event);
+      return "batched";
+    }
+
+    const uniqueSessions = new Set(this.burstState.recent.map((r) => r.sessionId));
+    if (this.burstState.recent.length >= this.batchTriggerCount && uniqueSessions.size >= 2) {
+      this.startBatch(event);
+      return "batched";
+    }
+
+    return "send";
+  }
+
+  private startBatch(firstEvent: OrchestratorEvent): void {
+    const timer = setTimeout(() => {
+      void this.flushAndNotify();
+    }, this.batchWindowMs);
+
+    this.burstState.activeBatch = {
+      events: [firstEvent],
+      timer,
+    };
+  }
+
+  private async flushAndNotify(): Promise<void> {
+    const payload = this.flushBatch();
+    if (!payload || !this.onBatchReady) return;
+    await this.onBatchReady(payload);
+  }
+
+  flushBatch(): OpenClawWebhookPayload | null {
+    const pending = this.burstState.activeBatch;
+    if (!pending) return null;
+    clearTimeout(pending.timer);
+    this.burstState.activeBatch = null;
+    this.burstState.recent = [];
+
+    if (pending.events.length === 0) return null;
+
+    return {
+      message: buildBatchSummary(pending.events),
+      name: this.senderName,
+      sessionKey: this.batchSessionKey,
+      wakeMode: this.wakeMode,
+      deliver: this.deliver,
+    };
+  }
+}

--- a/packages/plugins/notifier-openclaw/src/noise-control.ts
+++ b/packages/plugins/notifier-openclaw/src/noise-control.ts
@@ -121,7 +121,9 @@ export class EscalationNoiseController {
 
   private startBatch(firstEvent: OrchestratorEvent): void {
     const timer = setTimeout(() => {
-      void this.flushAndNotify();
+      this.flushAndNotify().catch((error) => {
+        console.error("[notifier-openclaw] Failed to flush escalation batch:", error);
+      });
     }, this.batchWindowMs);
 
     this.burstState.activeBatch = {

--- a/packages/plugins/notifier-openclaw/src/session-classification.ts
+++ b/packages/plugins/notifier-openclaw/src/session-classification.ts
@@ -1,0 +1,55 @@
+import type { AoSessionInfo } from "./commands.js";
+
+export interface AoSessionStateCounts {
+  total: number;
+  active: number;
+  degraded: number;
+  dead: number;
+}
+
+export function classifySessionState(session: AoSessionInfo): "active" | "degraded" | "dead" | "other" {
+  const status = (session.status ?? "").toLowerCase();
+  const activity = (session.activity ?? "").toLowerCase();
+
+  if (activity === "active" || status === "working") {
+    return "active";
+  }
+
+  if (["killed", "dead", "crashed", "failed", "error"].includes(status)) {
+    return "dead";
+  }
+
+  if (["blocked", "stuck", "unknown"].includes(status) || activity === "inactive") {
+    return "degraded";
+  }
+
+  return "other";
+}
+
+export function summarizeSessionStates(sessions: AoSessionInfo[]): AoSessionStateCounts {
+  let active = 0;
+  let degraded = 0;
+  let dead = 0;
+
+  for (const session of sessions) {
+    const classification = classifySessionState(session);
+    if (classification === "active") {
+      active += 1;
+      continue;
+    }
+    if (classification === "dead") {
+      dead += 1;
+      continue;
+    }
+    if (classification === "degraded") {
+      degraded += 1;
+    }
+  }
+
+  return {
+    total: sessions.length,
+    active,
+    degraded,
+    dead,
+  };
+}


### PR DESCRIPTION
## Summary
- add deterministic `/ao` operational command adapters (`status`, `sessions`, `retry`, `kill`) with AO CLI runner and compact responses
- add AO health polling utilities (`collectAoHealthSummary`, `AoHealthPollingService`) with stale-session detection and failed command counters
- add notifier-side escalation guardrails: repeated escalation debounce + burst batching summary delivery
- document Phase 1 runbook details for commands, permissions, and troubleshooting
- add unit/integration coverage for command success, AO CLI unavailable behavior, and burst-noise reduction

## Testing
- `pnpm -r build`
- `pnpm --filter @composio/ao-plugin-notifier-openclaw test`
- `pnpm --filter @composio/ao-integration-tests exec vitest run --config vitest.config.ts src/openclaw-ops.integration.test.ts src/notifier-openclaw.integration.test.ts`

Closes #386
