### PR TITLE
feat: add fork upstream sync and convergence primitives (v1)

### DIFF
--- a/docs/fork-convergence-workflow.md
+++ b/docs/fork-convergence-workflow.md
@@ -1,0 +1,56 @@
+# Fork Convergence Workflow (v1)
+
+This workflow documents how to operate the `fork.sync_upstream` primitive introduced for issue #401.
+
+## Goal
+
+Keep fork branches converged with upstream while avoiding unmanaged drift.
+
+## Primitive
+
+- Name: `fork.sync_upstream`
+- Behavior: fetch upstream and perform a **fast-forward-only** sync when safe.
+- Non-goals in v1: no federation protocol, no implicit conflict resolution merge.
+
+## Sync State Model
+
+`fork.sync_upstream` computes and returns:
+
+- `ahead`: local-only commits
+- `behind`: upstream-only commits
+- `diverged`: `ahead > 0 && behind > 0`
+- `relation`: `up_to_date | ahead | behind | diverged`
+
+## Operator Decision Guide
+
+1. `up_to_date`
+- No action needed.
+
+2. `behind`
+- Run `fork.sync_upstream`.
+- Expected result: `action=fast_forward`, `relation=up_to_date`.
+
+3. `ahead`
+- Do not sync from upstream (nothing to fast-forward).
+- Use upstreamable patch flow (open PR from fork branch).
+
+4. `diverged`
+- Primitive returns `action=blocked` with drift alert suggestions.
+- Perform manual convergence (rebase/merge strategy per team policy), then re-run sync state.
+
+## Convergence Suggestions
+
+The primitive emits deterministic hints:
+
+- `sync_upstream`: behind upstream; run sync.
+- `upstreamable_patch`: ahead upstream; propose patch/PR upstream.
+- `drift_alert`: branch diverged; manual convergence required.
+
+## Expected Failure Path
+
+If fast-forward is expected but `git merge --ff-only` fails, result is:
+
+- `action=blocked`
+- `synced=false`
+- state remains unchanged
+- suggestions keep the sync hint for operator follow-up

--- a/docs/reviews/pr-402-explainer.html
+++ b/docs/reviews/pr-402-explainer.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>PR #402 Pre-Merge Explainer</title>
+  <style>
+    :root {
+      --bg: #f5f7fb;
+      --card: #ffffff;
+      --ink: #142033;
+      --muted: #4a5c78;
+      --accent: #0b6bcb;
+      --ok: #0a7a3d;
+      --warn: #a25a00;
+      --border: #d9e1ee;
+      --code: #edf3ff;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "IBM Plex Sans", "Segoe UI", Arial, sans-serif;
+      color: var(--ink);
+      background: linear-gradient(180deg, #eef4ff 0%, #f7f9fd 35%, #f5f7fb 100%);
+      line-height: 1.5;
+    }
+    main {
+      max-width: 980px;
+      margin: 0 auto;
+      padding: 28px 18px 60px;
+    }
+    h1, h2 { margin: 0 0 10px; }
+    h1 { font-size: 1.9rem; }
+    h2 { font-size: 1.25rem; margin-top: 8px; }
+    .meta, .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 16px;
+      box-shadow: 0 6px 18px rgba(12, 37, 72, 0.05);
+    }
+    .meta { margin-bottom: 14px; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 12px;
+      margin: 12px 0;
+    }
+    .card h3 {
+      margin: 0 0 8px;
+      font-size: 1.04rem;
+      color: #17325f;
+    }
+    ul { margin: 8px 0 0 18px; padding: 0; }
+    li { margin: 3px 0; }
+    code {
+      background: var(--code);
+      border: 1px solid #d8e5ff;
+      border-radius: 6px;
+      padding: 1px 6px;
+      font-family: "IBM Plex Mono", Consolas, monospace;
+      font-size: 0.92em;
+    }
+    pre {
+      background: #111c2e;
+      color: #f0f5ff;
+      border-radius: 10px;
+      padding: 12px;
+      overflow: auto;
+      margin: 8px 0 0;
+      font-size: 0.9rem;
+    }
+    .ok { color: var(--ok); font-weight: 700; }
+    .warn { color: var(--warn); font-weight: 700; }
+    .merge {
+      margin-top: 14px;
+      border-left: 4px solid var(--ok);
+      background: #ebf9f0;
+      padding: 12px;
+      border-radius: 8px;
+      font-weight: 700;
+    }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>PR #402 Pre-Merge Explainer</h1>
+    <div class="meta">
+      <div><strong>PR:</strong> <a href="https://github.com/ComposioHQ/agent-orchestrator/pull/402">#402</a></div>
+      <div><strong>Issue:</strong> <a href="https://github.com/ComposioHQ/agent-orchestrator/issues/401">#401</a></div>
+      <div><strong>Branch:</strong> <code>feat/401</code></div>
+      <div><strong>Snapshot:</strong> 2026-03-10 17:30:05 UTC</div>
+    </div>
+
+    <div class="grid">
+      <section class="card">
+        <h3>What This PR Does</h3>
+        <ul>
+          <li>Adds v1 fork convergence primitives to the SCM contract.</li>
+          <li>Implements <code>fork.sync_upstream</code> in GitHub SCM with fast-forward-only semantics.</li>
+          <li>Computes and exposes deterministic ahead/behind/diverged sync state.</li>
+          <li>Adds convergence suggestions (sync hint, upstreamable patch hint, drift alert).</li>
+          <li>Documents operator workflow for sync and divergence handling.</li>
+        </ul>
+      </section>
+
+      <section class="card">
+        <h3>Architecture / Design Choices</h3>
+        <ul>
+          <li>Pure helper for state computation: <code>computeForkSyncState</code>.</li>
+          <li>Pure helper for suggestions: <code>buildConvergenceSuggestions</code>.</li>
+          <li>Single parser path for git count output to avoid duplicate parsing logic.</li>
+          <li>No implicit conflict merge in v1; diverged or ff-failure returns <code>blocked</code>.</li>
+          <li>Sync action remains explicit and explainable via returned state + suggestions.</li>
+        </ul>
+      </section>
+    </div>
+
+    <div class="grid">
+      <section class="card">
+        <h3>Iterations & Feedback Addressed</h3>
+        <ul>
+          <li><strong>Iteration 1</strong> (<code>6494800</code>): initial implementation + tests + workflow doc.</li>
+          <li><strong>Iteration 2</strong> (<code>c570526</code>): Bugbot feedback fix for fork-sync test mock call order.</li>
+          <li>Bugbot thread resolved after fix and retest.</li>
+        </ul>
+      </section>
+
+      <section class="card">
+        <h3>Testing Performed</h3>
+        <pre>pnpm --filter @composio/ao-core build
+# Result: success
+
+pnpm --filter @composio/ao-plugin-scm-github test
+# Result: 72 passed, 0 failed</pre>
+        <ul>
+          <li>Coverage includes up-to-date/ahead/behind/diverged state cases.</li>
+          <li>Covers sync no-op, fast-forward, diverged blocked, and ff-only failure path.</li>
+        </ul>
+      </section>
+    </div>
+
+    <div class="grid">
+      <section class="card">
+        <h3>CI and Bugbot Snapshot</h3>
+        <ul>
+          <li class="ok">All CI checks passing.</li>
+          <li class="ok">Cursor Bugbot check passing.</li>
+          <li class="ok">No unresolved Bugbot review threads.</li>
+        </ul>
+      </section>
+
+      <section class="card">
+        <h3>Review Pass Method</h3>
+        <ul>
+          <li>Requested: slash-review command if available.</li>
+          <li>Session capability: no slash-review interface available in this terminal session.</li>
+          <li>Fallback used: structured manual deep review checklist over API contract, behavior paths, tests, docs, and regressions.</li>
+          <li>Outcome: no remaining blockers found.</li>
+        </ul>
+      </section>
+    </div>
+
+    <section class="card">
+      <h3>Remaining Risks</h3>
+      <ul>
+        <li>Operational risk is low-to-moderate: behavior depends on local git remote naming and branch topology.</li>
+        <li>v1 intentionally does not auto-resolve divergence; operators must perform manual convergence when blocked.</li>
+        <li>Future improvement opportunity: richer structured error reasons for blocked paths.</li>
+      </ul>
+      <div class="merge">Merge recommendation: <span class="ok">MERGE</span></div>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/reviews/pr-402-premerge-status.md
+++ b/docs/reviews/pr-402-premerge-status.md
@@ -1,0 +1,58 @@
+# PR #402 Pre-Merge Status
+
+Snapshot time (UTC): 2026-03-10 17:30:05 UTC
+PR: https://github.com/ComposioHQ/agent-orchestrator/pull/402
+Branch: `feat/401`
+
+## 1) CI and Bugbot Status
+
+### CI checks
+All checks are `pass` on the latest head commit (`c570526`):
+
+- Cursor Bugbot
+- Dependency Review
+- Integration Tests
+- Lint
+- NPM Audit
+- Scan for Secrets
+- Test
+- Test (Web)
+- Test Fresh Onboarding
+- Typecheck
+
+### Bugbot review status
+- Bugbot reported 1 issue (test mock call ordering).
+- Issue was fixed in commit `c570526`.
+- Bugbot discussion thread is resolved.
+- Bugbot check is green.
+
+## 2) Explicit Quality Answers
+
+- **Are you satisfied with implementation quality?** Yes.
+- **Should this PR be merged?** Yes.
+- **Are you proud of this PR?** Yes.
+
+## 3) Review Pass Execution
+
+- Requested mode: agent "slash review" if available.
+- Availability in this session: **not available** (shell-only environment; no slash-review interface exposed).
+- Fallback used: **structured manual deep review**.
+
+### Manual deep review checklist (completed)
+
+- API/type contract review for new SCM fork sync primitives.
+- Determinism review for sync-state and suggestion helpers.
+- Behavior-path review for fast-forward success, no-op, diverged, and ff-only failure.
+- Test quality review (assertion realism, call ordering, regression sensitivity).
+- Docs review for operator workflow and failure path clarity.
+- Regression surface review against existing SCM methods.
+
+Findings:
+- No remaining blockers found.
+- One previously identified test realism issue was already fixed and verified (`c570526`).
+
+## 4) Final Verdict
+
+## MERGE
+
+Rationale: requirements are implemented, tests are present and passing, CI is green, Bugbot concern has been addressed and resolved, and no unresolved review blockers remain.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -575,6 +575,55 @@ export interface SCM {
 
   /** Check if PR is ready to merge */
   getMergeability(pr: PRInfo): Promise<MergeReadiness>;
+
+  // --- Fork Convergence (v1) ---
+
+  /** Compute ahead/behind/diverged sync state against an upstream ref. */
+  getForkSyncState?(input: ForkSyncInput): Promise<ForkSyncState>;
+
+  /** Generate deterministic convergence suggestions from a sync state. */
+  getForkConvergenceSuggestions?(state: ForkSyncState): ForkConvergenceSuggestion[];
+
+  /** v1 primitive: fork.sync_upstream (fast-forward-only sync). */
+  forkSyncUpstream?(input: ForkSyncInput): Promise<ForkSyncResult>;
+}
+
+export interface ForkSyncInput {
+  /** Local repository path where git commands should run. */
+  workspacePath: string;
+  /** Upstream remote name (defaults to "upstream" in implementations). */
+  upstreamRemote?: string;
+  /** Upstream branch name (defaults to "main" in implementations). */
+  upstreamBranch?: string;
+  /** Local branch to sync (defaults to currently checked out branch in implementations). */
+  localBranch?: string;
+}
+
+export type ForkSyncRelation = "up_to_date" | "ahead" | "behind" | "diverged";
+
+export interface ForkSyncState {
+  upstreamRef: string;
+  localRef: string;
+  ahead: number;
+  behind: number;
+  diverged: boolean;
+  relation: ForkSyncRelation;
+}
+
+export interface ForkConvergenceSuggestion {
+  type: "upstreamable_patch" | "drift_alert" | "sync_upstream";
+  message: string;
+}
+
+export type ForkSyncAction = "none" | "fast_forward" | "blocked";
+
+export interface ForkSyncResult {
+  primitive: "fork.sync_upstream";
+  action: ForkSyncAction;
+  synced: boolean;
+  stateBefore: ForkSyncState;
+  stateAfter: ForkSyncState;
+  suggestions: ForkConvergenceSuggestion[];
 }
 
 // --- PR Types ---

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -22,6 +22,10 @@ import {
   type ReviewComment,
   type AutomatedComment,
   type MergeReadiness,
+  type ForkSyncInput,
+  type ForkSyncState,
+  type ForkSyncResult,
+  type ForkConvergenceSuggestion,
 } from "@composio/ao-core";
 
 const execFileAsync = promisify(execFile);
@@ -85,6 +89,79 @@ function parseDate(val: string | undefined | null): Date {
   if (!val) return new Date(0);
   const d = new Date(val);
   return isNaN(d.getTime()) ? new Date(0) : d;
+}
+
+function normalizePositiveCount(value: number): number {
+  if (!Number.isFinite(value) || value < 0) return 0;
+  return Math.floor(value);
+}
+
+export function computeForkSyncState(
+  aheadCount: number,
+  behindCount: number,
+  refs: { localRef: string; upstreamRef: string },
+): ForkSyncState {
+  const ahead = normalizePositiveCount(aheadCount);
+  const behind = normalizePositiveCount(behindCount);
+  const diverged = ahead > 0 && behind > 0;
+  const relation: ForkSyncState["relation"] = diverged
+    ? "diverged"
+    : ahead > 0
+      ? "ahead"
+      : behind > 0
+        ? "behind"
+        : "up_to_date";
+
+  return {
+    localRef: refs.localRef,
+    upstreamRef: refs.upstreamRef,
+    ahead,
+    behind,
+    diverged,
+    relation,
+  };
+}
+
+export function buildConvergenceSuggestions(
+  state: ForkSyncState,
+): ForkConvergenceSuggestion[] {
+  const suggestions: ForkConvergenceSuggestion[] = [];
+
+  if (state.behind > 0) {
+    suggestions.push({
+      type: "sync_upstream",
+      message: `Local branch is behind upstream by ${state.behind} commit(s); run fork.sync_upstream.`,
+    });
+  }
+
+  if (state.ahead > 0) {
+    suggestions.push({
+      type: "upstreamable_patch",
+      message: `Local branch is ahead by ${state.ahead} commit(s); consider upstreaming these changes via PR.`,
+    });
+  }
+
+  if (state.diverged) {
+    suggestions.push({
+      type: "drift_alert",
+      message:
+        "Fork has diverged from upstream (ahead and behind simultaneously); manual convergence is required.",
+    });
+  }
+
+  return suggestions;
+}
+
+function parseLeftRightCounts(raw: string): { behind: number; ahead: number } {
+  // `git rev-list --left-right --count upstream...local` returns "<left>\t<right>".
+  const match = raw.trim().match(/^(\d+)\s+(\d+)$/);
+  if (!match) {
+    throw new Error(`Unexpected git rev-list count output: "${raw.trim()}"`);
+  }
+  return {
+    behind: Number.parseInt(match[1], 10),
+    ahead: Number.parseInt(match[2], 10),
+  };
 }
 
 function isUnsupportedPrChecksJsonError(err: unknown): boolean {
@@ -230,6 +307,27 @@ function prInfoFromView(
 // ---------------------------------------------------------------------------
 
 function createGitHubSCM(): SCM {
+  async function resolveForkSyncState(
+    input: ForkSyncInput,
+  ): Promise<ForkSyncState> {
+    const upstreamRemote = input.upstreamRemote ?? "upstream";
+    const upstreamBranch = input.upstreamBranch ?? "main";
+    const localBranch =
+      input.localBranch ?? (await git(["branch", "--show-current"], input.workspacePath));
+    const upstreamRef = `${upstreamRemote}/${upstreamBranch}`;
+
+    const countsRaw = await git(
+      ["rev-list", "--left-right", "--count", `${upstreamRef}...${localBranch}`],
+      input.workspacePath,
+    );
+    const counts = parseLeftRightCounts(countsRaw);
+
+    return computeForkSyncState(counts.ahead, counts.behind, {
+      localRef: localBranch,
+      upstreamRef,
+    });
+  }
+
   return {
     name: "github",
 
@@ -727,6 +825,75 @@ function createGitHubSCM(): SCM {
         approved,
         noConflicts,
         blockers,
+      };
+    },
+
+    async getForkSyncState(input: ForkSyncInput): Promise<ForkSyncState> {
+      const upstreamRemote = input.upstreamRemote ?? "upstream";
+      const upstreamBranch = input.upstreamBranch ?? "main";
+      const upstreamRef = `${upstreamRemote}/${upstreamBranch}`;
+
+      await git(["fetch", upstreamRemote, upstreamBranch], input.workspacePath);
+      await git(["rev-parse", "--verify", upstreamRef], input.workspacePath);
+
+      return resolveForkSyncState(input);
+    },
+
+    getForkConvergenceSuggestions(state: ForkSyncState): ForkConvergenceSuggestion[] {
+      return buildConvergenceSuggestions(state);
+    },
+
+    async forkSyncUpstream(input: ForkSyncInput): Promise<ForkSyncResult> {
+      const upstreamRemote = input.upstreamRemote ?? "upstream";
+      const upstreamBranch = input.upstreamBranch ?? "main";
+      const localBranch =
+        input.localBranch ?? (await git(["branch", "--show-current"], input.workspacePath));
+      const upstreamRef = `${upstreamRemote}/${upstreamBranch}`;
+      const localRef = localBranch;
+
+      await git(["fetch", upstreamRemote, upstreamBranch], input.workspacePath);
+      await git(["rev-parse", "--verify", upstreamRef], input.workspacePath);
+
+      const stateBefore = await resolveForkSyncState({
+        ...input,
+        upstreamRemote,
+        upstreamBranch,
+        localBranch,
+      });
+
+      let action: ForkSyncResult["action"] = "none";
+
+      if (stateBefore.behind > 0 && stateBefore.ahead === 0) {
+        try {
+          await git(["merge", "--ff-only", upstreamRef], input.workspacePath);
+          action = "fast_forward";
+        } catch {
+          action = "blocked";
+        }
+      } else if (stateBefore.diverged) {
+        action = "blocked";
+      }
+
+      const stateAfter =
+        action === "fast_forward"
+          ? await resolveForkSyncState({
+              ...input,
+              upstreamRemote,
+              upstreamBranch,
+              localBranch,
+            })
+          : computeForkSyncState(stateBefore.ahead, stateBefore.behind, {
+              localRef,
+              upstreamRef,
+            });
+
+      return {
+        primitive: "fork.sync_upstream",
+        action,
+        synced: action === "fast_forward" && stateAfter.behind === 0,
+        stateBefore,
+        stateAfter,
+        suggestions: buildConvergenceSuggestions(stateAfter),
       };
     },
   };

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -846,8 +846,13 @@ function createGitHubSCM(): SCM {
     async forkSyncUpstream(input: ForkSyncInput): Promise<ForkSyncResult> {
       const upstreamRemote = input.upstreamRemote ?? "upstream";
       const upstreamBranch = input.upstreamBranch ?? "main";
-      const localBranch =
-        input.localBranch ?? (await git(["branch", "--show-current"], input.workspacePath));
+      const currentBranch = await git(["branch", "--show-current"], input.workspacePath);
+      const localBranch = input.localBranch ?? currentBranch;
+      if (input.localBranch && input.localBranch !== currentBranch) {
+        throw new Error(
+          `fork.sync_upstream localBranch "${input.localBranch}" is not checked out (current: "${currentBranch}")`,
+        );
+      }
       const upstreamRef = `${upstreamRemote}/${upstreamBranch}`;
       const localRef = localBranch;
 

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -14,7 +14,12 @@ vi.mock("node:child_process", () => {
   return { execFile };
 });
 
-import { create, manifest } from "../src/index.js";
+import {
+  create,
+  manifest,
+  computeForkSyncState,
+  buildConvergenceSuggestions,
+} from "../src/index.js";
 import type { PRInfo, Session, ProjectConfig } from "@composio/ao-core";
 
 // ---------------------------------------------------------------------------
@@ -1003,6 +1008,149 @@ describe("scm-github plugin", () => {
       const result = await scm.getMergeability(pr);
       expect(result.blockers).toHaveLength(4);
       expect(result.mergeable).toBe(false);
+    });
+  });
+
+  // ---- fork convergence --------------------------------------------------
+
+  describe("fork convergence helpers", () => {
+    it("computes up_to_date state", () => {
+      expect(
+        computeForkSyncState(0, 0, { localRef: "feat/xyz", upstreamRef: "upstream/main" }),
+      ).toMatchObject({
+        relation: "up_to_date",
+        ahead: 0,
+        behind: 0,
+        diverged: false,
+      });
+    });
+
+    it("computes ahead state", () => {
+      expect(
+        computeForkSyncState(3, 0, { localRef: "feat/xyz", upstreamRef: "upstream/main" }),
+      ).toMatchObject({
+        relation: "ahead",
+        ahead: 3,
+        behind: 0,
+        diverged: false,
+      });
+    });
+
+    it("computes behind state", () => {
+      expect(
+        computeForkSyncState(0, 2, { localRef: "feat/xyz", upstreamRef: "upstream/main" }),
+      ).toMatchObject({
+        relation: "behind",
+        ahead: 0,
+        behind: 2,
+        diverged: false,
+      });
+    });
+
+    it("computes diverged state", () => {
+      expect(
+        computeForkSyncState(4, 5, { localRef: "feat/xyz", upstreamRef: "upstream/main" }),
+      ).toMatchObject({
+        relation: "diverged",
+        ahead: 4,
+        behind: 5,
+        diverged: true,
+      });
+    });
+
+    it("generates deterministic convergence suggestions", () => {
+      const state = computeForkSyncState(2, 3, {
+        localRef: "feat/xyz",
+        upstreamRef: "upstream/main",
+      });
+      expect(buildConvergenceSuggestions(state)).toEqual([
+        {
+          type: "sync_upstream",
+          message: "Local branch is behind upstream by 3 commit(s); run fork.sync_upstream.",
+        },
+        {
+          type: "upstreamable_patch",
+          message:
+            "Local branch is ahead by 2 commit(s); consider upstreaming these changes via PR.",
+        },
+        {
+          type: "drift_alert",
+          message:
+            "Fork has diverged from upstream (ahead and behind simultaneously); manual convergence is required.",
+        },
+      ]);
+    });
+  });
+
+  describe("forkSyncUpstream", () => {
+    it("returns no-op for up-to-date branch", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "" }); // fetch
+      ghMock.mockResolvedValueOnce({ stdout: "ok\n" }); // rev-parse
+      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
+      ghMock.mockResolvedValueOnce({ stdout: "0\t0\n" }); // rev-list
+
+      const result = await scm.forkSyncUpstream?.({ workspacePath: "/tmp/repo" });
+
+      expect(result).toMatchObject({
+        primitive: "fork.sync_upstream",
+        action: "none",
+        synced: false,
+      });
+      expect(result?.stateBefore.relation).toBe("up_to_date");
+      expect(result?.stateAfter.relation).toBe("up_to_date");
+    });
+
+    it("fast-forwards when strictly behind", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "" }); // fetch
+      ghMock.mockResolvedValueOnce({ stdout: "ok\n" }); // rev-parse
+      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
+      ghMock.mockResolvedValueOnce({ stdout: "2\t0\n" }); // rev-list before
+      ghMock.mockResolvedValueOnce({ stdout: "" }); // merge --ff-only
+      ghMock.mockResolvedValueOnce({ stdout: "0\t0\n" }); // rev-list after
+
+      const result = await scm.forkSyncUpstream?.({ workspacePath: "/tmp/repo" });
+
+      expect(result).toMatchObject({
+        primitive: "fork.sync_upstream",
+        action: "fast_forward",
+        synced: true,
+      });
+      expect(result?.stateBefore.relation).toBe("behind");
+      expect(result?.stateAfter.relation).toBe("up_to_date");
+    });
+
+    it("does not attempt merge for diverged branches and returns drift alert", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "" }); // fetch
+      ghMock.mockResolvedValueOnce({ stdout: "ok\n" }); // rev-parse
+      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
+      ghMock.mockResolvedValueOnce({ stdout: "4\t3\n" }); // rev-list before
+
+      const result = await scm.forkSyncUpstream?.({ workspacePath: "/tmp/repo" });
+
+      expect(result?.action).toBe("blocked");
+      expect(result?.synced).toBe(false);
+      expect(result?.stateBefore.relation).toBe("diverged");
+      expect(result?.suggestions.some((s) => s.type === "drift_alert")).toBe(true);
+      expect(ghMock).not.toHaveBeenCalledWith(
+        "git",
+        ["merge", "--ff-only", "upstream/main"],
+        expect.anything(),
+      );
+    });
+
+    it("returns blocked when ff-only merge fails (conflict path)", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "" }); // fetch
+      ghMock.mockResolvedValueOnce({ stdout: "ok\n" }); // rev-parse
+      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
+      ghMock.mockResolvedValueOnce({ stdout: "1\t0\n" }); // rev-list before
+      ghMock.mockRejectedValueOnce(new Error("ff-only failed")); // merge --ff-only
+
+      const result = await scm.forkSyncUpstream?.({ workspacePath: "/tmp/repo" });
+
+      expect(result?.action).toBe("blocked");
+      expect(result?.synced).toBe(false);
+      expect(result?.stateAfter.relation).toBe("behind");
+      expect(result?.suggestions.some((s) => s.type === "sync_upstream")).toBe(true);
     });
   });
 });

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -1084,9 +1084,9 @@ describe("scm-github plugin", () => {
 
   describe("forkSyncUpstream", () => {
     it("returns no-op for up-to-date branch", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
       ghMock.mockResolvedValueOnce({ stdout: "" }); // fetch
       ghMock.mockResolvedValueOnce({ stdout: "ok\n" }); // rev-parse
-      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
       ghMock.mockResolvedValueOnce({ stdout: "0\t0\n" }); // rev-list
 
       const result = await scm.forkSyncUpstream?.({ workspacePath: "/tmp/repo" });
@@ -1098,12 +1098,19 @@ describe("scm-github plugin", () => {
       });
       expect(result?.stateBefore.relation).toBe("up_to_date");
       expect(result?.stateAfter.relation).toBe("up_to_date");
+      expect(result?.stateBefore.localRef).toBe("feat/my-feature");
+      expect(ghMock).toHaveBeenNthCalledWith(
+        1,
+        "git",
+        ["branch", "--show-current"],
+        expect.objectContaining({ cwd: "/tmp/repo" }),
+      );
     });
 
     it("fast-forwards when strictly behind", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
       ghMock.mockResolvedValueOnce({ stdout: "" }); // fetch
       ghMock.mockResolvedValueOnce({ stdout: "ok\n" }); // rev-parse
-      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
       ghMock.mockResolvedValueOnce({ stdout: "2\t0\n" }); // rev-list before
       ghMock.mockResolvedValueOnce({ stdout: "" }); // merge --ff-only
       ghMock.mockResolvedValueOnce({ stdout: "0\t0\n" }); // rev-list after
@@ -1117,12 +1124,13 @@ describe("scm-github plugin", () => {
       });
       expect(result?.stateBefore.relation).toBe("behind");
       expect(result?.stateAfter.relation).toBe("up_to_date");
+      expect(result?.stateBefore.localRef).toBe("feat/my-feature");
     });
 
     it("does not attempt merge for diverged branches and returns drift alert", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
       ghMock.mockResolvedValueOnce({ stdout: "" }); // fetch
       ghMock.mockResolvedValueOnce({ stdout: "ok\n" }); // rev-parse
-      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
       ghMock.mockResolvedValueOnce({ stdout: "4\t3\n" }); // rev-list before
 
       const result = await scm.forkSyncUpstream?.({ workspacePath: "/tmp/repo" });
@@ -1130,6 +1138,7 @@ describe("scm-github plugin", () => {
       expect(result?.action).toBe("blocked");
       expect(result?.synced).toBe(false);
       expect(result?.stateBefore.relation).toBe("diverged");
+      expect(result?.stateBefore.localRef).toBe("feat/my-feature");
       expect(result?.suggestions.some((s) => s.type === "drift_alert")).toBe(true);
       expect(ghMock).not.toHaveBeenCalledWith(
         "git",
@@ -1139,9 +1148,9 @@ describe("scm-github plugin", () => {
     });
 
     it("returns blocked when ff-only merge fails (conflict path)", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
       ghMock.mockResolvedValueOnce({ stdout: "" }); // fetch
       ghMock.mockResolvedValueOnce({ stdout: "ok\n" }); // rev-parse
-      ghMock.mockResolvedValueOnce({ stdout: "feat/my-feature\n" }); // branch
       ghMock.mockResolvedValueOnce({ stdout: "1\t0\n" }); // rev-list before
       ghMock.mockRejectedValueOnce(new Error("ff-only failed")); // merge --ff-only
 
@@ -1150,6 +1159,7 @@ describe("scm-github plugin", () => {
       expect(result?.action).toBe("blocked");
       expect(result?.synced).toBe(false);
       expect(result?.stateAfter.relation).toBe("behind");
+      expect(result?.stateAfter.localRef).toBe("feat/my-feature");
       expect(result?.suggestions.some((s) => s.type === "sync_upstream")).toBe(true);
     });
   });

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -1162,5 +1162,26 @@ describe("scm-github plugin", () => {
       expect(result?.stateAfter.localRef).toBe("feat/my-feature");
       expect(result?.suggestions.some((s) => s.type === "sync_upstream")).toBe(true);
     });
+
+    it("throws when provided localBranch is not the checked out HEAD branch", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "feat/current\n" }); // branch
+
+      await expect(
+        scm.forkSyncUpstream?.({
+          workspacePath: "/tmp/repo",
+          localBranch: "feat/other",
+        }),
+      ).rejects.toThrow(
+        'fork.sync_upstream localBranch "feat/other" is not checked out (current: "feat/current")',
+      );
+
+      expect(ghMock).toHaveBeenCalledTimes(1);
+      expect(ghMock).toHaveBeenNthCalledWith(
+        1,
+        "git",
+        ["branch", "--show-current"],
+        expect.objectContaining({ cwd: "/tmp/repo" }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add v1 fork convergence SCM primitives including `fork.sync_upstream`
- compute and expose deterministic ahead/behind/diverged sync state
- add convergence suggestions for upstreamable patches and drift alerts
- document operator workflow for sync + divergence handling

## Implementation
- extended SCM types with `ForkSyncInput`, `ForkSyncState`, `ForkSyncResult`, and suggestion models
- implemented `getForkSyncState`, `getForkConvergenceSuggestions`, and `forkSyncUpstream` in `@composio/ao-plugin-scm-github`
- centralized git sync-state parsing in a single `rev-list --left-right --count` parser
- kept sync behavior fast-forward-only in v1 (no federation protocol, no implicit merge conflict resolution)

## Validation
- added tests for sync state computation across up-to-date/ahead/behind/diverged
- added tests for deterministic suggestion generation
- added sync behavior tests for no-op, behind->fast-forward, diverged blocked, and ff-only conflict/error path
- test evidence:
  - `pnpm --filter @composio/ao-core build`
  - `pnpm --filter @composio/ao-plugin-scm-github test`

Closes #401
