### PR TITLE
feat(core): minimal report->issue->session improvement pipeline

### DIFF
--- a/packages/core/src/__tests__/improvement.integration.test.ts
+++ b/packages/core/src/__tests__/improvement.integration.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { createSessionManager } from "../session-manager.js";
+import { createImprovementService } from "../improvement.js";
+import { getSessionsDir } from "../paths.js";
+import type { ImprovementLinkage, NormalizedFeedbackReport } from "../improvement.js";
+import type {
+  Agent,
+  OrchestratorConfig,
+  PluginRegistry,
+  Runtime,
+  RuntimeHandle,
+  Tracker,
+  Workspace,
+} from "../types.js";
+
+interface TestReport extends Omit<NormalizedFeedbackReport, "linkage"> {
+  linkage?: Partial<ImprovementLinkage>;
+}
+
+function makeHandle(id: string): RuntimeHandle {
+  return { id, runtimeName: "mock-runtime", data: {} };
+}
+
+describe("improvement.spawn integration", () => {
+  let tmpDir: string;
+  let configPath: string;
+  let sessionsDir: string;
+  let config: OrchestratorConfig;
+  let runtime: Runtime;
+  let agent: Agent;
+  let workspace: Workspace;
+  let tracker: Tracker;
+  let registry: PluginRegistry;
+  let reports: Map<string, TestReport>;
+  let createdIssueCount: number;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `ao-improvement-${randomUUID()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    configPath = join(tmpDir, "agent-orchestrator.yaml");
+    writeFileSync(configPath, "projects: {}\n");
+
+    config = {
+      configPath,
+      defaults: {
+        runtime: "mock-runtime",
+        agent: "mock-agent",
+        workspace: "mock-workspace",
+        notifiers: [],
+      },
+      projects: {
+        app: {
+          name: "app",
+          repo: "acme/upstream-repo",
+          path: join(tmpDir, "repo"),
+          defaultBranch: "main",
+          sessionPrefix: "app",
+          tracker: { plugin: "github" },
+        },
+      },
+      notifiers: {},
+      notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+      reactions: {},
+      readyThresholdMs: 300_000,
+    };
+
+    sessionsDir = getSessionsDir(configPath, config.projects.app.path);
+    mkdirSync(sessionsDir, { recursive: true });
+
+    runtime = {
+      name: "mock-runtime",
+      create: vi.fn().mockResolvedValue(makeHandle("rt-1")),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      getOutput: vi.fn().mockResolvedValue(""),
+      isAlive: vi.fn().mockResolvedValue(true),
+    };
+
+    agent = {
+      name: "mock-agent",
+      processName: "mock-agent",
+      getLaunchCommand: vi.fn().mockReturnValue("mock-agent"),
+      getEnvironment: vi.fn().mockReturnValue({}),
+      detectActivity: vi.fn().mockReturnValue("active"),
+      getActivityState: vi.fn().mockResolvedValue({ state: "active" }),
+      isProcessRunning: vi.fn().mockResolvedValue(true),
+      getSessionInfo: vi.fn().mockResolvedValue(null),
+    };
+
+    workspace = {
+      name: "mock-workspace",
+      create: vi.fn().mockResolvedValue({
+        path: join(tmpDir, "worktrees", "app-1"),
+        branch: "feat/issue-101",
+        sessionId: "app-1",
+        projectId: "app",
+      }),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue([]),
+    };
+
+    createdIssueCount = 0;
+    tracker = {
+      name: "github",
+      getIssue: vi.fn().mockImplementation(async (id: string) => ({
+        id,
+        title: `Issue ${id}`,
+        description: "Issue body",
+        url: `https://github.com/acme/fork-repo/issues/${id}`,
+        state: "open",
+        labels: [],
+      })),
+      isCompleted: vi.fn().mockResolvedValue(false),
+      issueUrl: vi.fn().mockImplementation((id: string, project) => {
+        return `https://github.com/${project.repo}/issues/${String(id).replace(/^#/, "")}`;
+      }),
+      issueLabel: vi.fn().mockReturnValue("#101"),
+      branchName: vi.fn().mockImplementation((id: string) => `feat/issue-${id.replace(/^#/, "")}`),
+      generatePrompt: vi.fn().mockResolvedValue("tracker prompt"),
+      createIssue: vi.fn().mockImplementation(async (_input, project) => {
+        createdIssueCount += 1;
+        return {
+          id: "101",
+          title: "Improve pipeline",
+          description: "created issue",
+          url: `https://github.com/${project.repo}/issues/101`,
+          state: "open",
+          labels: [],
+        };
+      }),
+    };
+
+    registry = {
+      register: vi.fn(),
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return runtime;
+        if (slot === "agent") return agent;
+        if (slot === "workspace") return workspace;
+        if (slot === "tracker") return tracker;
+        return null;
+      }),
+      list: vi.fn().mockReturnValue([]),
+      loadBuiltins: vi.fn().mockResolvedValue(undefined),
+      loadFromConfig: vi.fn().mockResolvedValue(undefined),
+    };
+
+    reports = new Map<string, TestReport>([
+      [
+        "r-1",
+        {
+          id: "r-1",
+          projectId: "app",
+          kind: "improvement_suggestion",
+          title: "Improve spawn reliability",
+          body: "Pipeline occasionally drops metadata links.",
+          evidence: "Observed in session app-77",
+          sourceSessionId: "app-77",
+          confidence: 0.9,
+          severity: "warning",
+          labels: ["self-improvement"],
+        },
+      ],
+    ]);
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  const makeReportsAdapter = () => ({
+    getReport: vi.fn(async (reportId: string) => reports.get(reportId) ?? null),
+    normalize: vi.fn((report: TestReport) => report),
+    updateLinkage: vi.fn(async (reportId: string, patch: Partial<ImprovementLinkage>) => {
+      const current = reports.get(reportId);
+      if (!current) throw new Error(`missing report ${reportId}`);
+      reports.set(reportId, {
+        ...current,
+        linkage: {
+          ...(current.linkage ?? {}),
+          ...patch,
+        },
+      });
+    }),
+  });
+
+  it("links report -> issue -> session with metadata and fork-mode target", async () => {
+    const reportAdapter = makeReportsAdapter();
+    const sessionManager = createSessionManager({ config, registry });
+    const service = createImprovementService({
+      config,
+      registry,
+      sessionManager,
+      reports: reportAdapter,
+      forkMode: {
+        resolveIssueTarget: vi.fn().mockResolvedValue({
+          repo: "acme/fork-repo",
+          mode: "fork-first",
+        }),
+      },
+      guardrails: { minConfidence: 0.5, minSeverity: "info" },
+    });
+
+    const result = await service.spawn("r-1");
+
+    expect(result.reportId).toBe("r-1");
+    expect(result.issue.id).toBe("101");
+    expect(result.session.id).toBe("app-1");
+    expect(result.issueTarget).toEqual({ repo: "acme/fork-repo", mode: "fork-first" });
+
+    expect(tracker.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Improve spawn reliability" }),
+      expect.objectContaining({ repo: "acme/fork-repo" }),
+    );
+
+    const rawMeta = readFileSync(join(sessionsDir, "app-1"), "utf-8");
+    expect(rawMeta).toContain("improvementReportId=r-1");
+    expect(rawMeta).toContain("improvementIssueId=101");
+    expect(rawMeta).toContain("improvementIssueRepo=acme/fork-repo");
+    expect(rawMeta).toContain("improvementIssueMode=fork-first");
+
+    const linkedReport = reports.get("r-1");
+    expect(linkedReport?.linkage?.issueId).toBe("101");
+    expect(linkedReport?.linkage?.sessionId).toBe("app-1");
+    expect(linkedReport?.linkage?.issueRepo).toBe("acme/fork-repo");
+  });
+
+  it("is idempotent for repeat spawn(reportId) calls", async () => {
+    const reportAdapter = makeReportsAdapter();
+    const sessionManager = createSessionManager({ config, registry });
+    const service = createImprovementService({
+      config,
+      registry,
+      sessionManager,
+      reports: reportAdapter,
+      guardrails: { minConfidence: 0.5, minSeverity: "info" },
+    });
+
+    const first = await service.spawn("r-1");
+    const second = await service.spawn("r-1");
+
+    expect(first.session.id).toBe("app-1");
+    expect(second.session.id).toBe("app-1");
+    expect(second.idempotentReuse).toBe(true);
+    expect(createdIssueCount).toBe(1);
+    expect(runtime.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("records failure state when guardrails block spawning", async () => {
+    reports.set("r-2", {
+      id: "r-2",
+      projectId: "app",
+      kind: "bug_report",
+      title: "Low confidence report",
+      body: "Potential issue",
+      evidence: "none",
+      sourceSessionId: "app-2",
+      confidence: 0.2,
+      severity: "info",
+    });
+    const reportAdapter = makeReportsAdapter();
+    const sessionManager = createSessionManager({ config, registry });
+    const service = createImprovementService({
+      config,
+      registry,
+      sessionManager,
+      reports: reportAdapter,
+      guardrails: { minConfidence: 0.8, minSeverity: "warning" },
+    });
+
+    await expect(service.spawn("r-2")).rejects.toThrow("below threshold");
+    expect(createdIssueCount).toBe(0);
+    expect(reports.get("r-2")?.linkage?.lastError).toContain("below threshold");
+  });
+
+  it("persists issue linkage when spawn fails after issue creation", async () => {
+    runtime.create = vi.fn().mockRejectedValue(new Error("runtime unavailable"));
+    const reportAdapter = makeReportsAdapter();
+    const sessionManager = createSessionManager({ config, registry });
+    const service = createImprovementService({
+      config,
+      registry,
+      sessionManager,
+      reports: reportAdapter,
+    });
+
+    await expect(service.spawn("r-1")).rejects.toThrow("runtime unavailable");
+    expect(createdIssueCount).toBe(1);
+    expect(reports.get("r-1")?.linkage?.issueId).toBe("101");
+    expect(reports.get("r-1")?.linkage?.sessionId).toBeUndefined();
+    expect(reports.get("r-1")?.linkage?.lastError).toContain("runtime unavailable");
+  });
+});

--- a/packages/core/src/__tests__/improvement.integration.test.ts
+++ b/packages/core/src/__tests__/improvement.integration.test.ts
@@ -4,9 +4,12 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createSessionManager } from "../session-manager.js";
-import { createImprovementService } from "../improvement.js";
+import {
+  createImprovementService,
+  type ImprovementLinkage,
+  type NormalizedFeedbackReport,
+} from "../improvement.js";
 import { getSessionsDir } from "../paths.js";
-import type { ImprovementLinkage, NormalizedFeedbackReport } from "../improvement.js";
 import type {
   Agent,
   OrchestratorConfig,

--- a/packages/core/src/improvement.ts
+++ b/packages/core/src/improvement.ts
@@ -141,7 +141,7 @@ function buildIssueInput(report: NormalizedFeedbackReport): CreateIssueInput {
     "",
     "## Evidence",
     report.evidence || "No evidence provided",
-  ].filter((line): line is string => Boolean(line));
+  ].filter((line): line is string => line !== undefined);
 
   return {
     title: report.title,

--- a/packages/core/src/improvement.ts
+++ b/packages/core/src/improvement.ts
@@ -1,0 +1,296 @@
+import type {
+  CreateIssueInput,
+  Issue,
+  OrchestratorConfig,
+  PluginRegistry,
+  ProjectConfig,
+  Session,
+  SessionManager,
+  Tracker,
+} from "./types.js";
+
+/**
+ * Adapter layer for issue #400.
+ *
+ * Assumptions until #398/#399 contracts land in this branch:
+ * - Feedback schema is consumed through `FeedbackReportAdapter.normalize(...)`.
+ * - Managed fork mode policy is consumed through `ForkModePolicyAdapter.resolveIssueTarget(...)`.
+ * - This module does not define upstream state/storage formats; it composes existing services.
+ */
+
+export type ImprovementSeverity = "error" | "warning" | "info";
+
+export interface NormalizedFeedbackReport {
+  id: string;
+  projectId: string;
+  kind: "bug_report" | "improvement_suggestion";
+  title: string;
+  body: string;
+  evidence: string;
+  sourceSessionId: string;
+  confidence: number;
+  severity: ImprovementSeverity;
+  labels?: string[];
+  dedupeKey?: string;
+  linkage?: Partial<ImprovementLinkage>;
+}
+
+export interface ImprovementLinkage {
+  reportId: string;
+  issueId: string;
+  issueUrl: string;
+  issueRepo: string;
+  issueMode: string;
+  sessionId: string;
+  prUrl?: string;
+  lastAttemptAt: string;
+  lastError?: string;
+}
+
+export interface FeedbackReportAdapter<TRawReport = unknown> {
+  getReport(reportId: string): Promise<TRawReport | null>;
+  normalize(report: TRawReport, reportId: string): NormalizedFeedbackReport;
+  updateLinkage(reportId: string, patch: Partial<ImprovementLinkage>): Promise<void>;
+}
+
+export interface ForkModeTarget {
+  repo: string;
+  mode: string;
+}
+
+export interface ForkModePolicyAdapter {
+  resolveIssueTarget(input: { projectId: string; project: ProjectConfig }): Promise<ForkModeTarget>;
+}
+
+export interface ImprovementSpawnGuardrails {
+  minConfidence: number;
+  minSeverity: ImprovementSeverity;
+}
+
+export interface ImprovementServiceDeps<TRawReport = unknown> {
+  config: OrchestratorConfig;
+  registry: PluginRegistry;
+  sessionManager: SessionManager;
+  reports: FeedbackReportAdapter<TRawReport>;
+  forkMode?: ForkModePolicyAdapter;
+  guardrails?: Partial<ImprovementSpawnGuardrails>;
+}
+
+export interface ImprovementSpawnResult {
+  reportId: string;
+  issue: Issue;
+  session: Session;
+  issueTarget: ForkModeTarget;
+  idempotentReuse: boolean;
+}
+
+const SEVERITY_RANK: Record<ImprovementSeverity, number> = {
+  info: 0,
+  warning: 1,
+  error: 2,
+};
+
+function ensureGuardrails(
+  report: NormalizedFeedbackReport,
+  guardrails: ImprovementSpawnGuardrails,
+): void {
+  if (report.confidence < guardrails.minConfidence) {
+    throw new Error(
+      `Report ${report.id} confidence ${report.confidence} is below threshold ${guardrails.minConfidence}`,
+    );
+  }
+  if (SEVERITY_RANK[report.severity] < SEVERITY_RANK[guardrails.minSeverity]) {
+    throw new Error(
+      `Report ${report.id} severity ${report.severity} is below threshold ${guardrails.minSeverity}`,
+    );
+  }
+}
+
+function resolveTracker(
+  config: OrchestratorConfig,
+  registry: PluginRegistry,
+  projectId: string,
+): { project: ProjectConfig; tracker: Tracker } {
+  const project = config.projects[projectId];
+  if (!project) throw new Error(`Unknown project for report: ${projectId}`);
+  if (!project.tracker) {
+    throw new Error(`Project ${projectId} has no tracker configured`);
+  }
+  const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
+  if (!tracker) {
+    throw new Error(`Tracker plugin '${project.tracker.plugin}' not found for project ${projectId}`);
+  }
+  if (!tracker.createIssue) {
+    throw new Error(`Tracker plugin '${tracker.name}' does not support createIssue(...)`);
+  }
+  return { project, tracker };
+}
+
+function buildIssueInput(report: NormalizedFeedbackReport): CreateIssueInput {
+  const sections = [
+    "## Feedback Report",
+    `- Report ID: ${report.id}`,
+    `- Kind: ${report.kind}`,
+    `- Source Session: ${report.sourceSessionId}`,
+    `- Confidence: ${report.confidence}`,
+    `- Severity: ${report.severity}`,
+    report.dedupeKey ? `- Dedupe Key: ${report.dedupeKey}` : undefined,
+    "",
+    "## Summary",
+    report.body,
+    "",
+    "## Evidence",
+    report.evidence || "No evidence provided",
+  ].filter((line): line is string => Boolean(line));
+
+  return {
+    title: report.title,
+    description: sections.join("\n"),
+    labels: [...new Set(["self-improvement", ...(report.labels ?? [])])],
+  };
+}
+
+function buildSpawnPrompt(report: NormalizedFeedbackReport): string {
+  return [
+    `You are implementing feedback report ${report.id}.`,
+    `Kind: ${report.kind}`,
+    `Severity: ${report.severity}`,
+    `Confidence: ${report.confidence}`,
+    `Source session: ${report.sourceSessionId}`,
+    "",
+    "Focus on the reported problem and include tests for the reported behavior.",
+  ].join("\n");
+}
+
+async function maybeReuseExistingSession(
+  sessionManager: SessionManager,
+  report: NormalizedFeedbackReport,
+): Promise<Session | null> {
+  const existingSessionId = report.linkage?.sessionId;
+  if (!existingSessionId) return null;
+  return sessionManager.get(existingSessionId);
+}
+
+function toIsoNow(): string {
+  return new Date().toISOString();
+}
+
+export function createImprovementService<TRawReport = unknown>(
+  deps: ImprovementServiceDeps<TRawReport>,
+): { spawn(reportId: string): Promise<ImprovementSpawnResult> } {
+  const guardrails: ImprovementSpawnGuardrails = {
+    minConfidence: deps.guardrails?.minConfidence ?? 0,
+    minSeverity: deps.guardrails?.minSeverity ?? "info",
+  };
+
+  const resolveForkMode = async (
+    projectId: string,
+    project: ProjectConfig,
+  ): Promise<ForkModeTarget> => {
+    if (deps.forkMode) {
+      return deps.forkMode.resolveIssueTarget({ projectId, project });
+    }
+    return { repo: project.repo, mode: "upstream-first" };
+  };
+
+  return {
+    async spawn(reportId: string): Promise<ImprovementSpawnResult> {
+      const raw = await deps.reports.getReport(reportId);
+      if (!raw) throw new Error(`Feedback report not found: ${reportId}`);
+      const report = deps.reports.normalize(raw, reportId);
+
+      const { project, tracker } = resolveTracker(deps.config, deps.registry, report.projectId);
+      const issueTarget = await resolveForkMode(report.projectId, project);
+
+      const existingSession = await maybeReuseExistingSession(deps.sessionManager, report);
+      if (existingSession && report.linkage?.issueId && report.linkage?.issueUrl) {
+        if (existingSession.pr?.url) {
+          await deps.reports.updateLinkage(report.id, { prUrl: existingSession.pr.url });
+        }
+        return {
+          reportId: report.id,
+          issue: {
+            id: report.linkage.issueId,
+            url: report.linkage.issueUrl,
+            title: report.title,
+            description: report.body,
+            state: "open",
+            labels: report.labels ?? [],
+          },
+          session: existingSession,
+          issueTarget,
+          idempotentReuse: true,
+        };
+      }
+
+      try {
+        ensureGuardrails(report, guardrails);
+
+        const issue =
+          report.linkage?.issueId && report.linkage?.issueUrl
+            ? {
+                id: report.linkage.issueId,
+                url: report.linkage.issueUrl,
+                title: report.title,
+                description: report.body,
+                state: "open" as const,
+                labels: report.labels ?? [],
+              }
+            : await tracker.createIssue!(buildIssueInput(report), {
+                ...project,
+                repo: issueTarget.repo,
+              });
+
+        await deps.reports.updateLinkage(report.id, {
+          issueId: issue.id,
+          issueUrl: issue.url,
+          issueRepo: issueTarget.repo,
+          issueMode: issueTarget.mode,
+          lastAttemptAt: toIsoNow(),
+          lastError: "",
+        });
+
+        const session = await deps.sessionManager.spawn({
+          projectId: report.projectId,
+          issueId: issue.id,
+          prompt: buildSpawnPrompt(report),
+          metadata: {
+            improvementReportId: report.id,
+            improvementIssueId: issue.id,
+            improvementIssueUrl: issue.url,
+            improvementIssueRepo: issueTarget.repo,
+            improvementIssueMode: issueTarget.mode,
+            improvementSourceSessionId: report.sourceSessionId,
+            improvementConfidence: String(report.confidence),
+            improvementSeverity: report.severity,
+          },
+        });
+
+        await deps.reports.updateLinkage(report.id, {
+          issueId: issue.id,
+          issueUrl: issue.url,
+          issueRepo: issueTarget.repo,
+          issueMode: issueTarget.mode,
+          sessionId: session.id,
+          prUrl: session.pr?.url,
+          lastAttemptAt: toIsoNow(),
+          lastError: "",
+        });
+
+        return {
+          reportId: report.id,
+          issue,
+          session,
+          issueTarget,
+          idempotentReuse: false,
+        };
+      } catch (err) {
+        await deps.reports.updateLinkage(report.id, {
+          lastAttemptAt: toIsoNow(),
+          lastError: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,17 @@ export {
 // Session manager — session CRUD
 export { createSessionManager } from "./session-manager.js";
 export type { SessionManagerDeps } from "./session-manager.js";
+export { createImprovementService } from "./improvement.js";
+export type {
+  ImprovementServiceDeps,
+  ImprovementSpawnResult,
+  ImprovementSpawnGuardrails,
+  FeedbackReportAdapter,
+  NormalizedFeedbackReport,
+  ImprovementLinkage,
+  ForkModePolicyAdapter,
+  ForkModeTarget,
+} from "./improvement.js";
 
 // Lifecycle manager — state machine + reaction engine
 export { createLifecycleManager } from "./lifecycle-manager.js";

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -830,6 +830,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     }
 
     // Write metadata and run post-launch setup — clean up on failure
+    const sessionMetadata: Record<string, string> = {
+      ...(spawnConfig.metadata ?? {}),
+      ...(reusedOpenCodeSessionId ? { opencodeSessionId: reusedOpenCodeSessionId } : {}),
+    };
+
     const session: Session = {
       id: sessionId,
       projectId: spawnConfig.projectId,
@@ -843,9 +848,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       agentInfo: null,
       createdAt: new Date(),
       lastActivityAt: new Date(),
-      metadata: {
-        ...(reusedOpenCodeSessionId ? { opencodeSessionId: reusedOpenCodeSessionId } : {}),
-      },
+      metadata: sessionMetadata,
     };
 
     try {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -178,6 +178,8 @@ export interface SessionSpawnConfig {
   issueId?: string;
   branch?: string;
   prompt?: string;
+  /** Optional metadata keys persisted into the session metadata file */
+  metadata?: Record<string, string>;
   /** Override the agent plugin for this session (e.g. "codex", "claude-code") */
   agent?: string;
   /** Override the OpenCode subagent for this session (e.g. "sisyphus", "oracle") */


### PR DESCRIPTION
## Summary
Implements a narrow vertical slice for issue #400 as a composition layer in `@composio/ao-core`:
- Adds `createImprovementService(...).spawn(reportId)` wrapper for report -> issue -> session flow
- Uses adapter interfaces for feedback schema + managed fork mode policy (no contract redefinition)
- Persists report/issue/session linkage and failure state through report adapter updates
- Adds spawn metadata passthrough so session metadata stores report/issue linkage keys
- Adds integration tests for linkage, failure handling, and idempotency

## Assumptions
- #398 and #399 stable contracts are not yet available in this branch, so this PR introduces a minimal adapter layer in `packages/core/src/improvement.ts` and documents those assumptions in code comments.

## Test Evidence
- `pnpm --filter @composio/ao-core test -- src/__tests__/improvement.integration.test.ts`
- `pnpm --filter @composio/ao-core test -- src/__tests__/session-manager.test.ts`
- `pnpm --filter @composio/ao-core typecheck`

Closes #400
