### PR TITLE
feat: support explicit OpenClaw notifier destination routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ See [CLAUDE.md](CLAUDE.md) for code conventions and architecture details.
 | Doc | What it covers |
 |-----|---------------|
 | [Setup Guide](SETUP.md) | Detailed installation and configuration |
+| [OpenClaw Notifier Setup](docs/openclaw-notifier-setup.md) | Env-only OpenClaw notifier setup and smoke test |
 | [Examples](examples/) | Config templates (GitHub, Linear, multi-project, auto-merge) |
 | [CLAUDE.md](CLAUDE.md) | Architecture, conventions, plugin pattern |
 | [Troubleshooting](TROUBLESHOOTING.md) | Common issues and fixes |

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -87,10 +87,10 @@ projects:
 #     channel: "#agent-updates"
 #   openclaw:
 #     plugin: openclaw
-#     url: http://127.0.0.1:18789/hooks/agent
+#     url: ${OPENCLAW_HOOKS_URL}
 #     token: ${OPENCLAW_HOOKS_TOKEN}
 #     deliver: true
-#     # Optional fixed-destination routing; omit to use OpenClaw-side resolution
+#     # Set both fields to avoid falling back to OpenClaw's last resolved target
 #     channel: discord
 #     to: "1481253232679325817"
 

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -85,6 +85,14 @@ projects:
 #     plugin: slack
 #     webhook: ${SLACK_WEBHOOK_URL}
 #     channel: "#agent-updates"
+#   openclaw:
+#     plugin: openclaw
+#     url: http://127.0.0.1:18789/hooks/agent
+#     token: ${OPENCLAW_HOOKS_TOKEN}
+#     deliver: true
+#     # Optional fixed-destination routing; omit to use OpenClaw-side resolution
+#     channel: discord
+#     to: "1481253232679325817"
 
 # Notification routing by priority
 # notificationRouting:

--- a/docs/openclaw-notifier-setup.md
+++ b/docs/openclaw-notifier-setup.md
@@ -1,0 +1,43 @@
+# OpenClaw Notifier Setup
+
+Use env vars only. Do not put `OPENCLAW_HOOKS_TOKEN`, `LINEAR_API_KEY`, or any other token in git-tracked files.
+
+## AO config
+
+Add an OpenClaw notifier entry with explicit destination routing so delivery does not fall back to OpenClaw's remembered last target:
+
+```yaml
+notifiers:
+  openclaw:
+    plugin: openclaw
+    url: ${OPENCLAW_HOOKS_URL}
+    token: ${OPENCLAW_HOOKS_TOKEN}
+    sessionKeyPrefix: "hook:ao:"
+    wakeMode: now
+    deliver: true
+    channel: discord
+    to: "1481253232679325817"
+```
+
+`channel` and `to` should match the destination you want OpenClaw to deliver into every time.
+
+## Smoke test
+
+```bash
+export OPENCLAW_HOOKS_URL="http://127.0.0.1:18789/hooks/agent"
+export OPENCLAW_HOOKS_TOKEN="..."
+export AO_DIR="$HOME/.agent-orchestrator"
+export OPENCLAW_CHANNEL_KIND="discord"
+export OPENCLAW_CHANNEL_TARGET="1481253232679325817"
+
+./scripts/openclaw-notifier-smoke.sh
+```
+
+Expected result:
+
+- script prints the exact `channel` and `to` it is sending
+- HTTP status is `200` or another `2xx`
+- OpenClaw response body is printed
+- the notification lands in the configured Discord or Telegram destination, not the previous fallback target
+
+If you want a different destination, change `OPENCLAW_CHANNEL_KIND` and `OPENCLAW_CHANNEL_TARGET` before rerunning the script.

--- a/packages/integration-tests/src/notifier-openclaw.integration.test.ts
+++ b/packages/integration-tests/src/notifier-openclaw.integration.test.ts
@@ -92,6 +92,24 @@ describe("notifier-openclaw integration", () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.deliver).toBe(true);
     expect(body.wakeMode).toBe("now");
+    expect(body.channel).toBeUndefined();
+    expect(body.to).toBeUndefined();
+  });
+
+  it("passes explicit destination override fields through to OpenClaw", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const notifier = openClawPlugin.create({
+      token: "tok",
+      channel: "discord",
+      to: "1481253232679325817",
+    });
+    await notifier.notify(makeEvent({ sessionId: "ao-22" }));
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.channel).toBe("discord");
+    expect(body.to).toBe("1481253232679325817");
   });
 
   it("retries 503 then succeeds", async () => {

--- a/packages/plugins/notifier-openclaw/README.md
+++ b/packages/plugins/notifier-openclaw/README.md
@@ -21,12 +21,12 @@ OpenClaw notifier plugin for AO escalation events.
 notifiers:
   openclaw:
     plugin: openclaw
-    url: http://127.0.0.1:18789/hooks/agent
+    url: ${OPENCLAW_HOOKS_URL}
     token: ${OPENCLAW_HOOKS_TOKEN}
     sessionKeyPrefix: "hook:ao:"
     wakeMode: now
     deliver: true
-    # Optional fixed-destination routing for mixed Discord/Telegram/etc setups
+    # Set both fields for fixed routing; otherwise OpenClaw may reuse its last target
     channel: discord
     to: "1481253232679325817"
 ```
@@ -38,6 +38,22 @@ notifiers:
 - Includes `channel` and `to` in the payload when configured for deterministic routing.
 - Retries on `429` and `5xx` responses with exponential backoff.
 - If `deliver: true` is set without `channel` or `to`, final delivery depends on OpenClaw-side destination resolution.
+
+## Smoke test
+
+Use [`scripts/openclaw-notifier-smoke.sh`](../../../scripts/openclaw-notifier-smoke.sh) with env vars only:
+
+```bash
+export OPENCLAW_HOOKS_URL="http://127.0.0.1:18789/hooks/agent"
+export OPENCLAW_HOOKS_TOKEN="..."
+export AO_DIR="$HOME/.agent-orchestrator"
+export OPENCLAW_CHANNEL_KIND="discord"
+export OPENCLAW_CHANNEL_TARGET="1481253232679325817"
+
+./scripts/openclaw-notifier-smoke.sh
+```
+
+See [`docs/openclaw-notifier-setup.md`](../../../docs/openclaw-notifier-setup.md) for the full setup and expected output.
 
 ## Token rotation
 

--- a/packages/plugins/notifier-openclaw/README.md
+++ b/packages/plugins/notifier-openclaw/README.md
@@ -23,13 +23,21 @@ notifiers:
     plugin: openclaw
     url: http://127.0.0.1:18789/hooks/agent
     token: ${OPENCLAW_HOOKS_TOKEN}
+    sessionKeyPrefix: "hook:ao:"
+    wakeMode: now
+    deliver: true
+    # Optional fixed-destination routing for mixed Discord/Telegram/etc setups
+    channel: discord
+    to: "1481253232679325817"
 ```
 
 ## Behavior
 
 - Sends `POST /hooks/agent` payloads with per-session key `hook:ao:<sessionId>`.
 - Defaults `wakeMode: now` and `deliver: true`.
+- Includes `channel` and `to` in the payload when configured for deterministic routing.
 - Retries on `429` and `5xx` responses with exponential backoff.
+- If `deliver: true` is set without `channel` or `to`, final delivery depends on OpenClaw-side destination resolution.
 
 ## Token rotation
 

--- a/packages/plugins/notifier-openclaw/src/index.test.ts
+++ b/packages/plugins/notifier-openclaw/src/index.test.ts
@@ -56,6 +56,19 @@ describe("notifier-openclaw", () => {
     expect(headers["Authorization"]).toBe("Bearer env-token");
   });
 
+  it("resolves token from ${VAR} syntax in config", async () => {
+    process.env.OPENCLAW_HOOKS_TOKEN = "env-token";
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const notifier = create({ token: "${OPENCLAW_HOOKS_TOKEN}" });
+    await notifier.notify(makeEvent());
+
+    const headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers["Authorization"]).toBe("Bearer env-token");
+  });
+
   it("warns and sends without Authorization when token missing", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const fetchMock = vi.fn().mockResolvedValue({ ok: true });

--- a/packages/plugins/notifier-openclaw/src/index.test.ts
+++ b/packages/plugins/notifier-openclaw/src/index.test.ts
@@ -20,6 +20,7 @@ describe("notifier-openclaw", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     delete process.env.OPENCLAW_HOOKS_TOKEN;
+    delete process.env.OPENCLAW_HOOKS_URL;
   });
 
   afterEach(() => {
@@ -41,6 +42,20 @@ describe("notifier-openclaw", () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(fetchMock.mock.calls[0][0]).toBe("http://127.0.0.1:18789/hooks/agent");
+  });
+
+  it("uses url from ${OPENCLAW_HOOKS_URL} config syntax", async () => {
+    process.env.OPENCLAW_HOOKS_URL = "http://127.0.0.1:18789/hooks/agent";
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const notifier = create({ token: "tok", url: "${OPENCLAW_HOOKS_URL}" });
+    await notifier.notify(makeEvent());
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0][0]).toBe("http://127.0.0.1:18789/hooks/agent");
+    delete process.env.OPENCLAW_HOOKS_URL;
   });
 
   it("uses token from OPENCLAW_HOOKS_TOKEN env", async () => {

--- a/packages/plugins/notifier-openclaw/src/index.test.ts
+++ b/packages/plugins/notifier-openclaw/src/index.test.ts
@@ -125,6 +125,8 @@ describe("notifier-openclaw", () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.wakeMode).toBe("now");
     expect(body.deliver).toBe(true);
+    expect(body.channel).toBeUndefined();
+    expect(body.to).toBeUndefined();
   });
 
   it("supports wakeMode=next-heartbeat when configured", async () => {
@@ -136,6 +138,22 @@ describe("notifier-openclaw", () => {
 
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.wakeMode).toBe("next-heartbeat");
+  });
+
+  it("includes explicit destination override when configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const notifier = create({
+      token: "tok",
+      channel: "discord",
+      to: "1481253232679325817",
+    });
+    await notifier.notify(makeEvent());
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.channel).toBe("discord");
+    expect(body.to).toBe("1481253232679325817");
   });
 
   it("retries on 5xx response", async () => {

--- a/packages/plugins/notifier-openclaw/src/index.ts
+++ b/packages/plugins/notifier-openclaw/src/index.ts
@@ -27,6 +27,21 @@ interface OpenClawWebhookPayload {
   to?: string;
 }
 
+function resolveToken(rawToken: unknown): string | undefined {
+  if (typeof rawToken !== "string") return process.env.OPENCLAW_HOOKS_TOKEN;
+
+  const token = rawToken.trim();
+  if (!token) return process.env.OPENCLAW_HOOKS_TOKEN;
+
+  const envMatch = /^\$\{([^{}]+)\}$/.exec(token);
+  if (envMatch) {
+    const envName = envMatch[1];
+    return process.env[envName] ?? undefined;
+  }
+
+  return token;
+}
+
 async function postWithRetry(
   url: string,
   payload: OpenClawWebhookPayload,
@@ -114,9 +129,7 @@ export function create(config?: Record<string, unknown>): Notifier {
   const url =
     (typeof config?.url === "string" ? config.url : undefined) ??
     "http://127.0.0.1:18789/hooks/agent";
-  const token =
-    (typeof config?.token === "string" ? config.token : undefined) ??
-    process.env.OPENCLAW_HOOKS_TOKEN;
+  const token = resolveToken(config?.token);
   const senderName = typeof config?.name === "string" ? config.name : "AO";
   const sessionKeyPrefix =
     typeof config?.sessionKeyPrefix === "string" ? config.sessionKeyPrefix : "hook:ao:";

--- a/packages/plugins/notifier-openclaw/src/index.ts
+++ b/packages/plugins/notifier-openclaw/src/index.ts
@@ -23,6 +23,8 @@ interface OpenClawWebhookPayload {
   sessionKey?: string;
   wakeMode?: WakeMode;
   deliver?: boolean;
+  channel?: string;
+  to?: string;
 }
 
 async function postWithRetry(
@@ -120,6 +122,8 @@ export function create(config?: Record<string, unknown>): Notifier {
     typeof config?.sessionKeyPrefix === "string" ? config.sessionKeyPrefix : "hook:ao:";
   const wakeMode: WakeMode = config?.wakeMode === "next-heartbeat" ? "next-heartbeat" : "now";
   const deliver = typeof config?.deliver === "boolean" ? config.deliver : true;
+  const channel = typeof config?.channel === "string" ? config.channel : undefined;
+  const to = typeof config?.to === "string" ? config.to : undefined;
 
   const { retries, retryDelayMs } = normalizeRetryConfig(config);
 
@@ -142,18 +146,30 @@ export function create(config?: Record<string, unknown>): Notifier {
     await postWithRetry(url, payload, headers, retries, retryDelayMs, { sessionId });
   }
 
+  function buildPayload(
+    payload: Omit<OpenClawWebhookPayload, "name" | "wakeMode" | "deliver" | "channel" | "to">,
+  ): OpenClawWebhookPayload {
+    return {
+      ...payload,
+      name: senderName,
+      wakeMode,
+      deliver,
+      ...(channel ? { channel } : {}),
+      ...(to ? { to } : {}),
+    };
+  }
+
   return {
     name: "openclaw",
 
     async notify(event: OrchestratorEvent): Promise<void> {
       const sessionKey = `${sessionKeyPrefix}${sanitizeSessionId(event.sessionId)}`;
-      await sendPayload({
+      await sendPayload(
+        buildPayload({
         message: formatEscalationMessage(event),
-        name: senderName,
         sessionKey,
-        wakeMode,
-        deliver,
-      });
+        }),
+      );
     },
 
     async notifyWithActions(event: OrchestratorEvent, actions: NotifyAction[]): Promise<void> {
@@ -161,26 +177,24 @@ export function create(config?: Record<string, unknown>): Notifier {
       const actionsLine = formatActionsLine(actions);
       const message = [formatEscalationMessage(event), actionsLine].filter(Boolean).join("\n");
 
-      await sendPayload({
+      await sendPayload(
+        buildPayload({
         message,
-        name: senderName,
         sessionKey,
-        wakeMode,
-        deliver,
-      });
+        }),
+      );
     },
 
     async post(message: string, context?: NotifyContext): Promise<string | null> {
       const sessionId = context?.sessionId ? sanitizeSessionId(context.sessionId) : "default";
       const sessionKey = `${sessionKeyPrefix}${sessionId}`;
 
-      await sendPayload({
+      await sendPayload(
+        buildPayload({
         message,
-        name: senderName,
         sessionKey,
-        wakeMode,
-        deliver,
-      });
+        }),
+      );
 
       return null;
     },

--- a/packages/plugins/notifier-openclaw/src/index.ts
+++ b/packages/plugins/notifier-openclaw/src/index.ts
@@ -27,19 +27,23 @@ interface OpenClawWebhookPayload {
   to?: string;
 }
 
-function resolveToken(rawToken: unknown): string | undefined {
-  if (typeof rawToken !== "string") return process.env.OPENCLAW_HOOKS_TOKEN;
+function resolveEnvStyleString(rawValue: unknown): string | undefined {
+  if (typeof rawValue !== "string") return undefined;
 
-  const token = rawToken.trim();
-  if (!token) return process.env.OPENCLAW_HOOKS_TOKEN;
+  const value = rawValue.trim();
+  if (!value) return undefined;
 
-  const envMatch = /^\$\{([^{}]+)\}$/.exec(token);
+  const envMatch = /^\$\{([^{}]+)\}$/.exec(value);
   if (envMatch) {
     const envName = envMatch[1];
     return process.env[envName] ?? undefined;
   }
 
-  return token;
+  return value;
+}
+
+function resolveToken(rawToken: unknown): string | undefined {
+  return resolveEnvStyleString(rawToken) ?? process.env.OPENCLAW_HOOKS_TOKEN;
 }
 
 async function postWithRetry(
@@ -127,7 +131,7 @@ function formatActionsLine(actions: NotifyAction[]): string {
 
 export function create(config?: Record<string, unknown>): Notifier {
   const url =
-    (typeof config?.url === "string" ? config.url : undefined) ??
+    resolveEnvStyleString(config?.url) ??
     "http://127.0.0.1:18789/hooks/agent";
   const token = resolveToken(config?.token);
   const senderName = typeof config?.name === "string" ? config.name : "AO";

--- a/scripts/openclaw-notifier-smoke.sh
+++ b/scripts/openclaw-notifier-smoke.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "error: required env var missing: $name" >&2
+    exit 1
+  fi
+}
+
+require_env OPENCLAW_HOOKS_TOKEN
+require_env OPENCLAW_HOOKS_URL
+require_env AO_DIR
+require_env OPENCLAW_CHANNEL_KIND
+require_env OPENCLAW_CHANNEL_TARGET
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "error: curl is required" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "error: node is required" >&2
+  exit 1
+fi
+
+session_key_prefix="${OPENCLAW_SESSION_KEY_PREFIX:-hook:ao:}"
+session_name="${OPENCLAW_SMOKE_SESSION_NAME:-smoke}"
+timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+session_key="${session_key_prefix}${session_name}-${timestamp}"
+smoke_message="${OPENCLAW_SMOKE_MESSAGE:-AO OpenClaw notifier smoke test}"
+sender_name="${OPENCLAW_SENDER_NAME:-AO smoke}"
+wake_mode="${OPENCLAW_WAKE_MODE:-now}"
+deliver="${OPENCLAW_DELIVER:-true}"
+
+payload="$(
+  SESSION_KEY="$session_key" \
+  SMOKE_MESSAGE="$smoke_message" \
+  SENDER_NAME="$sender_name" \
+  WAKE_MODE="$wake_mode" \
+  DELIVER="$deliver" \
+  OPENCLAW_CHANNEL_KIND="$OPENCLAW_CHANNEL_KIND" \
+  OPENCLAW_CHANNEL_TARGET="$OPENCLAW_CHANNEL_TARGET" \
+  AO_DIR="$AO_DIR" \
+  node <<'EOF'
+const payload = {
+  message: `${process.env.SMOKE_MESSAGE}\nContext: ${JSON.stringify({
+    aoDir: process.env.AO_DIR,
+    smoke: true,
+    sentAt: new Date().toISOString(),
+  })}`,
+  name: process.env.SENDER_NAME,
+  sessionKey: process.env.SESSION_KEY,
+  wakeMode: process.env.WAKE_MODE,
+  deliver: process.env.DELIVER === "true",
+  channel: process.env.OPENCLAW_CHANNEL_KIND,
+  to: process.env.OPENCLAW_CHANNEL_TARGET,
+};
+
+process.stdout.write(JSON.stringify(payload));
+EOF
+)"
+
+echo "OpenClaw notifier smoke test"
+echo "  url: $OPENCLAW_HOOKS_URL"
+echo "  channel: $OPENCLAW_CHANNEL_KIND"
+echo "  to: $OPENCLAW_CHANNEL_TARGET"
+echo "  sessionKey: $session_key"
+echo "  auth: Bearer [redacted]"
+echo "  payload: $payload"
+
+tmp_body="$(mktemp)"
+trap 'rm -f "$tmp_body"' EXIT
+
+http_status="$(
+  curl -sS \
+    -o "$tmp_body" \
+    -w "%{http_code}" \
+    -X POST "$OPENCLAW_HOOKS_URL" \
+    -H "Authorization: Bearer $OPENCLAW_HOOKS_TOKEN" \
+    -H "Content-Type: application/json" \
+    --data "$payload"
+)"
+
+echo "  http_status: $http_status"
+echo "  response:"
+sed 's/^/    /' "$tmp_body"
+
+if [[ ! "$http_status" =~ ^2 ]]; then
+  echo "error: OpenClaw hook request failed" >&2
+  exit 1
+fi
+
+echo "success: OpenClaw accepted explicit channel/to routing payload"


### PR DESCRIPTION
## Summary
- add optional `channel` and `to` passthrough fields to the OpenClaw notifier payload
- preserve existing behavior when destination overrides are omitted
- document fixed-destination routing and cover both default and explicit-routing cases in tests

## Testing
- `pnpm --filter @composio/ao-plugin-notifier-openclaw test`
- `pnpm --filter @composio/ao-integration-tests exec vitest run --config vitest.config.ts src/notifier-openclaw.integration.test.ts`

Refs internal ticket TOP-104