### PR TITLE
fix: derive external dashboard issue URLs from tracker ids

### DIFF
--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -8,6 +8,7 @@ import {
   type OrchestratorConfig,
   type PluginRegistry,
   type SCM,
+  type Tracker,
 } from "@composio/ao-core";
 import * as serialize from "@/lib/serialize";
 import { getSCM } from "@/lib/services";
@@ -137,9 +138,30 @@ const mockSCM: SCM = {
   })),
 };
 
+const mockTracker: Tracker = {
+  name: "linear",
+  getIssue: vi.fn(async (id: string) => ({
+    id,
+    title: `Issue ${id}`,
+    description: "",
+    url: `https://linear.app/topshark/issue/${id}`,
+    state: "open",
+    labels: [],
+  })),
+  isCompleted: vi.fn(async () => false),
+  issueUrl: vi.fn((identifier: string) => `https://linear.app/topshark/issue/${identifier}`),
+  issueLabel: vi.fn((url: string) => url.split("/").pop() ?? url),
+  branchName: vi.fn((identifier: string) => `feat/${identifier}`),
+  generatePrompt: vi.fn(async (identifier: string) => `Prompt for ${identifier}`),
+};
+
 const mockRegistry: PluginRegistry = {
   register: vi.fn(),
-  get: vi.fn(() => mockSCM) as PluginRegistry["get"],
+  get: vi.fn((slot: string) => {
+    if (slot === "tracker") return mockTracker;
+    if (slot === "scm") return mockSCM;
+    return null;
+  }) as PluginRegistry["get"],
   list: vi.fn(() => []),
   loadBuiltins: vi.fn(async () => {}),
   loadFromConfig: vi.fn(async () => {}),
@@ -162,6 +184,7 @@ const mockConfig: OrchestratorConfig = {
       path: "/tmp/my-app",
       defaultBranch: "main",
       sessionPrefix: "my-app",
+      tracker: { plugin: "linear" },
       scm: { plugin: "github", webhook: {} },
     },
   },
@@ -231,6 +254,14 @@ beforeEach(() => {
     branch: "feat/health-check",
     data: {},
   });
+  (mockTracker.getIssue as ReturnType<typeof vi.fn>).mockImplementation(async (id: string) => ({
+    id,
+    title: `Issue ${id}`,
+    description: "",
+    url: `https://linear.app/topshark/issue/${id}`,
+    state: "open",
+    labels: [],
+  }));
 });
 
 describe("API Routes", () => {
@@ -266,6 +297,18 @@ describe("API Routes", () => {
       expect(session).toHaveProperty("status");
       expect(session).toHaveProperty("activity");
       expect(session).toHaveProperty("createdAt");
+    });
+
+    it("returns full external issueUrl values for tracker-backed sessions", async () => {
+      const res = await sessionsGET(makeRequest("http://localhost:3000/api/sessions"));
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      const session = data.sessions.find((s: { id: string }) => s.id === "frontend-1");
+
+      expect(session.issueId).toBe("INT-1270");
+      expect(session.issueUrl).toBe("https://linear.app/topshark/issue/INT-1270");
+      expect(session.issueLabel).toBe("INT-1270");
     });
 
     it("skips PR enrichment when metadata enrichment hits timeout", async () => {

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -126,6 +126,26 @@ describe("sessionToDashboard", () => {
     expect(dashboard.lastActivityAt).toBe("2025-01-01T01:00:00.000Z");
   });
 
+  it("should preserve issueUrl when issueId is already an absolute URL", () => {
+    const coreSession = createCoreSession({
+      issueId: "https://linear.app/acme/issue/INT-100",
+    });
+
+    const dashboard = sessionToDashboard(coreSession);
+
+    expect(dashboard.issueId).toBe("https://linear.app/acme/issue/INT-100");
+    expect(dashboard.issueUrl).toBe("https://linear.app/acme/issue/INT-100");
+  });
+
+  it("should not treat bare tracker identifiers as issue URLs", () => {
+    const coreSession = createCoreSession({ issueId: "INT-100" });
+
+    const dashboard = sessionToDashboard(coreSession);
+
+    expect(dashboard.issueId).toBe("INT-100");
+    expect(dashboard.issueUrl).toBeNull();
+  });
+
   it("should use agentInfo summary with summaryIsFallback false", () => {
     const coreSession = createCoreSession({
       agentInfo: {
@@ -805,6 +825,57 @@ describe("enrichSessionsMetadata", () => {
     // Summary enriched (async)
     expect(dashboard.summary).toBe("Implementing auth fix");
     // Issue title enriched (async, depends on issueLabel from sync step)
+    expect(dashboard.issueTitle).toBe("Fix auth bug");
+  });
+
+  it("should derive issueUrl from tracker for identifier-backed sessions", async () => {
+    const tracker = mockTracker("Fix auth bug");
+    tracker.issueUrl = vi.fn().mockReturnValue("https://linear.app/acme/issue/INT-100");
+    tracker.issueLabel = vi.fn().mockReturnValue("INT-100");
+    tracker.getIssue = vi.fn().mockResolvedValue({
+      id: "INT-100",
+      title: "Fix auth bug",
+      description: "",
+      url: "https://linear.app/acme/issue/INT-100",
+      state: "open",
+      labels: [],
+    });
+    const agent = mockAgent("Implementing auth fix");
+    const registry = mockRegistry(tracker, agent);
+
+    const core = createCoreSession({ issueId: "INT-100" });
+    const dashboard = sessionToDashboard(core);
+
+    await enrichSessionsMetadata([core], [dashboard], testConfig, registry);
+
+    expect(tracker.issueUrl).toHaveBeenCalledWith("INT-100", testProject);
+    expect(dashboard.issueUrl).toBe("https://linear.app/acme/issue/INT-100");
+    expect(dashboard.issueLabel).toBe("INT-100");
+    expect(dashboard.issueTitle).toBe("Fix auth bug");
+  });
+
+  it("should derive GitHub issueUrl from tracker for identifier-backed sessions", async () => {
+    const tracker = mockTracker("Fix auth bug");
+    tracker.issueUrl = vi.fn().mockReturnValue("https://github.com/test/repo/issues/420");
+    tracker.issueLabel = vi.fn().mockReturnValue("#420");
+    tracker.getIssue = vi.fn().mockResolvedValue({
+      id: "420",
+      title: "Fix auth bug",
+      description: "",
+      url: "https://github.com/test/repo/issues/420",
+      state: "open",
+      labels: [],
+    });
+    const agent = mockAgent("Implementing auth fix");
+    const registry = mockRegistry(tracker, agent);
+
+    const core = createCoreSession({ issueId: "420" });
+    const dashboard = sessionToDashboard(core);
+
+    await enrichSessionsMetadata([core], [dashboard], testConfig, registry);
+
+    expect(dashboard.issueUrl).toBe("https://github.com/test/repo/issues/420");
+    expect(dashboard.issueLabel).toBe("#420");
     expect(dashboard.issueTitle).toBe("Fix auth bug");
   });
 

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -21,6 +21,15 @@ import { TTLCache, prCache, prCacheKey, type PREnrichmentData } from "./cache";
 /** Cache for issue titles (5 min TTL — issue titles rarely change) */
 const issueTitleCache = new TTLCache<string>(300_000);
 
+function isAbsoluteHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 /** Resolve which project a session belongs to. */
 export function resolveProject(
   core: Session,
@@ -51,7 +60,7 @@ export function sessionToDashboard(session: Session): DashboardSession {
     activity: session.activity,
     branch: session.branch,
     issueId: session.issueId, // Deprecated: kept for backwards compatibility
-    issueUrl: session.issueId, // issueId is actually the full URL
+    issueUrl: session.issueId && isAbsoluteHttpUrl(session.issueId) ? session.issueId : null,
     issueLabel: null, // Will be enriched by enrichSessionIssue()
     issueTitle: null, // Will be enriched by enrichSessionIssueTitle()
     summary,
@@ -343,6 +352,23 @@ export async function enrichSessionsMetadata(
 ): Promise<void> {
   // Resolve projects once per session (avoids repeated Object.entries lookups)
   const projects = coreSessions.map((core) => resolveProject(core, config.projects));
+
+  // Derive external issue URLs from tracker identifiers before label/title enrichment.
+  projects.forEach((project, i) => {
+    const dashboard = dashboardSessions[i];
+    const core = coreSessions[i];
+    if (dashboard?.issueUrl || !core?.issueId || !project?.tracker) return;
+
+    const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
+    if (!tracker) return;
+
+    try {
+      const issueUrl = tracker.issueUrl(core.issueId, project);
+      dashboard.issueUrl = isAbsoluteHttpUrl(issueUrl) ? issueUrl : null;
+    } catch {
+      dashboard.issueUrl = null;
+    }
+  });
 
   // Enrich issue labels (synchronous — must run before async title enrichment)
   projects.forEach((project, i) => {


### PR DESCRIPTION
## Summary
- derive full external issue URLs from tracker identifiers during dashboard metadata enrichment
- preserve already-absolute issue URLs while avoiding relative `href` values for bare tracker ids
- add regression coverage for serialize logic and `/api/sessions` tracker-backed payloads

## Testing
- pnpm --filter @composio/ao-web test -- src/lib/__tests__/serialize.test.ts
- pnpm --filter @composio/ao-web test -- src/__tests__/api-routes.test.ts