### PR TITLE
docs: Rename `webhook` to `webhookUrl` in `multi-project.yaml`

### DIFF
--- a/examples/multi-project.yaml
+++ b/examples/multi-project.yaml
@@ -46,7 +46,7 @@ projects:
 notifiers:
   slack:
     plugin: slack
-    webhook: ${SLACK_WEBHOOK_URL}
+    webhookUrl: ${SLACK_WEBHOOK_URL}
     channel: "#agent-updates"
 
 # Route notifications by priority


### PR DESCRIPTION
This pull request makes a minor update to the notifier configuration in `examples/multi-project.yaml`. The change improves clarity and consistency in naming.

* Renamed the Slack webhook property from `webhook` to `webhookUrl` in the `projects` section of `examples/multi-project.yaml` for clearer configuration.