### PR TITLE
fix(codex): improve Codex plugin stability and feature parity with Claude Code

### DIFF
--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -16,6 +16,7 @@ const {
   mockOpen,
   mockCreateReadStream,
   mockHomedir,
+  mockReadLastJsonlEntry,
 } = vi.hoisted(() => ({
   mockExecFileAsync: vi.fn(),
   mockWriteFile: vi.fn().mockResolvedValue(undefined),
@@ -28,6 +29,7 @@ const {
   mockOpen: vi.fn(),
   mockCreateReadStream: vi.fn(),
   mockHomedir: vi.fn(() => "/mock/home"),
+  mockReadLastJsonlEntry: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => {
@@ -61,8 +63,13 @@ vi.mock("node:os", () => ({
   homedir: mockHomedir,
 }));
 
+vi.mock("@composio/ao-core", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...(actual as Record<string, unknown>), readLastJsonlEntry: mockReadLastJsonlEntry };
+});
+
 import { Readable } from "node:stream";
-import { create, manifest, default as defaultExport, resolveCodexBinary, _resetSessionFileCache } from "./index.js";
+import { create, manifest, default as defaultExport, resolveCodexBinary, _resetSessionFileCache, _resetPsCache } from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -167,6 +174,7 @@ function setupMockStream(content: string) {
 beforeEach(() => {
   vi.clearAllMocks();
   _resetSessionFileCache();
+  _resetPsCache();
   mockHomedir.mockReturnValue("/mock/home");
   // Default: open() returns a handle with empty content (no session_meta match).
   // Session tests call setupMockOpen(content) to override.
@@ -643,13 +651,26 @@ describe("getActivityState", () => {
     expect(await agent.getActivityState(session)).toBeNull();
   });
 
-  it("returns active when session file was recently modified", async () => {
+  it("returns null when session file exists but readLastJsonlEntry returns null", async () => {
     mockTmuxWithProcess("codex");
     const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     setupMockOpen(content);
-    // mtime = now (just modified)
-    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    mockReadLastJsonlEntry.mockResolvedValue(null);
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    expect(await agent.getActivityState(session)).toBeNull();
+  });
+
+  // --- Active states (user, tool_use, progress) ---
+  it("returns active when last entry is user type and recent", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    mockReadLastJsonlEntry.mockResolvedValue({ lastType: "user", modifiedAt: new Date() });
 
     const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
     const result = await agent.getActivityState(session);
@@ -657,19 +678,133 @@ describe("getActivityState", () => {
     expect(result?.timestamp).toBeInstanceOf(Date);
   });
 
-  it("returns idle when session file is stale", async () => {
+  it("returns active when last entry is tool_use type and recent", async () => {
     mockTmuxWithProcess("codex");
     const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     setupMockOpen(content);
-    // mtime = 10 minutes ago (past the 5-minute threshold)
-    const staleTime = Date.now() - 600_000;
-    mockStat.mockResolvedValue({ mtimeMs: staleTime, mtime: new Date(staleTime) });
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    mockReadLastJsonlEntry.mockResolvedValue({ lastType: "tool_use", modifiedAt: new Date() });
 
     const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
-    const result = await agent.getActivityState(session);
-    expect(result?.state).toBe("idle");
-    expect(result?.timestamp).toBeInstanceOf(Date);
+    expect((await agent.getActivityState(session))?.state).toBe("active");
+  });
+
+  it("returns active when last entry is progress type and recent", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    mockReadLastJsonlEntry.mockResolvedValue({ lastType: "progress", modifiedAt: new Date() });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    expect((await agent.getActivityState(session))?.state).toBe("active");
+  });
+
+  // --- Ready states (assistant, system, summary, result) ---
+  it("returns ready when last entry is assistant type and recent", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    mockReadLastJsonlEntry.mockResolvedValue({ lastType: "assistant", modifiedAt: new Date() });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    expect((await agent.getActivityState(session))?.state).toBe("ready");
+  });
+
+  it("returns ready when last entry is summary type and recent", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    mockReadLastJsonlEntry.mockResolvedValue({ lastType: "summary", modifiedAt: new Date() });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    expect((await agent.getActivityState(session))?.state).toBe("ready");
+  });
+
+  it("returns ready when last entry is result type and recent", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    mockReadLastJsonlEntry.mockResolvedValue({ lastType: "result", modifiedAt: new Date() });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    expect((await agent.getActivityState(session))?.state).toBe("ready");
+  });
+
+  // --- Waiting input state (permission_request) ---
+  it("returns waiting_input when last entry is permission_request", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    // permission_request returns waiting_input regardless of age
+    const staleTime = new Date(Date.now() - 600_000);
+    mockReadLastJsonlEntry.mockResolvedValue({ lastType: "permission_request", modifiedAt: staleTime });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    expect((await agent.getActivityState(session))?.state).toBe("waiting_input");
+  });
+
+  // --- Blocked state (error) ---
+  it("returns blocked when last entry is error", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    mockReadLastJsonlEntry.mockResolvedValue({ lastType: "error", modifiedAt: new Date() });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    expect((await agent.getActivityState(session))?.state).toBe("blocked");
+  });
+
+  // --- Idle (stale entries) ---
+  it("returns idle when active-type entry is stale", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    const staleTime = new Date(Date.now() - 600_000);
+    mockReadLastJsonlEntry.mockResolvedValue({ lastType: "user", modifiedAt: staleTime });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    expect((await agent.getActivityState(session))?.state).toBe("idle");
+  });
+
+  it("returns idle when ready-type entry is stale", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    const staleTime = new Date(Date.now() - 600_000);
+    mockReadLastJsonlEntry.mockResolvedValue({ lastType: "assistant", modifiedAt: staleTime });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    expect((await agent.getActivityState(session))?.state).toBe("idle");
+  });
+
+  // --- Default (unknown type) ---
+  it("returns active for unknown entry type when recent", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+    mockReadLastJsonlEntry.mockResolvedValue({ lastType: "unknown_type", modifiedAt: new Date() });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    expect((await agent.getActivityState(session))?.state).toBe("active");
   });
 
   it("returns exited when process handle has dead PID", async () => {
@@ -804,7 +939,7 @@ describe("getSessionInfo", () => {
     expect(result!.cost!.outputTokens).toBe(200);
   });
 
-  it("returns null summary when no model in session_meta", async () => {
+  it("returns null summary when no model, no summary event, and no user message", async () => {
     const content = jsonl(
       { type: "session_meta", cwd: "/workspace/test" },
       { type: "event_msg", msg: { type: "token_count", input_tokens: 100, output_tokens: 50 } },
@@ -933,6 +1068,292 @@ describe("getSessionInfo", () => {
       (call: string[]) => typeof call[0] === "string" && call[0].includes("sessions/"),
     );
     expect(readFileCalls.length).toBe(0); // streaming replaces readFile for full parse
+  });
+});
+
+// =========================================================================
+// getSessionInfo — summary extraction
+// =========================================================================
+describe("getSessionInfo — summary extraction", () => {
+  const agent = create();
+
+  function jsonl(...lines: Record<string, unknown>[]): string {
+    return lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+  }
+
+  it("extracts summary from summary event", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
+      { type: "summary", summary: "Implemented auth flow" },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    expect(result!.summary).toBe("Implemented auth flow");
+    expect(result!.summaryIsFallback).toBe(false);
+  });
+
+  it("falls back to first user message when no summary event", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
+      { type: "user", content: "Fix the login bug in auth.ts" },
+      { type: "assistant", content: "I'll look into it" },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    expect(result!.summary).toBe("Fix the login bug in auth.ts");
+    expect(result!.summaryIsFallback).toBe(true);
+  });
+
+  it("truncates long user messages to 120 chars with ellipsis", async () => {
+    const longMessage = "A".repeat(200);
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
+      { type: "user", content: longMessage },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    expect(result!.summary).toBe("A".repeat(120) + "...");
+    expect(result!.summaryIsFallback).toBe(true);
+  });
+
+  it("uses role=user as fallback for user message detection", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
+      { role: "user", content: "Help me debug this" },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    expect(result!.summary).toBe("Help me debug this");
+    expect(result!.summaryIsFallback).toBe(true);
+  });
+
+  it("prefers summary event over user message", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
+      { type: "user", content: "Fix the bug" },
+      { type: "summary", summary: "Fixed authentication bug in login flow" },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    expect(result!.summary).toBe("Fixed authentication bug in login flow");
+    expect(result!.summaryIsFallback).toBe(false);
+  });
+
+  it("falls back to model name when no summary and no user message", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "o3-mini" },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    expect(result!.summary).toBe("Codex session (o3-mini)");
+    expect(result!.summaryIsFallback).toBe(true);
+  });
+});
+
+// =========================================================================
+// getSessionInfo — cost estimation
+// =========================================================================
+describe("getSessionInfo — cost estimation", () => {
+  const agent = create();
+
+  function jsonl(...lines: Record<string, unknown>[]): string {
+    return lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+  }
+
+  it("uses costUSD field when available", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
+      { costUSD: 0.05 },
+      { costUSD: 0.03 },
+      { type: "event_msg", msg: { type: "token_count", input_tokens: 1000, output_tokens: 500 } },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    expect(result!.cost).toBeDefined();
+    // costUSD takes precedence: 0.05 + 0.03 = 0.08
+    expect(result!.cost!.estimatedCostUsd).toBeCloseTo(0.08);
+  });
+
+  it("tracks cache_read_input_tokens and cache_creation_input_tokens", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
+      { type: "event_msg", msg: {
+        type: "token_count",
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_read_input_tokens: 200,
+        cache_creation_input_tokens: 100,
+      }},
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    expect(result!.cost).toBeDefined();
+    // Total input = 1000 + 200 + 100 = 1300
+    expect(result!.cost!.inputTokens).toBe(1300);
+    expect(result!.cost!.outputTokens).toBe(500);
+  });
+
+  it("uses gpt-4o pricing for gpt-4o model", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
+      { type: "event_msg", msg: { type: "token_count", input_tokens: 1_000_000, output_tokens: 1_000_000 } },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    // gpt-4o: $2.5/M input + $10/M output = $12.50
+    expect(result!.cost!.estimatedCostUsd).toBeCloseTo(12.5);
+  });
+
+  it("uses o3 pricing for o3 model", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "o3" },
+      { type: "event_msg", msg: { type: "token_count", input_tokens: 1_000_000, output_tokens: 1_000_000 } },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    // o3: $10/M input + $40/M output = $50
+    expect(result!.cost!.estimatedCostUsd).toBeCloseTo(50.0);
+  });
+
+  it("uses o4-mini pricing for o4-mini model", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "o4-mini" },
+      { type: "event_msg", msg: { type: "token_count", input_tokens: 1_000_000, output_tokens: 1_000_000 } },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    // o4-mini: $1.1/M input + $4.4/M output = $5.50
+    expect(result!.cost!.estimatedCostUsd).toBeCloseTo(5.5);
+  });
+
+  it("uses default pricing for unknown model", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "some-future-model" },
+      { type: "event_msg", msg: { type: "token_count", input_tokens: 1_000_000, output_tokens: 1_000_000 } },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    // default: $2.5/M input + $10/M output = $12.50
+    expect(result!.cost!.estimatedCostUsd).toBeCloseTo(12.5);
+  });
+
+  it("matches model prefix for versioned model names", async () => {
+    const content = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "o3-mini-2025-01-31" },
+      { type: "event_msg", msg: { type: "token_count", input_tokens: 1_000_000, output_tokens: 1_000_000 } },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    // o3-mini: $1.1/M input + $4.4/M output = $5.50
+    expect(result!.cost!.estimatedCostUsd).toBeCloseTo(5.5);
+  });
+});
+
+// =========================================================================
+// PS process cache
+// =========================================================================
+describe("PS process cache", () => {
+  const agent = create();
+
+  it("reuses cached ps output for multiple isProcessRunning calls", async () => {
+    let psCallCount = 0;
+    mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "list-panes") {
+        return Promise.resolve({ stdout: "/dev/ttys001\n", stderr: "" });
+      }
+      if (cmd === "ps") {
+        psCallCount++;
+        return Promise.resolve({
+          stdout: "  PID TT       ARGS\n  100 ttys001  codex\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+
+    // Call isProcessRunning twice — ps should only be called once (cached)
+    await agent.isProcessRunning(makeTmuxHandle());
+    await agent.isProcessRunning(makeTmuxHandle());
+
+    expect(psCallCount).toBe(1);
+  });
+
+  it("refreshes cache after TTL expires", async () => {
+    let psCallCount = 0;
+    mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "list-panes") {
+        return Promise.resolve({ stdout: "/dev/ttys001\n", stderr: "" });
+      }
+      if (cmd === "ps") {
+        psCallCount++;
+        return Promise.resolve({
+          stdout: "  PID TT       ARGS\n  100 ttys001  codex\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+
+    await agent.isProcessRunning(makeTmuxHandle());
+    expect(psCallCount).toBe(1);
+
+    // Reset cache to simulate TTL expiry
+    _resetPsCache();
+
+    await agent.isProcessRunning(makeTmuxHandle());
+    expect(psCallCount).toBe(2);
   });
 });
 

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_READY_THRESHOLD_MS,
+  readLastJsonlEntry,
   shellEscape,
   type Agent,
   type AgentSessionInfo,
@@ -338,6 +339,10 @@ interface CodexJsonlLine {
   // User message content (from user input events)
   content?: string;
   role?: string;
+  // Summary text from summary events
+  summary?: string;
+  // Direct cost field (preferred over token-based estimation)
+  costUSD?: number;
   // event_msg with token_count subtype
   msg?: {
     type?: string;
@@ -345,6 +350,8 @@ interface CodexJsonlLine {
     output_tokens?: number;
     cached_tokens?: number;
     reasoning_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
   };
 }
 
@@ -471,6 +478,11 @@ interface CodexSessionData {
   threadId: string | null;
   inputTokens: number;
   outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  totalCostUsd: number;
+  summary: string | null;
+  firstUserMessage: string | null;
 }
 
 /**
@@ -480,7 +492,17 @@ interface CodexSessionData {
  */
 async function streamCodexSessionData(filePath: string): Promise<CodexSessionData | null> {
   try {
-    const data: CodexSessionData = { model: null, threadId: null, inputTokens: 0, outputTokens: 0 };
+    const data: CodexSessionData = {
+      model: null,
+      threadId: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      totalCostUsd: 0,
+      summary: null,
+      firstUserMessage: null,
+    };
     const rl = createInterface({
       input: createReadStream(filePath, { encoding: "utf-8" }),
       crlfDelay: Infinity,
@@ -500,9 +522,31 @@ async function streamCodexSessionData(filePath: string): Promise<CodexSessionDat
         if (typeof entry.threadId === "string" && entry.threadId) {
           data.threadId = entry.threadId;
         }
+
+        // Summary extraction: prefer explicit summary events, track first user message as fallback
+        if (entry.type === "summary" && typeof entry.summary === "string" && entry.summary) {
+          data.summary = entry.summary;
+        }
+        if (
+          data.firstUserMessage === null &&
+          (entry.type === "user" || entry.role === "user") &&
+          typeof entry.content === "string" &&
+          entry.content.trim().length > 0
+        ) {
+          data.firstUserMessage = entry.content.trim();
+        }
+
+        // Cost: prefer direct costUSD field
+        if (typeof entry.costUSD === "number") {
+          data.totalCostUsd += entry.costUSD;
+        }
+
+        // Token counts from event_msg with token_count subtype
         if (entry.type === "event_msg" && entry.msg?.type === "token_count") {
           data.inputTokens += entry.msg.input_tokens ?? 0;
           data.outputTokens += entry.msg.output_tokens ?? 0;
+          data.cacheReadInputTokens += entry.msg.cache_read_input_tokens ?? 0;
+          data.cacheCreationInputTokens += entry.msg.cache_creation_input_tokens ?? 0;
         }
       } catch {
         // Skip malformed lines
@@ -609,6 +653,76 @@ async function findCodexSessionFileCached(workspacePath: string): Promise<string
   return result;
 }
 
+// =============================================================================
+// PS Process Cache
+// =============================================================================
+
+/**
+ * TTL cache for `ps -eo pid,tty,args` output. Without this, listing N sessions
+ * would spawn N concurrent `ps` processes. The cache ensures `ps` is called at
+ * most once per TTL window regardless of how many sessions are being enriched.
+ */
+let psCache: { output: string; timestamp: number; promise?: Promise<string> } | null = null;
+const PS_CACHE_TTL_MS = 5_000;
+
+/** Reset the ps cache. Exported for testing only. */
+export function _resetPsCache(): void {
+  psCache = null;
+}
+
+async function getCachedProcessList(): Promise<string> {
+  const now = Date.now();
+  if (psCache && now - psCache.timestamp < PS_CACHE_TTL_MS) {
+    if (psCache.promise) return psCache.promise;
+    return psCache.output;
+  }
+
+  const promise = execFileAsync("ps", ["-eo", "pid,tty,args"], {
+    timeout: 5_000,
+  }).then(({ stdout }) => {
+    if (psCache?.promise === promise) {
+      psCache = { output: stdout, timestamp: Date.now() };
+    }
+    return stdout;
+  });
+
+  psCache = { output: "", timestamp: now, promise };
+
+  try {
+    return await promise;
+  } catch {
+    if (psCache?.promise === promise) {
+      psCache = null;
+    }
+    return "";
+  }
+}
+
+// =============================================================================
+// Model Pricing
+// =============================================================================
+
+/** Per-model pricing (USD per million tokens). Falls back to GPT-4o pricing. */
+const MODEL_PRICING: Record<string, { input: number; output: number }> = {
+  "gpt-4o": { input: 2.5, output: 10.0 },
+  "gpt-4o-mini": { input: 0.15, output: 0.6 },
+  "o3": { input: 10.0, output: 40.0 },
+  "o3-mini": { input: 1.1, output: 4.4 },
+  "o4-mini": { input: 1.1, output: 4.4 },
+};
+const DEFAULT_PRICING = { input: 2.5, output: 10.0 };
+
+function getModelPricing(model: string | null): { input: number; output: number } {
+  if (!model) return DEFAULT_PRICING;
+  if (MODEL_PRICING[model]) return MODEL_PRICING[model];
+  // Prefix match: try longest keys first so "o3-mini-2025" matches "o3-mini" not "o3"
+  const keys = Object.keys(MODEL_PRICING).sort((a, b) => b.length - a.length);
+  for (const key of keys) {
+    if (model.startsWith(key)) return MODEL_PRICING[key];
+  }
+  return DEFAULT_PRICING;
+}
+
 function createCodexAgent(): Agent {
   /** Cached resolved binary path (populated by init or first getLaunchCommand) */
   let resolvedBinary: string | null = null;
@@ -691,28 +805,39 @@ function createCodexAgent(): Agent {
       const running = await this.isProcessRunning(session.runtimeHandle);
       if (!running) return { state: "exited", timestamp: exitedAt };
 
-      // Use session file mtime as a proxy for activity. Codex continuously
-      // appends to its rollout JSONL file while working, so a recently
-      // modified file means the agent is active.
       if (!session.workspacePath) return null;
 
       const sessionFile = await findCodexSessionFileCached(session.workspacePath);
       if (!sessionFile) return null;
 
-      try {
-        const s = await stat(sessionFile);
-        const timestamp = s.mtime;
-        const ageMs = Date.now() - s.mtimeMs;
+      // Read the last JSONL entry to classify activity by entry type,
+      // matching Claude Code's 5-state activity detection.
+      const entry = await readLastJsonlEntry(sessionFile);
+      if (!entry) return null;
 
-        if (ageMs <= threshold) {
-          // File was recently modified — agent is actively working
-          return { state: "active", timestamp };
-        }
+      const ageMs = Date.now() - entry.modifiedAt.getTime();
+      const timestamp = entry.modifiedAt;
 
-        // File is stale — agent finished or is idle
-        return { state: "idle", timestamp };
-      } catch {
-        return null;
+      switch (entry.lastType) {
+        case "user":
+        case "tool_use":
+        case "progress":
+          return { state: ageMs > threshold ? "idle" : "active", timestamp };
+
+        case "assistant":
+        case "system":
+        case "summary":
+        case "result":
+          return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+
+        case "permission_request":
+          return { state: "waiting_input", timestamp };
+
+        case "error":
+          return { state: "blocked", timestamp };
+
+        default:
+          return { state: ageMs > threshold ? "idle" : "active", timestamp };
       }
     },
 
@@ -722,7 +847,7 @@ function createCodexAgent(): Agent {
           const { stdout: ttyOut } = await execFileAsync(
             "tmux",
             ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
-            { timeout: 30_000 },
+            { timeout: 5_000 },
           );
           const ttys = ttyOut
             .trim()
@@ -731,9 +856,9 @@ function createCodexAgent(): Agent {
             .filter(Boolean);
           if (ttys.length === 0) return false;
 
-          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
-            timeout: 30_000,
-          });
+          const psOut = await getCachedProcessList();
+          if (!psOut) return false;
+
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
           const processRe = /(?:^|\/)codex(?:\s|$)/;
           for (const line of psOut.split("\n")) {
@@ -780,19 +905,45 @@ function createCodexAgent(): Agent {
 
       const agentSessionId = basename(sessionFile, ".jsonl");
 
-      const cost: CostEstimate | undefined =
-        data.inputTokens === 0 && data.outputTokens === 0
-          ? undefined
-          : {
-              inputTokens: data.inputTokens,
-              outputTokens: data.outputTokens,
-              estimatedCostUsd:
-                (data.inputTokens / 1_000_000) * 2.5 + (data.outputTokens / 1_000_000) * 10.0,
-            };
+      // Summary: prefer explicit summary events, fall back to first user message
+      let summary: string | null = null;
+      let summaryIsFallback = true;
+      if (data.summary) {
+        summary = data.summary;
+        summaryIsFallback = false;
+      } else if (data.firstUserMessage) {
+        const msg = data.firstUserMessage;
+        summary = msg.length > 120 ? msg.substring(0, 120) + "..." : msg;
+        summaryIsFallback = true;
+      } else if (data.model) {
+        summary = `Codex session (${data.model})`;
+        summaryIsFallback = true;
+      }
+
+      // Cost: prefer direct costUSD, then token-based with model-aware pricing
+      const totalInputTokens = data.inputTokens + data.cacheReadInputTokens + data.cacheCreationInputTokens;
+      const hasTokens = totalInputTokens > 0 || data.outputTokens > 0;
+      const hasCost = data.totalCostUsd > 0;
+      let cost: CostEstimate | undefined;
+
+      if (hasCost || hasTokens) {
+        let estimatedCostUsd = data.totalCostUsd;
+        if (estimatedCostUsd === 0 && hasTokens) {
+          const pricing = getModelPricing(data.model);
+          estimatedCostUsd =
+            (totalInputTokens / 1_000_000) * pricing.input +
+            (data.outputTokens / 1_000_000) * pricing.output;
+        }
+        cost = {
+          inputTokens: totalInputTokens,
+          outputTokens: data.outputTokens,
+          estimatedCostUsd,
+        };
+      }
 
       return {
-        summary: data.model ? `Codex session (${data.model})` : null,
-        summaryIsFallback: true,
+        summary,
+        summaryIsFallback,
         agentSessionId,
         cost,
       };


### PR DESCRIPTION
## Summary

Closes #454

- **Activity state machine**: Replace file mtime-based binary detection with JSONL entry type classification, matching Claude Code's 5-state model (active/ready/waiting_input/blocked/idle)
- **Summary extraction**: Parse `summary` events from JSONL, fall back to first user message truncated to 120 chars, then to model name
- **Cost estimation**: Prefer `costUSD` field when available, track `cache_read_input_tokens` and `cache_creation_input_tokens`, use per-model pricing table (gpt-4o, o3, o3-mini, o4-mini) instead of hardcoded GPT-4 rates
- **PS process cache**: Add 5-second TTL cache with in-flight promise sharing for `ps` output, avoiding N separate `ps` calls when listing N sessions

## Test plan

- [x] Added tests for all 5 activity states (active, ready, waiting_input, blocked, idle)
- [x] Added tests for summary extraction: summary event, user message fallback, truncation, model fallback
- [x] Added tests for cost estimation: costUSD field, cache tokens, per-model pricing (gpt-4o, o3, o4-mini), prefix matching for versioned models
- [x] Added tests for PS cache TTL behavior and reuse
- [x] All 218 tests pass (`pnpm --filter @composio/ao-plugin-agent-codex test`)
- [x] Type checks pass (`pnpm typecheck`)
- [x] Lint passes with 0 errors (`pnpm lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)