### PR TITLE
feat: add Base governance contracts and Foundry tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ CLAUDE.md
 AGENTS.md
 .claude/
 .opencode/
+
+# Foundry artifacts
+contracts/out/
+contracts/cache/

--- a/contracts/AttestationLog.sol
+++ b/contracts/AttestationLog.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title AttestationLog
+/// @notice Append-only evidence hash log for CI, review, and convergence attestations.
+contract AttestationLog is Ownable {
+    enum AttestationKind {
+        CI,
+        ReviewVerdict,
+        ConvergencePattern,
+        Custom
+    }
+
+    struct Attestation {
+        bytes32 forkId;
+        uint256 proposalId;
+        bytes32 evidenceHash;
+        AttestationKind kind;
+        address attester;
+        uint64 timestamp;
+    }
+
+    error InvalidForkId();
+    error InvalidEvidenceHash();
+    error UnauthorizedAttester(address caller);
+
+    event AttesterUpdated(address indexed attester, bool isAllowed);
+    event AttestationAppended(
+        uint256 indexed attestationId,
+        uint256 indexed proposalId,
+        bytes32 indexed forkId,
+        AttestationKind kind,
+        bytes32 evidenceHash,
+        address attester
+    );
+
+    mapping(address => bool) public attesters;
+    Attestation[] private _attestations;
+    mapping(bytes32 => uint256[]) private _attestationIdsByFork;
+    mapping(uint256 => uint256[]) private _attestationIdsByProposal;
+
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    function setAttester(address attester, bool isAllowed) external onlyOwner {
+        attesters[attester] = isAllowed;
+        emit AttesterUpdated(attester, isAllowed);
+    }
+
+    function appendAttestation(bytes32 forkId, uint256 proposalId, AttestationKind kind, bytes32 evidenceHash)
+        external
+        returns (uint256 attestationId)
+    {
+        if (forkId == bytes32(0)) revert InvalidForkId();
+        if (evidenceHash == bytes32(0)) revert InvalidEvidenceHash();
+        if (msg.sender != owner() && !attesters[msg.sender]) {
+            revert UnauthorizedAttester(msg.sender);
+        }
+
+        attestationId = _attestations.length;
+        _attestations.push(
+            Attestation({
+                forkId: forkId,
+                proposalId: proposalId,
+                evidenceHash: evidenceHash,
+                kind: kind,
+                attester: msg.sender,
+                timestamp: uint64(block.timestamp)
+            })
+        );
+        _attestationIdsByFork[forkId].push(attestationId);
+        _attestationIdsByProposal[proposalId].push(attestationId);
+
+        emit AttestationAppended(attestationId, proposalId, forkId, kind, evidenceHash, msg.sender);
+    }
+
+    function getAttestation(uint256 attestationId) external view returns (Attestation memory) {
+        return _attestations[attestationId];
+    }
+
+    function totalAttestations() external view returns (uint256) {
+        return _attestations.length;
+    }
+
+    function attestationIdsByFork(bytes32 forkId) external view returns (uint256[] memory) {
+        return _attestationIdsByFork[forkId];
+    }
+
+    function attestationIdsByProposal(uint256 proposalId) external view returns (uint256[] memory) {
+        return _attestationIdsByProposal[proposalId];
+    }
+}

--- a/contracts/ExecutionPolicy.sol
+++ b/contracts/ExecutionPolicy.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+interface IGovernanceRegistry {
+    enum ProposalStatus {
+        Draft,
+        Active,
+        Approved,
+        Rejected,
+        Executed,
+        Cancelled
+    }
+
+    function proposalStatus(uint256 proposalId) external view returns (ProposalStatus);
+    function proposalForkId(uint256 proposalId) external view returns (bytes32);
+}
+
+interface IVotingPolicy {
+    enum ThresholdType {
+        Majority,
+        Supermajority,
+        Unanimous
+    }
+
+    function isApproved(bytes32 forkId, uint256 proposalId) external view returns (bool);
+    function isApprovedWithThreshold(bytes32 forkId, uint256 proposalId, ThresholdType threshold)
+        external
+        view
+        returns (bool);
+}
+
+/// @title ExecutionPolicy
+/// @notice Binds approved proposals to explicit mutation scopes and enforces consumption boundaries.
+contract ExecutionPolicy is Ownable {
+    bytes32 public constant CONSENT_GATE_SCOPE = keccak256("CONSENT_GATE_CHANGE");
+
+    struct ProposalExecutionState {
+        bytes32 forkId;
+        bool scopesDefined;
+        bool approved;
+    }
+
+    error InvalidForkId();
+    error InvalidProposal(uint256 proposalId);
+    error InvalidScope(bytes32 scope);
+    error DuplicateScope(bytes32 scope);
+    error ScopesAlreadyDefined(uint256 proposalId);
+    error ProposalAlreadyExecutionApproved(uint256 proposalId);
+    error ProposalNotApprovedInRegistry(uint256 proposalId);
+    error ProposalNotApprovedByVoting(uint256 proposalId);
+    error ForkMismatch(uint256 proposalId, bytes32 expectedForkId, bytes32 actualForkId);
+    error MissingSupermajorityForConsentGate(uint256 proposalId);
+    error ProposalNotExecutionApproved(uint256 proposalId);
+    error ScopeNotAllowed(uint256 proposalId, bytes32 scope);
+    error ScopeAlreadyConsumed(uint256 proposalId, bytes32 scope);
+    error UnauthorizedExecutor(address caller);
+
+    event MutationExecutorUpdated(address indexed executor);
+    event ProposalScopesDefined(uint256 indexed proposalId, bytes32 indexed forkId, bytes32[] scopes);
+    event ProposalExecutionApproved(uint256 indexed proposalId, bytes32 indexed forkId);
+    event ScopeConsumed(uint256 indexed proposalId, bytes32 indexed scope, address indexed executor);
+
+    IGovernanceRegistry public immutable governanceRegistry;
+    IVotingPolicy public immutable votingPolicy;
+    address public mutationExecutor;
+
+    mapping(uint256 => ProposalExecutionState) private _proposalState;
+    mapping(uint256 => mapping(bytes32 => bool)) private _allowedScope;
+    mapping(uint256 => mapping(bytes32 => bool)) private _consumedScope;
+    mapping(uint256 => bytes32[]) private _proposalScopes;
+
+    constructor(address initialOwner, address governanceRegistry_, address votingPolicy_, address mutationExecutor_)
+        Ownable(initialOwner)
+    {
+        governanceRegistry = IGovernanceRegistry(governanceRegistry_);
+        votingPolicy = IVotingPolicy(votingPolicy_);
+        mutationExecutor = mutationExecutor_;
+    }
+
+    function setMutationExecutor(address executor) external onlyOwner {
+        mutationExecutor = executor;
+        emit MutationExecutorUpdated(executor);
+    }
+
+    function defineProposalScopes(uint256 proposalId, bytes32 forkId, bytes32[] calldata scopes) external onlyOwner {
+        if (proposalId == 0) revert InvalidProposal(proposalId);
+        if (forkId == bytes32(0)) revert InvalidForkId();
+        if (scopes.length == 0) revert InvalidScope(bytes32(0));
+
+        ProposalExecutionState storage state = _proposalState[proposalId];
+        if (state.scopesDefined) revert ScopesAlreadyDefined(proposalId);
+
+        state.forkId = forkId;
+        state.scopesDefined = true;
+
+        uint256 len = scopes.length;
+        for (uint256 i = 0; i < len; ++i) {
+            bytes32 scope = scopes[i];
+            if (scope == bytes32(0)) revert InvalidScope(scope);
+            if (_allowedScope[proposalId][scope]) revert DuplicateScope(scope);
+            _allowedScope[proposalId][scope] = true;
+            _proposalScopes[proposalId].push(scope);
+        }
+
+        emit ProposalScopesDefined(proposalId, forkId, scopes);
+    }
+
+    function approveProposalForExecution(uint256 proposalId) external {
+        ProposalExecutionState storage state = _proposalState[proposalId];
+        if (!state.scopesDefined) revert InvalidProposal(proposalId);
+        if (state.approved) revert ProposalAlreadyExecutionApproved(proposalId);
+
+        bytes32 registryForkId = governanceRegistry.proposalForkId(proposalId);
+        if (registryForkId != state.forkId) {
+            revert ForkMismatch(proposalId, state.forkId, registryForkId);
+        }
+
+        IGovernanceRegistry.ProposalStatus status = governanceRegistry.proposalStatus(proposalId);
+        if (status != IGovernanceRegistry.ProposalStatus.Approved) {
+            revert ProposalNotApprovedInRegistry(proposalId);
+        }
+        if (!votingPolicy.isApproved(state.forkId, proposalId)) {
+            revert ProposalNotApprovedByVoting(proposalId);
+        }
+
+        if (_allowedScope[proposalId][CONSENT_GATE_SCOPE]) {
+            bool hasSupermajority = votingPolicy.isApprovedWithThreshold(
+                state.forkId, proposalId, IVotingPolicy.ThresholdType.Supermajority
+            );
+            if (!hasSupermajority) {
+                revert MissingSupermajorityForConsentGate(proposalId);
+            }
+        }
+
+        state.approved = true;
+        emit ProposalExecutionApproved(proposalId, state.forkId);
+    }
+
+    function consumeScope(uint256 proposalId, bytes32 scope) external {
+        if (msg.sender != mutationExecutor && msg.sender != owner()) {
+            revert UnauthorizedExecutor(msg.sender);
+        }
+
+        ProposalExecutionState memory state = _proposalState[proposalId];
+        if (!state.approved) revert ProposalNotExecutionApproved(proposalId);
+        if (!_allowedScope[proposalId][scope]) revert ScopeNotAllowed(proposalId, scope);
+        if (_consumedScope[proposalId][scope]) revert ScopeAlreadyConsumed(proposalId, scope);
+
+        _consumedScope[proposalId][scope] = true;
+        emit ScopeConsumed(proposalId, scope, msg.sender);
+    }
+
+    function getProposalState(uint256 proposalId) external view returns (ProposalExecutionState memory) {
+        return _proposalState[proposalId];
+    }
+
+    function proposalScopes(uint256 proposalId) external view returns (bytes32[] memory) {
+        return _proposalScopes[proposalId];
+    }
+
+    function isScopeAllowed(uint256 proposalId, bytes32 scope) external view returns (bool) {
+        return _allowedScope[proposalId][scope];
+    }
+
+    function isScopeConsumed(uint256 proposalId, bytes32 scope) external view returns (bool) {
+        return _consumedScope[proposalId][scope];
+    }
+}

--- a/contracts/GovernanceRegistry.sol
+++ b/contracts/GovernanceRegistry.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title GovernanceRegistry
+/// @notice Stores governance proposal metadata with fork-scoped defaults.
+contract GovernanceRegistry is Ownable {
+    uint256 public constant TARGET_CHAIN_ID = 8453;
+
+    enum ProposalStatus {
+        Draft,
+        Active,
+        Approved,
+        Rejected,
+        Executed,
+        Cancelled
+    }
+
+    struct Proposal {
+        bytes32 contentHash;
+        bytes32 forkId;
+        address proposer;
+        uint64 createdAt;
+        ProposalStatus status;
+    }
+
+    error InvalidForkId();
+    error InvalidContentHash();
+    error ProposalNotFound(uint256 proposalId);
+    error UnauthorizedStatusUpdate(address caller, uint256 proposalId);
+    error InvalidStatusTransition(ProposalStatus from, ProposalStatus to);
+
+    event ProposalCreated(
+        uint256 indexed proposalId, bytes32 indexed forkId, address indexed proposer, bytes32 contentHash
+    );
+    event ProposalStatusUpdated(
+        uint256 indexed proposalId, ProposalStatus previousStatus, ProposalStatus newStatus, address indexed updatedBy
+    );
+    event StatusManagerUpdated(address indexed manager, bool isAllowed);
+
+    bytes32 public immutable defaultForkId;
+
+    uint256 private _nextProposalId = 1;
+    mapping(uint256 => Proposal) private _proposals;
+    mapping(bytes32 => uint256[]) private _proposalIdsByFork;
+    mapping(address => bool) public statusManagers;
+
+    constructor(address initialOwner, bytes32 defaultForkId_) Ownable(initialOwner) {
+        if (defaultForkId_ == bytes32(0)) revert InvalidForkId();
+        defaultForkId = defaultForkId_;
+    }
+
+    function createProposal(bytes32 contentHash) external returns (uint256 proposalId) {
+        return createProposalForFork(defaultForkId, contentHash);
+    }
+
+    function createProposalForFork(bytes32 forkId, bytes32 contentHash) public returns (uint256 proposalId) {
+        if (forkId == bytes32(0)) revert InvalidForkId();
+        if (contentHash == bytes32(0)) revert InvalidContentHash();
+
+        proposalId = _nextProposalId++;
+        _proposals[proposalId] = Proposal({
+            contentHash: contentHash,
+            forkId: forkId,
+            proposer: msg.sender,
+            createdAt: uint64(block.timestamp),
+            status: ProposalStatus.Draft
+        });
+        _proposalIdsByFork[forkId].push(proposalId);
+
+        emit ProposalCreated(proposalId, forkId, msg.sender, contentHash);
+    }
+
+    function setStatusManager(address manager, bool isAllowed) external onlyOwner {
+        statusManagers[manager] = isAllowed;
+        emit StatusManagerUpdated(manager, isAllowed);
+    }
+
+    function updateProposalStatus(uint256 proposalId, ProposalStatus newStatus) external {
+        Proposal storage proposal = _proposalForUpdate(proposalId);
+        ProposalStatus currentStatus = proposal.status;
+
+        bool canManage = msg.sender == owner() || statusManagers[msg.sender];
+        bool canSelfCancel = (msg.sender == proposal.proposer) && (newStatus == ProposalStatus.Cancelled)
+            && (currentStatus == ProposalStatus.Draft || currentStatus == ProposalStatus.Active);
+        if (!canManage && !canSelfCancel) revert UnauthorizedStatusUpdate(msg.sender, proposalId);
+        if (!_canTransition(currentStatus, newStatus)) {
+            revert InvalidStatusTransition(currentStatus, newStatus);
+        }
+
+        proposal.status = newStatus;
+        emit ProposalStatusUpdated(proposalId, currentStatus, newStatus, msg.sender);
+    }
+
+    function getProposal(uint256 proposalId) external view returns (Proposal memory proposal) {
+        proposal = _proposals[proposalId];
+        if (proposal.proposer == address(0)) revert ProposalNotFound(proposalId);
+    }
+
+    function proposalStatus(uint256 proposalId) external view returns (ProposalStatus) {
+        Proposal memory proposal = _proposals[proposalId];
+        if (proposal.proposer == address(0)) revert ProposalNotFound(proposalId);
+        return proposal.status;
+    }
+
+    function proposalForkId(uint256 proposalId) external view returns (bytes32) {
+        Proposal memory proposal = _proposals[proposalId];
+        if (proposal.proposer == address(0)) revert ProposalNotFound(proposalId);
+        return proposal.forkId;
+    }
+
+    function proposalCountByFork(bytes32 forkId) external view returns (uint256) {
+        return _proposalIdsByFork[forkId].length;
+    }
+
+    function proposalIdsByFork(bytes32 forkId) external view returns (uint256[] memory) {
+        return _proposalIdsByFork[forkId];
+    }
+
+    function nextProposalId() external view returns (uint256) {
+        return _nextProposalId;
+    }
+
+    function _proposalForUpdate(uint256 proposalId) private view returns (Proposal storage proposal) {
+        proposal = _proposals[proposalId];
+        if (proposal.proposer == address(0)) revert ProposalNotFound(proposalId);
+    }
+
+    function _canTransition(ProposalStatus from, ProposalStatus to) private pure returns (bool) {
+        if (from == ProposalStatus.Draft) {
+            return to == ProposalStatus.Active || to == ProposalStatus.Cancelled;
+        }
+        if (from == ProposalStatus.Active) {
+            return to == ProposalStatus.Approved || to == ProposalStatus.Rejected || to == ProposalStatus.Cancelled;
+        }
+        if (from == ProposalStatus.Approved) {
+            return to == ProposalStatus.Executed || to == ProposalStatus.Cancelled;
+        }
+        return false;
+    }
+}

--- a/contracts/VotingPolicy.sol
+++ b/contracts/VotingPolicy.sol
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+/// @title VotingPolicy
+/// @notice Maintainer-based governance voting with per-fork quorum and delegation.
+contract VotingPolicy is Ownable {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    enum ThresholdType {
+        Majority,
+        Supermajority,
+        Unanimous
+    }
+
+    enum VoteChoice {
+        Against,
+        For,
+        Abstain
+    }
+
+    struct ForkConfig {
+        uint16 quorumBps;
+        ThresholdType threshold;
+        bool exists;
+    }
+
+    struct VoteTally {
+        uint32 forVotes;
+        uint32 againstVotes;
+        uint32 abstainVotes;
+    }
+
+    error InvalidForkId();
+    error InvalidQuorum(uint16 quorumBps);
+    error NotMaintainer(address account);
+    error InvalidDelegate(address delegatee);
+    error DelegationCycle();
+    error NoVotingPower(address voter);
+    error InvalidProposal(uint256 proposalId);
+
+    event MaintainerUpdated(address indexed maintainer, bool isActive);
+    event ForkPolicyUpdated(bytes32 indexed forkId, uint16 quorumBps, ThresholdType thresholdType);
+    event DelegationUpdated(address indexed delegator, address indexed delegatee);
+    event VoteCast(
+        bytes32 indexed forkId,
+        uint256 indexed proposalId,
+        address indexed voter,
+        VoteChoice choice,
+        uint256 votingPower
+    );
+
+    bytes32 public immutable defaultForkId;
+
+    EnumerableSet.AddressSet private _maintainers;
+    mapping(address => address) public delegationOf;
+    mapping(bytes32 => ForkConfig) private _forkConfigs;
+    mapping(bytes32 => mapping(uint256 => VoteTally)) private _voteTallies;
+    mapping(bytes32 => mapping(uint256 => mapping(address => bool))) private _hasVotedByMaintainer;
+
+    constructor(address initialOwner, bytes32 defaultForkId_, uint16 defaultQuorumBps, ThresholdType defaultThreshold)
+        Ownable(initialOwner)
+    {
+        if (defaultForkId_ == bytes32(0)) revert InvalidForkId();
+        if (defaultQuorumBps == 0 || defaultQuorumBps > 10_000) revert InvalidQuorum(defaultQuorumBps);
+
+        defaultForkId = defaultForkId_;
+        _forkConfigs[defaultForkId_] =
+            ForkConfig({quorumBps: defaultQuorumBps, threshold: defaultThreshold, exists: true});
+
+        emit ForkPolicyUpdated(defaultForkId_, defaultQuorumBps, defaultThreshold);
+    }
+
+    function setMaintainer(address maintainer, bool isActive) external onlyOwner {
+        if (maintainer == address(0)) revert NotMaintainer(maintainer);
+
+        if (isActive) {
+            if (_maintainers.add(maintainer)) {
+                emit MaintainerUpdated(maintainer, true);
+            }
+            return;
+        }
+
+        if (_maintainers.remove(maintainer)) {
+            delete delegationOf[maintainer];
+            uint256 count = _maintainers.length();
+            for (uint256 i = 0; i < count; ++i) {
+                address member = _maintainers.at(i);
+                if (delegationOf[member] == maintainer) {
+                    delete delegationOf[member];
+                    emit DelegationUpdated(member, address(0));
+                }
+            }
+            emit MaintainerUpdated(maintainer, false);
+        }
+    }
+
+    function setForkPolicy(bytes32 forkId, uint16 quorumBps, ThresholdType threshold) external onlyOwner {
+        if (forkId == bytes32(0)) revert InvalidForkId();
+        if (quorumBps == 0 || quorumBps > 10_000) revert InvalidQuorum(quorumBps);
+
+        _forkConfigs[forkId] = ForkConfig({quorumBps: quorumBps, threshold: threshold, exists: true});
+        emit ForkPolicyUpdated(forkId, quorumBps, threshold);
+    }
+
+    function setDelegation(address delegatee) external {
+        if (!_maintainers.contains(msg.sender)) revert NotMaintainer(msg.sender);
+
+        if (delegatee == address(0)) {
+            delete delegationOf[msg.sender];
+            emit DelegationUpdated(msg.sender, address(0));
+            return;
+        }
+        if (delegatee == msg.sender || !_maintainers.contains(delegatee)) {
+            revert InvalidDelegate(delegatee);
+        }
+        if (_wouldCreateCycle(msg.sender, delegatee)) revert DelegationCycle();
+
+        delegationOf[msg.sender] = delegatee;
+        emit DelegationUpdated(msg.sender, delegatee);
+    }
+
+    function castVote(uint256 proposalId, VoteChoice choice) external returns (uint256 votingPower) {
+        return castVoteForFork(defaultForkId, proposalId, choice);
+    }
+
+    function castVoteForFork(bytes32 forkId, uint256 proposalId, VoteChoice choice)
+        public
+        returns (uint256 votingPower)
+    {
+        if (proposalId == 0) revert InvalidProposal(proposalId);
+        if (!_maintainers.contains(msg.sender)) revert NotMaintainer(msg.sender);
+        _forkConfig(forkId);
+
+        uint256 count = _maintainers.length();
+        for (uint256 i = 0; i < count; ++i) {
+            address maintainer = _maintainers.at(i);
+            if (_hasVotedByMaintainer[forkId][proposalId][maintainer]) {
+                continue;
+            }
+            if (_effectiveDelegate(maintainer) == msg.sender) {
+                _hasVotedByMaintainer[forkId][proposalId][maintainer] = true;
+                unchecked {
+                    ++votingPower;
+                }
+            }
+        }
+
+        if (votingPower == 0) revert NoVotingPower(msg.sender);
+
+        VoteTally storage tally = _voteTallies[forkId][proposalId];
+        if (choice == VoteChoice.For) {
+            tally.forVotes += uint32(votingPower);
+        } else if (choice == VoteChoice.Against) {
+            tally.againstVotes += uint32(votingPower);
+        } else {
+            tally.abstainVotes += uint32(votingPower);
+        }
+
+        emit VoteCast(forkId, proposalId, msg.sender, choice, votingPower);
+    }
+
+    function isMaintainer(address account) external view returns (bool) {
+        return _maintainers.contains(account);
+    }
+
+    function maintainerCount() external view returns (uint256) {
+        return _maintainers.length();
+    }
+
+    function maintainers() external view returns (address[] memory) {
+        return _maintainers.values();
+    }
+
+    function getForkPolicy(bytes32 forkId) external view returns (ForkConfig memory) {
+        return _forkConfig(forkId);
+    }
+
+    function getVoteTally(bytes32 forkId, uint256 proposalId) external view returns (VoteTally memory) {
+        return _voteTallies[forkId][proposalId];
+    }
+
+    function hasMaintainerVoted(bytes32 forkId, uint256 proposalId, address maintainer) external view returns (bool) {
+        return _hasVotedByMaintainer[forkId][proposalId][maintainer];
+    }
+
+    function effectiveDelegateOf(address maintainer) external view returns (address) {
+        if (!_maintainers.contains(maintainer)) revert NotMaintainer(maintainer);
+        return _effectiveDelegate(maintainer);
+    }
+
+    function proposalResult(bytes32 forkId, uint256 proposalId)
+        public
+        view
+        returns (bool quorumMet, bool thresholdMet, bool approved)
+    {
+        ForkConfig memory cfg = _forkConfig(forkId);
+        VoteTally memory tally = _voteTallies[forkId][proposalId];
+        uint256 total = _maintainers.length();
+        uint256 participation = uint256(tally.forVotes) + uint256(tally.againstVotes) + uint256(tally.abstainVotes);
+
+        quorumMet = participation >= _requiredQuorumVotes(total, cfg.quorumBps);
+        thresholdMet = _meetsThreshold(cfg.threshold, tally, total);
+        approved = quorumMet && thresholdMet;
+    }
+
+    function isApproved(bytes32 forkId, uint256 proposalId) external view returns (bool) {
+        (,, bool approved) = proposalResult(forkId, proposalId);
+        return approved;
+    }
+
+    function isApprovedWithThreshold(bytes32 forkId, uint256 proposalId, ThresholdType threshold)
+        external
+        view
+        returns (bool)
+    {
+        ForkConfig memory cfg = _forkConfig(forkId);
+        VoteTally memory tally = _voteTallies[forkId][proposalId];
+        uint256 total = _maintainers.length();
+        uint256 participation = uint256(tally.forVotes) + uint256(tally.againstVotes) + uint256(tally.abstainVotes);
+        bool quorumMet = participation >= _requiredQuorumVotes(total, cfg.quorumBps);
+        return quorumMet && _meetsThreshold(threshold, tally, total);
+    }
+
+    function _forkConfig(bytes32 forkId) private view returns (ForkConfig memory cfg) {
+        cfg = _forkConfigs[forkId];
+        if (!cfg.exists) {
+            cfg = _forkConfigs[defaultForkId];
+        }
+    }
+
+    function _requiredQuorumVotes(uint256 maintainerTotal, uint16 quorumBps) private pure returns (uint256) {
+        if (maintainerTotal == 0) {
+            return 0;
+        }
+        return (maintainerTotal * quorumBps + 9_999) / 10_000;
+    }
+
+    function _meetsThreshold(ThresholdType threshold, VoteTally memory tally, uint256 maintainerTotal)
+        private
+        pure
+        returns (bool)
+    {
+        if (threshold == ThresholdType.Unanimous) {
+            return maintainerTotal > 0 && tally.forVotes == maintainerTotal;
+        }
+
+        uint256 decisiveVotes = uint256(tally.forVotes) + uint256(tally.againstVotes);
+        if (decisiveVotes == 0) {
+            return false;
+        }
+
+        if (threshold == ThresholdType.Majority) {
+            return tally.forVotes > tally.againstVotes;
+        }
+
+        return uint256(tally.forVotes) * 3 >= decisiveVotes * 2;
+    }
+
+    function _effectiveDelegate(address maintainer) private view returns (address) {
+        address cursor = maintainer;
+        address next = delegationOf[cursor];
+
+        while (next != address(0)) {
+            cursor = next;
+            next = delegationOf[cursor];
+        }
+        return cursor;
+    }
+
+    function _wouldCreateCycle(address delegator, address delegatee) private view returns (bool) {
+        address cursor = delegatee;
+        while (cursor != address(0)) {
+            if (cursor == delegator) {
+                return true;
+            }
+            cursor = delegationOf[cursor];
+        }
+        return false;
+    }
+}

--- a/contracts/test/AttestationLog.t.sol
+++ b/contracts/test/AttestationLog.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {AttestationLog} from "../AttestationLog.sol";
+import {TestBase} from "./utils/TestBase.sol";
+
+contract AttestationLogTest is TestBase {
+    bytes32 private constant FORK_ID = keccak256("fork/default");
+    uint256 private constant PROPOSAL_ID = 42;
+    bytes32 private constant EVIDENCE_HASH = keccak256("ci-passing-sha");
+
+    address private owner = address(0xA11CE);
+    address private attester = address(0xBEEF);
+    address private outsider = address(0xDEAD);
+
+    AttestationLog private log;
+
+    function setUp() public {
+        log = new AttestationLog(owner);
+    }
+
+    function testOwnerCanAppendAttestation() public {
+        vm.prank(owner);
+        uint256 attestationId =
+            log.appendAttestation(FORK_ID, PROPOSAL_ID, AttestationLog.AttestationKind.CI, EVIDENCE_HASH);
+
+        assertEq(attestationId, 0, "first attestation id should be zero");
+        AttestationLog.Attestation memory attestation = log.getAttestation(attestationId);
+        assertEq(attestation.forkId, FORK_ID, "fork id should match");
+        assertEq(attestation.proposalId, PROPOSAL_ID, "proposal id should match");
+        assertEq(attestation.evidenceHash, EVIDENCE_HASH, "evidence hash should match");
+        assertEq(attestation.attester, owner, "owner should be recorded as attester");
+    }
+
+    function testAuthorizedAttesterCanAppend() public {
+        vm.prank(owner);
+        log.setAttester(attester, true);
+
+        vm.prank(attester);
+        log.appendAttestation(FORK_ID, PROPOSAL_ID, AttestationLog.AttestationKind.ReviewVerdict, EVIDENCE_HASH);
+
+        assertEq(log.totalAttestations(), 1, "attestation should be appended");
+    }
+
+    function testUnauthorizedAttesterReverts() public {
+        vm.prank(outsider);
+        vm.expectRevert(abi.encodeWithSelector(AttestationLog.UnauthorizedAttester.selector, outsider));
+        log.appendAttestation(FORK_ID, PROPOSAL_ID, AttestationLog.AttestationKind.CI, EVIDENCE_HASH);
+    }
+
+    function testAppendRejectsInvalidForkOrEvidenceHash() public {
+        vm.prank(owner);
+        vm.expectRevert(AttestationLog.InvalidForkId.selector);
+        log.appendAttestation(bytes32(0), PROPOSAL_ID, AttestationLog.AttestationKind.CI, EVIDENCE_HASH);
+
+        vm.prank(owner);
+        vm.expectRevert(AttestationLog.InvalidEvidenceHash.selector);
+        log.appendAttestation(FORK_ID, PROPOSAL_ID, AttestationLog.AttestationKind.CI, bytes32(0));
+    }
+
+    function testAttestationIndexesByForkAndProposal() public {
+        vm.prank(owner);
+        log.appendAttestation(FORK_ID, PROPOSAL_ID, AttestationLog.AttestationKind.CI, keccak256("ci"));
+        vm.prank(owner);
+        log.appendAttestation(FORK_ID, PROPOSAL_ID, AttestationLog.AttestationKind.ConvergencePattern, keccak256("cv"));
+
+        uint256[] memory byFork = log.attestationIdsByFork(FORK_ID);
+        uint256[] memory byProposal = log.attestationIdsByProposal(PROPOSAL_ID);
+        assertEq(byFork.length, 2, "fork index should include both attestations");
+        assertEq(byProposal.length, 2, "proposal index should include both attestations");
+    }
+}

--- a/contracts/test/ExecutionPolicy.t.sol
+++ b/contracts/test/ExecutionPolicy.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {GovernanceRegistry} from "../GovernanceRegistry.sol";
+import {VotingPolicy} from "../VotingPolicy.sol";
+import {ExecutionPolicy} from "../ExecutionPolicy.sol";
+import {TestBase} from "./utils/TestBase.sol";
+
+contract ExecutionPolicyTest is TestBase {
+    bytes32 private constant DEFAULT_FORK = keccak256("fork/default");
+    bytes32 private constant CONTENT_HASH = keccak256("execution-proposal");
+    bytes32 private constant SCOPE_METADATA = keccak256("MUTATE_METADATA");
+
+    address private owner = address(0xA11CE);
+    address private proposer = address(0xBEEF);
+    address private executor = address(0xC0DE);
+    address private outsider = address(0xDEAD);
+
+    address private m1 = address(0x1001);
+    address private m2 = address(0x1002);
+    address private m3 = address(0x1003);
+    address private m4 = address(0x1004);
+    address private m5 = address(0x1005);
+
+    GovernanceRegistry private registry;
+    VotingPolicy private voting;
+    ExecutionPolicy private executionPolicy;
+
+    function setUp() public {
+        registry = new GovernanceRegistry(owner, DEFAULT_FORK);
+        voting = new VotingPolicy(owner, DEFAULT_FORK, 5_000, VotingPolicy.ThresholdType.Majority);
+        executionPolicy = new ExecutionPolicy(owner, address(registry), address(voting), executor);
+
+        vm.prank(owner);
+        voting.setMaintainer(m1, true);
+        vm.prank(owner);
+        voting.setMaintainer(m2, true);
+        vm.prank(owner);
+        voting.setMaintainer(m3, true);
+        vm.prank(owner);
+        voting.setMaintainer(m4, true);
+        vm.prank(owner);
+        voting.setMaintainer(m5, true);
+    }
+
+    function testApprovedProposalCanConsumeAllowedScopeOnce() public {
+        uint256 proposalId = _createProposalAndMarkApprovedInRegistry();
+        _voteAllFor(proposalId);
+
+        bytes32[] memory scopes = new bytes32[](1);
+        scopes[0] = SCOPE_METADATA;
+        vm.prank(owner);
+        executionPolicy.defineProposalScopes(proposalId, DEFAULT_FORK, scopes);
+
+        executionPolicy.approveProposalForExecution(proposalId);
+
+        vm.prank(executor);
+        executionPolicy.consumeScope(proposalId, SCOPE_METADATA);
+        assertTrue(executionPolicy.isScopeConsumed(proposalId, SCOPE_METADATA), "scope should be consumed");
+
+        vm.prank(executor);
+        vm.expectRevert(
+            abi.encodeWithSelector(ExecutionPolicy.ScopeAlreadyConsumed.selector, proposalId, SCOPE_METADATA)
+        );
+        executionPolicy.consumeScope(proposalId, SCOPE_METADATA);
+    }
+
+    function testDefineScopeTwiceRevertsToPreventScopeCreep() public {
+        uint256 proposalId = _createProposalAndMarkApprovedInRegistry();
+        _voteAllFor(proposalId);
+
+        bytes32[] memory scopes = new bytes32[](1);
+        scopes[0] = SCOPE_METADATA;
+
+        vm.prank(owner);
+        executionPolicy.defineProposalScopes(proposalId, DEFAULT_FORK, scopes);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(ExecutionPolicy.ScopesAlreadyDefined.selector, proposalId));
+        executionPolicy.defineProposalScopes(proposalId, DEFAULT_FORK, scopes);
+    }
+
+    function testConsentGateScopeRequiresSupermajority() public {
+        uint256 proposalId = _createProposalAndMarkApprovedInRegistry();
+
+        vm.prank(m1);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m2);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m3);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m4);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.Against);
+        vm.prank(m5);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.Against);
+
+        bytes32[] memory scopes = new bytes32[](1);
+        scopes[0] = executionPolicy.CONSENT_GATE_SCOPE();
+        vm.prank(owner);
+        executionPolicy.defineProposalScopes(proposalId, DEFAULT_FORK, scopes);
+
+        vm.expectRevert(abi.encodeWithSelector(ExecutionPolicy.MissingSupermajorityForConsentGate.selector, proposalId));
+        executionPolicy.approveProposalForExecution(proposalId);
+    }
+
+    function testOnlyOwnerOrExecutorCanConsumeScope() public {
+        uint256 proposalId = _createProposalAndMarkApprovedInRegistry();
+        _voteAllFor(proposalId);
+
+        bytes32[] memory scopes = new bytes32[](1);
+        scopes[0] = SCOPE_METADATA;
+        vm.prank(owner);
+        executionPolicy.defineProposalScopes(proposalId, DEFAULT_FORK, scopes);
+        executionPolicy.approveProposalForExecution(proposalId);
+
+        vm.prank(outsider);
+        vm.expectRevert(abi.encodeWithSelector(ExecutionPolicy.UnauthorizedExecutor.selector, outsider));
+        executionPolicy.consumeScope(proposalId, SCOPE_METADATA);
+    }
+
+    function _createProposalAndMarkApprovedInRegistry() private returns (uint256 proposalId) {
+        vm.prank(proposer);
+        proposalId = registry.createProposal(CONTENT_HASH);
+
+        vm.prank(owner);
+        registry.updateProposalStatus(proposalId, GovernanceRegistry.ProposalStatus.Active);
+        vm.prank(owner);
+        registry.updateProposalStatus(proposalId, GovernanceRegistry.ProposalStatus.Approved);
+    }
+
+    function _voteAllFor(uint256 proposalId) private {
+        vm.prank(m1);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m2);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m3);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m4);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m5);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+    }
+}

--- a/contracts/test/GovernanceRegistry.t.sol
+++ b/contracts/test/GovernanceRegistry.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {GovernanceRegistry} from "../GovernanceRegistry.sol";
+import {TestBase} from "./utils/TestBase.sol";
+
+contract GovernanceRegistryTest is TestBase {
+    bytes32 private constant DEFAULT_FORK = keccak256("fork/default");
+    bytes32 private constant ALT_FORK = keccak256("fork/alt");
+    bytes32 private constant CONTENT_HASH = keccak256("proposal-content");
+
+    address private owner = address(0xA11CE);
+    address private proposer = address(0xBEEF);
+    address private manager = address(0xCAFE);
+    address private outsider = address(0xD00D);
+
+    GovernanceRegistry private registry;
+
+    function setUp() public {
+        registry = new GovernanceRegistry(owner, DEFAULT_FORK);
+    }
+
+    function testCreateProposalUsesDefaultFork() public {
+        vm.prank(proposer);
+        uint256 proposalId = registry.createProposal(CONTENT_HASH);
+
+        GovernanceRegistry.Proposal memory proposal = registry.getProposal(proposalId);
+        assertEq(proposal.forkId, DEFAULT_FORK, "default fork should be assigned");
+        assertEq(proposal.proposer, proposer, "proposer should be stored");
+        assertEq(
+            uint256(proposal.status), uint256(GovernanceRegistry.ProposalStatus.Draft), "status should start at draft"
+        );
+        assertEq(registry.proposalCountByFork(DEFAULT_FORK), 1, "fork proposal count should increment");
+    }
+
+    function testCreateProposalForForkOverridesDefault() public {
+        vm.prank(proposer);
+        uint256 proposalId = registry.createProposalForFork(ALT_FORK, CONTENT_HASH);
+
+        GovernanceRegistry.Proposal memory proposal = registry.getProposal(proposalId);
+        assertEq(proposal.forkId, ALT_FORK, "explicit fork should be stored");
+    }
+
+    function testCreateProposalRevertsForZeroHash() public {
+        vm.prank(proposer);
+        vm.expectRevert(GovernanceRegistry.InvalidContentHash.selector);
+        registry.createProposal(bytes32(0));
+    }
+
+    function testOwnerCanAssignStatusManagerAndManagerCanTransition() public {
+        vm.prank(owner);
+        registry.setStatusManager(manager, true);
+
+        vm.prank(proposer);
+        uint256 proposalId = registry.createProposal(CONTENT_HASH);
+
+        vm.prank(manager);
+        registry.updateProposalStatus(proposalId, GovernanceRegistry.ProposalStatus.Active);
+        vm.prank(manager);
+        registry.updateProposalStatus(proposalId, GovernanceRegistry.ProposalStatus.Approved);
+
+        assertEq(
+            uint256(registry.proposalStatus(proposalId)),
+            uint256(GovernanceRegistry.ProposalStatus.Approved),
+            "manager should advance status"
+        );
+    }
+
+    function testProposerCanCancelDraftOrActiveOnly() public {
+        vm.prank(proposer);
+        uint256 proposalId = registry.createProposal(CONTENT_HASH);
+
+        vm.prank(proposer);
+        registry.updateProposalStatus(proposalId, GovernanceRegistry.ProposalStatus.Cancelled);
+        assertEq(
+            uint256(registry.proposalStatus(proposalId)),
+            uint256(GovernanceRegistry.ProposalStatus.Cancelled),
+            "proposer can cancel draft"
+        );
+
+        vm.prank(proposer);
+        uint256 secondProposalId = registry.createProposal(CONTENT_HASH);
+
+        vm.prank(owner);
+        registry.updateProposalStatus(secondProposalId, GovernanceRegistry.ProposalStatus.Active);
+        vm.prank(proposer);
+        registry.updateProposalStatus(secondProposalId, GovernanceRegistry.ProposalStatus.Cancelled);
+        assertEq(
+            uint256(registry.proposalStatus(secondProposalId)),
+            uint256(GovernanceRegistry.ProposalStatus.Cancelled),
+            "proposer can cancel active"
+        );
+    }
+
+    function testUnauthorizedActorCannotUpdateStatus() public {
+        vm.prank(proposer);
+        uint256 proposalId = registry.createProposal(CONTENT_HASH);
+
+        vm.prank(outsider);
+        vm.expectRevert(
+            abi.encodeWithSelector(GovernanceRegistry.UnauthorizedStatusUpdate.selector, outsider, proposalId)
+        );
+        registry.updateProposalStatus(proposalId, GovernanceRegistry.ProposalStatus.Active);
+    }
+
+    function testInvalidTransitionReverts() public {
+        vm.prank(proposer);
+        uint256 proposalId = registry.createProposal(CONTENT_HASH);
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                GovernanceRegistry.InvalidStatusTransition.selector,
+                GovernanceRegistry.ProposalStatus.Draft,
+                GovernanceRegistry.ProposalStatus.Executed
+            )
+        );
+        registry.updateProposalStatus(proposalId, GovernanceRegistry.ProposalStatus.Executed);
+    }
+}

--- a/contracts/test/VotingPolicy.t.sol
+++ b/contracts/test/VotingPolicy.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {VotingPolicy} from "../VotingPolicy.sol";
+import {TestBase} from "./utils/TestBase.sol";
+
+contract VotingPolicyTest is TestBase {
+    bytes32 private constant DEFAULT_FORK = keccak256("fork/default");
+    bytes32 private constant ALT_FORK = keccak256("fork/alt");
+
+    address private owner = address(0xA11CE);
+    address private m1 = address(0x1001);
+    address private m2 = address(0x1002);
+    address private m3 = address(0x1003);
+    address private m4 = address(0x1004);
+    address private m5 = address(0x1005);
+    address private outsider = address(0x9999);
+
+    VotingPolicy private voting;
+
+    function setUp() public {
+        voting = new VotingPolicy(owner, DEFAULT_FORK, 5_000, VotingPolicy.ThresholdType.Majority);
+
+        vm.prank(owner);
+        voting.setMaintainer(m1, true);
+        vm.prank(owner);
+        voting.setMaintainer(m2, true);
+        vm.prank(owner);
+        voting.setMaintainer(m3, true);
+        vm.prank(owner);
+        voting.setMaintainer(m4, true);
+        vm.prank(owner);
+        voting.setMaintainer(m5, true);
+    }
+
+    function testMajorityApprovalWithDefaultFork() public {
+        uint256 proposalId = 1;
+
+        vm.prank(m1);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m2);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.Against);
+        vm.prank(m3);
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+
+        (bool quorumMet, bool thresholdMet, bool approved) = voting.proposalResult(DEFAULT_FORK, proposalId);
+        assertTrue(quorumMet, "quorum should be met");
+        assertTrue(thresholdMet, "majority threshold should be met");
+        assertTrue(approved, "proposal should be approved");
+    }
+
+    function testDelegationAccumulatesVotingPower() public {
+        uint256 proposalId = 2;
+
+        vm.prank(m1);
+        voting.setDelegation(m2);
+
+        vm.prank(m2);
+        uint256 votingPower = voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+        assertEq(votingPower, 2, "delegate should receive delegated power");
+
+        VotingPolicy.VoteTally memory tally = voting.getVoteTally(DEFAULT_FORK, proposalId);
+        assertEq(tally.forVotes, 2, "tally should include delegated weight");
+
+        vm.prank(m1);
+        vm.expectRevert(abi.encodeWithSelector(VotingPolicy.NoVotingPower.selector, m1));
+        voting.castVote(proposalId, VotingPolicy.VoteChoice.For);
+    }
+
+    function testDelegationCycleReverts() public {
+        vm.prank(m1);
+        voting.setDelegation(m2);
+        vm.prank(m2);
+        voting.setDelegation(m3);
+
+        vm.prank(m3);
+        vm.expectRevert(VotingPolicy.DelegationCycle.selector);
+        voting.setDelegation(m1);
+    }
+
+    function testPerForkSupermajorityPolicy() public {
+        uint256 proposalId = 3;
+        vm.prank(owner);
+        voting.setForkPolicy(ALT_FORK, 6_000, VotingPolicy.ThresholdType.Supermajority);
+
+        vm.prank(m1);
+        voting.castVoteForFork(ALT_FORK, proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m2);
+        voting.castVoteForFork(ALT_FORK, proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m3);
+        voting.castVoteForFork(ALT_FORK, proposalId, VotingPolicy.VoteChoice.Against);
+
+        (bool quorumMet, bool thresholdMet, bool approved) = voting.proposalResult(ALT_FORK, proposalId);
+        assertTrue(quorumMet, "quorum should be met");
+        assertTrue(thresholdMet, "2/3 support should pass supermajority");
+        assertTrue(approved, "proposal should be approved");
+    }
+
+    function testPerForkUnanimousPolicy() public {
+        uint256 proposalId = 4;
+        vm.prank(owner);
+        voting.setForkPolicy(ALT_FORK, 10_000, VotingPolicy.ThresholdType.Unanimous);
+
+        vm.prank(m1);
+        voting.castVoteForFork(ALT_FORK, proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m2);
+        voting.castVoteForFork(ALT_FORK, proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m3);
+        voting.castVoteForFork(ALT_FORK, proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m4);
+        voting.castVoteForFork(ALT_FORK, proposalId, VotingPolicy.VoteChoice.For);
+        vm.prank(m5);
+        voting.castVoteForFork(ALT_FORK, proposalId, VotingPolicy.VoteChoice.For);
+
+        (, bool thresholdMet, bool approved) = voting.proposalResult(ALT_FORK, proposalId);
+        assertTrue(thresholdMet, "all maintainers should satisfy unanimous threshold");
+        assertTrue(approved, "proposal should be approved");
+    }
+
+    function testNonMaintainerCannotVote() public {
+        vm.prank(outsider);
+        vm.expectRevert(abi.encodeWithSelector(VotingPolicy.NotMaintainer.selector, outsider));
+        voting.castVote(5, VotingPolicy.VoteChoice.For);
+    }
+}

--- a/contracts/test/utils/TestBase.sol
+++ b/contracts/test/utils/TestBase.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface Vm {
+    function prank(address msgSender) external;
+    function startPrank(address msgSender) external;
+    function stopPrank() external;
+    function expectRevert(bytes calldata revertData) external;
+    function expectRevert(bytes4 revertData) external;
+    function expectRevert() external;
+}
+
+error AssertionFailed(string message);
+
+abstract contract TestBase {
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function assertTrue(bool condition, string memory message) internal pure {
+        if (!condition) revert AssertionFailed(message);
+    }
+
+    function assertFalse(bool condition, string memory message) internal pure {
+        if (condition) revert AssertionFailed(message);
+    }
+
+    function assertEq(uint256 left, uint256 right, string memory message) internal pure {
+        if (left != right) revert AssertionFailed(message);
+    }
+
+    function assertEq(address left, address right, string memory message) internal pure {
+        if (left != right) revert AssertionFailed(message);
+    }
+
+    function assertEq(bytes32 left, bytes32 right, string memory message) internal pure {
+        if (left != right) revert AssertionFailed(message);
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,11 @@
+[profile.default]
+src = "contracts"
+test = "contracts/test"
+out = "contracts/out"
+cache_path = "contracts/cache"
+libs = ["node_modules"]
+solc_version = "0.8.28"
+optimizer = true
+optimizer_runs = 200
+auto_detect_remappings = false
+remappings = ["@openzeppelin/=node_modules/@openzeppelin/"]

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
     "@eslint/js": "^10.0.1",
+    "@openzeppelin/contracts": "^5.4.0",
     "@types/node": "^25.2.3",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.0(jiti@2.6.1))
+      '@openzeppelin/contracts':
+        specifier: ^5.4.0
+        version: 5.6.1
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
@@ -1585,6 +1588,9 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@openzeppelin/contracts@5.6.1':
+    resolution: {integrity: sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -3634,6 +3640,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -4964,6 +4971,8 @@ snapshots:
       semver: 7.7.4
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@openzeppelin/contracts@5.6.1': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true


### PR DESCRIPTION
## Summary
- add `GovernanceRegistry.sol` with fork-scoped proposal metadata and status lifecycle transitions
- add `VotingPolicy.sol` with maintainer registry, per-fork quorum + threshold policies, and delegation support
- add `ExecutionPolicy.sol` to bind approved proposals to explicit mutation scopes and enforce supermajority on consent-gate scope changes
- add `AttestationLog.sol` as an append-only evidence-hash ledger for CI/review/convergence attestations
- add Foundry configuration and Solidity tests covering governance lifecycle, voting behavior, execution gating, and attestation logging

## Validation
- `~/.foundry/bin/forge test`

Closes #465