### PR TITLE
fix(core): scale tmux paste delay with message length

### DIFF
--- a/packages/core/src/tmux.ts
+++ b/packages/core/src/tmux.ts
@@ -164,7 +164,9 @@ export async function sendKeys(
     // Higher delay needed when using paste-buffer to ensure tmux processes the paste
     // before receiving the Enter keystroke (especially with Claude permission prompts)
     if (text.includes("\n") || text.length > 200) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const baseDelay = 1000;
+      const lengthDelay = Math.floor((text.length / 1000) * 500);
+      await new Promise((resolve) => setTimeout(resolve, baseDelay + lengthDelay));
     }
     await tmux("send-keys", "-t", sessionName, "Enter");
   }


### PR DESCRIPTION
## Summary
Fixes an issue where long messages sent via `ao send` with the tmux paste buffer could fail to process because the 1000ms delay was insufficient for large inputs, causing the Enter keystroke to be swallowed.

## Problem
Closes #373

## Solution
Scaled the delay based on the message length. The logic uses a 1000ms base delay and adds 500ms for every 1000 characters to ensure tmux processes the paste operation completely before the Enter keystroke is simulated.

## Testing
- Tests pass: `pnpm -r test`
- Linting successful