### PR TITLE
fix: strip cd/pushd prefix in PostToolUse hook before command detection

### DIFF
--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -121,6 +121,18 @@ update_metadata_key() {
 }
 
 # ============================================================================
+# Command Normalization
+# ============================================================================
+
+# Strip leading cd/pushd prefixes so anchored regexes still match.
+# Agents frequently run: "cd /some/path && gh pr create ..."
+# Without this, the ^-anchored patterns below fail to detect the command.
+# Handles chained prefixes: "cd /a && cd /b && git checkout -b feat"
+while [[ "$command" =~ ^[[:space:]]*(cd|pushd)[[:space:]]+[^&]*&&[[:space:]]*(.*) ]]; do
+  command="\${BASH_REMATCH[2]}"
+done
+
+# ============================================================================
 # Command Detection and Parsing
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Fixes the PostToolUse metadata-updater hook script failing to detect `gh pr create`, `git checkout -b`, and `gh pr merge` commands when prefixed with `cd`.

## Problem

The hook script uses `^`-anchored regexes to detect commands:
```bash
if [[ "$command" =~ ^gh[[:space:]]+pr[[:space:]]+create ]]; then
```

But agents frequently `cd` into a directory before running the command:
```bash
cd ~/.worktrees/mercury/cleanup-dropbox && gh pr create --title "fix: ..." --base master
```

The `^` anchor fails because the command starts with `cd`, not `gh` or `git`. This causes:
- PR metadata never getting written → dashboard Kanban shows sessions without PR associations
- Branch name changes not being tracked
- Merge status never updating

Fixes #324

## Solution

Add a command normalization step before the pattern matching that strips leading `cd`/`pushd` chains:

```bash
# Strip: "cd /foo && cd /bar && gh pr create" → "gh pr create"
while [[ "$command" =~ ^[[:space:]]*(cd|pushd)[[:space:]]+[^&]*&&[[:space:]]*(.*) ]]; do
  command="${BASH_REMATCH[2]}"
done
```

Handles:
- Single prefix: `cd /path && gh pr create`
- Chained prefixes: `cd /a && cd /b && git checkout -b feat`
- Leading whitespace: `  cd /path && git switch -c branch`
- `pushd` as well as `cd`

## Changes

### `packages/plugins/agent-claude-code/src/index.ts`
- Added command normalization block between `update_metadata_key()` function and command detection section
- No changes to existing regex patterns — the normalization makes them work with prefixed commands

## Testing

- The normalization is a pure string transform that runs before existing pattern matching
- All existing detection logic remains unchanged
- CI will verify build passes
