### PR TITLE
fix: pass defaults.env and project.env from YAML config to agent sess…

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -158,6 +158,7 @@ const ProjectConfigSchema = z.object({
   scm: SCMConfigSchema.optional(),
   symlinks: z.array(z.string()).optional(),
   postCreate: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
   agentConfig: AgentSpecificConfigSchema.default({}),
   orchestrator: RoleAgentConfigSchema,
   worker: RoleAgentConfigSchema,
@@ -179,6 +180,7 @@ const DefaultPluginsSchema = z.object({
   notifiers: z.array(z.string()).default(["composio", "desktop"]),
   orchestrator: RoleAgentDefaultsSchema,
   worker: RoleAgentDefaultsSchema,
+  env: z.record(z.string()).optional(),
 });
 
 const OrchestratorConfigSchema = z.object({

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1065,6 +1065,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         workspacePath,
         launchCommand,
         environment: {
+          ...config.defaults.env,
+          ...project.env,
           ...environment,
           AO_SESSION: sessionId,
           AO_DATA_DIR: sessionsDir, // Pass sessions directory (not root dataDir)
@@ -1360,6 +1362,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       workspacePath: project.path,
       launchCommand,
       environment: {
+        ...config.defaults.env,
+        ...project.env,
         ...environment,
         AO_SESSION: sessionId,
         AO_DATA_DIR: sessionsDir,
@@ -2366,6 +2370,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       workspacePath,
       launchCommand,
       environment: {
+        ...config.defaults.env,
+        ...project.env,
         ...environment,
         AO_SESSION: sessionId,
         AO_DATA_DIR: sessionsDir,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -925,6 +925,9 @@ export interface DefaultPlugins {
   worker?: {
     agent?: string;
   };
+
+  /** Environment variables passed to all sessions */
+  env?: Record<string, string>;
 }
 
 export interface RoleAgentConfig {
@@ -968,6 +971,9 @@ export interface ProjectConfig {
 
   /** Commands to run after workspace creation */
   postCreate?: string[];
+
+  /** Environment variables for this project's sessions */
+  env?: Record<string, string>;
 
   /** Agent-specific configuration */
   agentConfig?: AgentSpecificConfig;


### PR DESCRIPTION
…ions

The env block in agent-orchestrator.yaml (under defaults and per-project) was silently ignored — environment variables like CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY configured in the YAML never reached agent sessions.

Add env field to ProjectConfig and DefaultPlugins interfaces, Zod schemas, and merge config env into the runtime environment in both spawn() and spawnOrchestrator(). Priority order (each layer overrides the previous):
  defaults.env → project.env → agent env → AO internal vars

Closes #457