### PR TITLE
fix: auto-archive sessions on killed/merged transition

### DIFF
--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -33,7 +33,7 @@ import {
   type EventPriority,
   type ProjectConfig as _ProjectConfig,
 } from "./types.js";
-import { updateMetadata } from "./metadata.js";
+import { updateMetadata, deleteMetadata } from "./metadata.js";
 import { getSessionsDir } from "./paths.js";
 import { createCorrelationId, createProjectObserver } from "./observability.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
@@ -781,6 +781,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             data: { oldStatus, newStatus },
           });
           await notifyHuman(event, priority);
+        }
+      }
+
+      // Auto-archive sessions that reach terminal states (killed/merged).
+      // Without this, organically-exited sessions (agent crashed, auth failed)
+      // leave active metadata files and appear as zombies in `ao status`.
+      if (newStatus === "killed" || newStatus === "merged") {
+        const project = config.projects[session.projectId];
+        if (project) {
+          const sessionsDir = getSessionsDir(config.configPath, project.path);
+          deleteMetadata(sessionsDir, session.id, true);
         }
       }
     } else {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -784,22 +784,27 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         }
       }
 
-      // Auto-archive sessions that reach terminal states (killed/merged).
-      // Without this, organically-exited sessions (agent crashed, auth failed)
-      // leave active metadata files and appear as zombies in `ao status`.
-      if (newStatus === "killed" || newStatus === "merged") {
-        const project = config.projects[session.projectId];
-        if (project) {
-          const sessionsDir = getSessionsDir(config.configPath, project.path);
-          deleteMetadata(sessionsDir, session.id, true);
-        }
-      }
     } else {
       // No transition but track current state
       states.set(session.id, newStatus);
     }
 
+    // Dispatch review backlog BEFORE archiving metadata so any metadata
+    // updates land before the file is deleted (prevents recreation).
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction);
+
+    // Auto-archive sessions that reach terminal states (killed/merged).
+    // Without this, organically-exited sessions (agent crashed, auth failed)
+    // leave active metadata files and appear as zombies in `ao status`.
+    // Must run AFTER maybeDispatchReviewBacklog to avoid the backlog
+    // function recreating the just-deleted metadata file.
+    if (newStatus === "killed" || newStatus === "merged") {
+      const project = config.projects[session.projectId];
+      if (project) {
+        const sessionsDir = getSessionsDir(config.configPath, project.path);
+        deleteMetadata(sessionsDir, session.id, true);
+      }
+    }
   }
 
   /** Run one polling cycle across all sessions. */


### PR DESCRIPTION
## Summary

Fixes zombie sessions that persist in `ao status` after agents exit organically.

## Problem

Sessions that crash/exit without `ao kill` (auth failure, agent crash, natural completion) are detected as `killed` by the lifecycle manager, but only `status=killed` is written to the active metadata file. The file never moves to `archive/`, so `ao status` shows them indefinitely.

Fixes #458

## Solution

Call `deleteMetadata(sessionsDir, sessionId, true)` in the lifecycle-manager's `checkSession()` after a transition to a terminal state (`killed` or `merged`). This archives the metadata file, consistent with what `ao kill` does.

## Changes

- `packages/core/src/lifecycle-manager.ts`: Import `deleteMetadata` from `metadata.js`, call it for terminal-state transitions