### PR TITLE
fix: auto-scan for free port on dashboard port conflict

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -275,21 +275,27 @@ async function runStartup(
 
   // Start dashboard (unless --no-dashboard)
   if (opts?.dashboard !== false) {
-    if (opts?.autoPort) {
-      // Port was auto-selected during config generation — if it's now busy
-      // (race condition), find another free port instead of erroring.
-      if (!(await isPortAvailable(port))) {
-        const newPort = await findFreePort(DEFAULT_PORT);
-        if (newPort === null) {
-          throw new Error(
-            `No free port found in range ${DEFAULT_PORT}–${DEFAULT_PORT + MAX_PORT_SCAN - 1}.`,
-          );
-        }
+    // Auto-scan for a free port when configured port is busy.
+    // Multi-project setups commonly conflict on the default port (3000).
+    let skipDashboard = false;
+    if (!(await isPortAvailable(port))) {
+      const newPort = await findFreePort(port + 1);
+      if (newPort === null) {
+        console.warn(
+          chalk.yellow(
+            `⚠ Dashboard unavailable (port ${port}–${port + MAX_PORT_SCAN - 1} all in use). Sessions will still work.`,
+          ),
+        );
+        skipDashboard = true;
+      } else {
+        console.warn(
+          chalk.yellow(`⚠ Port ${port} in use, dashboard starting on port ${newPort} instead`),
+        );
         port = newPort;
       }
-    } else {
-      await preflight.checkPort(port);
     }
+
+    if (!skipDashboard) {
     const webDir = findWebDir();
     if (!existsSync(resolve(webDir, "package.json"))) {
       throw new Error("Could not find @composio/ao-web package. Run: pnpm install");
@@ -310,6 +316,7 @@ async function runStartup(
     );
     spinner.succeed(`Dashboard starting on http://localhost:${port}`);
     console.log(chalk.dim("  (Dashboard will be ready in a few seconds)\n"));
+    }
   }
 
   if (shouldStartLifecycle) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -274,16 +274,16 @@ async function runStartup(
   let reused = false;
 
   // Start dashboard (unless --no-dashboard)
+  let skipDashboard = false;
   if (opts?.dashboard !== false) {
     // Auto-scan for a free port when configured port is busy.
     // Multi-project setups commonly conflict on the default port (3000).
-    let skipDashboard = false;
     if (!(await isPortAvailable(port))) {
       const newPort = await findFreePort(port + 1);
       if (newPort === null) {
         console.warn(
           chalk.yellow(
-            `⚠ Dashboard unavailable (port ${port}–${port + MAX_PORT_SCAN - 1} all in use). Sessions will still work.`,
+            `⚠ Dashboard unavailable (port ${port}–${port + MAX_PORT_SCAN} all in use). Sessions will still work.`,
           ),
         );
         skipDashboard = true;
@@ -371,7 +371,7 @@ async function runStartup(
   // Print summary
   console.log(chalk.bold.green("\n✓ Startup complete\n"));
 
-  if (opts?.dashboard !== false) {
+  if (opts?.dashboard !== false && !skipDashboard) {
     console.log(chalk.cyan("Dashboard:"), `http://localhost:${port}`);
   }
 
@@ -395,7 +395,7 @@ async function runStartup(
   // Polls the port instead of using a fixed delay — deterministic and works regardless of
   // how long Next.js takes to compile. AbortController cancels polling on early exit.
   let openAbort: AbortController | undefined;
-  if (opts?.dashboard !== false) {
+  if (opts?.dashboard !== false && !skipDashboard) {
     openAbort = new AbortController();
     const orchestratorUrl = `http://localhost:${port}/sessions/${sessionId}`;
     void waitForPortAndOpen(port, orchestratorUrl, openAbort.signal);


### PR DESCRIPTION
## Summary

Replaces the hard error on port conflict with auto-scanning, matching vite/next dev behavior.

## Problem

When port 3000 is in use (common in multi-project setups), `ao start` throws an error blocking all session operations — even though the dashboard is not required for spawning/running agents.

Fixes #300

## Solution

Replace `preflight.checkPort()` (which throws) with auto-scanning:

```
⚠ Port 3000 in use, dashboard starting on port 3001 instead
✔ Orchestrator session created
  Dashboard: http://localhost:3001
```

If ALL ports are taken (port through port+MAX_PORT_SCAN), skip the dashboard with a warning:
```
⚠ Dashboard unavailable (port 3000–3009 all in use). Sessions will still work.
```

## Changes

- `packages/cli/src/commands/start.ts`: Replace `checkPort` with `findFreePort` auto-scanning for all start modes (not just URL-started projects)