### PR TITLE
fix: resolve gh path at plugin init instead of hardcoding

### DIFF
--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -656,6 +656,18 @@ function createCodexAgent(): Agent {
   /** Guard against concurrent resolveGhBinary() calls */
   let resolvingGh: Promise<string> | null = null;
 
+  // Eagerly start GH binary resolution so it's ready by the time
+  // getEnvironment() is called for the first session. Without this,
+  // the first session falls back to the hardcoded path.
+  resolvingGh = resolveGhBinary().then((path) => {
+    resolvedGhPath = path;
+    resolvingGh = null;
+    return path;
+  }).catch(() => {
+    resolvingGh = null;
+    return PREFERRED_GH_PATH_FALLBACK;
+  });
+
   return {
     name: "codex",
     processName: "codex",
@@ -885,10 +897,9 @@ function createCodexAgent(): Agent {
           resolvingBinary = null;
         }
       }
-      if (!resolvedGhPath) {
-        if (!resolvingGh) {
-          resolvingGh = resolveGhBinary();
-        }
+      // GH path is resolved eagerly in createCodexAgent(); postLaunchSetup
+      // only needs to await if it hasn't finished yet.
+      if (!resolvedGhPath && resolvingGh) {
         try {
           resolvedGhPath = await resolvingGh;
         } finally {

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -37,7 +37,44 @@ function normalizePermissionMode(mode: string | undefined): "permissionless" | "
 const AO_BIN_DIR = join(homedir(), ".ao", "bin");
 const DEFAULT_PATH = "/usr/bin:/bin";
 const PREFERRED_GH_BIN_DIR = "/usr/local/bin";
-const PREFERRED_GH_PATH = `${PREFERRED_GH_BIN_DIR}/gh`;
+const PREFERRED_GH_PATH_FALLBACK = `${PREFERRED_GH_BIN_DIR}/gh`;
+
+/**
+ * Resolve the real `gh` binary path at plugin init time.
+ * Checks `which gh` (respecting the user's PATH), then falls back to
+ * common locations. This ensures GH_PATH points to the user's configured
+ * and authenticated `gh` regardless of linuxbrew/homebrew ordering.
+ */
+async function resolveGhBinary(): Promise<string> {
+  // 1. Try `which gh` — finds the user's configured gh
+  try {
+    const { stdout } = await execFileAsync("which", ["gh"], { timeout: 5000 });
+    const resolved = stdout.trim();
+    // Skip if it resolves to our own wrapper
+    if (resolved && !resolved.startsWith(AO_BIN_DIR)) return resolved;
+  } catch {
+    // Not found via which
+  }
+
+  // 2. Check common locations (prefer /usr/local/bin, then Homebrew)
+  const candidates = [
+    "/usr/local/bin/gh",
+    "/opt/homebrew/bin/gh",
+    "/home/linuxbrew/.linuxbrew/bin/gh",
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      await stat(candidate);
+      return candidate;
+    } catch {
+      // Not found at this location
+    }
+  }
+
+  // 3. Fallback
+  return PREFERRED_GH_PATH_FALLBACK;
+}
 
 function buildAgentPath(basePath: string | undefined): string {
   const inherited = (basePath ?? DEFAULT_PATH).split(":").filter(Boolean);
@@ -614,6 +651,10 @@ function createCodexAgent(): Agent {
   let resolvedBinary: string | null = null;
   /** Guard against concurrent resolveCodexBinary() calls */
   let resolvingBinary: Promise<string> | null = null;
+  /** Cached resolved gh binary path */
+  let resolvedGhPath: string | null = null;
+  /** Guard against concurrent resolveGhBinary() calls */
+  let resolvingGh: Promise<string> | null = null;
 
   return {
     name: "codex",
@@ -656,7 +697,7 @@ function createCodexAgent(): Agent {
       // The wrappers strip this directory from PATH before calling the real
       // binary, so there's no infinite recursion.
       env["PATH"] = buildAgentPath(process.env["PATH"]);
-      env["GH_PATH"] = PREFERRED_GH_PATH;
+      env["GH_PATH"] = resolvedGhPath ?? PREFERRED_GH_PATH_FALLBACK;
       // Disable Codex's version check/update prompt for non-interactive AO sessions.
       env["CODEX_DISABLE_UPDATE_CHECK"] = "1";
 
@@ -842,6 +883,16 @@ function createCodexAgent(): Agent {
           resolvedBinary = await resolvingBinary;
         } finally {
           resolvingBinary = null;
+        }
+      }
+      if (!resolvedGhPath) {
+        if (!resolvingGh) {
+          resolvingGh = resolveGhBinary();
+        }
+        try {
+          resolvedGhPath = await resolvingGh;
+        } finally {
+          resolvingGh = null;
         }
       }
       if (!session.workspacePath) return;


### PR DESCRIPTION
## Summary

Resolves the actual `gh` binary path at plugin init time instead of hardcoding `/usr/local/bin/gh`.

## Problem

`GH_PATH` was hardcoded to `/usr/local/bin/gh`, which doesn't exist on:
- Apple Silicon Macs (`/opt/homebrew/bin/gh`)
- Systems where gh is only in linuxbrew (`/home/linuxbrew/.linuxbrew/bin/gh`)

The gh wrapper falls through to PATH-based resolution, which finds the wrong (unauthenticated) gh binary.

Fixes #341

## Solution

Add `resolveGhBinary()` (same pattern as existing `resolveCodexBinary()`):
1. `which gh` — finds the user's configured, authenticated binary
2. `/usr/local/bin/gh` — common location
3. `/opt/homebrew/bin/gh` — Apple Silicon
4. `/home/linuxbrew/.linuxbrew/bin/gh` — linuxbrew last

Resolved at plugin init time (`postLaunchSetup`), cached, passed as `GH_PATH` to sessions.

## Changes

- `packages/plugins/agent-codex/src/index.ts`: Added `resolveGhBinary()`, replaced hardcoded `PREFERRED_GH_PATH` with dynamic resolution