### PR TITLE
fix: auto-accept MCP servers and TOS in non-interactive sessions

### DIFF
--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -688,6 +688,17 @@ function createClaudeCodeAgent(): Agent {
         env["AO_ISSUE_ID"] = config.issueId;
       }
 
+      // Auto-accept interactive prompts that block non-interactive sessions:
+      // - MCP server approval ("New MCP server found in .mcp.json")
+      // - Terms of service acceptance ("Do you accept?")
+      // These prompts require manual keystrokes and block all agents on
+      // first run in repos with .mcp.json or on fresh installations.
+      const permissionMode = normalizePermissionMode(config.permissions);
+      if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
+        env["CLAUDE_CODE_ACCEPT_TOS"] = "1";
+        env["CLAUDE_CODE_TRUST_MCP_SERVERS"] = "1";
+      }
+
       return env;
     },
 


### PR DESCRIPTION
When ao spawn launches Claude Code with --dangerously-skip-permissions, agents still get blocked by two interactive prompts:
  1. 'New MCP server found in .mcp.json' — requires selecting option 1
  2. 'Do you accept?' (TOS) — requires navigating to Yes

These block all agents on first run, requiring manual intervention.

Set CLAUDE_CODE_ACCEPT_TOS=1 and CLAUDE_CODE_TRUST_MCP_SERVERS=1 in getEnvironment() when permissions are permissionless or auto-edit. This tells Claude Code to auto-accept these prompts without blocking.

Closes #462