### PR TITLE
fix: force NODE_ENV=development for dashboard to fix Tailwind v4 CSS

### DIFF
--- a/packages/cli/src/lib/web-dir.ts
+++ b/packages/cli/src/lib/web-dir.ts
@@ -116,6 +116,13 @@ export async function buildDashboardEnv(
 ): Promise<Record<string, string>> {
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
 
+  // Force development mode — the dashboard always runs via `next dev`.
+  // If the parent process sets NODE_ENV=production (common in CI or when
+  // ao itself is globally installed), devDependencies like @tailwindcss/postcss
+  // won't be resolved, causing Tailwind v4 CSS compilation to fail with:
+  //   "Cannot find module '@tailwindcss/postcss'"
+  env["NODE_ENV"] = "development";
+
   // Pass config path so dashboard uses the same config as the CLI
   if (configPath) {
     env["AO_CONFIG_PATH"] = configPath;


### PR DESCRIPTION
## Summary

Forces `NODE_ENV=development` when spawning the dashboard process.

## Problem

`buildDashboardEnv()` spreads `process.env`, which may include `NODE_ENV=production` (common in CI, Docker, or when ao is globally installed). Since the dashboard runs via `next dev`, Tailwind v4's `@import 'tailwindcss'` syntax requires `@tailwindcss/postcss` (a devDependency). With `NODE_ENV=production`, Node.js can't resolve devDependencies, causing:

```
Cannot find module '@tailwindcss/postcss'
```

Fixes #460

## Solution

Set `env['NODE_ENV'] = 'development'` in `buildDashboardEnv()` after spreading `process.env`. The dashboard always uses `next dev`, so development mode is always correct.

## Changes

- `packages/cli/src/lib/web-dir.ts`: Force `NODE_ENV=development` in `buildDashboardEnv()`