### PR TITLE
feat(cli): show issue ID column in `ao status` output

### DIFF
--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -385,10 +385,44 @@ describe("status command", () => {
 
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain("Session");
+    expect(output).toContain("Issue");
     expect(output).toContain("Branch");
     expect(output).toContain("PR");
     expect(output).toContain("CI");
     expect(output).toContain("Activity");
+  });
+
+  it("displays issue ID from session metadata in table and JSON output", async () => {
+    writeFileSync(
+      join(sessionsDir, "app-1"),
+      "worktree=/tmp/wt/app-1\nbranch=feat/INT-100\nstatus=working\nissue=INT-100\n",
+    );
+    writeFileSync(
+      join(sessionsDir, "app-2"),
+      "worktree=/tmp/wt/app-2\nbranch=feat/no-issue\nstatus=working\n",
+    );
+
+    mockTmux.mockImplementation(async (...args: string[]) => {
+      if (args[0] === "list-sessions") return "app-1\napp-2";
+      if (args[0] === "display-message") return String(Math.floor(Date.now() / 1000) - 60);
+      return null;
+    });
+    mockGit.mockResolvedValue(null);
+
+    // Verify table output contains the issue
+    await program.parseAsync(["node", "test", "status"]);
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("INT-100");
+
+    // Verify JSON output includes the issue field
+    consoleSpy.mockClear();
+    await program.parseAsync(["node", "test", "status", "--json"]);
+    const jsonCalls = consoleSpy.mock.calls.map((c) => c[0]).join("");
+    const parsed = JSON.parse(jsonCalls);
+    const withIssue = parsed.find((e: { name: string }) => e.name === "app-1");
+    const withoutIssue = parsed.find((e: { name: string }) => e.name === "app-2");
+    expect(withIssue.issue).toBe("INT-100");
+    expect(withoutIssue.issue).toBeNull();
   });
 
   it("shows PR number, CI status, review decision, and threads", async () => {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -140,6 +140,7 @@ async function gatherSessionInfo(
 // Column widths for the table
 const COL = {
   session: 14,
+  issue: 12,
   branch: 24,
   pr: 6,
   ci: 6,
@@ -152,6 +153,7 @@ const COL = {
 function printTableHeader(): void {
   const hdr =
     padCol("Session", COL.session) +
+    padCol("Issue", COL.issue) +
     padCol("Branch", COL.branch) +
     padCol("PR", COL.pr) +
     padCol("CI", COL.ci) +
@@ -161,15 +163,25 @@ function printTableHeader(): void {
     "Age";
   console.log(chalk.dim(`  ${hdr}`));
   const totalWidth =
-    COL.session + COL.branch + COL.pr + COL.ci + COL.review + COL.threads + COL.activity + 3;
+    COL.session +
+    COL.issue +
+    COL.branch +
+    COL.pr +
+    COL.ci +
+    COL.review +
+    COL.threads +
+    COL.activity +
+    3;
   console.log(chalk.dim(`  ${"─".repeat(totalWidth)}`));
 }
 
 function printSessionRow(info: SessionInfo): void {
   const prStr = info.prNumber ? `#${info.prNumber}` : "-";
+  const issueStr = info.issue ?? "-";
 
   const row =
     padCol(chalk.green(info.name), COL.session) +
+    padCol(info.issue ? chalk.yellow(issueStr) : chalk.dim(issueStr), COL.issue) +
     padCol(info.branch ? chalk.cyan(info.branch) : chalk.dim("-"), COL.branch) +
     padCol(info.prNumber ? chalk.blue(prStr) : chalk.dim(prStr), COL.pr) +
     padCol(ciStatusIcon(info.ciStatus), COL.ci) +


### PR DESCRIPTION
## Summary

- Adds an **Issue** column to the `ao status` table between Session and Branch
- The `issue` field was already gathered from session metadata (`session.issueId`) and included in `--json` output, but was never rendered in the table view
- Issue IDs display in yellow when present, dim `-` when absent

Closes #303

## Changes

- `packages/cli/src/commands/status.ts` — added `issue` column to `COL` widths, `printTableHeader()`, and `printSessionRow()`
- `packages/cli/__tests__/commands/status.test.ts` — added test for issue display in both table and JSON output, updated header assertion to include Issue column

## Before / After

**Before:** Session has `issue=#7` in metadata but `ao status` drops it:
```
Session       Branch                  PR    CI    Rev   Thr Activity Age
────────────────────────────────────────────────────────────────────────
pwv-1         feat/fix-nav            -     -     -     -   exited   -
```

**After:**
```
Session       Issue       Branch                  PR    CI    Rev   Thr Activity Age
────────────────────────────────────────────────────────────────────────────────────
pwv-1         #7          feat/fix-nav            -     -     -     -   exited   -
```

## Test plan

- [x] `pnpm --filter @composio/ao-cli build` — passes (no type errors)
- [x] `pnpm --filter @composio/ao-cli test` — 208/208 tests pass (1 new test added)
- [x] `eslint` — no errors on changed files
- [x] `prettier --check` — passes on changed files
- [x] Manual reproduction: ran `ao status` on a local project with issue metadata, confirmed column renders correctly