### PR TITLE
feat(core): add GNAP persistent state layer for parallel agent task handoffs

### DIFF
--- a/packages/core/src/__tests__/gnap.test.ts
+++ b/packages/core/src/__tests__/gnap.test.ts
@@ -439,6 +439,12 @@ describe("generateGnapTaskId", () => {
       "https-github-com-org-repo-issues-42",
     );
   });
+
+  it("falls back to session ID when issue sanitizes to empty string", () => {
+    expect(generateGnapTaskId("int-1", "#")).toBe("int-1");
+    expect(generateGnapTaskId("int-1", "///")).toBe("int-1");
+    expect(generateGnapTaskId("int-1", "@")).toBe("int-1");
+  });
 });
 
 describe("syncSessionToGnap", () => {
@@ -615,16 +621,17 @@ describe("syncDecompositionToGnap", () => {
   it("creates parent and child tasks", () => {
     syncDecompositionToGnap({
       projectPath,
+      planId: "plan-1",
       rootTaskDescription: "Build full-stack app",
       tasks: [
         { id: "task-1", description: "Implement backend API" },
-        { id: "task-2", description: "Build frontend UI", parentId: "plan-root" },
+        { id: "task-2", description: "Build frontend UI", parentId: "plan-1" },
         { id: "task-3", description: "Write integration tests" },
       ],
     });
 
     // Parent task
-    const parent = readGnapTask(projectPath, "plan-root");
+    const parent = readGnapTask(projectPath, "plan-1");
     expect(parent).not.toBeNull();
     expect(parent!.title).toBe("Build full-stack app");
     expect(parent!.state).toBe("in_progress");
@@ -634,19 +641,45 @@ describe("syncDecompositionToGnap", () => {
     const task1 = readGnapTask(projectPath, "task-1");
     expect(task1).not.toBeNull();
     expect(task1!.title).toBe("Implement backend API");
-    expect(task1!.parent).toBe("plan-root");
+    expect(task1!.parent).toBe("plan-1");
     expect(task1!.state).toBe("ready"); // No session assigned
 
     const task2 = readGnapTask(projectPath, "task-2");
-    expect(task2!.parent).toBe("plan-root");
+    expect(task2!.parent).toBe("plan-1");
 
     const task3 = readGnapTask(projectPath, "task-3");
-    expect(task3!.parent).toBe("plan-root");
+    expect(task3!.parent).toBe("plan-1");
+  });
+
+  it("multiple decompositions do not collide", () => {
+    syncDecompositionToGnap({
+      projectPath,
+      planId: "plan-a",
+      rootTaskDescription: "First plan",
+      tasks: [{ id: "a-1", description: "Task A" }],
+    });
+    syncDecompositionToGnap({
+      projectPath,
+      planId: "plan-b",
+      rootTaskDescription: "Second plan",
+      tasks: [{ id: "b-1", description: "Task B" }],
+    });
+
+    const planA = readGnapTask(projectPath, "plan-a");
+    const planB = readGnapTask(projectPath, "plan-b");
+    expect(planA!.title).toBe("First plan");
+    expect(planB!.title).toBe("Second plan");
+
+    const taskA = readGnapTask(projectPath, "a-1");
+    expect(taskA!.parent).toBe("plan-a");
+    const taskB = readGnapTask(projectPath, "b-1");
+    expect(taskB!.parent).toBe("plan-b");
   });
 
   it("marks tasks with sessions as in_progress", () => {
     syncDecompositionToGnap({
       projectPath,
+      planId: "plan-2",
       rootTaskDescription: "Build app",
       tasks: [
         { id: "task-1", description: "Backend", sessionId: "int-1" },

--- a/packages/core/src/__tests__/gnap.test.ts
+++ b/packages/core/src/__tests__/gnap.test.ts
@@ -176,6 +176,24 @@ describe("task operations", () => {
     expect(listGnapTasks(projectPath)).toEqual([]);
   });
 
+  it("rejects task IDs with path traversal", () => {
+    expect(() =>
+      writeGnapTask(projectPath, { ...sampleTask, id: "../../etc/evil" }),
+    ).toThrow("invalid path characters");
+  });
+
+  it("rejects task IDs with forward slashes", () => {
+    expect(() =>
+      writeGnapTask(projectPath, { ...sampleTask, id: "foo/bar" }),
+    ).toThrow("invalid path characters");
+  });
+
+  it("rejects empty task IDs", () => {
+    expect(() =>
+      writeGnapTask(projectPath, { ...sampleTask, id: "" }),
+    ).toThrow("must not be empty");
+  });
+
   it("handles task with parent field", () => {
     writeGnapTask(projectPath, {
       ...sampleTask,

--- a/packages/core/src/__tests__/gnap.test.ts
+++ b/packages/core/src/__tests__/gnap.test.ts
@@ -1,0 +1,675 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import {
+  initGnapDir,
+  isGnapInitialized,
+  getGnapDir,
+  writeGnapTask,
+  readGnapTask,
+  updateGnapTask,
+  listGnapTasks,
+  readGnapAgents,
+  writeGnapAgent,
+  writeGnapRun,
+  readGnapRun,
+  updateGnapRun,
+  writeGnapMessage,
+  sessionStatusToGnapState,
+  gnapTaskStateToRunState,
+  generateGnapTaskId,
+  syncSessionToGnap,
+  syncDecompositionToGnap,
+  type GnapTask,
+  type GnapAgent,
+  type GnapRun,
+  type GnapMessage,
+} from "../gnap.js";
+
+let projectPath: string;
+
+beforeEach(() => {
+  projectPath = join(tmpdir(), `ao-test-gnap-${randomUUID()}`);
+  mkdirSync(projectPath, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(projectPath, { recursive: true, force: true });
+});
+
+describe("initGnapDir", () => {
+  it("creates the .gnap directory structure", () => {
+    initGnapDir(projectPath);
+
+    expect(existsSync(join(projectPath, ".gnap", "version"))).toBe(true);
+    expect(existsSync(join(projectPath, ".gnap", "agents.json"))).toBe(true);
+    expect(existsSync(join(projectPath, ".gnap", "tasks"))).toBe(true);
+    expect(existsSync(join(projectPath, ".gnap", "runs"))).toBe(true);
+    expect(existsSync(join(projectPath, ".gnap", "messages"))).toBe(true);
+  });
+
+  it("writes protocol version 4", () => {
+    initGnapDir(projectPath);
+
+    const version = readFileSync(join(projectPath, ".gnap", "version"), "utf-8");
+    expect(version).toBe("4");
+  });
+
+  it("initializes empty agents.json", () => {
+    initGnapDir(projectPath);
+
+    const agents = JSON.parse(readFileSync(join(projectPath, ".gnap", "agents.json"), "utf-8"));
+    expect(agents).toEqual({});
+  });
+
+  it("is idempotent — safe to call multiple times", () => {
+    initGnapDir(projectPath);
+    initGnapDir(projectPath);
+
+    expect(existsSync(join(projectPath, ".gnap", "version"))).toBe(true);
+  });
+
+  it("supports custom gnap directory", () => {
+    initGnapDir(projectPath, ".my-gnap");
+
+    expect(existsSync(join(projectPath, ".my-gnap", "version"))).toBe(true);
+    expect(existsSync(join(projectPath, ".my-gnap", "tasks"))).toBe(true);
+  });
+});
+
+describe("isGnapInitialized", () => {
+  it("returns false for uninitialized project", () => {
+    expect(isGnapInitialized(projectPath)).toBe(false);
+  });
+
+  it("returns true after initialization", () => {
+    initGnapDir(projectPath);
+    expect(isGnapInitialized(projectPath)).toBe(true);
+  });
+});
+
+describe("getGnapDir", () => {
+  it("returns default .gnap path", () => {
+    expect(getGnapDir(projectPath)).toBe(join(projectPath, ".gnap"));
+  });
+
+  it("supports custom directory", () => {
+    expect(getGnapDir(projectPath, ".custom")).toBe(join(projectPath, ".custom"));
+  });
+});
+
+describe("task operations", () => {
+  beforeEach(() => {
+    initGnapDir(projectPath);
+  });
+
+  const sampleTask: GnapTask = {
+    id: "FA-1",
+    title: "Build authentication",
+    desc: "Implement OAuth2 login flow",
+    assigned_to: ["claude-1"],
+    state: "in_progress",
+    created_by: "ao-orchestrator",
+    created_at: "2026-03-18T10:00:00Z",
+    tags: ["auth"],
+  };
+
+  it("writes and reads a task", () => {
+    writeGnapTask(projectPath, sampleTask);
+
+    const task = readGnapTask(projectPath, "FA-1");
+    expect(task).not.toBeNull();
+    expect(task!.id).toBe("FA-1");
+    expect(task!.title).toBe("Build authentication");
+    expect(task!.state).toBe("in_progress");
+    expect(task!.assigned_to).toEqual(["claude-1"]);
+  });
+
+  it("writes valid JSON to tasks directory", () => {
+    writeGnapTask(projectPath, sampleTask);
+
+    const content = readFileSync(join(projectPath, ".gnap", "tasks", "FA-1.json"), "utf-8");
+    const parsed = JSON.parse(content);
+    expect(parsed.id).toBe("FA-1");
+  });
+
+  it("returns null for nonexistent task", () => {
+    expect(readGnapTask(projectPath, "nonexistent")).toBeNull();
+  });
+
+  it("updates a task preserving existing fields", () => {
+    writeGnapTask(projectPath, sampleTask);
+
+    const updated = updateGnapTask(projectPath, "FA-1", {
+      state: "review",
+    });
+
+    expect(updated).toBe(true);
+    const task = readGnapTask(projectPath, "FA-1");
+    expect(task!.state).toBe("review");
+    expect(task!.title).toBe("Build authentication");
+    expect(task!.updated_at).toBeDefined();
+  });
+
+  it("returns false when updating nonexistent task", () => {
+    expect(updateGnapTask(projectPath, "nope", { state: "done" })).toBe(false);
+  });
+
+  it("lists all tasks", () => {
+    writeGnapTask(projectPath, sampleTask);
+    writeGnapTask(projectPath, {
+      ...sampleTask,
+      id: "FA-2",
+      title: "Write tests",
+      state: "ready",
+    });
+
+    const tasks = listGnapTasks(projectPath);
+    expect(tasks).toHaveLength(2);
+    const ids = tasks.map((t) => t.id).sort();
+    expect(ids).toEqual(["FA-1", "FA-2"]);
+  });
+
+  it("returns empty array when no tasks exist", () => {
+    expect(listGnapTasks(projectPath)).toEqual([]);
+  });
+
+  it("handles task with parent field", () => {
+    writeGnapTask(projectPath, {
+      ...sampleTask,
+      id: "FA-1-1",
+      parent: "FA-1",
+    });
+
+    const task = readGnapTask(projectPath, "FA-1-1");
+    expect(task!.parent).toBe("FA-1");
+  });
+
+  it("handles blocked tasks", () => {
+    writeGnapTask(projectPath, {
+      ...sampleTask,
+      state: "blocked",
+      blocked: true,
+      blocked_reason: "Waiting for API credentials",
+    });
+
+    const task = readGnapTask(projectPath, "FA-1");
+    expect(task!.state).toBe("blocked");
+    expect(task!.blocked).toBe(true);
+    expect(task!.blocked_reason).toBe("Waiting for API credentials");
+  });
+
+  it("handles task with comments", () => {
+    writeGnapTask(projectPath, {
+      ...sampleTask,
+      comments: [
+        { by: "claude-1", at: "2026-03-18T11:00:00Z", text: "Started implementation" },
+      ],
+    });
+
+    const task = readGnapTask(projectPath, "FA-1");
+    expect(task!.comments).toHaveLength(1);
+    expect(task!.comments![0].by).toBe("claude-1");
+  });
+});
+
+describe("agent operations", () => {
+  beforeEach(() => {
+    initGnapDir(projectPath);
+  });
+
+  it("writes and reads an agent", () => {
+    const agent: GnapAgent = {
+      id: "claude-1",
+      name: "Claude Code (int-1)",
+      type: "ai",
+      status: "active",
+      capabilities: ["coding", "testing"],
+    };
+
+    writeGnapAgent(projectPath, agent);
+
+    const agents = readGnapAgents(projectPath);
+    expect(agents["claude-1"]).toBeDefined();
+    expect(agents["claude-1"].name).toBe("Claude Code (int-1)");
+    expect(agents["claude-1"].type).toBe("ai");
+    expect(agents["claude-1"].status).toBe("active");
+  });
+
+  it("updates existing agent in agents.json", () => {
+    writeGnapAgent(projectPath, {
+      id: "claude-1",
+      name: "Claude 1",
+      type: "ai",
+      status: "active",
+    });
+    writeGnapAgent(projectPath, {
+      id: "claude-2",
+      name: "Claude 2",
+      type: "ai",
+      status: "active",
+    });
+
+    const agents = readGnapAgents(projectPath);
+    expect(Object.keys(agents)).toHaveLength(2);
+    expect(agents["claude-1"]).toBeDefined();
+    expect(agents["claude-2"]).toBeDefined();
+  });
+
+  it("returns empty object when no agents file exists", () => {
+    rmSync(join(projectPath, ".gnap", "agents.json"));
+    expect(readGnapAgents(projectPath)).toEqual({});
+  });
+});
+
+describe("run operations", () => {
+  beforeEach(() => {
+    initGnapDir(projectPath);
+  });
+
+  it("writes and reads a run", () => {
+    const run: GnapRun = {
+      id: "FA-1-claude-1",
+      task_id: "FA-1",
+      agent_id: "claude-1",
+      state: "running",
+      started_at: "2026-03-18T10:00:00Z",
+    };
+
+    writeGnapRun(projectPath, run);
+
+    const read = readGnapRun(projectPath, "FA-1-claude-1");
+    expect(read).not.toBeNull();
+    expect(read!.task_id).toBe("FA-1");
+    expect(read!.state).toBe("running");
+  });
+
+  it("returns null for nonexistent run", () => {
+    expect(readGnapRun(projectPath, "nonexistent")).toBeNull();
+  });
+
+  it("updates a run", () => {
+    writeGnapRun(projectPath, {
+      id: "FA-1-claude-1",
+      task_id: "FA-1",
+      agent_id: "claude-1",
+      state: "running",
+      started_at: "2026-03-18T10:00:00Z",
+    });
+
+    const updated = updateGnapRun(projectPath, "FA-1-claude-1", {
+      state: "completed",
+      completed_at: "2026-03-18T12:00:00Z",
+      result: "PR #42 merged",
+    });
+
+    expect(updated).toBe(true);
+    const run = readGnapRun(projectPath, "FA-1-claude-1");
+    expect(run!.state).toBe("completed");
+    expect(run!.completed_at).toBe("2026-03-18T12:00:00Z");
+    expect(run!.result).toBe("PR #42 merged");
+  });
+});
+
+describe("message operations", () => {
+  beforeEach(() => {
+    initGnapDir(projectPath);
+  });
+
+  it("writes a message", () => {
+    const message: GnapMessage = {
+      id: "1",
+      from: "ao-orchestrator",
+      to: ["claude-1"],
+      type: "directive",
+      text: "Start working on authentication",
+      sent_at: "2026-03-18T10:00:00Z",
+    };
+
+    writeGnapMessage(projectPath, message);
+
+    const content = readFileSync(join(projectPath, ".gnap", "messages", "1.json"), "utf-8");
+    const parsed = JSON.parse(content);
+    expect(parsed.from).toBe("ao-orchestrator");
+    expect(parsed.type).toBe("directive");
+  });
+});
+
+describe("sessionStatusToGnapState", () => {
+  it("maps spawning to ready", () => {
+    expect(sessionStatusToGnapState("spawning")).toBe("ready");
+  });
+
+  it("maps working to in_progress", () => {
+    expect(sessionStatusToGnapState("working")).toBe("in_progress");
+  });
+
+  it("maps ci_failed to in_progress", () => {
+    expect(sessionStatusToGnapState("ci_failed")).toBe("in_progress");
+  });
+
+  it("maps changes_requested to in_progress", () => {
+    expect(sessionStatusToGnapState("changes_requested")).toBe("in_progress");
+  });
+
+  it("maps pr_open to review", () => {
+    expect(sessionStatusToGnapState("pr_open")).toBe("review");
+  });
+
+  it("maps review_pending to review", () => {
+    expect(sessionStatusToGnapState("review_pending")).toBe("review");
+  });
+
+  it("maps approved to review", () => {
+    expect(sessionStatusToGnapState("approved")).toBe("review");
+  });
+
+  it("maps mergeable to review", () => {
+    expect(sessionStatusToGnapState("mergeable")).toBe("review");
+  });
+
+  it("maps merged to done", () => {
+    expect(sessionStatusToGnapState("merged")).toBe("done");
+  });
+
+  it("maps done to done", () => {
+    expect(sessionStatusToGnapState("done")).toBe("done");
+  });
+
+  it("maps needs_input to blocked", () => {
+    expect(sessionStatusToGnapState("needs_input")).toBe("blocked");
+  });
+
+  it("maps stuck to blocked", () => {
+    expect(sessionStatusToGnapState("stuck")).toBe("blocked");
+  });
+
+  it("maps errored to blocked", () => {
+    expect(sessionStatusToGnapState("errored")).toBe("blocked");
+  });
+
+  it("maps killed to cancelled", () => {
+    expect(sessionStatusToGnapState("killed")).toBe("cancelled");
+  });
+
+  it("maps terminated to cancelled", () => {
+    expect(sessionStatusToGnapState("terminated")).toBe("cancelled");
+  });
+});
+
+describe("gnapTaskStateToRunState", () => {
+  it("maps done to completed", () => {
+    expect(gnapTaskStateToRunState("done")).toBe("completed");
+  });
+
+  it("maps cancelled to cancelled", () => {
+    expect(gnapTaskStateToRunState("cancelled")).toBe("cancelled");
+  });
+
+  it("maps blocked to failed", () => {
+    expect(gnapTaskStateToRunState("blocked")).toBe("failed");
+  });
+
+  it("maps in_progress to running", () => {
+    expect(gnapTaskStateToRunState("in_progress")).toBe("running");
+  });
+
+  it("maps review to running", () => {
+    expect(gnapTaskStateToRunState("review")).toBe("running");
+  });
+});
+
+describe("generateGnapTaskId", () => {
+  it("uses issue ID when available", () => {
+    expect(generateGnapTaskId("int-1", "INT-123")).toBe("INT-123");
+  });
+
+  it("sanitizes issue ID with special characters", () => {
+    expect(generateGnapTaskId("int-1", "#472")).toBe("472");
+  });
+
+  it("falls back to session ID when no issue", () => {
+    expect(generateGnapTaskId("int-1")).toBe("int-1");
+  });
+
+  it("sanitizes issue URLs", () => {
+    expect(generateGnapTaskId("int-1", "https://github.com/org/repo/issues/42")).toBe(
+      "https-github-com-org-repo-issues-42",
+    );
+  });
+});
+
+describe("syncSessionToGnap", () => {
+  it("initializes gnap and creates task + agent + run on first sync", () => {
+    syncSessionToGnap({
+      projectPath,
+      sessionId: "int-1",
+      agentName: "claude-code",
+      issueId: "INT-123",
+      issueTitle: "Build authentication",
+      issueDescription: "Implement OAuth2",
+      status: "spawning",
+      branch: "feat/INT-123",
+    });
+
+    // GNAP dir should be initialized
+    expect(isGnapInitialized(projectPath)).toBe(true);
+
+    // Task should be created
+    const task = readGnapTask(projectPath, "INT-123");
+    expect(task).not.toBeNull();
+    expect(task!.title).toBe("Build authentication");
+    expect(task!.desc).toBe("Implement OAuth2");
+    expect(task!.state).toBe("ready"); // spawning → ready
+    expect(task!.assigned_to).toEqual(["int-1"]);
+    expect(task!.created_by).toBe("ao-orchestrator");
+    expect(task!.tags).toContain("branch:feat/INT-123");
+
+    // Agent should be registered
+    const agents = readGnapAgents(projectPath);
+    expect(agents["int-1"]).toBeDefined();
+    expect(agents["int-1"].name).toBe("claude-code (int-1)");
+    expect(agents["int-1"].type).toBe("ai");
+
+    // Run should be created
+    const run = readGnapRun(projectPath, "INT-123-int-1");
+    expect(run).not.toBeNull();
+    expect(run!.task_id).toBe("INT-123");
+    expect(run!.agent_id).toBe("int-1");
+    expect(run!.state).toBe("running");
+  });
+
+  it("updates existing task on status change", () => {
+    // Initial spawn
+    syncSessionToGnap({
+      projectPath,
+      sessionId: "int-1",
+      agentName: "claude-code",
+      issueId: "INT-123",
+      issueTitle: "Build auth",
+      status: "spawning",
+    });
+
+    // Transition to working
+    syncSessionToGnap({
+      projectPath,
+      sessionId: "int-1",
+      agentName: "claude-code",
+      issueId: "INT-123",
+      status: "working",
+    });
+
+    const task = readGnapTask(projectPath, "INT-123");
+    expect(task!.state).toBe("in_progress");
+    expect(task!.updated_at).toBeDefined();
+  });
+
+  it("marks task as blocked when agent is stuck", () => {
+    syncSessionToGnap({
+      projectPath,
+      sessionId: "int-1",
+      agentName: "claude-code",
+      issueId: "INT-123",
+      issueTitle: "Build auth",
+      status: "spawning",
+    });
+
+    syncSessionToGnap({
+      projectPath,
+      sessionId: "int-1",
+      agentName: "claude-code",
+      issueId: "INT-123",
+      status: "stuck",
+    });
+
+    const task = readGnapTask(projectPath, "INT-123");
+    expect(task!.state).toBe("blocked");
+    expect(task!.blocked).toBe(true);
+    expect(task!.blocked_reason).toContain("stuck");
+  });
+
+  it("marks task as done when merged", () => {
+    syncSessionToGnap({
+      projectPath,
+      sessionId: "int-1",
+      agentName: "claude-code",
+      issueId: "INT-123",
+      issueTitle: "Build auth",
+      status: "spawning",
+    });
+
+    syncSessionToGnap({
+      projectPath,
+      sessionId: "int-1",
+      agentName: "claude-code",
+      issueId: "INT-123",
+      status: "merged",
+    });
+
+    const task = readGnapTask(projectPath, "INT-123");
+    expect(task!.state).toBe("done");
+
+    const run = readGnapRun(projectPath, "INT-123-int-1");
+    expect(run!.state).toBe("completed");
+    expect(run!.completed_at).toBeDefined();
+
+    const agents = readGnapAgents(projectPath);
+    expect(agents["int-1"].status).toBe("offline");
+  });
+
+  it("creates task without issue using session ID", () => {
+    syncSessionToGnap({
+      projectPath,
+      sessionId: "int-1",
+      agentName: "claude-code",
+      status: "working",
+    });
+
+    const task = readGnapTask(projectPath, "int-1");
+    expect(task).not.toBeNull();
+    expect(task!.title).toBe("Session int-1");
+  });
+
+  it("clears blocked state when transitioning away", () => {
+    syncSessionToGnap({
+      projectPath,
+      sessionId: "int-1",
+      agentName: "claude-code",
+      issueId: "INT-123",
+      issueTitle: "Build auth",
+      status: "stuck",
+    });
+
+    expect(readGnapTask(projectPath, "INT-123")!.blocked).toBe(true);
+
+    syncSessionToGnap({
+      projectPath,
+      sessionId: "int-1",
+      agentName: "claude-code",
+      issueId: "INT-123",
+      status: "working",
+    });
+
+    const task = readGnapTask(projectPath, "INT-123");
+    expect(task!.blocked).toBe(false);
+    expect(task!.state).toBe("in_progress");
+  });
+
+  it("supports custom gnap directory", () => {
+    syncSessionToGnap({
+      projectPath,
+      gnapDir: ".custom-gnap",
+      sessionId: "int-1",
+      agentName: "claude-code",
+      status: "working",
+    });
+
+    expect(isGnapInitialized(projectPath, ".custom-gnap")).toBe(true);
+    expect(readGnapTask(projectPath, "int-1", ".custom-gnap")).not.toBeNull();
+  });
+});
+
+describe("syncDecompositionToGnap", () => {
+  it("creates parent and child tasks", () => {
+    syncDecompositionToGnap({
+      projectPath,
+      rootTaskDescription: "Build full-stack app",
+      tasks: [
+        { id: "task-1", description: "Implement backend API" },
+        { id: "task-2", description: "Build frontend UI", parentId: "plan-root" },
+        { id: "task-3", description: "Write integration tests" },
+      ],
+    });
+
+    // Parent task
+    const parent = readGnapTask(projectPath, "plan-root");
+    expect(parent).not.toBeNull();
+    expect(parent!.title).toBe("Build full-stack app");
+    expect(parent!.state).toBe("in_progress");
+    expect(parent!.tags).toContain("decomposed");
+
+    // Child tasks
+    const task1 = readGnapTask(projectPath, "task-1");
+    expect(task1).not.toBeNull();
+    expect(task1!.title).toBe("Implement backend API");
+    expect(task1!.parent).toBe("plan-root");
+    expect(task1!.state).toBe("ready"); // No session assigned
+
+    const task2 = readGnapTask(projectPath, "task-2");
+    expect(task2!.parent).toBe("plan-root");
+
+    const task3 = readGnapTask(projectPath, "task-3");
+    expect(task3!.parent).toBe("plan-root");
+  });
+
+  it("marks tasks with sessions as in_progress", () => {
+    syncDecompositionToGnap({
+      projectPath,
+      rootTaskDescription: "Build app",
+      tasks: [
+        { id: "task-1", description: "Backend", sessionId: "int-1" },
+        { id: "task-2", description: "Frontend" },
+      ],
+    });
+
+    const task1 = readGnapTask(projectPath, "task-1");
+    expect(task1!.state).toBe("in_progress");
+    expect(task1!.assigned_to).toEqual(["int-1"]);
+
+    const task2 = readGnapTask(projectPath, "task-2");
+    expect(task2!.state).toBe("ready");
+    expect(task2!.assigned_to).toEqual([]);
+  });
+
+  it("initializes gnap directory if needed", () => {
+    syncDecompositionToGnap({
+      projectPath,
+      rootTaskDescription: "Build app",
+      tasks: [{ id: "task-1", description: "Backend" }],
+    });
+
+    expect(isGnapInitialized(projectPath)).toBe(true);
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -142,6 +142,13 @@ const DecomposerConfigSchema = z
     requireApproval: true,
   });
 
+const GnapConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    dir: z.string().default(".gnap"),
+  })
+  .default({ enabled: false, dir: ".gnap" });
+
 const ProjectConfigSchema = z.object({
   name: z.string().optional(),
   repo: z.string(),
@@ -170,6 +177,7 @@ const ProjectConfigSchema = z.object({
     .optional(),
   opencodeIssueSessionStrategy: z.enum(["reuse", "delete", "ignore"]).optional(),
   decomposer: DecomposerConfigSchema.optional(),
+  gnap: GnapConfigSchema.optional(),
 });
 
 const DefaultPluginsSchema = z.object({

--- a/packages/core/src/gnap.ts
+++ b/packages/core/src/gnap.ts
@@ -1,0 +1,658 @@
+/**
+ * GNAP (Git-Native Agent Protocol) — persistent state layer for task handoffs.
+ *
+ * Implements GNAP Protocol v4 for persisting task state alongside code in a
+ * `.gnap/` directory within the project's git repository. This enables:
+ * - Long-running task persistence across agent restarts
+ * - Clear ownership (who's working on what)
+ * - Git-based task state that lives alongside the code
+ *
+ * Protocol reference: https://github.com/farol-team/gnap
+ *
+ * Integration: Called by SessionManager on spawn and LifecycleManager on
+ * status transitions. Enabled per-project via `gnap.enabled` in config.
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { atomicWriteFileSync } from "./atomic-write.js";
+import type { SessionStatus } from "./types.js";
+
+// =============================================================================
+// GNAP PROTOCOL TYPES (v4)
+// =============================================================================
+
+/** GNAP task states following the protocol state machine. */
+export type GnapTaskState =
+  | "backlog"
+  | "ready"
+  | "in_progress"
+  | "review"
+  | "done"
+  | "blocked"
+  | "cancelled";
+
+/** A comment on a GNAP task. */
+export interface GnapComment {
+  by: string;
+  at: string;
+  text: string;
+}
+
+/** GNAP task entity — one JSON file per task in `.gnap/tasks/`. */
+export interface GnapTask {
+  id: string;
+  title: string;
+  desc?: string;
+  assigned_to: string[];
+  state: GnapTaskState;
+  created_by: string;
+  created_at: string;
+  updated_at?: string;
+  parent?: string;
+  priority?: number;
+  due?: string;
+  blocked?: boolean;
+  blocked_reason?: string;
+  reviewer?: string;
+  tags?: string[];
+  comments?: GnapComment[];
+}
+
+/** Agent types in GNAP. */
+export type GnapAgentType = "ai" | "human";
+
+/** Agent status in GNAP. */
+export type GnapAgentStatus = "active" | "idle" | "offline";
+
+/** GNAP agent entry in `agents.json`. */
+export interface GnapAgent {
+  id: string;
+  name: string;
+  type: GnapAgentType;
+  status: GnapAgentStatus;
+  capabilities?: string[];
+}
+
+/** GNAP agents file — maps agent IDs to agent info. */
+export interface GnapAgentsFile {
+  [agentId: string]: GnapAgent;
+}
+
+/** GNAP run states. */
+export type GnapRunState = "running" | "completed" | "failed" | "cancelled";
+
+/** GNAP run entity — one JSON file per execution attempt in `.gnap/runs/`. */
+export interface GnapRun {
+  id: string;
+  task_id: string;
+  agent_id: string;
+  state: GnapRunState;
+  started_at: string;
+  completed_at?: string;
+  result?: string;
+  error?: string;
+  commits?: string[];
+}
+
+/** GNAP message types. */
+export type GnapMessageType = "directive" | "status" | "request" | "info" | "alert";
+
+/** GNAP message entity — one JSON file per message in `.gnap/messages/`. */
+export interface GnapMessage {
+  id: string;
+  from: string;
+  to: string[];
+  type: GnapMessageType;
+  text: string;
+  sent_at: string;
+  thread?: string;
+  channel?: string;
+  read_by?: string[];
+}
+
+/** GNAP config for a project. */
+export interface GnapConfig {
+  /** Enable GNAP state persistence (default: false) */
+  enabled: boolean;
+  /** Directory for GNAP files relative to project root (default: ".gnap") */
+  dir?: string;
+}
+
+export const DEFAULT_GNAP_CONFIG: GnapConfig = {
+  enabled: false,
+  dir: ".gnap",
+};
+
+/** Current GNAP protocol version. */
+const GNAP_PROTOCOL_VERSION = "4";
+
+// =============================================================================
+// DIRECTORY OPERATIONS
+// =============================================================================
+
+/** Get the GNAP root directory for a project. */
+export function getGnapDir(projectPath: string, gnapDir = ".gnap"): string {
+  return join(projectPath, gnapDir);
+}
+
+/** Get the GNAP tasks directory. */
+function getTasksDir(gnapRoot: string): string {
+  return join(gnapRoot, "tasks");
+}
+
+/** Get the GNAP runs directory. */
+function getRunsDir(gnapRoot: string): string {
+  return join(gnapRoot, "runs");
+}
+
+/** Get the GNAP messages directory. */
+function getMessagesDir(gnapRoot: string): string {
+  return join(gnapRoot, "messages");
+}
+
+/**
+ * Initialize the `.gnap/` directory structure for a project.
+ * Creates directories and version file if they don't exist.
+ * Safe to call multiple times (idempotent).
+ */
+export function initGnapDir(projectPath: string, gnapDir = ".gnap"): string {
+  const root = getGnapDir(projectPath, gnapDir);
+
+  mkdirSync(getTasksDir(root), { recursive: true });
+  mkdirSync(getRunsDir(root), { recursive: true });
+  mkdirSync(getMessagesDir(root), { recursive: true });
+
+  // Write version file
+  const versionPath = join(root, "version");
+  if (!existsSync(versionPath)) {
+    writeFileSync(versionPath, GNAP_PROTOCOL_VERSION, "utf-8");
+  }
+
+  // Initialize empty agents.json if it doesn't exist
+  const agentsPath = join(root, "agents.json");
+  if (!existsSync(agentsPath)) {
+    writeFileSync(agentsPath, "{}\n", "utf-8");
+  }
+
+  return root;
+}
+
+/**
+ * Check if a GNAP directory is initialized for a project.
+ */
+export function isGnapInitialized(projectPath: string, gnapDir = ".gnap"): boolean {
+  const root = getGnapDir(projectPath, gnapDir);
+  return existsSync(join(root, "version"));
+}
+
+// =============================================================================
+// TASK OPERATIONS
+// =============================================================================
+
+/**
+ * Write a GNAP task file. Creates or overwrites the task file.
+ */
+export function writeGnapTask(projectPath: string, task: GnapTask, gnapDir = ".gnap"): void {
+  const root = getGnapDir(projectPath, gnapDir);
+  const tasksDir = getTasksDir(root);
+  mkdirSync(tasksDir, { recursive: true });
+
+  const taskPath = join(tasksDir, `${task.id}.json`);
+  atomicWriteFileSync(taskPath, JSON.stringify(task, null, 2) + "\n");
+}
+
+/**
+ * Read a GNAP task by ID. Returns null if the task doesn't exist.
+ */
+export function readGnapTask(
+  projectPath: string,
+  taskId: string,
+  gnapDir = ".gnap",
+): GnapTask | null {
+  const taskPath = join(getTasksDir(getGnapDir(projectPath, gnapDir)), `${taskId}.json`);
+  if (!existsSync(taskPath)) return null;
+
+  try {
+    return JSON.parse(readFileSync(taskPath, "utf-8")) as GnapTask;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Update specific fields of a GNAP task. Merges updates with existing data.
+ */
+export function updateGnapTask(
+  projectPath: string,
+  taskId: string,
+  updates: Partial<GnapTask>,
+  gnapDir = ".gnap",
+): boolean {
+  const existing = readGnapTask(projectPath, taskId, gnapDir);
+  if (!existing) return false;
+
+  const updated: GnapTask = {
+    ...existing,
+    ...updates,
+    updated_at: new Date().toISOString(),
+  };
+
+  writeGnapTask(projectPath, updated, gnapDir);
+  return true;
+}
+
+/**
+ * List all GNAP tasks for a project.
+ */
+export function listGnapTasks(projectPath: string, gnapDir = ".gnap"): GnapTask[] {
+  const tasksDir = getTasksDir(getGnapDir(projectPath, gnapDir));
+  if (!existsSync(tasksDir)) return [];
+
+  const tasks: GnapTask[] = [];
+  for (const file of readdirSync(tasksDir)) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const content = readFileSync(join(tasksDir, file), "utf-8");
+      tasks.push(JSON.parse(content) as GnapTask);
+    } catch {
+      // Skip corrupt files
+    }
+  }
+
+  return tasks;
+}
+
+// =============================================================================
+// AGENT OPERATIONS
+// =============================================================================
+
+/**
+ * Read all agents from the agents.json file.
+ */
+export function readGnapAgents(projectPath: string, gnapDir = ".gnap"): GnapAgentsFile {
+  const agentsPath = join(getGnapDir(projectPath, gnapDir), "agents.json");
+  if (!existsSync(agentsPath)) return {};
+
+  try {
+    return JSON.parse(readFileSync(agentsPath, "utf-8")) as GnapAgentsFile;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Write or update an agent in agents.json.
+ */
+export function writeGnapAgent(
+  projectPath: string,
+  agent: GnapAgent,
+  gnapDir = ".gnap",
+): void {
+  const root = getGnapDir(projectPath, gnapDir);
+  mkdirSync(root, { recursive: true });
+
+  const agentsPath = join(root, "agents.json");
+  const agents = readGnapAgents(projectPath, gnapDir);
+  agents[agent.id] = agent;
+
+  atomicWriteFileSync(agentsPath, JSON.stringify(agents, null, 2) + "\n");
+}
+
+// =============================================================================
+// RUN OPERATIONS
+// =============================================================================
+
+/**
+ * Write a GNAP run file.
+ */
+export function writeGnapRun(projectPath: string, run: GnapRun, gnapDir = ".gnap"): void {
+  const root = getGnapDir(projectPath, gnapDir);
+  const runsDir = getRunsDir(root);
+  mkdirSync(runsDir, { recursive: true });
+
+  const runPath = join(runsDir, `${run.id}.json`);
+  atomicWriteFileSync(runPath, JSON.stringify(run, null, 2) + "\n");
+}
+
+/**
+ * Read a GNAP run by ID. Returns null if the run doesn't exist.
+ */
+export function readGnapRun(
+  projectPath: string,
+  runId: string,
+  gnapDir = ".gnap",
+): GnapRun | null {
+  const runPath = join(getRunsDir(getGnapDir(projectPath, gnapDir)), `${runId}.json`);
+  if (!existsSync(runPath)) return null;
+
+  try {
+    return JSON.parse(readFileSync(runPath, "utf-8")) as GnapRun;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Update specific fields of a GNAP run.
+ */
+export function updateGnapRun(
+  projectPath: string,
+  runId: string,
+  updates: Partial<GnapRun>,
+  gnapDir = ".gnap",
+): boolean {
+  const existing = readGnapRun(projectPath, runId, gnapDir);
+  if (!existing) return false;
+
+  const updated: GnapRun = { ...existing, ...updates };
+  writeGnapRun(projectPath, updated, gnapDir);
+  return true;
+}
+
+// =============================================================================
+// MESSAGE OPERATIONS
+// =============================================================================
+
+/**
+ * Write a GNAP message file.
+ */
+export function writeGnapMessage(
+  projectPath: string,
+  message: GnapMessage,
+  gnapDir = ".gnap",
+): void {
+  const root = getGnapDir(projectPath, gnapDir);
+  const messagesDir = getMessagesDir(root);
+  mkdirSync(messagesDir, { recursive: true });
+
+  const messagePath = join(messagesDir, `${message.id}.json`);
+  atomicWriteFileSync(messagePath, JSON.stringify(message, null, 2) + "\n");
+}
+
+// =============================================================================
+// STATE MAPPING
+// =============================================================================
+
+/**
+ * Map an AO SessionStatus to a GNAP task state.
+ *
+ * AO status machine → GNAP state machine:
+ *   spawning     → ready        (task assigned, agent starting)
+ *   working      → in_progress  (agent actively coding)
+ *   pr_open      → review       (PR created, awaiting review)
+ *   ci_failed    → in_progress  (agent needs to fix CI)
+ *   review_pending → review     (waiting for human review)
+ *   changes_requested → in_progress (agent addressing feedback)
+ *   approved     → review       (approved but not yet merged)
+ *   mergeable    → review       (ready to merge)
+ *   merged       → done         (PR merged, task complete)
+ *   needs_input  → blocked      (agent needs human input)
+ *   stuck        → blocked      (agent is stuck)
+ *   errored      → blocked      (agent hit an error)
+ *   killed       → cancelled    (session killed)
+ *   idle         → in_progress  (agent idle but task not done)
+ *   done         → done         (task completed)
+ *   terminated   → cancelled    (session terminated)
+ *   cleanup      → cancelled    (session being cleaned up)
+ */
+export function sessionStatusToGnapState(status: SessionStatus): GnapTaskState {
+  switch (status) {
+    case "spawning":
+      return "ready";
+    case "working":
+    case "ci_failed":
+    case "changes_requested":
+    case "idle":
+      return "in_progress";
+    case "pr_open":
+    case "review_pending":
+    case "approved":
+    case "mergeable":
+      return "review";
+    case "merged":
+    case "done":
+      return "done";
+    case "needs_input":
+    case "stuck":
+    case "errored":
+      return "blocked";
+    case "killed":
+    case "terminated":
+    case "cleanup":
+      return "cancelled";
+    default:
+      return "in_progress";
+  }
+}
+
+/**
+ * Map a GNAP task state to a GNAP run state.
+ */
+export function gnapTaskStateToRunState(state: GnapTaskState): GnapRunState {
+  switch (state) {
+    case "done":
+      return "completed";
+    case "cancelled":
+      return "cancelled";
+    case "blocked":
+      return "failed";
+    default:
+      return "running";
+  }
+}
+
+// =============================================================================
+// SESSION-TO-GNAP SYNC
+// =============================================================================
+
+/** Options for syncing a session to GNAP state. */
+export interface GnapSyncOptions {
+  projectPath: string;
+  gnapDir?: string;
+  sessionId: string;
+  agentName: string;
+  issueId?: string;
+  issueTitle?: string;
+  issueDescription?: string;
+  status: SessionStatus;
+  branch?: string;
+  parentTaskId?: string;
+}
+
+/**
+ * Generate a deterministic GNAP task ID from a session's issue or session ID.
+ * Uses the issue ID if available, otherwise falls back to session ID.
+ */
+export function generateGnapTaskId(sessionId: string, issueId?: string): string {
+  if (issueId) {
+    // Sanitize issue ID for use as filename: replace slashes, spaces, special chars
+    return issueId
+      .replace(/[^a-zA-Z0-9_-]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "");
+  }
+  return sessionId;
+}
+
+/**
+ * Sync an AO session's state to GNAP task files.
+ *
+ * This is the main integration point — called by SessionManager on spawn
+ * and by LifecycleManager on status transitions. It:
+ * 1. Initializes the `.gnap/` directory if needed
+ * 2. Registers the agent in `agents.json`
+ * 3. Creates or updates the task in `tasks/`
+ * 4. Creates or updates the run in `runs/`
+ */
+export function syncSessionToGnap(opts: GnapSyncOptions): void {
+  const gnapDir = opts.gnapDir ?? ".gnap";
+
+  // Initialize GNAP directory if needed
+  if (!isGnapInitialized(opts.projectPath, gnapDir)) {
+    initGnapDir(opts.projectPath, gnapDir);
+  }
+
+  const now = new Date().toISOString();
+  const taskId = generateGnapTaskId(opts.sessionId, opts.issueId);
+  const agentId = opts.sessionId; // Use session ID as agent ID for uniqueness
+  const gnapState = sessionStatusToGnapState(opts.status);
+
+  // 1. Register/update agent
+  writeGnapAgent(
+    opts.projectPath,
+    {
+      id: agentId,
+      name: `${opts.agentName} (${opts.sessionId})`,
+      type: "ai",
+      status: gnapState === "done" || gnapState === "cancelled" ? "offline" : "active",
+    },
+    gnapDir,
+  );
+
+  // 2. Create or update task
+  const existingTask = readGnapTask(opts.projectPath, taskId, gnapDir);
+  if (existingTask) {
+    // Update existing task
+    const updates: Partial<GnapTask> = {
+      state: gnapState,
+    };
+
+    // Update blocked fields
+    if (gnapState === "blocked") {
+      updates.blocked = true;
+      updates.blocked_reason = `Agent ${opts.status}: ${opts.sessionId}`;
+    } else if (existingTask.blocked) {
+      updates.blocked = false;
+      updates.blocked_reason = undefined;
+    }
+
+    // Add agent to assigned_to if not already there
+    if (!existingTask.assigned_to.includes(agentId)) {
+      updates.assigned_to = [...existingTask.assigned_to, agentId];
+    }
+
+    updateGnapTask(opts.projectPath, taskId, updates, gnapDir);
+  } else {
+    // Create new task
+    const task: GnapTask = {
+      id: taskId,
+      title: opts.issueTitle ?? opts.issueId ?? `Session ${opts.sessionId}`,
+      desc: opts.issueDescription,
+      assigned_to: [agentId],
+      state: gnapState,
+      created_by: "ao-orchestrator",
+      created_at: now,
+      parent: opts.parentTaskId,
+      tags: opts.branch ? [`branch:${opts.branch}`] : undefined,
+    };
+
+    if (gnapState === "blocked") {
+      task.blocked = true;
+      task.blocked_reason = `Agent ${opts.status}: ${opts.sessionId}`;
+    }
+
+    writeGnapTask(opts.projectPath, task, gnapDir);
+  }
+
+  // 3. Create or update run
+  const runId = `${taskId}-${agentId}`;
+  const existingRun = readGnapRun(opts.projectPath, runId, gnapDir);
+  const runState = gnapTaskStateToRunState(gnapState);
+
+  if (existingRun) {
+    const runUpdates: Partial<GnapRun> = {
+      state: runState,
+    };
+    if (runState === "completed" || runState === "failed" || runState === "cancelled") {
+      runUpdates.completed_at = now;
+    }
+    if (runState === "failed" && opts.status === "errored") {
+      runUpdates.error = `Agent errored: ${opts.sessionId}`;
+    }
+    updateGnapRun(opts.projectPath, runId, runUpdates, gnapDir);
+  } else {
+    writeGnapRun(
+      opts.projectPath,
+      {
+        id: runId,
+        task_id: taskId,
+        agent_id: agentId,
+        state: runState,
+        started_at: now,
+      },
+      gnapDir,
+    );
+  }
+}
+
+// =============================================================================
+// DECOMPOSITION SYNC
+// =============================================================================
+
+/** Options for syncing a decomposition plan to GNAP. */
+export interface GnapDecompositionSyncOptions {
+  projectPath: string;
+  gnapDir?: string;
+  rootTaskDescription: string;
+  /** Leaf tasks from the decomposition — each will get a GNAP task file. */
+  tasks: Array<{
+    id: string;
+    description: string;
+    parentId?: string;
+    sessionId?: string;
+  }>;
+}
+
+/**
+ * Sync a decomposition plan to GNAP task files.
+ * Creates a parent task and child tasks for each leaf.
+ */
+export function syncDecompositionToGnap(opts: GnapDecompositionSyncOptions): void {
+  const gnapDir = opts.gnapDir ?? ".gnap";
+
+  if (!isGnapInitialized(opts.projectPath, gnapDir)) {
+    initGnapDir(opts.projectPath, gnapDir);
+  }
+
+  const now = new Date().toISOString();
+
+  // Create parent task
+  const parentTaskId = "plan-root";
+  writeGnapTask(
+    opts.projectPath,
+    {
+      id: parentTaskId,
+      title: opts.rootTaskDescription,
+      assigned_to: [],
+      state: "in_progress",
+      created_by: "ao-decomposer",
+      created_at: now,
+      tags: ["decomposed"],
+    },
+    gnapDir,
+  );
+
+  // Create child tasks
+  for (const task of opts.tasks) {
+    writeGnapTask(
+      opts.projectPath,
+      {
+        id: task.id,
+        title: task.description,
+        assigned_to: task.sessionId ? [task.sessionId] : [],
+        state: task.sessionId ? "in_progress" : "ready",
+        created_by: "ao-decomposer",
+        created_at: now,
+        parent: task.parentId ?? parentTaskId,
+      },
+      gnapDir,
+    );
+  }
+}

--- a/packages/core/src/gnap.ts
+++ b/packages/core/src/gnap.ts
@@ -469,14 +469,18 @@ export interface GnapSyncOptions {
 /**
  * Generate a deterministic GNAP task ID from a session's issue or session ID.
  * Uses the issue ID if available, otherwise falls back to session ID.
+ * Always returns a non-empty string safe for use as a filename.
  */
 export function generateGnapTaskId(sessionId: string, issueId?: string): string {
   if (issueId) {
     // Sanitize issue ID for use as filename: replace slashes, spaces, special chars
-    return issueId
+    const sanitized = issueId
       .replace(/[^a-zA-Z0-9_-]/g, "-")
       .replace(/-+/g, "-")
       .replace(/^-|-$/g, "");
+    // Fall back to sessionId if sanitization produced an empty string
+    // (e.g. issueId was "#" or "///")
+    if (sanitized) return sanitized;
   }
   return sessionId;
 }
@@ -600,6 +604,8 @@ export function syncSessionToGnap(opts: GnapSyncOptions): void {
 export interface GnapDecompositionSyncOptions {
   projectPath: string;
   gnapDir?: string;
+  /** Unique ID for this decomposition plan (default: auto-generated from timestamp) */
+  planId?: string;
   rootTaskDescription: string;
   /** Leaf tasks from the decomposition — each will get a GNAP task file. */
   tasks: Array<{
@@ -623,8 +629,9 @@ export function syncDecompositionToGnap(opts: GnapDecompositionSyncOptions): voi
 
   const now = new Date().toISOString();
 
-  // Create parent task
-  const parentTaskId = "plan-root";
+  // Use provided planId or generate a unique one to avoid collisions
+  // across multiple decomposition invocations
+  const parentTaskId = opts.planId ?? `plan-${Date.now()}`;
   writeGnapTask(
     opts.projectPath,
     {

--- a/packages/core/src/gnap.ts
+++ b/packages/core/src/gnap.ts
@@ -19,8 +19,12 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  openSync,
+  closeSync,
+  unlinkSync,
+  constants,
 } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { atomicWriteFileSync } from "./atomic-write.js";
 import type { SessionStatus } from "./types.js";
 
@@ -134,6 +138,41 @@ export const DEFAULT_GNAP_CONFIG: GnapConfig = {
 const GNAP_PROTOCOL_VERSION = "4";
 
 // =============================================================================
+// VALIDATION
+// =============================================================================
+
+/**
+ * Validate that an ID is safe for use as a filename component.
+ * Rejects path traversal attempts (e.g. "../../etc/evil") and empty IDs.
+ * Throws on invalid IDs to prevent writing outside the `.gnap/` directory.
+ */
+function validateGnapId(id: string, entity: string): void {
+  if (!id) {
+    throw new Error(`${entity} ID must not be empty`);
+  }
+  // Reject path separators and traversal sequences
+  if (id.includes("/") || id.includes("\\") || id.includes("..")) {
+    throw new Error(`${entity} ID contains invalid path characters: ${id}`);
+  }
+}
+
+/**
+ * Safely build a file path within a base directory, preventing path traversal.
+ * Validates that the resolved path stays within the expected base directory.
+ */
+function safeFilePath(baseDir: string, id: string, entity: string): string {
+  validateGnapId(id, entity);
+  const filePath = join(baseDir, `${id}.json`);
+  // Double-check: resolved path must stay within baseDir
+  const resolvedBase = resolve(baseDir);
+  const resolvedFile = resolve(filePath);
+  if (!resolvedFile.startsWith(resolvedBase + "/") && resolvedFile !== resolvedBase) {
+    throw new Error(`${entity} ID resolves outside target directory: ${id}`);
+  }
+  return filePath;
+}
+
+// =============================================================================
 // DIRECTORY OPERATIONS
 // =============================================================================
 
@@ -204,7 +243,7 @@ export function writeGnapTask(projectPath: string, task: GnapTask, gnapDir = ".g
   const tasksDir = getTasksDir(root);
   mkdirSync(tasksDir, { recursive: true });
 
-  const taskPath = join(tasksDir, `${task.id}.json`);
+  const taskPath = safeFilePath(tasksDir, task.id, "Task");
   atomicWriteFileSync(taskPath, JSON.stringify(task, null, 2) + "\n");
 }
 
@@ -216,7 +255,7 @@ export function readGnapTask(
   taskId: string,
   gnapDir = ".gnap",
 ): GnapTask | null {
-  const taskPath = join(getTasksDir(getGnapDir(projectPath, gnapDir)), `${taskId}.json`);
+  const taskPath = safeFilePath(getTasksDir(getGnapDir(projectPath, gnapDir)), taskId, "Task");
   if (!existsSync(taskPath)) return null;
 
   try {
@@ -289,20 +328,55 @@ export function readGnapAgents(projectPath: string, gnapDir = ".gnap"): GnapAgen
 
 /**
  * Write or update an agent in agents.json.
+ *
+ * Uses a lockfile to make the read-modify-write cycle safe against
+ * concurrent processes (e.g. parallel agent spawns).
  */
 export function writeGnapAgent(
   projectPath: string,
   agent: GnapAgent,
   gnapDir = ".gnap",
 ): void {
+  validateGnapId(agent.id, "Agent");
   const root = getGnapDir(projectPath, gnapDir);
   mkdirSync(root, { recursive: true });
 
   const agentsPath = join(root, "agents.json");
-  const agents = readGnapAgents(projectPath, gnapDir);
-  agents[agent.id] = agent;
+  const lockPath = `${agentsPath}.lock`;
 
-  atomicWriteFileSync(agentsPath, JSON.stringify(agents, null, 2) + "\n");
+  // Acquire lockfile (O_EXCL ensures only one process wins)
+  const maxRetries = 5;
+  let lockFd: number | null = null;
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      lockFd = openSync(lockPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL);
+      break;
+    } catch {
+      // Lock held by another process — brief busy-wait and retry
+      const waitMs = 10 + Math.random() * 20;
+      const end = Date.now() + waitMs;
+      while (Date.now() < end) {
+        // spin
+      }
+    }
+  }
+
+  try {
+    // Read current agents (inside lock)
+    const agents = readGnapAgents(projectPath, gnapDir);
+    agents[agent.id] = agent;
+    atomicWriteFileSync(agentsPath, JSON.stringify(agents, null, 2) + "\n");
+  } finally {
+    // Release lock
+    if (lockFd !== null) {
+      closeSync(lockFd);
+    }
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // Lock file already removed — harmless
+    }
+  }
 }
 
 // =============================================================================
@@ -317,7 +391,7 @@ export function writeGnapRun(projectPath: string, run: GnapRun, gnapDir = ".gnap
   const runsDir = getRunsDir(root);
   mkdirSync(runsDir, { recursive: true });
 
-  const runPath = join(runsDir, `${run.id}.json`);
+  const runPath = safeFilePath(runsDir, run.id, "Run");
   atomicWriteFileSync(runPath, JSON.stringify(run, null, 2) + "\n");
 }
 
@@ -329,7 +403,7 @@ export function readGnapRun(
   runId: string,
   gnapDir = ".gnap",
 ): GnapRun | null {
-  const runPath = join(getRunsDir(getGnapDir(projectPath, gnapDir)), `${runId}.json`);
+  const runPath = safeFilePath(getRunsDir(getGnapDir(projectPath, gnapDir)), runId, "Run");
   if (!existsSync(runPath)) return null;
 
   try {
@@ -372,7 +446,7 @@ export function writeGnapMessage(
   const messagesDir = getMessagesDir(root);
   mkdirSync(messagesDir, { recursive: true });
 
-  const messagePath = join(messagesDir, `${message.id}.json`);
+  const messagePath = safeFilePath(messagesDir, message.id, "Message");
   atomicWriteFileSync(messagePath, JSON.stringify(message, null, 2) + "\n");
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,45 @@ export type {
   DecomposerConfig,
 } from "./decomposer.js";
 
+// GNAP — Git-Native Agent Protocol persistent state layer
+export {
+  initGnapDir,
+  isGnapInitialized,
+  getGnapDir,
+  writeGnapTask,
+  readGnapTask,
+  updateGnapTask,
+  listGnapTasks,
+  readGnapAgents,
+  writeGnapAgent,
+  writeGnapRun,
+  readGnapRun,
+  updateGnapRun,
+  writeGnapMessage,
+  sessionStatusToGnapState,
+  gnapTaskStateToRunState,
+  generateGnapTaskId,
+  syncSessionToGnap,
+  syncDecompositionToGnap,
+  DEFAULT_GNAP_CONFIG,
+} from "./gnap.js";
+export type {
+  GnapTask,
+  GnapTaskState,
+  GnapAgent,
+  GnapAgentType,
+  GnapAgentStatus,
+  GnapAgentsFile,
+  GnapRun,
+  GnapRunState,
+  GnapMessage,
+  GnapMessageType,
+  GnapComment,
+  GnapConfig,
+  GnapSyncOptions,
+  GnapDecompositionSyncOptions,
+} from "./gnap.js";
+
 // Orchestrator prompt — generates orchestrator context for `ao start`
 export { generateOrchestratorPrompt } from "./orchestrator-prompt.js";
 export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -35,6 +35,7 @@ import {
 } from "./types.js";
 import { updateMetadata } from "./metadata.js";
 import { getSessionsDir } from "./paths.js";
+import { syncSessionToGnap } from "./gnap.js";
 import { createCorrelationId, createProjectObserver } from "./observability.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
 
@@ -726,6 +727,24 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         data: { oldStatus, newStatus },
         level: transitionLogLevel(newStatus),
       });
+
+      // Sync status transition to GNAP persistent state (non-fatal)
+      const project = config.projects[session.projectId];
+      if (project?.gnap?.enabled) {
+        try {
+          syncSessionToGnap({
+            projectPath: project.path,
+            gnapDir: project.gnap.dir,
+            sessionId: session.id,
+            agentName: session.metadata["agent"] ?? "unknown",
+            issueId: session.issueId ?? undefined,
+            status: newStatus,
+            branch: session.branch ?? undefined,
+          });
+        } catch {
+          // GNAP sync is best-effort — never block lifecycle polling
+        }
+      }
 
       // Reset allCompleteEmitted when any session becomes active again
       if (newStatus !== "merged" && newStatus !== "killed") {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -55,6 +55,7 @@ import {
   reserveSessionId,
 } from "./metadata.js";
 import { buildPrompt } from "./prompt-builder.js";
+import { syncSessionToGnap } from "./gnap.js";
 import {
   getSessionsDir,
   getWorktreesDir,
@@ -1183,6 +1184,25 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       } catch {
         // Non-fatal: agent is running but didn't receive the initial prompt.
         // User can retry with `ao send`.
+      }
+    }
+
+    // Sync to GNAP persistent state layer (non-fatal — never block spawn)
+    if (project.gnap?.enabled) {
+      try {
+        syncSessionToGnap({
+          projectPath: project.path,
+          gnapDir: project.gnap.dir,
+          sessionId,
+          agentName: selection.agentName,
+          issueId: spawnConfig.issueId,
+          issueTitle: resolvedIssue?.title,
+          issueDescription: resolvedIssue?.description,
+          status: "spawning",
+          branch,
+        });
+      } catch {
+        // GNAP sync is best-effort — never block spawn
       }
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1009,6 +1009,14 @@ export interface ProjectConfig {
     /** Require human approval before executing decomposed plans (default: true) */
     requireApproval: boolean;
   };
+
+  /** GNAP (Git-Native Agent Protocol) persistent state layer */
+  gnap?: {
+    /** Enable GNAP state persistence (default: false) */
+    enabled: boolean;
+    /** Directory for GNAP files relative to project root (default: ".gnap") */
+    dir?: string;
+  };
 }
 
 export interface TrackerConfig {


### PR DESCRIPTION
## Summary

- Implements [GNAP (Git-Native Agent Protocol)](https://github.com/farol-team/gnap) v4 as an opt-in persistent state backend for the orchestration pipeline
- When enabled per-project via `gnap.enabled` config, task state is written as JSON files to `.gnap/` in the project's git repository
- Provides persistence across agent restarts, clear task ownership for parallel agents, and git-based audit trail

## What changed

### New files
- `packages/core/src/gnap.ts` — Core GNAP module implementing all four protocol entities (agents, tasks, runs, messages) with read/write operations, state mapping from AO session states to GNAP task states, and sync functions
- `packages/core/src/__tests__/gnap.test.ts` — 60 tests covering all GNAP operations

### Modified files
- `packages/core/src/types.ts` — Added `gnap` config field to `ProjectConfig`
- `packages/core/src/config.ts` — Added Zod schema for GNAP config validation
- `packages/core/src/session-manager.ts` — Syncs to GNAP on session spawn (best-effort, never blocks spawn)
- `packages/core/src/lifecycle-manager.ts` — Syncs status transitions to GNAP task state (best-effort, never blocks polling)
- `packages/core/src/index.ts` — Exports all GNAP types and functions

### Integration pattern
```yaml
# agent-orchestrator.yaml
projects:
  my-app:
    repo: org/repo
    path: ~/my-app
    gnap:
      enabled: true
```

This writes GNAP-compliant state to the project repo:
```
.gnap/
├── version          # "4"
├── agents.json      # {session-id: {name, type, status}}
├── tasks/
│   └── INT-123.json # {title, assigned_to, state, ...}
├── runs/
│   └── INT-123-int-1.json  # {task_id, agent_id, state, ...}
└── messages/
```

## Design decisions
- **Best-effort only** — GNAP sync failures never block session spawn or lifecycle polling
- **Opt-in** — Disabled by default, enabled per-project via config
- **No git operations** — Writes files only; committing/pushing is left to the application layer
- **Deterministic task IDs** — Uses issue ID when available, session ID as fallback

Closes #472

## Test plan
- [x] 60 new tests covering all GNAP operations (init, task CRUD, agent CRUD, run CRUD, messages, state mapping, session sync, decomposition sync)
- [x] All 531 existing core tests pass
- [x] TypeScript type-checking passes
- [x] ESLint passes (0 new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)