### PR TITLE
fix(dashboard): gracefully handle missing node-pty on linux-arm64

### DIFF
--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -107,7 +107,7 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
         JSON.stringify({
           active: activeSessions.size,
           sessions: Array.from(activeSessions.keys()),
-          nodePtyAvailable: ptySpawnFn !== null,
+          nodePtyAvailable: !!ptySpawnFn,
           ...(nodePtyLoadError && { nodePtyError: nodePtyLoadError }),
           metrics,
         }),

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -10,15 +10,54 @@
 import { createServer, type Server } from "node:http";
 import { spawn } from "node:child_process";
 import { WebSocketServer, WebSocket } from "ws";
-import { spawn as ptySpawn, type IPty } from "node-pty";
 import { homedir, userInfo } from "node:os";
 import { createCorrelationId } from "@composio/ao-core";
 import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js";
 import { createObserverContext, inferProjectId } from "./terminal-observability.js";
 
+/**
+ * Minimal PTY interface — the subset of node-pty's IPty we actually use.
+ * Defined inline so the module loads even when node-pty is absent.
+ */
+interface PtyProcess {
+  onData(callback: (data: string) => void): void;
+  onExit(callback: (e: { exitCode: number; signal?: number }) => void): void;
+  resize(columns: number, rows: number): void;
+  write(data: string): void;
+  kill(signal?: string): void;
+}
+
+type PtySpawnFn = (
+  file: string,
+  args: string[],
+  options: { name?: string; cols?: number; rows?: number; cwd?: string; env?: Record<string, string> },
+) => PtyProcess;
+
+// ── Graceful node-pty loading ─────────────────────────────────────────
+// node-pty ships prebuilt binaries for darwin and win32 but NOT linux-arm64.
+// On unsupported platforms without build tools (make, g++), the import fails.
+// Instead of crashing the process (which kills the entire dashboard via
+// concurrently), we degrade gracefully: the server stays up, health checks
+// report the status, and WebSocket clients receive close code 4002 so the
+// frontend can fall back to the ttyd-based terminal.
+
+let ptySpawnFn: PtySpawnFn | null = null;
+let nodePtyLoadError: string | null = null;
+
+try {
+  const nodePty = await import("node-pty");
+  ptySpawnFn = nodePty.spawn as PtySpawnFn;
+} catch (err) {
+  nodePtyLoadError = err instanceof Error ? err.message : String(err);
+  console.warn(`[DirectTerminal] node-pty unavailable: ${nodePtyLoadError}`);
+  console.warn(
+    "[DirectTerminal] Direct terminal disabled — dashboard will use ttyd fallback.",
+  );
+}
+
 interface TerminalSession {
   sessionId: string;
-  pty: IPty;
+  pty: PtyProcess;
   ws: WebSocket;
 }
 
@@ -68,6 +107,8 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
         JSON.stringify({
           active: activeSessions.size,
           sessions: Array.from(activeSessions.keys()),
+          nodePtyAvailable: ptySpawnFn !== null,
+          ...(nodePtyLoadError && { nodePtyError: nodePtyLoadError }),
           metrics,
         }),
       );
@@ -150,6 +191,22 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
       return;
     }
 
+    // Reject connection if node-pty is not available (e.g. linux-arm64 without prebuilds)
+    if (!ptySpawnFn) {
+      console.error(
+        "[DirectTerminal] node-pty unavailable, rejecting connection for:",
+        sessionId,
+      );
+      recordWebsocketMetric({
+        metric: "websocket_error",
+        outcome: "failure",
+        sessionId,
+        reason: "node-pty unavailable",
+      });
+      ws.close(4002, "node-pty unavailable");
+      return;
+    }
+
     console.log(`[DirectTerminal] New connection for session: ${tmuxSessionId}`);
 
     // Enable mouse mode for scrollback support
@@ -180,11 +237,11 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
       TMPDIR: process.env.TMPDIR || "/tmp",
     };
 
-    let pty: IPty;
+    let pty: PtyProcess;
     try {
       console.log(`[DirectTerminal] Spawning PTY: tmux attach-session -t ${tmuxSessionId}`);
 
-      pty = ptySpawn(TMUX, ["attach-session", "-t", tmuxSessionId], {
+      pty = ptySpawnFn(TMUX, ["attach-session", "-t", tmuxSessionId], {
         name: "xterm-256color",
         cols: 80,
         rows: 24,

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -10,6 +10,7 @@ import "xterm/css/xterm.css";
 // Dynamically import xterm types for TypeScript
 import type { Terminal as TerminalType } from "xterm";
 import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
+import { Terminal } from "./Terminal";
 
 interface DirectTerminalProps {
   sessionId: string;
@@ -91,6 +92,7 @@ export function DirectTerminal({
   const [error, setError] = useState<string | null>(null);
   const [reloading, setReloading] = useState(false);
   const [reloadError, setReloadError] = useState<string | null>(null);
+  const [useTtydFallback, setUseTtydFallback] = useState(false);
 
   // Update URL when fullscreen changes
   useEffect(() => {
@@ -402,6 +404,15 @@ export function DirectTerminal({
 
             if (!mounted) return;
 
+            // node-pty unavailable — fall back to ttyd terminal
+            if (event.code === 4002) {
+              console.log(
+                "[DirectTerminal] node-pty unavailable, falling back to ttyd terminal",
+              );
+              setUseTtydFallback(true);
+              return;
+            }
+
             // Permanent errors — don't retry
             if (PERMANENT_CLOSE_CODES.has(event.code)) {
               permanentErrorRef.current = true;
@@ -567,6 +578,24 @@ export function DirectTerminal({
       : status === "error"
         ? "text-[var(--color-status-error)]"
         : "text-[var(--color-text-tertiary)]";
+
+  // Fall back to ttyd-based terminal when node-pty is unavailable (e.g. linux-arm64)
+  if (useTtydFallback) {
+    return (
+      <div>
+        <div className="mb-2 flex items-center gap-2 rounded-[6px] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2">
+          <span className="text-[11px] font-semibold text-[var(--color-status-attention)]">
+            Degraded mode
+          </span>
+          <span className="text-[11px] text-[var(--color-text-secondary)]">
+            node-pty unavailable on this platform. Using iframe terminal (clipboard support
+            limited).
+          </span>
+        </div>
+        <Terminal sessionId={sessionId} />
+      </div>
+    );
+  }
 
   return (
     <div


### PR DESCRIPTION
## Summary

- Replace static `import { spawn } from "node-pty"` with dynamic `await import("node-pty")` in try/catch so `direct-terminal-ws.ts` stays up even when the native binary is missing (linux-arm64 without build tools)
- WebSocket clients receive close code **4002** when node-pty is unavailable, and the `DirectTerminal` React component detects this and falls back to the ttyd-based iframe terminal with a degraded-mode notice
- Health endpoint now reports `nodePtyAvailable` status for observability

Closes #489

## Test plan

- [x] All 45 `direct-terminal-ws.integration.test.ts` tests pass (node-pty available path unchanged)
- [x] 4 `DirectTerminal.test.ts` unit tests pass
- [x] No new TypeScript errors introduced
- [ ] Verify on linux-arm64: `ao start` shows dashboard with ttyd fallback terminal and "Degraded mode" banner
- [ ] Verify on darwin/win32: behavior unchanged, DirectTerminal uses node-pty as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)