### PR TITLE
fix: DirectTerminal stuck on 'Connecting...' when tmux session is dead

### DIFF
--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -342,7 +342,7 @@ describe("WebSocket connection validation", () => {
     const ws = new WebSocket(`ws://localhost:${port}/ws?session=ao-nonexistent-999`);
     const result = await waitForWsClose(ws);
 
-    expect(result.code).toBe(1008);
+    expect(result.code).toBe(4004);
     expect(result.reason).toContain("Session not found");
   });
 
@@ -351,7 +351,7 @@ describe("WebSocket connection validation", () => {
     const ws = new WebSocket(`ws://localhost:${port}/ws?session=definitely-not-real-${Date.now()}`);
     const result = await waitForWsClose(ws);
 
-    expect(result.code).toBe(1008);
+    expect(result.code).toBe(4004);
     expect(result.reason).toContain("Session not found");
   });
 });
@@ -570,7 +570,7 @@ describe("hash-prefixed session resolution", () => {
       const ws = new WebSocket(`ws://localhost:${port}/ws?session=${session1}`);
       const result = await waitForWsClose(ws);
 
-      expect(result.code).toBe(1008);
+      expect(result.code).toBe(4004);
       expect(result.reason).toContain("Session not found");
     } finally {
       try {

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -165,7 +165,7 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
         sessionId,
         reason: "Session not found",
       });
-      ws.close(1008, "Session not found");
+      ws.close(4004, "Session not found");
       return;
     }
 


### PR DESCRIPTION
## Summary

- Changes WebSocket close code from `1008` to `4004` when a tmux session is not found (`packages/web/server/direct-terminal-ws.ts:168`)
- The client already treats `4004` as a permanent failure and shows an error state — this stops the infinite reconnect loop

## Why

When a tmux session dies (system restart, `tmux kill-server`, crash), the server was closing with code `1008`. Since `1008` is not in the client's `PERMANENT_CLOSE_CODES` set (`4001`, `4004`), the client treated it as transient and retried forever, leaving users stuck on "Connecting...".

## Test plan

- [ ] Navigate to a stale session URL (bookmark/direct link to a deleted session)
- [ ] Verify the UI shows an error state instead of looping "Connecting..."
- [ ] Kill tmux server (`tmux kill-server`) while session is open and confirm reconnect stops with an error

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)