### PR TITLE
feat: add ClickUp tracker plugin

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,7 +168,7 @@ pr=https://github.com/ComposioHQ/integrator/pull/123
 **Key fields:**
 
 - `project` - Which project this session belongs to (for filtering)
-- `issue` - Linear/GitHub issue ID
+- `issue` - Linear/GitHub/ClickUp issue ID
 - `branch` - Git branch name
 - `worktree` - Path to git worktree
 - `status` - working/idle/pr_open/merged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ All plugin interfaces are in [`packages/core/src/types.ts`](packages/core/src/ty
 | `runtime`   | `Runtime`   | Run agents in Docker, SSH, cloud VMs |
 | `agent`     | `Agent`     | Adapt a new AI coding tool           |
 | `workspace` | `Workspace` | Different code isolation strategies  |
-| `tracker`   | `Tracker`   | Jira, Asana, or custom issue systems |
+| `tracker`   | `Tracker`   | ClickUp, Jira, Asana, or custom      |
 | `scm`       | `SCM`       | GitLab, Bitbucket support            |
 | `notifier`  | `Notifier`  | Email, Discord, custom webhooks      |
 | `terminal`  | `Terminal`  | Different terminal UI integrations   |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Spawn parallel AI coding agents, each in its own git worktree. Agents autonomous
 
 Agent Orchestrator manages fleets of AI coding agents working in parallel on your codebase. Each agent gets its own git worktree, its own branch, and its own PR. When CI fails, the agent fixes it. When reviewers leave comments, the agent addresses them. You only get pulled in when human judgment is needed.
 
-**Agent-agnostic** (Claude Code, Codex, Aider) · **Runtime-agnostic** (tmux, Docker) · **Tracker-agnostic** (GitHub, Linear)
+**Agent-agnostic** (Claude Code, Codex, Aider) · **Runtime-agnostic** (tmux, Docker) · **Tracker-agnostic** (GitHub, Linear, ClickUp)
 
 <div align="center">
 
@@ -145,7 +145,7 @@ Eight slots. Every abstraction is swappable.
 | Runtime   | tmux        | docker, k8s, process     |
 | Agent     | claude-code | codex, aider, opencode   |
 | Workspace | worktree    | clone                    |
-| Tracker   | github      | linear                   |
+| Tracker   | github      | linear, clickup          |
 | SCM       | github      | —                        |
 | Notifier  | desktop     | slack, composio, webhook |
 | Terminal  | iterm2      | web                      |
@@ -167,7 +167,7 @@ Running one AI agent in a terminal is easy. Running 30 across different issues, 
 | ---------------------------------------- | ------------------------------------------------------------ |
 | [Setup Guide](SETUP.md)                  | Detailed installation, configuration, and troubleshooting    |
 | [CLI Reference](docs/CLI.md)             | All `ao` commands (mostly used by the orchestrator agent)    |
-| [Examples](examples/)                    | Config templates (GitHub, Linear, multi-project, auto-merge) |
+| [Examples](examples/)                    | Config templates (GitHub, Linear, ClickUp, multi-project, auto-merge) |
 | [Development Guide](docs/DEVELOPMENT.md) | Architecture, conventions, plugin pattern                    |
 | [Contributing](CONTRIBUTING.md)          | How to contribute, build plugins, PR process                 |
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -195,7 +195,7 @@ Agent Orchestrator has 8 plugin slots. All are swappable:
 | **Runtime**   | How sessions run     | `tmux`        | `process`, `docker`, `kubernetes`, `ssh`, `e2b` |
 | **Agent**     | AI coding assistant  | `claude-code` | `codex`, `aider`, `goose`, custom               |
 | **Workspace** | Workspace isolation  | `worktree`    | `clone`, `copy`                                 |
-| **Tracker**   | Issue tracking       | `github`      | `linear`, `jira`, custom                        |
+| **Tracker**   | Issue tracking       | `github`      | `linear`, `clickup`, `jira`, custom              |
 | **SCM**       | Source control       | `github`      | GitLab, Bitbucket (future)                      |
 | **Notifier**  | Notifications        | `desktop`     | `slack`, `discord`, `webhook`, `email`          |
 | **Terminal**  | Terminal integration | `iterm2`      | `web`, custom                                   |
@@ -348,6 +348,37 @@ gh auth status
 
 ```bash
 echo $LINEAR_API_KEY  # Should print your key
+```
+
+### ClickUp
+
+**Setup:**
+
+1. Get your API token: https://app.clickup.com/settings/apps
+2. Add to environment:
+
+   ```bash
+   echo 'export CLICKUP_API_TOKEN="pk_..."' >> ~/.zshrc
+   source ~/.zshrc
+   ```
+
+3. Find your list ID:
+   - Open your ClickUp list in the browser
+   - The list ID is in the URL: `https://app.clickup.com/{workspace}/v/li/{listId}`
+
+4. Configure in `agent-orchestrator.yaml`:
+   ```yaml
+   projects:
+     my-app:
+       tracker:
+         plugin: clickup
+         listId: "your-list-id"
+   ```
+
+**Verification:**
+
+```bash
+echo $CLICKUP_API_TOKEN  # Should print your token
 ```
 
 ### Slack
@@ -771,6 +802,11 @@ projects:
     tracker:
       plugin: linear
       teamId: "..."
+
+  mobile:
+    tracker:
+      plugin: clickup
+      listId: "..."
 ```
 
 ### How do I monitor agent progress?

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -39,6 +39,11 @@ projects:
     # tracker:
     #   plugin: linear
     #   teamId: "your-team-id"
+    #
+    # ClickUp tracker:
+    # tracker:
+    #   plugin: clickup
+    #   listId: "your-list-id"
 
     # SCM webhook acceleration (optional)
     # scm:

--- a/artifacts/architecture-design.md
+++ b/artifacts/architecture-design.md
@@ -50,7 +50,7 @@ Human only intervenes when notified. Everything else is handled.
 | **Runtime**      | Where/how the session executes             | tmux, docker, k8s, process       |
 | **Agent**        | The AI coding tool being used              | claude-code, codex, aider        |
 | **Workspace**    | Isolated code copy for a session           | git worktree, clone, volume      |
-| **Tracker**      | Issue/task tracking system                 | github, linear, jira             |
+| **Tracker**      | Issue/task tracking system                 | github, linear, clickup, jira    |
 | **SCM**          | Source code management platform            | github, gitlab, bitbucket        |
 | **Notifier**     | Communication/alert channel                | slack, discord, desktop, webhook |
 | **Terminal**     | Human interaction interface                | iterm2, web terminal, none       |
@@ -725,6 +725,7 @@ agent-orchestrator/
 │       ├── workspace-clone/
 │       ├── tracker-github/
 │       ├── tracker-linear/
+│       ├── tracker-clickup/
 │       ├── scm-github/
 │       ├── notifier-desktop/
 │       ├── notifier-slack/

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,7 +25,7 @@ Every abstraction is a swappable plugin. All interfaces are defined in [`package
 | Runtime   | `Runtime`   | `tmux`        | `process`, `docker`, `k8s`, `ssh`, `e2b` |
 | Agent     | `Agent`     | `claude-code` | `codex`, `aider`, `opencode`             |
 | Workspace | `Workspace` | `worktree`    | `clone`                                  |
-| Tracker   | `Tracker`   | `github`      | `linear`                                 |
+| Tracker   | `Tracker`   | `github`      | `linear`, `clickup`                      |
 | SCM       | `SCM`       | `github`      | —                                        |
 | Notifier  | `Notifier`  | `desktop`     | `slack`, `webhook`, `composio`           |
 | Terminal  | `Terminal`  | `iterm2`      | `web`                                    |
@@ -109,7 +109,7 @@ agent-orchestrator/
 │   │   ├── runtime-*/     # Runtime plugins (tmux, docker, k8s)
 │   │   ├── agent-*/       # Agent adapters (claude-code, codex, aider)
 │   │   ├── workspace-*/   # Workspace providers (worktree, clone)
-│   │   ├── tracker-*/     # Issue trackers (github, linear)
+│   │   ├── tracker-*/     # Issue trackers (github, linear, clickup)
 │   │   ├── scm-github/    # SCM adapter
 │   │   ├── notifier-*/    # Notification channels
 │   │   └── terminal-*/    # Terminal UIs

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,6 +38,18 @@ Use this if:
 - You want agents to update Linear ticket status
 - You need custom agent rules per project
 
+### [clickup-team.yaml](./clickup-team.yaml)
+
+**ClickUp integration**
+
+Integrates with ClickUp for task management. Requires `CLICKUP_API_TOKEN` environment variable.
+
+Use this if:
+
+- Your team uses ClickUp for task management
+- You want agents to update ClickUp task status
+- You need custom agent rules per project
+
 ### [multi-project.yaml](./multi-project.yaml)
 
 **Multiple repos with different trackers**
@@ -47,7 +59,7 @@ Shows how to manage multiple projects with different trackers and notification r
 Use this if:
 
 - You're managing multiple repositories
-- Different projects use different trackers (GitHub Issues vs Linear)
+- Different projects use different trackers (GitHub Issues vs Linear vs ClickUp)
 - You want Slack notifications in addition to desktop
 - You need different rules per project
 

--- a/examples/clickup-team.yaml
+++ b/examples/clickup-team.yaml
@@ -1,0 +1,22 @@
+# ClickUp integration for task management
+# Requires CLICKUP_API_TOKEN environment variable
+
+dataDir: ~/.agent-orchestrator
+worktreeDir: ~/.worktrees
+
+projects:
+  my-app:
+    repo: owner/my-app
+    path: ~/my-app
+    defaultBranch: main
+
+    # ClickUp tracker integration
+    tracker:
+      plugin: clickup
+      listId: "your-list-id"
+
+    # Custom rules for agents
+    agentRules: |
+      Always reference ClickUp task IDs in commit messages.
+      Run tests before pushing.
+      Use conventional commits (feat:, fix:, chore:).

--- a/examples/multi-project.yaml
+++ b/examples/multi-project.yaml
@@ -42,6 +42,21 @@ projects:
       Add OpenAPI docs for new routes.
       Run `pnpm test` and `pnpm lint` before pushing.
 
+  mobile:
+    name: Mobile App
+    repo: org/mobile
+    path: ~/mobile
+    defaultBranch: main
+    sessionPrefix: mob
+
+    tracker:
+      plugin: clickup
+      listId: "your-list-id"
+
+    agentRules: |
+      Follow platform-specific guidelines.
+      Run `pnpm test` before pushing.
+
 # Slack notifications (requires SLACK_WEBHOOK_URL)
 notifiers:
   slack:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
     "@composio/ao-plugin-scm-github": "workspace:*",
     "@composio/ao-plugin-terminal-iterm2": "workspace:*",
     "@composio/ao-plugin-terminal-web": "workspace:*",
+    "@composio/ao-plugin-tracker-clickup": "workspace:*",
     "@composio/ao-plugin-tracker-github": "workspace:*",
     "@composio/ao-plugin-tracker-linear": "workspace:*",
     "@composio/ao-plugin-workspace-clone": "workspace:*",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,7 +20,7 @@ Every interface the system uses is defined here. If you're working on any part o
 - `Runtime` — where sessions execute (tmux, docker, k8s)
 - `Agent` — AI coding tool adapter (claude-code, codex, aider)
 - `Workspace` — code isolation (worktree, clone)
-- `Tracker` — issue tracking (GitHub Issues, Linear)
+- `Tracker` — issue tracking (GitHub Issues, Linear, ClickUp)
 - `SCM` — PR/CI/reviews (GitHub, GitLab)
 - `Notifier` — push notifications (desktop, Slack, webhook)
 - `Terminal` — human interaction UI (iTerm2, web)
@@ -95,7 +95,7 @@ Loads plugins and provides access to them:
 - runtime-tmux, runtime-process
 - agent-claude-code, agent-codex, agent-aider, agent-opencode
 - workspace-worktree, workspace-clone
-- tracker-github, tracker-linear
+- tracker-github, tracker-linear, tracker-clickup
 - scm-github
 - notifier-desktop, notifier-slack, notifier-composio, notifier-webhook
 - terminal-iterm2, terminal-web

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -5018,10 +5018,18 @@ describe("isIssueNotFoundError", () => {
     expect(isIssueNotFoundError(new Error("Invalid issue format: fix login bug"))).toBe(true);
   });
 
+  it("matches ClickUp API task-not-found errors", () => {
+    expect(isIssueNotFoundError(new Error("ClickUp API error: Task not found"))).toBe(true);
+    expect(isIssueNotFoundError(new Error("ClickUp API error: Task does not exist"))).toBe(true);
+  });
+
   it("does not match unrelated errors", () => {
     expect(isIssueNotFoundError(new Error("Unauthorized"))).toBe(false);
     expect(isIssueNotFoundError(new Error("Network timeout"))).toBe(false);
     expect(isIssueNotFoundError(new Error("API key not found"))).toBe(false);
+    // Must not false-positive on infrastructure errors containing "task"
+    expect(isIssueNotFoundError(new Error("background task not found"))).toBe(false);
+    expect(isIssueNotFoundError(new Error("scheduled task does not exist"))).toBe(false);
   });
 
   it("returns false for non-error values", () => {

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -39,6 +39,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "tracker", name: "github", pkg: "@composio/ao-plugin-tracker-github" },
   { slot: "tracker", name: "linear", pkg: "@composio/ao-plugin-tracker-linear" },
   { slot: "tracker", name: "gitlab", pkg: "@composio/ao-plugin-tracker-gitlab" },
+  { slot: "tracker", name: "clickup", pkg: "@composio/ao-plugin-tracker-clickup" },
   // SCM
   { slot: "scm", name: "github", pkg: "@composio/ao-plugin-scm-github" },
   { slot: "scm", name: "gitlab", pkg: "@composio/ao-plugin-scm-gitlab" },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1277,7 +1277,10 @@ export function isIssueNotFoundError(err: unknown): boolean {
     // Linear: "Issue <id> not found" or "No issue with identifier"
     message.includes("no issue with identifier") ||
     // GitHub: "invalid issue format" (ad-hoc free-text strings)
-    message.includes("invalid issue format")
+    message.includes("invalid issue format") ||
+    // ClickUp: "Task not found" or "Task does not exist"
+    (message.includes("task") &&
+      (message.includes("not found") || message.includes("does not exist")))
   );
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -447,7 +447,7 @@ export interface WorkspaceInfo {
 // =============================================================================
 
 /**
- * Issue/task tracker integration — GitHub Issues, Linear, Jira, etc.
+ * Issue/task tracker integration — GitHub Issues, Linear, ClickUp, Jira, etc.
  */
 export interface Tracker {
   readonly name: string;
@@ -1278,8 +1278,8 @@ export function isIssueNotFoundError(err: unknown): boolean {
     message.includes("no issue with identifier") ||
     // GitHub: "invalid issue format" (ad-hoc free-text strings)
     message.includes("invalid issue format") ||
-    // ClickUp: "Task not found" or "Task does not exist"
-    (message.includes("task") &&
+    // ClickUp: errors surfaced as "ClickUp API error: Task not found"
+    (message.includes("clickup") &&
       (message.includes("not found") || message.includes("does not exist")))
   );
 }

--- a/packages/plugins/tracker-clickup/package.json
+++ b/packages/plugins/tracker-clickup/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@composio/ao-plugin-tracker-clickup",
+  "version": "0.1.0",
+  "description": "Tracker plugin: ClickUp task management",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/tracker-clickup"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/tracker-clickup/src/index.ts
+++ b/packages/plugins/tracker-clickup/src/index.ts
@@ -1,0 +1,436 @@
+/**
+ * tracker-clickup plugin — ClickUp as an issue tracker.
+ *
+ * Uses the ClickUp API v2 for all interactions.
+ * Authentication via CLICKUP_API_TOKEN environment variable.
+ */
+
+import { request as httpsRequest } from "node:https";
+import type {
+  PluginModule,
+  Tracker,
+  Issue,
+  IssueFilters,
+  IssueUpdate,
+  CreateIssueInput,
+  ProjectConfig,
+} from "@composio/ao-core";
+
+// ---------------------------------------------------------------------------
+// API client
+// ---------------------------------------------------------------------------
+
+const CLICKUP_API_BASE = "https://api.clickup.com/api/v2";
+const REQUEST_TIMEOUT_MS = 30_000;
+
+function getApiToken(): string {
+  const token = process.env["CLICKUP_API_TOKEN"];
+  if (!token) {
+    throw new Error(
+      "CLICKUP_API_TOKEN environment variable is required for the ClickUp tracker plugin",
+    );
+  }
+  return token;
+}
+
+interface ClickUpErrorResponse {
+  err?: string;
+  ECODE?: string;
+}
+
+function clickUpRequest<T>(
+  method: "GET" | "POST" | "PUT" | "DELETE",
+  path: string,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  const token = getApiToken();
+  const url = new URL(`${CLICKUP_API_BASE}${path}`);
+  const payload = body ? JSON.stringify(body) : undefined;
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (!settled) {
+        settled = true;
+        fn();
+      }
+    };
+
+    const req = httpsRequest(
+      {
+        hostname: url.hostname,
+        path: url.pathname + url.search,
+        method,
+        headers: {
+          Authorization: token,
+          "Content-Type": "application/json",
+          ...(payload ? { "Content-Length": String(Buffer.byteLength(payload)) } : {}),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("error", (err: Error) => settle(() => reject(err)));
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          settle(() => {
+            try {
+              const text = Buffer.concat(chunks).toString("utf-8");
+              const status = res.statusCode ?? 0;
+
+              if (status < 200 || status >= 300) {
+                reject(
+                  new Error(`ClickUp API returned HTTP ${status}: ${text.slice(0, 200)}`),
+                );
+                return;
+              }
+
+              const json = JSON.parse(text) as T & ClickUpErrorResponse;
+
+              if (json.err) {
+                reject(new Error(`ClickUp API error: ${json.err}`));
+                return;
+              }
+
+              resolve(json);
+            } catch (err) {
+              reject(err);
+            }
+          });
+        });
+      },
+    );
+
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      settle(() => {
+        req.destroy();
+        reject(new Error("ClickUp API request timed out after 30s"));
+      });
+    });
+
+    req.on("error", (err) => settle(() => reject(err)));
+
+    if (payload) {
+      req.write(payload);
+    }
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// ClickUp API response types
+// ---------------------------------------------------------------------------
+
+interface ClickUpStatus {
+  status: string;
+  type: string; // "open" | "custom" | "closed" | "done"
+}
+
+interface ClickUpUser {
+  id: number;
+  username: string;
+}
+
+interface ClickUpTag {
+  name: string;
+}
+
+interface ClickUpTask {
+  id: string;
+  custom_id: string | null;
+  name: string;
+  description: string | null;
+  text_content: string | null;
+  status: ClickUpStatus;
+  priority: {
+    id: string;
+    priority: string; // "urgent" | "high" | "normal" | "low"
+    orderindex: string;
+  } | null;
+  assignees: ClickUpUser[];
+  tags: ClickUpTag[];
+  url: string;
+  list: {
+    id: string;
+    name: string;
+  };
+}
+
+interface ClickUpTaskList {
+  tasks: ClickUpTask[];
+}
+
+// ---------------------------------------------------------------------------
+// State mapping
+// ---------------------------------------------------------------------------
+
+function mapClickUpState(status: ClickUpStatus): Issue["state"] {
+  const type = status.type.toLowerCase();
+  if (type === "closed" || type === "done") return "closed";
+  if (type === "open") return "open";
+  // "custom" statuses: infer from the status name
+  const name = status.status.toLowerCase();
+  if (name === "in progress" || name === "in review" || name === "doing") return "in_progress";
+  if (name === "closed" || name === "done" || name === "complete" || name === "resolved") {
+    return "closed";
+  }
+  return "open";
+}
+
+function mapClickUpPriority(priority: ClickUpTask["priority"]): number | undefined {
+  if (!priority) return undefined;
+  // ClickUp priority: 1=urgent, 2=high, 3=normal, 4=low
+  // This matches the Issue.priority convention used by Linear
+  return Number(priority.id);
+}
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the ClickUp list ID from project tracker config. */
+function getListId(project: ProjectConfig): string | undefined {
+  return project.tracker?.["listId"] as string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tracker implementation
+// ---------------------------------------------------------------------------
+
+function toIssue(task: ClickUpTask): Issue {
+  return {
+    id: task.custom_id ?? task.id,
+    title: task.name,
+    description: task.text_content ?? task.description ?? "",
+    url: task.url,
+    state: mapClickUpState(task.status),
+    labels: task.tags.map((t) => t.name),
+    assignee: task.assignees[0]?.username,
+    priority: mapClickUpPriority(task.priority),
+  };
+}
+
+function createClickUpTracker(): Tracker {
+  return {
+    name: "clickup",
+
+    async getIssue(identifier: string, _project: ProjectConfig): Promise<Issue> {
+      const taskId = identifier.replace(/^#/, "");
+      const task = await clickUpRequest<ClickUpTask>(
+        "GET",
+        `/task/${taskId}?include_subtasks=true`,
+      );
+      return toIssue(task);
+    },
+
+    async isCompleted(identifier: string, _project: ProjectConfig): Promise<boolean> {
+      const taskId = identifier.replace(/^#/, "");
+      const task = await clickUpRequest<ClickUpTask>("GET", `/task/${taskId}`);
+      const state = mapClickUpState(task.status);
+      return state === "closed";
+    },
+
+    issueUrl(identifier: string, _project: ProjectConfig): string {
+      const taskId = identifier.replace(/^#/, "");
+      return `https://app.clickup.com/t/${taskId}`;
+    },
+
+    issueLabel(url: string, _project: ProjectConfig): string {
+      // Extract task ID from ClickUp URL
+      // Examples:
+      //   https://app.clickup.com/t/86abc123
+      //   https://app.clickup.com/t/PROJ-123
+      //   https://app.clickup.com/12345/v/li/67890
+      const shortMatch = url.match(/\/t\/([A-Za-z0-9-]+)/);
+      if (shortMatch) {
+        return shortMatch[1];
+      }
+      // Fallback: return the last segment
+      const parts = url.split("/");
+      return parts[parts.length - 1] || url;
+    },
+
+    branchName(identifier: string, _project: ProjectConfig): string {
+      const taskId = identifier.replace(/^#/, "");
+      return `feat/cu-${taskId}`;
+    },
+
+    async generatePrompt(identifier: string, project: ProjectConfig): Promise<string> {
+      const issue = await this.getIssue(identifier, project);
+      const lines = [
+        `You are working on ClickUp task ${issue.id}: ${issue.title}`,
+        `Task URL: ${issue.url}`,
+        "",
+      ];
+
+      if (issue.labels.length > 0) {
+        lines.push(`Tags: ${issue.labels.join(", ")}`);
+      }
+
+      if (issue.priority !== undefined) {
+        const priorityNames: Record<number, string> = {
+          1: "Urgent",
+          2: "High",
+          3: "Normal",
+          4: "Low",
+        };
+        lines.push(`Priority: ${priorityNames[issue.priority] ?? String(issue.priority)}`);
+      }
+
+      if (issue.description) {
+        lines.push("## Description", "", issue.description);
+      }
+
+      lines.push(
+        "",
+        "Please implement the changes described in this task. When done, commit and push your changes.",
+      );
+
+      return lines.join("\n");
+    },
+
+    async listIssues(filters: IssueFilters, project: ProjectConfig): Promise<Issue[]> {
+      const listId = getListId(project);
+      if (!listId) {
+        throw new Error("ClickUp tracker requires 'listId' in project tracker config");
+      }
+
+      const params = new URLSearchParams();
+
+      if (filters.state === "closed") {
+        params.set("statuses[]", "closed");
+        params.set("include_closed", "true");
+      } else if (filters.state !== "all") {
+        // Default: open tasks only (exclude closed)
+        params.set("include_closed", "false");
+      } else {
+        params.set("include_closed", "true");
+      }
+
+      if (filters.assignee) {
+        // ClickUp filters by user ID, but we accept usernames.
+        // The assignee filter is best-effort with username.
+        params.set("assignees[]", filters.assignee);
+      }
+
+      if (filters.labels && filters.labels.length > 0) {
+        for (const tag of filters.labels) {
+          params.append("tags[]", tag);
+        }
+      }
+
+      const limit = filters.limit ?? 30;
+      params.set("page", "0");
+      // ClickUp doesn't have a direct "limit" param — uses subtask_limit or pagination.
+      // We fetch and slice.
+
+      const queryStr = params.toString();
+      const data = await clickUpRequest<ClickUpTaskList>(
+        "GET",
+        `/list/${listId}/task${queryStr ? `?${queryStr}` : ""}`,
+      );
+
+      return data.tasks.slice(0, limit).map(toIssue);
+    },
+
+    async updateIssue(
+      identifier: string,
+      update: IssueUpdate,
+      _project: ProjectConfig,
+    ): Promise<void> {
+      const taskId = identifier.replace(/^#/, "");
+
+      // Handle state change
+      if (update.state) {
+        const statusName =
+          update.state === "closed"
+            ? "closed"
+            : update.state === "in_progress"
+              ? "in progress"
+              : "open";
+        await clickUpRequest("PUT", `/task/${taskId}`, {
+          status: statusName,
+        });
+      }
+
+      // Handle assignee
+      if (update.assignee) {
+        // ClickUp requires user IDs for assignment. We pass the username
+        // and let ClickUp resolve it via the assignees.add field.
+        // In practice, the caller would need to provide a ClickUp user ID.
+        await clickUpRequest("PUT", `/task/${taskId}`, {
+          assignees: { add: [update.assignee] },
+        });
+      }
+
+      // Handle adding tags (labels)
+      if (update.labels && update.labels.length > 0) {
+        for (const tag of update.labels) {
+          await clickUpRequest("POST", `/task/${taskId}/tag/${encodeURIComponent(tag)}`, {});
+        }
+      }
+
+      // Handle removing tags
+      if (update.removeLabels && update.removeLabels.length > 0) {
+        for (const tag of update.removeLabels) {
+          await clickUpRequest("DELETE", `/task/${taskId}/tag/${encodeURIComponent(tag)}`);
+        }
+      }
+
+      // Handle comment
+      if (update.comment) {
+        await clickUpRequest("POST", `/task/${taskId}/comment`, {
+          comment_text: update.comment,
+        });
+      }
+    },
+
+    async createIssue(input: CreateIssueInput, project: ProjectConfig): Promise<Issue> {
+      const listId = getListId(project);
+      if (!listId) {
+        throw new Error("ClickUp tracker requires 'listId' in project tracker config");
+      }
+
+      const body: Record<string, unknown> = {
+        name: input.title,
+        description: input.description ?? "",
+      };
+
+      if (input.priority !== undefined) {
+        body["priority"] = input.priority;
+      }
+
+      if (input.assignee) {
+        body["assignees"] = [input.assignee];
+      }
+
+      if (input.labels && input.labels.length > 0) {
+        body["tags"] = input.labels;
+      }
+
+      const task = await clickUpRequest<ClickUpTask>(
+        "POST",
+        `/list/${listId}/task`,
+        body,
+      );
+
+      return toIssue(task);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin module export
+// ---------------------------------------------------------------------------
+
+export const manifest = {
+  name: "clickup",
+  slot: "tracker" as const,
+  description: "Tracker plugin: ClickUp task management",
+  version: "0.1.0",
+};
+
+export function create(): Tracker {
+  return createClickUpTracker();
+}
+
+export default { manifest, create } satisfies PluginModule<Tracker>;

--- a/packages/plugins/tracker-clickup/src/index.ts
+++ b/packages/plugins/tracker-clickup/src/index.ts
@@ -5,6 +5,7 @@
  * Authentication via CLICKUP_API_TOKEN environment variable.
  */
 
+import type { IncomingMessage } from "node:http";
 import { request as httpsRequest } from "node:https";
 import type {
   PluginModule,
@@ -67,7 +68,7 @@ function clickUpRequest<T>(
           ...(payload ? { "Content-Length": String(Buffer.byteLength(payload)) } : {}),
         },
       },
-      (res) => {
+      (res: IncomingMessage) => {
         const chunks: Buffer[] = [];
         res.on("error", (err: Error) => settle(() => reject(err)));
         res.on("data", (chunk: Buffer) => chunks.push(chunk));
@@ -107,7 +108,7 @@ function clickUpRequest<T>(
       });
     });
 
-    req.on("error", (err) => settle(() => reject(err)));
+    req.on("error", (err: Error) => settle(() => reject(err)));
 
     if (payload) {
       req.write(payload);
@@ -198,7 +199,7 @@ function getListId(project: ProjectConfig): string | undefined {
 
 function toIssue(task: ClickUpTask): Issue {
   return {
-    id: task.custom_id ?? task.id,
+    id: task.id,
     title: task.name,
     description: task.text_content ?? task.description ?? "",
     url: task.url,
@@ -297,7 +298,9 @@ function createClickUpTracker(): Tracker {
       const params = new URLSearchParams();
 
       if (filters.state === "closed") {
-        params.set("statuses[]", "closed");
+        // Don't filter by status name — ClickUp spaces use custom names
+        // like "Done", "Complete", "Resolved" for closed-type statuses.
+        // Fetch all (including closed) and filter client-side via mapClickUpState.
         params.set("include_closed", "true");
       } else if (filters.state !== "all") {
         // Default: open tasks only (exclude closed)
@@ -329,7 +332,13 @@ function createClickUpTracker(): Tracker {
         `/list/${listId}/task${queryStr ? `?${queryStr}` : ""}`,
       );
 
-      return data.tasks.slice(0, limit).map(toIssue);
+      let tasks = data.tasks;
+
+      if (filters.state === "closed") {
+        tasks = tasks.filter((t) => mapClickUpState(t.status) === "closed");
+      }
+
+      return tasks.slice(0, limit).map(toIssue);
     },
 
     async updateIssue(

--- a/packages/plugins/tracker-clickup/test/index.test.ts
+++ b/packages/plugins/tracker-clickup/test/index.test.ts
@@ -1,0 +1,733 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+// ---------------------------------------------------------------------------
+// Mock node:https
+// ---------------------------------------------------------------------------
+
+const { requestMock } = vi.hoisted(() => ({ requestMock: vi.fn() }));
+
+vi.mock("node:https", () => ({
+  request: requestMock,
+}));
+
+import { create, manifest } from "../src/index.js";
+import type { ProjectConfig } from "@composio/ao-core";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const project: ProjectConfig = {
+  name: "test",
+  repo: "acme/my-app",
+  path: "/tmp/repo",
+  defaultBranch: "main",
+  sessionPrefix: "test",
+  tracker: {
+    plugin: "clickup",
+    listId: "list-123",
+  },
+};
+
+const projectNoList: ProjectConfig = {
+  ...project,
+  tracker: { plugin: "clickup" },
+};
+
+const sampleTask = {
+  id: "abc123",
+  custom_id: null as string | null,
+  name: "Fix login bug",
+  description: "<p>Users can't log in with SSO</p>",
+  text_content: "Users can't log in with SSO",
+  status: { status: "open", type: "open" },
+  priority: { id: "2", priority: "high", orderindex: "2" },
+  assignees: [{ id: 1001, username: "alice" }],
+  tags: [{ name: "bug" }, { name: "priority-high" }],
+  url: "https://app.clickup.com/t/abc123",
+  list: { id: "list-123", name: "Sprint Backlog" },
+};
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function mockClickUpAPI(responseData: unknown, statusCode = 200) {
+  const body = JSON.stringify(responseData);
+
+  requestMock.mockImplementationOnce(
+    (
+      _opts: Record<string, unknown>,
+      callback: (res: EventEmitter & { statusCode: number }) => void,
+    ) => {
+      const req = Object.assign(new EventEmitter(), {
+        write: vi.fn(),
+        end: vi.fn(() => {
+          const res = Object.assign(new EventEmitter(), { statusCode });
+          callback(res);
+          process.nextTick(() => {
+            res.emit("data", Buffer.from(body));
+            res.emit("end");
+          });
+        }),
+        destroy: vi.fn(),
+        setTimeout: vi.fn(),
+      });
+      return req;
+    },
+  );
+}
+
+function mockClickUpError(message: string) {
+  const body = JSON.stringify({ err: message, ECODE: "ERROR" });
+
+  requestMock.mockImplementationOnce(
+    (
+      _opts: Record<string, unknown>,
+      callback: (res: EventEmitter & { statusCode: number }) => void,
+    ) => {
+      const req = Object.assign(new EventEmitter(), {
+        write: vi.fn(),
+        end: vi.fn(() => {
+          const res = Object.assign(new EventEmitter(), { statusCode: 200 });
+          callback(res);
+          process.nextTick(() => {
+            res.emit("data", Buffer.from(body));
+            res.emit("end");
+          });
+        }),
+        destroy: vi.fn(),
+        setTimeout: vi.fn(),
+      });
+      return req;
+    },
+  );
+}
+
+function mockHTTPError(statusCode: number, body: string) {
+  requestMock.mockImplementationOnce(
+    (
+      _opts: Record<string, unknown>,
+      callback: (res: EventEmitter & { statusCode: number }) => void,
+    ) => {
+      const req = Object.assign(new EventEmitter(), {
+        write: vi.fn(),
+        end: vi.fn(() => {
+          const res = Object.assign(new EventEmitter(), { statusCode });
+          callback(res);
+          process.nextTick(() => {
+            res.emit("data", Buffer.from(body));
+            res.emit("end");
+          });
+        }),
+        destroy: vi.fn(),
+        setTimeout: vi.fn(),
+      });
+      return req;
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("tracker-clickup plugin", () => {
+  let tracker: ReturnType<typeof create>;
+  let savedApiToken: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savedApiToken = process.env["CLICKUP_API_TOKEN"];
+    process.env["CLICKUP_API_TOKEN"] = "pk_test_token_123";
+    tracker = create();
+  });
+
+  afterEach(() => {
+    if (savedApiToken === undefined) {
+      delete process.env["CLICKUP_API_TOKEN"];
+    } else {
+      process.env["CLICKUP_API_TOKEN"] = savedApiToken;
+    }
+  });
+
+  // ---- manifest ----------------------------------------------------------
+
+  describe("manifest", () => {
+    it("has correct metadata", () => {
+      expect(manifest.name).toBe("clickup");
+      expect(manifest.slot).toBe("tracker");
+      expect(manifest.version).toBe("0.1.0");
+    });
+  });
+
+  describe("create()", () => {
+    it("returns a Tracker with correct name", () => {
+      expect(tracker.name).toBe("clickup");
+    });
+  });
+
+  // ---- getIssue ----------------------------------------------------------
+
+  describe("getIssue", () => {
+    it("returns Issue with correct fields", async () => {
+      mockClickUpAPI(sampleTask);
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue).toEqual({
+        id: "abc123",
+        title: "Fix login bug",
+        description: "Users can't log in with SSO",
+        url: "https://app.clickup.com/t/abc123",
+        state: "open",
+        labels: ["bug", "priority-high"],
+        assignee: "alice",
+        priority: 2,
+      });
+    });
+
+    it("uses custom_id when present", async () => {
+      mockClickUpAPI({ ...sampleTask, custom_id: "PROJ-42" });
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue.id).toBe("PROJ-42");
+    });
+
+    it("maps closed status type to closed", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        status: { status: "done", type: "closed" },
+      });
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue.state).toBe("closed");
+    });
+
+    it("maps done status type to closed", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        status: { status: "complete", type: "done" },
+      });
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue.state).toBe("closed");
+    });
+
+    it("maps custom 'in progress' status to in_progress", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        status: { status: "in progress", type: "custom" },
+      });
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue.state).toBe("in_progress");
+    });
+
+    it("maps custom 'in review' status to in_progress", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        status: { status: "in review", type: "custom" },
+      });
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue.state).toBe("in_progress");
+    });
+
+    it("maps unknown custom status to open", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        status: { status: "backlog", type: "custom" },
+      });
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue.state).toBe("open");
+    });
+
+    it("handles null description and text_content", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        description: null,
+        text_content: null,
+      });
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue.description).toBe("");
+    });
+
+    it("prefers text_content over HTML description", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        description: "<p>HTML description</p>",
+        text_content: "Plain text description",
+      });
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue.description).toBe("Plain text description");
+    });
+
+    it("handles empty assignees", async () => {
+      mockClickUpAPI({ ...sampleTask, assignees: [] });
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue.assignee).toBeUndefined();
+    });
+
+    it("handles null priority", async () => {
+      mockClickUpAPI({ ...sampleTask, priority: null });
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue.priority).toBeUndefined();
+    });
+
+    it("handles empty tags", async () => {
+      mockClickUpAPI({ ...sampleTask, tags: [] });
+      const issue = await tracker.getIssue("abc123", project);
+      expect(issue.labels).toEqual([]);
+    });
+
+    it("strips # prefix from identifier", async () => {
+      mockClickUpAPI(sampleTask);
+      await tracker.getIssue("#abc123", project);
+      const callOpts = requestMock.mock.calls[0][0];
+      expect(callOpts.path).toContain("/task/abc123");
+    });
+
+    it("propagates API errors", async () => {
+      mockClickUpError("Task not found");
+      await expect(tracker.getIssue("invalid", project)).rejects.toThrow(
+        "ClickUp API error: Task not found",
+      );
+    });
+
+    it("throws when CLICKUP_API_TOKEN is missing", async () => {
+      delete process.env["CLICKUP_API_TOKEN"];
+      await expect(tracker.getIssue("abc123", project)).rejects.toThrow(
+        "CLICKUP_API_TOKEN environment variable is required",
+      );
+    });
+
+    it("throws on HTTP errors", async () => {
+      mockHTTPError(500, "Internal Server Error");
+      await expect(tracker.getIssue("abc123", project)).rejects.toThrow(
+        "ClickUp API returned HTTP 500",
+      );
+    });
+
+    it("throws on HTTP 401 unauthorized", async () => {
+      mockHTTPError(401, "Unauthorized");
+      await expect(tracker.getIssue("abc123", project)).rejects.toThrow(
+        "ClickUp API returned HTTP 401",
+      );
+    });
+  });
+
+  // ---- isCompleted -------------------------------------------------------
+
+  describe("isCompleted", () => {
+    it("returns true for closed status type", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        status: { status: "done", type: "closed" },
+      });
+      expect(await tracker.isCompleted("abc123", project)).toBe(true);
+    });
+
+    it("returns true for done status type", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        status: { status: "complete", type: "done" },
+      });
+      expect(await tracker.isCompleted("abc123", project)).toBe(true);
+    });
+
+    it("returns true for custom closed-like status", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        status: { status: "closed", type: "custom" },
+      });
+      expect(await tracker.isCompleted("abc123", project)).toBe(true);
+    });
+
+    it("returns false for open status", async () => {
+      mockClickUpAPI(sampleTask);
+      expect(await tracker.isCompleted("abc123", project)).toBe(false);
+    });
+
+    it("returns false for in_progress status", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        status: { status: "in progress", type: "custom" },
+      });
+      expect(await tracker.isCompleted("abc123", project)).toBe(false);
+    });
+  });
+
+  // ---- issueUrl ----------------------------------------------------------
+
+  describe("issueUrl", () => {
+    it("generates correct URL", () => {
+      expect(tracker.issueUrl("abc123", project)).toBe(
+        "https://app.clickup.com/t/abc123",
+      );
+    });
+
+    it("strips # prefix from identifier", () => {
+      expect(tracker.issueUrl("#abc123", project)).toBe(
+        "https://app.clickup.com/t/abc123",
+      );
+    });
+  });
+
+  // ---- issueLabel --------------------------------------------------------
+
+  describe("issueLabel", () => {
+    it("extracts task ID from short URL", () => {
+      expect(tracker.issueLabel!("https://app.clickup.com/t/86abc123", project)).toBe(
+        "86abc123",
+      );
+    });
+
+    it("extracts alphanumeric task ID", () => {
+      expect(tracker.issueLabel!("https://app.clickup.com/t/PROJ-123", project)).toBe(
+        "PROJ-123",
+      );
+    });
+
+    it("falls back to last segment for unexpected URL format", () => {
+      expect(tracker.issueLabel!("https://app.clickup.com/12345/v/li/67890", project)).toBe(
+        "67890",
+      );
+    });
+  });
+
+  // ---- branchName --------------------------------------------------------
+
+  describe("branchName", () => {
+    it("generates feat/cu-<id> format", () => {
+      expect(tracker.branchName("abc123", project)).toBe("feat/cu-abc123");
+    });
+
+    it("strips # prefix", () => {
+      expect(tracker.branchName("#abc123", project)).toBe("feat/cu-abc123");
+    });
+  });
+
+  // ---- generatePrompt ----------------------------------------------------
+
+  describe("generatePrompt", () => {
+    it("includes title and URL", async () => {
+      mockClickUpAPI(sampleTask);
+      const prompt = await tracker.generatePrompt("abc123", project);
+      expect(prompt).toContain("Fix login bug");
+      expect(prompt).toContain("https://app.clickup.com/t/abc123");
+      expect(prompt).toContain("ClickUp task");
+    });
+
+    it("includes tags when present", async () => {
+      mockClickUpAPI(sampleTask);
+      const prompt = await tracker.generatePrompt("abc123", project);
+      expect(prompt).toContain("bug, priority-high");
+    });
+
+    it("includes priority", async () => {
+      mockClickUpAPI(sampleTask);
+      const prompt = await tracker.generatePrompt("abc123", project);
+      expect(prompt).toContain("High");
+    });
+
+    it("maps priority numbers to names", async () => {
+      const priorities: Record<string, string> = {
+        "1": "Urgent",
+        "2": "High",
+        "3": "Normal",
+        "4": "Low",
+      };
+      for (const [id, name] of Object.entries(priorities)) {
+        mockClickUpAPI({
+          ...sampleTask,
+          priority: { id, priority: name.toLowerCase(), orderindex: id },
+        });
+        const prompt = await tracker.generatePrompt("abc123", project);
+        expect(prompt).toContain(name);
+      }
+    });
+
+    it("includes description", async () => {
+      mockClickUpAPI(sampleTask);
+      const prompt = await tracker.generatePrompt("abc123", project);
+      expect(prompt).toContain("Users can't log in with SSO");
+    });
+
+    it("omits tags section when no tags", async () => {
+      mockClickUpAPI({ ...sampleTask, tags: [] });
+      const prompt = await tracker.generatePrompt("abc123", project);
+      expect(prompt).not.toContain("Tags:");
+    });
+
+    it("omits description section when empty", async () => {
+      mockClickUpAPI({
+        ...sampleTask,
+        description: null,
+        text_content: null,
+      });
+      const prompt = await tracker.generatePrompt("abc123", project);
+      expect(prompt).not.toContain("## Description");
+    });
+
+    it("omits priority when null", async () => {
+      mockClickUpAPI({ ...sampleTask, priority: null });
+      const prompt = await tracker.generatePrompt("abc123", project);
+      expect(prompt).not.toContain("Priority:");
+    });
+  });
+
+  // ---- listIssues --------------------------------------------------------
+
+  describe("listIssues", () => {
+    it("returns mapped issues", async () => {
+      mockClickUpAPI({
+        tasks: [sampleTask, { ...sampleTask, id: "def456", name: "Another" }],
+      });
+      const issues = await tracker.listIssues!({}, project);
+      expect(issues).toHaveLength(2);
+      expect(issues[0].id).toBe("abc123");
+      expect(issues[1].id).toBe("def456");
+    });
+
+    it("throws when listId is missing", async () => {
+      await expect(tracker.listIssues!({}, projectNoList)).rejects.toThrow(
+        "listId",
+      );
+    });
+
+    it("includes closed tasks when state is 'all'", async () => {
+      mockClickUpAPI({ tasks: [] });
+      await tracker.listIssues!({ state: "all" }, project);
+
+      const callOpts = requestMock.mock.calls[0][0];
+      expect(callOpts.path).toContain("include_closed=true");
+    });
+
+    it("requests only closed tasks when state is 'closed'", async () => {
+      mockClickUpAPI({ tasks: [] });
+      await tracker.listIssues!({ state: "closed" }, project);
+
+      const callOpts = requestMock.mock.calls[0][0];
+      expect(callOpts.path).toContain("include_closed=true");
+    });
+
+    it("excludes closed tasks by default", async () => {
+      mockClickUpAPI({ tasks: [] });
+      await tracker.listIssues!({}, project);
+
+      const callOpts = requestMock.mock.calls[0][0];
+      expect(callOpts.path).toContain("include_closed=false");
+    });
+
+    it("passes tag filters", async () => {
+      mockClickUpAPI({ tasks: [] });
+      await tracker.listIssues!({ labels: ["bug", "urgent"] }, project);
+
+      const callOpts = requestMock.mock.calls[0][0];
+      expect(callOpts.path).toContain("tags%5B%5D=bug");
+      expect(callOpts.path).toContain("tags%5B%5D=urgent");
+    });
+
+    it("respects custom limit", async () => {
+      const tasks = Array.from({ length: 10 }, (_, i) => ({
+        ...sampleTask,
+        id: `task-${i}`,
+      }));
+      mockClickUpAPI({ tasks });
+      const issues = await tracker.listIssues!({ limit: 3 }, project);
+      expect(issues).toHaveLength(3);
+    });
+
+    it("defaults limit to 30", async () => {
+      const tasks = Array.from({ length: 35 }, (_, i) => ({
+        ...sampleTask,
+        id: `task-${i}`,
+      }));
+      mockClickUpAPI({ tasks });
+      const issues = await tracker.listIssues!({}, project);
+      expect(issues).toHaveLength(30);
+    });
+  });
+
+  // ---- updateIssue -------------------------------------------------------
+
+  describe("updateIssue", () => {
+    it("closes a task", async () => {
+      mockClickUpAPI({});
+      await tracker.updateIssue!("abc123", { state: "closed" }, project);
+
+      const callOpts = requestMock.mock.calls[0][0];
+      expect(callOpts.method).toBe("PUT");
+      expect(callOpts.path).toContain("/task/abc123");
+
+      const writeCall = requestMock.mock.results[0].value.write.mock.calls[0][0];
+      const body = JSON.parse(writeCall);
+      expect(body.status).toBe("closed");
+    });
+
+    it("sets task to in_progress", async () => {
+      mockClickUpAPI({});
+      await tracker.updateIssue!("abc123", { state: "in_progress" }, project);
+
+      const writeCall = requestMock.mock.results[0].value.write.mock.calls[0][0];
+      const body = JSON.parse(writeCall);
+      expect(body.status).toBe("in progress");
+    });
+
+    it("reopens a task", async () => {
+      mockClickUpAPI({});
+      await tracker.updateIssue!("abc123", { state: "open" }, project);
+
+      const writeCall = requestMock.mock.results[0].value.write.mock.calls[0][0];
+      const body = JSON.parse(writeCall);
+      expect(body.status).toBe("open");
+    });
+
+    it("adds a comment", async () => {
+      mockClickUpAPI({});
+      await tracker.updateIssue!("abc123", { comment: "Working on this" }, project);
+
+      const callOpts = requestMock.mock.calls[0][0];
+      expect(callOpts.method).toBe("POST");
+      expect(callOpts.path).toContain("/task/abc123/comment");
+
+      const writeCall = requestMock.mock.results[0].value.write.mock.calls[0][0];
+      const body = JSON.parse(writeCall);
+      expect(body.comment_text).toBe("Working on this");
+    });
+
+    it("adds tags (labels)", async () => {
+      mockClickUpAPI({});
+      mockClickUpAPI({});
+      await tracker.updateIssue!("abc123", { labels: ["bug", "urgent"] }, project);
+      expect(requestMock).toHaveBeenCalledTimes(2);
+
+      const call1Opts = requestMock.mock.calls[0][0];
+      expect(call1Opts.path).toContain("/task/abc123/tag/bug");
+      const call2Opts = requestMock.mock.calls[1][0];
+      expect(call2Opts.path).toContain("/task/abc123/tag/urgent");
+    });
+
+    it("removes tags (removeLabels) via DELETE", async () => {
+      mockClickUpAPI({});
+      mockClickUpAPI({});
+      await tracker.updateIssue!("abc123", { removeLabels: ["old-tag", "stale"] }, project);
+      expect(requestMock).toHaveBeenCalledTimes(2);
+
+      const call1Opts = requestMock.mock.calls[0][0];
+      expect(call1Opts.method).toBe("DELETE");
+      expect(call1Opts.path).toContain("/task/abc123/tag/old-tag");
+      const call2Opts = requestMock.mock.calls[1][0];
+      expect(call2Opts.method).toBe("DELETE");
+      expect(call2Opts.path).toContain("/task/abc123/tag/stale");
+    });
+
+    it("handles state change + comment together", async () => {
+      mockClickUpAPI({}); // state change
+      mockClickUpAPI({}); // comment
+      await tracker.updateIssue!(
+        "abc123",
+        { state: "closed", comment: "Done!" },
+        project,
+      );
+      expect(requestMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("strips # prefix from identifier", async () => {
+      mockClickUpAPI({});
+      await tracker.updateIssue!("#abc123", { state: "closed" }, project);
+
+      const callOpts = requestMock.mock.calls[0][0];
+      expect(callOpts.path).toContain("/task/abc123");
+    });
+  });
+
+  // ---- createIssue -------------------------------------------------------
+
+  describe("createIssue", () => {
+    it("creates a basic task", async () => {
+      mockClickUpAPI(sampleTask);
+
+      const issue = await tracker.createIssue!(
+        { title: "Fix login bug", description: "Users can't log in with SSO" },
+        project,
+      );
+      expect(issue).toMatchObject({
+        id: "abc123",
+        title: "Fix login bug",
+        state: "open",
+      });
+    });
+
+    it("passes priority to API", async () => {
+      mockClickUpAPI(sampleTask);
+
+      await tracker.createIssue!(
+        { title: "Bug", description: "", priority: 1 },
+        project,
+      );
+
+      const writeCall = requestMock.mock.results[0].value.write.mock.calls[0][0];
+      const body = JSON.parse(writeCall);
+      expect(body.priority).toBe(1);
+    });
+
+    it("passes tags and assignee", async () => {
+      mockClickUpAPI(sampleTask);
+
+      await tracker.createIssue!(
+        {
+          title: "Bug",
+          description: "",
+          labels: ["bug", "urgent"],
+          assignee: "alice",
+        },
+        project,
+      );
+
+      const writeCall = requestMock.mock.results[0].value.write.mock.calls[0][0];
+      const body = JSON.parse(writeCall);
+      expect(body.tags).toEqual(["bug", "urgent"]);
+      expect(body.assignees).toEqual(["alice"]);
+    });
+
+    it("throws when listId is missing", async () => {
+      await expect(
+        tracker.createIssue!({ title: "Bug", description: "" }, projectNoList),
+      ).rejects.toThrow("listId");
+    });
+
+    it("creates task in the correct list", async () => {
+      mockClickUpAPI(sampleTask);
+
+      await tracker.createIssue!(
+        { title: "Test", description: "" },
+        project,
+      );
+
+      const callOpts = requestMock.mock.calls[0][0];
+      expect(callOpts.path).toContain("/list/list-123/task");
+      expect(callOpts.method).toBe("POST");
+    });
+  });
+
+  // ---- error handling ----------------------------------------------------
+
+  describe("error handling", () => {
+    it("throws on missing CLICKUP_API_TOKEN", async () => {
+      delete process.env["CLICKUP_API_TOKEN"];
+      await expect(tracker.getIssue("abc123", project)).rejects.toThrow(
+        "CLICKUP_API_TOKEN",
+      );
+    });
+
+    it("throws on ClickUp API error response", async () => {
+      mockClickUpError("Team not authorized");
+      await expect(tracker.getIssue("abc123", project)).rejects.toThrow(
+        "ClickUp API error: Team not authorized",
+      );
+    });
+
+    it("throws on HTTP error status", async () => {
+      mockHTTPError(429, "Rate limit exceeded");
+      await expect(tracker.getIssue("abc123", project)).rejects.toThrow(
+        "ClickUp API returned HTTP 429",
+      );
+    });
+  });
+});

--- a/packages/plugins/tracker-clickup/test/index.test.ts
+++ b/packages/plugins/tracker-clickup/test/index.test.ts
@@ -186,10 +186,12 @@ describe("tracker-clickup plugin", () => {
       });
     });
 
-    it("uses custom_id when present", async () => {
+    it("always uses native task ID, not custom_id", async () => {
       mockClickUpAPI({ ...sampleTask, custom_id: "PROJ-42" });
       const issue = await tracker.getIssue("abc123", project);
-      expect(issue.id).toBe("PROJ-42");
+      // Must use native task.id for round-trip API compatibility —
+      // custom IDs require custom_task_ids=true&team_id=... query params
+      expect(issue.id).toBe("abc123");
     });
 
     it("maps closed status type to closed", async () => {
@@ -504,6 +506,25 @@ describe("tracker-clickup plugin", () => {
 
       const callOpts = requestMock.mock.calls[0][0];
       expect(callOpts.path).toContain("include_closed=true");
+      // Must not filter by literal status name — ClickUp spaces use
+      // custom names like "Done", "Complete" for closed-type statuses
+      expect(callOpts.path).not.toContain("statuses");
+    });
+
+    it("filters closed tasks client-side including custom status names", async () => {
+      mockClickUpAPI({
+        tasks: [
+          { ...sampleTask, id: "t1", status: { status: "open", type: "open" } },
+          { ...sampleTask, id: "t2", status: { status: "done", type: "closed" } },
+          { ...sampleTask, id: "t3", status: { status: "Complete", type: "done" } },
+          { ...sampleTask, id: "t4", status: { status: "in progress", type: "custom" } },
+          { ...sampleTask, id: "t5", status: { status: "resolved", type: "custom" } },
+        ],
+      });
+      const issues = await tracker.listIssues!({ state: "closed" }, project);
+      const ids = issues.map((i: { id: string }) => i.id);
+      // "done/closed" type and custom "resolved" are closed; "open" and "in progress" are not
+      expect(ids).toEqual(["t2", "t3", "t5"]);
     });
 
     it("excludes closed tasks by default", async () => {

--- a/packages/plugins/tracker-clickup/tsconfig.json
+++ b/packages/plugins/tracker-clickup/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,6 +32,7 @@
     "@composio/ao-plugin-agent-opencode": "workspace:*",
     "@composio/ao-plugin-runtime-tmux": "workspace:*",
     "@composio/ao-plugin-scm-github": "workspace:*",
+    "@composio/ao-plugin-tracker-clickup": "workspace:*",
     "@composio/ao-plugin-tracker-github": "workspace:*",
     "@composio/ao-plugin-tracker-linear": "workspace:*",
     "@composio/ao-plugin-workspace-worktree": "workspace:*",


### PR DESCRIPTION
## Summary
Adds a ClickUp tracker plugin for agent-orchestrator.

## Features
- Task retrieval
- Comment posting
- Status updates

## Implementation
- New ClickUp plugin package
- Added to plugin registry
- Updated type handling
- Added example configuration

Closes #579
