### PR TITLE
fix: update stale package path from packages/agent-orchestrator to packages/ao in scripts

### DIFF
--- a/packages/cli/__tests__/scripts/doctor-script.test.ts
+++ b/packages/cli/__tests__/scripts/doctor-script.test.ts
@@ -31,15 +31,15 @@ function createHealthyRepo(tempRoot: string): string {
   mkdirSync(join(fakeRepo, "node_modules"), { recursive: true });
   mkdirSync(join(fakeRepo, "packages", "core", "dist"), { recursive: true });
   mkdirSync(join(fakeRepo, "packages", "cli", "dist"), { recursive: true });
-  mkdirSync(join(fakeRepo, "packages", "agent-orchestrator", "bin"), { recursive: true });
+  mkdirSync(join(fakeRepo, "packages", "ao", "bin"), { recursive: true });
   mkdirSync(join(fakeRepo, "packages", "web"), { recursive: true });
   writeFileSync(join(fakeRepo, "packages", "core", "dist", "index.js"), "export {};\n");
   writeFileSync(join(fakeRepo, "packages", "cli", "dist", "index.js"), "export {};\n");
   writeFileSync(
-    join(fakeRepo, "packages", "agent-orchestrator", "bin", "ao.js"),
+    join(fakeRepo, "packages", "ao", "bin", "ao.js"),
     '#!/usr/bin/env node\nconsole.log("0.1.0");\n',
   );
-  chmodSync(join(fakeRepo, "packages", "agent-orchestrator", "bin", "ao.js"), 0o755);
+  chmodSync(join(fakeRepo, "packages", "ao", "bin", "ao.js"), 0o755);
   return fakeRepo;
 }
 

--- a/packages/cli/__tests__/scripts/update-script.test.ts
+++ b/packages/cli/__tests__/scripts/update-script.test.ts
@@ -78,9 +78,9 @@ esac\nexit 0`,
   it("runs the built-in smoke commands in smoke-only mode", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "ao-update-smoke-"));
     const fakeRepo = join(tempRoot, "repo");
-    mkdirSync(join(fakeRepo, "packages", "agent-orchestrator", "bin"), { recursive: true });
+    mkdirSync(join(fakeRepo, "packages", "ao", "bin"), { recursive: true });
     writeFileSync(
-      join(fakeRepo, "packages", "agent-orchestrator", "bin", "ao.js"),
+      join(fakeRepo, "packages", "ao", "bin", "ao.js"),
       "#!/usr/bin/env node\n",
     );
 
@@ -109,13 +109,13 @@ exit 0`,
 
     expect(result.status).toBe(0);
     expect(commands).toContain(
-      `node ${join(fakeRepo, "packages", "agent-orchestrator", "bin", "ao.js")} --version`,
+      `node ${join(fakeRepo, "packages", "ao", "bin", "ao.js")} --version`,
     );
     expect(commands).toContain(
-      `node ${join(fakeRepo, "packages", "agent-orchestrator", "bin", "ao.js")} doctor --help`,
+      `node ${join(fakeRepo, "packages", "ao", "bin", "ao.js")} doctor --help`,
     );
     expect(commands).toContain(
-      `node ${join(fakeRepo, "packages", "agent-orchestrator", "bin", "ao.js")} update --help`,
+      `node ${join(fakeRepo, "packages", "ao", "bin", "ao.js")} update --help`,
     );
   });
 

--- a/scripts/ao-doctor.sh
+++ b/scripts/ao-doctor.sh
@@ -261,12 +261,12 @@ check_install_layout() {
 }
 
 check_runtime_sanity() {
-  if [ ! -f "$REPO_ROOT/packages/agent-orchestrator/bin/ao.js" ]; then
+  if [ ! -f "$REPO_ROOT/packages/ao/bin/ao.js" ]; then
     fail "launcher entrypoint is missing. Fix: reinstall from a clean checkout"
     return
   fi
 
-  if node "$REPO_ROOT/packages/agent-orchestrator/bin/ao.js" --version >/dev/null 2>&1; then
+  if node "$REPO_ROOT/packages/ao/bin/ao.js" --version >/dev/null 2>&1; then
     pass "launcher runtime sanity check passed (ao --version)"
   else
     fail "launcher runtime sanity check failed. Fix: run pnpm build and refresh the launcher"

--- a/scripts/ao-update.sh
+++ b/scripts/ao-update.sh
@@ -58,9 +58,9 @@ run_cmd() {
 
 run_smoke_tests() {
   printf '\nRunning smoke tests...\n'
-  run_cmd node "$REPO_ROOT/packages/agent-orchestrator/bin/ao.js" --version
-  run_cmd node "$REPO_ROOT/packages/agent-orchestrator/bin/ao.js" doctor --help
-  run_cmd node "$REPO_ROOT/packages/agent-orchestrator/bin/ao.js" update --help
+  run_cmd node "$REPO_ROOT/packages/ao/bin/ao.js" --version
+  run_cmd node "$REPO_ROOT/packages/ao/bin/ao.js" doctor --help
+  run_cmd node "$REPO_ROOT/packages/ao/bin/ao.js" update --help
 }
 
 ensure_repo_clean() {


### PR DESCRIPTION
## Summary

- `scripts/ao-doctor.sh` and `scripts/ao-update.sh` referenced `packages/agent-orchestrator/bin/ao.js` which no longer exists — the package was renamed to `packages/ao`
- This caused `ao doctor` to always report `FAIL launcher entrypoint is missing` even on a healthy install
- Fixed the corresponding test in `packages/cli/__tests__/scripts/doctor-script.test.ts` which created a fake `packages/agent-orchestrator/` directory structure to match the old path

## Test plan

- [ ] Run `ao doctor` — launcher entrypoint check should now PASS instead of FAIL
- [ ] Run `pnpm test --filter @composio/ao-cli` — the previously failing `doctor-script.test.ts` test should now pass
- [ ] Run `bash scripts/ao-doctor.sh` directly from repo root — no FAIL on launcher entrypoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)