### PR TITLE
feat: add ttyd as a checked dependency in ao doctor and setup

### DIFF
--- a/scripts/ao-doctor.sh
+++ b/scripts/ao-doctor.sh
@@ -228,6 +228,18 @@ check_tmux() {
   warn "tmux is installed but failed a basic server health check. Fix: restart tmux or reinstall it"
 }
 
+check_ttyd() {
+  if ! command -v ttyd >/dev/null 2>&1; then
+    if [ "$(uname)" = "Darwin" ]; then
+      warn "ttyd is not installed. Fix: brew install ttyd (required for the web dashboard terminal)"
+    else
+      warn "ttyd is not installed. Fix: see https://github.com/tsl0922/ttyd for install instructions (required for the web dashboard terminal)"
+    fi
+    return
+  fi
+  pass "ttyd resolves to $(command -v ttyd)"
+}
+
 check_gh() {
   if ! command -v gh >/dev/null 2>&1; then
     warn "GitHub CLI is not installed. Fix: install gh from https://cli.github.com/"
@@ -333,6 +345,7 @@ check_git
 check_pnpm
 check_launcher
 check_tmux
+check_ttyd
 check_gh
 check_config_dirs
 check_stale_temp_files

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -71,6 +71,19 @@ else
   echo "[ok] tmux $(tmux -V | grep -oE '[0-9]+\.[0-9a-z]+')"
 fi
 
+# ttyd
+if ! command -v ttyd &> /dev/null; then
+  echo ""
+  echo "WARNING: ttyd is not installed (required for the web dashboard terminal feature)."
+  if [ "$(uname)" = "Darwin" ]; then
+    echo "  Install: brew install ttyd"
+  else
+    echo "  Install: https://github.com/tsl0922/ttyd"
+  fi
+else
+  echo "[ok] ttyd $(ttyd --version 2>&1 | head -n1)"
+fi
+
 # gh CLI authentication
 if ! command -v gh &> /dev/null; then
   echo ""


### PR DESCRIPTION
## Summary

- The web dashboard terminal feature requires `ttyd` to be installed, but neither `scripts/ao-doctor.sh` nor `scripts/setup.sh` checked for it
- Users opening a session terminal in the dashboard got a silent failure with no actionable error
- Added a `check_ttyd()` function to `ao-doctor.sh` that emits a WARN (not FAIL) with install instructions when `ttyd` is missing
- Added a ttyd presence check to `scripts/setup.sh` with the same install hint

## Test plan

- [ ] Run `ao doctor` without ttyd installed — should show `WARN ttyd is not installed` with fix instructions
- [ ] Run `ao doctor` with ttyd installed — should show `PASS ttyd is installed`
- [ ] Run `bash scripts/setup.sh` without ttyd — should print a WARNING with install hint but not exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)