### PR TITLE
fix: spawn terminal WebSocket servers alongside Next.js in ao dashboard

### DIFF
--- a/packages/cli/__tests__/scripts/doctor-script.test.ts
+++ b/packages/cli/__tests__/scripts/doctor-script.test.ts
@@ -149,7 +149,9 @@ describe("scripts/ao-doctor.sh", () => {
     const result = spawnSync("bash", [scriptPath, "--fix"], {
       env: {
         ...process.env,
-        PATH: `${binDir}:${process.env.PATH || ""}`,
+        // Use a minimal PATH so a real "ao" installed on the system (e.g.
+        // /opt/homebrew/bin/ao) is not visible, allowing the fix path to run.
+        PATH: `${binDir}:/usr/bin:/bin`,
         AO_REPO_ROOT: fakeRepo,
         AO_CONFIG_PATH: configPath,
         AO_DOCTOR_TMP_ROOT: tmpRoot,

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { resolve } from "node:path";
 import chalk from "chalk";
 import type { Command } from "commander";
 import { loadConfig } from "@composio/ao-core";
@@ -83,6 +84,34 @@ export function registerDashboard(program: Command): void {
         process.exit(1);
       });
 
+      // Spawn terminal WebSocket servers
+      const distServerDir = resolve(webDir, "dist-server");
+
+      function spawnTerminalServer(label: string, scriptName: string) {
+        const child = spawn("node", [resolve(distServerDir, scriptName)], {
+          cwd: webDir,
+          stdio: ["ignore", "pipe", "pipe"],
+          env,
+        });
+
+        child.stdout?.on("data", (data: Buffer) => {
+          for (const line of data.toString().split("\n").filter(Boolean)) {
+            process.stdout.write(`[${label}] ${line}\n`);
+          }
+        });
+
+        child.stderr?.on("data", (data: Buffer) => {
+          for (const line of data.toString().split("\n").filter(Boolean)) {
+            process.stderr.write(`[${label}] ${line}\n`);
+          }
+        });
+
+        return child;
+      }
+
+      const terminalServer = spawnTerminalServer("terminal", "terminal-websocket.js");
+      const directTerminalServer = spawnTerminalServer("direct-terminal", "direct-terminal-ws.js");
+
       let openAbort: AbortController | undefined;
 
       if (opts.open !== false) {
@@ -92,6 +121,10 @@ export function registerDashboard(program: Command): void {
 
       child.on("exit", (code) => {
         if (openAbort) openAbort.abort();
+
+        // Kill terminal servers when Next.js exits
+        terminalServer.kill("SIGTERM");
+        directTerminalServer.kill("SIGTERM");
 
         if (code !== 0 && code !== null && !opts.rebuild) {
           const stderr = stderrChunks.join("");

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -109,25 +109,25 @@ export function registerDashboard(program: Command): void {
       const distServerDir = resolve(webDir, "dist-server");
 
       function spawnTerminalServer(label: string, scriptName: string) {
-        const child = spawn("node", [resolve(distServerDir, scriptName)], {
+        const proc = spawn("node", [resolve(distServerDir, scriptName)], {
           cwd: webDir,
           stdio: ["ignore", "pipe", "pipe"],
           env,
         });
 
-        child.stdout?.on("data", (data: Buffer) => {
+        proc.stdout?.on("data", (data: Buffer) => {
           for (const line of data.toString().split("\n").filter(Boolean)) {
             process.stdout.write(`[${label}] ${line}\n`);
           }
         });
 
-        child.stderr?.on("data", (data: Buffer) => {
+        proc.stderr?.on("data", (data: Buffer) => {
           for (const line of data.toString().split("\n").filter(Boolean)) {
             process.stderr.write(`[${label}] ${line}\n`);
           }
         });
 
-        return child;
+        return proc;
       }
 
       terminalServer = spawnTerminalServer("terminal", "terminal-websocket.js");

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -112,6 +112,15 @@ export function registerDashboard(program: Command): void {
       const terminalServer = spawnTerminalServer("terminal", "terminal-websocket.js");
       const directTerminalServer = spawnTerminalServer("direct-terminal", "direct-terminal-ws.js");
 
+      // Kill terminal servers whenever the parent process is asked to exit,
+      // so they don't become orphans keeping ports occupied.
+      function killTerminalServers(): void {
+        terminalServer.kill("SIGTERM");
+        directTerminalServer.kill("SIGTERM");
+      }
+      process.once("SIGINT", killTerminalServers);
+      process.once("SIGTERM", killTerminalServers);
+
       let openAbort: AbortController | undefined;
 
       if (opts.open !== false) {
@@ -122,9 +131,10 @@ export function registerDashboard(program: Command): void {
       child.on("exit", (code) => {
         if (openAbort) openAbort.abort();
 
-        // Kill terminal servers when Next.js exits
-        terminalServer.kill("SIGTERM");
-        directTerminalServer.kill("SIGTERM");
+        // Kill terminal servers when Next.js exits (normal exit path)
+        killTerminalServers();
+        process.off("SIGINT", killTerminalServers);
+        process.off("SIGTERM", killTerminalServers);
 
         if (code !== 0 && code !== null && !opts.rebuild) {
           const stderr = stderrChunks.join("");

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -112,14 +112,18 @@ export function registerDashboard(program: Command): void {
       const terminalServer = spawnTerminalServer("terminal", "terminal-websocket.js");
       const directTerminalServer = spawnTerminalServer("direct-terminal", "direct-terminal-ws.js");
 
-      // Kill terminal servers whenever the parent process is asked to exit,
-      // so they don't become orphans keeping ports occupied.
-      function killTerminalServers(): void {
+      // Graceful shutdown: kill all child processes and exit.
+      // Must also kill Next.js and call process.exit() — registering a
+      // SIGINT/SIGTERM listener suppresses Node's default exit behavior.
+      function cleanup(exitCode: number = 0): void {
+        if (openAbort) openAbort.abort();
+        child.kill("SIGTERM");
         terminalServer.kill("SIGTERM");
         directTerminalServer.kill("SIGTERM");
+        process.exit(exitCode);
       }
-      process.once("SIGINT", killTerminalServers);
-      process.once("SIGTERM", killTerminalServers);
+      process.once("SIGINT", () => cleanup(0));
+      process.once("SIGTERM", () => cleanup(0));
 
       let openAbort: AbortController | undefined;
 
@@ -129,12 +133,12 @@ export function registerDashboard(program: Command): void {
       }
 
       child.on("exit", (code) => {
+        // Normal exit path: Next.js exited on its own, clean up terminal servers.
+        process.off("SIGINT", cleanup);
+        process.off("SIGTERM", cleanup);
         if (openAbort) openAbort.abort();
-
-        // Kill terminal servers when Next.js exits (normal exit path)
-        killTerminalServers();
-        process.off("SIGINT", killTerminalServers);
-        process.off("SIGTERM", killTerminalServers);
+        terminalServer.kill("SIGTERM");
+        directTerminalServer.kill("SIGTERM");
 
         if (code !== 0 && code !== null && !opts.rebuild) {
           const stderr = stderrChunks.join("");

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { resolve } from "node:path";
 import chalk from "chalk";
 import type { Command } from "commander";
@@ -78,10 +78,31 @@ export function registerDashboard(program: Command): void {
         process.stderr.write(data);
       });
 
+      // Declared as let so cleanup() can reference them before assignment;
+      // child.on("error") fires asynchronously so they are always assigned by then.
+      let terminalServer: ChildProcess | undefined;
+      let directTerminalServer: ChildProcess | undefined;
+      let openAbort: AbortController | undefined;
+
+      // Graceful shutdown: kill all child processes and exit.
+      // Must kill Next.js and call process.exit() — registering a SIGINT/SIGTERM
+      // listener suppresses Node's default exit behavior.
+      function cleanup(exitCode: number = 0): void {
+        if (openAbort) openAbort.abort();
+        child.kill("SIGTERM");
+        terminalServer?.kill("SIGTERM");
+        directTerminalServer?.kill("SIGTERM");
+        process.exit(exitCode);
+      }
+      // Named function so process.off() removes the exact same reference.
+      function handleSignal(): void { cleanup(0); }
+      process.once("SIGINT", handleSignal);
+      process.once("SIGTERM", handleSignal);
+
       child.on("error", (err) => {
         console.error(chalk.red("Could not start dashboard. Ensure Next.js is installed."));
         console.error(chalk.dim(String(err)));
-        process.exit(1);
+        cleanup(1);
       });
 
       // Spawn terminal WebSocket servers
@@ -109,23 +130,8 @@ export function registerDashboard(program: Command): void {
         return child;
       }
 
-      const terminalServer = spawnTerminalServer("terminal", "terminal-websocket.js");
-      const directTerminalServer = spawnTerminalServer("direct-terminal", "direct-terminal-ws.js");
-
-      // Graceful shutdown: kill all child processes and exit.
-      // Must also kill Next.js and call process.exit() — registering a
-      // SIGINT/SIGTERM listener suppresses Node's default exit behavior.
-      function cleanup(exitCode: number = 0): void {
-        if (openAbort) openAbort.abort();
-        child.kill("SIGTERM");
-        terminalServer.kill("SIGTERM");
-        directTerminalServer.kill("SIGTERM");
-        process.exit(exitCode);
-      }
-      process.once("SIGINT", () => cleanup(0));
-      process.once("SIGTERM", () => cleanup(0));
-
-      let openAbort: AbortController | undefined;
+      terminalServer = spawnTerminalServer("terminal", "terminal-websocket.js");
+      directTerminalServer = spawnTerminalServer("direct-terminal", "direct-terminal-ws.js");
 
       if (opts.open !== false) {
         openAbort = new AbortController();
@@ -134,11 +140,11 @@ export function registerDashboard(program: Command): void {
 
       child.on("exit", (code) => {
         // Normal exit path: Next.js exited on its own, clean up terminal servers.
-        process.off("SIGINT", cleanup);
-        process.off("SIGTERM", cleanup);
+        process.off("SIGINT", handleSignal);
+        process.off("SIGTERM", handleSignal);
         if (openAbort) openAbort.abort();
-        terminalServer.kill("SIGTERM");
-        directTerminalServer.kill("SIGTERM");
+        terminalServer?.kill("SIGTERM");
+        directTerminalServer?.kill("SIGTERM");
 
         if (code !== 0 && code !== null && !opts.rebuild) {
           const stderr = stderrChunks.join("");


### PR DESCRIPTION
## Summary

- `ao dashboard` only started the Next.js dev server but never started the terminal WebSocket servers (`terminal-websocket.js` and `direct-terminal-ws.js`)
- In production, `start-all.ts` correctly starts all three processes together — but the `ao dashboard` CLI command skipped the terminal servers entirely
- Users clicking the terminal view in the dashboard got a silent failure (connection refused on ports 14800/14801)
- Fixed by spawning both terminal servers after the Next.js process starts, using the same env already built by `buildDashboardEnv()`, with labeled stdout/stderr output and proper cleanup on exit

## Test plan

- [ ] Run `ao dashboard` and open a session's terminal view — should connect successfully instead of failing
- [ ] Check that `[terminal]` and `[direct-terminal]` log lines appear in dashboard output
- [ ] Kill the dashboard — both terminal server processes should also exit cleanly
- [ ] Verify ports 14800 and 14801 are released after dashboard exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)