### PR TITLE
fix(web): dedupe duplicate PR rows and counts

### DIFF
--- a/packages/web/src/__tests__/components.test.tsx
+++ b/packages/web/src/__tests__/components.test.tsx
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { Dashboard } from "@/components/Dashboard";
 import { CIBadge, CICheckList } from "@/components/CIBadge";
 import { PRStatus } from "@/components/PRStatus";
 import { SessionCard } from "@/components/SessionCard";
 import { AttentionZone } from "@/components/AttentionZone";
 import { ActivityDot } from "@/components/ActivityDot";
 import { makeSession, makePR } from "./helpers";
+
+vi.mock("@/hooks/useSessionEvents", () => ({
+  useSessionEvents: (initialSessions: unknown[]) => initialSessions,
+}));
 
 // ── ActivityDot ───────────────────────────────────────────────────────
 
@@ -492,5 +497,32 @@ describe("AttentionZone", () => {
     render(<AttentionZone level="respond" sessions={sessions} onRestore={onRestore} />);
     fireEvent.click(screen.getByText("restore"));
     expect(onRestore).toHaveBeenCalledWith("s1");
+  });
+});
+
+// ── Dashboard ───────────────────────────────────────────────────────
+
+describe("Dashboard", () => {
+  it("dedupes open PR rows by PR number", () => {
+    const sharedPr = makePR({ number: 42, title: "feat: shared PR" });
+    const sessions = [
+      makeSession({ id: "s1", pr: sharedPr }),
+      makeSession({ id: "s2", pr: sharedPr }),
+      makeSession({ id: "s3", pr: makePR({ number: 77, title: "feat: unique PR" }) }),
+    ];
+
+    render(
+      <Dashboard
+        initialSessions={sessions}
+        stats={{ totalSessions: 3, workingSessions: 3, openPRs: 2, needsReview: 0 }}
+      />,
+    );
+
+    const prTable = screen.getByRole("table");
+    const rows = within(prTable).getAllByRole("row");
+
+    expect(rows).toHaveLength(3);
+    expect(within(prTable).getAllByText("#42")).toHaveLength(1);
+    within(prTable).getByText("#77");
   });
 });

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -43,10 +43,14 @@ export function Dashboard({ initialSessions, stats, orchestratorId, projectName 
   }, [sessions]);
 
   const openPRs = useMemo(() => {
-    return sessions
-      .filter((s): s is DashboardSession & { pr: DashboardPR } => s.pr?.state === "open")
-      .map((s) => s.pr)
-      .sort((a, b) => mergeScore(a) - mergeScore(b));
+    const unique = new Map<number, DashboardPR>();
+    for (const session of sessions) {
+      if (session.pr?.state !== "open") continue;
+      if (!unique.has(session.pr.number)) {
+        unique.set(session.pr.number, session.pr);
+      }
+    }
+    return Array.from(unique.values()).sort((a, b) => mergeScore(a) - mergeScore(b));
   }, [sessions]);
 
   const handleSend = async (sessionId: string, message: string) => {

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -1007,6 +1007,42 @@ describe("computeStats", () => {
     expect(stats.totalSessions).toBe(5);
     expect(stats.workingSessions).toBe(3); // active + idle + ready
   });
+
+  it("counts unique open PRs instead of per-session duplicates", () => {
+    const sharedPr = {
+      number: 42,
+      url: "https://github.com/test/repo/pull/42",
+      title: "Shared PR",
+      owner: "test",
+      repo: "repo",
+      branch: "feat/shared",
+      baseBranch: "main",
+      isDraft: false,
+      state: "open" as const,
+      additions: 0,
+      deletions: 0,
+      ciStatus: "none" as const,
+      ciChecks: [],
+      reviewDecision: "none" as const,
+      mergeability: {
+        mergeable: false,
+        ciPassing: false,
+        approved: false,
+        noConflicts: true,
+        blockers: ["Data not loaded"],
+      },
+      unresolvedThreads: 0,
+      unresolvedComments: [],
+    };
+
+    const sessions = [
+      makeDashboard({ id: "s1", pr: sharedPr }),
+      makeDashboard({ id: "s2", pr: sharedPr }),
+      makeDashboard({ id: "s3", pr: { ...sharedPr, number: 77, url: "https://github.com/test/repo/pull/77" } }),
+    ];
+
+    expect(computeStats(sessions).openPRs).toBe(2);
+  });
 });
 
 describe("basicPRToDashboard defaults", () => {

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -378,10 +378,17 @@ export async function enrichSessionsMetadata(
 
 /** Compute dashboard stats from a list of sessions. */
 export function computeStats(sessions: DashboardSession[]): DashboardStats {
+  const uniqueOpenPRs = new Set<number>();
+  for (const session of sessions) {
+    if (session.pr?.state === "open") {
+      uniqueOpenPRs.add(session.pr.number);
+    }
+  }
+
   return {
     totalSessions: sessions.length,
     workingSessions: sessions.filter((s) => s.activity !== null && s.activity !== "exited").length,
-    openPRs: sessions.filter((s) => s.pr?.state === "open").length,
+    openPRs: uniqueOpenPRs.size,
     needsReview: sessions.filter((s) => s.pr && !s.pr.isDraft && s.pr.reviewDecision === "pending")
       .length,
   };


### PR DESCRIPTION
## Summary
- dedupe dashboard pull request rows by PR number so duplicate session mappings do not render duplicate entries
- count unique open PR numbers in dashboard stats instead of counting one per session
- add targeted regressions for the dashboard row rendering and stats computation

## Test Plan
- `pnpm --filter @composio/ao-web test -- src/__tests__/components.test.tsx -t "Dashboard"`
- `pnpm --filter @composio/ao-web test -- src/lib/__tests__/serialize.test.ts -t "counts unique open PRs instead of per-session duplicates"`