### PR TITLE
feat: LLM routing controls + smart agent routing + per-session model switch

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "@composio/ao-plugin-agent-aider": "workspace:*",
     "@composio/ao-plugin-agent-claude-code": "workspace:*",
     "@composio/ao-plugin-agent-codex": "workspace:*",
+    "@composio/ao-plugin-agent-local-llm": "workspace:*",
     "@composio/ao-plugin-agent-opencode": "workspace:*",
     "@composio/ao-plugin-notifier-composio": "workspace:*",
     "@composio/ao-plugin-notifier-desktop": "workspace:*",

--- a/packages/core/src/__tests__/classify-task-complexity.test.ts
+++ b/packages/core/src/__tests__/classify-task-complexity.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { classifyTaskComplexity } from "../session-manager.js";
+
+// Use vi.hoisted so mockCreate is available inside the vi.mock factory
+// (vi.mock calls are hoisted before variable declarations)
+const { mockCreate } = vi.hoisted(() => ({ mockCreate: vi.fn() }));
+
+vi.mock("@anthropic-ai/sdk", () => {
+  // Must use a class/function (not arrow) so it works as a constructor
+  class MockAnthropic {
+    messages = { create: mockCreate };
+  }
+  return { default: MockAnthropic };
+});
+
+describe("classifyTaskComplexity", () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+  });
+
+  it("returns 'simple' when Claude responds with 'simple'", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "simple" }],
+    });
+
+    const result = await classifyTaskComplexity("Fix typo in README");
+    expect(result).toBe("simple");
+  });
+
+  it("returns 'complex' when Claude responds with 'complex'", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "complex" }],
+    });
+
+    const result = await classifyTaskComplexity(
+      "Implement OAuth2 authentication with multi-provider support",
+    );
+    expect(result).toBe("complex");
+  });
+
+  it("trims and lowercases the response before comparing", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "  Simple  " }],
+    });
+
+    const result = await classifyTaskComplexity("Update config value");
+    expect(result).toBe("simple");
+  });
+
+  it("falls back to 'complex' on ambiguous response", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "I cannot determine" }],
+    });
+
+    const result = await classifyTaskComplexity("Some task");
+    expect(result).toBe("complex");
+  });
+
+  it("falls back to 'complex' when Anthropic SDK throws", async () => {
+    mockCreate.mockRejectedValueOnce(new Error("API error"));
+
+    const result = await classifyTaskComplexity("Some task");
+    expect(result).toBe("complex");
+  });
+
+  it("returns 'complex' immediately for empty input without calling API", async () => {
+    const result = await classifyTaskComplexity("");
+    expect(result).toBe("complex");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 'complex' immediately for whitespace-only input", async () => {
+    const result = await classifyTaskComplexity("   ");
+    expect(result).toBe("complex");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("calls Claude Haiku model for cost efficiency", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "simple" }],
+    });
+
+    await classifyTaskComplexity("Fix typo");
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "claude-haiku-4-5-20251001",
+      }),
+    );
+  });
+
+  it("includes the task description in the prompt", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "simple" }],
+    });
+
+    const taskDescription = "Add docstring to utils.py";
+    await classifyTaskComplexity(taskDescription);
+    const callArgs = mockCreate.mock.calls[0]?.[0] as
+      | { messages?: Array<{ content?: string }> }
+      | undefined;
+    const userMessage = callArgs?.messages?.[0]?.content;
+    expect(userMessage).toContain(taskDescription);
+  });
+});

--- a/packages/core/src/agent-selection.ts
+++ b/packages/core/src/agent-selection.ts
@@ -31,12 +31,25 @@ export function resolveAgentSelection(params: {
   defaults: DefaultPlugins;
   persistedAgent?: string;
   spawnAgentOverride?: string;
+  complexity?: "simple" | "complex";
 }): ResolvedAgentSelection {
-  const { role, project, defaults, persistedAgent, spawnAgentOverride } = params;
+  const { role, project, defaults, persistedAgent, spawnAgentOverride, complexity } = params;
   const roleProjectConfig = role === "orchestrator" ? project.orchestrator : project.worker;
   const roleDefaults = role === "orchestrator" ? defaults.orchestrator : defaults.worker;
   const sharedConfig = project.agentConfig ?? {};
   const roleAgentConfig = roleProjectConfig?.agentConfig ?? {};
+
+  // For simple worker tasks with no explicit override AND no project-level agent config,
+  // route to local-llm. Project-level config is an intentional user choice and takes priority.
+  const complexityDefault =
+    role === "worker" &&
+    !persistedAgent &&
+    !spawnAgentOverride &&
+    !roleProjectConfig?.agent &&
+    !project.agent &&
+    complexity === "simple"
+      ? "local-llm"
+      : undefined;
 
   const agentName = persistedAgent
     ? persistedAgent
@@ -44,6 +57,7 @@ export function resolveAgentSelection(params: {
       ? (spawnAgentOverride ??
         roleProjectConfig?.agent ??
         project.agent ??
+        complexityDefault ??
         roleDefaults?.agent ??
         defaults.agent)
       : (roleProjectConfig?.agent ?? project.agent ?? roleDefaults?.agent ?? defaults.agent);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -13,10 +13,11 @@
 import { readFileSync, existsSync } from "node:fs";
 import { resolve, join, basename } from "node:path";
 import { homedir } from "node:os";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, parseDocument } from "yaml";
 import { z } from "zod";
-import { ConfigNotFoundError, type OrchestratorConfig } from "./types.js";
+import { ConfigNotFoundError, type OrchestratorConfig, type RoutingConfig } from "./types.js";
 import { generateSessionPrefix } from "./paths.js";
+import { atomicWriteFileSync } from "./atomic-write.js";
 
 function inferScmPlugin(project: {
   repo: string;
@@ -142,6 +143,16 @@ const DecomposerConfigSchema = z
     requireApproval: true,
   });
 
+const LocalLlmConfigSchema = z.object({
+  baseUrl: z.string().default("http://localhost:11434/v1"),
+  model: z.string().default(""),
+});
+
+const RoutingConfigSchema = z.object({
+  mode: z.enum(["always-claude", "smart", "always-local"]).default("always-claude"),
+  localLlm: LocalLlmConfigSchema.default({}),
+});
+
 const ProjectConfigSchema = z.object({
   name: z.string().optional(),
   repo: z.string(),
@@ -196,6 +207,7 @@ const OrchestratorConfigSchema = z.object({
     info: ["composio"],
   }),
   reactions: z.record(ReactionConfigSchema).default({}),
+  routing: RoutingConfigSchema.optional(),
 });
 
 // =============================================================================
@@ -521,4 +533,33 @@ export function getDefaultConfig(): OrchestratorConfig {
   return validateConfig({
     projects: {},
   });
+}
+
+/**
+ * Write routing config back to the YAML config file.
+ * Reads the existing YAML, merges the routing section, and writes it back.
+ */
+export function writeRoutingConfig(routing: RoutingConfig, configPath?: string): void {
+  const path = configPath ?? findConfigFile();
+
+  if (!path) {
+    throw new ConfigNotFoundError();
+  }
+
+  const raw = readFileSync(path, "utf-8");
+
+  // Use parseDocument so comments and formatting are preserved on round-trip.
+  // parseDocument handles empty files (null contents) gracefully — setIn creates
+  // the root map if needed.
+  const doc = parseDocument(raw.trim() || "{}");
+
+  doc.setIn(["routing"], {
+    mode: routing.mode,
+    localLlm: {
+      baseUrl: routing.localLlm.baseUrl,
+      model: routing.localLlm.model,
+    },
+  });
+
+  atomicWriteFileSync(path, doc.toString());
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export {
   getDefaultConfig,
   findConfig,
   findConfigFile,
+  writeRoutingConfig,
 } from "./config.js";
 
 // Plugin registry
@@ -44,7 +45,7 @@ export {
 } from "./tmux.js";
 
 // Session manager — session CRUD
-export { createSessionManager } from "./session-manager.js";
+export { createSessionManager, classifyTaskComplexity } from "./session-manager.js";
 export type { SessionManagerDeps } from "./session-manager.js";
 
 // Lifecycle manager — state machine + reaction engine

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -93,6 +93,7 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
       ? Number(raw["directTerminalWsPort"])
       : undefined,
     opencodeSessionId: raw["opencodeSessionId"],
+    llmOverride: raw["llm_override"],
   };
 }
 
@@ -142,6 +143,7 @@ export function writeMetadata(
   if (metadata.directTerminalWsPort !== undefined)
     data["directTerminalWsPort"] = String(metadata.directTerminalWsPort);
   if (metadata.opencodeSessionId) data["opencodeSessionId"] = metadata.opencodeSessionId;
+  if (metadata.llmOverride) data["llm_override"] = metadata.llmOverride;
 
   atomicWriteFileSync(path, serializeMetadata(data));
 }

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -32,6 +32,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "codex", pkg: "@composio/ao-plugin-agent-codex" },
   { slot: "agent", name: "aider", pkg: "@composio/ao-plugin-agent-aider" },
   { slot: "agent", name: "opencode", pkg: "@composio/ao-plugin-agent-opencode" },
+  { slot: "agent", name: "local-llm", pkg: "@composio/ao-plugin-agent-local-llm" },
   // Workspaces
   { slot: "workspace", name: "worktree", pkg: "@composio/ao-plugin-workspace-worktree" },
   { slot: "workspace", name: "clone", pkg: "@composio/ao-plugin-workspace-clone" },

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -11,7 +11,7 @@
  * Reference: scripts/claude-ao-session, scripts/send-to-session
  */
 
-import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync, utimesSync } from "node:fs";
+import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync, utimesSync, readFileSync } from "node:fs";
 import { execFile } from "node:child_process";
 import { basename, join, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -74,10 +74,54 @@ import {
 import { sessionFromMetadata } from "./utils/session-from-metadata.js";
 import { safeJsonParse } from "./utils/validation.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
+import Anthropic from "@anthropic-ai/sdk";
 
 const execFileAsync = promisify(execFile);
 const OPENCODE_DISCOVERY_TIMEOUT_MS = 2_000;
 const OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS = 10_000;
+
+// =============================================================================
+// Task Complexity Classification
+// =============================================================================
+
+/**
+ * Classify a task as simple or complex using Claude Haiku.
+ *
+ * - Simple: single-file changes, typo fixes, config changes, small bug fixes, doc updates
+ * - Complex: multi-file changes, new features, architectural changes, debugging across systems
+ *
+ * Falls back to "complex" on any error to preserve existing behavior.
+ */
+export async function classifyTaskComplexity(
+  issueContext: string,
+): Promise<"simple" | "complex"> {
+  if (!issueContext.trim()) return "complex";
+
+  try {
+    const client = new Anthropic();
+    const res = await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 10,
+      messages: [
+        {
+          role: "user",
+          content: `Classify this software task as either 'simple' or 'complex'.
+Simple: single-file changes, typo fixes, config changes, small bug fixes, doc updates.
+Complex: multi-file changes, new features, architectural changes, debugging across systems, PR review cycles.
+Respond with only: simple or complex
+Task: ${issueContext}`,
+        },
+      ],
+    });
+
+    const text =
+      res.content[0]?.type === "text" ? res.content[0].text.trim().toLowerCase() : "";
+    return text === "simple" ? "simple" : "complex";
+  } catch {
+    // Fall back to complex on any error to preserve existing behavior
+    return "complex";
+  }
+}
 
 function errorIncludesSessionNotFound(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -723,11 +767,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     sessionId: string,
     metadata: Record<string, string>,
   ) {
+    const llmOverride = metadata["llm_override"] || undefined;
     return resolveAgentSelection({
       role: resolveSessionRole(sessionId, metadata),
       project,
       defaults: config.defaults,
-      persistedAgent: metadata["agent"],
+      persistedAgent: llmOverride ?? metadata["agent"],
     });
   }
 
@@ -903,27 +948,18 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       );
     }
 
-    const selection = resolveAgentSelection({
-      role: "worker",
-      project,
-      defaults: config.defaults,
-      spawnAgentOverride: spawnConfig.agent,
-    });
-    const plugins = resolvePlugins(project, selection.agentName);
-    if (!plugins.runtime) {
-      throw new Error(`Runtime plugin '${project.runtime ?? config.defaults.runtime}' not found`);
-    }
-
-    if (!plugins.agent) {
-      throw new Error(`Agent plugin '${selection.agentName}' not found`);
-    }
+    // Resolve tracker plugin early — needed for issue validation before agent selection
+    // (tracker does not depend on agent choice)
+    const trackerPlugin = project.tracker
+      ? registry.get<Tracker>("tracker", project.tracker.plugin)
+      : null;
 
     // Validate issue exists BEFORE creating any resources
     let resolvedIssue: Issue | undefined;
-    if (spawnConfig.issueId && plugins.tracker) {
+    if (spawnConfig.issueId && trackerPlugin) {
       try {
         // Fetch and validate the issue exists
-        resolvedIssue = await plugins.tracker.getIssue(spawnConfig.issueId, project);
+        resolvedIssue = await trackerPlugin.getIssue(spawnConfig.issueId, project);
       } catch (err) {
         // Issue fetch failed - determine why
         if (isIssueNotFoundError(err)) {
@@ -934,6 +970,48 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           throw new Error(`Failed to fetch issue ${spawnConfig.issueId}: ${err}`, { cause: err });
         }
       }
+    }
+
+    // Classify task complexity for smart agent routing.
+    // Priority order: explicit agent (CLI/config) > per-session llmOverride > global routing mode.
+    //   always-claude  → skip classification; complexity stays undefined (routes to Claude)
+    //   smart          → call classifier to decide per-task
+    //   always-local   → skip classification; force "simple" so resolveAgentSelection
+    //                    picks local-llm unconditionally
+    const hasExplicitAgent =
+      !!spawnConfig.agent || !!project.worker?.agent || !!project.agent;
+    // Per-session llmOverride maps directly to an agent name, bypassing routing mode.
+    const effectiveAgent = hasExplicitAgent
+      ? spawnConfig.agent
+      : spawnConfig.llmOverride ?? undefined;
+    const classificationInput = resolvedIssue
+      ? `${resolvedIssue.title}\n${resolvedIssue.description}`
+      : (spawnConfig.prompt ?? spawnConfig.issueId ?? "");
+    const routingMode = config.routing?.mode ?? "always-claude";
+    let complexity: "simple" | "complex" | undefined;
+    if (effectiveAgent || routingMode === "always-claude") {
+      complexity = undefined;
+    } else if (routingMode === "always-local") {
+      complexity = "simple";
+    } else {
+      // smart mode — classify and route based on result
+      complexity = await classifyTaskComplexity(classificationInput);
+    }
+
+    const selection = resolveAgentSelection({
+      role: "worker",
+      project,
+      defaults: config.defaults,
+      spawnAgentOverride: effectiveAgent,
+      complexity,
+    });
+    const plugins = resolvePlugins(project, selection.agentName);
+    if (!plugins.runtime) {
+      throw new Error(`Runtime plugin '${project.runtime ?? config.defaults.runtime}' not found`);
+    }
+
+    if (!plugins.agent) {
+      throw new Error(`Agent plugin '${selection.agentName}' not found`);
     }
 
     // Get the sessions directory for this project
@@ -1019,12 +1097,36 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     }
 
+    // Check for a HANDOFF.md from a previous session for the same issue.
+    // This is written by the outgoing agent when the user switches LLMs, providing
+    // continuity of context for the incoming agent.
+    let handoffContext: string | undefined;
+    if (spawnConfig.issueId) {
+      const allSessions = await list(spawnConfig.projectId);
+      for (const s of allSessions) {
+        if (s.issueId !== spawnConfig.issueId) continue;
+        const handoffPath = s.metadata["worktree"]
+          ? join(s.metadata["worktree"], "HANDOFF.md")
+          : null;
+        if (handoffPath && existsSync(handoffPath)) {
+          try {
+            handoffContext = readFileSync(handoffPath, "utf8");
+          } catch {
+            // best effort
+          }
+          break;
+        }
+      }
+    }
+
     const composedPrompt = buildPrompt({
       project,
       projectId: spawnConfig.projectId,
       issueId: spawnConfig.issueId,
       issueContext,
-      userPrompt: spawnConfig.prompt,
+      userPrompt: handoffContext
+        ? `${spawnConfig.prompt ?? ""}\n\n---\n**Handoff context from previous agent:**\n\n${handoffContext}`
+        : spawnConfig.prompt,
       lineage: spawnConfig.lineage,
       siblings: spawnConfig.siblings,
     });
@@ -1039,12 +1141,22 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
             strategy: opencodeIssueSessionStrategy,
           })
         : undefined;
+    // When routing to local-llm, forward the saved baseURL/model from routing config
+    // into agentConfig so the plugin's getEnvironment() can pick them up per-session.
+    const localLlmOverrides =
+      selection.agentName === "local-llm" && config.routing?.localLlm
+        ? {
+            baseURL: config.routing.localLlm.baseUrl,
+            ...(config.routing.localLlm.model ? { model: config.routing.localLlm.model } : {}),
+          }
+        : {};
     const agentLaunchConfig = {
       sessionId,
       projectConfig: {
         ...project,
         agentConfig: {
           ...selection.agentConfig,
+          ...localLlmOverrides,
           ...(reusedOpenCodeSessionId ? { opencodeSessionId: reusedOpenCodeSessionId } : {}),
         },
       },
@@ -2071,6 +2183,19 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     }
   }
 
+  async function setMetadata(
+    sessionId: SessionId,
+    updates: Record<string, string | undefined>,
+  ): Promise<void> {
+    const { sessionsDir } = requireSessionRecord(sessionId);
+    // Filter out undefined values — they represent key deletions (write empty string)
+    const patch: Record<string, string> = {};
+    for (const [k, v] of Object.entries(updates)) {
+      patch[k] = v ?? "";
+    }
+    updateMetadata(sessionsDir, sessionId, patch);
+  }
+
   async function claimPR(
     sessionId: SessionId,
     prRef: string,
@@ -2281,6 +2406,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         createdAt: raw["createdAt"],
         runtimeHandle: raw["runtimeHandle"],
         opencodeSessionId: raw["opencodeSessionId"],
+        llmOverride: raw["llm_override"],
       });
     }
 
@@ -2427,5 +2553,5 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return restoredSession;
   }
 
-  return { spawn, spawnOrchestrator, restore, list, get, kill, cleanup, send, claimPR, remap };
+  return { spawn, spawnOrchestrator, restore, list, get, kill, cleanup, send, claimPR, remap, setMetadata };
 }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -981,6 +981,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const hasExplicitAgent =
       !!spawnConfig.agent || !!project.worker?.agent || !!project.agent;
     // Per-session llmOverride maps directly to an agent name, bypassing routing mode.
+    // When hasExplicitAgent is true, use spawnConfig.agent as the override (may be
+    // undefined if the explicit agent comes from project config rather than spawn args —
+    // resolveAgentSelection will pick it up from the project anyway).
     const effectiveAgent = hasExplicitAgent
       ? spawnConfig.agent
       : spawnConfig.llmOverride ?? undefined;
@@ -989,7 +992,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       : (spawnConfig.prompt ?? spawnConfig.issueId ?? "");
     const routingMode = config.routing?.mode ?? "always-claude";
     let complexity: "simple" | "complex" | undefined;
-    if (effectiveAgent || routingMode === "always-claude") {
+    if (hasExplicitAgent || effectiveAgent || routingMode === "always-claude") {
+      // Skip classifier when any explicit agent is configured (spawn arg, project.worker.agent,
+      // or project.agent) — the result would be ignored by resolveAgentSelection anyway, so
+      // avoid the unnecessary Haiku API call.
       complexity = undefined;
     } else if (routingMode === "always-local") {
       complexity = "simple";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -193,6 +193,11 @@ export interface SessionSpawnConfig {
   lineage?: string[];
   /** Decomposition context — sibling task descriptions (passed to prompt builder) */
   siblings?: string[];
+  /**
+   * Per-session LLM override — bypasses global routing and forces a specific agent.
+   * "claude-code" | "local-llm" — takes precedence over routing.mode but not agent/worker.agent.
+   */
+  llmOverride?: "claude-code" | "local-llm";
 }
 
 /** Config for creating an orchestrator session */
@@ -877,6 +882,30 @@ export interface ReactionResult {
 // CONFIGURATION
 // =============================================================================
 
+/** Local LLM configuration for smart routing */
+export interface LocalLlmConfig {
+  /** OpenAI-compatible API base URL (e.g. http://localhost:11434/v1) */
+  baseUrl: string;
+  /** Model name to use (e.g. llama3, mistral) */
+  model: string;
+}
+
+/**
+ * Routing mode:
+ * - "always-claude": all sessions use Claude Code (default)
+ * - "smart": Haiku classifies task complexity; simple→local LLM, complex→Claude
+ * - "always-local": all sessions use the local LLM entirely
+ */
+export type RoutingMode = "always-claude" | "smart" | "always-local";
+
+/** Smart routing configuration — controls how tasks are routed to LLMs */
+export interface RoutingConfig {
+  /** Routing mode (default: "always-claude") */
+  mode: RoutingMode;
+  /** Local LLM endpoint settings (used when mode is "smart" or "always-local") */
+  localLlm: LocalLlmConfig;
+}
+
 /** Top-level orchestrator configuration (from agent-orchestrator.yaml) */
 export interface OrchestratorConfig {
   /**
@@ -912,6 +941,9 @@ export interface OrchestratorConfig {
 
   /** Default reaction configs */
   reactions: Record<string, ReactionConfig>;
+
+  /** Smart LLM routing configuration */
+  routing?: RoutingConfig;
 }
 
 export interface DefaultPlugins {
@@ -1158,6 +1190,7 @@ export interface SessionMetadata {
   terminalWsPort?: number;
   directTerminalWsPort?: number;
   opencodeSessionId?: string;
+  llmOverride?: string; // User-selected LLM override (e.g. "local-llm", "claude-code")
 }
 
 // =============================================================================
@@ -1178,6 +1211,8 @@ export interface SessionManager {
   ): Promise<CleanupResult>;
   send(sessionId: SessionId, message: string): Promise<void>;
   claimPR(sessionId: SessionId, prRef: string, options?: ClaimPROptions): Promise<ClaimPRResult>;
+  /** Merge key/value pairs into a session's persisted metadata. */
+  setMetadata(sessionId: SessionId, updates: Record<string, string | undefined>): Promise<void>;
 }
 
 /** OpenCode-specific session manager with remap capability */

--- a/packages/plugins/agent-local-llm/package.json
+++ b/packages/plugins/agent-local-llm/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@composio/ao-plugin-agent-local-llm",
+  "version": "0.1.0",
+  "description": "Agent plugin: local/OpenAI-compatible LLM (Ollama, LM Studio, vLLM, LocalAI, etc.)",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-local-llm"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-local-llm/src/index.ts
+++ b/packages/plugins/agent-local-llm/src/index.ts
@@ -52,6 +52,10 @@ function buildModelFlag(baseURL: string, model: string): string {
 
 // =============================================================================
 // Aider Activity Detection Helpers (copied from agent-aider)
+// TODO: hasRecentCommits, getChatHistoryMtime, and getActivityState are
+// duplicated verbatim from packages/plugins/agent-aider. If a shared
+// agent-base (or similar) package is introduced in the future, these helpers
+// should be extracted there and imported by both plugins.
 // =============================================================================
 
 /**

--- a/packages/plugins/agent-local-llm/src/index.ts
+++ b/packages/plugins/agent-local-llm/src/index.ts
@@ -1,0 +1,268 @@
+import {
+  shellEscape,
+  DEFAULT_READY_THRESHOLD_MS,
+  type Agent,
+  type AgentLaunchConfig,
+  type AgentSessionInfo,
+  type ActivityDetection,
+  type ActivityState,
+  type PluginModule,
+  type RuntimeHandle,
+  type Session,
+} from "@composio/ao-core";
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+import { stat, access } from "node:fs/promises";
+import { join } from "node:path";
+import { constants } from "node:fs";
+
+const execFileAsync = promisify(execFile);
+
+// =============================================================================
+// Plugin Config
+// =============================================================================
+
+const DEFAULT_BASE_URL = "http://localhost:11434/v1";
+const DEFAULT_MODEL = "qwen3:8b";
+
+export interface LocalLlmPluginConfig {
+  /** OpenAI-compatible API base URL. Works with Ollama, LM Studio, vLLM, LocalAI, etc.
+   *  @default "http://localhost:11434/v1" */
+  baseURL?: string;
+  /** Model name to pass to the API.
+   *  @default "qwen3:8b" */
+  model?: string;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Build the --model flag value for Aider based on the endpoint URL.
+ * Ollama endpoints get the `ollama/` prefix; all other OpenAI-compatible
+ * endpoints get the `openai/` prefix so Aider routes them correctly.
+ */
+function buildModelFlag(baseURL: string, model: string): string {
+  if (baseURL.includes("11434") || baseURL.toLowerCase().includes("ollama")) {
+    return `ollama/${model}`;
+  }
+  return `openai/${model}`;
+}
+
+// =============================================================================
+// Aider Activity Detection Helpers (copied from agent-aider)
+// =============================================================================
+
+/**
+ * Check if Aider has made recent commits (within last 60 seconds).
+ */
+async function hasRecentCommits(workspacePath: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["log", "--since=60 seconds ago", "--format=%H"],
+      { cwd: workspacePath, timeout: 5_000 },
+    );
+    return stdout.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get modification time of Aider chat history file.
+ */
+async function getChatHistoryMtime(workspacePath: string): Promise<Date | null> {
+  try {
+    const chatFile = join(workspacePath, ".aider.chat.history.md");
+    await access(chatFile, constants.R_OK);
+    const stats = await stat(chatFile);
+    return stats.mtime;
+  } catch {
+    return null;
+  }
+}
+
+// =============================================================================
+// Plugin Manifest
+// =============================================================================
+
+export const manifest = {
+  name: "local-llm",
+  slot: "agent" as const,
+  description: "Agent plugin: local/OpenAI-compatible LLM via Aider (Ollama, LM Studio, vLLM, LocalAI, etc.)",
+  version: "0.1.0",
+  displayName: "Local LLM",
+};
+
+// =============================================================================
+// Agent Implementation
+// =============================================================================
+
+function createLocalLlmAgent(pluginConfig: LocalLlmPluginConfig): Agent {
+  const configuredBaseURL = pluginConfig.baseURL ?? DEFAULT_BASE_URL;
+  const configuredModel = pluginConfig.model ?? DEFAULT_MODEL;
+
+  return {
+    name: "local-llm",
+    processName: "aider",
+    promptDelivery: "post-launch" as const,
+
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      // Resolve baseURL and model — per-session agentConfig overrides plugin defaults
+      const baseURL = (config.projectConfig.agentConfig?.["baseURL"] as string | undefined)
+        ?? configuredBaseURL;
+      const model = (config.projectConfig.agentConfig?.["model"] as string | undefined)
+        ?? config.model
+        ?? configuredModel;
+
+      const modelFlag = buildModelFlag(baseURL, model);
+
+      const parts: string[] = ["aider"];
+
+      // Keep Aider interactive — prompt will be delivered post-launch via tmux send-keys
+      parts.push("--yes-always");
+
+      // Route to the correct local model
+      parts.push("--model", shellEscape(modelFlag));
+
+      return parts.join(" ");
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      // Resolve baseURL per-session (agentConfig overrides plugin default)
+      const baseURL = (config.projectConfig.agentConfig?.["baseURL"] as string | undefined)
+        ?? configuredBaseURL;
+
+      const env: Record<string, string> = {
+        AO_SESSION_ID: config.sessionId,
+        // Point Aider at the local endpoint
+        OPENAI_API_BASE: baseURL,
+        // Any non-empty value satisfies Aider's key check for non-OpenAI endpoints
+        OPENAI_API_KEY: "local-llm",
+      };
+
+      if (config.issueId) {
+        env["AO_ISSUE_ID"] = config.issueId;
+      }
+
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      if (!terminalOutput.trim()) return "idle";
+      return "active";
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      try {
+        if (handle.runtimeName === "tmux" && handle.id) {
+          const { stdout: ttyOut } = await execFileAsync(
+            "tmux",
+            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+            { timeout: 30_000 },
+          );
+          const ttys = ttyOut
+            .trim()
+            .split("\n")
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (ttys.length === 0) return false;
+
+          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
+            timeout: 30_000,
+          });
+          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
+          const processRe = /(?:^|\/)aider(?:\s|$)/;
+          for (const line of psOut.split("\n")) {
+            const cols = line.trimStart().split(/\s+/);
+            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+            const args = cols.slice(2).join(" ");
+            if (processRe.test(args)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        const rawPid = handle.data["pid"];
+        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+        if (Number.isFinite(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+            return true;
+          } catch (err: unknown) {
+            if (err instanceof Error && "code" in err && err.code === "EPERM") {
+              return true;
+            }
+            return false;
+          }
+        }
+
+        return false;
+      } catch {
+        return false;
+      }
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
+      const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
+
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (!running) return { state: "exited", timestamp: exitedAt };
+
+      if (!session.workspacePath) return null;
+
+      // Check for recent git commits (Aider auto-commits changes)
+      const hasCommits = await hasRecentCommits(session.workspacePath);
+      if (hasCommits) return { state: "active" };
+
+      // Check chat history file modification time
+      const chatMtime = await getChatHistoryMtime(session.workspacePath);
+      if (!chatMtime) {
+        return null;
+      }
+
+      // Classify by age: <30s active, <threshold ready, >threshold idle
+      const ageMs = Date.now() - chatMtime.getTime();
+      const activeWindowMs = Math.min(30_000, threshold);
+      if (ageMs < activeWindowMs) return { state: "active", timestamp: chatMtime };
+      if (ageMs < threshold) return { state: "ready", timestamp: chatMtime };
+      return { state: "idle", timestamp: chatMtime };
+    },
+
+    async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {
+      // Aider doesn't expose structured session data for introspection
+      return null;
+    },
+  };
+}
+
+// =============================================================================
+// Plugin Export
+// =============================================================================
+
+export function create(config?: Record<string, unknown>): Agent {
+  const pluginConfig: LocalLlmPluginConfig = {
+    baseURL: typeof config?.["baseURL"] === "string" ? config["baseURL"] : undefined,
+    model: typeof config?.["model"] === "string" ? config["model"] : undefined,
+  };
+  return createLocalLlmAgent(pluginConfig);
+}
+
+export function detect(): boolean {
+  try {
+    execFileSync("aider", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-local-llm/tsconfig.json
+++ b/packages/plugins/agent-local-llm/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,8 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  serverExternalPackages: ["@composio/core"],
   transpilePackages: [
     "@composio/ao-core",
     "@composio/ao-plugin-agent-claude-code",
+    "@composio/ao-plugin-agent-local-llm",
     "@composio/ao-plugin-agent-opencode",
     "@composio/ao-plugin-runtime-tmux",
     "@composio/ao-plugin-scm-github",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@composio/ao-core": "workspace:*",
     "@composio/ao-plugin-agent-claude-code": "workspace:*",
+    "@composio/ao-plugin-agent-local-llm": "workspace:*",
     "@composio/ao-plugin-agent-opencode": "workspace:*",
     "@composio/ao-plugin-runtime-tmux": "workspace:*",
     "@composio/ao-plugin-scm-github": "workspace:*",

--- a/packages/web/src/app/api/routing/route.ts
+++ b/packages/web/src/app/api/routing/route.ts
@@ -1,0 +1,86 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { findConfigFile, writeRoutingConfig, type RoutingConfig, type RoutingMode } from "@composio/ao-core";
+import { getServices } from "@/lib/services";
+
+const VALID_MODES = new Set<RoutingMode>(["always-claude", "smart", "always-local"]);
+
+export async function GET() {
+  try {
+    const { config } = await getServices();
+    const routing: RoutingConfig = config.routing ?? {
+      mode: "always-claude",
+      localLlm: { baseUrl: "http://localhost:11434/v1", model: "" },
+    };
+    return NextResponse.json({ routing });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to read routing config" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const body = (await request.json().catch(() => null)) as unknown;
+    if (!body || typeof body !== "object") {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const { routing } = body as { routing?: unknown };
+    if (!routing || typeof routing !== "object") {
+      return NextResponse.json({ error: "Missing routing field" }, { status: 400 });
+    }
+
+    const r = routing as Record<string, unknown>;
+    const rawMode = r["mode"];
+    const mode: RoutingMode =
+      typeof rawMode === "string" && VALID_MODES.has(rawMode as RoutingMode)
+        ? (rawMode as RoutingMode)
+        : "always-claude";
+
+    const localLlm =
+      r["localLlm"] && typeof r["localLlm"] === "object"
+        ? (r["localLlm"] as Record<string, unknown>)
+        : {};
+    const rawBaseUrl =
+      typeof localLlm["baseUrl"] === "string"
+        ? localLlm["baseUrl"]
+        : "http://localhost:11434/v1";
+
+    // Validate baseUrl: must be a parseable URL with http/https protocol only
+    // (prevents SSRF to non-HTTP internal services and rejects malformed strings)
+    let baseUrl: string;
+    try {
+      const parsed = new URL(rawBaseUrl);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        return NextResponse.json(
+          { error: "baseUrl must use http or https protocol" },
+          { status: 400 },
+        );
+      }
+      baseUrl = parsed.toString().replace(/\/$/, "");
+    } catch {
+      return NextResponse.json({ error: "baseUrl is not a valid URL" }, { status: 400 });
+    }
+
+    const rawModel = typeof localLlm["model"] === "string" ? localLlm["model"] : "";
+    const model = rawModel.slice(0, 256); // cap length
+
+    const routingConfig: RoutingConfig = { mode, localLlm: { baseUrl, model } };
+
+    const configPath = findConfigFile() ?? undefined;
+    writeRoutingConfig(routingConfig, configPath);
+
+    // Update in-memory config for the running process
+    const { config } = await getServices();
+    config.routing = routingConfig;
+
+    return NextResponse.json({ routing: routingConfig });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to write routing config" },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -1,3 +1,7 @@
+import { execFile } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import { type NextRequest } from "next/server";
 import { getServices, getSCM } from "@/lib/services";
 import {
@@ -75,5 +79,137 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       });
     }
     return jsonWithCorrelation({ error: "Internal server error" }, { status: 500 }, correlationId);
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const { sessionManager } = await getServices();
+
+    const session = await sessionManager.get(id);
+    if (!session) {
+      return jsonWithCorrelation({ error: "Session not found" }, { status: 404 }, "");
+    }
+
+    const body = (await request.json()) as { llmOverride?: "claude-code" | "local-llm" | null };
+    if (!("llmOverride" in body)) {
+      return jsonWithCorrelation({ error: "llmOverride field required" }, { status: 400 }, "");
+    }
+
+    const newAgent = body.llmOverride; // "claude-code" | "local-llm"
+    if (!newAgent) {
+      return jsonWithCorrelation({ error: "llmOverride must be claude-code or local-llm" }, { status: 400 }, "");
+    }
+
+    // Skip if already using this agent
+    const currentAgent = session.metadata["agent"] ?? "claude-code";
+    if (currentAgent === newAgent) {
+      return jsonWithCorrelation({ ok: true, newSessionId: id }, { status: 200 }, "");
+    }
+
+    const worktreePath = session.metadata["worktree"] || session.workspacePath || null;
+    const branch = session.metadata["branch"] || session.branch || undefined;
+    const issueId = session.issueId ?? undefined;
+    const projectId = session.projectId;
+
+    let handoffContent: string | undefined;
+
+    const isActive =
+      session.activity !== null &&
+      session.activity !== "exited" &&
+      session.status !== "done" &&
+      session.status !== "merged";
+
+    if (isActive && currentAgent !== "local-llm") {
+      // Active Claude (or other interactive) session — request handoff
+      const HANDOFF_PROMPT =
+        `Please commit all your current work to git now. ` +
+        `Then create a file called HANDOFF.md in the workspace root with these sections:\n` +
+        `1. **Current task** — what you were asked to do\n` +
+        `2. **Progress** — files changed, tests run, commands executed\n` +
+        `3. **Current state** — state of key files and context the next agent needs\n` +
+        `4. **Remaining work** — what still needs to be done\n` +
+        `5. **Blockers / notes** — anything the next agent should be aware of\n` +
+        `After writing and committing HANDOFF.md, stop immediately and do not take any further actions.`;
+
+      try {
+        await sessionManager.send(id, HANDOFF_PROMPT);
+      } catch {
+        // best-effort
+      }
+
+      // Poll for HANDOFF.md (2s intervals, 60s max)
+      if (worktreePath) {
+        const handoffPath = join(worktreePath, "HANDOFF.md");
+        const deadline = Date.now() + 60_000;
+        while (Date.now() < deadline) {
+          if (existsSync(handoffPath)) {
+            handoffContent = readFileSync(handoffPath, "utf-8");
+            break;
+          }
+          await new Promise((r) => setTimeout(r, 2_000));
+        }
+      }
+    } else if (currentAgent === "local-llm" || !isActive) {
+      // local-llm is one-shot (already exited) — read its output file
+      // Also handles any other exited session with an existing HANDOFF.md
+      if (worktreePath) {
+        const localLlmOutput = join(worktreePath, "local-llm-output.md");
+        const handoffFile = join(worktreePath, "HANDOFF.md");
+        if (existsSync(localLlmOutput)) {
+          handoffContent = readFileSync(localLlmOutput, "utf-8");
+        } else if (existsSync(handoffFile)) {
+          handoffContent = readFileSync(handoffFile, "utf-8");
+        }
+      }
+    }
+
+    // Kill the current session
+    try {
+      await sessionManager.kill(id);
+    } catch {
+      // best-effort — may already be dead
+    }
+
+    // Ensure old worktree is freed before spawning on same branch
+    if (worktreePath) {
+      try {
+        const execFileAsync = promisify(execFile);
+        await execFileAsync("git", ["worktree", "remove", "--force", worktreePath]);
+        // Prune stale entries — run from the worktreePath's parent repo
+        const repoPath = (
+          await execFileAsync("git", ["-C", worktreePath, "rev-parse", "--show-toplevel"]).catch(
+            () => ({ stdout: "" }),
+          )
+        ).stdout.trim();
+        if (repoPath) {
+          await execFileAsync("git", ["-C", repoPath, "worktree", "prune"]);
+        }
+      } catch {
+        // best-effort — worktree may already be gone
+      }
+    }
+
+    // Spawn new session with new agent, same branch/issue, handoff as context
+    const spawnPrompt = handoffContent
+      ? `**Handoff context from previous agent:**\n\n${handoffContent}`
+      : undefined;
+
+    const newSession = await sessionManager.spawn({
+      projectId,
+      issueId,
+      branch,
+      agent: newAgent,
+      prompt: spawnPrompt,
+    });
+
+    return jsonWithCorrelation({ ok: true, newSessionId: newSession.id }, { status: 200 }, "");
+  } catch (err) {
+    return jsonWithCorrelation(
+      { error: err instanceof Error ? err.message : "Internal server error" },
+      { status: 500 },
+      "",
+    );
   }
 }

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -98,7 +98,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     }
 
     const newAgent = body.llmOverride; // "claude-code" | "local-llm"
-    if (!newAgent) {
+    const ALLOWED_AGENTS = ["claude-code", "local-llm"] as const;
+    if (!newAgent || !(ALLOWED_AGENTS as readonly string[]).includes(newAgent)) {
       return jsonWithCorrelation({ error: "llmOverride must be claude-code or local-llm" }, { status: 400 }, "");
     }
 
@@ -176,13 +177,15 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     if (worktreePath) {
       try {
         const execFileAsync = promisify(execFile);
-        await execFileAsync("git", ["worktree", "remove", "--force", worktreePath]);
-        // Prune stale entries — run from the worktreePath's parent repo
+        // Resolve the repo root BEFORE removing the worktree directory, because
+        // `git -C <path>` fails once the directory is gone.
         const repoPath = (
           await execFileAsync("git", ["-C", worktreePath, "rev-parse", "--show-toplevel"]).catch(
             () => ({ stdout: "" }),
           )
         ).stdout.trim();
+        await execFileAsync("git", ["worktree", "remove", "--force", worktreePath]);
+        // Prune stale entries — run from the worktreePath's parent repo
         if (repoPath) {
           await execFileAsync("git", ["-C", repoPath, "worktree", "prune"]);
         }

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -17,6 +17,7 @@ import { PRTableRow } from "./PRStatus";
 import { DynamicFavicon } from "./DynamicFavicon";
 import { useSessionEvents } from "@/hooks/useSessionEvents";
 import { ProjectSidebar } from "./ProjectSidebar";
+import { RoutingButton } from "./RoutingButton";
 import type { ProjectInfo } from "@/lib/project-name";
 
 interface DashboardProps {
@@ -256,7 +257,10 @@ export function Dashboard({
             </h1>
             <StatusLine stats={liveStats} />
           </div>
-          {!allProjectsView && <OrchestratorControl orchestrators={activeOrchestrators} />}
+          <div className="flex items-center gap-2">
+            {!allProjectsView && <OrchestratorControl orchestrators={activeOrchestrators} />}
+            <RoutingButton />
+          </div>
         </div>
 
         {globalPause && !globalPauseDismissed && (

--- a/packages/web/src/components/RoutingButton.tsx
+++ b/packages/web/src/components/RoutingButton.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { RoutingPanel } from "./RoutingPanel";
+
+export function RoutingButton() {
+  const [showPanel, setShowPanel] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        onClick={() => setShowPanel((v) => !v)}
+        className={`flex items-center gap-1.5 rounded border px-2.5 py-1 text-[11px] transition-colors ${
+          showPanel
+            ? "border-[var(--color-accent)] text-[var(--color-accent)]"
+            : "border-[var(--color-border-subtle)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-default)] hover:text-[var(--color-text-primary)]"
+        }`}
+        aria-label="LLM Routing settings"
+        title="LLM Routing"
+      >
+        <svg
+          className="h-3.5 w-3.5"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+        >
+          <circle cx="12" cy="12" r="3" />
+          <path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83" />
+        </svg>
+        <span>Routing</span>
+      </button>
+      {showPanel && (
+        <RoutingPanel onClose={() => setShowPanel(false)} triggerRef={buttonRef} />
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/RoutingPanel.tsx
+++ b/packages/web/src/components/RoutingPanel.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RoutingConfig, RoutingMode } from "@composio/ao-core";
+
+type ConnectionStatus = "idle" | "testing" | "ok" | "error";
+
+const MODE_OPTIONS: { value: RoutingMode; label: string; description: string }[] = [
+  {
+    value: "always-claude",
+    label: "Always Claude",
+    description: "All sessions use Claude Code (default)",
+  },
+  {
+    value: "smart",
+    label: "Smart routing",
+    description: "Haiku classifies complexity — simple tasks go to local LLM, complex to Claude",
+  },
+  {
+    value: "always-local",
+    label: "Always local LLM",
+    description: "All sessions use the local LLM; Claude is not used",
+  },
+];
+
+interface RoutingPanelProps {
+  onClose: () => void;
+  /** Ref to the button that opens/closes this panel — excluded from outside-click detection */
+  triggerRef?: React.RefObject<HTMLElement | null>;
+}
+
+export function RoutingPanel({ onClose, triggerRef }: RoutingPanelProps) {
+  const [mode, setMode] = useState<RoutingMode>("always-claude");
+  const [baseUrl, setBaseUrl] = useState("http://localhost:11434/v1");
+  const [model, setModel] = useState("");
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("idle");
+  const [connectionError, setConnectionError] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState("");
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const panelRef = useRef<HTMLDivElement>(null);
+  // When true the next auto-fetch cycle should not reset the model field —
+  // used to protect the value loaded from saved config on initial mount.
+  const skipModelResetRef = useRef(false);
+
+  // Load current config
+  useEffect(() => {
+    void fetch("/api/routing")
+      .then((r) => r.json())
+      .then((data: { routing?: RoutingConfig }) => {
+        if (data.routing) {
+          setMode(data.routing.mode);
+          setBaseUrl(data.routing.localLlm.baseUrl);
+          setModel(data.routing.localLlm.model);
+          // Guard the just-loaded model from being wiped by the auto-fetch
+          // effect that fires because showLlmSettings just became true.
+          skipModelResetRef.current = true;
+        }
+      })
+      .catch(() => {
+        // silently ignore — use defaults
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Close on outside click — skip clicks on the trigger button so the button's
+  // own onClick handler can toggle the panel without reopening it immediately
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      const target = e.target as Node;
+      if (triggerRef?.current?.contains(target)) return;
+      if (panelRef.current && !panelRef.current.contains(target)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose, triggerRef]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  const showLlmSettings = mode === "smart" || mode === "always-local";
+
+  const handleTestConnection = useCallback(async () => {
+    setConnectionStatus("testing");
+    setConnectionError("");
+    try {
+      const res = await fetch(`${baseUrl.replace(/\/$/, "")}/models`);
+      if (!res.ok) {
+        setConnectionStatus("error");
+        setConnectionError(`HTTP ${res.status}`);
+        return;
+      }
+      const data = (await res.json()) as { data?: { id: string }[] };
+      const models = data.data?.map((m) => m.id) ?? [];
+      setAvailableModels(models);
+      setConnectionStatus("ok");
+      if (models.length > 0 && !model) {
+        setModel(models[0] ?? "");
+      }
+    } catch (err) {
+      setConnectionStatus("error");
+      setConnectionError(err instanceof Error ? err.message : "Connection failed");
+    }
+  }, [baseUrl, model]);
+
+  // Auto-fetch models when baseUrl changes, debounced 500 ms to avoid firing on
+  // every keystroke. AbortController cancels any in-flight request when the URL
+  // changes again. Model is always reset so the select reflects the new endpoint.
+  useEffect(() => {
+    if (!showLlmSettings) return;
+
+    // Clear stale state immediately.
+    // Skip the model reset on the first run after config is loaded from the
+    // server so the saved model preference is preserved.
+    setAvailableModels([]);
+    setConnectionStatus("idle");
+    if (skipModelResetRef.current) {
+      skipModelResetRef.current = false;
+    } else {
+      setModel("");
+    }
+
+    const controller = new AbortController();
+
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const res = await fetch(
+            `${baseUrl.replace(/\/$/, "")}/models`,
+            { signal: controller.signal },
+          );
+          if (!res.ok) return;
+          const data = (await res.json()) as { data?: { id: string }[] };
+          const models = data.data?.map((m) => m.id) ?? [];
+          if (models.length > 0) {
+            setAvailableModels(models);
+            setConnectionStatus("ok");
+            // Only auto-select first model if nothing is set yet; if a saved
+            // model was loaded from config it's already in state and valid.
+            setModel((prev) => prev || (models[0] ?? ""));
+          }
+        } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") return;
+          // silently ignore other errors — user can Test connection manually
+        }
+      })();
+    }, 500);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [baseUrl, showLlmSettings]);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setSaveError("");
+    setSaveSuccess(false);
+    try {
+      const res = await fetch("/api/routing", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          routing: { mode, localLlm: { baseUrl, model } },
+        }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(data?.error ?? `HTTP ${res.status}`);
+      }
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 2000);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }, [mode, baseUrl, model]);
+
+  return (
+    <div
+      ref={panelRef}
+      className="absolute right-0 top-full z-50 mt-2 w-[400px] rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)] shadow-lg"
+      role="dialog"
+      aria-label="LLM Routing Settings"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-[var(--color-border-subtle)] px-4 py-3">
+        <span className="text-[12px] font-semibold text-[var(--color-text-primary)]">
+          LLM Routing
+        </span>
+        <button
+          onClick={onClose}
+          className="text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)]"
+          aria-label="Close"
+        >
+          <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <div className="p-4 space-y-4">
+        {loading ? (
+          <p className="text-[11px] text-[var(--color-text-tertiary)]">Loading…</p>
+        ) : (
+          <>
+            {/* Mode selector */}
+            <fieldset>
+              <legend className="mb-2 text-[11px] font-medium text-[var(--color-text-secondary)]">
+                Routing mode
+              </legend>
+              <div className="space-y-2">
+                {MODE_OPTIONS.map((opt) => (
+                  <label
+                    key={opt.value}
+                    className={`flex cursor-pointer items-start gap-2.5 rounded border px-3 py-2.5 transition-colors ${
+                      mode === opt.value
+                        ? "border-[var(--color-accent)] bg-[rgba(99,102,241,0.05)]"
+                        : "border-[var(--color-border-subtle)] hover:border-[var(--color-border-default)]"
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="routing-mode"
+                      value={opt.value}
+                      checked={mode === opt.value}
+                      onChange={() => setMode(opt.value)}
+                      className="mt-0.5 shrink-0 accent-[var(--color-accent)]"
+                    />
+                    <div>
+                      <div className="text-[11px] font-medium text-[var(--color-text-primary)]">
+                        {opt.label}
+                      </div>
+                      <div className="text-[10px] text-[var(--color-text-tertiary)]">
+                        {opt.description}
+                      </div>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            {/* LLM settings — shown when mode is smart or always-local */}
+            {showLlmSettings && (
+              <div className="space-y-3 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-secondary)] p-3">
+                <p className="text-[10px] font-medium uppercase tracking-wide text-[var(--color-text-tertiary)]">
+                  Local LLM endpoint
+                </p>
+
+                {/* Base URL */}
+                <div>
+                  <label className="mb-1 block text-[11px] text-[var(--color-text-secondary)]">
+                    Base URL
+                  </label>
+                  <input
+                    type="text"
+                    value={baseUrl}
+                    onChange={(e) => {
+                      setBaseUrl(e.target.value);
+                      setConnectionStatus("idle");
+                    }}
+                    placeholder="http://localhost:11434/v1"
+                    className="w-full rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)] px-2.5 py-1.5 text-[11px] text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent)]"
+                  />
+                </div>
+
+                {/* Model */}
+                <div>
+                  <label className="mb-1 block text-[11px] text-[var(--color-text-secondary)]">
+                    Model
+                  </label>
+                  {availableModels.length > 0 ? (
+                    <select
+                      value={model}
+                      onChange={(e) => setModel(e.target.value)}
+                      className="w-full rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)] px-2.5 py-1.5 text-[11px] text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent)]"
+                    >
+                      {availableModels.map((m) => (
+                        <option key={m} value={m}>
+                          {m}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      type="text"
+                      value={model}
+                      onChange={(e) => setModel(e.target.value)}
+                      placeholder="e.g. llama3, mistral"
+                      className="w-full rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)] px-2.5 py-1.5 text-[11px] text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent)]"
+                    />
+                  )}
+                </div>
+
+                {/* Test connection */}
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => void handleTestConnection()}
+                    disabled={connectionStatus === "testing"}
+                    className="rounded border border-[var(--color-border-subtle)] px-2.5 py-1 text-[10px] text-[var(--color-text-secondary)] hover:border-[var(--color-border-default)] hover:text-[var(--color-text-primary)] disabled:opacity-50"
+                  >
+                    {connectionStatus === "testing" ? "Testing…" : "Test connection"}
+                  </button>
+                  {connectionStatus === "ok" && (
+                    <span className="flex items-center gap-1 text-[10px] text-[var(--color-status-success)]">
+                      <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 20 20">
+                        <path
+                          fillRule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                      Connected
+                      {availableModels.length > 0 && (
+                        <span className="opacity-60">({availableModels.length} models)</span>
+                      )}
+                    </span>
+                  )}
+                  {connectionStatus === "error" && (
+                    <span className="text-[10px] text-[var(--color-status-error)]">
+                      {connectionError || "Unreachable"}
+                    </span>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Save */}
+            <div className="flex items-center justify-between pt-1">
+              <div className="text-[10px]">
+                {saveError && (
+                  <span className="text-[var(--color-status-error)]">{saveError}</span>
+                )}
+                {saveSuccess && (
+                  <span className="text-[var(--color-status-success)]">Saved</span>
+                )}
+              </div>
+              <button
+                onClick={() => void handleSave()}
+                disabled={saving}
+                className="rounded bg-[var(--color-accent)] px-3 py-1.5 text-[11px] font-medium text-white hover:opacity-90 disabled:opacity-50"
+              >
+                {saving ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -15,6 +15,7 @@ import { getSessionTitle } from "@/lib/format";
 import { PRStatus } from "./PRStatus";
 import { CICheckList } from "./CIBadge";
 import { ActivityDot } from "./ActivityDot";
+import { SessionLlmBadge } from "./SessionLlmBadge";
 
 interface SessionCardProps {
   session: DashboardSession;
@@ -87,12 +88,16 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
         setExpanded(!expanded);
       }}
     >
-      {/* Header row: dot + session ID + terminal link */}
+      {/* Header row: dot + session ID + llm badge + terminal link */}
       <div className="flex items-center gap-2 px-4 pt-4 pb-2">
         <ActivityDot activity={session.activity} />
         <span className="font-[var(--font-mono)] text-[11px] tracking-wide text-[var(--color-text-muted)]">
           {session.id}
         </span>
+        <SessionLlmBadge
+          sessionId={session.id}
+          agentName={session.metadata?.agent}
+        />
         <div className="flex-1" />
         {isRestorable && (
           <button

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/cn";
 import { CICheckList } from "./CIBadge";
 import { DirectTerminal } from "./DirectTerminal";
 import { ActivityDot } from "./ActivityDot";
+import { SessionLlmBadge } from "./SessionLlmBadge";
 
 interface OrchestratorZones {
   merge: number;
@@ -221,6 +222,7 @@ export function SessionDetail({
       {/* Nav bar — glass effect */}
       <nav className="nav-glass sticky top-0 z-10 border-b border-[var(--color-border-subtle)]">
         <div className="mx-auto flex max-w-[900px] items-center gap-2 px-8 py-2.5">
+          <div className="flex flex-1 items-center gap-2">
           <a
             href="/"
             className="flex items-center gap-1 text-[11px] font-medium text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-text-primary)] hover:no-underline"
@@ -252,6 +254,7 @@ export function SessionDetail({
               orchestrator
             </span>
           )}
+          </div>
         </div>
       </nav>
 
@@ -373,6 +376,12 @@ export function SessionDetail({
                 lastActivityAt={session.lastActivityAt}
               />
             </div>
+            {!isOrchestrator && (
+              <SessionLlmBadge
+                sessionId={session.id}
+                agentName={session.metadata["agent"] as string | undefined}
+              />
+            )}
           </div>
         </div>
 

--- a/packages/web/src/components/SessionLlmBadge.tsx
+++ b/packages/web/src/components/SessionLlmBadge.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+interface SessionLlmBadgeProps {
+  sessionId: string;
+  agentName: string | undefined;
+}
+
+const SWITCH_OPTIONS = [
+  { value: "claude-code" as const, label: "Switch to Claude" },
+  { value: "local-llm" as const, label: "Switch to Local LLM" },
+] as const;
+
+function agentLabel(agentName: string | undefined): string {
+  if (agentName === "local-llm") return "Local LLM";
+  return "Claude";
+}
+
+export function SessionLlmBadge({ sessionId, agentName }: SessionLlmBadgeProps) {
+  const [open, setOpen] = useState(false);
+  const [switching, setSwitching] = useState(false);
+  const [switchError, setSwitchError] = useState("");
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const displayLabel = agentLabel(agentName);
+
+  const handleSelect = async (nextAgent: "claude-code" | "local-llm") => {
+    const currentAgent = agentName ?? "claude-code";
+    if (nextAgent === currentAgent) {
+      setOpen(false);
+      return;
+    }
+    setOpen(false);
+    setSwitching(true);
+    setSwitchError("");
+    try {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ llmOverride: nextAgent }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(data?.error ?? `HTTP ${res.status}`);
+      }
+      // Success — old session will disappear via SSE, new session will appear
+    } catch (err) {
+      setSwitchError(err instanceof Error ? err.message : "Switch failed");
+    } finally {
+      setSwitching(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (!switching) setOpen((v) => !v);
+        }}
+        disabled={switching}
+        className="flex items-center gap-1 rounded border border-[rgba(125,133,144,0.4)] px-2 py-0.5 text-[11px] text-[var(--color-text-secondary)] transition-colors hover:border-[rgba(125,133,144,0.8)] hover:text-[var(--color-text-primary)] disabled:opacity-50"
+        title={`Using ${displayLabel}`}
+      >
+        <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83" />
+        </svg>
+        {switching ? "Switching…" : displayLabel}
+      </button>
+
+      {switchError && (
+        <p className="absolute left-0 top-full mt-0.5 max-w-[200px] text-[10px] text-[var(--color-status-error)]">
+          {switchError}
+        </p>
+      )}
+
+      {open && (
+        <div
+          className="absolute right-0 top-full z-50 mt-1 w-[160px] rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-primary)] py-1 shadow-lg"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <p className="px-2.5 pb-1 pt-0.5 text-[9px] font-semibold uppercase tracking-wider text-[var(--color-text-tertiary)]">
+            Switch LLM
+          </p>
+          {SWITCH_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => void handleSelect(opt.value)}
+              className={`flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[10px] transition-colors hover:bg-[var(--color-bg-hover)] ${
+                (agentName ?? "claude-code") === opt.value
+                  ? "text-[var(--color-accent)]"
+                  : "text-[var(--color-text-secondary)]"
+              }`}
+            >
+              {(agentName ?? "claude-code") === opt.value && (
+                <svg className="h-2.5 w-2.5 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              )}
+              {(agentName ?? "claude-code") !== opt.value && <span className="h-2.5 w-2.5 shrink-0" />}
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -37,6 +37,7 @@ import {
 // Static plugin imports — webpack needs these to be string literals
 import pluginRuntimeTmux from "@composio/ao-plugin-runtime-tmux";
 import pluginAgentClaudeCode from "@composio/ao-plugin-agent-claude-code";
+import pluginAgentLocalLlm from "@composio/ao-plugin-agent-local-llm";
 import pluginAgentOpencode from "@composio/ao-plugin-agent-opencode";
 import pluginWorkspaceWorktree from "@composio/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@composio/ao-plugin-scm-github";
@@ -79,6 +80,7 @@ async function initServices(): Promise<Services> {
   // Register plugins explicitly (webpack can't handle dynamic import() in core)
   registry.register(pluginRuntimeTmux);
   registry.register(pluginAgentClaudeCode);
+  registry.register(pluginAgentLocalLlm);
   registry.register(pluginAgentOpencode);
   registry.register(pluginWorkspaceWorktree);
   registry.register(pluginScmGithub);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@composio/ao-plugin-agent-codex':
         specifier: workspace:*
         version: link:../plugins/agent-codex
+      '@composio/ao-plugin-agent-local-llm':
+        specifier: workspace:*
+        version: link:../plugins/agent-local-llm
       '@composio/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
@@ -255,6 +258,22 @@ importers:
         version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugins/agent-codex:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/plugins/agent-local-llm:
     dependencies:
       '@composio/ao-core':
         specifier: workspace:*
@@ -556,6 +575,9 @@ importers:
       '@composio/ao-plugin-agent-claude-code':
         specifier: workspace:*
         version: link:../plugins/agent-claude-code
+      '@composio/ao-plugin-agent-local-llm':
+        specifier: workspace:*
+        version: link:../plugins/agent-local-llm
       '@composio/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode


### PR DESCRIPTION
## Summary

- **Local LLM plugin** (`packages/plugins/agent-local-llm`): runs agents against a local Ollama/OpenAI-compatible endpoint
- **Smart routing**: task complexity classifier auto-routes simple tasks to local LLM and complex tasks to Claude; configurable mode (auto / local / claude)
- **Routing panel** (home page only): `RoutingButton` + `RoutingPanel` lets you configure routing mode, local LLM base URL, and model selection from the dashboard home page
- **Per-session model switch**: `SessionLlmBadge` in the session detail header card allows live switching between Claude and local LLM for a running session
- New API endpoints: `PATCH /api/sessions/:id` (live LLM handoff), `GET|POST /api/routing` (read/write routing config)
- Routing config propagated through to the local-llm plugin; tests added for complexity classifier

## Test plan

- [ ] Open dashboard home page — verify Routing button appears in top-right header
- [ ] Open a session detail page — verify model switch badge appears in the header card (not nav bar), routing button is absent
- [ ] Toggle routing mode in the panel (auto/local/claude) and confirm config persists on reload
- [ ] With a local Ollama server running, set base URL + model and spawn a session in "local" mode — verify it connects to local LLM
- [ ] Use the session badge to switch a running session from Claude → Local LLM and back
- [ ] Run complexity classifier tests: `pnpm test --filter ao-core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)