### PR TITLE
fix: resolve `ao start` failure on npm global installs

### DIFF
--- a/packages/cli/__tests__/lib/preflight.test.ts
+++ b/packages/cli/__tests__/lib/preflight.test.ts
@@ -48,22 +48,22 @@ describe("preflight.checkPort", () => {
 
 describe("preflight.checkBuilt", () => {
   it("passes when node_modules and core dist exist", async () => {
+    // findPackageUp finds ao-core, then dist/index.js exists
     mockExistsSync.mockReturnValue(true);
     await expect(preflight.checkBuilt("/web")).resolves.toBeUndefined();
     expect(mockExistsSync).toHaveBeenCalled();
   });
 
-  it("throws 'pnpm install' when node_modules is missing", async () => {
-    // First call checks node_modules/@composio/ao-core — missing
+  it("throws 'pnpm install' when ao-core is not found anywhere", async () => {
+    // findPackageUp never finds node_modules/@composio/ao-core
     mockExistsSync.mockReturnValue(false);
     await expect(preflight.checkBuilt("/web")).rejects.toThrow(
       "pnpm install",
     );
   });
 
-  it("throws 'pnpm build' when node_modules exists but dist is missing", async () => {
-    // First call: node_modules/@composio/ao-core exists
-    // Second call: dist/index.js does not exist
+  it("throws 'pnpm build' when ao-core exists but dist is missing", async () => {
+    // findPackageUp finds ao-core (first call), but dist/index.js missing (second call)
     mockExistsSync
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(false);

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -8,7 +8,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, dirname } from "node:path";
 import { isPortAvailable } from "./web-dir.js";
 import { exec } from "./shell.js";
 
@@ -32,14 +32,31 @@ async function checkPort(port: number): Promise<void> {
  * starting the dashboard. Works with both `next dev` and `next build`.
  */
 async function checkBuilt(webDir: string): Promise<void> {
-  const nodeModules = resolve(webDir, "node_modules", "@composio", "ao-core");
-  if (!existsSync(nodeModules)) {
+  // Walk up from webDir checking node_modules/@composio/ao-core at each level.
+  // This handles both pnpm (symlinked in webDir/node_modules) and npm global
+  // installs (hoisted to a parent node_modules).
+  const corePkgDir = findPackageUp(webDir, "@composio", "ao-core");
+  if (!corePkgDir) {
     throw new Error("Dependencies not installed. Run: pnpm install && pnpm build");
   }
-  const coreEntry = resolve(nodeModules, "dist", "index.js");
+  const coreEntry = resolve(corePkgDir, "dist", "index.js");
   if (!existsSync(coreEntry)) {
     throw new Error("Packages not built. Run: pnpm build");
   }
+}
+
+/** Walk up from `startDir` looking for `node_modules/<segments>`. */
+function findPackageUp(startDir: string, ...segments: string[]): string | null {
+  let dir = resolve(startDir);
+  const root = dirname(dir) === dir ? dir : undefined; // filesystem root guard
+  while (true) {
+    const candidate = resolve(dir, "node_modules", ...segments);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir || parent === root) break;
+    dir = parent;
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`ao start` always fails with "Dependencies not installed"** on npm global installs because the preflight check uses a hardcoded path that doesn't account for npm's dependency hoisting
- Replace the single-directory `existsSync` check with a `findPackageUp` helper that walks up `node_modules` directories, mirroring Node's module resolution algorithm
- Works correctly with pnpm workspaces, npm global installs, and yarn hoisting

Closes #619

## Root Cause

`checkBuilt()` in `packages/cli/src/lib/preflight.ts` checked exactly one path:

```ts
resolve(webDir, "node_modules", "@composio", "ao-core")
```

This works with pnpm (which symlinks deps into each package's `node_modules`), but npm global installs **hoist** `ao-core` to a parent `node_modules`. The check always fails even when everything is properly installed and built.

## Approach

A `findPackageUp` helper walks up from `webDir`, checking `node_modules/@composio/ao-core` at each level until it finds it or hits the filesystem root. This mirrors Node's own resolution algorithm using simple `existsSync` calls.

`createRequire().resolve()` was considered but ruled out because `@composio/ao-core`'s `exports` field doesn't expose `./package.json` as a subpath and only defines `import` conditions (not `require`).

## Test plan

- [x] All 13 preflight tests pass
- [x] `pnpm --filter=@composio/ao-cli build` succeeds
- [ ] `ao start <project>` works on npm global install
- [ ] `ao start <project>` works in monorepo dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)