### PR TITLE
feat(plugin-registry): support loading external plugins from local paths

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "@composio/ao-plugin-runtime-process": "workspace:*",
     "@composio/ao-plugin-runtime-tmux": "workspace:*",
     "@composio/ao-plugin-scm-github": "workspace:*",
+        "@composio/ao-plugin-scm-gitlab": "workspace:*",
     "@composio/ao-plugin-terminal-iterm2": "workspace:*",
     "@composio/ao-plugin-terminal-web": "workspace:*",
     "@composio/ao-plugin-tracker-github": "workspace:*",

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -260,7 +260,7 @@ export function registerStatus(program: Command): void {
         // Resolve agent and SCM for this project
         const agentName = projectConfig.agent ?? config.defaults.agent;
         const agent = getAgentByName(agentName);
-        const scm = getSCM(config, projectId);
+        const scm = await getSCM(config, projectId);
 
         if (!opts.json) {
           console.log(header(projectConfig.name || projectId));

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -5,6 +5,7 @@ import codexPlugin from "@composio/ao-plugin-agent-codex";
 import aiderPlugin from "@composio/ao-plugin-agent-aider";
 import opencodePlugin from "@composio/ao-plugin-agent-opencode";
 import githubSCMPlugin from "@composio/ao-plugin-scm-github";
+import gitlabSCMPlugin from "@composio/ao-plugin-scm-gitlab";
 
 const agentPlugins: Record<string, { create(): Agent }> = {
   "claude-code": claudeCodePlugin,
@@ -15,6 +16,7 @@ const agentPlugins: Record<string, { create(): Agent }> = {
 
 const builtinSCMPlugins: Record<string, { create(): SCM }> = {
   github: githubSCMPlugin,
+  gitlab: gitlabSCMPlugin,
 };
 
 /**

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -1,4 +1,5 @@
 import type { Agent, OrchestratorConfig, SCM } from "@composio/ao-core";
+import { createPluginRegistry } from "@composio/ao-core";
 import claudeCodePlugin from "@composio/ao-plugin-agent-claude-code";
 import codexPlugin from "@composio/ao-plugin-agent-codex";
 import aiderPlugin from "@composio/ao-plugin-agent-aider";
@@ -12,7 +13,7 @@ const agentPlugins: Record<string, { create(): Agent }> = {
   opencode: opencodePlugin,
 };
 
-const scmPlugins: Record<string, { create(): SCM }> = {
+const builtinSCMPlugins: Record<string, { create(): SCM }> = {
   github: githubSCMPlugin,
 };
 
@@ -41,12 +42,24 @@ export function getAgentByName(name: string): Agent {
 
 /**
  * Resolve the SCM plugin for a project (or fall back to "github").
+ * First checks built-in plugins, then loads external plugins from config.
  */
-export function getSCM(config: OrchestratorConfig, projectId: string): SCM {
+export async function getSCM(config: OrchestratorConfig, projectId: string): Promise<SCM> {
   const scmName = config.projects[projectId]?.scm?.plugin || "github";
-  const plugin = scmPlugins[scmName];
-  if (!plugin) {
+  const scmConfig = config.projects[projectId]?.scm as Record<string, unknown> | undefined;
+
+  // Try built-in first
+  const builtin = builtinSCMPlugins[scmName];
+  if (builtin) {
+    return builtin.create();
+  }
+
+  // Fall back to plugin-registry (loads external plugins from config.plugins[])
+  const registry = createPluginRegistry();
+  await registry.loadFromConfig(config, (pkg: string) => import(pkg));
+  const scm = registry.get<SCM>("scm", scmName);
+  if (!scm) {
     throw new Error(`Unknown SCM plugin: ${scmName}`);
   }
-  return plugin.create();
+  return scm;
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -196,6 +196,10 @@ const OrchestratorConfigSchema = z.object({
     info: ["composio"],
   }),
   reactions: z.record(ReactionConfigSchema).default({}),
+  // External private plugins — loaded from local filesystem paths at startup
+  plugins: z
+    .array(z.object({ path: z.string() }))
+    .optional(),
 });
 
 // =============================================================================

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -139,7 +139,6 @@ export function createPluginRegistry(): PluginRegistry {
 
         // Resolve ~ to home directory, reusing the shared expandHome utility
         const resolvedPath = resolve(expandHome(entry.path));
-
         const entryPoint = `${resolvedPath}/dist/index.js`;
 
         try {
@@ -147,7 +146,7 @@ export function createPluginRegistry(): PluginRegistry {
           const mod = (await doImport(entryPoint)) as PluginModule;
           if (mod.manifest && typeof mod.create === "function") {
             this.register(mod);
-            console.log(`[plugin-registry] Loaded external plugin: ${mod.manifest.name} (${entryPoint})`);
+            console.log(`[plugin-registry] Loaded external plugin: ${mod.manifest.name} (${mod.manifest.slot}) from ${entryPoint}`);
           } else {
             console.warn(`[plugin-registry] Skipped ${entryPoint}: missing manifest or create()`);
           }

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -4,9 +4,11 @@
  * Plugins can be:
  * 1. Built-in (packages/plugins/*)
  * 2. npm packages (@composio/ao-plugin-*)
- * 3. Local file paths specified in config
+ * 3. Local file paths specified in config (via plugins[].path in agent-orchestrator.yaml)
  */
 
+import { homedir } from "node:os";
+import { resolve } from "node:path";
 import type {
   PluginSlot,
   PluginManifest,
@@ -130,8 +132,33 @@ export function createPluginRegistry(): PluginRegistry {
       // Load built-ins with orchestrator config so plugins receive their settings
       await this.loadBuiltins(config, importFn);
 
-      // Then, load any additional plugins specified in project configs
-      // (future: support npm package names and local file paths)
+      // Load external plugins declared in config plugins[].path
+      const externalPlugins = config.plugins ?? [];
+      for (const entry of externalPlugins) {
+        if (!entry.path) continue;
+
+        // Resolve ~ to home directory
+        const resolvedPath = entry.path.startsWith("~")
+          ? resolve(homedir(), entry.path.slice(2))
+          : resolve(entry.path);
+
+        const entryPoint = `${resolvedPath}/dist/index.js`;
+
+        try {
+          const doImport = importFn ?? ((p: string) => import(p));
+          const mod = (await doImport(entryPoint)) as PluginModule;
+          if (mod.manifest && typeof mod.create === "function") {
+            this.register(mod);
+            console.log(`[plugin-registry] Loaded external plugin: ${mod.manifest.name} (${entryPoint})`);
+          } else {
+            console.warn(`[plugin-registry] Skipped ${entryPoint}: missing manifest or create()`);
+          }
+        } catch (err) {
+          console.error(
+            `[plugin-registry] Failed to load external plugin from "${entryPoint}": ${(err as Error).message}`,
+          );
+        }
+      }
     },
   };
 }

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -7,8 +7,8 @@
  * 3. Local file paths specified in config (via plugins[].path in agent-orchestrator.yaml)
  */
 
-import { homedir } from "node:os";
 import { resolve } from "node:path";
+import { expandHome } from "./paths.js";
 import type {
   PluginSlot,
   PluginManifest,
@@ -137,10 +137,8 @@ export function createPluginRegistry(): PluginRegistry {
       for (const entry of externalPlugins) {
         if (!entry.path) continue;
 
-        // Resolve ~ to home directory
-        const resolvedPath = entry.path.startsWith("~")
-          ? resolve(homedir(), entry.path.slice(2))
-          : resolve(entry.path);
+        // Resolve ~ to home directory, reusing the shared expandHome utility
+        const resolvedPath = resolve(expandHome(entry.path));
 
         const entryPoint = `${resolvedPath}/dist/index.js`;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -912,6 +912,21 @@ export interface OrchestratorConfig {
 
   /** Default reaction configs */
   reactions: Record<string, ReactionConfig>;
+
+  /**
+   * External plugin paths to load at startup.
+   * Each entry is a local filesystem path to a built plugin's dist/index.js.
+   *
+   * Example (agent-orchestrator.yaml):
+   *   plugins:
+   *     - path: ~/ao-private-plugins/scm-gongfeng
+   */
+  plugins?: ExternalPluginConfig[];
+}
+
+export interface ExternalPluginConfig {
+  /** Absolute or home-relative path to the plugin directory (must contain dist/index.js) */
+  path: string;
 }
 
 export interface DefaultPlugins {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@composio/ao-plugin-scm-github':
         specifier: workspace:*
         version: link:../plugins/scm-github
+      '@composio/ao-plugin-scm-gitlab':
+        specifier: workspace:*
+        version: link:../plugins/scm-gitlab
       '@composio/ao-plugin-terminal-iterm2':
         specifier: workspace:*
         version: link:../plugins/terminal-iterm2
@@ -1641,6 +1644,7 @@ packages:
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}


### PR DESCRIPTION
## Problem

Users who maintain private plugins (e.g. integrations with internal company systems) had no way to load them without modifying the open-source repository — which breaks `ao update` and prevents clean upstream tracking.

Additionally, `getSCM()` in `cli/lib/plugins.ts` only knew about built-in plugins by name, so external SCM plugins configured via `plugins[].path` would throw `Unknown SCM plugin: <name>`.

## Solution

Add an optional `plugins` array to the top-level config schema. Each entry specifies a local filesystem path to a pre-built plugin directory. The registry resolves `~/...` paths, loads `dist/index.js`, validates the module shape, and registers it alongside built-ins.

```yaml
# agent-orchestrator.yaml
plugins:
  - path: ~/my-private-plugins/scm-internal
  - path: /opt/company/ao-plugins/tracker-jira

projects:
  my-app:
    scm:
      plugin: scm-internal   # references the externally loaded plugin
```

## Changes

**`packages/core`**
- `types.ts`: add `ExternalPluginConfig` interface; add optional `plugins?: ExternalPluginConfig[]` field to `OrchestratorConfig`
- `config.ts`: extend `OrchestratorConfigSchema` to parse the new field
- `plugin-registry.ts`: implement external plugin loading in `loadFromConfig()` — resolves path (with `expandHome`), imports `dist/index.js`, validates manifest + create(), registers with a log line

**`packages/cli`**
- `lib/plugins.ts`: make `getSCM()` async; fall back to plugin-registry when the plugin name is not in the built-in dict; add `gitlab` to `builtinSCMPlugins`
- `commands/status.ts`: updated to `await getSCM()`
- `package.json`: add `@composio/ao-plugin-scm-gitlab` dependency

**No breaking changes** — the `plugins` field is optional and defaults to `[]`. Existing configs continue to work without modification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)