### PR TITLE
chore: add dist-server/ to web package gitignore

### DIFF
--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -1,1 +1,2 @@
 build/
+dist-server/


### PR DESCRIPTION
### Background
`packages/web/dist-server/` is a build artifact directory (compiled server-side JS) that shows up as untracked. The root `.gitignore` covers `dist/` but not `dist-server/`.

### Goals
Silence the untracked files warning without committing build artifacts.

### Tenets
Minimal — one line added to existing `.gitignore`.

### High-level description of changes
Added `dist-server/` to `packages/web/.gitignore`, consistent with the root-level `dist/` ignore pattern.

### Testing
No code change — gitignore only.

### Low-level details
- **packages/web/.gitignore**: Added `dist-server/` alongside existing `build/`