### PR TITLE
fix: repair npm global install — walk-up dep resolution + spawn-helper chmod

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -102,4 +102,18 @@ export default tseslint.config(
       "no-console": "off", // Scripts use console for output
     },
   },
+
+  // ao bin scripts - Node.js environment (postinstall, etc.)
+  {
+    files: ["packages/ao/bin/**/*.js"],
+    languageOptions: {
+      globals: {
+        console: "readonly",
+        process: "readonly",
+      },
+    },
+    rules: {
+      "no-console": "off", // Bin scripts use console for install output
+    },
+  },
 );

--- a/packages/ao/bin/postinstall.js
+++ b/packages/ao/bin/postinstall.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Postinstall script for @composio/ao (npm/yarn global installs).
+ *
+ * Fixes the DirectTerminal "posix_spawnp failed" error that occurs when
+ * `ao start` is run after a global npm install.
+ *
+ * Root cause: node-pty ships a `spawn-helper` binary that it forks to create
+ * PTYs. This binary is published to npm without the execute bit set. In the
+ * monorepo, `scripts/rebuild-node-pty.js` fixes this via `node-gyp rebuild`
+ * after `pnpm install` — but that script uses a pnpm-specific path and never
+ * runs for global npm/yarn installs.
+ *
+ * Fix: locate spawn-helper using a walk-up node_modules search (same approach
+ * as the preflight checkBuilt fix) and chmod it to 0o755.
+ */
+
+import { chmodSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+if (process.platform === "win32") process.exit(0);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function findPackageUp(startDir, ...segments) {
+  let dir = resolve(startDir);
+  while (true) {
+    const candidate = resolve(dir, "node_modules", ...segments);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return null;
+}
+
+const nodePtyDir = findPackageUp(__dirname, "node-pty");
+if (!nodePtyDir) process.exit(0);
+
+const spawnHelper = resolve(
+  nodePtyDir,
+  "prebuilds",
+  `${process.platform}-${process.arch}`,
+  "spawn-helper",
+);
+
+if (!existsSync(spawnHelper)) process.exit(0);
+
+try {
+  chmodSync(spawnHelper, 0o755);
+  console.log("✓ node-pty spawn-helper permissions set");
+} catch {
+  console.warn("⚠️  Could not set spawn-helper permissions (non-critical)");
+}

--- a/packages/ao/package.json
+++ b/packages/ao/package.json
@@ -7,6 +7,9 @@
   "bin": {
     "ao": "bin/ao.js"
   },
+  "scripts": {
+    "postinstall": "node bin/postinstall.js"
+  },
   "files": [
     "bin"
   ],

--- a/packages/cli/__tests__/lib/preflight.test.ts
+++ b/packages/cli/__tests__/lib/preflight.test.ts
@@ -47,28 +47,46 @@ describe("preflight.checkPort", () => {
 });
 
 describe("preflight.checkBuilt", () => {
-  it("passes when node_modules and core dist exist", async () => {
+  it("passes when ao-core and dist exist at webDir level (pnpm layout)", async () => {
+    // findPackageUp finds ao-core on first check (pnpm symlink in webDir/node_modules)
     mockExistsSync.mockReturnValue(true);
     await expect(preflight.checkBuilt("/web")).resolves.toBeUndefined();
     expect(mockExistsSync).toHaveBeenCalled();
   });
 
-  it("throws 'pnpm install' when node_modules is missing", async () => {
-    // First call checks node_modules/@composio/ao-core — missing
-    mockExistsSync.mockReturnValue(false);
-    await expect(preflight.checkBuilt("/web")).rejects.toThrow(
-      "pnpm install",
-    );
+  it("finds ao-core when hoisted one level up (npm global install layout)", async () => {
+    // Simulates npm hoisting: ao-core is not in webDir/node_modules but one level up
+    // /web/node_modules/@composio/ao-core     — miss
+    // /node_modules/@composio/ao-core         — hit
+    // /node_modules/@composio/ao-core/dist/index.js — exists
+    mockExistsSync
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(true);
+    await expect(preflight.checkBuilt("/web")).resolves.toBeUndefined();
   });
 
-  it("throws 'pnpm build' when node_modules exists but dist is missing", async () => {
-    // First call: node_modules/@composio/ao-core exists
-    // Second call: dist/index.js does not exist
+  it("throws npm hint when ao-core not found in global install", async () => {
+    mockExistsSync.mockReturnValue(false);
+    await expect(
+      preflight.checkBuilt("/usr/local/lib/node_modules/@composio/ao-web"),
+    ).rejects.toThrow("npm install -g @composio/ao@latest");
+  });
+
+  it("throws pnpm hint when ao-core not found in monorepo", async () => {
+    mockExistsSync.mockReturnValue(false);
+    await expect(
+      preflight.checkBuilt("/home/user/agent-orchestrator/packages/web"),
+    ).rejects.toThrow("pnpm install && pnpm build");
+  });
+
+  it("throws 'pnpm build' when ao-core exists but dist is missing", async () => {
+    // findPackageUp finds ao-core, but dist/index.js is missing
     mockExistsSync
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(false);
     await expect(preflight.checkBuilt("/web")).rejects.toThrow(
-      "Packages not built. Run: pnpm build",
+      "Packages not built",
     );
   });
 });

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -8,7 +8,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, dirname } from "node:path";
 import { isPortAvailable } from "./web-dir.js";
 import { exec } from "./shell.js";
 
@@ -27,19 +27,45 @@ async function checkPort(port: number): Promise<void> {
 
 /**
  * Check that workspace packages have been compiled (TypeScript → JavaScript).
- * Verifies @composio/ao-core dist output exists from the web package's
- * node_modules, since a missing dist/ causes module resolution errors when
- * starting the dashboard. Works with both `next dev` and `next build`.
+ * Locates @composio/ao-core by walking up from webDir, handling both pnpm
+ * workspaces (symlinked deps in webDir/node_modules) and npm/yarn global
+ * installs (hoisted to a parent node_modules).
  */
 async function checkBuilt(webDir: string): Promise<void> {
-  const nodeModules = resolve(webDir, "node_modules", "@composio", "ao-core");
-  if (!existsSync(nodeModules)) {
-    throw new Error("Dependencies not installed. Run: pnpm install && pnpm build");
+  const corePkgDir = findPackageUp(webDir, "@composio", "ao-core");
+  if (!corePkgDir) {
+    const hint = webDir.includes("node_modules")
+      ? "Run: npm install -g @composio/ao@latest"
+      : "Run: pnpm install && pnpm build";
+    throw new Error(`Dependencies not installed. ${hint}`);
   }
-  const coreEntry = resolve(nodeModules, "dist", "index.js");
+  const coreEntry = resolve(corePkgDir, "dist", "index.js");
   if (!existsSync(coreEntry)) {
-    throw new Error("Packages not built. Run: pnpm build");
+    const hint = webDir.includes("node_modules")
+      ? "Run: npm install -g @composio/ao@latest"
+      : "Run: pnpm build";
+    throw new Error(`Packages not built. ${hint}`);
   }
+}
+
+/**
+ * Walk up from startDir looking for node_modules/<segments>.
+ * Mirrors Node's module resolution: checks each ancestor directory until
+ * the package is found or the filesystem root is reached.
+ *
+ * Works with pnpm workspaces (symlinked deps) and npm/yarn global installs
+ * (hoisted deps) transparently.
+ */
+export function findPackageUp(startDir: string, ...segments: string[]): string | null {
+  let dir = resolve(startDir);
+  while (true) {
+    const candidate = resolve(dir, "node_modules", ...segments);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return null;
 }
 
 /**

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -56,7 +56,7 @@ async function checkBuilt(webDir: string): Promise<void> {
  * Works with pnpm workspaces (symlinked deps) and npm/yarn global installs
  * (hoisted deps) transparently.
  */
-export function findPackageUp(startDir: string, ...segments: string[]): string | null {
+function findPackageUp(startDir: string, ...segments: string[]): string | null {
   let dir = resolve(startDir);
   while (true) {
     const candidate = resolve(dir, "node_modules", ...segments);


### PR DESCRIPTION
## Summary

  Fixes two bugs that together make `ao start` completely non-functional after `npm install -g @composio/ao`. Both only affect npm/yarn
  global installs — pnpm monorepo users are unaffected.

  - **Bug 1 (#619):** `checkBuilt` uses a hardcoded single-level path that doesn't account for npm's dependency hoisting — always fails
  with "Dependencies not installed"
  - **Bug 2 (#624):** node-pty's `spawn-helper` binary ships without the execute bit — `posix_spawnp` fails with `Operation not
  permitted` when opening a terminal panel

  ## Changes

  ### `packages/cli/src/lib/preflight.ts`
  Replace the single-level `existsSync` check with `findPackageUp()` — a walk-up resolver that checks `node_modules/@composio/ao-core`
  at every ancestor directory, mirroring Node's own module resolution. Error messages now distinguish between npm (`npm install -g
  @composio/ao@latest`) and pnpm (`pnpm install && pnpm build`) users.

  ### `packages/ao/bin/postinstall.js` (new)
  Runs after `npm install -g @composio/ao`. Locates `node-pty` via the same walk-up pattern, finds `spawn-helper` in
  `prebuilds/<platform>-<arch>/`, and `chmod 0o755`. Skips silently on Windows and when no prebuild exists. Non-fatal on failure.

  The monorepo already has `scripts/rebuild-node-pty.js` for this, but it hardcodes the pnpm store path and never runs for global
  installs. The upstream fix ([microsoft/node-pty#866](https://github.com/microsoft/node-pty/pull/866)) only shipped in `1.2.0-beta.*` —
   latest stable is still `1.1.0`.

  ### `packages/cli/__tests__/lib/preflight.test.ts`
  Expanded `checkBuilt` tests from 3 to 5, covering pnpm layout, npm hoisted layout (walk-up), npm/pnpm error hints, and missing dist.

  ### `eslint.config.js`
  Added `packages/ao/bin` override for Node.js globals (`process`, `console`) — matches existing `scripts/**` pattern.

  ## Test plan

  - [x] `pnpm build` passes
  - [x] `pnpm typecheck` passes
  - [x] All 15 preflight tests pass (5 new/updated for `checkBuilt`)
  - [x] `pnpm lint` — no new errors (pre-existing `packages/web/dist-server` errors unchanged)
  - [x] Verified locally: `ao start` works end-to-end after npm global install

  Closes #619, closes #624