### PR TITLE
Fix for #640 ao start fails with "Dependencies not installed" due to npm hoisting of @composio/ao-core 

### DIFF
--- a/packages/cli/__tests__/lib/preflight.test.ts
+++ b/packages/cli/__tests__/lib/preflight.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockExec, mockIsPortAvailable, mockExistsSync } = vi.hoisted(() => ({
-  mockExec: vi.fn(),
-  mockIsPortAvailable: vi.fn(),
-  mockExistsSync: vi.fn(),
-}));
+const { mockExec, mockIsPortAvailable, mockExistsSync, mockRequireResolve, mockCreateRequire } = vi.hoisted(() => {
+  const mockRequireResolve = vi.fn();
+  const mockCreateRequire = vi.fn(() => ({ resolve: mockRequireResolve }));
+  return {
+    mockExec: vi.fn(),
+    mockIsPortAvailable: vi.fn(),
+    mockExistsSync: vi.fn(),
+    mockRequireResolve,
+    mockCreateRequire,
+  };
+});
 
 vi.mock("../../src/lib/shell.js", () => ({
   exec: mockExec,
@@ -18,12 +24,19 @@ vi.mock("node:fs", () => ({
   existsSync: mockExistsSync,
 }));
 
+vi.mock("node:module", () => ({
+  createRequire: mockCreateRequire,
+}));
+
 import { preflight } from "../../src/lib/preflight.js";
 
 beforeEach(() => {
   mockExec.mockReset();
   mockIsPortAvailable.mockReset();
   mockExistsSync.mockReset();
+  mockRequireResolve.mockReset();
+  mockCreateRequire.mockReset();
+  mockCreateRequire.mockReturnValue({ resolve: mockRequireResolve });
 });
 
 describe("preflight.checkPort", () => {
@@ -47,29 +60,32 @@ describe("preflight.checkPort", () => {
 });
 
 describe("preflight.checkBuilt", () => {
-  it("passes when node_modules and core dist exist", async () => {
+  it("passes when ao-core resolves and dist exists", async () => {
+    mockRequireResolve.mockReturnValue("/some/path/@composio/ao-core/package.json");
     mockExistsSync.mockReturnValue(true);
     await expect(preflight.checkBuilt("/web")).resolves.toBeUndefined();
+    expect(mockRequireResolve).toHaveBeenCalledWith("@composio/ao-core/package.json");
     expect(mockExistsSync).toHaveBeenCalled();
   });
 
-  it("throws 'pnpm install' when node_modules is missing", async () => {
-    // First call checks node_modules/@composio/ao-core — missing
-    mockExistsSync.mockReturnValue(false);
-    await expect(preflight.checkBuilt("/web")).rejects.toThrow(
-      "pnpm install",
-    );
+  it("throws 'pnpm install' when ao-core cannot be resolved (not installed)", async () => {
+    mockRequireResolve.mockImplementation(() => { throw new Error("Cannot find module"); });
+    await expect(preflight.checkBuilt("/web")).rejects.toThrow("pnpm install");
   });
 
-  it("throws 'pnpm build' when node_modules exists but dist is missing", async () => {
-    // First call: node_modules/@composio/ao-core exists
-    // Second call: dist/index.js does not exist
-    mockExistsSync
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(false);
+  it("throws 'pnpm build' when ao-core resolves but dist/index.js is missing", async () => {
+    mockRequireResolve.mockReturnValue("/some/path/@composio/ao-core/package.json");
+    mockExistsSync.mockReturnValue(false);
     await expect(preflight.checkBuilt("/web")).rejects.toThrow(
       "Packages not built. Run: pnpm build",
     );
+  });
+
+  it("resolves ao-core via hoisted path (npm global install)", async () => {
+    // Simulate hoisted path: ao-core is not under webDir/node_modules but resolves via createRequire
+    mockRequireResolve.mockReturnValue("/global/node_modules/@composio/ao-core/package.json");
+    mockExistsSync.mockReturnValue(true);
+    await expect(preflight.checkBuilt("/web")).resolves.toBeUndefined();
   });
 });
 

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -8,7 +8,8 @@
  */
 
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { createRequire } from "node:module";
+import { resolve, dirname } from "node:path";
 import { isPortAvailable } from "./web-dir.js";
 import { exec } from "./shell.js";
 
@@ -30,13 +31,22 @@ async function checkPort(port: number): Promise<void> {
  * Verifies @composio/ao-core dist output exists from the web package's
  * node_modules, since a missing dist/ causes module resolution errors when
  * starting the dashboard. Works with both `next dev` and `next build`.
+ *
+ * Uses Node's module resolution (createRequire) so that npm-hoisted packages
+ * are found correctly when `ao` is installed globally via npm.
  */
 async function checkBuilt(webDir: string): Promise<void> {
-  const nodeModules = resolve(webDir, "node_modules", "@composio", "ao-core");
-  if (!existsSync(nodeModules)) {
+  const require = createRequire(resolve(webDir, "package.json"));
+
+  let coreDir: string;
+  try {
+    const corePkgJson = require.resolve("@composio/ao-core/package.json");
+    coreDir = dirname(corePkgJson);
+  } catch {
     throw new Error("Dependencies not installed. Run: pnpm install && pnpm build");
   }
-  const coreEntry = resolve(nodeModules, "dist", "index.js");
+
+  const coreEntry = resolve(coreDir, "dist", "index.js");
   if (!existsSync(coreEntry)) {
     throw new Error("Packages not built. Run: pnpm build");
   }

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,4 +1,10 @@
 import { defineConfig } from "vitest/config";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const coreDir = resolve(__dirname, "../core/src");
+const pluginsDir = resolve(__dirname, "../plugins");
 
 export default defineConfig({
   test: {
@@ -10,6 +16,20 @@ export default defineConfig({
         minThreads: 1,
         maxThreads: 8,
       },
+    },
+    alias: {
+      // Resolve @composio/ao-core and its sub-path exports from source so
+      // tests run without requiring a pre-built dist.
+      "@composio/ao-core/scm-webhook-utils": resolve(coreDir, "scm-webhook-utils.ts"),
+      "@composio/ao-core/utils": resolve(coreDir, "utils.ts"),
+      "@composio/ao-core/types": resolve(coreDir, "types.ts"),
+      "@composio/ao-core": resolve(coreDir, "index.ts"),
+      // Plugin aliases
+      "@composio/ao-plugin-agent-aider": resolve(pluginsDir, "agent-aider/src/index.ts"),
+      "@composio/ao-plugin-agent-claude-code": resolve(pluginsDir, "agent-claude-code/src/index.ts"),
+      "@composio/ao-plugin-agent-codex": resolve(pluginsDir, "agent-codex/src/index.ts"),
+      "@composio/ao-plugin-agent-opencode": resolve(pluginsDir, "agent-opencode/src/index.ts"),
+      "@composio/ao-plugin-scm-github": resolve(pluginsDir, "scm-github/src/index.ts"),
     },
   },
 });

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
         "../plugins/tracker-github/src/index.ts",
       ),
       "@composio/ao-plugin-scm-github": resolve(__dirname, "../plugins/scm-github/src/index.ts"),
+      // The plugins above import from @composio/ao-core. Alias sub-path
+      // exports to source so the tests work without a pre-built dist.
+      "@composio/ao-core/scm-webhook-utils": resolve(__dirname, "src/scm-webhook-utils.ts"),
+      "@composio/ao-core": resolve(__dirname, "src/index.ts"),
     },
   },
 });

--- a/packages/plugins/agent-aider/vitest.config.ts
+++ b/packages/plugins/agent-aider/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/agent-claude-code/vitest.config.ts
+++ b/packages/plugins/agent-claude-code/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/agent-codex/vitest.config.ts
+++ b/packages/plugins/agent-codex/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/agent-opencode/vitest.config.ts
+++ b/packages/plugins/agent-opencode/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/notifier-composio/vitest.config.ts
+++ b/packages/plugins/notifier-composio/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/notifier-desktop/vitest.config.ts
+++ b/packages/plugins/notifier-desktop/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/notifier-openclaw/vitest.config.ts
+++ b/packages/plugins/notifier-openclaw/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/notifier-slack/vitest.config.ts
+++ b/packages/plugins/notifier-slack/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/notifier-webhook/vitest.config.ts
+++ b/packages/plugins/notifier-webhook/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/runtime-process/vitest.config.ts
+++ b/packages/plugins/runtime-process/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/runtime-tmux/vitest.config.ts
+++ b/packages/plugins/runtime-tmux/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/scm-github/vitest.config.ts
+++ b/packages/plugins/scm-github/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/scm-gitlab/vitest.config.ts
+++ b/packages/plugins/scm-gitlab/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/terminal-iterm2/vitest.config.ts
+++ b/packages/plugins/terminal-iterm2/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/terminal-web/vitest.config.ts
+++ b/packages/plugins/terminal-web/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/tracker-github/vitest.config.ts
+++ b/packages/plugins/tracker-github/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/tracker-gitlab/vitest.config.ts
+++ b/packages/plugins/tracker-gitlab/vitest.config.ts
@@ -1,0 +1,17 @@
+import { mergeConfig, defineConfig } from "vitest/config";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import sharedConfig from "../vitest.config.shared.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default mergeConfig(sharedConfig, defineConfig({
+  test: {
+    alias: {
+      "@composio/ao-plugin-scm-gitlab/glab-utils": resolve(
+        __dirname,
+        "../scm-gitlab/src/glab-utils.ts",
+      ),
+    },
+  },
+}));

--- a/packages/plugins/tracker-linear/vitest.config.ts
+++ b/packages/plugins/tracker-linear/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/vitest.config.shared.ts
+++ b/packages/plugins/vitest.config.shared.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared vitest configuration for all @composio/ao plugins.
+ *
+ * Aliases @composio/ao-core (and its sub-path exports) to source files so
+ * tests run without requiring a pre-built dist of ao-core.
+ */
+import { defineConfig } from "vitest/config";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const coreDir = resolve(__dirname, "../core/src");
+
+export default defineConfig({
+  test: {
+    alias: {
+      "@composio/ao-core/scm-webhook-utils": resolve(coreDir, "scm-webhook-utils.ts"),
+      "@composio/ao-core/utils": resolve(coreDir, "utils.ts"),
+      "@composio/ao-core/types": resolve(coreDir, "types.ts"),
+      "@composio/ao-core": resolve(coreDir, "index.ts"),
+    },
+  },
+});

--- a/packages/plugins/workspace-clone/vitest.config.ts
+++ b/packages/plugins/workspace-clone/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});

--- a/packages/plugins/workspace-worktree/vitest.config.ts
+++ b/packages/plugins/workspace-worktree/vitest.config.ts
@@ -1,0 +1,4 @@
+import { mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.config.shared.js";
+
+export default mergeConfig(sharedConfig, {});


### PR DESCRIPTION
Fix for https://github.com/ComposioHQ/agent-orchestrator/issues/640

1: Fixed error by using Node's module resolution in preflight.ts

2: Running pnpm test across the monorepo produced widespread failures in every plugin package and the CLI because @composio/ao-core's package.json exports field points to ./dist/… (compiled output), which doesn't exist until pnpm build is run. Vitest/Vite can't resolve the package and immediately aborts:

`Error: Failed to resolve entry for package "@composio/ao-core".`

**Fix**
Added Vite alias entries in vitest configs that redirect @composio/ao-core (and its sub-path exports /utils, /scm-webhook-utils, /types) directly to TypeScript source files — no build step needed.




**Final Check**
- 64 test files — 1,730+ tests — all passing, zero failures ✅
- Gitleaks v8.27.2 scan (files + git history) → no leaks found ✅
- CodeQL static analysis → 0 alerts ✅
- Automated code review → no comments ✅