### PR TITLE
UI changes: review requests, issue links, sidebar polish

### DIFF
--- a/docs/superpowers/specs/2026-03-24-request-review-design.md
+++ b/docs/superpowers/specs/2026-03-24-request-review-design.md
@@ -1,0 +1,137 @@
+# Request Review: Replace "Ask to Post" with GitHub Review Requests
+
+**Date:** 2026-03-24
+**Status:** Draft
+
+## Problem
+
+The kanban card's "ask to post" button currently sends a message to the agent: `"Post {pr.url} on slack asking for a review."` This assumes Slack integration exists. It doesn't — the team uses GitHub only. The action is unreliable because it depends on the agent interpreting a free-text message correctly.
+
+## Solution
+
+Replace the agent-message approach with a direct GitHub API call that requests reviewers on the PR. Reviewers are configured per-project via a new `defaultReviewers` field in `ProjectConfig`.
+
+## Design
+
+### 1. Config & Types (`packages/core/src/types.ts`)
+
+**ProjectConfig** — add `defaultReviewers`:
+
+```typescript
+export interface ProjectConfig {
+  // ... existing fields ...
+
+  /** GitHub usernames or team slugs to request as PR reviewers */
+  defaultReviewers?: string[];
+}
+```
+
+**SCM interface** — add `requestReviewers`:
+
+```typescript
+export interface SCM {
+  // ... existing methods ...
+
+  /** Request reviewers on a PR. Optional — not all SCM backends may support it. */
+  requestReviewers?(pr: PRInfo, reviewers: string[]): Promise<void>;
+}
+```
+
+**User configuration example:**
+
+```json
+{
+  "projects": {
+    "my-app": {
+      "repo": "org/my-app",
+      "path": "/home/user/my-app",
+      "defaultBranch": "main",
+      "sessionPrefix": "app",
+      "defaultReviewers": ["alice", "org/frontend-team"]
+    }
+  }
+}
+```
+
+### 2. GitHub SCM Plugin (`packages/plugins/scm-github/src/index.ts`)
+
+Implement `requestReviewers` using the `gh` CLI, consistent with all other methods in this plugin:
+
+```typescript
+async requestReviewers(pr: PRInfo, reviewers: string[]): Promise<void> {
+  await execCli("gh", [
+    "pr", "edit", String(pr.number),
+    ...reviewers.flatMap(r => ["--add-reviewer", r]),
+    "-R", pr.repo,
+  ]);
+}
+```
+
+This adds individual users and team slugs (e.g., `org/team-name`) as reviewers via GitHub's native review request mechanism. Requested users receive GitHub notifications automatically.
+
+### 3. API Route (`packages/web/src/app/api/prs/[id]/request-review/route.ts`)
+
+New `POST /api/prs/:id/request-review` endpoint. Follows the same pattern as the existing merge route (`/api/prs/[id]/merge/route.ts`):
+
+1. Validate PR number (must be numeric)
+2. Find session by PR number from session manager
+3. Look up project config for the session
+4. Get SCM plugin for the project; return 500 if not configured
+5. Check that `requestReviewers` is supported by the SCM plugin; return 501 if not
+6. Read `defaultReviewers` from project config; return 422 if not configured or empty
+7. Call `scm.requestReviewers(pr, defaultReviewers)`
+8. Record observability data
+9. Return `{ ok: true, prNumber, reviewers: [...] }`
+
+**Error responses:**
+
+| Status | Condition |
+|--------|-----------|
+| 400 | Invalid PR number |
+| 404 | PR/session not found |
+| 422 | `defaultReviewers` not configured for the project |
+| 500 | SCM plugin not configured |
+| 501 | SCM plugin does not support `requestReviewers` |
+
+### 4. Frontend Changes
+
+**Dashboard** (`packages/web/src/components/Dashboard.tsx`):
+
+Add `handleRequestReview` callback following the `handleMerge` pattern:
+
+```typescript
+const handleRequestReview = useCallback(async (prNumber: number) => {
+  const res = await fetch(`/api/prs/${prNumber}/request-review`, { method: "POST" });
+  if (!res.ok) {
+    console.error(`Failed to request review for PR #${prNumber}:`, await res.text());
+  }
+}, []);
+```
+
+Pass `onRequestReview` down through `AttentionZone` to `SessionCard`.
+
+**SessionCard** (`packages/web/src/components/SessionCard.tsx`):
+
+For the "needs review" alert (currently lines 659-669):
+
+- Remove the `actionMessage` field (no longer sending agent messages for this action)
+- The button click calls `onRequestReview(pr.number)` instead of `handleAction` / `onSend`
+- Button label changes from "ask to post" to "request review" (clearer without Slack context)
+- On click: show "sent!" feedback for 2 seconds (same UX as today)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `packages/core/src/types.ts` | Add `defaultReviewers` to `ProjectConfig`, add `requestReviewers` to `SCM` |
+| `packages/plugins/scm-github/src/index.ts` | Implement `requestReviewers` via `gh pr edit --add-reviewer` |
+| `packages/web/src/app/api/prs/[id]/request-review/route.ts` | New API route (mirrors merge route pattern) |
+| `packages/web/src/components/Dashboard.tsx` | Add `handleRequestReview` callback, pass to children |
+| `packages/web/src/components/AttentionZone.tsx` | Thread `onRequestReview` prop through |
+| `packages/web/src/components/SessionCard.tsx` | Wire "needs review" button to `onRequestReview`, rename label |
+
+## Out of Scope
+
+- Reviewer selection logic (CODEOWNERS, round-robin, load-balancing) — always uses `defaultReviewers` from config
+- Slack or other notification channels
+- GitLab support (can be added later by implementing `requestReviewers` in `scm-gitlab`)

--- a/docs/superpowers/specs/2026-03-24-request-review-design.md
+++ b/docs/superpowers/specs/2026-03-24-request-review-design.md
@@ -59,13 +59,15 @@ Implement `requestReviewers` using the `gh` CLI, consistent with all other metho
 
 ```typescript
 async requestReviewers(pr: PRInfo, reviewers: string[]): Promise<void> {
-  await execCli("gh", [
+  await gh([
     "pr", "edit", String(pr.number),
+    "--repo", repoFlag(pr),
     ...reviewers.flatMap(r => ["--add-reviewer", r]),
-    "-R", pr.repo,
   ]);
 }
 ```
+
+> Uses the existing `gh()` helper and `repoFlag(pr)` pattern consistent with all other methods (e.g., `assignPRToCurrentUser`, `mergePR`, `closePR`).
 
 This adds individual users and team slugs (e.g., `org/team-name`) as reviewers via GitHub's native review request mechanism. Requested users receive GitHub notifications automatically.
 
@@ -117,7 +119,9 @@ For the "needs review" alert (currently lines 659-669):
 - Remove the `actionMessage` field (no longer sending agent messages for this action)
 - The button click calls `onRequestReview(pr.number)` instead of `handleAction` / `onSend`
 - Button label changes from "ask to post" to "request review" (clearer without Slack context)
-- On click: show "sent!" feedback for 2 seconds (same UX as today)
+- On click: optimistically show "sent!" feedback for 2 seconds (same UX as today — no loading/error state)
+
+**Note:** Adding `onRequestReview` to `AttentionZone` props also requires updating `areAttentionZonePropsEqual` (the custom memoization comparator) to include it.
 
 ## Files Changed
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -566,6 +566,9 @@ export interface SCM {
   /** Close a PR without merging */
   closePR(pr: PRInfo): Promise<void>;
 
+  /** Request reviewers on a PR */
+  requestReviewers?(pr: PRInfo, reviewers: string[]): Promise<void>;
+
   // --- CI Tracking ---
 
   /** Get individual CI check statuses */
@@ -975,6 +978,9 @@ export interface ProjectConfig {
   orchestrator?: RoleAgentConfig;
 
   worker?: RoleAgentConfig;
+
+  /** GitHub usernames or team slugs to request as PR reviewers */
+  defaultReviewers?: string[];
 
   /** Per-project reaction overrides */
   reactions?: Record<string, Partial<ReactionConfig>>;

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -638,6 +638,17 @@ function createGitHubSCM(): SCM {
       await gh(["pr", "close", String(pr.number), "--repo", repoFlag(pr)]);
     },
 
+    async requestReviewers(pr: PRInfo, reviewers: string[]): Promise<void> {
+      await gh([
+        "pr",
+        "edit",
+        String(pr.number),
+        "--repo",
+        repoFlag(pr),
+        ...reviewers.flatMap((r) => ["--add-reviewer", r]),
+      ]);
+    },
+
     async getCIChecks(pr: PRInfo): Promise<CICheck[]> {
       try {
         const raw = await gh([

--- a/packages/web/src/app/api/prs/[id]/request-review/route.ts
+++ b/packages/web/src/app/api/prs/[id]/request-review/route.ts
@@ -1,0 +1,90 @@
+import { type NextRequest } from "next/server";
+import { getServices, getSCM } from "@/lib/services";
+import { getCorrelationId, jsonWithCorrelation, recordApiObservation } from "@/lib/observability";
+
+/** POST /api/prs/:id/request-review — Request reviewers on a PR */
+export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const correlationId = getCorrelationId(_request);
+  const startedAt = Date.now();
+  const { id } = await params;
+  if (!/^\d+$/.test(id)) {
+    return jsonWithCorrelation({ error: "Invalid PR number" }, { status: 400 }, correlationId);
+  }
+  const prNumber = Number(id);
+
+  try {
+    const { config, registry, sessionManager } = await getServices();
+    const sessions = await sessionManager.list();
+
+    const session = sessions.find((s) => s.pr?.number === prNumber);
+    if (!session?.pr) {
+      return jsonWithCorrelation({ error: "PR not found" }, { status: 404 }, correlationId);
+    }
+
+    const project = config.projects[session.projectId];
+    const scm = getSCM(registry, project);
+    if (!scm) {
+      return jsonWithCorrelation(
+        { error: "No SCM plugin configured for this project" },
+        { status: 500 },
+        correlationId,
+      );
+    }
+
+    if (!scm.requestReviewers) {
+      return jsonWithCorrelation(
+        { error: "SCM plugin does not support requesting reviewers" },
+        { status: 501 },
+        correlationId,
+      );
+    }
+
+    const reviewers = project.defaultReviewers;
+    if (!reviewers || reviewers.length === 0) {
+      return jsonWithCorrelation(
+        { error: "No defaultReviewers configured for this project" },
+        { status: 422 },
+        correlationId,
+      );
+    }
+
+    await scm.requestReviewers(session.pr, reviewers);
+    recordApiObservation({
+      config,
+      method: "POST",
+      path: "/api/prs/[id]/request-review",
+      correlationId,
+      startedAt,
+      outcome: "success",
+      statusCode: 200,
+      projectId: session.projectId,
+      sessionId: session.id,
+      data: { prNumber, reviewers },
+    });
+    return jsonWithCorrelation(
+      { ok: true, prNumber, reviewers },
+      { status: 200 },
+      correlationId,
+    );
+  } catch (err) {
+    const { config } = await getServices().catch(() => ({ config: undefined }));
+    if (config) {
+      recordApiObservation({
+        config,
+        method: "POST",
+        path: "/api/prs/[id]/request-review",
+        correlationId,
+        startedAt,
+        outcome: "failure",
+        statusCode: 500,
+        reason: err instanceof Error ? err.message : "Failed to request reviewers",
+        data: { prNumber },
+      });
+    }
+    return jsonWithCorrelation(
+      { error: err instanceof Error ? err.message : "Failed to request reviewers" },
+      { status: 500 },
+      correlationId,
+    );
+  }
+}

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1336,29 +1336,110 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   border-right: 1px solid var(--color-border-subtle);
   background: linear-gradient(
     180deg,
-    color-mix(in srgb, var(--color-bg-elevated) 92%, black 8%) 0%,
-    color-mix(in srgb, var(--color-bg-base) 90%, black 10%) 100%
+    color-mix(in srgb, var(--color-bg-elevated) 94%, black 6%) 0%,
+    color-mix(in srgb, var(--color-bg-base) 88%, black 12%) 100%
   );
+  box-shadow:
+    inset -1px 0 0 color-mix(in srgb, white 3%, transparent),
+    12px 0 28px rgba(0, 0, 0, 0.04);
 }
 
 .project-sidebar--collapsed {
   align-items: center;
+  position: relative;
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-accent) 5%, transparent) 0%,
+      transparent 16%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-bg-elevated) 96%, black 4%) 0%,
+      color-mix(in srgb, var(--color-bg-base) 90%, black 10%) 100%
+    );
+}
+
+.project-sidebar--collapsed::before {
+  content: "";
+  position: absolute;
+  top: 12px;
+  bottom: 12px;
+  left: 50%;
+  width: 1px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-accent) 18%, transparent) 0%,
+    color-mix(in srgb, var(--color-border-subtle) 85%, transparent) 18%,
+    color-mix(in srgb, var(--color-border-subtle) 55%, transparent) 82%,
+    transparent 100%
+  );
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.project-sidebar__collapsed-stack {
+  position: relative;
+  z-index: 1;
+}
+
+.project-sidebar__collapsed-header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 14px;
+  padding-bottom: 10px;
+}
+
+.project-sidebar__collapsed-header::after {
+  content: "";
+  width: 18px;
+  height: 1px;
+  background: color-mix(in srgb, var(--color-border-default) 72%, transparent);
+}
+
+.project-sidebar__collapsed-eyebrow {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.project-sidebar__collapsed-label {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
 }
 
 .project-sidebar__header {
   border-bottom: 1px solid var(--color-border-subtle);
-  background: linear-gradient(
+  background:
+    radial-gradient(
+      circle at top left,
+      color-mix(in srgb, var(--color-accent) 10%, transparent) 0%,
+      transparent 42%
+    ),
+    linear-gradient(
     180deg,
-    color-mix(in srgb, var(--color-accent) 4%, transparent) 0%,
-    transparent 100%
-  );
+      color-mix(in srgb, var(--color-accent) 6%, transparent) 0%,
+      transparent 100%
+    );
 }
 
 .project-sidebar__eyebrow {
   font-size: 10px;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--color-accent);
+  opacity: 0.92;
 }
 
 .project-sidebar__title-row {
@@ -1370,10 +1451,10 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 }
 
 .project-sidebar__title {
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1.1;
   letter-spacing: -0.02em;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--color-text-primary);
 }
 
@@ -1382,111 +1463,146 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   max-width: 18ch;
   font-size: 10px;
   line-height: 1.4;
-  color: var(--color-text-muted);
+  color: color-mix(in srgb, var(--color-text-muted) 88%, var(--color-text-secondary));
 }
 
 .project-sidebar__badge {
   display: inline-flex;
-  min-width: 22px;
-  height: 22px;
+  min-width: 26px;
+  height: 26px;
   align-items: center;
   justify-content: center;
   border: 1px solid var(--color-border-default);
-  background: color-mix(in srgb, var(--color-bg-base) 42%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-bg-base) 30%, var(--color-bg-elevated)),
+    color-mix(in srgb, var(--color-bg-base) 72%, transparent)
+  );
   font-size: 10px;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--color-text-primary);
   font-variant-numeric: tabular-nums;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 6%, transparent),
+    0 4px 10px rgba(0, 0, 0, 0.04);
 }
 
 .project-sidebar__summary {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 6px;
-  margin-top: 10px;
+  gap: 8px;
+  margin-top: 12px;
 }
 
 .project-sidebar__metric {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 6px 6px 5px;
-  border: 1px solid var(--color-border-subtle);
-  background: color-mix(in srgb, var(--color-bg-base) 40%, transparent);
+  gap: 3px;
+  padding: 7px 7px 6px;
+  border: 1px solid color-mix(in srgb, var(--color-border-default) 80%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-bg-elevated) 82%, transparent),
+    color-mix(in srgb, var(--color-bg-base) 58%, transparent)
+  );
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 5%, transparent);
 }
 
 .project-sidebar__metric-value {
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1;
   letter-spacing: -0.03em;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--color-text-primary);
   font-variant-numeric: tabular-nums;
 }
 
 .project-sidebar__metric-label {
   font-size: 9px;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
 
 .project-sidebar__divider {
-  border-top: 1px solid var(--color-border-subtle);
+  border-top: 1px solid color-mix(in srgb, var(--color-border-default) 55%, transparent);
 }
 
 .project-sidebar__item {
   position: relative;
   border: 1px solid transparent;
-  background: transparent;
+  background: linear-gradient(90deg, transparent, transparent);
+  overflow: hidden;
 }
 
 .project-sidebar__item:hover {
-  background: var(--color-hover-overlay);
-  border-color: var(--color-border-subtle);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-hover-overlay) 96%, transparent),
+    transparent 100%
+  );
+  border-color: color-mix(in srgb, var(--color-border-default) 72%, transparent);
 }
 
 .project-sidebar__item--active {
-  border-color: color-mix(in srgb, var(--color-accent) 24%, var(--color-border-default));
+  border-color: color-mix(in srgb, var(--color-accent) 34%, var(--color-border-default));
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--color-accent) 16%, transparent),
+    color-mix(in srgb, var(--color-accent) 18%, transparent),
     transparent 90%
   );
+  box-shadow:
+    inset 3px 0 0 var(--color-accent),
+    inset 0 1px 0 color-mix(in srgb, white 4%, transparent);
+}
+
+.project-sidebar__item[data-health="red"] {
+  border-left-color: color-mix(in srgb, var(--color-status-error) 44%, transparent);
+}
+
+.project-sidebar__item[data-health="yellow"] {
+  border-left-color: color-mix(in srgb, var(--color-status-attention) 40%, transparent);
+}
+
+.project-sidebar__item[data-health="green"] {
+  border-left-color: color-mix(in srgb, var(--color-status-ready) 36%, transparent);
 }
 
 .project-sidebar__count {
-  border: 1px solid var(--color-border-subtle);
-  background: color-mix(in srgb, var(--color-bg-base) 40%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border-default) 68%, transparent);
+  background: color-mix(in srgb, var(--color-bg-base) 34%, var(--color-bg-elevated));
+  font-weight: 700;
 }
 
 .project-sidebar__children {
   position: relative;
-  margin-top: 4px;
-  border-left: 1px solid color-mix(in srgb, var(--color-border-subtle) 82%, transparent);
+  margin-top: 6px;
+  margin-left: 8px;
+  border-left: 1px solid color-mix(in srgb, var(--color-border-default) 50%, transparent);
+  padding-left: 4px;
 }
 
 .project-sidebar__session {
   position: relative;
-  margin: 2px 0 2px 8px;
+  margin: 4px 0 4px 8px;
   border: 1px solid transparent;
-  background: transparent;
+  background: linear-gradient(90deg, transparent, transparent);
 }
 
 .project-sidebar__session:hover {
-  border-color: var(--color-border-subtle);
+  border-color: color-mix(in srgb, var(--color-border-default) 68%, transparent);
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--color-hover-overlay) 90%, transparent),
+    color-mix(in srgb, var(--color-hover-overlay) 96%, transparent),
     transparent 100%
   );
 }
 
 .project-sidebar__session--active {
-  border-color: color-mix(in srgb, var(--color-accent) 18%, var(--color-border-subtle));
+  border-color: color-mix(in srgb, var(--color-accent) 22%, var(--color-border-subtle));
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--color-accent) 12%, transparent),
+    color-mix(in srgb, var(--color-accent) 14%, transparent),
     transparent 88%
   );
   box-shadow: inset 2px 0 0 var(--color-accent);
@@ -1499,20 +1615,20 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   top: 50%;
   width: 8px;
   height: 1px;
-  background: var(--color-border-subtle);
+  background: color-mix(in srgb, var(--color-border-default) 68%, transparent);
   transform: translateY(-50%);
 }
 
 .project-sidebar__session-tone {
   flex-shrink: 0;
   padding: 2px 6px;
-  border: 1px solid var(--color-border-subtle);
-  background: color-mix(in srgb, var(--color-bg-base) 40%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border-default) 60%, transparent);
+  background: color-mix(in srgb, var(--color-bg-base) 30%, var(--color-bg-elevated));
   font-size: 9px;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--color-text-muted);
+  color: color-mix(in srgb, var(--color-text-muted) 82%, var(--color-text-secondary));
 }
 
 .project-sidebar__session-id {
@@ -1541,8 +1657,12 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   justify-content: center;
   gap: 8px;
   width: 100%;
-  border: 1px solid var(--color-border-subtle);
-  background: color-mix(in srgb, var(--color-bg-base) 40%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border-default) 68%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-bg-elevated) 82%, transparent),
+    color-mix(in srgb, var(--color-bg-base) 56%, transparent)
+  );
   color: var(--color-text-secondary);
   font-size: 11px;
   font-weight: 600;
@@ -1564,44 +1684,91 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 .project-sidebar__collapse-btn:hover,
 .project-sidebar__collapsed-toggle:hover {
   border-color: var(--color-border-default);
-  background: var(--color-hover-overlay);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-hover-overlay) 92%, var(--color-bg-elevated)),
+    color-mix(in srgb, var(--color-hover-overlay) 42%, transparent)
+  );
   color: var(--color-text-primary);
 }
 
 .project-sidebar__collapsed-project {
   position: relative;
   display: inline-flex;
-  width: 36px;
-  height: 36px;
+  width: 42px;
+  height: 46px;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--color-border-subtle);
-  border-radius: 8px;
-  background: var(--color-bg-surface);
+  border: 1px solid color-mix(in srgb, var(--color-border-default) 68%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-bg-elevated) 92%, transparent),
+    color-mix(in srgb, var(--color-bg-base) 68%, transparent)
+  );
   cursor: pointer;
+  overflow: hidden;
   transition:
     border-color 0.15s ease,
     background 0.15s ease,
-    box-shadow 0.15s ease;
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent),
+    0 10px 18px rgba(0, 0, 0, 0.05);
+}
+
+.project-sidebar__collapsed-project-rim {
+  position: absolute;
+  inset: 0;
+  border-left: 3px solid transparent;
+  opacity: 0.9;
+}
+
+.project-sidebar__collapsed-project[data-health="red"] .project-sidebar__collapsed-project-rim {
+  border-left-color: var(--color-status-error);
+}
+
+.project-sidebar__collapsed-project[data-health="yellow"] .project-sidebar__collapsed-project-rim {
+  border-left-color: var(--color-status-attention);
+}
+
+.project-sidebar__collapsed-project[data-health="green"] .project-sidebar__collapsed-project-rim {
+  border-left-color: var(--color-status-ready);
 }
 
 .project-sidebar__collapsed-project:hover {
   border-color: var(--color-border-default);
-  background: var(--color-bg-elevated);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-hover-overlay) 86%, var(--color-bg-elevated)),
+    color-mix(in srgb, var(--color-hover-overlay) 22%, transparent)
+  );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent),
+    0 12px 22px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
 }
 
 .project-sidebar__collapsed-project--active {
-  border-color: color-mix(in srgb, var(--color-accent) 35%, var(--color-border-default));
-  background: color-mix(in srgb, var(--color-accent) 8%, var(--color-bg-elevated));
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 12%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-border-default));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-accent) 14%, var(--color-bg-elevated)),
+    color-mix(in srgb, var(--color-accent) 8%, var(--color-bg-base))
+  );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--color-accent) 18%, transparent),
+    0 14px 24px rgba(57, 74, 181, 0.14);
 }
 
 .project-sidebar__avatar {
-  font-size: 13px;
-  font-weight: 600;
+  position: relative;
+  z-index: 1;
+  font-size: 16px;
+  font-weight: 700;
   line-height: 1;
-  color: var(--color-text-secondary);
+  color: color-mix(in srgb, var(--color-text-secondary) 88%, var(--color-text-primary));
   user-select: none;
 }
 
@@ -1611,13 +1778,14 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 
 .project-sidebar__health-indicator {
   position: absolute;
-  top: -2px;
-  right: -2px;
-  width: 7px;
-  height: 7px;
+  top: 7px;
+  right: 6px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
-  border: 1.5px solid var(--color-bg-surface);
+  border: 2px solid color-mix(in srgb, var(--color-bg-elevated) 92%, white 8%);
   box-sizing: content-box;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.85);
 }
 
 /* ── Kanban board ────────────────────────────────────────────────────── */

--- a/packages/web/src/components/AttentionZone.tsx
+++ b/packages/web/src/components/AttentionZone.tsx
@@ -11,6 +11,7 @@ interface AttentionZoneProps {
   onKill?: (sessionId: string) => void;
   onMerge?: (prNumber: number) => void;
   onRestore?: (sessionId: string) => void;
+  onRequestReview?: (prNumber: number) => void;
 }
 
 const zoneConfig: Record<
@@ -64,6 +65,7 @@ function AttentionZoneView({
   onKill,
   onMerge,
   onRestore,
+  onRequestReview,
 }: AttentionZoneProps) {
   const config = zoneConfig[level];
 
@@ -89,6 +91,7 @@ function AttentionZoneView({
                 onKill={onKill}
                 onMerge={onMerge}
                 onRestore={onRestore}
+                onRequestReview={onRequestReview}
               />
             ))}
           </div>
@@ -109,6 +112,7 @@ function areAttentionZonePropsEqual(prev: AttentionZoneProps, next: AttentionZon
     prev.onKill === next.onKill &&
     prev.onMerge === next.onMerge &&
     prev.onRestore === next.onRestore &&
+    prev.onRequestReview === next.onRequestReview &&
     prev.sessions.length === next.sessions.length &&
     prev.sessions.every((session, index) => session === next.sessions[index])
   );

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -69,7 +69,10 @@ export function Dashboard({
     useState<DashboardOrchestratorLink[]>(orchestratorLinks);
   const [spawningProjectIds, setSpawningProjectIds] = useState<string[]>([]);
   const [spawnErrors, setSpawnErrors] = useState<Record<string, string>>({});
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth < 768;
+  });
   const showSidebar = projects.length > 1;
   const allProjectsView = showSidebar && projectId === undefined;
 

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -177,6 +177,13 @@ export function Dashboard({
     }
   }, []);
 
+  const handleRequestReview = useCallback(async (prNumber: number) => {
+    const res = await fetch(`/api/prs/${prNumber}/request-review`, { method: "POST" });
+    if (!res.ok) {
+      console.error(`Failed to request review for PR #${prNumber}:`, await res.text());
+    }
+  }, []);
+
   const handleRestore = useCallback(async (sessionId: string) => {
     if (!confirm(`Restore session ${sessionId}?`)) return;
     const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/restore`, {
@@ -402,6 +409,7 @@ export function Dashboard({
                   onKill={handleKill}
                   onMerge={handleMerge}
                   onRestore={handleRestore}
+                  onRequestReview={handleRequestReview}
                 />
               ))}
             </div>

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -156,8 +156,12 @@ function ProjectSidebarInner({
 
   if (collapsed) {
     return (
-      <aside className="project-sidebar project-sidebar--collapsed flex h-full w-[56px] flex-col items-center py-3">
-        <div className="flex flex-1 flex-col items-center gap-2">
+      <aside className="project-sidebar project-sidebar--collapsed flex h-full w-[64px] flex-col items-center py-3">
+        <div className="project-sidebar__collapsed-header" aria-hidden="true">
+          <span className="project-sidebar__collapsed-eyebrow">AO</span>
+          <span className="project-sidebar__collapsed-label">Projects</span>
+        </div>
+        <div className="project-sidebar__collapsed-stack flex flex-1 flex-col items-center gap-2">
           {projects.map((project) => {
             const entry = sessionsByProject.map.get(project.id);
             const health = entry ? computeProjectHealth(entry.all) : ("gray" as ProjectHealth);
@@ -168,12 +172,15 @@ function ProjectSidebarInner({
                 key={project.id}
                 type="button"
                 onClick={() => router.push(pathname + `?project=${encodeURIComponent(project.id)}`)}
+                aria-label={project.name}
+                data-health={health}
                 className={cn(
                   "project-sidebar__collapsed-project",
                   isActive && "project-sidebar__collapsed-project--active",
                 )}
                 title={project.name}
               >
+                <span className="project-sidebar__collapsed-project-rim" aria-hidden="true" />
                 <span className="project-sidebar__avatar">{initial}</span>
                 {health !== "gray" && (
                   <span
@@ -283,6 +290,7 @@ function ProjectSidebarInner({
               {/* Project header */}
               <button
                 onClick={() => handleProjectHeaderClick(project.id)}
+                data-health={health}
                 className={cn(
                   "project-sidebar__item flex w-full items-center gap-2 px-2.5 py-[9px] text-left text-[12px] font-medium transition-colors",
                   isActive

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -21,6 +21,7 @@ interface SessionCardProps {
   onKill?: (sessionId: string) => void;
   onMerge?: (prNumber: number) => void;
   onRestore?: (sessionId: string) => void;
+  onRequestReview?: (prNumber: number) => void;
 }
 
 /**
@@ -91,7 +92,7 @@ function getDoneStatusInfo(session: DashboardSession): {
   };
 }
 
-function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: SessionCardProps) {
+function SessionCardView({ session, onSend, onKill, onMerge, onRestore, onRequestReview }: SessionCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [sendingAction, setSendingAction] = useState<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -113,6 +114,15 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
 
   const rateLimited = pr ? isPRRateLimited(pr) : false;
   const alerts = getAlerts(session);
+
+  // Wire "needs review" alert to direct API call instead of agent messaging
+  const reviewAlert = alerts.find((a) => a.key === "review");
+  if (reviewAlert && pr && onRequestReview) {
+    reviewAlert.actionLabel = "request review";
+    reviewAlert.onAction = () => onRequestReview(pr.number);
+    delete reviewAlert.actionMessage;
+  }
+
   const isReadyToMerge = !rateLimited && pr?.mergeability.mergeable && pr.state === "open";
   const isTerminal =
     TERMINAL_STATUSES.has(session.status) ||
@@ -498,7 +508,14 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
-                        handleAction(alert.key, alert.actionMessage ?? "");
+                        if (alert.onAction) {
+                          setSendingAction(alert.key);
+                          alert.onAction();
+                          if (timerRef.current) clearTimeout(timerRef.current);
+                          timerRef.current = setTimeout(() => setSendingAction(null), 2000);
+                        } else {
+                          handleAction(alert.key, alert.actionMessage ?? "");
+                        }
                       }}
                       disabled={sendingAction === alert.key}
                       className={cn(
@@ -593,7 +610,8 @@ function areSessionCardPropsEqual(prev: SessionCardProps, next: SessionCardProps
     prev.onSend === next.onSend &&
     prev.onKill === next.onKill &&
     prev.onMerge === next.onMerge &&
-    prev.onRestore === next.onRestore
+    prev.onRestore === next.onRestore &&
+    prev.onRequestReview === next.onRequestReview
   );
 }
 
@@ -610,6 +628,8 @@ interface Alert {
   actionLabel?: string;
   actionMessage?: string;
   actionClassName?: string;
+  /** Direct action handler — bypasses agent messaging when set */
+  onAction?: () => void;
 }
 
 function getAlerts(session: DashboardSession): Alert[] {

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -270,13 +270,23 @@ export async function enrichSessionPR(
   return true;
 }
 
-/** Enrich a DashboardSession's issue label using the tracker plugin. */
+/** Enrich a DashboardSession's issue URL and label using the tracker plugin. */
 export function enrichSessionIssue(
   dashboard: DashboardSession,
   tracker: Tracker,
   project: ProjectConfig,
 ): void {
   if (!dashboard.issueUrl) return;
+
+  // issueUrl may be a raw identifier (e.g. "#42") rather than a full URL.
+  // Resolve it to a proper URL using the tracker plugin.
+  if (!dashboard.issueUrl.startsWith("http")) {
+    try {
+      dashboard.issueUrl = tracker.issueUrl(dashboard.issueUrl, project);
+    } catch {
+      // If resolution fails, keep the original value
+    }
+  }
 
   // Use tracker plugin to extract human-readable label from URL
   if (tracker.issueLabel) {


### PR DESCRIPTION
## Summary
- **Direct GitHub review requests**: Replaced the "ask to post" (Slack) button with a direct GitHub reviewer request via `gh pr edit --add-reviewer`, using `defaultReviewers` from project config
- **Issue link fix**: Fixed kanban card footer issue links navigating to `localhost/#issue` instead of the actual GitHub issue page — raw identifiers are now resolved to full URLs via the tracker plugin
- **Sidebar polish**: Redesigned collapsed sidebar with header, vertical label, health indicator rims, and refined gradients/spacing/typography

## Test plan
- [ ] Verify "request review" button on kanban cards with `needs review` alert triggers GitHub reviewer assignment
- [ ] Verify issue number links in card footer open the correct GitHub issue page
- [ ] Verify collapsed sidebar renders with new header, health indicators, and hover states
- [ ] Run `pnpm test` for serialize tests (52 passing)
- [ ] Typecheck passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)