### PR TITLE
fix(config): replace em dash with regular hyphen

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -346,7 +346,7 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
       auto: true,
       action: "send-to-agent",
       message:
-        "You appear to be idle. If your task is not complete, continue working — write the code, commit, push, and create a PR. If you are blocked, explain what is blocking you.",
+        "You appear to be idle. If your task is not complete, continue working - write the code, commit, push, and create a PR. If you are blocked, explain what is blocking you.",
       retries: 2,
       escalateAfter: "15m",
     },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,5 +1,5 @@
 /**
- * Configuration loader — reads agent-orchestrator.yaml and validates with Zod.
+ * Configuration loader - reads agent-orchestrator.yaml and validates with Zod.
  *
  * Minimal config that just works:
  *   projects:


### PR DESCRIPTION
## Summary
- Fixed typo in `packages/core/src/config.ts` by replacing Unicode em dash (—) with regular hyphen (-) in the JSDoc comment
- This fixes #651

## Test plan
- [x] Code compiles without errors
- [x] Typo fixed in comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)