### PR TITLE
feat: add MiniMax as LLM provider for task decomposer (default M3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,29 @@ CI fails → agent gets the logs and fixes it. Reviewer requests changes → age
 
 See [`agent-orchestrator.yaml.example`](agent-orchestrator.yaml.example) for the full reference, or run `ao config-help` for the complete schema.
 
+### Task Decomposer — LLM Provider
+
+The task decomposer supports multiple LLM providers for breaking complex issues into subtasks:
+
+| Provider  | Model Examples                        | Env Variable       |
+| --------- | ------------------------------------- | ------------------ |
+| Anthropic | `claude-sonnet-4-20250514` (default)  | `ANTHROPIC_API_KEY` |
+| [MiniMax](https://www.minimaxi.com)   | `MiniMax-M2.7`, `MiniMax-M2.5`       | `MINIMAX_API_KEY`  |
+
+```yaml
+# Use MiniMax for task decomposition
+projects:
+  my-app:
+    repo: owner/my-app
+    path: ~/my-app
+    decomposer:
+      enabled: true
+      provider: minimax          # anthropic (default) | minimax
+      model: MiniMax-M2.7        # MiniMax model to use
+```
+
+MiniMax models are accessed via their [OpenAI-compatible API](https://platform.minimaxi.com/document/OpenAI%20compatibility), so no additional SDK is needed.
+
 ## Plugin Architecture
 
 Eight slots. Every abstraction is swappable.

--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ See [`agent-orchestrator.yaml.example`](agent-orchestrator.yaml.example) for the
 
 The task decomposer supports multiple LLM providers for breaking complex issues into subtasks:
 
-| Provider  | Model Examples                        | Env Variable       |
-| --------- | ------------------------------------- | ------------------ |
-| Anthropic | `claude-sonnet-4-20250514` (default)  | `ANTHROPIC_API_KEY` |
-| [MiniMax](https://www.minimaxi.com)   | `MiniMax-M2.7`, `MiniMax-M2.5`       | `MINIMAX_API_KEY`  |
+| Provider  | Model Examples                                       | Env Variable        |
+| --------- | ---------------------------------------------------- | ------------------- |
+| Anthropic | `claude-sonnet-4-20250514` (default)                 | `ANTHROPIC_API_KEY` |
+| [MiniMax](https://www.minimaxi.com)   | `MiniMax-M3` (default), `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` | `MINIMAX_API_KEY`   |
 
 ```yaml
 # Use MiniMax for task decomposition
@@ -154,7 +154,7 @@ projects:
     decomposer:
       enabled: true
       provider: minimax          # anthropic (default) | minimax
-      model: MiniMax-M2.7        # MiniMax model to use
+      model: MiniMax-M3          # MiniMax model to use (512K context, 128K output)
 ```
 
 MiniMax models are accessed via their [OpenAI-compatible API](https://platform.minimaxi.com/document/OpenAI%20compatibility), so no additional SDK is needed.

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -88,6 +88,14 @@ projects:
     # OpenCode issue session strategy (only for agent: opencode)
     # opencodeIssueSessionStrategy: reuse   # reuse | delete | ignore
 
+    # Task decomposer configuration
+    # decomposer:
+    #   enabled: false
+    #   maxDepth: 3
+    #   model: claude-sonnet-4-20250514     # or MiniMax-M2.7 for MiniMax
+    #   provider: anthropic                  # anthropic | minimax
+    #   requireApproval: true
+
     # Per-project reaction overrides
     # reactions:
     #   approved-and-green:

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -92,7 +92,7 @@ projects:
     # decomposer:
     #   enabled: false
     #   maxDepth: 3
-    #   model: claude-sonnet-4-20250514     # or MiniMax-M2.7 for MiniMax
+    #   model: claude-sonnet-4-20250514     # or MiniMax-M3 for MiniMax
     #   provider: anthropic                  # anthropic | minimax
     #   requireApproval: true
 

--- a/packages/core/src/__tests__/decomposer-integration.test.ts
+++ b/packages/core/src/__tests__/decomposer-integration.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Integration tests for decomposer module — end-to-end decompose() flow
+ * with mocked LLM providers, config validation, and provider switching.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { decompose, DEFAULT_DECOMPOSER_CONFIG } from "../decomposer.js";
+import type { DecomposerConfig } from "../decomposer.js";
+import { validateConfig } from "../config.js";
+
+// =============================================================================
+// decompose() with Anthropic (mocked)
+// =============================================================================
+
+describe("decompose() — Anthropic provider", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("decomposes an atomic task (Anthropic mock)", async () => {
+    // Mock Anthropic SDK
+    vi.mock("@anthropic-ai/sdk", () => ({
+      default: class MockAnthropic {
+        messages = {
+          create: vi.fn().mockResolvedValue({
+            content: [{ type: "text", text: "atomic" }],
+          }),
+        };
+      },
+    }));
+
+    const config: DecomposerConfig = {
+      ...DEFAULT_DECOMPOSER_CONFIG,
+      provider: "anthropic",
+    };
+
+    const plan = await decompose("Fix login button color", config);
+    expect(plan.tree.kind).toBe("atomic");
+    expect(plan.tree.status).toBe("ready");
+    expect(plan.tree.children).toHaveLength(0);
+    expect(plan.phase).toBe("review"); // requireApproval defaults to true
+  });
+});
+
+// =============================================================================
+// decompose() with MiniMax (mocked)
+// =============================================================================
+
+describe("decompose() — MiniMax provider", () => {
+  const originalKey = process.env["MINIMAX_API_KEY"];
+
+  beforeEach(() => {
+    process.env["MINIMAX_API_KEY"] = "test-minimax-key";
+  });
+
+  afterEach(() => {
+    if (originalKey) {
+      process.env["MINIMAX_API_KEY"] = originalKey;
+    } else {
+      delete process.env["MINIMAX_API_KEY"];
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("decomposes a composite task (MiniMax mock)", async () => {
+    let callCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: classify → composite
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                choices: [{ message: { content: "<think>This is complex</think>composite" } }],
+              }),
+          });
+        }
+        if (callCount === 2) {
+          // Second call: decompose → subtasks
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                choices: [
+                  {
+                    message: {
+                      content:
+                        '<think>Breaking down</think>["Implement backend API", "Build frontend UI"]',
+                    },
+                  },
+                ],
+              }),
+          });
+        }
+        // Remaining calls: classify children → atomic
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              choices: [{ message: { content: "atomic" } }],
+            }),
+        });
+      }),
+    );
+
+    const config: DecomposerConfig = {
+      enabled: true,
+      maxDepth: 3,
+      model: "MiniMax-M2.7",
+      requireApproval: false,
+      provider: "minimax",
+    };
+
+    const plan = await decompose("Build a full-stack user management system", config);
+
+    expect(plan.tree.kind).toBe("composite");
+    expect(plan.tree.children).toHaveLength(2);
+    expect(plan.tree.children[0].description).toBe("Implement backend API");
+    expect(plan.tree.children[1].description).toBe("Build frontend UI");
+    expect(plan.tree.children[0].kind).toBe("atomic");
+    expect(plan.tree.children[1].kind).toBe("atomic");
+    expect(plan.phase).toBe("approved"); // requireApproval: false
+  });
+
+  it("handles MiniMax API failure gracefully", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Internal Server Error"),
+      }),
+    );
+
+    const config: DecomposerConfig = {
+      enabled: true,
+      maxDepth: 3,
+      model: "MiniMax-M2.7",
+      requireApproval: true,
+      provider: "minimax",
+    };
+
+    await expect(decompose("Build something", config)).rejects.toThrow("MiniMax API error (500)");
+  });
+});
+
+// =============================================================================
+// Config integration — decomposer with provider
+// =============================================================================
+
+describe("Config integration — decomposer provider", () => {
+  it("full config with MiniMax decomposer validates correctly", () => {
+    const config = validateConfig({
+      projects: {
+        "my-app": {
+          path: "/repos/my-app",
+          repo: "org/my-app",
+          defaultBranch: "main",
+          decomposer: {
+            enabled: true,
+            maxDepth: 2,
+            model: "MiniMax-M2.7",
+            provider: "minimax",
+            requireApproval: false,
+          },
+        },
+      },
+    });
+
+    const decomposer = config.projects["my-app"].decomposer;
+    expect(decomposer).toBeDefined();
+    expect(decomposer!.enabled).toBe(true);
+    expect(decomposer!.maxDepth).toBe(2);
+    expect(decomposer!.model).toBe("MiniMax-M2.7");
+    expect(decomposer!.provider).toBe("minimax");
+    expect(decomposer!.requireApproval).toBe(false);
+  });
+
+  it("config without decomposer section uses defaults", () => {
+    const config = validateConfig({
+      projects: {
+        "my-app": {
+          path: "/repos/my-app",
+          repo: "org/my-app",
+          defaultBranch: "main",
+        },
+      },
+    });
+
+    // decomposer section is optional at project level
+    const decomposer = config.projects["my-app"].decomposer;
+    // When not specified, the full default object is applied
+    if (decomposer) {
+      expect(decomposer.provider).toBe("anthropic");
+      expect(decomposer.enabled).toBe(false);
+    }
+  });
+
+  it("MiniMax decomposer config alongside Anthropic agent config", () => {
+    const config = validateConfig({
+      defaults: {
+        agent: "claude-code",
+      },
+      projects: {
+        "my-app": {
+          path: "/repos/my-app",
+          repo: "org/my-app",
+          defaultBranch: "main",
+          agentConfig: {
+            model: "opus",
+            permissions: "permissionless",
+          },
+          decomposer: {
+            enabled: true,
+            provider: "minimax",
+            model: "MiniMax-M2.7",
+          },
+        },
+      },
+    });
+
+    // Agent uses Anthropic (Claude Code)
+    expect(config.defaults.agent).toBe("claude-code");
+    expect(config.projects["my-app"].agentConfig?.model).toBe("opus");
+
+    // Decomposer uses MiniMax
+    expect(config.projects["my-app"].decomposer?.provider).toBe("minimax");
+    expect(config.projects["my-app"].decomposer?.model).toBe("MiniMax-M2.7");
+  });
+});

--- a/packages/core/src/__tests__/decomposer-integration.test.ts
+++ b/packages/core/src/__tests__/decomposer-integration.test.ts
@@ -113,7 +113,7 @@ describe("decompose() — MiniMax provider", () => {
     const config: DecomposerConfig = {
       enabled: true,
       maxDepth: 3,
-      model: "MiniMax-M2.7",
+      model: "MiniMax-M3",
       requireApproval: false,
       provider: "minimax",
     };
@@ -142,7 +142,7 @@ describe("decompose() — MiniMax provider", () => {
     const config: DecomposerConfig = {
       enabled: true,
       maxDepth: 3,
-      model: "MiniMax-M2.7",
+      model: "MiniMax-M3",
       requireApproval: true,
       provider: "minimax",
     };
@@ -166,7 +166,7 @@ describe("Config integration — decomposer provider", () => {
           decomposer: {
             enabled: true,
             maxDepth: 2,
-            model: "MiniMax-M2.7",
+            model: "MiniMax-M3",
             provider: "minimax",
             requireApproval: false,
           },
@@ -178,7 +178,7 @@ describe("Config integration — decomposer provider", () => {
     expect(decomposer).toBeDefined();
     expect(decomposer!.enabled).toBe(true);
     expect(decomposer!.maxDepth).toBe(2);
-    expect(decomposer!.model).toBe("MiniMax-M2.7");
+    expect(decomposer!.model).toBe("MiniMax-M3");
     expect(decomposer!.provider).toBe("minimax");
     expect(decomposer!.requireApproval).toBe(false);
   });
@@ -220,7 +220,7 @@ describe("Config integration — decomposer provider", () => {
           decomposer: {
             enabled: true,
             provider: "minimax",
-            model: "MiniMax-M2.7",
+            model: "MiniMax-M3",
           },
         },
       },
@@ -232,6 +232,6 @@ describe("Config integration — decomposer provider", () => {
 
     // Decomposer uses MiniMax
     expect(config.projects["my-app"].decomposer?.provider).toBe("minimax");
-    expect(config.projects["my-app"].decomposer?.model).toBe("MiniMax-M2.7");
+    expect(config.projects["my-app"].decomposer?.model).toBe("MiniMax-M3");
   });
 });

--- a/packages/core/src/__tests__/decomposer.test.ts
+++ b/packages/core/src/__tests__/decomposer.test.ts
@@ -1,0 +1,575 @@
+/**
+ * Unit tests for decomposer module — LLM provider abstraction, thinking-tag
+ * stripping, config validation, and MiniMax integration.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  formatLineage,
+  formatSiblings,
+  getLeaves,
+  getSiblings,
+  formatPlanTree,
+  propagateStatus,
+  stripThinkingTags,
+  createLLMClient,
+  DEFAULT_DECOMPOSER_CONFIG,
+} from "../decomposer.js";
+import type { TaskNode, DecomposerConfig } from "../decomposer.js";
+
+// =============================================================================
+// HELPER FACTORIES
+// =============================================================================
+
+function makeTaskNode(overrides: Partial<TaskNode> = {}): TaskNode {
+  return {
+    id: "1",
+    depth: 0,
+    description: "Test task",
+    status: "pending",
+    lineage: [],
+    children: [],
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// stripThinkingTags
+// =============================================================================
+
+describe("stripThinkingTags", () => {
+  it("removes single thinking block", () => {
+    const input = '<think>Let me analyze this...</think>atomic';
+    expect(stripThinkingTags(input)).toBe("atomic");
+  });
+
+  it("removes multiple thinking blocks", () => {
+    const input = '<think>First thought</think>some text<think>Second thought</think>result';
+    expect(stripThinkingTags(input)).toBe("some textresult");
+  });
+
+  it("handles multiline thinking blocks", () => {
+    const input = `<think>
+Let me think about this carefully.
+This task involves multiple concerns.
+</think>
+composite`;
+    expect(stripThinkingTags(input)).toBe("composite");
+  });
+
+  it("preserves text without thinking tags", () => {
+    const input = '["Build API endpoint", "Create frontend form"]';
+    expect(stripThinkingTags(input)).toBe('["Build API endpoint", "Create frontend form"]');
+  });
+
+  it("handles empty thinking tags", () => {
+    const input = "<think></think>atomic";
+    expect(stripThinkingTags(input)).toBe("atomic");
+  });
+
+  it("handles empty string input", () => {
+    expect(stripThinkingTags("")).toBe("");
+  });
+
+  it("strips thinking before JSON array output", () => {
+    const input =
+      '<think>This is a composite task with backend and frontend work</think>["Implement REST API", "Build React UI"]';
+    const result = stripThinkingTags(input);
+    expect(result).toBe('["Implement REST API", "Build React UI"]');
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+});
+
+// =============================================================================
+// createLLMClient
+// =============================================================================
+
+describe("createLLMClient", () => {
+  it("creates anthropic client by default", () => {
+    const client = createLLMClient();
+    expect(client).toBeDefined();
+    expect(typeof client.chatCompletion).toBe("function");
+  });
+
+  it("creates anthropic client explicitly", () => {
+    const client = createLLMClient("anthropic");
+    expect(client).toBeDefined();
+    expect(typeof client.chatCompletion).toBe("function");
+  });
+
+  it("throws when creating minimax client without API key", () => {
+    const original = process.env["MINIMAX_API_KEY"];
+    delete process.env["MINIMAX_API_KEY"];
+
+    expect(() => createLLMClient("minimax")).toThrow("MINIMAX_API_KEY");
+
+    if (original) process.env["MINIMAX_API_KEY"] = original;
+  });
+
+  it("creates minimax client when API key is set", () => {
+    const original = process.env["MINIMAX_API_KEY"];
+    process.env["MINIMAX_API_KEY"] = "test-key-123";
+
+    const client = createLLMClient("minimax");
+    expect(client).toBeDefined();
+    expect(typeof client.chatCompletion).toBe("function");
+
+    if (original) {
+      process.env["MINIMAX_API_KEY"] = original;
+    } else {
+      delete process.env["MINIMAX_API_KEY"];
+    }
+  });
+});
+
+// =============================================================================
+// MiniMax client — fetch-based tests
+// =============================================================================
+
+describe("MiniMax LLM client", () => {
+  const originalKey = process.env["MINIMAX_API_KEY"];
+  const originalBaseURL = process.env["MINIMAX_BASE_URL"];
+
+  beforeEach(() => {
+    process.env["MINIMAX_API_KEY"] = "test-minimax-key";
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    if (originalKey) {
+      process.env["MINIMAX_API_KEY"] = originalKey;
+    } else {
+      delete process.env["MINIMAX_API_KEY"];
+    }
+    if (originalBaseURL) {
+      process.env["MINIMAX_BASE_URL"] = originalBaseURL;
+    } else {
+      delete process.env["MINIMAX_BASE_URL"];
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("sends correct request to MiniMax API", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: "atomic" } }],
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const client = createLLMClient("minimax");
+    const result = await client.chatCompletion({
+      model: "MiniMax-M2.7",
+      maxTokens: 10,
+      system: "You are a classifier.",
+      userMessage: "Classify this task.",
+    });
+
+    expect(result).toBe("atomic");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.minimax.io/v1/chat/completions");
+    expect(options.method).toBe("POST");
+
+    const headers = options.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer test-minimax-key");
+    expect(headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse(options.body as string);
+    expect(body.model).toBe("MiniMax-M2.7");
+    expect(body.max_tokens).toBe(10);
+    expect(body.temperature).toBeGreaterThanOrEqual(0);
+    expect(body.temperature).toBeLessThanOrEqual(1);
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].role).toBe("system");
+    expect(body.messages[1].role).toBe("user");
+  });
+
+  it("strips thinking tags from MiniMax response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [
+              {
+                message: {
+                  content: "<think>Let me analyze...</think>composite",
+                },
+              },
+            ],
+          }),
+      }),
+    );
+
+    const client = createLLMClient("minimax");
+    const result = await client.chatCompletion({
+      model: "MiniMax-M2.7",
+      maxTokens: 10,
+      system: "Classify.",
+      userMessage: "Task.",
+    });
+
+    expect(result).toBe("composite");
+  });
+
+  it("handles MiniMax API error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('{"error":"invalid_api_key"}'),
+      }),
+    );
+
+    const client = createLLMClient("minimax");
+    await expect(
+      client.chatCompletion({
+        model: "MiniMax-M2.7",
+        maxTokens: 10,
+        system: "Classify.",
+        userMessage: "Task.",
+      }),
+    ).rejects.toThrow("MiniMax API error (401)");
+  });
+
+  it("respects custom MINIMAX_BASE_URL", async () => {
+    process.env["MINIMAX_BASE_URL"] = "https://custom-proxy.example.com/v1";
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: "atomic" } }],
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const client = createLLMClient("minimax");
+    await client.chatCompletion({
+      model: "MiniMax-M2.7",
+      maxTokens: 10,
+      system: "Classify.",
+      userMessage: "Task.",
+    });
+
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://custom-proxy.example.com/v1/chat/completions");
+  });
+
+  it("returns decomposition JSON from MiniMax", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [
+              {
+                message: {
+                  content:
+                    '<think>Breaking this into parts...</think>["Build REST API", "Create React frontend"]',
+                },
+              },
+            ],
+          }),
+      }),
+    );
+
+    const client = createLLMClient("minimax");
+    const result = await client.chatCompletion({
+      model: "MiniMax-M2.7",
+      maxTokens: 1024,
+      system: "Decompose.",
+      userMessage: "Build a full-stack app.",
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed).toEqual(["Build REST API", "Create React frontend"]);
+  });
+
+  it("handles empty choices from MiniMax", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [],
+          }),
+      }),
+    );
+
+    const client = createLLMClient("minimax");
+    const result = await client.chatCompletion({
+      model: "MiniMax-M2.7",
+      maxTokens: 10,
+      system: "Classify.",
+      userMessage: "Task.",
+    });
+
+    expect(result).toBe("");
+  });
+});
+
+// =============================================================================
+// DEFAULT_DECOMPOSER_CONFIG
+// =============================================================================
+
+describe("DEFAULT_DECOMPOSER_CONFIG", () => {
+  it("has expected defaults", () => {
+    expect(DEFAULT_DECOMPOSER_CONFIG).toEqual({
+      enabled: false,
+      maxDepth: 3,
+      model: "claude-sonnet-4-20250514",
+      requireApproval: true,
+      provider: "anthropic",
+    });
+  });
+});
+
+// =============================================================================
+// Config schema — provider field
+// =============================================================================
+
+describe("DecomposerConfig provider field", () => {
+  it("accepts anthropic provider", async () => {
+    const { validateConfig } = await import("../config.js");
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          decomposer: {
+            enabled: true,
+            provider: "anthropic",
+            model: "claude-sonnet-4-20250514",
+          },
+        },
+      },
+    });
+
+    expect(config.projects.proj1.decomposer?.provider).toBe("anthropic");
+  });
+
+  it("accepts minimax provider", async () => {
+    const { validateConfig } = await import("../config.js");
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          decomposer: {
+            enabled: true,
+            provider: "minimax",
+            model: "MiniMax-M2.7",
+          },
+        },
+      },
+    });
+
+    expect(config.projects.proj1.decomposer?.provider).toBe("minimax");
+    expect(config.projects.proj1.decomposer?.model).toBe("MiniMax-M2.7");
+  });
+
+  it("defaults provider to anthropic", async () => {
+    const { validateConfig } = await import("../config.js");
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          decomposer: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    expect(config.projects.proj1.decomposer?.provider).toBe("anthropic");
+  });
+
+  it("rejects invalid provider", async () => {
+    const { validateConfig } = await import("../config.js");
+    expect(() =>
+      validateConfig({
+        projects: {
+          proj1: {
+            path: "/repos/test",
+            repo: "org/test",
+            defaultBranch: "main",
+            decomposer: {
+              enabled: true,
+              provider: "invalid-provider",
+            },
+          },
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+// =============================================================================
+// EXISTING PURE FUNCTION TESTS
+// =============================================================================
+
+describe("formatLineage", () => {
+  it("formats empty lineage with current task", () => {
+    const result = formatLineage([], "Build auth module");
+    expect(result).toBe("0. Build auth module  <-- (this task)");
+  });
+
+  it("formats deep lineage hierarchy", () => {
+    const result = formatLineage(["Full-stack app", "Backend services"], "Auth endpoint");
+    expect(result).toContain("0. Full-stack app");
+    expect(result).toContain("  1. Backend services");
+    expect(result).toContain("    2. Auth endpoint  <-- (this task)");
+  });
+});
+
+describe("formatSiblings", () => {
+  it("returns empty string for no siblings", () => {
+    expect(formatSiblings([], "Task")).toBe("");
+  });
+
+  it("marks current task with arrow", () => {
+    const result = formatSiblings(["Backend", "Frontend"], "Backend");
+    expect(result).toContain("Backend  <-- (you)");
+    expect(result).toContain("  - Frontend");
+  });
+});
+
+describe("getLeaves", () => {
+  it("returns single node when no children", () => {
+    const node = makeTaskNode();
+    expect(getLeaves(node)).toEqual([node]);
+  });
+
+  it("returns all leaf nodes from nested tree", () => {
+    const tree = makeTaskNode({
+      id: "1",
+      children: [
+        makeTaskNode({
+          id: "1.1",
+          children: [
+            makeTaskNode({ id: "1.1.1", description: "Leaf A" }),
+            makeTaskNode({ id: "1.1.2", description: "Leaf B" }),
+          ],
+        }),
+        makeTaskNode({ id: "1.2", description: "Leaf C" }),
+      ],
+    });
+
+    const leaves = getLeaves(tree);
+    expect(leaves).toHaveLength(3);
+    expect(leaves.map((l) => l.description)).toEqual(["Leaf A", "Leaf B", "Leaf C"]);
+  });
+});
+
+describe("getSiblings", () => {
+  it("returns empty for root task", () => {
+    const root = makeTaskNode({ id: "1" });
+    expect(getSiblings(root, "1")).toEqual([]);
+  });
+
+  it("returns sibling descriptions", () => {
+    const root = makeTaskNode({
+      id: "1",
+      children: [
+        makeTaskNode({ id: "1.1", description: "Backend" }),
+        makeTaskNode({ id: "1.2", description: "Frontend" }),
+        makeTaskNode({ id: "1.3", description: "Tests" }),
+      ],
+    });
+
+    const siblings = getSiblings(root, "1.2");
+    expect(siblings).toEqual(["Backend", "Tests"]);
+  });
+});
+
+describe("propagateStatus", () => {
+  it("marks parent done when all children done", () => {
+    const tree = makeTaskNode({
+      children: [
+        makeTaskNode({ status: "done" }),
+        makeTaskNode({ status: "done" }),
+      ],
+    });
+
+    propagateStatus(tree);
+    expect(tree.status).toBe("done");
+  });
+
+  it("marks parent failed when any child failed", () => {
+    const tree = makeTaskNode({
+      children: [
+        makeTaskNode({ status: "done" }),
+        makeTaskNode({ status: "failed" }),
+      ],
+    });
+
+    propagateStatus(tree);
+    expect(tree.status).toBe("failed");
+  });
+
+  it("marks parent running when some children done", () => {
+    const tree = makeTaskNode({
+      children: [
+        makeTaskNode({ status: "done" }),
+        makeTaskNode({ status: "pending" }),
+      ],
+    });
+
+    propagateStatus(tree);
+    expect(tree.status).toBe("running");
+  });
+
+  it("does not change status for leaf nodes", () => {
+    const leaf = makeTaskNode({ status: "pending" });
+    propagateStatus(leaf);
+    expect(leaf.status).toBe("pending");
+  });
+});
+
+describe("formatPlanTree", () => {
+  it("formats atomic leaf node", () => {
+    const node = makeTaskNode({
+      id: "1.1",
+      kind: "atomic",
+      description: "Build API",
+      status: "ready",
+    });
+
+    const result = formatPlanTree(node);
+    expect(result).toContain("[ATOMIC]");
+    expect(result).toContain("Build API");
+  });
+
+  it("formats composite tree with children", () => {
+    const tree = makeTaskNode({
+      id: "1",
+      kind: "composite",
+      description: "Full-stack app",
+      status: "ready",
+      children: [
+        makeTaskNode({ id: "1.1", kind: "atomic", description: "Backend", status: "ready" }),
+        makeTaskNode({ id: "1.2", kind: "atomic", description: "Frontend", status: "ready" }),
+      ],
+    });
+
+    const result = formatPlanTree(tree);
+    expect(result).toContain("[COMPOSITE]");
+    expect(result).toContain("Full-stack app");
+    expect(result).toContain("[ATOMIC]");
+    expect(result).toContain("Backend");
+    expect(result).toContain("Frontend");
+  });
+});

--- a/packages/core/src/__tests__/decomposer.test.ts
+++ b/packages/core/src/__tests__/decomposer.test.ts
@@ -161,7 +161,7 @@ describe("MiniMax LLM client", () => {
 
     const client = createLLMClient("minimax");
     const result = await client.chatCompletion({
-      model: "MiniMax-M2.7",
+      model: "MiniMax-M3",
       maxTokens: 10,
       system: "You are a classifier.",
       userMessage: "Classify this task.",
@@ -179,7 +179,7 @@ describe("MiniMax LLM client", () => {
     expect(headers["Content-Type"]).toBe("application/json");
 
     const body = JSON.parse(options.body as string);
-    expect(body.model).toBe("MiniMax-M2.7");
+    expect(body.model).toBe("MiniMax-M3");
     expect(body.max_tokens).toBe(10);
     expect(body.temperature).toBeGreaterThanOrEqual(0);
     expect(body.temperature).toBeLessThanOrEqual(1);
@@ -208,7 +208,7 @@ describe("MiniMax LLM client", () => {
 
     const client = createLLMClient("minimax");
     const result = await client.chatCompletion({
-      model: "MiniMax-M2.7",
+      model: "MiniMax-M3",
       maxTokens: 10,
       system: "Classify.",
       userMessage: "Task.",
@@ -230,7 +230,7 @@ describe("MiniMax LLM client", () => {
     const client = createLLMClient("minimax");
     await expect(
       client.chatCompletion({
-        model: "MiniMax-M2.7",
+        model: "MiniMax-M3",
         maxTokens: 10,
         system: "Classify.",
         userMessage: "Task.",
@@ -252,7 +252,7 @@ describe("MiniMax LLM client", () => {
 
     const client = createLLMClient("minimax");
     await client.chatCompletion({
-      model: "MiniMax-M2.7",
+      model: "MiniMax-M3",
       maxTokens: 10,
       system: "Classify.",
       userMessage: "Task.",
@@ -283,7 +283,7 @@ describe("MiniMax LLM client", () => {
 
     const client = createLLMClient("minimax");
     const result = await client.chatCompletion({
-      model: "MiniMax-M2.7",
+      model: "MiniMax-M3",
       maxTokens: 1024,
       system: "Decompose.",
       userMessage: "Build a full-stack app.",
@@ -307,7 +307,7 @@ describe("MiniMax LLM client", () => {
 
     const client = createLLMClient("minimax");
     const result = await client.chatCompletion({
-      model: "MiniMax-M2.7",
+      model: "MiniMax-M3",
       maxTokens: 10,
       system: "Classify.",
       userMessage: "Task.",
@@ -369,14 +369,14 @@ describe("DecomposerConfig provider field", () => {
           decomposer: {
             enabled: true,
             provider: "minimax",
-            model: "MiniMax-M2.7",
+            model: "MiniMax-M3",
           },
         },
       },
     });
 
     expect(config.projects.proj1.decomposer?.provider).toBe("minimax");
-    expect(config.projects.proj1.decomposer?.model).toBe("MiniMax-M2.7");
+    expect(config.projects.proj1.decomposer?.model).toBe("MiniMax-M3");
   });
 
   it("defaults provider to anthropic", async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -134,12 +134,14 @@ const DecomposerConfigSchema = z
     maxDepth: z.number().min(1).max(5).default(3),
     model: z.string().default("claude-sonnet-4-20250514"),
     requireApproval: z.boolean().default(true),
+    provider: z.enum(["anthropic", "minimax"]).default("anthropic"),
   })
   .default({
     enabled: false,
     maxDepth: 3,
     model: "claude-sonnet-4-20250514",
     requireApproval: true,
+    provider: "anthropic",
   });
 
 const ProjectConfigSchema = z.object({

--- a/packages/core/src/decomposer.ts
+++ b/packages/core/src/decomposer.ts
@@ -5,6 +5,10 @@
  * (needs to be broken into subtasks). Composite tasks are recursively
  * decomposed until all leaves are atomic.
  *
+ * Supports multiple LLM providers:
+ *   - Anthropic (default) — via @anthropic-ai/sdk
+ *   - MiniMax — via OpenAI-compatible API (https://api.minimax.io/v1)
+ *
  * Integration: sits upstream of SessionManager.spawn(). When enabled,
  * complex issues are decomposed into child issues before agents are spawned.
  */
@@ -17,6 +21,9 @@ import Anthropic from "@anthropic-ai/sdk";
 
 export type TaskKind = "atomic" | "composite";
 export type TaskStatus = "pending" | "decomposing" | "ready" | "running" | "done" | "failed";
+
+/** Supported decomposer LLM providers */
+export type DecomposerProvider = "anthropic" | "minimax";
 
 export interface TaskNode {
   id: string; // hierarchical: "1", "1.2", "1.2.3"
@@ -51,6 +58,12 @@ export interface DecomposerConfig {
   model: string;
   /** Require human approval before executing decomposed plans (default: true) */
   requireApproval: boolean;
+  /**
+   * LLM provider to use for decomposition (default: "anthropic").
+   * - "anthropic": uses Anthropic SDK (ANTHROPIC_API_KEY)
+   * - "minimax": uses MiniMax OpenAI-compatible API (MINIMAX_API_KEY)
+   */
+  provider?: DecomposerProvider;
 }
 
 export const DEFAULT_DECOMPOSER_CONFIG: DecomposerConfig = {
@@ -58,6 +71,7 @@ export const DEFAULT_DECOMPOSER_CONFIG: DecomposerConfig = {
   maxDepth: 3,
   model: "claude-sonnet-4-20250514",
   requireApproval: true,
+  provider: "anthropic",
 };
 
 // =============================================================================
@@ -76,6 +90,108 @@ export function formatSiblings(siblings: string[], current: string): string {
   if (siblings.length === 0) return "";
   const lines = siblings.map((s) => (s === current ? `  - ${s}  <-- (you)` : `  - ${s}`));
   return `Sibling tasks being worked on in parallel:\n${lines.join("\n")}`;
+}
+
+// =============================================================================
+// LLM CLIENT ABSTRACTION
+// =============================================================================
+
+/** Internal abstraction for LLM chat completion, allowing multiple providers. */
+interface LLMClient {
+  chatCompletion(params: {
+    model: string;
+    maxTokens: number;
+    system: string;
+    userMessage: string;
+  }): Promise<string>;
+}
+
+/** Create an Anthropic-backed LLM client. */
+function createAnthropicClient(): LLMClient {
+  const client = new Anthropic();
+  return {
+    async chatCompletion({ model, maxTokens, system, userMessage }) {
+      const res = await client.messages.create({
+        model,
+        max_tokens: maxTokens,
+        system,
+        messages: [{ role: "user", content: userMessage }],
+      });
+      return res.content[0].type === "text" ? res.content[0].text.trim() : "";
+    },
+  };
+}
+
+/**
+ * Strip MiniMax thinking tags from response text.
+ * MiniMax M2.5/M2.7 models may include <think>...</think> blocks in output.
+ */
+export function stripThinkingTags(text: string): string {
+  return text.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
+}
+
+/**
+ * Clamp temperature for MiniMax models.
+ * MiniMax accepts temperature in the range [0, 1.0].
+ */
+function clampTemperature(temp: number): number {
+  return Math.max(0, Math.min(1, temp));
+}
+
+/** Create a MiniMax-backed LLM client via OpenAI-compatible API. */
+function createMiniMaxClient(): LLMClient {
+  const apiKey = process.env["MINIMAX_API_KEY"];
+  if (!apiKey) {
+    throw new Error(
+      "MINIMAX_API_KEY environment variable is required when using provider: minimax. " +
+        "Get your API key at https://platform.minimaxi.com/",
+    );
+  }
+
+  const baseURL = process.env["MINIMAX_BASE_URL"] || "https://api.minimax.io/v1";
+
+  return {
+    async chatCompletion({ model, maxTokens, system, userMessage }) {
+      const response = await fetch(`${baseURL}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: maxTokens,
+          temperature: clampTemperature(0.1),
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: userMessage },
+          ],
+        }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`MiniMax API error (${response.status}): ${body}`);
+      }
+
+      const data = (await response.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+      const text = data.choices?.[0]?.message?.content ?? "";
+      return stripThinkingTags(text).trim();
+    },
+  };
+}
+
+/** Create an LLM client for the given provider. */
+export function createLLMClient(provider: DecomposerProvider = "anthropic"): LLMClient {
+  switch (provider) {
+    case "minimax":
+      return createMiniMaxClient();
+    case "anthropic":
+    default:
+      return createAnthropicClient();
+  }
 }
 
 // =============================================================================
@@ -112,39 +228,37 @@ Respond with a JSON array of strings, each being a subtask description. Example:
 Nothing else — just the JSON array.`;
 
 async function classifyTask(
-  client: Anthropic,
+  client: LLMClient,
   model: string,
   task: string,
   lineage: string[],
 ): Promise<TaskKind> {
   const context = formatLineage(lineage, task);
-  const res = await client.messages.create({
+  const text = await client.chatCompletion({
     model,
-    max_tokens: 10,
+    maxTokens: 10,
     system: CLASSIFY_SYSTEM,
-    messages: [{ role: "user", content: `Task hierarchy:\n${context}` }],
+    userMessage: `Task hierarchy:\n${context}`,
   });
 
-  const text = res.content[0].type === "text" ? res.content[0].text.trim().toLowerCase() : "";
-  return text === "composite" ? "composite" : "atomic";
+  return text.toLowerCase() === "composite" ? "composite" : "atomic";
 }
 
 async function decomposeTask(
-  client: Anthropic,
+  client: LLMClient,
   model: string,
   task: string,
   lineage: string[],
 ): Promise<string[]> {
   const context = formatLineage(lineage, task);
-  const res = await client.messages.create({
+  const text = await client.chatCompletion({
     model,
-    max_tokens: 1024,
+    maxTokens: 1024,
     system: DECOMPOSE_SYSTEM,
-    messages: [{ role: "user", content: `Task hierarchy:\n${context}` }],
+    userMessage: `Task hierarchy:\n${context}`,
   });
 
-  const text = res.content[0].type === "text" ? res.content[0].text.trim() : "[]";
-  const jsonMatch = text.match(/\[[\s\S]*\]/);
+  const jsonMatch = (text || "[]").match(/\[[\s\S]*\]/);
   if (!jsonMatch) {
     throw new Error(`Decomposition failed — no JSON array in response: ${text}`);
   }
@@ -172,7 +286,7 @@ function createTaskNode(
 
 /** Recursively decompose a task tree (planning phase — no execution). */
 async function planTree(
-  client: Anthropic,
+  client: LLMClient,
   model: string,
   task: TaskNode,
   maxDepth: number,
@@ -210,7 +324,7 @@ export async function decompose(
   taskDescription: string,
   config: DecomposerConfig = DEFAULT_DECOMPOSER_CONFIG,
 ): Promise<DecompositionPlan> {
-  const client = new Anthropic();
+  const client = createLLMClient(config.provider);
   const tree = createTaskNode("1", taskDescription, 0, []);
 
   await planTree(client, config.model, tree, config.maxDepth);

--- a/packages/core/src/decomposer.ts
+++ b/packages/core/src/decomposer.ts
@@ -124,7 +124,7 @@ function createAnthropicClient(): LLMClient {
 
 /**
  * Strip MiniMax thinking tags from response text.
- * MiniMax M2.5/M2.7 models may include <think>...</think> blocks in output.
+ * MiniMax M3/M2.7 models may include <think>...</think> blocks in output.
  */
 export function stripThinkingTags(text: string): string {
   return text.replace(/<think>[\s\S]*?<\/think>/g, "").trim();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,8 @@ export {
   formatLineage,
   formatSiblings,
   propagateStatus,
+  stripThinkingTags,
+  createLLMClient,
   DEFAULT_DECOMPOSER_CONFIG,
 } from "./decomposer.js";
 export type {
@@ -72,6 +74,7 @@ export type {
   TaskStatus,
   DecompositionPlan,
   DecomposerConfig,
+  DecomposerProvider,
 } from "./decomposer.js";
 
 // Orchestrator prompt — generates orchestrator context for `ao start`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1008,6 +1008,12 @@ export interface ProjectConfig {
     model: string;
     /** Require human approval before executing decomposed plans (default: true) */
     requireApproval: boolean;
+    /**
+     * LLM provider for decomposition (default: "anthropic").
+     * - "anthropic": uses Anthropic SDK (ANTHROPIC_API_KEY)
+     * - "minimax": uses MiniMax OpenAI-compatible API (MINIMAX_API_KEY)
+     */
+    provider?: "anthropic" | "minimax";
   };
 }
 


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimaxi.com) as an alternative LLM provider for the task decomposition module, alongside Anthropic. Default to `MiniMax-M3` (latest model, 512K context window, 128K max output, image input support).

- Introduce `provider` field in `DecomposerConfig` (`"anthropic"` | `"minimax"`)
- Create an internal `LLMClient` abstraction that routes to either Anthropic SDK or MiniMax OpenAI-compatible API
- Handle MiniMax-specific behaviors: temperature clamping to `[0, 1]`, `<think>` tag stripping for reasoning models (M3 / M2.7)
- Support `MINIMAX_API_KEY` env var and optional `MINIMAX_BASE_URL` override (defaults to `https://api.minimax.io/v1`)
- Update Zod config schema, example config, and README with MiniMax documentation

### Model lineup

| Model | Context | Output | Notes |
|-------|---------|--------|-------|
| `MiniMax-M3` (default) | 512K | 128K | Latest model, supports image input |
| `MiniMax-M2.7` | 192K | — | Previous-gen reasoning model |
| `MiniMax-M2.7-highspeed` | 192K | — | Previous-gen low-latency variant |

Older models (M2.5 / M2.1 / M2 / M1) are not surfaced in the documented lineup.

### Files changed

| File | Change |
|------|--------|
| `packages/core/src/decomposer.ts` | LLM client abstraction + MiniMax provider |
| `packages/core/src/config.ts` | Add provider enum to decomposer schema |
| `packages/core/src/types.ts` | Add provider field to decomposer config |
| `packages/core/src/index.ts` | Export new types |
| `packages/core/src/__tests__/decomposer.test.ts` | Unit tests (M3 default) |
| `packages/core/src/__tests__/decomposer-integration.test.ts` | Integration tests (M3 default) |
| `agent-orchestrator.yaml.example` | Decomposer config with MiniMax option |
| `README.md` | MiniMax provider documentation |

## Test plan

- [x] Unit tests pass (mock-based, no real API calls)
- [x] Integration tests pass with mocked provider
- [x] `pnpm build` succeeds with no type errors