### PR TITLE
fix(cli): propagate signals to dashboard child and scan port range on stop

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -644,6 +644,15 @@ async function runStartup(
       }
       process.exit(code ?? 0);
     });
+
+    // Propagate termination signals to the dashboard child so it doesn't
+    // become an orphan when the user presses Ctrl+C or the parent is killed.
+    const killDashboard = (): void => {
+      try { dashboardProcess?.kill("SIGTERM"); } catch { /* already dead */ }
+    };
+    process.on("SIGINT", killDashboard);
+    process.on("SIGTERM", killDashboard);
+    process.on("exit", killDashboard);
   }
 
   return port;
@@ -652,27 +661,44 @@ async function runStartup(
 /**
  * Stop dashboard server.
  * Uses lsof to find the process listening on the port, then kills it.
+ * If nothing is found on the given port, scans the port range
+ * [port+1 .. port+MAX_PORT_SCAN] to catch orphaned processes that were
+ * started on a reassigned port (e.g. when the original port was busy).
  * Best effort — if it fails, just warn the user.
  */
 async function stopDashboard(port: number): Promise<void> {
-  try {
-    // Find PIDs listening on the port (can be multiple: parent + children)
-    const { stdout } = await exec("lsof", ["-ti", `:${port}`]);
-    const pids = stdout
-      .trim()
-      .split("\n")
-      .filter((p) => p.length > 0);
-
-    if (pids.length > 0) {
-      // Kill all processes (pass PIDs as separate arguments)
+  // Try to kill by port. Returns true if a process was found and killed.
+  async function killOnPort(p: number): Promise<boolean> {
+    try {
+      const { stdout } = await exec("lsof", ["-ti", `:${p}`]);
+      const pids = stdout
+        .trim()
+        .split("\n")
+        .filter((line) => line.length > 0);
+      if (pids.length === 0) return false;
       await exec("kill", pids);
-      console.log(chalk.green("Dashboard stopped"));
-    } else {
-      console.log(chalk.yellow(`Dashboard not running on port ${port}`));
+      return true;
+    } catch {
+      return false;
     }
-  } catch {
-    console.log(chalk.yellow("Could not stop dashboard (may not be running)"));
   }
+
+  // 1. Try the expected port first.
+  if (await killOnPort(port)) {
+    console.log(chalk.green("Dashboard stopped"));
+    return;
+  }
+
+  // 2. Fallback: scan the port range to find an orphaned dashboard that was
+  //    auto-reassigned to a different port at startup.
+  for (let p = port + 1; p <= port + MAX_PORT_SCAN; p++) {
+    if (await killOnPort(p)) {
+      console.log(chalk.green(`Dashboard stopped (was on port ${p})`));
+      return;
+    }
+  }
+
+  console.log(chalk.yellow("Could not stop dashboard (may not be running)"));
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes two related issues that caused `ao stop` to fail killing the dashboard when it was started on a reassigned port (#645):

- **Signal propagation**: Register `SIGINT`/`SIGTERM`/`exit` handlers in `runStartup` so the dashboard child process is explicitly killed when the user presses `Ctrl+C` or the parent exits. Node.js does not guarantee signal propagation to non-detached child processes.
- **Port range fallback in `stopDashboard`**: When `ao start` is Ctrl+C'd, its PID is dead so `getRunning()` prunes `running.json` and returns `null`, causing the stop logic to fall back to `config.port` (e.g. 3000). If the dashboard was actually started on a reassigned port (e.g. 3006), `lsof` finds nothing there and the process is left running. The fix scans `[port+1 .. port+MAX_PORT_SCAN]` as a fallback to find and kill the orphaned process.

Closes #645

## Test plan

- [ ] Start with port 3000 occupied → verify `ao start` picks a new port (e.g. 3006)
- [ ] Press `Ctrl+C` → verify next-server is killed immediately (no orphan)
- [ ] Start again with port 3000 occupied, then `ao stop` → verify dashboard on reassigned port is found and killed, no "Could not stop dashboard" message
- [ ] Normal flow (port 3000 free) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)