### PR TITLE
fix(agent-claude-code): restore Claude CLI colors when spawned via piped stdio

### DIFF
--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -266,6 +266,12 @@ describe("getEnvironment", () => {
     expect(env["CLAUDECODE"]).toBe("");
   });
 
+  it("forces ANSI colors for piped stdio launches", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["FORCE_COLOR"]).toBe("1");
+    expect(env["TERM"]).toBe("xterm-256color");
+  });
+
   it("sets AO_SESSION_ID but not AO_PROJECT_ID (caller's responsibility)", () => {
     const env = agent.getEnvironment(makeLaunchConfig());
     expect(env["AO_SESSION_ID"]).toBe("sess-1");

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -699,6 +699,12 @@ function createClaudeCodeAgent(): Agent {
       // Unset CLAUDECODE to avoid nested agent conflicts
       env["CLAUDECODE"] = "";
 
+      // Force color output even when stdout is piped (not a TTY).
+      // Without this, Claude CLI detects no TTY and disables colors,
+      // making its output look different from running Claude directly.
+      env["FORCE_COLOR"] = "1";
+      env["TERM"] = "xterm-256color";
+
       // Set session info for introspection
       env["AO_SESSION_ID"] = config.sessionId;
 

--- a/packages/web/src/components/__tests__/DirectTerminal.test.ts
+++ b/packages/web/src/components/__tests__/DirectTerminal.test.ts
@@ -34,12 +34,21 @@ function contrastRatio(a: string, b: string): number {
 }
 
 describe("buildTerminalThemes", () => {
-  it("dark theme has valid hex colors for bg, fg, and all ANSI slots", () => {
-    const { dark } = buildTerminalThemes("agent");
+  it("orchestrator dark theme has valid hex colors for bg, fg, and all ANSI slots", () => {
+    const { dark } = buildTerminalThemes("orchestrator");
     expect(dark.background).toMatch(HEX_RE);
     expect(dark.foreground).toMatch(HEX_RE);
     for (const key of ANSI_KEYS) {
       expect(dark[key]).toMatch(HEX_RE);
+    }
+  });
+
+  it("agent dark theme leaves ANSI slots unset so terminal-native colors are preserved", () => {
+    const { dark } = buildTerminalThemes("agent");
+    expect(dark.background).toMatch(HEX_RE);
+    expect(dark.foreground).toMatch(HEX_RE);
+    for (const key of ANSI_KEYS) {
+      expect(dark[key]).toBeUndefined();
     }
   });
 
@@ -73,12 +82,21 @@ describe("buildTerminalThemes", () => {
     expect(agent.light.selectionBackground).toBe(orch.light.selectionBackground);
   });
 
+  it("orchestrator dark theme keeps its AO-specific ANSI palette", () => {
+    const { dark } = buildTerminalThemes("orchestrator");
+    expect(dark.blue).toBe("#5b7ef8");
+    expect(dark.magenta).toBe("#a371f7");
+  });
+
   it("keeps ANSI magenta distinct from ANSI blue", () => {
-    const { dark, light } = buildTerminalThemes("agent");
-    expect(dark.magenta).not.toBe(dark.blue);
-    expect(dark.brightMagenta).not.toBe(dark.brightBlue);
-    expect(light.magenta).not.toBe(light.blue);
-    expect(light.brightMagenta).not.toBe(light.brightBlue);
+    const { dark: agentDark, light: agentLight } = buildTerminalThemes("agent");
+    const { dark: orchDark } = buildTerminalThemes("orchestrator");
+    expect(agentDark.magenta).toBeUndefined();
+    expect(agentDark.brightMagenta).toBeUndefined();
+    expect(orchDark.magenta).not.toBe(orchDark.blue);
+    expect(orchDark.brightMagenta).not.toBe(orchDark.brightBlue);
+    expect(agentLight.magenta).not.toBe(agentLight.blue);
+    expect(agentLight.brightMagenta).not.toBe(agentLight.brightBlue);
   });
 
   it("selection colors differ between dark and light themes", () => {

--- a/packages/web/src/components/terminal/terminal-themes.ts
+++ b/packages/web/src/components/terminal/terminal-themes.ts
@@ -2,7 +2,7 @@ import type { ITheme } from "@xterm/xterm";
 
 export type TerminalVariant = "agent" | "orchestrator";
 
-export function buildTerminalThemes(_variant: TerminalVariant): { dark: ITheme; light: ITheme } {
+export function buildTerminalThemes(variant: TerminalVariant): { dark: ITheme; light: ITheme } {
   // Orchestrator and agent currently share the design-system accent; the
   // variant parameter is preserved for API compatibility and future divergence.
   const accent = {
@@ -18,23 +18,27 @@ export function buildTerminalThemes(_variant: TerminalVariant): { dark: ITheme; 
     cursorAccent: "#0a0a0f",
     selectionBackground: accent.selDark,
     selectionInactiveBackground: "rgba(128, 128, 128, 0.2)",
-    // ANSI colors — slightly warmer than pure defaults
-    black: "#1a1a24",
-    red: "#ef4444",
-    green: "#22c55e",
-    yellow: "#f59e0b",
-    blue: "#5b7ef8",
-    magenta: "#a371f7",
-    cyan: "#22d3ee",
-    white: "#d4d4d8",
-    brightBlack: "#50506a",
-    brightRed: "#f87171",
-    brightGreen: "#4ade80",
-    brightYellow: "#fbbf24",
-    brightBlue: "#7b9cfb",
-    brightMagenta: "#c084fc",
-    brightCyan: "#67e8f9",
-    brightWhite: "#eeeef5",
+    ...(variant === "orchestrator"
+      ? {
+          // Keep the orchestrator terminal aligned with the AO design system.
+          black: "#1a1a24",
+          red: "#ef4444",
+          green: "#22c55e",
+          yellow: "#f59e0b",
+          blue: "#5b7ef8",
+          magenta: "#a371f7",
+          cyan: "#22d3ee",
+          white: "#d4d4d8",
+          brightBlack: "#50506a",
+          brightRed: "#f87171",
+          brightGreen: "#4ade80",
+          brightYellow: "#fbbf24",
+          brightBlue: "#7b9cfb",
+          brightMagenta: "#c084fc",
+          brightCyan: "#67e8f9",
+          brightWhite: "#eeeef5",
+        }
+      : {}),
   };
 
   const light: ITheme = {


### PR DESCRIPTION
## Summary

- Claude CLI disables colors when `stdout` is not a TTY (which happens when the process runtime uses `stdio: ["pipe","pipe","pipe"]`).
- This made Claude's output inside ao look visually different (no colors) compared to running Claude directly in a terminal.
- Fixed by setting `FORCE_COLOR=1` and `TERM=xterm-256color` in the agent environment, so Claude preserves its normal color scheme regardless of TTY detection.

## Test plan
- [ ] Verify Claude CLI output inside ao shows the same colors as running `claude` directly in a terminal
- [ ] All 149 unit tests in `agent-claude-code` package pass

Closes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)