### PR TITLE
fix: surface notifier delivery failures

### DIFF
--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -479,6 +479,34 @@ describe("Config Schema Validation", () => {
     expect(config.projects.proj1.agentConfig?.permissions).toBe("suggest");
     expect(config.projects.proj1.worker?.agentConfig?.permissions).toBeUndefined();
   });
+
+  it("rejects notifier names containing dots", () => {
+    expect(() =>
+      validateConfig({
+        defaults: {
+          notifiers: ["team.slack"],
+        },
+        notifiers: {
+          "team.slack": {
+            plugin: "desktop",
+          },
+        },
+        notificationRouting: {
+          urgent: ["team.slack"],
+          action: ["team.slack"],
+          warning: [],
+          info: [],
+        },
+        projects: {
+          proj1: {
+            path: "/repos/test",
+            repo: "org/test",
+            defaultBranch: "main",
+          },
+        },
+      }),
+    ).toThrow(/notifier names.*dot/i);
+  });
 });
 
 describe("Config Defaults", () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1343,7 +1343,12 @@ describe("reactions", () => {
     expect(metadata?.["notifier.desktop.status"]).toBe("ok");
   });
 
-  it("retries notify reactions when no notifier plugin resolves", async () => {
+  it("retries notify reactions when configured notifiers become available later", async () => {
+    const recoveredNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
     const mockSCM: SCM = {
       name: "mock-scm",
       detectPR: vi.fn(),
@@ -1370,11 +1375,14 @@ describe("reactions", () => {
       getMergeability: vi.fn(),
     };
 
-    const registryGet = vi.fn().mockImplementation((slot: string) => {
+    let notifierAvailable = false;
+    const registryGet = vi.fn().mockImplementation((slot: string, name: string) => {
       if (slot === "runtime") return mockRuntime;
       if (slot === "agent") return mockAgent;
       if (slot === "scm") return mockSCM;
-      if (slot === "notifier") return null;
+      if (slot === "notifier" && name === "desktop") {
+        return notifierAvailable ? recoveredNotifier : null;
+      }
       return null;
     });
 
@@ -1422,21 +1430,31 @@ describe("reactions", () => {
     await lm.check("app-1");
     let metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
-    expect(registryGet).toHaveBeenCalledWith("notifier", "desktop");
-    expect(
-      registryGet.mock.calls.filter(
-        ([slot, name]) => slot === "notifier" && name === "desktop",
-      ),
-    ).toHaveLength(1);
+    expect(recoveredNotifier.notify).not.toHaveBeenCalled();
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBe("1");
+    expect(metadata?.["reaction.changes-requested.firstTriggeredAt"]).toBeTruthy();
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBe("desktop");
 
     await lm.check("app-1");
     metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
-    expect(
-      registryGet.mock.calls.filter(
-        ([slot, name]) => slot === "notifier" && name === "desktop",
-      ),
-    ).toHaveLength(2);
+    expect(recoveredNotifier.notify).not.toHaveBeenCalled();
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBe("1");
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBe("desktop");
+
+    notifierAvailable = true;
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
+    expect(recoveredNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.firstTriggeredAt"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBeUndefined();
+
+    await lm.check("app-1");
+    expect(recoveredNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(registryGet).toHaveBeenCalledWith("notifier", "desktop");
   });
 
   it("does not persist review dispatch hashes when escalation notify delivery fails", async () => {
@@ -1540,7 +1558,12 @@ describe("reactions", () => {
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
   });
 
-  it("retries escalation when no notifier plugin resolves", async () => {
+  it("retries escalation when configured notifiers become available later", async () => {
+    const recoveredNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
     const mockSCM: SCM = {
       name: "mock-scm",
       detectPR: vi.fn(),
@@ -1567,11 +1590,14 @@ describe("reactions", () => {
       getMergeability: vi.fn(),
     };
 
-    const registryGet = vi.fn().mockImplementation((slot: string) => {
+    let notifierAvailable = false;
+    const registryGet = vi.fn().mockImplementation((slot: string, name: string) => {
       if (slot === "runtime") return mockRuntime;
       if (slot === "agent") return mockAgent;
       if (slot === "scm") return mockSCM;
-      if (slot === "notifier") return null;
+      if (slot === "notifier" && name === "desktop") {
+        return notifierAvailable ? recoveredNotifier : null;
+      }
       return null;
     });
 
@@ -1628,23 +1654,29 @@ describe("reactions", () => {
     await lm.check("app-1");
     metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
-    // Poll 2 must be the escalation path, not another send-to-agent attempt.
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
-    expect(
-      registryGet.mock.calls.filter(
-        ([slot, name]) => slot === "notifier" && name === "desktop",
-      ),
-    ).toHaveLength(1);
+    expect(recoveredNotifier.notify).not.toHaveBeenCalled();
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBe("2");
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBe("desktop");
 
     await lm.check("app-1");
     metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
-    expect(
-      registryGet.mock.calls.filter(
-        ([slot, name]) => slot === "notifier" && name === "desktop",
-      ),
-    ).toHaveLength(2);
+    expect(recoveredNotifier.notify).not.toHaveBeenCalled();
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBe("2");
+
+    notifierAvailable = true;
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(recoveredNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.firstTriggeredAt"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBeUndefined();
+    expect(registryGet).toHaveBeenCalledWith("notifier", "desktop");
   });
 
   it("does not treat an empty notification route as successful delivery", async () => {
@@ -1849,6 +1881,109 @@ describe("reactions", () => {
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
     expect(notifier.notify).toHaveBeenCalledTimes(1);
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.firstTriggeredAt"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBeUndefined();
+
+    await lm2.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(notifier.notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries auto-merge notifications while the session remains mergeable", async () => {
+    const flakyNotifier: Notifier = {
+      name: "desktop",
+      notify: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("OpenClaw unavailable"))
+        .mockResolvedValueOnce(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      }),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return flakyNotifier;
+        return null;
+      }),
+    };
+
+    const configWithAutoMergeReaction: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        action: ["desktop"],
+      },
+      reactions: {
+        ...config.reactions,
+        "approved-and-green": {
+          auto: true,
+          action: "auto-merge",
+          priority: "action",
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithAutoMergeReaction,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(flakyNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["status"]).toBe("mergeable");
+    expect(metadata?.["reaction.approved-and-green.attempts"]).toBe("1");
+    expect(metadata?.["reaction.approved-and-green.firstTriggeredAt"]).toBeTruthy();
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(flakyNotifier.notify).toHaveBeenCalledTimes(2);
+    expect(metadata?.["status"]).toBe("mergeable");
+    expect(metadata?.["reaction.approved-and-green.attempts"]).toBeUndefined();
+    expect(metadata?.["reaction.approved-and-green.firstTriggeredAt"]).toBeUndefined();
+    expect(metadata?.["reaction.approved-and-green.unresolvedNotifierSignature"]).toBeUndefined();
+
+    await lm.check("app-1");
+    expect(flakyNotifier.notify).toHaveBeenCalledTimes(2);
   });
 
   it("does not double-send when changes_requested transition already triggered the reaction", async () => {
@@ -2523,6 +2658,67 @@ describe("reactions", () => {
             trace.data?.["notifier"] === "desktop",
         ),
       ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries all-complete notifications when a notifier becomes available later", async () => {
+    vi.useFakeTimers();
+    try {
+      const recoveredNotifier: Notifier = {
+        name: "desktop",
+        notify: vi.fn().mockResolvedValue(undefined),
+      };
+
+      let notifierAvailable = false;
+      const registryWithFlappingNotifier: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string, name: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return mockAgent;
+          if (slot === "notifier" && name === "desktop") {
+            return notifierAvailable ? recoveredNotifier : null;
+          }
+          return null;
+        }),
+      };
+
+      const configWithAllCompleteReaction: OrchestratorConfig = {
+        ...config,
+        notificationRouting: {
+          ...config.notificationRouting,
+          info: ["desktop"],
+        },
+        reactions: {
+          ...config.reactions,
+          "all-complete": {
+            auto: true,
+            action: "notify",
+            priority: "info",
+          },
+        },
+      };
+
+      vi.mocked(mockSessionManager.list).mockResolvedValue([
+        makeSession({ id: "app-1", status: "merged" }),
+      ]);
+
+      const lm = createLifecycleManager({
+        config: configWithAllCompleteReaction,
+        registry: registryWithFlappingNotifier,
+        sessionManager: mockSessionManager,
+      });
+
+      lm.start(1_000);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(recoveredNotifier.notify).not.toHaveBeenCalled();
+
+      notifierAvailable = true;
+      await vi.advanceTimersByTimeAsync(1_000);
+      lm.stop();
+
+      expect(recoveredNotifier.notify).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1343,6 +1343,102 @@ describe("reactions", () => {
     expect(metadata?.["notifier.desktop.status"]).toBe("ok");
   });
 
+  it("retries notify reactions when no notifier plugin resolves", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryGet = vi.fn().mockImplementation((slot: string) => {
+      if (slot === "runtime") return mockRuntime;
+      if (slot === "agent") return mockAgent;
+      if (slot === "scm") return mockSCM;
+      if (slot === "notifier") return null;
+      return null;
+    });
+
+    const registryWithMissingNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: registryGet,
+    };
+
+    const configWithNotifyReaction: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        action: ["desktop"],
+      },
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "notify",
+          priority: "action",
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithNotifyReaction,
+      registry: registryWithMissingNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(registryGet).toHaveBeenCalledWith("notifier", "desktop");
+    expect(
+      registryGet.mock.calls.filter(
+        ([slot, name]) => slot === "notifier" && name === "desktop",
+      ),
+    ).toHaveLength(1);
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(
+      registryGet.mock.calls.filter(
+        ([slot, name]) => slot === "notifier" && name === "desktop",
+      ),
+    ).toHaveLength(2);
+  });
+
   it("does not persist review dispatch hashes when escalation notify delivery fails", async () => {
     const failingNotifier: Notifier = {
       name: "desktop",
@@ -1435,11 +1531,324 @@ describe("reactions", () => {
     metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(failingNotifier.notify).toHaveBeenCalledTimes(1);
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
 
     await lm.check("app-1");
     metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(failingNotifier.notify).toHaveBeenCalledTimes(2);
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries escalation when no notifier plugin resolves", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryGet = vi.fn().mockImplementation((slot: string) => {
+      if (slot === "runtime") return mockRuntime;
+      if (slot === "agent") return mockAgent;
+      if (slot === "scm") return mockSCM;
+      if (slot === "notifier") return null;
+      return null;
+    });
+
+    const registryWithMissingNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: registryGet,
+    };
+
+    const configWithEscalation = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        urgent: ["desktop"],
+      },
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "send-to-agent" as const,
+          message: "Handle review comments.",
+          retries: 1,
+          escalateAfter: 1,
+          priority: "urgent" as const,
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.send).mockRejectedValue(new Error("agent unavailable"));
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithEscalation,
+      registry: registryWithMissingNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    // Poll 2 must be the escalation path, not another send-to-agent attempt.
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(
+      registryGet.mock.calls.filter(
+        ([slot, name]) => slot === "notifier" && name === "desktop",
+      ),
+    ).toHaveLength(1);
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(
+      registryGet.mock.calls.filter(
+        ([slot, name]) => slot === "notifier" && name === "desktop",
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("does not treat an empty notification route as successful delivery", async () => {
+    const fallbackNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryGet = vi.fn().mockImplementation((slot: string, name: string) => {
+      if (slot === "runtime") return mockRuntime;
+      if (slot === "agent") return mockAgent;
+      if (slot === "scm") return mockSCM;
+      if (slot === "notifier" && name === "desktop") return fallbackNotifier;
+      return null;
+    });
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: registryGet,
+    };
+
+    const configWithEmptyRoute: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        action: [],
+      },
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "notify",
+          priority: "action",
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithEmptyRoute,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(fallbackNotifier.notify).not.toHaveBeenCalled();
+    expect(
+      registryGet.mock.calls.filter(
+        ([slot, name]) => slot === "notifier" && name === "desktop",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("escalates after a lifecycle manager restart instead of retrying send-to-agent", async () => {
+    const notifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    const configWithEscalation = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        urgent: ["desktop"],
+      },
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "send-to-agent" as const,
+          message: "Handle review comments.",
+          retries: 1,
+          escalateAfter: 1,
+          priority: "urgent" as const,
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.send).mockRejectedValue(new Error("agent unavailable"));
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm1 = createLifecycleManager({
+      config: configWithEscalation,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm1.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(notifier.notify).not.toHaveBeenCalled();
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["reaction.changes-requested.attempts"]).toBe(
+      "1",
+    );
+
+    const restoredSession = makeSession({
+      status: "pr_open",
+      pr: makePR(),
+      metadata: readMetadataRaw(sessionsDir, "app-1") ?? {},
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(restoredSession);
+
+    const lm2 = createLifecycleManager({
+      config: configWithEscalation,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm2.check("app-1");
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(notifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
   });
 
   it("does not double-send when changes_requested transition already triggered the reaction", async () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { createLifecycleManager } from "../lifecycle-manager.js";
 import { createSessionManager } from "../session-manager.js";
 import { writeMetadata, readMetadataRaw } from "../metadata.js";
+import { readObservabilitySummary } from "../observability.js";
 import { getSessionsDir, getProjectBaseDir } from "../paths.js";
 import type {
   OrchestratorConfig,
@@ -1426,6 +1427,360 @@ describe("reactions", () => {
     expect(mockNotifier.notify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "merge.completed" }),
     );
+  });
+
+  it("records notifier failures, persists warning metadata, and continues to later notifiers", async () => {
+    const failingNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockRejectedValue(new Error("OpenClaw unavailable")),
+    };
+    const succeedingNotifier: Notifier = {
+      name: "slack",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifiers: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return failingNotifier;
+        if (slot === "notifier" && name === "slack") return succeedingNotifier;
+        return null;
+      }),
+    };
+
+    const configWithMultipleNotifiers: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop", "slack"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        action: ["desktop", "slack"],
+      },
+    };
+
+    const session = makeSession({ status: "approved", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithMultipleNotifiers,
+      registry: registryWithNotifiers,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("merged");
+    expect(failingNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(succeedingNotifier.notify).toHaveBeenCalledTimes(1);
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["notifier.desktop.status"]).toBe("warn");
+    expect(metadata?.["notifier.desktop.lastFailureReason"]).toBe("OpenClaw unavailable");
+    expect(metadata?.["notifier.desktop.consecutiveFailures"]).toBe("1");
+    expect(metadata?.["notifier.slack.status"]).toBe("ok");
+    expect(metadata?.["notifier.slack.consecutiveFailures"]).toBe("0");
+    expect(metadata?.["notifier.slack.lastSuccessAt"]).toBeTruthy();
+
+    const summary = readObservabilitySummary(configWithMultipleNotifiers);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.total).toBe(2);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.success).toBe(1);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.failure).toBe(1);
+    expect(
+      summary.projects["my-app"]?.recentTraces.some(
+        (trace) =>
+          trace.operation === "notifier.notify" &&
+          trace.sessionId === "app-1" &&
+          trace.data?.["notifier"] === "desktop" &&
+          trace.reason === "OpenClaw unavailable",
+      ),
+    ).toBe(true);
+  });
+
+  it("records notifier observability even when session lookup fails after delivery", async () => {
+    const mockNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "approved", pr: makePR() });
+    vi.mocked(mockSessionManager.get)
+      .mockResolvedValueOnce(session)
+      .mockRejectedValueOnce(new Error("lookup failed"));
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["notifier.desktop.status"]).toBeUndefined();
+
+    const summary = readObservabilitySummary(config);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.total).toBe(1);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.success).toBe(1);
+    expect(
+      summary.projects["my-app"]?.recentTraces.some(
+        (trace) =>
+          trace.operation === "notifier.notify" &&
+          trace.sessionId === "app-1" &&
+          trace.data?.["notifier"] === "desktop",
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves lastSuccessAt when a notifier later fails", async () => {
+    const flakyNotifier: Notifier = {
+      name: "desktop",
+      notify: vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("Temporary OpenClaw outage")),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return flakyNotifier;
+        return null;
+      }),
+    };
+
+    const configWithInfoRouting: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        ...config.notificationRouting,
+        info: ["desktop"],
+        urgent: ["desktop"],
+      },
+    };
+
+    const session = makeSession({ status: "spawning" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockAgent.getActivityState)
+      .mockResolvedValueOnce({ state: "waiting_input" as ActivityState })
+      .mockResolvedValueOnce({ state: "active" as ActivityState });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "spawning",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithInfoRouting,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    const successMetadata = readMetadataRaw(sessionsDir, "app-1");
+    const lastSuccessAt = successMetadata?.["notifier.desktop.lastSuccessAt"];
+    expect(lastSuccessAt).toBeTruthy();
+
+    await lm.check("app-1");
+    const failureMetadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(failureMetadata?.["notifier.desktop.status"]).toBe("warn");
+    expect(failureMetadata?.["notifier.desktop.lastFailureReason"]).toBe("Temporary OpenClaw outage");
+    expect(failureMetadata?.["notifier.desktop.lastSuccessAt"]).toBe(lastSuccessAt);
+  });
+
+  it("clears notifier warning state after a later successful delivery", async () => {
+    const flakyNotifier: Notifier = {
+      name: "desktop",
+      notify: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Temporary OpenClaw outage"))
+        .mockResolvedValueOnce(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return flakyNotifier;
+        return null;
+      }),
+    };
+
+    const configWithInfoRouting: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        ...config.notificationRouting,
+        info: ["desktop"],
+        urgent: ["desktop"],
+      },
+    };
+
+    const session = makeSession({ status: "spawning" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockAgent.getActivityState)
+      .mockResolvedValueOnce({ state: "active" as ActivityState })
+      .mockResolvedValueOnce({ state: "waiting_input" as ActivityState });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "spawning",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithInfoRouting,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["notifier.desktop.status"]).toBe("warn");
+    expect(metadata?.["notifier.desktop.consecutiveFailures"]).toBe("1");
+    expect(metadata?.["notifier.desktop.lastFailureReason"]).toBe("Temporary OpenClaw outage");
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["notifier.desktop.status"]).toBe("ok");
+    expect(metadata?.["notifier.desktop.consecutiveFailures"]).toBe("0");
+    expect(metadata?.["notifier.desktop.lastFailureAt"]).toBeUndefined();
+    expect(metadata?.["notifier.desktop.lastFailureReason"]).toBeUndefined();
+    expect(metadata?.["notifier.desktop.lastSuccessAt"]).toBeTruthy();
+  });
+
+  it("records notifier observability for all-complete system notifications", async () => {
+    vi.useFakeTimers();
+    try {
+      const mockNotifier: Notifier = {
+        name: "desktop",
+        notify: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const registryWithNotifier: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string, name: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return mockAgent;
+          if (slot === "notifier" && name === "desktop") return mockNotifier;
+          return null;
+        }),
+      };
+
+      const configWithAllCompleteReaction: OrchestratorConfig = {
+        ...config,
+        notificationRouting: {
+          ...config.notificationRouting,
+          info: ["desktop"],
+        },
+        reactions: {
+          ...config.reactions,
+          "all-complete": {
+            action: "notify",
+            priority: "info",
+          },
+        },
+      };
+
+      vi.mocked(mockSessionManager.list).mockResolvedValue([
+        makeSession({ id: "app-1", status: "merged" }),
+      ]);
+
+      const lm = createLifecycleManager({
+        config: configWithAllCompleteReaction,
+        registry: registryWithNotifier,
+        sessionManager: mockSessionManager,
+      });
+
+      lm.start(1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+      lm.stop();
+
+      expect(mockNotifier.notify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "reaction.triggered",
+          sessionId: "system",
+          projectId: "all",
+        }),
+      );
+
+      const summary = readObservabilitySummary(configWithAllCompleteReaction);
+      expect(summary.projects["all"]?.metrics["notification"]?.total).toBe(1);
+      expect(summary.projects["all"]?.metrics["notification"]?.success).toBe(1);
+      expect(
+        summary.projects["all"]?.recentTraces.some(
+          (trace) =>
+            trace.operation === "notifier.notify" &&
+            trace.sessionId === "system" &&
+            trace.data?.["notifier"] === "desktop",
+        ),
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1224,6 +1224,93 @@ describe("reactions", () => {
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
   });
 
+  it("retries notify reactions when every notifier delivery fails", async () => {
+    const flakyNotifier: Notifier = {
+      name: "desktop",
+      notify: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("OpenClaw unavailable"))
+        .mockResolvedValueOnce(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return flakyNotifier;
+        return null;
+      }),
+    };
+
+    const configWithNotifyReaction: OrchestratorConfig = {
+      ...config,
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "notify",
+          priority: "action",
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithNotifyReaction,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(flakyNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(metadata?.["notifier.desktop.status"]).toBe("warn");
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(flakyNotifier.notify).toHaveBeenCalledTimes(2);
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
+    expect(metadata?.["notifier.desktop.status"]).toBe("ok");
+  });
+
   it("does not double-send when changes_requested transition already triggered the reaction", async () => {
     config.reactions = {
       "changes-requested": {
@@ -1523,6 +1610,62 @@ describe("reactions", () => {
     ).toBe(true);
   });
 
+  it("sanitizes multiline notifier failure reasons before persisting metadata", async () => {
+    const failingNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockRejectedValue(new Error("OpenClaw unavailable\nretry later\r\nsee logs")),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return failingNotifier;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "approved", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["notifier.desktop.lastFailureReason"]).toBe(
+      "OpenClaw unavailable retry later see logs",
+    );
+  });
+
   it("records notifier observability even when session lookup fails after delivery", async () => {
     const mockNotifier: Notifier = {
       name: "desktop",
@@ -1589,6 +1732,67 @@ describe("reactions", () => {
           trace.data?.["notifier"] === "desktop",
       ),
     ).toBe(true);
+  });
+
+  it("does not reclassify successful notifier delivery when outcome persistence fails", async () => {
+    const mockNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const validSession = makeSession({ status: "approved", pr: makePR() });
+    const sessionWithInvalidId = makeSession({ id: "bad/id", status: "approved", pr: makePR() });
+    vi.mocked(mockSessionManager.get)
+      .mockResolvedValueOnce(validSession)
+      .mockResolvedValueOnce(sessionWithInvalidId);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await expect(lm.check("app-1")).resolves.toBeUndefined();
+    expect(lm.getStates().get("app-1")).toBe("merged");
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+
+    const summary = readObservabilitySummary(config);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.total).toBe(1);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.success).toBe(1);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.failure).toBe(0);
   });
 
   it("preserves lastSuccessAt when a notifier later fails", async () => {
@@ -1739,6 +1943,7 @@ describe("reactions", () => {
         reactions: {
           ...config.reactions,
           "all-complete": {
+            auto: true,
             action: "notify",
             priority: "info",
           },

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1343,6 +1343,105 @@ describe("reactions", () => {
     expect(metadata?.["notifier.desktop.status"]).toBe("ok");
   });
 
+  it("does not persist review dispatch hashes when escalation notify delivery fails", async () => {
+    const failingNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockRejectedValue(new Error("OpenClaw unavailable")),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return failingNotifier;
+        return null;
+      }),
+    };
+
+    const configWithEscalation = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        urgent: ["desktop"],
+      },
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "send-to-agent" as const,
+          message: "Handle review comments.",
+          retries: 1,
+          escalateAfter: 1,
+          priority: "urgent" as const,
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.send).mockRejectedValue(new Error("agent unavailable"));
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithEscalation,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(failingNotifier.notify).not.toHaveBeenCalled();
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(failingNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(failingNotifier.notify).toHaveBeenCalledTimes(2);
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+  });
+
   it("does not double-send when changes_requested transition already triggered the reaction", async () => {
     config.reactions = {
       "changes-requested": {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -176,6 +176,38 @@ describe("start / stop", () => {
     // Should not throw on double stop
     lm.stop();
   });
+
+  it("records observability when an individual polled session check fails", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(mockSessionManager.list).mockResolvedValue([
+        makeSession({ id: "bad/id", status: "spawning" }),
+      ]);
+
+      const lm = createLifecycleManager({
+        config,
+        registry: mockRegistry,
+        sessionManager: mockSessionManager,
+      });
+
+      lm.start(1_000);
+      await vi.advanceTimersByTimeAsync(0);
+      lm.stop();
+
+      const summary = readObservabilitySummary(config);
+      expect(
+        summary.projects["my-app"]?.recentTraces.some(
+          (trace) =>
+            trace.operation === "lifecycle.check" &&
+            trace.sessionId === "bad/id" &&
+            trace.outcome === "failure" &&
+            trace.reason?.includes("Invalid session ID: bad/id"),
+        ),
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("check (single session)", () => {

--- a/packages/core/src/__tests__/observability.test.ts
+++ b/packages/core/src/__tests__/observability.test.ts
@@ -122,4 +122,38 @@ describe("observability snapshot", () => {
     expect(project.health["lifecycle.worker"]?.status).toBe("warn");
     expect(summary.overallStatus).toBe("warn");
   });
+
+  it("keeps lifecycle transitions in the session summary slot while excluding notifier traces", () => {
+    const observer = createProjectObserver(config, "lifecycle-manager");
+
+    observer.recordOperation({
+      metric: "lifecycle_poll",
+      operation: "lifecycle.transition",
+      outcome: "success",
+      correlationId: "corr-lifecycle",
+      projectId: "my-app",
+      sessionId: "app-1",
+      data: { oldStatus: "approved", newStatus: "merged" },
+      level: "info",
+    });
+
+    observer.recordOperation({
+      metric: "notification",
+      operation: "notifier.notify",
+      outcome: "failure",
+      correlationId: "corr-notifier",
+      projectId: "my-app",
+      sessionId: "app-1",
+      reason: "OpenClaw unavailable",
+      data: { notifier: "openclaw", eventType: "merge.completed", priority: "action" },
+      level: "error",
+    });
+
+    const summary = readObservabilitySummary(config);
+    const project = summary.projects["my-app"];
+
+    expect(project.sessions["app-1"]?.operation).toBe("lifecycle.transition");
+    expect(project.sessions["app-1"]?.outcome).toBe("success");
+    expect(project.metrics["notification"]?.failure).toBe(1);
+  });
 });

--- a/packages/core/src/__tests__/observability.test.ts
+++ b/packages/core/src/__tests__/observability.test.ts
@@ -79,6 +79,18 @@ describe("observability snapshot", () => {
       level: "error",
     });
 
+    observer.recordOperation({
+      metric: "notification",
+      operation: "notifier.notify",
+      outcome: "failure",
+      correlationId: "corr-2b",
+      projectId: "my-app",
+      sessionId: "app-1",
+      reason: "OpenClaw unavailable",
+      data: { notifier: "openclaw", eventType: "merge.completed", priority: "action" },
+      level: "error",
+    });
+
     observer.setHealth({
       surface: "lifecycle.worker",
       status: "warn",
@@ -95,8 +107,18 @@ describe("observability snapshot", () => {
     expect(project.metrics["spawn"]?.total).toBe(1);
     expect(project.metrics["spawn"]?.success).toBe(1);
     expect(project.metrics["send"]?.failure).toBe(1);
+    expect(project.metrics["notification"]?.failure).toBe(1);
     expect(project.sessions["app-1"]?.operation).toBe("session.send");
     expect(project.recentTraces.some((trace) => trace.operation === "session.spawn")).toBe(true);
+    expect(
+      project.recentTraces.some(
+        (trace) =>
+          trace.operation === "notifier.notify" &&
+          trace.sessionId === "app-1" &&
+          trace.reason === "OpenClaw unavailable" &&
+          trace.data?.["notifier"] === "openclaw",
+      ),
+    ).toBe(true);
     expect(project.health["lifecycle.worker"]?.status).toBe("warn");
     expect(summary.overallStatus).toBe("warn");
   });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -306,6 +306,30 @@ function validateProjectUniqueness(config: OrchestratorConfig): void {
   }
 }
 
+function validateNotifierNames(config: OrchestratorConfig): void {
+  const notifierNames = new Set<string>();
+
+  for (const name of Object.keys(config.notifiers)) {
+    notifierNames.add(name);
+  }
+  for (const name of config.defaults.notifiers) {
+    notifierNames.add(name);
+  }
+  for (const names of Object.values(config.notificationRouting)) {
+    for (const name of names) {
+      notifierNames.add(name);
+    }
+  }
+
+  for (const name of notifierNames) {
+    if (name.includes(".")) {
+      throw new Error(
+        `Invalid notifier name "${name}": notifier names cannot contain dots.`,
+      );
+    }
+  }
+}
+
 /** Apply default reactions */
 function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
   const defaults: Record<string, (typeof config.reactions)[string]> = {
@@ -512,6 +536,7 @@ export function validateConfig(raw: unknown): OrchestratorConfig {
 
   // Validate project uniqueness and prefix collisions
   validateProjectUniqueness(config);
+  validateNotifierNames(config);
 
   return config;
 }

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -528,6 +528,67 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     session.metadata = cleaned;
   }
 
+  function notifierMetadataKey(notifierName: string, field: string): string {
+    return `notifier.${notifierName}.${field}`;
+  }
+
+  function recordNotifierOutcome(
+    projectId: string,
+    session: Session | null,
+    notifierName: string,
+    event: OrchestratorEvent,
+    priority: EventPriority,
+    outcome: "success" | "failure",
+    error?: unknown,
+  ): void {
+    const correlationId = createCorrelationId("notifier");
+    const timestamp = new Date().toISOString();
+    const reason =
+      outcome === "failure"
+        ? error instanceof Error
+          ? error.message
+          : String(error)
+        : undefined;
+
+    observer.recordOperation({
+      metric: "notification",
+      operation: "notifier.notify",
+      outcome,
+      correlationId,
+      projectId,
+      sessionId: event.sessionId,
+      reason,
+      data: {
+        notifier: notifierName,
+        eventType: event.type,
+        priority,
+      },
+      level: outcome === "failure" ? "error" : "info",
+    });
+
+    if (!session) {
+      return;
+    }
+
+    const currentFailures = Number.parseInt(
+      session.metadata[notifierMetadataKey(notifierName, "consecutiveFailures")] ?? "0",
+      10,
+    );
+
+    updateSessionMetadata(session, {
+      [notifierMetadataKey(notifierName, "status")]: outcome === "failure" ? "warn" : "ok",
+      [notifierMetadataKey(notifierName, "lastEventType")]: event.type,
+      [notifierMetadataKey(notifierName, "lastPriority")]: priority,
+      [notifierMetadataKey(notifierName, "consecutiveFailures")]:
+        outcome === "failure" ? String(currentFailures + 1) : "0",
+      [notifierMetadataKey(notifierName, "lastFailureAt")]: outcome === "failure" ? timestamp : "",
+      [notifierMetadataKey(notifierName, "lastFailureReason")]: outcome === "failure" ? reason! : "",
+      ...(outcome === "success"
+        ? { [notifierMetadataKey(notifierName, "lastSuccessAt")]: timestamp }
+        : {}),
+    });
+  }
+
   function makeFingerprint(ids: string[]): string {
     return [...ids].sort().join(",");
   }
@@ -690,12 +751,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     for (const name of notifierNames) {
       const notifier = registry.get<Notifier>("notifier", name);
-      if (notifier) {
-        try {
-          await notifier.notify(eventWithPriority);
-        } catch {
-          // Notifier failed — not much we can do
-        }
+      if (!notifier) {
+        // Known limitation: missing/unloaded configured notifiers are still silent.
+        // Track separately rather than widening this PR's notifier outcome scope.
+        continue;
+      }
+      try {
+        await notifier.notify(eventWithPriority);
+        const session = await sessionManager.get(event.sessionId).catch(() => null);
+        recordNotifierOutcome(event.projectId, session, name, eventWithPriority, priority, "success");
+      } catch (error) {
+        const session = await sessionManager.get(event.sessionId).catch(() => null);
+        recordNotifierOutcome(event.projectId, session, name, eventWithPriority, priority, "failure", error);
       }
     }
   }

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -185,6 +185,18 @@ export interface LifecycleManagerDeps {
 interface ReactionTracker {
   attempts: number;
   firstTriggered: Date;
+  unresolvedNotifierSignature?: string;
+}
+
+interface NotificationTarget {
+  name: string;
+  notifier: Notifier;
+}
+
+interface NotificationPlan {
+  notifierNames: string[];
+  resolvedTargets: NotificationTarget[];
+  signature: string;
 }
 
 /** Create a LifecycleManager instance. */
@@ -373,30 +385,53 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     reactionConfig: ReactionConfig,
   ): Promise<ReactionResult> {
     const tracker = getReactionTracker(session, sessionId, reactionKey);
+    const action = reactionConfig.action ?? "notify";
+    const nextAttempt = tracker.attempts + 1;
+    const shouldEscalate = shouldEscalateReaction(tracker, reactionConfig, nextAttempt);
 
-    // Increment attempts before checking escalation
-    tracker.attempts++;
-    persistReactionTracker(session, sessionId, reactionKey, tracker);
-
-    // Check if we should escalate
-    const maxRetries = reactionConfig.retries ?? Infinity;
-    const escalateAfter = reactionConfig.escalateAfter;
-    let shouldEscalate = false;
-
-    if (tracker.attempts > maxRetries) {
-      shouldEscalate = true;
+    let notificationPriority: EventPriority | null = null;
+    if (shouldEscalate) {
+      notificationPriority = reactionConfig.priority ?? "urgent";
+    } else if (action === "notify") {
+      notificationPriority = reactionConfig.priority ?? "info";
+    } else if (action === "auto-merge") {
+      notificationPriority = "action";
     }
 
-    if (typeof escalateAfter === "string") {
-      const durationMs = parseDuration(escalateAfter);
-      if (durationMs > 0 && Date.now() - tracker.firstTriggered.getTime() > durationMs) {
-        shouldEscalate = true;
+    const notificationAction = shouldEscalate ? "escalated" : action;
+    const notificationPlan = notificationPriority
+      ? resolveNotificationPlan(notificationPriority)
+      : null;
+
+    if (notificationPlan && shouldSkipUnresolvedNotification(tracker, notificationPlan)) {
+      return {
+        reactionType: reactionKey,
+        success: false,
+        action: notificationAction,
+        escalated: shouldEscalate,
+      };
+    }
+
+    tracker.attempts = nextAttempt;
+    if (notificationPlan) {
+      if (
+        notificationPlan.notifierNames.length > 0 &&
+        notificationPlan.resolvedTargets.length === 0
+      ) {
+        tracker.unresolvedNotifierSignature = notificationPlan.signature;
+        persistReactionTracker(session, sessionId, reactionKey, tracker);
+        return {
+          reactionType: reactionKey,
+          success: false,
+          action: notificationAction,
+          escalated: shouldEscalate,
+        };
       }
+      tracker.unresolvedNotifierSignature = undefined;
+    } else {
+      tracker.unresolvedNotifierSignature = undefined;
     }
-
-    if (typeof escalateAfter === "number" && tracker.attempts > escalateAfter) {
-      shouldEscalate = true;
-    }
+    persistReactionTracker(session, sessionId, reactionKey, tracker);
 
     if (shouldEscalate) {
       // Escalate to human
@@ -406,7 +441,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         message: `Reaction '${reactionKey}' escalated after ${tracker.attempts} attempts`,
         data: { reactionKey, attempts: tracker.attempts },
       });
-      const delivered = await notifyHuman(event, reactionConfig.priority ?? "urgent");
+      const delivered = await notifyHuman(
+        event,
+        reactionConfig.priority ?? "urgent",
+        notificationPlan ?? undefined,
+      );
       if (delivered) {
         clearReactionTracker(sessionId, reactionKey, session);
       }
@@ -417,9 +456,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         escalated: true,
       };
     }
-
-    // Execute the reaction action
-    const action = reactionConfig.action ?? "notify";
 
     switch (action) {
       case "send-to-agent": {
@@ -455,7 +491,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           message: `Reaction '${reactionKey}' triggered notification`,
           data: { reactionKey },
         });
-        const delivered = await notifyHuman(event, reactionConfig.priority ?? "info");
+        const delivered = await notifyHuman(
+          event,
+          reactionConfig.priority ?? "info",
+          notificationPlan ?? undefined,
+        );
         if (delivered) {
           clearReactionTracker(sessionId, reactionKey, session);
         }
@@ -476,11 +516,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           message: `Reaction '${reactionKey}' triggered auto-merge`,
           data: { reactionKey },
         });
-        await notifyHuman(event, "action");
-        clearReactionTracker(sessionId, reactionKey, session);
+        const delivered = await notifyHuman(event, "action", notificationPlan ?? undefined);
+        if (delivered) {
+          clearReactionTracker(sessionId, reactionKey, session);
+        }
         return {
           reactionType: reactionKey,
-          success: true,
+          success: delivered,
           action: "auto-merge",
           escalated: false,
         };
@@ -530,9 +572,71 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   function reactionTrackerMetadataKey(
     reactionKey: string,
-    field: "attempts" | "firstTriggeredAt",
+    field: "attempts" | "firstTriggeredAt" | "unresolvedNotifierSignature",
   ): string {
     return `reaction.${reactionKey}.${field}`;
+  }
+
+  function shouldEscalateReaction(
+    tracker: ReactionTracker,
+    reactionConfig: ReactionConfig,
+    attempts: number,
+  ): boolean {
+    const maxRetries = reactionConfig.retries ?? Infinity;
+    const escalateAfter = reactionConfig.escalateAfter;
+    let shouldEscalate = attempts > maxRetries;
+
+    if (typeof escalateAfter === "string") {
+      const durationMs = parseDuration(escalateAfter);
+      if (durationMs > 0 && Date.now() - tracker.firstTriggered.getTime() > durationMs) {
+        shouldEscalate = true;
+      }
+    }
+
+    if (typeof escalateAfter === "number" && attempts > escalateAfter) {
+      shouldEscalate = true;
+    }
+
+    return shouldEscalate;
+  }
+
+  function resolveNotificationPlan(priority: EventPriority): NotificationPlan {
+    const notifierNames = config.notificationRouting[priority] ?? config.defaults.notifiers;
+    const resolvedTargets: NotificationTarget[] = [];
+
+    for (const name of notifierNames) {
+      const notifier = registry.get<Notifier>("notifier", name);
+      if (notifier) {
+        resolvedTargets.push({ name, notifier });
+      }
+    }
+
+    return {
+      notifierNames,
+      resolvedTargets,
+      signature: notifierNames.join(","),
+    };
+  }
+
+  function shouldSkipUnresolvedNotification(
+    tracker: ReactionTracker,
+    plan: NotificationPlan,
+  ): boolean {
+    return (
+      plan.notifierNames.length > 0 &&
+      plan.resolvedTargets.length === 0 &&
+      tracker.unresolvedNotifierSignature === plan.signature
+    );
+  }
+
+  function hasReactionTrackerState(session: Session, reactionKey: string): boolean {
+    return (
+      reactionTrackers.has(`${session.id}:${reactionKey}`) ||
+      session.metadata[reactionTrackerMetadataKey(reactionKey, "attempts")] !== undefined ||
+      session.metadata[reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")] !== undefined ||
+      session.metadata[reactionTrackerMetadataKey(reactionKey, "unresolvedNotifierSignature")] !==
+        undefined
+    );
   }
 
   function getReactionTracker(
@@ -552,6 +656,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const persistedFirstTriggeredAt = session?.metadata[
       reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")
     ];
+    const persistedUnresolvedNotifierSignature = session?.metadata[
+      reactionTrackerMetadataKey(reactionKey, "unresolvedNotifierSignature")
+    ];
     const parsedFirstTriggered = persistedFirstTriggeredAt
       ? new Date(persistedFirstTriggeredAt)
       : new Date();
@@ -560,6 +667,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       attempts: Number.isFinite(persistedAttempts) ? persistedAttempts : 0,
       firstTriggered:
         Number.isNaN(parsedFirstTriggered.getTime()) ? new Date() : parsedFirstTriggered,
+      unresolvedNotifierSignature: persistedUnresolvedNotifierSignature,
     };
     reactionTrackers.set(trackerKey, tracker);
     return tracker;
@@ -580,6 +688,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       [reactionTrackerMetadataKey(reactionKey, "attempts")]: String(tracker.attempts),
       [reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")]:
         tracker.firstTriggered.toISOString(),
+      [reactionTrackerMetadataKey(reactionKey, "unresolvedNotifierSignature")]:
+        tracker.unresolvedNotifierSignature ?? "",
     });
   }
 
@@ -596,6 +706,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     updateSessionMetadata(session, {
       [reactionTrackerMetadataKey(reactionKey, "attempts")]: "",
       [reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")]: "",
+      [reactionTrackerMetadataKey(reactionKey, "unresolvedNotifierSignature")]: "",
     });
   }
 
@@ -863,20 +974,42 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
   }
 
+  async function maybeRetryMergeableReaction(
+    session: Session,
+    oldStatus: SessionStatus,
+    newStatus: SessionStatus,
+  ): Promise<void> {
+    const reactionKey = "approved-and-green";
+    if (newStatus !== "mergeable" || oldStatus !== newStatus) {
+      return;
+    }
+    if (!hasReactionTrackerState(session, reactionKey)) {
+      return;
+    }
+
+    const reactionConfig = getReactionConfigForSession(session, reactionKey);
+    if (
+      !reactionConfig ||
+      !reactionConfig.action ||
+      (reactionConfig.auto === false && reactionConfig.action !== "notify")
+    ) {
+      return;
+    }
+
+    await executeReaction(session, session.id, session.projectId, reactionKey, reactionConfig);
+  }
+
   /** Send a notification to all configured notifiers. */
-  async function notifyHuman(event: OrchestratorEvent, priority: EventPriority): Promise<boolean> {
+  async function notifyHuman(
+    event: OrchestratorEvent,
+    priority: EventPriority,
+    plan?: NotificationPlan,
+  ): Promise<boolean> {
     const eventWithPriority = { ...event, priority };
-    const notifierNames = config.notificationRouting[priority] ?? config.defaults.notifiers;
+    const notificationPlan = plan ?? resolveNotificationPlan(priority);
     let delivered = false;
 
-    for (const name of notifierNames) {
-      const notifier = registry.get<Notifier>("notifier", name);
-      if (!notifier) {
-        // Known limitation: missing/unloaded configured notifiers are still silent.
-        // Track separately rather than widening this PR's notifier outcome scope.
-        continue;
-      }
-
+    for (const { name, notifier } of notificationPlan.resolvedTargets) {
       let outcome: "success" | "failure" = "success";
       let notifyError: unknown;
       try {
@@ -996,6 +1129,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction);
+    await maybeRetryMergeableReaction(session, oldStatus, newStatus);
   }
 
   /** Run one polling cycle across all sessions. */
@@ -1048,7 +1182,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       // Check if all sessions are complete (trigger reaction only once)
       const activeSessions = sessions.filter((s) => s.status !== "merged" && s.status !== "killed");
       if (sessions.length > 0 && activeSessions.length === 0 && !allCompleteEmitted) {
-        allCompleteEmitted = true;
+        let emitAllComplete = true;
 
         // Execute all-complete reaction if configured
         const reactionKey = eventToReactionKey("summary.all_complete");
@@ -1056,16 +1190,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const reactionConfig = config.reactions[reactionKey];
           if (reactionConfig && reactionConfig.action) {
             if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
-              await executeReaction(
+              const result = await executeReaction(
                 null,
                 "system",
                 "all",
                 reactionKey,
                 reactionConfig as ReactionConfig,
               );
+              emitAllComplete = result.success;
             }
           }
         }
+        allCompleteEmitted = emitAllComplete;
       }
       if (scopedProjectId) {
         observer.recordOperation({

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -455,10 +455,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           message: `Reaction '${reactionKey}' triggered notification`,
           data: { reactionKey },
         });
-        await notifyHuman(event, reactionConfig.priority ?? "info");
+        const delivered = await notifyHuman(event, reactionConfig.priority ?? "info");
         return {
           reactionType: reactionKey,
-          success: true,
+          success: delivered,
           action: "notify",
           escalated: false,
         };
@@ -532,6 +532,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return `notifier.${notifierName}.${field}`;
   }
 
+  function sanitizeNotifierReason(error: unknown): string {
+    return (error instanceof Error ? error.message : String(error))
+      .replace(/[\r\n]+/g, " ")
+      .trim()
+      .slice(0, 200);
+  }
+
   function recordNotifierOutcome(
     projectId: string,
     session: Session | null,
@@ -543,12 +550,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   ): void {
     const correlationId = createCorrelationId("notifier");
     const timestamp = new Date().toISOString();
-    const reason =
-      outcome === "failure"
-        ? error instanceof Error
-          ? error.message
-          : String(error)
-        : undefined;
+    const reason = outcome === "failure" ? sanitizeNotifierReason(error) : undefined;
 
     observer.recordOperation({
       metric: "notification",
@@ -587,6 +589,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         ? { [notifierMetadataKey(notifierName, "lastSuccessAt")]: timestamp }
         : {}),
     });
+  }
+
+  function logNotifierOutcomeRecordingError(
+    notifierName: string,
+    event: OrchestratorEvent,
+    error: unknown,
+  ): void {
+    const reason = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      `[ao] failed to record notifier outcome for ${notifierName} on ${event.type} (${event.sessionId}): ${reason}\n`,
+    );
   }
 
   function makeFingerprint(ids: string[]): string {
@@ -745,9 +758,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   }
 
   /** Send a notification to all configured notifiers. */
-  async function notifyHuman(event: OrchestratorEvent, priority: EventPriority): Promise<void> {
+  async function notifyHuman(event: OrchestratorEvent, priority: EventPriority): Promise<boolean> {
     const eventWithPriority = { ...event, priority };
     const notifierNames = config.notificationRouting[priority] ?? config.defaults.notifiers;
+    let delivered = false;
 
     for (const name of notifierNames) {
       const notifier = registry.get<Notifier>("notifier", name);
@@ -756,15 +770,34 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         // Track separately rather than widening this PR's notifier outcome scope.
         continue;
       }
+
+      let outcome: "success" | "failure" = "success";
+      let notifyError: unknown;
       try {
         await notifier.notify(eventWithPriority);
-        const session = await sessionManager.get(event.sessionId).catch(() => null);
-        recordNotifierOutcome(event.projectId, session, name, eventWithPriority, priority, "success");
+        delivered = true;
       } catch (error) {
-        const session = await sessionManager.get(event.sessionId).catch(() => null);
-        recordNotifierOutcome(event.projectId, session, name, eventWithPriority, priority, "failure", error);
+        outcome = "failure";
+        notifyError = error;
+      }
+
+      const session = await sessionManager.get(event.sessionId).catch(() => null);
+      try {
+        recordNotifierOutcome(
+          event.projectId,
+          session,
+          name,
+          eventWithPriority,
+          priority,
+          outcome,
+          notifyError,
+        );
+      } catch (recordError) {
+        logNotifierOutcomeRecordingError(name, eventWithPriority, recordError);
       }
     }
+
+    return delivered;
   }
 
   /** Poll a single session and handle state transitions. */

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -366,21 +366,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   /** Execute a reaction for a session. */
   async function executeReaction(
+    session: Session | null,
     sessionId: SessionId,
     projectId: string,
     reactionKey: string,
     reactionConfig: ReactionConfig,
   ): Promise<ReactionResult> {
-    const trackerKey = `${sessionId}:${reactionKey}`;
-    let tracker = reactionTrackers.get(trackerKey);
-
-    if (!tracker) {
-      tracker = { attempts: 0, firstTriggered: new Date() };
-      reactionTrackers.set(trackerKey, tracker);
-    }
+    const tracker = getReactionTracker(session, sessionId, reactionKey);
 
     // Increment attempts before checking escalation
     tracker.attempts++;
+    persistReactionTracker(session, sessionId, reactionKey, tracker);
 
     // Check if we should escalate
     const maxRetries = reactionConfig.retries ?? Infinity;
@@ -411,6 +407,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         data: { reactionKey, attempts: tracker.attempts },
       });
       const delivered = await notifyHuman(event, reactionConfig.priority ?? "urgent");
+      if (delivered) {
+        clearReactionTracker(sessionId, reactionKey, session);
+      }
       return {
         reactionType: reactionKey,
         success: delivered,
@@ -427,6 +426,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         if (reactionConfig.message) {
           try {
             await sessionManager.send(sessionId, reactionConfig.message);
+            clearReactionTracker(sessionId, reactionKey, session);
 
             return {
               reactionType: reactionKey,
@@ -456,6 +456,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           data: { reactionKey },
         });
         const delivered = await notifyHuman(event, reactionConfig.priority ?? "info");
+        if (delivered) {
+          clearReactionTracker(sessionId, reactionKey, session);
+        }
         return {
           reactionType: reactionKey,
           success: delivered,
@@ -474,6 +477,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           data: { reactionKey },
         });
         await notifyHuman(event, "action");
+        clearReactionTracker(sessionId, reactionKey, session);
         return {
           reactionType: reactionKey,
           success: true,
@@ -489,10 +493,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       action,
       escalated: false,
     };
-  }
-
-  function clearReactionTracker(sessionId: SessionId, reactionKey: string): void {
-    reactionTrackers.delete(`${sessionId}:${reactionKey}`);
   }
 
   function getReactionConfigForSession(
@@ -526,6 +526,77 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       cleaned[key] = value;
     }
     session.metadata = cleaned;
+  }
+
+  function reactionTrackerMetadataKey(
+    reactionKey: string,
+    field: "attempts" | "firstTriggeredAt",
+  ): string {
+    return `reaction.${reactionKey}.${field}`;
+  }
+
+  function getReactionTracker(
+    session: Session | null,
+    sessionId: SessionId,
+    reactionKey: string,
+  ): ReactionTracker {
+    const trackerKey = `${sessionId}:${reactionKey}`;
+    const tracked = reactionTrackers.get(trackerKey);
+    if (tracked) {
+      return tracked;
+    }
+
+    const persistedAttempts = session
+      ? Number.parseInt(session.metadata[reactionTrackerMetadataKey(reactionKey, "attempts")] ?? "0", 10)
+      : 0;
+    const persistedFirstTriggeredAt = session?.metadata[
+      reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")
+    ];
+    const parsedFirstTriggered = persistedFirstTriggeredAt
+      ? new Date(persistedFirstTriggeredAt)
+      : new Date();
+
+    const tracker: ReactionTracker = {
+      attempts: Number.isFinite(persistedAttempts) ? persistedAttempts : 0,
+      firstTriggered:
+        Number.isNaN(parsedFirstTriggered.getTime()) ? new Date() : parsedFirstTriggered,
+    };
+    reactionTrackers.set(trackerKey, tracker);
+    return tracker;
+  }
+
+  function persistReactionTracker(
+    session: Session | null,
+    sessionId: SessionId,
+    reactionKey: string,
+    tracker: ReactionTracker,
+  ): void {
+    reactionTrackers.set(`${sessionId}:${reactionKey}`, tracker);
+    if (!session) {
+      return;
+    }
+
+    updateSessionMetadata(session, {
+      [reactionTrackerMetadataKey(reactionKey, "attempts")]: String(tracker.attempts),
+      [reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")]:
+        tracker.firstTriggered.toISOString(),
+    });
+  }
+
+  function clearReactionTracker(
+    sessionId: SessionId,
+    reactionKey: string,
+    session?: Session | null,
+  ): void {
+    reactionTrackers.delete(`${sessionId}:${reactionKey}`);
+    if (!session) {
+      return;
+    }
+
+    updateSessionMetadata(session, {
+      [reactionTrackerMetadataKey(reactionKey, "attempts")]: "",
+      [reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")]: "",
+    });
   }
 
   function notifierMetadataKey(notifierName: string, field: string): string {
@@ -655,8 +726,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const automatedReactionKey = "bugbot-comments";
 
     if (newStatus === "merged" || newStatus === "killed") {
-      clearReactionTracker(session.id, humanReactionKey);
-      clearReactionTracker(session.id, automatedReactionKey);
+      clearReactionTracker(session.id, humanReactionKey, session);
+      clearReactionTracker(session.id, automatedReactionKey, session);
       updateSessionMetadata(session, {
         lastPendingReviewFingerprint: "",
         lastPendingReviewDispatchHash: "",
@@ -695,7 +766,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         pendingFingerprint !== lastPendingFingerprint &&
         transitionReaction?.key !== humanReactionKey
       ) {
-        clearReactionTracker(session.id, humanReactionKey);
+        clearReactionTracker(session.id, humanReactionKey, session);
       }
       if (pendingFingerprint !== lastPendingFingerprint) {
         updateSessionMetadata(session, {
@@ -704,7 +775,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
 
       if (!pendingFingerprint) {
-        clearReactionTracker(session.id, humanReactionKey);
+        clearReactionTracker(session.id, humanReactionKey, session);
         updateSessionMetadata(session, {
           lastPendingReviewFingerprint: "",
           lastPendingReviewDispatchHash: "",
@@ -731,6 +802,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           (reactionConfig.auto !== false || reactionConfig.action === "notify")
         ) {
           const result = await executeReaction(
+            session,
             session.id,
             session.projectId,
             humanReactionKey,
@@ -753,14 +825,14 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       const lastAutomatedDispatchHash = session.metadata["lastAutomatedReviewDispatchHash"] ?? "";
 
       if (automatedFingerprint !== lastAutomatedFingerprint) {
-        clearReactionTracker(session.id, automatedReactionKey);
+        clearReactionTracker(session.id, automatedReactionKey, session);
         updateSessionMetadata(session, {
           lastAutomatedReviewFingerprint: automatedFingerprint,
         });
       }
 
       if (!automatedFingerprint) {
-        clearReactionTracker(session.id, automatedReactionKey);
+        clearReactionTracker(session.id, automatedReactionKey, session);
         updateSessionMetadata(session, {
           lastAutomatedReviewFingerprint: "",
           lastAutomatedReviewDispatchHash: "",
@@ -774,6 +846,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           (reactionConfig.auto !== false || reactionConfig.action === "notify")
         ) {
           const result = await executeReaction(
+            session,
             session.id,
             session.projectId,
             automatedReactionKey,
@@ -870,7 +943,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       if (oldEventType) {
         const oldReactionKey = eventToReactionKey(oldEventType);
         if (oldReactionKey) {
-          clearReactionTracker(session.id, oldReactionKey);
+          clearReactionTracker(session.id, oldReactionKey, session);
         }
       }
 
@@ -887,6 +960,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             // auto: false skips automated agent actions but still allows notifications
             if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
               const reactionResult = await executeReaction(
+                session,
                 session.id,
                 session.projectId,
                 reactionKey,
@@ -982,7 +1056,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const reactionConfig = config.reactions[reactionKey];
           if (reactionConfig && reactionConfig.action) {
             if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
-              await executeReaction("system", "all", reactionKey, reactionConfig as ReactionConfig);
+              await executeReaction(
+                null,
+                "system",
+                "all",
+                reactionKey,
+                reactionConfig as ReactionConfig,
+              );
             }
           }
         }

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -410,10 +410,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         message: `Reaction '${reactionKey}' escalated after ${tracker.attempts} attempts`,
         data: { reactionKey, attempts: tracker.attempts },
       });
-      await notifyHuman(event, reactionConfig.priority ?? "urgent");
+      const delivered = await notifyHuman(event, reactionConfig.priority ?? "urgent");
       return {
         reactionType: reactionKey,
-        success: true,
+        success: delivered,
         action: "escalated",
         escalated: true,
       };

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -602,6 +602,39 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     );
   }
 
+  function recordSessionCheckFailure(
+    session: Session,
+    correlationId: string,
+    error: unknown,
+  ): void {
+    const reason = error instanceof Error ? error.message : String(error);
+    observer.recordOperation({
+      metric: "lifecycle_poll",
+      operation: "lifecycle.check",
+      outcome: "failure",
+      correlationId,
+      projectId: session.projectId,
+      sessionId: session.id,
+      reason,
+      data: {
+        phase: "poll",
+      },
+      level: "error",
+    });
+    observer.setHealth({
+      surface: "lifecycle.session-check",
+      status: "error",
+      projectId: session.projectId,
+      correlationId,
+      reason,
+      details: {
+        projectId: session.projectId,
+        sessionId: session.id,
+      },
+    });
+    process.stderr.write(`[ao] lifecycle check failed for ${session.id}: ${reason}\n`);
+  }
+
   function makeFingerprint(ids: string[]): string {
     return [...ids].sort().join(",");
   }
@@ -911,8 +944,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         return tracked !== undefined && tracked !== s.status;
       });
 
-      // Poll all sessions concurrently
-      await Promise.allSettled(sessionsToCheck.map((s) => checkSession(s)));
+      // Poll all sessions concurrently and record individual failures so one
+      // bad session cannot disappear behind the batch-level success path.
+      const pollResults = await Promise.allSettled(sessionsToCheck.map((s) => checkSession(s)));
+      let failedSessionCount = 0;
+      for (const [index, result] of pollResults.entries()) {
+        if (result.status !== "rejected") continue;
+        failedSessionCount++;
+        const session = sessionsToCheck[index];
+        if (!session) continue;
+        recordSessionCheckFailure(session, correlationId, result.reason);
+      }
 
       // Prune stale entries from states and reactionTrackers for sessions
       // that no longer appear in the session list (e.g., after kill/cleanup)
@@ -953,7 +995,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           correlationId,
           projectId: scopedProjectId,
           durationMs: Date.now() - startedAt,
-          data: { sessionCount: sessions.length, activeSessionCount: activeSessions.length },
+          data: {
+            sessionCount: sessions.length,
+            activeSessionCount: activeSessions.length,
+            failedSessionCount,
+          },
           level: "info",
         });
         observer.setHealth({
@@ -965,6 +1011,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             projectId: scopedProjectId,
             sessionCount: sessions.length,
             activeSessionCount: activeSessions.length,
+            failedSessionCount,
           },
         });
       }

--- a/packages/core/src/observability.ts
+++ b/packages/core/src/observability.ts
@@ -234,6 +234,10 @@ function compareIsoDesc(a: string, b: string): number {
   return b.localeCompare(a);
 }
 
+function shouldTrackSessionSummary(operation: string): boolean {
+  return operation.startsWith("session.") || operation === "lifecycle.transition";
+}
+
 function mergeCounter(
   target: ObservabilityMetricCounter | undefined,
   source: ObservabilityMetricCounter,
@@ -376,7 +380,7 @@ export function createProjectObserver(
             .sort((a, b) => compareIsoDesc(a.timestamp, b.timestamp))
             .slice(0, TRACE_LIMIT);
 
-          if (input.sessionId && operation.startsWith("session.")) {
+          if (input.sessionId && shouldTrackSessionSummary(operation)) {
             snapshot.sessions[input.sessionId] = {
               sessionId: input.sessionId,
               projectId: input.projectId,

--- a/packages/core/src/observability.ts
+++ b/packages/core/src/observability.ts
@@ -20,6 +20,7 @@ export type ObservabilityMetricName =
   | "cleanup"
   | "kill"
   | "lifecycle_poll"
+  | "notification"
   | "restore"
   | "send"
   | "spawn"
@@ -375,7 +376,7 @@ export function createProjectObserver(
             .sort((a, b) => compareIsoDesc(a.timestamp, b.timestamp))
             .slice(0, TRACE_LIMIT);
 
-          if (input.sessionId) {
+          if (input.sessionId && operation.startsWith("session.")) {
             snapshot.sessions[input.sessionId] = {
               sessionId: input.sessionId,
               projectId: input.projectId,

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -195,6 +195,7 @@ vi.mock("@/lib/services", () => ({
 // ── Import routes after mocking ───────────────────────────────────────
 
 import { GET as sessionsGET } from "@/app/api/sessions/route";
+import { GET as sessionGET } from "@/app/api/sessions/[id]/route";
 import { POST as orchestratorsPOST } from "@/app/api/orchestrators/route";
 import { POST as spawnPOST } from "@/app/api/spawn/route";
 import { POST as sendPOST } from "@/app/api/sessions/[id]/send/route";
@@ -255,6 +256,7 @@ describe("API Routes", () => {
       expect(session).toHaveProperty("status");
       expect(session).toHaveProperty("activity");
       expect(session).toHaveProperty("createdAt");
+      expect(session).toHaveProperty("notificationState");
     });
 
     it("skips PR enrichment when metadata enrichment hits timeout", async () => {
@@ -388,6 +390,44 @@ describe("API Routes", () => {
         pausedUntil,
         reason: "Rate limit hit",
         sourceSessionId: "docs-orchestrator",
+      });
+    });
+  });
+
+  describe("GET /api/sessions/:id", () => {
+    it("returns notificationState on detail responses", async () => {
+      (mockSessionManager.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        makeSession({
+          id: "backend-3",
+          metadata: {
+            "notifier.openclaw.status": "warn",
+            "notifier.openclaw.consecutiveFailures": "1",
+            "notifier.openclaw.lastFailureReason": "Connection refused",
+          },
+        }),
+      );
+
+      const res = await sessionGET(makeRequest("http://localhost:3000/api/sessions/backend-3"), {
+        params: Promise.resolve({ id: "backend-3" }),
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.notificationState).toEqual({
+        status: "warn",
+        failingNotifiers: ["openclaw"],
+        notifiers: [
+          {
+            name: "openclaw",
+            status: "warn",
+            consecutiveFailures: 1,
+            lastFailureAt: null,
+            lastFailureReason: "Connection refused",
+            lastSuccessAt: null,
+            lastEventType: null,
+            lastPriority: null,
+          },
+        ],
       });
     });
   });

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -3,7 +3,8 @@ import { NextRequest } from "next/server";
 import {
   SessionNotFoundError,
   SessionNotRestorableError,
-  SessionNotFoundError,
+  type LifecycleManager,
+  type SCMWebhookEvent,
   type Session,
   type SessionManager,
   type OrchestratorConfig,
@@ -126,6 +127,13 @@ const mockSessionManager: SessionManager = {
   }),
 };
 
+const mockLifecycleManager: LifecycleManager = {
+  start: vi.fn(),
+  stop: vi.fn(),
+  getStates: vi.fn(() => new Map()),
+  check: vi.fn(async () => undefined),
+};
+
 const mockSCM: SCM = {
   name: "github",
   detectPR: vi.fn(async () => null),
@@ -188,6 +196,7 @@ vi.mock("@/lib/services", () => ({
     config: mockConfig,
     registry: mockRegistry,
     sessionManager: mockSessionManager,
+    lifecycleManager: mockLifecycleManager,
   })),
   getSCM: vi.fn(() => mockSCM),
 }));
@@ -204,6 +213,7 @@ import { POST as killPOST } from "@/app/api/sessions/[id]/kill/route";
 import { POST as restorePOST } from "@/app/api/sessions/[id]/restore/route";
 import { POST as remapPOST } from "@/app/api/sessions/[id]/remap/route";
 import { POST as mergePOST } from "@/app/api/prs/[id]/merge/route";
+import { POST as webhooksPOST } from "@/app/api/webhooks/[...slug]/route";
 import { GET as eventsGET } from "@/app/api/events/route";
 import { GET as observabilityGET } from "@/app/api/observability/route";
 
@@ -221,6 +231,13 @@ beforeEach(() => {
   (mockSessionManager.get as ReturnType<typeof vi.fn>).mockImplementation(
     async (id: string) => testSessions.find((s) => s.id === id) ?? null,
   );
+  (mockLifecycleManager.check as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  mockConfig.projects["my-app"] = {
+    ...mockConfig.projects["my-app"],
+    scm: { plugin: "github" },
+  };
+  (mockSCM.verifyWebhook as ReturnType<typeof vi.fn> | undefined)?.mockReset?.();
+  (mockSCM.parseWebhook as ReturnType<typeof vi.fn> | undefined)?.mockReset?.();
 });
 
 describe("API Routes", () => {
@@ -830,6 +847,73 @@ describe("API Routes", () => {
       expect(res.status).toBe(409);
       const data = await res.json();
       expect(data.error).toMatch(/merged/);
+    });
+  });
+
+  describe("POST /api/webhooks/[...slug]", () => {
+    it("logs lifecycle check failures while returning 202", async () => {
+      const webhookEvent: SCMWebhookEvent = {
+        provider: "github",
+        kind: "push",
+        action: "updated",
+        rawEventType: "push",
+        repository: { owner: "acme", name: "my-app" },
+        branch: "feat/hook-fail",
+        data: {},
+      };
+
+      mockConfig.projects["my-app"] = {
+        ...mockConfig.projects["my-app"],
+        scm: {
+          plugin: "github",
+          webhook: {
+            enabled: true,
+            path: "/api/webhooks/github",
+          },
+        },
+      };
+
+      (mockSCM as SCM & {
+        verifyWebhook: ReturnType<typeof vi.fn>;
+        parseWebhook: ReturnType<typeof vi.fn>;
+      }).verifyWebhook = vi.fn(async () => ({ ok: true }));
+      (mockSCM as SCM & {
+        verifyWebhook: ReturnType<typeof vi.fn>;
+        parseWebhook: ReturnType<typeof vi.fn>;
+      }).parseWebhook = vi.fn(async () => webhookEvent);
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeSession({
+          id: "backend-3",
+          projectId: "my-app",
+          status: "working",
+          activity: "active",
+          branch: "feat/hook-fail",
+        }),
+      ]);
+      (mockLifecycleManager.check as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("boom"),
+      );
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        const req = new Request("http://localhost:3000/api/webhooks/github", {
+          method: "POST",
+          body: JSON.stringify({}),
+          headers: { "Content-Type": "application/json" },
+        });
+
+        const res = await webhooksPOST(req);
+        expect(res.status).toBe(202);
+
+        const data = await res.json();
+        expect(data.lifecycleErrors).toEqual(["session backend-3: boom"]);
+        expect(errorSpy).toHaveBeenCalledWith(
+          "[webhook] lifecycle checks failed:",
+          ["session backend-3: boom"],
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/web/src/__tests__/helpers.ts
+++ b/packages/web/src/__tests__/helpers.ts
@@ -16,6 +16,7 @@ export function makeSession(overrides: Partial<DashboardSession> = {}): Dashboar
     createdAt: new Date().toISOString(),
     lastActivityAt: new Date().toISOString(),
     pr: null,
+    notificationState: { status: "ok", failingNotifiers: [], notifiers: [] },
     metadata: {},
     ...overrides,
   };

--- a/packages/web/src/app/api/webhooks/[...slug]/route.ts
+++ b/packages/web/src/app/api/webhooks/[...slug]/route.ts
@@ -99,6 +99,10 @@ export async function POST(request: Request): Promise<Response> {
       );
     }
 
+    if (lifecycleErrors.length > 0) {
+      console.error("[webhook] lifecycle checks failed:", lifecycleErrors);
+    }
+
     return NextResponse.json(
       {
         ok: true,

--- a/packages/web/src/lib/__tests__/format.test.ts
+++ b/packages/web/src/lib/__tests__/format.test.ts
@@ -26,6 +26,7 @@ function makeSession(overrides?: Partial<DashboardSession>): DashboardSession {
     createdAt: new Date().toISOString(),
     lastActivityAt: new Date().toISOString(),
     pr: null,
+    notificationState: { status: "ok", failingNotifiers: [], notifiers: [] },
     metadata: {},
     ...overrides,
   };

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -213,6 +213,78 @@ describe("sessionToDashboard", () => {
 
     expect(dashboard.pr).toBeNull();
   });
+
+  it("should expose empty notificationState when no notifier metadata exists", () => {
+    const coreSession = createCoreSession();
+    const dashboard = sessionToDashboard(coreSession);
+
+    expect(dashboard.notificationState).toEqual({
+      status: "ok",
+      failingNotifiers: [],
+      notifiers: [],
+    });
+  });
+
+  it("should derive notificationState from flat notifier metadata", () => {
+    const coreSession = createCoreSession({
+      metadata: {
+        "notifier.openclaw.status": "warn",
+        "notifier.openclaw.consecutiveFailures": "2",
+        "notifier.openclaw.lastFailureAt": "2026-03-24T10:00:00.000Z",
+        "notifier.openclaw.lastFailureReason": "401 Unauthorized",
+        "notifier.openclaw.lastEventType": "merge.completed",
+        "notifier.openclaw.lastPriority": "action",
+        "notifier.desktop.status": "ok",
+        "notifier.desktop.consecutiveFailures": "0",
+        "notifier.desktop.lastSuccessAt": "2026-03-24T10:05:00.000Z",
+      },
+    });
+
+    const dashboard = sessionToDashboard(coreSession);
+
+    expect(dashboard.notificationState).toEqual({
+      status: "warn",
+      failingNotifiers: ["openclaw"],
+      notifiers: [
+        {
+          name: "desktop",
+          status: "ok",
+          consecutiveFailures: 0,
+          lastFailureAt: null,
+          lastFailureReason: null,
+          lastSuccessAt: "2026-03-24T10:05:00.000Z",
+          lastEventType: null,
+          lastPriority: null,
+        },
+        {
+          name: "openclaw",
+          status: "warn",
+          consecutiveFailures: 2,
+          lastFailureAt: "2026-03-24T10:00:00.000Z",
+          lastFailureReason: "401 Unauthorized",
+          lastSuccessAt: null,
+          lastEventType: "merge.completed",
+          lastPriority: "action",
+        },
+      ],
+    });
+  });
+
+  it("should ignore unknown notifier metadata fields without creating a notifier entry", () => {
+    const coreSession = createCoreSession({
+      metadata: {
+        "notifier.openclaw.lastAttemptAt": "2026-03-24T10:00:00.000Z",
+      },
+    });
+
+    const dashboard = sessionToDashboard(coreSession);
+
+    expect(dashboard.notificationState).toEqual({
+      status: "ok",
+      failingNotifiers: [],
+      notifiers: [],
+    });
+  });
 });
 
 describe("resolveProject", () => {
@@ -405,6 +477,7 @@ describe("enrichSessionPR", () => {
       createdAt: new Date().toISOString(),
       lastActivityAt: new Date().toISOString(),
       pr: null,
+      notificationState: { status: "ok", failingNotifiers: [], notifiers: [] },
       metadata: {},
     };
     const pr = createPRInfo();

--- a/packages/web/src/lib/__tests__/types.test.ts
+++ b/packages/web/src/lib/__tests__/types.test.ts
@@ -35,6 +35,7 @@ function createSession(overrides?: Partial<DashboardSession>): DashboardSession 
     createdAt: new Date().toISOString(),
     lastActivityAt: new Date().toISOString(),
     pr: null,
+    notificationState: { status: "ok", failingNotifiers: [], notifiers: [] },
     metadata: {},
     ...overrides,
   };

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -21,6 +21,8 @@ import type {
   DashboardPR,
   DashboardStats,
   DashboardOrchestratorLink,
+  DashboardNotificationState,
+  DashboardNotifierState,
 } from "./types.js";
 import { TTLCache, prCache, prCacheKey, type PREnrichmentData } from "./cache";
 
@@ -45,6 +47,78 @@ export function resolveProject(
   return firstKey ? projects[firstKey] : undefined;
 }
 
+function parseNotifierState(metadata: Record<string, string>): DashboardNotificationState {
+  const byNotifier = new Map<string, Partial<DashboardNotifierState>>();
+
+  for (const [key, value] of Object.entries(metadata)) {
+    const match = /^notifier\.([^.]+)\.status$/.exec(key);
+    if (!match) continue;
+
+    const [, name] = match;
+    if (value === "ok" || value === "warn") {
+      byNotifier.set(name, { name, status: value });
+    }
+  }
+
+  for (const [key, value] of Object.entries(metadata)) {
+    const match = /^notifier\.([^.]+)\.(.+)$/.exec(key);
+    if (!match) continue;
+
+    const [, name, field] = match;
+    const current = byNotifier.get(name);
+    if (!current) continue;
+
+    switch (field) {
+      case "consecutiveFailures":
+        current.consecutiveFailures = Number.parseInt(value, 10) || 0;
+        break;
+      case "lastFailureAt":
+        current.lastFailureAt = value || null;
+        break;
+      case "lastFailureReason":
+        current.lastFailureReason = value || null;
+        break;
+      case "lastSuccessAt":
+        current.lastSuccessAt = value || null;
+        break;
+      case "lastEventType":
+        current.lastEventType = value || null;
+        break;
+      case "lastPriority":
+        current.lastPriority =
+          value === "urgent" || value === "action" || value === "warning" || value === "info"
+            ? value
+            : null;
+        break;
+    }
+
+    byNotifier.set(name, current);
+  }
+
+  const notifiers = [...byNotifier.values()]
+    .map(
+      (entry): DashboardNotifierState => ({
+        name: entry.name ?? "unknown",
+        status: entry.status ?? "ok",
+        consecutiveFailures: entry.consecutiveFailures ?? 0,
+        lastFailureAt: entry.lastFailureAt ?? null,
+        lastFailureReason: entry.lastFailureReason ?? null,
+        lastSuccessAt: entry.lastSuccessAt ?? null,
+        lastEventType: entry.lastEventType ?? null,
+        lastPriority: entry.lastPriority ?? null,
+      }),
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const failingNotifiers = notifiers.filter((notifier) => notifier.status === "warn").map((n) => n.name);
+
+  return {
+    status: failingNotifiers.length > 0 ? "warn" : "ok",
+    failingNotifiers,
+    notifiers,
+  };
+}
+
 /** Convert a core Session to a DashboardSession (without PR/issue enrichment). */
 export function sessionToDashboard(session: Session): DashboardSession {
   const agentSummary = session.agentInfo?.summary;
@@ -65,6 +139,7 @@ export function sessionToDashboard(session: Session): DashboardSession {
     createdAt: session.createdAt.toISOString(),
     lastActivityAt: session.lastActivityAt.toISOString(),
     pr: session.pr ? basicPRToDashboard(session.pr) : null,
+    notificationState: parseNotifierState(session.metadata),
     metadata: session.metadata,
   };
 }

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -74,6 +74,7 @@ export interface DashboardSession {
   createdAt: string;
   lastActivityAt: string;
   pr: DashboardPR | null;
+  notificationState?: DashboardNotificationState;
   metadata: Record<string, string>;
 }
 
@@ -128,6 +129,23 @@ export interface DashboardStats {
   workingSessions: number;
   openPRs: number;
   needsReview: number;
+}
+
+export interface DashboardNotifierState {
+  name: string;
+  status: "ok" | "warn";
+  consecutiveFailures: number;
+  lastFailureAt: string | null;
+  lastFailureReason: string | null;
+  lastSuccessAt: string | null;
+  lastEventType: string | null;
+  lastPriority: "urgent" | "action" | "warning" | "info" | null;
+}
+
+export interface DashboardNotificationState {
+  status: "ok" | "warn";
+  failingNotifiers: string[];
+  notifiers: DashboardNotifierState[];
 }
 
 export interface DashboardOrchestratorLink {


### PR DESCRIPTION
## Problem

When a notifier fails to deliver (wrong token, network error, OpenClaw unreachable), the lifecycle manager was silently swallowing the exception. Operators had no signal that escalation delivery was broken. Sessions requiring human attention could be stuck with no visible indication.

## Changes

### Core (`packages/core`)
- Wrap each notifier call in `notifyHuman()` with a delivery recorder — non-blocking, does not change lifecycle transitions
- On failure: record observability event, persist `notifier.<name>.status=warn` + failure fields to session metadata
- On success: record observability event, reset warning state, preserve `lastSuccessAt` across subsequent failures
- Notifier traces are session-correlated but do not overwrite the primary session summary slot in observability
- Validate notifier names at config load — reject names containing dots (incompatible with flat metadata key scheme)

### Web (`packages/web`)
- Add additive `notificationState?: DashboardNotificationState` to `DashboardSession`
- Populate in both `/api/sessions` and `/api/sessions/[id]`
- Serializer only materializes notifier entries from explicit `notifier.<name>.status` keys — unknown fields ignored

## What is not changing
- Notifier plugin interface
- Existing notifier implementations
- Lifecycle transition logic
- `ao status` CLI text output

## Known limitation
Configured-but-unloaded notifiers (plugin load failure) are still silent. Marked inline — tracked as a follow-up.

## Testing
- `HOME=/tmp pnpm --filter @composio/ao-core test -- --run src/__tests__/observability.test.ts src/__tests__/lifecycle-manager.test.ts src/__tests__/config-validation.test.ts` ✓
- `pnpm --filter @composio/ao-web test -- --run src/lib/__tests__/serialize.test.ts` ✓

## Pre-existing unrelated failure
`@composio/ao-web typecheck` fails due to missing `next-themes` type declarations — present on `main` before this branch.