### PR TITLE
fix: Replace em-dash with hyphen in config.ts JSDoc

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,5 +1,5 @@
 /**
- * Configuration loader — reads agent-orchestrator.yaml and validates with Zod.
+ * Configuration loader - reads agent-orchestrator.yaml and validates with Zod.
  *
  * Minimal config that just works:
  *   projects:


### PR DESCRIPTION
## Summary
- Fixed a typo in `packages/core/src/config.ts` - replaced em-dash (—) with regular hyphen (-) in the JSDoc comment

Fixes #651

## Test plan
- [x] Code change verified
- [ ] CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)