### PR TITLE
feat(notifier-openclaw): add channel/to fields for message routing

### DIFF
--- a/packages/plugins/notifier-openclaw/src/index.test.ts
+++ b/packages/plugins/notifier-openclaw/src/index.test.ts
@@ -172,4 +172,48 @@ describe("notifier-openclaw", () => {
     await expect(notifier.notify(makeEvent())).rejects.toThrow("OpenClaw webhook failed (401)");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("includes channel and to in payload when configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const notifier = create({
+      token: "tok",
+      channel: "discord",
+      to: "channel:1486249369291460650",
+    });
+    await notifier.notify(makeEvent());
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.channel).toBe("discord");
+    expect(body.to).toBe("channel:1486249369291460650");
+  });
+
+  it("omits channel and to from payload when not configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const notifier = create({ token: "tok" });
+    await notifier.notify(makeEvent());
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).not.toHaveProperty("channel");
+    expect(body).not.toHaveProperty("to");
+  });
+
+  it("includes channel and to in post payload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const notifier = create({
+      token: "tok",
+      channel: "telegram",
+      to: "chat:99999",
+    });
+    await notifier.post!("hello", { sessionId: "s1" });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.channel).toBe("telegram");
+    expect(body.to).toBe("chat:99999");
+  });
 });

--- a/packages/plugins/notifier-openclaw/src/index.ts
+++ b/packages/plugins/notifier-openclaw/src/index.ts
@@ -23,6 +23,8 @@ interface OpenClawWebhookPayload {
   sessionKey?: string;
   wakeMode?: WakeMode;
   deliver?: boolean;
+  channel?: string;
+  to?: string;
 }
 
 async function postWithRetry(
@@ -120,6 +122,8 @@ export function create(config?: Record<string, unknown>): Notifier {
     typeof config?.sessionKeyPrefix === "string" ? config.sessionKeyPrefix : "hook:ao:";
   const wakeMode: WakeMode = config?.wakeMode === "next-heartbeat" ? "next-heartbeat" : "now";
   const deliver = typeof config?.deliver === "boolean" ? config.deliver : true;
+  const channel = typeof config?.channel === "string" ? config.channel : undefined;
+  const to = typeof config?.to === "string" ? config.to : undefined;
 
   const { retries, retryDelayMs } = normalizeRetryConfig(config);
 
@@ -138,8 +142,13 @@ export function create(config?: Record<string, unknown>): Notifier {
     if (token) headers["Authorization"] = `Bearer ${token}`;
 
     const sessionId = payload.sessionKey?.slice(sessionKeyPrefix.length) ?? "default";
+    const enrichedPayload = {
+      ...payload,
+      ...(channel && { channel }),
+      ...(to && { to }),
+    };
 
-    await postWithRetry(url, payload, headers, retries, retryDelayMs, { sessionId });
+    await postWithRetry(url, enrichedPayload, headers, retries, retryDelayMs, { sessionId });
   }
 
   return {


### PR DESCRIPTION
## Summary
- Add optional `channel` and `to` fields to `notifier-openclaw` plugin config
- OpenClaw can now route notifications to specific channels (e.g. Discord, Telegram) instead of the default channel
- Fields are injected in `sendPayload`, so `notify`, `notifyWithActions`, `post` 모두 자동 적용

## Test plan
- [x] `pnpm build` — no TypeScript errors
- [x] `pnpm test` — 15/15 tests pass (3 new tests added)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no new errors (existing warnings only)

## YAML config example
```yaml
notifiers:
  openclaw:
    plugin: openclaw
    url: http://192.168.0.109:18789
    token: <token>
    channel: discord
    to: channel:1486249369291460650
