### PR TITLE
feat(core): cryptographic agent identity for orchestrated sub-agents

### DIFF
--- a/packages/core/src/__tests__/agent-identity.test.ts
+++ b/packages/core/src/__tests__/agent-identity.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import {
+  computeFingerprint,
+  generateAgentIdentity,
+  signClaim,
+  verifyClaim,
+  computeTrustScore,
+  saveAgentIdentityKey,
+  loadAgentIdentityKey,
+  loadAgentIdentity,
+  type AgentIdentityWithKey,
+  type TrustOutcome,
+} from "../agent-identity.js";
+
+let identitiesDir: string;
+
+beforeEach(() => {
+  identitiesDir = join(tmpdir(), `ao-test-identity-${randomUUID()}`);
+  mkdirSync(identitiesDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(identitiesDir, { recursive: true, force: true });
+});
+
+// =============================================================================
+// computeFingerprint
+// =============================================================================
+
+describe("computeFingerprint", () => {
+  it("returns a 64-char hex string (SHA-256)", () => {
+    const fingerprint = computeFingerprint("some public key pem content");
+    expect(fingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic for the same input", () => {
+    const pem = "-----BEGIN PUBLIC KEY-----\nfakepemdata\n-----END PUBLIC KEY-----\n";
+    expect(computeFingerprint(pem)).toBe(computeFingerprint(pem));
+  });
+
+  it("produces different fingerprints for different keys", () => {
+    const a = computeFingerprint("key-a");
+    const b = computeFingerprint("key-b");
+    expect(a).not.toBe(b);
+  });
+});
+
+// =============================================================================
+// generateAgentIdentity
+// =============================================================================
+
+describe("generateAgentIdentity", () => {
+  it("generates an identity with expected fields", () => {
+    const identity = generateAgentIdentity("app-1", "my-project", null);
+
+    expect(identity.sessionId).toBe("app-1");
+    expect(identity.projectId).toBe("my-project");
+    expect(identity.spawnedBy).toBeNull();
+    expect(identity.agentId).toMatch(/^did:ao:app-1:/);
+    expect(identity.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(identity.publicKey).toContain("BEGIN PUBLIC KEY");
+    expect(identity.privateKey).toContain("BEGIN PRIVATE KEY");
+    expect(identity.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("embeds a 16-char prefix of the fingerprint in agentId", () => {
+    const identity = generateAgentIdentity("app-2", "proj");
+    const idParts = identity.agentId.split(":");
+    expect(idParts).toHaveLength(4); // did, ao, sessionId, fingerprint-prefix
+    expect(identity.fingerprint.startsWith(idParts[3])).toBe(true);
+    expect(idParts[3]).toHaveLength(16);
+  });
+
+  it("records spawnedBy when provided", () => {
+    const identity = generateAgentIdentity("worker-1", "proj", "orchestrator-1");
+    expect(identity.spawnedBy).toBe("orchestrator-1");
+  });
+
+  it("generates unique key pairs for different sessions", () => {
+    const a = generateAgentIdentity("sess-a", "proj");
+    const b = generateAgentIdentity("sess-b", "proj");
+    expect(a.publicKey).not.toBe(b.publicKey);
+    expect(a.fingerprint).not.toBe(b.fingerprint);
+    expect(a.agentId).not.toBe(b.agentId);
+  });
+
+  it("fingerprint matches computeFingerprint of the public key", () => {
+    const identity = generateAgentIdentity("app-3", "proj");
+    expect(identity.fingerprint).toBe(computeFingerprint(identity.publicKey));
+  });
+});
+
+// =============================================================================
+// signClaim / verifyClaim
+// =============================================================================
+
+describe("signClaim / verifyClaim", () => {
+  let identity: AgentIdentityWithKey;
+
+  beforeEach(() => {
+    identity = generateAgentIdentity("signer-1", "test-project");
+  });
+
+  it("signs and verifies a simple payload", () => {
+    const claim = signClaim(identity.agentId, { action: "task_done", issueId: "INT-42" }, identity.privateKey);
+
+    expect(claim.agentId).toBe(identity.agentId);
+    expect(claim.payload).toEqual({ action: "task_done", issueId: "INT-42" });
+    expect(claim.signature).toBeTruthy();
+    expect(typeof claim.signedAt).toBe("string");
+
+    expect(verifyClaim(claim, identity.publicKey)).toBe(true);
+  });
+
+  it("returns false when the signature is tampered with", () => {
+    const claim = signClaim(identity.agentId, { status: "ok" }, identity.privateKey);
+    const tampered = { ...claim, signature: "invalidsignaturedata" };
+    expect(verifyClaim(tampered, identity.publicKey)).toBe(false);
+  });
+
+  it("returns false when the payload is modified after signing", () => {
+    const claim = signClaim(identity.agentId, { value: 1 }, identity.privateKey);
+    const tampered = { ...claim, payload: { value: 2 } };
+    expect(verifyClaim(tampered, identity.publicKey)).toBe(false);
+  });
+
+  it("returns false when verified with a different public key", () => {
+    const other = generateAgentIdentity("other-1", "proj");
+    const claim = signClaim(identity.agentId, { ping: true }, identity.privateKey);
+    expect(verifyClaim(claim, other.publicKey)).toBe(false);
+  });
+
+  it("handles null and array payloads", () => {
+    const nullClaim = signClaim(identity.agentId, null, identity.privateKey);
+    expect(verifyClaim(nullClaim, identity.publicKey)).toBe(true);
+
+    const arrClaim = signClaim(identity.agentId, [1, 2, 3], identity.privateKey);
+    expect(verifyClaim(arrClaim, identity.publicKey)).toBe(true);
+  });
+
+  it("returns false for a completely invalid claim object", () => {
+    const invalid = { agentId: "x", payload: {}, signedAt: "bad", signature: "!!!" };
+    expect(verifyClaim(invalid, identity.publicKey)).toBe(false);
+  });
+});
+
+// =============================================================================
+// computeTrustScore
+// =============================================================================
+
+describe("computeTrustScore", () => {
+  it("returns 0.5 neutral score for empty history", () => {
+    const score = computeTrustScore([]);
+    expect(score.score).toBe(0.5);
+    expect(score.sampleCount).toBe(0);
+    expect(score.outcomes).toEqual({});
+  });
+
+  it("perfect positive history scores above 0.5", () => {
+    const outcomes: TrustOutcome[] = ["pr_merged", "pr_merged", "approved", "ci_passed"];
+    const score = computeTrustScore(outcomes);
+    expect(score.score).toBeGreaterThan(0.5);
+    expect(score.sampleCount).toBe(4);
+  });
+
+  it("all failures scores below 0.5", () => {
+    const outcomes: TrustOutcome[] = ["errored", "errored", "ci_failed", "stuck"];
+    const score = computeTrustScore(outcomes);
+    expect(score.score).toBeLessThan(0.5);
+  });
+
+  it("score is clamped to [0, 1]", () => {
+    const allBad: TrustOutcome[] = Array(20).fill("errored") as TrustOutcome[];
+    const allGood: TrustOutcome[] = Array(20).fill("pr_merged") as TrustOutcome[];
+
+    expect(computeTrustScore(allBad).score).toBeGreaterThanOrEqual(0);
+    expect(computeTrustScore(allBad).score).toBeLessThanOrEqual(1);
+    expect(computeTrustScore(allGood).score).toBeGreaterThanOrEqual(0);
+    expect(computeTrustScore(allGood).score).toBeLessThanOrEqual(1);
+  });
+
+  it("counts outcomes correctly", () => {
+    const outcomes: TrustOutcome[] = ["pr_merged", "ci_failed", "pr_merged", "ci_failed", "ci_failed"];
+    const score = computeTrustScore(outcomes);
+    expect(score.outcomes["pr_merged"]).toBe(2);
+    expect(score.outcomes["ci_failed"]).toBe(3);
+    expect(score.outcomes["errored"]).toBeUndefined();
+  });
+
+  it("mixed outcomes produce a middle range score", () => {
+    const outcomes: TrustOutcome[] = ["pr_merged", "errored", "ci_passed", "ci_failed"];
+    const score = computeTrustScore(outcomes);
+    expect(score.score).toBeGreaterThan(0);
+    expect(score.score).toBeLessThan(1);
+  });
+});
+
+// =============================================================================
+// saveAgentIdentityKey / loadAgentIdentityKey / loadAgentIdentity
+// =============================================================================
+
+describe("saveAgentIdentityKey / loadAgentIdentityKey", () => {
+  it("saves and loads a full identity", () => {
+    const original = generateAgentIdentity("app-10", "project-x", "orch-1");
+    saveAgentIdentityKey(identitiesDir, original);
+
+    const loaded = loadAgentIdentityKey(identitiesDir, "app-10");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.agentId).toBe(original.agentId);
+    expect(loaded!.sessionId).toBe(original.sessionId);
+    expect(loaded!.projectId).toBe(original.projectId);
+    expect(loaded!.fingerprint).toBe(original.fingerprint);
+    expect(loaded!.publicKey).toBe(original.publicKey);
+    expect(loaded!.privateKey).toBe(original.privateKey);
+    expect(loaded!.createdAt).toBe(original.createdAt);
+    expect(loaded!.spawnedBy).toBe("orch-1");
+  });
+
+  it("creates the identities directory if it does not exist", () => {
+    const nested = join(identitiesDir, "new-subdir");
+    const identity = generateAgentIdentity("app-11", "proj");
+    saveAgentIdentityKey(nested, identity);
+    expect(existsSync(nested)).toBe(true);
+  });
+
+  it("returns null for a non-existent session", () => {
+    expect(loadAgentIdentityKey(identitiesDir, "missing-99")).toBeNull();
+  });
+
+  it("persists with mode 0600 (owner read/write only)", () => {
+    const identity = generateAgentIdentity("app-12", "proj");
+    saveAgentIdentityKey(identitiesDir, identity);
+    const filePath = join(identitiesDir, "app-12.identity.json");
+    const stat = statSync(filePath);
+    // On POSIX, mode & 0o777 should be 0o600
+    // On Windows this check is skipped (file permissions work differently)
+    if (process.platform !== "win32") {
+      expect(stat.mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("the identity file is valid JSON", () => {
+    const identity = generateAgentIdentity("app-13", "proj");
+    saveAgentIdentityKey(identitiesDir, identity);
+    const filePath = join(identitiesDir, "app-13.identity.json");
+    expect(() => JSON.parse(readFileSync(filePath, "utf-8"))).not.toThrow();
+  });
+});
+
+describe("loadAgentIdentity (public only)", () => {
+  it("loads public identity without privateKey", () => {
+    const original = generateAgentIdentity("pub-1", "proj");
+    saveAgentIdentityKey(identitiesDir, original);
+
+    const pub = loadAgentIdentity(identitiesDir, "pub-1");
+    expect(pub).not.toBeNull();
+    expect(pub!.agentId).toBe(original.agentId);
+    expect(pub!.fingerprint).toBe(original.fingerprint);
+    expect(pub!.publicKey).toBe(original.publicKey);
+    // privateKey must not be present
+    expect("privateKey" in pub!).toBe(false);
+  });
+
+  it("returns null when no identity exists", () => {
+    expect(loadAgentIdentity(identitiesDir, "no-such-session")).toBeNull();
+  });
+});
+
+// =============================================================================
+// End-to-end: generate → save → load → sign → verify
+// =============================================================================
+
+describe("end-to-end identity workflow", () => {
+  it("an agent can sign a claim that another party verifies using only the public identity", () => {
+    // Agent generates its identity and stores the key pair
+    const agentIdentity = generateAgentIdentity("e2e-agent-1", "my-project", "orchestrator-1");
+    saveAgentIdentityKey(identitiesDir, agentIdentity);
+
+    // Agent signs a claim
+    const claim = signClaim(
+      agentIdentity.agentId,
+      { taskId: "TASK-123", outcome: "pr_merged" },
+      agentIdentity.privateKey,
+    );
+
+    // Verifier loads only the public identity (no private key needed)
+    const publicIdentity = loadAgentIdentity(identitiesDir, "e2e-agent-1");
+    expect(publicIdentity).not.toBeNull();
+
+    // Verifier checks the claim is authentic
+    expect(verifyClaim(claim, publicIdentity!.publicKey)).toBe(true);
+
+    // The fingerprint stored in metadata matches the loaded public key
+    expect(publicIdentity!.fingerprint).toBe(computeFingerprint(publicIdentity!.publicKey));
+  });
+});

--- a/packages/core/src/agent-identity.ts
+++ b/packages/core/src/agent-identity.ts
@@ -1,0 +1,336 @@
+/**
+ * Agent Identity — Cryptographic identity for orchestrated sub-agents.
+ *
+ * Each agent session spawned by the orchestrator receives an Ed25519 key pair.
+ * The public key fingerprint is stored in session metadata for audit trails.
+ * The private key is persisted in a separate identities directory so agents
+ * can sign claims that other parties can independently verify.
+ *
+ * Identity format:
+ *   agentId: "did:ao:{sessionId}:{fingerprint}"
+ *   fingerprint: hex-encoded SHA-256 of the DER-encoded public key
+ *
+ * Trust scoring:
+ *   Computed from session outcomes (merged PRs, successful CI, etc.) and
+ *   used to rank agents for task assignment in parallel orchestration.
+ */
+
+import {
+  createHash,
+  generateKeyPairSync,
+  sign as cryptoSign,
+  verify as cryptoVerify,
+} from "node:crypto";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import type { SessionId } from "./types.js";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/** Cryptographic identity assigned to an agent session. */
+export interface AgentIdentity {
+  /** DID-like identifier: "did:ao:{sessionId}:{fingerprint}" */
+  agentId: string;
+
+  /** The session this identity belongs to */
+  sessionId: SessionId;
+
+  /** The project this session belongs to */
+  projectId: string;
+
+  /**
+   * Hex-encoded SHA-256 fingerprint of the DER-encoded public key.
+   * Stored in session metadata for verification without the full key.
+   */
+  fingerprint: string;
+
+  /** PEM-encoded Ed25519 public key */
+  publicKey: string;
+
+  /** ISO timestamp when this identity was created */
+  createdAt: string;
+
+  /**
+   * Session ID of the orchestrator or parent that spawned this agent.
+   * Null for top-level orchestrator sessions.
+   */
+  spawnedBy: SessionId | null;
+}
+
+/** Full identity including private key — never persisted to metadata. */
+export interface AgentIdentityWithKey extends AgentIdentity {
+  /** PEM-encoded Ed25519 private key — keep secret, store in identities dir only */
+  privateKey: string;
+}
+
+/** A signed claim produced by an agent. */
+export interface AgentClaim {
+  /** The agent identity that signed this claim */
+  agentId: string;
+
+  /** The claim payload as a JSON-serialisable value */
+  payload: unknown;
+
+  /** ISO timestamp when the claim was signed */
+  signedAt: string;
+
+  /** Base64-encoded Ed25519 signature over `agentId + signedAt + JSON(payload)` */
+  signature: string;
+}
+
+/** Possible outcomes used to calculate trust score. */
+export type TrustOutcome =
+  | "pr_merged" // Session's PR was merged — strong positive signal
+  | "ci_passed" // CI passed without failures — positive signal
+  | "ci_failed" // CI failed — mild negative signal
+  | "changes_requested" // PR required changes — mild negative signal
+  | "approved" // PR approved without changes — positive signal
+  | "stuck" // Session became stuck / needed input — mild negative signal
+  | "errored"; // Session errored out — strong negative signal
+
+/** Trust score for an agent, computed from historical outcomes. */
+export interface TrustScore {
+  /** Normalised score in [0, 1]; higher is better */
+  score: number;
+
+  /** Number of outcomes considered */
+  sampleCount: number;
+
+  /** Breakdown of outcome counts */
+  outcomes: Partial<Record<TrustOutcome, number>>;
+}
+
+// =============================================================================
+// IDENTITY GENERATION
+// =============================================================================
+
+/**
+ * Compute a hex-encoded SHA-256 fingerprint from a PEM-encoded public key.
+ */
+export function computeFingerprint(publicKeyPem: string): string {
+  return createHash("sha256").update(publicKeyPem).digest("hex");
+}
+
+/**
+ * Generate a new Ed25519 cryptographic identity for an agent session.
+ *
+ * Returns the full identity including the private key. Callers are
+ * responsible for persisting the private key via `saveAgentIdentityKey`.
+ */
+export function generateAgentIdentity(
+  sessionId: SessionId,
+  projectId: string,
+  spawnedBy: SessionId | null = null,
+): AgentIdentityWithKey {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519", {
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+
+  const fingerprint = computeFingerprint(publicKey);
+  const agentId = `did:ao:${sessionId}:${fingerprint.slice(0, 16)}`;
+  const createdAt = new Date().toISOString();
+
+  return {
+    agentId,
+    sessionId,
+    projectId,
+    fingerprint,
+    publicKey,
+    privateKey,
+    createdAt,
+    spawnedBy,
+  };
+}
+
+// =============================================================================
+// CLAIM SIGNING & VERIFICATION
+// =============================================================================
+
+/**
+ * Build the canonical string that is signed/verified for a claim.
+ * Format: `{agentId}\n{signedAt}\n{JSON(payload)}`
+ */
+function buildSigningInput(agentId: string, signedAt: string, payload: unknown): string {
+  return `${agentId}\n${signedAt}\n${JSON.stringify(payload)}`;
+}
+
+/**
+ * Sign a claim payload with the agent's Ed25519 private key.
+ *
+ * @param agentId - The agent's DID identifier
+ * @param payload - Any JSON-serialisable value to sign
+ * @param privateKeyPem - PEM-encoded Ed25519 private key
+ * @returns A signed `AgentClaim`
+ */
+export function signClaim(
+  agentId: string,
+  payload: unknown,
+  privateKeyPem: string,
+): AgentClaim {
+  const signedAt = new Date().toISOString();
+  const input = buildSigningInput(agentId, signedAt, payload);
+
+  // Ed25519 uses null as the algorithm — the hash is internal to the key scheme.
+  const signature = cryptoSign(null, Buffer.from(input), privateKeyPem).toString("base64");
+
+  return { agentId, payload, signedAt, signature };
+}
+
+/**
+ * Verify a signed claim against the agent's public key.
+ *
+ * @returns `true` if the signature is valid, `false` otherwise
+ */
+export function verifyClaim(claim: AgentClaim, publicKeyPem: string): boolean {
+  try {
+    const input = buildSigningInput(claim.agentId, claim.signedAt, claim.payload);
+    return cryptoVerify(
+      null,
+      Buffer.from(input),
+      publicKeyPem,
+      Buffer.from(claim.signature, "base64"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+// =============================================================================
+// TRUST SCORING
+// =============================================================================
+
+/** Weight assigned to each outcome type (positive = trust boost). */
+const OUTCOME_WEIGHTS: Record<TrustOutcome, number> = {
+  pr_merged: 1.0,
+  approved: 0.6,
+  ci_passed: 0.4,
+  ci_failed: -0.3,
+  changes_requested: -0.2,
+  stuck: -0.15,
+  errored: -0.6,
+};
+
+/**
+ * Compute a trust score from a list of historical session outcomes.
+ *
+ * The score is normalised to [0, 1] where 0.5 is neutral (no history).
+ * Each outcome shifts the score by its weight divided by the sample count
+ * to prevent gaming with large numbers of minor events.
+ */
+export function computeTrustScore(outcomes: TrustOutcome[]): TrustScore {
+  if (outcomes.length === 0) {
+    return { score: 0.5, sampleCount: 0, outcomes: {} };
+  }
+
+  const counts: Partial<Record<TrustOutcome, number>> = {};
+  let weightedSum = 0;
+
+  for (const outcome of outcomes) {
+    counts[outcome] = (counts[outcome] ?? 0) + 1;
+    weightedSum += OUTCOME_WEIGHTS[outcome];
+  }
+
+  // Normalise: start at 0.5, add average weight scaled to [−0.5, +0.5]
+  const avgWeight = weightedSum / outcomes.length;
+  const maxAbsWeight = Math.max(...Object.values(OUTCOME_WEIGHTS).map(Math.abs));
+  const score = Math.min(1, Math.max(0, 0.5 + avgWeight / (2 * maxAbsWeight)));
+
+  return { score, sampleCount: outcomes.length, outcomes: counts };
+}
+
+// =============================================================================
+// PERSISTENCE
+// =============================================================================
+
+/** File name for the identity key store within the identities directory. */
+function identityKeyPath(identitiesDir: string, sessionId: SessionId): string {
+  return join(identitiesDir, `${sessionId}.identity.json`);
+}
+
+/**
+ * Persist an agent's full identity (including private key) to the identities
+ * directory. The file is readable only by the current user (mode 0600).
+ */
+export function saveAgentIdentityKey(
+  identitiesDir: string,
+  identity: AgentIdentityWithKey,
+): void {
+  mkdirSync(identitiesDir, { recursive: true });
+  const path = identityKeyPath(identitiesDir, identity.sessionId);
+  const content = JSON.stringify(
+    {
+      agentId: identity.agentId,
+      sessionId: identity.sessionId,
+      projectId: identity.projectId,
+      fingerprint: identity.fingerprint,
+      publicKey: identity.publicKey,
+      privateKey: identity.privateKey,
+      createdAt: identity.createdAt,
+      spawnedBy: identity.spawnedBy,
+    },
+    null,
+    2,
+  );
+  writeFileSync(path, content, { mode: 0o600 });
+}
+
+/**
+ * Load a persisted agent identity (including private key) from disk.
+ * Returns `null` if no identity exists for the given session.
+ */
+export function loadAgentIdentityKey(
+  identitiesDir: string,
+  sessionId: SessionId,
+): AgentIdentityWithKey | null {
+  const path = identityKeyPath(identitiesDir, sessionId);
+  if (!existsSync(path)) return null;
+
+  try {
+    const raw: unknown = JSON.parse(readFileSync(path, "utf-8"));
+    if (!raw || typeof raw !== "object") return null;
+
+    const r = raw as Record<string, unknown>;
+    if (
+      typeof r["agentId"] !== "string" ||
+      typeof r["sessionId"] !== "string" ||
+      typeof r["projectId"] !== "string" ||
+      typeof r["fingerprint"] !== "string" ||
+      typeof r["publicKey"] !== "string" ||
+      typeof r["privateKey"] !== "string" ||
+      typeof r["createdAt"] !== "string"
+    ) {
+      return null;
+    }
+
+    return {
+      agentId: r["agentId"],
+      sessionId: r["sessionId"],
+      projectId: r["projectId"],
+      fingerprint: r["fingerprint"],
+      publicKey: r["publicKey"],
+      privateKey: r["privateKey"],
+      createdAt: r["createdAt"],
+      spawnedBy: typeof r["spawnedBy"] === "string" ? r["spawnedBy"] : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load only the public identity (no private key) from a persisted identity
+ * file. Useful for verification without needing the private key.
+ */
+export function loadAgentIdentity(
+  identitiesDir: string,
+  sessionId: SessionId,
+): AgentIdentity | null {
+  const full = loadAgentIdentityKey(identitiesDir, sessionId);
+  if (!full) return null;
+
+  const { privateKey: _privateKey, ...publicIdentity } = full;
+  return publicIdentity;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -148,6 +148,7 @@ export {
   getSessionsDir,
   getWorktreesDir,
   getFeedbackReportsDir,
+  getIdentitiesDir,
   getObservabilityBaseDir,
   getArchiveDir,
   getOriginFilePath,
@@ -157,6 +158,25 @@ export {
   expandHome,
   validateAndStoreOrigin,
 } from "./paths.js";
+
+// Agent identity — cryptographic identity for orchestrated sub-agents
+export {
+  computeFingerprint,
+  generateAgentIdentity,
+  signClaim,
+  verifyClaim,
+  computeTrustScore,
+  saveAgentIdentityKey,
+  loadAgentIdentityKey,
+  loadAgentIdentity,
+} from "./agent-identity.js";
+export type {
+  AgentIdentity,
+  AgentIdentityWithKey,
+  AgentClaim,
+  TrustOutcome,
+  TrustScore,
+} from "./agent-identity.js";
 
 // Config generator — auto-generate config from repo URL
 export {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -93,6 +93,9 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
       ? Number(raw["directTerminalWsPort"])
       : undefined,
     opencodeSessionId: raw["opencodeSessionId"],
+    agentId: raw["agentId"],
+    agentFingerprint: raw["agentFingerprint"],
+    agentSpawnedBy: raw["agentSpawnedBy"],
   };
 }
 
@@ -142,6 +145,9 @@ export function writeMetadata(
   if (metadata.directTerminalWsPort !== undefined)
     data["directTerminalWsPort"] = String(metadata.directTerminalWsPort);
   if (metadata.opencodeSessionId) data["opencodeSessionId"] = metadata.opencodeSessionId;
+  if (metadata.agentId) data["agentId"] = metadata.agentId;
+  if (metadata.agentFingerprint) data["agentFingerprint"] = metadata.agentFingerprint;
+  if (metadata.agentSpawnedBy) data["agentSpawnedBy"] = metadata.agentSpawnedBy;
 
   atomicWriteFileSync(path, serializeMetadata(data));
 }

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -120,6 +120,15 @@ export function getFeedbackReportsDir(configPath: string, projectPath: string): 
 }
 
 /**
+ * Get the identities directory for a project.
+ * Ed25519 key files for each session are stored here (mode 0600).
+ * Format: ~/.agent-orchestrator/{hash}-{projectId}/identities
+ */
+export function getIdentitiesDir(configPath: string, projectPath: string): string {
+  return join(getProjectBaseDir(configPath, projectPath), "identities");
+}
+
+/**
  * Get the archive directory for a project.
  * Format: ~/.agent-orchestrator/{hash}-{projectId}/archive
  */

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -59,10 +59,15 @@ import {
   getSessionsDir,
   getWorktreesDir,
   getProjectBaseDir,
+  getIdentitiesDir,
   generateTmuxName,
   generateConfigHash,
   validateAndStoreOrigin,
 } from "./paths.js";
+import {
+  generateAgentIdentity,
+  saveAgentIdentityKey,
+} from "./agent-identity.js";
 import { asValidOpenCodeSessionId } from "./opencode-session-id.js";
 import { normalizeOrchestratorSessionStrategy } from "./orchestrator-session-strategy.js";
 import {
@@ -284,6 +289,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
    */
   function getProjectSessionsDir(project: ProjectConfig): string {
     return getSessionsDir(config.configPath, project.path);
+  }
+
+  /**
+   * Get the identities directory for a project.
+   */
+  function getProjectIdentitiesDir(project: ProjectConfig): string {
+    return getIdentitiesDir(config.configPath, project.path);
   }
 
   function getProjectPause(project: ProjectConfig): {
@@ -1115,6 +1127,28 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       },
     };
 
+    // Generate cryptographic identity for the new agent session.
+    // The private key is stored in the project's identities directory;
+    // only the fingerprint and agentId are stored in session metadata.
+    const orchestratorId = `${project.sessionPrefix}-orchestrator`;
+    const orchestratorRaw = readMetadataRaw(sessionsDir, orchestratorId);
+    const spawnedBy =
+      orchestratorRaw && orchestratorRaw["role"] === "orchestrator" ? orchestratorId : null;
+
+    let agentIdentityMeta: { agentId?: string; agentFingerprint?: string; agentSpawnedBy?: string } =
+      {};
+    try {
+      const identity = generateAgentIdentity(sessionId, spawnConfig.projectId, spawnedBy);
+      saveAgentIdentityKey(getProjectIdentitiesDir(project), identity);
+      agentIdentityMeta = {
+        agentId: identity.agentId,
+        agentFingerprint: identity.fingerprint,
+        ...(identity.spawnedBy ? { agentSpawnedBy: identity.spawnedBy } : {}),
+      };
+    } catch {
+      // Identity generation is best-effort — session still spawns without it
+    }
+
     try {
       writeMetadata(sessionsDir, sessionId, {
         worktree: workspacePath,
@@ -1127,6 +1161,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         createdAt: new Date().toISOString(),
         runtimeHandle: JSON.stringify(handle),
         opencodeSessionId: reusedOpenCodeSessionId,
+        ...agentIdentityMeta,
       });
 
       if (plugins.agent.postLaunchSetup) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1158,6 +1158,12 @@ export interface SessionMetadata {
   terminalWsPort?: number;
   directTerminalWsPort?: number;
   opencodeSessionId?: string;
+  /** DID-like identifier for this agent: "did:ao:{sessionId}:{fingerprint}" */
+  agentId?: string;
+  /** Hex-encoded SHA-256 fingerprint of the agent's Ed25519 public key */
+  agentFingerprint?: string;
+  /** Session ID of the orchestrator/parent that spawned this agent */
+  agentSpawnedBy?: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Closes #671

- **`AgentIdentity` module** (`packages/core/src/agent-identity.ts`): Each session spawned by the orchestrator now receives an Ed25519 key pair at spawn time.
- **DID-like identifier** (`did:ao:{sessionId}:{fingerprint_prefix}`): stored in session metadata (`agentId`, `agentFingerprint`, `agentSpawnedBy`) for independent audit and verification.
- **Signed claims** via `signClaim` / `verifyClaim`: agents can cryptographically prove authorship of task outcomes.
- **Trust scoring** via `computeTrustScore`: ranks agents from historical outcomes (`pr_merged`, `ci_passed`, `ci_failed`, `errored`, etc.) into a normalised [0, 1] score.
- **Key persistence**: private keys stored in `~/.agent-orchestrator/{hash}-{project}/identities/{sessionId}.identity.json` at mode `0600`; public keys loadable without the private key for verification.
- **`getIdentitiesDir` path helper** added to `paths.ts` following existing conventions.
- Identity generation is best-effort: if key generation fails, the session still spawns successfully.

## Test plan

- [x] 28 unit tests added in `packages/core/src/__tests__/agent-identity.test.ts`
  - `computeFingerprint` — determinism, uniqueness, hex format
  - `generateAgentIdentity` — field shape, DID format, key uniqueness, fingerprint consistency
  - `signClaim` / `verifyClaim` — round-trip, tamper detection (signature, payload, wrong key)
  - `computeTrustScore` — neutral baseline, positive/negative skew, clamping, outcome counts
  - `saveAgentIdentityKey` / `loadAgentIdentityKey` — full round-trip, missing session, file mode 0600
  - `loadAgentIdentity` — public-only load (no privateKey field)
  - End-to-end workflow: generate → save → load → sign → verify
- [x] All existing 512 tests continue to pass
- [x] `pnpm build` ✅
- [x] `pnpm typecheck` ✅
- [x] `pnpm lint` — no new errors introduced (pre-existing 116 errors unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)