### PR TITLE
Fix/ao api review followups

### DIFF
--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -95,6 +95,28 @@ describe("Config Validation - Session Prefix Uniqueness", () => {
     expect(() => validateConfig(config)).toThrow(/"app"/);
   });
 
+  it("rejects nested prefixes that would make session IDs ambiguous", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/app",
+          repo: "org/app",
+          defaultBranch: "main",
+          sessionPrefix: "app",
+        },
+        proj2: {
+          path: "/repos/app-foo",
+          repo: "org/app-foo",
+          defaultBranch: "main",
+          sessionPrefix: "app-foo",
+        },
+      },
+    };
+
+    expect(() => validateConfig(config)).toThrow(/session prefix/i);
+    expect(() => validateConfig(config)).toThrow(/app-foo/);
+  });
+
   it("rejects duplicate auto-generated prefixes", () => {
     const config = {
       projects: {

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -479,6 +479,34 @@ describe("Config Schema Validation", () => {
     expect(config.projects.proj1.agentConfig?.permissions).toBe("suggest");
     expect(config.projects.proj1.worker?.agentConfig?.permissions).toBeUndefined();
   });
+
+  it("rejects notifier names containing dots", () => {
+    expect(() =>
+      validateConfig({
+        defaults: {
+          notifiers: ["team.slack"],
+        },
+        notifiers: {
+          "team.slack": {
+            plugin: "desktop",
+          },
+        },
+        notificationRouting: {
+          urgent: ["team.slack"],
+          action: ["team.slack"],
+          warning: [],
+          info: [],
+        },
+        projects: {
+          proj1: {
+            path: "/repos/test",
+            repo: "org/test",
+            defaultBranch: "main",
+          },
+        },
+      }),
+    ).toThrow(/notifier names.*dot/i);
+  });
 });
 
 describe("Config Defaults", () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1343,7 +1343,12 @@ describe("reactions", () => {
     expect(metadata?.["notifier.desktop.status"]).toBe("ok");
   });
 
-  it("retries notify reactions when no notifier plugin resolves", async () => {
+  it("retries notify reactions when configured notifiers become available later", async () => {
+    const recoveredNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
     const mockSCM: SCM = {
       name: "mock-scm",
       detectPR: vi.fn(),
@@ -1370,11 +1375,14 @@ describe("reactions", () => {
       getMergeability: vi.fn(),
     };
 
-    const registryGet = vi.fn().mockImplementation((slot: string) => {
+    let notifierAvailable = false;
+    const registryGet = vi.fn().mockImplementation((slot: string, name: string) => {
       if (slot === "runtime") return mockRuntime;
       if (slot === "agent") return mockAgent;
       if (slot === "scm") return mockSCM;
-      if (slot === "notifier") return null;
+      if (slot === "notifier" && name === "desktop") {
+        return notifierAvailable ? recoveredNotifier : null;
+      }
       return null;
     });
 
@@ -1422,21 +1430,31 @@ describe("reactions", () => {
     await lm.check("app-1");
     let metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
-    expect(registryGet).toHaveBeenCalledWith("notifier", "desktop");
-    expect(
-      registryGet.mock.calls.filter(
-        ([slot, name]) => slot === "notifier" && name === "desktop",
-      ),
-    ).toHaveLength(1);
+    expect(recoveredNotifier.notify).not.toHaveBeenCalled();
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBe("1");
+    expect(metadata?.["reaction.changes-requested.firstTriggeredAt"]).toBeTruthy();
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBe("desktop");
 
     await lm.check("app-1");
     metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
-    expect(
-      registryGet.mock.calls.filter(
-        ([slot, name]) => slot === "notifier" && name === "desktop",
-      ),
-    ).toHaveLength(2);
+    expect(recoveredNotifier.notify).not.toHaveBeenCalled();
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBe("1");
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBe("desktop");
+
+    notifierAvailable = true;
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
+    expect(recoveredNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.firstTriggeredAt"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBeUndefined();
+
+    await lm.check("app-1");
+    expect(recoveredNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(registryGet).toHaveBeenCalledWith("notifier", "desktop");
   });
 
   it("does not persist review dispatch hashes when escalation notify delivery fails", async () => {
@@ -1540,7 +1558,12 @@ describe("reactions", () => {
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
   });
 
-  it("retries escalation when no notifier plugin resolves", async () => {
+  it("retries escalation when configured notifiers become available later", async () => {
+    const recoveredNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
     const mockSCM: SCM = {
       name: "mock-scm",
       detectPR: vi.fn(),
@@ -1567,11 +1590,14 @@ describe("reactions", () => {
       getMergeability: vi.fn(),
     };
 
-    const registryGet = vi.fn().mockImplementation((slot: string) => {
+    let notifierAvailable = false;
+    const registryGet = vi.fn().mockImplementation((slot: string, name: string) => {
       if (slot === "runtime") return mockRuntime;
       if (slot === "agent") return mockAgent;
       if (slot === "scm") return mockSCM;
-      if (slot === "notifier") return null;
+      if (slot === "notifier" && name === "desktop") {
+        return notifierAvailable ? recoveredNotifier : null;
+      }
       return null;
     });
 
@@ -1628,23 +1654,29 @@ describe("reactions", () => {
     await lm.check("app-1");
     metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
-    // Poll 2 must be the escalation path, not another send-to-agent attempt.
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
-    expect(
-      registryGet.mock.calls.filter(
-        ([slot, name]) => slot === "notifier" && name === "desktop",
-      ),
-    ).toHaveLength(1);
+    expect(recoveredNotifier.notify).not.toHaveBeenCalled();
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBe("2");
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBe("desktop");
 
     await lm.check("app-1");
     metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
-    expect(
-      registryGet.mock.calls.filter(
-        ([slot, name]) => slot === "notifier" && name === "desktop",
-      ),
-    ).toHaveLength(2);
+    expect(recoveredNotifier.notify).not.toHaveBeenCalled();
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBe("2");
+
+    notifierAvailable = true;
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(recoveredNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.firstTriggeredAt"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBeUndefined();
+    expect(registryGet).toHaveBeenCalledWith("notifier", "desktop");
   });
 
   it("does not treat an empty notification route as successful delivery", async () => {
@@ -1849,6 +1881,109 @@ describe("reactions", () => {
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
     expect(notifier.notify).toHaveBeenCalledTimes(1);
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.firstTriggeredAt"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBeUndefined();
+
+    await lm2.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(notifier.notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries auto-merge notifications while the session remains mergeable", async () => {
+    const flakyNotifier: Notifier = {
+      name: "desktop",
+      notify: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("OpenClaw unavailable"))
+        .mockResolvedValueOnce(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      }),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return flakyNotifier;
+        return null;
+      }),
+    };
+
+    const configWithAutoMergeReaction: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        action: ["desktop"],
+      },
+      reactions: {
+        ...config.reactions,
+        "approved-and-green": {
+          auto: true,
+          action: "auto-merge",
+          priority: "action",
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithAutoMergeReaction,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(flakyNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["status"]).toBe("mergeable");
+    expect(metadata?.["reaction.approved-and-green.attempts"]).toBe("1");
+    expect(metadata?.["reaction.approved-and-green.firstTriggeredAt"]).toBeTruthy();
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(flakyNotifier.notify).toHaveBeenCalledTimes(2);
+    expect(metadata?.["status"]).toBe("mergeable");
+    expect(metadata?.["reaction.approved-and-green.attempts"]).toBeUndefined();
+    expect(metadata?.["reaction.approved-and-green.firstTriggeredAt"]).toBeUndefined();
+    expect(metadata?.["reaction.approved-and-green.unresolvedNotifierSignature"]).toBeUndefined();
+
+    await lm.check("app-1");
+    expect(flakyNotifier.notify).toHaveBeenCalledTimes(2);
   });
 
   it("does not double-send when changes_requested transition already triggered the reaction", async () => {
@@ -2523,6 +2658,67 @@ describe("reactions", () => {
             trace.data?.["notifier"] === "desktop",
         ),
       ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries all-complete notifications when a notifier becomes available later", async () => {
+    vi.useFakeTimers();
+    try {
+      const recoveredNotifier: Notifier = {
+        name: "desktop",
+        notify: vi.fn().mockResolvedValue(undefined),
+      };
+
+      let notifierAvailable = false;
+      const registryWithFlappingNotifier: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string, name: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return mockAgent;
+          if (slot === "notifier" && name === "desktop") {
+            return notifierAvailable ? recoveredNotifier : null;
+          }
+          return null;
+        }),
+      };
+
+      const configWithAllCompleteReaction: OrchestratorConfig = {
+        ...config,
+        notificationRouting: {
+          ...config.notificationRouting,
+          info: ["desktop"],
+        },
+        reactions: {
+          ...config.reactions,
+          "all-complete": {
+            auto: true,
+            action: "notify",
+            priority: "info",
+          },
+        },
+      };
+
+      vi.mocked(mockSessionManager.list).mockResolvedValue([
+        makeSession({ id: "app-1", status: "merged" }),
+      ]);
+
+      const lm = createLifecycleManager({
+        config: configWithAllCompleteReaction,
+        registry: registryWithFlappingNotifier,
+        sessionManager: mockSessionManager,
+      });
+
+      lm.start(1_000);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(recoveredNotifier.notify).not.toHaveBeenCalled();
+
+      notifierAvailable = true;
+      await vi.advanceTimersByTimeAsync(1_000);
+      lm.stop();
+
+      expect(recoveredNotifier.notify).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2033,7 +2033,10 @@ describe("reactions", () => {
 
     const session = makeSession({ status: "pr_open", pr: makePR() });
     vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+    const metadataSnapshotsDuringSend: Array<Record<string, string> | null> = [];
+    vi.mocked(mockSessionManager.send).mockImplementation(async () => {
+      metadataSnapshotsDuringSend.push(readMetadataRaw(sessionsDir, "app-1"));
+    });
 
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp",
@@ -2053,6 +2056,13 @@ describe("reactions", () => {
 
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
     expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "Handle requested changes.");
+    expect(metadataSnapshotsDuringSend).toHaveLength(1);
+    expect(metadataSnapshotsDuringSend[0]?.["reaction.changes-requested.attempts"]).toBeUndefined();
+    expect(metadataSnapshotsDuringSend[0]?.["reaction.changes-requested.firstTriggeredAt"]).toBeUndefined();
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["reaction.changes-requested.attempts"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.firstTriggeredAt"]).toBeUndefined();
+    expect(metadata?.["reaction.changes-requested.unresolvedNotifierSignature"]).toBeUndefined();
   });
 
   it("dispatches automated review comments only once for an unchanged backlog", async () => {
@@ -2261,6 +2271,7 @@ describe("reactions", () => {
     expect(lm.getStates().get("app-1")).toBe("merged");
     expect(failingNotifier.notify).toHaveBeenCalledTimes(1);
     expect(succeedingNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(mockSessionManager.get).toHaveBeenCalledTimes(1);
 
     const metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(metadata?.["notifier.desktop.status"]).toBe("warn");
@@ -2341,7 +2352,7 @@ describe("reactions", () => {
     );
   });
 
-  it("records notifier observability even when session lookup fails after delivery", async () => {
+  it("records notifier metadata and observability without refetching the session after delivery", async () => {
     const mockNotifier: Notifier = {
       name: "desktop",
       notify: vi.fn().mockResolvedValue(undefined),
@@ -2374,9 +2385,7 @@ describe("reactions", () => {
     };
 
     const session = makeSession({ status: "approved", pr: makePR() });
-    vi.mocked(mockSessionManager.get)
-      .mockResolvedValueOnce(session)
-      .mockRejectedValueOnce(new Error("lookup failed"));
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
 
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp",
@@ -2394,7 +2403,9 @@ describe("reactions", () => {
     await lm.check("app-1");
 
     const metadata = readMetadataRaw(sessionsDir, "app-1");
-    expect(metadata?.["notifier.desktop.status"]).toBeUndefined();
+    expect(metadata?.["notifier.desktop.status"]).toBe("ok");
+    expect(metadata?.["notifier.desktop.lastSuccessAt"]).toBeTruthy();
+    expect(mockSessionManager.get).toHaveBeenCalledTimes(1);
 
     const summary = readObservabilitySummary(config);
     expect(summary.projects["my-app"]?.metrics["notification"]?.total).toBe(1);

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1343,6 +1343,102 @@ describe("reactions", () => {
     expect(metadata?.["notifier.desktop.status"]).toBe("ok");
   });
 
+  it("retries notify reactions when no notifier plugin resolves", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryGet = vi.fn().mockImplementation((slot: string) => {
+      if (slot === "runtime") return mockRuntime;
+      if (slot === "agent") return mockAgent;
+      if (slot === "scm") return mockSCM;
+      if (slot === "notifier") return null;
+      return null;
+    });
+
+    const registryWithMissingNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: registryGet,
+    };
+
+    const configWithNotifyReaction: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        action: ["desktop"],
+      },
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "notify",
+          priority: "action",
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithNotifyReaction,
+      registry: registryWithMissingNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(registryGet).toHaveBeenCalledWith("notifier", "desktop");
+    expect(
+      registryGet.mock.calls.filter(
+        ([slot, name]) => slot === "notifier" && name === "desktop",
+      ),
+    ).toHaveLength(1);
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(
+      registryGet.mock.calls.filter(
+        ([slot, name]) => slot === "notifier" && name === "desktop",
+      ),
+    ).toHaveLength(2);
+  });
+
   it("does not persist review dispatch hashes when escalation notify delivery fails", async () => {
     const failingNotifier: Notifier = {
       name: "desktop",
@@ -1435,11 +1531,324 @@ describe("reactions", () => {
     metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(failingNotifier.notify).toHaveBeenCalledTimes(1);
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
 
     await lm.check("app-1");
     metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(failingNotifier.notify).toHaveBeenCalledTimes(2);
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries escalation when no notifier plugin resolves", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryGet = vi.fn().mockImplementation((slot: string) => {
+      if (slot === "runtime") return mockRuntime;
+      if (slot === "agent") return mockAgent;
+      if (slot === "scm") return mockSCM;
+      if (slot === "notifier") return null;
+      return null;
+    });
+
+    const registryWithMissingNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: registryGet,
+    };
+
+    const configWithEscalation = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        urgent: ["desktop"],
+      },
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "send-to-agent" as const,
+          message: "Handle review comments.",
+          retries: 1,
+          escalateAfter: 1,
+          priority: "urgent" as const,
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.send).mockRejectedValue(new Error("agent unavailable"));
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithEscalation,
+      registry: registryWithMissingNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    // Poll 2 must be the escalation path, not another send-to-agent attempt.
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(
+      registryGet.mock.calls.filter(
+        ([slot, name]) => slot === "notifier" && name === "desktop",
+      ),
+    ).toHaveLength(1);
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(
+      registryGet.mock.calls.filter(
+        ([slot, name]) => slot === "notifier" && name === "desktop",
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("does not treat an empty notification route as successful delivery", async () => {
+    const fallbackNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryGet = vi.fn().mockImplementation((slot: string, name: string) => {
+      if (slot === "runtime") return mockRuntime;
+      if (slot === "agent") return mockAgent;
+      if (slot === "scm") return mockSCM;
+      if (slot === "notifier" && name === "desktop") return fallbackNotifier;
+      return null;
+    });
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: registryGet,
+    };
+
+    const configWithEmptyRoute: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        action: [],
+      },
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "notify",
+          priority: "action",
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithEmptyRoute,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(fallbackNotifier.notify).not.toHaveBeenCalled();
+    expect(
+      registryGet.mock.calls.filter(
+        ([slot, name]) => slot === "notifier" && name === "desktop",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("escalates after a lifecycle manager restart instead of retrying send-to-agent", async () => {
+    const notifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    const configWithEscalation = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        urgent: ["desktop"],
+      },
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "send-to-agent" as const,
+          message: "Handle review comments.",
+          retries: 1,
+          escalateAfter: 1,
+          priority: "urgent" as const,
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.send).mockRejectedValue(new Error("agent unavailable"));
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm1 = createLifecycleManager({
+      config: configWithEscalation,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm1.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(notifier.notify).not.toHaveBeenCalled();
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["reaction.changes-requested.attempts"]).toBe(
+      "1",
+    );
+
+    const restoredSession = makeSession({
+      status: "pr_open",
+      pr: makePR(),
+      metadata: readMetadataRaw(sessionsDir, "app-1") ?? {},
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(restoredSession);
+
+    const lm2 = createLifecycleManager({
+      config: configWithEscalation,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm2.check("app-1");
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(notifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
   });
 
   it("does not double-send when changes_requested transition already triggered the reaction", async () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { createLifecycleManager } from "../lifecycle-manager.js";
 import { createSessionManager } from "../session-manager.js";
 import { writeMetadata, readMetadataRaw } from "../metadata.js";
+import { readObservabilitySummary } from "../observability.js";
 import { getSessionsDir, getProjectBaseDir } from "../paths.js";
 import type {
   OrchestratorConfig,
@@ -1426,6 +1427,360 @@ describe("reactions", () => {
     expect(mockNotifier.notify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "merge.completed" }),
     );
+  });
+
+  it("records notifier failures, persists warning metadata, and continues to later notifiers", async () => {
+    const failingNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockRejectedValue(new Error("OpenClaw unavailable")),
+    };
+    const succeedingNotifier: Notifier = {
+      name: "slack",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifiers: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return failingNotifier;
+        if (slot === "notifier" && name === "slack") return succeedingNotifier;
+        return null;
+      }),
+    };
+
+    const configWithMultipleNotifiers: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop", "slack"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        action: ["desktop", "slack"],
+      },
+    };
+
+    const session = makeSession({ status: "approved", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithMultipleNotifiers,
+      registry: registryWithNotifiers,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("merged");
+    expect(failingNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(succeedingNotifier.notify).toHaveBeenCalledTimes(1);
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["notifier.desktop.status"]).toBe("warn");
+    expect(metadata?.["notifier.desktop.lastFailureReason"]).toBe("OpenClaw unavailable");
+    expect(metadata?.["notifier.desktop.consecutiveFailures"]).toBe("1");
+    expect(metadata?.["notifier.slack.status"]).toBe("ok");
+    expect(metadata?.["notifier.slack.consecutiveFailures"]).toBe("0");
+    expect(metadata?.["notifier.slack.lastSuccessAt"]).toBeTruthy();
+
+    const summary = readObservabilitySummary(configWithMultipleNotifiers);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.total).toBe(2);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.success).toBe(1);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.failure).toBe(1);
+    expect(
+      summary.projects["my-app"]?.recentTraces.some(
+        (trace) =>
+          trace.operation === "notifier.notify" &&
+          trace.sessionId === "app-1" &&
+          trace.data?.["notifier"] === "desktop" &&
+          trace.reason === "OpenClaw unavailable",
+      ),
+    ).toBe(true);
+  });
+
+  it("records notifier observability even when session lookup fails after delivery", async () => {
+    const mockNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "approved", pr: makePR() });
+    vi.mocked(mockSessionManager.get)
+      .mockResolvedValueOnce(session)
+      .mockRejectedValueOnce(new Error("lookup failed"));
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["notifier.desktop.status"]).toBeUndefined();
+
+    const summary = readObservabilitySummary(config);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.total).toBe(1);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.success).toBe(1);
+    expect(
+      summary.projects["my-app"]?.recentTraces.some(
+        (trace) =>
+          trace.operation === "notifier.notify" &&
+          trace.sessionId === "app-1" &&
+          trace.data?.["notifier"] === "desktop",
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves lastSuccessAt when a notifier later fails", async () => {
+    const flakyNotifier: Notifier = {
+      name: "desktop",
+      notify: vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("Temporary OpenClaw outage")),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return flakyNotifier;
+        return null;
+      }),
+    };
+
+    const configWithInfoRouting: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        ...config.notificationRouting,
+        info: ["desktop"],
+        urgent: ["desktop"],
+      },
+    };
+
+    const session = makeSession({ status: "spawning" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockAgent.getActivityState)
+      .mockResolvedValueOnce({ state: "waiting_input" as ActivityState })
+      .mockResolvedValueOnce({ state: "active" as ActivityState });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "spawning",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithInfoRouting,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    const successMetadata = readMetadataRaw(sessionsDir, "app-1");
+    const lastSuccessAt = successMetadata?.["notifier.desktop.lastSuccessAt"];
+    expect(lastSuccessAt).toBeTruthy();
+
+    await lm.check("app-1");
+    const failureMetadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(failureMetadata?.["notifier.desktop.status"]).toBe("warn");
+    expect(failureMetadata?.["notifier.desktop.lastFailureReason"]).toBe("Temporary OpenClaw outage");
+    expect(failureMetadata?.["notifier.desktop.lastSuccessAt"]).toBe(lastSuccessAt);
+  });
+
+  it("clears notifier warning state after a later successful delivery", async () => {
+    const flakyNotifier: Notifier = {
+      name: "desktop",
+      notify: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Temporary OpenClaw outage"))
+        .mockResolvedValueOnce(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return flakyNotifier;
+        return null;
+      }),
+    };
+
+    const configWithInfoRouting: OrchestratorConfig = {
+      ...config,
+      notificationRouting: {
+        ...config.notificationRouting,
+        info: ["desktop"],
+        urgent: ["desktop"],
+      },
+    };
+
+    const session = makeSession({ status: "spawning" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockAgent.getActivityState)
+      .mockResolvedValueOnce({ state: "active" as ActivityState })
+      .mockResolvedValueOnce({ state: "waiting_input" as ActivityState });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "spawning",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithInfoRouting,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["notifier.desktop.status"]).toBe("warn");
+    expect(metadata?.["notifier.desktop.consecutiveFailures"]).toBe("1");
+    expect(metadata?.["notifier.desktop.lastFailureReason"]).toBe("Temporary OpenClaw outage");
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["notifier.desktop.status"]).toBe("ok");
+    expect(metadata?.["notifier.desktop.consecutiveFailures"]).toBe("0");
+    expect(metadata?.["notifier.desktop.lastFailureAt"]).toBeUndefined();
+    expect(metadata?.["notifier.desktop.lastFailureReason"]).toBeUndefined();
+    expect(metadata?.["notifier.desktop.lastSuccessAt"]).toBeTruthy();
+  });
+
+  it("records notifier observability for all-complete system notifications", async () => {
+    vi.useFakeTimers();
+    try {
+      const mockNotifier: Notifier = {
+        name: "desktop",
+        notify: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const registryWithNotifier: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string, name: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return mockAgent;
+          if (slot === "notifier" && name === "desktop") return mockNotifier;
+          return null;
+        }),
+      };
+
+      const configWithAllCompleteReaction: OrchestratorConfig = {
+        ...config,
+        notificationRouting: {
+          ...config.notificationRouting,
+          info: ["desktop"],
+        },
+        reactions: {
+          ...config.reactions,
+          "all-complete": {
+            action: "notify",
+            priority: "info",
+          },
+        },
+      };
+
+      vi.mocked(mockSessionManager.list).mockResolvedValue([
+        makeSession({ id: "app-1", status: "merged" }),
+      ]);
+
+      const lm = createLifecycleManager({
+        config: configWithAllCompleteReaction,
+        registry: registryWithNotifier,
+        sessionManager: mockSessionManager,
+      });
+
+      lm.start(1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+      lm.stop();
+
+      expect(mockNotifier.notify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "reaction.triggered",
+          sessionId: "system",
+          projectId: "all",
+        }),
+      );
+
+      const summary = readObservabilitySummary(configWithAllCompleteReaction);
+      expect(summary.projects["all"]?.metrics["notification"]?.total).toBe(1);
+      expect(summary.projects["all"]?.metrics["notification"]?.success).toBe(1);
+      expect(
+        summary.projects["all"]?.recentTraces.some(
+          (trace) =>
+            trace.operation === "notifier.notify" &&
+            trace.sessionId === "system" &&
+            trace.data?.["notifier"] === "desktop",
+        ),
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1224,6 +1224,93 @@ describe("reactions", () => {
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
   });
 
+  it("retries notify reactions when every notifier delivery fails", async () => {
+    const flakyNotifier: Notifier = {
+      name: "desktop",
+      notify: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("OpenClaw unavailable"))
+        .mockResolvedValueOnce(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return flakyNotifier;
+        return null;
+      }),
+    };
+
+    const configWithNotifyReaction: OrchestratorConfig = {
+      ...config,
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "notify",
+          priority: "action",
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithNotifyReaction,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(flakyNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+    expect(metadata?.["notifier.desktop.status"]).toBe("warn");
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(flakyNotifier.notify).toHaveBeenCalledTimes(2);
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
+    expect(metadata?.["notifier.desktop.status"]).toBe("ok");
+  });
+
   it("does not double-send when changes_requested transition already triggered the reaction", async () => {
     config.reactions = {
       "changes-requested": {
@@ -1523,6 +1610,62 @@ describe("reactions", () => {
     ).toBe(true);
   });
 
+  it("sanitizes multiline notifier failure reasons before persisting metadata", async () => {
+    const failingNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockRejectedValue(new Error("OpenClaw unavailable\nretry later\r\nsee logs")),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return failingNotifier;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "approved", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["notifier.desktop.lastFailureReason"]).toBe(
+      "OpenClaw unavailable retry later see logs",
+    );
+  });
+
   it("records notifier observability even when session lookup fails after delivery", async () => {
     const mockNotifier: Notifier = {
       name: "desktop",
@@ -1589,6 +1732,67 @@ describe("reactions", () => {
           trace.data?.["notifier"] === "desktop",
       ),
     ).toBe(true);
+  });
+
+  it("does not reclassify successful notifier delivery when outcome persistence fails", async () => {
+    const mockNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const validSession = makeSession({ status: "approved", pr: makePR() });
+    const sessionWithInvalidId = makeSession({ id: "bad/id", status: "approved", pr: makePR() });
+    vi.mocked(mockSessionManager.get)
+      .mockResolvedValueOnce(validSession)
+      .mockResolvedValueOnce(sessionWithInvalidId);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await expect(lm.check("app-1")).resolves.toBeUndefined();
+    expect(lm.getStates().get("app-1")).toBe("merged");
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+
+    const summary = readObservabilitySummary(config);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.total).toBe(1);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.success).toBe(1);
+    expect(summary.projects["my-app"]?.metrics["notification"]?.failure).toBe(0);
   });
 
   it("preserves lastSuccessAt when a notifier later fails", async () => {
@@ -1739,6 +1943,7 @@ describe("reactions", () => {
         reactions: {
           ...config.reactions,
           "all-complete": {
+            auto: true,
             action: "notify",
             priority: "info",
           },

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2674,6 +2674,61 @@ describe("reactions", () => {
     }
   });
 
+  it("does not look up a session for all-complete system notifications when session is explicitly null", async () => {
+    vi.useFakeTimers();
+    try {
+      const mockNotifier: Notifier = {
+        name: "desktop",
+        notify: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const registryWithNotifier: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string, name: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return mockAgent;
+          if (slot === "notifier" && name === "desktop") return mockNotifier;
+          return null;
+        }),
+      };
+
+      const configWithAllCompleteReaction: OrchestratorConfig = {
+        ...config,
+        notificationRouting: {
+          ...config.notificationRouting,
+          info: ["desktop"],
+        },
+        reactions: {
+          ...config.reactions,
+          "all-complete": {
+            auto: true,
+            action: "notify",
+            priority: "info",
+          },
+        },
+      };
+
+      vi.mocked(mockSessionManager.list).mockResolvedValue([
+        makeSession({ id: "app-1", status: "merged" }),
+      ]);
+
+      const lm = createLifecycleManager({
+        config: configWithAllCompleteReaction,
+        registry: registryWithNotifier,
+        sessionManager: mockSessionManager,
+      });
+
+      lm.start(1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+      lm.stop();
+
+      expect(mockNotifier.notify).toHaveBeenCalled();
+      expect(mockSessionManager.get).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("retries all-complete notifications when a notifier becomes available later", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1343,6 +1343,105 @@ describe("reactions", () => {
     expect(metadata?.["notifier.desktop.status"]).toBe("ok");
   });
 
+  it("does not persist review dispatch hashes when escalation notify delivery fails", async () => {
+    const failingNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockRejectedValue(new Error("OpenClaw unavailable")),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please rename this helper",
+          path: "src/app.ts",
+          line: 12,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return failingNotifier;
+        return null;
+      }),
+    };
+
+    const configWithEscalation = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        notifiers: ["desktop"],
+      },
+      notificationRouting: {
+        ...config.notificationRouting,
+        urgent: ["desktop"],
+      },
+      reactions: {
+        ...config.reactions,
+        "changes-requested": {
+          auto: true,
+          action: "send-to-agent" as const,
+          message: "Handle review comments.",
+          retries: 1,
+          escalateAfter: 1,
+          priority: "urgent" as const,
+        },
+      },
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.send).mockRejectedValue(new Error("agent unavailable"));
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithEscalation,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    let metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(failingNotifier.notify).not.toHaveBeenCalled();
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(failingNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+
+    await lm.check("app-1");
+    metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(failingNotifier.notify).toHaveBeenCalledTimes(2);
+    expect(metadata?.["lastPendingReviewDispatchHash"]).toBeUndefined();
+  });
+
   it("does not double-send when changes_requested transition already triggered the reaction", async () => {
     config.reactions = {
       "changes-requested": {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -176,6 +176,38 @@ describe("start / stop", () => {
     // Should not throw on double stop
     lm.stop();
   });
+
+  it("records observability when an individual polled session check fails", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(mockSessionManager.list).mockResolvedValue([
+        makeSession({ id: "bad/id", status: "spawning" }),
+      ]);
+
+      const lm = createLifecycleManager({
+        config,
+        registry: mockRegistry,
+        sessionManager: mockSessionManager,
+      });
+
+      lm.start(1_000);
+      await vi.advanceTimersByTimeAsync(0);
+      lm.stop();
+
+      const summary = readObservabilitySummary(config);
+      expect(
+        summary.projects["my-app"]?.recentTraces.some(
+          (trace) =>
+            trace.operation === "lifecycle.check" &&
+            trace.sessionId === "bad/id" &&
+            trace.outcome === "failure" &&
+            trace.reason?.includes("Invalid session ID: bad/id"),
+        ),
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("check (single session)", () => {

--- a/packages/core/src/__tests__/observability.test.ts
+++ b/packages/core/src/__tests__/observability.test.ts
@@ -122,4 +122,38 @@ describe("observability snapshot", () => {
     expect(project.health["lifecycle.worker"]?.status).toBe("warn");
     expect(summary.overallStatus).toBe("warn");
   });
+
+  it("keeps lifecycle transitions in the session summary slot while excluding notifier traces", () => {
+    const observer = createProjectObserver(config, "lifecycle-manager");
+
+    observer.recordOperation({
+      metric: "lifecycle_poll",
+      operation: "lifecycle.transition",
+      outcome: "success",
+      correlationId: "corr-lifecycle",
+      projectId: "my-app",
+      sessionId: "app-1",
+      data: { oldStatus: "approved", newStatus: "merged" },
+      level: "info",
+    });
+
+    observer.recordOperation({
+      metric: "notification",
+      operation: "notifier.notify",
+      outcome: "failure",
+      correlationId: "corr-notifier",
+      projectId: "my-app",
+      sessionId: "app-1",
+      reason: "OpenClaw unavailable",
+      data: { notifier: "openclaw", eventType: "merge.completed", priority: "action" },
+      level: "error",
+    });
+
+    const summary = readObservabilitySummary(config);
+    const project = summary.projects["my-app"];
+
+    expect(project.sessions["app-1"]?.operation).toBe("lifecycle.transition");
+    expect(project.sessions["app-1"]?.outcome).toBe("success");
+    expect(project.metrics["notification"]?.failure).toBe(1);
+  });
 });

--- a/packages/core/src/__tests__/observability.test.ts
+++ b/packages/core/src/__tests__/observability.test.ts
@@ -79,6 +79,18 @@ describe("observability snapshot", () => {
       level: "error",
     });
 
+    observer.recordOperation({
+      metric: "notification",
+      operation: "notifier.notify",
+      outcome: "failure",
+      correlationId: "corr-2b",
+      projectId: "my-app",
+      sessionId: "app-1",
+      reason: "OpenClaw unavailable",
+      data: { notifier: "openclaw", eventType: "merge.completed", priority: "action" },
+      level: "error",
+    });
+
     observer.setHealth({
       surface: "lifecycle.worker",
       status: "warn",
@@ -95,8 +107,18 @@ describe("observability snapshot", () => {
     expect(project.metrics["spawn"]?.total).toBe(1);
     expect(project.metrics["spawn"]?.success).toBe(1);
     expect(project.metrics["send"]?.failure).toBe(1);
+    expect(project.metrics["notification"]?.failure).toBe(1);
     expect(project.sessions["app-1"]?.operation).toBe("session.send");
     expect(project.recentTraces.some((trace) => trace.operation === "session.spawn")).toBe(true);
+    expect(
+      project.recentTraces.some(
+        (trace) =>
+          trace.operation === "notifier.notify" &&
+          trace.sessionId === "app-1" &&
+          trace.reason === "OpenClaw unavailable" &&
+          trace.data?.["notifier"] === "openclaw",
+      ),
+    ).toBe(true);
     expect(project.health["lifecycle.worker"]?.status).toBe("warn");
     expect(summary.overallStatus).toBe("warn");
   });

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   chmodSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -17,14 +18,17 @@ import {
   writeMetadata,
   readMetadata,
   readMetadataRaw,
+  readArchivedMetadataRaw,
   deleteMetadata,
   reserveSessionId,
   updateMetadata,
 } from "../metadata.js";
+import * as metadata from "../metadata.js";
 import { getSessionsDir, getProjectBaseDir, getWorktreesDir } from "../paths.js";
 import {
   SessionNotRestorableError,
   WorkspaceMissingError,
+  SessionNotFoundError,
   isIssueNotFoundError,
   type OrchestratorConfig,
   type PluginRegistry,
@@ -1652,6 +1656,38 @@ describe("get", () => {
     expect(await sm.get("nonexistent")).toBeNull();
   });
 
+  it("returns archived session by ID when includeArchived is enabled", async () => {
+    const managedWorktree = join(
+      getWorktreesDir(config.configPath, config.projects["my-app"]!.path),
+      "app-1",
+    );
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: managedWorktree,
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.kill("app-1");
+
+    const archiveDir = join(sessionsDir, "archive");
+    const archiveName = readdirSync(archiveDir).find((file) => file.startsWith("app-1_"));
+    if (!archiveName) throw new Error("expected archived metadata");
+    const archivedAt = new Date("2025-01-02T03:04:05.000Z");
+    utimesSync(join(archiveDir, archiveName), archivedAt, archivedAt);
+
+    await expect(sm.get("app-1")).resolves.toBeNull();
+    const session = await sm.get("app-1", { includeArchived: true });
+
+    expect(session).not.toBeNull();
+    expect(session?.id).toBe("app-1");
+    expect(session?.status).toBe("killed");
+    expect(session?.activity).toBe("exited");
+    expect(session?.lastActivityAt.toISOString()).toBe(archivedAt.toISOString());
+  });
+
   it("assigns owning project ID when loading legacy metadata without project", async () => {
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp",
@@ -1783,6 +1819,28 @@ describe("kill", () => {
     expect(readMetadata(sessionsDir, "app-1")).toBeNull(); // archived + deleted
   });
 
+  it("does not archive metadata when runtime destroy fails", async () => {
+    const managedWorktree = join(
+      getWorktreesDir(config.configPath, config.projects["my-app"]!.path),
+      "app-1",
+    );
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: managedWorktree,
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+    vi.mocked(mockRuntime.destroy).mockRejectedValueOnce(new Error("runtime destroy failed"));
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.kill("app-1")).rejects.toThrow("runtime destroy failed");
+
+    expect(readMetadata(sessionsDir, "app-1")).not.toBeNull();
+    expect(readArchivedMetadataRaw(sessionsDir, "app-1")).toBeNull();
+    expect(mockWorkspace.destroy).not.toHaveBeenCalled();
+  });
+
   it("does not destroy workspace paths outside managed roots", async () => {
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp/ws",
@@ -1852,10 +1910,11 @@ describe("kill", () => {
     await expect(sm.kill("nonexistent")).rejects.toThrow("not found");
   });
 
-  it("tolerates runtime destroy failure", async () => {
+  it("tolerates runtime destroy failures when the runtime is already gone", async () => {
     const failRuntime: Runtime = {
       ...mockRuntime,
       destroy: vi.fn().mockRejectedValue(new Error("already gone")),
+      isAlive: vi.fn().mockResolvedValue(false),
     };
     const registryWithFail: PluginRegistry = {
       ...mockRegistry,
@@ -1875,8 +1934,66 @@ describe("kill", () => {
     });
 
     const sm = createSessionManager({ config, registry: registryWithFail });
-    // Should not throw even though runtime.destroy fails
     await expect(sm.kill("app-1")).resolves.toBeUndefined();
+    expect(readMetadata(sessionsDir, "app-1")).toBeNull();
+    expect(readArchivedMetadataRaw(sessionsDir, "app-1")).toMatchObject({
+      status: "killed",
+    });
+  });
+
+  it("tolerates workspace destroy failures when the workspace is already gone", async () => {
+    const managedWorktree = join(
+      getWorktreesDir(config.configPath, config.projects["my-app"]!.path),
+      "app-1",
+    );
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: managedWorktree,
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+    vi.mocked(mockWorkspace.destroy).mockRejectedValueOnce(new Error("ENOENT: workspace not found"));
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.kill("app-1")).resolves.toBeUndefined();
+
+    expect(readMetadata(sessionsDir, "app-1")).toBeNull();
+    expect(readArchivedMetadataRaw(sessionsDir, "app-1")).toMatchObject({
+      status: "killed",
+    });
+  });
+
+  it("allows retrying kill after workspace destroy fails once", async () => {
+    const managedWorktree = join(
+      getWorktreesDir(config.configPath, config.projects["my-app"]!.path),
+      "app-1",
+    );
+    mkdirSync(managedWorktree, { recursive: true });
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: managedWorktree,
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+    vi.mocked(mockRuntime.destroy).mockResolvedValueOnce(undefined);
+    vi.mocked(mockWorkspace.destroy).mockRejectedValueOnce(new Error("workspace destroy failed"));
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.kill("app-1")).rejects.toThrow("workspace destroy failed");
+
+    expect(readMetadataRaw(sessionsDir, "app-1")).toMatchObject({
+      status: "killed",
+    });
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["runtimeHandle"]).toBeUndefined();
+    expect(readArchivedMetadataRaw(sessionsDir, "app-1")).toBeNull();
+
+    await expect(sm.kill("app-1")).resolves.toBeUndefined();
+    expect(readMetadata(sessionsDir, "app-1")).toBeNull();
+    expect(readArchivedMetadataRaw(sessionsDir, "app-1")).toMatchObject({
+      status: "killed",
+    });
   });
 
   it("does not purge mapped OpenCode session on default kill", async () => {
@@ -4221,6 +4338,109 @@ describe("restore", () => {
     await expect(sm.restore("app-1")).rejects.toThrow(SessionNotRestorableError);
 
     expect(readMetadataRaw(sessionsDir, "app-1")).toBeNull();
+  });
+
+  it("destroys a restored workspace when archive restore fails after workspace restore", async () => {
+    const wsPath = join(
+      getWorktreesDir(config.configPath, config.projects["my-app"]!.path),
+      "ws-app-restore-fails-after-workspace",
+    );
+    const mockWorkspaceWithRestore: Workspace = {
+      ...mockWorkspace,
+      exists: vi.fn().mockResolvedValue(false),
+      restore: vi.fn().mockResolvedValue({
+        path: wsPath,
+        branch: "feat/TEST-1",
+        sessionId: "app-1",
+        projectId: "my-app",
+      }),
+      postCreate: vi.fn().mockRejectedValue(new Error("workspace post-create failed")),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const registryWithRestore = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, _name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "workspace") return mockWorkspaceWithRestore;
+        return null;
+      }),
+    } satisfies PluginRegistry;
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: wsPath,
+      branch: "feat/TEST-1",
+      status: "killed",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+    });
+    deleteMetadata(sessionsDir, "app-1");
+
+    const sm = createSessionManager({ config, registry: registryWithRestore });
+    await expect(sm.restore("app-1")).rejects.toThrow(WorkspaceMissingError);
+
+    expect(mockWorkspaceWithRestore.destroy).toHaveBeenCalledWith(wsPath);
+    expect(readMetadataRaw(sessionsDir, "app-1")).toBeNull();
+  });
+
+  it("destroys the new runtime and leaves no active metadata when restore persistence fails", async () => {
+    const wsPath = join(tmpDir, "ws-app-restore-persistence-failure");
+    mkdirSync(wsPath, { recursive: true });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: wsPath,
+      branch: "feat/TEST-1",
+      status: "killed",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+    });
+    deleteMetadata(sessionsDir, "app-1");
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    chmodSync(sessionsDir, 0o500);
+
+    try {
+      await expect(sm.restore("app-1")).rejects.toThrow();
+    } finally {
+      chmodSync(sessionsDir, 0o700);
+    }
+
+    expect(mockRuntime.create).toHaveBeenCalled();
+    expect(mockRuntime.destroy).toHaveBeenCalledWith(makeHandle("rt-1"));
+    expect(readMetadataRaw(sessionsDir, "app-1")).toBeNull();
+  });
+
+  it("preserves active metadata when active restore persistence fails", async () => {
+    const wsPath = join(tmpDir, "ws-app-active-restore-persistence-failure");
+    mkdirSync(wsPath, { recursive: true });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: wsPath,
+      branch: "feat/TEST-1",
+      status: "killed",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+    });
+
+    const originalRaw = readMetadataRaw(sessionsDir, "app-1");
+    expect(originalRaw).not.toBeNull();
+
+    const updateMetadataSpy = vi
+      .spyOn(metadata, "updateMetadata")
+      .mockImplementationOnce(() => {
+        throw new Error("metadata write failed");
+      });
+
+    try {
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      await expect(sm.restore("app-1")).rejects.toThrow("metadata write failed");
+    } finally {
+      updateMetadataSpy.mockRestore();
+    }
+
+    expect(mockRuntime.create).toHaveBeenCalled();
+    expect(mockRuntime.destroy).toHaveBeenCalledWith(makeHandle("rt-1"));
+    expect(readMetadataRaw(sessionsDir, "app-1")).toEqual(originalRaw);
   });
 
   it("re-discovers OpenCode mapping when stored mapping is invalid", async () => {

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -28,7 +28,6 @@ import { getSessionsDir, getProjectBaseDir, getWorktreesDir } from "../paths.js"
 import {
   SessionNotRestorableError,
   WorkspaceMissingError,
-  SessionNotFoundError,
   isIssueNotFoundError,
   type OrchestratorConfig,
   type PluginRegistry,

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -1941,6 +1941,37 @@ describe("kill", () => {
     });
   });
 
+  it("does not ignore runtime destroy failures with unrelated not-found text", async () => {
+    const failRuntime: Runtime = {
+      ...mockRuntime,
+      destroy: vi.fn().mockRejectedValue(new Error("Config key not found")),
+      isAlive: vi.fn().mockRejectedValue(new Error("runtime status unavailable")),
+    };
+    const registryWithFail: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return failRuntime;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithFail });
+    await expect(sm.kill("app-1")).rejects.toThrow("Config key not found");
+    expect(readMetadataRaw(sessionsDir, "app-1")).toMatchObject({
+      status: "working",
+    });
+    expect(readArchivedMetadataRaw(sessionsDir, "app-1")).toBeNull();
+  });
+
   it("tolerates workspace destroy failures when the workspace is already gone", async () => {
     const managedWorktree = join(
       getWorktreesDir(config.configPath, config.projects["my-app"]!.path),
@@ -1962,6 +1993,30 @@ describe("kill", () => {
     expect(readArchivedMetadataRaw(sessionsDir, "app-1")).toMatchObject({
       status: "killed",
     });
+  });
+
+  it("does not ignore workspace destroy failures with unrelated not-found text", async () => {
+    const managedWorktree = join(
+      getWorktreesDir(config.configPath, config.projects["my-app"]!.path),
+      "app-1",
+    );
+    mkdirSync(managedWorktree, { recursive: true });
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: managedWorktree,
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+    vi.mocked(mockWorkspace.destroy).mockRejectedValueOnce(new Error("Config key not found"));
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.kill("app-1")).rejects.toThrow("Config key not found");
+    expect(readMetadataRaw(sessionsDir, "app-1")).toMatchObject({
+      status: "killed",
+    });
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["runtimeHandle"]).toBeUndefined();
+    expect(readArchivedMetadataRaw(sessionsDir, "app-1")).toBeNull();
   });
 
   it("allows retrying kill after workspace destroy fails once", async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -196,6 +196,11 @@ const OrchestratorConfigSchema = z.object({
     info: ["composio"],
   }),
   reactions: z.record(ReactionConfigSchema).default({}),
+  api: z
+    .object({
+      token: z.string().optional(),
+    })
+    .optional(),
 });
 
 // =============================================================================
@@ -298,6 +303,19 @@ function validateProjectUniqueness(config: OrchestratorConfig): void {
           `  ${configKey}:\n` +
           `    path: ${project.path}\n` +
           `    sessionPrefix: ${prefix}2  # Add explicit prefix\n`,
+      );
+    }
+
+    const overlappingPrefix = [...prefixes].find(
+      (existingPrefix) =>
+        prefix.startsWith(`${existingPrefix}-`) || existingPrefix.startsWith(`${prefix}-`),
+    );
+    if (overlappingPrefix) {
+      const firstProjectKey = prefixToProject[overlappingPrefix];
+      throw new Error(
+        `Overlapping session prefix detected: "${overlappingPrefix}" and "${prefix}"\n` +
+          `Projects "${firstProjectKey}" and "${configKey}" would produce ambiguous session IDs.\n\n` +
+          `Use prefixes where neither is the other's dash-delimited prefix.`,
       );
     }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -306,6 +306,30 @@ function validateProjectUniqueness(config: OrchestratorConfig): void {
   }
 }
 
+function validateNotifierNames(config: OrchestratorConfig): void {
+  const notifierNames = new Set<string>();
+
+  for (const name of Object.keys(config.notifiers)) {
+    notifierNames.add(name);
+  }
+  for (const name of config.defaults.notifiers) {
+    notifierNames.add(name);
+  }
+  for (const names of Object.values(config.notificationRouting)) {
+    for (const name of names) {
+      notifierNames.add(name);
+    }
+  }
+
+  for (const name of notifierNames) {
+    if (name.includes(".")) {
+      throw new Error(
+        `Invalid notifier name "${name}": notifier names cannot contain dots.`,
+      );
+    }
+  }
+}
+
 /** Apply default reactions */
 function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
   const defaults: Record<string, (typeof config.reactions)[string]> = {
@@ -512,6 +536,7 @@ export function validateConfig(raw: unknown): OrchestratorConfig {
 
   // Validate project uniqueness and prefix collisions
   validateProjectUniqueness(config);
+  validateNotifierNames(config);
 
   return config;
 }

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1026,7 +1026,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   ): Promise<boolean> {
     const eventWithPriority = { ...event, priority };
     const notificationPlan = plan ?? resolveNotificationPlan(priority);
-    const trackedSession = session ?? (await sessionManager.get(event.sessionId).catch(() => null));
+    const trackedSession =
+      session === undefined
+        ? await sessionManager.get(event.sessionId).catch(() => null)
+        : session;
     let delivered = false;
 
     for (const { name, notifier } of notificationPlan.resolvedTargets) {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -528,6 +528,67 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     session.metadata = cleaned;
   }
 
+  function notifierMetadataKey(notifierName: string, field: string): string {
+    return `notifier.${notifierName}.${field}`;
+  }
+
+  function recordNotifierOutcome(
+    projectId: string,
+    session: Session | null,
+    notifierName: string,
+    event: OrchestratorEvent,
+    priority: EventPriority,
+    outcome: "success" | "failure",
+    error?: unknown,
+  ): void {
+    const correlationId = createCorrelationId("notifier");
+    const timestamp = new Date().toISOString();
+    const reason =
+      outcome === "failure"
+        ? error instanceof Error
+          ? error.message
+          : String(error)
+        : undefined;
+
+    observer.recordOperation({
+      metric: "notification",
+      operation: "notifier.notify",
+      outcome,
+      correlationId,
+      projectId,
+      sessionId: event.sessionId,
+      reason,
+      data: {
+        notifier: notifierName,
+        eventType: event.type,
+        priority,
+      },
+      level: outcome === "failure" ? "error" : "info",
+    });
+
+    if (!session) {
+      return;
+    }
+
+    const currentFailures = Number.parseInt(
+      session.metadata[notifierMetadataKey(notifierName, "consecutiveFailures")] ?? "0",
+      10,
+    );
+
+    updateSessionMetadata(session, {
+      [notifierMetadataKey(notifierName, "status")]: outcome === "failure" ? "warn" : "ok",
+      [notifierMetadataKey(notifierName, "lastEventType")]: event.type,
+      [notifierMetadataKey(notifierName, "lastPriority")]: priority,
+      [notifierMetadataKey(notifierName, "consecutiveFailures")]:
+        outcome === "failure" ? String(currentFailures + 1) : "0",
+      [notifierMetadataKey(notifierName, "lastFailureAt")]: outcome === "failure" ? timestamp : "",
+      [notifierMetadataKey(notifierName, "lastFailureReason")]: outcome === "failure" ? reason! : "",
+      ...(outcome === "success"
+        ? { [notifierMetadataKey(notifierName, "lastSuccessAt")]: timestamp }
+        : {}),
+    });
+  }
+
   function makeFingerprint(ids: string[]): string {
     return [...ids].sort().join(",");
   }
@@ -690,12 +751,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     for (const name of notifierNames) {
       const notifier = registry.get<Notifier>("notifier", name);
-      if (notifier) {
-        try {
-          await notifier.notify(eventWithPriority);
-        } catch {
-          // Notifier failed — not much we can do
-        }
+      if (!notifier) {
+        // Known limitation: missing/unloaded configured notifiers are still silent.
+        // Track separately rather than widening this PR's notifier outcome scope.
+        continue;
+      }
+      try {
+        await notifier.notify(eventWithPriority);
+        const session = await sessionManager.get(event.sessionId).catch(() => null);
+        recordNotifierOutcome(event.projectId, session, name, eventWithPriority, priority, "success");
+      } catch (error) {
+        const session = await sessionManager.get(event.sessionId).catch(() => null);
+        recordNotifierOutcome(event.projectId, session, name, eventWithPriority, priority, "failure", error);
       }
     }
   }

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -185,6 +185,18 @@ export interface LifecycleManagerDeps {
 interface ReactionTracker {
   attempts: number;
   firstTriggered: Date;
+  unresolvedNotifierSignature?: string;
+}
+
+interface NotificationTarget {
+  name: string;
+  notifier: Notifier;
+}
+
+interface NotificationPlan {
+  notifierNames: string[];
+  resolvedTargets: NotificationTarget[];
+  signature: string;
 }
 
 /** Create a LifecycleManager instance. */
@@ -373,30 +385,53 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     reactionConfig: ReactionConfig,
   ): Promise<ReactionResult> {
     const tracker = getReactionTracker(session, sessionId, reactionKey);
+    const action = reactionConfig.action ?? "notify";
+    const nextAttempt = tracker.attempts + 1;
+    const shouldEscalate = shouldEscalateReaction(tracker, reactionConfig, nextAttempt);
 
-    // Increment attempts before checking escalation
-    tracker.attempts++;
-    persistReactionTracker(session, sessionId, reactionKey, tracker);
-
-    // Check if we should escalate
-    const maxRetries = reactionConfig.retries ?? Infinity;
-    const escalateAfter = reactionConfig.escalateAfter;
-    let shouldEscalate = false;
-
-    if (tracker.attempts > maxRetries) {
-      shouldEscalate = true;
+    let notificationPriority: EventPriority | null = null;
+    if (shouldEscalate) {
+      notificationPriority = reactionConfig.priority ?? "urgent";
+    } else if (action === "notify") {
+      notificationPriority = reactionConfig.priority ?? "info";
+    } else if (action === "auto-merge") {
+      notificationPriority = "action";
     }
 
-    if (typeof escalateAfter === "string") {
-      const durationMs = parseDuration(escalateAfter);
-      if (durationMs > 0 && Date.now() - tracker.firstTriggered.getTime() > durationMs) {
-        shouldEscalate = true;
+    const notificationAction = shouldEscalate ? "escalated" : action;
+    const notificationPlan = notificationPriority
+      ? resolveNotificationPlan(notificationPriority)
+      : null;
+
+    if (notificationPlan && shouldSkipUnresolvedNotification(tracker, notificationPlan)) {
+      return {
+        reactionType: reactionKey,
+        success: false,
+        action: notificationAction,
+        escalated: shouldEscalate,
+      };
+    }
+
+    tracker.attempts = nextAttempt;
+    if (notificationPlan) {
+      if (
+        notificationPlan.notifierNames.length > 0 &&
+        notificationPlan.resolvedTargets.length === 0
+      ) {
+        tracker.unresolvedNotifierSignature = notificationPlan.signature;
+        persistReactionTracker(session, sessionId, reactionKey, tracker);
+        return {
+          reactionType: reactionKey,
+          success: false,
+          action: notificationAction,
+          escalated: shouldEscalate,
+        };
       }
+      tracker.unresolvedNotifierSignature = undefined;
+    } else {
+      tracker.unresolvedNotifierSignature = undefined;
     }
-
-    if (typeof escalateAfter === "number" && tracker.attempts > escalateAfter) {
-      shouldEscalate = true;
-    }
+    persistReactionTracker(session, sessionId, reactionKey, tracker);
 
     if (shouldEscalate) {
       // Escalate to human
@@ -406,7 +441,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         message: `Reaction '${reactionKey}' escalated after ${tracker.attempts} attempts`,
         data: { reactionKey, attempts: tracker.attempts },
       });
-      const delivered = await notifyHuman(event, reactionConfig.priority ?? "urgent");
+      const delivered = await notifyHuman(
+        event,
+        reactionConfig.priority ?? "urgent",
+        notificationPlan ?? undefined,
+      );
       if (delivered) {
         clearReactionTracker(sessionId, reactionKey, session);
       }
@@ -417,9 +456,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         escalated: true,
       };
     }
-
-    // Execute the reaction action
-    const action = reactionConfig.action ?? "notify";
 
     switch (action) {
       case "send-to-agent": {
@@ -455,7 +491,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           message: `Reaction '${reactionKey}' triggered notification`,
           data: { reactionKey },
         });
-        const delivered = await notifyHuman(event, reactionConfig.priority ?? "info");
+        const delivered = await notifyHuman(
+          event,
+          reactionConfig.priority ?? "info",
+          notificationPlan ?? undefined,
+        );
         if (delivered) {
           clearReactionTracker(sessionId, reactionKey, session);
         }
@@ -476,11 +516,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           message: `Reaction '${reactionKey}' triggered auto-merge`,
           data: { reactionKey },
         });
-        await notifyHuman(event, "action");
-        clearReactionTracker(sessionId, reactionKey, session);
+        const delivered = await notifyHuman(event, "action", notificationPlan ?? undefined);
+        if (delivered) {
+          clearReactionTracker(sessionId, reactionKey, session);
+        }
         return {
           reactionType: reactionKey,
-          success: true,
+          success: delivered,
           action: "auto-merge",
           escalated: false,
         };
@@ -530,9 +572,71 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   function reactionTrackerMetadataKey(
     reactionKey: string,
-    field: "attempts" | "firstTriggeredAt",
+    field: "attempts" | "firstTriggeredAt" | "unresolvedNotifierSignature",
   ): string {
     return `reaction.${reactionKey}.${field}`;
+  }
+
+  function shouldEscalateReaction(
+    tracker: ReactionTracker,
+    reactionConfig: ReactionConfig,
+    attempts: number,
+  ): boolean {
+    const maxRetries = reactionConfig.retries ?? Infinity;
+    const escalateAfter = reactionConfig.escalateAfter;
+    let shouldEscalate = attempts > maxRetries;
+
+    if (typeof escalateAfter === "string") {
+      const durationMs = parseDuration(escalateAfter);
+      if (durationMs > 0 && Date.now() - tracker.firstTriggered.getTime() > durationMs) {
+        shouldEscalate = true;
+      }
+    }
+
+    if (typeof escalateAfter === "number" && attempts > escalateAfter) {
+      shouldEscalate = true;
+    }
+
+    return shouldEscalate;
+  }
+
+  function resolveNotificationPlan(priority: EventPriority): NotificationPlan {
+    const notifierNames = config.notificationRouting[priority] ?? config.defaults.notifiers;
+    const resolvedTargets: NotificationTarget[] = [];
+
+    for (const name of notifierNames) {
+      const notifier = registry.get<Notifier>("notifier", name);
+      if (notifier) {
+        resolvedTargets.push({ name, notifier });
+      }
+    }
+
+    return {
+      notifierNames,
+      resolvedTargets,
+      signature: notifierNames.join(","),
+    };
+  }
+
+  function shouldSkipUnresolvedNotification(
+    tracker: ReactionTracker,
+    plan: NotificationPlan,
+  ): boolean {
+    return (
+      plan.notifierNames.length > 0 &&
+      plan.resolvedTargets.length === 0 &&
+      tracker.unresolvedNotifierSignature === plan.signature
+    );
+  }
+
+  function hasReactionTrackerState(session: Session, reactionKey: string): boolean {
+    return (
+      reactionTrackers.has(`${session.id}:${reactionKey}`) ||
+      session.metadata[reactionTrackerMetadataKey(reactionKey, "attempts")] !== undefined ||
+      session.metadata[reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")] !== undefined ||
+      session.metadata[reactionTrackerMetadataKey(reactionKey, "unresolvedNotifierSignature")] !==
+        undefined
+    );
   }
 
   function getReactionTracker(
@@ -552,6 +656,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const persistedFirstTriggeredAt = session?.metadata[
       reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")
     ];
+    const persistedUnresolvedNotifierSignature = session?.metadata[
+      reactionTrackerMetadataKey(reactionKey, "unresolvedNotifierSignature")
+    ];
     const parsedFirstTriggered = persistedFirstTriggeredAt
       ? new Date(persistedFirstTriggeredAt)
       : new Date();
@@ -560,6 +667,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       attempts: Number.isFinite(persistedAttempts) ? persistedAttempts : 0,
       firstTriggered:
         Number.isNaN(parsedFirstTriggered.getTime()) ? new Date() : parsedFirstTriggered,
+      unresolvedNotifierSignature: persistedUnresolvedNotifierSignature,
     };
     reactionTrackers.set(trackerKey, tracker);
     return tracker;
@@ -580,6 +688,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       [reactionTrackerMetadataKey(reactionKey, "attempts")]: String(tracker.attempts),
       [reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")]:
         tracker.firstTriggered.toISOString(),
+      [reactionTrackerMetadataKey(reactionKey, "unresolvedNotifierSignature")]:
+        tracker.unresolvedNotifierSignature ?? "",
     });
   }
 
@@ -596,6 +706,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     updateSessionMetadata(session, {
       [reactionTrackerMetadataKey(reactionKey, "attempts")]: "",
       [reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")]: "",
+      [reactionTrackerMetadataKey(reactionKey, "unresolvedNotifierSignature")]: "",
     });
   }
 
@@ -863,20 +974,42 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
   }
 
+  async function maybeRetryMergeableReaction(
+    session: Session,
+    oldStatus: SessionStatus,
+    newStatus: SessionStatus,
+  ): Promise<void> {
+    const reactionKey = "approved-and-green";
+    if (newStatus !== "mergeable" || oldStatus !== newStatus) {
+      return;
+    }
+    if (!hasReactionTrackerState(session, reactionKey)) {
+      return;
+    }
+
+    const reactionConfig = getReactionConfigForSession(session, reactionKey);
+    if (
+      !reactionConfig ||
+      !reactionConfig.action ||
+      (reactionConfig.auto === false && reactionConfig.action !== "notify")
+    ) {
+      return;
+    }
+
+    await executeReaction(session, session.id, session.projectId, reactionKey, reactionConfig);
+  }
+
   /** Send a notification to all configured notifiers. */
-  async function notifyHuman(event: OrchestratorEvent, priority: EventPriority): Promise<boolean> {
+  async function notifyHuman(
+    event: OrchestratorEvent,
+    priority: EventPriority,
+    plan?: NotificationPlan,
+  ): Promise<boolean> {
     const eventWithPriority = { ...event, priority };
-    const notifierNames = config.notificationRouting[priority] ?? config.defaults.notifiers;
+    const notificationPlan = plan ?? resolveNotificationPlan(priority);
     let delivered = false;
 
-    for (const name of notifierNames) {
-      const notifier = registry.get<Notifier>("notifier", name);
-      if (!notifier) {
-        // Known limitation: missing/unloaded configured notifiers are still silent.
-        // Track separately rather than widening this PR's notifier outcome scope.
-        continue;
-      }
-
+    for (const { name, notifier } of notificationPlan.resolvedTargets) {
       let outcome: "success" | "failure" = "success";
       let notifyError: unknown;
       try {
@@ -996,6 +1129,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction);
+    await maybeRetryMergeableReaction(session, oldStatus, newStatus);
   }
 
   /** Run one polling cycle across all sessions. */
@@ -1048,7 +1182,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       // Check if all sessions are complete (trigger reaction only once)
       const activeSessions = sessions.filter((s) => s.status !== "merged" && s.status !== "killed");
       if (sessions.length > 0 && activeSessions.length === 0 && !allCompleteEmitted) {
-        allCompleteEmitted = true;
+        let emitAllComplete = true;
 
         // Execute all-complete reaction if configured
         const reactionKey = eventToReactionKey("summary.all_complete");
@@ -1056,16 +1190,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const reactionConfig = config.reactions[reactionKey];
           if (reactionConfig && reactionConfig.action) {
             if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
-              await executeReaction(
+              const result = await executeReaction(
                 null,
                 "system",
                 "all",
                 reactionKey,
                 reactionConfig as ReactionConfig,
               );
+              emitAllComplete = result.success;
             }
           }
         }
+        allCompleteEmitted = emitAllComplete;
       }
       if (scopedProjectId) {
         observer.recordOperation({

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -455,10 +455,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           message: `Reaction '${reactionKey}' triggered notification`,
           data: { reactionKey },
         });
-        await notifyHuman(event, reactionConfig.priority ?? "info");
+        const delivered = await notifyHuman(event, reactionConfig.priority ?? "info");
         return {
           reactionType: reactionKey,
-          success: true,
+          success: delivered,
           action: "notify",
           escalated: false,
         };
@@ -532,6 +532,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return `notifier.${notifierName}.${field}`;
   }
 
+  function sanitizeNotifierReason(error: unknown): string {
+    return (error instanceof Error ? error.message : String(error))
+      .replace(/[\r\n]+/g, " ")
+      .trim()
+      .slice(0, 200);
+  }
+
   function recordNotifierOutcome(
     projectId: string,
     session: Session | null,
@@ -543,12 +550,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   ): void {
     const correlationId = createCorrelationId("notifier");
     const timestamp = new Date().toISOString();
-    const reason =
-      outcome === "failure"
-        ? error instanceof Error
-          ? error.message
-          : String(error)
-        : undefined;
+    const reason = outcome === "failure" ? sanitizeNotifierReason(error) : undefined;
 
     observer.recordOperation({
       metric: "notification",
@@ -587,6 +589,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         ? { [notifierMetadataKey(notifierName, "lastSuccessAt")]: timestamp }
         : {}),
     });
+  }
+
+  function logNotifierOutcomeRecordingError(
+    notifierName: string,
+    event: OrchestratorEvent,
+    error: unknown,
+  ): void {
+    const reason = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      `[ao] failed to record notifier outcome for ${notifierName} on ${event.type} (${event.sessionId}): ${reason}\n`,
+    );
   }
 
   function makeFingerprint(ids: string[]): string {
@@ -745,9 +758,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   }
 
   /** Send a notification to all configured notifiers. */
-  async function notifyHuman(event: OrchestratorEvent, priority: EventPriority): Promise<void> {
+  async function notifyHuman(event: OrchestratorEvent, priority: EventPriority): Promise<boolean> {
     const eventWithPriority = { ...event, priority };
     const notifierNames = config.notificationRouting[priority] ?? config.defaults.notifiers;
+    let delivered = false;
 
     for (const name of notifierNames) {
       const notifier = registry.get<Notifier>("notifier", name);
@@ -756,15 +770,34 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         // Track separately rather than widening this PR's notifier outcome scope.
         continue;
       }
+
+      let outcome: "success" | "failure" = "success";
+      let notifyError: unknown;
       try {
         await notifier.notify(eventWithPriority);
-        const session = await sessionManager.get(event.sessionId).catch(() => null);
-        recordNotifierOutcome(event.projectId, session, name, eventWithPriority, priority, "success");
+        delivered = true;
       } catch (error) {
-        const session = await sessionManager.get(event.sessionId).catch(() => null);
-        recordNotifierOutcome(event.projectId, session, name, eventWithPriority, priority, "failure", error);
+        outcome = "failure";
+        notifyError = error;
+      }
+
+      const session = await sessionManager.get(event.sessionId).catch(() => null);
+      try {
+        recordNotifierOutcome(
+          event.projectId,
+          session,
+          name,
+          eventWithPriority,
+          priority,
+          outcome,
+          notifyError,
+        );
+      } catch (recordError) {
+        logNotifierOutcomeRecordingError(name, eventWithPriority, recordError);
       }
     }
+
+    return delivered;
   }
 
   /** Poll a single session and handle state transitions. */

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -366,21 +366,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   /** Execute a reaction for a session. */
   async function executeReaction(
+    session: Session | null,
     sessionId: SessionId,
     projectId: string,
     reactionKey: string,
     reactionConfig: ReactionConfig,
   ): Promise<ReactionResult> {
-    const trackerKey = `${sessionId}:${reactionKey}`;
-    let tracker = reactionTrackers.get(trackerKey);
-
-    if (!tracker) {
-      tracker = { attempts: 0, firstTriggered: new Date() };
-      reactionTrackers.set(trackerKey, tracker);
-    }
+    const tracker = getReactionTracker(session, sessionId, reactionKey);
 
     // Increment attempts before checking escalation
     tracker.attempts++;
+    persistReactionTracker(session, sessionId, reactionKey, tracker);
 
     // Check if we should escalate
     const maxRetries = reactionConfig.retries ?? Infinity;
@@ -411,6 +407,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         data: { reactionKey, attempts: tracker.attempts },
       });
       const delivered = await notifyHuman(event, reactionConfig.priority ?? "urgent");
+      if (delivered) {
+        clearReactionTracker(sessionId, reactionKey, session);
+      }
       return {
         reactionType: reactionKey,
         success: delivered,
@@ -427,6 +426,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         if (reactionConfig.message) {
           try {
             await sessionManager.send(sessionId, reactionConfig.message);
+            clearReactionTracker(sessionId, reactionKey, session);
 
             return {
               reactionType: reactionKey,
@@ -456,6 +456,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           data: { reactionKey },
         });
         const delivered = await notifyHuman(event, reactionConfig.priority ?? "info");
+        if (delivered) {
+          clearReactionTracker(sessionId, reactionKey, session);
+        }
         return {
           reactionType: reactionKey,
           success: delivered,
@@ -474,6 +477,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           data: { reactionKey },
         });
         await notifyHuman(event, "action");
+        clearReactionTracker(sessionId, reactionKey, session);
         return {
           reactionType: reactionKey,
           success: true,
@@ -489,10 +493,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       action,
       escalated: false,
     };
-  }
-
-  function clearReactionTracker(sessionId: SessionId, reactionKey: string): void {
-    reactionTrackers.delete(`${sessionId}:${reactionKey}`);
   }
 
   function getReactionConfigForSession(
@@ -526,6 +526,77 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       cleaned[key] = value;
     }
     session.metadata = cleaned;
+  }
+
+  function reactionTrackerMetadataKey(
+    reactionKey: string,
+    field: "attempts" | "firstTriggeredAt",
+  ): string {
+    return `reaction.${reactionKey}.${field}`;
+  }
+
+  function getReactionTracker(
+    session: Session | null,
+    sessionId: SessionId,
+    reactionKey: string,
+  ): ReactionTracker {
+    const trackerKey = `${sessionId}:${reactionKey}`;
+    const tracked = reactionTrackers.get(trackerKey);
+    if (tracked) {
+      return tracked;
+    }
+
+    const persistedAttempts = session
+      ? Number.parseInt(session.metadata[reactionTrackerMetadataKey(reactionKey, "attempts")] ?? "0", 10)
+      : 0;
+    const persistedFirstTriggeredAt = session?.metadata[
+      reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")
+    ];
+    const parsedFirstTriggered = persistedFirstTriggeredAt
+      ? new Date(persistedFirstTriggeredAt)
+      : new Date();
+
+    const tracker: ReactionTracker = {
+      attempts: Number.isFinite(persistedAttempts) ? persistedAttempts : 0,
+      firstTriggered:
+        Number.isNaN(parsedFirstTriggered.getTime()) ? new Date() : parsedFirstTriggered,
+    };
+    reactionTrackers.set(trackerKey, tracker);
+    return tracker;
+  }
+
+  function persistReactionTracker(
+    session: Session | null,
+    sessionId: SessionId,
+    reactionKey: string,
+    tracker: ReactionTracker,
+  ): void {
+    reactionTrackers.set(`${sessionId}:${reactionKey}`, tracker);
+    if (!session) {
+      return;
+    }
+
+    updateSessionMetadata(session, {
+      [reactionTrackerMetadataKey(reactionKey, "attempts")]: String(tracker.attempts),
+      [reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")]:
+        tracker.firstTriggered.toISOString(),
+    });
+  }
+
+  function clearReactionTracker(
+    sessionId: SessionId,
+    reactionKey: string,
+    session?: Session | null,
+  ): void {
+    reactionTrackers.delete(`${sessionId}:${reactionKey}`);
+    if (!session) {
+      return;
+    }
+
+    updateSessionMetadata(session, {
+      [reactionTrackerMetadataKey(reactionKey, "attempts")]: "",
+      [reactionTrackerMetadataKey(reactionKey, "firstTriggeredAt")]: "",
+    });
   }
 
   function notifierMetadataKey(notifierName: string, field: string): string {
@@ -655,8 +726,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const automatedReactionKey = "bugbot-comments";
 
     if (newStatus === "merged" || newStatus === "killed") {
-      clearReactionTracker(session.id, humanReactionKey);
-      clearReactionTracker(session.id, automatedReactionKey);
+      clearReactionTracker(session.id, humanReactionKey, session);
+      clearReactionTracker(session.id, automatedReactionKey, session);
       updateSessionMetadata(session, {
         lastPendingReviewFingerprint: "",
         lastPendingReviewDispatchHash: "",
@@ -695,7 +766,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         pendingFingerprint !== lastPendingFingerprint &&
         transitionReaction?.key !== humanReactionKey
       ) {
-        clearReactionTracker(session.id, humanReactionKey);
+        clearReactionTracker(session.id, humanReactionKey, session);
       }
       if (pendingFingerprint !== lastPendingFingerprint) {
         updateSessionMetadata(session, {
@@ -704,7 +775,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
 
       if (!pendingFingerprint) {
-        clearReactionTracker(session.id, humanReactionKey);
+        clearReactionTracker(session.id, humanReactionKey, session);
         updateSessionMetadata(session, {
           lastPendingReviewFingerprint: "",
           lastPendingReviewDispatchHash: "",
@@ -731,6 +802,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           (reactionConfig.auto !== false || reactionConfig.action === "notify")
         ) {
           const result = await executeReaction(
+            session,
             session.id,
             session.projectId,
             humanReactionKey,
@@ -753,14 +825,14 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       const lastAutomatedDispatchHash = session.metadata["lastAutomatedReviewDispatchHash"] ?? "";
 
       if (automatedFingerprint !== lastAutomatedFingerprint) {
-        clearReactionTracker(session.id, automatedReactionKey);
+        clearReactionTracker(session.id, automatedReactionKey, session);
         updateSessionMetadata(session, {
           lastAutomatedReviewFingerprint: automatedFingerprint,
         });
       }
 
       if (!automatedFingerprint) {
-        clearReactionTracker(session.id, automatedReactionKey);
+        clearReactionTracker(session.id, automatedReactionKey, session);
         updateSessionMetadata(session, {
           lastAutomatedReviewFingerprint: "",
           lastAutomatedReviewDispatchHash: "",
@@ -774,6 +846,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           (reactionConfig.auto !== false || reactionConfig.action === "notify")
         ) {
           const result = await executeReaction(
+            session,
             session.id,
             session.projectId,
             automatedReactionKey,
@@ -870,7 +943,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       if (oldEventType) {
         const oldReactionKey = eventToReactionKey(oldEventType);
         if (oldReactionKey) {
-          clearReactionTracker(session.id, oldReactionKey);
+          clearReactionTracker(session.id, oldReactionKey, session);
         }
       }
 
@@ -887,6 +960,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             // auto: false skips automated agent actions but still allows notifications
             if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
               const reactionResult = await executeReaction(
+                session,
                 session.id,
                 session.projectId,
                 reactionKey,
@@ -982,7 +1056,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const reactionConfig = config.reactions[reactionKey];
           if (reactionConfig && reactionConfig.action) {
             if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
-              await executeReaction("system", "all", reactionKey, reactionConfig as ReactionConfig);
+              await executeReaction(
+                null,
+                "system",
+                "all",
+                reactionKey,
+                reactionConfig as ReactionConfig,
+              );
             }
           }
         }

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -431,7 +431,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     } else {
       tracker.unresolvedNotifierSignature = undefined;
     }
-    persistReactionTracker(session, sessionId, reactionKey, tracker);
+    cacheReactionTracker(sessionId, reactionKey, tracker);
 
     if (shouldEscalate) {
       // Escalate to human
@@ -445,9 +445,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         event,
         reactionConfig.priority ?? "urgent",
         notificationPlan ?? undefined,
+        session,
       );
       if (delivered) {
         clearReactionTracker(sessionId, reactionKey, session);
+      } else {
+        persistReactionTracker(session, sessionId, reactionKey, tracker);
       }
       return {
         reactionType: reactionKey,
@@ -473,6 +476,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             };
           } catch {
             // Send failed — allow retry on next poll cycle (don't escalate immediately)
+            persistReactionTracker(session, sessionId, reactionKey, tracker);
             return {
               reactionType: reactionKey,
               success: false,
@@ -495,9 +499,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           event,
           reactionConfig.priority ?? "info",
           notificationPlan ?? undefined,
+          session,
         );
         if (delivered) {
           clearReactionTracker(sessionId, reactionKey, session);
+        } else {
+          persistReactionTracker(session, sessionId, reactionKey, tracker);
         }
         return {
           reactionType: reactionKey,
@@ -516,9 +523,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           message: `Reaction '${reactionKey}' triggered auto-merge`,
           data: { reactionKey },
         });
-        const delivered = await notifyHuman(event, "action", notificationPlan ?? undefined);
+        const delivered = await notifyHuman(event, "action", notificationPlan ?? undefined, session);
         if (delivered) {
           clearReactionTracker(sessionId, reactionKey, session);
+        } else {
+          persistReactionTracker(session, sessionId, reactionKey, tracker);
         }
         return {
           reactionType: reactionKey,
@@ -529,6 +538,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
     }
 
+    persistReactionTracker(session, sessionId, reactionKey, tracker);
     return {
       reactionType: reactionKey,
       success: false,
@@ -679,7 +689,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     reactionKey: string,
     tracker: ReactionTracker,
   ): void {
-    reactionTrackers.set(`${sessionId}:${reactionKey}`, tracker);
+    cacheReactionTracker(sessionId, reactionKey, tracker);
     if (!session) {
       return;
     }
@@ -691,6 +701,14 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       [reactionTrackerMetadataKey(reactionKey, "unresolvedNotifierSignature")]:
         tracker.unresolvedNotifierSignature ?? "",
     });
+  }
+
+  function cacheReactionTracker(
+    sessionId: SessionId,
+    reactionKey: string,
+    tracker: ReactionTracker,
+  ): void {
+    reactionTrackers.set(`${sessionId}:${reactionKey}`, tracker);
   }
 
   function clearReactionTracker(
@@ -1004,9 +1022,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     event: OrchestratorEvent,
     priority: EventPriority,
     plan?: NotificationPlan,
+    session?: Session | null,
   ): Promise<boolean> {
     const eventWithPriority = { ...event, priority };
     const notificationPlan = plan ?? resolveNotificationPlan(priority);
+    const trackedSession = session ?? (await sessionManager.get(event.sessionId).catch(() => null));
     let delivered = false;
 
     for (const { name, notifier } of notificationPlan.resolvedTargets) {
@@ -1020,11 +1040,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         notifyError = error;
       }
 
-      const session = await sessionManager.get(event.sessionId).catch(() => null);
       try {
         recordNotifierOutcome(
           event.projectId,
-          session,
+          trackedSession,
           name,
           eventWithPriority,
           priority,
@@ -1120,7 +1139,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             message: `${session.id}: ${oldStatus} → ${newStatus}`,
             data: { oldStatus, newStatus },
           });
-          await notifyHuman(event, priority);
+          await notifyHuman(event, priority, undefined, session);
         }
       }
     } else {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -410,10 +410,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         message: `Reaction '${reactionKey}' escalated after ${tracker.attempts} attempts`,
         data: { reactionKey, attempts: tracker.attempts },
       });
-      await notifyHuman(event, reactionConfig.priority ?? "urgent");
+      const delivered = await notifyHuman(event, reactionConfig.priority ?? "urgent");
       return {
         reactionType: reactionKey,
-        success: true,
+        success: delivered,
         action: "escalated",
         escalated: true,
       };

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -602,6 +602,39 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     );
   }
 
+  function recordSessionCheckFailure(
+    session: Session,
+    correlationId: string,
+    error: unknown,
+  ): void {
+    const reason = error instanceof Error ? error.message : String(error);
+    observer.recordOperation({
+      metric: "lifecycle_poll",
+      operation: "lifecycle.check",
+      outcome: "failure",
+      correlationId,
+      projectId: session.projectId,
+      sessionId: session.id,
+      reason,
+      data: {
+        phase: "poll",
+      },
+      level: "error",
+    });
+    observer.setHealth({
+      surface: "lifecycle.session-check",
+      status: "error",
+      projectId: session.projectId,
+      correlationId,
+      reason,
+      details: {
+        projectId: session.projectId,
+        sessionId: session.id,
+      },
+    });
+    process.stderr.write(`[ao] lifecycle check failed for ${session.id}: ${reason}\n`);
+  }
+
   function makeFingerprint(ids: string[]): string {
     return [...ids].sort().join(",");
   }
@@ -911,8 +944,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         return tracked !== undefined && tracked !== s.status;
       });
 
-      // Poll all sessions concurrently
-      await Promise.allSettled(sessionsToCheck.map((s) => checkSession(s)));
+      // Poll all sessions concurrently and record individual failures so one
+      // bad session cannot disappear behind the batch-level success path.
+      const pollResults = await Promise.allSettled(sessionsToCheck.map((s) => checkSession(s)));
+      let failedSessionCount = 0;
+      for (const [index, result] of pollResults.entries()) {
+        if (result.status !== "rejected") continue;
+        failedSessionCount++;
+        const session = sessionsToCheck[index];
+        if (!session) continue;
+        recordSessionCheckFailure(session, correlationId, result.reason);
+      }
 
       // Prune stale entries from states and reactionTrackers for sessions
       // that no longer appear in the session list (e.g., after kill/cleanup)
@@ -953,7 +995,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           correlationId,
           projectId: scopedProjectId,
           durationMs: Date.now() - startedAt,
-          data: { sessionCount: sessions.length, activeSessionCount: activeSessions.length },
+          data: {
+            sessionCount: sessions.length,
+            activeSessionCount: activeSessions.length,
+            failedSessionCount,
+          },
           level: "info",
         });
         observer.setHealth({
@@ -965,6 +1011,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             projectId: scopedProjectId,
             sessionCount: sessions.length,
             activeSessionCount: activeSessions.length,
+            failedSessionCount,
           },
         });
       }

--- a/packages/core/src/observability.ts
+++ b/packages/core/src/observability.ts
@@ -234,6 +234,10 @@ function compareIsoDesc(a: string, b: string): number {
   return b.localeCompare(a);
 }
 
+function shouldTrackSessionSummary(operation: string): boolean {
+  return operation.startsWith("session.") || operation === "lifecycle.transition";
+}
+
 function mergeCounter(
   target: ObservabilityMetricCounter | undefined,
   source: ObservabilityMetricCounter,
@@ -376,7 +380,7 @@ export function createProjectObserver(
             .sort((a, b) => compareIsoDesc(a.timestamp, b.timestamp))
             .slice(0, TRACE_LIMIT);
 
-          if (input.sessionId && operation.startsWith("session.")) {
+          if (input.sessionId && shouldTrackSessionSummary(operation)) {
             snapshot.sessions[input.sessionId] = {
               sessionId: input.sessionId,
               projectId: input.projectId,

--- a/packages/core/src/observability.ts
+++ b/packages/core/src/observability.ts
@@ -20,6 +20,7 @@ export type ObservabilityMetricName =
   | "cleanup"
   | "kill"
   | "lifecycle_poll"
+  | "notification"
   | "restore"
   | "send"
   | "spawn"
@@ -375,7 +376,7 @@ export function createProjectObserver(
             .sort((a, b) => compareIsoDesc(a.timestamp, b.timestamp))
             .slice(0, TRACE_LIMIT);
 
-          if (input.sessionId) {
+          if (input.sessionId && operation.startsWith("session.")) {
             snapshot.sessions[input.sessionId] = {
               sessionId: input.sessionId,
               projectId: input.projectId,

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -86,6 +86,15 @@ function errorIncludesSessionNotFound(err: unknown): boolean {
   return /session not found/i.test(combined);
 }
 
+function errorIncludesMissingResource(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const e = err as Error & { stderr?: string; stdout?: string; code?: string };
+  const combined = [err.message, e.stderr, e.stdout, e.code].filter(Boolean).join("\n");
+  return /already gone|session not found|not found|does not exist|no such file or directory|enoent/i.test(
+    combined,
+  );
+}
+
 async function deleteOpenCodeSession(sessionId: string): Promise<void> {
   const validatedSessionId = asValidOpenCodeSessionId(sessionId);
   if (!validatedSessionId) return;
@@ -271,6 +280,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     sessionsDir: string;
     project: ProjectConfig;
     projectId: string;
+    createdAt?: Date;
+    modifiedAt?: Date;
   }
 
   interface ActiveSessionRecord {
@@ -342,6 +353,38 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     const roots = getManagedWorkspaceRoots(project, projectId);
     return roots.some((root) => isPathInside(workspacePath, root));
+  }
+
+  async function canIgnoreRuntimeDestroyError(
+    runtimePlugin: Runtime,
+    handle: RuntimeHandle,
+    error: unknown,
+  ): Promise<boolean> {
+    try {
+      return !(await runtimePlugin.isAlive(handle));
+    } catch (aliveError) {
+      return errorIncludesMissingResource(error) || errorIncludesMissingResource(aliveError);
+    }
+  }
+
+  async function canIgnoreWorkspaceDestroyError(
+    workspacePlugin: Workspace,
+    workspacePath: string,
+    error: unknown,
+  ): Promise<boolean> {
+    if (!existsSync(workspacePath)) {
+      return true;
+    }
+
+    if (!workspacePlugin.exists) {
+      return errorIncludesMissingResource(error);
+    }
+
+    try {
+      return !(await workspacePlugin.exists(workspacePath));
+    } catch (existsError) {
+      return errorIncludesMissingResource(error) || errorIncludesMissingResource(existsError);
+    }
   }
 
   function listArchivedSessionIds(sessionsDir: string): string[] {
@@ -772,6 +815,43 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       });
 
       return { raw: repaired.raw, sessionsDir, project, projectId };
+    }
+
+    return null;
+  }
+
+  function findArchivedSessionRecord(sessionId: SessionId): LocatedSession | null {
+    for (const [projectId, project] of Object.entries(config.projects)) {
+      const sessionsDir = getProjectSessionsDir(project);
+      const archiveDir = join(sessionsDir, "archive");
+      if (!existsSync(archiveDir)) continue;
+
+      const prefix = `${sessionId}_`;
+      let latestArchiveFile: string | null = null;
+      for (const file of readdirSync(archiveDir)) {
+        if (!file.startsWith(prefix)) continue;
+        const charAfterPrefix = file[prefix.length];
+        if (!charAfterPrefix || charAfterPrefix < "0" || charAfterPrefix > "9") continue;
+        if (!latestArchiveFile || file > latestArchiveFile) {
+          latestArchiveFile = file;
+        }
+      }
+
+      if (!latestArchiveFile) continue;
+      const raw = readArchivedMetadataRaw(sessionsDir, sessionId);
+      if (!raw) continue;
+
+      let createdAt: Date | undefined;
+      let modifiedAt: Date | undefined;
+      try {
+        const stats = statSync(join(archiveDir, latestArchiveFile));
+        createdAt = stats.birthtime;
+        modifiedAt = stats.mtime;
+      } catch {
+        // If stat fails, timestamps will fall back to current time
+      }
+
+      return { raw, sessionsDir, project, projectId, createdAt, modifiedAt };
     }
 
     return null;
@@ -1513,14 +1593,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return resolved.filter((session): session is Session => session !== null);
   }
 
-  async function get(sessionId: SessionId): Promise<Session | null> {
-    // Try to find the session in any project's sessions directory
-    for (const [projectId, project] of Object.entries(config.projects)) {
-      const sessionsDir = getProjectSessionsDir(project);
-      const raw = readMetadataRaw(sessionsDir, sessionId);
-      if (!raw) continue;
+  async function get(
+    sessionId: SessionId,
+    options?: { includeArchived?: boolean },
+  ): Promise<Session | null> {
+    const activeRecord = findSessionRecord(sessionId);
+    if (activeRecord) {
+      const { raw, sessionsDir, project, projectId } = activeRecord;
 
-      // Get file timestamps for createdAt/lastActivityAt
       let createdAt: Date | undefined;
       let modifiedAt: Date | undefined;
       try {
@@ -1539,7 +1619,6 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       });
 
       const session = metadataToSession(sessionId, repaired.raw, projectId, createdAt, modifiedAt);
-
       const selection = resolveSelectionForSession(project, sessionId, repaired.raw);
       const effectiveAgentName = selection.agentName;
       const plugins = resolvePlugins(project, effectiveAgentName);
@@ -1555,13 +1634,47 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       return session;
     }
 
-    return null;
+    if (!options?.includeArchived) {
+      return null;
+    }
+
+    const archivedRecord = findArchivedSessionRecord(sessionId);
+    if (!archivedRecord) {
+      return null;
+    }
+
+    const session = metadataToSession(
+      sessionId,
+      archivedRecord.raw,
+      archivedRecord.projectId,
+      archivedRecord.createdAt,
+      archivedRecord.modifiedAt,
+    );
+    const selection = resolveSelectionForSession(
+      archivedRecord.project,
+      sessionId,
+      archivedRecord.raw,
+    );
+    const plugins = resolvePlugins(archivedRecord.project, selection.agentName);
+    await enrichSessionWithRuntimeState(session, plugins, true);
+    return session;
   }
 
   async function kill(sessionId: SessionId, options?: { purgeOpenCode?: boolean }): Promise<void> {
-    const { raw, sessionsDir, project, projectId } = requireSessionRecord(sessionId);
+    const located = requireSessionRecord(sessionId);
+    let { raw } = located;
+    const { sessionsDir, project, projectId } = located;
 
     const cleanupAgent = resolveSelectionForSession(project, sessionId, raw).agentName;
+
+    const persistKilledMetadata = (): void => {
+      updateMetadata(sessionsDir, sessionId, {
+        status: "killed",
+        runtimeHandle: "",
+      });
+      raw = { ...raw, status: "killed" };
+      delete raw["runtimeHandle"];
+    };
 
     // Destroy runtime — prefer handle.runtimeName to find the correct plugin
     if (raw["runtimeHandle"]) {
@@ -1575,8 +1688,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         if (runtimePlugin) {
           try {
             await runtimePlugin.destroy(handle);
-          } catch {
-            // Runtime might already be gone
+          } catch (error) {
+            if (await canIgnoreRuntimeDestroyError(runtimePlugin, handle, error)) {
+              void 0;
+            } else {
+              throw error instanceof Error
+                ? error
+                : new Error(`Failed to destroy runtime for ${sessionId}`);
+            }
           }
         }
       }
@@ -1590,8 +1709,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       if (workspacePlugin) {
         try {
           await workspacePlugin.destroy(worktree);
-        } catch {
-          // Workspace might already be gone
+        } catch (error) {
+          if (!(await canIgnoreWorkspaceDestroyError(workspacePlugin, worktree, error))) {
+            persistKilledMetadata();
+            throw error instanceof Error
+              ? error
+              : new Error(`Failed to destroy workspace for ${sessionId}`);
+          }
         }
       }
     }
@@ -1614,6 +1738,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         }
       }
     }
+
+    persistKilledMetadata();
 
     // Archive metadata
     deleteMetadata(sessionsDir, sessionId, true);
@@ -2264,26 +2390,6 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       throw new SessionNotRestorableError(sessionId, "session is not in a terminal state");
     }
 
-    if (fromArchive) {
-      writeMetadata(sessionsDir, sessionId, {
-        worktree: raw["worktree"] ?? "",
-        branch: raw["branch"] ?? "",
-        status: raw["status"] ?? "killed",
-        role: raw["role"],
-        tmuxName: raw["tmuxName"],
-        issue: raw["issue"],
-        pr: raw["pr"],
-        prAutoDetect:
-          raw["prAutoDetect"] === "off" ? "off" : raw["prAutoDetect"] === "on" ? "on" : undefined,
-        summary: raw["summary"],
-        project: raw["project"],
-        agent: raw["agent"],
-        createdAt: raw["createdAt"],
-        runtimeHandle: raw["runtimeHandle"],
-        opencodeSessionId: raw["opencodeSessionId"],
-      });
-    }
-
     // 4. Validate required plugins (plugins already resolved above for enrichment)
     if (!plugins.runtime) {
       throw new Error(`Runtime plugin '${project.runtime ?? config.defaults.runtime}' not found`);
@@ -2298,6 +2404,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       ? await plugins.workspace.exists(workspacePath)
       : existsSync(workspacePath);
 
+    let restoredWorkspacePath: string | null = null;
     if (!workspaceExists) {
       // Try to restore workspace if plugin supports it
       if (!plugins.workspace?.restore) {
@@ -2316,12 +2423,24 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           },
           workspacePath,
         );
+        restoredWorkspacePath = wsInfo.path;
 
         // Run post-create hooks on restored workspace
         if (plugins.workspace.postCreate) {
           await plugins.workspace.postCreate(wsInfo, project);
         }
       } catch (err) {
+        if (
+          restoredWorkspacePath &&
+          plugins.workspace?.destroy &&
+          shouldDestroyWorkspacePath(project, projectId, restoredWorkspacePath)
+        ) {
+          try {
+            await plugins.workspace.destroy(restoredWorkspacePath);
+          } catch {
+            void 0;
+          }
+        }
         throw new WorkspaceMissingError(
           workspacePath,
           `restore failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -2369,30 +2488,69 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     // 8. Create runtime (reuse tmuxName from metadata)
     const tmuxName = raw["tmuxName"];
-    const handle = await plugins.runtime.create({
-      sessionId: tmuxName ?? sessionId,
-      workspacePath,
-      launchCommand,
-      environment: {
-        ...environment,
-        AO_SESSION: sessionId,
-        AO_DATA_DIR: sessionsDir,
-        AO_SESSION_NAME: sessionId,
-        ...(tmuxName && { AO_TMUX_NAME: tmuxName }),
-        AO_CALLER_TYPE: "agent",
-        ...(projectId && { AO_PROJECT_ID: projectId }),
-        AO_CONFIG_PATH: config.configPath,
-        ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) }),
-      },
-    });
-
-    // 9. Update metadata — merge updates, preserving existing fields
+    let handle: RuntimeHandle | null = null;
     const now = new Date().toISOString();
-    updateMetadata(sessionsDir, sessionId, {
-      status: "spawning",
-      runtimeHandle: JSON.stringify(handle),
-      restoredAt: now,
-    });
+    try {
+      handle = await plugins.runtime.create({
+        sessionId: tmuxName ?? sessionId,
+        workspacePath,
+        launchCommand,
+        environment: {
+          ...environment,
+          AO_SESSION: sessionId,
+          AO_DATA_DIR: sessionsDir,
+          AO_SESSION_NAME: sessionId,
+          ...(tmuxName && { AO_TMUX_NAME: tmuxName }),
+          AO_CALLER_TYPE: "agent",
+          ...(projectId && { AO_PROJECT_ID: projectId }),
+          AO_CONFIG_PATH: config.configPath,
+          ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) }),
+        },
+      });
+
+      const metadataUpdates = {
+        status: "spawning",
+        runtimeHandle: JSON.stringify(handle),
+        restoredAt: now,
+      };
+
+      if (fromArchive) {
+        updateMetadata(
+          sessionsDir,
+          sessionId,
+          applyMetadataUpdatesToRaw(raw, metadataUpdates),
+        );
+      } else {
+        updateMetadata(sessionsDir, sessionId, metadataUpdates);
+      }
+    } catch (error) {
+      if (handle) {
+        try {
+          await plugins.runtime.destroy(handle);
+        } catch {
+          void 0;
+        }
+      }
+      if (fromArchive) {
+        try {
+          deleteMetadata(sessionsDir, sessionId, false);
+        } catch {
+          void 0;
+        }
+      }
+      if (
+        restoredWorkspacePath &&
+        plugins.workspace?.destroy &&
+        shouldDestroyWorkspacePath(project, projectId, restoredWorkspacePath)
+      ) {
+        try {
+          await plugins.workspace.destroy(restoredWorkspacePath);
+        } catch {
+          void 0;
+        }
+      }
+      throw error;
+    }
 
     // 10. Run postLaunchSetup (non-fatal)
     const restoredSession: Session = {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -90,8 +90,20 @@ function errorIncludesMissingResource(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const e = err as Error & { stderr?: string; stdout?: string; code?: string };
   const combined = [err.message, e.stderr, e.stdout, e.code].filter(Boolean).join("\n");
-  return /already gone|session not found|not found|does not exist|no such file or directory|enoent/i.test(
-    combined,
+  if (
+    /\balready gone\b/i.test(combined) ||
+    /\bsession not found\b/i.test(combined) ||
+    /\bworkspace not found\b/i.test(combined) ||
+    /\bworktree not found\b/i.test(combined) ||
+    /\bno such file or directory\b/i.test(combined) ||
+    /\benoent\b/i.test(combined)
+  ) {
+    return true;
+  }
+
+  return (
+    /\bdoes not exist\b/i.test(combined) &&
+    /\b(session|workspace|worktree|path|file|directory)\b/i.test(combined)
   );
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -912,6 +912,11 @@ export interface OrchestratorConfig {
 
   /** Default reaction configs */
   reactions: Record<string, ReactionConfig>;
+
+  /** HTTP API configuration */
+  api?: {
+    token?: string;
+  };
 }
 
 export interface DefaultPlugins {
@@ -1170,7 +1175,7 @@ export interface SessionManager {
   spawnOrchestrator(config: OrchestratorSpawnConfig): Promise<Session>;
   restore(sessionId: SessionId): Promise<Session>;
   list(projectId?: string): Promise<Session[]>;
-  get(sessionId: SessionId): Promise<Session | null>;
+  get(sessionId: SessionId, options?: { includeArchived?: boolean }): Promise<Session | null>;
   kill(sessionId: SessionId, options?: { purgeOpenCode?: boolean }): Promise<void>;
   cleanup(
     projectId?: string,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -3,7 +3,7 @@
  */
 
 import { open, stat } from "node:fs/promises";
-import type { OrchestratorConfig } from "./types.js";
+type ProjectWithPrefix = { sessionPrefix?: string };
 
 /**
  * POSIX-safe shell escaping: wraps value in single quotes,
@@ -138,14 +138,20 @@ export async function readLastJsonlEntry(
  * to by matching session prefixes.
  */
 export function resolveProjectIdForSessionId(
-  config: OrchestratorConfig,
+  config: { projects: Record<string, ProjectWithPrefix> },
   sessionId: string,
 ): string | undefined {
+  let bestMatch: { projectId: string; prefix: string } | null = null;
+
   for (const [projectId, project] of Object.entries(config.projects)) {
     const prefix = project.sessionPrefix;
+    if (!prefix) continue;
     if (sessionId === prefix || sessionId.startsWith(`${prefix}-`)) {
-      return projectId;
+      if (!bestMatch || prefix.length > bestMatch.prefix.length) {
+        bestMatch = { projectId, prefix };
+      }
     }
   }
-  return undefined;
+
+  return bestMatch?.projectId;
 }

--- a/packages/web/src/__tests__/api-ao.test.ts
+++ b/packages/web/src/__tests__/api-ao.test.ts
@@ -1,0 +1,675 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LifecycleManager, OrchestratorConfig, PluginRegistry, Session, SessionManager } from "@composio/ao-core";
+import {
+  SessionNotFoundError,
+  SessionNotRestorableError,
+  WorkspaceMissingError,
+} from "@composio/ao-core";
+import { getServices } from "@/lib/services";
+import { getCachedConfig } from "@/lib/config-cache";
+
+function makeSession(overrides: Partial<Session> & { id: string }): Session {
+  return {
+    id: overrides.id,
+    projectId: "my-app",
+    status: "working",
+    activity: "active",
+    branch: null,
+    issueId: null,
+    pr: null,
+    workspacePath: null,
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date("2026-03-25T00:00:00.000Z"),
+    lastActivityAt: new Date("2026-03-25T00:00:00.000Z"),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+const testSessions: Session[] = [
+  makeSession({ id: "worker-1", status: "working", projectId: "my-app" }),
+  makeSession({
+    id: "worker-2",
+    status: "stuck",
+    projectId: "docs-app",
+    metadata: {
+      "notifier.openclaw.status": "warn",
+      "notifier.openclaw.consecutiveFailures": "2",
+    },
+  }),
+  makeSession({ id: "orchestrator-1", projectId: "my-app", metadata: { role: "orchestrator" } }),
+];
+
+const mockSessionManager = {
+  list: vi.fn(async () => testSessions),
+  get: vi.fn(async (id: string) => testSessions.find((session) => session.id === id) ?? null),
+  kill: vi.fn(async (_id: string) => {}),
+  restore: vi.fn(async (id: string) => testSessions.find((session) => session.id === id) ?? null),
+} as unknown as SessionManager;
+
+const mockConfig: OrchestratorConfig = {
+  configPath: "/tmp/ao-test/agent-orchestrator.yaml",
+  port: 3000,
+  readyThresholdMs: 300_000,
+  defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+  projects: {
+    "my-app": {
+      name: "My App",
+      repo: "acme/my-app",
+      path: "/tmp/my-app",
+      defaultBranch: "main",
+      sessionPrefix: "my-app",
+      scm: { plugin: "github" },
+    },
+    "docs-app": {
+      name: "Docs App",
+      repo: "acme/docs-app",
+      path: "/tmp/docs-app",
+      defaultBranch: "main",
+      sessionPrefix: "docs",
+      scm: { plugin: "github" },
+    },
+  },
+  notifiers: {},
+  notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+  reactions: {},
+  api: {
+    token: "secret-token",
+  },
+};
+
+vi.mock("@/lib/config-cache", () => ({
+  getCachedConfig: vi.fn(() => mockConfig),
+}));
+
+vi.mock("@/lib/services", () => ({
+  getServices: vi.fn(async () => ({
+    config: mockConfig,
+    registry: {} as PluginRegistry,
+    sessionManager: mockSessionManager,
+    lifecycleManager: {} as LifecycleManager,
+  })),
+}));
+
+import { checkAuth } from "@/app/api/ao/_auth";
+import { GET as statusGET } from "@/app/api/ao/status/route";
+import { GET as sessionsGET } from "@/app/api/ao/sessions/route";
+import { GET as sessionGET } from "@/app/api/ao/sessions/[id]/route";
+import { POST as retryPOST } from "@/app/api/ao/sessions/[id]/retry/route";
+import { POST as killPOST } from "@/app/api/ao/sessions/[id]/kill/route";
+import webPackage from "../../package.json";
+
+function makeRequest(path: string, init?: RequestInit): Request {
+  return new Request(new URL(path, "http://localhost:3000"), init);
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockConfig.api = { token: "secret-token" };
+  vi.mocked(getServices).mockResolvedValue({
+    config: mockConfig,
+    registry: {} as PluginRegistry,
+    sessionManager: mockSessionManager,
+    lifecycleManager: {} as LifecycleManager,
+  });
+  vi.mocked(getCachedConfig).mockReturnValue(mockConfig);
+  vi.mocked(mockSessionManager.list).mockResolvedValue(testSessions);
+  vi.mocked(mockSessionManager.get).mockImplementation(
+    async (id: string) => testSessions.find((session) => session.id === id) ?? null,
+  );
+  vi.mocked(mockSessionManager.restore).mockResolvedValue(testSessions[0]);
+  vi.mocked(mockSessionManager.kill).mockResolvedValue(undefined);
+});
+
+describe("AO API Routes", () => {
+  describe("auth", () => {
+    it("request with correct token passes through", () => {
+      const result = checkAuth(
+        makeRequest("/api/ao/status", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        "secret-token",
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("request with wrong token returns 401", async () => {
+      const result = checkAuth(
+        makeRequest("/api/ao/status", {
+          headers: { authorization: "Bearer wrong-token" },
+        }),
+        "secret-token",
+      );
+
+      expect(result?.status).toBe(401);
+      await expect(result?.json()).resolves.toEqual({ error: "Unauthorized" });
+    });
+
+    it("request when no token configured passes through", () => {
+      const result = checkAuth(makeRequest("/api/ao/status"), undefined);
+
+      expect(result).toBeNull();
+    });
+
+    it("request when token is blank fails closed", async () => {
+      const result = checkAuth(makeRequest("/api/ao/status"), "   ");
+
+      expect(result?.status).toBe(401);
+      await expect(result?.json()).resolves.toEqual({ error: "Unauthorized" });
+    });
+  });
+
+  describe("GET /api/ao/status", () => {
+    it("rejects unauthorized requests before initializing services", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const response = await statusGET(
+        makeRequest("/api/ao/status", {
+          headers: { authorization: "Bearer wrong-token" },
+        }),
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
+    it("returns correct session count", async () => {
+      const response = await statusGET(
+        makeRequest("/api/ao/status", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        version: webPackage.version,
+        sessionCount: testSessions.length,
+      });
+    });
+
+    it('notifierHealth is "warn" when any session has a warned notifier', async () => {
+      const response = await statusGET(
+        makeRequest("/api/ao/status", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+
+      await expect(response.json()).resolves.toMatchObject({
+        notifierHealth: "warn",
+      });
+    });
+
+    it('notifierHealth is "ok" when no sessions are warned', async () => {
+      vi.mocked(mockSessionManager.list).mockResolvedValue([
+        makeSession({ id: "worker-1", projectId: "my-app" }),
+        makeSession({ id: "worker-2", projectId: "docs-app", status: "needs_input" }),
+      ]);
+
+      const response = await statusGET(
+        makeRequest("/api/ao/status", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+
+      const data = await response.json();
+      expect(data.notifierHealth).toBe("ok");
+      expect(typeof data.uptime).toBe("number");
+    });
+  });
+
+  describe("GET /api/ao/sessions", () => {
+    it("rejects unauthorized requests before initializing services", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const response = await sessionsGET(
+        makeRequest("/api/ao/sessions", {
+          headers: { authorization: "Bearer wrong-token" },
+        }),
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
+    it("returns all sessions when no filters", async () => {
+      const response = await sessionsGET(
+        makeRequest("/api/ao/sessions", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(Array.isArray(data)).toBe(true);
+      expect(data).toHaveLength(testSessions.length);
+      expect(
+        data.find((session: { id: string }) => session.id === "worker-2")?.notificationState?.status,
+      ).toBe("warn");
+    });
+
+    it("filters by status param correctly", async () => {
+      const response = await sessionsGET(
+        makeRequest("/api/ao/sessions?status=stuck,killed", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+
+      const data = await response.json();
+      expect(data.map((session: { id: string }) => session.id)).toEqual(["worker-2"]);
+    });
+
+    it("filters by project param correctly", async () => {
+      const response = await sessionsGET(
+        makeRequest("/api/ao/sessions?project=docs-app", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+
+      const data = await response.json();
+      expect(data.map((session: { id: string }) => session.id)).toEqual(["worker-2"]);
+    });
+
+    it("filters by project using session prefix fallback semantics", async () => {
+      vi.mocked(mockSessionManager.list).mockResolvedValue([
+        makeSession({
+          id: "docs-9",
+          projectId: "missing-project",
+          status: "working",
+        }),
+      ]);
+
+      const response = await sessionsGET(
+        makeRequest("/api/ao/sessions?project=docs-app", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+
+      const data = await response.json();
+      expect(data.map((session: { id: string }) => session.id)).toEqual(["docs-9"]);
+      expect(data[0]?.projectId).toBe("docs-app");
+    });
+
+    it("does not match overlapping session prefixes when filtering by project", async () => {
+      mockConfig.projects["app"] = {
+        name: "App",
+        repo: "acme/app",
+        path: "/tmp/app",
+        defaultBranch: "main",
+        sessionPrefix: "app",
+        scm: { plugin: "github" },
+      };
+      mockConfig.projects["apple"] = {
+        name: "Apple",
+        repo: "acme/apple",
+        path: "/tmp/apple",
+        defaultBranch: "main",
+        sessionPrefix: "apple",
+        scm: { plugin: "github" },
+      };
+      vi.mocked(mockSessionManager.list).mockResolvedValue([
+        makeSession({ id: "app-1", projectId: "missing-project" }),
+        makeSession({ id: "apple-1", projectId: "missing-project" }),
+      ]);
+
+      const response = await sessionsGET(
+        makeRequest("/api/ao/sessions?project=app", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual([
+        expect.objectContaining({ id: "app-1", projectId: "app" }),
+      ]);
+    });
+
+    it("matches the longest session prefix when prefixes are nested", async () => {
+      mockConfig.projects["app"] = {
+        name: "App",
+        repo: "acme/app",
+        path: "/tmp/app",
+        defaultBranch: "main",
+        sessionPrefix: "app",
+        scm: { plugin: "github" },
+      };
+      mockConfig.projects["app-foo"] = {
+        name: "App Foo",
+        repo: "acme/app-foo",
+        path: "/tmp/app-foo",
+        defaultBranch: "main",
+        sessionPrefix: "app-foo",
+        scm: { plugin: "github" },
+      };
+      vi.mocked(mockSessionManager.list).mockResolvedValue([
+        makeSession({ id: "app-1", projectId: "missing-project" }),
+        makeSession({ id: "app-foo-1", projectId: "missing-project" }),
+      ]);
+
+      const appResponse = await sessionsGET(
+        makeRequest("/api/ao/sessions?project=app", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+      const appFooResponse = await sessionsGET(
+        makeRequest("/api/ao/sessions?project=app-foo", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+
+      await expect(appResponse.json()).resolves.toEqual([
+        expect.objectContaining({ id: "app-1", projectId: "app" }),
+      ]);
+      await expect(appFooResponse.json()).resolves.toEqual([
+        expect.objectContaining({ id: "app-foo-1", projectId: "app-foo" }),
+      ]);
+    });
+
+    it('warned=true returns only sessions with notificationState.status === "warn"', async () => {
+      const response = await sessionsGET(
+        makeRequest("/api/ao/sessions?warned=true", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+
+      const data = await response.json();
+      expect(data.map((session: { id: string }) => session.id)).toEqual(["worker-2"]);
+    });
+  });
+
+  describe("GET /api/ao/sessions/[id]", () => {
+    it("rejects unauthorized requests before validating the id", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const response = await sessionGET(
+        makeRequest("/api/ao/sessions/bad/id", {
+          headers: { authorization: "Bearer wrong-token" },
+        }),
+        { params: Promise.resolve({ id: "bad/id" }) },
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
+    it("returns correct session", async () => {
+      const response = await sessionGET(
+        makeRequest("/api/ao/sessions/worker-2", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "worker-2" }) },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        id: "worker-2",
+        notificationState: { status: "warn" },
+      });
+      expect(mockSessionManager.get).toHaveBeenCalledWith("worker-2", { includeArchived: true });
+    });
+
+    it("returns archived sessions through includeArchived lookup", async () => {
+      vi.mocked(mockSessionManager.get).mockResolvedValueOnce(
+        makeSession({
+          id: "docs-9",
+          projectId: "missing-project",
+          status: "killed",
+          activity: "exited",
+        }),
+      );
+
+      const response = await sessionGET(
+        makeRequest("/api/ao/sessions/docs-9", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "docs-9" }) },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        id: "docs-9",
+        status: "killed",
+        projectId: "docs-app",
+      });
+      expect(mockSessionManager.get).toHaveBeenCalledWith("docs-9", { includeArchived: true });
+    });
+
+    it("returns 404 for unknown id", async () => {
+      const response = await sessionGET(
+        makeRequest("/api/ao/sessions/missing", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "missing" }) },
+      );
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({ error: "Session not found" });
+    });
+
+    it("returns 400 for invalid id", async () => {
+      const response = await sessionGET(
+        makeRequest("/api/ao/sessions/bad/id", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "bad/id" }) },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "id must match [a-zA-Z0-9_-]+" });
+    });
+  });
+
+  describe("POST /api/ao/sessions/[id]/retry", () => {
+    it("rejects unauthorized retry requests before initializing services", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const response = await retryPOST(
+        makeRequest("/api/ao/sessions/worker-1/retry", {
+          method: "POST",
+          headers: { authorization: "Bearer wrong-token" },
+        }),
+        { params: Promise.resolve({ id: "worker-1" }) },
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
+    it("calls restore on session manager and returns { ok: true } for archived sessions", async () => {
+      vi.mocked(mockSessionManager.restore).mockResolvedValueOnce(
+        makeSession({ id: "archived-1", status: "spawning", activity: "active" }),
+      );
+
+      const response = await retryPOST(
+        makeRequest("/api/ao/sessions/archived-1/retry", {
+          method: "POST",
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "archived-1" }) },
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockSessionManager.restore).toHaveBeenCalledWith("archived-1");
+      expect(mockSessionManager.get).not.toHaveBeenCalled();
+      await expect(response.json()).resolves.toEqual({ ok: true });
+    });
+
+    it("returns 404 for unknown id", async () => {
+      vi.mocked(mockSessionManager.restore).mockRejectedValueOnce(new SessionNotFoundError("missing"));
+
+      const response = await retryPOST(
+        makeRequest("/api/ao/sessions/missing/retry", {
+          method: "POST",
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "missing" }) },
+      );
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({ error: "Session not found" });
+    });
+
+    it("returns 400 for invalid id", async () => {
+      const response = await retryPOST(
+        makeRequest("/api/ao/sessions/bad/id/retry", {
+          method: "POST",
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "bad/id" }) },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "id must match [a-zA-Z0-9_-]+" });
+    });
+
+    it("returns 409 with { ok: false, error } when restore throws SessionNotRestorableError", async () => {
+      vi.mocked(mockSessionManager.restore).mockRejectedValueOnce(
+        new SessionNotRestorableError("worker-1", "session is not in a terminal state"),
+      );
+
+      const response = await retryPOST(
+        makeRequest("/api/ao/sessions/worker-1/retry", {
+          method: "POST",
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "worker-1" }) },
+      );
+
+      expect(response.status).toBe(409);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: "Session worker-1 cannot be restored: session is not in a terminal state",
+      });
+    });
+
+    it("returns 422 with { ok: false, error } when restore throws WorkspaceMissingError", async () => {
+      vi.mocked(mockSessionManager.restore).mockRejectedValueOnce(
+        new WorkspaceMissingError("/tmp/missing", "restore failed"),
+      );
+
+      const response = await retryPOST(
+        makeRequest("/api/ao/sessions/worker-1/retry", {
+          method: "POST",
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "worker-1" }) },
+      );
+
+      expect(response.status).toBe(422);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: "Workspace missing at /tmp/missing: restore failed",
+      });
+    });
+
+    it("returns 500 with { ok: false, error } when restore throws generic error", async () => {
+      vi.mocked(mockSessionManager.restore).mockRejectedValueOnce(new Error("restore failed"));
+
+      const response = await retryPOST(
+        makeRequest("/api/ao/sessions/worker-1/retry", {
+          method: "POST",
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "worker-1" }) },
+      );
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({ ok: false, error: "restore failed" });
+    });
+  });
+
+  describe("POST /api/ao/sessions/[id]/kill", () => {
+    it("rejects unauthorized kill requests before validating the id", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const response = await killPOST(
+        makeRequest("/api/ao/sessions/bad/id/kill", {
+          method: "POST",
+          headers: { authorization: "Bearer wrong-token" },
+        }),
+        { params: Promise.resolve({ id: "bad/id" }) },
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
+    it("calls kill on session manager and returns { ok: true }", async () => {
+      const response = await killPOST(
+        makeRequest("/api/ao/sessions/worker-1/kill", {
+          method: "POST",
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "worker-1" }) },
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockSessionManager.kill).toHaveBeenCalledWith("worker-1");
+      await expect(response.json()).resolves.toEqual({ ok: true });
+    });
+
+    it("returns 404 for unknown id", async () => {
+      vi.mocked(mockSessionManager.kill).mockRejectedValueOnce(new SessionNotFoundError("missing"));
+
+      const response = await killPOST(
+        makeRequest("/api/ao/sessions/missing/kill", {
+          method: "POST",
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "missing" }) },
+      );
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({ error: "Session not found" });
+    });
+
+    it("returns 400 for invalid id", async () => {
+      const response = await killPOST(
+        makeRequest("/api/ao/sessions/bad/id/kill", {
+          method: "POST",
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "bad/id" }) },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "id must match [a-zA-Z0-9_-]+" });
+    });
+
+    it("returns 500 with { ok: false, error } when kill throws", async () => {
+      vi.mocked(mockSessionManager.kill).mockRejectedValueOnce(new Error("kill failed"));
+
+      const response = await killPOST(
+        makeRequest("/api/ao/sessions/worker-1/kill", {
+          method: "POST",
+          headers: { authorization: "Bearer secret-token" },
+        }),
+        { params: Promise.resolve({ id: "worker-1" }) },
+      );
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({ ok: false, error: "kill failed" });
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns 500 when getServices throws", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services unavailable"));
+
+      const response = await statusGET(
+        makeRequest("/api/ao/status", {
+          headers: { authorization: "Bearer secret-token" },
+        }),
+      );
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({ error: "services unavailable" });
+    });
+  });
+});

--- a/packages/web/src/__tests__/api-ao.test.ts
+++ b/packages/web/src/__tests__/api-ao.test.ts
@@ -1,9 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { LifecycleManager, OrchestratorConfig, PluginRegistry, Session, SessionManager } from "@composio/ao-core";
 import {
   SessionNotFoundError,
   SessionNotRestorableError,
   WorkspaceMissingError,
+  type LifecycleManager,
+  type OrchestratorConfig,
+  type PluginRegistry,
+  type Session,
+  type SessionManager,
 } from "@composio/ao-core";
 import { getServices } from "@/lib/services";
 import { getCachedConfig } from "@/lib/config-cache";

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -195,6 +195,7 @@ vi.mock("@/lib/services", () => ({
 // ── Import routes after mocking ───────────────────────────────────────
 
 import { GET as sessionsGET } from "@/app/api/sessions/route";
+import { GET as sessionGET } from "@/app/api/sessions/[id]/route";
 import { POST as orchestratorsPOST } from "@/app/api/orchestrators/route";
 import { POST as spawnPOST } from "@/app/api/spawn/route";
 import { POST as sendPOST } from "@/app/api/sessions/[id]/send/route";
@@ -255,6 +256,7 @@ describe("API Routes", () => {
       expect(session).toHaveProperty("status");
       expect(session).toHaveProperty("activity");
       expect(session).toHaveProperty("createdAt");
+      expect(session).toHaveProperty("notificationState");
     });
 
     it("skips PR enrichment when metadata enrichment hits timeout", async () => {
@@ -388,6 +390,44 @@ describe("API Routes", () => {
         pausedUntil,
         reason: "Rate limit hit",
         sourceSessionId: "docs-orchestrator",
+      });
+    });
+  });
+
+  describe("GET /api/sessions/:id", () => {
+    it("returns notificationState on detail responses", async () => {
+      (mockSessionManager.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        makeSession({
+          id: "backend-3",
+          metadata: {
+            "notifier.openclaw.status": "warn",
+            "notifier.openclaw.consecutiveFailures": "1",
+            "notifier.openclaw.lastFailureReason": "Connection refused",
+          },
+        }),
+      );
+
+      const res = await sessionGET(makeRequest("http://localhost:3000/api/sessions/backend-3"), {
+        params: Promise.resolve({ id: "backend-3" }),
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.notificationState).toEqual({
+        status: "warn",
+        failingNotifiers: ["openclaw"],
+        notifiers: [
+          {
+            name: "openclaw",
+            status: "warn",
+            consecutiveFailures: 1,
+            lastFailureAt: null,
+            lastFailureReason: "Connection refused",
+            lastSuccessAt: null,
+            lastEventType: null,
+            lastPriority: null,
+          },
+        ],
       });
     });
   });

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -3,7 +3,8 @@ import { NextRequest } from "next/server";
 import {
   SessionNotFoundError,
   SessionNotRestorableError,
-  SessionNotFoundError,
+  type LifecycleManager,
+  type SCMWebhookEvent,
   type Session,
   type SessionManager,
   type OrchestratorConfig,
@@ -126,6 +127,13 @@ const mockSessionManager: SessionManager = {
   }),
 };
 
+const mockLifecycleManager: LifecycleManager = {
+  start: vi.fn(),
+  stop: vi.fn(),
+  getStates: vi.fn(() => new Map()),
+  check: vi.fn(async () => undefined),
+};
+
 const mockSCM: SCM = {
   name: "github",
   detectPR: vi.fn(async () => null),
@@ -188,6 +196,7 @@ vi.mock("@/lib/services", () => ({
     config: mockConfig,
     registry: mockRegistry,
     sessionManager: mockSessionManager,
+    lifecycleManager: mockLifecycleManager,
   })),
   getSCM: vi.fn(() => mockSCM),
 }));
@@ -204,6 +213,7 @@ import { POST as killPOST } from "@/app/api/sessions/[id]/kill/route";
 import { POST as restorePOST } from "@/app/api/sessions/[id]/restore/route";
 import { POST as remapPOST } from "@/app/api/sessions/[id]/remap/route";
 import { POST as mergePOST } from "@/app/api/prs/[id]/merge/route";
+import { POST as webhooksPOST } from "@/app/api/webhooks/[...slug]/route";
 import { GET as eventsGET } from "@/app/api/events/route";
 import { GET as observabilityGET } from "@/app/api/observability/route";
 
@@ -221,6 +231,13 @@ beforeEach(() => {
   (mockSessionManager.get as ReturnType<typeof vi.fn>).mockImplementation(
     async (id: string) => testSessions.find((s) => s.id === id) ?? null,
   );
+  (mockLifecycleManager.check as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  mockConfig.projects["my-app"] = {
+    ...mockConfig.projects["my-app"],
+    scm: { plugin: "github" },
+  };
+  (mockSCM.verifyWebhook as ReturnType<typeof vi.fn> | undefined)?.mockReset?.();
+  (mockSCM.parseWebhook as ReturnType<typeof vi.fn> | undefined)?.mockReset?.();
 });
 
 describe("API Routes", () => {
@@ -830,6 +847,73 @@ describe("API Routes", () => {
       expect(res.status).toBe(409);
       const data = await res.json();
       expect(data.error).toMatch(/merged/);
+    });
+  });
+
+  describe("POST /api/webhooks/[...slug]", () => {
+    it("logs lifecycle check failures while returning 202", async () => {
+      const webhookEvent: SCMWebhookEvent = {
+        provider: "github",
+        kind: "push",
+        action: "updated",
+        rawEventType: "push",
+        repository: { owner: "acme", name: "my-app" },
+        branch: "feat/hook-fail",
+        data: {},
+      };
+
+      mockConfig.projects["my-app"] = {
+        ...mockConfig.projects["my-app"],
+        scm: {
+          plugin: "github",
+          webhook: {
+            enabled: true,
+            path: "/api/webhooks/github",
+          },
+        },
+      };
+
+      (mockSCM as SCM & {
+        verifyWebhook: ReturnType<typeof vi.fn>;
+        parseWebhook: ReturnType<typeof vi.fn>;
+      }).verifyWebhook = vi.fn(async () => ({ ok: true }));
+      (mockSCM as SCM & {
+        verifyWebhook: ReturnType<typeof vi.fn>;
+        parseWebhook: ReturnType<typeof vi.fn>;
+      }).parseWebhook = vi.fn(async () => webhookEvent);
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeSession({
+          id: "backend-3",
+          projectId: "my-app",
+          status: "working",
+          activity: "active",
+          branch: "feat/hook-fail",
+        }),
+      ]);
+      (mockLifecycleManager.check as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("boom"),
+      );
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        const req = new Request("http://localhost:3000/api/webhooks/github", {
+          method: "POST",
+          body: JSON.stringify({}),
+          headers: { "Content-Type": "application/json" },
+        });
+
+        const res = await webhooksPOST(req);
+        expect(res.status).toBe(202);
+
+        const data = await res.json();
+        expect(data.lifecycleErrors).toEqual(["session backend-3: boom"]);
+        expect(errorSpy).toHaveBeenCalledWith(
+          "[webhook] lifecycle checks failed:",
+          ["session backend-3: boom"],
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -12,7 +12,8 @@ import {
   type SCM,
 } from "@composio/ao-core";
 import * as serialize from "@/lib/serialize";
-import { getSCM } from "@/lib/services";
+import { getServices, getSCM } from "@/lib/services";
+import { getCachedConfig } from "@/lib/config-cache";
 
 // ── Mock Data ─────────────────────────────────────────────────────────
 // Provides test sessions covering the key states the dashboard needs.
@@ -189,7 +190,14 @@ const mockConfig: OrchestratorConfig = {
   notifiers: {},
   notificationRouting: { urgent: [], action: [], warning: [], info: [] },
   reactions: {},
+  api: {
+    token: "secret-token",
+  },
 };
+
+vi.mock("@/lib/config-cache", () => ({
+  getCachedConfig: vi.fn(() => mockConfig),
+}));
 
 vi.mock("@/lib/services", () => ({
   getServices: vi.fn(async () => ({
@@ -217,20 +225,127 @@ import { POST as webhooksPOST } from "@/app/api/webhooks/[...slug]/route";
 import { GET as eventsGET } from "@/app/api/events/route";
 import { GET as observabilityGET } from "@/app/api/observability/route";
 
-function makeRequest(url: string, init?: RequestInit): NextRequest {
+function makeRawRequest(url: string, init?: RequestInit): NextRequest {
   return new NextRequest(
     new URL(url, "http://localhost:3000"),
     init as ConstructorParameters<typeof NextRequest>[1],
   );
 }
 
+function makeRequest(url: string, init?: RequestInit): NextRequest {
+  const headers = new Headers(init?.headers);
+  const token = mockConfig.api?.token?.trim();
+  if (token && !headers.has("authorization")) {
+    headers.set("authorization", `Bearer ${token}`);
+  }
+  return makeRawRequest(url, { ...init, headers });
+}
+
 beforeEach(() => {
-  vi.clearAllMocks();
-  // Re-set default return values
+  vi.restoreAllMocks();
+  mockConfig.api = { token: "secret-token" };
+
+  vi.mocked(getServices).mockReset();
+  vi.mocked(getSCM).mockReset();
+  vi.mocked(getCachedConfig).mockReset();
+
+  (mockRegistry.get as ReturnType<typeof vi.fn>).mockReset();
+  (mockRegistry.get as ReturnType<typeof vi.fn>).mockImplementation(() => mockSCM);
+
+  (mockSessionManager.list as ReturnType<typeof vi.fn>).mockReset();
+  (mockSessionManager.get as ReturnType<typeof vi.fn>).mockReset();
+  (mockSessionManager.spawn as ReturnType<typeof vi.fn>).mockReset();
+  (mockSessionManager.kill as ReturnType<typeof vi.fn>).mockReset();
+  (mockSessionManager.send as ReturnType<typeof vi.fn>).mockReset();
+  (mockSessionManager.cleanup as ReturnType<typeof vi.fn>).mockReset();
+  (mockSessionManager.spawnOrchestrator as ReturnType<typeof vi.fn>).mockReset();
+  (mockSessionManager.remap as ReturnType<typeof vi.fn>).mockReset();
+  (mockSessionManager.restore as ReturnType<typeof vi.fn>).mockReset();
+
+  (mockSCM.detectPR as ReturnType<typeof vi.fn>).mockReset();
+  (mockSCM.getPRState as ReturnType<typeof vi.fn>).mockReset();
+  (mockSCM.mergePR as ReturnType<typeof vi.fn>).mockReset();
+  (mockSCM.closePR as ReturnType<typeof vi.fn>).mockReset();
+  (mockSCM.getCIChecks as ReturnType<typeof vi.fn>).mockReset();
+  (mockSCM.getCISummary as ReturnType<typeof vi.fn>).mockReset();
+  (mockSCM.getReviews as ReturnType<typeof vi.fn>).mockReset();
+  (mockSCM.getReviewDecision as ReturnType<typeof vi.fn>).mockReset();
+  (mockSCM.getPendingComments as ReturnType<typeof vi.fn>).mockReset();
+  (mockSCM.getAutomatedComments as ReturnType<typeof vi.fn>).mockReset();
+  (mockSCM.getMergeability as ReturnType<typeof vi.fn>).mockReset();
+
+  vi.mocked(getCachedConfig).mockReturnValue(mockConfig);
+  vi.mocked(getServices).mockResolvedValue({
+    config: mockConfig,
+    registry: mockRegistry,
+    sessionManager: mockSessionManager,
+    lifecycleManager: mockLifecycleManager,
+  });
+  vi.mocked(getSCM).mockReturnValue(mockSCM);
+
   (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValue(testSessions);
   (mockSessionManager.get as ReturnType<typeof vi.fn>).mockImplementation(
     async (id: string) => testSessions.find((s) => s.id === id) ?? null,
   );
+  (mockSessionManager.spawn as ReturnType<typeof vi.fn>).mockImplementation(async (config) =>
+    makeSession({
+      id: `session-${Date.now()}`,
+      projectId: config.projectId,
+      issueId: config.issueId ?? null,
+      status: "spawning",
+    }),
+  );
+  (mockSessionManager.kill as ReturnType<typeof vi.fn>).mockImplementation(async (id: string) => {
+    if (!testSessions.find((s) => s.id === id)) {
+      throw new SessionNotFoundError(id);
+    }
+  });
+  (mockSessionManager.send as ReturnType<typeof vi.fn>).mockImplementation(async (id: string) => {
+    if (!testSessions.find((s) => s.id === id)) {
+      throw new SessionNotFoundError(id);
+    }
+  });
+  (mockSessionManager.cleanup as ReturnType<typeof vi.fn>).mockResolvedValue({
+    killed: [],
+    skipped: [],
+    errors: [],
+  });
+  (mockSessionManager.spawnOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValue(
+    makeSession({
+      id: "my-app-orchestrator",
+      projectId: "my-app",
+      metadata: { role: "orchestrator" },
+    }),
+  );
+  (mockSessionManager.remap as ReturnType<typeof vi.fn>).mockResolvedValue("ses_mock");
+  (mockSessionManager.restore as ReturnType<typeof vi.fn>).mockImplementation(async (id: string) => {
+    const session = testSessions.find((s) => s.id === id);
+    if (!session) {
+      throw new SessionNotFoundError(id);
+    }
+    if (session.status === "working" && session.activity !== "exited") {
+      throw new SessionNotRestorableError(id, "session is not in a terminal state");
+    }
+    return { ...session, status: "spawning" as const, activity: "active" as const };
+  });
+
+  (mockSCM.detectPR as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  (mockSCM.getPRState as ReturnType<typeof vi.fn>).mockResolvedValue("open" as const);
+  (mockSCM.mergePR as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  (mockSCM.closePR as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  (mockSCM.getCIChecks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  (mockSCM.getCISummary as ReturnType<typeof vi.fn>).mockResolvedValue("passing" as const);
+  (mockSCM.getReviews as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  (mockSCM.getReviewDecision as ReturnType<typeof vi.fn>).mockResolvedValue("approved" as const);
+  (mockSCM.getPendingComments as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  (mockSCM.getAutomatedComments as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  (mockSCM.getMergeability as ReturnType<typeof vi.fn>).mockResolvedValue({
+    mergeable: true,
+    ciPassing: true,
+    approved: true,
+    noConflicts: true,
+    blockers: [],
+  });
   (mockLifecycleManager.check as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
   mockConfig.projects["my-app"] = {
     ...mockConfig.projects["my-app"],
@@ -244,6 +359,20 @@ describe("API Routes", () => {
   // ── GET /api/sessions ──────────────────────────────────────────────
 
   describe("GET /api/sessions", () => {
+    it("rejects unauthorized requests before initializing services", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const res = await sessionsGET(
+        makeRequest("http://localhost:3000/api/sessions", {
+          headers: { authorization: "Bearer wrong-token" },
+        }),
+      );
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get("x-correlation-id")).toBeTruthy();
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
     it("returns sessions array and stats", async () => {
       const res = await sessionsGET(makeRequest("http://localhost:3000/api/sessions"));
       expect(res.status).toBe(200);
@@ -335,6 +464,26 @@ describe("API Routes", () => {
       expect(mockSessionManager.list).toHaveBeenCalledWith("docs-app");
     });
 
+    it("normalizes fallback projectId in list responses", async () => {
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+        makeSession({
+          id: "docs-9",
+          projectId: "missing-project",
+          status: "working",
+          activity: "active",
+        }),
+      ]);
+
+      const res = await sessionsGET(
+        makeRequest("http://localhost:3000/api/sessions?project=docs-app"),
+      );
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        sessions: [expect.objectContaining({ id: "docs-9", projectId: "docs-app" })],
+      });
+    });
+
     it("keeps global pause sourced from all projects even for project-scoped requests", async () => {
       const pausedUntil = new Date(Date.now() + 60_000).toISOString();
       const pausedSessions = [
@@ -412,6 +561,21 @@ describe("API Routes", () => {
   });
 
   describe("GET /api/sessions/:id", () => {
+    it("rejects unauthorized requests before initializing services", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const res = await sessionGET(
+        makeRequest("http://localhost:3000/api/sessions/frontend-1", {
+          headers: { authorization: "Bearer wrong-token" },
+        }),
+        { params: Promise.resolve({ id: "frontend-1" }) },
+      );
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get("x-correlation-id")).toBeTruthy();
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
     it("returns notificationState on detail responses", async () => {
       (mockSessionManager.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
         makeSession({
@@ -445,6 +609,52 @@ describe("API Routes", () => {
             lastPriority: null,
           },
         ],
+      });
+    });
+
+    it("returns archived sessions via includeArchived lookup", async () => {
+      (mockSessionManager.get as ReturnType<typeof vi.fn>).mockImplementation(
+        async (id: string, options?: { includeArchived?: boolean }) => {
+          if (id === "frontend-1" && options?.includeArchived) {
+            return makeSession({
+              id: "frontend-1",
+              projectId: "my-app",
+              status: "killed",
+              activity: "exited",
+            });
+          }
+          return null;
+        },
+      );
+
+      const res = await sessionGET(makeRequest("http://localhost:3000/api/sessions/frontend-1"), {
+        params: Promise.resolve({ id: "frontend-1" }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockSessionManager.get).toHaveBeenCalledWith("frontend-1", {
+        includeArchived: true,
+      });
+    });
+
+    it("normalizes fallback projectId on detail responses", async () => {
+      (mockSessionManager.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        makeSession({
+          id: "docs-9",
+          projectId: "missing-project",
+          status: "working",
+          activity: "active",
+        }),
+      );
+
+      const res = await sessionGET(makeRequest("http://localhost:3000/api/sessions/docs-9"), {
+        params: Promise.resolve({ id: "docs-9" }),
+      });
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        id: "docs-9",
+        projectId: "docs-app",
       });
     });
   });
@@ -593,6 +803,21 @@ describe("API Routes", () => {
   // ── POST /api/sessions/:id/send ────────────────────────────────────
 
   describe("POST /api/sessions/:id/send", () => {
+    it("rejects requests without auth before initializing services", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const req = makeRawRequest("/api/sessions/backend-3/send", {
+        method: "POST",
+        body: JSON.stringify({ message: "Fix the tests" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      const res = await sendPOST(req, { params: Promise.resolve({ id: "backend-3" }) });
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get("x-correlation-id")).toBeTruthy();
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
     it("sends a message to a valid session", async () => {
       const req = makeRequest("/api/sessions/backend-3/send", {
         method: "POST",
@@ -655,6 +880,21 @@ describe("API Routes", () => {
   });
 
   describe("POST /api/sessions/:id/message", () => {
+    it("rejects requests without auth before initializing services", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const req = makeRawRequest("/api/sessions/backend-3/message", {
+        method: "POST",
+        body: JSON.stringify({ message: "Fix the tests" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      const res = await messagePOST(req, { params: Promise.resolve({ id: "backend-3" }) });
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get("x-correlation-id")).toBeTruthy();
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
     it("sends a message to a valid session", async () => {
       const req = makeRequest("/api/sessions/backend-3/message", {
         method: "POST",
@@ -720,6 +960,66 @@ describe("API Routes", () => {
   // ── POST /api/sessions/:id/kill ────────────────────────────────────
 
   describe("POST /api/sessions/:id/kill", () => {
+    it("rejects unauthorized requests before initializing services", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const res = await killPOST(
+        makeRequest("/api/sessions/backend-3/kill", {
+          method: "POST",
+          headers: { authorization: "Bearer wrong-token" },
+        }),
+        { params: Promise.resolve({ id: "backend-3" }) },
+      );
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get("x-correlation-id")).toBeTruthy();
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [
+        "kill",
+        () => killPOST(makeRequest("/api/sessions/backend-3/kill", { method: "POST" }), {
+          params: Promise.resolve({ id: "backend-3" }),
+        }),
+      ],
+      [
+        "restore",
+        () => restorePOST(makeRequest("/api/sessions/frontend-1/restore", { method: "POST" }), {
+          params: Promise.resolve({ id: "frontend-1" }),
+        }),
+      ],
+      [
+        "send",
+        () =>
+          sendPOST(
+            makeRequest("/api/sessions/backend-3/send", {
+              method: "POST",
+              body: JSON.stringify({ message: "Fix the tests" }),
+              headers: { "Content-Type": "application/json" },
+            }),
+            { params: Promise.resolve({ id: "backend-3" }) },
+          ),
+      ],
+      [
+        "remap",
+        () => remapPOST(makeRequest("/api/sessions/backend-3/remap", { method: "POST" }), {
+          params: Promise.resolve({ id: "backend-3" }),
+        }),
+      ],
+    ])("returns a JSON 500 when auth config reload fails for %s", async (_name, invoke) => {
+      vi.mocked(getCachedConfig).mockImplementationOnce(() => {
+        throw new Error("invalid config");
+      });
+
+      const res = await invoke();
+
+      expect(res.status).toBe(500);
+      expect(res.headers.get("x-correlation-id")).toBeTruthy();
+      await expect(res.json()).resolves.toMatchObject({ error: "invalid config" });
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
     it("kills a valid session", async () => {
       const req = makeRequest("/api/sessions/backend-3/kill", { method: "POST" });
       const res = await killPOST(req, { params: Promise.resolve({ id: "backend-3" }) });
@@ -742,6 +1042,22 @@ describe("API Routes", () => {
   // ── POST /api/sessions/:id/restore ─────────────────────────────────
 
   describe("POST /api/sessions/:id/restore", () => {
+    it("rejects unauthorized requests before initializing services", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const res = await restorePOST(
+        makeRequest("/api/sessions/frontend-1/restore", {
+          method: "POST",
+          headers: { authorization: "Bearer wrong-token" },
+        }),
+        { params: Promise.resolve({ id: "frontend-1" }) },
+      );
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get("x-correlation-id")).toBeTruthy();
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
     it("restores a killed session", async () => {
       const req = makeRequest("/api/sessions/frontend-1/restore", { method: "POST" });
       const res = await restorePOST(req, { params: Promise.resolve({ id: "frontend-1" }) });
@@ -767,6 +1083,17 @@ describe("API Routes", () => {
   });
 
   describe("POST /api/sessions/:id/remap", () => {
+    it("rejects requests without auth before initializing services", async () => {
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("services should not initialize"));
+
+      const req = makeRawRequest("/api/sessions/backend-3/remap", { method: "POST" });
+      const res = await remapPOST(req, { params: Promise.resolve({ id: "backend-3" }) });
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get("x-correlation-id")).toBeTruthy();
+      expect(getServices).not.toHaveBeenCalled();
+    });
+
     it("remaps a valid session", async () => {
       const req = makeRequest("/api/sessions/backend-3/remap", { method: "POST" });
       const res = await remapPOST(req, { params: Promise.resolve({ id: "backend-3" }) });

--- a/packages/web/src/__tests__/helpers.ts
+++ b/packages/web/src/__tests__/helpers.ts
@@ -16,6 +16,7 @@ export function makeSession(overrides: Partial<DashboardSession> = {}): Dashboar
     createdAt: new Date().toISOString(),
     lastActivityAt: new Date().toISOString(),
     pr: null,
+    notificationState: { status: "ok", failingNotifiers: [], notifiers: [] },
     metadata: {},
     ...overrides,
   };

--- a/packages/web/src/__tests__/services.test.ts
+++ b/packages/web/src/__tests__/services.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { utimesSync, writeFileSync } from "node:fs";
 
 const {
   mockLoadConfig,
   mockRegister,
   mockCreateSessionManager,
+  mockCreateLifecycleManager,
   mockRegistry,
   tmuxPlugin,
   claudePlugin,
@@ -16,6 +18,12 @@ const {
   const mockLoadConfig = vi.fn();
   const mockRegister = vi.fn();
   const mockCreateSessionManager = vi.fn();
+  const mockCreateLifecycleManager = vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+    getStates: vi.fn(),
+    check: vi.fn(),
+  }));
   const mockRegistry = {
     register: mockRegister,
     get: vi.fn(),
@@ -28,6 +36,7 @@ const {
     mockLoadConfig,
     mockRegister,
     mockCreateSessionManager,
+    mockCreateLifecycleManager,
     mockRegistry,
     tmuxPlugin: { manifest: { name: "tmux" } },
     claudePlugin: { manifest: { name: "claude-code" } },
@@ -43,12 +52,7 @@ vi.mock("@composio/ao-core", () => ({
   loadConfig: mockLoadConfig,
   createPluginRegistry: () => mockRegistry,
   createSessionManager: mockCreateSessionManager,
-  createLifecycleManager: () => ({
-    start: vi.fn(),
-    stop: vi.fn(),
-    getStates: vi.fn(),
-    check: vi.fn(),
-  }),
+  createLifecycleManager: mockCreateLifecycleManager,
   decompose: vi.fn(),
   getLeaves: vi.fn(),
   getSiblings: vi.fn(),
@@ -70,7 +74,14 @@ describe("services", () => {
     vi.resetModules();
     mockRegister.mockClear();
     mockCreateSessionManager.mockReset();
+    mockCreateLifecycleManager.mockReset();
     mockLoadConfig.mockReset();
+    mockCreateLifecycleManager.mockImplementation(() => ({
+      start: vi.fn(),
+      stop: vi.fn(),
+      getStates: vi.fn(),
+      check: vi.fn(),
+    }));
     mockLoadConfig.mockReturnValue({
       configPath: "/tmp/agent-orchestrator.yaml",
       port: 3000,
@@ -82,13 +93,18 @@ describe("services", () => {
       reactions: {},
     });
     mockCreateSessionManager.mockReturnValue({});
+    writeFileSync("/tmp/agent-orchestrator.yaml", "projects: {}\n");
+    delete (globalThis as typeof globalThis & { _aoConfigCache?: unknown })._aoConfigCache;
     delete (globalThis as typeof globalThis & { _aoServices?: unknown })._aoServices;
     delete (globalThis as typeof globalThis & { _aoServicesInit?: unknown })._aoServicesInit;
+    delete (globalThis as typeof globalThis & { _aoServicesConfig?: unknown })._aoServicesConfig;
   });
 
   afterEach(() => {
+    delete (globalThis as typeof globalThis & { _aoConfigCache?: unknown })._aoConfigCache;
     delete (globalThis as typeof globalThis & { _aoServices?: unknown })._aoServices;
     delete (globalThis as typeof globalThis & { _aoServicesInit?: unknown })._aoServicesInit;
+    delete (globalThis as typeof globalThis & { _aoServicesConfig?: unknown })._aoServicesConfig;
   });
 
   it("registers the OpenCode agent plugin with web services", async () => {
@@ -107,6 +123,87 @@ describe("services", () => {
 
     expect(first).toBe(second);
     expect(mockCreateSessionManager).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads cached config when the config file changes", async () => {
+    mockLoadConfig
+      .mockReturnValueOnce({
+        configPath: "/tmp/agent-orchestrator.yaml",
+        port: 3000,
+        readyThresholdMs: 300_000,
+        defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+        projects: {},
+        notifiers: {},
+        notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+        reactions: {},
+      })
+      .mockReturnValueOnce({
+        configPath: "/tmp/agent-orchestrator.yaml",
+        port: 4000,
+        readyThresholdMs: 300_000,
+        defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+        projects: {},
+        notifiers: {},
+        notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+        reactions: {},
+      });
+
+    const { getCachedConfig } = await import("../lib/services");
+
+    const first = getCachedConfig();
+    const changedAt = new Date(Date.now() + 5_000);
+    utimesSync("/tmp/agent-orchestrator.yaml", changedAt, changedAt);
+    const second = getCachedConfig();
+
+    expect(first.port).toBe(3000);
+    expect(second.port).toBe(4000);
+    expect(mockLoadConfig).toHaveBeenCalledTimes(2);
+  });
+
+  it("rebuilds cached services when the config file changes", async () => {
+    mockLoadConfig
+      .mockReturnValueOnce({
+        configPath: "/tmp/agent-orchestrator.yaml",
+        port: 3000,
+        readyThresholdMs: 300_000,
+        defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+        projects: {},
+        notifiers: {},
+        notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+        reactions: {},
+      })
+      .mockReturnValueOnce({
+        configPath: "/tmp/agent-orchestrator.yaml",
+        port: 4000,
+        readyThresholdMs: 300_000,
+        defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+        projects: {},
+        notifiers: {},
+        notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+        reactions: {},
+      });
+
+    mockCreateSessionManager
+      .mockReturnValueOnce({ name: "session-manager-1" })
+      .mockReturnValueOnce({ name: "session-manager-2" });
+
+    const { getServices } = await import("../lib/services");
+
+    const first = await getServices();
+    const firstLifecycle = mockCreateLifecycleManager.mock.results[0]?.value as
+      | { stop: ReturnType<typeof vi.fn> }
+      | undefined;
+
+    const changedAt = new Date(Date.now() + 5_000);
+    utimesSync("/tmp/agent-orchestrator.yaml", changedAt, changedAt);
+
+    const second = await getServices();
+
+    expect(first).not.toBe(second);
+    expect(first.config.port).toBe(3000);
+    expect(second.config.port).toBe(4000);
+    expect(mockCreateSessionManager).toHaveBeenCalledTimes(2);
+    expect(firstLifecycle?.stop).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -146,11 +243,14 @@ describe("pollBacklog", () => {
       list: vi.fn().mockResolvedValue([]),
     });
 
+    writeFileSync("/tmp/agent-orchestrator.yaml", "projects: {}\n");
+    delete (globalThis as typeof globalThis & { _aoConfigCache?: unknown })._aoConfigCache;
     delete (globalThis as typeof globalThis & { _aoServices?: unknown })._aoServices;
     delete (globalThis as typeof globalThis & { _aoServicesInit?: unknown })._aoServicesInit;
   });
 
   afterEach(() => {
+    delete (globalThis as typeof globalThis & { _aoConfigCache?: unknown })._aoConfigCache;
     delete (globalThis as typeof globalThis & { _aoServices?: unknown })._aoServices;
     delete (globalThis as typeof globalThis & { _aoServicesInit?: unknown })._aoServicesInit;
   });

--- a/packages/web/src/app/api/ao/_auth.ts
+++ b/packages/web/src/app/api/ao/_auth.ts
@@ -1,0 +1,1 @@
+export { checkAuth, checkConfiguredAuth } from "@/lib/api-auth";

--- a/packages/web/src/app/api/ao/sessions/[id]/kill/route.ts
+++ b/packages/web/src/app/api/ao/sessions/[id]/kill/route.ts
@@ -1,0 +1,39 @@
+import { SessionNotFoundError } from "@composio/ao-core";
+import { checkConfiguredAuth } from "@/app/api/ao/_auth";
+import { getServices } from "@/lib/services";
+import { validateIdentifier } from "@/lib/validation";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Internal server error";
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  try {
+    const authError = checkConfiguredAuth(request);
+    if (authError) {
+      return authError;
+    }
+
+    const { id } = await params;
+    const idErr = validateIdentifier(id, "id");
+    if (idErr) {
+      return Response.json({ error: idErr }, { status: 400 });
+    }
+
+    const { sessionManager } = await getServices();
+    try {
+      await sessionManager.kill(id);
+      return Response.json({ ok: true });
+    } catch (error) {
+      if (error instanceof SessionNotFoundError) {
+        return Response.json({ error: "Session not found" }, { status: 404 });
+      }
+      return Response.json({ ok: false, error: getErrorMessage(error) }, { status: 500 });
+    }
+  } catch (error) {
+    return Response.json({ error: getErrorMessage(error) }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/ao/sessions/[id]/retry/route.ts
+++ b/packages/web/src/app/api/ao/sessions/[id]/retry/route.ts
@@ -1,0 +1,49 @@
+import {
+  SessionNotFoundError,
+  SessionNotRestorableError,
+  WorkspaceMissingError,
+} from "@composio/ao-core";
+import { checkConfiguredAuth } from "@/app/api/ao/_auth";
+import { getServices } from "@/lib/services";
+import { validateIdentifier } from "@/lib/validation";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Internal server error";
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  try {
+    const authError = checkConfiguredAuth(request);
+    if (authError) {
+      return authError;
+    }
+
+    const { id } = await params;
+    const idErr = validateIdentifier(id, "id");
+    if (idErr) {
+      return Response.json({ error: idErr }, { status: 400 });
+    }
+
+    const { sessionManager } = await getServices();
+    try {
+      await sessionManager.restore(id);
+      return Response.json({ ok: true });
+    } catch (error) {
+      if (error instanceof SessionNotFoundError) {
+        return Response.json({ error: "Session not found" }, { status: 404 });
+      }
+      if (error instanceof SessionNotRestorableError) {
+        return Response.json({ ok: false, error: error.message }, { status: 409 });
+      }
+      if (error instanceof WorkspaceMissingError) {
+        return Response.json({ ok: false, error: error.message }, { status: 422 });
+      }
+      return Response.json({ ok: false, error: getErrorMessage(error) }, { status: 500 });
+    }
+  } catch (error) {
+    return Response.json({ error: getErrorMessage(error) }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/ao/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/ao/sessions/[id]/route.ts
@@ -1,0 +1,44 @@
+import type { Session, SessionManager } from "@composio/ao-core";
+import { checkConfiguredAuth } from "@/app/api/ao/_auth";
+import { toAODashboardSession } from "@/lib/ao-sessions";
+import { getServices } from "@/lib/services";
+import { validateIdentifier } from "@/lib/validation";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Internal server error";
+}
+
+type ArchivedLookupSessionManager = SessionManager & {
+  get(sessionId: string, options?: { includeArchived?: boolean }): Promise<Session | null>;
+};
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  try {
+    const authError = checkConfiguredAuth(request);
+    if (authError) {
+      return authError;
+    }
+
+    const { id } = await params;
+    const idErr = validateIdentifier(id, "id");
+    if (idErr) {
+      return Response.json({ error: idErr }, { status: 400 });
+    }
+
+    const { config, sessionManager } = await getServices();
+    const session = await (sessionManager as ArchivedLookupSessionManager).get(id, {
+      includeArchived: true,
+    });
+
+    if (!session) {
+      return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    return Response.json(toAODashboardSession(session, config));
+  } catch (error) {
+    return Response.json({ error: getErrorMessage(error) }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/ao/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/ao/sessions/[id]/route.ts
@@ -1,6 +1,6 @@
 import type { Session, SessionManager } from "@composio/ao-core";
 import { checkConfiguredAuth } from "@/app/api/ao/_auth";
-import { toAODashboardSession } from "@/lib/ao-sessions";
+import { toDashboardSessionWithNormalizedProject } from "@/lib/ao-sessions";
 import { getServices } from "@/lib/services";
 import { validateIdentifier } from "@/lib/validation";
 
@@ -37,7 +37,7 @@ export async function GET(
       return Response.json({ error: "Session not found" }, { status: 404 });
     }
 
-    return Response.json(toAODashboardSession(session, config));
+    return Response.json(toDashboardSessionWithNormalizedProject(session, config));
   } catch (error) {
     return Response.json({ error: getErrorMessage(error) }, { status: 500 });
   }

--- a/packages/web/src/app/api/ao/sessions/route.ts
+++ b/packages/web/src/app/api/ao/sessions/route.ts
@@ -1,0 +1,53 @@
+import { checkConfiguredAuth } from "@/app/api/ao/_auth";
+import { toAODashboardSession } from "@/lib/ao-sessions";
+import type { DashboardSession } from "@/lib/types";
+import { getServices } from "@/lib/services";
+import { filterProjectSessions } from "@/lib/project-utils";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Internal server error";
+}
+
+function filterByStatus(sessions: DashboardSession[], rawStatuses: string | null): DashboardSession[] {
+  if (!rawStatuses) {
+    return sessions;
+  }
+
+  const statuses = new Set(
+    rawStatuses
+      .split(",")
+      .map((status) => status.trim())
+      .filter((status) => status.length > 0),
+  );
+
+  if (statuses.size === 0) {
+    return sessions;
+  }
+
+  return sessions.filter((session) => statuses.has(session.status));
+}
+
+export async function GET(request: Request): Promise<Response> {
+  try {
+    const authError = checkConfiguredAuth(request);
+    if (authError) {
+      return authError;
+    }
+
+    const { config, sessionManager } = await getServices();
+    const { searchParams } = new URL(request.url);
+    const project = searchParams.get("project");
+    const coreSessions = filterProjectSessions(await sessionManager.list(), project, config.projects);
+    let sessions = coreSessions.map((session) => toAODashboardSession(session, config));
+
+    sessions = filterByStatus(sessions, searchParams.get("status"));
+
+    if (searchParams.get("warned") === "true") {
+      sessions = sessions.filter((session) => session.notificationState?.status === "warn");
+    }
+
+    return Response.json(sessions);
+  } catch (error) {
+    return Response.json({ error: getErrorMessage(error) }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/ao/sessions/route.ts
+++ b/packages/web/src/app/api/ao/sessions/route.ts
@@ -1,5 +1,5 @@
 import { checkConfiguredAuth } from "@/app/api/ao/_auth";
-import { toAODashboardSession } from "@/lib/ao-sessions";
+import { toDashboardSessionWithNormalizedProject } from "@/lib/ao-sessions";
 import type { DashboardSession } from "@/lib/types";
 import { getServices } from "@/lib/services";
 import { filterProjectSessions } from "@/lib/project-utils";
@@ -38,7 +38,9 @@ export async function GET(request: Request): Promise<Response> {
     const { searchParams } = new URL(request.url);
     const project = searchParams.get("project");
     const coreSessions = filterProjectSessions(await sessionManager.list(), project, config.projects);
-    let sessions = coreSessions.map((session) => toAODashboardSession(session, config));
+    let sessions = coreSessions.map((session) =>
+      toDashboardSessionWithNormalizedProject(session, config),
+    );
 
     sessions = filterByStatus(sessions, searchParams.get("status"));
 

--- a/packages/web/src/app/api/ao/status/route.ts
+++ b/packages/web/src/app/api/ao/status/route.ts
@@ -1,0 +1,34 @@
+import webPackage from "../../../../../package.json";
+import { checkConfiguredAuth } from "@/app/api/ao/_auth";
+import { getServices } from "@/lib/services";
+import { sessionToDashboard } from "@/lib/serialize";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Internal server error";
+}
+
+export async function GET(request: Request): Promise<Response> {
+  try {
+    const authError = checkConfiguredAuth(request);
+    if (authError) {
+      return authError;
+    }
+
+    const { sessionManager } = await getServices();
+    const sessions = await sessionManager.list();
+    const notifierHealth = sessions.some(
+      (session) => sessionToDashboard(session).notificationState?.status === "warn",
+    )
+      ? "warn"
+      : "ok";
+
+    return Response.json({
+      version: webPackage.version,
+      sessionCount: sessions.length,
+      notifierHealth,
+      uptime: process.uptime(),
+    });
+  } catch (error) {
+    return Response.json({ error: getErrorMessage(error) }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/sessions/[id]/kill/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/kill/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest } from "next/server";
 import { validateIdentifier } from "@/lib/validation";
 import { getServices } from "@/lib/services";
+import { checkConfiguredAuth } from "@/lib/api-auth";
 import { SessionNotFoundError } from "@composio/ao-core";
 import {
   getCorrelationId,
@@ -13,14 +14,28 @@ import {
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const correlationId = getCorrelationId(_request);
   const startedAt = Date.now();
-  const { id } = await params;
-  const idErr = validateIdentifier(id, "id");
-  if (idErr) {
-    return jsonWithCorrelation({ error: idErr }, { status: 400 }, correlationId);
-  }
-
+  let config: (Awaited<ReturnType<typeof getServices>>)["config"] | undefined;
+  let id: string | undefined;
   try {
-    const { config, sessionManager } = await getServices();
+    const authError = checkConfiguredAuth(_request, {
+      correlationId,
+      method: "POST",
+      path: "/api/sessions/[id]/kill",
+      startedAt,
+    });
+    if (authError) {
+      return authError;
+    }
+
+    ({ id } = await params);
+    const idErr = validateIdentifier(id, "id");
+    if (idErr) {
+      return jsonWithCorrelation({ error: idErr }, { status: 400 }, correlationId);
+    }
+
+    const services = await getServices();
+    config = services.config;
+    const { sessionManager } = services;
     const projectId = resolveProjectIdForSessionId(config, id);
     await sessionManager.kill(id);
     recordApiObservation({
@@ -39,8 +54,7 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
     if (err instanceof SessionNotFoundError) {
       return jsonWithCorrelation({ error: err.message }, { status: 404 }, correlationId);
     }
-    const { config } = await getServices().catch(() => ({ config: undefined }));
-    const projectId = config ? resolveProjectIdForSessionId(config, id) : undefined;
+    const projectId = config && id ? resolveProjectIdForSessionId(config, id) : undefined;
     if (config) {
       recordApiObservation({
         config,

--- a/packages/web/src/app/api/sessions/[id]/message/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/message/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest } from "next/server";
 import { getServices } from "@/lib/services";
+import { checkConfiguredAuth } from "@/lib/api-auth";
 import { stripControlChars, validateIdentifier, validateString } from "@/lib/validation";
 import { SessionNotFoundError } from "@composio/ao-core";
 import {
@@ -15,6 +16,16 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const correlationId = getCorrelationId(request);
   const startedAt = Date.now();
   try {
+    const authError = checkConfiguredAuth(request, {
+      correlationId,
+      method: "POST",
+      path: "/api/sessions/[id]/message",
+      startedAt,
+    });
+    if (authError) {
+      return authError;
+    }
+
     const { id } = await params;
 
     // Validate session ID to prevent injection

--- a/packages/web/src/app/api/sessions/[id]/remap/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/remap/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest } from "next/server";
 import { validateIdentifier } from "@/lib/validation";
 import { getServices } from "@/lib/services";
+import { checkConfiguredAuth } from "@/lib/api-auth";
 import { SessionNotFoundError } from "@composio/ao-core";
 import {
   getCorrelationId,
@@ -12,14 +13,28 @@ import {
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const correlationId = getCorrelationId(request);
   const startedAt = Date.now();
-  const { id } = await params;
-  const idErr = validateIdentifier(id, "id");
-  if (idErr) {
-    return jsonWithCorrelation({ error: idErr }, { status: 400 }, correlationId);
-  }
-
+  let config: (Awaited<ReturnType<typeof getServices>>)["config"] | undefined;
+  let id: string | undefined;
   try {
-    const { config, sessionManager } = await getServices();
+    const authError = checkConfiguredAuth(request, {
+      correlationId,
+      method: "POST",
+      path: "/api/sessions/[id]/remap",
+      startedAt,
+    });
+    if (authError) {
+      return authError;
+    }
+
+    ({ id } = await params);
+    const idErr = validateIdentifier(id, "id");
+    if (idErr) {
+      return jsonWithCorrelation({ error: idErr }, { status: 400 }, correlationId);
+    }
+
+    const services = await getServices();
+    config = services.config;
+    const { sessionManager } = services;
     const projectId = resolveProjectIdForSessionId(config, id);
     const opencodeSessionId = await sessionManager.remap(id, true);
     recordApiObservation({
@@ -39,8 +54,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       correlationId,
     );
   } catch (err) {
-    const { config } = await getServices().catch(() => ({ config: undefined }));
-    const projectId = config ? resolveProjectIdForSessionId(config, id) : undefined;
+    const projectId = config && id ? resolveProjectIdForSessionId(config, id) : undefined;
     if (err instanceof SessionNotFoundError) {
       if (config) {
         recordApiObservation({

--- a/packages/web/src/app/api/sessions/[id]/restore/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/restore/route.ts
@@ -1,7 +1,8 @@
 import { type NextRequest } from "next/server";
 import { validateIdentifier } from "@/lib/validation";
 import { getServices } from "@/lib/services";
-import { sessionToDashboard } from "@/lib/serialize";
+import { checkConfiguredAuth } from "@/lib/api-auth";
+import { toDashboardSessionWithNormalizedProject } from "@/lib/ao-sessions";
 import {
   SessionNotRestorableError,
   WorkspaceMissingError,
@@ -18,14 +19,28 @@ import {
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const correlationId = getCorrelationId(_request);
   const startedAt = Date.now();
-  const { id } = await params;
-  const idErr = validateIdentifier(id, "id");
-  if (idErr) {
-    return jsonWithCorrelation({ error: idErr }, { status: 400 }, correlationId);
-  }
-
+  let config: (Awaited<ReturnType<typeof getServices>>)["config"] | undefined;
+  let id: string | undefined;
   try {
-    const { config, sessionManager } = await getServices();
+    const authError = checkConfiguredAuth(_request, {
+      correlationId,
+      method: "POST",
+      path: "/api/sessions/[id]/restore",
+      startedAt,
+    });
+    if (authError) {
+      return authError;
+    }
+
+    ({ id } = await params);
+    const idErr = validateIdentifier(id, "id");
+    if (idErr) {
+      return jsonWithCorrelation({ error: idErr }, { status: 400 }, correlationId);
+    }
+
+    const services = await getServices();
+    config = services.config;
+    const { sessionManager } = services;
     const projectId = resolveProjectIdForSessionId(config, id);
     const restored = await sessionManager.restore(id);
 
@@ -45,7 +60,7 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
       {
         ok: true,
         sessionId: id,
-        session: sessionToDashboard(restored),
+        session: toDashboardSessionWithNormalizedProject(restored, config),
       },
       { status: 200 },
       correlationId,
@@ -60,8 +75,7 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
     if (err instanceof WorkspaceMissingError) {
       return jsonWithCorrelation({ error: err.message }, { status: 422 }, correlationId);
     }
-    const { config } = await getServices().catch(() => ({ config: undefined }));
-    const projectId = config ? resolveProjectIdForSessionId(config, id) : undefined;
+    const projectId = config && id ? resolveProjectIdForSessionId(config, id) : undefined;
     if (config) {
       recordApiObservation({
         config,

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -1,7 +1,8 @@
 import { type NextRequest } from "next/server";
 import { getServices, getSCM } from "@/lib/services";
+import { checkConfiguredAuth } from "@/lib/api-auth";
+import { toDashboardSessionWithNormalizedProject } from "@/lib/ao-sessions";
 import {
-  sessionToDashboard,
   resolveProject,
   enrichSessionPR,
   enrichSessionsMetadata,
@@ -12,15 +13,25 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   const correlationId = getCorrelationId(_request);
   const startedAt = Date.now();
   try {
+    const authError = checkConfiguredAuth(_request, {
+      correlationId,
+      method: "GET",
+      path: "/api/sessions/[id]",
+      startedAt,
+    });
+    if (authError) {
+      return authError;
+    }
+
     const { id } = await params;
     const { config, registry, sessionManager } = await getServices();
 
-    const coreSession = await sessionManager.get(id);
+    const coreSession = await sessionManager.get(id, { includeArchived: true });
     if (!coreSession) {
       return jsonWithCorrelation({ error: "Session not found" }, { status: 404 }, correlationId);
     }
 
-    const dashboardSession = sessionToDashboard(coreSession);
+    const dashboardSession = toDashboardSessionWithNormalizedProject(coreSession, config);
 
     // Enrich metadata (issue labels, agent summaries, issue titles)
     await enrichSessionsMetadata([coreSession], [dashboardSession], config, registry);
@@ -59,7 +70,9 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       config: undefined,
       sessionManager: undefined,
     }));
-    const session = sessionManager ? await sessionManager.get(id).catch(() => null) : null;
+    const session = sessionManager
+      ? await sessionManager.get(id, { includeArchived: true }).catch(() => null)
+      : null;
     if (config) {
       recordApiObservation({
         config,

--- a/packages/web/src/app/api/sessions/[id]/send/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/send/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest } from "next/server";
 import { validateIdentifier, validateString, stripControlChars } from "@/lib/validation";
 import { getServices } from "@/lib/services";
+import { checkConfiguredAuth } from "@/lib/api-auth";
 import { SessionNotFoundError } from "@composio/ao-core";
 import {
   getCorrelationId,
@@ -15,32 +16,46 @@ const MAX_MESSAGE_LENGTH = 10_000;
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const correlationId = getCorrelationId(request);
   const startedAt = Date.now();
-  const { id } = await params;
-  const idErr = validateIdentifier(id, "id");
-  if (idErr) {
-    return jsonWithCorrelation({ error: idErr }, { status: 400 }, correlationId);
-  }
-
-  const body = (await request.json().catch(() => null)) as Record<string, unknown> | null;
-  const messageErr = validateString(body?.message, "message", MAX_MESSAGE_LENGTH);
-  if (messageErr) {
-    return jsonWithCorrelation({ error: messageErr }, { status: 400 }, correlationId);
-  }
-
-  // Strip control characters to prevent injection when passed to shell-based runtimes
-  const message = stripControlChars(String(body?.message ?? ""));
-
-  // Re-validate after stripping — a control-char-only message becomes empty
-  if (message.trim().length === 0) {
-    return jsonWithCorrelation(
-      { error: "message must not be empty after sanitization" },
-      { status: 400 },
-      correlationId,
-    );
-  }
-
+  let config: (Awaited<ReturnType<typeof getServices>>)["config"] | undefined;
+  let id: string | undefined;
   try {
-    const { config, sessionManager } = await getServices();
+    const authError = checkConfiguredAuth(request, {
+      correlationId,
+      method: "POST",
+      path: "/api/sessions/[id]/send",
+      startedAt,
+    });
+    if (authError) {
+      return authError;
+    }
+
+    ({ id } = await params);
+    const idErr = validateIdentifier(id, "id");
+    if (idErr) {
+      return jsonWithCorrelation({ error: idErr }, { status: 400 }, correlationId);
+    }
+
+    const body = (await request.json().catch(() => null)) as Record<string, unknown> | null;
+    const messageErr = validateString(body?.message, "message", MAX_MESSAGE_LENGTH);
+    if (messageErr) {
+      return jsonWithCorrelation({ error: messageErr }, { status: 400 }, correlationId);
+    }
+
+    // Strip control characters to prevent injection when passed to shell-based runtimes
+    const message = stripControlChars(String(body?.message ?? ""));
+
+    // Re-validate after stripping — a control-char-only message becomes empty
+    if (message.trim().length === 0) {
+      return jsonWithCorrelation(
+        { error: "message must not be empty after sanitization" },
+        { status: 400 },
+        correlationId,
+      );
+    }
+
+    const services = await getServices();
+    config = services.config;
+    const { sessionManager } = services;
     const projectId = resolveProjectIdForSessionId(config, id);
     await sessionManager.send(id, message);
     recordApiObservation({
@@ -64,8 +79,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     if (err instanceof SessionNotFoundError) {
       return jsonWithCorrelation({ error: err.message }, { status: 404 }, correlationId);
     }
-    const { config } = await getServices().catch(() => ({ config: undefined }));
-    const projectId = config ? resolveProjectIdForSessionId(config, id) : undefined;
+    const projectId = config && id ? resolveProjectIdForSessionId(config, id) : undefined;
     if (config) {
       recordApiObservation({
         config,
@@ -78,7 +92,6 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         projectId,
         sessionId: id,
         reason: err instanceof Error ? err.message : "Failed to send message",
-        data: { messageLength: message.length },
       });
     }
     const msg = err instanceof Error ? err.message : "Failed to send message";

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -1,7 +1,8 @@
 import { ACTIVITY_STATE, isOrchestratorSession } from "@composio/ao-core";
 import { getServices, getSCM } from "@/lib/services";
+import { checkConfiguredAuth } from "@/lib/api-auth";
+import { toDashboardSessionWithNormalizedProject } from "@/lib/ao-sessions";
 import {
-  sessionToDashboard,
   resolveProject,
   enrichSessionPR,
   enrichSessionsMetadata,
@@ -35,6 +36,16 @@ export async function GET(request: Request) {
   const correlationId = getCorrelationId(request);
   const startedAt = Date.now();
   try {
+    const authError = checkConfiguredAuth(request, {
+      correlationId,
+      method: "GET",
+      path: "/api/sessions",
+      startedAt,
+    });
+    if (authError) {
+      return authError;
+    }
+
     const { searchParams } = new URL(request.url);
     const projectFilter = searchParams.get("project");
     const activeOnly = searchParams.get("active") === "true";
@@ -53,7 +64,9 @@ export async function GET(request: Request) {
     let workerSessions = visibleSessions.filter((session) => !isOrchestratorSession(session));
 
     // Convert to dashboard format
-    let dashboardSessions = workerSessions.map(sessionToDashboard);
+    let dashboardSessions = workerSessions.map((session) =>
+      toDashboardSessionWithNormalizedProject(session, config),
+    );
 
     if (activeOnly) {
       const activeIndices = dashboardSessions

--- a/packages/web/src/app/api/webhooks/[...slug]/route.ts
+++ b/packages/web/src/app/api/webhooks/[...slug]/route.ts
@@ -99,6 +99,10 @@ export async function POST(request: Request): Promise<Response> {
       );
     }
 
+    if (lifecycleErrors.length > 0) {
+      console.error("[webhook] lifecycle checks failed:", lifecycleErrors);
+    }
+
     return NextResponse.json(
       {
         ok: true,

--- a/packages/web/src/lib/__tests__/api-auth.test.ts
+++ b/packages/web/src/lib/__tests__/api-auth.test.ts
@@ -1,3 +1,4 @@
+import type * as cryptoModule from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockTimingSafeEqual = vi.fn();
@@ -13,7 +14,7 @@ describe("api-auth", () => {
     mockTimingSafeEqual.mockReturnValueOnce(false);
 
     vi.doMock("node:crypto", async (importOriginal) => {
-      const actual = await importOriginal<typeof import("node:crypto")>();
+      const actual = await importOriginal<typeof cryptoModule>();
       return {
         ...actual,
         timingSafeEqual: mockTimingSafeEqual,

--- a/packages/web/src/lib/__tests__/api-auth.test.ts
+++ b/packages/web/src/lib/__tests__/api-auth.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockTimingSafeEqual = vi.fn();
+
+describe("api-auth", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockTimingSafeEqual.mockReset();
+    mockTimingSafeEqual.mockReturnValue(true);
+  });
+
+  it("uses timingSafeEqual for bearer token comparison", async () => {
+    mockTimingSafeEqual.mockReturnValueOnce(false);
+
+    vi.doMock("node:crypto", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:crypto")>();
+      return {
+        ...actual,
+        timingSafeEqual: mockTimingSafeEqual,
+      };
+    });
+
+    const { checkAuth } = await import("../api-auth");
+    const result = checkAuth(
+      new Request("http://localhost/api/ao/status", {
+        headers: { authorization: "Bearer secret-tokem" },
+      }),
+      "secret-token",
+    );
+
+    expect(result?.status).toBe(401);
+    expect(mockTimingSafeEqual).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/lib/__tests__/format.test.ts
+++ b/packages/web/src/lib/__tests__/format.test.ts
@@ -26,6 +26,7 @@ function makeSession(overrides?: Partial<DashboardSession>): DashboardSession {
     createdAt: new Date().toISOString(),
     lastActivityAt: new Date().toISOString(),
     pr: null,
+    notificationState: { status: "ok", failingNotifiers: [], notifiers: [] },
     metadata: {},
     ...overrides,
   };

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -339,6 +339,24 @@ describe("resolveProject", () => {
     const session = createCoreSession({ id: "app-1", projectId: "app" });
     expect(resolveProject(session, projects)).toBe(projects.app);
   });
+
+  it("should not match overlapping prefixes loosely", () => {
+    const projects = {
+      app: makeProject({ name: "app", sessionPrefix: "app" }),
+      apple: makeProject({ name: "apple", sessionPrefix: "apple" }),
+    };
+    const session = createCoreSession({ id: "apple-1", projectId: "unknown" });
+    expect(resolveProject(session, projects)).toBe(projects.apple);
+  });
+
+  it("should prefer the longest matching prefix when prefixes are nested", () => {
+    const projects = {
+      app: makeProject({ name: "app", sessionPrefix: "app" }),
+      "app-foo": makeProject({ name: "app-foo", sessionPrefix: "app-foo" }),
+    };
+    const session = createCoreSession({ id: "app-foo-1", projectId: "unknown" });
+    expect(resolveProject(session, projects)).toBe(projects["app-foo"]);
+  });
 });
 
 describe("enrichSessionPR", () => {

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -213,6 +213,78 @@ describe("sessionToDashboard", () => {
 
     expect(dashboard.pr).toBeNull();
   });
+
+  it("should expose empty notificationState when no notifier metadata exists", () => {
+    const coreSession = createCoreSession();
+    const dashboard = sessionToDashboard(coreSession);
+
+    expect(dashboard.notificationState).toEqual({
+      status: "ok",
+      failingNotifiers: [],
+      notifiers: [],
+    });
+  });
+
+  it("should derive notificationState from flat notifier metadata", () => {
+    const coreSession = createCoreSession({
+      metadata: {
+        "notifier.openclaw.status": "warn",
+        "notifier.openclaw.consecutiveFailures": "2",
+        "notifier.openclaw.lastFailureAt": "2026-03-24T10:00:00.000Z",
+        "notifier.openclaw.lastFailureReason": "401 Unauthorized",
+        "notifier.openclaw.lastEventType": "merge.completed",
+        "notifier.openclaw.lastPriority": "action",
+        "notifier.desktop.status": "ok",
+        "notifier.desktop.consecutiveFailures": "0",
+        "notifier.desktop.lastSuccessAt": "2026-03-24T10:05:00.000Z",
+      },
+    });
+
+    const dashboard = sessionToDashboard(coreSession);
+
+    expect(dashboard.notificationState).toEqual({
+      status: "warn",
+      failingNotifiers: ["openclaw"],
+      notifiers: [
+        {
+          name: "desktop",
+          status: "ok",
+          consecutiveFailures: 0,
+          lastFailureAt: null,
+          lastFailureReason: null,
+          lastSuccessAt: "2026-03-24T10:05:00.000Z",
+          lastEventType: null,
+          lastPriority: null,
+        },
+        {
+          name: "openclaw",
+          status: "warn",
+          consecutiveFailures: 2,
+          lastFailureAt: "2026-03-24T10:00:00.000Z",
+          lastFailureReason: "401 Unauthorized",
+          lastSuccessAt: null,
+          lastEventType: "merge.completed",
+          lastPriority: "action",
+        },
+      ],
+    });
+  });
+
+  it("should ignore unknown notifier metadata fields without creating a notifier entry", () => {
+    const coreSession = createCoreSession({
+      metadata: {
+        "notifier.openclaw.lastAttemptAt": "2026-03-24T10:00:00.000Z",
+      },
+    });
+
+    const dashboard = sessionToDashboard(coreSession);
+
+    expect(dashboard.notificationState).toEqual({
+      status: "ok",
+      failingNotifiers: [],
+      notifiers: [],
+    });
+  });
 });
 
 describe("resolveProject", () => {
@@ -405,6 +477,7 @@ describe("enrichSessionPR", () => {
       createdAt: new Date().toISOString(),
       lastActivityAt: new Date().toISOString(),
       pr: null,
+      notificationState: { status: "ok", failingNotifiers: [], notifiers: [] },
       metadata: {},
     };
     const pr = createPRInfo();

--- a/packages/web/src/lib/__tests__/source-compatibility.test.ts
+++ b/packages/web/src/lib/__tests__/source-compatibility.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function readLocal(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), "utf-8");
+}
+
+describe("web lib source compatibility", () => {
+  it("does not use .js extensions for local src/lib imports", () => {
+    const files = [
+      "../api-auth.ts",
+      "../format.ts",
+      "../serialize.ts",
+      "../services.ts",
+    ];
+
+    for (const file of files) {
+      const source = readLocal(file);
+      expect(source).not.toMatch(/from\s+["']\.\.?\/[^"']+\.js["']/);
+    }
+  });
+});

--- a/packages/web/src/lib/__tests__/types.test.ts
+++ b/packages/web/src/lib/__tests__/types.test.ts
@@ -35,6 +35,7 @@ function createSession(overrides?: Partial<DashboardSession>): DashboardSession 
     createdAt: new Date().toISOString(),
     lastActivityAt: new Date().toISOString(),
     pr: null,
+    notificationState: { status: "ok", failingNotifiers: [], notifiers: [] },
     metadata: {},
     ...overrides,
   };

--- a/packages/web/src/lib/ao-sessions.ts
+++ b/packages/web/src/lib/ao-sessions.ts
@@ -1,0 +1,31 @@
+import { resolveProjectIdForSessionId, type OrchestratorConfig, type Session } from "@composio/ao-core";
+import { sessionToDashboard } from "@/lib/serialize";
+import type { DashboardSession } from "@/lib/types";
+
+export function normalizeSessionProjectId(
+  session: Session,
+  config: OrchestratorConfig,
+): string {
+  if (config.projects[session.projectId]) {
+    return session.projectId;
+  }
+
+  return resolveProjectIdForSessionId(config, session.id) ?? session.projectId;
+}
+
+export function toAODashboardSession(
+  session: Session,
+  config: OrchestratorConfig,
+): DashboardSession {
+  return toDashboardSessionWithNormalizedProject(session, config);
+}
+
+export function toDashboardSessionWithNormalizedProject(
+  session: Session,
+  config: OrchestratorConfig,
+): DashboardSession {
+  return {
+    ...sessionToDashboard(session),
+    projectId: normalizeSessionProjectId(session, config),
+  };
+}

--- a/packages/web/src/lib/ao-sessions.ts
+++ b/packages/web/src/lib/ao-sessions.ts
@@ -13,13 +13,6 @@ export function normalizeSessionProjectId(
   return resolveProjectIdForSessionId(config, session.id) ?? session.projectId;
 }
 
-export function toAODashboardSession(
-  session: Session,
-  config: OrchestratorConfig,
-): DashboardSession {
-  return toDashboardSessionWithNormalizedProject(session, config);
-}
-
 export function toDashboardSessionWithNormalizedProject(
   session: Session,
   config: OrchestratorConfig,

--- a/packages/web/src/lib/api-auth.ts
+++ b/packages/web/src/lib/api-auth.ts
@@ -1,0 +1,71 @@
+import type { OrchestratorConfig } from "@composio/ao-core";
+import { getCachedConfig } from "./config-cache.js";
+import { getCorrelationId, jsonWithCorrelation, recordApiObservation } from "./observability.js";
+
+type AuthContext = {
+  config?: OrchestratorConfig;
+  correlationId?: string;
+  method?: string;
+  path?: string;
+  startedAt?: number;
+  projectId?: string;
+  sessionId?: string;
+  data?: Record<string, unknown>;
+};
+
+function unauthorized(request: Request, context?: AuthContext): Response {
+  const correlationId = context?.correlationId ?? getCorrelationId(request);
+
+  if (
+    context?.config &&
+    context.method &&
+    context.path &&
+    context.startedAt !== undefined
+  ) {
+    recordApiObservation({
+      config: context.config,
+      method: context.method,
+      path: context.path,
+      correlationId,
+      startedAt: context.startedAt,
+      outcome: "failure",
+      statusCode: 401,
+      projectId: context.projectId,
+      sessionId: context.sessionId,
+      reason: "Unauthorized",
+      data: context.data,
+    });
+  }
+
+  return jsonWithCorrelation({ error: "Unauthorized" }, { status: 401 }, correlationId);
+}
+
+export function checkAuth(
+  request: Request,
+  token: string | undefined,
+  context?: AuthContext,
+): Response | null {
+  if (token === undefined) return null;
+
+  const normalizedToken = token.trim();
+  if (normalizedToken.length === 0) {
+    return unauthorized(request, context);
+  }
+
+  const header = request.headers.get("authorization");
+  if (!header) {
+    return unauthorized(request, context);
+  }
+
+  const match = /^\s*Bearer\s+(.+?)\s*$/i.exec(header);
+  if (!match || match[1] !== normalizedToken) {
+    return unauthorized(request, context);
+  }
+
+  return null;
+}
+
+export function checkConfiguredAuth(request: Request, context?: Omit<AuthContext, "config">): Response | null {
+  const config = getCachedConfig();
+  return checkAuth(request, config.api?.token, { ...context, config });
+}

--- a/packages/web/src/lib/api-auth.ts
+++ b/packages/web/src/lib/api-auth.ts
@@ -1,7 +1,7 @@
 import * as crypto from "node:crypto";
 import type { OrchestratorConfig } from "@composio/ao-core";
-import { getCachedConfig } from "./config-cache.js";
-import { getCorrelationId, jsonWithCorrelation, recordApiObservation } from "./observability.js";
+import { getCachedConfig } from "./config-cache";
+import { getCorrelationId, jsonWithCorrelation, recordApiObservation } from "./observability";
 
 type AuthContext = {
   config?: OrchestratorConfig;

--- a/packages/web/src/lib/api-auth.ts
+++ b/packages/web/src/lib/api-auth.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import type { OrchestratorConfig } from "@composio/ao-core";
 import { getCachedConfig } from "./config-cache.js";
 import { getCorrelationId, jsonWithCorrelation, recordApiObservation } from "./observability.js";
@@ -40,6 +41,12 @@ function unauthorized(request: Request, context?: AuthContext): Response {
   return jsonWithCorrelation({ error: "Unauthorized" }, { status: 401 }, correlationId);
 }
 
+function tokensMatch(providedToken: string, expectedToken: string): boolean {
+  const providedDigest = crypto.createHash("sha256").update(providedToken, "utf8").digest();
+  const expectedDigest = crypto.createHash("sha256").update(expectedToken, "utf8").digest();
+  return crypto.timingSafeEqual(providedDigest, expectedDigest);
+}
+
 export function checkAuth(
   request: Request,
   token: string | undefined,
@@ -58,7 +65,7 @@ export function checkAuth(
   }
 
   const match = /^\s*Bearer\s+(.+?)\s*$/i.exec(header);
-  if (!match || match[1] !== normalizedToken) {
+  if (!match || !tokensMatch(match[1], normalizedToken)) {
     return unauthorized(request, context);
   }
 

--- a/packages/web/src/lib/config-cache.ts
+++ b/packages/web/src/lib/config-cache.ts
@@ -1,0 +1,40 @@
+import { statSync } from "node:fs";
+import { loadConfig, type OrchestratorConfig } from "@composio/ao-core";
+
+type ConfigCacheEntry = {
+  config: OrchestratorConfig;
+  configPathEnv: string | null;
+  mtimeMs: number | null;
+};
+
+const globalForConfigCache = globalThis as typeof globalThis & {
+  _aoConfigCache?: ConfigCacheEntry;
+};
+
+function getConfigMtime(config: OrchestratorConfig): number | null {
+  try {
+    return statSync(config.configPath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+export function getCachedConfig(): OrchestratorConfig {
+  const configPathEnv = process.env.AO_CONFIG_PATH ?? null;
+  const cached = globalForConfigCache._aoConfigCache;
+
+  if (cached) {
+    const currentMtime = getConfigMtime(cached.config);
+    if (cached.configPathEnv === configPathEnv && cached.mtimeMs === currentMtime) {
+      return cached.config;
+    }
+  }
+
+  const config = loadConfig();
+  globalForConfigCache._aoConfigCache = {
+    config,
+    configPathEnv,
+    mtimeMs: getConfigMtime(config),
+  };
+  return config;
+}

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -3,7 +3,7 @@
  * No side effects, no external dependencies.
  */
 
-import type { DashboardSession } from "./types.js";
+import type { DashboardSession } from "./types";
 
 /**
  * Humanize a git branch name into a readable title.

--- a/packages/web/src/lib/project-utils.ts
+++ b/packages/web/src/lib/project-utils.ts
@@ -1,4 +1,4 @@
-import { isOrchestratorSession } from "@composio/ao-core";
+import { isOrchestratorSession, resolveProjectIdForSessionId } from "@composio/ao-core";
 
 type ProjectWithPrefix = { sessionPrefix?: string };
 type SessionLike = { id: string; projectId: string; metadata?: Record<string, string> };
@@ -17,9 +17,7 @@ function matchesProject(
   projects: Record<string, ProjectWithPrefix>,
 ): boolean {
   if (session.projectId === projectId) return true;
-  const project = projects[projectId];
-  if (project?.sessionPrefix && session.id.startsWith(project.sessionPrefix)) return true;
-  return projects[session.projectId]?.sessionPrefix === projectId;
+  return resolveProjectIdForSessionId({ projects }, session.id) === projectId;
 }
 
 export function filterProjectSessions<T extends SessionLike>(

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -21,6 +21,8 @@ import type {
   DashboardPR,
   DashboardStats,
   DashboardOrchestratorLink,
+  DashboardNotificationState,
+  DashboardNotifierState,
 } from "./types.js";
 import { TTLCache, prCache, prCacheKey, type PREnrichmentData } from "./cache";
 
@@ -45,6 +47,78 @@ export function resolveProject(
   return firstKey ? projects[firstKey] : undefined;
 }
 
+function parseNotifierState(metadata: Record<string, string>): DashboardNotificationState {
+  const byNotifier = new Map<string, Partial<DashboardNotifierState>>();
+
+  for (const [key, value] of Object.entries(metadata)) {
+    const match = /^notifier\.([^.]+)\.status$/.exec(key);
+    if (!match) continue;
+
+    const [, name] = match;
+    if (value === "ok" || value === "warn") {
+      byNotifier.set(name, { name, status: value });
+    }
+  }
+
+  for (const [key, value] of Object.entries(metadata)) {
+    const match = /^notifier\.([^.]+)\.(.+)$/.exec(key);
+    if (!match) continue;
+
+    const [, name, field] = match;
+    const current = byNotifier.get(name);
+    if (!current) continue;
+
+    switch (field) {
+      case "consecutiveFailures":
+        current.consecutiveFailures = Number.parseInt(value, 10) || 0;
+        break;
+      case "lastFailureAt":
+        current.lastFailureAt = value || null;
+        break;
+      case "lastFailureReason":
+        current.lastFailureReason = value || null;
+        break;
+      case "lastSuccessAt":
+        current.lastSuccessAt = value || null;
+        break;
+      case "lastEventType":
+        current.lastEventType = value || null;
+        break;
+      case "lastPriority":
+        current.lastPriority =
+          value === "urgent" || value === "action" || value === "warning" || value === "info"
+            ? value
+            : null;
+        break;
+    }
+
+    byNotifier.set(name, current);
+  }
+
+  const notifiers = [...byNotifier.values()]
+    .map(
+      (entry): DashboardNotifierState => ({
+        name: entry.name ?? "unknown",
+        status: entry.status ?? "ok",
+        consecutiveFailures: entry.consecutiveFailures ?? 0,
+        lastFailureAt: entry.lastFailureAt ?? null,
+        lastFailureReason: entry.lastFailureReason ?? null,
+        lastSuccessAt: entry.lastSuccessAt ?? null,
+        lastEventType: entry.lastEventType ?? null,
+        lastPriority: entry.lastPriority ?? null,
+      }),
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const failingNotifiers = notifiers.filter((notifier) => notifier.status === "warn").map((n) => n.name);
+
+  return {
+    status: failingNotifiers.length > 0 ? "warn" : "ok",
+    failingNotifiers,
+    notifiers,
+  };
+}
+
 /** Convert a core Session to a DashboardSession (without PR/issue enrichment). */
 export function sessionToDashboard(session: Session): DashboardSession {
   const agentSummary = session.agentInfo?.summary;
@@ -65,6 +139,7 @@ export function sessionToDashboard(session: Session): DashboardSession {
     createdAt: session.createdAt.toISOString(),
     lastActivityAt: session.lastActivityAt.toISOString(),
     pr: session.pr ? basicPRToDashboard(session.pr) : null,
+    notificationState: parseNotifierState(session.metadata),
     metadata: session.metadata,
   };
 }

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -7,6 +7,7 @@
 
 import {
   isOrchestratorSession,
+  resolveProjectIdForSessionId,
   type Session,
   type Agent,
   type SCM,
@@ -38,9 +39,10 @@ export function resolveProject(
   const direct = projects[core.projectId];
   if (direct) return direct;
 
-  // Match by session prefix
-  const entry = Object.entries(projects).find(([, p]) => core.id.startsWith(p.sessionPrefix));
-  if (entry) return entry[1];
+  const resolvedProjectId = resolveProjectIdForSessionId({ projects }, core.id);
+  if (resolvedProjectId) {
+    return projects[resolvedProjectId];
+  }
 
   // Fall back to first project
   const firstKey = Object.keys(projects)[0];

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -24,7 +24,7 @@ import type {
   DashboardOrchestratorLink,
   DashboardNotificationState,
   DashboardNotifierState,
-} from "./types.js";
+} from "./types";
 import { TTLCache, prCache, prCacheKey, type PREnrichmentData } from "./cache";
 
 /** Cache for issue titles (5 min TTL — issue titles rarely change) */

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -11,7 +11,6 @@
  */
 
 import {
-  loadConfig,
   createPluginRegistry,
   createSessionManager,
   createLifecycleManager,
@@ -42,6 +41,7 @@ import pluginWorkspaceWorktree from "@composio/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@composio/ao-plugin-scm-github";
 import pluginTrackerGithub from "@composio/ao-plugin-tracker-github";
 import pluginTrackerLinear from "@composio/ao-plugin-tracker-linear";
+import { getCachedConfig } from "./config-cache.js";
 
 export interface Services {
   config: OrchestratorConfig;
@@ -54,26 +54,64 @@ export interface Services {
 const globalForServices = globalThis as typeof globalThis & {
   _aoServices?: Services;
   _aoServicesInit?: Promise<Services>;
+  _aoServicesConfig?: OrchestratorConfig;
 };
+
+export { getCachedConfig };
 
 /** Get (or lazily initialize) the core services singleton. */
 export function getServices(): Promise<Services> {
-  if (globalForServices._aoServices) {
+  const config = getCachedConfig();
+
+  if (globalForServices._aoServices && globalForServices._aoServicesConfig === config) {
     return Promise.resolve(globalForServices._aoServices);
   }
-  if (!globalForServices._aoServicesInit) {
-    globalForServices._aoServicesInit = initServices().catch((err) => {
-      // Clear the cached promise so the next call retries instead of
-      // permanently returning a rejected promise.
-      globalForServices._aoServicesInit = undefined;
+
+  if (
+    globalForServices._aoServices &&
+    globalForServices._aoServicesConfig &&
+    globalForServices._aoServicesConfig !== config
+  ) {
+    try {
+      globalForServices._aoServices.lifecycleManager.stop();
+    } catch {
+      void 0;
+    }
+    globalForServices._aoServices = undefined;
+  }
+
+  if (globalForServices._aoServicesInit && globalForServices._aoServicesConfig === config) {
+    return globalForServices._aoServicesInit;
+  }
+
+  globalForServices._aoServicesConfig = config;
+  globalForServices._aoServicesInit = initServices(config)
+    .then((services) => {
+      if (globalForServices._aoServicesConfig !== config) {
+        try {
+          services.lifecycleManager.stop();
+        } catch {
+          void 0;
+        }
+        return services;
+      }
+
+      globalForServices._aoServices = services;
+      return services;
+    })
+    .catch((err) => {
+      if (globalForServices._aoServicesConfig === config) {
+        // Clear the cached promise so the next call retries instead of
+        // permanently returning a rejected promise.
+        globalForServices._aoServicesInit = undefined;
+        globalForServices._aoServicesConfig = undefined;
+      }
       throw err;
     });
-  }
   return globalForServices._aoServicesInit;
 }
 
-async function initServices(): Promise<Services> {
-  const config = loadConfig();
+async function initServices(config: OrchestratorConfig): Promise<Services> {
   const registry = createPluginRegistry();
 
   // Register plugins explicitly (webpack can't handle dynamic import() in core)
@@ -92,9 +130,7 @@ async function initServices(): Promise<Services> {
   const lifecycleManager = createLifecycleManager({ config, registry, sessionManager });
   lifecycleManager.start(30_000);
 
-  const services = { config, registry, sessionManager, lifecycleManager };
-  globalForServices._aoServices = services;
-  return services;
+  return { config, registry, sessionManager, lifecycleManager };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -41,7 +41,7 @@ import pluginWorkspaceWorktree from "@composio/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@composio/ao-plugin-scm-github";
 import pluginTrackerGithub from "@composio/ao-plugin-tracker-github";
 import pluginTrackerLinear from "@composio/ao-plugin-tracker-linear";
-import { getCachedConfig } from "./config-cache.js";
+import { getCachedConfig } from "./config-cache";
 
 export interface Services {
   config: OrchestratorConfig;

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -74,6 +74,7 @@ export interface DashboardSession {
   createdAt: string;
   lastActivityAt: string;
   pr: DashboardPR | null;
+  notificationState?: DashboardNotificationState;
   metadata: Record<string, string>;
 }
 
@@ -128,6 +129,23 @@ export interface DashboardStats {
   workingSessions: number;
   openPRs: number;
   needsReview: number;
+}
+
+export interface DashboardNotifierState {
+  name: string;
+  status: "ok" | "warn";
+  consecutiveFailures: number;
+  lastFailureAt: string | null;
+  lastFailureReason: string | null;
+  lastSuccessAt: string | null;
+  lastEventType: string | null;
+  lastPriority: "urgent" | "action" | "warning" | "info" | null;
+}
+
+export interface DashboardNotificationState {
+  status: "ok" | "warn";
+  failingNotifiers: string[];
+  notifiers: DashboardNotifierState[];
 }
 
 export interface DashboardOrchestratorLink {


### PR DESCRIPTION
 ## Summary
  - add token-protected `/api/ao/*` endpoints for status, session listing, session detail, kill, and retry flows
  - harden core session lifecycle handling for archived lookups, stale runtime/worktree cleanup, restore rollback, and ambiguous nested session prefixes
  - align legacy `/api/sessions*` behavior with AO routes for auth handling, correlation-safe error responses, and fallback project normalization
  - address follow-up review issues by narrowing missing-resource detection, switching API token checks to constant-time comparison, and removing redundant AO
  session serialization indirection

  ## Test Plan
  - [x] `HOME=/tmp pnpm --filter @composio/ao-core test -- src/__tests__/config-validation.test.ts src/__tests__/session-manager.test.ts`
  - [x] `HOME=/tmp pnpm --filter @composio/ao-core test -- src/__tests__/session-manager.test.ts`
  - [x] `pnpm --filter @composio/ao-core build`
  - [x] `pnpm --filter @composio/ao-web test -- src/__tests__/services.test.ts src/__tests__/api-routes.test.ts src/__tests__/api-ao.test.ts src/lib/__tests__/
  serialize.test.ts src/lib/__tests__/api-auth.test.ts`
  - [x] `pnpm --filter @composio/ao-core typecheck`
  - [x] `pnpm --filter @composio/ao-web typecheck`