### PR TITLE
fix(core): fix two broken reaction sequences (closes #614)

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1427,6 +1427,147 @@ describe("reactions", () => {
       expect.objectContaining({ type: "merge.completed" }),
     );
   });
+
+  it("uses fallback message when send-to-agent reaction has no message field", async () => {
+    // Regression for #614: config omits message (as in auto-merge.yaml example)
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        retries: 2,
+        escalateAfter: 2,
+        // no message field
+      },
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    // Must send the fallback message instead of silently doing nothing
+    expect(mockSessionManager.send).toHaveBeenCalledWith(
+      "app-1",
+      expect.stringContaining("CI is failing"),
+    );
+  });
+
+  it("notifies human when send-to-agent reaction fails (send throws)", async () => {
+    // Regression for #614: reactionHandledNotify was always true, suppressing
+    // human notification even when the reaction failed.
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    // Simulate send failure
+    vi.mocked(mockSessionManager.send).mockRejectedValue(new Error("agent unreachable"));
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const configWithReaction = {
+      ...config,
+      notificationRouting: {
+        ...config.notificationRouting,
+        warning: ["desktop"], // ci.failing events are "warning" priority
+      },
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent" as const,
+          message: "Fix CI",
+          retries: 3,
+          escalateAfter: 3,
+        },
+      },
+    };
+
+    const lm = createLifecycleManager({
+      config: configWithReaction,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+    // send failed, so human notification must still fire
+    expect(mockNotifier.notify).toHaveBeenCalled();
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "ci.failing" }),
+    );
+  });
 });
 
 describe("getStates", () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -306,34 +306,50 @@ function validateProjectUniqueness(config: OrchestratorConfig): void {
   }
 }
 
+/**
+ * Default messages for send-to-agent reactions.
+ * Exported so lifecycle-manager can use them as fallbacks when a user overrides
+ * a reaction config without providing a message field, keeping both in sync.
+ */
+export const DEFAULT_SEND_TO_AGENT_MESSAGES: Record<string, string> = {
+  "ci-failed":
+    "CI is failing on your PR. Run `gh pr checks` to see the failures, fix them, and push.",
+  "changes-requested":
+    "There are review comments on your PR. Check with `gh pr view --comments` and `gh api` for inline comments. Address each one, push fixes, and reply.",
+  "bugbot-comments":
+    "Automated review comments found on your PR. Fix the issues flagged by the bot.",
+  "merge-conflicts":
+    "Your branch has merge conflicts. Rebase on the default branch and resolve them.",
+  "agent-idle":
+    "You appear to be idle. If your task is not complete, continue working — write the code, commit, push, and create a PR. If you are blocked, explain what is blocking you.",
+};
+
 /** Apply default reactions */
 function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
   const defaults: Record<string, (typeof config.reactions)[string]> = {
     "ci-failed": {
       auto: true,
       action: "send-to-agent",
-      message:
-        "CI is failing on your PR. Run `gh pr checks` to see the failures, fix them, and push.",
+      message: DEFAULT_SEND_TO_AGENT_MESSAGES["ci-failed"],
       retries: 2,
       escalateAfter: 2,
     },
     "changes-requested": {
       auto: true,
       action: "send-to-agent",
-      message:
-        "There are review comments on your PR. Check with `gh pr view --comments` and `gh api` for inline comments. Address each one, push fixes, and reply.",
+      message: DEFAULT_SEND_TO_AGENT_MESSAGES["changes-requested"],
       escalateAfter: "30m",
     },
     "bugbot-comments": {
       auto: true,
       action: "send-to-agent",
-      message: "Automated review comments found on your PR. Fix the issues flagged by the bot.",
+      message: DEFAULT_SEND_TO_AGENT_MESSAGES["bugbot-comments"],
       escalateAfter: "30m",
     },
     "merge-conflicts": {
       auto: true,
       action: "send-to-agent",
-      message: "Your branch has merge conflicts. Rebase on the default branch and resolve them.",
+      message: DEFAULT_SEND_TO_AGENT_MESSAGES["merge-conflicts"],
       escalateAfter: "15m",
     },
     "approved-and-green": {
@@ -345,8 +361,7 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
     "agent-idle": {
       auto: true,
       action: "send-to-agent",
-      message:
-        "You appear to be idle. If your task is not complete, continue working — write the code, commit, push, and create a PR. If you are blocked, explain what is blocking you.",
+      message: DEFAULT_SEND_TO_AGENT_MESSAGES["agent-idle"],
       retries: 2,
       escalateAfter: "15m",
     },

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -37,6 +37,7 @@ import { updateMetadata } from "./metadata.js";
 import { getSessionsDir } from "./paths.js";
 import { createCorrelationId, createProjectObserver } from "./observability.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
+import { DEFAULT_SEND_TO_AGENT_MESSAGES } from "./config.js";
 
 /** Parse a duration string like "10m", "30s", "1h" to milliseconds. */
 function parseDuration(str: string): number {
@@ -364,20 +365,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return session.status;
   }
 
-  /** Fallback messages for send-to-agent reactions that omit a message field. */
-  const SEND_TO_AGENT_FALLBACKS: Record<string, string> = {
-    "ci-failed":
-      "CI is failing on your PR. Run `gh pr checks` to see the failures, fix them, and push.",
-    "changes-requested":
-      "There are review comments on your PR. Check with `gh pr view --comments` and `gh api` for inline comments. Address each one, push fixes, and reply.",
-    "bugbot-comments":
-      "Automated review comments found on your PR. Fix the issues flagged by the bot.",
-    "merge-conflicts":
-      "Your branch has merge conflicts. Rebase on the default branch and resolve them.",
-    "agent-idle":
-      "You appear to be idle. If your task is not complete, continue working — write the code, commit, push, and create a PR. If you are blocked, explain what is blocking you.",
-  };
-
   /** Execute a reaction for a session. */
   async function executeReaction(
     sessionId: SessionId,
@@ -438,7 +425,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     switch (action) {
       case "send-to-agent": {
-        const message = reactionConfig.message ?? SEND_TO_AGENT_FALLBACKS[reactionKey];
+        const message = reactionConfig.message ?? DEFAULT_SEND_TO_AGENT_MESSAGES[reactionKey];
         if (message) {
           try {
             await sessionManager.send(sessionId, message);

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -364,6 +364,20 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return session.status;
   }
 
+  /** Fallback messages for send-to-agent reactions that omit a message field. */
+  const SEND_TO_AGENT_FALLBACKS: Record<string, string> = {
+    "ci-failed":
+      "CI is failing on your PR. Run `gh pr checks` to see the failures, fix them, and push.",
+    "changes-requested":
+      "There are review comments on your PR. Check with `gh pr view --comments` and `gh api` for inline comments. Address each one, push fixes, and reply.",
+    "bugbot-comments":
+      "Automated review comments found on your PR. Fix the issues flagged by the bot.",
+    "merge-conflicts":
+      "Your branch has merge conflicts. Rebase on the default branch and resolve them.",
+    "agent-idle":
+      "You appear to be idle. If your task is not complete, continue working — write the code, commit, push, and create a PR. If you are blocked, explain what is blocking you.",
+  };
+
   /** Execute a reaction for a session. */
   async function executeReaction(
     sessionId: SessionId,
@@ -424,19 +438,31 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     switch (action) {
       case "send-to-agent": {
-        if (reactionConfig.message) {
+        const message = reactionConfig.message ?? SEND_TO_AGENT_FALLBACKS[reactionKey];
+        if (message) {
           try {
-            await sessionManager.send(sessionId, reactionConfig.message);
+            await sessionManager.send(sessionId, message);
 
             return {
               reactionType: reactionKey,
               success: true,
               action: "send-to-agent",
-              message: reactionConfig.message,
+              message,
               escalated: false,
             };
           } catch {
             // Send failed — allow retry on next poll cycle (don't escalate immediately)
+            observer.recordOperation({
+              metric: "lifecycle_poll",
+              operation: "reaction.execute",
+              outcome: "failure",
+              correlationId: createCorrelationId("reaction"),
+              projectId,
+              sessionId,
+              reason: "send-to-agent delivery failed",
+              data: { reactionKey },
+              level: "warn",
+            });
             return {
               reactionType: reactionKey,
               success: false,
@@ -445,6 +471,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             };
           }
         }
+        // No message and no fallback — log and return failure
+        observer.recordOperation({
+          metric: "lifecycle_poll",
+          operation: "reaction.execute",
+          outcome: "failure",
+          correlationId: createCorrelationId("reaction"),
+          projectId,
+          sessionId,
+          reason: "send-to-agent reaction has no message and no fallback",
+          data: { reactionKey },
+          level: "warn",
+        });
         break;
       }
 
@@ -760,11 +798,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
                 reactionConfig,
               );
               transitionReaction = { key: reactionKey, result: reactionResult };
-              // Reaction is handling this event — suppress immediate human notification.
-              // "send-to-agent" retries + escalates on its own; "notify"/"auto-merge"
-              // already call notifyHuman internally. Notifying here would bypass the
-              // delayed escalation behaviour configured via retries/escalateAfter.
-              reactionHandledNotify = true;
+              // Suppress immediate human notification only when the reaction succeeded.
+              // On failure (e.g. send-to-agent with no reachable agent), fall through
+              // to notify humans so the event isn't silently lost.
+              // "notify"/"auto-merge" always return success:true and call notifyHuman
+              // internally, so they're unaffected by this change.
+              reactionHandledNotify = reactionResult.success;
             }
           }
         }


### PR DESCRIPTION
## Summary

Audit of the reaction engine found two bugs that together produce the double-failure described in #614: the agent never gets the CI error AND the human never gets notified.

- **`send-to-agent` silent no-op when `message` is missing** — When a reaction config omits the `message` field (as in the documented `examples/auto-merge.yaml`), the `send-to-agent` case skipped the send entirely and returned `success: false` with no log, no notification, and no indication anything went wrong. Added a static fallback message map for the five built-in `send-to-agent` reaction keys so agents always receive actionable guidance. Added `reaction.execute` observability traces for failed sends and the no-message/no-fallback edge case.

- **`reactionHandledNotify` suppressed human fallback even on failure** — `reactionHandledNotify` was set to `true` unconditionally after executing any reaction, even when the reaction returned `success: false` (e.g. agent unreachable, send threw). This silently dropped the event with no fallback. Changed to `reactionHandledNotify = result.success` so a failed reaction still triggers the human notification path.

## Test plan

- [x] New test: `send-to-agent` without `message` uses fallback (verifies exact "CI is failing" string)
- [x] New test: failed `send-to-agent` (throws) still fires human notification
- [x] Existing 30 lifecycle-manager tests still pass (32 total, no regressions)
- [x] `pnpm build` clean
- [x] `pnpm typecheck` clean
- [x] No lint errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)