### PR TITLE
fix(cli): add --project flag to ao spawn for multi-project orchestration

### DIFF
--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -478,6 +478,123 @@ describe("spawn command", () => {
   });
 });
 
+describe("spawn --project flag", () => {
+  it("uses --project flag to override auto-detection", async () => {
+    // Add a second project so auto-detection would fail without --project
+    (mockConfigRef.current as Record<string, unknown>).projects = {
+      "my-app": {
+        name: "My App",
+        repo: "org/my-app",
+        path: join(tmpDir, "main-repo"),
+        defaultBranch: "main",
+        sessionPrefix: "app",
+      },
+      "other-app": {
+        name: "Other App",
+        repo: "org/other-app",
+        path: join(tmpDir, "other-repo"),
+        defaultBranch: "main",
+        sessionPrefix: "other",
+      },
+    };
+
+    const fakeSession: Session = {
+      id: "other-1",
+      projectId: "other-app",
+      status: "spawning",
+      activity: null,
+      branch: "feat/INT-200",
+      issueId: "INT-200",
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-other-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync(["node", "test", "spawn", "--project", "other-app", "INT-200"]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "other-app",
+      issueId: "INT-200",
+    });
+  });
+
+  it("errors with clear message when --project ID does not exist in config", async () => {
+    await expect(
+      program.parseAsync(["node", "test", "spawn", "--project", "nonexistent"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const errors = vi
+      .mocked(console.error)
+      .mock.calls.map((c) => String(c[0]))
+      .join("\n");
+    expect(errors).toContain("Unknown project: nonexistent");
+    expect(errors).toContain("my-app");
+    expect(mockSessionManager.spawn).not.toHaveBeenCalled();
+  });
+
+  it("--project flag takes priority over AO_PROJECT_ID env var", async () => {
+    // Add a second project
+    (mockConfigRef.current as Record<string, unknown>).projects = {
+      "my-app": {
+        name: "My App",
+        repo: "org/my-app",
+        path: join(tmpDir, "main-repo"),
+        defaultBranch: "main",
+        sessionPrefix: "app",
+      },
+      "other-app": {
+        name: "Other App",
+        repo: "org/other-app",
+        path: join(tmpDir, "other-repo"),
+        defaultBranch: "main",
+        sessionPrefix: "other",
+      },
+    };
+
+    const originalEnv = process.env.AO_PROJECT_ID;
+    process.env.AO_PROJECT_ID = "my-app";
+
+    const fakeSession: Session = {
+      id: "other-1",
+      projectId: "other-app",
+      status: "spawning",
+      activity: null,
+      branch: null,
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-other-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    try {
+      await program.parseAsync(["node", "test", "spawn", "--project", "other-app"]);
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.AO_PROJECT_ID;
+      } else {
+        process.env.AO_PROJECT_ID = originalEnv;
+      }
+    }
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "other-app",
+      issueId: undefined,
+    });
+  });
+});
+
 describe("spawn pre-flight checks", () => {
   it("fails with clear error when tmux is not installed (default runtime)", async () => {
     mockExec.mockRejectedValue(new Error("ENOENT"));

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -162,6 +162,7 @@ export function registerSpawn(program: Command): void {
     .argument("[first]", "Issue identifier (project is auto-detected)")
     .argument("[second]", "", /* hidden second arg to catch old two-arg usage */)
     .option("--open", "Open session in terminal tab")
+    .option("--project <id>", "Override project ID (default: auto-detected)")
     .option("--agent <name>", "Override the agent plugin (e.g. codex, claude-code)")
     .option("--claim-pr <pr>", "Immediately claim an existing PR for the spawned session")
     .option("--assign-on-github", "Assign the claimed PR to the authenticated GitHub user")
@@ -173,6 +174,7 @@ export function registerSpawn(program: Command): void {
         second: string | undefined,
         opts: {
           open?: boolean;
+          project?: string;
           agent?: string;
           claimPr?: string;
           assignOnGithub?: boolean;
@@ -199,14 +201,20 @@ export function registerSpawn(program: Command): void {
 
         if (first) {
           issueId = first;
-          try {
-            projectId = autoDetectProject(config);
-          } catch (err) {
-            console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+        }
+
+        // --project flag takes highest priority over auto-detection
+        if (opts.project) {
+          if (!config.projects[opts.project]) {
+            console.error(
+              chalk.red(
+                `Unknown project: ${opts.project}\nAvailable: ${Object.keys(config.projects).join(", ")}`,
+              ),
+            );
             process.exit(1);
           }
+          projectId = opts.project;
         } else {
-          // No args: auto-detect project, no issue
           try {
             projectId = autoDetectProject(config);
           } catch (err) {
@@ -296,24 +304,29 @@ export function registerBatchSpawn(program: Command): void {
     .description("Spawn sessions for multiple issues with duplicate detection")
     .argument("<issues...>", "Issue identifiers (project is auto-detected)")
     .option("--open", "Open sessions in terminal tabs")
-    .action(async (issues: string[], opts: { open?: boolean }) => {
+    .option("--project <id>", "Override project ID (default: auto-detected)")
+    .action(async (issues: string[], opts: { open?: boolean; project?: string }) => {
       const config = loadConfig();
       let projectId: string;
 
-      try {
-        projectId = autoDetectProject(config);
-      } catch (err) {
-        console.error(chalk.red(err instanceof Error ? err.message : String(err)));
-        process.exit(1);
-      }
-
-      if (!config.projects[projectId]) {
-        console.error(
-          chalk.red(
-            `Unknown project: ${projectId}\nAvailable: ${Object.keys(config.projects).join(", ")}`,
-          ),
-        );
-        process.exit(1);
+      // --project flag takes highest priority over auto-detection
+      if (opts.project) {
+        if (!config.projects[opts.project]) {
+          console.error(
+            chalk.red(
+              `Unknown project: ${opts.project}\nAvailable: ${Object.keys(config.projects).join(", ")}`,
+            ),
+          );
+          process.exit(1);
+        }
+        projectId = opts.project;
+      } else {
+        try {
+          projectId = autoDetectProject(config);
+        } catch (err) {
+          console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+          process.exit(1);
+        }
       }
 
       console.log(banner("BATCH SESSION SPAWNER"));


### PR DESCRIPTION
## Problem

When an orchestrator session uses `ao spawn` or `ao batch-spawn` to start sub-agent sessions, the `AO_PROJECT_ID` environment variable (injected into the orchestrator's own environment) causes `autoDetectProject` to resolve to the orchestrator's project. This means every spawned sub-agent session is placed under the orchestrator project instead of the intended target project — breaking multi-project orchestration workflows.

## Fix

Add a `--project <id>` flag to both `ao spawn` and `ao batch-spawn`. When provided, the flag bypasses `autoDetectProject` entirely and uses the supplied project ID directly. The flag validates the ID against the loaded config and exits with a human-readable error (listing available IDs) if the value is unknown.

Example usage from an orchestrator session:
```
ao spawn --project my-other-project 123
ao batch-spawn --project my-other-project 123 124 125
```

## Changes
- `packages/cli/src/commands/spawn.ts` — add `--project <id>` option to `registerSpawn` and `registerBatchSpawn`, with validation
- `packages/cli/__tests__/commands/spawn.test.ts` — tests covering the new flag and its error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)