### PR TITLE
fix(web): persist 'ask to fix' CI button based on live GitHub CI data

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@ export default tseslint.config(
       "**/node_modules/**",
       "**/.next/**",
       "**/coverage/**",
+      "packages/web/dist-server/**",
       "packages/web/next-env.d.ts",
       "packages/web/next.config.js",
       "packages/web/postcss.config.mjs",
@@ -68,6 +69,26 @@ export default tseslint.config(
       "no-console": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-non-null-assertion": "off",
+    },
+  },
+
+  // Plugin packages and CLI run in Node.js — declare standard Node.js globals
+  {
+    files: ["packages/plugins/**/*.ts", "packages/cli/**/*.ts"],
+    languageOptions: {
+      globals: {
+        console: "readonly",
+        process: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+        URL: "readonly",
+        URLSearchParams: "readonly",
+        Buffer: "readonly",
+        __dirname: "readonly",
+        __filename: "readonly",
+      },
     },
   },
 

--- a/packages/web/src/__tests__/components.test.tsx
+++ b/packages/web/src/__tests__/components.test.tsx
@@ -269,9 +269,10 @@ describe("SessionCard", () => {
     expect(onMerge).toHaveBeenCalledWith(42);
   });
 
-  it("shows ask-to-fix when session is ci_failed even before PR enrichment runs", () => {
-    // Simulates the case where SSE has already updated session.status to ci_failed
-    // but the PR enrichment hasn't populated pr.ciStatus yet (still at default "none").
+  it("does not show ask-to-fix when pr.ciStatus is not failing (session status ignored)", () => {
+    // Button visibility is driven by pr.ciStatus (GitHub data), not session.status.
+    // Even when session.status is ci_failed, if pr.ciStatus isn't failing yet
+    // (e.g. enrichment hasn't run), the button should NOT show.
     const pr = makePR({
       state: "open",
       ciStatus: "none", // PR enrichment not yet loaded
@@ -287,11 +288,11 @@ describe("SessionCard", () => {
     });
     const session = makeSession({ status: "ci_failed", activity: "idle", pr });
     render(<SessionCard session={session} />);
-    // Button must persist based on session status alone
-    expect(screen.getByText("ask to fix")).toBeInTheDocument();
+    // No button until pr.ciStatus is updated to "failing" via SSE snapshot patch
+    expect(screen.queryByText("ask to fix")).not.toBeInTheDocument();
   });
 
-  it("shows CI failing alert", () => {
+  it("shows CI failing alert with count when checks are available", () => {
     const pr = makePR({
       state: "open",
       ciStatus: "failing",
@@ -313,35 +314,9 @@ describe("SessionCard", () => {
     expect(screen.getByText("1 CI check failing")).toBeInTheDocument();
   });
 
-  it("shows CI failing with ask-to-fix when session is ci_failed but no check details", () => {
-    // This happens when GitHub API fails - getCISummary returns "failing"
-    // but getCIChecks returns empty array, yet the session status is authoritative.
-    const pr = makePR({
-      state: "open",
-      ciStatus: "failing",
-      ciChecks: [], // Empty - API failed to fetch checks
-      reviewDecision: "none",
-      mergeability: {
-        mergeable: false,
-        ciPassing: false,
-        approved: false,
-        noConflicts: true,
-        blockers: ["CI is failing"],
-      },
-    });
-    const session = makeSession({ status: "ci_failed", activity: "idle", pr });
-    render(<SessionCard session={session} />);
-    // Session status is authoritative — show actionable "CI failing" label
-    expect(screen.getByText("CI failing")).toBeInTheDocument();
-    // Should NOT show "0 CI check failing"
-    expect(screen.queryByText(/0.*CI check.*failing/i)).not.toBeInTheDocument();
-    // Should show "ask to fix" since session status confirms CI is failing
-    expect(screen.getByText("ask to fix")).toBeInTheDocument();
-  });
-
-  it("shows CI status unknown without ask-to-fix when only PR data says failing but no check details", () => {
-    // This happens when pr.ciStatus=failing but the session status hasn't been set
-    // to ci_failed yet — don't offer to fix when we don't know which checks failed.
+  it("shows CI failing with ask-to-fix even when no check details are available", () => {
+    // pr.ciStatus="failing" is the authoritative GitHub signal — show the action
+    // button even when ciChecks is empty (API inconsistency or enrichment lag).
     const pr = makePR({
       state: "open",
       ciStatus: "failing",
@@ -357,9 +332,32 @@ describe("SessionCard", () => {
     });
     const session = makeSession({ status: "working", activity: "active", pr });
     render(<SessionCard session={session} />);
-    expect(screen.getByText("CI unknown")).toBeInTheDocument();
-    // Should NOT show "ask to fix" when we don't know which CI checks failed
-    expect(screen.queryByText("ask to fix")).not.toBeInTheDocument();
+    // pr.ciStatus is the GitHub signal — show "CI failing" with action button
+    expect(screen.getByText("CI failing")).toBeInTheDocument();
+    expect(screen.getByText("ask to fix")).toBeInTheDocument();
+    // Should NOT show "0 CI check failing"
+    expect(screen.queryByText(/0.*CI check.*failing/i)).not.toBeInTheDocument();
+  });
+
+  it("shows ask-to-fix based on pr.ciStatus regardless of session status", () => {
+    // Button is shown when pr.ciStatus=failing even when session is "working"
+    // (agent already handling it) — human override remains available while CI is red.
+    const pr = makePR({
+      state: "open",
+      ciStatus: "failing",
+      ciChecks: [{ name: "test", status: "failed" }],
+      reviewDecision: "approved",
+      mergeability: {
+        mergeable: false,
+        ciPassing: false,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      },
+    });
+    const session = makeSession({ status: "working", activity: "active", pr });
+    render(<SessionCard session={session} />);
+    expect(screen.getByText("ask to fix")).toBeInTheDocument();
   });
 
   it("shows changes requested alert", () => {

--- a/packages/web/src/__tests__/components.test.tsx
+++ b/packages/web/src/__tests__/components.test.tsx
@@ -269,6 +269,28 @@ describe("SessionCard", () => {
     expect(onMerge).toHaveBeenCalledWith(42);
   });
 
+  it("shows ask-to-fix when session is ci_failed even before PR enrichment runs", () => {
+    // Simulates the case where SSE has already updated session.status to ci_failed
+    // but the PR enrichment hasn't populated pr.ciStatus yet (still at default "none").
+    const pr = makePR({
+      state: "open",
+      ciStatus: "none", // PR enrichment not yet loaded
+      ciChecks: [],
+      reviewDecision: "none",
+      mergeability: {
+        mergeable: false,
+        ciPassing: false,
+        approved: false,
+        noConflicts: true,
+        blockers: ["Data not loaded"],
+      },
+    });
+    const session = makeSession({ status: "ci_failed", activity: "idle", pr });
+    render(<SessionCard session={session} />);
+    // Button must persist based on session status alone
+    expect(screen.getByText("ask to fix")).toBeInTheDocument();
+  });
+
   it("shows CI failing alert", () => {
     const pr = makePR({
       state: "open",
@@ -291,9 +313,9 @@ describe("SessionCard", () => {
     expect(screen.getByText("1 CI check failing")).toBeInTheDocument();
   });
 
-  it("shows CI status unknown when ciStatus is failing but no failed checks", () => {
+  it("shows CI failing with ask-to-fix when session is ci_failed but no check details", () => {
     // This happens when GitHub API fails - getCISummary returns "failing"
-    // but getCIChecks returns empty array
+    // but getCIChecks returns empty array, yet the session status is authoritative.
     const pr = makePR({
       state: "open",
       ciStatus: "failing",
@@ -309,10 +331,34 @@ describe("SessionCard", () => {
     });
     const session = makeSession({ status: "ci_failed", activity: "idle", pr });
     render(<SessionCard session={session} />);
-    expect(screen.getByText("CI unknown")).toBeInTheDocument();
+    // Session status is authoritative — show actionable "CI failing" label
+    expect(screen.getByText("CI failing")).toBeInTheDocument();
     // Should NOT show "0 CI check failing"
     expect(screen.queryByText(/0.*CI check.*failing/i)).not.toBeInTheDocument();
-    // Should NOT show "ask to fix" action for unknown CI
+    // Should show "ask to fix" since session status confirms CI is failing
+    expect(screen.getByText("ask to fix")).toBeInTheDocument();
+  });
+
+  it("shows CI status unknown without ask-to-fix when only PR data says failing but no check details", () => {
+    // This happens when pr.ciStatus=failing but the session status hasn't been set
+    // to ci_failed yet — don't offer to fix when we don't know which checks failed.
+    const pr = makePR({
+      state: "open",
+      ciStatus: "failing",
+      ciChecks: [], // Empty - API failed to fetch individual checks
+      reviewDecision: "none",
+      mergeability: {
+        mergeable: false,
+        ciPassing: false,
+        approved: false,
+        noConflicts: true,
+        blockers: ["CI is failing"],
+      },
+    });
+    const session = makeSession({ status: "working", activity: "active", pr });
+    render(<SessionCard session={session} />);
+    expect(screen.getByText("CI unknown")).toBeInTheDocument();
+    // Should NOT show "ask to fix" when we don't know which CI checks failed
     expect(screen.queryByText("ask to fix")).not.toBeInTheDocument();
   });
 

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -1,5 +1,5 @@
-import { getServices } from "@/lib/services";
-import { sessionToDashboard } from "@/lib/serialize";
+import { getServices, getSCM } from "@/lib/services";
+import { sessionToDashboard, enrichSessionPR, resolveProject } from "@/lib/serialize";
 import { getAttentionLevel } from "@/lib/types";
 import { filterWorkerSessions } from "@/lib/project-utils";
 import {
@@ -71,7 +71,7 @@ export async function GET(request: Request): Promise<Response> {
         }
 
         try {
-          const { config, sessionManager } = await getServices();
+          const { config, registry, sessionManager } = await getServices();
           const requestedProjectId =
             projectFilter && projectFilter !== "all" && config.projects[projectFilter]
               ? projectFilter
@@ -79,6 +79,18 @@ export async function GET(request: Request): Promise<Response> {
           const sessions = await sessionManager.list(requestedProjectId);
           const workerSessions = filterWorkerSessions(sessions, projectFilter, config.projects);
           const dashboardSessions = workerSessions.map(sessionToDashboard);
+
+          // Enrich PR CI data from cache only — no GitHub API calls, just cache lookups.
+          // This keeps the snapshot current with the latest CI status without adding latency.
+          for (let i = 0; i < workerSessions.length; i++) {
+            const core = workerSessions[i];
+            if (!core?.pr) continue;
+            const project = resolveProject(core, config.projects);
+            const scm = getSCM(registry, project);
+            if (!scm) continue;
+            await enrichSessionPR(dashboardSessions[i], scm, core.pr, { cacheOnly: true });
+          }
+
           const projectObserver = ensureObserver(config);
 
           const initialEvent = {
@@ -91,6 +103,8 @@ export async function GET(request: Request): Promise<Response> {
               activity: s.activity,
               attentionLevel: getAttentionLevel(s),
               lastActivityAt: s.lastActivityAt,
+              prCiStatus: s.pr?.ciStatus ?? null,
+              prCiChecks: s.pr?.ciChecks ?? null,
             })),
           };
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(initialEvent)}\n\n`));
@@ -130,7 +144,7 @@ export async function GET(request: Request): Promise<Response> {
         void (async () => {
           let dashboardSessions;
           try {
-            const { config, sessionManager } = await getServices();
+            const { config, registry, sessionManager } = await getServices();
             const requestedProjectId =
               projectFilter && projectFilter !== "all" && config.projects[projectFilter]
                 ? projectFilter
@@ -138,6 +152,17 @@ export async function GET(request: Request): Promise<Response> {
             const sessions = await sessionManager.list(requestedProjectId);
             const workerSessions = filterWorkerSessions(sessions, projectFilter, config.projects);
             dashboardSessions = workerSessions.map(sessionToDashboard);
+
+            // Enrich PR CI data from cache only — no GitHub API calls, just cache lookups.
+            for (let i = 0; i < workerSessions.length; i++) {
+              const core = workerSessions[i];
+              if (!core?.pr) continue;
+              const project = resolveProject(core, config.projects);
+              const scm = getSCM(registry, project);
+              if (!scm) continue;
+              await enrichSessionPR(dashboardSessions[i], scm, core.pr, { cacheOnly: true });
+            }
+
             const projectObserver = ensureObserver(config);
 
             if (projectObserver && observerProjectId) {
@@ -165,6 +190,8 @@ export async function GET(request: Request): Promise<Response> {
                   activity: s.activity,
                   attentionLevel: getAttentionLevel(s),
                   lastActivityAt: s.lastActivityAt,
+                  prCiStatus: s.pr?.ciStatus ?? null,
+                  prCiChecks: s.pr?.ciChecks ?? null,
                 })),
               };
               controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -619,38 +619,28 @@ function getAlerts(session: DashboardSession): Alert[] {
 
   const alerts: Alert[] = [];
 
-  // Show CI failure alert when the session status authoritatively says CI is failing
-  // (updated in real-time via SSE) OR when enriched PR data confirms it.
-  // Checking both ensures the button persists even before PR enrichment data is fetched.
-  if (session.status === "ci_failed" || pr.ciStatus === CI_STATUS.FAILING) {
+  // Button visibility is driven solely by GitHub CI data (pr.ciStatus), not by
+  // session lifecycle status. pr.ciStatus is kept current via SSE snapshot patches
+  // (cache-only enrichment on every 5s poll), so the button reflects the actual
+  // GitHub state without waiting for the 15s+ stale full-refresh cycle.
+  if (pr.ciStatus === CI_STATUS.FAILING) {
     const failedCheck = pr.ciChecks.find((c) => c.status === "failed");
     const failCount = pr.ciChecks.filter((c) => c.status === "failed").length;
     if (failCount === 0) {
-      if (session.status === "ci_failed") {
-        // Session status confirms CI is failing — show actionable button even
-        // without specific check details (enrichment may not have run yet).
-        alerts.push({
-          key: "ci-fail",
-          label: "CI failing",
-          className: "",
-          color: "var(--color-alert-ci)",
-          borderColor: "var(--color-alert-ci)",
-          url: pr.url + "/checks",
-          actionLabel: "ask to fix",
-          actionMessage: `Please fix the failing CI checks on ${pr.url}`,
-          actionClassName: "bg-[var(--color-alert-ci-bg)] text-white hover:brightness-110",
-        });
-      } else {
-        // pr.ciStatus says failing but no failed checks found — likely an API
-        // inconsistency; show informational alert without an action button.
-        alerts.push({
-          key: "ci-unknown",
-          label: "CI unknown",
-          className: "",
-          color: "var(--color-alert-ci-unknown)",
-          url: pr.url + "/checks",
-        });
-      }
+      // GitHub reports CI as failing but individual check details aren't available
+      // (API inconsistency or enrichment lag). Still offer the action button since
+      // pr.ciStatus is the authoritative GitHub signal that CI is red.
+      alerts.push({
+        key: "ci-fail",
+        label: "CI failing",
+        className: "",
+        color: "var(--color-alert-ci)",
+        borderColor: "var(--color-alert-ci)",
+        url: pr.url + "/checks",
+        actionLabel: "ask to fix",
+        actionMessage: `Please fix the failing CI checks on ${pr.url}`,
+        actionClassName: "bg-[var(--color-alert-ci-bg)] text-white hover:brightness-110",
+      });
     } else {
       alerts.push({
         key: "ci-fail",

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -619,17 +619,38 @@ function getAlerts(session: DashboardSession): Alert[] {
 
   const alerts: Alert[] = [];
 
-  if (pr.ciStatus === CI_STATUS.FAILING) {
+  // Show CI failure alert when the session status authoritatively says CI is failing
+  // (updated in real-time via SSE) OR when enriched PR data confirms it.
+  // Checking both ensures the button persists even before PR enrichment data is fetched.
+  if (session.status === "ci_failed" || pr.ciStatus === CI_STATUS.FAILING) {
     const failedCheck = pr.ciChecks.find((c) => c.status === "failed");
     const failCount = pr.ciChecks.filter((c) => c.status === "failed").length;
     if (failCount === 0) {
-      alerts.push({
-        key: "ci-unknown",
-        label: "CI unknown",
-        className: "",
-        color: "var(--color-alert-ci-unknown)",
-        url: pr.url + "/checks",
-      });
+      if (session.status === "ci_failed") {
+        // Session status confirms CI is failing — show actionable button even
+        // without specific check details (enrichment may not have run yet).
+        alerts.push({
+          key: "ci-fail",
+          label: "CI failing",
+          className: "",
+          color: "var(--color-alert-ci)",
+          borderColor: "var(--color-alert-ci)",
+          url: pr.url + "/checks",
+          actionLabel: "ask to fix",
+          actionMessage: `Please fix the failing CI checks on ${pr.url}`,
+          actionClassName: "bg-[var(--color-alert-ci-bg)] text-white hover:brightness-110",
+        });
+      } else {
+        // pr.ciStatus says failing but no failed checks found — likely an API
+        // inconsistency; show informational alert without an action button.
+        alerts.push({
+          key: "ci-unknown",
+          label: "CI unknown",
+          className: "",
+          color: "var(--color-alert-ci-unknown)",
+          url: pr.url + "/checks",
+        });
+      }
     } else {
       alerts.push({
         key: "ci-fail",

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -25,10 +25,24 @@ function reducer(state: State, action: Action): State {
       const next = state.sessions.map((s) => {
         const patch = patchMap.get(s.id);
         if (!patch) return s;
+
+        // Check if any field we care about has changed
+        const prCiStatusChanged =
+          patch.prCiStatus !== undefined &&
+          patch.prCiStatus !== null &&
+          s.pr !== null &&
+          s.pr?.ciStatus !== patch.prCiStatus;
+        const prCiChecksChanged =
+          patch.prCiChecks !== undefined &&
+          patch.prCiChecks !== null &&
+          s.pr !== null;
+
         if (
           s.status === patch.status &&
           s.activity === patch.activity &&
-          s.lastActivityAt === patch.lastActivityAt
+          s.lastActivityAt === patch.lastActivityAt &&
+          !prCiStatusChanged &&
+          !prCiChecksChanged
         ) {
           return s;
         }
@@ -38,6 +52,16 @@ function reducer(state: State, action: Action): State {
           status: patch.status,
           activity: patch.activity,
           lastActivityAt: patch.lastActivityAt,
+          // Patch PR CI data when the snapshot includes fresh cache data
+          ...(s.pr && patch.prCiStatus !== null && patch.prCiStatus !== undefined
+            ? {
+                pr: {
+                  ...s.pr,
+                  ciStatus: patch.prCiStatus,
+                  ciChecks: patch.prCiChecks ?? s.pr.ciChecks,
+                },
+              }
+            : {}),
         };
       });
       return changed ? { ...state, sessions: next } : state;

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -147,6 +147,10 @@ export interface SSESnapshotEvent {
     activity: ActivityState | null;
     attentionLevel: AttentionLevel;
     lastActivityAt: string;
+    /** Current CI status from GitHub — included when cached PR data is available */
+    prCiStatus?: DashboardPR["ciStatus"] | null;
+    /** Current CI checks from GitHub — included when cached PR data is available */
+    prCiChecks?: DashboardPR["ciChecks"] | null;
   }>;
 }
 


### PR DESCRIPTION
## Summary

Fixes the 'ask to fix' CI failure button disappearing before users can click it.

**Root cause:** The button visibility was tied to `session.status === "ci_failed"`, which transitions away when the orchestrator auto-reacts and starts working — even though CI is still red on GitHub. The button should persist as long as GitHub reports CI as failing, independent of the orchestrator lifecycle.

**Changes:**

- **`/api/events/route.ts`** — SSE polling (every 5s) now includes `prCiStatus` and `prCiChecks` in each snapshot via cache-only PR enrichment (zero extra GitHub API calls — pure in-memory cache lookup from the `prCache` populated by `/api/sessions`)
- **`useSessionEvents.ts`** — Reducer patches `pr.ciStatus`/`pr.ciChecks` from SSE snapshots, keeping client CI state in sync every ~5s instead of waiting for the 15s+ stale full-refresh
- **`SessionCard.tsx` (`getAlerts`)** — Button condition is `pr.ciStatus === FAILING` only — decoupled from `session.status` entirely. When `pr.ciStatus=failing` but `ciChecks` is empty (API inconsistency), shows "CI failing" + "ask to fix" since `pr.ciStatus` is the authoritative GitHub signal
- **`eslint.config.js`** — Fixed 66 pre-existing `no-undef` lint errors by declaring Node.js globals for plugin/CLI packages; added `dist-server/**` to ignore list

## Test plan

- [x] `pnpm lint` — 0 errors (was 66 errors pre-existing on main)
- [x] `pnpm typecheck` — passes
- [x] `pnpm build` — passes
- [x] Web unit tests — 427 tests pass
- [x] Web server integration tests — 137 tests pass
- [x] New tests: button shows when `pr.ciStatus=failing` regardless of session status; button hidden when `pr.ciStatus≠failing` even if `session.status=ci_failed`

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)