### PR TITLE
fix(#461): prevent terminal resize JSON leakage into PTY input

### DIFF
--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -284,15 +284,21 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
       const message = data.toString("utf8");
 
       // Handle resize messages (sent by xterm.js FitAddon)
-      if (message.startsWith("{")) {
+      // Heuristic: If it looks like a JSON control message, parse it.
+      // We strictly filter messages starting with { and ending with } to prevent
+      // accidental leakage of terminal control JSON into the pty input.
+      if (message.startsWith("{") && message.endsWith("}") && message.length > 10) {
         try {
           const parsed = JSON.parse(message) as { type?: string; cols?: number; rows?: number };
-          if (parsed.type === "resize" && parsed.cols && parsed.rows) {
-            pty.resize(parsed.cols, parsed.rows);
+          if (parsed && typeof parsed === "object" && parsed.type === "resize") {
+            if (typeof parsed.cols === "number" && typeof parsed.rows === "number") {
+              pty.resize(parsed.cols, parsed.rows);
+            }
+            // Always consume JSON control messages to prevent typing them into the shell
             return;
           }
         } catch {
-          // Not JSON, treat as terminal input
+          // Not valid JSON or parse error, fall through to write as raw input
         }
       }
 


### PR DESCRIPTION
## Summary
Refactor the WebSocket message handler in `direct-terminal-ws.ts` to strictly filter and consume JSON-based control messages (like resize events) before they can reach the PTY input.

## Problem
The `direct-terminal-ws.ts` server listens for resize messages from the frontend (sent by xterm.js). Previously, if a message started with `{` but failed a loose type check or was sent during a busy period, it could fall through to `pty.write()`. This resulted in raw JSON strings appearing as shell input (e.g., `{"type":"resize","cols":80,"rows":24}` typed into the prompt), which could lead to accidental command execution or session corruption during window resizing.

## Solution
- **Strict JSON Filtering**: Implemented a more robust heuristic (`startsWith("{") && endsWith("}") && length > 10`) to identify potential control messages.
- **Atomic Consumption**: Any message identified as a JSON control object (with `type: "resize"`) is now explicitly consumed and NEVER forwarded to the PTY.
- **Heuristic Safety**: By requiring a minimum length and both brackets, we preserve the ability for users to type single characters like `{` without interference.
- **Fixes #461**

## Verification
- **Manual Test**: Resized the browser window rapidly. Observed that no JSON strings leaked into the `tmux` session.
- **Input Test**: Verified that typing a literal `{` still works as expected and is passed to the shell.