### PR TITLE
fix(lifecycle): keep polling killed sessions with open PRs

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -962,6 +962,284 @@ describe("check (single session)", () => {
     await lm.check("app-1");
     expect(lm.getStates().get("app-1")).toBe("working");
   });
+
+  it("killed session with open PR transitions to ci_failed when CI fails", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "killed", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "killed",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    // Should transition from killed to ci_failed even though runtime is dead
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+  });
+
+  it("killed session with open PR transitions to mergeable when approved and green", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      }),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "killed", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "killed",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    // Should transition from killed to mergeable when approved and green
+    expect(lm.getStates().get("app-1")).toBe("mergeable");
+  });
+
+  it("killed session without PR stays killed and does not query SCM", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    // Session with no PR
+    const session = makeSession({ status: "killed", pr: null });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "killed",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    // Should stay killed and not query SCM
+    expect(lm.getStates().get("app-1")).toBe("killed");
+    expect(mockSCM.getPRState).not.toHaveBeenCalled();
+  });
+});
+
+describe("pollAll filtering", () => {
+  it("includes killed sessions with open PR in polling set", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const killedSessionWithPR = makeSession({ id: "app-1", status: "killed", pr: makePR() });
+    const workingSession = makeSession({ id: "app-2", status: "working" });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([killedSessionWithPR, workingSession]);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "killed",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    // First poll: should check the killed session with PR
+    await new Promise<void>((resolve) => {
+      lm.start(10);
+      setTimeout(() => {
+        lm.stop();
+        resolve();
+      }, 50);
+    });
+
+    // The killed session with PR should have been checked (getPRState called)
+    expect(mockSCM.getPRState).toHaveBeenCalled();
+  });
+
+  it("excludes merged sessions from polling set", async () => {
+    const mergedSession = makeSession({ id: "app-1", status: "merged", pr: makePR() });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([mergedSession]);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "merged",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    // Set tracked state to merged so we're past the transition
+    const privateLm = lm as any;
+    privateLm.states = new Map([["app-1", "merged"]]);
+
+    // First poll: should NOT check merged session even though it has a PR
+    await new Promise<void>((resolve) => {
+      lm.start(10);
+      setTimeout(() => {
+        lm.stop();
+        resolve();
+      }, 50);
+    });
+
+    // Merged session should NOT have been checked
+    expect(mockSessionManager.get).not.toHaveBeenCalled();
+  });
+
+  it("excludes killed sessions without PR from polling set", async () => {
+    const killedSessionNoPR = makeSession({ id: "app-1", status: "killed", pr: null });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([killedSessionNoPR]);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "killed",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    // Set tracked state to killed so we're past the transition
+    const privateLm = lm as any;
+    privateLm.states = new Map([["app-1", "killed"]]);
+
+    // First poll: should NOT check killed session without PR
+    await new Promise<void>((resolve) => {
+      lm.start(10);
+      setTimeout(() => {
+        lm.stop();
+        resolve();
+      }, 50);
+    });
+
+    // Killed session without PR should NOT have been checked
+    expect(mockSessionManager.get).not.toHaveBeenCalled();
+  });
 });
 
 describe("reactions", () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -226,8 +226,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     // Track activity state across steps so stuck detection can run after PR checks
     let detectedIdleTimestamp: Date | null = null;
 
-    // 1. Check if runtime is alive
-    if (session.runtimeHandle) {
+    // Skip runtime checks for already-killed sessions — we still need to poll
+    // for CI status, merge conflicts, and approval state.
+    const alreadyKilled = session.status === "killed";
+
+    // 1. Check if runtime is alive (skip if already killed)
+    if (!alreadyKilled && session.runtimeHandle) {
       const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
       if (runtime) {
         const alive = await runtime.isAlive(session.runtimeHandle).catch(() => true);
@@ -236,7 +240,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     // 2. Check agent activity — prefer JSONL-based detection (runtime-agnostic)
-    if (agent && session.runtimeHandle) {
+    // Skip for already-killed sessions to avoid unnecessary runtime checks
+    if (!alreadyKilled && agent && session.runtimeHandle) {
       try {
         // Try JSONL-based activity detection first (reads agent's session files directly)
         const activityState = await agent.getActivityState(session, config.readyThresholdMs);
@@ -804,11 +809,16 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
       // Include sessions that are active OR whose status changed from what we last saw
       // (e.g., list() detected a dead runtime and marked it "killed" — we need to
-      // process that transition even though the new status is terminal)
+      // process that transition even though the new status is terminal).
+      // Also keep killed sessions with an open PR — they still need monitoring for
+      // CI status, merge conflicts, and approval state.
       const sessionsToCheck = sessions.filter((s) => {
         if (s.status !== "merged" && s.status !== "killed") return true;
         const tracked = states.get(s.id);
-        return tracked !== undefined && tracked !== s.status;
+        // Check for state transition OR open PR that still needs monitoring
+        const hasTransition = tracked !== undefined && tracked !== s.status;
+        const hasOpenPR = s.pr !== null;
+        return hasTransition || hasOpenPR;
       });
 
       // Poll all sessions concurrently

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -815,9 +815,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       const sessionsToCheck = sessions.filter((s) => {
         if (s.status !== "merged" && s.status !== "killed") return true;
         const tracked = states.get(s.id);
-        // Check for state transition OR open PR that still needs monitoring
+        // Check for state transition OR killed session with PR that still needs monitoring
         const hasTransition = tracked !== undefined && tracked !== s.status;
-        const hasOpenPR = s.pr !== null;
+        const hasOpenPR = s.status === "killed" && s.pr !== null;
         return hasTransition || hasOpenPR;
       });
 
@@ -839,8 +839,15 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         }
       }
 
-      // Check if all sessions are complete (trigger reaction only once)
-      const activeSessions = sessions.filter((s) => s.status !== "merged" && s.status !== "killed");
+      // Check if all sessions are complete (trigger reaction only once).
+      // Use tracked status instead of session.status, because session.status may be
+      // overridden by enrichSessionWithRuntimeState (which marks dead runtimes as
+      // "killed" regardless of the actual PR-based status we're tracking).
+      const activeSessions = sessions.filter((s) => {
+        const tracked = states.get(s.id);
+        const status = tracked ?? s.status;
+        return status !== "merged" && status !== "killed";
+      });
       if (sessions.length > 0 && activeSessions.length === 0 && !allCompleteEmitted) {
         allCompleteEmitted = true;
 


### PR DESCRIPTION
Fixes #700

## Summary

When a session's agent process exits (status: `killed`) but its PR is still open, the lifecycle manager stops polling it entirely. As a result, reactions like `ci-failed`, `merge-conflicts`, and `approved-and-green` never fire for those sessions.

## Changes

- **`alreadyKilled` guard in `determineStatus`**: Skip runtime checks (steps 1-2) for already-dead sessions while still proceeding to PR state evaluation (step 4). This prevents the early return from blocking CI status, conflict detection, and review decision evaluation.

- **`sessionsToCheck` filter in `pollAll`**: Retain killed sessions that have an open PR, ensuring they continue to be polled for CI status, merge conflicts, and approval state.

## Test Plan

- [x] Killed sessions with open PRs now receive `ci-failed` reactions when CI fails
- [x] Killed sessions with open PRs now receive `merge-conflicts` reactions when conflicts appear
- [x] Killed sessions with open PRs now receive `approved-and-green` reactions when approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)