### PR TITLE
fix(scm-github): filter bot comments by __typename to fix GraphQL/REST mismatch

### DIFF
--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -790,7 +790,7 @@ function createGitHubSCM(): SCM {
                     comments(first: 1) {
                       nodes {
                         id
-                        author { login }
+                        author { login __typename }
                         body
                         path
                         line
@@ -815,7 +815,7 @@ function createGitHubSCM(): SCM {
                     comments: {
                       nodes: Array<{
                         id: string;
-                        author: { login: string } | null;
+                        author: { login: string; __typename: string } | null;
                         body: string;
                         path: string | null;
                         line: number | null;
@@ -837,6 +837,9 @@ function createGitHubSCM(): SCM {
             if (t.isResolved) return false; // only pending (unresolved) threads
             const c = t.comments.nodes[0];
             if (!c) return false; // skip threads with no comments
+            // Filter out bot authors via __typename check (catches GitHub App bots)
+            // or BOT_AUTHORS name check (catches non-App bots like snyk-bot)
+            if (c.author?.__typename === "Bot") return false;
             const author = c.author?.login ?? "";
             return !BOT_AUTHORS.has(author);
           })

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -772,6 +772,7 @@ describe("scm-github plugin", () => {
         isResolved: boolean;
         id: string;
         author: string | null;
+        authorTypename?: string | null;
         body: string;
         path: string | null;
         line: number | null;
@@ -790,7 +791,9 @@ describe("scm-github plugin", () => {
                     nodes: [
                       {
                         id: t.id,
-                        author: t.author ? { login: t.author } : null,
+                        author: t.author
+                          ? { login: t.author, __typename: t.authorTypename || "User" }
+                          : null,
                         body: t.body,
                         path: t.path,
                         line: t.line,
@@ -877,6 +880,52 @@ describe("scm-github plugin", () => {
       const comments = await scm.getPendingComments(pr);
       expect(comments).toHaveLength(1);
       expect(comments[0].author).toBe("alice");
+    });
+
+    it("filters out GitHub App bots by __typename (regardless of login format)", async () => {
+      // Simulate GraphQL API returning bot author without [bot] suffix
+      // This is the actual behavior for GitHub App bots
+      mockGh(
+        makeGraphQLThreads([
+          {
+            isResolved: false,
+            id: "C1",
+            author: "alice",
+            body: "Human comment",
+            path: "a.ts",
+            line: 1,
+            url: "u",
+            createdAt: "2025-01-01T00:00:00Z",
+          },
+          {
+            isResolved: false,
+            id: "C2",
+            author: "cursor",
+            authorTypename: "Bot",
+            body: "Cursor Bugbot says fix this",
+            path: "a.ts",
+            line: 2,
+            url: "u",
+            createdAt: "2025-01-01T00:00:00Z",
+          },
+          {
+            isResolved: false,
+            id: "C3",
+            author: "github-actions",
+            authorTypename: "Bot",
+            body: "GitHub Actions comment",
+            path: "a.ts",
+            line: 3,
+            url: "u",
+            createdAt: "2025-01-01T00:00:00Z",
+          },
+        ]),
+      );
+
+      const comments = await scm.getPendingComments(pr);
+      expect(comments).toHaveLength(1);
+      expect(comments[0].author).toBe("alice");
+      // Bot comments should be filtered out even though they don't have [bot] suffix
     });
 
     it("throws on error", async () => {


### PR DESCRIPTION
## Summary

Fixes #702

Bot review comments were leaking through `getPendingComments()` because GitHub's GraphQL API returns bot actor logins **without** the `[bot]` suffix, while REST API returns them **with** it.

| API | Bot login | Example |
|-----|-----------|---------|
| GraphQL | `cursor` | `author { login }` returns `"cursor"` |
| REST | `cursor[bot]` | `user.login` returns `"cursor[bot]"` |

The `BOT_AUTHORS` set contains entries with the `[bot]` suffix, so checking the login alone failed to filter out GitHub App bots (like Cursor Bugbot).

## Changes

- Add `__typename` to GraphQL query's `author` field
- Update TypeScript types to include `__typename`
- Filter out comments where `author.__typename === "Bot"` (catches GitHub App bots) in addition to `BOT_AUTHORS` name check (catches non-App bots like `snyk-bot`)

## Test plan

- [x] All existing tests pass (73 tests)
- [x] Added new test case for `__typename` filtering to verify GitHub App bots are correctly filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)