### PR TITLE
fix(core): expand ${VAR} env var references in config

### DIFF
--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -97,7 +97,7 @@ projects:
 # notifiers:
 #   slack:
 #     plugin: slack
-#     webhook: ${SLACK_WEBHOOK_URL}
+#     webhookUrl: ${SLACK_WEBHOOK_URL}
 #     channel: "#agent-updates"
 
 # Notification routing by priority

--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -21,6 +21,9 @@ describe("Config Loading", () => {
 
     // Change to test directory
     process.chdir(testDir);
+
+    // Clear AO_CONFIG_PATH to avoid picking up parent config
+    delete process.env["AO_CONFIG_PATH"];
   });
 
   afterEach(() => {
@@ -140,6 +143,135 @@ projects:
 
       const config = loadConfig();
       expect(config.port).toBe(3001); // Should use env, not local
+    });
+  });
+
+  describe("Environment Variable Expansion", () => {
+    it("should expand ${VAR} references in config", () => {
+      const configPath = join(testDir, "agent-orchestrator.yaml");
+      writeFileSync(
+        configPath,
+        `
+port: \${TEST_PORT}
+projects:
+  test-project:
+    repo: test/repo
+    path: ${testDir}
+    defaultBranch: main
+`,
+      );
+
+      process.env["TEST_PORT"] = "9999";
+      const config = loadConfig(configPath);
+      expect(config.port).toBe(9999);
+    });
+
+    it("should expand ${VAR} in notifier config", () => {
+      const configPath = join(testDir, "agent-orchestrator.yaml");
+      writeFileSync(
+        configPath,
+        `
+notifiers:
+  slack:
+    plugin: slack
+    webhookUrl: \${SLACK_WEBHOOK_URL}
+projects:
+  test-project:
+    repo: test/repo
+    path: ${testDir}
+    defaultBranch: main
+`,
+      );
+
+      process.env["SLACK_WEBHOOK_URL"] = "https://hooks.slack.com/services/ABC/123/XYZ";
+      const config = loadConfig(configPath);
+      expect(config.notifiers.slack.webhookUrl).toBe(
+        "https://hooks.slack.com/services/ABC/123/XYZ",
+      );
+    });
+
+    it("should leave placeholder unchanged if env var not set", () => {
+      const configPath = join(testDir, "agent-orchestrator.yaml");
+      writeFileSync(
+        configPath,
+        `
+notifiers:
+  slack:
+    plugin: slack
+    webhookUrl: \${UNDEFINED_VAR}
+projects:
+  test-project:
+    repo: test/repo
+    path: ${testDir}
+    defaultBranch: main
+`,
+      );
+
+      // Don't set UNDEFINED_VAR
+      const config = loadConfig(configPath);
+      expect(config.notifiers.slack.webhookUrl).toBe("${UNDEFINED_VAR}");
+    });
+
+    it("should expand multiple env var references", () => {
+      const configPath = join(testDir, "agent-orchestrator.yaml");
+      writeFileSync(
+        configPath,
+        `
+notifiers:
+  slack:
+    plugin: slack
+    webhookUrl: \${SLACK_WEBHOOK_URL}
+  discord:
+    plugin: discord
+    webhookUrl: \${DISCORD_WEBHOOK_URL}
+projects:
+  test-project:
+    repo: test/repo
+    path: \${PROJECT_PATH}
+    defaultBranch: main
+`,
+      );
+
+      process.env["SLACK_WEBHOOK_URL"] = "https://hooks.slack.com/services/ABC/123/XYZ";
+      process.env["DISCORD_WEBHOOK_URL"] = "https://discord.com/api/webhooks/123/abc";
+      process.env["PROJECT_PATH"] = testDir;
+
+      const config = loadConfig(configPath);
+      expect(config.notifiers.slack.webhookUrl).toBe(
+        "https://hooks.slack.com/services/ABC/123/XYZ",
+      );
+      expect(config.notifiers.discord.webhookUrl).toBe(
+        "https://discord.com/api/webhooks/123/abc",
+      );
+      expect(config.projects["test-project"].path).toBe(testDir);
+    });
+
+    it("should expand env var with complex value", () => {
+      const configPath = join(testDir, "agent-orchestrator.yaml");
+      writeFileSync(
+        configPath,
+        `
+notifiers:
+  custom:
+    plugin: custom
+    apiKey: \${API_KEY}
+    endpoint: \${API_ENDPOINT}
+projects:
+  test-project:
+    repo: test/repo
+    path: ${testDir}
+    defaultBranch: main
+`,
+      );
+
+      process.env["API_KEY"] = "sk-1234567890abcdef";
+      process.env["API_ENDPOINT"] = "https://api.example.com/v1/endpoint?param=value";
+
+      const config = loadConfig(configPath);
+      expect(config.notifiers.custom.apiKey).toBe("sk-1234567890abcdef");
+      expect(config.notifiers.custom.endpoint).toBe(
+        "https://api.example.com/v1/endpoint?param=value",
+      );
     });
   });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -210,6 +210,14 @@ function expandHome(filepath: string): string {
   return filepath;
 }
 
+/** Expand ${VAR} environment variable references in a string */
+function expandEnvVars(content: string): string {
+  return content.replace(/\$\{([^}]+)\}/g, (_match, varName) => {
+    const value = process.env[varName];
+    return value !== undefined ? value : `\${${varName}}`;
+  });
+}
+
 /** Expand all path fields in the config */
 function expandPaths(config: OrchestratorConfig): OrchestratorConfig {
   for (const project of Object.values(config.projects)) {
@@ -471,7 +479,8 @@ export function loadConfig(configPath?: string): OrchestratorConfig {
   }
 
   const raw = readFileSync(path, "utf-8");
-  const parsed = parseYaml(raw);
+  const expanded = expandEnvVars(raw);
+  const parsed = parseYaml(expanded);
   const config = validateConfig(parsed);
 
   // Set the config path in the config object for hash generation
@@ -492,7 +501,8 @@ export function loadConfigWithPath(configPath?: string): {
   }
 
   const raw = readFileSync(path, "utf-8");
-  const parsed = parseYaml(raw);
+  const expanded = expandEnvVars(raw);
+  const parsed = parseYaml(expanded);
   const config = validateConfig(parsed);
 
   // Set the config path in the config object for hash generation


### PR DESCRIPTION
## Summary

- Add `expandEnvVars` function that replaces `${VAR}` with `process.env` values
- Update `loadConfig` and `loadConfigWithPath` to expand env vars before parsing
- Add comprehensive tests for env var expansion behavior
- Leave placeholders unchanged if referenced env var is not set

## What Changed

Environment variable references like `${SLACK_WEBHOOK_URL}` in `agent-orchestrator.yaml` are now expanded before YAML parsing, allowing users to keep sensitive values (webhook URLs, API tokens, etc.) in environment variables instead of hardcoding them in config files.

## Test plan

- [x] Add tests for env var expansion in config
- [x] Add tests for env var expansion in notifier config
- [x] Add test for leaving placeholder unchanged if env var not set
- [x] Add test for multiple env var references
- [x] Add test for complex env var values
- [x] All existing tests pass

Fixes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)