### PR TITLE
docs: add GitLab integration example config

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -76,6 +76,18 @@ Use this if:
 - You need agent-specific configuration
 - You're evaluating different AI coding assistants
 
+### [gitlab-integration.yaml](./gitlab-integration.yaml)
+
+**GitLab with merge requests and GitLab Issues**
+
+Uses GitLab as both the SCM (merge requests, CI) and issue tracker. Includes a commented-out self-hosted GitLab example.
+
+Use this if:
+
+- Your project is hosted on GitLab (SaaS or self-hosted)
+- You want to use GitLab Issues for task tracking
+- You want agents to create merge requests instead of pull requests
+
 ## Configuration Tips
 
 1. **Start simple** - Use `simple-github.yaml` as a starting point
@@ -97,6 +109,10 @@ export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
 
 # GitHub (usually set by gh CLI)
 # export GITHUB_TOKEN="ghp_..."
+
+# GitLab (usually set by glab CLI via `glab auth login`)
+# export GITLAB_TOKEN="glpat-..."
+# export GITLAB_WEBHOOK_SECRET="your-webhook-secret"
 ```
 
 Add these to your shell profile (`~/.zshrc` or `~/.bashrc`) to persist them.

--- a/examples/gitlab-integration.yaml
+++ b/examples/gitlab-integration.yaml
@@ -1,0 +1,48 @@
+# GitLab integration with merge requests and GitLab Issues
+# Requires `glab` CLI authenticated (run `glab auth login`)
+
+dataDir: ~/.agent-orchestrator
+worktreeDir: ~/.worktrees
+
+defaults:
+  runtime: tmux
+  agent: claude-code
+  workspace: worktree
+  notifiers: [desktop]
+
+projects:
+  my-app:
+    repo: my-group/my-app
+    path: ~/my-app
+    defaultBranch: main
+
+    # GitLab SCM for merge requests and CI pipelines
+    scm:
+      plugin: gitlab
+
+    # GitLab Issues as the issue tracker
+    tracker:
+      plugin: gitlab
+
+    # Webhook acceleration for faster event processing (optional)
+    # scm:
+    #   plugin: gitlab
+    #   webhook:
+    #     path: /api/webhooks/gitlab
+    #     secretEnvVar: GITLAB_WEBHOOK_SECRET
+
+    agentRules: |
+      Always run tests before pushing.
+      Use conventional commits (feat:, fix:, chore:).
+
+  # Self-hosted GitLab example
+  # internal-app:
+  #   repo: gitlab.company.com/team/internal-app
+  #   path: ~/internal-app
+  #   defaultBranch: main
+  #   scm:
+  #     plugin: gitlab
+  #     host: gitlab.company.com
+  #   tracker:
+  #     plugin: gitlab
+  #     host: gitlab.company.com


### PR DESCRIPTION
adds an example configuration for GitLab SCM (merge requests) and issue tracker integration.