### PR TITLE
feat(core): expose dashboardBaseUrl and include session dashboardUrl in spawn responses (closes #717)

### DIFF
--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -10,6 +10,12 @@ worktreeDir: ~/.worktrees
 # Web dashboard port
 port: 3000
 
+# Optional: publicly reachable base URL for the dashboard. When set, AO will
+# include fully-qualified session URLs (e.g. https://ao.example.com/sessions/ao-1)
+# in spawn responses and notifications. If omitted AO will default to
+# http://localhost:<port> for generated links.
+# dashboardBaseUrl: https://ao.example.com
+
 # Terminal server ports (defaults: 14800/14801 — chosen to avoid conflicts with dev tools)
 # Override when running multiple dashboards to avoid EADDRINUSE
 # terminalPort: 14800

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -137,6 +137,11 @@ async function spawnSession(
     console.log(`  Attach:   ${chalk.dim(`tmux attach -t ${tmuxTarget}`)}`);
     console.log();
 
+    if (session.dashboardUrl) {
+      console.log(`  Dashboard: ${chalk.dim(session.dashboardUrl)}`);
+      console.log();
+    }
+
     // Open terminal tab if requested
     if (openTab) {
       try {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -183,6 +183,7 @@ const DefaultPluginsSchema = z.object({
 
 const OrchestratorConfigSchema = z.object({
   port: z.number().default(3000),
+  dashboardBaseUrl: z.string().url().optional(),
   terminalPort: z.number().optional(),
   directTerminalPort: z.number().optional(),
   readyThresholdMs: z.number().nonnegative().default(300_000),

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1115,6 +1115,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       },
     };
 
+    // Compute dashboard URL if a base is configured (or infer localhost)
+    try {
+      const base = config.dashboardBaseUrl ?? `http://localhost:${config.port ?? 3000}`;
+      session.dashboardUrl = `${base.replace(/\/$/, "")}/sessions/${sessionId}`;
+    } catch {
+      session.dashboardUrl = null;
+    }
+
     try {
       writeMetadata(sessionsDir, sessionId, {
         worktree: workspacePath,
@@ -1394,6 +1402,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         ...(reusableOpenCodeSessionId ? { opencodeSessionId: reusableOpenCodeSessionId } : {}),
       },
     };
+
+    // Attach dashboard URL to orchestrator session as well
+    try {
+      const base = config.dashboardBaseUrl ?? `http://localhost:${config.port ?? 3000}`;
+      session.dashboardUrl = `${base.replace(/\/$/, "")}/sessions/${session.id}`;
+    } catch {
+      session.dashboardUrl = null;
+    }
 
     try {
       writeMetadata(sessionsDir, sessionId, {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -202,6 +202,17 @@ function getSessionNumber(sessionId: string, prefix: string): number | undefined
   return Number.isNaN(parsed) ? undefined : parsed;
 }
 
+/**
+ * Build a dashboard URL for a given session id using the configured base URL
+ * (or a localhost fallback). Returns `null` when no base is available.
+ */
+function buildDashboardUrl(config: OrchestratorConfig, sessionId: string): string | null {
+  const base = config.dashboardBaseUrl ?? `http://localhost:${config.port ?? 3000}`;
+  if (!base) return null;
+  const trimmed = base.replace(/\/+$/, "");
+  return `${trimmed}/sessions/${encodeURIComponent(sessionId)}`;
+}
+
 const PR_TRACKING_STATUSES: ReadonlySet<string> = new Set([
   "pr_open",
   "ci_failed",
@@ -1116,12 +1127,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     };
 
     // Compute dashboard URL if a base is configured (or infer localhost)
-    try {
-      const base = config.dashboardBaseUrl ?? `http://localhost:${config.port ?? 3000}`;
-      session.dashboardUrl = `${base.replace(/\/$/, "")}/sessions/${sessionId}`;
-    } catch {
-      session.dashboardUrl = null;
-    }
+    session.dashboardUrl = buildDashboardUrl(config, sessionId);
 
     try {
       writeMetadata(sessionsDir, sessionId, {
@@ -1404,12 +1410,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     };
 
     // Attach dashboard URL to orchestrator session as well
-    try {
-      const base = config.dashboardBaseUrl ?? `http://localhost:${config.port ?? 3000}`;
-      session.dashboardUrl = `${base.replace(/\/$/, "")}/sessions/${session.id}`;
-    } catch {
-      session.dashboardUrl = null;
-    }
+    session.dashboardUrl = buildDashboardUrl(config, session.id);
 
     try {
       writeMetadata(sessionsDir, sessionId, {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -165,6 +165,9 @@ export interface Session {
   /** Last activity timestamp */
   lastActivityAt: Date;
 
+  /** Optional URL to the dashboard session page (if known) */
+  dashboardUrl?: string | null;
+
   /** When this session was last restored (undefined if never restored) */
   restoredAt?: Date;
 
@@ -912,6 +915,8 @@ export interface OrchestratorConfig {
 
   /** Default reaction configs */
   reactions: Record<string, ReactionConfig>;
+  /** Optional publicly reachable base URL for the dashboard (e.g. https://ao.example.com) */
+  dashboardBaseUrl?: string;
 }
 
 export interface DefaultPlugins {


### PR DESCRIPTION
Expose an optional `dashboardBaseUrl` config option and populate `session.dashboardUrl` when spawning sessions so the CLI and plugins can surface a direct Dashboard link for each session.

**Files Changed**

types.ts: add `dashboardBaseUrl` to `OrchestratorConfig` and `dashboardUrl` to `Session`.
config.ts: validate `dashboardBaseUrl` in config schema.
session-manager.ts: compute and attach `session.dashboardUrl` during spawn flows.
spawn.ts: print `Dashboard: <url>` when available.
agent-orchestrator.yaml.example: document `dashboardBaseUrl` example.

Notes:

- Backwards compatible: `dashboardBaseUrl` is optional; if unset behavior is unchanged.
- No new tests were added (existing test suites pass; see earlier test run: core 484 / cli 224 passed).
- Follow-up: plugin (e.g., OpenClaw) can use `session.dashboardUrl` to construct links - consider updating plugins to prefer that field.

Closes #717 