### PR TITLE
Add Cursor agent plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Spawn parallel AI coding agents, each in its own git worktree. Agents autonomous
 
 Agent Orchestrator manages fleets of AI coding agents working in parallel on your codebase. Each agent gets its own git worktree, its own branch, and its own PR. When CI fails, the agent fixes it. When reviewers leave comments, the agent addresses them. You only get pulled in when human judgment is needed.
 
-**Agent-agnostic** (Claude Code, Codex, Aider) · **Runtime-agnostic** (tmux, Docker) · **Tracker-agnostic** (GitHub, Linear)
+**Agent-agnostic** (Claude Code, Codex, Cursor, Aider) · **Runtime-agnostic** (tmux, Docker) · **Tracker-agnostic** (GitHub, Linear)
 
 <div align="center">
 
@@ -143,7 +143,7 @@ Eight slots. Every abstraction is swappable.
 | Slot      | Default     | Alternatives             |
 | --------- | ----------- | ------------------------ |
 | Runtime   | tmux        | docker, k8s, process     |
-| Agent     | claude-code | codex, aider, opencode   |
+| Agent     | claude-code | codex, aider, cursor, opencode   |
 | Workspace | worktree    | clone                    |
 | Tracker   | github      | linear                   |
 | SCM       | github      | —                        |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -23,7 +23,7 @@ Every abstraction is a swappable plugin. All interfaces are defined in [`package
 | Slot      | Interface   | Default       | Alternatives                             |
 | --------- | ----------- | ------------- | ---------------------------------------- |
 | Runtime   | `Runtime`   | `tmux`        | `process`, `docker`, `k8s`, `ssh`, `e2b` |
-| Agent     | `Agent`     | `claude-code` | `codex`, `aider`, `opencode`             |
+| Agent     | `Agent`     | `claude-code` | `codex`, `aider`, `cursor`, `opencode`   |
 | Workspace | `Workspace` | `worktree`    | `clone`                                  |
 | Tracker   | `Tracker`   | `github`      | `linear`                                 |
 | SCM       | `SCM`       | `github`      | —                                        |
@@ -107,7 +107,7 @@ agent-orchestrator/
 │   ├── web/               # Next.js dashboard
 │   ├── plugins/           # All plugin packages
 │   │   ├── runtime-*/     # Runtime plugins (tmux, docker, k8s)
-│   │   ├── agent-*/       # Agent adapters (claude-code, codex, aider)
+│   │   ├── agent-*/       # Agent adapters (claude-code, codex, aider, cursor)
 │   │   ├── workspace-*/   # Workspace providers (worktree, clone)
 │   │   ├── tracker-*/     # Issue trackers (github, linear)
 │   │   ├── scm-github/    # SCM adapter

--- a/packages/cli/__tests__/lib/detect-agent.test.ts
+++ b/packages/cli/__tests__/lib/detect-agent.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { PluginModule } from "@composio/ao-core";
+import {
+  detectAgentRuntime,
+  detectAvailableAgents,
+} from "../../src/lib/detect-agent.js";
+
+function makePlugin(
+  displayName: string,
+  detectable: boolean,
+): PluginModule {
+  return {
+    manifest: {
+      displayName,
+    },
+    detect: () => detectable,
+  } as PluginModule;
+}
+
+describe("detectAvailableAgents", () => {
+  it("includes cursor when the plugin is installed and detectable", async () => {
+    const loadPlugin = async (pkg: string): Promise<PluginModule | null> => {
+      if (pkg === "@composio/ao-plugin-agent-cursor") {
+        return makePlugin("Cursor", true);
+      }
+      return null;
+    };
+
+    await expect(detectAvailableAgents(loadPlugin)).resolves.toEqual([
+      { name: "cursor", displayName: "Cursor" },
+    ]);
+  });
+
+  it("skips undetectable and missing plugins", async () => {
+    const loadPlugin = async (pkg: string): Promise<PluginModule | null> => {
+      if (pkg === "@composio/ao-plugin-agent-cursor") {
+        return makePlugin("Cursor", false);
+      }
+      if (pkg === "@composio/ao-plugin-agent-codex") {
+        return makePlugin("OpenAI Codex", true);
+      }
+      return null;
+    };
+
+    await expect(detectAvailableAgents(loadPlugin)).resolves.toEqual([
+      { name: "codex", displayName: "OpenAI Codex" },
+    ]);
+  });
+});
+
+describe("detectAgentRuntime", () => {
+  it("selects cursor when it is the only available agent", async () => {
+    await expect(
+      detectAgentRuntime([{ name: "cursor", displayName: "Cursor" }]),
+    ).resolves.toBe("cursor");
+  });
+
+  it("falls back to claude-code when nothing is detected", async () => {
+    await expect(detectAgentRuntime([])).resolves.toBe("claude-code");
+  });
+});

--- a/packages/cli/__tests__/lib/plugins.test.ts
+++ b/packages/cli/__tests__/lib/plugins.test.ts
@@ -71,6 +71,10 @@ describe("getAgentByName", () => {
     expect(getAgentByName("opencode").name).toBe("opencode");
   });
 
+  it("returns agent for cursor", () => {
+    expect(getAgentByName("cursor").name).toBe("cursor");
+  });
+
   it("throws on unknown name", () => {
     expect(() => getAgentByName("unknown")).toThrow("Unknown agent plugin: unknown");
   });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "@composio/ao-plugin-agent-aider": "workspace:*",
     "@composio/ao-plugin-agent-claude-code": "workspace:*",
     "@composio/ao-plugin-agent-codex": "workspace:*",
+    "@composio/ao-plugin-agent-cursor": "workspace:*",
     "@composio/ao-plugin-agent-opencode": "workspace:*",
     "@composio/ao-plugin-notifier-composio": "workspace:*",
     "@composio/ao-plugin-notifier-desktop": "workspace:*",

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -298,6 +298,12 @@ const AGENT_INSTALL_OPTIONS: AgentInstallOption[] = [
     args: ["install", "-g", "@openai/codex"],
   },
   {
+    id: "cursor",
+    label: "Cursor Agent",
+    cmd: "bash",
+    args: ["-lc", "curl https://cursor.com/install -fsS | bash"],
+  },
+  {
     id: "aider",
     label: "Aider",
     cmd: "pipx",

--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -19,7 +19,7 @@ readyThresholdMs: 300000      # Ms before "ready" session becomes "idle" (defaul
 
 defaults:
   runtime: tmux               # tmux | process
-  agent: claude-code          # claude-code | aider | codex | opencode
+  agent: claude-code          # claude-code | aider | codex | cursor | opencode
   workspace: worktree         # worktree | clone
   notifiers:                  # List of active notifier plugins
     - desktop                 # desktop | slack | webhook | composio | openclaw
@@ -117,7 +117,7 @@ notificationRouting:
 
 # ── Available plugins ───────────────────────────────────────────────
 #
-# Agent:     claude-code, aider, codex, opencode
+# Agent:     claude-code, aider, codex, cursor, opencode
 # Runtime:   tmux, process
 # Workspace: worktree, clone
 # SCM:       github, gitlab

--- a/packages/cli/src/lib/detect-agent.ts
+++ b/packages/cli/src/lib/detect-agent.ts
@@ -17,29 +17,37 @@ const AGENT_PLUGINS: Array<{ name: string; pkg: string }> = [
   { name: "claude-code", pkg: "@composio/ao-plugin-agent-claude-code" },
   { name: "aider", pkg: "@composio/ao-plugin-agent-aider" },
   { name: "codex", pkg: "@composio/ao-plugin-agent-codex" },
+  { name: "cursor", pkg: "@composio/ao-plugin-agent-cursor" },
   { name: "opencode", pkg: "@composio/ao-plugin-agent-opencode" },
 ];
+
+type AgentPluginLoader = (pkg: string) => Promise<PluginModule | null>;
+
+async function importAgentPlugin(pkg: string): Promise<PluginModule | null> {
+  try {
+    const raw = await import(pkg);
+    return (raw.detect ? raw : raw.default) as PluginModule;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Discover which agent runtimes are available on this system.
  * Imports each agent plugin and calls its detect() method.
  */
-export async function detectAvailableAgents(): Promise<DetectedAgent[]> {
+export async function detectAvailableAgents(
+  loadPlugin: AgentPluginLoader = importAgentPlugin,
+): Promise<DetectedAgent[]> {
   const available: DetectedAgent[] = [];
 
   for (const { name, pkg } of AGENT_PLUGINS) {
-    try {
-      const raw = await import(pkg);
-      // Handle both named export and default export shapes
-      const mod = (raw.detect ? raw : raw.default) as PluginModule;
-      if (typeof mod?.detect === "function" && mod.detect()) {
-        available.push({
-          name,
-          displayName: mod.manifest?.displayName ?? name,
-        });
-      }
-    } catch {
-      // Plugin not installed or import failed — skip
+    const mod = await loadPlugin(pkg);
+    if (typeof mod?.detect === "function" && mod.detect()) {
+      available.push({
+        name,
+        displayName: mod.manifest?.displayName ?? name,
+      });
     }
   }
 

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -2,6 +2,7 @@ import type { Agent, OrchestratorConfig, SCM } from "@composio/ao-core";
 import claudeCodePlugin from "@composio/ao-plugin-agent-claude-code";
 import codexPlugin from "@composio/ao-plugin-agent-codex";
 import aiderPlugin from "@composio/ao-plugin-agent-aider";
+import cursorPlugin from "@composio/ao-plugin-agent-cursor";
 import opencodePlugin from "@composio/ao-plugin-agent-opencode";
 import githubSCMPlugin from "@composio/ao-plugin-scm-github";
 
@@ -9,6 +10,7 @@ const agentPlugins: Record<string, { create(): Agent }> = {
   "claude-code": claudeCodePlugin,
   codex: codexPlugin,
   aider: aiderPlugin,
+  cursor: cursorPlugin,
   opencode: opencodePlugin,
 };
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,7 +18,7 @@ Every interface the system uses is defined here. If you're working on any part o
 **Main interfaces:**
 
 - `Runtime` — where sessions execute (tmux, docker, k8s)
-- `Agent` — AI coding tool adapter (claude-code, codex, aider)
+- `Agent` — AI coding tool adapter (claude-code, codex, aider, cursor)
 - `Workspace` — code isolation (worktree, clone)
 - `Tracker` — issue tracking (GitHub Issues, Linear)
 - `SCM` — PR/CI/reviews (GitHub, GitLab)
@@ -93,7 +93,7 @@ Loads plugins and provides access to them:
 **Built-in plugins** (loaded by default):
 
 - runtime-tmux, runtime-process
-- agent-claude-code, agent-codex, agent-aider, agent-opencode
+- agent-claude-code, agent-codex, agent-aider, agent-cursor, agent-opencode
 - workspace-worktree, workspace-clone
 - tracker-github, tracker-linear
 - scm-github

--- a/packages/core/src/__tests__/plugin-registry.test.ts
+++ b/packages/core/src/__tests__/plugin-registry.test.ts
@@ -146,11 +146,13 @@ describe("loadBuiltins", () => {
 
     const fakeClaudeCode = makePlugin("agent", "claude-code");
     const fakeCodex = makePlugin("agent", "codex");
+    const fakeCursor = makePlugin("agent", "cursor");
     const fakeOpenCode = makePlugin("agent", "opencode");
 
     await registry.loadBuiltins(undefined, async (pkg: string) => {
       if (pkg === "@composio/ao-plugin-agent-claude-code") return fakeClaudeCode;
       if (pkg === "@composio/ao-plugin-agent-codex") return fakeCodex;
+      if (pkg === "@composio/ao-plugin-agent-cursor") return fakeCursor;
       if (pkg === "@composio/ao-plugin-agent-opencode") return fakeOpenCode;
       throw new Error(`Not found: ${pkg}`);
     });
@@ -158,10 +160,12 @@ describe("loadBuiltins", () => {
     const agents = registry.list("agent");
     expect(agents).toContainEqual(expect.objectContaining({ name: "claude-code", slot: "agent" }));
     expect(agents).toContainEqual(expect.objectContaining({ name: "codex", slot: "agent" }));
+    expect(agents).toContainEqual(expect.objectContaining({ name: "cursor", slot: "agent" }));
     expect(agents).toContainEqual(expect.objectContaining({ name: "opencode", slot: "agent" }));
 
     expect(registry.get("agent", "codex")).not.toBeNull();
     expect(registry.get("agent", "claude-code")).not.toBeNull();
+    expect(registry.get("agent", "cursor")).not.toBeNull();
     expect(registry.get("agent", "opencode")).not.toBeNull();
   });
 

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -1388,7 +1388,7 @@ describe("list", () => {
     expect(sessions[0].activity).toBe("active");
   });
 
-  it.each(["claude-code", "codex", "aider", "opencode"])(
+  it.each(["claude-code", "codex", "aider", "cursor", "opencode"])(
     "uses tmuxName fallback handle for %s activity detection when runtimeHandle is missing",
     async (agentName: string) => {
       const expectedTmuxName = "hash-app-1";

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -31,6 +31,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "claude-code", pkg: "@composio/ao-plugin-agent-claude-code" },
   { slot: "agent", name: "codex", pkg: "@composio/ao-plugin-agent-codex" },
   { slot: "agent", name: "aider", pkg: "@composio/ao-plugin-agent-aider" },
+  { slot: "agent", name: "cursor", pkg: "@composio/ao-plugin-agent-cursor" },
   { slot: "agent", name: "opencode", pkg: "@composio/ao-plugin-agent-opencode" },
   // Workspaces
   { slot: "workspace", name: "worktree", pkg: "@composio/ao-plugin-workspace-worktree" },

--- a/packages/plugins/agent-cursor/package.json
+++ b/packages/plugins/agent-cursor/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@composio/ao-plugin-agent-cursor",
+  "version": "0.2.0",
+  "description": "Agent plugin: Cursor Agent CLI",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-cursor"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-cursor/src/index.test.ts
+++ b/packages/plugins/agent-cursor/src/index.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Session, RuntimeHandle, AgentLaunchConfig } from "@composio/ao-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { AgentLaunchConfig, RuntimeHandle, Session } from "@composio/ao-core";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -21,11 +27,17 @@ vi.mock("node:child_process", () => {
 });
 
 vi.mock("node:fs", async () => {
-  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  const actual = await vi.importActual("node:fs");
   return { ...actual, accessSync: mockAccessSync };
 });
 
-import { create, manifest, detect, default as defaultExport } from "./index.js";
+import {
+  create,
+  detect,
+  manifest,
+  resetCursorCaches,
+  default as defaultExport,
+} from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -79,12 +91,11 @@ function makeLaunchConfig(
 
 function mockTmuxWithProcess(processName: string, found = true) {
   mockExecFileAsync.mockImplementation((cmd: string) => {
-    if (cmd === "tmux")
+    if (cmd === "tmux") {
       return Promise.resolve({ stdout: "/dev/ttys005\n", stderr: "" });
+    }
     if (cmd === "ps") {
-      const line = found
-        ? `  444 ttys005  ${processName}`
-        : "  444 ttys005  zsh";
+      const line = found ? `  444 ttys005  ${processName}` : "  444 ttys005  zsh";
       return Promise.resolve({
         stdout: `  PID TT       ARGS\n${line}\n`,
         stderr: "",
@@ -94,14 +105,229 @@ function mockTmuxWithProcess(processName: string, found = true) {
   });
 }
 
-beforeEach(() => {
+function encodeCursorProjectPath(workspacePath: string): string {
+  return workspacePath.replace(/^[\\/]+/, "").replace(/[/.]/g, "-");
+}
+
+function hashCursorWorkspacePath(workspacePath: string): string {
+  return createHash("md5").update(workspacePath).digest("hex");
+}
+
+async function createCursorStoreDb(params: {
+  storeDbPath: string;
+  chatId: string;
+  title: string;
+  model?: string;
+  inputBlobChars?: number;
+  userPrompt?: string;
+  assistantText?: string;
+}): Promise<void> {
+  const {
+    storeDbPath,
+    chatId,
+    title,
+    model = "gpt-5.4-xhigh-fast",
+    inputBlobChars = 12_000,
+    userPrompt = "Implement Cursor parity",
+    assistantText = "Done",
+  } = params;
+
+  const db = new DatabaseSync(storeDbPath);
+  try {
+    db.exec("CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)");
+    db.exec("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)");
+
+    const meta = Buffer.from(
+      JSON.stringify({
+        agentId: chatId,
+        latestRootBlobId: "root-blob",
+        name: title,
+        lastUsedModel: model,
+        createdAt: Date.now(),
+      }),
+      "utf-8",
+    ).toString("hex");
+
+    db.prepare("INSERT INTO meta (key, value) VALUES (?, ?)").run("0", meta);
+    db.prepare("INSERT INTO blobs (id, data) VALUES (?, ?)").run(
+      "input-context",
+      Buffer.from("X".repeat(inputBlobChars), "utf-8"),
+    );
+    db.prepare("INSERT INTO blobs (id, data) VALUES (?, ?)").run(
+      "user-message",
+      Buffer.from(
+        JSON.stringify({
+          role: "user",
+          content: [{ type: "text", text: userPrompt }],
+          providerOptions: { cursor: { requestId: "req-1" } },
+        }),
+        "utf-8",
+      ),
+    );
+    db.prepare("INSERT INTO blobs (id, data) VALUES (?, ?)").run(
+      "assistant-message",
+      Buffer.from(
+        JSON.stringify({
+          role: "assistant",
+          content: [
+            {
+              type: "reasoning",
+              text: "Thinking...",
+              providerOptions: { cursor: { modelName: model } },
+            },
+            { type: "text", text: assistantText },
+          ],
+          providerOptions: { cursor: { modelName: model } },
+        }),
+        "utf-8",
+      ),
+    );
+  } finally {
+    db.close();
+  }
+}
+
+async function writeCursorSessionFixture(params: {
+  homeDir: string;
+  workspacePath: string;
+  chatId?: string;
+  title?: string;
+  model?: string;
+  firstUserText?: string;
+  assistantText?: string;
+  inputBlobChars?: number;
+  transcriptAgeMs?: number;
+  workerLogAgeMs?: number;
+  workerLogContent?: string;
+  withTranscript?: boolean;
+  withStore?: boolean;
+}): Promise<{ chatId: string; transcriptPath: string; storeDbPath: string; workerLogPath: string }> {
+  const {
+    homeDir,
+    workspacePath,
+    chatId = "cursor-chat-1",
+    title = "Cursor Fixer",
+    model = "gpt-5.4-xhigh-fast",
+    firstUserText = "Implement Cursor parity",
+    assistantText = "Cursor parity is implemented.",
+    inputBlobChars = 12_000,
+    transcriptAgeMs = 0,
+    workerLogAgeMs = 0,
+    workerLogContent = "[info] Applying changes\n",
+    withTranscript = true,
+    withStore = true,
+  } = params;
+
+  const projectDir = join(homeDir, ".cursor", "projects", encodeCursorProjectPath(workspacePath));
+  const transcriptPath = join(
+    projectDir,
+    "agent-transcripts",
+    chatId,
+    `${chatId}.jsonl`,
+  );
+  const workerLogPath = join(projectDir, "worker.log");
+  const storeDbPath = join(
+    homeDir,
+    ".cursor",
+    "chats",
+    hashCursorWorkspacePath(workspacePath),
+    chatId,
+    "store.db",
+  );
+
+  await mkdir(projectDir, { recursive: true });
+  await writeFile(join(projectDir, "repo.json"), JSON.stringify({ id: "repo-1" }) + "\n", "utf-8");
+  await writeFile(workerLogPath, workerLogContent, "utf-8");
+
+  if (withTranscript) {
+    await mkdir(join(projectDir, "agent-transcripts", chatId), { recursive: true });
+    await writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          role: "user",
+          message: {
+            content: [{ type: "text", text: firstUserText }],
+          },
+        }),
+        JSON.stringify({
+          role: "assistant",
+          message: {
+            content: [{ type: "text", text: assistantText }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+  }
+
+  if (withStore) {
+    await mkdir(join(homeDir, ".cursor", "chats", hashCursorWorkspacePath(workspacePath), chatId), {
+      recursive: true,
+    });
+    await createCursorStoreDb({
+      storeDbPath,
+      chatId,
+      title,
+      model,
+      inputBlobChars,
+      userPrompt: firstUserText,
+      assistantText,
+    });
+  }
+
+  const now = Date.now();
+  const transcriptTime = new Date(now - transcriptAgeMs);
+  const workerTime = new Date(now - workerLogAgeMs);
+
+  await utimes(workerLogPath, workerTime, workerTime);
+  if (withTranscript) {
+    await utimes(transcriptPath, transcriptTime, transcriptTime);
+  }
+  if (withStore) {
+    await utimes(storeDbPath, transcriptTime, transcriptTime);
+  }
+
+  return { chatId, transcriptPath, storeDbPath, workerLogPath };
+}
+
+let homeDir = "";
+let originalHome: string | undefined;
+let originalPath: string | undefined;
+
+beforeEach(async () => {
+  originalHome = process.env["HOME"];
+  originalPath = process.env["PATH"];
+  homeDir = await mkdtemp(join(tmpdir(), "ao-cursor-home-"));
+  process.env["HOME"] = homeDir;
+  process.env["PATH"] = "/usr/bin:/bin";
+
   vi.clearAllMocks();
+  resetCursorCaches();
+
   mockExecFileSync.mockImplementation(() => {
     throw new Error("missing");
   });
   mockAccessSync.mockImplementation(() => {
     throw new Error("missing");
   });
+});
+
+afterEach(async () => {
+  resetCursorCaches();
+  if (originalHome === undefined) {
+    delete process.env["HOME"];
+  } else {
+    process.env["HOME"] = originalHome;
+  }
+  if (originalPath === undefined) {
+    delete process.env["PATH"];
+  } else {
+    process.env["PATH"] = originalPath;
+  }
+  if (homeDir) {
+    await rm(homeDir, { recursive: true, force: true });
+  }
 });
 
 // =========================================================================
@@ -113,7 +339,7 @@ describe("plugin manifest & exports", () => {
       name: "cursor",
       slot: "agent",
       description: "Agent plugin: Cursor Agent CLI",
-      version: "0.1.0",
+      version: "0.1.1",
       displayName: "Cursor",
     });
   });
@@ -194,7 +420,6 @@ describe("getLaunchCommand", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig());
     expect(cmd).not.toContain("--mode");
     expect(cmd).not.toContain("--model");
-    expect(cmd).not.toContain("--prompt");
   });
 
   it("combines systemPrompt with prompt into a single initial message", () => {
@@ -270,39 +495,62 @@ describe("getEnvironment", () => {
     expect(env["AO_ISSUE_ID"]).toBe("LIN-99");
   });
 
-  it("omits AO_ISSUE_ID when not provided", () => {
+  it("prepends ~/.ao/bin and preferred gh bin to PATH", () => {
+    process.env["PATH"] = "/opt/custom/bin:/usr/bin";
     const env = agent.getEnvironment(makeLaunchConfig());
-    expect(env["AO_ISSUE_ID"]).toBeUndefined();
+    expect(env["PATH"]).toBe(`${join(homeDir, ".ao", "bin")}:/usr/local/bin:/opt/custom/bin:/usr/bin`);
+    expect(env["GH_PATH"]).toBe("/usr/local/bin/gh");
   });
 
   it("passes through CURSOR_API_KEY from parent env", () => {
-    const original = process.env["CURSOR_API_KEY"];
-    try {
-      process.env["CURSOR_API_KEY"] = "test-key-123";
-      const env = agent.getEnvironment(makeLaunchConfig());
-      expect(env["CURSOR_API_KEY"]).toBe("test-key-123");
-    } finally {
-      if (original === undefined) {
-        delete process.env["CURSOR_API_KEY"];
-      } else {
-        process.env["CURSOR_API_KEY"] = original;
-      }
-    }
+    process.env["CURSOR_API_KEY"] = "test-key-123";
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["CURSOR_API_KEY"]).toBe("test-key-123");
   });
 
   it("passes through CURSOR_AUTH_TOKEN from parent env", () => {
-    const original = process.env["CURSOR_AUTH_TOKEN"];
-    try {
-      process.env["CURSOR_AUTH_TOKEN"] = "auth-token-456";
-      const env = agent.getEnvironment(makeLaunchConfig());
-      expect(env["CURSOR_AUTH_TOKEN"]).toBe("auth-token-456");
-    } finally {
-      if (original === undefined) {
-        delete process.env["CURSOR_AUTH_TOKEN"];
-      } else {
-        process.env["CURSOR_AUTH_TOKEN"] = original;
-      }
-    }
+    process.env["CURSOR_AUTH_TOKEN"] = "auth-token-456";
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["CURSOR_AUTH_TOKEN"]).toBe("auth-token-456");
+  });
+});
+
+// =========================================================================
+// setupWorkspaceHooks
+// =========================================================================
+describe("setupWorkspaceHooks", () => {
+  it("writes metadata wrappers and AGENTS.md context", async () => {
+    const agent = create();
+    const workspacePath = join(homeDir, "workspace", "repo");
+    await mkdir(workspacePath, { recursive: true });
+
+    await agent.setupWorkspaceHooks!(workspacePath, { dataDir: join(homeDir, ".ao-sessions") });
+
+    const aoBinDir = join(homeDir, ".ao", "bin");
+    expect(existsSync(join(aoBinDir, "ao-metadata-helper.sh"))).toBe(true);
+    expect(existsSync(join(aoBinDir, "gh"))).toBe(true);
+    expect(existsSync(join(aoBinDir, "git"))).toBe(true);
+
+    const helper = await readFile(join(aoBinDir, "ao-metadata-helper.sh"), "utf-8");
+    expect(helper).toContain("AO_DATA_DIR");
+    expect(helper).toContain("AO_SESSION");
+
+    const agentsMd = await readFile(join(workspacePath, "AGENTS.md"), "utf-8");
+    expect(agentsMd).toContain("Agent Orchestrator (ao) Session");
+    expect(agentsMd).toContain("update_ao_metadata");
+  });
+
+  it("does not duplicate the AGENTS.md section", async () => {
+    const agent = create();
+    const workspacePath = join(homeDir, "workspace", "repo");
+    await mkdir(workspacePath, { recursive: true });
+    await writeFile(join(workspacePath, "AGENTS.md"), "# Existing\n", "utf-8");
+
+    await agent.setupWorkspaceHooks!(workspacePath, { dataDir: join(homeDir, ".ao-sessions") });
+    await agent.setupWorkspaceHooks!(workspacePath, { dataDir: join(homeDir, ".ao-sessions") });
+
+    const agentsMd = await readFile(join(workspacePath, "AGENTS.md"), "utf-8");
+    expect(agentsMd.match(/Agent Orchestrator \(ao\) Session/g)?.length ?? 0).toBe(1);
   });
 });
 
@@ -325,6 +573,15 @@ describe("isProcessRunning", () => {
   it("returns false when cursor not on tmux pane TTY", async () => {
     mockTmuxWithProcess("cursor-agent", false);
     expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("uses the shared ps cache across calls", async () => {
+    mockTmuxWithProcess("cursor-agent");
+    expect(await agent.isProcessRunning(makeTmuxHandle("pane-1"))).toBe(true);
+    expect(await agent.isProcessRunning(makeTmuxHandle("pane-2"))).toBe(true);
+    expect(
+      mockExecFileAsync.mock.calls.filter(([cmd]) => cmd === "ps"),
+    ).toHaveLength(1);
   });
 
   it("returns true for process handle with alive PID", async () => {
@@ -360,46 +617,6 @@ describe("isProcessRunning", () => {
     expect(await agent.isProcessRunning(makeProcessHandle(789))).toBe(true);
     killSpy.mockRestore();
   });
-
-  it("finds cursor on any pane in multi-pane session", async () => {
-    mockExecFileAsync.mockImplementation((cmd: string) => {
-      if (cmd === "tmux") {
-        return Promise.resolve({
-          stdout: "/dev/ttys001\n/dev/ttys002\n",
-          stderr: "",
-        });
-      }
-      if (cmd === "ps") {
-        return Promise.resolve({
-          stdout:
-            "  PID TT ARGS\n  100 ttys001  bash\n  200 ttys002  cursor agent --prompt fix\n",
-          stderr: "",
-        });
-      }
-      return Promise.reject(new Error("unexpected"));
-    });
-    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
-  });
-
-  it("finds cursor-agent on any pane in multi-pane session", async () => {
-    mockExecFileAsync.mockImplementation((cmd: string) => {
-      if (cmd === "tmux") {
-        return Promise.resolve({
-          stdout: "/dev/ttys001\n/dev/ttys002\n",
-          stderr: "",
-        });
-      }
-      if (cmd === "ps") {
-        return Promise.resolve({
-          stdout:
-            "  PID TT ARGS\n  100 ttys001  bash\n  200 ttys002  cursor-agent --workspace /tmp/repo\n",
-          stderr: "",
-        });
-      }
-      return Promise.reject(new Error("unexpected"));
-    });
-    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
-  });
 });
 
 // =========================================================================
@@ -412,14 +629,8 @@ describe("detectActivity", () => {
     expect(agent.detectActivity("")).toBe("idle");
   });
 
-  it("returns idle for whitespace-only terminal output", () => {
-    expect(agent.detectActivity("   \n  ")).toBe("idle");
-  });
-
   it("returns active for non-empty terminal output", () => {
-    expect(agent.detectActivity("cursor is processing files\n")).toBe(
-      "active",
-    );
+    expect(agent.detectActivity("cursor is processing files\n")).toBe("active");
   });
 
   it("returns idle when showing input prompt", () => {
@@ -427,21 +638,101 @@ describe("detectActivity", () => {
   });
 
   it("returns waiting_input for permission prompts", () => {
-    expect(
-      agent.detectActivity("Editing file.ts\nPermission required to write"),
-    ).toBe("waiting_input");
+    expect(agent.detectActivity("Editing file.ts\nPermission required to write")).toBe("waiting_input");
   });
 
   it("returns waiting_input for yes/no prompts", () => {
-    expect(
-      agent.detectActivity("Apply changes?\n(y)es / (n)o"),
-    ).toBe("waiting_input");
+    expect(agent.detectActivity("Apply changes?\n(y)es / (n)o")).toBe("waiting_input");
+  });
+});
+
+// =========================================================================
+// getActivityState
+// =========================================================================
+describe("getActivityState", () => {
+  const agent = create();
+
+  it("returns ready when the latest transcript entry is assistant output", async () => {
+    const workspacePath = join(homeDir, "workspace", "repo-ready");
+    await writeCursorSessionFixture({
+      homeDir,
+      workspacePath,
+      workerLogAgeMs: 60_000,
+      transcriptAgeMs: 2_000,
+    });
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({
+        workspacePath,
+        runtimeHandle: makeProcessHandle(123),
+      }),
+    );
+    killSpy.mockRestore();
+
+    expect(state?.state).toBe("ready");
   });
 
-  it("returns waiting_input for allow/deny prompts", () => {
-    expect(
-      agent.detectActivity("File access requested\nAllow or Deny?"),
-    ).toBe("waiting_input");
+  it("returns active when worker.log is newer than the transcript", async () => {
+    const workspacePath = join(homeDir, "workspace", "repo-active");
+    await writeCursorSessionFixture({
+      homeDir,
+      workspacePath,
+      workerLogAgeMs: 500,
+      transcriptAgeMs: 15_000,
+      workerLogContent: "[info] Applying changes\n",
+    });
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({
+        workspacePath,
+        runtimeHandle: makeProcessHandle(123),
+      }),
+    );
+    killSpy.mockRestore();
+
+    expect(state?.state).toBe("active");
+  });
+
+  it("returns waiting_input when worker.log shows an approval prompt", async () => {
+    const workspacePath = join(homeDir, "workspace", "repo-waiting");
+    await writeCursorSessionFixture({
+      homeDir,
+      workspacePath,
+      workerLogContent: "MCP Server Approval Required\n[a] Approve all servers\n[c] Continue without approval\n",
+    });
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({
+        workspacePath,
+        runtimeHandle: makeProcessHandle(123),
+      }),
+    );
+    killSpy.mockRestore();
+
+    expect(state?.state).toBe("waiting_input");
+  });
+
+  it("returns blocked when worker.log ends with an error", async () => {
+    const workspacePath = join(homeDir, "workspace", "repo-blocked");
+    await writeCursorSessionFixture({
+      homeDir,
+      workspacePath,
+      workerLogContent: "[error] Request initialize failed with message: boom\n",
+    });
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({
+        workspacePath,
+        runtimeHandle: makeProcessHandle(123),
+      }),
+    );
+    killSpy.mockRestore();
+
+    expect(state?.state).toBe("blocked");
   });
 });
 
@@ -451,11 +742,86 @@ describe("detectActivity", () => {
 describe("getSessionInfo", () => {
   const agent = create();
 
-  it("always returns null (not yet implemented)", async () => {
-    expect(await agent.getSessionInfo(makeSession())).toBeNull();
+  it("extracts summary, chat id, and estimated cost from Cursor session files", async () => {
+    const workspacePath = join(homeDir, "workspace", "repo-info");
+    const { chatId } = await writeCursorSessionFixture({
+      homeDir,
+      workspacePath,
+      chatId: "cursor-chat-42",
+      title: "Cursor Metadata Fixer",
+      model: "gpt-5.4-xhigh-fast",
+      firstUserText: "Implement Cursor parity and metadata tracking",
+      assistantText: "Implemented Cursor parity.",
+      inputBlobChars: 16_000,
+    });
+
+    const info = await agent.getSessionInfo(makeSession({ workspacePath }));
+
+    expect(info?.summary).toBe("Cursor Metadata Fixer");
+    expect(info?.summaryIsFallback).toBe(false);
+    expect(info?.agentSessionId).toBe(chatId);
+    expect(info?.cost?.inputTokens).toBeGreaterThan(3000);
+    expect(info?.cost?.outputTokens).toBeGreaterThan(1);
+    expect(info?.cost?.estimatedCostUsd).toBeGreaterThan(0);
+  });
+
+  it("falls back to the first user prompt when the title is generic", async () => {
+    const workspacePath = join(homeDir, "workspace", "repo-fallback");
+    await writeCursorSessionFixture({
+      homeDir,
+      workspacePath,
+      title: "New Agent",
+      firstUserText: "Fix the broken restore flow for Cursor sessions",
+    });
+
+    const info = await agent.getSessionInfo(makeSession({ workspacePath }));
+    expect(info?.summary).toBe("Fix the broken restore flow for Cursor sessions");
+    expect(info?.summaryIsFallback).toBe(true);
+  });
+
+  it("returns null when no Cursor session artifacts exist", async () => {
     expect(
-      await agent.getSessionInfo(makeSession({ workspacePath: "/some/path" })),
+      await agent.getSessionInfo(makeSession({ workspacePath: join(homeDir, "workspace", "missing") })),
     ).toBeNull();
+  });
+});
+
+// =========================================================================
+// getRestoreCommand
+// =========================================================================
+describe("getRestoreCommand", () => {
+  const agent = create();
+
+  it("resumes the latest chat id with workspace, model, and permissions", async () => {
+    const workspacePath = join(homeDir, "workspace", "repo-restore");
+    await writeCursorSessionFixture({
+      homeDir,
+      workspacePath,
+      chatId: "restore-chat-id",
+      withTranscript: false,
+      withStore: true,
+    });
+
+    const command = await agent.getRestoreCommand(
+      makeSession({ workspacePath }),
+      {
+        name: "my-project",
+        repo: "owner/repo",
+        path: workspacePath,
+        defaultBranch: "main",
+        sessionPrefix: "my",
+        agentConfig: {
+          permissions: "permissionless",
+          model: "gpt-5.4-xhigh-fast",
+        },
+      },
+    );
+
+    expect(command).toBe(
+      "'cursor-agent' --workspace '" +
+        workspacePath +
+        "' --resume 'restore-chat-id' --force --model 'gpt-5.4-xhigh-fast'",
+    );
   });
 });
 
@@ -486,5 +852,21 @@ describe("detect", () => {
     });
 
     expect(detect()).toBe(true);
+  });
+
+  it("caches detect() results", () => {
+    mockExecFileSync.mockImplementation((cmd: string, args?: string[]) => {
+      if (cmd === "which" && args?.[0] === "cursor-agent") {
+        return "/usr/local/bin/cursor-agent\n";
+      }
+      if (cmd === "/usr/local/bin/cursor-agent" && args?.[0] === "--version") {
+        return "2026.03.25-933d5a6";
+      }
+      throw new Error(`unexpected sync command: ${cmd} ${(args ?? []).join(" ")}`);
+    });
+
+    expect(detect()).toBe(true);
+    expect(detect()).toBe(true);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/plugins/agent-cursor/src/index.test.ts
+++ b/packages/plugins/agent-cursor/src/index.test.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Session, RuntimeHandle, AgentLaunchConfig } from "@composio/ao-core";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const { mockExecFileAsync } = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => {
+  const fn = Object.assign((..._args: unknown[]) => {}, {
+    [Symbol.for("nodejs.util.promisify.custom")]: mockExecFileAsync,
+  });
+  return { execFile: fn };
+});
+
+import { create, manifest, default as defaultExport } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "test-1",
+    projectId: "test-project",
+    status: "working",
+    activity: "active",
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/workspace/test",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeTmuxHandle(id = "test-session"): RuntimeHandle {
+  return { id, runtimeName: "tmux", data: {} };
+}
+
+function makeProcessHandle(pid?: number): RuntimeHandle {
+  return {
+    id: "proc-1",
+    runtimeName: "process",
+    data: pid !== undefined ? { pid } : {},
+  };
+}
+
+function makeLaunchConfig(
+  overrides: Partial<AgentLaunchConfig> = {},
+): AgentLaunchConfig {
+  return {
+    sessionId: "sess-1",
+    projectConfig: {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/repo",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+    },
+    ...overrides,
+  };
+}
+
+function mockTmuxWithProcess(processName: string, found = true) {
+  mockExecFileAsync.mockImplementation((cmd: string) => {
+    if (cmd === "tmux")
+      return Promise.resolve({ stdout: "/dev/ttys005\n", stderr: "" });
+    if (cmd === "ps") {
+      const line = found
+        ? `  444 ttys005  ${processName}`
+        : "  444 ttys005  zsh";
+      return Promise.resolve({
+        stdout: `  PID TT       ARGS\n${line}\n`,
+        stderr: "",
+      });
+    }
+    return Promise.reject(new Error("unexpected"));
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// =========================================================================
+// Manifest & Exports
+// =========================================================================
+describe("plugin manifest & exports", () => {
+  it("has correct manifest", () => {
+    expect(manifest).toEqual({
+      name: "cursor",
+      slot: "agent",
+      description: "Agent plugin: Cursor Agent CLI",
+      version: "0.1.0",
+      displayName: "Cursor",
+    });
+  });
+
+  it("create() returns agent with correct name and processName", () => {
+    const agent = create();
+    expect(agent.name).toBe("cursor");
+    expect(agent.processName).toBe("cursor-agent");
+  });
+
+  it("default export is a valid PluginModule", () => {
+    expect(defaultExport.manifest).toBe(manifest);
+    expect(typeof defaultExport.create).toBe("function");
+  });
+});
+
+// =========================================================================
+// getLaunchCommand
+// =========================================================================
+describe("getLaunchCommand", () => {
+  const agent = create();
+
+  it("generates base command with workspace", () => {
+    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe(
+      "'cursor-agent' --workspace '/workspace/repo'",
+    );
+  });
+
+  it("includes --mode plan when permissions=suggest", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "suggest" }),
+    );
+    expect(cmd).toContain("--mode plan");
+  });
+
+  it("includes --force for permissionless", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "permissionless" }),
+    );
+    expect(cmd).toContain("--force");
+  });
+
+  it("includes --model with shell-escaped value", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ model: "claude-sonnet-4-5-20250929" }),
+    );
+    expect(cmd).toContain("--model 'claude-sonnet-4-5-20250929'");
+  });
+
+  it("includes inline prompt as positional argument", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ prompt: "Fix the tests" }),
+    );
+    expect(cmd).toContain("'Fix the tests'");
+  });
+
+  it("combines all options", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        permissions: "suggest",
+        model: "gpt-4o",
+        prompt: "Go",
+      }),
+    );
+    expect(cmd).toBe(
+      "'cursor-agent' --workspace '/workspace/repo' --mode plan --model 'gpt-4o' 'Go'",
+    );
+  });
+
+  it("escapes single quotes in prompt (POSIX shell escaping)", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ prompt: "it's broken" }),
+    );
+    expect(cmd).toContain("'it'\\''s broken'");
+  });
+
+  it("omits optional flags when not provided", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig());
+    expect(cmd).not.toContain("--mode");
+    expect(cmd).not.toContain("--model");
+    expect(cmd).not.toContain("--prompt");
+  });
+
+  it("combines systemPrompt with prompt into a single initial message", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        systemPrompt: "You are a helpful engineer",
+        prompt: "Fix the bug",
+      }),
+    );
+    expect(cmd).toContain("'You are a helpful engineer\n\nFix the bug'");
+  });
+
+  it("prefers systemPromptFile over inline systemPrompt", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        systemPrompt: "inline",
+        systemPromptFile: "/tmp/prompt.txt",
+        prompt: "do the task",
+      }),
+    );
+    expect(cmd).toContain("$(cat '/tmp/prompt.txt'; printf '\\n\\n'; printf %s 'do the task')");
+    expect(cmd).not.toContain("'inline'");
+  });
+
+  it("treats legacy permissions=skip as permissionless", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        permissions: "skip" as unknown as AgentLaunchConfig["permissions"],
+      }),
+    );
+    expect(cmd).toContain("--force");
+  });
+
+  it("includes --force for auto-edit", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "auto-edit" }),
+    );
+    expect(cmd).toContain("--force");
+  });
+});
+
+// =========================================================================
+// getEnvironment
+// =========================================================================
+describe("getEnvironment", () => {
+  const agent = create();
+
+  it("sets AO_SESSION_ID", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["AO_SESSION_ID"]).toBe("sess-1");
+  });
+
+  it("sets AO_ISSUE_ID when provided", () => {
+    const env = agent.getEnvironment(makeLaunchConfig({ issueId: "LIN-99" }));
+    expect(env["AO_ISSUE_ID"]).toBe("LIN-99");
+  });
+
+  it("omits AO_ISSUE_ID when not provided", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["AO_ISSUE_ID"]).toBeUndefined();
+  });
+
+  it("passes through CURSOR_API_KEY from parent env", () => {
+    const original = process.env["CURSOR_API_KEY"];
+    try {
+      process.env["CURSOR_API_KEY"] = "test-key-123";
+      const env = agent.getEnvironment(makeLaunchConfig());
+      expect(env["CURSOR_API_KEY"]).toBe("test-key-123");
+    } finally {
+      if (original === undefined) {
+        delete process.env["CURSOR_API_KEY"];
+      } else {
+        process.env["CURSOR_API_KEY"] = original;
+      }
+    }
+  });
+
+  it("passes through CURSOR_AUTH_TOKEN from parent env", () => {
+    const original = process.env["CURSOR_AUTH_TOKEN"];
+    try {
+      process.env["CURSOR_AUTH_TOKEN"] = "auth-token-456";
+      const env = agent.getEnvironment(makeLaunchConfig());
+      expect(env["CURSOR_AUTH_TOKEN"]).toBe("auth-token-456");
+    } finally {
+      if (original === undefined) {
+        delete process.env["CURSOR_AUTH_TOKEN"];
+      } else {
+        process.env["CURSOR_AUTH_TOKEN"] = original;
+      }
+    }
+  });
+});
+
+// =========================================================================
+// isProcessRunning
+// =========================================================================
+describe("isProcessRunning", () => {
+  const agent = create();
+
+  it("returns true when cursor found on tmux pane TTY", async () => {
+    mockTmuxWithProcess("cursor-agent");
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("returns true when cursor wrapper command found on tmux pane", async () => {
+    mockTmuxWithProcess("cursor agent --prompt hello");
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("returns false when cursor not on tmux pane TTY", async () => {
+    mockTmuxWithProcess("cursor-agent", false);
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns true for process handle with alive PID", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    expect(await agent.isProcessRunning(makeProcessHandle(456))).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(456, 0);
+    killSpy.mockRestore();
+  });
+
+  it("returns false for process handle with dead PID", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(456))).toBe(false);
+    killSpy.mockRestore();
+  });
+
+  it("returns false for unknown runtime without PID", async () => {
+    const handle: RuntimeHandle = { id: "x", runtimeName: "other", data: {} };
+    expect(await agent.isProcessRunning(handle)).toBe(false);
+  });
+
+  it("returns false on tmux command failure", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("tmux gone"));
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns true when PID exists but throws EPERM", async () => {
+    const epermErr = Object.assign(new Error("EPERM"), { code: "EPERM" });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw epermErr;
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(789))).toBe(true);
+    killSpy.mockRestore();
+  });
+
+  it("finds cursor on any pane in multi-pane session", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") {
+        return Promise.resolve({
+          stdout: "/dev/ttys001\n/dev/ttys002\n",
+          stderr: "",
+        });
+      }
+      if (cmd === "ps") {
+        return Promise.resolve({
+          stdout:
+            "  PID TT ARGS\n  100 ttys001  bash\n  200 ttys002  cursor agent --prompt fix\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("finds cursor-agent on any pane in multi-pane session", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") {
+        return Promise.resolve({
+          stdout: "/dev/ttys001\n/dev/ttys002\n",
+          stderr: "",
+        });
+      }
+      if (cmd === "ps") {
+        return Promise.resolve({
+          stdout:
+            "  PID TT ARGS\n  100 ttys001  bash\n  200 ttys002  cursor-agent --workspace /tmp/repo\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+});
+
+// =========================================================================
+// detectActivity — terminal output classification
+// =========================================================================
+describe("detectActivity", () => {
+  const agent = create();
+
+  it("returns idle for empty terminal output", () => {
+    expect(agent.detectActivity("")).toBe("idle");
+  });
+
+  it("returns idle for whitespace-only terminal output", () => {
+    expect(agent.detectActivity("   \n  ")).toBe("idle");
+  });
+
+  it("returns active for non-empty terminal output", () => {
+    expect(agent.detectActivity("cursor is processing files\n")).toBe(
+      "active",
+    );
+  });
+
+  it("returns idle when showing input prompt", () => {
+    expect(agent.detectActivity("some output\n> ")).toBe("idle");
+  });
+
+  it("returns waiting_input for permission prompts", () => {
+    expect(
+      agent.detectActivity("Editing file.ts\nPermission required to write"),
+    ).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for yes/no prompts", () => {
+    expect(
+      agent.detectActivity("Apply changes?\n(y)es / (n)o"),
+    ).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for allow/deny prompts", () => {
+    expect(
+      agent.detectActivity("File access requested\nAllow or Deny?"),
+    ).toBe("waiting_input");
+  });
+});
+
+// =========================================================================
+// getSessionInfo
+// =========================================================================
+describe("getSessionInfo", () => {
+  const agent = create();
+
+  it("always returns null (not yet implemented)", async () => {
+    expect(await agent.getSessionInfo(makeSession())).toBeNull();
+    expect(
+      await agent.getSessionInfo(makeSession({ workspacePath: "/some/path" })),
+    ).toBeNull();
+  });
+});

--- a/packages/plugins/agent-cursor/src/index.test.ts
+++ b/packages/plugins/agent-cursor/src/index.test.ts
@@ -8,14 +8,24 @@ const { mockExecFileAsync } = vi.hoisted(() => ({
   mockExecFileAsync: vi.fn(),
 }));
 
+const { mockExecFileSync, mockAccessSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+  mockAccessSync: vi.fn(),
+}));
+
 vi.mock("node:child_process", () => {
   const fn = Object.assign((..._args: unknown[]) => {}, {
     [Symbol.for("nodejs.util.promisify.custom")]: mockExecFileAsync,
   });
-  return { execFile: fn };
+  return { execFile: fn, execFileSync: mockExecFileSync };
 });
 
-import { create, manifest, default as defaultExport } from "./index.js";
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return { ...actual, accessSync: mockAccessSync };
+});
+
+import { create, manifest, detect, default as defaultExport } from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -86,6 +96,12 @@ function mockTmuxWithProcess(processName: string, found = true) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockExecFileSync.mockImplementation(() => {
+    throw new Error("missing");
+  });
+  mockAccessSync.mockImplementation(() => {
+    throw new Error("missing");
+  });
 });
 
 // =========================================================================
@@ -217,6 +233,24 @@ describe("getLaunchCommand", () => {
       makeLaunchConfig({ permissions: "auto-edit" }),
     );
     expect(cmd).toContain("--force");
+  });
+
+  it("uses the cursor wrapper when cursor-agent is unavailable", () => {
+    const wrapperAgent = create();
+
+    mockExecFileSync.mockImplementation((cmd: string, args?: string[]) => {
+      if (cmd === "which" && args?.[0] === "cursor-agent") {
+        throw new Error("missing");
+      }
+      if (cmd === "which" && args?.[0] === "cursor") {
+        return "/usr/local/bin/cursor\n";
+      }
+      throw new Error(`unexpected sync command: ${cmd} ${(args ?? []).join(" ")}`);
+    });
+
+    expect(wrapperAgent.getLaunchCommand(makeLaunchConfig())).toBe(
+      "'/usr/local/bin/cursor' agent --workspace '/workspace/repo'",
+    );
   });
 });
 
@@ -422,5 +456,35 @@ describe("getSessionInfo", () => {
     expect(
       await agent.getSessionInfo(makeSession({ workspacePath: "/some/path" })),
     ).toBeNull();
+  });
+});
+
+// =========================================================================
+// detect
+// =========================================================================
+describe("detect", () => {
+  it("returns true when only the Cursor app bundle binary is available", () => {
+    mockExecFileSync.mockImplementation((cmd: string, args?: string[]) => {
+      if (cmd === "which" && (args?.[0] === "cursor-agent" || args?.[0] === "cursor")) {
+        throw new Error("missing");
+      }
+      if (
+        cmd === "/Applications/Cursor.app/Contents/Resources/app/bin/cursor" &&
+        args?.[0] === "agent" &&
+        args?.[1] === "--version"
+      ) {
+        return "2026.03.25-933d5a6";
+      }
+      throw new Error(`unexpected sync command: ${cmd} ${(args ?? []).join(" ")}`);
+    });
+
+    mockAccessSync.mockImplementation((path: string) => {
+      if (path === "/Applications/Cursor.app/Contents/Resources/app/bin/cursor") {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    expect(detect()).toBe(true);
   });
 });

--- a/packages/plugins/agent-cursor/src/index.ts
+++ b/packages/plugins/agent-cursor/src/index.ts
@@ -14,7 +14,7 @@ import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import { stat, access } from "node:fs/promises";
 import { basename, join } from "node:path";
-import { constants } from "node:fs";
+import { accessSync, constants } from "node:fs";
 import { homedir } from "node:os";
 
 const execFileAsync = promisify(execFile);
@@ -108,6 +108,14 @@ function buildCursorInvocation(binary: string): string[] {
   return [shellEscape(binary)];
 }
 
+function buildCursorVersionArgs(binary: string): string[] {
+  const binaryName = basename(binary);
+  if (binaryName === "cursor") {
+    return ["agent", "--version"];
+  }
+  return ["--version"];
+}
+
 function buildInitialPrompt(config: AgentLaunchConfig): string | undefined {
   if (config.systemPromptFile) {
     if (config.prompt) {
@@ -140,6 +148,44 @@ function buildInitialPrompt(config: AgentLaunchConfig): string | undefined {
  * Prefer the dedicated `cursor-agent` binary, but fall back to the
  * `cursor agent` wrapper when that's all the user has installed.
  */
+function getCursorBinaryCandidates(): string[] {
+  const home = homedir();
+  return [
+    "/usr/local/bin/cursor-agent",
+    "/opt/homebrew/bin/cursor-agent",
+    join(home, ".local", "bin", "cursor-agent"),
+    "/usr/local/bin/cursor",
+    "/opt/homebrew/bin/cursor",
+    join(home, ".local", "bin", "cursor"),
+    "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+  ];
+}
+
+export function resolveCursorBinarySync(): string {
+  for (const candidate of ["cursor-agent", "cursor"]) {
+    try {
+      const resolved = execFileSync("which", [candidate], {
+        timeout: 10_000,
+        encoding: "utf8",
+      }).trim();
+      if (resolved) return resolved;
+    } catch {
+      // Not found via which
+    }
+  }
+
+  for (const candidate of getCursorBinaryCandidates()) {
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Not found at this location
+    }
+  }
+
+  return "cursor-agent";
+}
+
 export async function resolveCursorBinary(): Promise<string> {
   // 1. Try PATH resolution first
   for (const candidate of ["cursor-agent", "cursor"]) {
@@ -155,18 +201,7 @@ export async function resolveCursorBinary(): Promise<string> {
   }
 
   // 2. Check common install locations
-  const home = homedir();
-  const candidates = [
-    "/usr/local/bin/cursor-agent",
-    "/opt/homebrew/bin/cursor-agent",
-    join(home, ".local", "bin", "cursor-agent"),
-    "/usr/local/bin/cursor",
-    "/opt/homebrew/bin/cursor",
-    join(home, ".local", "bin", "cursor"),
-    "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
-  ];
-
-  for (const candidate of candidates) {
+  for (const candidate of getCursorBinaryCandidates()) {
     try {
       await stat(candidate);
       return candidate;
@@ -197,14 +232,20 @@ export const manifest = {
 
 function createCursorAgent(): Agent {
   let resolvedBinary: string | null = null;
-  let resolvingBinary: Promise<string> | null = null;
+
+  function getResolvedBinary(): string {
+    if (!resolvedBinary) {
+      resolvedBinary = resolveCursorBinarySync();
+    }
+    return resolvedBinary;
+  }
 
   return {
     name: "cursor",
     processName: "cursor-agent",
 
     getLaunchCommand(config: AgentLaunchConfig): string {
-      const binary = resolvedBinary ?? "cursor-agent";
+      const binary = getResolvedBinary();
       const parts: string[] = [
         ...buildCursorInvocation(binary),
         "--workspace",
@@ -358,16 +399,7 @@ function createCursorAgent(): Agent {
     },
 
     async postLaunchSetup(_session: Session): Promise<void> {
-      if (!resolvedBinary) {
-        if (!resolvingBinary) {
-          resolvingBinary = resolveCursorBinary();
-        }
-        try {
-          resolvedBinary = await resolvingBinary;
-        } finally {
-          resolvingBinary = null;
-        }
-      }
+      resolvedBinary = getResolvedBinary();
     },
   };
 }
@@ -382,15 +414,11 @@ export function create(): Agent {
 
 export function detect(): boolean {
   try {
-    execFileSync("cursor-agent", ["--version"], { stdio: "ignore" });
+    const binary = resolveCursorBinarySync();
+    execFileSync(binary, buildCursorVersionArgs(binary), { stdio: "ignore" });
     return true;
   } catch {
-    try {
-      execFileSync("cursor", ["agent", "--version"], { stdio: "ignore" });
-      return true;
-    } catch {
-      return false;
-    }
+    return false;
   }
 }
 

--- a/packages/plugins/agent-cursor/src/index.ts
+++ b/packages/plugins/agent-cursor/src/index.ts
@@ -19,8 +19,8 @@ import { access, mkdir, open, readFile, readdir, rename, stat, writeFile } from 
 import { createHash, randomBytes } from "node:crypto";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
+import { createRequire } from "node:module";
 import { createInterface } from "node:readline";
-import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -530,10 +530,22 @@ function parseCursorMeta(metaHex: string): CursorStoreMeta | null {
   }
 }
 
-function readStoreData(storeDbPath: string): CursorStoreData | null {
-  let db: DatabaseSync | null = null;
+export function readStoreData(storeDbPath: string): CursorStoreData | null {
+  let DatabaseSyncClass: typeof import("node:sqlite").DatabaseSync;
   try {
-    db = new DatabaseSync(storeDbPath, { readOnly: true });
+    // node:sqlite is experimental (Node >= 22.5). Use dynamic require
+    // so the plugin still works without it — we just skip store metadata.
+    const require = createRequire(import.meta.url);
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require("node:sqlite") as typeof import("node:sqlite");
+    DatabaseSyncClass = mod.DatabaseSync;
+  } catch {
+    // node:sqlite not available — gracefully degrade
+    return null;
+  }
+  let db: InstanceType<typeof DatabaseSyncClass> | null = null;
+  try {
+    db = new DatabaseSyncClass(storeDbPath, { readOnly: true });
 
     const metaRow = db
       .prepare("SELECT value FROM meta WHERE key = '0' OR key = 0 LIMIT 1")

--- a/packages/plugins/agent-cursor/src/index.ts
+++ b/packages/plugins/agent-cursor/src/index.ts
@@ -6,16 +6,22 @@ import {
   type AgentLaunchConfig,
   type ActivityDetection,
   type ActivityState,
+  type CostEstimate,
   type PluginModule,
+  type ProjectConfig,
   type RuntimeHandle,
   type Session,
+  type WorkspaceHooksConfig,
 } from "@composio/ao-core";
 import { execFile, execFileSync } from "node:child_process";
-import { promisify } from "node:util";
-import { stat, access } from "node:fs/promises";
-import { basename, join } from "node:path";
-import { accessSync, constants } from "node:fs";
+import { accessSync, constants, createReadStream } from "node:fs";
+import { access, mkdir, open, readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
+import { createHash, randomBytes } from "node:crypto";
 import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { createInterface } from "node:readline";
+import { DatabaseSync } from "node:sqlite";
+import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
@@ -40,65 +46,690 @@ function normalizePermissionMode(
 }
 
 // =============================================================================
-// Cursor Activity Detection Helpers
+// Shared AO Wrapper Setup
 // =============================================================================
 
-/**
- * Check if Cursor has made recent commits (within last 60 seconds).
- * Cursor agent creates commits when making changes, similar to Aider.
- */
-async function hasRecentCommits(workspacePath: string): Promise<boolean> {
+const DEFAULT_PATH = "/usr/bin:/bin";
+const PREFERRED_GH_BIN_DIR = "/usr/local/bin";
+const PREFERRED_GH_PATH = `${PREFERRED_GH_BIN_DIR}/gh`;
+const AO_WRAPPER_VERSION = "0.1.1";
+
+function getAoBinDir(): string {
+  return join(homedir(), ".ao", "bin");
+}
+
+function buildAgentPath(basePath: string | undefined): string {
+  const inherited = (basePath ?? DEFAULT_PATH).split(":").filter(Boolean);
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+
+  const add = (entry: string): void => {
+    if (!entry || seen.has(entry)) return;
+    ordered.push(entry);
+    seen.add(entry);
+  };
+
+  add(getAoBinDir());
+  add(PREFERRED_GH_BIN_DIR);
+  for (const entry of inherited) add(entry);
+
+  return ordered.join(":");
+}
+
+/* eslint-disable no-useless-escape -- \$ escapes are intentional for shell wrapper literals */
+const AO_METADATA_HELPER = `#!/usr/bin/env bash
+# ao-metadata-helper — shared by gh/git wrappers
+# Provides: update_ao_metadata <key> <value>
+
+update_ao_metadata() {
+  local key="\$1" value="\$2"
+  local ao_dir="\${AO_DATA_DIR:-}"
+  local ao_session="\${AO_SESSION:-}"
+
+  [[ -z "\$ao_dir" || -z "\$ao_session" ]] && return 0
+
+  case "\$ao_session" in
+    */* | *..*) return 0 ;;
+  esac
+
+  case "\$ao_dir" in
+    "\$HOME"/.ao/* | "\$HOME"/.agent-orchestrator/* | /tmp/*) ;;
+    *) return 0 ;;
+  esac
+
+  local metadata_file="\$ao_dir/\$ao_session"
+
+  local real_dir real_ao_dir
+  real_ao_dir="\$(cd "\$ao_dir" 2>/dev/null && pwd -P)" || return 0
+  real_dir="\$(cd "\$(dirname "\$metadata_file")" 2>/dev/null && pwd -P)" || return 0
+  [[ "\$real_dir" == "\$real_ao_dir"* ]] || return 0
+
+  [[ -f "\$metadata_file" ]] || return 0
+
+  local temp_file="\${metadata_file}.tmp.\$\$"
+  local clean_value="\$(printf '%s' "\$value" | tr -d '\\n')"
+  local escaped_value="\$(printf '%s' "\$clean_value" | sed 's/[&|\\\\]/\\\\&/g')"
+
+  if grep -q "^\${key}=" "\$metadata_file" 2>/dev/null; then
+    sed "s|^\${key}=.*|\${key}=\${escaped_value}|" "\$metadata_file" > "\$temp_file"
+  else
+    cp "\$metadata_file" "\$temp_file"
+    printf '%s=%s\\n' "\$key" "\$clean_value" >> "\$temp_file"
+  fi
+
+  mv "\$temp_file" "\$metadata_file"
+}
+`;
+
+const GH_WRAPPER = `#!/usr/bin/env bash
+# ao gh wrapper — auto-updates session metadata on PR operations
+
+ao_bin_dir="\$(cd "\$(dirname "\$0")" && pwd)"
+clean_path="\$(echo "\$PATH" | tr ':' '\\n' | grep -Fxv "\$ao_bin_dir" | grep . | tr '\\n' ':')"
+clean_path="\${clean_path%:}"
+real_gh=""
+
+if [[ -n "\${GH_PATH:-}" && -x "\$GH_PATH" ]]; then
+  gh_dir="\$(cd "\$(dirname "\$GH_PATH")" 2>/dev/null && pwd)"
+  if [[ "\$gh_dir" != "\$ao_bin_dir" ]]; then
+    real_gh="\$GH_PATH"
+  fi
+fi
+
+if [[ -z "\$real_gh" ]]; then
+  real_gh="\$(PATH="\$clean_path" command -v gh 2>/dev/null)"
+fi
+
+if [[ -z "\$real_gh" ]]; then
+  echo "ao-wrapper: gh not found in PATH" >&2
+  exit 127
+fi
+
+source "\$ao_bin_dir/ao-metadata-helper.sh" 2>/dev/null || true
+
+case "\$1/\$2" in
+  pr/create|pr/merge)
+    tmpout="\$(mktemp)"
+    trap 'rm -f "\$tmpout"' EXIT
+
+    "\$real_gh" "\$@" 2>&1 | tee "\$tmpout"
+    exit_code=\${PIPESTATUS[0]}
+
+    if [[ \$exit_code -eq 0 ]]; then
+      output="\$(cat "\$tmpout")"
+      case "\$1/\$2" in
+        pr/create)
+          pr_url="\$(echo "\$output" | grep -Eo 'https://github\\.com/[^/]+/[^/]+/pull/[0-9]+' | head -1)"
+          if [[ -n "\$pr_url" ]]; then
+            update_ao_metadata pr "\$pr_url"
+            update_ao_metadata status pr_open
+          fi
+          ;;
+        pr/merge)
+          update_ao_metadata status merged
+          ;;
+      esac
+    fi
+
+    exit \$exit_code
+    ;;
+  *)
+    exec "\$real_gh" "\$@"
+    ;;
+esac
+`;
+
+const GIT_WRAPPER = `#!/usr/bin/env bash
+# ao git wrapper — auto-updates session metadata on branch operations
+
+ao_bin_dir="\$(cd "\$(dirname "\$0")" && pwd)"
+clean_path="\$(echo "\$PATH" | tr ':' '\\n' | grep -Fxv "\$ao_bin_dir" | grep . | tr '\\n' ':')"
+clean_path="\${clean_path%:}"
+real_git="\$(PATH="\$clean_path" command -v git 2>/dev/null)"
+
+if [[ -z "\$real_git" ]]; then
+  echo "ao-wrapper: git not found in PATH" >&2
+  exit 127
+fi
+
+source "\$ao_bin_dir/ao-metadata-helper.sh" 2>/dev/null || true
+
+"\$real_git" "\$@"
+exit_code=\$?
+
+if [[ \$exit_code -eq 0 ]]; then
+  case "\$1/\$2" in
+    checkout/-b)
+      update_ao_metadata branch "\$3"
+      ;;
+    switch/-c)
+      update_ao_metadata branch "\$3"
+      ;;
+  esac
+fi
+
+exit \$exit_code
+`;
+
+const AO_AGENTS_MD_SECTION = `
+## Agent Orchestrator (ao) Session
+
+You are running inside an Agent Orchestrator managed workspace.
+Session metadata is updated automatically via shell wrappers.
+
+If automatic updates fail, you can manually update metadata:
+\`\`\`bash
+~/.ao/bin/ao-metadata-helper.sh  # sourced automatically
+# Then call: update_ao_metadata <key> <value>
+\`\`\`
+`;
+/* eslint-enable no-useless-escape */
+
+async function atomicWriteFile(filePath: string, content: string, mode: number): Promise<void> {
+  const suffix = randomBytes(6).toString("hex");
+  const tmpPath = `${filePath}.tmp.${suffix}`;
+  await writeFile(tmpPath, content, { encoding: "utf-8", mode });
+  await rename(tmpPath, filePath);
+}
+
+async function setupCursorWorkspace(workspacePath: string): Promise<void> {
+  const aoBinDir = getAoBinDir();
+  await mkdir(aoBinDir, { recursive: true });
+
+  await atomicWriteFile(join(aoBinDir, "ao-metadata-helper.sh"), AO_METADATA_HELPER, 0o755);
+
+  const markerPath = join(aoBinDir, ".ao-version");
+  let needsUpdate = true;
   try {
-    const { stdout } = await execFileAsync(
-      "git",
-      ["log", "--since=60 seconds ago", "--format=%H"],
-      { cwd: workspacePath, timeout: 5_000 },
-    );
-    return stdout.trim().length > 0;
+    const existing = await readFile(markerPath, "utf-8");
+    if (existing.trim() === AO_WRAPPER_VERSION) needsUpdate = false;
   } catch {
-    return false;
+    // missing marker => rewrite wrappers
   }
+
+  if (needsUpdate) {
+    await atomicWriteFile(join(aoBinDir, "gh"), GH_WRAPPER, 0o755);
+    await atomicWriteFile(join(aoBinDir, "git"), GIT_WRAPPER, 0o755);
+    await atomicWriteFile(markerPath, AO_WRAPPER_VERSION, 0o644);
+  }
+
+  const agentsMdPath = join(workspacePath, "AGENTS.md");
+  let existingAgents = "";
+  try {
+    existingAgents = await readFile(agentsMdPath, "utf-8");
+  } catch {
+    // AGENTS.md absent
+  }
+
+  if (!existingAgents.includes("Agent Orchestrator (ao) Session")) {
+    const content = existingAgents
+      ? existingAgents.trimEnd() + "\n" + AO_AGENTS_MD_SECTION
+      : AO_AGENTS_MD_SECTION.trimStart();
+    await writeFile(agentsMdPath, content, "utf-8");
+  }
+}
+
+// =============================================================================
+// Cursor Session Discovery and Parsing
+// =============================================================================
+
+const SESSION_ARTIFACT_CACHE_TTL_MS = 30_000;
+const PS_CACHE_TTL_MS = 5_000;
+const DEFAULT_INPUT_TOKEN_CHARS = 4;
+const DEFAULT_OUTPUT_TOKEN_CHARS = 4;
+
+interface CursorTranscriptContentPart {
+  type?: string;
+  text?: string;
+}
+
+interface CursorTranscriptLine {
+  role?: string;
+  message?: {
+    content?: CursorTranscriptContentPart[];
+  };
+}
+
+interface CursorTranscriptData {
+  firstUserText: string | null;
+  lastRole: string | null;
+  assistantChars: number;
+}
+
+interface CursorStoreMeta {
+  agentId?: string;
+  latestRootBlobId?: string;
+  name?: string;
+  mode?: string;
+  createdAt?: number;
+  lastUsedModel?: string;
+}
+
+interface CursorStoreData {
+  title: string | null;
+  model: string | null;
+  inputChars: number;
+}
+
+interface CursorSessionArtifacts {
+  chatId: string;
+  transcriptFile: string | null;
+  storeDbPath: string | null;
+}
+
+let sessionArtifactsCache = new Map<string, { value: CursorSessionArtifacts | null; expiry: number }>();
+let psCache: { output: string; timestamp: number; promise?: Promise<string> } | null = null;
+let detectCache: boolean | null = null;
+let resolvedBinaryCache: string | null = null;
+let resolvingBinaryCache: Promise<string> | null = null;
+
+function countMeaningfulChars(text: string): number {
+  let count = 0;
+  for (const char of text) {
+    const code = char.codePointAt(0) ?? 0;
+    if (char === "\uFFFD") continue;
+    if (code === 9 || code === 10 || code === 13) {
+      count++;
+      continue;
+    }
+    if (code >= 32 && !(code >= 127 && code <= 159)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+function truncateSummary(text: string): string {
+  return text.length > 120 ? text.substring(0, 120) + "..." : text;
+}
+
+function isGenericCursorTitle(title: string | null | undefined): boolean {
+  if (!title) return true;
+  return /^(new agent|untitled|new chat)$/i.test(title.trim());
+}
+
+function extractTranscriptText(parts: CursorTranscriptContentPart[] | undefined): string {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .map((part) => (part?.type === "text" && typeof part.text === "string" ? part.text : ""))
+    .join("")
+    .trim();
 }
 
 function encodeCursorProjectPath(workspacePath: string): string {
   return workspacePath.replace(/^[\\/]+/, "").replace(/[/.]/g, "-");
 }
 
-function getCursorWorkerLogPath(workspacePath: string): string {
-  return join(
-    homedir(),
-    ".cursor",
-    "projects",
-    encodeCursorProjectPath(workspacePath),
-    "worker.log",
-  );
+function hashCursorWorkspacePath(workspacePath: string): string {
+  return createHash("md5").update(workspacePath).digest("hex");
 }
 
-async function getWorkerLogMtime(workspacePath: string): Promise<Date | null> {
+function getCursorProjectDir(workspacePath: string): string {
+  return join(homedir(), ".cursor", "projects", encodeCursorProjectPath(workspacePath));
+}
+
+function getCursorWorkerLogPath(workspacePath: string): string {
+  return join(getCursorProjectDir(workspacePath), "worker.log");
+}
+
+function getCursorTranscriptRoot(workspacePath: string): string {
+  return join(getCursorProjectDir(workspacePath), "agent-transcripts");
+}
+
+function getCursorStoreRoot(workspacePath: string): string {
+  return join(homedir(), ".cursor", "chats", hashCursorWorkspacePath(workspacePath));
+}
+
+async function listCursorTranscriptFiles(
+  workspacePath: string,
+): Promise<Array<{ chatId: string; path: string; mtimeMs: number }>> {
+  const root = getCursorTranscriptRoot(workspacePath);
+  let entries: string[];
   try {
-    const workerLog = getCursorWorkerLogPath(workspacePath);
-    await access(workerLog, constants.R_OK);
-    const stats = await stat(workerLog);
-    return stats.mtime;
+    entries = await readdir(root);
+  } catch {
+    return [];
+  }
+
+  const results: Array<{ chatId: string; path: string; mtimeMs: number }> = [];
+  for (const chatId of entries) {
+    const transcriptPath = join(root, chatId, `${chatId}.jsonl`);
+    try {
+      const s = await stat(transcriptPath);
+      results.push({ chatId, path: transcriptPath, mtimeMs: s.mtimeMs });
+    } catch {
+      // missing transcript file
+    }
+  }
+  return results;
+}
+
+async function listCursorStoreDbs(
+  workspacePath: string,
+): Promise<Array<{ chatId: string; path: string; mtimeMs: number }>> {
+  const root = getCursorStoreRoot(workspacePath);
+  let entries: string[];
+  try {
+    entries = await readdir(root);
+  } catch {
+    return [];
+  }
+
+  const results: Array<{ chatId: string; path: string; mtimeMs: number }> = [];
+  for (const chatId of entries) {
+    const storeDbPath = join(root, chatId, "store.db");
+    try {
+      const s = await stat(storeDbPath);
+      results.push({ chatId, path: storeDbPath, mtimeMs: s.mtimeMs });
+    } catch {
+      // missing store db
+    }
+  }
+  return results;
+}
+
+async function findLatestCursorSessionArtifacts(
+  workspacePath: string,
+): Promise<CursorSessionArtifacts | null> {
+  const candidates = new Map<
+    string,
+    { chatId: string; transcriptFile: string | null; storeDbPath: string | null; latestMtimeMs: number }
+  >();
+
+  for (const transcript of await listCursorTranscriptFiles(workspacePath)) {
+    const existing = candidates.get(transcript.chatId);
+    candidates.set(transcript.chatId, {
+      chatId: transcript.chatId,
+      transcriptFile: transcript.path,
+      storeDbPath: existing?.storeDbPath ?? null,
+      latestMtimeMs: Math.max(existing?.latestMtimeMs ?? 0, transcript.mtimeMs),
+    });
+  }
+
+  for (const store of await listCursorStoreDbs(workspacePath)) {
+    const existing = candidates.get(store.chatId);
+    candidates.set(store.chatId, {
+      chatId: store.chatId,
+      transcriptFile: existing?.transcriptFile ?? null,
+      storeDbPath: store.path,
+      latestMtimeMs: Math.max(existing?.latestMtimeMs ?? 0, store.mtimeMs),
+    });
+  }
+
+  const latest = [...candidates.values()].sort((a, b) => b.latestMtimeMs - a.latestMtimeMs)[0];
+  return latest
+    ? {
+        chatId: latest.chatId,
+        transcriptFile: latest.transcriptFile,
+        storeDbPath: latest.storeDbPath,
+      }
+    : null;
+}
+
+async function findLatestCursorSessionArtifactsCached(
+  workspacePath: string,
+): Promise<CursorSessionArtifacts | null> {
+  const cached = sessionArtifactsCache.get(workspacePath);
+  if (cached && Date.now() < cached.expiry) {
+    return cached.value;
+  }
+
+  const value = await findLatestCursorSessionArtifacts(workspacePath);
+  sessionArtifactsCache.set(workspacePath, {
+    value,
+    expiry: Date.now() + SESSION_ARTIFACT_CACHE_TTL_MS,
+  });
+  return value;
+}
+
+async function readTranscriptData(filePath: string): Promise<CursorTranscriptData | null> {
+  try {
+    const stream = createReadStream(filePath, { encoding: "utf-8" });
+    const lines = createInterface({ input: stream, crlfDelay: Infinity });
+
+    let firstUserText: string | null = null;
+    let lastRole: string | null = null;
+    let assistantChars = 0;
+
+    for await (const rawLine of lines) {
+      const line = rawLine.trim();
+      if (!line) continue;
+
+      try {
+        const parsed = JSON.parse(line) as CursorTranscriptLine;
+        const role = typeof parsed.role === "string" ? parsed.role : null;
+        const text = extractTranscriptText(parsed.message?.content);
+
+        if (role === "user" && !firstUserText && text) {
+          firstUserText = text;
+        }
+        if (role === "assistant" && text) {
+          assistantChars += text.length;
+        }
+        if (role) {
+          lastRole = role;
+        }
+      } catch {
+        // skip malformed transcript lines
+      }
+    }
+
+    return { firstUserText, lastRole, assistantChars };
   } catch {
     return null;
   }
 }
 
-function classifyRecentActivity(
-  mtime: Date,
-  threshold: number,
-): ActivityDetection {
-  const ageMs = Date.now() - mtime.getTime();
-  const activeWindowMs = Math.min(30_000, threshold);
-  if (ageMs < activeWindowMs) {
-    return { state: "active", timestamp: mtime };
+function parseCursorMeta(metaHex: string): CursorStoreMeta | null {
+  try {
+    const decoded = Buffer.from(metaHex, "hex").toString("utf-8");
+    const parsed = JSON.parse(decoded) as CursorStoreMeta;
+    return typeof parsed === "object" && parsed !== null ? parsed : null;
+  } catch {
+    return null;
   }
-  if (ageMs < threshold) {
-    return { state: "ready", timestamp: mtime };
-  }
-  return { state: "idle", timestamp: mtime };
 }
+
+function readStoreData(storeDbPath: string): CursorStoreData | null {
+  let db: DatabaseSync | null = null;
+  try {
+    db = new DatabaseSync(storeDbPath, { readOnly: true });
+
+    const metaRow = db
+      .prepare("SELECT value FROM meta WHERE key = '0' OR key = 0 LIMIT 1")
+      .get() as { value?: string } | undefined;
+    const meta = typeof metaRow?.value === "string" ? parseCursorMeta(metaRow.value) : null;
+
+    let model = meta?.lastUsedModel ?? null;
+    let inputChars = 0;
+
+    const rows = db.prepare("SELECT data FROM blobs").all() as Array<{ data: Uint8Array }>;
+    for (const row of rows) {
+      const rawText = Buffer.from(row.data).toString("utf-8");
+      const text = rawText.trim();
+      if (!text) continue;
+
+      if (!model) {
+        const modelMatch = text.match(/"modelName":"([^"]+)"/);
+        if (modelMatch?.[1]) {
+          model = modelMatch[1];
+        }
+      }
+
+      if (text.includes('"role":"assistant"')) {
+        continue;
+      }
+
+      inputChars += countMeaningfulChars(text);
+    }
+
+    return {
+      title: meta?.name ?? null,
+      model,
+      inputChars,
+    };
+  } catch {
+    return null;
+  } finally {
+    db?.close();
+  }
+}
+
+function estimateCursorCost(
+  inputChars: number,
+  assistantChars: number,
+  model: string | null,
+): CostEstimate | undefined {
+  const inputTokens = Math.max(0, Math.round(inputChars / DEFAULT_INPUT_TOKEN_CHARS));
+  const outputTokens = Math.max(0, Math.round(assistantChars / DEFAULT_OUTPUT_TOKEN_CHARS));
+
+  if (inputTokens === 0 && outputTokens === 0) {
+    return undefined;
+  }
+
+  const modelName = model?.toLowerCase() ?? "";
+  let inputPerMillion = 2.5;
+  let outputPerMillion = 10.0;
+
+  if (modelName.includes("sonnet")) {
+    inputPerMillion = 3.0;
+    outputPerMillion = 15.0;
+  } else if (modelName.includes("opus")) {
+    inputPerMillion = 15.0;
+    outputPerMillion = 75.0;
+  } else if (modelName.includes("haiku")) {
+    inputPerMillion = 0.8;
+    outputPerMillion = 4.0;
+  } else if (modelName.includes("mini")) {
+    inputPerMillion = 0.6;
+    outputPerMillion = 2.4;
+  }
+
+  return {
+    inputTokens,
+    outputTokens,
+    estimatedCostUsd:
+      (inputTokens / 1_000_000) * inputPerMillion +
+      (outputTokens / 1_000_000) * outputPerMillion,
+  };
+}
+
+async function readWorkerLogTail(
+  workspacePath: string,
+  maxBytes = 32_768,
+): Promise<{ text: string; modifiedAt: Date } | null> {
+  const filePath = getCursorWorkerLogPath(workspacePath);
+  try {
+    const s = await stat(filePath);
+    const offset = Math.max(0, s.size - maxBytes);
+
+    const handle = await open(filePath, "r");
+    try {
+      const buffer = Buffer.allocUnsafe(s.size - offset);
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, offset);
+      let content = buffer.subarray(0, bytesRead).toString("utf-8");
+      if (offset > 0) {
+        const firstNewline = content.indexOf("\n");
+        if (firstNewline >= 0) {
+          content = content.slice(firstNewline + 1);
+        }
+      }
+      return { text: content, modifiedAt: s.mtime };
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+async function getCachedProcessList(): Promise<string> {
+  const now = Date.now();
+  if (psCache && now - psCache.timestamp < PS_CACHE_TTL_MS) {
+    if (psCache.promise) return psCache.promise;
+    return psCache.output;
+  }
+
+  const promise = execFileAsync("ps", ["-eo", "pid,tty,args"], {
+    timeout: 5_000,
+  }).then(({ stdout }) => {
+    if (psCache?.promise === promise) {
+      psCache = { output: stdout, timestamp: Date.now() };
+    }
+    return stdout;
+  });
+
+  psCache = { output: "", timestamp: now, promise };
+
+  try {
+    return await promise;
+  } catch {
+    if (psCache?.promise === promise) {
+      psCache = null;
+    }
+    return "";
+  }
+}
+
+function classifyWorkerLogTail(
+  text: string,
+  timestamp: Date,
+  readyThresholdMs: number,
+): ActivityDetection | null {
+  const lines = text
+    .trim()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return null;
+
+  const tail = lines.slice(-40).join("\n");
+  if (
+    /approval required|approve all servers|continue without approval|permission.*required|allow.*deny|approve|reject|\(y\)es.*\(n\)o/i.test(
+      tail,
+    )
+  ) {
+    return { state: "waiting_input", timestamp };
+  }
+  if (/\[error\]|fatal|uncaught|exception|request initialize failed|tool call failed/i.test(tail)) {
+    return { state: "blocked", timestamp };
+  }
+
+  const ageMs = Date.now() - timestamp.getTime();
+  return ageMs <= readyThresholdMs
+    ? { state: "active", timestamp }
+    : { state: "idle", timestamp };
+}
+
+function buildCursorSessionSummary(
+  transcript: CursorTranscriptData | null,
+  store: CursorStoreData | null,
+): { summary: string | null; summaryIsFallback?: boolean } {
+  if (store?.title && !isGenericCursorTitle(store.title)) {
+    return { summary: store.title, summaryIsFallback: false };
+  }
+
+  const firstUserText = transcript?.firstUserText?.trim();
+  if (firstUserText) {
+    return {
+      summary: truncateSummary(firstUserText),
+      summaryIsFallback: true,
+    };
+  }
+
+  if (store?.model) {
+    return {
+      summary: `Cursor session (${store.model})`,
+      summaryIsFallback: true,
+    };
+  }
+
+  return { summary: null };
+}
+
+// =============================================================================
+// Cursor CLI Helpers
+// =============================================================================
 
 function buildCursorInvocation(binary: string): string[] {
   const binaryName = basename(binary);
@@ -139,15 +770,6 @@ function buildInitialPrompt(config: AgentLaunchConfig): string | undefined {
   return undefined;
 }
 
-// =============================================================================
-// Binary Resolution
-// =============================================================================
-
-/**
- * Resolve the Cursor CLI binary path.
- * Prefer the dedicated `cursor-agent` binary, but fall back to the
- * `cursor agent` wrapper when that's all the user has installed.
- */
 function getCursorBinaryCandidates(): string[] {
   const home = homedir();
   return [
@@ -170,7 +792,7 @@ export function resolveCursorBinarySync(): string {
       }).trim();
       if (resolved) return resolved;
     } catch {
-      // Not found via which
+      // not in PATH
     }
   }
 
@@ -179,39 +801,55 @@ export function resolveCursorBinarySync(): string {
       accessSync(candidate, constants.X_OK);
       return candidate;
     } catch {
-      // Not found at this location
+      // not executable
     }
   }
 
   return "cursor-agent";
 }
 
-export async function resolveCursorBinary(): Promise<string> {
-  // 1. Try PATH resolution first
-  for (const candidate of ["cursor-agent", "cursor"]) {
-    try {
-      const { stdout } = await execFileAsync("which", [candidate], {
-        timeout: 10_000,
-      });
-      const resolved = stdout.trim();
-      if (resolved) return resolved;
-    } catch {
-      // Not found via which
-    }
+async function resolveCursorBinaryCached(): Promise<string> {
+  if (resolvedBinaryCache) return resolvedBinaryCache;
+  if (!resolvingBinaryCache) {
+    resolvingBinaryCache = (async () => {
+      for (const candidate of ["cursor-agent", "cursor"]) {
+        try {
+          const { stdout } = await execFileAsync("which", [candidate], {
+            timeout: 10_000,
+          });
+          const resolved = stdout.trim();
+          if (resolved) return resolved;
+        } catch {
+          // not in PATH
+        }
+      }
+
+      for (const candidate of getCursorBinaryCandidates()) {
+        try {
+          await access(candidate, constants.X_OK);
+          return candidate;
+        } catch {
+          // not executable
+        }
+      }
+
+      return "cursor-agent";
+    })();
   }
 
-  // 2. Check common install locations
-  for (const candidate of getCursorBinaryCandidates()) {
-    try {
-      await stat(candidate);
-      return candidate;
-    } catch {
-      // Not found at this location
-    }
+  try {
+    resolvedBinaryCache = await resolvingBinaryCache;
+    return resolvedBinaryCache;
+  } finally {
+    resolvingBinaryCache = null;
   }
+}
 
-  // 3. Fallback: let the shell resolve it
-  return "cursor-agent";
+function getResolvedBinarySync(): string {
+  if (!resolvedBinaryCache) {
+    resolvedBinaryCache = resolveCursorBinarySync();
+  }
+  return resolvedBinaryCache;
 }
 
 // =============================================================================
@@ -222,7 +860,7 @@ export const manifest = {
   name: "cursor",
   slot: "agent" as const,
   description: "Agent plugin: Cursor Agent CLI",
-  version: "0.1.0",
+  version: "0.1.1",
   displayName: "Cursor",
 };
 
@@ -231,21 +869,12 @@ export const manifest = {
 // =============================================================================
 
 function createCursorAgent(): Agent {
-  let resolvedBinary: string | null = null;
-
-  function getResolvedBinary(): string {
-    if (!resolvedBinary) {
-      resolvedBinary = resolveCursorBinarySync();
-    }
-    return resolvedBinary;
-  }
-
   return {
     name: "cursor",
     processName: "cursor-agent",
 
     getLaunchCommand(config: AgentLaunchConfig): string {
-      const binary = getResolvedBinary();
+      const binary = getResolvedBinarySync();
       const parts: string[] = [
         ...buildCursorInvocation(binary),
         "--workspace",
@@ -256,10 +885,7 @@ function createCursorAgent(): Agent {
       if (permissionMode === "suggest") {
         parts.push("--mode", "plan");
       }
-      if (
-        permissionMode === "permissionless" ||
-        permissionMode === "auto-edit"
-      ) {
+      if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
         parts.push("--force");
       }
 
@@ -267,6 +893,8 @@ function createCursorAgent(): Agent {
         parts.push("--model", shellEscape(config.model));
       }
 
+      // Verified against Cursor Agent 2026.03.25: positional prompts keep the
+      // interactive TUI alive after responding, so inline prompt delivery is correct.
       const initialPrompt = buildInitialPrompt(config);
       if (initialPrompt) {
         parts.push(initialPrompt);
@@ -282,6 +910,9 @@ function createCursorAgent(): Agent {
       if (config.issueId) {
         env["AO_ISSUE_ID"] = config.issueId;
       }
+
+      env["PATH"] = buildAgentPath(process.env["PATH"]);
+      env["GH_PATH"] = PREFERRED_GH_PATH;
 
       const apiKey = process.env["CURSOR_API_KEY"];
       if (apiKey) {
@@ -304,7 +935,8 @@ function createCursorAgent(): Agent {
 
       if (/^[>$#]\s*$/.test(lastLine)) return "idle";
 
-      const tail = lines.slice(-5).join("\n");
+      const tail = lines.slice(-8).join("\n");
+      if (/approval required/i.test(tail)) return "waiting_input";
       if (/permission.*required/i.test(tail)) return "waiting_input";
       if (/\(y\)es.*\(n\)o/i.test(tail)) return "waiting_input";
       if (/allow.*deny/i.test(tail)) return "waiting_input";
@@ -318,8 +950,8 @@ function createCursorAgent(): Agent {
       readyThresholdMs?: number,
     ): Promise<ActivityDetection | null> {
       const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
-
       const exitedAt = new Date();
+
       if (!session.runtimeHandle) {
         return { state: "exited", timestamp: exitedAt };
       }
@@ -328,13 +960,49 @@ function createCursorAgent(): Agent {
 
       if (!session.workspacePath) return null;
 
-      const hasCommits = await hasRecentCommits(session.workspacePath);
-      if (hasCommits) return { state: "active" };
+      const workerLog = await readWorkerLogTail(session.workspacePath);
+      const workerClassification = workerLog
+        ? classifyWorkerLogTail(workerLog.text, workerLog.modifiedAt, threshold)
+        : null;
+      if (workerClassification?.state === "waiting_input" || workerClassification?.state === "blocked") {
+        return workerClassification;
+      }
 
-      const workerLogMtime = await getWorkerLogMtime(session.workspacePath);
-      if (!workerLogMtime) return null;
+      const artifacts = await findLatestCursorSessionArtifactsCached(session.workspacePath);
+      const transcriptStats = artifacts?.transcriptFile
+        ? await readTranscriptData(artifacts.transcriptFile)
+        : null;
+      const transcriptTimestamp = artifacts?.transcriptFile
+        ? await stat(artifacts.transcriptFile)
+            .then((s) => s.mtime)
+            .catch(() => null)
+        : null;
 
-      return classifyRecentActivity(workerLogMtime, threshold);
+      if (workerLog && transcriptTimestamp && workerLog.modifiedAt.getTime() > transcriptTimestamp.getTime()) {
+        const ageMs = Date.now() - workerLog.modifiedAt.getTime();
+        if (ageMs <= threshold) {
+          return { state: "active", timestamp: workerLog.modifiedAt };
+        }
+      }
+
+      if (transcriptStats && transcriptTimestamp) {
+        const ageMs = Date.now() - transcriptTimestamp.getTime();
+        if (transcriptStats.lastRole === "assistant") {
+          return {
+            state: ageMs <= threshold ? "ready" : "idle",
+            timestamp: transcriptTimestamp,
+          };
+        }
+        if (transcriptStats.lastRole === "user") {
+          return {
+            state: ageMs <= threshold ? "active" : "idle",
+            timestamp: transcriptTimestamp,
+          };
+        }
+      }
+
+      if (workerClassification) return workerClassification;
+      return null;
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
@@ -352,11 +1020,9 @@ function createCursorAgent(): Agent {
             .filter(Boolean);
           if (ttys.length === 0) return false;
 
-          const { stdout: psOut } = await execFileAsync(
-            "ps",
-            ["-eo", "pid,tty,args"],
-            { timeout: 30_000 },
-          );
+          const psOut = await getCachedProcessList();
+          if (!psOut) return false;
+
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
           const processRe = /(?:^|\/)(?:cursor-agent|cursor)(?:\s|$)/;
           for (const line of psOut.split("\n")) {
@@ -377,11 +1043,7 @@ function createCursorAgent(): Agent {
             process.kill(pid, 0);
             return true;
           } catch (err: unknown) {
-            if (
-              err instanceof Error &&
-              "code" in err &&
-              err.code === "EPERM"
-            ) {
+            if (err instanceof Error && "code" in err && err.code === "EPERM") {
               return true;
             }
             return false;
@@ -394,12 +1056,65 @@ function createCursorAgent(): Agent {
       }
     },
 
-    async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {
-      return null;
+    async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {
+      if (!session.workspacePath) return null;
+
+      const artifacts = await findLatestCursorSessionArtifactsCached(session.workspacePath);
+      if (!artifacts) return null;
+
+      const transcript = artifacts.transcriptFile
+        ? await readTranscriptData(artifacts.transcriptFile)
+        : null;
+      const store = artifacts.storeDbPath ? readStoreData(artifacts.storeDbPath) : null;
+      const summary = buildCursorSessionSummary(transcript, store);
+      const cost = estimateCursorCost(store?.inputChars ?? 0, transcript?.assistantChars ?? 0, store?.model ?? null);
+
+      return {
+        summary: summary.summary,
+        summaryIsFallback: summary.summaryIsFallback,
+        agentSessionId: artifacts.chatId,
+        cost,
+      };
     },
 
-    async postLaunchSetup(_session: Session): Promise<void> {
-      resolvedBinary = getResolvedBinary();
+    async getRestoreCommand(session: Session, project: ProjectConfig): Promise<string | null> {
+      if (!session.workspacePath) return null;
+
+      const artifacts = await findLatestCursorSessionArtifactsCached(session.workspacePath);
+      if (!artifacts?.chatId) return null;
+
+      const binary = getResolvedBinarySync();
+      const parts: string[] = [
+        ...buildCursorInvocation(binary),
+        "--workspace",
+        shellEscape(session.workspacePath),
+        "--resume",
+        shellEscape(artifacts.chatId),
+      ];
+
+      const permissionMode = normalizePermissionMode(project.agentConfig?.permissions);
+      if (permissionMode === "suggest") {
+        parts.push("--mode", "plan");
+      }
+      if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
+        parts.push("--force");
+      }
+
+      if (project.agentConfig?.model) {
+        parts.push("--model", shellEscape(project.agentConfig.model as string));
+      }
+
+      return parts.join(" ");
+    },
+
+    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+      await setupCursorWorkspace(workspacePath);
+    },
+
+    async postLaunchSetup(session: Session): Promise<void> {
+      await resolveCursorBinaryCached();
+      if (!session.workspacePath) return;
+      await setupCursorWorkspace(session.workspacePath);
     },
   };
 }
@@ -412,12 +1127,25 @@ export function create(): Agent {
   return createCursorAgent();
 }
 
+/** Reset module-level caches. Exported for testing only. */
+export function resetCursorCaches(): void {
+  sessionArtifactsCache = new Map();
+  psCache = null;
+  detectCache = null;
+  resolvedBinaryCache = null;
+  resolvingBinaryCache = null;
+}
+
 export function detect(): boolean {
+  if (detectCache !== null) return detectCache;
+
   try {
-    const binary = resolveCursorBinarySync();
+    const binary = getResolvedBinarySync();
     execFileSync(binary, buildCursorVersionArgs(binary), { stdio: "ignore" });
+    detectCache = true;
     return true;
   } catch {
+    detectCache = false;
     return false;
   }
 }

--- a/packages/plugins/agent-cursor/src/index.ts
+++ b/packages/plugins/agent-cursor/src/index.ts
@@ -1,0 +1,397 @@
+import {
+  shellEscape,
+  DEFAULT_READY_THRESHOLD_MS,
+  type Agent,
+  type AgentSessionInfo,
+  type AgentLaunchConfig,
+  type ActivityDetection,
+  type ActivityState,
+  type PluginModule,
+  type RuntimeHandle,
+  type Session,
+} from "@composio/ao-core";
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+import { stat, access } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { constants } from "node:fs";
+import { homedir } from "node:os";
+
+const execFileAsync = promisify(execFile);
+
+// =============================================================================
+// Permission Mode Normalization
+// =============================================================================
+
+function normalizePermissionMode(
+  mode: string | undefined,
+): "permissionless" | "default" | "auto-edit" | "suggest" | undefined {
+  if (!mode) return undefined;
+  if (mode === "skip") return "permissionless";
+  if (
+    mode === "permissionless" ||
+    mode === "default" ||
+    mode === "auto-edit" ||
+    mode === "suggest"
+  ) {
+    return mode;
+  }
+  return undefined;
+}
+
+// =============================================================================
+// Cursor Activity Detection Helpers
+// =============================================================================
+
+/**
+ * Check if Cursor has made recent commits (within last 60 seconds).
+ * Cursor agent creates commits when making changes, similar to Aider.
+ */
+async function hasRecentCommits(workspacePath: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["log", "--since=60 seconds ago", "--format=%H"],
+      { cwd: workspacePath, timeout: 5_000 },
+    );
+    return stdout.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function encodeCursorProjectPath(workspacePath: string): string {
+  return workspacePath.replace(/^[\\/]+/, "").replace(/[/.]/g, "-");
+}
+
+function getCursorWorkerLogPath(workspacePath: string): string {
+  return join(
+    homedir(),
+    ".cursor",
+    "projects",
+    encodeCursorProjectPath(workspacePath),
+    "worker.log",
+  );
+}
+
+async function getWorkerLogMtime(workspacePath: string): Promise<Date | null> {
+  try {
+    const workerLog = getCursorWorkerLogPath(workspacePath);
+    await access(workerLog, constants.R_OK);
+    const stats = await stat(workerLog);
+    return stats.mtime;
+  } catch {
+    return null;
+  }
+}
+
+function classifyRecentActivity(
+  mtime: Date,
+  threshold: number,
+): ActivityDetection {
+  const ageMs = Date.now() - mtime.getTime();
+  const activeWindowMs = Math.min(30_000, threshold);
+  if (ageMs < activeWindowMs) {
+    return { state: "active", timestamp: mtime };
+  }
+  if (ageMs < threshold) {
+    return { state: "ready", timestamp: mtime };
+  }
+  return { state: "idle", timestamp: mtime };
+}
+
+function buildCursorInvocation(binary: string): string[] {
+  const binaryName = basename(binary);
+  if (binaryName === "cursor") {
+    return [shellEscape(binary), "agent"];
+  }
+  return [shellEscape(binary)];
+}
+
+function buildInitialPrompt(config: AgentLaunchConfig): string | undefined {
+  if (config.systemPromptFile) {
+    if (config.prompt) {
+      return `"$(cat ${shellEscape(config.systemPromptFile)}; printf '\\n\\n'; printf %s ${shellEscape(config.prompt)})"`;
+    }
+    return `"$(cat ${shellEscape(config.systemPromptFile)})"`;
+  }
+
+  if (config.systemPrompt && config.prompt) {
+    return shellEscape(`${config.systemPrompt}\n\n${config.prompt}`);
+  }
+
+  if (config.systemPrompt) {
+    return shellEscape(config.systemPrompt);
+  }
+
+  if (config.prompt) {
+    return shellEscape(config.prompt);
+  }
+
+  return undefined;
+}
+
+// =============================================================================
+// Binary Resolution
+// =============================================================================
+
+/**
+ * Resolve the Cursor CLI binary path.
+ * Prefer the dedicated `cursor-agent` binary, but fall back to the
+ * `cursor agent` wrapper when that's all the user has installed.
+ */
+export async function resolveCursorBinary(): Promise<string> {
+  // 1. Try PATH resolution first
+  for (const candidate of ["cursor-agent", "cursor"]) {
+    try {
+      const { stdout } = await execFileAsync("which", [candidate], {
+        timeout: 10_000,
+      });
+      const resolved = stdout.trim();
+      if (resolved) return resolved;
+    } catch {
+      // Not found via which
+    }
+  }
+
+  // 2. Check common install locations
+  const home = homedir();
+  const candidates = [
+    "/usr/local/bin/cursor-agent",
+    "/opt/homebrew/bin/cursor-agent",
+    join(home, ".local", "bin", "cursor-agent"),
+    "/usr/local/bin/cursor",
+    "/opt/homebrew/bin/cursor",
+    join(home, ".local", "bin", "cursor"),
+    "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      await stat(candidate);
+      return candidate;
+    } catch {
+      // Not found at this location
+    }
+  }
+
+  // 3. Fallback: let the shell resolve it
+  return "cursor-agent";
+}
+
+// =============================================================================
+// Plugin Manifest
+// =============================================================================
+
+export const manifest = {
+  name: "cursor",
+  slot: "agent" as const,
+  description: "Agent plugin: Cursor Agent CLI",
+  version: "0.1.0",
+  displayName: "Cursor",
+};
+
+// =============================================================================
+// Agent Implementation
+// =============================================================================
+
+function createCursorAgent(): Agent {
+  let resolvedBinary: string | null = null;
+  let resolvingBinary: Promise<string> | null = null;
+
+  return {
+    name: "cursor",
+    processName: "cursor-agent",
+
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      const binary = resolvedBinary ?? "cursor-agent";
+      const parts: string[] = [
+        ...buildCursorInvocation(binary),
+        "--workspace",
+        shellEscape(config.projectConfig.path),
+      ];
+
+      const permissionMode = normalizePermissionMode(config.permissions);
+      if (permissionMode === "suggest") {
+        parts.push("--mode", "plan");
+      }
+      if (
+        permissionMode === "permissionless" ||
+        permissionMode === "auto-edit"
+      ) {
+        parts.push("--force");
+      }
+
+      if (config.model) {
+        parts.push("--model", shellEscape(config.model));
+      }
+
+      const initialPrompt = buildInitialPrompt(config);
+      if (initialPrompt) {
+        parts.push(initialPrompt);
+      }
+
+      return parts.join(" ");
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      const env: Record<string, string> = {};
+
+      env["AO_SESSION_ID"] = config.sessionId;
+      if (config.issueId) {
+        env["AO_ISSUE_ID"] = config.issueId;
+      }
+
+      const apiKey = process.env["CURSOR_API_KEY"];
+      if (apiKey) {
+        env["CURSOR_API_KEY"] = apiKey;
+      }
+
+      const authToken = process.env["CURSOR_AUTH_TOKEN"];
+      if (authToken) {
+        env["CURSOR_AUTH_TOKEN"] = authToken;
+      }
+
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      if (!terminalOutput.trim()) return "idle";
+
+      const lines = terminalOutput.trim().split("\n");
+      const lastLine = lines[lines.length - 1]?.trim() ?? "";
+
+      if (/^[>$#]\s*$/.test(lastLine)) return "idle";
+
+      const tail = lines.slice(-5).join("\n");
+      if (/permission.*required/i.test(tail)) return "waiting_input";
+      if (/\(y\)es.*\(n\)o/i.test(tail)) return "waiting_input";
+      if (/allow.*deny/i.test(tail)) return "waiting_input";
+      if (/approve|reject/i.test(tail)) return "waiting_input";
+
+      return "active";
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
+      const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
+
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) {
+        return { state: "exited", timestamp: exitedAt };
+      }
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (!running) return { state: "exited", timestamp: exitedAt };
+
+      if (!session.workspacePath) return null;
+
+      const hasCommits = await hasRecentCommits(session.workspacePath);
+      if (hasCommits) return { state: "active" };
+
+      const workerLogMtime = await getWorkerLogMtime(session.workspacePath);
+      if (!workerLogMtime) return null;
+
+      return classifyRecentActivity(workerLogMtime, threshold);
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      try {
+        if (handle.runtimeName === "tmux" && handle.id) {
+          const { stdout: ttyOut } = await execFileAsync(
+            "tmux",
+            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+            { timeout: 30_000 },
+          );
+          const ttys = ttyOut
+            .trim()
+            .split("\n")
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (ttys.length === 0) return false;
+
+          const { stdout: psOut } = await execFileAsync(
+            "ps",
+            ["-eo", "pid,tty,args"],
+            { timeout: 30_000 },
+          );
+          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
+          const processRe = /(?:^|\/)(?:cursor-agent|cursor)(?:\s|$)/;
+          for (const line of psOut.split("\n")) {
+            const cols = line.trimStart().split(/\s+/);
+            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+            const args = cols.slice(2).join(" ");
+            if (processRe.test(args)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        const rawPid = handle.data["pid"];
+        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+        if (Number.isFinite(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+            return true;
+          } catch (err: unknown) {
+            if (
+              err instanceof Error &&
+              "code" in err &&
+              err.code === "EPERM"
+            ) {
+              return true;
+            }
+            return false;
+          }
+        }
+
+        return false;
+      } catch {
+        return false;
+      }
+    },
+
+    async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {
+      return null;
+    },
+
+    async postLaunchSetup(_session: Session): Promise<void> {
+      if (!resolvedBinary) {
+        if (!resolvingBinary) {
+          resolvingBinary = resolveCursorBinary();
+        }
+        try {
+          resolvedBinary = await resolvingBinary;
+        } finally {
+          resolvingBinary = null;
+        }
+      }
+    },
+  };
+}
+
+// =============================================================================
+// Plugin Export
+// =============================================================================
+
+export function create(): Agent {
+  return createCursorAgent();
+}
+
+export function detect(): boolean {
+  try {
+    execFileSync("cursor-agent", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    try {
+      execFileSync("cursor", ["agent", "--version"], { stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-cursor/src/readStoreData.sqlite-degrade.test.ts
+++ b/packages/plugins/agent-cursor/src/readStoreData.sqlite-degrade.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("node:module", () => ({
+  createRequire: () => (specifier: string) => {
+    if (specifier === "node:sqlite") {
+      throw new Error("Cannot find module 'node:sqlite'");
+    }
+    throw new Error(`unexpected require: ${specifier}`);
+  },
+}));
+
+import { readStoreData } from "./index.js";
+
+describe("readStoreData when node:sqlite cannot be loaded", () => {
+  it("returns null instead of throwing", () => {
+    expect(readStoreData("/tmp/does-not-matter.db")).toBeNull();
+  });
+});

--- a/packages/plugins/agent-cursor/tsconfig.json
+++ b/packages/plugins/agent-cursor/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@composio/ao-plugin-agent-codex':
         specifier: workspace:*
         version: link:../plugins/agent-codex
+      '@composio/ao-plugin-agent-cursor':
+        specifier: workspace:*
+        version: link:../plugins/agent-cursor
       '@composio/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
@@ -255,6 +258,22 @@ importers:
         version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugins/agent-codex:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/plugins/agent-cursor:
     dependencies:
       '@composio/ao-core':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- add a new `@composio/ao-plugin-agent-cursor` package backed by the current Cursor Agent CLI
- register Cursor in the built-in agent registry, CLI plugin resolution, runtime detection, config instructions, and install flow
- add tests for the new plugin plus CLI/core coverage for Cursor detection and registration
- update the README and development docs to list Cursor as a supported agent option

## Why direct `cursor-agent`
- `agent-orchestrator` launches terminal-native agent runtimes, so integrating the current `cursor-agent` CLI is a better fit than adding an ACP bridge
- support both `cursor-agent` and `cursor agent` detection paths so the plugin works with the standalone binary and Cursor's wrapper command
- map activity detection to Cursor's current on-disk runtime state under `~/.cursor/projects/.../worker.log` rather than the older `~/.cursor-agent/...` layout

## Test Plan
- `pnpm --filter @composio/ao-plugin-agent-cursor test`
- `pnpm --filter @composio/ao-cli test`
- `pnpm --filter @composio/ao-core test`
- `pnpm --filter @composio/ao-plugin-agent-cursor build`
- `pnpm --filter @composio/ao-cli build`
- `pnpm --filter @composio/ao-core build`
- `git diff --check`
