### PR TITLE
fix(web): preserve sessions when project filter is stale

### DIFF
--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -316,6 +316,50 @@ describe("API Routes", () => {
       expect(mockSessionManager.list).toHaveBeenCalledWith("docs-app");
     });
 
+    it("accepts sessionPrefix aliases in project-scoped session queries", async () => {
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockImplementation(
+        async (projectId?: string) =>
+          multiProjectSessions.filter((session) => !projectId || session.projectId === projectId),
+      );
+
+      const res = await sessionsGET(
+        makeRequest("http://localhost:3000/api/sessions?project=docs"),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+
+      expect(data.orchestratorId).toBe("docs-orchestrator");
+      expect(data.orchestrators).toEqual([
+        { id: "docs-orchestrator", projectId: "docs-app", projectName: "Docs App" },
+      ]);
+      expect(data.sessions.map((session: { id: string }) => session.id)).toEqual(["docs-2"]);
+      expect(mockSessionManager.list).toHaveBeenNthCalledWith(1, "docs-app");
+      expect(mockSessionManager.list).toHaveBeenNthCalledWith(2);
+    });
+
+    it("falls back to all sessions when project filter is stale or unknown", async () => {
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        multiProjectSessions,
+      );
+
+      const res = await sessionsGET(
+        makeRequest("http://localhost:3000/api/sessions?project=legacy-app"),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+
+      expect(data.sessions.map((session: { id: string }) => session.id)).toEqual([
+        "backend-3",
+        "docs-2",
+      ]);
+      expect(data.orchestrators).toEqual([
+        { id: "docs-orchestrator", projectId: "docs-app", projectName: "Docs App" },
+        { id: "app-orchestrator", projectId: "my-app", projectName: "My App" },
+      ]);
+      expect(mockSessionManager.list).toHaveBeenCalledTimes(1);
+      expect(mockSessionManager.list).toHaveBeenCalledWith(undefined);
+    });
+
     it("keeps global pause sourced from all projects even for project-scoped requests", async () => {
       const pausedUntil = new Date(Date.now() + 60_000).toISOString();
       const pausedSessions = [
@@ -819,6 +863,26 @@ describe("API Routes", () => {
       expect(event.sessions.length).toBeGreaterThan(0);
       expect(event.sessions[0]).toHaveProperty("id");
       expect(event.sessions[0]).toHaveProperty("attentionLevel");
+    });
+
+    it("falls back to all sessions when SSE project filter is stale or unknown", async () => {
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValue(multiProjectSessions);
+
+      const req = makeRequest("/api/events?project=legacy-app", { method: "GET" });
+      const res = await eventsGET(req);
+      const reader = res.body!.getReader();
+      const { value } = await reader.read();
+      reader.cancel();
+
+      const text = new TextDecoder().decode(value);
+      const jsonStr = text.replace("data: ", "").trim();
+      const event = JSON.parse(jsonStr);
+      expect(event.type).toBe("snapshot");
+      expect(event.sessions.map((session: { id: string }) => session.id).sort()).toEqual([
+        "backend-3",
+        "docs-2",
+      ]);
+      expect(mockSessionManager.list).toHaveBeenCalledWith(undefined);
     });
   });
 

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -1,7 +1,7 @@
 import { getServices } from "@/lib/services";
 import { sessionToDashboard } from "@/lib/serialize";
 import { getAttentionLevel } from "@/lib/types";
-import { filterWorkerSessions } from "@/lib/project-utils";
+import { filterWorkerSessions, resolveProjectFilter } from "@/lib/project-utils";
 import {
   createCorrelationId,
   createProjectObserver,
@@ -29,10 +29,7 @@ export async function GET(request: Request): Promise<Response> {
 
   const ensureObserver = (config: ServicesConfig): ProjectObserver | null => {
     if (!observerProjectId) {
-      const requestedProjectId =
-        projectFilter && projectFilter !== "all" && config.projects[projectFilter]
-          ? projectFilter
-          : undefined;
+      const requestedProjectId = resolveProjectFilter(projectFilter, config.projects);
       observerProjectId = requestedProjectId ?? Object.keys(config.projects)[0];
     }
     if (!observerProjectId) return null;
@@ -72,10 +69,7 @@ export async function GET(request: Request): Promise<Response> {
 
         try {
           const { config, sessionManager } = await getServices();
-          const requestedProjectId =
-            projectFilter && projectFilter !== "all" && config.projects[projectFilter]
-              ? projectFilter
-              : undefined;
+          const requestedProjectId = resolveProjectFilter(projectFilter, config.projects);
           const sessions = await sessionManager.list(requestedProjectId);
           const workerSessions = filterWorkerSessions(sessions, projectFilter, config.projects);
           const dashboardSessions = workerSessions.map(sessionToDashboard);
@@ -131,10 +125,7 @@ export async function GET(request: Request): Promise<Response> {
           let dashboardSessions;
           try {
             const { config, sessionManager } = await getServices();
-            const requestedProjectId =
-              projectFilter && projectFilter !== "all" && config.projects[projectFilter]
-                ? projectFilter
-                : undefined;
+            const requestedProjectId = resolveProjectFilter(projectFilter, config.projects);
             const sessions = await sessionManager.list(requestedProjectId);
             const workerSessions = filterWorkerSessions(sessions, projectFilter, config.projects);
             dashboardSessions = workerSessions.map(sessionToDashboard);

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/serialize";
 import { getCorrelationId, jsonWithCorrelation, recordApiObservation } from "@/lib/observability";
 import { resolveGlobalPause } from "@/lib/global-pause";
-import { filterProjectSessions } from "@/lib/project-utils";
+import { filterProjectSessions, resolveProjectFilter } from "@/lib/project-utils";
 
 const METADATA_ENRICH_TIMEOUT_MS = 3_000;
 const PR_ENRICH_TIMEOUT_MS = 4_000;
@@ -40,10 +40,7 @@ export async function GET(request: Request) {
     const activeOnly = searchParams.get("active") === "true";
 
     const { config, registry, sessionManager } = await getServices();
-    const requestedProjectId =
-      projectFilter && projectFilter !== "all" && config.projects[projectFilter]
-        ? projectFilter
-        : undefined;
+    const requestedProjectId = resolveProjectFilter(projectFilter, config.projects);
     const coreSessions = await sessionManager.list(requestedProjectId);
     const allSessions = requestedProjectId ? await sessionManager.list() : coreSessions;
     const visibleSessions = filterProjectSessions(coreSessions, projectFilter, config.projects);

--- a/packages/web/src/lib/project-utils.ts
+++ b/packages/web/src/lib/project-utils.ts
@@ -3,6 +3,24 @@ import { isOrchestratorSession } from "@composio/ao-core";
 type ProjectWithPrefix = { sessionPrefix?: string };
 type SessionLike = { id: string; projectId: string; metadata?: Record<string, string> };
 
+export function resolveProjectFilter(
+  projectFilter: string | null | undefined,
+  projects: Record<string, ProjectWithPrefix>,
+): string | undefined {
+  if (!projectFilter || projectFilter === "all") return undefined;
+  if (projects[projectFilter]) return projectFilter;
+
+  const matchedByPrefix = Object.entries(projects).find(
+    ([, project]) => project.sessionPrefix === projectFilter,
+  );
+  if (matchedByPrefix) return matchedByPrefix[0];
+
+  const projectIds = Object.keys(projects);
+  if (projectIds.length === 1) return projectIds[0];
+
+  return undefined;
+}
+
 /**
  * Check if a session belongs to a specific project.
  * Matches by projectId or sessionPrefix (same logic as resolveProject).
@@ -28,7 +46,9 @@ export function filterProjectSessions<T extends SessionLike>(
   projects: Record<string, ProjectWithPrefix>,
 ): T[] {
   if (!projectFilter || projectFilter === "all") return sessions;
-  return sessions.filter((session) => matchesProject(session, projectFilter, projects));
+  const resolved = resolveProjectFilter(projectFilter, projects);
+  if (!resolved) return sessions;
+  return sessions.filter((session) => matchesProject(session, resolved, projects));
 }
 
 export function filterWorkerSessions<T extends SessionLike>(


### PR DESCRIPTION
## Summary
- normalize dashboard project filters to accept project IDs and session-prefix aliases
- fall back to all sessions when the project query is stale/unknown instead of returning empty data
- apply the same normalization in both /api/sessions and /api/events to keep SSR + SSE behavior consistent
- add API route regression tests for stale project filters and prefix aliases

## Problem
In some fresh/updated setups, dashboard URLs can carry stale or alias project query values. The API treated these as strict project IDs, which caused empty session responses even while sessions were running.

## Validation
- pnpm --filter @composio/ao-web exec vitest run src/__tests__/api-routes.test.ts