### PR TITLE
fix: disable tmux mouse mode to prevent cursor moving during scrollback

### DIFF
--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -171,20 +171,44 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
 
     console.log(`[DirectTerminal] New connection for session: ${tmuxSessionId}`);
 
-    // Disable tmux mouse mode to prevent cursor from moving during scrollback.
-    // xterm.js handles scrollback natively with scrollback: 10000.
+    // Disable tmux mouse mode so tmux doesn't capture scroll events; this prevents cursor
+    // from jumping while user scrolls. Scrollback is handled by browser terminal client.
     const mouseProc = spawn(TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "off"]);
+    let mouseStderr = "";
+    mouseProc.stderr?.on("data", (data) => {
+      mouseStderr += data.toString();
+    });
     mouseProc.on("error", (err) => {
       console.error(`[DirectTerminal] Failed to disable mouse mode for ${tmuxSessionId}:`, err.message);
+    });
+    mouseProc.on("close", (code) => {
+      if (code !== 0) {
+        console.error(
+          `[DirectTerminal] Failed to disable mouse mode for ${tmuxSessionId}: tmux exited with code ${code}`,
+          mouseStderr ? `stderr: ${mouseStderr}` : "",
+        );
+      }
     });
 
     // Hide the green status bar for cleaner appearance
     const statusProc = spawn(TMUX, ["set-option", "-t", tmuxSessionId, "status", "off"]);
+    let statusStderr = "";
+    statusProc.stderr?.on("data", (data) => {
+      statusStderr += data.toString();
+    });
     statusProc.on("error", (err) => {
       console.error(
         `[DirectTerminal] Failed to hide status bar for ${tmuxSessionId}:`,
         err.message,
       );
+    });
+    statusProc.on("close", (code) => {
+      if (code !== 0) {
+        console.error(
+          `[DirectTerminal] Failed to hide status bar for ${tmuxSessionId}: tmux exited with code ${code}`,
+          statusStderr ? `stderr: ${statusStderr}` : "",
+        );
+      }
     });
 
     // Build complete environment - node-pty requires proper env setup

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -171,10 +171,11 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
 
     console.log(`[DirectTerminal] New connection for session: ${tmuxSessionId}`);
 
-    // Enable mouse mode for scrollback support
-    const mouseProc = spawn(TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "on"]);
+    // Disable tmux mouse mode to prevent cursor from moving during scrollback.
+    // xterm.js handles scrollback natively with scrollback: 10000.
+    const mouseProc = spawn(TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "off"]);
     mouseProc.on("error", (err) => {
-      console.error(`[DirectTerminal] Failed to set mouse mode for ${tmuxSessionId}:`, err.message);
+      console.error(`[DirectTerminal] Failed to disable mouse mode for ${tmuxSessionId}:`, err.message);
     });
 
     // Hide the green status bar for cleaner appearance

--- a/packages/web/server/terminal-websocket.ts
+++ b/packages/web/server/terminal-websocket.ts
@@ -186,10 +186,11 @@ function getOrSpawnTtyd(sessionId: string, tmuxSessionName: string): TtydInstanc
   metrics.totalSpawns += 1;
   metrics.lastSpawnAt = new Date().toISOString();
 
-  // Enable mouse mode for scrollback support
-  const mouseProc = spawn(TMUX, ["set-option", "-t", tmuxSessionName, "mouse", "on"]);
+  // Disable tmux mouse mode to prevent cursor from moving during scrollback.
+  // ttyd/xterm.js handles scrollback natively with scrollback: 10000.
+  const mouseProc = spawn(TMUX, ["set-option", "-t", tmuxSessionName, "mouse", "off"]);
   mouseProc.on("error", (err) => {
-    console.error(`[Terminal] Failed to set mouse mode for ${tmuxSessionName}:`, err.message);
+    console.error(`[Terminal] Failed to disable mouse mode for ${tmuxSessionName}:`, err.message);
   });
 
   // Hide the green status bar for cleaner appearance

--- a/packages/web/server/terminal-websocket.ts
+++ b/packages/web/server/terminal-websocket.ts
@@ -186,17 +186,41 @@ function getOrSpawnTtyd(sessionId: string, tmuxSessionName: string): TtydInstanc
   metrics.totalSpawns += 1;
   metrics.lastSpawnAt = new Date().toISOString();
 
-  // Disable tmux mouse mode to prevent cursor from moving during scrollback.
-  // ttyd/xterm.js handles scrollback natively with scrollback: 10000.
+  // Disable tmux mouse mode so tmux doesn't capture scroll events; this prevents cursor
+  // from jumping while user scrolls. Scrollback is handled by browser terminal client.
   const mouseProc = spawn(TMUX, ["set-option", "-t", tmuxSessionName, "mouse", "off"]);
+  let mouseStderr = "";
+  mouseProc.stderr?.on("data", (data) => {
+    mouseStderr += data.toString();
+  });
   mouseProc.on("error", (err) => {
     console.error(`[Terminal] Failed to disable mouse mode for ${tmuxSessionName}:`, err.message);
+  });
+  mouseProc.on("close", (code) => {
+    if (code !== 0) {
+      console.error(
+        `[Terminal] Failed to disable mouse mode for ${tmuxSessionName}: tmux exited with code ${code}`,
+        mouseStderr ? `stderr: ${mouseStderr}` : "",
+      );
+    }
   });
 
   // Hide the green status bar for cleaner appearance
   const statusProc = spawn(TMUX, ["set-option", "-t", tmuxSessionName, "status", "off"]);
+  let statusStderr = "";
+  statusProc.stderr?.on("data", (data) => {
+    statusStderr += data.toString();
+  });
   statusProc.on("error", (err) => {
     console.error(`[Terminal] Failed to hide status bar for ${tmuxSessionName}:`, err.message);
+  });
+  statusProc.on("close", (code) => {
+    if (code !== 0) {
+      console.error(
+        `[Terminal] Failed to hide status bar for ${tmuxSessionName}: tmux exited with code ${code}`,
+        statusStderr ? `stderr: ${statusStderr}` : "",
+      );
+    }
   });
 
   // Use user-facing sessionId for base-path (matches URL the dashboard uses)


### PR DESCRIPTION
## Summary

Fixes #738

Previously, `tmux mouse on` was enabled when terminal connections were established. This caused tmux to intercept mouse wheel events and scroll its own viewport, making the blinking cursor/active prompt appear to travel up/down as the user scrolled terminal history.

## Changes

- **`packages/web/server/direct-terminal-ws.ts`**: Changed `tmux mouse on` to `tmux mouse off`
- **`packages/web/server/terminal-websocket.ts`**: Changed `tmux mouse on` to `tmux mouse off`

## Expected behavior after fix

Now tmux mouse mode is disabled, allowing xterm.js to handle scrollback natively with its `scrollback: 10000` configuration. This keeps the active prompt/cursor anchored at the bottom of the viewport while viewing prior output, matching expected terminal behavior.

## Test plan

- [ ] Start an AO worker session that uses Codex
- [ ] Open the session in the AO web UI
- [ ] Wait until Codex is at an interactive prompt
- [ ] Scroll the terminal viewport up/down with mouse wheel/trackpad
- [ ] Verify that the blinking cursor/prompt stays anchored at the bottom while viewing prior output

🤖 Generated with [Claude Code](https://claude.com/claude-code)