### PR TITLE
feat: OpenClaw plugin should know how to construct session dashboard URLs

### DIFF
--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -10,6 +10,11 @@ worktreeDir: ~/.worktrees
 # Web dashboard port
 port: 3000
 
+# Public base URL for the dashboard (optional, for constructing dashboard URLs in notifications)
+# Set this when the dashboard is accessible from a public IP or domain
+# Example: dashboardBaseUrl: http://91.107.194.138:3000
+# dashboardBaseUrl: http://localhost:3000
+
 # Terminal server ports (defaults: 14800/14801 — chosen to avoid conflicts with dev tools)
 # Override when running multiple dashboards to avoid EADDRINUSE
 # terminalPort: 14800

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -5,6 +5,8 @@ import {
   fetchIssues,
   mergeStringLists,
   parseStringArraySetting,
+  getDashboardBaseUrl,
+  constructDashboardUrl,
 } from "./index.ts";
 
 function makeIssue(number: number, title: string, repo: string) {
@@ -121,4 +123,88 @@ test("allowlist helpers preserve existing entries while adding AO requirements",
     "custom:tools",
   ]);
   assert.deepEqual(parseStringArraySetting("null"), []);
+});
+
+test("getDashboardBaseUrl extracts dashboardBaseUrl from config", () => {
+  const mockConfigPath = "/tmp/test-ao-config.yaml";
+  const originalResolveAoConfigPath = (global as any).__resolveAoConfigPath;
+  const originalReadFileSync = (global as any).__readFileSync;
+
+  (global as any).__resolveAoConfigPath = () => mockConfigPath;
+  (global as any).__readFileSync = (path: string) => {
+    if (path === mockConfigPath) {
+      return "port: 3000\ndashboardBaseUrl: http://91.107.194.138:3000\n\nprojects:\n  test:\n    repo: test/repo";
+    }
+    throw new Error("Unexpected read");
+  };
+
+  try {
+    const config = { aoCwd: "/tmp" };
+    const result = getDashboardBaseUrl(config);
+    assert.equal(result, "http://91.107.194.138:3000");
+  } finally {
+    (global as any).__resolveAoConfigPath = originalResolveAoConfigPath;
+    (global as any).__readFileSync = originalReadFileSync;
+  }
+});
+
+test("getDashboardBaseUrl returns null when not configured", () => {
+  const mockConfigPath = "/tmp/test-ao-config.yaml";
+  const originalResolveAoConfigPath = (global as any).__resolveAoConfigPath;
+  const originalReadFileSync = (global as any).__readFileSync;
+
+  (global as any).__resolveAoConfigPath = () => mockConfigPath;
+  (global as any).__readFileSync = (path: string) => {
+    if (path === mockConfigPath) {
+      return "port: 3000\n\nprojects:\n  test:\n    repo: test/repo";
+    }
+    throw new Error("Unexpected read");
+  };
+
+  try {
+    const config = { aoCwd: "/tmp" };
+    const result = getDashboardBaseUrl(config);
+    assert.equal(result, null);
+  } finally {
+    (global as any).__resolveAoConfigPath = originalResolveAoConfigPath;
+    (global as any).__readFileSync = originalReadFileSync;
+  }
+});
+
+test("getDashboardBaseUrl handles quoted URLs", () => {
+  const mockConfigPath = "/tmp/test-ao-config.yaml";
+  const originalResolveAoConfigPath = (global as any).__resolveAoConfigPath;
+  const originalReadFileSync = (global as any).__readFileSync;
+
+  (global as any).__resolveAoConfigPath = () => mockConfigPath;
+  (global as any).__readFileSync = (path: string) => {
+    if (path === mockConfigPath) {
+      return 'dashboardBaseUrl: "http://example.com:3000"\n\nprojects:\n  test:\n    repo: test/repo';
+    }
+    throw new Error("Unexpected read");
+  };
+
+  try {
+    const config = { aoCwd: "/tmp" };
+    const result = getDashboardBaseUrl(config);
+    assert.equal(result, "http://example.com:3000");
+  } finally {
+    (global as any).__resolveAoConfigPath = originalResolveAoConfigPath;
+    (global as any).__readFileSync = originalReadFileSync;
+  }
+});
+
+test("constructDashboardUrl builds correct session URL", () => {
+  assert.equal(
+    constructDashboardUrl("ao-123", "http://example.com:3000"),
+    "http://example.com:3000/sessions/ao-123"
+  );
+  assert.equal(
+    constructDashboardUrl("my-session", "https://dashboard.example.com"),
+    "https://dashboard.example.com/sessions/my-session"
+  );
+  assert.equal(
+    constructDashboardUrl("session-1", "http://example.com:3000/"),
+    "http://example.com:3000/sessions/session-1"
+  );
 });

--- a/openclaw-plugin/index.ts
+++ b/openclaw-plugin/index.ts
@@ -273,6 +273,46 @@ function getConfiguredRepos(config: PluginConfig): string[] {
   }
 }
 
+/** Extract dashboardBaseUrl from agent-orchestrator.yaml config file. */
+function getDashboardBaseUrl(config: PluginConfig): string | null {
+  const configPath = resolveAoConfigPath(config);
+  if (!configPath) return null;
+
+  try {
+    const rawYaml = readFileSync(configPath, "utf-8");
+    const lines = rawYaml.split(/\r?\n/);
+    let inTopLevel = true;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+
+      // End of top-level section (e.g., "projects:")
+      if (trimmed.endsWith(":") && inTopLevel && !trimmed.startsWith("dashboardBaseUrl")) {
+        inTopLevel = false;
+        continue;
+      }
+
+      if (inTopLevel) {
+        const match = trimmed.match(/^dashboardBaseUrl:\s*(.+)$/);
+        if (match) {
+          const url = normalizeYamlScalar(match[1]);
+          return url || null;
+        }
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Construct a dashboard URL for a session ID. */
+function constructDashboardUrl(sessionId: string, baseUrl: string): string {
+  const cleaned = baseUrl.replace(/\/$/, "");
+  return `${cleaned}/sessions/${sessionId}`;
+}
+
 function getIssueRepository(issue: GitHubIssue): string | null {
   if (issue.repository) return issue.repository;
   const match = issue.url.match(/github\.com\/([^/]+\/[^/]+)\/issues\//);
@@ -868,18 +908,58 @@ export default function (api: PluginApi) {
     name: "ao_sessions",
     description:
       "Returns live session data from Agent Orchestrator — what agents are running, " +
-      "their status, branches, and progress. Use when the user asks about status or progress.",
+      "their status, branches, progress, and dashboard URLs. Use when the user asks about status, progress, or wants session detail links.",
     parameters: { type: "object", properties: {}, required: [] },
     async execute() {
-      const result = tryRunAo(config, ["status"]);
+      const result = tryRunAo(config, ["status", "--json"]);
       if (!result.ok) {
         return {
           content: [{ type: "text", text: `Failed to get sessions: ${result.error}` }],
           isError: true,
         };
       }
+      // Parse JSON output and format with dashboard URLs highlighted
+      let output = result.output || "No active sessions.";
+      if (result.output) {
+        try {
+          const sessions = JSON.parse(result.output) as Array<{
+            name: string;
+            role: string;
+            branch: string | null;
+            status: string | null;
+            summary: string | null;
+            pr: string | null;
+            issue: string | null;
+            lastActivity: string;
+            project: string | null;
+            dashboardUrl: string | null;
+          }>;
+          if (sessions.length > 0) {
+            const lines: string[] = [];
+            const dashboardBaseUrl = getDashboardBaseUrl(config);
+            for (const s of sessions) {
+              const role = s.role === "orchestrator" ? "Orchestrator" : "Session";
+              lines.push(`${role}: ${s.name}`);
+              if (s.project) lines.push(`  Project: ${s.project}`);
+              if (s.branch) lines.push(`  Branch: ${s.branch}`);
+              if (s.issue) lines.push(`  Issue: ${s.issue}`);
+              if (s.pr) lines.push(`  PR: ${s.pr}`);
+              if (s.status) lines.push(`  Status: ${s.status}`);
+              if (s.summary) lines.push(`  Summary: ${s.summary.slice(0, 100)}${s.summary.length > 100 ? "..." : ""}`);
+              // Use dashboardUrl from JSON if available, otherwise construct from config
+              const url = s.dashboardUrl || (dashboardBaseUrl ? constructDashboardUrl(s.name, dashboardBaseUrl) : null);
+              if (url) lines.push(`  Dashboard: ${url}`);
+              lines.push("");
+            }
+            output = lines.join("\n");
+          }
+        } catch {
+          // JSON parsing failed, fall back to raw output
+          output = result.output;
+        }
+      }
       return {
-        content: [{ type: "text", text: result.output || "No active sessions." }],
+        content: [{ type: "text", text: output }],
       };
     },
   });
@@ -929,7 +1009,8 @@ export default function (api: PluginApi) {
       "Spawn a durable coding agent (Claude Code, Codex, or OpenCode) on a task. " +
       "Creates an isolated git worktree, starts the agent, and wires up feedback " +
       "loops — CI failures and PR reviews automatically route back to the agent. " +
-      "Works with issue numbers (#42) or without for freeform tasks.",
+      "Works with issue numbers (#42) or without for freeform tasks. " +
+      "Returns a dashboard URL when dashboardBaseUrl is configured.",
     parameters: {
       type: "object",
       properties: {

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -132,6 +132,12 @@ async function spawnSession(
     if (branchStr) console.log(`  Branch:   ${chalk.dim(branchStr)}`);
     if (claimedPrUrl) console.log(`  PR:       ${chalk.dim(claimedPrUrl)}`);
 
+    // Show dashboard URL if configured
+    if (config.dashboardBaseUrl) {
+      const dashboardBaseUrl = config.dashboardBaseUrl.replace(/\/$/, "");
+      console.log(`  Dashboard: ${chalk.dim(`${dashboardBaseUrl}/sessions/${session.id}`)}`);
+    }
+
     // Show the tmux name for attaching (stored in metadata or runtimeHandle)
     const tmuxTarget = session.runtimeHandle?.id ?? session.id;
     console.log(`  Attach:   ${chalk.dim(`tmux attach -t ${tmuxTarget}`)}`);
@@ -400,6 +406,11 @@ export function registerBatchSpawn(program: Command): void {
       if (failed.length > 0) {
         console.log(chalk.red(`Failed ${failed.length} issues:`));
         for (const item of failed) console.log(`  ${item.issue}: ${item.error}`);
+      }
+      // Show dashboard URL hint if configured
+      if (created.length > 0 && config.dashboardBaseUrl) {
+        const dashboardBaseUrl = config.dashboardBaseUrl.replace(/\/$/, "");
+        console.log(chalk.dim(`  Dashboard: ${dashboardBaseUrl}/sessions/[session-id]`));
       }
       console.log();
     });

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -42,6 +42,7 @@ interface SessionInfo {
   reviewDecision: ReviewDecision | null;
   pendingThreads: number | null;
   activity: ActivityState | null;
+  dashboardUrl: string | null;
 }
 
 async function gatherSessionInfo(
@@ -118,6 +119,13 @@ async function gatherSessionInfo(
     }
   }
 
+  // Compute dashboard URL if configured
+  let dashboardUrl: string | null = null;
+  if (projectConfig.dashboardBaseUrl) {
+    const baseUrl = projectConfig.dashboardBaseUrl.replace(/\/$/, "");
+    dashboardUrl = `${baseUrl}/sessions/${session.id}`;
+  }
+
   return {
     name: session.id,
     role: isOrchestratorSession(session) ? "orchestrator" : "worker",
@@ -134,6 +142,7 @@ async function gatherSessionInfo(
     reviewDecision,
     pendingThreads,
     activity,
+    dashboardUrl,
   };
 }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -183,6 +183,7 @@ const DefaultPluginsSchema = z.object({
 
 const OrchestratorConfigSchema = z.object({
   port: z.number().default(3000),
+  dashboardBaseUrl: z.string().url().optional(),
   terminalPort: z.number().optional(),
   directTerminalPort: z.number().optional(),
   readyThresholdMs: z.number().nonnegative().default(300_000),

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -70,14 +70,20 @@ function extractPluginConfig(
       const matches = hasExplicitPlugin ? configuredPlugin === name : notifierName === name;
       if (matches) {
         const { plugin: _plugin, ...rest } = notifierConfig as Record<string, unknown>;
-        // Include dashboard configuration for notifiers that need to construct dashboard URLs
-        if (config.dashboardBaseUrl) {
-          (rest as Record<string, unknown>).dashboardBaseUrl = config.dashboardBaseUrl;
+        const restConfig = rest as Record<string, unknown>;
+        // Include dashboard configuration for notifiers that need to construct dashboard URLs,
+        // but allow per-notifier overrides to take precedence.
+        if (config.dashboardBaseUrl !== undefined && config.dashboardBaseUrl !== null) {
+          if (restConfig["dashboardBaseUrl"] == null) {
+            restConfig["dashboardBaseUrl"] = config.dashboardBaseUrl;
+          }
         }
-        if (config.port) {
-          (rest as Record<string, unknown>).dashboardPort = config.port;
+        if (config.port !== undefined && config.port !== null) {
+          if (restConfig["dashboardPort"] == null) {
+            restConfig["dashboardPort"] = config.port;
+          }
         }
-        return rest;
+        return restConfig;
       }
     }
   }

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -70,6 +70,13 @@ function extractPluginConfig(
       const matches = hasExplicitPlugin ? configuredPlugin === name : notifierName === name;
       if (matches) {
         const { plugin: _plugin, ...rest } = notifierConfig as Record<string, unknown>;
+        // Include dashboard configuration for notifiers that need to construct dashboard URLs
+        if (config.dashboardBaseUrl) {
+          (rest as Record<string, unknown>).dashboardBaseUrl = config.dashboardBaseUrl;
+        }
+        if (config.port) {
+          (rest as Record<string, unknown>).dashboardPort = config.port;
+        }
         return rest;
       }
     }

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -74,12 +74,12 @@ function extractPluginConfig(
         // Include dashboard configuration for notifiers that need to construct dashboard URLs,
         // but allow per-notifier overrides to take precedence.
         if (config.dashboardBaseUrl !== undefined && config.dashboardBaseUrl !== null) {
-          if (restConfig["dashboardBaseUrl"] == null) {
+          if (restConfig["dashboardBaseUrl"] === null || restConfig["dashboardBaseUrl"] === undefined) {
             restConfig["dashboardBaseUrl"] = config.dashboardBaseUrl;
           }
         }
         if (config.port !== undefined && config.port !== null) {
-          if (restConfig["dashboardPort"] == null) {
+          if (restConfig["dashboardPort"] === null || restConfig["dashboardPort"] === undefined) {
             restConfig["dashboardPort"] = config.port;
           }
         }

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -71,16 +71,11 @@ function extractPluginConfig(
       if (matches) {
         const { plugin: _plugin, ...rest } = notifierConfig as Record<string, unknown>;
         const restConfig = rest as Record<string, unknown>;
-        // Include dashboard configuration for notifiers that need to construct dashboard URLs,
+        // Include dashboardBaseUrl for notifiers that need to construct dashboard URLs,
         // but allow per-notifier overrides to take precedence.
         if (config.dashboardBaseUrl !== undefined && config.dashboardBaseUrl !== null) {
           if (restConfig["dashboardBaseUrl"] === null || restConfig["dashboardBaseUrl"] === undefined) {
             restConfig["dashboardBaseUrl"] = config.dashboardBaseUrl;
-          }
-          // Only inject dashboardPort when dashboardBaseUrl is configured, as port alone
-          // doesn't give us a meaningful public URL (it would still be localhost)
-          if (restConfig["dashboardPort"] === null || restConfig["dashboardPort"] === undefined) {
-            restConfig["dashboardPort"] = config.port;
           }
         }
         return restConfig;

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -77,8 +77,8 @@ function extractPluginConfig(
           if (restConfig["dashboardBaseUrl"] === null || restConfig["dashboardBaseUrl"] === undefined) {
             restConfig["dashboardBaseUrl"] = config.dashboardBaseUrl;
           }
-        }
-        if (config.port !== undefined && config.port !== null) {
+          // Only inject dashboardPort when dashboardBaseUrl is configured, as port alone
+          // doesn't give us a meaningful public URL (it would still be localhost)
           if (restConfig["dashboardPort"] === null || restConfig["dashboardPort"] === undefined) {
             restConfig["dashboardPort"] = config.port;
           }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -889,6 +889,9 @@ export interface OrchestratorConfig {
   /** Web dashboard port (defaults to 3000) */
   port?: number;
 
+  /** Public base URL for the dashboard (e.g., "http://91.107.194.138:3000") */
+  dashboardBaseUrl?: string;
+
   /** Terminal WebSocket server port (defaults to 3001) */
   terminalPort?: number;
 

--- a/packages/plugins/notifier-openclaw/src/index.ts
+++ b/packages/plugins/notifier-openclaw/src/index.ts
@@ -209,7 +209,8 @@ export function create(config?: Record<string, unknown>): Notifier {
     if (dashboardBaseUrl) {
       // Remove trailing slash from base URL
       const baseUrl = dashboardBaseUrl.replace(/\/$/, "");
-      return `${baseUrl}/sessions/${sanitizeSessionId(sessionId)}`;
+      // Use raw session ID - web routes expect unsanitized ID
+      return `${baseUrl}/sessions/${sessionId}`;
     }
     return undefined;
   }

--- a/packages/plugins/notifier-openclaw/src/index.ts
+++ b/packages/plugins/notifier-openclaw/src/index.ts
@@ -47,6 +47,8 @@ interface OpenClawWebhookPayload {
   sessionKey?: string;
   wakeMode?: WakeMode;
   deliver?: boolean;
+  /** Dashboard URL for viewing this session's details page */
+  dashboardUrl?: string;
 }
 
 async function postWithRetry(
@@ -182,6 +184,12 @@ export function create(config?: Record<string, unknown>): Notifier {
   const wakeMode: WakeMode = config?.wakeMode === "next-heartbeat" ? "next-heartbeat" : "now";
   const deliver = typeof config?.deliver === "boolean" ? config.deliver : true;
 
+  // Dashboard configuration for constructing dashboard URLs
+  const dashboardBaseUrl =
+    typeof config?.dashboardBaseUrl === "string" ? config.dashboardBaseUrl : undefined;
+  const dashboardPort =
+    typeof config?.dashboardPort === "number" ? config.dashboardPort : undefined;
+
   const { retries, retryDelayMs } = normalizeRetryConfig(config);
 
   validateUrl(url, "notifier-openclaw");
@@ -192,6 +200,23 @@ export function create(config?: Record<string, unknown>): Notifier {
         "  Set OPENCLAW_HOOKS_TOKEN env var, or add token to your notifier config.\n" +
         "  Run: ao setup openclaw",
     );
+  }
+
+  /**
+   * Construct the dashboard URL for a session.
+   * Uses dashboardBaseUrl if configured, otherwise falls back to localhost:port.
+   */
+  function buildDashboardUrl(sessionId: string): string | undefined {
+    if (dashboardBaseUrl) {
+      // Remove trailing slash from base URL
+      const baseUrl = dashboardBaseUrl.replace(/\/$/, "");
+      return `${baseUrl}/sessions/${sanitizeSessionId(sessionId)}`;
+    }
+    if (dashboardPort) {
+      // Fallback: use port from config (localhost only)
+      return `http://localhost:${dashboardPort}/sessions/${sanitizeSessionId(sessionId)}`;
+    }
+    return undefined;
   }
 
   async function sendPayload(payload: OpenClawWebhookPayload): Promise<void> {
@@ -216,6 +241,7 @@ export function create(config?: Record<string, unknown>): Notifier {
         sessionKey,
         wakeMode,
         deliver,
+        dashboardUrl: buildDashboardUrl(event.sessionId),
       });
     },
 
@@ -230,6 +256,7 @@ export function create(config?: Record<string, unknown>): Notifier {
         sessionKey,
         wakeMode,
         deliver,
+        dashboardUrl: buildDashboardUrl(event.sessionId),
       });
     },
 
@@ -243,6 +270,7 @@ export function create(config?: Record<string, unknown>): Notifier {
         sessionKey,
         wakeMode,
         deliver,
+        dashboardUrl: context?.sessionId ? buildDashboardUrl(context.sessionId) : undefined,
       });
 
       return null;

--- a/packages/plugins/notifier-openclaw/src/index.ts
+++ b/packages/plugins/notifier-openclaw/src/index.ts
@@ -187,8 +187,6 @@ export function create(config?: Record<string, unknown>): Notifier {
   // Dashboard configuration for constructing dashboard URLs
   const dashboardBaseUrl =
     typeof config?.dashboardBaseUrl === "string" ? config.dashboardBaseUrl : undefined;
-  const dashboardPort =
-    typeof config?.dashboardPort === "number" ? config.dashboardPort : undefined;
 
   const { retries, retryDelayMs } = normalizeRetryConfig(config);
 
@@ -204,17 +202,14 @@ export function create(config?: Record<string, unknown>): Notifier {
 
   /**
    * Construct the dashboard URL for a session.
-   * Uses dashboardBaseUrl if configured, otherwise falls back to localhost:port.
+   * Uses dashboardBaseUrl if configured.
+   * Returns undefined if no dashboard URL is configured.
    */
   function buildDashboardUrl(sessionId: string): string | undefined {
     if (dashboardBaseUrl) {
       // Remove trailing slash from base URL
       const baseUrl = dashboardBaseUrl.replace(/\/$/, "");
       return `${baseUrl}/sessions/${sanitizeSessionId(sessionId)}`;
-    }
-    if (dashboardPort) {
-      // Fallback: use port from config (localhost only)
-      return `http://localhost:${dashboardPort}/sessions/${sanitizeSessionId(sessionId)}`;
     }
     return undefined;
   }

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -20,6 +20,7 @@ export async function GET(request: Request): Promise<Response> {
   const encoder = new TextEncoder();
   const correlationId = createCorrelationId("sse");
   const { searchParams } = new URL(request.url);
+  const origin = new URL(request.url).origin;
   const projectFilter = searchParams.get("project");
   type ServicesConfig = Awaited<ReturnType<typeof getServices>>["config"];
   let heartbeat: ReturnType<typeof setInterval> | undefined;
@@ -82,6 +83,7 @@ export async function GET(request: Request): Promise<Response> {
             sessionToDashboard(session, {
               dashboardBaseUrl: config.dashboardBaseUrl,
               port: config.port,
+              origin,
             }),
           );
           const projectObserver = ensureObserver(config);
@@ -146,6 +148,7 @@ export async function GET(request: Request): Promise<Response> {
               sessionToDashboard(session, {
                 dashboardBaseUrl: config.dashboardBaseUrl,
                 port: config.port,
+                origin,
               }),
             );
             const projectObserver = ensureObserver(config);

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -78,7 +78,12 @@ export async function GET(request: Request): Promise<Response> {
               : undefined;
           const sessions = await sessionManager.list(requestedProjectId);
           const workerSessions = filterWorkerSessions(sessions, projectFilter, config.projects);
-          const dashboardSessions = workerSessions.map(sessionToDashboard);
+          const dashboardSessions = workerSessions.map((session) =>
+            sessionToDashboard(session, {
+              dashboardBaseUrl: config.dashboardBaseUrl,
+              port: config.port,
+            }),
+          );
           const projectObserver = ensureObserver(config);
 
           const initialEvent = {
@@ -137,7 +142,12 @@ export async function GET(request: Request): Promise<Response> {
                 : undefined;
             const sessions = await sessionManager.list(requestedProjectId);
             const workerSessions = filterWorkerSessions(sessions, projectFilter, config.projects);
-            dashboardSessions = workerSessions.map(sessionToDashboard);
+            dashboardSessions = workerSessions.map((session) =>
+              sessionToDashboard(session, {
+                dashboardBaseUrl: config.dashboardBaseUrl,
+                port: config.port,
+              }),
+            );
             const projectObserver = ensureObserver(config);
 
             if (projectObserver && observerProjectId) {

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -20,7 +20,6 @@ export async function GET(request: Request): Promise<Response> {
   const encoder = new TextEncoder();
   const correlationId = createCorrelationId("sse");
   const { searchParams } = new URL(request.url);
-  const origin = new URL(request.url).origin;
   const projectFilter = searchParams.get("project");
   type ServicesConfig = Awaited<ReturnType<typeof getServices>>["config"];
   let heartbeat: ReturnType<typeof setInterval> | undefined;
@@ -82,7 +81,6 @@ export async function GET(request: Request): Promise<Response> {
           const dashboardSessions = workerSessions.map((session) =>
             sessionToDashboard(session, {
               dashboardBaseUrl: config.dashboardBaseUrl,
-              origin,
             }),
           );
           const projectObserver = ensureObserver(config);
@@ -146,7 +144,6 @@ export async function GET(request: Request): Promise<Response> {
             dashboardSessions = workerSessions.map((session) =>
               sessionToDashboard(session, {
                 dashboardBaseUrl: config.dashboardBaseUrl,
-                origin,
               }),
             );
             const projectObserver = ensureObserver(config);

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -82,7 +82,6 @@ export async function GET(request: Request): Promise<Response> {
           const dashboardSessions = workerSessions.map((session) =>
             sessionToDashboard(session, {
               dashboardBaseUrl: config.dashboardBaseUrl,
-              port: config.port,
               origin,
             }),
           );
@@ -147,7 +146,6 @@ export async function GET(request: Request): Promise<Response> {
             dashboardSessions = workerSessions.map((session) =>
               sessionToDashboard(session, {
                 dashboardBaseUrl: config.dashboardBaseUrl,
-                port: config.port,
                 origin,
               }),
             );

--- a/packages/web/src/app/api/sessions/[id]/restore/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/restore/route.ts
@@ -48,6 +48,7 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
         session: sessionToDashboard(restored, {
           dashboardBaseUrl: config.dashboardBaseUrl,
           port: config.port,
+          origin: _request.nextUrl.origin,
         }),
       },
       { status: 200 },

--- a/packages/web/src/app/api/sessions/[id]/restore/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/restore/route.ts
@@ -45,7 +45,10 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
       {
         ok: true,
         sessionId: id,
-        session: sessionToDashboard(restored),
+        session: sessionToDashboard(restored, {
+          dashboardBaseUrl: config.dashboardBaseUrl,
+          port: config.port,
+        }),
       },
       { status: 200 },
       correlationId,

--- a/packages/web/src/app/api/sessions/[id]/restore/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/restore/route.ts
@@ -47,7 +47,6 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
         sessionId: id,
         session: sessionToDashboard(restored, {
           dashboardBaseUrl: config.dashboardBaseUrl,
-          port: config.port,
           origin: _request.nextUrl.origin,
         }),
       },

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -23,6 +23,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     const dashboardSession = sessionToDashboard(coreSession, {
       dashboardBaseUrl: config.dashboardBaseUrl,
       port: config.port,
+      origin: _request.nextUrl.origin,
     });
 
     // Enrich metadata (issue labels, agent summaries, issue titles)

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -20,7 +20,10 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       return jsonWithCorrelation({ error: "Session not found" }, { status: 404 }, correlationId);
     }
 
-    const dashboardSession = sessionToDashboard(coreSession);
+    const dashboardSession = sessionToDashboard(coreSession, {
+      dashboardBaseUrl: config.dashboardBaseUrl,
+      port: config.port,
+    });
 
     // Enrich metadata (issue labels, agent summaries, issue titles)
     await enrichSessionsMetadata([coreSession], [dashboardSession], config, registry);

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -22,7 +22,6 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 
     const dashboardSession = sessionToDashboard(coreSession, {
       dashboardBaseUrl: config.dashboardBaseUrl,
-      port: config.port,
       origin: _request.nextUrl.origin,
     });
 

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -82,6 +82,7 @@ export async function GET(request: Request) {
       sessionToDashboard(session, {
         dashboardBaseUrl: config.dashboardBaseUrl,
         port: config.port,
+        origin: request.nextUrl.origin,
       }),
     );
 

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -78,7 +78,12 @@ export async function GET(request: Request) {
     let workerSessions = visibleSessions.filter((session) => !isOrchestratorSession(session));
 
     // Convert to dashboard format
-    let dashboardSessions = workerSessions.map(sessionToDashboard);
+    let dashboardSessions = workerSessions.map((session) =>
+      sessionToDashboard(session, {
+        dashboardBaseUrl: config.dashboardBaseUrl,
+        port: config.port,
+      }),
+    );
 
     if (activeOnly) {
       const activeIndices = dashboardSessions

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -1,4 +1,5 @@
 import { ACTIVITY_STATE, isOrchestratorSession } from "@composio/ao-core";
+import { type NextRequest } from "next/server";
 import { getServices, getSCM } from "@/lib/services";
 import {
   sessionToDashboard,
@@ -31,7 +32,7 @@ async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Prom
   }
 }
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   const correlationId = getCorrelationId(request);
   const startedAt = Date.now();
   try {

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -82,7 +82,6 @@ export async function GET(request: NextRequest) {
     let dashboardSessions = workerSessions.map((session) =>
       sessionToDashboard(session, {
         dashboardBaseUrl: config.dashboardBaseUrl,
-        port: config.port,
         origin: request.nextUrl.origin,
       }),
     );

--- a/packages/web/src/app/api/spawn/route.ts
+++ b/packages/web/src/app/api/spawn/route.ts
@@ -50,6 +50,7 @@ export async function POST(request: NextRequest) {
         session: sessionToDashboard(session, {
           dashboardBaseUrl: config.dashboardBaseUrl,
           port: config.port,
+          origin: request.nextUrl.origin,
         }),
       },
       { status: 201 },

--- a/packages/web/src/app/api/spawn/route.ts
+++ b/packages/web/src/app/api/spawn/route.ts
@@ -46,7 +46,12 @@ export async function POST(request: NextRequest) {
     });
 
     return jsonWithCorrelation(
-      { session: sessionToDashboard(session) },
+      {
+        session: sessionToDashboard(session, {
+          dashboardBaseUrl: config.dashboardBaseUrl,
+          port: config.port,
+        }),
+      },
       { status: 201 },
       correlationId,
     );

--- a/packages/web/src/app/api/spawn/route.ts
+++ b/packages/web/src/app/api/spawn/route.ts
@@ -49,7 +49,6 @@ export async function POST(request: NextRequest) {
       {
         session: sessionToDashboard(session, {
           dashboardBaseUrl: config.dashboardBaseUrl,
-          port: config.port,
           origin: request.nextUrl.origin,
         }),
       },

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -213,6 +213,61 @@ describe("sessionToDashboard", () => {
 
     expect(dashboard.pr).toBeNull();
   });
+
+  describe("dashboardUrl", () => {
+    it("should construct dashboardUrl when dashboardBaseUrl is provided", () => {
+      const coreSession = createCoreSession({ id: "session-123" });
+      const dashboard = sessionToDashboard(coreSession, {
+        dashboardBaseUrl: "http://91.107.194.138:3000",
+      });
+
+      expect(dashboard.dashboardUrl).toBe("http://91.107.194.138:3000/sessions/session-123");
+    });
+
+    it("should construct dashboardUrl with origin when dashboardBaseUrl is not provided", () => {
+      const coreSession = createCoreSession({ id: "session-456" });
+      const dashboard = sessionToDashboard(coreSession, {
+        origin: "https://example.com",
+      });
+
+      expect(dashboard.dashboardUrl).toBe("https://example.com/sessions/session-456");
+    });
+
+    it("should construct relative dashboardUrl when neither dashboardBaseUrl nor origin is provided", () => {
+      const coreSession = createCoreSession({ id: "session-789" });
+      const dashboard = sessionToDashboard(coreSession);
+
+      expect(dashboard.dashboardUrl).toBe("/sessions/session-789");
+    });
+
+    it("should prefer dashboardBaseUrl over origin", () => {
+      const coreSession = createCoreSession({ id: "session-000" });
+      const dashboard = sessionToDashboard(coreSession, {
+        dashboardBaseUrl: "http://dashboard.example.com",
+        origin: "https://request.example.com",
+      });
+
+      expect(dashboard.dashboardUrl).toBe("http://dashboard.example.com/sessions/session-000");
+    });
+
+    it("should remove trailing slash from dashboardBaseUrl", () => {
+      const coreSession = createCoreSession({ id: "session-111" });
+      const dashboard = sessionToDashboard(coreSession, {
+        dashboardBaseUrl: "http://example.com:3000/",
+      });
+
+      expect(dashboard.dashboardUrl).toBe("http://example.com:3000/sessions/session-111");
+    });
+
+    it("should remove trailing slash from origin", () => {
+      const coreSession = createCoreSession({ id: "session-222" });
+      const dashboard = sessionToDashboard(coreSession, {
+        origin: "https://example.com/",
+      });
+
+      expect(dashboard.dashboardUrl).toBe("https://example.com/sessions/session-222");
+    });
+  });
 });
 
 describe("resolveProject", () => {

--- a/packages/web/src/lib/dashboard-page-data.ts
+++ b/packages/web/src/lib/dashboard-page-data.ts
@@ -59,7 +59,12 @@ export const getDashboardPageData = cache(async function getDashboardPageData(pr
     pageData.orchestrators = listDashboardOrchestrators(visibleSessions, config.projects);
 
     const coreSessions = filterWorkerSessions(allSessions, projectFilter, config.projects);
-    pageData.sessions = coreSessions.map(sessionToDashboard);
+    pageData.sessions = coreSessions.map((session) =>
+      sessionToDashboard(session, {
+        dashboardBaseUrl: config.dashboardBaseUrl,
+        port: config.port,
+      }),
+    );
 
     const metaTimeout = new Promise<void>((resolve) => setTimeout(resolve, 3_000));
     await Promise.race([

--- a/packages/web/src/lib/dashboard-page-data.ts
+++ b/packages/web/src/lib/dashboard-page-data.ts
@@ -62,7 +62,6 @@ export const getDashboardPageData = cache(async function getDashboardPageData(pr
     pageData.sessions = coreSessions.map((session) =>
       sessionToDashboard(session, {
         dashboardBaseUrl: config.dashboardBaseUrl,
-        port: config.port,
       }),
     );
 

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -48,20 +48,24 @@ export function resolveProject(
 /** Convert a core Session to a DashboardSession (without PR/issue enrichment). */
 export function sessionToDashboard(
   session: Session,
-  config?: { dashboardBaseUrl?: string; port?: number },
+  config?: { dashboardBaseUrl?: string; port?: number; origin?: string },
 ): DashboardSession {
   const agentSummary = session.agentInfo?.summary;
   const summary = agentSummary ?? session.metadata["summary"] ?? null;
 
-  // Construct dashboard URL if base URL is configured
+  // Construct dashboard URL based on configuration or fall back to a relative path
   let dashboardUrl: string | undefined;
   if (config?.dashboardBaseUrl) {
     // Remove trailing slash from base URL and prepend
     const baseUrl = config.dashboardBaseUrl.replace(/\/$/, "");
     dashboardUrl = `${baseUrl}/sessions/${session.id}`;
-  } else if (config?.port) {
-    // Fallback: use port from config (localhost only)
-    dashboardUrl = `http://localhost:${config.port}/sessions/${session.id}`;
+  } else if (config?.origin) {
+    // Use caller-provided origin (e.g. request origin) for absolute URLs
+    const origin = config.origin.replace(/\/$/, "");
+    dashboardUrl = `${origin}/sessions/${session.id}`;
+  } else {
+    // Fallback: use a relative URL to avoid leaking an incorrect absolute host
+    dashboardUrl = `/sessions/${session.id}`;
   }
 
   return {

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -46,9 +46,23 @@ export function resolveProject(
 }
 
 /** Convert a core Session to a DashboardSession (without PR/issue enrichment). */
-export function sessionToDashboard(session: Session): DashboardSession {
+export function sessionToDashboard(
+  session: Session,
+  config?: { dashboardBaseUrl?: string; port?: number },
+): DashboardSession {
   const agentSummary = session.agentInfo?.summary;
   const summary = agentSummary ?? session.metadata["summary"] ?? null;
+
+  // Construct dashboard URL if base URL is configured
+  let dashboardUrl: string | undefined;
+  if (config?.dashboardBaseUrl) {
+    // Remove trailing slash from base URL and prepend
+    const baseUrl = config.dashboardBaseUrl.replace(/\/$/, "");
+    dashboardUrl = `${baseUrl}/sessions/${session.id}`;
+  } else if (config?.port) {
+    // Fallback: use port from config (localhost only)
+    dashboardUrl = `http://localhost:${config.port}/sessions/${session.id}`;
+  }
 
   return {
     id: session.id,
@@ -66,6 +80,7 @@ export function sessionToDashboard(session: Session): DashboardSession {
     lastActivityAt: session.lastActivityAt.toISOString(),
     pr: session.pr ? basicPRToDashboard(session.pr) : null,
     metadata: session.metadata,
+    dashboardUrl,
   };
 }
 

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -48,7 +48,7 @@ export function resolveProject(
 /** Convert a core Session to a DashboardSession (without PR/issue enrichment). */
 export function sessionToDashboard(
   session: Session,
-  config?: { dashboardBaseUrl?: string; port?: number; origin?: string },
+  config?: { dashboardBaseUrl?: string; origin?: string },
 ): DashboardSession {
   const agentSummary = session.agentInfo?.summary;
   const summary = agentSummary ?? session.metadata["summary"] ?? null;

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -75,6 +75,8 @@ export interface DashboardSession {
   lastActivityAt: string;
   pr: DashboardPR | null;
   metadata: Record<string, string>;
+  /** Dashboard URL for viewing this session's details page (e.g. "http://example.com:3000/sessions/ao-97") */
+  dashboardUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR implements the changes described in issue #717, allowing the OpenClaw plugin and CLI to construct and provide dashboard URLs for sessions.

## Changes

### CLI Changes (`packages/cli/src/commands/`)

1. **`spawn.ts`**: Added dashboard URL display when `dashboardBaseUrl` is configured in `agent-orchestrator.yaml`
   - Shows `Dashboard: <url>` after session creation
   - Also added to `batch-spawn` output as a hint

2. **`status.ts`**: Added `dashboardUrl` field to JSON output
   - Added `dashboardUrl` to `SessionInfo` interface
   - Computed from `dashboardBaseUrl` config when available
   - Pattern: `{dashboardBaseUrl}/sessions/{sessionId}`

### OpenClaw Plugin Changes (`openclaw-plugin/`)

1. **`index.ts`**: Updated `ao_sessions` tool to use JSON output
   - Now parses `ao status --json` to get structured session data
   - Formats output with dashboard URLs highlighted
   - Added description mention of dashboard URLs in `ao_spawn` tool

2. **New helper functions**:
   - `getDashboardBaseUrl(config)`: Extracts `dashboardBaseUrl` from `agent-orchestrator.yaml`
   - `constructDashboardUrl(sessionId, baseUrl)`: Constructs dashboard URL for a session

3. **`index.test.ts`**: Added tests for new helper functions
   - Tests for `getDashboardBaseUrl` with various config formats
   - Tests for `constructDashboardUrl` URL construction

## How It Works

When users configure `dashboardBaseUrl` in their `agent-orchestrator.yaml`:

```yaml
dashboardBaseUrl: http://91.107.194.138:3000
```

The dashboard URLs will now be available:
1. **CLI spawn**: Shows the URL in the output after creating a session
2. **CLI status --json**: Includes `dashboardUrl` in the session data
3. **OpenClaw plugin**: The `ao_sessions` tool now displays dashboard URLs in its formatted output

## URL Pattern

The dashboard URL pattern is: `{dashboardBaseUrl}/sessions/{sessionId}`

For example, with `dashboardBaseUrl: http://91.107.194.138:3000` and session `ao-97`:
`http://91.107.194.138:3000/sessions/ao-97`

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)