### PR TITLE
fix: improve codex session status tracking

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -200,6 +200,61 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("needs_input");
   });
 
+  it("detects needs_input for codex from terminal output even when getActivityState returns idle", async () => {
+    const codexAgent: Agent = {
+      ...plugins.agent,
+      name: "codex",
+      processName: "codex",
+      getActivityState: vi.fn().mockResolvedValue({
+        state: "idle" as ActivityState,
+        timestamp: new Date(),
+      }),
+      detectActivity: vi.fn().mockReturnValue("waiting_input" as ActivityState),
+    };
+
+    const runtimeWithApprovalPrompt = {
+      ...plugins.runtime,
+      getOutput: vi.fn().mockResolvedValue("Approval required\n(y)es / (n)o\n"),
+    };
+
+    const registryWithCodex: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return runtimeWithApprovalPrompt;
+        if (slot === "agent") {
+          if (name === "codex") return codexAgent;
+          if (name === "mock-agent") return plugins.agent;
+        }
+        return null;
+      }),
+    };
+
+    const configWithCodexWorker: OrchestratorConfig = {
+      ...config,
+      projects: {
+        ...config.projects,
+        "my-app": {
+          ...config.projects["my-app"],
+          worker: { agent: "codex" },
+        },
+      },
+    };
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working", metadata: { agent: "codex" } }),
+      metaOverrides: { agent: "codex" },
+      registry: registryWithCodex,
+      configOverride: configWithCodexWorker,
+    });
+
+    await lm.check("app-1");
+
+    expect(codexAgent.getActivityState).toHaveBeenCalled();
+    expect(runtimeWithApprovalPrompt.getOutput).toHaveBeenCalled();
+    expect(codexAgent.detectActivity).toHaveBeenCalledWith("Approval required\n(y)es / (n)o\n");
+    expect(lm.getStates().get("app-1")).toBe("needs_input");
+  });
+
   it("transitions to stuck when idle exceeds agent-stuck threshold (OpenCode-style activity)", async () => {
     config.reactions = {
       "agent-stuck": { auto: true, action: "notify", threshold: "1m" },
@@ -316,6 +371,25 @@ describe("check (single session)", () => {
 
     const lm = setupCheck("app-1", {
       session: makeSession({ status: "stuck" }),
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("stuck");
+  });
+
+  it("still marks a session as stuck when native idle detection succeeds but getOutput throws", async () => {
+    config.reactions = {
+      "agent-stuck": { auto: true, action: "notify", threshold: "1m" },
+    };
+
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({
+      state: "idle",
+      timestamp: new Date(Date.now() - 120_000),
+    });
+    vi.mocked(plugins.runtime.getOutput).mockRejectedValue(new Error("tmux error"));
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
     });
 
     await lm.check("app-1");

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -222,13 +222,15 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }).agentName;
     const agent = registry.get<Agent>("agent", agentName);
     const scm = project.scm ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    const runtime = session.runtimeHandle
+      ? registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime)
+      : null;
 
     // Track activity state across steps so stuck detection can run after PR checks
     let detectedIdleTimestamp: Date | null = null;
 
     // 1. Check if runtime is alive
     if (session.runtimeHandle) {
-      const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
       if (runtime) {
         const alive = await runtime.isAlive(session.runtimeHandle).catch(() => true);
         if (!alive) return "killed";
@@ -251,14 +253,28 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             detectedIdleTimestamp = activityState.timestamp;
           }
 
+          // Some agents can surface higher-priority prompt states like
+          // waiting_input only through terminal parsing. Preserve the native
+          // activity probe, but allow recent output to upgrade the session
+          // into needs_input without forcing every agent to encode that state
+          // in getActivityState().
+          if (runtime) {
+            try {
+              const terminalOutput = await runtime.getOutput(session.runtimeHandle, 10);
+              if (terminalOutput) {
+                const activity = agent.detectActivity(terminalOutput);
+                if (activity === "waiting_input") return "needs_input";
+              }
+            } catch {
+              // Output probing is only an upgrade path for waiting_input.
+              // Preserve the native activity result if terminal capture fails.
+            }
+          }
+
           // active/ready/idle (below threshold)/blocked (below threshold) —
           // proceed to PR checks below
         } else {
           // getActivityState returned null — fall back to terminal output parsing
-          const runtime = registry.get<Runtime>(
-            "runtime",
-            project.runtime ?? config.defaults.runtime,
-          );
           const terminalOutput = runtime ? await runtime.getOutput(session.runtimeHandle, 10) : "";
           if (terminalOutput) {
             const activity = agent.detectActivity(terminalOutput);

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -196,6 +196,7 @@ describe("plugin manifest & exports", () => {
     const agent = create();
     expect(agent.name).toBe("codex");
     expect(agent.processName).toBe("codex");
+    expect(agent.promptDelivery).toBe("post-launch");
   });
 
   it("default export is a valid PluginModule", () => {
@@ -250,29 +251,29 @@ describe("getLaunchCommand", () => {
     expect(cmd).toContain("--model 'gpt-4o'");
   });
 
-  it("appends shell-escaped prompt with -- separator", () => {
+  it("does not inline the prompt into the launch command", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "Fix it" }));
-    expect(cmd).toContain("-- 'Fix it'");
+    expect(cmd).not.toContain("Fix it");
+    expect(cmd).not.toContain(" -- ");
   });
 
   it("combines all options", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ permissions: "permissionless", model: "o3", prompt: "Go" }),
     );
-    expect(cmd).toBe("'codex' -c check_for_update_on_startup=false --dangerously-bypass-approvals-and-sandbox --model 'o3' -c model_reasoning_effort=high -- 'Go'");
+    expect(cmd).toBe("'codex' -c check_for_update_on_startup=false --dangerously-bypass-approvals-and-sandbox --model 'o3' -c model_reasoning_effort=high");
   });
 
-  it("escapes single quotes in prompt (POSIX shell escaping)", () => {
+  it("does not include prompt text with quotes in the launch command", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "it's broken" }));
-    expect(cmd).toContain("-- 'it'\\''s broken'");
+    expect(cmd).not.toContain("it's broken");
   });
 
-  it("escapes dangerous characters in prompt", () => {
+  it("does not include prompt text with dangerous shell characters in the launch command", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ prompt: "$(rm -rf /); `evil`; $HOME" }),
     );
-    // Single-quoted strings prevent shell expansion
-    expect(cmd).toContain("-- '$(rm -rf /); `evil`; $HOME'");
+    expect(cmd).not.toContain("$(rm -rf /); `evil`; $HOME");
   });
 
   it("includes -c model_instructions_file when systemPromptFile is set", () => {
@@ -581,6 +582,14 @@ describe("detectActivity", () => {
     ).toBe("waiting_input");
     expect(
       agent.detectActivity("Working (esc to interrupt)\nFinished\n(y)es / (n)o\n"),
+    ).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for the numbered command approval prompt", () => {
+    expect(
+      agent.detectActivity(
+        "Would you like to run the following command?\n\n$ printf '\\033[2J\\033[H'\n\n1. Yes, proceed (y)\n2. Yes, and don't ask again\n3. No, and tell Codex what to do differently (esc)\n\nPress enter to confirm or esc to cancel\n",
+      ),
     ).toBe("waiting_input");
   });
 

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -619,6 +619,7 @@ function createCodexAgent(): Agent {
   return {
     name: "codex",
     processName: "codex",
+    promptDelivery: "post-launch",
 
     getLaunchCommand(config: AgentLaunchConfig): string {
       const binary = resolvedBinary ?? "codex";
@@ -636,11 +637,9 @@ function createCodexAgent(): Agent {
         parts.push("-c", `developer_instructions=${shellEscape(config.systemPrompt)}`);
       }
 
-      if (config.prompt) {
-        // Use `--` to end option parsing so prompts starting with `-` aren't
-        // misinterpreted as flags.
-        parts.push("--", shellEscape(config.prompt));
-      }
+      // NOTE: prompt is NOT included here. Delivering it post-launch keeps
+      // Codex in interactive mode; inlining the prompt can cause Codex to run
+      // as a one-shot command and exit before AO can track live status.
 
       return parts.join(" ");
     },
@@ -673,10 +672,23 @@ function createCodexAgent(): Agent {
       // If Codex is showing its input prompt, it's idle
       if (/^[>$#]\s*$/.test(lastLine)) return "idle";
 
-      // Check last few lines for approval prompts
-      const tail = lines.slice(-5).join("\n");
+      // Check the recent buffer for approval prompts. Codex uses both the
+      // older "(y)es / (n)o" style and a newer numbered approval UI.
+      // Strip ANSI escape codes — tmux pane output is raw and contains color/
+      // cursor sequences that break regex matching.
+      const stripAnsi = (s: string): string =>
+        s.replace(/\x1b\[[0-9;]*[mGKHFABCDJr]/g, "");
+    
+      const tail = lines.slice(-15).map(stripAnsi).join("\n");
       if (/approval required/i.test(tail)) return "waiting_input";
       if (/\(y\)es.*\(n\)o/i.test(tail)) return "waiting_input";
+      if (/press enter to confirm or esc to cancel/i.test(tail)) return "waiting_input";
+
+      // Numbered approval menu fallback — matches the "1. Yes, proceed (y)" +
+      // "3. No, and tell Codex..." pattern seen in the Codex v0.117.0 UI.
+      const hasYesOption = /^\s*1\.\s*yes[,\s]/im.test(tail);
+      const hasNoOption = /^\s*[>*]?\s*[23]\.\s*no[,\s]/im.test(tail);
+      if (hasYesOption && hasNoOption) return "waiting_input";
 
       // Default to active — specific patterns (esc to interrupt, spinner
       // symbols) all map to "active" so no need to check them individually.


### PR DESCRIPTION
Closes #746 

## Summary

Codex already knows how to detect approval prompts from terminal output, and lifecycle already knows how to map `waiting_input` to `needs_input`. The gap was in how those two paths interacted.

Codex session status tracking where sessions could stay `working` or `idle` even when Codex was actually waiting for user input.

The main issue was that lifecycle prefers `getActivityState()`, but Codex’s prompt-level waiting-input detection lives in terminal parsing. If `getActivityState()` returned a non-null state like `idle`, AO would not consult the terminal-parsing path, so approval prompts could be missed.

## What changed

- allow lifecycle to upgrade a non-terminal activity result into `needs_input` when recent terminal output clearly shows a waiting-for-input prompt
- keep the existing `waiting_input -> needs_input` mapping unchanged
- preserve native idle/stuck detection if terminal output capture fails