### PR TITLE
fix: use terminal statuses in lifecycle poll accounting

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -779,6 +779,78 @@ describe("reactions", () => {
   });
 });
 
+describe("pollAll", () => {
+  it("processes transitions into terminal statuses beyond merged and killed", async () => {
+    const terminalSession = makeSession({ status: "done", activity: "exited" });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(makeSession({ status: "working" }));
+
+    writeMetadata(env.sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("working");
+
+    vi.mocked(mockSessionManager.list).mockResolvedValue([terminalSession]);
+    vi.mocked(mockSessionManager.get).mockResolvedValue(terminalSession);
+
+    lm.start(60_000);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    lm.stop();
+
+    expect(lm.getStates().get("app-1")).toBe("done");
+  });
+
+  it("treats canonical terminal statuses as inactive for all-complete", async () => {
+    const notifier = createMockNotifier();
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      notifier,
+    });
+
+    config.reactions = {
+      "all-complete": { auto: true, action: "notify" },
+    };
+    config.notificationRouting.info = ["desktop"];
+
+    vi.mocked(mockSessionManager.list).mockResolvedValue([
+      makeSession({ status: "done", activity: "exited" }),
+      makeSession({ id: "app-2", status: "errored", activity: "exited" }),
+      makeSession({ id: "app-3", status: "cleanup", activity: "exited" }),
+      makeSession({ id: "app-4", status: "terminated", activity: "exited" }),
+    ]);
+
+    const lm = createLifecycleManager({
+      config,
+      registry,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(60_000);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    lm.stop();
+
+    expect(mockSessionManager.get).not.toHaveBeenCalled();
+    expect(notifier.notify).toHaveBeenCalledTimes(1);
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "reaction.triggered",
+        data: expect.objectContaining({ reactionKey: "all-complete" }),
+      }),
+    );
+  });
+});
+
 describe("getStates", () => {
   it("returns copy of states map", async () => {
     const lm = setupCheck("app-1", {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -13,6 +13,7 @@
 import { randomUUID } from "node:crypto";
 import {
   SESSION_STATUS,
+  TERMINAL_STATUSES,
   PR_STATE,
   CI_STATUS,
   type LifecycleManager,
@@ -728,7 +729,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       });
 
       // Reset allCompleteEmitted when any session becomes active again
-      if (newStatus !== "merged" && newStatus !== "killed") {
+      if (!TERMINAL_STATUSES.has(newStatus)) {
         allCompleteEmitted = false;
       }
 
@@ -806,7 +807,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       // (e.g., list() detected a dead runtime and marked it "killed" — we need to
       // process that transition even though the new status is terminal)
       const sessionsToCheck = sessions.filter((s) => {
-        if (s.status !== "merged" && s.status !== "killed") return true;
+        if (!TERMINAL_STATUSES.has(s.status)) return true;
         const tracked = states.get(s.id);
         return tracked !== undefined && tracked !== s.status;
       });
@@ -830,7 +831,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
 
       // Check if all sessions are complete (trigger reaction only once)
-      const activeSessions = sessions.filter((s) => s.status !== "merged" && s.status !== "killed");
+      const activeSessions = sessions.filter((s) => !TERMINAL_STATUSES.has(s.status));
       if (sessions.length > 0 && activeSessions.length === 0 && !allCompleteEmitted) {
         allCompleteEmitted = true;
 


### PR DESCRIPTION
Closes #752

## Summary

This updates lifecycle polling to use the terminal-status set instead of only treating `merged` and `killed` as inactive.

That fixes cases where sessions in states like `done`, `terminated`, `cleanup`, or `errored` could still be counted as active.

## What changed

- use `TERMINAL_STATUSES` in `pollAll()` when deciding which sessions are still active
- use the same terminal-status check when deciding which terminal sessions still need transition handling
- add regression tests around terminal-session polling and `all-complete`

## Why

The core types already define the full terminal set, but `pollAll()` was using a narrower inline check. This keeps lifecycle accounting aligned with the shared status model.