### PR TITLE
fix: use shared terminal statuses in lifecycle polling

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -82,6 +82,41 @@ describe("start / stop", () => {
     // Should not throw on double stop
     lm.stop();
   });
+
+  it("treats done sessions as complete for the all-complete reaction", async () => {
+    const notifier = createMockNotifier();
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      notifier,
+    });
+
+    config.reactions = {
+      "all-complete": { auto: true, action: "notify", priority: "info" },
+    };
+    config.notificationRouting = {
+      ...config.notificationRouting,
+      info: ["desktop"],
+    };
+
+    vi.mocked(mockSessionManager.list).mockResolvedValue([
+      makeSession({ status: "done", activity: "exited" }),
+    ]);
+
+    const lm = createLifecycleManager({
+      config,
+      registry,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(60_000);
+
+    await vi.waitFor(() => {
+      expect(notifier.notify).toHaveBeenCalledTimes(1);
+    });
+
+    lm.stop();
+  });
 });
 
 describe("check (single session)", () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -13,6 +13,7 @@
 import { randomUUID } from "node:crypto";
 import {
   SESSION_STATUS,
+  TERMINAL_STATUSES,
   PR_STATE,
   CI_STATUS,
   type LifecycleManager,
@@ -728,7 +729,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       });
 
       // Reset allCompleteEmitted when any session becomes active again
-      if (newStatus !== "merged" && newStatus !== "killed") {
+      if (!TERMINAL_STATUSES.has(newStatus)) {
         allCompleteEmitted = false;
       }
 
@@ -806,7 +807,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       // (e.g., list() detected a dead runtime and marked it "killed" — we need to
       // process that transition even though the new status is terminal)
       const sessionsToCheck = sessions.filter((s) => {
-        if (s.status !== "merged" && s.status !== "killed") return true;
+        if (!TERMINAL_STATUSES.has(s.status)) return true;
         const tracked = states.get(s.id);
         return tracked !== undefined && tracked !== s.status;
       });
@@ -830,7 +831,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
 
       // Check if all sessions are complete (trigger reaction only once)
-      const activeSessions = sessions.filter((s) => s.status !== "merged" && s.status !== "killed");
+      const activeSessions = sessions.filter((s) => !TERMINAL_STATUSES.has(s.status));
       if (sessions.length > 0 && activeSessions.length === 0 && !allCompleteEmitted) {
         allCompleteEmitted = true;
 


### PR DESCRIPTION
## Summary
- replace hardcoded `merged`/`killed` checks in lifecycle polling with shared `TERMINAL_STATUSES`
- treat `done` sessions as complete for the `all-complete` reaction
- add a regression test covering the `done` session case

## Testing
- pnpm --filter @composio/ao-core test -- lifecycle-manager
- pnpm --filter @composio/ao-core test

Closes #776
