### PR TITLE
fix: surface prompt delivery failures and improve session state tracking

### DIFF
--- a/packages/cli/__tests__/commands/setup.test.ts
+++ b/packages/cli/__tests__/commands/setup.test.ts
@@ -124,7 +124,7 @@ describe("setup openclaw command", () => {
         "--url",
         "http://127.0.0.1:18789/hooks/agent",
         "--token",
-        "test-token",
+        "x",
         "--non-interactive",
       ]);
 
@@ -137,7 +137,7 @@ describe("setup openclaw command", () => {
     });
 
     it("reads token from OPENCLAW_HOOKS_TOKEN env var and skips validation", async () => {
-      process.env["OPENCLAW_HOOKS_TOKEN"] = "env-token";
+      process.env["OPENCLAW_HOOKS_TOKEN"] = "x";
       const program = createProgram();
 
       await program.parseAsync([
@@ -204,7 +204,7 @@ describe("setup openclaw command", () => {
         "--url",
         "http://127.0.0.1:18789/hooks/agent",
         "--token",
-        "good-token",
+        "x",
         "--non-interactive",
       ]);
 

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -206,9 +206,20 @@ describe("check (single session)", () => {
       "Do you want to continue?\n(y)es / (n)o\n",
     );
     vi.mocked(plugins.agent.detectActivity).mockReturnValue("waiting_input");
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     const lm = setupCheck("app-1", {
-      session: makeSession({ status: "working" }),
+      session: makeSession({
+        status: "working",
+        metadata: {
+          promptDeliveryStatus: "failed",
+          promptDeliveryAttemptedAt: new Date(Date.now() - 10_000).toISOString(),
+        },
+      }),
+      metaOverrides: {
+        promptDeliveryStatus: "failed",
+        promptDeliveryAttemptedAt: new Date(Date.now() - 10_000).toISOString(),
+      },
     });
 
     await lm.check("app-1");
@@ -216,6 +227,12 @@ describe("check (single session)", () => {
     expect(plugins.runtime.getOutput).toHaveBeenCalled();
     expect(plugins.agent.detectActivity).toHaveBeenCalled();
     expect(lm.getStates().get("app-1")).toBe("needs_input");
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"operation":"early-needs-input"'),
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('"detectionMethod":"terminal"'));
+
+    stderrSpy.mockRestore();
   });
 
   it("logs anomaly when session quickly enters needs_input after failed prompt delivery", async () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -236,6 +236,20 @@ describe("check (single session)", () => {
     stderrSpy.mockRestore();
   });
 
+  it("does not probe terminal output for active activity state", async () => {
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "active" });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
+    });
+
+    await lm.check("app-1");
+
+    expect(plugins.runtime.getOutput).not.toHaveBeenCalled();
+    expect(plugins.agent.detectActivity).not.toHaveBeenCalled();
+    expect(lm.getStates().get("app-1")).toBe("working");
+  });
+
   it("logs anomaly when session quickly enters needs_input after failed prompt delivery", async () => {
     vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "waiting_input" });
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -303,6 +303,37 @@ describe("check (single session)", () => {
     stderrSpy.mockRestore();
   });
 
+  it("does not log early-needs-input anomaly while prompt delivery is pending", async () => {
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "waiting_input" });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const attemptedAt = new Date(Date.now() - 15_000).toISOString();
+    const lm = setupCheck("app-1", {
+      session: makeSession({
+        status: "working",
+        metadata: {
+          promptDeliveryStatus: "pending",
+          promptDeliveryAttemptedAt: attemptedAt,
+        },
+      }),
+      metaOverrides: {
+        promptDeliveryStatus: "pending",
+        promptDeliveryAttemptedAt: attemptedAt,
+      },
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("needs_input");
+
+    const wroteAnomalyLog = stderrSpy.mock.calls.some((call) =>
+      String(call[0]).includes('"operation":"early-needs-input"'),
+    );
+    expect(wroteAnomalyLog).toBe(false);
+
+    stderrSpy.mockRestore();
+  });
+
   it("transitions to stuck when idle exceeds agent-stuck threshold (OpenCode-style activity)", async () => {
     config.reactions = {
       "agent-stuck": { auto: true, action: "notify", threshold: "1m" },

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -230,6 +230,7 @@ describe("check (single session)", () => {
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining('"operation":"early-needs-input"'),
     );
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('"level":"warn"'));
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('"detectionMethod":"terminal"'));
 
     stderrSpy.mockRestore();
@@ -263,6 +264,7 @@ describe("check (single session)", () => {
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining('"promptDeliveryStatus":"failed"'),
     );
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('"level":"warn"'));
 
     stderrSpy.mockRestore();
   });

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -200,6 +200,76 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("needs_input");
   });
 
+  it("upgrades idle activity to needs_input when terminal output shows waiting prompt", async () => {
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "idle" });
+    vi.mocked(plugins.runtime.getOutput).mockResolvedValue(
+      "Do you want to continue?\n(y)es / (n)o\n",
+    );
+    vi.mocked(plugins.agent.detectActivity).mockReturnValue("waiting_input");
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
+    });
+
+    await lm.check("app-1");
+
+    expect(plugins.runtime.getOutput).toHaveBeenCalled();
+    expect(plugins.agent.detectActivity).toHaveBeenCalled();
+    expect(lm.getStates().get("app-1")).toBe("needs_input");
+  });
+
+  it("logs anomaly when session quickly enters needs_input after failed prompt delivery", async () => {
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "waiting_input" });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const attemptedAt = new Date(Date.now() - 15_000).toISOString();
+    const lm = setupCheck("app-1", {
+      session: makeSession({
+        status: "working",
+        metadata: {
+          promptDeliveryStatus: "failed",
+          promptDeliveryAttemptedAt: attemptedAt,
+        },
+      }),
+      metaOverrides: {
+        promptDeliveryStatus: "failed",
+        promptDeliveryAttemptedAt: attemptedAt,
+      },
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("needs_input");
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"operation":"early-needs-input"'),
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"promptDeliveryStatus":"failed"'),
+    );
+
+    stderrSpy.mockRestore();
+  });
+
+  it("does not log early-needs-input anomaly when prompt delivery was never attempted", async () => {
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "waiting_input" });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("needs_input");
+
+    const wroteAnomalyLog = stderrSpy.mock.calls.some((call) =>
+      String(call[0]).includes('"operation":"early-needs-input"'),
+    );
+    expect(wroteAnomalyLog).toBe(false);
+
+    stderrSpy.mockRestore();
+  });
+
   it("transitions to stuck when idle exceeds agent-stuck threshold (OpenCode-style activity)", async () => {
     config.reactions = {
       "agent-stuck": { auto: true, action: "notify", threshold: "1m" },

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1004,8 +1004,9 @@ describe("spawn", () => {
     expect(session.status).toBe("spawning");
     expect(mockRuntime.sendMessage).toHaveBeenCalled();
     expect(stderrSpy).toHaveBeenCalledWith(
-      expect.stringContaining('"operation":"metadata-update"'),
+      expect.stringContaining('"operation":"prompt-delivery.metadata-update"'),
     );
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('"level":"warn"'));
 
     updateMetadataSpy.mockRestore();
     stderrSpy.mockRestore();

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import {
-  chmodSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-  existsSync,
-} from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { createSessionManager } from "../../session-manager.js";
 import { validateConfig } from "../../config.js";
@@ -26,7 +20,12 @@ import type {
   Tracker,
   RuntimeHandle,
 } from "../../types.js";
-import { setupTestContext, teardownTestContext, makeHandle, type TestContext } from "../test-utils.js";
+import {
+  setupTestContext,
+  teardownTestContext,
+  makeHandle,
+  type TestContext,
+} from "../test-utils.js";
 import { installMockOpencode, installMockGit } from "./opencode-helpers.js";
 
 let ctx: TestContext;
@@ -41,7 +40,16 @@ let originalPath: string | undefined;
 
 beforeEach(() => {
   ctx = setupTestContext();
-  ({ tmpDir, sessionsDir, mockRuntime, mockAgent, mockWorkspace, mockRegistry, config, originalPath } = ctx);
+  ({
+    tmpDir,
+    sessionsDir,
+    mockRuntime,
+    mockAgent,
+    mockWorkspace,
+    mockRegistry,
+    config,
+    originalPath,
+  } = ctx);
 });
 
 afterEach(() => {
@@ -873,7 +881,7 @@ describe("spawn", () => {
 
     const sm = createSessionManager({ config, registry: registryWithPostLaunch });
     const spawnPromise = sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
-    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(2_000);
     await spawnPromise;
 
     // Prompt should be sent via runtime.sendMessage, not included in launch command
@@ -910,7 +918,7 @@ describe("spawn", () => {
 
     const sm = createSessionManager({ config, registry: registryWithPostLaunch });
     const spawnPromise = sm.spawn({ projectId: "my-app" });
-    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(2_000);
     await spawnPromise;
 
     expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
@@ -942,14 +950,65 @@ describe("spawn", () => {
 
     const sm = createSessionManager({ config, registry: registryWithFailingSend });
     const spawnPromise = sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
-    await vi.advanceTimersByTimeAsync(5_000);
+    // Retry logic uses fixed delays: 2s, 4s, 8s
+    await vi.advanceTimersByTimeAsync(14_000);
     const session = await spawnPromise;
 
     // Session should still be returned successfully despite sendMessage failure
     expect(session.id).toBe("app-1");
     expect(session.status).toBe("spawning");
+    expect(failingRuntime.sendMessage).toHaveBeenCalledTimes(3);
+    expect(session.metadata["promptDeliveryStatus"]).toBe("failed");
+    expect(session.metadata["promptDeliveryAttemptedAt"]).toBeDefined();
+
+    const meta = readMetadataRaw(sessionsDir, "app-1");
+    expect(meta?.["promptDeliveryStatus"]).toBe("failed");
+    expect(meta?.["promptDeliveryAttemptedAt"]).toBeDefined();
     // Runtime should NOT have been destroyed
     expect(failingRuntime.destroy).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("continues spawn when prompt metadata persistence fails", async () => {
+    vi.useFakeTimers();
+
+    const postLaunchAgent = {
+      ...mockAgent,
+      promptDelivery: "post-launch" as const,
+    };
+
+    const registryWithPostLaunch: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return postLaunchAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    const metadataModule = await import("../../metadata.js");
+    const updateMetadataSpy = vi.spyOn(metadataModule, "updateMetadata");
+    updateMetadataSpy.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const sm = createSessionManager({ config, registry: registryWithPostLaunch });
+    const spawnPromise = sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
+    await vi.advanceTimersByTimeAsync(2_000);
+    const session = await spawnPromise;
+
+    expect(session.id).toBe("app-1");
+    expect(session.status).toBe("spawning");
+    expect(mockRuntime.sendMessage).toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"operation":"metadata-update"'),
+    );
+
+    updateMetadataSpy.mockRestore();
+    stderrSpy.mockRestore();
     vi.useRealTimers();
   });
 
@@ -972,12 +1031,12 @@ describe("spawn", () => {
     const sm = createSessionManager({ config, registry: registryWithPostLaunch });
     const spawnPromise = sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
 
-    // Advance only 4s — not enough, message should not have been sent yet
-    await vi.advanceTimersByTimeAsync(4_000);
+    // Advance only 1s — not enough, message should not have been sent yet (initial delay is 2s)
+    await vi.advanceTimersByTimeAsync(1_000);
     expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
 
-    // Advance the remaining 1s — now it should fire
-    await vi.advanceTimersByTimeAsync(1_000);
+    // Advance the remaining time to exceed 2s (initial delay)
+    await vi.advanceTimersByTimeAsync(2_000);
     await spawnPromise;
     expect(mockRuntime.sendMessage).toHaveBeenCalled();
     vi.useRealTimers();
@@ -1996,4 +2055,3 @@ describe("spawn", () => {
     });
   });
 });
-

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { isRetryableHttpStatus, normalizeRetryConfig, readLastJsonlEntry } from "../utils.js";
+import {
+  hasApprovalPrompt,
+  isRetryableHttpStatus,
+  normalizeRetryConfig,
+  readLastJsonlEntry,
+} from "../utils.js";
 import { parsePrFromUrl } from "../utils/pr.js";
 
 describe("readLastJsonlEntry", () => {
@@ -137,5 +142,17 @@ describe("parsePrFromUrl", () => {
 
   it("returns null when the URL has no PR number", () => {
     expect(parsePrFromUrl("https://example.com/foo/bar/pull/not-a-number")).toBeNull();
+  });
+});
+
+describe("hasApprovalPrompt", () => {
+  it("detects numbered yes/no options when cursor is on option 1", () => {
+    const output = "Would you like to run this command?\n> 1. Yes, proceed\n  3. No, cancel";
+    expect(hasApprovalPrompt(output)).toBe(true);
+  });
+
+  it("does not detect when only option 1 is present", () => {
+    const output = "Would you like to run this command?\n> 1. Yes, proceed";
+    expect(hasApprovalPrompt(output)).toBe(false);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,7 +78,6 @@ export type {
 export { generateOrchestratorPrompt } from "./orchestrator-prompt.js";
 export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";
 
-
 // Global pause constants and utilities
 export {
   GLOBAL_PAUSE_UNTIL_KEY,
@@ -96,6 +95,7 @@ export {
   normalizeRetryConfig,
   readLastJsonlEntry,
   resolveProjectIdForSessionId,
+  hasApprovalPrompt,
 } from "./utils.js";
 export {
   getWebhookHeader,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -209,6 +209,35 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return idleMs > stuckThresholdMs;
   }
 
+  function maybeLogEarlyNeedsInputAnomaly(
+    session: Session,
+    options?: { detectionMethod?: "activity" | "terminal" },
+  ): void {
+    const promptAttemptedAt = session.metadata["promptDeliveryAttemptedAt"];
+    if (!promptAttemptedAt) return;
+
+    const createdAt = new Date(promptAttemptedAt);
+    const ageMs = Date.now() - createdAt.getTime();
+    const promptStatus = session.metadata["promptDeliveryStatus"];
+    if (ageMs >= 120_000 || promptStatus === "success") return;
+
+    const isTerminalDetection = options?.detectionMethod === "terminal";
+    const anomalyLogEntry = {
+      source: "ao-lifecycle-manager",
+      component: "anomaly-detection",
+      operation: "early-needs-input",
+      outcome: "detected" as const,
+      sessionId: session.id,
+      projectId: session.projectId,
+      reason: `Session entered needs_input within ${Math.round(ageMs / 1000)}s of creation${isTerminalDetection ? " (terminal detection)" : ""}. Likely prompt delivery failure (status: ${promptStatus ?? "unknown"}).`,
+      ageMs,
+      promptDeliveryStatus: promptStatus ?? "unknown",
+      ...(isTerminalDetection ? { detectionMethod: "terminal" as const } : {}),
+      timestamp: new Date().toISOString(),
+    };
+    process.stderr.write(`${JSON.stringify(anomalyLogEntry)}\n`);
+  }
+
   /** Determine current status for a session by polling plugins. */
   async function determineStatus(session: Session): Promise<SessionStatus> {
     const project = config.projects[session.projectId];
@@ -244,30 +273,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         const activityState = await agent.getActivityState(session, config.readyThresholdMs);
         if (activityState) {
           if (activityState.state === "waiting_input") {
-            // Detect early needs_input — likely a failed prompt delivery
-            const createdAt = new Date(
-              session.metadata["promptDeliveryAttemptedAt"] ?? session.createdAt,
-            );
-            const ageMs = Date.now() - createdAt.getTime();
-            const promptStatus = session.metadata["promptDeliveryStatus"];
-            const promptAttemptedAt = session.metadata["promptDeliveryAttemptedAt"];
-
-            // Flag as anomaly if session hit needs_input within 2 minutes and prompt wasn't delivered
-            if (promptAttemptedAt && ageMs < 120_000 && promptStatus !== "success") {
-              const anomalyLogEntry = {
-                source: "ao-lifecycle-manager",
-                component: "anomaly-detection",
-                operation: "early-needs-input",
-                outcome: "detected" as const,
-                sessionId: session.id,
-                projectId: session.projectId,
-                reason: `Session entered needs_input within ${Math.round(ageMs / 1000)}s of creation. Likely prompt delivery failure (status: ${promptStatus ?? "unknown"}).`,
-                ageMs,
-                promptDeliveryStatus: promptStatus ?? "unknown",
-                timestamp: new Date().toISOString(),
-              };
-              process.stderr.write(`${JSON.stringify(anomalyLogEntry)}\n`);
-            }
+            maybeLogEarlyNeedsInputAnomaly(session);
             return "needs_input";
           }
           if (activityState.state === "exited") return "killed";
@@ -305,30 +311,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           if (terminalOutput) {
             const activity = agent.detectActivity(terminalOutput);
             if (activity === "waiting_input") {
-              // Detect early needs_input via terminal output — likely a failed prompt delivery
-              const createdAt = new Date(
-                session.metadata["promptDeliveryAttemptedAt"] ?? session.createdAt,
-              );
-              const ageMs = Date.now() - createdAt.getTime();
-              const promptStatus = session.metadata["promptDeliveryStatus"];
-              const promptAttemptedAt = session.metadata["promptDeliveryAttemptedAt"];
-
-              if (promptAttemptedAt && ageMs < 120_000 && promptStatus !== "success") {
-                const anomalyLogEntry = {
-                  source: "ao-lifecycle-manager",
-                  component: "anomaly-detection",
-                  operation: "early-needs-input",
-                  outcome: "detected" as const,
-                  sessionId: session.id,
-                  projectId: session.projectId,
-                  reason: `Session entered needs_input within ${Math.round(ageMs / 1000)}s of creation (terminal detection). Likely prompt delivery failure (status: ${promptStatus ?? "unknown"}).`,
-                  ageMs,
-                  promptDeliveryStatus: promptStatus ?? "unknown",
-                  detectionMethod: "terminal",
-                  timestamp: new Date().toISOString(),
-                };
-                process.stderr.write(`${JSON.stringify(anomalyLogEntry)}\n`);
-              }
+              maybeLogEarlyNeedsInputAnomaly(session, { detectionMethod: "terminal" });
               return "needs_input";
             }
 

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -222,13 +222,15 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }).agentName;
     const agent = registry.get<Agent>("agent", agentName);
     const scm = project.scm ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    const runtime = session.runtimeHandle
+      ? registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime)
+      : null;
 
     // Track activity state across steps so stuck detection can run after PR checks
     let detectedIdleTimestamp: Date | null = null;
 
     // 1. Check if runtime is alive
     if (session.runtimeHandle) {
-      const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
       if (runtime) {
         const alive = await runtime.isAlive(session.runtimeHandle).catch(() => true);
         if (!alive) return "killed";
@@ -241,7 +243,33 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         // Try JSONL-based activity detection first (reads agent's session files directly)
         const activityState = await agent.getActivityState(session, config.readyThresholdMs);
         if (activityState) {
-          if (activityState.state === "waiting_input") return "needs_input";
+          if (activityState.state === "waiting_input") {
+            // Detect early needs_input — likely a failed prompt delivery
+            const createdAt = new Date(
+              session.metadata["promptDeliveryAttemptedAt"] ?? session.createdAt,
+            );
+            const ageMs = Date.now() - createdAt.getTime();
+            const promptStatus = session.metadata["promptDeliveryStatus"];
+            const promptAttemptedAt = session.metadata["promptDeliveryAttemptedAt"];
+
+            // Flag as anomaly if session hit needs_input within 2 minutes and prompt wasn't delivered
+            if (promptAttemptedAt && ageMs < 120_000 && promptStatus !== "success") {
+              const anomalyLogEntry = {
+                source: "ao-lifecycle-manager",
+                component: "anomaly-detection",
+                operation: "early-needs-input",
+                outcome: "detected" as const,
+                sessionId: session.id,
+                projectId: session.projectId,
+                reason: `Session entered needs_input within ${Math.round(ageMs / 1000)}s of creation. Likely prompt delivery failure (status: ${promptStatus ?? "unknown"}).`,
+                ageMs,
+                promptDeliveryStatus: promptStatus ?? "unknown",
+                timestamp: new Date().toISOString(),
+              };
+              process.stderr.write(`${JSON.stringify(anomalyLogEntry)}\n`);
+            }
+            return "needs_input";
+          }
           if (activityState.state === "exited") return "killed";
 
           if (
@@ -251,18 +279,58 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             detectedIdleTimestamp = activityState.timestamp;
           }
 
+          // Some agents can surface higher-priority prompt states like
+          // waiting_input only through terminal parsing. Preserve the native
+          // activity probe, but allow recent output to upgrade the session
+          // into needs_input without forcing every agent to encode that state
+          // in getActivityState().
+          if (runtime) {
+            try {
+              const terminalOutput = await runtime.getOutput(session.runtimeHandle, 10);
+              if (terminalOutput) {
+                const activity = agent.detectActivity(terminalOutput);
+                if (activity === "waiting_input") return "needs_input";
+              }
+            } catch {
+              // Output probing is only an upgrade path for waiting_input.
+              // Preserve the native activity result if terminal capture fails.
+            }
+          }
+
           // active/ready/idle (below threshold)/blocked (below threshold) —
           // proceed to PR checks below
         } else {
           // getActivityState returned null — fall back to terminal output parsing
-          const runtime = registry.get<Runtime>(
-            "runtime",
-            project.runtime ?? config.defaults.runtime,
-          );
           const terminalOutput = runtime ? await runtime.getOutput(session.runtimeHandle, 10) : "";
           if (terminalOutput) {
             const activity = agent.detectActivity(terminalOutput);
-            if (activity === "waiting_input") return "needs_input";
+            if (activity === "waiting_input") {
+              // Detect early needs_input via terminal output — likely a failed prompt delivery
+              const createdAt = new Date(
+                session.metadata["promptDeliveryAttemptedAt"] ?? session.createdAt,
+              );
+              const ageMs = Date.now() - createdAt.getTime();
+              const promptStatus = session.metadata["promptDeliveryStatus"];
+              const promptAttemptedAt = session.metadata["promptDeliveryAttemptedAt"];
+
+              if (promptAttemptedAt && ageMs < 120_000 && promptStatus !== "success") {
+                const anomalyLogEntry = {
+                  source: "ao-lifecycle-manager",
+                  component: "anomaly-detection",
+                  operation: "early-needs-input",
+                  outcome: "detected" as const,
+                  sessionId: session.id,
+                  projectId: session.projectId,
+                  reason: `Session entered needs_input within ${Math.round(ageMs / 1000)}s of creation (terminal detection). Likely prompt delivery failure (status: ${promptStatus ?? "unknown"}).`,
+                  ageMs,
+                  promptDeliveryStatus: promptStatus ?? "unknown",
+                  detectionMethod: "terminal",
+                  timestamp: new Date().toISOString(),
+                };
+                process.stderr.write(`${JSON.stringify(anomalyLogEntry)}\n`);
+              }
+              return "needs_input";
+            }
 
             const processAlive = await agent.isProcessRunning(session.runtimeHandle);
             if (!processAlive) return "killed";

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -216,26 +216,34 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const promptAttemptedAt = session.metadata["promptDeliveryAttemptedAt"];
     if (!promptAttemptedAt) return;
 
-    const createdAt = new Date(promptAttemptedAt);
-    const ageMs = Date.now() - createdAt.getTime();
+    const attemptedAt = new Date(promptAttemptedAt);
+    const attemptedAtTime = attemptedAt.getTime();
+    if (!Number.isFinite(attemptedAtTime)) return;
+
+    let ageMs = Date.now() - attemptedAtTime;
+    if (ageMs < 0) {
+      ageMs = 0;
+    }
+
     const promptStatus = session.metadata["promptDeliveryStatus"];
     if (ageMs >= 120_000 || promptStatus === "success") return;
 
     const isTerminalDetection = options?.detectionMethod === "terminal";
-    const anomalyLogEntry = {
-      source: "ao-lifecycle-manager",
-      component: "anomaly-detection",
+    observer.recordOperation({
+      metric: "lifecycle_poll",
       operation: "early-needs-input",
-      outcome: "detected" as const,
+      outcome: "failure",
+      correlationId: createCorrelationId("early-needs-input"),
       sessionId: session.id,
       projectId: session.projectId,
-      reason: `Session entered needs_input within ${Math.round(ageMs / 1000)}s of creation${isTerminalDetection ? " (terminal detection)" : ""}. Likely prompt delivery failure (status: ${promptStatus ?? "unknown"}).`,
-      ageMs,
-      promptDeliveryStatus: promptStatus ?? "unknown",
-      ...(isTerminalDetection ? { detectionMethod: "terminal" as const } : {}),
-      timestamp: new Date().toISOString(),
-    };
-    process.stderr.write(`${JSON.stringify(anomalyLogEntry)}\n`);
+      reason: `Session entered needs_input within ${Math.round(ageMs / 1000)}s of prompt delivery attempt${isTerminalDetection ? " (terminal detection)" : ""}. Likely prompt delivery failure (status: ${promptStatus ?? "unknown"}).`,
+      data: {
+        ageMs,
+        promptDeliveryStatus: promptStatus ?? "unknown",
+        ...(isTerminalDetection ? { detectionMethod: "terminal" as const } : {}),
+      },
+      level: "warn",
+    });
   }
 
   /** Determine current status for a session by polling plugins. */

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -226,7 +226,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     const promptStatus = session.metadata["promptDeliveryStatus"];
-    if (ageMs >= 120_000 || promptStatus === "success") return;
+    if (ageMs >= 120_000 || promptStatus !== "failed") return;
 
     const isTerminalDetection = options?.detectionMethod === "terminal";
     observer.recordOperation({
@@ -236,10 +236,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       correlationId: createCorrelationId("early-needs-input"),
       sessionId: session.id,
       projectId: session.projectId,
-      reason: `Session entered needs_input within ${Math.round(ageMs / 1000)}s of prompt delivery attempt${isTerminalDetection ? " (terminal detection)" : ""}. Likely prompt delivery failure (status: ${promptStatus ?? "unknown"}).`,
+      reason: `Session entered needs_input within ${Math.round(ageMs / 1000)}s of prompt delivery attempt${isTerminalDetection ? " (terminal detection)" : ""} after prompt delivery failed.`,
       data: {
         ageMs,
-        promptDeliveryStatus: promptStatus ?? "unknown",
+        promptDeliveryStatus: promptStatus,
         ...(isTerminalDetection ? { detectionMethod: "terminal" as const } : {}),
       },
       level: "warn",

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -295,7 +295,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
               const terminalOutput = await runtime.getOutput(session.runtimeHandle, 10);
               if (terminalOutput) {
                 const activity = agent.detectActivity(terminalOutput);
-                if (activity === "waiting_input") return "needs_input";
+                if (activity === "waiting_input") {
+                  maybeLogEarlyNeedsInputAnomaly(session, { detectionMethod: "terminal" });
+                  return "needs_input";
+                }
               }
             } catch {
               // Output probing is only an upgrade path for waiting_input.

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -298,7 +298,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           // activity probe, but allow recent output to upgrade the session
           // into needs_input without forcing every agent to encode that state
           // in getActivityState().
-          if (runtime) {
+          if (
+            runtime &&
+            (activityState.state === "idle" ||
+              activityState.state === "blocked" ||
+              activityState.state === "ready")
+          ) {
             try {
               const terminalOutput = await runtime.getOutput(session.runtimeHandle, 10);
               if (terminalOutput) {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1215,7 +1215,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
         try {
           const delay = retryDelaysMs[attempt];
-          await new Promise((resolve) => setTimeout(resolve, delay));
+          await sleep(delay);
           await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
 
           promptDeliveryStatus = "success";

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -63,6 +63,7 @@ import {
   generateConfigHash,
   validateAndStoreOrigin,
 } from "./paths.js";
+import { createCorrelationId, createProjectObserver } from "./observability.js";
 import { asValidOpenCodeSessionId } from "./opencode-session-id.js";
 import { normalizeOrchestratorSessionStrategy } from "./orchestrator-session-strategy.js";
 import {
@@ -265,6 +266,7 @@ export interface SessionManagerDeps {
 /** Create a SessionManager instance. */
 export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionManager {
   const { config, registry } = deps;
+  const observer = createProjectObserver(config, "session-manager");
 
   interface LocatedSession {
     raw: Record<string, string>;
@@ -1191,17 +1193,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           updateMetadata(sessionsDir, sessionId, patch);
         } catch (err) {
           const errorDetails = err instanceof Error ? err.message : String(err);
-          const metadataFailureLogEntry = {
-            source: "ao-session-manager",
-            component: "prompt-delivery",
-            operation: "metadata-update",
-            outcome: "failure" as const,
+          observer.recordOperation({
+            metric: "spawn",
+            operation: "prompt-delivery.metadata-update",
+            outcome: "failure",
+            correlationId: createCorrelationId("spawn-prompt-metadata"),
             sessionId,
             projectId: spawnConfig.projectId,
             reason: `Failed to persist prompt delivery metadata: ${errorDetails}`,
-            timestamp: new Date().toISOString(),
-          };
-          process.stderr.write(`${JSON.stringify(metadataFailureLogEntry)}\n`);
+            level: "warn",
+          });
         }
       };
 
@@ -1219,48 +1220,53 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
 
           promptDeliveryStatus = "success";
-          const successLogEntry = {
-            source: "ao-session-manager",
-            component: "prompt-delivery",
-            operation: "post-launch-prompt",
-            outcome: "success" as const,
+          observer.recordOperation({
+            metric: "spawn",
+            operation: "prompt-delivery.post-launch",
+            outcome: "success",
+            correlationId: createCorrelationId("spawn-prompt-delivery"),
             sessionId,
             projectId: spawnConfig.projectId,
             reason: `Initial prompt delivered on attempt ${attempt + 1}`,
-            attempt: attempt + 1,
-            timestamp: new Date().toISOString(),
-          };
-          process.stderr.write(`${JSON.stringify(successLogEntry)}\n`);
+            data: {
+              attempt: attempt + 1,
+              maxAttempts,
+            },
+            level: "info",
+          });
           break;
         } catch (err) {
           const errorDetails = err instanceof Error ? err.message : String(err);
-          const failureLogEntry = {
-            source: "ao-session-manager",
-            component: "prompt-delivery",
-            operation: "post-launch-prompt",
-            outcome: "failure" as const,
+          observer.recordOperation({
+            metric: "spawn",
+            operation: "prompt-delivery.post-launch",
+            outcome: "failure",
+            correlationId: createCorrelationId("spawn-prompt-delivery"),
             sessionId,
             projectId: spawnConfig.projectId,
             reason: `Failed to deliver initial prompt on attempt ${attempt + 1}/${maxAttempts}: ${errorDetails}`,
-            attempt: attempt + 1,
-            maxAttempts,
-            timestamp: new Date().toISOString(),
-          };
-          process.stderr.write(`${JSON.stringify(failureLogEntry)}\n`);
+            data: {
+              attempt: attempt + 1,
+              maxAttempts,
+            },
+            level: "warn",
+          });
 
           if (attempt === maxAttempts - 1) {
             promptDeliveryStatus = "failed";
-            const finalFailureLogEntry = {
-              source: "ao-session-manager",
-              component: "prompt-delivery",
-              operation: "post-launch-prompt",
-              outcome: "failure" as const,
+            observer.recordOperation({
+              metric: "spawn",
+              operation: "prompt-delivery.post-launch",
+              outcome: "failure",
+              correlationId: createCorrelationId("spawn-prompt-delivery"),
               sessionId,
               projectId: spawnConfig.projectId,
               reason: `All ${maxAttempts} attempts to deliver initial prompt failed. Agent may need manual input via 'ao send'.`,
-              timestamp: new Date().toISOString(),
-            };
-            process.stderr.write(`${JSON.stringify(finalFailureLogEntry)}\n`);
+              data: {
+                maxAttempts,
+              },
+              level: "warn",
+            });
           }
         }
       }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1073,7 +1073,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           AO_CALLER_TYPE: "agent",
           AO_PROJECT_ID: spawnConfig.projectId,
           AO_CONFIG_PATH: config.configPath,
-          ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) }),
+          ...(config.port !== undefined &&
+            config.port !== null && { AO_PORT: String(config.port) }),
         },
       });
     } catch (err) {
@@ -1179,15 +1180,96 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     // exits after -p, so we send the prompt after it starts in interactive mode).
     // This is intentionally outside the try/catch above — a prompt delivery failure
     // should NOT destroy the session. The agent is running; user can retry with `ao send`.
+    let promptDeliveryStatus: "success" | "failed" | "pending" = "pending";
     if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt) {
-      try {
-        // Wait for agent to start and be ready for input
-        await new Promise((resolve) => setTimeout(resolve, 5_000));
-        await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
-      } catch {
-        // Non-fatal: agent is running but didn't receive the initial prompt.
-        // User can retry with `ao send`.
+      const retryDelaysMs = [2_000, 4_000, 8_000] as const;
+      const maxAttempts = retryDelaysMs.length;
+      const promptDeliveryAttemptedAt = new Date().toISOString();
+
+      const safeUpdatePromptDeliveryMetadata = (patch: Record<string, string>): void => {
+        try {
+          updateMetadata(sessionsDir, sessionId, patch);
+        } catch (err) {
+          const errorDetails = err instanceof Error ? err.message : String(err);
+          const metadataFailureLogEntry = {
+            source: "ao-session-manager",
+            component: "prompt-delivery",
+            operation: "metadata-update",
+            outcome: "failure" as const,
+            sessionId,
+            projectId: spawnConfig.projectId,
+            reason: `Failed to persist prompt delivery metadata: ${errorDetails}`,
+            timestamp: new Date().toISOString(),
+          };
+          process.stderr.write(`${JSON.stringify(metadataFailureLogEntry)}\n`);
+        }
+      };
+
+      session.metadata["promptDeliveryStatus"] = promptDeliveryStatus;
+      session.metadata["promptDeliveryAttemptedAt"] = promptDeliveryAttemptedAt;
+      safeUpdatePromptDeliveryMetadata({
+        promptDeliveryStatus,
+        promptDeliveryAttemptedAt,
+      });
+
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+          const delay = retryDelaysMs[attempt];
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
+
+          promptDeliveryStatus = "success";
+          const successLogEntry = {
+            source: "ao-session-manager",
+            component: "prompt-delivery",
+            operation: "post-launch-prompt",
+            outcome: "success" as const,
+            sessionId,
+            projectId: spawnConfig.projectId,
+            reason: `Initial prompt delivered on attempt ${attempt + 1}`,
+            attempt: attempt + 1,
+            timestamp: new Date().toISOString(),
+          };
+          process.stderr.write(`${JSON.stringify(successLogEntry)}\n`);
+          break;
+        } catch (err) {
+          const errorDetails = err instanceof Error ? err.message : String(err);
+          const failureLogEntry = {
+            source: "ao-session-manager",
+            component: "prompt-delivery",
+            operation: "post-launch-prompt",
+            outcome: "failure" as const,
+            sessionId,
+            projectId: spawnConfig.projectId,
+            reason: `Failed to deliver initial prompt on attempt ${attempt + 1}/${maxAttempts}: ${errorDetails}`,
+            attempt: attempt + 1,
+            maxAttempts,
+            timestamp: new Date().toISOString(),
+          };
+          process.stderr.write(`${JSON.stringify(failureLogEntry)}\n`);
+
+          if (attempt === maxAttempts - 1) {
+            promptDeliveryStatus = "failed";
+            const finalFailureLogEntry = {
+              source: "ao-session-manager",
+              component: "prompt-delivery",
+              operation: "post-launch-prompt",
+              outcome: "failure" as const,
+              sessionId,
+              projectId: spawnConfig.projectId,
+              reason: `All ${maxAttempts} attempts to deliver initial prompt failed. Agent may need manual input via 'ao send'.`,
+              timestamp: new Date().toISOString(),
+            };
+            process.stderr.write(`${JSON.stringify(finalFailureLogEntry)}\n`);
+          }
+        }
       }
+
+      session.metadata["promptDeliveryStatus"] = promptDeliveryStatus;
+      safeUpdatePromptDeliveryMetadata({ promptDeliveryStatus });
+
+      // Non-fatal: agent is running but didn't receive the initial prompt after all retries.
+      // User can retry with `ao send`.
     }
 
     return session;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -3,6 +3,7 @@
  */
 
 import { open, stat } from "node:fs/promises";
+import { stripVTControlCharacters } from "node:util";
 import type { OrchestratorConfig } from "./types.js";
 
 /**
@@ -51,9 +52,10 @@ export function normalizeRetryConfig(
   const rawRetries = config?.retries as number | undefined;
   const rawDelay = config?.retryDelayMs as number | undefined;
   const retries = Number.isFinite(rawRetries) ? Math.max(0, rawRetries ?? 0) : defaults.retries;
-  const retryDelayMs = Number.isFinite(rawDelay) && (rawDelay ?? -1) >= 0
-    ? (rawDelay as number)
-    : defaults.retryDelayMs;
+  const retryDelayMs =
+    Number.isFinite(rawDelay) && (rawDelay ?? -1) >= 0
+      ? (rawDelay as number)
+      : defaults.retryDelayMs;
   return { retries, retryDelayMs };
 }
 
@@ -148,4 +150,27 @@ export function resolveProjectIdForSessionId(
     }
   }
   return undefined;
+}
+
+/**
+ * Shared approval prompt detector for terminal output.
+ * Handles ANSI-colored output and common yes/no confirmation formats.
+ */
+export function hasApprovalPrompt(terminalOutput: string): boolean {
+  if (!terminalOutput.trim()) return false;
+
+  const tail = terminalOutput
+    .trim()
+    .split("\n")
+    .slice(-15)
+    .map((line) => stripVTControlCharacters(line))
+    .join("\n");
+
+  if (/approval required/i.test(tail)) return true;
+  if (/\(y\)es.*\(n\)o/i.test(tail)) return true;
+  if (/press enter to confirm or esc to cancel/i.test(tail)) return true;
+
+  const hasYesOption = /^\s*1\.\s*(yes|proceed|allow)/im.test(tail);
+  const hasNoOption = /^\s*[>*]?\s*[2-9]\.\s*(no|deny|skip|cancel)/im.test(tail);
+  return hasYesOption && hasNoOption;
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -170,7 +170,7 @@ export function hasApprovalPrompt(terminalOutput: string): boolean {
   if (/\(y\)es.*\(n\)o/i.test(tail)) return true;
   if (/press enter to confirm or esc to cancel/i.test(tail)) return true;
 
-  const hasYesOption = /^\s*1\.\s*(yes|proceed|allow)/im.test(tail);
+  const hasYesOption = /^\s*[>*]?\s*1\.\s*(yes|proceed|allow)/im.test(tail);
   const hasNoOption = /^\s*[>*]?\s*[2-9]\.\s*(no|deny|skip|cancel)/im.test(tail);
   return hasYesOption && hasNoOption;
 }

--- a/packages/integration-tests/src/agent-codex-launch-env.integration.test.ts
+++ b/packages/integration-tests/src/agent-codex-launch-env.integration.test.ts
@@ -19,6 +19,10 @@ function makeLaunchConfig(overrides: Partial<AgentLaunchConfig> = {}): AgentLaun
 describe("agent-codex launch/env wiring (integration)", () => {
   const agent = codexPlugin.create();
 
+  it("uses post-launch prompt delivery mode", () => {
+    expect(agent.promptDelivery).toBe("post-launch");
+  });
+
   it("includes check_for_update_on_startup=false in launch command", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig());
     expect(cmd).toContain("-c check_for_update_on_startup=false");
@@ -33,6 +37,7 @@ describe("agent-codex launch/env wiring (integration)", () => {
       }),
     );
     expect(cmd).toContain("-c check_for_update_on_startup=false");
+    expect(cmd).not.toContain("Do the thing");
     expect(cmd).not.toContain("--ask-for-approval");
     expect(cmd).toContain("--model 'o3-mini'");
     expect(cmd).toContain("-c model_reasoning_effort=high");

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -6,22 +6,7 @@ import type {
   AgentSpecificConfig,
 } from "@composio/ao-core";
 
-vi.mock("@composio/ao-core", async (importOriginal) => {
-  const actual = (await importOriginal()) as object;
-  return {
-    ...actual,
-    hasApprovalPrompt: (terminalOutput: string): boolean => {
-      if (!terminalOutput.trim()) return false;
-      const tail = terminalOutput.trim().split("\n").slice(-15).join("\n");
-      if (/approval required/i.test(tail)) return true;
-      if (/\(y\)es.*\(n\)o/i.test(tail)) return true;
-      if (/press enter to confirm or esc to cancel/i.test(tail)) return true;
-      const hasYesOption = /^\s*1\.\s*(yes|proceed|allow)/im.test(tail);
-      const hasNoOption = /^\s*[>*]?\s*[2-9]\.\s*(no|deny|skip|cancel)/im.test(tail);
-      return hasYesOption && hasNoOption;
-    },
-  };
-});
+vi.mock("@composio/ao-core", async (importOriginal) => importOriginal());
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — available inside vi.mock factories

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Session, RuntimeHandle, AgentLaunchConfig, AgentSpecificConfig } from "@composio/ao-core";
+import type {
+  Session,
+  RuntimeHandle,
+  AgentLaunchConfig,
+  AgentSpecificConfig,
+} from "@composio/ao-core";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — available inside vi.mock factories
@@ -62,7 +67,13 @@ vi.mock("node:os", () => ({
 }));
 
 import { Readable } from "node:stream";
-import { create, manifest, default as defaultExport, resolveCodexBinary, _resetSessionFileCache } from "./index.js";
+import {
+  create,
+  manifest,
+  default as defaultExport,
+  resolveCodexBinary,
+  _resetSessionFileCache,
+} from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -131,11 +142,13 @@ function mockTmuxWithProcess(processName: string, found = true) {
 function makeFakeFileHandle(content: string) {
   const buf = Buffer.from(content, "utf-8");
   return {
-    read: vi.fn().mockImplementation((buffer: Buffer, offset: number, length: number, _position: number) => {
-      const bytesToCopy = Math.min(length, buf.length);
-      buf.copy(buffer, offset, 0, bytesToCopy);
-      return Promise.resolve({ bytesRead: bytesToCopy, buffer });
-    }),
+    read: vi
+      .fn()
+      .mockImplementation((buffer: Buffer, offset: number, length: number, _position: number) => {
+        const bytesToCopy = Math.min(length, buf.length);
+        buf.copy(buffer, offset, 0, bytesToCopy);
+        return Promise.resolve({ bytesRead: bytesToCopy, buffer });
+      }),
     close: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -196,6 +209,7 @@ describe("plugin manifest & exports", () => {
     const agent = create();
     expect(agent.name).toBe("codex");
     expect(agent.processName).toBe("codex");
+    expect(agent.promptDelivery).toBe("post-launch");
   });
 
   it("default export is a valid PluginModule", () => {
@@ -211,7 +225,9 @@ describe("getLaunchCommand", () => {
   const agent = create();
 
   it("generates base command", () => {
-    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("'codex' -c check_for_update_on_startup=false");
+    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe(
+      "'codex' -c check_for_update_on_startup=false",
+    );
   });
 
   it("includes bypass flag when permissions=permissionless", () => {
@@ -250,29 +266,28 @@ describe("getLaunchCommand", () => {
     expect(cmd).toContain("--model 'gpt-4o'");
   });
 
-  it("appends shell-escaped prompt with -- separator", () => {
+  it("does not inline prompt in launch command (post-launch delivery)", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "Fix it" }));
-    expect(cmd).toContain("-- 'Fix it'");
+    expect(cmd).not.toContain("Fix it");
   });
 
   it("combines all options", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ permissions: "permissionless", model: "o3", prompt: "Go" }),
     );
-    expect(cmd).toBe("'codex' -c check_for_update_on_startup=false --dangerously-bypass-approvals-and-sandbox --model 'o3' -c model_reasoning_effort=high -- 'Go'");
-  });
-
-  it("escapes single quotes in prompt (POSIX shell escaping)", () => {
-    const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "it's broken" }));
-    expect(cmd).toContain("-- 'it'\\''s broken'");
-  });
-
-  it("escapes dangerous characters in prompt", () => {
-    const cmd = agent.getLaunchCommand(
-      makeLaunchConfig({ prompt: "$(rm -rf /); `evil`; $HOME" }),
+    expect(cmd).toBe(
+      "'codex' -c check_for_update_on_startup=false --dangerously-bypass-approvals-and-sandbox --model 'o3' -c model_reasoning_effort=high",
     );
-    // Single-quoted strings prevent shell expansion
-    expect(cmd).toContain("-- '$(rm -rf /); `evil`; $HOME'");
+  });
+
+  it("keeps launch command stable with quoted prompt input", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "it's broken" }));
+    expect(cmd).toBe("'codex' -c check_for_update_on_startup=false");
+  });
+
+  it("keeps launch command stable with dangerous prompt characters", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "$(rm -rf /); `evil`; $HOME" }));
+    expect(cmd).toBe("'codex' -c check_for_update_on_startup=false");
   });
 
   it("includes -c model_instructions_file when systemPromptFile is set", () => {
@@ -395,7 +410,7 @@ describe("getEnvironment", () => {
       process.env["PATH"] = originalPath;
     }
   });
- 
+
   it("sets CODEX_DISABLE_UPDATE_CHECK=1 to suppress interactive update prompts", () => {
     const env = agent.getEnvironment(makeLaunchConfig());
     expect(env["CODEX_DISABLE_UPDATE_CHECK"]).toBe("1");
@@ -573,15 +588,35 @@ describe("detectActivity", () => {
     expect(agent.detectActivity("Do you want to continue?\n(y)es / (n)o\n")).toBe("waiting_input");
   });
 
+  it("returns waiting_input for 'Press enter to confirm or esc to cancel' prompt", () => {
+    expect(agent.detectActivity("Press enter to confirm or esc to cancel\n")).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for numbered approval options", () => {
+    expect(
+      agent.detectActivity(
+        "Would you like to run this command?\n1. Yes, proceed\n> 3. No, and tell Codex what to do differently\n",
+      ),
+    ).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for ANSI-colored approval options", () => {
+    expect(
+      agent.detectActivity(
+        "\u001b[32m1. Yes, proceed\u001b[0m\n\u001b[36m> 3. No, and tell Codex what to do differently\u001b[0m\nPress enter to confirm or esc to cancel\n",
+      ),
+    ).toBe("waiting_input");
+  });
+
   it("returns waiting_input when permission prompt follows historical activity", () => {
     // Permission prompt at the bottom should NOT be overridden by historical
     // spinner/esc output higher in the buffer.
-    expect(
-      agent.detectActivity("✶ Writing files\nDone.\napproval required\n"),
-    ).toBe("waiting_input");
-    expect(
-      agent.detectActivity("Working (esc to interrupt)\nFinished\n(y)es / (n)o\n"),
-    ).toBe("waiting_input");
+    expect(agent.detectActivity("✶ Writing files\nDone.\napproval required\n")).toBe(
+      "waiting_input",
+    );
+    expect(agent.detectActivity("Working (esc to interrupt)\nFinished\n(y)es / (n)o\n")).toBe(
+      "waiting_input",
+    );
   });
 
   // -- Active states --
@@ -640,7 +675,10 @@ describe("getActivityState", () => {
   it("returns null when process is running but no session file found", async () => {
     mockTmuxWithProcess("codex");
     mockReaddir.mockRejectedValue(new Error("ENOENT"));
-    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const session = makeSession({
+      runtimeHandle: makeTmuxHandle(),
+      workspacePath: "/workspace/test",
+    });
     expect(await agent.getActivityState(session)).toBeNull();
   });
 
@@ -652,7 +690,10 @@ describe("getActivityState", () => {
     // mtime = now (just modified)
     mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
 
-    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const session = makeSession({
+      runtimeHandle: makeTmuxHandle(),
+      workspacePath: "/workspace/test",
+    });
     const result = await agent.getActivityState(session);
     expect(result?.state).toBe("active");
     expect(result?.timestamp).toBeInstanceOf(Date);
@@ -667,7 +708,10 @@ describe("getActivityState", () => {
     const staleTime = Date.now() - 600_000;
     mockStat.mockResolvedValue({ mtimeMs: staleTime, mtime: new Date(staleTime) });
 
-    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const session = makeSession({
+      runtimeHandle: makeTmuxHandle(),
+      workspacePath: "/workspace/test",
+    });
     const result = await agent.getActivityState(session);
     expect(result?.state).toBe("idle");
     expect(result?.timestamp).toBeInstanceOf(Date);
@@ -719,14 +763,34 @@ describe("getSessionInfo", () => {
     const content = jsonl({ type: "session_meta", cwd: "/other/workspace", model: "gpt-4o" });
     setupMockOpen(content);
     mockReadFile.mockResolvedValue(content);
-    expect(await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }))).toBeNull();
+    expect(
+      await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" })),
+    ).toBeNull();
   });
 
   it("returns session info with cost and model when matching session found", async () => {
     const sessionContent = jsonl(
       { type: "session_meta", cwd: "/workspace/test", model: "o3-mini" },
-      { type: "event_msg", msg: { type: "token_count", input_tokens: 1000, output_tokens: 500, cached_tokens: 200, reasoning_tokens: 100 } },
-      { type: "event_msg", msg: { type: "token_count", input_tokens: 2000, output_tokens: 300, cached_tokens: 0, reasoning_tokens: 0 } },
+      {
+        type: "event_msg",
+        msg: {
+          type: "token_count",
+          input_tokens: 1000,
+          output_tokens: 500,
+          cached_tokens: 200,
+          reasoning_tokens: 100,
+        },
+      },
+      {
+        type: "event_msg",
+        msg: {
+          type: "token_count",
+          input_tokens: 2000,
+          output_tokens: 300,
+          cached_tokens: 0,
+          reasoning_tokens: 0,
+        },
+      },
     );
 
     mockReaddir.mockResolvedValue(["session-123.jsonl"]);
@@ -751,12 +815,8 @@ describe("getSessionInfo", () => {
   });
 
   it("picks the most recently modified matching session file", async () => {
-    const oldContent = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
-    );
-    const newContent = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "o3" },
-    );
+    const oldContent = jsonl({ type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" });
+    const newContent = jsonl({ type: "session_meta", cwd: "/workspace/test", model: "o3" });
 
     mockReaddir.mockResolvedValue(["old-session.jsonl", "new-session.jsonl"]);
     mockOpen.mockImplementation(async (path: string) => {
@@ -788,7 +848,8 @@ describe("getSessionInfo", () => {
   });
 
   it("handles corrupt/malformed JSONL lines gracefully", async () => {
-    const content = '{"type":"session_meta","cwd":"/workspace/test","model":"gpt-4o"}\n' +
+    const content =
+      '{"type":"session_meta","cwd":"/workspace/test","model":"gpt-4o"}\n' +
       "not valid json\n" +
       '{"type":"event_msg","msg":{"type":"token_count","input_tokens":500,"output_tokens":200}}\n';
 
@@ -851,15 +912,17 @@ describe("getSessionInfo", () => {
     setupMockOpen(jsonl({ type: "session_meta", cwd: "/workspace/test" }));
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
     mockReadFile.mockRejectedValue(new Error("EACCES"));
-    mockCreateReadStream.mockImplementation(() => { throw new Error("EACCES"); });
+    mockCreateReadStream.mockImplementation(() => {
+      throw new Error("EACCES");
+    });
 
-    expect(await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }))).toBeNull();
+    expect(
+      await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" })),
+    ).toBeNull();
   });
 
   it("skips session files when stat throws", async () => {
-    const content = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
-    );
+    const content = jsonl({ type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" });
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     setupMockOpen(content);
     mockReadFile.mockResolvedValue(content);
@@ -900,9 +963,7 @@ describe("getSessionInfo", () => {
     mockLstat.mockResolvedValue({ isDirectory: () => true });
     // stat is used by findCodexSessionFile to get mtimeMs of matching JSONL files
     mockStat.mockResolvedValue({ mtimeMs: 2000 });
-    const content = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "o3-mini" },
-    );
+    const content = jsonl({ type: "session_meta", cwd: "/workspace/test", model: "o3-mini" });
     setupMockOpen(content);
     setupMockStream(content);
     mockReadFile.mockResolvedValue(content);
@@ -915,9 +976,7 @@ describe("getSessionInfo", () => {
 
   it("ignores non-JSONL files in sessions directory", async () => {
     mockReaddir.mockResolvedValue(["notes.txt", "config.json", "sess.jsonl"]);
-    const content = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
-    );
+    const content = jsonl({ type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" });
     setupMockOpen(content);
     setupMockStream(content);
     mockReadFile.mockResolvedValue(content);
@@ -1021,9 +1080,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { permissions: "permissionless" },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { permissions: "permissionless" },
+      }),
+    );
 
     expect(cmd).toContain("--dangerously-bypass-approvals-and-sandbox");
     expect(cmd).not.toContain("--ask-for-approval");
@@ -1041,9 +1103,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { permissions: "skip" as unknown as AgentSpecificConfig["permissions"] },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { permissions: "skip" as unknown as AgentSpecificConfig["permissions"] },
+      }),
+    );
 
     expect(cmd).toContain("--dangerously-bypass-approvals-and-sandbox");
   });
@@ -1060,9 +1125,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { permissions: "auto-edit" },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { permissions: "auto-edit" },
+      }),
+    );
 
     expect(cmd).toContain("--ask-for-approval never");
     expect(cmd).not.toContain("--dangerously-bypass-approvals-and-sandbox");
@@ -1080,9 +1148,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { permissions: "suggest" },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { permissions: "suggest" },
+      }),
+    );
 
     expect(cmd).toContain("--ask-for-approval untrusted");
   });
@@ -1099,9 +1170,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { permissions: "auto-edit", model: "o3-mini" },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { permissions: "auto-edit", model: "o3-mini" },
+      }),
+    );
 
     expect(cmd).not.toBeNull();
     // threadId should come after all flags
@@ -1124,9 +1198,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { model: "o3-mini" },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { model: "o3-mini" },
+      }),
+    );
 
     expect(cmd).toContain("--model 'o3-mini'");
     expect(cmd).toContain("-c model_reasoning_effort=high");
@@ -1156,7 +1233,9 @@ describe("getRestoreCommand", () => {
     setupMockOpen(jsonl({ type: "session_meta", cwd: "/workspace/test" }));
     // readFile (full parse) fails
     mockReadFile.mockRejectedValue(new Error("EACCES"));
-    mockCreateReadStream.mockImplementation(() => { throw new Error("EACCES"); });
+    mockCreateReadStream.mockImplementation(() => {
+      throw new Error("EACCES");
+    });
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
@@ -1277,13 +1356,17 @@ describe("postLaunchSetup", () => {
     mockReadFile.mockRejectedValue(new Error("ENOENT"));
 
     // Before postLaunchSetup, binary is "codex"
-    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("'codex' -c check_for_update_on_startup=false");
+    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe(
+      "'codex' -c check_for_update_on_startup=false",
+    );
 
     // After postLaunchSetup resolves the binary
     await agent.postLaunchSetup!(makeSession({ workspacePath: "/workspace/test" }));
 
     // Now getLaunchCommand should use the resolved binary
-    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("'/opt/bin/codex' -c check_for_update_on_startup=false");
+    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe(
+      "'/opt/bin/codex' -c check_for_update_on_startup=false",
+    );
   });
 });
 
@@ -1500,8 +1583,7 @@ describe("setupWorkspaceHooks", () => {
     // Every wrapper file should be written to a .tmp file first, then renamed
     // This ensures concurrent readers never see a partially written file
     const tmpWrites = mockWriteFile.mock.calls.filter(
-      (call: [string, string, object]) =>
-        typeof call[0] === "string" && call[0].includes(".tmp."),
+      (call: [string, string, object]) => typeof call[0] === "string" && call[0].includes(".tmp."),
     );
     const renames = mockRename.mock.calls;
 
@@ -1522,7 +1604,9 @@ describe("setupWorkspaceHooks", () => {
         return Promise.resolve("0.1.1");
       }
       if (typeof path === "string" && path.endsWith("AGENTS.md")) {
-        return Promise.resolve("# Existing\n\n## Agent Orchestrator (ao) Session\n\nAlready here.\n");
+        return Promise.resolve(
+          "# Existing\n\n## Agent Orchestrator (ao) Session\n\nAlready here.\n",
+        );
       }
       return Promise.reject(new Error("ENOENT"));
     });
@@ -1559,10 +1643,9 @@ describe("shell wrapper content", () => {
 
     // With atomic writes, content is written to a .tmp. file
     const call = mockWriteFile.mock.calls.find(
-      (c: [string, string, object]) =>
-        typeof c[0] === "string" && c[0].includes(`/${name}.tmp.`),
+      (c: [string, string, object]) => typeof c[0] === "string" && c[0].includes(`/${name}.tmp.`),
     );
-    return call ? call[1] as string : "";
+    return call ? (call[1] as string) : "";
   }
 
   describe("metadata helper", () => {

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -6,6 +6,23 @@ import type {
   AgentSpecificConfig,
 } from "@composio/ao-core";
 
+vi.mock("@composio/ao-core", async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    hasApprovalPrompt: (terminalOutput: string): boolean => {
+      if (!terminalOutput.trim()) return false;
+      const tail = terminalOutput.trim().split("\n").slice(-15).join("\n");
+      if (/approval required/i.test(tail)) return true;
+      if (/\(y\)es.*\(n\)o/i.test(tail)) return true;
+      if (/press enter to confirm or esc to cancel/i.test(tail)) return true;
+      const hasYesOption = /^\s*1\.\s*(yes|proceed|allow)/im.test(tail);
+      const hasNoOption = /^\s*[>*]?\s*[2-9]\.\s*(no|deny|skip|cancel)/im.test(tail);
+      return hasYesOption && hasNoOption;
+    },
+  };
+});
+
 // ---------------------------------------------------------------------------
 // Hoisted mocks — available inside vi.mock factories
 // ---------------------------------------------------------------------------

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_READY_THRESHOLD_MS,
+  hasApprovalPrompt,
   shellEscape,
   type Agent,
   type AgentSessionInfo,
@@ -675,13 +676,7 @@ function createCodexAgent(): Agent {
 
       // Check last few lines for approval prompts
       const tail = lines.slice(-15).map(stripAnsi).join("\n");
-      if (/approval required/i.test(tail)) return "waiting_input";
-      if (/\(y\)es.*\(n\)o/i.test(tail)) return "waiting_input";
-      if (/press enter to confirm or esc to cancel/i.test(tail)) return "waiting_input";
-
-      const hasYesOption = /^\s*1\.\s*(yes|proceed|allow)/im.test(tail);
-      const hasNoOption = /^\s*[>*]?\s*[2-9]\.\s*(no|deny|skip|cancel)/im.test(tail);
-      if (hasYesOption && hasNoOption) return "waiting_input";
+      if (hasApprovalPrompt(tail)) return "waiting_input";
 
       // Default to active — specific patterns (esc to interrupt, spinner
       // symbols) all map to "active" so no need to check them individually.

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -19,7 +19,7 @@ import { writeFile, mkdir, readFile, readdir, rename, stat, lstat, open } from "
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import { createInterface } from "node:readline";
-import { promisify } from "node:util";
+import { promisify, stripVTControlCharacters } from "node:util";
 import { randomBytes } from "node:crypto";
 
 const execFileAsync = promisify(execFile);
@@ -665,8 +665,7 @@ function createCodexAgent(): Agent {
     detectActivity(terminalOutput: string): ActivityState {
       if (!terminalOutput.trim()) return "idle";
 
-      const stripAnsi = (value: string): string =>
-        value.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "");
+      const stripAnsi = (value: string): string => stripVTControlCharacters(value);
 
       const lines = terminalOutput.trim().split("\n");
       const lastLine = stripAnsi(lines[lines.length - 1] ?? "").trim();

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -24,10 +24,17 @@ import { randomBytes } from "node:crypto";
 
 const execFileAsync = promisify(execFile);
 
-function normalizePermissionMode(mode: string | undefined): "permissionless" | "default" | "auto-edit" | "suggest" | undefined {
+function normalizePermissionMode(
+  mode: string | undefined,
+): "permissionless" | "default" | "auto-edit" | "suggest" | undefined {
   if (!mode) return undefined;
   if (mode === "skip") return "permissionless";
-  if (mode === "permissionless" || mode === "default" || mode === "auto-edit" || mode === "suggest") {
+  if (
+    mode === "permissionless" ||
+    mode === "default" ||
+    mode === "auto-edit" ||
+    mode === "suggest"
+  ) {
     return mode;
   }
   return undefined;
@@ -279,11 +286,7 @@ async function setupCodexWorkspace(workspacePath: string): Promise<void> {
   // 1. Write shared wrappers to ~/.ao/bin/
   await mkdir(AO_BIN_DIR, { recursive: true });
 
-  await atomicWriteFile(
-    join(AO_BIN_DIR, "ao-metadata-helper.sh"),
-    AO_METADATA_HELPER,
-    0o755,
-  );
+  await atomicWriteFile(join(AO_BIN_DIR, "ao-metadata-helper.sh"), AO_METADATA_HELPER, 0o755);
 
   // Only write wrappers if they don't exist or are outdated (check marker)
   const markerPath = join(AO_BIN_DIR, ".ao-version");
@@ -397,10 +400,7 @@ async function collectJsonlFiles(dir: string, depth = 0): Promise<string[]> {
  * entry matching the given workspace path. Reads only the first 4 KB
  * to avoid loading large rollout files into memory.
  */
-async function sessionFileMatchesCwd(
-  filePath: string,
-  workspacePath: string,
-): Promise<boolean> {
+async function sessionFileMatchesCwd(filePath: string, workspacePath: string): Promise<boolean> {
   try {
     // Read only the first 4 KB — session_meta is always in the first few lines.
     // Avoids loading large rollout files (100 MB+) into memory.
@@ -606,7 +606,10 @@ async function findCodexSessionFileCached(workspacePath: string): Promise<string
     return cached.path;
   }
   const result = await findCodexSessionFile(workspacePath);
-  sessionFileCache.set(workspacePath, { path: result, expiry: Date.now() + SESSION_FILE_CACHE_TTL_MS });
+  sessionFileCache.set(workspacePath, {
+    path: result,
+    expiry: Date.now() + SESSION_FILE_CACHE_TTL_MS,
+  });
   return result;
 }
 
@@ -619,6 +622,7 @@ function createCodexAgent(): Agent {
   return {
     name: "codex",
     processName: "codex",
+    promptDelivery: "post-launch",
 
     getLaunchCommand(config: AgentLaunchConfig): string {
       const binary = resolvedBinary ?? "codex";
@@ -634,12 +638,6 @@ function createCodexAgent(): Agent {
       } else if (config.systemPrompt) {
         // Codex accepts inline developer instructions via config override
         parts.push("-c", `developer_instructions=${shellEscape(config.systemPrompt)}`);
-      }
-
-      if (config.prompt) {
-        // Use `--` to end option parsing so prompts starting with `-` aren't
-        // misinterpreted as flags.
-        parts.push("--", shellEscape(config.prompt));
       }
 
       return parts.join(" ");
@@ -667,23 +665,34 @@ function createCodexAgent(): Agent {
     detectActivity(terminalOutput: string): ActivityState {
       if (!terminalOutput.trim()) return "idle";
 
+      const stripAnsi = (value: string): string =>
+        value.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "");
+
       const lines = terminalOutput.trim().split("\n");
-      const lastLine = lines[lines.length - 1]?.trim() ?? "";
+      const lastLine = stripAnsi(lines[lines.length - 1] ?? "").trim();
 
       // If Codex is showing its input prompt, it's idle
       if (/^[>$#]\s*$/.test(lastLine)) return "idle";
 
       // Check last few lines for approval prompts
-      const tail = lines.slice(-5).join("\n");
+      const tail = lines.slice(-15).map(stripAnsi).join("\n");
       if (/approval required/i.test(tail)) return "waiting_input";
       if (/\(y\)es.*\(n\)o/i.test(tail)) return "waiting_input";
+      if (/press enter to confirm or esc to cancel/i.test(tail)) return "waiting_input";
+
+      const hasYesOption = /^\s*1\.\s*(yes|proceed|allow)/im.test(tail);
+      const hasNoOption = /^\s*[>*]?\s*[2-9]\.\s*(no|deny|skip|cancel)/im.test(tail);
+      if (hasYesOption && hasNoOption) return "waiting_input";
 
       // Default to active — specific patterns (esc to interrupt, spinner
       // symbols) all map to "active" so no need to check them individually.
       return "active";
     },
 
-    async getActivityState(session: Session, readyThresholdMs?: number): Promise<ActivityDetection | null> {
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
       const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
 
       // Check if process is running first

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -666,16 +666,14 @@ function createCodexAgent(): Agent {
     detectActivity(terminalOutput: string): ActivityState {
       if (!terminalOutput.trim()) return "idle";
 
-      const stripAnsi = (value: string): string => stripVTControlCharacters(value);
-
       const lines = terminalOutput.trim().split("\n");
-      const lastLine = stripAnsi(lines[lines.length - 1] ?? "").trim();
+      const lastLine = stripVTControlCharacters(lines[lines.length - 1] ?? "").trim();
 
       // If Codex is showing its input prompt, it's idle
       if (/^[>$#]\s*$/.test(lastLine)) return "idle";
 
       // Check last few lines for approval prompts
-      const tail = lines.slice(-15).map(stripAnsi).join("\n");
+      const tail = lines.slice(-15).join("\n");
       if (hasApprovalPrompt(tail)) return "waiting_input";
 
       // Default to active — specific patterns (esc to interrupt, spinner

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -516,6 +516,34 @@ describe("detectActivity — terminal output classification", () => {
   it("returns active for non-empty terminal output", () => {
     expect(agent.detectActivity("opencode is working\n")).toBe("active");
   });
+
+  it("returns waiting_input for approval required text", () => {
+    expect(agent.detectActivity("approval required\n")).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for (y)es / (n)o prompt", () => {
+    expect(agent.detectActivity("Do you want to continue?\n(y)es / (n)o\n")).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for 'Press enter to confirm or esc to cancel' prompt", () => {
+    expect(agent.detectActivity("Press enter to confirm or esc to cancel\n")).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for numbered approval options", () => {
+    expect(
+      agent.detectActivity(
+        "Would you like to run this command?\n1. Yes, proceed\n> 3. No, and tell OpenCode what to do differently\n",
+      ),
+    ).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for ANSI-colored approval options", () => {
+    expect(
+      agent.detectActivity(
+        "\u001b[32m1. Yes, proceed\u001b[0m\n\u001b[36m> 3. No, and tell OpenCode what to do differently\u001b[0m\n",
+      ),
+    ).toBe("waiting_input");
+  });
 });
 
 describe("getActivityState", () => {

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Session, RuntimeHandle, AgentLaunchConfig } from "@composio/ao-core";
 
+vi.mock("@composio/ao-core", async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    hasApprovalPrompt: (terminalOutput: string): boolean => {
+      if (!terminalOutput.trim()) return false;
+      const tail = terminalOutput.trim().split("\n").slice(-15).join("\n");
+      if (/approval required/i.test(tail)) return true;
+      if (/\(y\)es.*\(n\)o/i.test(tail)) return true;
+      if (/press enter to confirm or esc to cancel/i.test(tail)) return true;
+      const hasYesOption = /^\s*1\.\s*(yes|proceed|allow)/im.test(tail);
+      const hasNoOption = /^\s*[>*]?\s*[2-9]\.\s*(no|deny|skip|cancel)/im.test(tail);
+      return hasYesOption && hasNoOption;
+    },
+  };
+});
+
 const mockExecFileAsync = vi.fn();
 vi.mock("node:child_process", () => ({
   execFile: (...args: unknown[]) => {

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -1,22 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Session, RuntimeHandle, AgentLaunchConfig } from "@composio/ao-core";
 
-vi.mock("@composio/ao-core", async (importOriginal) => {
-  const actual = (await importOriginal()) as object;
-  return {
-    ...actual,
-    hasApprovalPrompt: (terminalOutput: string): boolean => {
-      if (!terminalOutput.trim()) return false;
-      const tail = terminalOutput.trim().split("\n").slice(-15).join("\n");
-      if (/approval required/i.test(tail)) return true;
-      if (/\(y\)es.*\(n\)o/i.test(tail)) return true;
-      if (/press enter to confirm or esc to cancel/i.test(tail)) return true;
-      const hasYesOption = /^\s*1\.\s*(yes|proceed|allow)/im.test(tail);
-      const hasNoOption = /^\s*[>*]?\s*[2-9]\.\s*(no|deny|skip|cancel)/im.test(tail);
-      return hasYesOption && hasNoOption;
-    },
-  };
-});
+vi.mock("@composio/ao-core", async (importOriginal) => importOriginal());
 
 const mockExecFileAsync = vi.fn();
 vi.mock("node:child_process", () => ({

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_READY_THRESHOLD_MS,
+  hasApprovalPrompt,
   shellEscape,
   asValidOpenCodeSessionId,
   type Agent,
@@ -242,13 +243,7 @@ function createOpenCodeAgent(): Agent {
       const stripAnsi = (value: string): string => stripVTControlCharacters(value);
       const tail = terminalOutput.trim().split("\n").slice(-15).map(stripAnsi).join("\n");
 
-      if (/approval required/i.test(tail)) return "waiting_input";
-      if (/\(y\)es.*\(n\)o/i.test(tail)) return "waiting_input";
-      if (/press enter to confirm or esc to cancel/i.test(tail)) return "waiting_input";
-
-      const hasYesOption = /^\s*1\.\s*(yes|proceed|allow)/im.test(tail);
-      const hasNoOption = /^\s*[>*]?\s*[2-9]\.\s*(no|deny|skip|cancel)/im.test(tail);
-      if (hasYesOption && hasNoOption) return "waiting_input";
+      if (hasApprovalPrompt(tail)) return "waiting_input";
 
       return "active";
     },

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -238,7 +238,19 @@ function createOpenCodeAgent(): Agent {
 
     detectActivity(terminalOutput: string): ActivityState {
       if (!terminalOutput.trim()) return "idle";
-      // OpenCode doesn't have rich terminal output patterns yet
+
+      const stripAnsi = (value: string): string =>
+        value.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "");
+      const tail = terminalOutput.trim().split("\n").slice(-15).map(stripAnsi).join("\n");
+
+      if (/approval required/i.test(tail)) return "waiting_input";
+      if (/\(y\)es.*\(n\)o/i.test(tail)) return "waiting_input";
+      if (/press enter to confirm or esc to cancel/i.test(tail)) return "waiting_input";
+
+      const hasYesOption = /^\s*1\.\s*(yes|proceed|allow)/im.test(tail);
+      const hasNoOption = /^\s*[>*]?\s*[2-9]\.\s*(no|deny|skip|cancel)/im.test(tail);
+      if (hasYesOption && hasNoOption) return "waiting_input";
+
       return "active";
     },
 

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -13,7 +13,7 @@ import {
   type OpenCodeAgentConfig,
 } from "@composio/ao-core";
 import { execFile, execFileSync } from "node:child_process";
-import { promisify } from "node:util";
+import { promisify, stripVTControlCharacters } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
@@ -239,8 +239,7 @@ function createOpenCodeAgent(): Agent {
     detectActivity(terminalOutput: string): ActivityState {
       if (!terminalOutput.trim()) return "idle";
 
-      const stripAnsi = (value: string): string =>
-        value.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "");
+      const stripAnsi = (value: string): string => stripVTControlCharacters(value);
       const tail = terminalOutput.trim().split("\n").slice(-15).map(stripAnsi).join("\n");
 
       if (/approval required/i.test(tail)) return "waiting_input";

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -14,10 +14,9 @@ import {
   type OpenCodeAgentConfig,
 } from "@composio/ao-core";
 import { execFile, execFileSync } from "node:child_process";
-import { promisify, stripVTControlCharacters } from "node:util";
+import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-const stripAnsi = (value: string): string => stripVTControlCharacters(value);
 
 interface OpenCodeSessionListEntry {
   id: string;
@@ -240,7 +239,7 @@ function createOpenCodeAgent(): Agent {
 
     detectActivity(terminalOutput: string): ActivityState {
       if (!terminalOutput.trim()) return "idle";
-      const tail = terminalOutput.trim().split("\n").slice(-15).map(stripAnsi).join("\n");
+      const tail = terminalOutput.trim().split("\n").slice(-15).join("\n");
 
       if (hasApprovalPrompt(tail)) return "waiting_input";
 

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -17,6 +17,7 @@ import { execFile, execFileSync } from "node:child_process";
 import { promisify, stripVTControlCharacters } from "node:util";
 
 const execFileAsync = promisify(execFile);
+const stripAnsi = (value: string): string => stripVTControlCharacters(value);
 
 interface OpenCodeSessionListEntry {
   id: string;
@@ -239,8 +240,6 @@ function createOpenCodeAgent(): Agent {
 
     detectActivity(terminalOutput: string): ActivityState {
       if (!terminalOutput.trim()) return "idle";
-
-      const stripAnsi = (value: string): string => stripVTControlCharacters(value);
       const tail = terminalOutput.trim().split("\n").slice(-15).map(stripAnsi).join("\n");
 
       if (hasApprovalPrompt(tail)) return "waiting_input";


### PR DESCRIPTION
## Summary
- Fixes silent post-launch prompt delivery failures by adding bounded retries, explicit observability events, and prompt-delivery metadata persistence.
- Improves lifecycle `needs_input` anomaly detection so it triggers only when prompt delivery was attempted, with validated timestamps and terminal-upgrade coverage.
- Improves Codex/OpenCode waiting-input detection and uses shared approval-prompt logic; Codex now uses post-launch prompt delivery.

## Issues
Closes #718
Closes #746
Closes #747

## Validation
- Targeted unit tests for core spawn/lifecycle behavior and Codex/OpenCode detection.
- Integration test: `agent-codex-launch-env.integration.test.ts`.
- Manual E2E for #718 (forced post-launch send failure): retries + failure-status metadata + recovery via `ao send`.

## Notes
- Kept unrelated workspace changes out of this PR scope.
- Follow-up noise comments removed and review threads resolved.