### PR TITLE
fix(web): return 400 for malformed /api/verify JSON

### DIFF
--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -202,6 +202,7 @@ import { POST as killPOST } from "@/app/api/sessions/[id]/kill/route";
 import { POST as restorePOST } from "@/app/api/sessions/[id]/restore/route";
 import { POST as remapPOST } from "@/app/api/sessions/[id]/remap/route";
 import { POST as mergePOST } from "@/app/api/prs/[id]/merge/route";
+import { POST as verifyPOST } from "@/app/api/verify/route";
 import { GET as eventsGET } from "@/app/api/events/route";
 import { GET as observabilityGET } from "@/app/api/observability/route";
 import { GET as runtimeTerminalGET } from "@/app/api/runtime/terminal/route";
@@ -633,6 +634,62 @@ describe("API Routes", () => {
       expect(res.status).toBe(500);
       const data = await res.json();
       expect(data.error).toBe("boom");
+    });
+  });
+
+  describe("POST /api/verify", () => {
+    it("returns 400 for malformed JSON", async () => {
+      const req = makeRequest("/api/verify", {
+        method: "POST",
+        body: "not json",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const res = await verifyPOST(req);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toMatch(/Invalid JSON body/);
+    });
+
+    it("verifies an issue when payload is valid", async () => {
+      const trackerUpdateIssue = vi.fn(async () => undefined);
+      (mockRegistry.get as ReturnType<typeof vi.fn>).mockReturnValue({
+        ...mockSCM,
+        updateIssue: trackerUpdateIssue,
+      });
+
+      const previousProjectConfig = mockConfig.projects["my-app"];
+      mockConfig.projects["my-app"] = {
+        ...previousProjectConfig,
+        tracker: { plugin: "github" },
+      };
+
+      try {
+        const req = makeRequest("/api/verify", {
+          method: "POST",
+          body: JSON.stringify({
+            issueId: "INT-800",
+            projectId: "my-app",
+            action: "verify",
+          }),
+          headers: { "Content-Type": "application/json" },
+        });
+
+        const res = await verifyPOST(req);
+
+        expect(res.status).toBe(200);
+        expect(trackerUpdateIssue).toHaveBeenCalledWith(
+          "INT-800",
+          expect.objectContaining({
+            state: "closed",
+            labels: ["verified", "agent:done"],
+            removeLabels: ["merged-unverified"],
+          }),
+          mockConfig.projects["my-app"],
+        );
+      } finally {
+        mockConfig.projects["my-app"] = previousProjectConfig;
+      }
     });
   });
 

--- a/packages/web/src/app/api/verify/route.ts
+++ b/packages/web/src/app/api/verify/route.ts
@@ -25,14 +25,18 @@ export async function GET() {
  * Body: { issueId: string, projectId: string, action: "verify" | "fail", comment?: string }
  */
 export async function POST(req: NextRequest) {
+  const body = (await req.json().catch(() => null)) as {
+    issueId: string;
+    projectId: string;
+    action: "verify" | "fail";
+    comment?: string;
+  } | null;
+  if (!body) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
   try {
-    const body = await req.json();
-    const { issueId, projectId, action, comment } = body as {
-      issueId: string;
-      projectId: string;
-      action: "verify" | "fail";
-      comment?: string;
-    };
+    const { issueId, projectId, action, comment } = body;
 
     if (!issueId || !projectId || !action) {
       return NextResponse.json(
@@ -42,10 +46,7 @@ export async function POST(req: NextRequest) {
     }
 
     if (action !== "verify" && action !== "fail") {
-      return NextResponse.json(
-        { error: 'action must be "verify" or "fail"' },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: 'action must be "verify" or "fail"' }, { status: 400 });
     }
 
     const { config, registry } = await getServices();


### PR DESCRIPTION
Closes #800

## Summary
- return `400 Invalid JSON body` for malformed JSON in `POST /api/verify`
- keep existing validation and tracker update behavior for valid requests
- add API route tests for malformed JSON and valid verify action paths

## Testing
- `pnpm --filter @composio/ao-web exec vitest run src/__tests__/api-routes.test.ts`
- `pnpm exec eslint packages/web/src/app/api/verify/route.ts packages/web/src/__tests__/api-routes.test.ts`