### PR TITLE
fix(tracker-linear): eliminate PromiseRejectionHandledWarning in timeout test

### DIFF
--- a/packages/plugins/tracker-linear/test/composio-transport.test.ts
+++ b/packages/plugins/tracker-linear/test/composio-transport.test.ts
@@ -317,16 +317,6 @@ describe("tracker-linear Composio transport", () => {
       // Now switch to fake timers
       vi.useFakeTimers();
 
-      // Vitest's fake timers fire the setTimeout callback synchronously
-      // during advanceTimersByTimeAsync, before the microtask queue can
-      // process the .catch() handler on timeoutPromise. Suppress the
-      // transient unhandled rejection that vitest detects in that window.
-      const suppressed: unknown[] = [];
-      const handler = (reason: unknown) => {
-        suppressed.push(reason);
-      };
-      process.on("unhandledRejection", handler);
-
       try {
         // Make execute hang forever
         mockExecute.mockImplementationOnce(
@@ -334,13 +324,15 @@ describe("tracker-linear Composio transport", () => {
         );
 
         const promise = tracker.getIssue("INT-123", project);
+        const timeoutExpectation = expect(promise).rejects.toThrow(
+          "Composio Linear API request timed out after 30s",
+        );
 
         // Advance timers past the 30s timeout
         await vi.advanceTimersByTimeAsync(30_001);
 
-        await expect(promise).rejects.toThrow("Composio Linear API request timed out after 30s");
+        await timeoutExpectation;
       } finally {
-        process.removeListener("unhandledRejection", handler);
         vi.useRealTimers();
       }
     });


### PR DESCRIPTION
## Summary
- remove the test-level `unhandledRejection` listener workaround in the tracker-linear Composio timeout test
- attach the rejection assertion to the pending request promise before advancing fake timers so the timeout rejection is handled immediately
- keep timeout behavior coverage unchanged while making `pnpm --filter @composio/ao-plugin-tracker-linear test` run cleanly without PromiseRejectionHandledWarning

## Testing
- `pnpm --filter @composio/ao-plugin-tracker-linear test`
- `pnpm --filter @composio/ao-plugin-tracker-linear typecheck`
- `pnpm lint` (passes with existing repo warnings)
- `pnpm typecheck` (fails due to pre-existing errors in `packages/plugins/scm-github`)

Closes #778