### PR TITLE
feat: extract shared process detection and permission normalization into core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,11 +96,7 @@ export {
   readLastJsonlEntry,
   resolveProjectIdForSessionId,
 } from "./utils.js";
-export {
-  isAgentProcessRunning,
-  resetProcessListCache,
-  normalizePermissionMode,
-} from "./process-detection.js";
+export { isAgentProcessRunning, resetProcessListCache } from "./process-detection.js";
 export type { AgentProcessDetectionOptions } from "./process-detection.js";
 export {
   getWebhookHeader,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,7 +78,6 @@ export type {
 export { generateOrchestratorPrompt } from "./orchestrator-prompt.js";
 export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";
 
-
 // Global pause constants and utilities
 export {
   GLOBAL_PAUSE_UNTIL_KEY,
@@ -97,6 +96,12 @@ export {
   readLastJsonlEntry,
   resolveProjectIdForSessionId,
 } from "./utils.js";
+export {
+  isAgentProcessRunning,
+  resetProcessListCache,
+  normalizePermissionMode,
+} from "./process-detection.js";
+export type { AgentProcessDetectionOptions } from "./process-detection.js";
 export {
   getWebhookHeader,
   parseWebhookJsonObject,

--- a/packages/core/src/process-detection.ts
+++ b/packages/core/src/process-detection.ts
@@ -1,0 +1,117 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  normalizeAgentPermissionMode,
+  type AgentPermissionMode,
+  type RuntimeHandle,
+} from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_PS_CACHE_TTL_MS = 5_000;
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+
+let psCache: { output: string; timestamp: number; promise?: Promise<string> } | null = null;
+
+export interface AgentProcessDetectionOptions {
+  psCacheTtlMs?: number;
+  commandTimeoutMs?: number;
+}
+
+function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function getCachedProcessList(cacheTtlMs: number, commandTimeoutMs: number): Promise<string> {
+  const now = Date.now();
+  if (psCache && now - psCache.timestamp < cacheTtlMs) {
+    if (psCache.promise) return psCache.promise;
+    return psCache.output;
+  }
+
+  const promise = execFileAsync("ps", ["-eo", "pid,tty,args"], {
+    timeout: commandTimeoutMs,
+  }).then(({ stdout }) => {
+    if (psCache?.promise === promise) {
+      psCache = { output: stdout, timestamp: Date.now() };
+    }
+    return stdout;
+  });
+
+  psCache = { output: "", timestamp: now, promise };
+
+  try {
+    return await promise;
+  } catch {
+    if (psCache?.promise === promise) {
+      psCache = null;
+    }
+    return "";
+  }
+}
+
+export function resetProcessListCache(): void {
+  psCache = null;
+}
+
+export async function isAgentProcessRunning(
+  handle: RuntimeHandle,
+  processName: string,
+  options: AgentProcessDetectionOptions = {},
+): Promise<boolean> {
+  const cacheTtlMs = options.psCacheTtlMs ?? DEFAULT_PS_CACHE_TTL_MS;
+  const commandTimeoutMs = options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+
+  try {
+    if (handle.runtimeName === "tmux" && handle.id) {
+      const { stdout: ttyOut } = await execFileAsync(
+        "tmux",
+        ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+        { timeout: commandTimeoutMs },
+      );
+      const ttys = ttyOut
+        .trim()
+        .split("\n")
+        .map((tty) => tty.trim())
+        .filter(Boolean);
+      if (ttys.length === 0) return false;
+
+      const psOut = await getCachedProcessList(cacheTtlMs, commandTimeoutMs);
+      if (!psOut) return false;
+
+      const ttySet = new Set(ttys.map((tty) => tty.replace(/^\/dev\//, "")));
+      const processRe = new RegExp(`(?:^|/)${escapeRegex(processName)}(?:\\s|$)`);
+      for (const line of psOut.split("\n")) {
+        const cols = line.trimStart().split(/\s+/);
+        if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+        const args = cols.slice(2).join(" ");
+        if (processRe.test(args)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    const rawPid = handle.data["pid"];
+    const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+    if (Number.isFinite(pid) && pid > 0) {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch (err: unknown) {
+        if (err instanceof Error && "code" in err && err.code === "EPERM") {
+          return true;
+        }
+        return false;
+      }
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export function normalizePermissionMode(mode: string | undefined): AgentPermissionMode | undefined {
+  return normalizeAgentPermissionMode(mode);
+}

--- a/packages/core/src/process-detection.ts
+++ b/packages/core/src/process-detection.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { RuntimeHandle } from "./types.js";
+import { escapeRegex } from "./utils.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -12,10 +13,6 @@ let psCache: { output: string; timestamp: number; promise?: Promise<string> } | 
 export interface AgentProcessDetectionOptions {
   psCacheTtlMs?: number;
   commandTimeoutMs?: number;
-}
-
-function escapeRegex(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 async function getCachedProcessList(cacheTtlMs: number, commandTimeoutMs: number): Promise<string> {

--- a/packages/core/src/process-detection.ts
+++ b/packages/core/src/process-detection.ts
@@ -1,10 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import {
-  normalizeAgentPermissionMode,
-  type AgentPermissionMode,
-  type RuntimeHandle,
-} from "./types.js";
+import type { RuntimeHandle } from "./types.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -110,8 +106,4 @@ export async function isAgentProcessRunning(
   } catch {
     return false;
   }
-}
-
-export function normalizePermissionMode(mode: string | undefined): AgentPermissionMode | undefined {
-  return normalizeAgentPermissionMode(mode);
 }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -72,6 +72,7 @@ import {
   parsePauseUntil,
 } from "./global-pause.js";
 import { sessionFromMetadata } from "./utils/session-from-metadata.js";
+import { escapeRegex } from "./utils.js";
 import { safeJsonParse } from "./utils/validation.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
 
@@ -173,11 +174,6 @@ async function discoverOpenCodeSessionIdByTitle(
 ): Promise<string | undefined> {
   const matches = await discoverOpenCodeSessionIdsByTitle(sessionId, timeoutMs, sessionListPromise);
   return matches[0];
-}
-
-/** Escape regex metacharacters in a string. */
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /** Get the next session number for a project. */
@@ -1073,7 +1069,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           AO_CALLER_TYPE: "agent",
           AO_PROJECT_ID: spawnConfig.projectId,
           AO_CONFIG_PATH: config.configPath,
-          ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) }),
+          ...(config.port !== undefined &&
+            config.port !== null && { AO_PORT: String(config.port) }),
         },
       });
     } catch (err) {
@@ -1372,7 +1369,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         AO_CALLER_TYPE: "orchestrator",
         AO_PROJECT_ID: orchestratorConfig.projectId,
         AO_CONFIG_PATH: config.configPath,
-        ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) })
+        ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) }),
       },
     });
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -23,6 +23,11 @@ export function escapeAppleScript(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
+/** Escape regex metacharacters in a string. */
+export function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
  * Validate that a URL starts with http:// or https://.
  * Throws with a descriptive error including the plugin label if invalid.
@@ -51,9 +56,10 @@ export function normalizeRetryConfig(
   const rawRetries = config?.retries as number | undefined;
   const rawDelay = config?.retryDelayMs as number | undefined;
   const retries = Number.isFinite(rawRetries) ? Math.max(0, rawRetries ?? 0) : defaults.retries;
-  const retryDelayMs = Number.isFinite(rawDelay) && (rawDelay ?? -1) >= 0
-    ? (rawDelay as number)
-    : defaults.retryDelayMs;
+  const retryDelayMs =
+    Number.isFinite(rawDelay) && (rawDelay ?? -1) >= 0
+      ? (rawDelay as number)
+      : defaults.retryDelayMs;
   return { retries, retryDelayMs };
 }
 

--- a/packages/plugins/agent-aider/src/index.test.ts
+++ b/packages/plugins/agent-aider/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Session, RuntimeHandle, AgentLaunchConfig } from "@composio/ao-core";
+import {
+  resetProcessListCache,
+  type Session,
+  type RuntimeHandle,
+  type AgentLaunchConfig,
+} from "@composio/ao-core";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -77,6 +82,7 @@ function mockTmuxWithProcess(processName: string, found = true) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetProcessListCache();
 });
 
 // =========================================================================

--- a/packages/plugins/agent-aider/src/index.ts
+++ b/packages/plugins/agent-aider/src/index.ts
@@ -1,6 +1,8 @@
 import {
   shellEscape,
   DEFAULT_READY_THRESHOLD_MS,
+  isAgentProcessRunning,
+  normalizePermissionMode,
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
@@ -17,15 +19,6 @@ import { join } from "node:path";
 import { constants } from "node:fs";
 
 const execFileAsync = promisify(execFile);
-
-function normalizePermissionMode(mode: string | undefined): "permissionless" | "default" | "auto-edit" | "suggest" | undefined {
-  if (!mode) return undefined;
-  if (mode === "skip") return "permissionless";
-  if (mode === "permissionless" || mode === "default" || mode === "auto-edit" || mode === "suggest") {
-    return mode;
-  }
-  return undefined;
-}
 
 // =============================================================================
 // Aider Activity Detection Helpers
@@ -158,54 +151,7 @@ function createAiderAgent(): Agent {
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
-      try {
-        if (handle.runtimeName === "tmux" && handle.id) {
-          const { stdout: ttyOut } = await execFileAsync(
-            "tmux",
-            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
-            { timeout: 30_000 },
-          );
-          const ttys = ttyOut
-            .trim()
-            .split("\n")
-            .map((t) => t.trim())
-            .filter(Boolean);
-          if (ttys.length === 0) return false;
-
-          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
-            timeout: 30_000,
-          });
-          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
-          const processRe = /(?:^|\/)aider(?:\s|$)/;
-          for (const line of psOut.split("\n")) {
-            const cols = line.trimStart().split(/\s+/);
-            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
-            const args = cols.slice(2).join(" ");
-            if (processRe.test(args)) {
-              return true;
-            }
-          }
-          return false;
-        }
-
-        const rawPid = handle.data["pid"];
-        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
-        if (Number.isFinite(pid) && pid > 0) {
-          try {
-            process.kill(pid, 0);
-            return true;
-          } catch (err: unknown) {
-            if (err instanceof Error && "code" in err && err.code === "EPERM") {
-              return true;
-            }
-            return false;
-          }
-        }
-
-        return false;
-      } catch {
-        return false;
-      }
+      return isAgentProcessRunning(handle, "aider");
     },
 
     async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {

--- a/packages/plugins/agent-aider/src/index.ts
+++ b/packages/plugins/agent-aider/src/index.ts
@@ -2,7 +2,7 @@ import {
   shellEscape,
   DEFAULT_READY_THRESHOLD_MS,
   isAgentProcessRunning,
-  normalizePermissionMode,
+  normalizeAgentPermissionMode,
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
@@ -78,7 +78,7 @@ function createAiderAgent(): Agent {
     getLaunchCommand(config: AgentLaunchConfig): string {
       const parts: string[] = ["aider"];
 
-      const permissionMode = normalizePermissionMode(config.permissions);
+      const permissionMode = normalizeAgentPermissionMode(config.permissions);
       if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
         parts.push("--yes");
       }

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type {
-  Session,
-  RuntimeHandle,
-  AgentLaunchConfig,
-  WorkspaceHooksConfig,
+import {
+  resetProcessListCache,
+  type Session,
+  type RuntimeHandle,
+  type AgentLaunchConfig,
+  type WorkspaceHooksConfig,
 } from "@composio/ao-core";
-import { resetProcessListCache } from "@composio/ao-core";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — available inside vi.mock factories

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Session, RuntimeHandle, AgentLaunchConfig, WorkspaceHooksConfig } from "@composio/ao-core";
+import type {
+  Session,
+  RuntimeHandle,
+  AgentLaunchConfig,
+  WorkspaceHooksConfig,
+} from "@composio/ao-core";
+import { resetProcessListCache } from "@composio/ao-core";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — available inside vi.mock factories
@@ -50,7 +56,7 @@ vi.mock("node:os", () => ({
   homedir: mockHomedir,
 }));
 
-import { create, manifest, default as defaultExport, resetPsCache, METADATA_UPDATER_SCRIPT } from "./index.js";
+import { create, manifest, default as defaultExport, METADATA_UPDATER_SCRIPT } from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -128,7 +134,7 @@ function mockJsonlFiles(
 // ---------------------------------------------------------------------------
 beforeEach(() => {
   vi.clearAllMocks();
-  resetPsCache();
+  resetProcessListCache();
   mockHomedir.mockReturnValue("/mock/home");
 });
 
@@ -720,12 +726,8 @@ describe("METADATA_UPDATER_SCRIPT content", () => {
   it("does NOT use ^-anchored regexes directly on $command for gh/git detection", () => {
     // The old buggy patterns matched $command with ^ anchor.
     // After the fix, ^ is still used but on $clean_command (which has cd stripped).
-    expect(METADATA_UPDATER_SCRIPT).not.toMatch(
-      /"\$command"\s*=~\s*\^gh/,
-    );
-    expect(METADATA_UPDATER_SCRIPT).not.toMatch(
-      /"\$command"\s*=~\s*\^git/,
-    );
+    expect(METADATA_UPDATER_SCRIPT).not.toMatch(/"\$command"\s*=~\s*\^gh/);
+    expect(METADATA_UPDATER_SCRIPT).not.toMatch(/"\$command"\s*=~\s*\^git/);
   });
 
   it("strips cd prefixes with both && and ; delimiters", () => {
@@ -737,21 +739,15 @@ describe("METADATA_UPDATER_SCRIPT content", () => {
   });
 
   it("detects gh pr create on clean_command", () => {
-    expect(METADATA_UPDATER_SCRIPT).toMatch(
-      /"\$clean_command"\s*=~\s*\^gh\[/,
-    );
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/"\$clean_command"\s*=~\s*\^gh\[/);
   });
 
   it("detects git checkout -b on clean_command", () => {
-    expect(METADATA_UPDATER_SCRIPT).toMatch(
-      /"\$clean_command"\s*=~\s*\^git\[.*checkout/,
-    );
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/"\$clean_command"\s*=~\s*\^git\[.*checkout/);
   });
 
   it("detects gh pr merge on clean_command", () => {
-    expect(METADATA_UPDATER_SCRIPT).toMatch(
-      /"\$clean_command"\s*=~\s*\^gh\[.*merge/,
-    );
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/"\$clean_command"\s*=~\s*\^gh\[.*merge/);
   });
 });
 

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -2,6 +2,8 @@ import {
   shellEscape,
   readLastJsonlEntry,
   DEFAULT_READY_THRESHOLD_MS,
+  isAgentProcessRunning,
+  normalizePermissionMode,
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
@@ -14,23 +16,11 @@ import {
   type Session,
   type WorkspaceHooksConfig,
 } from "@composio/ao-core";
-import { execFile, execFileSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readdir, readFile, stat, open, writeFile, mkdir, chmod } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
-
-function normalizePermissionMode(mode: string | undefined): "permissionless" | "default" | "auto-edit" | "suggest" | undefined {
-  if (!mode) return undefined;
-  if (mode === "skip") return "permissionless";
-  if (mode === "permissionless" || mode === "default" || mode === "auto-edit" || mode === "suggest") {
-    return mode;
-  }
-  return undefined;
-}
 
 // =============================================================================
 // Metadata Updater Hook Script
@@ -314,8 +304,7 @@ async function parseJsonlFileTail(filePath: string, maxBytes = 131_072): Promise
   // Skip potentially truncated first line only when we started mid-file.
   // If offset === 0 we read from the start so the first line is complete.
   const firstNewline = content.indexOf("\n");
-  const safeContent =
-    offset > 0 && firstNewline >= 0 ? content.slice(firstNewline + 1) : content;
+  const safeContent = offset > 0 && firstNewline >= 0 ? content.slice(firstNewline + 1) : content;
   const lines: JsonlLine[] = [];
   for (const line of safeContent.split("\n")) {
     const trimmed = line.trim();
@@ -333,9 +322,7 @@ async function parseJsonlFileTail(filePath: string, maxBytes = 131_072): Promise
 }
 
 /** Extract auto-generated summary from JSONL (last "summary" type entry) */
-function extractSummary(
-  lines: JsonlLine[],
-): { summary: string; isFallback: boolean } | null {
+function extractSummary(lines: JsonlLine[]): { summary: string; isFallback: boolean } | null {
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i];
     if (line?.type === "summary" && line.summary) {
@@ -406,121 +393,6 @@ function extractCost(lines: JsonlLine[]): CostEstimate | undefined {
   }
 
   return { inputTokens, outputTokens, estimatedCostUsd: totalCost };
-}
-
-// =============================================================================
-// Process Detection
-// =============================================================================
-
-/**
- * TTL cache for `ps -eo pid,tty,args` output. Without this, listing N sessions
- * would spawn N concurrent `ps` processes, each taking 30+ seconds on machines
- * with many processes. The cache ensures `ps` is called at most once per TTL
- * window regardless of how many sessions are being enriched.
- */
-let psCache: { output: string; timestamp: number; promise?: Promise<string> } | null = null;
-const PS_CACHE_TTL_MS = 5_000;
-
-/** Reset the ps cache. Exported for testing only. */
-export function resetPsCache(): void {
-  psCache = null;
-}
-
-async function getCachedProcessList(): Promise<string> {
-  const now = Date.now();
-  if (psCache && now - psCache.timestamp < PS_CACHE_TTL_MS) {
-    // Cache hit — return resolved output or wait for in-flight request
-    if (psCache.promise) return psCache.promise;
-    return psCache.output;
-  }
-
-  // Cache miss or expired — start a single `ps` call and share the promise.
-  // Guard both callbacks so they only update psCache if it still belongs to
-  // this request — a newer request may have replaced it while we were waiting.
-  const promise = execFileAsync("ps", ["-eo", "pid,tty,args"], {
-    timeout: 5_000,
-  }).then(({ stdout }) => {
-    if (psCache?.promise === promise) {
-      psCache = { output: stdout, timestamp: Date.now() };
-    }
-    return stdout;
-  });
-
-  // Store the in-flight promise so concurrent callers share it
-  psCache = { output: "", timestamp: now, promise };
-
-  try {
-    return await promise;
-  } catch {
-    // On failure, clear cache so the next caller retries — but only if
-    // psCache still points to this request (avoid clobbering a newer entry)
-    if (psCache?.promise === promise) {
-      psCache = null;
-    }
-    return "";
-  }
-}
-
-/**
- * Check if a process named "claude" is running in the given runtime handle's context.
- * Uses ps to find processes by TTY (for tmux) or by PID.
- */
-async function findClaudeProcess(handle: RuntimeHandle): Promise<number | null> {
-  try {
-    // For tmux runtime, get the pane TTY and find claude on it
-    if (handle.runtimeName === "tmux" && handle.id) {
-      const { stdout: ttyOut } = await execFileAsync(
-        "tmux",
-        ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
-        { timeout: 5_000 },
-      );
-      // Iterate all pane TTYs (multi-pane sessions) — succeed on any match
-      const ttys = ttyOut
-        .trim()
-        .split("\n")
-        .map((t) => t.trim())
-        .filter(Boolean);
-      if (ttys.length === 0) return null;
-
-      const psOut = await getCachedProcessList();
-      if (!psOut) return null;
-
-      const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
-      // Match "claude" as a word boundary — prevents false positives on
-      // names like "claude-code" or paths that merely contain the substring.
-      const processRe = /(?:^|\/)claude(?:\s|$)/;
-      for (const line of psOut.split("\n")) {
-        const cols = line.trimStart().split(/\s+/);
-        if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
-        const args = cols.slice(2).join(" ");
-        if (processRe.test(args)) {
-          return parseInt(cols[0] ?? "0", 10);
-        }
-      }
-      return null;
-    }
-
-    // For process runtime, check if the PID stored in handle data is alive
-    const rawPid = handle.data["pid"];
-    const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
-    if (Number.isFinite(pid) && pid > 0) {
-      try {
-        process.kill(pid, 0); // Signal 0 = check existence
-        return pid;
-      } catch (err: unknown) {
-        // EPERM means the process exists but we lack permission to signal it
-        if (err instanceof Error && "code" in err && err.code === "EPERM") {
-          return pid;
-        }
-        return null;
-      }
-    }
-
-    // No reliable way to identify the correct process for this session
-    return null;
-  } catch {
-    return null;
-  }
 }
 
 // =============================================================================
@@ -713,8 +585,7 @@ function createClaudeCodeAgent(): Agent {
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
-      const pid = await findClaudeProcess(handle);
-      return pid !== null;
+      return isAgentProcessRunning(handle, "claude");
     },
 
     async getActivityState(

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -193,6 +193,8 @@ export const manifest = {
   displayName: "Claude Code",
 };
 
+const PROCESS_DETECTION_TIMEOUT_MS = 5_000;
+
 // =============================================================================
 // JSONL Helpers
 // =============================================================================
@@ -585,7 +587,9 @@ function createClaudeCodeAgent(): Agent {
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
-      return isAgentProcessRunning(handle, "claude");
+      return isAgentProcessRunning(handle, "claude", {
+        commandTimeoutMs: PROCESS_DETECTION_TIMEOUT_MS,
+      });
     },
 
     async getActivityState(

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -3,7 +3,7 @@ import {
   readLastJsonlEntry,
   DEFAULT_READY_THRESHOLD_MS,
   isAgentProcessRunning,
-  normalizePermissionMode,
+  normalizeAgentPermissionMode,
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
@@ -533,7 +533,7 @@ function createClaudeCodeAgent(): Agent {
       // This command must be safe for both shell and execFile contexts.
       const parts: string[] = ["claude"];
 
-      const permissionMode = normalizePermissionMode(config.permissions);
+      const permissionMode = normalizeAgentPermissionMode(config.permissions);
       if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
         parts.push("--dangerously-skip-permissions");
       }
@@ -692,7 +692,7 @@ function createClaudeCodeAgent(): Agent {
       // Build resume command
       const parts: string[] = ["claude", "--resume", shellEscape(sessionUuid)];
 
-      const permissionMode = normalizePermissionMode(project.agentConfig?.permissions);
+      const permissionMode = normalizeAgentPermissionMode(project.agentConfig?.permissions);
       if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
         parts.push("--dangerously-skip-permissions");
       }

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Session, RuntimeHandle, AgentLaunchConfig, AgentSpecificConfig } from "@composio/ao-core";
+import {
+  resetProcessListCache,
+  type Session,
+  type RuntimeHandle,
+  type AgentLaunchConfig,
+  type AgentSpecificConfig,
+} from "@composio/ao-core";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — available inside vi.mock factories
@@ -62,7 +68,13 @@ vi.mock("node:os", () => ({
 }));
 
 import { Readable } from "node:stream";
-import { create, manifest, default as defaultExport, resolveCodexBinary, _resetSessionFileCache } from "./index.js";
+import {
+  create,
+  manifest,
+  default as defaultExport,
+  resolveCodexBinary,
+  _resetSessionFileCache,
+} from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -131,11 +143,13 @@ function mockTmuxWithProcess(processName: string, found = true) {
 function makeFakeFileHandle(content: string) {
   const buf = Buffer.from(content, "utf-8");
   return {
-    read: vi.fn().mockImplementation((buffer: Buffer, offset: number, length: number, _position: number) => {
-      const bytesToCopy = Math.min(length, buf.length);
-      buf.copy(buffer, offset, 0, bytesToCopy);
-      return Promise.resolve({ bytesRead: bytesToCopy, buffer });
-    }),
+    read: vi
+      .fn()
+      .mockImplementation((buffer: Buffer, offset: number, length: number, _position: number) => {
+        const bytesToCopy = Math.min(length, buf.length);
+        buf.copy(buffer, offset, 0, bytesToCopy);
+        return Promise.resolve({ bytesRead: bytesToCopy, buffer });
+      }),
     close: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -166,6 +180,7 @@ function setupMockStream(content: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetProcessListCache();
   _resetSessionFileCache();
   mockHomedir.mockReturnValue("/mock/home");
   // Default: open() returns a handle with empty content (no session_meta match).
@@ -211,7 +226,9 @@ describe("getLaunchCommand", () => {
   const agent = create();
 
   it("generates base command", () => {
-    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("'codex' -c check_for_update_on_startup=false");
+    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe(
+      "'codex' -c check_for_update_on_startup=false",
+    );
   });
 
   it("includes bypass flag when permissions=permissionless", () => {
@@ -259,7 +276,9 @@ describe("getLaunchCommand", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ permissions: "permissionless", model: "o3", prompt: "Go" }),
     );
-    expect(cmd).toBe("'codex' -c check_for_update_on_startup=false --dangerously-bypass-approvals-and-sandbox --model 'o3' -c model_reasoning_effort=high -- 'Go'");
+    expect(cmd).toBe(
+      "'codex' -c check_for_update_on_startup=false --dangerously-bypass-approvals-and-sandbox --model 'o3' -c model_reasoning_effort=high -- 'Go'",
+    );
   });
 
   it("escapes single quotes in prompt (POSIX shell escaping)", () => {
@@ -268,9 +287,7 @@ describe("getLaunchCommand", () => {
   });
 
   it("escapes dangerous characters in prompt", () => {
-    const cmd = agent.getLaunchCommand(
-      makeLaunchConfig({ prompt: "$(rm -rf /); `evil`; $HOME" }),
-    );
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "$(rm -rf /); `evil`; $HOME" }));
     // Single-quoted strings prevent shell expansion
     expect(cmd).toContain("-- '$(rm -rf /); `evil`; $HOME'");
   });
@@ -395,7 +412,7 @@ describe("getEnvironment", () => {
       process.env["PATH"] = originalPath;
     }
   });
- 
+
   it("sets CODEX_DISABLE_UPDATE_CHECK=1 to suppress interactive update prompts", () => {
     const env = agent.getEnvironment(makeLaunchConfig());
     expect(env["CODEX_DISABLE_UPDATE_CHECK"]).toBe("1");
@@ -576,12 +593,12 @@ describe("detectActivity", () => {
   it("returns waiting_input when permission prompt follows historical activity", () => {
     // Permission prompt at the bottom should NOT be overridden by historical
     // spinner/esc output higher in the buffer.
-    expect(
-      agent.detectActivity("✶ Writing files\nDone.\napproval required\n"),
-    ).toBe("waiting_input");
-    expect(
-      agent.detectActivity("Working (esc to interrupt)\nFinished\n(y)es / (n)o\n"),
-    ).toBe("waiting_input");
+    expect(agent.detectActivity("✶ Writing files\nDone.\napproval required\n")).toBe(
+      "waiting_input",
+    );
+    expect(agent.detectActivity("Working (esc to interrupt)\nFinished\n(y)es / (n)o\n")).toBe(
+      "waiting_input",
+    );
   });
 
   // -- Active states --
@@ -640,7 +657,10 @@ describe("getActivityState", () => {
   it("returns null when process is running but no session file found", async () => {
     mockTmuxWithProcess("codex");
     mockReaddir.mockRejectedValue(new Error("ENOENT"));
-    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const session = makeSession({
+      runtimeHandle: makeTmuxHandle(),
+      workspacePath: "/workspace/test",
+    });
     expect(await agent.getActivityState(session)).toBeNull();
   });
 
@@ -652,7 +672,10 @@ describe("getActivityState", () => {
     // mtime = now (just modified)
     mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
 
-    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const session = makeSession({
+      runtimeHandle: makeTmuxHandle(),
+      workspacePath: "/workspace/test",
+    });
     const result = await agent.getActivityState(session);
     expect(result?.state).toBe("active");
     expect(result?.timestamp).toBeInstanceOf(Date);
@@ -667,7 +690,10 @@ describe("getActivityState", () => {
     const staleTime = Date.now() - 600_000;
     mockStat.mockResolvedValue({ mtimeMs: staleTime, mtime: new Date(staleTime) });
 
-    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const session = makeSession({
+      runtimeHandle: makeTmuxHandle(),
+      workspacePath: "/workspace/test",
+    });
     const result = await agent.getActivityState(session);
     expect(result?.state).toBe("idle");
     expect(result?.timestamp).toBeInstanceOf(Date);
@@ -719,14 +745,34 @@ describe("getSessionInfo", () => {
     const content = jsonl({ type: "session_meta", cwd: "/other/workspace", model: "gpt-4o" });
     setupMockOpen(content);
     mockReadFile.mockResolvedValue(content);
-    expect(await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }))).toBeNull();
+    expect(
+      await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" })),
+    ).toBeNull();
   });
 
   it("returns session info with cost and model when matching session found", async () => {
     const sessionContent = jsonl(
       { type: "session_meta", cwd: "/workspace/test", model: "o3-mini" },
-      { type: "event_msg", msg: { type: "token_count", input_tokens: 1000, output_tokens: 500, cached_tokens: 200, reasoning_tokens: 100 } },
-      { type: "event_msg", msg: { type: "token_count", input_tokens: 2000, output_tokens: 300, cached_tokens: 0, reasoning_tokens: 0 } },
+      {
+        type: "event_msg",
+        msg: {
+          type: "token_count",
+          input_tokens: 1000,
+          output_tokens: 500,
+          cached_tokens: 200,
+          reasoning_tokens: 100,
+        },
+      },
+      {
+        type: "event_msg",
+        msg: {
+          type: "token_count",
+          input_tokens: 2000,
+          output_tokens: 300,
+          cached_tokens: 0,
+          reasoning_tokens: 0,
+        },
+      },
     );
 
     mockReaddir.mockResolvedValue(["session-123.jsonl"]);
@@ -751,12 +797,8 @@ describe("getSessionInfo", () => {
   });
 
   it("picks the most recently modified matching session file", async () => {
-    const oldContent = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
-    );
-    const newContent = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "o3" },
-    );
+    const oldContent = jsonl({ type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" });
+    const newContent = jsonl({ type: "session_meta", cwd: "/workspace/test", model: "o3" });
 
     mockReaddir.mockResolvedValue(["old-session.jsonl", "new-session.jsonl"]);
     mockOpen.mockImplementation(async (path: string) => {
@@ -788,7 +830,8 @@ describe("getSessionInfo", () => {
   });
 
   it("handles corrupt/malformed JSONL lines gracefully", async () => {
-    const content = '{"type":"session_meta","cwd":"/workspace/test","model":"gpt-4o"}\n' +
+    const content =
+      '{"type":"session_meta","cwd":"/workspace/test","model":"gpt-4o"}\n' +
       "not valid json\n" +
       '{"type":"event_msg","msg":{"type":"token_count","input_tokens":500,"output_tokens":200}}\n';
 
@@ -851,15 +894,17 @@ describe("getSessionInfo", () => {
     setupMockOpen(jsonl({ type: "session_meta", cwd: "/workspace/test" }));
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
     mockReadFile.mockRejectedValue(new Error("EACCES"));
-    mockCreateReadStream.mockImplementation(() => { throw new Error("EACCES"); });
+    mockCreateReadStream.mockImplementation(() => {
+      throw new Error("EACCES");
+    });
 
-    expect(await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }))).toBeNull();
+    expect(
+      await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" })),
+    ).toBeNull();
   });
 
   it("skips session files when stat throws", async () => {
-    const content = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
-    );
+    const content = jsonl({ type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" });
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     setupMockOpen(content);
     mockReadFile.mockResolvedValue(content);
@@ -900,9 +945,7 @@ describe("getSessionInfo", () => {
     mockLstat.mockResolvedValue({ isDirectory: () => true });
     // stat is used by findCodexSessionFile to get mtimeMs of matching JSONL files
     mockStat.mockResolvedValue({ mtimeMs: 2000 });
-    const content = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "o3-mini" },
-    );
+    const content = jsonl({ type: "session_meta", cwd: "/workspace/test", model: "o3-mini" });
     setupMockOpen(content);
     setupMockStream(content);
     mockReadFile.mockResolvedValue(content);
@@ -915,9 +958,7 @@ describe("getSessionInfo", () => {
 
   it("ignores non-JSONL files in sessions directory", async () => {
     mockReaddir.mockResolvedValue(["notes.txt", "config.json", "sess.jsonl"]);
-    const content = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
-    );
+    const content = jsonl({ type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" });
     setupMockOpen(content);
     setupMockStream(content);
     mockReadFile.mockResolvedValue(content);
@@ -1021,9 +1062,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { permissions: "permissionless" },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { permissions: "permissionless" },
+      }),
+    );
 
     expect(cmd).toContain("--dangerously-bypass-approvals-and-sandbox");
     expect(cmd).not.toContain("--ask-for-approval");
@@ -1041,9 +1085,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { permissions: "skip" as unknown as AgentSpecificConfig["permissions"] },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { permissions: "skip" as unknown as AgentSpecificConfig["permissions"] },
+      }),
+    );
 
     expect(cmd).toContain("--dangerously-bypass-approvals-and-sandbox");
   });
@@ -1060,9 +1107,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { permissions: "auto-edit" },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { permissions: "auto-edit" },
+      }),
+    );
 
     expect(cmd).toContain("--ask-for-approval never");
     expect(cmd).not.toContain("--dangerously-bypass-approvals-and-sandbox");
@@ -1080,9 +1130,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { permissions: "suggest" },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { permissions: "suggest" },
+      }),
+    );
 
     expect(cmd).toContain("--ask-for-approval untrusted");
   });
@@ -1099,9 +1152,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { permissions: "auto-edit", model: "o3-mini" },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { permissions: "auto-edit", model: "o3-mini" },
+      }),
+    );
 
     expect(cmd).not.toBeNull();
     // threadId should come after all flags
@@ -1124,9 +1180,12 @@ describe("getRestoreCommand", () => {
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
-    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig({
-      agentConfig: { model: "o3-mini" },
-    }));
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeProjectConfig({
+        agentConfig: { model: "o3-mini" },
+      }),
+    );
 
     expect(cmd).toContain("--model 'o3-mini'");
     expect(cmd).toContain("-c model_reasoning_effort=high");
@@ -1156,7 +1215,9 @@ describe("getRestoreCommand", () => {
     setupMockOpen(jsonl({ type: "session_meta", cwd: "/workspace/test" }));
     // readFile (full parse) fails
     mockReadFile.mockRejectedValue(new Error("EACCES"));
-    mockCreateReadStream.mockImplementation(() => { throw new Error("EACCES"); });
+    mockCreateReadStream.mockImplementation(() => {
+      throw new Error("EACCES");
+    });
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
 
     const session = makeSession({ workspacePath: "/workspace/test" });
@@ -1277,13 +1338,17 @@ describe("postLaunchSetup", () => {
     mockReadFile.mockRejectedValue(new Error("ENOENT"));
 
     // Before postLaunchSetup, binary is "codex"
-    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("'codex' -c check_for_update_on_startup=false");
+    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe(
+      "'codex' -c check_for_update_on_startup=false",
+    );
 
     // After postLaunchSetup resolves the binary
     await agent.postLaunchSetup!(makeSession({ workspacePath: "/workspace/test" }));
 
     // Now getLaunchCommand should use the resolved binary
-    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("'/opt/bin/codex' -c check_for_update_on_startup=false");
+    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe(
+      "'/opt/bin/codex' -c check_for_update_on_startup=false",
+    );
   });
 });
 
@@ -1500,8 +1565,7 @@ describe("setupWorkspaceHooks", () => {
     // Every wrapper file should be written to a .tmp file first, then renamed
     // This ensures concurrent readers never see a partially written file
     const tmpWrites = mockWriteFile.mock.calls.filter(
-      (call: [string, string, object]) =>
-        typeof call[0] === "string" && call[0].includes(".tmp."),
+      (call: [string, string, object]) => typeof call[0] === "string" && call[0].includes(".tmp."),
     );
     const renames = mockRename.mock.calls;
 
@@ -1522,7 +1586,9 @@ describe("setupWorkspaceHooks", () => {
         return Promise.resolve("0.1.1");
       }
       if (typeof path === "string" && path.endsWith("AGENTS.md")) {
-        return Promise.resolve("# Existing\n\n## Agent Orchestrator (ao) Session\n\nAlready here.\n");
+        return Promise.resolve(
+          "# Existing\n\n## Agent Orchestrator (ao) Session\n\nAlready here.\n",
+        );
       }
       return Promise.reject(new Error("ENOENT"));
     });
@@ -1559,10 +1625,9 @@ describe("shell wrapper content", () => {
 
     // With atomic writes, content is written to a .tmp. file
     const call = mockWriteFile.mock.calls.find(
-      (c: [string, string, object]) =>
-        typeof c[0] === "string" && c[0].includes(`/${name}.tmp.`),
+      (c: [string, string, object]) => typeof c[0] === "string" && c[0].includes(`/${name}.tmp.`),
     );
-    return call ? call[1] as string : "";
+    return call ? (call[1] as string) : "";
   }
 
   describe("metadata helper", () => {

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -1,7 +1,7 @@
 import {
   DEFAULT_READY_THRESHOLD_MS,
   isAgentProcessRunning,
-  normalizePermissionMode,
+  normalizeAgentPermissionMode,
   shellEscape,
   type Agent,
   type AgentSessionInfo,
@@ -549,7 +549,7 @@ export async function resolveCodexBinary(): Promise<string> {
 
 /** Append approval-policy flags to a command parts array */
 function appendApprovalFlags(parts: string[], permissions: string | undefined): void {
-  const mode = normalizePermissionMode(permissions);
+  const mode = normalizeAgentPermissionMode(permissions);
   if (mode === "permissionless") {
     parts.push("--dangerously-bypass-approvals-and-sandbox");
   } else if (mode === "auto-edit") {

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -1,5 +1,7 @@
 import {
   DEFAULT_READY_THRESHOLD_MS,
+  isAgentProcessRunning,
+  normalizePermissionMode,
   shellEscape,
   type Agent,
   type AgentSessionInfo,
@@ -23,15 +25,6 @@ import { promisify } from "node:util";
 import { randomBytes } from "node:crypto";
 
 const execFileAsync = promisify(execFile);
-
-function normalizePermissionMode(mode: string | undefined): "permissionless" | "default" | "auto-edit" | "suggest" | undefined {
-  if (!mode) return undefined;
-  if (mode === "skip") return "permissionless";
-  if (mode === "permissionless" || mode === "default" || mode === "auto-edit" || mode === "suggest") {
-    return mode;
-  }
-  return undefined;
-}
 
 /** Shared bin directory for ao shell wrappers (prepended to PATH) */
 const AO_BIN_DIR = join(homedir(), ".ao", "bin");
@@ -279,11 +272,7 @@ async function setupCodexWorkspace(workspacePath: string): Promise<void> {
   // 1. Write shared wrappers to ~/.ao/bin/
   await mkdir(AO_BIN_DIR, { recursive: true });
 
-  await atomicWriteFile(
-    join(AO_BIN_DIR, "ao-metadata-helper.sh"),
-    AO_METADATA_HELPER,
-    0o755,
-  );
+  await atomicWriteFile(join(AO_BIN_DIR, "ao-metadata-helper.sh"), AO_METADATA_HELPER, 0o755);
 
   // Only write wrappers if they don't exist or are outdated (check marker)
   const markerPath = join(AO_BIN_DIR, ".ao-version");
@@ -397,10 +386,7 @@ async function collectJsonlFiles(dir: string, depth = 0): Promise<string[]> {
  * entry matching the given workspace path. Reads only the first 4 KB
  * to avoid loading large rollout files into memory.
  */
-async function sessionFileMatchesCwd(
-  filePath: string,
-  workspacePath: string,
-): Promise<boolean> {
+async function sessionFileMatchesCwd(filePath: string, workspacePath: string): Promise<boolean> {
   try {
     // Read only the first 4 KB — session_meta is always in the first few lines.
     // Avoids loading large rollout files (100 MB+) into memory.
@@ -606,7 +592,10 @@ async function findCodexSessionFileCached(workspacePath: string): Promise<string
     return cached.path;
   }
   const result = await findCodexSessionFile(workspacePath);
-  sessionFileCache.set(workspacePath, { path: result, expiry: Date.now() + SESSION_FILE_CACHE_TTL_MS });
+  sessionFileCache.set(workspacePath, {
+    path: result,
+    expiry: Date.now() + SESSION_FILE_CACHE_TTL_MS,
+  });
   return result;
 }
 
@@ -683,7 +672,10 @@ function createCodexAgent(): Agent {
       return "active";
     },
 
-    async getActivityState(session: Session, readyThresholdMs?: number): Promise<ActivityDetection | null> {
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
       const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
 
       // Check if process is running first
@@ -718,54 +710,7 @@ function createCodexAgent(): Agent {
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
-      try {
-        if (handle.runtimeName === "tmux" && handle.id) {
-          const { stdout: ttyOut } = await execFileAsync(
-            "tmux",
-            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
-            { timeout: 30_000 },
-          );
-          const ttys = ttyOut
-            .trim()
-            .split("\n")
-            .map((t) => t.trim())
-            .filter(Boolean);
-          if (ttys.length === 0) return false;
-
-          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
-            timeout: 30_000,
-          });
-          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
-          const processRe = /(?:^|\/)codex(?:\s|$)/;
-          for (const line of psOut.split("\n")) {
-            const cols = line.trimStart().split(/\s+/);
-            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
-            const args = cols.slice(2).join(" ");
-            if (processRe.test(args)) {
-              return true;
-            }
-          }
-          return false;
-        }
-
-        const rawPid = handle.data["pid"];
-        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
-        if (Number.isFinite(pid) && pid > 0) {
-          try {
-            process.kill(pid, 0);
-            return true;
-          } catch (err: unknown) {
-            if (err instanceof Error && "code" in err && err.code === "EPERM") {
-              return true;
-            }
-            return false;
-          }
-        }
-
-        return false;
-      } catch {
-        return false;
-      }
+      return isAgentProcessRunning(handle, "codex");
     },
 
     async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Session, RuntimeHandle, AgentLaunchConfig } from "@composio/ao-core";
+import {
+  resetProcessListCache,
+  type Session,
+  type RuntimeHandle,
+  type AgentLaunchConfig,
+} from "@composio/ao-core";
 
 const mockExecFileAsync = vi.fn();
 vi.mock("node:child_process", () => ({
@@ -72,6 +77,7 @@ function mockTmuxWithProcess(processName: string, found = true) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetProcessListCache();
 });
 
 describe("plugin manifest & exports", () => {

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_READY_THRESHOLD_MS,
+  isAgentProcessRunning,
   shellEscape,
   asValidOpenCodeSessionId,
   type Agent,
@@ -294,54 +295,7 @@ function createOpenCodeAgent(): Agent {
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
-      try {
-        if (handle.runtimeName === "tmux" && handle.id) {
-          const { stdout: ttyOut } = await execFileAsync(
-            "tmux",
-            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
-            { timeout: 30_000 },
-          );
-          const ttys = ttyOut
-            .trim()
-            .split("\n")
-            .map((t) => t.trim())
-            .filter(Boolean);
-          if (ttys.length === 0) return false;
-
-          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
-            timeout: 30_000,
-          });
-          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
-          const processRe = /(?:^|\/)opencode(?:\s|$)/;
-          for (const line of psOut.split("\n")) {
-            const cols = line.trimStart().split(/\s+/);
-            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
-            const args = cols.slice(2).join(" ");
-            if (processRe.test(args)) {
-              return true;
-            }
-          }
-          return false;
-        }
-
-        const rawPid = handle.data["pid"];
-        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
-        if (Number.isFinite(pid) && pid > 0) {
-          try {
-            process.kill(pid, 0);
-            return true;
-          } catch (err: unknown) {
-            if (err instanceof Error && "code" in err && err.code === "EPERM") {
-              return true;
-            }
-            return false;
-          }
-        }
-
-        return false;
-      } catch {
-        return false;
-      }
+      return isAgentProcessRunning(handle, "opencode");
     },
 
     async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {


### PR DESCRIPTION
## Summary

Extracts shared `isAgentProcessRunning` and `normalizePermissionMode` logic into `@composio/ao-core` to eliminate duplication across agent plugins.

## Changes

- New shared module `packages/core/src/process-detection.ts`:
  - `isAgentProcessRunning(handle, processName, options?)` with ps caching, tmux TTY matching, PID/EPERM handling
  - `resetProcessListCache()` for testing
  - `normalizePermissionMode(mode)` delegating to core type normalizer
- Export new APIs from `@composio/ao-core`
- Refactor plugins to use shared helpers:
  - `agent-codex`
  - `agent-claude-code`
  - `agent-opencode`
  - `agent-aider`
- Remove duplicated local implementations of process detection and permission normalization
- Update plugin tests to reset shared cache in `beforeEach`

## Testing

- All process detection tests pass across plugins (opencode, aider, codex, claude)
- Core typecheck passes
- Existing unit tests continue to pass (except pre‑existing Windows‑path and integration‑environment failures)

Closes #783