### PR TITLE
feat: add opt-in docker runtime and runtime config commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Recommended for servers:
 - Prefer rootless Docker on Linux
 - Use a pinned image instead of `latest` for reproducibility
 - Add `readOnlyRoot`, `capDrop`, and explicit CPU/memory limits for multi-tenant hosts
-- Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; AO uses `/tmp` inside the container to deliver long or multiline prompts safely
+- Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; many agent CLIs and shells still expect a writable `/tmp`
 - Use `ao doctor` after changing Docker runtime config; it now checks Docker daemon access and warns about missing image/rootless/GPU setup
 
 ## Plugin Architecture

--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ See [`agent-orchestrator.yaml.example`](agent-orchestrator.yaml.example) for the
 
 Docker is opt-in. The local default stays `tmux`, but you can switch a project or a single startup to Docker when you want isolation, reproducible images, or server/CI-friendly sessions without changing the local default.
 
+For first-time users, the easiest path is:
+
+```bash
+ao docker prepare my-app
+```
+
+That command picks the project's worker agent, pulls the matching official Docker image reference, and writes `runtime: docker` plus `runtimeConfig.image` back into the project config. If you prefer not to rely on a prebuilt image, you can ask AO to build one locally instead:
+
+```bash
+ao docker prepare my-app --build-local
+ao docker prepare my-app --build-local --agent codex
+ao docker prepare my-app --image ghcr.io/your-org/custom-agent:latest --no-pull
+```
+
 ```yaml
 projects:
   my-app:
@@ -151,7 +165,7 @@ projects:
     defaultBranch: main
     runtime: docker
     runtimeConfig:
-      image: ghcr.io/composio/ao:latest
+      image: ghcr.io/composio/ao-claude-code:latest
       limits:
         cpus: 2
         memory: 4g
@@ -160,19 +174,19 @@ projects:
       tmpfs: [/tmp]
 ```
 
-You can also override runtime per command:
+You can still override runtime per command:
 
 ```bash
-ao start --runtime docker --runtime-image ghcr.io/composio/ao:latest
-ao spawn 123 --runtime docker --runtime-image ghcr.io/composio/ao:latest
+ao start --runtime docker --runtime-image ghcr.io/composio/ao-claude-code:latest
+ao spawn 123 --runtime docker --runtime-image ghcr.io/composio/ao-claude-code:latest
 ao spawn 123 --runtime docker --runtime-memory 4g --runtime-cpus 2 --runtime-read-only
 ```
 
-Or persist runtime selection in config:
+Or persist runtime selection in config directly:
 
 ```bash
 ao runtime show
-ao runtime set docker my-app --image ghcr.io/composio/ao:latest --memory 4g --cpus 2 --read-only
+ao runtime set docker my-app --image ghcr.io/composio/ao-claude-code:latest --memory 4g --cpus 2 --read-only
 ao runtime clear my-app
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ To install from source (for contributors):
 git clone https://github.com/ComposioHQ/agent-orchestrator.git
 cd agent-orchestrator && bash scripts/setup.sh
 ```
+
 </details>
 
 ### Start
@@ -137,6 +138,42 @@ reactions:
 CI fails → agent gets the logs and fixes it. Reviewer requests changes → agent addresses them. PR approved with green CI → you get a notification to merge.
 
 See [`agent-orchestrator.yaml.example`](agent-orchestrator.yaml.example) for the full reference, or run `ao config-help` for the complete schema.
+
+### Using Docker runtime
+
+Docker is opt-in. The local default stays `tmux`, but you can switch a project or a single startup to Docker when you want isolation or a reproducible server/CI environment.
+
+```yaml
+projects:
+  my-app:
+    repo: owner/my-app
+    path: ~/my-app
+    defaultBranch: main
+    runtime: docker
+    runtimeConfig:
+      image: ghcr.io/composio/ao:latest
+      limits:
+        cpus: 2
+        memory: 4g
+      readOnlyRoot: true
+      capDrop: [ALL]
+      tmpfs: [/tmp]
+```
+
+You can also override runtime per command:
+
+```bash
+ao start --runtime docker --runtime-image ghcr.io/composio/ao:latest
+ao spawn 123 --runtime docker --runtime-image ghcr.io/composio/ao:latest
+ao spawn 123 --runtime docker --runtime-memory 4g --runtime-cpus 2 --runtime-read-only
+```
+
+Recommended for servers:
+
+- Prefer rootless Docker on Linux
+- Use a pinned image instead of `latest` for reproducibility
+- Add `readOnlyRoot`, `capDrop`, and explicit CPU/memory limits for multi-tenant hosts
+- Use `ao doctor` after changing Docker runtime config; it now checks Docker daemon access and warns about missing image/rootless/GPU setup
 
 ## Plugin Architecture
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ ao spawn 123 --runtime docker --runtime-image ghcr.io/composio/ao:latest
 ao spawn 123 --runtime docker --runtime-memory 4g --runtime-cpus 2 --runtime-read-only
 ```
 
+Or persist runtime selection in config:
+
+```bash
+ao runtime show
+ao runtime set docker my-app --image ghcr.io/composio/ao:latest --memory 4g --cpus 2 --read-only
+ao runtime clear my-app
+```
+
+`ao runtime set <name>` without a project updates `defaults.runtime`. For Docker, the project form is usually the right choice because `runtimeConfig.image` is stored per project.
+
 Your Docker image must include the basics AO expects to drive an interactive agent session:
 
 - `/bin/sh` (or the shell you set in `runtimeConfig.shell`)

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Your Docker image must include the basics AO expects to drive an interactive age
 - `tmux`
 - `git`
 - The agent CLI you plan to run inside the container (`claude`, `codex`, `aider`, etc.)
+- Any auth material that CLI expects, usually through environment variables in the container
 
 AO bind-mounts the project workspace into the container at the same absolute host path. That keeps agent tooling and terminal attach behavior consistent, but it also means Docker must be able to access that host path.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Spawn parallel AI coding agents, each in its own git worktree. Agents autonomous
 
 Agent Orchestrator manages fleets of AI coding agents working in parallel on your codebase. Each agent gets its own git worktree, its own branch, and its own PR. When CI fails, the agent fixes it. When reviewers leave comments, the agent addresses them. You only get pulled in when human judgment is needed.
 
-**Agent-agnostic** (Claude Code, Codex, Aider) · **Runtime-agnostic** (tmux, Docker) · **Tracker-agnostic** (GitHub, Linear)
+**Agent-agnostic** (Claude Code, Codex, OpenCode, Aider) · **Runtime-agnostic** (tmux, Docker) · **Tracker-agnostic** (GitHub, Linear)
 
 <div align="center">
 
@@ -141,7 +141,7 @@ See [`agent-orchestrator.yaml.example`](agent-orchestrator.yaml.example) for the
 
 ### Using Docker runtime
 
-Docker is opt-in. The local default stays `tmux`, but you can switch a project or a single startup to Docker when you want isolation or a reproducible server/CI environment.
+Docker is opt-in. The local default stays `tmux`, but you can switch a project or a single startup to Docker when you want isolation, reproducible images, or server/CI-friendly sessions without changing the local default.
 
 ```yaml
 projects:
@@ -178,24 +178,43 @@ ao runtime clear my-app
 
 `ao runtime set <name>` without a project updates `defaults.runtime`. For Docker, the project form is usually the right choice because `runtimeConfig.image` is stored per project.
 
+#### What the Docker runtime actually does
+
+- Starts one long-lived container per AO session
+- Starts `tmux` inside the container so attach, send, and output stay interactive
+- Mounts the worktree at the same absolute path as the host
+- Mounts the worktree's shared Git metadata when the repo uses `.git` indirection or worktrees
+- Returns runtime-aware attach info so `ao session attach`, `ao open`, and the web terminal all use `docker exec ... tmux attach`
+
+This branch also keeps the runtime itself generic: agent plugins provide Docker-specific home mounts and env defaults through runtime hints, instead of hardcoding agent behavior directly into the Docker runtime.
+
 Your Docker image must include the basics AO expects to drive an interactive agent session:
 
 - `/bin/sh` (or the shell you set in `runtimeConfig.shell`)
 - `tmux`
 - `git`
 - The agent CLI you plan to run inside the container (`claude`, `codex`, `aider`, etc.)
-- Any auth material that CLI expects, usually through environment variables in the container
+- Any auth material that CLI expects inside the container
 
 AO bind-mounts the project workspace into the container at the same absolute host path. That keeps agent tooling and terminal attach behavior consistent, but it also means Docker must be able to access that host path.
 
-When present on the host, AO also mounts common local auth/config state into `/home/ao` inside the container:
+When present on the host, AO also mounts common developer config into `/home/ao` inside the container:
 
-- `~/.codex`
 - `~/.gitconfig`
 - `~/.git-credentials`
 - `~/.config/gh`
 
-That is enough for real Codex, Git, and GitHub-backed sessions to reuse local login state in typical setups, as long as the image also includes the corresponding CLIs.
+That covers Git/GitHub basics. Agent-specific state is requested by the agent plugin itself.
+
+#### Verified built-in agents
+
+These were live-validated on this branch with real AO Docker sessions:
+
+- `claude-code`: mounts `~/.claude`, sets `CLAUDE_CONFIG_DIR`, and reuses a Linux-style Claude config/auth home in the container. The first Docker-backed Claude session may require a one-time in-container Claude sign-in; later containers reuse the mounted config home.
+- `codex`: mounts `~/.codex`, sets `CODEX_HOME`, and can reuse host Codex state. A fresh worktree path may still show Codex's normal trust prompt the first time it opens.
+- `opencode`: mounts OpenCode config/auth state, sets `OPENCODE_CONFIG_DIR`, and passes common provider API keys through from the host when present.
+
+Other agents can still use the Docker runtime as long as the image includes the agent CLI and its auth model is available in-container, but the three agents above are the ones explicitly exercised end-to-end here.
 
 CLI attach, `ao open`, and the web dashboard terminal are runtime-aware. For Docker sessions they attach with `docker exec ... tmux attach`, not host tmux.
 
@@ -205,8 +224,8 @@ Recommended for servers:
 - Use a pinned image instead of `latest` for reproducibility
 - Add `readOnlyRoot`, `capDrop`, and explicit CPU/memory limits for multi-tenant hosts
 - Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; many agent CLIs and shells still expect a writable `/tmp`
-- Expect a one-time Codex workspace trust prompt the first time a brand-new worktree path is opened in-container
 - Use `ao doctor` after changing Docker runtime config; it now checks Docker daemon access and warns about missing image/rootless/GPU setup
+- See [`packages/plugins/runtime-docker/README.md`](packages/plugins/runtime-docker/README.md) for the plugin-level Docker details and minimal image pattern
 
 ## Plugin Architecture
 
@@ -214,8 +233,8 @@ Seven plugin slots. Lifecycle stays in core.
 
 | Slot      | Default     | Alternatives             |
 | --------- | ----------- | ------------------------ |
-| Runtime   | tmux        | process                  |
-| Agent     | claude-code | codex, aider, opencode   |
+| Runtime   | tmux        | docker, process          |
+| Agent     | claude-code | codex, opencode, aider   |
 | Workspace | worktree    | clone                    |
 | Tracker   | github      | linear, gitlab           |
 | SCM       | github      | gitlab                   |

--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ Your Docker image must include the basics AO expects to drive an interactive age
 
 AO bind-mounts the project workspace into the container at the same absolute host path. That keeps agent tooling and terminal attach behavior consistent, but it also means Docker must be able to access that host path.
 
+When present on the host, AO also mounts common local auth/config state into `/home/ao` inside the container:
+
+- `~/.codex`
+- `~/.gitconfig`
+- `~/.git-credentials`
+- `~/.config/gh`
+
+That is enough for real Codex, Git, and GitHub-backed sessions to reuse local login state in typical setups, as long as the image also includes the corresponding CLIs.
+
 CLI attach, `ao open`, and the web dashboard terminal are runtime-aware. For Docker sessions they attach with `docker exec ... tmux attach`, not host tmux.
 
 Recommended for servers:
@@ -196,6 +205,7 @@ Recommended for servers:
 - Use a pinned image instead of `latest` for reproducibility
 - Add `readOnlyRoot`, `capDrop`, and explicit CPU/memory limits for multi-tenant hosts
 - Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; many agent CLIs and shells still expect a writable `/tmp`
+- Expect a one-time Codex workspace trust prompt the first time a brand-new worktree path is opened in-container
 - Use `ao doctor` after changing Docker runtime config; it now checks Docker daemon access and warns about missing image/rootless/GPU setup
 
 ## Plugin Architecture

--- a/README.md
+++ b/README.md
@@ -168,11 +168,23 @@ ao spawn 123 --runtime docker --runtime-image ghcr.io/composio/ao:latest
 ao spawn 123 --runtime docker --runtime-memory 4g --runtime-cpus 2 --runtime-read-only
 ```
 
+Your Docker image must include the basics AO expects to drive an interactive agent session:
+
+- `/bin/sh` (or the shell you set in `runtimeConfig.shell`)
+- `tmux`
+- `git`
+- The agent CLI you plan to run inside the container (`claude`, `codex`, `aider`, etc.)
+
+AO bind-mounts the project workspace into the container at the same absolute host path. That keeps agent tooling and terminal attach behavior consistent, but it also means Docker must be able to access that host path.
+
+CLI attach, `ao open`, and the web dashboard terminal are runtime-aware. For Docker sessions they attach with `docker exec ... tmux attach`, not host tmux.
+
 Recommended for servers:
 
 - Prefer rootless Docker on Linux
 - Use a pinned image instead of `latest` for reproducibility
 - Add `readOnlyRoot`, `capDrop`, and explicit CPU/memory limits for multi-tenant hosts
+- Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; AO uses `/tmp` inside the container to deliver long or multiline prompts safely
 - Use `ao doctor` after changing Docker runtime config; it now checks Docker daemon access and warns about missing image/rootless/GPU setup
 
 ## Plugin Architecture

--- a/SETUP.md
+++ b/SETUP.md
@@ -235,6 +235,7 @@ Supported Docker runtime keys in this branch:
 Notes:
 
 - Your image must include `/bin/sh` (or the configured `shell`), `tmux`, `git`, and the agent CLI you want AO to launch.
+- Any credentials your agent CLI needs must be available inside the container, typically through environment variables.
 - AO bind-mounts the workspace into the container at the same absolute path from the host.
 - CLI attach, `ao open`, and the web dashboard terminal attach to Docker sessions with `docker exec ... tmux attach`.
 - Prefer rootless Docker on Linux hosts.
@@ -242,6 +243,22 @@ Notes:
 - Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; AO uses `/tmp` inside the container for long or multiline prompt delivery.
 - `readOnlyRoot` only affects the container root filesystem. The bind-mounted workspace remains writable unless you mount it read-only yourself.
 - `ao doctor` now checks Docker availability, daemon access, configured image presence, Linux rootless hints, and GPU-runtime hints when `runtime: docker` is enabled.
+
+Minimal image pattern:
+
+```dockerfile
+FROM node:20-bookworm
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git tmux \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install the agent CLI used by this project.
+# RUN npm install -g @openai/codex
+# RUN npm install -g @anthropic-ai/claude-code
+
+WORKDIR /workspace
+```
 
 ### Plugin Slots
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -224,6 +224,8 @@ projects:
 Supported Docker runtime keys in this branch:
 
 - `image`: container image to run
+- `shell`: shell used to bootstrap the keepalive process and launch command
+- `user`: explicit container user; defaults to host `uid:gid` when available
 - `limits.cpus`, `limits.memory`, `limits.gpus`: resource controls passed to `docker run`
 - `readOnlyRoot`: sets `--read-only`
 - `capDrop`: repeated `--cap-drop`
@@ -232,8 +234,13 @@ Supported Docker runtime keys in this branch:
 
 Notes:
 
+- Your image must include `/bin/sh` (or the configured `shell`), `tmux`, `git`, and the agent CLI you want AO to launch.
+- AO bind-mounts the workspace into the container at the same absolute path from the host.
+- CLI attach, `ao open`, and the web dashboard terminal attach to Docker sessions with `docker exec ... tmux attach`.
 - Prefer rootless Docker on Linux hosts.
 - Use pinned image tags for reproducibility.
+- Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; AO uses `/tmp` inside the container for long or multiline prompt delivery.
+- `readOnlyRoot` only affects the container root filesystem. The bind-mounted workspace remains writable unless you mount it read-only yourself.
 - `ao doctor` now checks Docker availability, daemon access, configured image presence, Linux rootless hints, and GPU-runtime hints when `runtime: docker` is enabled.
 
 ### Plugin Slots

--- a/SETUP.md
+++ b/SETUP.md
@@ -594,10 +594,10 @@ lsof -ti:3000 | xargs kill
 **Solution:**
 
 ```bash
-# AO stores runtime data under ~/.agent-orchestrator/
+# AO stores session metadata under ~/.agent-orchestrator/
 ls -la ~/.agent-orchestrator
 
-# Check the default worktree root
+# Worktree-backed sessions use managed worktrees under ~/.worktrees/
 ls -la ~/.worktrees
 
 # Create the base directory if missing
@@ -910,8 +910,8 @@ ao session ls --json | jq -r '.[] | select(.status == "merged") | .id' | xargs -
 Yes! Each orchestrator instance should have:
 
 - A different config file or config directory, so AO gets a different hash namespace
-- Different dashboard port (`port`) — e.g., 3000 for project A, 3001 for project B
-- Different config file contents as needed
+- Different dashboard port (`port`) - e.g., 3000 for project A, 3001 for project B
+- Different project paths or config contents as needed
 
 AO derives runtime directories from the config location, so separate config locations already produce separate hash-scoped runtime paths under `~/.agent-orchestrator/`. Terminal WebSocket ports are auto-detected by default, so you typically only need to set `port:` differently. If you need explicit control, you can also set `terminalPort:` and `directTerminalPort:` per config.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -203,6 +203,20 @@ See [agent-orchestrator.yaml.example](./agent-orchestrator.yaml.example) for a f
 
 Use Docker when you want stronger session isolation, reproducible images, or resource limits on shared servers. AO still defaults to `tmux` locally.
 
+For a first-time user, the simplest setup path is:
+
+```bash
+ao docker prepare my-app
+```
+
+That prepares Docker for the project's worker agent, pulls the matching official image reference, and writes the project runtime config for you. You can also let AO build locally-managed images:
+
+```bash
+ao docker prepare my-app --build-local
+ao docker prepare my-app --build-local --agent codex
+ao docker prepare my-app --image ghcr.io/your-org/custom-agent:latest --no-pull
+```
+
 ```yaml
 projects:
   my-app:
@@ -211,7 +225,7 @@ projects:
     defaultBranch: main
     runtime: docker
     runtimeConfig:
-      image: ghcr.io/composio/ao:latest
+      image: ghcr.io/composio/ao-claude-code:latest
       limits:
         cpus: 2
         memory: 4g
@@ -236,7 +250,7 @@ You can also persist runtime selection from the CLI:
 
 ```bash
 ao runtime show
-ao runtime set docker my-app --image ghcr.io/composio/ao:latest --memory 4g --cpus 2 --read-only
+ao runtime set docker my-app --image ghcr.io/composio/ao-claude-code:latest --memory 4g --cpus 2 --read-only
 ao runtime clear my-app
 ```
 
@@ -246,6 +260,7 @@ Notes on `ao runtime`:
 - `ao runtime set <name> <project>` writes a project override.
 - Docker config flags are project-only because `runtimeConfig` lives under each project.
 - `ao runtime clear <project>` removes both the project `runtime` and its `runtimeConfig`, so the project falls back to the default runtime.
+- `ao docker prepare <project>` is the onboarding path when you want AO to choose or build an image for you.
 
 Notes:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -255,7 +255,7 @@ Notes:
 - CLI attach, `ao open`, and the web dashboard terminal attach to Docker sessions with `docker exec ... tmux attach`.
 - Prefer rootless Docker on Linux hosts.
 - Use pinned image tags for reproducibility.
-- Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; AO uses `/tmp` inside the container for long or multiline prompt delivery.
+- Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; many shells and agent CLIs still expect a writable `/tmp`.
 - `readOnlyRoot` only affects the container root filesystem. The bind-mounted workspace remains writable unless you mount it read-only yourself.
 - `ao doctor` now checks Docker availability, daemon access, configured image presence, Linux rootless hints, and GPU-runtime hints when `runtime: docker` is enabled.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -597,6 +597,9 @@ lsof -ti:3000 | xargs kill
 # AO stores runtime data under ~/.agent-orchestrator/
 ls -la ~/.agent-orchestrator
 
+# Check the default worktree root
+ls -la ~/.worktrees
+
 # Create the base directory if missing
 mkdir -p ~/.agent-orchestrator
 
@@ -906,8 +909,9 @@ ao session ls --json | jq -r '.[] | select(.status == "merged") | .id' | xargs -
 
 Yes! Each orchestrator instance should have:
 
+- A different config file or config directory, so AO gets a different hash namespace
 - Different dashboard port (`port`) — e.g., 3000 for project A, 3001 for project B
-- Different config location or project paths
+- Different config file contents as needed
 
 AO derives runtime directories from the config location, so separate config locations already produce separate hash-scoped runtime paths under `~/.agent-orchestrator/`. Terminal WebSocket ports are auto-detected by default, so you typically only need to set `port:` differently. If you need explicit control, you can also set `terminalPort:` and `directTerminalPort:` per config.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -45,6 +45,19 @@ Comprehensive guide to installing, configuring, and troubleshooting Agent Orches
   # See: https://github.com/cli/cli/blob/trunk/docs/install_linux.md
   ```
 
+- **Docker** (for docker runtime) - Optional, but recommended for server or CI isolation
+
+  ```bash
+  docker --version
+  docker info
+
+  # macOS
+  # Install Docker Desktop: https://docs.docker.com/desktop/setup/install/mac-install/
+
+  # Linux
+  # Install Docker Engine or rootless Docker: https://docs.docker.com/engine/install/
+  ```
+
 ### Optional
 
 - **Linear API Key** - If using Linear for issue tracking
@@ -185,6 +198,43 @@ projects:
 ### Full Configuration Schema
 
 See [agent-orchestrator.yaml.example](./agent-orchestrator.yaml.example) for a fully commented example with all options.
+
+### Docker Runtime Configuration
+
+Use Docker when you want stronger session isolation, reproducible images, or resource limits on shared servers. AO still defaults to `tmux` locally.
+
+```yaml
+projects:
+  my-app:
+    repo: owner/my-app
+    path: ~/my-app
+    defaultBranch: main
+    runtime: docker
+    runtimeConfig:
+      image: ghcr.io/composio/ao:latest
+      limits:
+        cpus: 2
+        memory: 4g
+      readOnlyRoot: true
+      capDrop: [ALL]
+      network: bridge
+      tmpfs: [/tmp]
+```
+
+Supported Docker runtime keys in this branch:
+
+- `image`: container image to run
+- `limits.cpus`, `limits.memory`, `limits.gpus`: resource controls passed to `docker run`
+- `readOnlyRoot`: sets `--read-only`
+- `capDrop`: repeated `--cap-drop`
+- `network`: sets `--network`
+- `tmpfs`: repeated `--tmpfs`
+
+Notes:
+
+- Prefer rootless Docker on Linux hosts.
+- Use pinned image tags for reproducibility.
+- `ao doctor` now checks Docker availability, daemon access, configured image presence, Linux rootless hints, and GPU-runtime hints when `runtime: docker` is enabled.
 
 ### Plugin Slots
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -232,6 +232,21 @@ Supported Docker runtime keys in this branch:
 - `network`: sets `--network`
 - `tmpfs`: repeated `--tmpfs`
 
+You can also persist runtime selection from the CLI:
+
+```bash
+ao runtime show
+ao runtime set docker my-app --image ghcr.io/composio/ao:latest --memory 4g --cpus 2 --read-only
+ao runtime clear my-app
+```
+
+Notes on `ao runtime`:
+
+- `ao runtime set <name>` updates `defaults.runtime`.
+- `ao runtime set <name> <project>` writes a project override.
+- Docker config flags are project-only because `runtimeConfig` lives under each project.
+- `ao runtime clear <project>` removes both the project `runtime` and its `runtimeConfig`, so the project falls back to the default runtime.
+
 Notes:
 
 - Your image must include `/bin/sh` (or the configured `shell`), `tmux`, `git`, and the agent CLI you want AO to launch.

--- a/SETUP.md
+++ b/SETUP.md
@@ -252,10 +252,12 @@ Notes:
 - Your image must include `/bin/sh` (or the configured `shell`), `tmux`, `git`, and the agent CLI you want AO to launch.
 - Any credentials your agent CLI needs must be available inside the container, typically through environment variables.
 - AO bind-mounts the workspace into the container at the same absolute path from the host.
+- When present on the host, AO also mounts `~/.codex`, `~/.gitconfig`, `~/.git-credentials`, and `~/.config/gh` into `/home/ao` so Codex/Git/GitHub auth can work in-container without baking secrets into the image.
 - CLI attach, `ao open`, and the web dashboard terminal attach to Docker sessions with `docker exec ... tmux attach`.
 - Prefer rootless Docker on Linux hosts.
 - Use pinned image tags for reproducibility.
 - Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; many shells and agent CLIs still expect a writable `/tmp`.
+- A fresh Codex worktree path may still prompt for trust the first time it opens inside the container.
 - `readOnlyRoot` only affects the container root filesystem. The bind-mounted workspace remains writable unless you mount it read-only yourself.
 - `ao doctor` now checks Docker availability, daemon access, configured image presence, Linux rootless hints, and GPU-runtime hints when `runtime: docker` is enabled.
 

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -1,9 +1,9 @@
 # Agent Orchestrator Configuration
 # Copy to agent-orchestrator.yaml and customize.
 
-# Runtime data directories are auto-derived from this config location under:
-#   ~/.agent-orchestrator/{hash}-{projectId}/
-# You usually do not need to configure paths manually.
+# AO derives session metadata paths from this config location automatically.
+# Worktree-based sessions also get managed Git worktrees under ~/.worktrees/.
+# You usually do not need to configure dataDir/worktreeDir manually.
 
 # Web dashboard port
 port: 3000
@@ -15,8 +15,8 @@ port: 3000
 
 # Default plugins (these are the defaults — you can omit this section)
 defaults:
-  runtime: tmux           # tmux | process
-  agent: claude-code      # claude-code | codex | aider | opencode
+  runtime: tmux           # tmux | process | docker | other runtime plugin
+  agent: claude-code      # claude-code | codex | aider | opencode | other agent plugin
   # orchestrator:
   #   agent: claude-code
   # worker:
@@ -45,6 +45,23 @@ projects:
     path: ~/my-app
     defaultBranch: main
     sessionPrefix: app
+    # Runtime helpers:
+    # ao runtime show my-app
+    # ao runtime set docker my-app --image ghcr.io/composio/ao:latest --memory 4g --cpus 2 --read-only
+    # ao runtime clear my-app
+    # runtime: docker
+    # runtimeConfig:
+    #   image: ghcr.io/composio/ao:latest
+    #   shell: /bin/sh
+    #   user: "1000:1000" # optional; defaults to host uid:gid when available
+    #   limits:
+    #     cpus: 2
+    #     memory: 4g
+    #     gpus: all
+    #   readOnlyRoot: true
+    #   capDrop: [ALL]
+    #   network: bridge
+    #   tmpfs: [/tmp] # recommended when using readOnlyRoot
 
     # Issue tracker (defaults to github issues)
     # tracker:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -48,5 +48,13 @@ ao config-help                         # Show full config schema reference
 ao start --runtime docker --runtime-image ghcr.io/composio/ao:latest
 ao start --runtime docker --runtime-memory 4g --runtime-cpus 2 --runtime-read-only
 ao spawn 123 --runtime docker --runtime-network bridge --runtime-cap-drop ALL
+ao spawn 123 --runtime docker --runtime-read-only --runtime-tmpfs /tmp --runtime-cap-drop ALL --runtime-cap-drop NET_RAW
 ao spawn 123 --runtime docker --runtime-config '{"limits":{"memory":"4g"}}'
 ```
+
+Runtime override rules:
+
+- Command-line runtime overrides merge on top of the project's configured `runtimeConfig`.
+- `--runtime-config` is merged first, then explicit flags such as `--runtime-memory` or `--runtime-read-only` win for the same keys.
+- `--runtime-cap-drop` and `--runtime-tmpfs` are repeatable.
+- Runtime-aware attach surfaces (`ao session attach`, `ao open`, and the web dashboard terminal) use `docker exec ... tmux attach` for Docker sessions.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -12,8 +12,9 @@ ao stop                                # Stop everything (dashboard, orchestrato
 ao status                              # Overview of all sessions
 ao status --watch                      # Live-updating terminal status view
 ao dashboard                           # Open web dashboard in browser
+ao docker prepare my-app               # Pull/build a Docker image and wire the project config
 ao runtime show                        # Show default runtime and project overrides
-ao runtime set docker my-app --image ghcr.io/composio/ao:latest
+ao runtime set docker my-app --image ghcr.io/composio/ao-claude-code:latest
 ```
 
 ## Commands the orchestrator agent uses
@@ -23,7 +24,7 @@ These are primarily invoked by the orchestrator agent running inside a tmux sess
 ```bash
 ao spawn [issue]                       # Spawn an agent (project auto-detected from cwd)
 ao spawn 123 --agent codex             # Override agent for this session
-ao spawn 123 --runtime docker --runtime-image ghcr.io/composio/ao:latest
+ao spawn 123 --runtime docker --runtime-image ghcr.io/composio/ao-claude-code:latest
 ao batch-spawn 101 102 103             # Spawn agents for multiple issues at once
 ao send <session> "Fix the tests"      # Send instructions to a running agent
 ao session ls                          # List sessions
@@ -44,6 +45,26 @@ ao config-help                         # Show full config schema reference
 
 `ao update` fast-forwards the local install on `main`, reinstalls dependencies, clean-rebuilds core packages, refreshes the launcher, and runs smoke tests. Use `ao update --skip-smoke` to stop after rebuild, or `ao update --smoke-only` to rerun just the smoke checks.
 
+## Docker onboarding
+
+Use `ao docker prepare` when you want AO to pick or build an image for you instead of manually editing `runtimeConfig.image`.
+
+```bash
+ao docker prepare my-app
+ao docker prepare my-app --agent codex
+ao docker prepare my-app --build-local --agent opencode
+ao docker prepare my-app --build-local --tag ao-real-codex:demo --agent codex
+ao docker prepare my-app --image ghcr.io/your-org/custom-agent:latest --no-pull
+```
+
+Rules:
+
+- By default, `ao docker prepare` picks the worker agent for the project and pulls an official image reference for that agent.
+- `--build-local` builds a local image from an AO-managed Dockerfile template instead of pulling.
+- `--image` lets you point AO at a custom image; pair it with `--no-pull` if the image already exists locally.
+- `--read-only` automatically adds `tmpfs: [/tmp]` so `tmux` and agent CLIs still have writable runtime scratch space.
+- The command writes `runtime: docker` and `runtimeConfig.image` back into `agent-orchestrator.yaml` for the selected project.
+
 ## Runtime config commands
 
 Use `ao runtime` when you want to persist runtime selection into `agent-orchestrator.yaml` instead of applying a one-off flag.
@@ -52,8 +73,8 @@ Use `ao runtime` when you want to persist runtime selection into `agent-orchestr
 ao runtime show
 ao runtime show my-app
 ao runtime set process                 # updates defaults.runtime
-ao runtime set docker my-app --image ghcr.io/composio/ao:latest
-ao runtime set docker my-app --image ghcr.io/composio/ao:latest --memory 4g --cpus 2 --read-only
+ao runtime set docker my-app --image ghcr.io/composio/ao-claude-code:latest
+ao runtime set docker my-app --image ghcr.io/composio/ao-claude-code:latest --memory 4g --cpus 2 --read-only
 ao runtime clear my-app
 ```
 
@@ -68,7 +89,7 @@ Runtime config rules:
 ## Runtime override examples
 
 ```bash
-ao start --runtime docker --runtime-image ghcr.io/composio/ao:latest
+ao start --runtime docker --runtime-image ghcr.io/composio/ao-claude-code:latest
 ao start --runtime docker --runtime-memory 4g --runtime-cpus 2 --runtime-read-only
 ao spawn 123 --runtime docker --runtime-network bridge --runtime-cap-drop ALL
 ao spawn 123 --runtime docker --runtime-read-only --runtime-tmpfs /tmp --runtime-cap-drop ALL --runtime-cap-drop NET_RAW

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -41,3 +41,12 @@ ao config-help                         # Show full config schema reference
 `ao doctor` checks PATH and launcher resolution, required binaries, configured plugin resolution, tmux and GitHub CLI health, config support directories, stale AO temp files, and core build/runtime sanity. If your config enables `runtime: docker`, it also verifies Docker daemon access, checks that an image is configured, and warns about Linux rootless/GPU setup.
 
 `ao update` fast-forwards the local install on `main`, reinstalls dependencies, clean-rebuilds core packages, refreshes the launcher, and runs smoke tests. Use `ao update --skip-smoke` to stop after rebuild, or `ao update --smoke-only` to rerun just the smoke checks.
+
+## Runtime override examples
+
+```bash
+ao start --runtime docker --runtime-image ghcr.io/composio/ao:latest
+ao start --runtime docker --runtime-memory 4g --runtime-cpus 2 --runtime-read-only
+ao spawn 123 --runtime docker --runtime-network bridge --runtime-cap-drop ALL
+ao spawn 123 --runtime docker --runtime-config '{"limits":{"memory":"4g"}}'
+```

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,6 +21,7 @@ These are primarily invoked by the orchestrator agent running inside a tmux sess
 ```bash
 ao spawn [issue]                       # Spawn an agent (project auto-detected from cwd)
 ao spawn 123 --agent codex             # Override agent for this session
+ao spawn 123 --runtime docker --runtime-image ghcr.io/composio/ao:latest
 ao batch-spawn 101 102 103             # Spawn agents for multiple issues at once
 ao send <session> "Fix the tests"      # Send instructions to a running agent
 ao session ls                          # List sessions
@@ -37,6 +38,6 @@ ao update                              # Update local AO install (source install
 ao config-help                         # Show full config schema reference
 ```
 
-`ao doctor` checks PATH and launcher resolution, required binaries, configured plugin resolution, tmux and GitHub CLI health, config support directories, stale AO temp files, and core build/runtime sanity.
+`ao doctor` checks PATH and launcher resolution, required binaries, configured plugin resolution, tmux and GitHub CLI health, config support directories, stale AO temp files, and core build/runtime sanity. If your config enables `runtime: docker`, it also verifies Docker daemon access, checks that an image is configured, and warns about Linux rootless/GPU setup.
 
 `ao update` fast-forwards the local install on `main`, reinstalls dependencies, clean-rebuilds core packages, refreshes the launcher, and runs smoke tests. Use `ao update --skip-smoke` to stop after rebuild, or `ao update --smoke-only` to rerun just the smoke checks.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -12,6 +12,8 @@ ao stop                                # Stop everything (dashboard, orchestrato
 ao status                              # Overview of all sessions
 ao status --watch                      # Live-updating terminal status view
 ao dashboard                           # Open web dashboard in browser
+ao runtime show                        # Show default runtime and project overrides
+ao runtime set docker my-app --image ghcr.io/composio/ao:latest
 ```
 
 ## Commands the orchestrator agent uses
@@ -42,6 +44,27 @@ ao config-help                         # Show full config schema reference
 
 `ao update` fast-forwards the local install on `main`, reinstalls dependencies, clean-rebuilds core packages, refreshes the launcher, and runs smoke tests. Use `ao update --skip-smoke` to stop after rebuild, or `ao update --smoke-only` to rerun just the smoke checks.
 
+## Runtime config commands
+
+Use `ao runtime` when you want to persist runtime selection into `agent-orchestrator.yaml` instead of applying a one-off flag.
+
+```bash
+ao runtime show
+ao runtime show my-app
+ao runtime set process                 # updates defaults.runtime
+ao runtime set docker my-app --image ghcr.io/composio/ao:latest
+ao runtime set docker my-app --image ghcr.io/composio/ao:latest --memory 4g --cpus 2 --read-only
+ao runtime clear my-app
+```
+
+Runtime config rules:
+
+- `ao runtime set <name>` without a project updates `defaults.runtime`.
+- `ao runtime set <name> <project>` writes a per-project runtime override.
+- Docker config flags such as `--image`, `--memory`, `--cpus`, `--cap-drop`, and `--tmpfs` are project-only.
+- `ao runtime clear <project>` removes that project's explicit `runtime` and `runtimeConfig`, so it falls back to the default runtime.
+- `ao runtime set docker` at the defaults level changes selection only; each Docker-backed project still needs its own `runtimeConfig.image`.
+
 ## Runtime override examples
 
 ```bash
@@ -55,6 +78,7 @@ ao spawn 123 --runtime docker --runtime-config '{"limits":{"memory":"4g"}}'
 Runtime override rules:
 
 - Command-line runtime overrides merge on top of the project's configured `runtimeConfig`.
+- Runtime override flags are one-off; they do not rewrite `agent-orchestrator.yaml`.
 - `--runtime-config` is merged first, then explicit flags such as `--runtime-memory` or `--runtime-read-only` win for the same keys.
 - `--runtime-cap-drop` and `--runtime-tmpfs` are repeatable.
 - Runtime-aware attach surfaces (`ao session attach`, `ao open`, and the web dashboard terminal) use `docker exec ... tmux attach` for Docker sessions.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -68,6 +68,7 @@ Activity states (orthogonal to lifecycle): `active`, `ready`, `idle`, `waiting_i
 | `packages/core/src/prompt-builder.ts`    | 3-layer prompt assembly (base + config + rules) |
 | `packages/core/src/config.ts`            | Config loading and Zod validation               |
 | `packages/core/src/plugin-registry.ts`   | Plugin discovery, loading, resolution           |
+| `packages/core/src/runtime-selection.ts` | Shared runtime/runtimeConfig resolution helpers |
 | `packages/core/src/agent-selection.ts`   | Resolves worker vs orchestrator agent roles     |
 | `packages/core/src/observability.ts`     | Correlation IDs, structured logging, metrics    |
 | `packages/core/src/paths.ts`             | Hash-based path and session name generation     |

--- a/packages/cli/__tests__/commands/docker.test.ts
+++ b/packages/cli/__tests__/commands/docker.test.ts
@@ -121,6 +121,9 @@ projects:
     const raw = readConfig();
     const project = (raw["projects"] as Record<string, Record<string, unknown>>)["app"];
     expect(project["runtime"]).toBe("docker");
+    expect(project["agent"]).toBe("codex");
+    expect((project["worker"] as Record<string, unknown>)["agent"]).toBe("codex");
+    expect((project["orchestrator"] as Record<string, unknown>)["agent"]).toBe("codex");
     expect(project["runtimeConfig"]).toEqual({
       image: "ghcr.io/composio/ao-codex:latest",
     });
@@ -180,6 +183,7 @@ projects:
 
     const raw = readConfig();
     const project = (raw["projects"] as Record<string, Record<string, unknown>>)["app"];
+    expect(project["agent"]).toBe("opencode");
     expect(project["runtimeConfig"]).toEqual({
       image: "ao-real-opencode:test",
     });
@@ -217,6 +221,7 @@ projects:
 
     const raw = readConfig();
     const project = (raw["projects"] as Record<string, Record<string, unknown>>)["app"];
+    expect(project["agent"]).toBe("claude-code");
     expect(project["runtimeConfig"]).toEqual({
       image: "ghcr.io/composio/ao-claude-code:latest",
       readOnlyRoot: true,
@@ -251,6 +256,7 @@ projects:
     expect(mockExec).not.toHaveBeenCalled();
     const raw = readConfig();
     const project = (raw["projects"] as Record<string, Record<string, unknown>>)["app"];
+    expect(project["agent"]).toBe("claude-code");
     expect(project["runtimeConfig"]).toEqual({
       image: "example/custom:1.0",
     });

--- a/packages/cli/__tests__/commands/docker.test.ts
+++ b/packages/cli/__tests__/commands/docker.test.ts
@@ -1,0 +1,280 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type * as ProcessModule from "node:process";
+import { parse as yamlParse } from "yaml";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockConfigPathRef, mockExec, mockCheckDocker, mockCwdRef, observedDockerfileRef } = vi.hoisted(
+  () => ({
+    mockConfigPathRef: { current: null as string | null },
+    mockExec: vi.fn(),
+    mockCheckDocker: vi.fn(),
+    mockCwdRef: { current: "" },
+    observedDockerfileRef: { current: null as string | null },
+  }),
+);
+
+vi.mock("@composio/ao-core", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown> & {
+    loadConfigWithPath: (configPath?: string) => unknown;
+  };
+  return {
+    ...actual,
+    loadConfigWithPath: (configPath?: string) =>
+      actual.loadConfigWithPath(configPath ?? mockConfigPathRef.current ?? undefined),
+  };
+});
+
+vi.mock("../../src/lib/shell.js", () => ({
+  exec: mockExec,
+}));
+
+vi.mock("../../src/lib/preflight.js", () => ({
+  preflight: {
+    checkDocker: (...args: unknown[]) => mockCheckDocker(...args),
+  },
+}));
+
+vi.mock("node:process", async (importOriginal) => {
+  const actual = await importOriginal<typeof ProcessModule>();
+  return {
+    ...actual,
+    cwd: () => mockCwdRef.current || actual.cwd(),
+  };
+});
+
+import { registerDocker } from "../../src/commands/docker.js";
+
+let tempDir: string;
+let program: Command;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+function writeConfig(content: string): void {
+  writeFileSync(mockConfigPathRef.current!, content, "utf-8");
+}
+
+function readConfig(): Record<string, unknown> {
+  return yamlParse(readFileSync(mockConfigPathRef.current!, "utf-8")) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "ao-docker-prepare-"));
+  mockConfigPathRef.current = join(tempDir, "agent-orchestrator.yaml");
+  mockCwdRef.current = tempDir;
+  observedDockerfileRef.current = null;
+
+  program = new Command();
+  program.exitOverride();
+  registerDocker(program);
+
+  consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new Error(`process.exit(${code})`);
+  });
+
+  mockExec.mockReset();
+  mockCheckDocker.mockReset();
+  mockCheckDocker.mockResolvedValue(undefined);
+  mockExec.mockImplementation(async (_cmd: string, args: string[]) => {
+    if (args[0] === "build") {
+      const buildDir = args[args.length - 1]!;
+      observedDockerfileRef.current = readFileSync(join(buildDir, "Dockerfile"), "utf-8");
+    }
+    return { stdout: "", stderr: "" };
+  });
+});
+
+afterEach(() => {
+  mockConfigPathRef.current = null;
+  mockCwdRef.current = "";
+  observedDockerfileRef.current = null;
+  rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("docker prepare command", () => {
+  it("pulls the official image for the resolved worker agent and writes docker runtime config", async () => {
+    writeConfig(`
+defaults:
+  runtime: tmux
+  agent: codex
+projects:
+  app:
+    repo: org/app
+    path: ${tempDir}
+    defaultBranch: main
+`);
+
+    await program.parseAsync(["node", "test", "docker", "prepare", "app"]);
+
+    expect(mockCheckDocker).toHaveBeenCalledWith({
+      image: "ghcr.io/composio/ao-codex:latest",
+      readOnlyRoot: undefined,
+      tmpfs: [],
+    });
+    expect(mockExec).toHaveBeenCalledWith("docker", ["pull", "ghcr.io/composio/ao-codex:latest"]);
+
+    const raw = readConfig();
+    const project = (raw["projects"] as Record<string, Record<string, unknown>>)["app"];
+    expect(project["runtime"]).toBe("docker");
+    expect(project["runtimeConfig"]).toEqual({
+      image: "ghcr.io/composio/ao-codex:latest",
+    });
+  });
+
+  it("uses project worker agent when auto-detecting the target project", async () => {
+    writeConfig(`
+defaults:
+  runtime: tmux
+  agent: codex
+projects:
+  app:
+    repo: org/app
+    path: ${tempDir}
+    defaultBranch: main
+    worker:
+      agent: opencode
+`);
+
+    await program.parseAsync(["node", "test", "docker", "prepare"]);
+
+    expect(mockExec).toHaveBeenCalledWith("docker", ["pull", "ghcr.io/composio/ao-opencode:latest"]);
+    const output = consoleLogSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toContain("Agent:   opencode");
+  });
+
+  it("builds a local image and captures the agent-specific Dockerfile", async () => {
+    writeConfig(`
+defaults:
+  runtime: tmux
+  agent: claude-code
+projects:
+  app:
+    repo: org/app
+    path: ${tempDir}
+    defaultBranch: main
+`);
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "docker",
+      "prepare",
+      "app",
+      "--agent",
+      "opencode",
+      "--build-local",
+      "--tag",
+      "ao-real-opencode:test",
+    ]);
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["build", "-t", "ao-real-opencode:test"]),
+    );
+    expect(observedDockerfileRef.current).toContain("npm install -g opencode-ai");
+
+    const raw = readConfig();
+    const project = (raw["projects"] as Record<string, Record<string, unknown>>)["app"];
+    expect(project["runtimeConfig"]).toEqual({
+      image: "ao-real-opencode:test",
+    });
+  });
+
+  it("adds /tmp tmpfs automatically when read-only root is requested", async () => {
+    writeConfig(`
+defaults:
+  runtime: tmux
+  agent: claude-code
+projects:
+  app:
+    repo: org/app
+    path: ${tempDir}
+    defaultBranch: main
+`);
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "docker",
+      "prepare",
+      "app",
+      "--read-only",
+      "--memory",
+      "4g",
+    ]);
+
+    expect(mockCheckDocker).toHaveBeenCalledWith({
+      image: "ghcr.io/composio/ao-claude-code:latest",
+      readOnlyRoot: true,
+      tmpfs: ["/tmp"],
+      limits: { memory: "4g" },
+    });
+
+    const raw = readConfig();
+    const project = (raw["projects"] as Record<string, Record<string, unknown>>)["app"];
+    expect(project["runtimeConfig"]).toEqual({
+      image: "ghcr.io/composio/ao-claude-code:latest",
+      readOnlyRoot: true,
+      limits: { memory: "4g" },
+      tmpfs: ["/tmp"],
+    });
+  });
+
+  it("supports custom images without pulling when --no-pull is set", async () => {
+    writeConfig(`
+defaults:
+  runtime: tmux
+  agent: claude-code
+projects:
+  app:
+    repo: org/app
+    path: ${tempDir}
+    defaultBranch: main
+`);
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "docker",
+      "prepare",
+      "app",
+      "--image",
+      "example/custom:1.0",
+      "--no-pull",
+    ]);
+
+    expect(mockExec).not.toHaveBeenCalled();
+    const raw = readConfig();
+    const project = (raw["projects"] as Record<string, Record<string, unknown>>)["app"];
+    expect(project["runtimeConfig"]).toEqual({
+      image: "example/custom:1.0",
+    });
+  });
+
+  it("suggests --build-local when pulling the official image fails", async () => {
+    writeConfig(`
+defaults:
+  runtime: tmux
+  agent: claude-code
+projects:
+  app:
+    repo: org/app
+    path: ${tempDir}
+    defaultBranch: main
+`);
+
+    mockExec.mockRejectedValueOnce(new Error("manifest unknown"));
+
+    await expect(
+      program.parseAsync(["node", "test", "docker", "prepare", "app"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const errors = consoleErrorSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(errors).toContain("--build-local");
+  });
+});

--- a/packages/cli/__tests__/commands/doctor.test.ts
+++ b/packages/cli/__tests__/commands/doctor.test.ts
@@ -182,7 +182,7 @@ describe("doctor command", () => {
     expect(output).toContain('defaults.notifiers: alerts (plugin: slack) -> notifier plugin "slack"');
   });
 
-  it("warns when Claude Code uses docker without ANTHROPIC_API_KEY", async () => {
+  it("warns when Claude Code uses docker without portable auth", async () => {
     const config = makeConfig();
     config.projects["my-app"].runtime = "docker";
     mockFindConfigFile.mockReturnValue(config.configPath);
@@ -219,6 +219,8 @@ describe("doctor command", () => {
 
     const output = consoleLogSpy.mock.calls.map((call) => call[0]).join("\n");
     expect(output).toContain("projects.my-app (worker) uses Claude Code with docker");
+    expect(output).toContain("ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN");
+    expect(output).toContain("mounted ~/.claude Docker config home");
   });
 
   it("does not warn about Claude Docker portability when ANTHROPIC_API_KEY is set", async () => {
@@ -255,6 +257,90 @@ describe("doctor command", () => {
         delete process.env["ANTHROPIC_API_KEY"];
       } else {
         process.env["ANTHROPIC_API_KEY"] = originalAnthropic;
+      }
+    }
+
+    const output = consoleLogSpy.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("No known Docker agent portability warnings detected");
+    expect(output).not.toContain("uses Claude Code with docker");
+  });
+
+  it("does not warn about Claude Docker portability when CLAUDE_CODE_OAUTH_TOKEN is set", async () => {
+    const config = makeConfig();
+    config.projects["my-app"].runtime = "docker";
+    mockFindConfigFile.mockReturnValue(config.configPath);
+    mockLoadConfig.mockReturnValue(config);
+
+    mockRegistry.list.mockImplementation((slot: string) => {
+      switch (slot) {
+        case "runtime":
+          return [manifest("runtime", "tmux"), manifest("runtime", "docker")];
+        case "agent":
+          return [manifest("agent", "claude-code"), manifest("agent", "codex")];
+        case "workspace":
+          return [manifest("workspace", "worktree")];
+        case "tracker":
+          return [manifest("tracker", "github")];
+        case "scm":
+          return [manifest("scm", "github")];
+        case "notifier":
+          return [manifest("notifier", "slack")];
+        default:
+          return [];
+      }
+    });
+
+    const originalOauth = process.env["CLAUDE_CODE_OAUTH_TOKEN"];
+    process.env["CLAUDE_CODE_OAUTH_TOKEN"] = "claude-oauth-token";
+    try {
+      await program.parseAsync(["node", "test", "doctor"]);
+    } finally {
+      if (originalOauth === undefined) {
+        delete process.env["CLAUDE_CODE_OAUTH_TOKEN"];
+      } else {
+        process.env["CLAUDE_CODE_OAUTH_TOKEN"] = originalOauth;
+      }
+    }
+
+    const output = consoleLogSpy.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("No known Docker agent portability warnings detected");
+    expect(output).not.toContain("uses Claude Code with docker");
+  });
+
+  it("does not warn about Claude Docker portability when ANTHROPIC_AUTH_TOKEN is set", async () => {
+    const config = makeConfig();
+    config.projects["my-app"].runtime = "docker";
+    mockFindConfigFile.mockReturnValue(config.configPath);
+    mockLoadConfig.mockReturnValue(config);
+
+    mockRegistry.list.mockImplementation((slot: string) => {
+      switch (slot) {
+        case "runtime":
+          return [manifest("runtime", "tmux"), manifest("runtime", "docker")];
+        case "agent":
+          return [manifest("agent", "claude-code"), manifest("agent", "codex")];
+        case "workspace":
+          return [manifest("workspace", "worktree")];
+        case "tracker":
+          return [manifest("tracker", "github")];
+        case "scm":
+          return [manifest("scm", "github")];
+        case "notifier":
+          return [manifest("notifier", "slack")];
+        default:
+          return [];
+      }
+    });
+
+    const originalAuthToken = process.env["ANTHROPIC_AUTH_TOKEN"];
+    process.env["ANTHROPIC_AUTH_TOKEN"] = "anthropic-auth-token";
+    try {
+      await program.parseAsync(["node", "test", "doctor"]);
+    } finally {
+      if (originalAuthToken === undefined) {
+        delete process.env["ANTHROPIC_AUTH_TOKEN"];
+      } else {
+        process.env["ANTHROPIC_AUTH_TOKEN"] = originalAuthToken;
       }
     }
 

--- a/packages/cli/__tests__/commands/doctor.test.ts
+++ b/packages/cli/__tests__/commands/doctor.test.ts
@@ -182,6 +182,87 @@ describe("doctor command", () => {
     expect(output).toContain('defaults.notifiers: alerts (plugin: slack) -> notifier plugin "slack"');
   });
 
+  it("warns when Claude Code uses docker without ANTHROPIC_API_KEY", async () => {
+    const config = makeConfig();
+    config.projects["my-app"].runtime = "docker";
+    mockFindConfigFile.mockReturnValue(config.configPath);
+    mockLoadConfig.mockReturnValue(config);
+
+    mockRegistry.list.mockImplementation((slot: string) => {
+      switch (slot) {
+        case "runtime":
+          return [manifest("runtime", "tmux"), manifest("runtime", "docker")];
+        case "agent":
+          return [manifest("agent", "claude-code"), manifest("agent", "codex")];
+        case "workspace":
+          return [manifest("workspace", "worktree")];
+        case "tracker":
+          return [manifest("tracker", "github")];
+        case "scm":
+          return [manifest("scm", "github")];
+        case "notifier":
+          return [manifest("notifier", "slack")];
+        default:
+          return [];
+      }
+    });
+
+    const originalAnthropic = process.env["ANTHROPIC_API_KEY"];
+    delete process.env["ANTHROPIC_API_KEY"];
+    try {
+      await program.parseAsync(["node", "test", "doctor"]);
+    } finally {
+      if (originalAnthropic !== undefined) {
+        process.env["ANTHROPIC_API_KEY"] = originalAnthropic;
+      }
+    }
+
+    const output = consoleLogSpy.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("projects.my-app (worker) uses Claude Code with docker");
+  });
+
+  it("does not warn about Claude Docker portability when ANTHROPIC_API_KEY is set", async () => {
+    const config = makeConfig();
+    config.projects["my-app"].runtime = "docker";
+    mockFindConfigFile.mockReturnValue(config.configPath);
+    mockLoadConfig.mockReturnValue(config);
+
+    mockRegistry.list.mockImplementation((slot: string) => {
+      switch (slot) {
+        case "runtime":
+          return [manifest("runtime", "tmux"), manifest("runtime", "docker")];
+        case "agent":
+          return [manifest("agent", "claude-code"), manifest("agent", "codex")];
+        case "workspace":
+          return [manifest("workspace", "worktree")];
+        case "tracker":
+          return [manifest("tracker", "github")];
+        case "scm":
+          return [manifest("scm", "github")];
+        case "notifier":
+          return [manifest("notifier", "slack")];
+        default:
+          return [];
+      }
+    });
+
+    const originalAnthropic = process.env["ANTHROPIC_API_KEY"];
+    process.env["ANTHROPIC_API_KEY"] = "sk-ant-test";
+    try {
+      await program.parseAsync(["node", "test", "doctor"]);
+    } finally {
+      if (originalAnthropic === undefined) {
+        delete process.env["ANTHROPIC_API_KEY"];
+      } else {
+        process.env["ANTHROPIC_API_KEY"] = originalAnthropic;
+      }
+    }
+
+    const output = consoleLogSpy.mock.calls.map((call) => call[0]).join("\n");
+    expect(output).toContain("No known Docker agent portability warnings detected");
+    expect(output).not.toContain("uses Claude Code with docker");
+  });
+
   it("fails when a referenced plugin cannot be loaded", async () => {
     const config = makeConfig();
     config.projects["my-app"].scm = { plugin: "gitlab" };

--- a/packages/cli/__tests__/commands/open.test.ts
+++ b/packages/cli/__tests__/commands/open.test.ts
@@ -21,7 +21,7 @@ vi.mock("../../src/lib/shell.js", () => ({
 }));
 
 vi.mock("@composio/ao-core", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@composio/ao-core")>();
+  const actual = (await importOriginal()) as Record<string, unknown>;
   return {
     ...actual,
     loadConfig: () => mockConfigRef.current,

--- a/packages/cli/__tests__/commands/open.test.ts
+++ b/packages/cli/__tests__/commands/open.test.ts
@@ -112,8 +112,8 @@ afterEach(() => {
 describe("open command", () => {
   it("opens all sessions when target is 'all'", async () => {
     mockSessionManager.list.mockResolvedValue([
-      makeSession({ id: "app-1" }),
       makeSession({ id: "app-2", runtimeHandle: { id: "app-2", runtimeName: "tmux", data: {} } }),
+      makeSession({ id: "app-1" }),
       makeSession({
         id: "backend-1",
         projectId: "backend",
@@ -128,6 +128,7 @@ describe("open command", () => {
     expect(output).toContain("app-1");
     expect(output).toContain("app-2");
     expect(output).toContain("backend-1");
+    expect(mockExec.mock.calls.map((call) => call[1]?.[0])).toEqual(["app-1", "app-2", "backend-1"]);
   });
 
   it("opens all sessions when no target given", async () => {

--- a/packages/cli/__tests__/commands/open.test.ts
+++ b/packages/cli/__tests__/commands/open.test.ts
@@ -1,34 +1,62 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Session, SessionManager } from "@composio/ao-core";
 
-const { mockExec, mockConfigRef, mockTmux } = vi.hoisted(() => ({
+const { mockExec, mockConfigRef, mockSessionManager } = vi.hoisted(() => ({
   mockExec: vi.fn(),
-  mockTmux: vi.fn(),
   mockConfigRef: { current: null as Record<string, unknown> | null },
+  mockSessionManager: {
+    list: vi.fn(),
+    getAttachInfo: vi.fn(),
+  },
 }));
 
 vi.mock("../../src/lib/shell.js", () => ({
   exec: mockExec,
   execSilent: vi.fn(),
-  tmux: mockTmux,
+  tmux: vi.fn(),
   git: vi.fn(),
   gh: vi.fn(),
-  getTmuxSessions: async () => {
-    const output = await mockTmux("list-sessions", "-F", "#{session_name}");
-    if (!output) return [];
-    return output.split("\n").filter(Boolean);
-  },
+  getTmuxSessions: vi.fn().mockResolvedValue([]),
   getTmuxActivity: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock("@composio/ao-core", () => ({
-  loadConfig: () => mockConfigRef.current,
+vi.mock("@composio/ao-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@composio/ao-core")>();
+  return {
+    ...actual,
+    loadConfig: () => mockConfigRef.current,
+  };
+});
+
+vi.mock("../../src/lib/create-session-manager.js", () => ({
+  getSessionManager: async (): Promise<SessionManager> => mockSessionManager as SessionManager,
 }));
 
 import { Command } from "commander";
 import { registerOpen } from "../../src/commands/open.js";
 
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "app-1",
+    projectId: "my-app",
+    status: "running",
+    activity: null,
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/tmp/workspace",
+    runtimeHandle: { id: "app-1", runtimeName: "tmux", data: {} },
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
 let program: Command;
-let consoleSpy: ReturnType<typeof vi.spyOn>;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   mockConfigRef.current = {
@@ -61,18 +89,20 @@ beforeEach(() => {
     reactions: {},
   } as Record<string, unknown>;
 
+  mockSessionManager.list.mockReset();
+  mockSessionManager.getAttachInfo.mockReset();
+  mockSessionManager.getAttachInfo.mockResolvedValue(null);
+  mockExec.mockReset();
+  mockExec.mockResolvedValue({ stdout: "", stderr: "" });
+
   program = new Command();
   program.exitOverride();
   registerOpen(program);
-  consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-  vi.spyOn(console, "error").mockImplementation(() => {});
+  consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   vi.spyOn(process, "exit").mockImplementation((code) => {
     throw new Error(`process.exit(${code})`);
   });
-
-  mockExec.mockReset();
-  mockTmux.mockReset();
-  mockExec.mockResolvedValue({ stdout: "", stderr: "" });
 });
 
 afterEach(() => {
@@ -81,14 +111,19 @@ afterEach(() => {
 
 describe("open command", () => {
   it("opens all sessions when target is 'all'", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1\napp-2\nbackend-1";
-      return null;
-    });
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({ id: "app-1" }),
+      makeSession({ id: "app-2", runtimeHandle: { id: "app-2", runtimeName: "tmux", data: {} } }),
+      makeSession({
+        id: "backend-1",
+        projectId: "backend",
+        runtimeHandle: { id: "backend-1", runtimeName: "tmux", data: {} },
+      }),
+    ]);
 
     await program.parseAsync(["node", "test", "open", "all"]);
 
-    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    const output = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(output).toContain("Opening 3 sessions");
     expect(output).toContain("app-1");
     expect(output).toContain("app-2");
@@ -96,26 +131,28 @@ describe("open command", () => {
   });
 
   it("opens all sessions when no target given", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1";
-      return null;
-    });
+    mockSessionManager.list.mockResolvedValue([makeSession({ id: "app-1" })]);
 
     await program.parseAsync(["node", "test", "open"]);
 
-    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    const output = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(output).toContain("Opening 1 session");
   });
 
   it("opens sessions for a specific project", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1\napp-2\nbackend-1";
-      return null;
-    });
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({ id: "app-1" }),
+      makeSession({ id: "app-2", runtimeHandle: { id: "app-2", runtimeName: "tmux", data: {} } }),
+      makeSession({
+        id: "backend-1",
+        projectId: "backend",
+        runtimeHandle: { id: "backend-1", runtimeName: "tmux", data: {} },
+      }),
+    ]);
 
     await program.parseAsync(["node", "test", "open", "my-app"]);
 
-    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    const output = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(output).toContain("Opening 2 sessions");
     expect(output).toContain("app-1");
     expect(output).toContain("app-2");
@@ -123,59 +160,111 @@ describe("open command", () => {
   });
 
   it("opens a single session by name", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1\napp-2";
-      return null;
-    });
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({ id: "app-1" }),
+      makeSession({ id: "app-2", runtimeHandle: { id: "app-2", runtimeName: "tmux", data: {} } }),
+    ]);
 
     await program.parseAsync(["node", "test", "open", "app-1"]);
 
-    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    const output = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(output).toContain("Opening 1 session");
     expect(output).toContain("app-1");
   });
 
   it("rejects unknown target", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1";
-      return null;
-    });
+    mockSessionManager.list.mockResolvedValue([makeSession({ id: "app-1" })]);
 
     await expect(program.parseAsync(["node", "test", "open", "nonexistent"])).rejects.toThrow(
       "process.exit(1)",
     );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Unknown target: nonexistent"),
+    );
   });
 
-  it("passes --new-window flag to open-iterm-tab", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1";
-      return null;
-    });
+  it("passes --new-window flag to open-iterm-tab for tmux sessions", async () => {
+    mockSessionManager.list.mockResolvedValue([makeSession({ id: "app-1" })]);
 
     await program.parseAsync(["node", "test", "open", "-w", "app-1"]);
 
     expect(mockExec).toHaveBeenCalledWith("open-iterm-tab", ["--new-window", "app-1"]);
   });
 
+  it("opens docker sessions in iTerm using runtime attach info", async () => {
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({
+        id: "app-1",
+        runtimeHandle: {
+          id: "container-1",
+          runtimeName: "docker",
+          data: { tmuxSessionName: "tmux-1" },
+        },
+      }),
+    ]);
+    mockSessionManager.getAttachInfo.mockResolvedValue({
+      type: "docker",
+      target: "container-1",
+      command: "docker exec -it container-1 tmux attach -t tmux-1",
+      program: "docker",
+      args: ["exec", "-it", "container-1", "tmux", "attach", "-t", "tmux-1"],
+      requiresPty: true,
+    });
+
+    await program.parseAsync(["node", "test", "open", "app-1"]);
+
+    expect(mockExec).toHaveBeenCalledWith("open-iterm-tab", [
+      "--title",
+      "container-1",
+      "--command",
+      "docker exec -it container-1 tmux attach -t tmux-1",
+    ]);
+  });
+
   it("falls back gracefully when open-iterm-tab fails", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1";
-      return null;
+    mockSessionManager.list.mockResolvedValue([makeSession({ id: "app-1" })]);
+    mockExec.mockRejectedValue(new Error("command not found"));
+
+    await program.parseAsync(["node", "test", "open", "app-1"]);
+
+    const output = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("tmux attach");
+  });
+
+  it("prints docker attach command when runtime-aware open fails", async () => {
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({
+        id: "app-1",
+        runtimeHandle: {
+          id: "container-1",
+          runtimeName: "docker",
+          data: { tmuxSessionName: "tmux-1" },
+        },
+      }),
+    ]);
+    mockSessionManager.getAttachInfo.mockResolvedValue({
+      type: "docker",
+      target: "container-1",
+      command: "docker exec -it container-1 tmux attach -t tmux-1",
+      program: "docker",
+      args: ["exec", "-it", "container-1", "tmux", "attach", "-t", "tmux-1"],
+      requiresPty: true,
     });
     mockExec.mockRejectedValue(new Error("command not found"));
 
     await program.parseAsync(["node", "test", "open", "app-1"]);
 
-    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
-    expect(output).toContain("http://localhost:3000/sessions/app-1");
+    const output = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("docker exec -it container-1 tmux attach -t tmux-1");
   });
 
   it("shows 'No sessions to open' when none exist", async () => {
-    mockTmux.mockResolvedValue(null);
+    mockSessionManager.list.mockResolvedValue([]);
 
     await program.parseAsync(["node", "test", "open", "my-app"]);
 
-    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    const output = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(output).toContain("No sessions to open");
   });
 });

--- a/packages/cli/__tests__/commands/runtime.test.ts
+++ b/packages/cli/__tests__/commands/runtime.test.ts
@@ -1,0 +1,254 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse as yamlParse } from "yaml";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockConfigPathRef } = vi.hoisted(() => ({
+  mockConfigPathRef: { current: null as string | null },
+}));
+
+vi.mock("@composio/ao-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@composio/ao-core")>();
+  return {
+    ...actual,
+    loadConfigWithPath: (configPath?: string) =>
+      actual.loadConfigWithPath(configPath ?? mockConfigPathRef.current ?? undefined),
+  };
+});
+
+import { registerRuntime } from "../../src/commands/runtime.js";
+
+let tempDir: string;
+let program: Command;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+function writeConfig(content: string): void {
+  writeFileSync(mockConfigPathRef.current!, content, "utf-8");
+}
+
+function readConfig(): Record<string, unknown> {
+  return yamlParse(readFileSync(mockConfigPathRef.current!, "utf-8")) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "ao-runtime-command-"));
+  mockConfigPathRef.current = join(tempDir, "agent-orchestrator.yaml");
+
+  program = new Command();
+  program.exitOverride();
+  registerRuntime(program);
+
+  consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new Error(`process.exit(${code})`);
+  });
+});
+
+afterEach(() => {
+  mockConfigPathRef.current = null;
+  rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("runtime command", () => {
+  it("shows a summary of default runtime and project overrides", async () => {
+    writeConfig(`
+defaults:
+  runtime: tmux
+projects:
+  app:
+    repo: org/app
+    path: ~/app
+    defaultBranch: main
+    runtime: docker
+    runtimeConfig:
+      image: ghcr.io/composio/ao:test
+  api:
+    repo: org/api
+    path: ~/api
+    defaultBranch: main
+`);
+
+    await program.parseAsync(["node", "test", "runtime", "show"]);
+
+    const output = consoleLogSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toContain("Default runtime");
+    expect(output).toContain("app");
+    expect(output).toContain("docker");
+    expect(output).toContain("image=ghcr.io/composio/ao:test");
+    expect(output).toContain("api");
+    expect(output).toContain("inherit (tmux)");
+  });
+
+  it("shows detailed runtime info for a project", async () => {
+    writeConfig(`
+defaults:
+  runtime: tmux
+projects:
+  app:
+    repo: org/app
+    path: ~/app
+    defaultBranch: main
+    runtime: docker
+    runtimeConfig:
+      image: ghcr.io/composio/ao:test
+      limits:
+        memory: 4g
+`);
+
+    await program.parseAsync(["node", "test", "runtime", "show", "app"]);
+
+    const output = consoleLogSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toContain("Configured runtime");
+    expect(output).toContain("Effective runtime");
+    expect(output).toContain('"image": "ghcr.io/composio/ao:test"');
+    expect(output).toContain('"memory": "4g"');
+  });
+
+  it("sets defaults.runtime when no project is provided", async () => {
+    writeConfig(`
+projects:
+  app:
+    repo: org/app
+    path: ~/app
+    defaultBranch: main
+`);
+
+    await program.parseAsync(["node", "test", "runtime", "set", "process"]);
+
+    const raw = readConfig();
+    expect((raw["defaults"] as Record<string, unknown>)["runtime"]).toBe("process");
+  });
+
+  it("sets a project docker runtime and merges runtimeConfig flags", async () => {
+    writeConfig(`
+defaults:
+  runtime: tmux
+projects:
+  app:
+    repo: org/app
+    path: ~/app
+    defaultBranch: main
+    runtimeConfig:
+      image: ghcr.io/composio/ao:old
+`);
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "runtime",
+      "set",
+      "docker",
+      "app",
+      "--image",
+      "ghcr.io/composio/ao:new",
+      "--memory",
+      "4g",
+      "--cpus",
+      "2",
+      "--read-only",
+      "--cap-drop",
+      "ALL",
+      "--tmpfs",
+      "/tmp",
+    ]);
+
+    const raw = readConfig();
+    const project = (raw["projects"] as Record<string, Record<string, unknown>>)["app"];
+    expect(project["runtime"]).toBe("docker");
+    expect(project["runtimeConfig"]).toEqual({
+      image: "ghcr.io/composio/ao:new",
+      limits: { memory: "4g", cpus: "2" },
+      readOnlyRoot: true,
+      capDrop: ["ALL"],
+      tmpfs: ["/tmp"],
+    });
+  });
+
+  it("clears a project runtime override and runtimeConfig together", async () => {
+    writeConfig(`
+defaults:
+  runtime: tmux
+projects:
+  app:
+    repo: org/app
+    path: ~/app
+    defaultBranch: main
+    runtime: docker
+    runtimeConfig:
+      image: ghcr.io/composio/ao:test
+`);
+
+    await program.parseAsync(["node", "test", "runtime", "clear", "app"]);
+
+    const raw = readConfig();
+    const project = (raw["projects"] as Record<string, Record<string, unknown>>)["app"];
+    expect(project["runtime"]).toBeUndefined();
+    expect(project["runtimeConfig"]).toBeUndefined();
+  });
+
+  it("clears defaults.runtime and falls back to implicit tmux", async () => {
+    writeConfig(`
+defaults:
+  runtime: docker
+projects:
+  app:
+    repo: org/app
+    path: ~/app
+    defaultBranch: main
+`);
+
+    await program.parseAsync(["node", "test", "runtime", "clear"]);
+
+    const raw = readConfig();
+    expect((raw["defaults"] as Record<string, unknown>)["runtime"]).toBeUndefined();
+  });
+
+  it("rejects project runtime config flags without a project argument", async () => {
+    writeConfig(`
+projects:
+  app:
+    repo: org/app
+    path: ~/app
+    defaultBranch: main
+`);
+
+    await expect(
+      program.parseAsync([
+        "node",
+        "test",
+        "runtime",
+        "set",
+        "docker",
+        "--image",
+        "ghcr.io/composio/ao:test",
+      ]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const errors = consoleErrorSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(errors).toContain("Runtime config flags require a project argument");
+  });
+
+  it("rejects docker project selection without a runtimeConfig.image", async () => {
+    writeConfig(`
+defaults:
+  runtime: tmux
+projects:
+  app:
+    repo: org/app
+    path: ~/app
+    defaultBranch: main
+`);
+
+    await expect(
+      program.parseAsync(["node", "test", "runtime", "set", "docker", "app"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const errors = consoleErrorSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(errors).toContain("needs runtimeConfig.image");
+  });
+});

--- a/packages/cli/__tests__/commands/runtime.test.ts
+++ b/packages/cli/__tests__/commands/runtime.test.ts
@@ -10,7 +10,9 @@ const { mockConfigPathRef } = vi.hoisted(() => ({
 }));
 
 vi.mock("@composio/ao-core", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@composio/ao-core")>();
+  const actual = (await importOriginal()) as Record<string, unknown> & {
+    loadConfigWithPath: (configPath?: string) => unknown;
+  };
   return {
     ...actual,
     loadConfigWithPath: (configPath?: string) =>

--- a/packages/cli/__tests__/commands/session.test.ts
+++ b/packages/cli/__tests__/commands/session.test.ts
@@ -44,6 +44,7 @@ const {
     restore: vi.fn(),
     remap: vi.fn(),
     get: vi.fn(),
+    getAttachInfo: vi.fn(),
     spawn: vi.fn(),
     spawnOrchestrator: vi.fn(),
     send: vi.fn(),
@@ -203,6 +204,7 @@ beforeEach(() => {
   mockSessionManager.restore.mockReset();
   mockSessionManager.remap.mockReset();
   mockSessionManager.get.mockReset();
+  mockSessionManager.getAttachInfo.mockReset();
   mockSessionManager.spawn.mockReset();
   mockSessionManager.send.mockReset();
   mockSessionManager.claimPR.mockReset();
@@ -225,6 +227,7 @@ beforeEach(() => {
   } satisfies CleanupResult);
   mockSessionManager.restore.mockResolvedValue(undefined);
   mockSessionManager.remap.mockResolvedValue("ses_mock");
+  mockSessionManager.getAttachInfo.mockResolvedValue(null);
   mockSessionManager.claimPR.mockResolvedValue({
     sessionId: "app-1",
     projectId: "my-app",

--- a/packages/cli/__tests__/commands/session.test.ts
+++ b/packages/cli/__tests__/commands/session.test.ts
@@ -334,6 +334,39 @@ describe("session ls", () => {
     const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(output).toContain("https://github.com/org/repo/pull/42");
   });
+
+  it("uses last activity directly for non-tmux runtimes", async () => {
+    mockSessionManager.list.mockResolvedValue([
+      {
+        id: "app-1",
+        projectId: "my-app",
+        status: "working",
+        activity: null,
+        branch: "feat/docker",
+        issueId: null,
+        pr: null,
+        workspacePath: null,
+        runtimeHandle: { id: "container-1", runtimeName: "docker", data: {} },
+        agentInfo: null,
+        createdAt: new Date(),
+        lastActivityAt: new Date(Date.now() - 30_000),
+        metadata: {},
+      } satisfies Session,
+    ]);
+
+    await program.parseAsync(["node", "test", "session", "ls"]);
+
+    expect(mockTmux).not.toHaveBeenCalledWith(
+      "display-message",
+      "-t",
+      "container-1",
+      "-p",
+      "#{session_activity}",
+    );
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("app-1");
+    expect(output).toContain("feat/docker");
+  });
 });
 
 describe("session kill", () => {
@@ -414,6 +447,72 @@ describe("session attach", () => {
     await expect(
       program.parseAsync(["node", "test", "session", "attach", "unknown-1"]),
     ).rejects.toThrow("process.exit(1)");
+  });
+
+  it("fails when a non-tmux runtime has no attach command", async () => {
+    mockSessionManager.get.mockResolvedValue({
+      id: "app-1",
+      projectId: "my-app",
+      status: "working",
+      activity: null,
+      branch: null,
+      issueId: null,
+      pr: null,
+      workspacePath: null,
+      runtimeHandle: { id: "container-1", runtimeName: "docker", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    } satisfies Session);
+    mockSessionManager.getAttachInfo.mockResolvedValue(null);
+
+    await expect(
+      program.parseAsync(["node", "test", "session", "attach", "app-1"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const errors = vi
+      .mocked(console.error)
+      .mock.calls.map((c) => String(c[0]))
+      .join("\n");
+    expect(errors).toContain("does not expose an attach command");
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+});
+
+describe("session restore", () => {
+  it("shows the runtime-aware attach command after restoring", async () => {
+    mockSessionManager.restore.mockResolvedValue({
+      id: "app-1",
+      projectId: "my-app",
+      status: "working",
+      activity: null,
+      branch: "feat/restore",
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/restore-worktree",
+      runtimeHandle: { id: "container-1", runtimeName: "docker", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    } satisfies Session);
+    mockSessionManager.getAttachInfo.mockResolvedValue({
+      type: "docker",
+      target: "container-1",
+      program: "docker",
+      args: ["exec", "-it", "container-1", "tmux", "attach", "-t", "tmux-1"],
+      command: "docker exec -it container-1 tmux attach -t tmux-1",
+      requiresPty: true,
+    });
+
+    await program.parseAsync(["node", "test", "session", "restore", "app-1"]);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("Session app-1 restored.");
+    expect(output).toContain("/tmp/restore-worktree");
+    expect(output).toContain("feat/restore");
+    expect(output).toContain("docker exec -it container-1 tmux attach -t tmux-1");
   });
 });
 

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -55,6 +55,12 @@ vi.mock("@composio/ao-core", async (importOriginal) => {
 
 vi.mock("../../src/lib/create-session-manager.js", () => ({
   getSessionManager: async (): Promise<SessionManager> => mockSessionManager as SessionManager,
+  getPluginRegistry: async () => ({
+    list: (slot: string) =>
+      slot === "runtime"
+        ? [{ name: "tmux" }, { name: "docker" }, { name: "process" }]
+        : [],
+  }),
 }));
 
 vi.mock("../../src/lib/lifecycle-service.js", () => ({

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -13,6 +13,7 @@ const { mockExec, mockConfigRef, mockSessionManager, mockEnsureLifecycleWorker }
       kill: vi.fn(),
       cleanup: vi.fn(),
       get: vi.fn(),
+      getAttachInfo: vi.fn(),
       spawn: vi.fn(),
       spawnOrchestrator: vi.fn(),
       send: vi.fn(),
@@ -120,6 +121,8 @@ beforeEach(() => {
   mockSpinner.fail.mockClear().mockReturnThis();
   mockSessionManager.spawn.mockReset();
   mockSessionManager.claimPR.mockReset();
+  mockSessionManager.getAttachInfo.mockReset();
+  mockSessionManager.getAttachInfo.mockResolvedValue(null);
   mockExec.mockReset();
   mockEnsureLifecycleWorker.mockReset();
   mockEnsureLifecycleWorker.mockResolvedValue({
@@ -369,6 +372,64 @@ describe("spawn command", () => {
     });
   });
 
+  it("passes docker runtime override flags through to sessionManager.spawn()", async () => {
+    const fakeSession: Session = {
+      id: "app-1",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: null,
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "container-123", runtimeName: "docker", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "spawn",
+      "--runtime",
+      "docker",
+      "--runtime-image",
+      "ghcr.io/composio/ao:test",
+      "--runtime-cpus",
+      "2",
+      "--runtime-memory",
+      "4g",
+      "--runtime-read-only",
+      "--runtime-network",
+      "bridge",
+      "--runtime-cap-drop",
+      "ALL",
+      "--runtime-tmpfs",
+      "/tmp",
+    ]);
+
+    expect(mockExec).toHaveBeenCalledWith("docker", ["--version"]);
+    expect(mockExec).toHaveBeenCalledWith("docker", ["info"]);
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: undefined,
+      agent: undefined,
+      runtime: "docker",
+      runtimeConfig: {
+        image: "ghcr.io/composio/ao:test",
+        limits: { cpus: "2", memory: "4g" },
+        readOnlyRoot: true,
+        network: "bridge",
+        capDrop: ["ALL"],
+        tmpfs: ["/tmp"],
+      },
+    });
+  });
+
   it("warns and exits when two positional args given (old syntax)", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -385,9 +446,7 @@ describe("spawn command", () => {
   it("reports error when spawn fails", async () => {
     mockSessionManager.spawn.mockRejectedValue(new Error("worktree creation failed"));
 
-    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow(
-      "process.exit(1)",
-    );
+    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow("process.exit(1)");
   });
 
   it("claims a PR for the spawned session when --claim-pr is provided", async () => {
@@ -479,14 +538,7 @@ describe("spawn command", () => {
       takenOverFrom: ["app-9"],
     });
 
-    await program.parseAsync([
-      "node",
-      "test",
-      "spawn",
-      "--claim-pr",
-      "123",
-      "--assign-on-github",
-    ]);
+    await program.parseAsync(["node", "test", "spawn", "--claim-pr", "123", "--assign-on-github"]);
 
     expect(mockSessionManager.claimPR).toHaveBeenCalledWith("app-1", "123", {
       assignOnGithub: true,
@@ -545,9 +597,7 @@ describe("spawn pre-flight checks", () => {
   it("fails with clear error when tmux is not installed (default runtime)", async () => {
     mockExec.mockRejectedValue(new Error("ENOENT"));
 
-    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow(
-      "process.exit(1)",
-    );
+    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow("process.exit(1)");
 
     const errors = vi
       .mocked(console.error)
@@ -604,9 +654,7 @@ describe("spawn pre-flight checks", () => {
       .mockResolvedValueOnce({ stdout: "gh version 2.40", stderr: "" }) // gh --version
       .mockRejectedValueOnce(new Error("not logged in")); // gh auth status
 
-    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow(
-      "process.exit(1)",
-    );
+    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow("process.exit(1)");
 
     const errors = vi
       .mocked(console.error)
@@ -747,9 +795,7 @@ describe("spawn pre-flight checks", () => {
       .mockResolvedValueOnce({ stdout: "tmux 3.3a", stderr: "" }) // tmux -V
       .mockRejectedValueOnce(new Error("ENOENT")); // gh --version fails
 
-    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow(
-      "process.exit(1)",
-    );
+    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow("process.exit(1)");
 
     const errors = vi
       .mocked(console.error)

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -77,7 +77,7 @@ let configPath: string;
 let cwdSpy: ReturnType<typeof vi.spyOn> | undefined;
 
 import { Command } from "commander";
-import { registerSpawn } from "../../src/commands/spawn.js";
+import { registerBatchSpawn, registerSpawn } from "../../src/commands/spawn.js";
 
 let program: Command;
 let consoleSpy: ReturnType<typeof vi.spyOn>;
@@ -115,6 +115,7 @@ beforeEach(() => {
   program = new Command();
   program.exitOverride();
   registerSpawn(program);
+  registerBatchSpawn(program);
   consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   vi.spyOn(console, "error").mockImplementation(() => {});
   vi.spyOn(process, "exit").mockImplementation((code) => {
@@ -850,5 +851,179 @@ describe("spawn pre-flight checks", () => {
       .join("\n");
     expect(errors).toContain("not installed");
     expect(errors).not.toContain("not authenticated");
+  });
+});
+
+describe("batch-spawn command", () => {
+  it("creates sessions, skips duplicates, and opens requested sessions", async () => {
+    mockSessionManager.list.mockResolvedValue([
+      {
+        id: "app-existing",
+        projectId: "my-app",
+        status: "working",
+        issueId: "INT-2",
+        lastActivityAt: new Date(),
+      },
+    ]);
+
+    mockSessionManager.spawn
+      .mockResolvedValueOnce({
+        id: "app-1",
+        projectId: "my-app",
+        status: "spawning",
+        activity: null,
+        branch: null,
+        issueId: "INT-1",
+        pr: null,
+        workspacePath: "/tmp/wt-1",
+        runtimeHandle: { id: "container-1", runtimeName: "docker", data: {} },
+        agentInfo: null,
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
+        metadata: {},
+      } satisfies Session)
+      .mockResolvedValueOnce({
+        id: "app-2",
+        projectId: "my-app",
+        status: "spawning",
+        activity: null,
+        branch: null,
+        issueId: "INT-3",
+        pr: null,
+        workspacePath: "/tmp/wt-3",
+        runtimeHandle: { id: "container-3", runtimeName: "docker", data: {} },
+        agentInfo: null,
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
+        metadata: {},
+      } satisfies Session);
+
+    mockSessionManager.getAttachInfo
+      .mockResolvedValueOnce({
+        type: "docker",
+        target: "container-1",
+        command: "docker exec -it container-1 tmux attach -t tmux-1",
+        program: "docker",
+        args: ["exec", "-it", "container-1", "tmux", "attach", "-t", "tmux-1"],
+        requiresPty: true,
+      })
+      .mockResolvedValueOnce({
+        type: "docker",
+        target: "container-3",
+        command: "docker exec -it container-3 tmux attach -t tmux-3",
+        program: "docker",
+        args: ["exec", "-it", "container-3", "tmux", "attach", "-t", "tmux-3"],
+        requiresPty: true,
+      });
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "batch-spawn",
+      "INT-1",
+      "INT-1",
+      "INT-2",
+      "INT-3",
+      "--open",
+      "--runtime",
+      "docker",
+      "--runtime-image",
+      "ghcr.io/composio/ao:test",
+    ]);
+
+    expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ configPath: expect.any(String) }),
+      "my-app",
+    );
+    expect(mockSessionManager.spawn).toHaveBeenCalledTimes(2);
+    expect(mockSessionManager.spawn).toHaveBeenNthCalledWith(1, {
+      projectId: "my-app",
+      issueId: "INT-1",
+      runtime: "docker",
+      runtimeConfig: { image: "ghcr.io/composio/ao:test" },
+    });
+    expect(mockSessionManager.spawn).toHaveBeenNthCalledWith(2, {
+      projectId: "my-app",
+      issueId: "INT-3",
+      runtime: "docker",
+      runtimeConfig: { image: "ghcr.io/composio/ao:test" },
+    });
+    expect(mockExec).toHaveBeenCalledWith("open-iterm-tab", [
+      "--title",
+      "container-1",
+      "--command",
+      "docker exec -it container-1 tmux attach -t tmux-1",
+    ]);
+    expect(mockExec).toHaveBeenCalledWith("open-iterm-tab", [
+      "--title",
+      "container-3",
+      "--command",
+      "docker exec -it container-3 tmux attach -t tmux-3",
+    ]);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("Skip INT-1 — duplicate in this batch");
+    expect(output).toContain("Skip INT-2 — already has session app-existing");
+    expect(output).toContain("Created 2 sessions:");
+    expect(output).toContain("Skipped 2 issues:");
+  });
+
+  it("records failures and continues through the batch", async () => {
+    mockSessionManager.list.mockResolvedValue([]);
+    mockSessionManager.spawn
+      .mockRejectedValueOnce(new Error("workspace creation failed"))
+      .mockResolvedValueOnce({
+        id: "app-2",
+        projectId: "my-app",
+        status: "spawning",
+        activity: null,
+        branch: null,
+        issueId: "INT-2",
+        pr: null,
+        workspacePath: "/tmp/wt-2",
+        runtimeHandle: { id: "hash-app-2", runtimeName: "tmux", data: {} },
+        agentInfo: null,
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
+        metadata: {},
+      } satisfies Session);
+
+    await program.parseAsync(["node", "test", "batch-spawn", "INT-1", "INT-2"]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledTimes(2);
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("Failed 1 issues:");
+    expect(output).toContain("INT-1: workspace creation failed");
+    expect(output).toContain("Created 1 sessions:");
+  });
+
+  it("fails cleanly when project auto-detection cannot choose a project", async () => {
+    (mockConfigRef.current as Record<string, unknown>).projects = {
+      frontend: {
+        name: "Frontend",
+        repo: "org/frontend",
+        path: join(tmpDir, "frontend"),
+        defaultBranch: "main",
+        sessionPrefix: "fe",
+      },
+      backend: {
+        name: "Backend",
+        repo: "org/backend",
+        path: join(tmpDir, "backend"),
+        defaultBranch: "main",
+        sessionPrefix: "be",
+      },
+    };
+
+    await expect(
+      program.parseAsync(["node", "test", "batch-spawn", "INT-1"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    expect(mockSessionManager.spawn).not.toHaveBeenCalled();
+    const errors = vi
+      .mocked(console.error)
+      .mock.calls.map((c) => String(c[0]))
+      .join("\n");
+    expect(errors).toContain("Multiple projects configured");
   });
 });

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -319,8 +319,7 @@ describe("spawn command", () => {
 
     const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(output).toContain("http://localhost:3000/sessions/app-7");
-    expect(output).not.toContain("tmux attach");
-    expect(output).not.toContain("8474d6f29887-app-7");
+    expect(output).toContain("tmux attach -t 8474d6f29887-app-7");
   });
 
   it("opens docker sessions with runtime attach info when --open is used", async () => {

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -316,6 +316,47 @@ describe("spawn command", () => {
     expect(output).not.toContain("8474d6f29887-app-7");
   });
 
+  it("opens docker sessions with runtime attach info when --open is used", async () => {
+    const fakeSession: Session = {
+      id: "app-7",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: "feat/fix",
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: {
+        id: "container-7",
+        runtimeName: "docker",
+        data: { tmuxSessionName: "tmux-7" },
+      },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+    mockSessionManager.getAttachInfo.mockResolvedValue({
+      type: "docker",
+      target: "container-7",
+      command: "docker exec -it container-7 tmux attach -t tmux-7",
+      program: "docker",
+      args: ["exec", "-it", "container-7", "tmux", "attach", "-t", "tmux-7"],
+      requiresPty: true,
+    });
+
+    await program.parseAsync(["node", "test", "spawn", "--open"]);
+
+    expect(mockExec).toHaveBeenCalledWith("open-iterm-tab", [
+      "--title",
+      "container-7",
+      "--command",
+      "docker exec -it container-7 tmux attach -t tmux-7",
+    ]);
+  });
+
   it("passes --agent flag to sessionManager.spawn()", async () => {
     const fakeSession: Session = {
       id: "app-1",

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -25,6 +25,9 @@ const {
   mockSpawn,
   mockEnsureLifecycleWorker,
   mockStopLifecycleWorker,
+  mockCheckTmux,
+  mockCheckDocker,
+  mockCheckRuntime,
 } = vi.hoisted(() => ({
   mockExec: vi.fn(),
   mockExecSilent: vi.fn(),
@@ -34,6 +37,7 @@ const {
     kill: vi.fn(),
     cleanup: vi.fn(),
     get: vi.fn(),
+    getAttachInfo: vi.fn(),
     spawn: vi.fn(),
     spawnOrchestrator: vi.fn(),
     send: vi.fn(),
@@ -43,6 +47,9 @@ const {
   mockSpawn: vi.fn(),
   mockEnsureLifecycleWorker: vi.fn(),
   mockStopLifecycleWorker: vi.fn(),
+  mockCheckTmux: vi.fn().mockResolvedValue(undefined),
+  mockCheckDocker: vi.fn().mockResolvedValue(undefined),
+  mockCheckRuntime: vi.fn().mockResolvedValue(undefined),
 }));
 
 const { mockDetectOpenClawInstallation } = vi.hoisted(() => ({
@@ -122,7 +129,9 @@ vi.mock("../../src/lib/preflight.js", () => ({
   preflight: {
     checkPort: vi.fn(),
     checkBuilt: vi.fn(),
-    checkTmux: vi.fn().mockResolvedValue(undefined),
+    checkTmux: mockCheckTmux,
+    checkDocker: mockCheckDocker,
+    checkRuntime: mockCheckRuntime,
   },
 }));
 
@@ -141,7 +150,13 @@ vi.mock("../../src/lib/caller-context.js", () => ({
 
 vi.mock("../../src/lib/detect-env.js", () => ({
   detectEnvironment: vi.fn().mockResolvedValue({
-    git: { isRepo: true, remoteUrl: null, ownerRepo: null, currentBranch: "main", defaultBranch: "main" },
+    git: {
+      isRepo: true,
+      remoteUrl: null,
+      ownerRepo: null,
+      currentBranch: "main",
+      defaultBranch: "main",
+    },
     tools: { hasTmux: true, hasGh: false, ghAuthed: false },
     apiKeys: { hasLinear: false, hasSlack: false },
   }),
@@ -218,6 +233,8 @@ beforeEach(() => {
   mockSessionManager.list.mockReset();
   mockSessionManager.list.mockResolvedValue([]);
   mockSessionManager.get.mockReset();
+  mockSessionManager.getAttachInfo.mockReset();
+  mockSessionManager.getAttachInfo.mockResolvedValue(null);
   mockSessionManager.spawnOrchestrator.mockReset();
   mockSessionManager.kill.mockReset();
   mockExec.mockReset();
@@ -250,6 +267,12 @@ beforeEach(() => {
     gatewayUrl: "http://127.0.0.1:18789",
     probe: { reachable: false, error: "not running" },
   });
+  mockCheckTmux.mockReset();
+  mockCheckTmux.mockResolvedValue(undefined);
+  mockCheckDocker.mockReset();
+  mockCheckDocker.mockResolvedValue(undefined);
+  mockCheckRuntime.mockReset();
+  mockCheckRuntime.mockResolvedValue(undefined);
   mockSpawn.mockClear();
   mockProcessCwd.mockReset();
 });
@@ -377,9 +400,9 @@ describe("start command — project resolution", () => {
       backend: makeProject({ name: "Backend" }),
     });
 
-    await expect(
-      program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
-    ).rejects.toThrow("process.exit(1)");
+    await expect(program.parseAsync(["node", "test", "start", "--no-dashboard"])).rejects.toThrow(
+      "process.exit(1)",
+    );
 
     const errors = vi
       .mocked(console.error)
@@ -391,9 +414,9 @@ describe("start command — project resolution", () => {
   it("errors when no projects configured", async () => {
     mockConfigRef.current = makeConfig({});
 
-    await expect(
-      program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
-    ).rejects.toThrow("process.exit(1)");
+    await expect(program.parseAsync(["node", "test", "start", "--no-dashboard"])).rejects.toThrow(
+      "process.exit(1)",
+    );
 
     const errors = vi
       .mocked(console.error)
@@ -709,9 +732,9 @@ describe("start command — non-interactive install safety", () => {
       return null;
     });
 
-    await expect(
-      program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
-    ).rejects.toThrow("process.exit(1)");
+    await expect(program.parseAsync(["node", "test", "start", "--no-dashboard"])).rejects.toThrow(
+      "process.exit(1)",
+    );
 
     expect(hasPrivilegedInstallAttempt()).toBe(false);
     expect(mockExec.mock.calls.some((call) => String(call[0]) === "tmux")).toBe(false);
@@ -790,6 +813,25 @@ describe("start command — browser open waits for port", () => {
     expect(mockEnsureLifecycleWorker).not.toHaveBeenCalled();
   });
 
+  it("skips docker preflight when orchestrator startup is disabled", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "start",
+      "--no-dashboard",
+      "--no-orchestrator",
+      "--runtime",
+      "docker",
+      "--runtime-image",
+      "ghcr.io/composio/ao:test",
+    ]);
+
+    expect(mockCheckDocker).not.toHaveBeenCalled();
+    expect(mockCheckRuntime).not.toHaveBeenCalled();
+  });
+
   it("skips browser open but still starts lifecycle with --no-dashboard alone", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
@@ -803,6 +845,62 @@ describe("start command — browser open waits for port", () => {
       expect.objectContaining({ configPath: expect.any(String) }),
       "my-app",
     );
+  });
+
+  it("passes docker runtime override flags to spawnOrchestrator()", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    mockSessionManager.get.mockResolvedValue(null);
+    mockSessionManager.spawnOrchestrator.mockResolvedValue({
+      id: "app-orchestrator",
+      runtimeHandle: { id: "container-123", runtimeName: "docker", data: {} },
+    });
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "start",
+      "--no-dashboard",
+      "--runtime",
+      "docker",
+      "--runtime-image",
+      "ghcr.io/composio/ao:test",
+      "--runtime-cpus",
+      "2",
+      "--runtime-memory",
+      "4g",
+      "--runtime-gpus",
+      "all",
+      "--runtime-read-only",
+      "--runtime-network",
+      "bridge",
+      "--runtime-cap-drop",
+      "ALL",
+      "--runtime-tmpfs",
+      "/tmp",
+    ]);
+
+    expect(mockCheckDocker).toHaveBeenCalledWith({
+      image: "ghcr.io/composio/ao:test",
+      limits: { cpus: "2", memory: "4g", gpus: "all" },
+      readOnlyRoot: true,
+      network: "bridge",
+      capDrop: ["ALL"],
+      tmpfs: ["/tmp"],
+    });
+    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith({
+      projectId: "my-app",
+      systemPrompt: expect.any(String),
+      runtime: "docker",
+      runtimeConfig: {
+        image: "ghcr.io/composio/ao:test",
+        limits: { cpus: "2", memory: "4g", gpus: "all" },
+        readOnlyRoot: true,
+        network: "bridge",
+        capDrop: ["ALL"],
+        tmpfs: ["/tmp"],
+      },
+    });
   });
 });
 

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -886,14 +886,19 @@ describe("start command — browser open waits for port", () => {
       "/tmp",
     ]);
 
-    expect(mockCheckDocker).toHaveBeenCalledWith({
-      image: "ghcr.io/composio/ao:test",
-      limits: { cpus: "2", memory: "4g", gpus: "all" },
-      readOnlyRoot: true,
-      network: "bridge",
-      capDrop: ["ALL"],
-      tmpfs: ["/tmp"],
-    });
+    expect(mockCheckDocker).not.toHaveBeenCalled();
+    expect(mockCheckRuntime).toHaveBeenCalledWith(
+      "docker",
+      {
+        image: "ghcr.io/composio/ao:test",
+        limits: { cpus: "2", memory: "4g", gpus: "all" },
+        readOnlyRoot: true,
+        network: "bridge",
+        capDrop: ["ALL"],
+        tmpfs: ["/tmp"],
+      },
+      ["tmux", "docker", "process"],
+    );
     expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith({
       projectId: "my-app",
       systemPrompt: expect.any(String),

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -104,6 +104,12 @@ vi.mock("@composio/ao-core", async (importOriginal) => {
 
 vi.mock("../../src/lib/create-session-manager.js", () => ({
   getSessionManager: async (): Promise<SessionManager> => mockSessionManager as SessionManager,
+  getPluginRegistry: async () => ({
+    list: (slot: string) =>
+      slot === "runtime"
+        ? [{ name: "tmux" }, { name: "docker" }, { name: "process" }]
+        : [],
+  }),
 }));
 
 vi.mock("../../src/lib/lifecycle-service.js", () => ({

--- a/packages/cli/__tests__/lib/attach.test.ts
+++ b/packages/cli/__tests__/lib/attach.test.ts
@@ -1,19 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter } from "node:events";
+import type * as ChildProcessModule from "node:child_process";
 
 const { mockSpawn } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
 }));
 
 vi.mock("node:child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:child_process")>();
+  const actual = await importOriginal<typeof ChildProcessModule>();
   return {
     ...actual,
     spawn: mockSpawn,
   };
 });
 
-import { runAttachCommand } from "../../src/lib/attach.js";
+import { formatAttachCommand, runAttachCommand } from "../../src/lib/attach.js";
 
 function makeChild(exitCode = 0): EventEmitter {
   const child = new EventEmitter() as EventEmitter & { stdio?: unknown };
@@ -29,6 +30,24 @@ beforeEach(() => {
 });
 
 describe("runAttachCommand", () => {
+  it("formats a structured attach command when available", () => {
+    expect(
+      formatAttachCommand(
+        {
+          type: "docker",
+          target: "container-1",
+          program: "docker",
+          args: ["exec", "-it", "container-1", "tmux", "attach", "-t", "tmux-1"],
+        },
+        "tmux attach -t fallback",
+      ),
+    ).toBe("'docker' 'exec' '-it' 'container-1' 'tmux' 'attach' '-t' 'tmux-1'");
+  });
+
+  it("falls back to the provided command string when no attach info exists", () => {
+    expect(formatAttachCommand(null, "tmux attach -t fallback")).toBe("tmux attach -t fallback");
+  });
+
   it("uses structured attach info when program/args are provided", async () => {
     mockSpawn.mockReturnValue(makeChild());
 
@@ -66,5 +85,21 @@ describe("runAttachCommand", () => {
       ["-c", "docker exec -it container-1 tmux attach -t tmux-1"],
       { stdio: "inherit" },
     );
+  });
+
+  it("rejects when the attach process exits non-zero", async () => {
+    mockSpawn.mockReturnValue(makeChild(2));
+
+    await expect(
+      runAttachCommand(
+        {
+          type: "docker",
+          target: "container-1",
+          program: "docker",
+          args: ["exec", "-it", "container-1", "tmux", "attach", "-t", "tmux-1"],
+        },
+        { program: "tmux", args: ["attach", "-t", "fallback"] },
+      ),
+    ).rejects.toThrow("attach command exited with code 2");
   });
 });

--- a/packages/cli/__tests__/lib/attach.test.ts
+++ b/packages/cli/__tests__/lib/attach.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+const { mockSpawn } = vi.hoisted(() => ({
+  mockSpawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: mockSpawn,
+  };
+});
+
+import { runAttachCommand } from "../../src/lib/attach.js";
+
+function makeChild(exitCode = 0): EventEmitter {
+  const child = new EventEmitter() as EventEmitter & { stdio?: unknown };
+  queueMicrotask(() => {
+    child.emit("exit", exitCode);
+  });
+  return child;
+}
+
+beforeEach(() => {
+  mockSpawn.mockReset();
+  process.env["SHELL"] = "/bin/zsh";
+});
+
+describe("runAttachCommand", () => {
+  it("uses structured attach info when program/args are provided", async () => {
+    mockSpawn.mockReturnValue(makeChild());
+
+    await runAttachCommand(
+      {
+        type: "docker",
+        target: "container-1",
+        program: "docker",
+        args: ["exec", "-it", "container-1", "tmux", "attach", "-t", "tmux-1"],
+      },
+      { program: "tmux", args: ["attach", "-t", "fallback"] },
+    );
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "docker",
+      ["exec", "-it", "container-1", "tmux", "attach", "-t", "tmux-1"],
+      { stdio: "inherit" },
+    );
+  });
+
+  it("uses shell -c when only a command string is available", async () => {
+    mockSpawn.mockReturnValue(makeChild());
+
+    await runAttachCommand(
+      {
+        type: "docker",
+        target: "container-1",
+        command: "docker exec -it container-1 tmux attach -t tmux-1",
+      },
+      { program: "tmux", args: ["attach", "-t", "fallback"] },
+    );
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/bin/zsh",
+      ["-c", "docker exec -it container-1 tmux attach -t tmux-1"],
+      { stdio: "inherit" },
+    );
+  });
+});

--- a/packages/cli/__tests__/lib/preflight.test.ts
+++ b/packages/cli/__tests__/lib/preflight.test.ts
@@ -182,6 +182,10 @@ describe("preflight.checkRuntime", () => {
       'Unknown runtime "dokcer"',
     );
   });
+
+  it("allows custom runtime plugins when explicitly registered", async () => {
+    await expect(preflight.checkRuntime("kubernetes", undefined, ["tmux", "docker", "kubernetes"])).resolves.toBeUndefined();
+  });
 });
 
 describe("preflight.checkGhAuth", () => {

--- a/packages/cli/__tests__/lib/preflight.test.ts
+++ b/packages/cli/__tests__/lib/preflight.test.ts
@@ -148,6 +148,29 @@ describe("preflight.checkTmux", () => {
   });
 });
 
+describe("preflight.checkDocker", () => {
+  it("passes when docker is installed, daemon is running, and image is configured", async () => {
+    mockExec
+      .mockResolvedValueOnce({ stdout: "Docker version 27.0.0", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "Server: Docker Engine", stderr: "" });
+
+    await expect(
+      preflight.checkDocker({ image: "ghcr.io/composio/ao:test" }),
+    ).resolves.toBeUndefined();
+
+    expect(mockExec).toHaveBeenCalledWith("docker", ["--version"]);
+    expect(mockExec).toHaveBeenCalledWith("docker", ["info"]);
+  });
+
+  it("throws with override guidance when no docker image is configured", async () => {
+    mockExec
+      .mockResolvedValueOnce({ stdout: "Docker version 27.0.0", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "Server: Docker Engine", stderr: "" });
+
+    await expect(preflight.checkDocker()).rejects.toThrow("--runtime-image");
+  });
+});
+
 describe("preflight.checkGhAuth", () => {
   it("passes when gh is installed and authenticated", async () => {
     mockExec.mockResolvedValue({ stdout: "ok", stderr: "" });

--- a/packages/cli/__tests__/lib/preflight.test.ts
+++ b/packages/cli/__tests__/lib/preflight.test.ts
@@ -169,6 +169,19 @@ describe("preflight.checkDocker", () => {
 
     await expect(preflight.checkDocker()).rejects.toThrow("--runtime-image");
   });
+
+  it("rejects readOnlyRoot without a /tmp tmpfs", async () => {
+    mockExec
+      .mockResolvedValueOnce({ stdout: "Docker version 27.0.0", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "Server: Docker Engine", stderr: "" });
+
+    await expect(
+      preflight.checkDocker({
+        image: "ghcr.io/composio/ao:test",
+        readOnlyRoot: true,
+      }),
+    ).rejects.toThrow("tmpfs");
+  });
 });
 
 describe("preflight.checkRuntime", () => {

--- a/packages/cli/__tests__/lib/preflight.test.ts
+++ b/packages/cli/__tests__/lib/preflight.test.ts
@@ -171,6 +171,19 @@ describe("preflight.checkDocker", () => {
   });
 });
 
+describe("preflight.checkRuntime", () => {
+  it("passes through process runtime without extra checks", async () => {
+    await expect(preflight.checkRuntime("process")).resolves.toBeUndefined();
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("throws for unknown runtime names", async () => {
+    await expect(preflight.checkRuntime("dokcer")).rejects.toThrow(
+      'Unknown runtime "dokcer"',
+    );
+  });
+});
+
 describe("preflight.checkGhAuth", () => {
   it("passes when gh is installed and authenticated", async () => {
     mockExec.mockResolvedValue({ stdout: "ok", stderr: "" });

--- a/packages/cli/__tests__/lib/runtime-overrides.test.ts
+++ b/packages/cli/__tests__/lib/runtime-overrides.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { OrchestratorConfig, ProjectConfig } from "@composio/ao-core";
+import {
+  appendStringOption,
+  resolveRuntimeOverride,
+} from "../../src/lib/runtime-overrides.js";
+
+function makeConfig(runtime?: string): OrchestratorConfig {
+  return {
+    configPath: "/tmp/agent-orchestrator.yaml",
+    port: 3000,
+    defaults: {
+      runtime: runtime ?? "tmux",
+      agent: "claude-code",
+      workspace: "worktree",
+      notifiers: [],
+    },
+    projects: {},
+    notifiers: {},
+    notificationRouting: {},
+    reactions: {},
+  };
+}
+
+function makeProject(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    name: "My App",
+    repo: "org/my-app",
+    path: "/tmp/my-app",
+    defaultBranch: "main",
+    sessionPrefix: "app",
+    ...overrides,
+  };
+}
+
+describe("appendStringOption", () => {
+  it("appends values in order", () => {
+    expect(appendStringOption("beta", ["alpha"])).toEqual(["alpha", "beta"]);
+  });
+});
+
+describe("resolveRuntimeOverride", () => {
+  it("falls back to the project runtime and merges nested runtimeConfig objects", () => {
+    const config = makeConfig("tmux");
+    const project = makeProject({
+      runtime: "docker",
+      runtimeConfig: {
+        image: "ghcr.io/composio/ao:base",
+        limits: { memory: "2g" },
+        network: "bridge",
+      },
+    });
+
+    const override = resolveRuntimeOverride(config, project, {
+      runtimeConfig: JSON.stringify({
+        limits: { cpus: "2" },
+        tmpfs: ["/tmp"],
+      }),
+      runtimeMemory: "4g",
+      runtimeCapDrop: [" ALL ", ""],
+      runtimeTmpfs: [" /cache ", ""],
+    });
+
+    expect(override.runtime).toBeUndefined();
+    expect(override.effectiveRuntime).toBe("docker");
+    expect(override.runtimeConfig).toEqual({
+      limits: { cpus: "2", memory: "4g" },
+      capDrop: ["ALL"],
+      tmpfs: ["/cache"],
+    });
+    expect(override.effectiveRuntimeConfig).toEqual({
+      image: "ghcr.io/composio/ao:base",
+      limits: { memory: "4g", cpus: "2" },
+      network: "bridge",
+      capDrop: ["ALL"],
+      tmpfs: ["/cache"],
+    });
+  });
+
+  it("uses tmux as the implicit default when neither config nor project sets a runtime", () => {
+    const config = makeConfig();
+    (config.defaults as { runtime?: string }).runtime = undefined;
+
+    const override = resolveRuntimeOverride(config, makeProject(), {});
+    expect(override.effectiveRuntime).toBe("tmux");
+    expect(override.runtimeConfig).toBeUndefined();
+    expect(override.effectiveRuntimeConfig).toBeUndefined();
+  });
+
+  it("applies explicit runtime and trims docker flag values", () => {
+    const override = resolveRuntimeOverride(makeConfig("process"), makeProject(), {
+      runtime: " docker ",
+      runtimeImage: " ghcr.io/composio/ao:test ",
+      runtimeNetwork: " host ",
+      runtimeCpus: " 2 ",
+      runtimeGpus: " all ",
+      runtimeReadOnly: true,
+      runtimeCapDrop: [" SYS_ADMIN ", " "],
+      runtimeTmpfs: [" /tmp ", ""],
+    });
+
+    expect(override.runtime).toBe("docker");
+    expect(override.effectiveRuntime).toBe("docker");
+    expect(override.runtimeConfig).toEqual({
+      image: "ghcr.io/composio/ao:test",
+      network: "host",
+      readOnlyRoot: true,
+      capDrop: ["SYS_ADMIN"],
+      tmpfs: ["/tmp"],
+      limits: { cpus: "2", gpus: "all" },
+    });
+  });
+
+  it("rejects invalid JSON runtime-config values", () => {
+    expect(() =>
+      resolveRuntimeOverride(makeConfig(), makeProject(), {
+        runtimeConfig: "{not-json}",
+      }),
+    ).toThrow("Invalid --runtime-config JSON");
+  });
+
+  it("rejects non-object JSON runtime-config values", () => {
+    expect(() =>
+      resolveRuntimeOverride(makeConfig(), makeProject(), {
+        runtimeConfig: JSON.stringify(["not", "an", "object"]),
+      }),
+    ).toThrow("--runtime-config must be a JSON object.");
+  });
+});

--- a/packages/cli/__tests__/scripts/doctor-script.test.ts
+++ b/packages/cli/__tests__/scripts/doctor-script.test.ts
@@ -125,21 +125,17 @@ describe("scripts/ao-doctor.sh", () => {
     const binDir = join(tempRoot, "bin");
     mkdirSync(binDir, { recursive: true });
     createHealthyPath(binDir);
+    mkdirSync(join(tempRoot, ".agent-orchestrator"), { recursive: true });
+    mkdirSync(join(tempRoot, ".worktrees"), { recursive: true });
 
     const configPath = join(tempRoot, "agent-orchestrator.yaml");
-    const dataDir = join(tempRoot, "data");
-    const worktreeDir = join(tempRoot, "worktrees");
-    mkdirSync(dataDir, { recursive: true });
-    mkdirSync(worktreeDir, { recursive: true });
-    writeFileSync(
-      configPath,
-      [`dataDir: ${dataDir}`, `worktreeDir: ${worktreeDir}`, "projects: {}"].join("\n"),
-    );
+    writeFileSync(configPath, "projects: {}\n");
 
     const result = spawnSync("bash", [scriptPath], {
       env: {
         ...process.env,
         PATH: `${binDir}:/bin:/usr/bin`,
+        HOME: tempRoot,
         AO_REPO_ROOT: fakeRepo,
         AO_CONFIG_PATH: configPath,
       },
@@ -169,6 +165,8 @@ describe("scripts/ao-doctor.sh", () => {
     );
 
     const configPath = join(tempRoot, "agent-orchestrator.yaml");
+    const metadataRoot = join(tempRoot, ".agent-orchestrator");
+    const worktreeRoot = join(tempRoot, ".worktrees");
     const dataDir = join(tempRoot, "data");
     const worktreeDir = join(tempRoot, "worktrees");
     const commentedDataDir = `${dataDir} # session metadata`;
@@ -191,6 +189,7 @@ describe("scripts/ao-doctor.sh", () => {
       env: {
         ...process.env,
         PATH: `${binDir}:/bin:/usr/bin`,
+        HOME: tempRoot,
         AO_REPO_ROOT: fakeRepo,
         AO_CONFIG_PATH: configPath,
         AO_DOCTOR_TMP_ROOT: tmpRoot,
@@ -200,8 +199,8 @@ describe("scripts/ao-doctor.sh", () => {
 
     const npmCommands = readFileSync(npmLog, "utf8");
     const staleStillExists = existsSync(staleFile);
-    const dataDirExists = existsSync(dataDir);
-    const worktreeDirExists = existsSync(worktreeDir);
+    const metadataRootExists = existsSync(metadataRoot);
+    const worktreeRootExists = existsSync(worktreeRoot);
     const commentedDataDirExists = existsSync(commentedDataDir);
     const commentedWorktreeDirExists = existsSync(commentedWorktreeDir);
     rmSync(tempRoot, { recursive: true, force: true });
@@ -211,9 +210,10 @@ describe("scripts/ao-doctor.sh", () => {
     expect(npmCommands).toContain("link");
     expect(result.stdout).toContain("launcher");
     expect(result.stdout).toContain("stale temp files");
+    expect(result.stdout).toContain("legacy and ignored");
     expect(staleStillExists).toBe(false);
-    expect(dataDirExists).toBe(true);
-    expect(worktreeDirExists).toBe(true);
+    expect(metadataRootExists).toBe(true);
+    expect(worktreeRootExists).toBe(true);
     expect(commentedDataDirExists).toBe(false);
     expect(commentedWorktreeDirExists).toBe(false);
   });
@@ -227,10 +227,8 @@ describe("scripts/ao-doctor.sh", () => {
     createHealthyDocker(binDir, { rootless: true, gpu: true });
 
     const configPath = join(tempRoot, "agent-orchestrator.yaml");
-    const dataDir = join(tempRoot, "data");
-    const worktreeDir = join(tempRoot, "worktrees");
-    mkdirSync(dataDir, { recursive: true });
-    mkdirSync(worktreeDir, { recursive: true });
+    mkdirSync(join(tempRoot, ".agent-orchestrator"), { recursive: true });
+    mkdirSync(join(tempRoot, ".worktrees"), { recursive: true });
     writeFileSync(
       configPath,
       [
@@ -243,8 +241,6 @@ describe("scripts/ao-doctor.sh", () => {
         "    runtimeConfig:",
         "      image: ghcr.io/composio/ao:test",
         "      gpus: all",
-        `dataDir: ${dataDir}`,
-        `worktreeDir: ${worktreeDir}`,
       ].join("\n"),
     );
 
@@ -252,6 +248,7 @@ describe("scripts/ao-doctor.sh", () => {
       env: {
         ...process.env,
         PATH: `${binDir}:${process.env.PATH || ""}`,
+        HOME: tempRoot,
         AO_REPO_ROOT: fakeRepo,
         AO_CONFIG_PATH: configPath,
       },
@@ -284,10 +281,8 @@ describe("scripts/ao-doctor.sh", () => {
     createHealthyDocker(binDir, { rootless: true });
 
     const configPath = join(tempRoot, "agent-orchestrator.yaml");
-    const dataDir = join(tempRoot, "data");
-    const worktreeDir = join(tempRoot, "worktrees");
-    mkdirSync(dataDir, { recursive: true });
-    mkdirSync(worktreeDir, { recursive: true });
+    mkdirSync(join(tempRoot, ".agent-orchestrator"), { recursive: true });
+    mkdirSync(join(tempRoot, ".worktrees"), { recursive: true });
     writeFileSync(
       configPath,
       [
@@ -300,8 +295,6 @@ describe("scripts/ao-doctor.sh", () => {
         "    runtimeConfig:",
         "      limits:",
         "        memory: 4g",
-        `dataDir: ${dataDir}`,
-        `worktreeDir: ${worktreeDir}`,
       ].join("\n"),
     );
 
@@ -309,6 +302,7 @@ describe("scripts/ao-doctor.sh", () => {
       env: {
         ...process.env,
         PATH: `${binDir}:${process.env.PATH || ""}`,
+        HOME: tempRoot,
         AO_REPO_ROOT: fakeRepo,
         AO_CONFIG_PATH: configPath,
       },

--- a/packages/cli/__tests__/scripts/doctor-script.test.ts
+++ b/packages/cli/__tests__/scripts/doctor-script.test.ts
@@ -78,6 +78,46 @@ function createHealthyPath(binDir: string): void {
   createFakeBinary(binDir, "ao", 'printf "/fake/ao\\n" >/dev/null\nexit 0');
 }
 
+function createHealthyDocker(
+  binDir: string,
+  options?: { rootless?: boolean; gpu?: boolean },
+): void {
+  const rootless = options?.rootless ?? true;
+  const gpu = options?.gpu ?? false;
+  createFakeBinary(
+    binDir,
+    "docker",
+    [
+      'if [ "$1" = "--version" ]; then',
+      '  printf "Docker version 27.0.0\\n"',
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "info" ] && [ $# -eq 1 ]; then',
+      '  printf "Server: Docker Engine\\n"',
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "info" ] && [ "$2" = "--format" ]; then',
+      '  if printf "%s" "$3" | grep -q "SecurityOptions"; then',
+      rootless ? "    printf '[\"name=rootless\"]\\n'" : "    printf '[\"name=seccomp\"]\\n'",
+      "    exit 0",
+      "  fi",
+      '  if printf "%s" "$3" | grep -q "Runtimes"; then',
+      gpu ? '    printf \'{"runc":{},"nvidia":{}}\\n\'' : "    printf '{\"runc\":{}}\\n'",
+      "    exit 0",
+      "  fi",
+      "fi",
+      'if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then',
+      "  exit 1",
+      "fi",
+      'if [ "$1" = "manifest" ] && [ "$2" = "inspect" ]; then',
+      '  printf "{}\\n"',
+      "  exit 0",
+      "fi",
+      "exit 0",
+    ].join("\n"),
+  );
+}
+
 describe("scripts/ao-doctor.sh", () => {
   it("reports a healthy install as PASS", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-script-"));
@@ -176,5 +216,110 @@ describe("scripts/ao-doctor.sh", () => {
     expect(worktreeDirExists).toBe(true);
     expect(commentedDataDirExists).toBe(false);
     expect(commentedWorktreeDirExists).toBe(false);
+  });
+
+  it("validates docker runtime config when runtime: docker is enabled", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-docker-"));
+    const fakeRepo = createHealthyRepo(tempRoot);
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    createHealthyPath(binDir);
+    createHealthyDocker(binDir, { rootless: true, gpu: true });
+
+    const configPath = join(tempRoot, "agent-orchestrator.yaml");
+    const dataDir = join(tempRoot, "data");
+    const worktreeDir = join(tempRoot, "worktrees");
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(worktreeDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      [
+        "projects:",
+        "  app:",
+        "    repo: org/repo",
+        "    path: ~/repo",
+        "    defaultBranch: main",
+        "    runtime: docker",
+        "    runtimeConfig:",
+        "      image: ghcr.io/composio/ao:test",
+        "      gpus: all",
+        `dataDir: ${dataDir}`,
+        `worktreeDir: ${worktreeDir}`,
+      ].join("\n"),
+    );
+
+    const result = spawnSync("bash", [scriptPath], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH || ""}`,
+        AO_REPO_ROOT: fakeRepo,
+        AO_CONFIG_PATH: configPath,
+      },
+      encoding: "utf8",
+    });
+
+    rmSync(tempRoot, { recursive: true, force: true });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("docker CLI is installed");
+    expect(result.stdout).toContain("docker daemon is reachable");
+    expect(result.stdout).toContain(
+      "docker runtime image is configured as ghcr.io/composio/ao:test",
+    );
+    expect(result.stdout).toContain(
+      "docker image ghcr.io/composio/ao:test is available or reachable",
+    );
+    if (process.platform === "linux") {
+      expect(result.stdout).toContain("docker appears to be running in rootless mode");
+    }
+    expect(result.stdout).toContain("docker advertises an nvidia runtime for GPU sessions");
+  });
+
+  it("fails when docker runtime is configured without an image", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-docker-missing-image-"));
+    const fakeRepo = createHealthyRepo(tempRoot);
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    createHealthyPath(binDir);
+    createHealthyDocker(binDir, { rootless: true });
+
+    const configPath = join(tempRoot, "agent-orchestrator.yaml");
+    const dataDir = join(tempRoot, "data");
+    const worktreeDir = join(tempRoot, "worktrees");
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(worktreeDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      [
+        "projects:",
+        "  app:",
+        "    repo: org/repo",
+        "    path: ~/repo",
+        "    defaultBranch: main",
+        "    runtime: docker",
+        "    runtimeConfig:",
+        "      limits:",
+        "        memory: 4g",
+        `dataDir: ${dataDir}`,
+        `worktreeDir: ${worktreeDir}`,
+      ].join("\n"),
+    );
+
+    const result = spawnSync("bash", [scriptPath], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH || ""}`,
+        AO_REPO_ROOT: fakeRepo,
+        AO_CONFIG_PATH: configPath,
+      },
+      encoding: "utf8",
+    });
+
+    rmSync(tempRoot, { recursive: true, force: true });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      "runtime: docker is configured but no runtimeConfig.image was found",
+    );
   });
 });

--- a/packages/cli/__tests__/scripts/open-iterm-tab.test.ts
+++ b/packages/cli/__tests__/scripts/open-iterm-tab.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+const scriptPath = join(repoRoot, "scripts", "open-iterm-tab");
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+function createFakeOsascript(binDir: string, logFile: string): void {
+  writeExecutable(
+    join(binDir, "osascript"),
+    [
+      "#!/bin/bash",
+      "set -e",
+      `LOG_FILE=${JSON.stringify(logFile)}`,
+      `COUNT_FILE=${JSON.stringify(`${logFile}.count`)}`,
+      "count=0",
+      'if [ -f "$COUNT_FILE" ]; then',
+      '  count=$(cat "$COUNT_FILE")',
+      "fi",
+      "count=$((count + 1))",
+      'printf "%s" "$count" > "$COUNT_FILE"',
+      'printf "%s\\n---\\n" "$2" >> "$LOG_FILE"',
+      'if [ "$count" -eq 1 ]; then',
+      '  printf "NOT_FOUND\\n"',
+      "else",
+      '  printf "OK\\n"',
+      "fi",
+    ].join("\n"),
+  );
+}
+
+function createFakeTmux(binDir: string, logFile: string): void {
+  writeExecutable(
+    join(binDir, "tmux"),
+    [
+      "#!/bin/bash",
+      "set -e",
+      `printf "%s\\n" "$*" >> ${JSON.stringify(logFile)}`,
+      'if [ "$1" = "has-session" ]; then',
+      "  exit 0",
+      "fi",
+      "exit 0",
+    ].join("\n"),
+  );
+}
+
+describe("scripts/open-iterm-tab", () => {
+  it("supports the legacy tmux session form", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "ao-open-iterm-script-"));
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const osascriptLog = join(tempRoot, "osascript.log");
+    const tmuxLog = join(tempRoot, "tmux.log");
+    createFakeOsascript(binDir, osascriptLog);
+    createFakeTmux(binDir, tmuxLog);
+
+    const result = spawnSync("bash", [scriptPath, "app-1"], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH || ""}`,
+      },
+      encoding: "utf8",
+    });
+
+    const osascriptOutput = readFileSync(osascriptLog, "utf8");
+    const tmuxOutput = readFileSync(tmuxLog, "utf8");
+    rmSync(tempRoot, { recursive: true, force: true });
+
+    expect(result.status).toBe(0);
+    expect(tmuxOutput).toContain("has-session -t app-1");
+    expect(osascriptOutput).toContain('if name of aSession is equal to "app-1"');
+    expect(osascriptOutput).toContain("tmux attach -t 'app-1'");
+  });
+
+  it("supports runtime-aware title/command mode without tmux lookup", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "ao-open-iterm-runtime-"));
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const osascriptLog = join(tempRoot, "osascript.log");
+    const tmuxLog = join(tempRoot, "tmux.log");
+    createFakeOsascript(binDir, osascriptLog);
+    createFakeTmux(binDir, tmuxLog);
+
+    const result = spawnSync(
+      "bash",
+      [
+        scriptPath,
+        "--title",
+        "container-1",
+        "--command",
+        "docker exec -it container-1 tmux attach -t tmux-1",
+      ],
+      {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH || ""}`,
+        },
+        encoding: "utf8",
+      },
+    );
+
+    const osascriptOutput = readFileSync(osascriptLog, "utf8");
+    const tmuxOutput = existsSync(tmuxLog) ? readFileSync(tmuxLog, "utf8") : "";
+    rmSync(tempRoot, { recursive: true, force: true });
+
+    expect(result.status).toBe(0);
+    expect(tmuxOutput).toBe("");
+    expect(osascriptOutput).toContain('set name to "container-1"');
+    expect(osascriptOutput).toContain("docker exec -it container-1 tmux attach -t tmux-1");
+  });
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
     "@composio/ao-plugin-notifier-openclaw": "workspace:*",
     "@composio/ao-plugin-notifier-slack": "workspace:*",
     "@composio/ao-plugin-notifier-webhook": "workspace:*",
+    "@composio/ao-plugin-runtime-docker": "workspace:*",
     "@composio/ao-plugin-runtime-process": "workspace:*",
     "@composio/ao-plugin-runtime-tmux": "workspace:*",
     "@composio/ao-plugin-scm-github": "workspace:*",

--- a/packages/cli/src/commands/docker.ts
+++ b/packages/cli/src/commands/docker.ts
@@ -1,0 +1,333 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { cwd } from "node:process";
+import { tmpdir } from "node:os";
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  ConfigNotFoundError,
+  loadConfigWithPath,
+  type OrchestratorConfig,
+  type ProjectConfig,
+} from "@composio/ao-core";
+import { parse as yamlParse, stringify as yamlStringify } from "yaml";
+import { exec } from "../lib/shell.js";
+import { findProjectForDirectory } from "../lib/project-resolution.js";
+import { appendStringOption, resolveRuntimeOverride } from "../lib/runtime-overrides.js";
+import { preflight } from "../lib/preflight.js";
+
+type RawConfig = Record<string, unknown>;
+type RawProjectConfig = Record<string, unknown>;
+
+interface DockerPrepareOptions {
+  agent?: string;
+  image?: string;
+  buildLocal?: boolean;
+  tag?: string;
+  pull?: boolean;
+  cpus?: string;
+  memory?: string;
+  gpus?: string;
+  readOnly?: boolean;
+  network?: string;
+  capDrop?: string[];
+  tmpfs?: string[];
+}
+
+interface DockerAgentTemplate {
+  agent: string;
+  officialImage: string;
+  localTag: string;
+  installCommand: string;
+  extraPackages?: string[];
+}
+
+const DOCKER_AGENT_TEMPLATES: Record<string, DockerAgentTemplate> = {
+  "claude-code": {
+    agent: "claude-code",
+    officialImage: "ghcr.io/composio/ao-claude-code:latest",
+    localTag: "ao-claude-code:local",
+    installCommand: "npm install -g @anthropic-ai/claude-code",
+  },
+  codex: {
+    agent: "codex",
+    officialImage: "ghcr.io/composio/ao-codex:latest",
+    localTag: "ao-codex:local",
+    installCommand: "npm install -g @openai/codex",
+  },
+  opencode: {
+    agent: "opencode",
+    officialImage: "ghcr.io/composio/ao-opencode:latest",
+    localTag: "ao-opencode:local",
+    installCommand: "npm install -g opencode-ai",
+  },
+  aider: {
+    agent: "aider",
+    officialImage: "ghcr.io/composio/ao-aider:latest",
+    localTag: "ao-aider:local",
+    extraPackages: ["python3", "python3-pip"],
+    installCommand: "pip3 install --break-system-packages aider-chat",
+  },
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readRawConfig(path: string): RawConfig {
+  const parsed = yamlParse(readFileSync(path, "utf-8"));
+  return isPlainObject(parsed) ? parsed : {};
+}
+
+function writeRawConfig(path: string, rawConfig: RawConfig): void {
+  writeFileSync(path, yamlStringify(rawConfig, { indent: 2 }), "utf-8");
+}
+
+function getRawProjects(rawConfig: RawConfig): Record<string, RawProjectConfig> {
+  if (!isPlainObject(rawConfig["projects"])) {
+    rawConfig["projects"] = {};
+  }
+  return rawConfig["projects"] as Record<string, RawProjectConfig>;
+}
+
+function getProjectOrExit(config: OrchestratorConfig, projectId: string): ProjectConfig {
+  const project = config.projects[projectId];
+  if (project) return project;
+
+  console.error(
+    chalk.red(
+      `Project "${projectId}" not found. Available projects: ${Object.keys(config.projects).join(", ")}`,
+    ),
+  );
+  process.exit(1);
+}
+
+function resolveProjectId(config: OrchestratorConfig, projectId?: string): string {
+  if (projectId) {
+    getProjectOrExit(config, projectId);
+    return projectId;
+  }
+
+  const projectIds = Object.keys(config.projects);
+  if (projectIds.length === 0) {
+    console.error(chalk.red("No projects configured. Run `ao start` first."));
+    process.exit(1);
+  }
+  if (projectIds.length === 1) {
+    return projectIds[0];
+  }
+
+  const envProject = process.env["AO_PROJECT_ID"];
+  if (envProject && config.projects[envProject]) {
+    return envProject;
+  }
+
+  const matchedProjectId = findProjectForDirectory(config.projects, resolve(cwd()));
+  if (matchedProjectId) {
+    return matchedProjectId;
+  }
+
+  console.error(
+    chalk.red(
+      `Multiple projects configured. Specify one: ${projectIds.join(", ")}\nOr run from within a project directory.`,
+    ),
+  );
+  process.exit(1);
+}
+
+function resolveWorkerAgent(config: OrchestratorConfig, project: ProjectConfig, override?: string): string {
+  return (
+    override ??
+    project.worker?.agent ??
+    project.agent ??
+    config.defaults.worker?.agent ??
+    config.defaults.agent
+  );
+}
+
+function getDockerTemplate(agent: string): DockerAgentTemplate {
+  const template = DOCKER_AGENT_TEMPLATES[agent];
+  if (template) return template;
+
+  console.error(
+    chalk.red(
+      `No Docker template is available for agent "${agent}". Use --image with a custom image instead.`,
+    ),
+  );
+  process.exit(1);
+}
+
+function buildDockerfile(template: DockerAgentTemplate): string {
+  const extraPackages = template.extraPackages?.join(" ");
+  const aptPackages = ["git", "tmux", "gh", "ca-certificates", extraPackages]
+    .filter(Boolean)
+    .join(" ");
+
+  return [
+    "FROM node:20-bookworm",
+    `RUN apt-get update \\`,
+    `  && apt-get install -y --no-install-recommends ${aptPackages} \\`,
+    "  && rm -rf /var/lib/apt/lists/*",
+    `RUN ${template.installCommand}`,
+    "WORKDIR /workspace",
+    "",
+  ].join("\n");
+}
+
+async function pullImage(image: string): Promise<void> {
+  console.log(chalk.dim(`Pulling ${image}...`));
+  try {
+    await exec("docker", ["pull", image]);
+  } catch (err) {
+    throw new Error(
+      `Failed to pull Docker image ${image}. If you want AO to build an image locally instead, rerun with --build-local.`,
+      { cause: err },
+    );
+  }
+}
+
+async function buildLocalImage(image: string, template: DockerAgentTemplate): Promise<void> {
+  const buildDir = mkdtempSync(join(tmpdir(), "ao-docker-prepare-"));
+  try {
+    const dockerfilePath = join(buildDir, "Dockerfile");
+    writeFileSync(dockerfilePath, buildDockerfile(template), "utf-8");
+    console.log(chalk.dim(`Building ${image}...`));
+    try {
+      await exec("docker", ["build", "-t", image, buildDir]);
+    } catch (err) {
+      throw new Error(`Failed to build Docker image ${image}.`, { cause: err });
+    }
+  } finally {
+    rmSync(buildDir, { recursive: true, force: true });
+  }
+}
+
+function toRuntimeOverrideOptions(image: string, opts: DockerPrepareOptions) {
+  return {
+    runtime: "docker",
+    runtimeImage: image,
+    runtimeCpus: opts.cpus,
+    runtimeMemory: opts.memory,
+    runtimeGpus: opts.gpus,
+    runtimeReadOnly: opts.readOnly,
+    runtimeNetwork: opts.network,
+    runtimeCapDrop: opts.capDrop,
+    runtimeTmpfs: opts.tmpfs,
+  };
+}
+
+async function withLoadedConfig<T>(
+  handler: (ctx: {
+    config: OrchestratorConfig;
+    path: string;
+    rawConfig: RawConfig;
+  }) => Promise<T> | T,
+): Promise<T> {
+  return Promise.resolve()
+    .then(async () => {
+      const { config, path } = loadConfigWithPath();
+      const rawConfig = readRawConfig(path);
+      return handler({ config, path, rawConfig });
+    })
+    .catch((err) => {
+      if (err instanceof ConfigNotFoundError) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+      throw err;
+    });
+}
+
+export function registerDocker(program: Command): void {
+  const docker = program
+    .command("docker")
+    .description("Prepare first-time-user Docker images and runtime config");
+
+  docker
+    .command("prepare")
+    .description("Pull an official Docker image or build one locally, then configure a project to use it")
+    .argument("[project]", "Optional project ID; auto-detected when possible")
+    .option("--agent <name>", "Choose the worker agent (claude-code, codex, opencode, aider)")
+    .option("--image <image>", "Use this image reference instead of the official default")
+    .option("--build-local", "Build a local image instead of pulling the official one")
+    .option("--tag <image>", "Tag to use with --build-local (defaults to an agent-specific local tag)")
+    .option("--pull", "Pull the selected image before updating config")
+    .option("--no-pull", "Skip pulling the selected image before updating config")
+    .option("--cpus <cpus>", "Set project runtimeConfig.limits.cpus")
+    .option("--memory <memory>", "Set project runtimeConfig.limits.memory")
+    .option("--gpus <gpus>", "Set project runtimeConfig.limits.gpus")
+    .option("--read-only", "Set project runtimeConfig.readOnlyRoot=true")
+    .option("--network <network>", "Set project runtimeConfig.network")
+    .option("--cap-drop <cap>", "Append project runtimeConfig.capDrop entry", appendStringOption)
+    .option("--tmpfs <mount>", "Append project runtimeConfig.tmpfs entry", appendStringOption)
+    .action(async (projectArg: string | undefined, opts: DockerPrepareOptions) => {
+      try {
+        await withLoadedConfig(async ({ config, path, rawConfig }) => {
+          const projectId = resolveProjectId(config, projectArg);
+          const project = getProjectOrExit(config, projectId);
+          const agent = resolveWorkerAgent(config, project, opts.agent);
+          const template = getDockerTemplate(agent);
+
+          const image = opts.buildLocal
+            ? (opts.tag ?? opts.image ?? template.localTag)
+            : (opts.image ?? template.officialImage);
+
+          const tmpfs = [...(opts.tmpfs ?? [])];
+          if (opts.readOnly && !tmpfs.some((mount) => mount.split(":")[0]?.trim() === "/tmp")) {
+            tmpfs.push("/tmp");
+          }
+
+          await preflight.checkDocker({
+            image,
+            readOnlyRoot: opts.readOnly,
+            tmpfs,
+            ...(opts.cpus || opts.memory || opts.gpus
+              ? {
+                limits: {
+                  ...(opts.cpus ? { cpus: opts.cpus } : {}),
+                  ...(opts.memory ? { memory: opts.memory } : {}),
+                  ...(opts.gpus ? { gpus: opts.gpus } : {}),
+                },
+              }
+              : {}),
+          });
+
+          if (opts.buildLocal) {
+            await buildLocalImage(image, template);
+          } else if (opts.pull !== false) {
+            await pullImage(image);
+          }
+
+          const rawProjects = getRawProjects(rawConfig);
+          const rawProject = rawProjects[projectId] ?? {};
+          rawProjects[projectId] = rawProject;
+
+          const runtimeOverride = resolveRuntimeOverride(
+            config,
+            project,
+            toRuntimeOverrideOptions(image, {
+              ...opts,
+              tmpfs,
+            }),
+          );
+          const effectiveRuntimeConfig = runtimeOverride.effectiveRuntimeConfig;
+
+          rawProject["runtime"] = "docker";
+          if (effectiveRuntimeConfig && Object.keys(effectiveRuntimeConfig).length > 0) {
+            rawProject["runtimeConfig"] = effectiveRuntimeConfig;
+          }
+
+          writeRawConfig(path, rawConfig);
+
+          console.log(chalk.green(`Prepared Docker runtime for project "${projectId}"`));
+          console.log(chalk.dim(`  Agent:   ${agent}`));
+          console.log(chalk.dim(`  Image:   ${image}`));
+          console.log(chalk.dim(`  Config:  ${path}`));
+          console.log(chalk.dim(`  Next:    ao spawn --agent ${agent} "your task here"`));
+        });
+      } catch (err) {
+        console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/commands/docker.ts
+++ b/packages/cli/src/commands/docker.ts
@@ -90,6 +90,14 @@ function getRawProjects(rawConfig: RawConfig): Record<string, RawProjectConfig> 
   return rawConfig["projects"] as Record<string, RawProjectConfig>;
 }
 
+function getRawProjectRoleConfig(rawProject: RawProjectConfig, key: "worker" | "orchestrator"): RawProjectConfig {
+  const current = rawProject[key];
+  if (!isPlainObject(current)) {
+    rawProject[key] = {};
+  }
+  return rawProject[key] as RawProjectConfig;
+}
+
 function getProjectOrExit(config: OrchestratorConfig, projectId: string): ProjectConfig {
   const project = config.projects[projectId];
   if (project) return project;
@@ -302,6 +310,9 @@ export function registerDocker(program: Command): void {
           const rawProject = rawProjects[projectId] ?? {};
           rawProjects[projectId] = rawProject;
 
+          rawProject["agent"] = agent;
+          getRawProjectRoleConfig(rawProject, "worker")["agent"] = agent;
+          getRawProjectRoleConfig(rawProject, "orchestrator")["agent"] = agent;
           const runtimeOverride = resolveRuntimeOverride(
             config,
             project,
@@ -323,7 +334,7 @@ export function registerDocker(program: Command): void {
           console.log(chalk.dim(`  Agent:   ${agent}`));
           console.log(chalk.dim(`  Image:   ${image}`));
           console.log(chalk.dim(`  Config:  ${path}`));
-          console.log(chalk.dim(`  Next:    ao spawn --agent ${agent} "your task here"`));
+          console.log(chalk.dim(`  Next:    ao spawn "your task here"`));
         });
       } catch (err) {
         console.error(chalk.red(err instanceof Error ? err.message : String(err)));

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -372,11 +372,17 @@ function checkDockerAgentWarnings(config: OrchestratorConfig): void {
     for (const role of roles) {
       const agent = resolveProjectAgent(config, projectId, role);
       if (agent !== "claude-code") continue;
-      if (process.env["ANTHROPIC_API_KEY"]) continue;
+      if (
+        process.env["ANTHROPIC_API_KEY"] ||
+        process.env["ANTHROPIC_AUTH_TOKEN"] ||
+        process.env["CLAUDE_CODE_OAUTH_TOKEN"]
+      ) {
+        continue;
+      }
 
       warn(
-        `projects.${projectId} (${role}) uses Claude Code with docker, but ANTHROPIC_API_KEY is not set. ` +
-          "Claude host login may not carry into containers; prefer ANTHROPIC_API_KEY or container-native auth.",
+        `projects.${projectId} (${role}) uses Claude Code with docker, but no portable Claude auth is configured. ` +
+          "Claude host login may not carry into containers; prefer ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, or a prior Docker-side Claude login persisted in the mounted ~/.claude Docker config home.",
       );
       warned = true;
     }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -58,6 +58,36 @@ interface NotifierTarget {
   pluginName: string;
 }
 
+function resolveProjectRuntime(config: OrchestratorConfig, projectId: string): string | undefined {
+  const project = config.projects[projectId];
+  return project?.runtime ?? config.defaults.runtime;
+}
+
+function resolveProjectAgent(
+  config: OrchestratorConfig,
+  projectId: string,
+  role: "orchestrator" | "worker",
+): string | undefined {
+  const project = config.projects[projectId];
+  if (!project) return undefined;
+
+  if (role === "orchestrator") {
+    return (
+      project.orchestrator?.agent ??
+      project.agent ??
+      config.defaults.orchestrator?.agent ??
+      config.defaults.agent
+    );
+  }
+
+  return (
+    project.worker?.agent ??
+    project.agent ??
+    config.defaults.worker?.agent ??
+    config.defaults.agent
+  );
+}
+
 async function loadPluginRegistry(config: OrchestratorConfig): Promise<PluginRegistry> {
   const registry = createPluginRegistry();
   await registry.loadFromConfig(config, importPluginModuleFromSource);
@@ -329,6 +359,34 @@ async function checkNotifierConnectivity(
   }
 }
 
+function checkDockerAgentWarnings(config: OrchestratorConfig): void {
+  console.log("");
+  console.log("Docker agent portability:");
+
+  let warned = false;
+  for (const projectId of Object.keys(config.projects)) {
+    const runtime = resolveProjectRuntime(config, projectId);
+    if (runtime !== "docker") continue;
+
+    const roles: Array<"orchestrator" | "worker"> = ["orchestrator", "worker"];
+    for (const role of roles) {
+      const agent = resolveProjectAgent(config, projectId, role);
+      if (agent !== "claude-code") continue;
+      if (process.env["ANTHROPIC_API_KEY"]) continue;
+
+      warn(
+        `projects.${projectId} (${role}) uses Claude Code with docker, but ANTHROPIC_API_KEY is not set. ` +
+          "Claude host login may not carry into containers; prefer ANTHROPIC_API_KEY or container-native auth.",
+      );
+      warned = true;
+    }
+  }
+
+  if (!warned) {
+    pass("No known Docker agent portability warnings detected");
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Test-notify (Gap 3)
 // ---------------------------------------------------------------------------
@@ -428,6 +486,7 @@ export function registerDoctor(program: Command): void {
         try {
           config = loadConfig(configPath);
           registry = await checkPluginResolution(config, fail);
+          checkDockerAgentWarnings(config);
           await checkNotifierConnectivity(config, fail);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -1,20 +1,9 @@
 import chalk from "chalk";
 import type { Command } from "commander";
 import { loadConfig } from "@composio/ao-core";
-import { exec } from "../lib/shell.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
 import { formatAttachCommand } from "../lib/attach.js";
-
-async function openInTerminal(sessionName: string, newWindow?: boolean): Promise<boolean> {
-  try {
-    const args = newWindow ? ["--new-window", sessionName] : [sessionName];
-    await exec("open-iterm-tab", args);
-    return true;
-  } catch {
-    // Fall back to tmux attach hint
-    return false;
-  }
-}
+import { openInIterm } from "../lib/open-iterm.js";
 
 export function registerOpen(program: Command): void {
   program
@@ -57,15 +46,21 @@ export function registerOpen(program: Command): void {
         const runtimeName = session.runtimeHandle?.runtimeName ?? config.defaults.runtime;
         const targetName = session.runtimeHandle?.id ?? session.id;
         const attachInfo = await sm.getAttachInfo(session.id).catch(() => null);
-        const attachCommand = formatAttachCommand(attachInfo, `tmux attach -t ${targetName}`);
-        const opened =
-          runtimeName === "tmux" ? await openInTerminal(targetName, opts.newWindow) : false;
+        const attachCommand = formatAttachCommand(
+          attachInfo,
+          runtimeName === "tmux" ? `tmux attach -t ${targetName}` : "(attach command unavailable)",
+        );
+        const opened = await openInIterm({
+          tabTitle: targetName,
+          tmuxTarget: targetName,
+          runtimeName,
+          attachInfo,
+          newWindow: opts.newWindow,
+        });
         if (opened) {
           console.log(chalk.green(`  Opened: ${session.id}`));
         } else {
-          console.log(
-            `  ${chalk.yellow(session.id)} — attach with: ${chalk.dim(attachCommand)}`,
-          );
+          console.log(`  ${chalk.yellow(session.id)} — attach with: ${chalk.dim(attachCommand)}`);
         }
       }
       console.log();

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
 import type { Command } from "commander";
 import { loadConfig } from "@composio/ao-core";
-import { exec, getTmuxSessions } from "../lib/shell.js";
-import { matchesPrefix, stripHashPrefix } from "../lib/session-utils.js";
-import { DEFAULT_PORT } from "../lib/constants.js";
+import { exec } from "../lib/shell.js";
+import { getSessionManager } from "../lib/create-session-manager.js";
+import { formatAttachCommand } from "../lib/attach.js";
 
 async function openInTerminal(sessionName: string, newWindow?: boolean): Promise<boolean> {
   try {
@@ -24,25 +24,17 @@ export function registerOpen(program: Command): void {
     .option("-w, --new-window", "Open in a new terminal window")
     .action(async (target: string | undefined, opts: { newWindow?: boolean }) => {
       const config = loadConfig();
-      const allTmux = await getTmuxSessions();
+      const sm = await getSessionManager(config);
+      const allSessions = await sm.list();
 
-      let sessionsToOpen: string[] = [];
+      let sessionsToOpen = allSessions;
 
       if (!target || target === "all") {
-        // Open all sessions across all projects
-        for (const [projectId, project] of Object.entries(config.projects)) {
-          const prefix = project.sessionPrefix || projectId;
-          const matching = allTmux.filter((s) => matchesPrefix(s, prefix));
-          sessionsToOpen.push(...matching);
-        }
+        sessionsToOpen = allSessions;
       } else if (config.projects[target]) {
-        // Open all sessions for a specific project
-        const project = config.projects[target];
-        const prefix = project.sessionPrefix || target;
-        sessionsToOpen = allTmux.filter((s) => matchesPrefix(s, prefix));
-      } else if (allTmux.includes(target)) {
-        // Open a specific session
-        sessionsToOpen = [target];
+        sessionsToOpen = allSessions.filter((session) => session.projectId === target);
+      } else if (allSessions.some((session) => session.id === target)) {
+        sessionsToOpen = allSessions.filter((session) => session.id === target);
       } else {
         console.error(
           chalk.red(`Unknown target: ${target}\nSpecify a session name, project ID, or "all".`),
@@ -57,19 +49,22 @@ export function registerOpen(program: Command): void {
 
       console.log(
         chalk.bold(
-          `Opening ${sessionsToOpen.length} session${sessionsToOpen.length > 1 ? "s" : ""}...\n`,
+          `Opening ${sessionsToOpen.length} session${sessionsToOpen.length !== 1 ? "s" : ""}...\n`,
         ),
       );
 
-      const port = config.port ?? DEFAULT_PORT;
       for (const session of sessionsToOpen.sort()) {
-        const opened = await openInTerminal(session, opts.newWindow);
+        const runtimeName = session.runtimeHandle?.runtimeName ?? config.defaults.runtime;
+        const targetName = session.runtimeHandle?.id ?? session.id;
+        const attachInfo = await sm.getAttachInfo(session.id).catch(() => null);
+        const attachCommand = formatAttachCommand(attachInfo, `tmux attach -t ${targetName}`);
+        const opened =
+          runtimeName === "tmux" ? await openInTerminal(targetName, opts.newWindow) : false;
         if (opened) {
-          console.log(chalk.green(`  Opened: ${session}`));
+          console.log(chalk.green(`  Opened: ${session.id}`));
         } else {
-          const sessionId = stripHashPrefix(session);
           console.log(
-            `  ${chalk.yellow(session)} — view at: ${chalk.dim(`http://localhost:${port}/sessions/${sessionId}`)}`,
+            `  ${chalk.yellow(session.id)} — attach with: ${chalk.dim(attachCommand)}`,
           );
         }
       }

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -42,7 +42,7 @@ export function registerOpen(program: Command): void {
         ),
       );
 
-      for (const session of sessionsToOpen.sort()) {
+      for (const session of [...sessionsToOpen].sort((a, b) => a.id.localeCompare(b.id))) {
         const runtimeName = session.runtimeHandle?.runtimeName ?? config.defaults.runtime;
         const targetName = session.runtimeHandle?.id ?? session.id;
         const attachInfo = await sm.getAttachInfo(session.id).catch(() => null);

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1,0 +1,321 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  ConfigNotFoundError,
+  loadConfigWithPath,
+  type OrchestratorConfig,
+  type ProjectConfig,
+} from "@composio/ao-core";
+import { parse as yamlParse, stringify as yamlStringify } from "yaml";
+import {
+  appendStringOption,
+  resolveRuntimeOverride,
+  type RuntimeOverrideFlagOptions,
+} from "../lib/runtime-overrides.js";
+
+type RawConfig = Record<string, unknown>;
+type RawProjectConfig = Record<string, unknown>;
+
+interface RuntimeSetOptions {
+  config?: string;
+  image?: string;
+  cpus?: string;
+  memory?: string;
+  gpus?: string;
+  readOnly?: boolean;
+  network?: string;
+  capDrop?: string[];
+  tmpfs?: string[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readRawConfig(path: string): RawConfig {
+  const parsed = yamlParse(readFileSync(path, "utf-8"));
+  return isPlainObject(parsed) ? parsed : {};
+}
+
+function writeRawConfig(path: string, rawConfig: RawConfig): void {
+  writeFileSync(path, yamlStringify(rawConfig, { indent: 2 }), "utf-8");
+}
+
+function getRawProjects(rawConfig: RawConfig): Record<string, RawProjectConfig> {
+  if (!isPlainObject(rawConfig["projects"])) {
+    rawConfig["projects"] = {};
+  }
+  return rawConfig["projects"] as Record<string, RawProjectConfig>;
+}
+
+function getRawDefaults(rawConfig: RawConfig): Record<string, unknown> {
+  if (!isPlainObject(rawConfig["defaults"])) {
+    rawConfig["defaults"] = {};
+  }
+  return rawConfig["defaults"] as Record<string, unknown>;
+}
+
+function getProjectOrExit(config: OrchestratorConfig, projectId: string): ProjectConfig {
+  const project = config.projects[projectId];
+  if (project) return project;
+
+  console.error(
+    chalk.red(
+      `Project "${projectId}" not found. Available projects: ${Object.keys(config.projects).join(", ")}`,
+    ),
+  );
+  process.exit(1);
+}
+
+function hasConfigFlags(opts: RuntimeSetOptions): boolean {
+  return Boolean(
+    opts.config ||
+    opts.image ||
+    opts.cpus ||
+    opts.memory ||
+    opts.gpus ||
+    opts.readOnly ||
+    opts.network ||
+    (opts.capDrop && opts.capDrop.length > 0) ||
+    (opts.tmpfs && opts.tmpfs.length > 0),
+  );
+}
+
+function toRuntimeOverrideOptions(
+  runtime: string,
+  opts: RuntimeSetOptions,
+): RuntimeOverrideFlagOptions {
+  return {
+    runtime,
+    runtimeConfig: opts.config,
+    runtimeImage: opts.image,
+    runtimeCpus: opts.cpus,
+    runtimeMemory: opts.memory,
+    runtimeGpus: opts.gpus,
+    runtimeReadOnly: opts.readOnly,
+    runtimeNetwork: opts.network,
+    runtimeCapDrop: opts.capDrop,
+    runtimeTmpfs: opts.tmpfs,
+  };
+}
+
+function runtimeConfigImage(runtimeConfig: unknown): string | undefined {
+  if (!isPlainObject(runtimeConfig)) return undefined;
+  const image = runtimeConfig["image"];
+  return typeof image === "string" && image.trim().length > 0 ? image : undefined;
+}
+
+function printProjectRuntimeSummary(
+  projectId: string,
+  project: ProjectConfig,
+  rawProject: RawProjectConfig | undefined,
+  defaultRuntime: string,
+): void {
+  const configuredRuntime =
+    typeof rawProject?.["runtime"] === "string" ? rawProject["runtime"] : null;
+  const effectiveRuntime = project.runtime ?? defaultRuntime;
+  const image = runtimeConfigImage(rawProject?.["runtimeConfig"]);
+  const label = configuredRuntime ? configuredRuntime : `inherit (${effectiveRuntime})`;
+  const suffix = image ? ` image=${image}` : "";
+  console.log(`  ${projectId}: ${chalk.dim(label)}${suffix}`);
+}
+
+function withLoadedConfig<T>(
+  handler: (ctx: {
+    config: OrchestratorConfig;
+    path: string;
+    rawConfig: RawConfig;
+  }) => Promise<T> | T,
+): Promise<T> {
+  return Promise.resolve()
+    .then(async () => {
+      const { config, path } = loadConfigWithPath();
+      const rawConfig = readRawConfig(path);
+      return handler({ config, path, rawConfig });
+    })
+    .catch((err) => {
+      if (err instanceof ConfigNotFoundError) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+      throw err;
+    });
+}
+
+export function registerRuntime(program: Command): void {
+  const runtime = program.command("runtime").description("Inspect or update configured runtimes");
+
+  runtime
+    .command("show")
+    .description("Show configured runtime defaults and project overrides")
+    .argument("[project]", "Project ID to inspect")
+    .action(async (projectId?: string) => {
+      await withLoadedConfig(({ config, path, rawConfig }) => {
+        const rawProjects = getRawProjects(rawConfig);
+
+        if (projectId) {
+          const project = getProjectOrExit(config, projectId);
+          const rawProject = rawProjects[projectId];
+          const configuredRuntime =
+            typeof rawProject?.["runtime"] === "string" ? rawProject["runtime"] : "<inherit>";
+          const effectiveRuntime = project.runtime ?? config.defaults.runtime;
+          const runtimeConfig = isPlainObject(rawProject?.["runtimeConfig"])
+            ? rawProject["runtimeConfig"]
+            : undefined;
+
+          console.log(chalk.bold(projectId));
+          console.log(`  Config:            ${chalk.dim(path)}`);
+          console.log(`  Configured runtime: ${chalk.dim(configuredRuntime)}`);
+          console.log(`  Effective runtime:  ${chalk.dim(effectiveRuntime)}`);
+          if (runtimeConfig) {
+            console.log("  runtimeConfig:");
+            console.log(
+              JSON.stringify(runtimeConfig, null, 2)
+                .split("\n")
+                .map((line) => `    ${line}`)
+                .join("\n"),
+            );
+          } else {
+            console.log(`  runtimeConfig:      ${chalk.dim("<none>")}`);
+          }
+          return;
+        }
+
+        console.log(chalk.bold("Runtime configuration"));
+        console.log(`  Config:           ${chalk.dim(path)}`);
+        console.log(`  Default runtime:  ${chalk.dim(config.defaults.runtime)}`);
+        console.log("  Projects:");
+        for (const id of Object.keys(config.projects).sort()) {
+          printProjectRuntimeSummary(
+            id,
+            config.projects[id],
+            rawProjects[id],
+            config.defaults.runtime,
+          );
+        }
+      });
+    });
+
+  runtime
+    .command("set")
+    .description("Set the default runtime or a project-specific runtime override")
+    .argument("<runtime>", "Runtime name to set (tmux, docker, process, ...)")
+    .argument("[project]", "Optional project ID; omit to update defaults.runtime")
+    .option("--config <json>", "Merge JSON into project runtimeConfig")
+    .option("--image <image>", "Set project runtimeConfig.image")
+    .option("--cpus <cpus>", "Set project runtimeConfig.limits.cpus")
+    .option("--memory <memory>", "Set project runtimeConfig.limits.memory")
+    .option("--gpus <gpus>", "Set project runtimeConfig.limits.gpus")
+    .option("--read-only", "Set project runtimeConfig.readOnlyRoot=true")
+    .option("--network <network>", "Set project runtimeConfig.network")
+    .option("--cap-drop <cap>", "Append project runtimeConfig.capDrop entry", appendStringOption)
+    .option("--tmpfs <mount>", "Append project runtimeConfig.tmpfs entry", appendStringOption)
+    .action(async (runtimeName: string, projectId: string | undefined, opts: RuntimeSetOptions) => {
+      await withLoadedConfig(({ config, path, rawConfig }) => {
+        if (!projectId) {
+          if (hasConfigFlags(opts)) {
+            console.error(
+              chalk.red(
+                "Runtime config flags require a project argument; defaults only support runtime.",
+              ),
+            );
+            process.exit(1);
+          }
+
+          const rawDefaults = getRawDefaults(rawConfig);
+          rawDefaults["runtime"] = runtimeName;
+          writeRawConfig(path, rawConfig);
+
+          console.log(chalk.green(`Set defaults.runtime = ${runtimeName}`));
+          if (runtimeName === "docker") {
+            console.log(
+              chalk.yellow(
+                "Each project still needs runtimeConfig.image before Docker sessions can start.",
+              ),
+            );
+          }
+          return;
+        }
+
+        const project = getProjectOrExit(config, projectId);
+        const rawProjects = getRawProjects(rawConfig);
+        const rawProject = rawProjects[projectId] ?? {};
+        rawProjects[projectId] = rawProject;
+
+        const runtimeOverride = resolveRuntimeOverride(
+          config,
+          project,
+          toRuntimeOverrideOptions(runtimeName, opts),
+        );
+        const effectiveRuntimeConfig = runtimeOverride.effectiveRuntimeConfig;
+
+        if (runtimeName !== "docker" && hasConfigFlags(opts)) {
+          console.error(
+            chalk.red(
+              "Runtime config flags are currently supported only when setting runtime=docker.",
+            ),
+          );
+          process.exit(1);
+        }
+
+        if (runtimeName === "docker" && !runtimeConfigImage(effectiveRuntimeConfig)) {
+          console.error(
+            chalk.red(
+              `Project "${projectId}" needs runtimeConfig.image when runtime is docker. Use --image or set it in config first.`,
+            ),
+          );
+          process.exit(1);
+        }
+
+        rawProject["runtime"] = runtimeName;
+        if (effectiveRuntimeConfig && Object.keys(effectiveRuntimeConfig).length > 0) {
+          rawProject["runtimeConfig"] = effectiveRuntimeConfig;
+        } else {
+          delete rawProject["runtimeConfig"];
+        }
+
+        if (runtimeName !== "docker") {
+          delete rawProject["runtimeConfig"];
+        }
+
+        writeRawConfig(path, rawConfig);
+
+        console.log(chalk.green(`Set runtime for project "${projectId}" = ${runtimeName}`));
+        if (runtimeName === "docker" && effectiveRuntimeConfig) {
+          console.log(chalk.dim(`  runtimeConfig: ${JSON.stringify(effectiveRuntimeConfig)}`));
+        }
+      });
+    });
+
+  runtime
+    .command("clear")
+    .description("Clear the default runtime or a project-specific runtime override")
+    .argument("[project]", "Optional project ID; omit to clear defaults.runtime")
+    .action(async (projectId?: string) => {
+      await withLoadedConfig(({ config, path, rawConfig }) => {
+        if (!projectId) {
+          const rawDefaults = getRawDefaults(rawConfig);
+          delete rawDefaults["runtime"];
+          writeRawConfig(path, rawConfig);
+          console.log(
+            chalk.green("Cleared defaults.runtime; effective default falls back to tmux."),
+          );
+          return;
+        }
+
+        getProjectOrExit(config, projectId);
+        const rawProjects = getRawProjects(rawConfig);
+        const rawProject = rawProjects[projectId] ?? {};
+        delete rawProject["runtime"];
+        delete rawProject["runtimeConfig"];
+        rawProjects[projectId] = rawProject;
+        writeRawConfig(path, rawConfig);
+        console.log(
+          chalk.green(
+            `Cleared runtime override for project "${projectId}"; it now inherits ${config.defaults.runtime}.`,
+          ),
+        );
+      });
+    });
+}

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import chalk from "chalk";
 import type { Command } from "commander";
 import { loadConfig, SessionNotRestorableError, WorkspaceMissingError } from "@composio/ao-core";
@@ -7,6 +6,7 @@ import { git, getTmuxActivity, tmux } from "../lib/shell.js";
 import { formatAge } from "../lib/format.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
 import { isOrchestratorSessionName } from "../lib/session-utils.js";
+import { formatAttachCommand, runAttachCommand } from "../lib/attach.js";
 
 export function registerSession(program: Command): void {
   const session = program
@@ -64,8 +64,11 @@ export function registerSession(program: Command): void {
 
         const activities = await Promise.all(
           projectSessions.map((s) => {
-            const tmuxTarget = s.runtimeHandle?.id ?? s.id;
-            return getTmuxActivity(tmuxTarget).catch(() => null);
+            if (!s.runtimeHandle || s.runtimeHandle.runtimeName === "tmux") {
+              const tmuxTarget = s.runtimeHandle?.id ?? s.id;
+              return getTmuxActivity(tmuxTarget).catch(() => s.lastActivityAt.getTime());
+            }
+            return Promise.resolve(s.lastActivityAt.getTime());
           }),
         );
 
@@ -99,23 +102,26 @@ export function registerSession(program: Command): void {
       const sm = await getSessionManager(config);
       const sessionInfo = await sm.get(sessionName);
       const tmuxTarget = sessionInfo?.runtimeHandle?.id ?? sessionName;
+      const runtimeName = sessionInfo?.runtimeHandle?.runtimeName ?? "tmux";
+      const fallbackCommand = `tmux attach -t ${tmuxTarget}`;
+      const attachInfo = await sm.getAttachInfo(sessionName).catch(() => null);
 
-      const exists = await tmux("has-session", "-t", tmuxTarget);
-      if (exists === null) {
-        console.error(chalk.red(`Session '${sessionName}' does not exist`));
+      if (runtimeName === "tmux") {
+        const exists = await tmux("has-session", "-t", tmuxTarget);
+        if (exists === null) {
+          console.error(chalk.red(`Session '${sessionName}' does not exist`));
+          process.exit(1);
+        }
+      } else if (!attachInfo) {
+        console.error(
+          chalk.red(`Session '${sessionName}' does not expose an attach command for runtime '${runtimeName}'`),
+        );
         process.exit(1);
       }
 
-      await new Promise<void>((resolve, reject) => {
-        const child = spawn("tmux", ["attach", "-t", tmuxTarget], { stdio: "inherit" });
-        child.once("error", (err) => reject(err));
-        child.once("exit", (code) => {
-          if (code === 0 || code === null) {
-            resolve();
-            return;
-          }
-          reject(new Error(`tmux attach exited with code ${code}`));
-        });
+      await runAttachCommand(attachInfo, {
+        program: "tmux",
+        args: ["attach", "-t", tmuxTarget],
       }).catch((err) => {
         console.error(chalk.red(`Failed to attach to session ${sessionName}: ${err}`));
         process.exit(1);
@@ -304,6 +310,13 @@ export function registerSession(program: Command): void {
         }
         const port = config.port ?? DEFAULT_PORT;
         console.log(chalk.dim(`  View:     http://localhost:${port}/sessions/${sessionName}`));
+        const tmuxTarget = restored.runtimeHandle?.id ?? sessionName;
+        const attachInfo = await sm.getAttachInfo(sessionName).catch(() => null);
+        console.log(
+          chalk.dim(
+            `  Attach:   ${formatAttachCommand(attachInfo, `tmux attach -t ${tmuxTarget}`)}`,
+          ),
+        );
       } catch (err) {
         if (err instanceof SessionNotRestorableError) {
           console.error(chalk.red(`Cannot restore: ${err.reason}`));

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -103,7 +103,6 @@ export function registerSession(program: Command): void {
       const sessionInfo = await sm.get(sessionName);
       const tmuxTarget = sessionInfo?.runtimeHandle?.id ?? sessionName;
       const runtimeName = sessionInfo?.runtimeHandle?.runtimeName ?? "tmux";
-      const fallbackCommand = `tmux attach -t ${tmuxTarget}`;
       const attachInfo = await sm.getAttachInfo(sessionName).catch(() => null);
 
       if (runtimeName === "tmux") {

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -20,6 +20,13 @@ import { getSessionManager } from "../lib/create-session-manager.js";
 import { ensureLifecycleWorker } from "../lib/lifecycle-service.js";
 import { preflight } from "../lib/preflight.js";
 import { findProjectForDirectory } from "../lib/project-resolution.js";
+import { formatAttachCommand } from "../lib/attach.js";
+import {
+  appendStringOption,
+  resolveRuntimeOverride,
+  type RuntimeOverride,
+  type RuntimeOverrideFlagOptions,
+} from "../lib/runtime-overrides.js";
 
 /**
  * Auto-detect the project ID from the config.
@@ -68,13 +75,14 @@ interface SpawnClaimOptions {
 async function runSpawnPreflight(
   config: OrchestratorConfig,
   projectId: string,
+  runtimeOverride: RuntimeOverride,
   options?: SpawnClaimOptions,
 ): Promise<void> {
   const project = config.projects[projectId];
-  const runtime = project?.runtime ?? config.defaults.runtime;
-  if (runtime === "tmux") {
-    await preflight.checkTmux();
-  }
+  await preflight.checkRuntime(
+    runtimeOverride.effectiveRuntime,
+    runtimeOverride.effectiveRuntimeConfig,
+  );
   const needsGitHubAuth =
     project?.tracker?.plugin === "github" ||
     (options?.claimPr && project?.scm?.plugin === "github");
@@ -89,6 +97,7 @@ async function spawnSession(
   issueId?: string,
   openTab?: boolean,
   agent?: string,
+  runtimeOverride?: Pick<RuntimeOverride, "runtime" | "runtimeConfig">,
   claimOptions?: SpawnClaimOptions,
 ): Promise<string> {
   const spinner = ora("Creating session").start();
@@ -100,7 +109,9 @@ async function spawnSession(
     const session = await sm.spawn({
       projectId,
       issueId,
-      agent,
+      ...(agent ? { agent } : {}),
+      ...(runtimeOverride?.runtime ? { runtime: runtimeOverride.runtime } : {}),
+      ...(runtimeOverride?.runtimeConfig ? { runtimeConfig: runtimeOverride.runtimeConfig } : {}),
     });
 
     let claimedPrUrl: string | null = null;
@@ -138,9 +149,15 @@ async function spawnSession(
         ),
       );
     }
+    const tmuxTarget = session.runtimeHandle?.id ?? session.id;
+    const attachInfo = await sm.getAttachInfo(session.id).catch(() => null);
+    console.log(
+      `  Attach:   ${chalk.dim(formatAttachCommand(attachInfo, `tmux attach -t ${tmuxTarget}`))}`,
+    );
+    console.log();
 
     // Open terminal tab if requested
-    if (openTab) {
+    if (openTab && (attachInfo?.type ?? session.runtimeHandle?.runtimeName) === "tmux") {
       try {
         const tmuxTarget = session.runtimeHandle?.id ?? session.id;
         await exec("open-iterm-tab", [tmuxTarget]);
@@ -166,6 +183,26 @@ export function registerSpawn(program: Command): void {
     .argument("[second]", "" /* hidden second arg to catch old two-arg usage */)
     .option("--open", "Open session in terminal tab")
     .option("--agent <name>", "Override the agent plugin (e.g. codex, claude-code)")
+    .option("--runtime <name>", "Override the runtime plugin (e.g. tmux, docker)")
+    .option("--runtime-image <image>", "Override runtimeConfig.image for docker runtime")
+    .option("--runtime-config <json>", "Override runtimeConfig with a JSON object")
+    .option("--runtime-cpus <cpus>", "Override runtimeConfig.limits.cpus for docker runtime")
+    .option("--runtime-memory <memory>", "Override runtimeConfig.limits.memory for docker runtime")
+    .option("--runtime-gpus <gpus>", "Override runtimeConfig.limits.gpus for docker runtime")
+    .option("--runtime-read-only", "Set runtimeConfig.readOnlyRoot=true for docker runtime")
+    .option("--runtime-network <network>", "Override runtimeConfig.network for docker runtime")
+    .option(
+      "--runtime-cap-drop <cap>",
+      "Append a runtimeConfig.capDrop entry for docker runtime (repeatable)",
+      appendStringOption,
+      [],
+    )
+    .option(
+      "--runtime-tmpfs <mount>",
+      "Append a runtimeConfig.tmpfs entry for docker runtime (repeatable)",
+      appendStringOption,
+      [],
+    )
     .option("--claim-pr <pr>", "Immediately claim an existing PR for the spawned session")
     .option("--assign-on-github", "Assign the claimed PR to the authenticated GitHub user")
     .option("--decompose", "Decompose issue into subtasks before spawning")
@@ -181,6 +218,16 @@ export function registerSpawn(program: Command): void {
           assignOnGithub?: boolean;
           decompose?: boolean;
           maxDepth?: string;
+          runtime?: string;
+          runtimeConfig?: string;
+          runtimeImage?: string;
+          runtimeCpus?: string;
+          runtimeMemory?: string;
+          runtimeGpus?: string;
+          runtimeReadOnly?: boolean;
+          runtimeNetwork?: string;
+          runtimeCapDrop?: string[];
+          runtimeTmpfs?: string[];
         },
       ) => {
         // Catch old two-arg usage: ao spawn <project> <issue>
@@ -229,7 +276,8 @@ export function registerSpawn(program: Command): void {
         };
 
         try {
-          await runSpawnPreflight(config, projectId, claimOptions);
+          const runtimeOverride = resolveRuntimeOverride(config, config.projects[projectId], opts);
+          await runSpawnPreflight(config, projectId, runtimeOverride, claimOptions);
           await ensureLifecycleWorker(config, projectId);
 
           if (opts.decompose && issueId) {
@@ -256,7 +304,15 @@ export function registerSpawn(program: Command): void {
 
             if (leaves.length <= 1) {
               console.log(chalk.yellow("Task is atomic — spawning directly."));
-              await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions);
+              await spawnSession(
+                config,
+                projectId,
+                issueId,
+                opts.open,
+                opts.agent,
+                runtimeOverride,
+                claimOptions,
+              );
             } else {
               // Create child issues and spawn sessions with lineage context
               const sm = await getSessionManager(config);
@@ -271,7 +327,11 @@ export function registerSpawn(program: Command): void {
                     issueId, // All work on the same parent issue for now
                     lineage: leaf.lineage,
                     siblings,
-                    agent: opts.agent,
+                    ...(opts.agent ? { agent: opts.agent } : {}),
+                    ...(runtimeOverride.runtime ? { runtime: runtimeOverride.runtime } : {}),
+                    ...(runtimeOverride.runtimeConfig
+                      ? { runtimeConfig: runtimeOverride.runtimeConfig }
+                      : {}),
                   });
                   console.log(`  ${chalk.green("✓")} ${session.id} — ${leaf.description}`);
                 } catch (err) {
@@ -283,7 +343,15 @@ export function registerSpawn(program: Command): void {
               }
             }
           } else {
-            await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions);
+            await spawnSession(
+              config,
+              projectId,
+              issueId,
+              opts.open,
+              opts.agent,
+              runtimeOverride,
+              claimOptions,
+            );
           }
         } catch (err) {
           console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
@@ -299,111 +367,161 @@ export function registerBatchSpawn(program: Command): void {
     .description("Spawn sessions for multiple issues with duplicate detection")
     .argument("<issues...>", "Issue identifiers (project is auto-detected)")
     .option("--open", "Open sessions in terminal tabs")
-    .action(async (issues: string[], opts: { open?: boolean }) => {
-      const config = loadConfig();
-      let projectId: string;
-
-      try {
-        projectId = autoDetectProject(config);
-      } catch (err) {
-        console.error(chalk.red(err instanceof Error ? err.message : String(err)));
-        process.exit(1);
-      }
-
-      if (!config.projects[projectId]) {
-        console.error(
-          chalk.red(
-            `Unknown project: ${projectId}\nAvailable: ${Object.keys(config.projects).join(", ")}`,
-          ),
-        );
-        process.exit(1);
-      }
-
-      console.log(banner("BATCH SESSION SPAWNER"));
-      console.log();
-      console.log(`  Project: ${chalk.bold(projectId)}`);
-      console.log(`  Issues:  ${issues.join(", ")}`);
-      console.log();
-
-      // Pre-flight once before the loop so a missing prerequisite fails fast
-      try {
-        await runSpawnPreflight(config, projectId);
-        await ensureLifecycleWorker(config, projectId);
-      } catch (err) {
-        console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
-        process.exit(1);
-      }
-
-      const sm = await getSessionManager(config);
-      const created: Array<{ session: string; issue: string }> = [];
-      const skipped: Array<{ issue: string; existing: string }> = [];
-      const failed: Array<{ issue: string; error: string }> = [];
-      const spawnedIssues = new Set<string>();
-
-      // Load existing sessions once before the loop to avoid repeated reads + enrichment.
-      // Exclude terminal sessions so completed/merged sessions don't block respawning
-      // (e.g. when an issue is reopened after its PR was merged).
-      const existingSessions = await sm.list(projectId);
-      const existingIssueMap = new Map(
-        existingSessions
-          .filter((s) => s.issueId && !TERMINAL_STATUSES.has(s.status))
-          .map((s) => [s.issueId!.toLowerCase(), s.id]),
-      );
-
-      for (const issue of issues) {
-        // Duplicate detection — check both existing sessions and same-run duplicates
-        if (spawnedIssues.has(issue.toLowerCase())) {
-          console.log(chalk.yellow(`  Skip ${issue} — duplicate in this batch`));
-          skipped.push({ issue, existing: "(this batch)" });
-          continue;
-        }
-
-        // Check existing sessions (pre-loaded before loop)
-        const existingSessionId = existingIssueMap.get(issue.toLowerCase());
-        if (existingSessionId) {
-          console.log(chalk.yellow(`  Skip ${issue} — already has session ${existingSessionId}`));
-          skipped.push({ issue, existing: existingSessionId });
-          continue;
-        }
+    .option("--runtime <name>", "Override the runtime plugin (e.g. tmux, docker)")
+    .option("--runtime-image <image>", "Override runtimeConfig.image for docker runtime")
+    .option("--runtime-config <json>", "Override runtimeConfig with a JSON object")
+    .option("--runtime-cpus <cpus>", "Override runtimeConfig.limits.cpus for docker runtime")
+    .option("--runtime-memory <memory>", "Override runtimeConfig.limits.memory for docker runtime")
+    .option("--runtime-gpus <gpus>", "Override runtimeConfig.limits.gpus for docker runtime")
+    .option("--runtime-read-only", "Set runtimeConfig.readOnlyRoot=true for docker runtime")
+    .option("--runtime-network <network>", "Override runtimeConfig.network for docker runtime")
+    .option(
+      "--runtime-cap-drop <cap>",
+      "Append a runtimeConfig.capDrop entry for docker runtime (repeatable)",
+      appendStringOption,
+      [],
+    )
+    .option(
+      "--runtime-tmpfs <mount>",
+      "Append a runtimeConfig.tmpfs entry for docker runtime (repeatable)",
+      appendStringOption,
+      [],
+    )
+    .action(
+      async (
+        issues: string[],
+        opts: {
+          open?: boolean;
+          runtime?: string;
+          runtimeConfig?: string;
+          runtimeImage?: string;
+          runtimeCpus?: string;
+          runtimeMemory?: string;
+          runtimeGpus?: string;
+          runtimeReadOnly?: boolean;
+          runtimeNetwork?: string;
+          runtimeCapDrop?: string[];
+          runtimeTmpfs?: string[];
+        },
+      ) => {
+        const config = loadConfig();
+        let projectId: string;
 
         try {
-          const session = await sm.spawn({ projectId, issueId: issue });
-          created.push({ session: session.id, issue });
-          spawnedIssues.add(issue.toLowerCase());
-          console.log(chalk.green(`  Created ${session.id} for ${issue}`));
+          projectId = autoDetectProject(config);
+        } catch (err) {
+          console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+          process.exit(1);
+        }
 
-          if (opts.open) {
+        if (!config.projects[projectId]) {
+          console.error(
+            chalk.red(
+              `Unknown project: ${projectId}\nAvailable: ${Object.keys(config.projects).join(", ")}`,
+            ),
+          );
+          process.exit(1);
+        }
+
+        console.log(banner("BATCH SESSION SPAWNER"));
+        console.log();
+        console.log(`  Project: ${chalk.bold(projectId)}`);
+        console.log(`  Issues:  ${issues.join(", ")}`);
+        console.log();
+
+        // Pre-flight once before the loop so a missing prerequisite fails fast
+        try {
+          const runtimeOverride = resolveRuntimeOverride(config, config.projects[projectId], opts);
+          await runSpawnPreflight(config, projectId, runtimeOverride);
+          await ensureLifecycleWorker(config, projectId);
+          const sm = await getSessionManager(config);
+          const created: Array<{ session: string; issue: string }> = [];
+          const skipped: Array<{ issue: string; existing: string }> = [];
+          const failed: Array<{ issue: string; error: string }> = [];
+          const spawnedIssues = new Set<string>();
+
+          // Load existing sessions once before the loop to avoid repeated reads + enrichment.
+          // Exclude terminal sessions so completed/merged sessions don't block respawning
+          // (e.g. when an issue is reopened after its PR was merged).
+          const existingSessions = await sm.list(projectId);
+          const existingIssueMap = new Map(
+            existingSessions
+              .filter((s) => s.issueId && !TERMINAL_STATUSES.has(s.status))
+              .map((s) => [s.issueId!.toLowerCase(), s.id]),
+          );
+
+          for (const issue of issues) {
+            // Duplicate detection — check both existing sessions and same-run duplicates
+            if (spawnedIssues.has(issue.toLowerCase())) {
+              console.log(chalk.yellow(`  Skip ${issue} — duplicate in this batch`));
+              skipped.push({ issue, existing: "(this batch)" });
+              continue;
+            }
+
+            // Check existing sessions (pre-loaded before loop)
+            const existingSessionId = existingIssueMap.get(issue.toLowerCase());
+            if (existingSessionId) {
+              console.log(
+                chalk.yellow(`  Skip ${issue} — already has session ${existingSessionId}`),
+              );
+              skipped.push({ issue, existing: existingSessionId });
+              continue;
+            }
+
             try {
-              const tmuxTarget = session.runtimeHandle?.id ?? session.id;
-              await exec("open-iterm-tab", [tmuxTarget]);
-            } catch {
-              // best effort
+              const session = await sm.spawn({
+                projectId,
+                issueId: issue,
+                ...(runtimeOverride.runtime ? { runtime: runtimeOverride.runtime } : {}),
+                ...(runtimeOverride.runtimeConfig
+                  ? { runtimeConfig: runtimeOverride.runtimeConfig }
+                  : {}),
+              });
+              created.push({ session: session.id, issue });
+              spawnedIssues.add(issue.toLowerCase());
+              console.log(chalk.green(`  Created ${session.id} for ${issue}`));
+
+              if (opts.open) {
+                try {
+                  if ((session.runtimeHandle?.runtimeName ?? config.defaults.runtime) === "tmux") {
+                    const tmuxTarget = session.runtimeHandle?.id ?? session.id;
+                    await exec("open-iterm-tab", [tmuxTarget]);
+                  }
+                } catch {
+                  // best effort
+                }
+              }
+            } catch (err) {
+              failed.push({
+                issue,
+                error: err instanceof Error ? err.message : String(err),
+              });
+              console.log(
+                chalk.red(
+                  `  Failed ${issue} — ${err instanceof Error ? err.message : String(err)}`,
+                ),
+              );
             }
           }
-        } catch (err) {
-          failed.push({
-            issue,
-            error: err instanceof Error ? err.message : String(err),
-          });
-          console.log(
-            chalk.red(`  Failed ${issue} — ${err instanceof Error ? err.message : String(err)}`),
-          );
-        }
-      }
 
-      console.log();
-      if (created.length > 0) {
-        console.log(chalk.green(`Created ${created.length} sessions:`));
-        for (const item of created) console.log(`  ${item.session} ← ${item.issue}`);
-      }
-      if (skipped.length > 0) {
-        console.log(chalk.yellow(`Skipped ${skipped.length} issues:`));
-        for (const item of skipped) console.log(`  ${item.issue} (existing: ${item.existing})`);
-      }
-      if (failed.length > 0) {
-        console.log(chalk.red(`Failed ${failed.length} issues:`));
-        for (const item of failed) console.log(`  ${item.issue}: ${item.error}`);
-      }
-      console.log();
-    });
+          console.log();
+          if (created.length > 0) {
+            console.log(chalk.green(`Created ${created.length} sessions:`));
+            for (const item of created) console.log(`  ${item.session} ← ${item.issue}`);
+          }
+          if (skipped.length > 0) {
+            console.log(chalk.yellow(`Skipped ${skipped.length} issues:`));
+            for (const item of skipped) console.log(`  ${item.issue} (existing: ${item.existing})`);
+          }
+          if (failed.length > 0) {
+            console.log(chalk.red(`Failed ${failed.length} issues:`));
+            for (const item of failed) console.log(`  ${item.issue}: ${item.error}`);
+          }
+          console.log();
+        } catch (err) {
+          console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+          process.exit(1);
+        }
+      },
+    );
 }

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -15,7 +15,7 @@ import {
 } from "@composio/ao-core";
 import { DEFAULT_PORT } from "../lib/constants.js";
 import { banner } from "../lib/format.js";
-import { getSessionManager } from "../lib/create-session-manager.js";
+import { getPluginRegistry, getSessionManager } from "../lib/create-session-manager.js";
 import { ensureLifecycleWorker } from "../lib/lifecycle-service.js";
 import { preflight } from "../lib/preflight.js";
 import { findProjectForDirectory } from "../lib/project-resolution.js";
@@ -78,9 +78,12 @@ async function runSpawnPreflight(
   options?: SpawnClaimOptions,
 ): Promise<void> {
   const project = config.projects[projectId];
+  const registry = await getPluginRegistry(config);
+  const knownRuntimeNames = registry.list("runtime").map((plugin) => plugin.name);
   await preflight.checkRuntime(
     runtimeOverride.effectiveRuntime,
     runtimeOverride.effectiveRuntimeConfig,
+    knownRuntimeNames,
   );
   const needsGitHubAuth =
     project?.tracker?.plugin === "github" ||

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -21,6 +21,7 @@ import { ensureLifecycleWorker } from "../lib/lifecycle-service.js";
 import { preflight } from "../lib/preflight.js";
 import { findProjectForDirectory } from "../lib/project-resolution.js";
 import { formatAttachCommand } from "../lib/attach.js";
+import { openInIterm } from "../lib/open-iterm.js";
 import {
   appendStringOption,
   resolveRuntimeOverride,
@@ -151,19 +152,25 @@ async function spawnSession(
     }
     const tmuxTarget = session.runtimeHandle?.id ?? session.id;
     const attachInfo = await sm.getAttachInfo(session.id).catch(() => null);
+    const runtimeName = session.runtimeHandle?.runtimeName ?? config.defaults.runtime;
     console.log(
-      `  Attach:   ${chalk.dim(formatAttachCommand(attachInfo, `tmux attach -t ${tmuxTarget}`))}`,
+      `  Attach:   ${chalk.dim(
+        formatAttachCommand(
+          attachInfo,
+          runtimeName === "tmux" ? `tmux attach -t ${tmuxTarget}` : "(attach command unavailable)",
+        ),
+      )}`,
     );
     console.log();
 
     // Open terminal tab if requested
-    if (openTab && (attachInfo?.type ?? session.runtimeHandle?.runtimeName) === "tmux") {
-      try {
-        const tmuxTarget = session.runtimeHandle?.id ?? session.id;
-        await exec("open-iterm-tab", [tmuxTarget]);
-      } catch {
-        // Terminal plugin not available
-      }
+    if (openTab) {
+      await openInIterm({
+        tabTitle: tmuxTarget,
+        tmuxTarget,
+        runtimeName,
+        attachInfo,
+      });
     }
 
     // Output for scripting
@@ -482,14 +489,14 @@ export function registerBatchSpawn(program: Command): void {
               console.log(chalk.green(`  Created ${session.id} for ${issue}`));
 
               if (opts.open) {
-                try {
-                  if ((session.runtimeHandle?.runtimeName ?? config.defaults.runtime) === "tmux") {
-                    const tmuxTarget = session.runtimeHandle?.id ?? session.id;
-                    await exec("open-iterm-tab", [tmuxTarget]);
-                  }
-                } catch {
-                  // best effort
-                }
+                const tmuxTarget = session.runtimeHandle?.id ?? session.id;
+                const attachInfo = await sm.getAttachInfo(session.id).catch(() => null);
+                await openInIterm({
+                  tabTitle: tmuxTarget,
+                  tmuxTarget,
+                  runtimeName: session.runtimeHandle?.runtimeName ?? config.defaults.runtime,
+                  attachInfo,
+                });
               }
             } catch (err) {
               failed.push({

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -14,7 +14,6 @@ import {
   DEFAULT_DECOMPOSER_CONFIG,
 } from "@composio/ao-core";
 import { DEFAULT_PORT } from "../lib/constants.js";
-import { exec } from "../lib/shell.js";
 import { banner } from "../lib/format.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
 import { ensureLifecycleWorker } from "../lib/lifecycle-service.js";
@@ -26,7 +25,6 @@ import {
   appendStringOption,
   resolveRuntimeOverride,
   type RuntimeOverride,
-  type RuntimeOverrideFlagOptions,
 } from "../lib/runtime-overrides.js";
 
 /**
@@ -451,10 +449,12 @@ export function registerBatchSpawn(program: Command): void {
           // Exclude terminal sessions so completed/merged sessions don't block respawning
           // (e.g. when an issue is reopened after its PR was merged).
           const existingSessions = await sm.list(projectId);
+          const sessionsWithIssues = existingSessions.filter(
+            (s): s is typeof s & { issueId: string } =>
+              typeof s.issueId === "string" && !TERMINAL_STATUSES.has(s.status),
+          );
           const existingIssueMap = new Map(
-            existingSessions
-              .filter((s) => s.issueId && !TERMINAL_STATUSES.has(s.status))
-              .map((s) => [s.issueId!.toLowerCase(), s.id]),
+            sessionsWithIssues.map((s) => [s.issueId.toLowerCase(), s.id]),
           );
 
           for (const issue of issues) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -949,8 +949,6 @@ async function runStartup(
     const knownRuntimeNames = registry.list("runtime").map((plugin) => plugin.name);
     if (runtimeOverride.effectiveRuntime === "tmux") {
       await ensureTmux();
-    } else if (runtimeOverride.effectiveRuntime === "docker") {
-      await preflight.checkDocker(runtimeOverride.effectiveRuntimeConfig);
     } else {
       await preflight.checkRuntime(
         runtimeOverride.effectiveRuntime,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -37,7 +37,7 @@ import {
 } from "@composio/ao-core";
 import { parse as yamlParse, stringify as yamlStringify } from "yaml";
 import { exec, execSilent, git } from "../lib/shell.js";
-import { getSessionManager } from "../lib/create-session-manager.js";
+import { getPluginRegistry, getSessionManager } from "../lib/create-session-manager.js";
 import { ensureLifecycleWorker, stopLifecycleWorker } from "../lib/lifecycle-service.js";
 import {
   findWebDir,
@@ -946,6 +946,8 @@ async function runStartup(
 
   // Only require runtime dependencies when we are actually starting the orchestrator.
   if (opts?.orchestrator !== false) {
+    const registry = await getPluginRegistry(config);
+    const knownRuntimeNames = registry.list("runtime").map((plugin) => plugin.name);
     if (runtimeOverride.effectiveRuntime === "tmux") {
       await ensureTmux();
     } else if (runtimeOverride.effectiveRuntime === "docker") {
@@ -954,6 +956,7 @@ async function runStartup(
       await preflight.checkRuntime(
         runtimeOverride.effectiveRuntime,
         runtimeOverride.effectiveRuntimeConfig,
+        knownRuntimeNames,
       );
     }
   }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -50,10 +50,20 @@ import {
 } from "../lib/web-dir.js";
 import { rebuildDashboardProductionArtifacts } from "../lib/dashboard-rebuild.js";
 import { preflight } from "../lib/preflight.js";
-import { register, unregister, isAlreadyRunning, getRunning, waitForExit } from "../lib/running-state.js";
+import {
+  register,
+  unregister,
+  isAlreadyRunning,
+  getRunning,
+  waitForExit,
+} from "../lib/running-state.js";
 import { isHumanCaller } from "../lib/caller-context.js";
 import { detectEnvironment } from "../lib/detect-env.js";
-import { detectAgentRuntime, detectAvailableAgents, type DetectedAgent } from "../lib/detect-agent.js";
+import {
+  detectAgentRuntime,
+  detectAvailableAgents,
+  type DetectedAgent,
+} from "../lib/detect-agent.js";
 import { detectDefaultBranch } from "../lib/git-utils.js";
 import { promptConfirm, promptSelect } from "../lib/prompts.js";
 import {
@@ -65,6 +75,13 @@ import { formatCommandError } from "../lib/cli-errors.js";
 import { detectOpenClawInstallation } from "../lib/openclaw-probe.js";
 import { applyOpenClawCredentials } from "../lib/credential-resolver.js";
 import { findProjectForDirectory } from "../lib/project-resolution.js";
+import { formatAttachCommand } from "../lib/attach.js";
+import {
+  appendStringOption,
+  resolveRuntimeOverride,
+  type RuntimeOverride,
+  type RuntimeOverrideFlagOptions,
+} from "../lib/runtime-overrides.js";
 
 import { DEFAULT_PORT } from "../lib/constants.js";
 const IS_TTY = Boolean(process.stdin.isTTY && process.stdout.isTTY);
@@ -230,7 +247,11 @@ function gitInstallAttempts(): InstallAttempt[] {
   }
   if (process.platform === "linux") {
     return [
-      { cmd: "sudo", args: ["apt-get", "install", "-y", "git"], label: "sudo apt-get install -y git" },
+      {
+        cmd: "sudo",
+        args: ["apt-get", "install", "-y", "git"],
+        label: "sudo apt-get install -y git",
+      },
       { cmd: "sudo", args: ["dnf", "install", "-y", "git"], label: "sudo dnf install -y git" },
     ];
   }
@@ -249,10 +270,7 @@ function gitInstallAttempts(): InstallAttempt[] {
 function gitInstallHints(): string[] {
   if (process.platform === "darwin") return ["brew install git"];
   if (process.platform === "win32") return ["winget install --id Git.Git -e --source winget"];
-  return [
-    "sudo apt install git      # Debian/Ubuntu",
-    "sudo dnf install git      # Fedora/RHEL",
-  ];
+  return ["sudo apt install git      # Debian/Ubuntu", "sudo dnf install git      # Fedora/RHEL"];
 }
 
 function ghInstallAttempts(): InstallAttempt[] {
@@ -261,7 +279,11 @@ function ghInstallAttempts(): InstallAttempt[] {
   }
   if (process.platform === "linux") {
     return [
-      { cmd: "sudo", args: ["apt-get", "install", "-y", "gh"], label: "sudo apt-get install -y gh" },
+      {
+        cmd: "sudo",
+        args: ["apt-get", "install", "-y", "gh"],
+        label: "sudo apt-get install -y gh",
+      },
       { cmd: "sudo", args: ["dnf", "install", "-y", "gh"], label: "sudo dnf install -y gh" },
     ];
   }
@@ -616,7 +638,9 @@ async function autoCreateConfig(workingDir: string): Promise<OrchestratorConfig>
     console.log(chalk.yellow("⚠ tmux not found — will prompt to install at startup"));
   }
   if (!env.hasGh) {
-    console.log(chalk.yellow("⚠ GitHub CLI (gh) not found — optional, but recommended for GitHub workflows."));
+    console.log(
+      chalk.yellow("⚠ GitHub CLI (gh) not found — optional, but recommended for GitHub workflows."),
+    );
     const shouldInstallGh = await askYesNo("Install GitHub CLI now?", false);
     if (shouldInstallGh) {
       const installedGh = await tryInstallWithAttempts(
@@ -657,7 +681,9 @@ async function addProjectToConfig(
     let i = 2;
     while (config.projects[`${projectId}-${i}`]) i++;
     const newId = `${projectId}-${i}`;
-    console.log(chalk.yellow(`  ⚠ Project "${projectId}" already exists — using "${newId}" instead.`));
+    console.log(
+      chalk.yellow(`  ⚠ Project "${projectId}" already exists — using "${newId}" instead.`),
+    );
     projectId = newId;
   }
 
@@ -822,7 +848,11 @@ function tmuxInstallAttempts(): InstallAttempt[] {
   }
   if (process.platform === "linux") {
     return [
-      { cmd: "sudo", args: ["apt-get", "install", "-y", "tmux"], label: "sudo apt-get install -y tmux" },
+      {
+        cmd: "sudo",
+        args: ["apt-get", "install", "-y", "tmux"],
+        label: "sudo apt-get install -y tmux",
+      },
       { cmd: "sudo", args: ["dnf", "install", "-y", "tmux"], label: "sudo dnf install -y tmux" },
     ];
   }
@@ -831,21 +861,16 @@ function tmuxInstallAttempts(): InstallAttempt[] {
 
 function tmuxInstallHints(): string[] {
   if (process.platform === "darwin") return ["brew install tmux"];
-  if (process.platform === "win32") return [
-    "# Install WSL first, then inside WSL:",
-    "sudo apt install tmux",
-  ];
-  return [
-    "sudo apt install tmux      # Debian/Ubuntu",
-    "sudo dnf install tmux      # Fedora/RHEL",
-  ];
+  if (process.platform === "win32")
+    return ["# Install WSL first, then inside WSL:", "sudo apt install tmux"];
+  return ["sudo apt install tmux      # Debian/Ubuntu", "sudo dnf install tmux      # Fedora/RHEL"];
 }
 
 async function ensureTmux(): Promise<void> {
   const hasTmux = (await execSilent("tmux", ["-V"])) !== null;
   if (hasTmux) return;
 
-  console.log(chalk.yellow("⚠ tmux is required for runtime \"tmux\"."));
+  console.log(chalk.yellow('⚠ tmux is required for runtime "tmux".'));
   const shouldInstall = await askYesNo("Install tmux now?", true, false);
   if (shouldInstall) {
     const installed = await tryInstallWithAttempts(
@@ -912,13 +937,27 @@ async function runStartup(
   config: OrchestratorConfig,
   projectId: string,
   project: ProjectConfig,
-  opts?: { dashboard?: boolean; orchestrator?: boolean; rebuild?: boolean; dev?: boolean },
+  opts?: RuntimeOverrideFlagOptions & {
+    dashboard?: boolean;
+    orchestrator?: boolean;
+    rebuild?: boolean;
+    dev?: boolean;
+  },
 ): Promise<number> {
-  // Ensure tmux is available before doing anything — covers all entry paths
-  // (normal start, URL start, retry with existing config)
-  const runtime = config.defaults?.runtime ?? "tmux";
-  if (runtime === "tmux") {
-    await ensureTmux();
+  const runtimeOverride = resolveRuntimeOverride(config, project, opts ?? {});
+
+  // Only require runtime dependencies when we are actually starting the orchestrator.
+  if (opts?.orchestrator !== false) {
+    if (runtimeOverride.effectiveRuntime === "tmux") {
+      await ensureTmux();
+    } else if (runtimeOverride.effectiveRuntime === "docker") {
+      await preflight.checkDocker(runtimeOverride.effectiveRuntimeConfig);
+    } else {
+      await preflight.checkRuntime(
+        runtimeOverride.effectiveRuntime,
+        runtimeOverride.effectiveRuntimeConfig,
+      );
+    }
   }
   await warnAboutOpenClawStatus(config);
 
@@ -1011,7 +1050,6 @@ async function runStartup(
   // Create orchestrator session (unless --no-orchestrator or existing orchestrators found)
   let hasExistingOrchestrators = false;
   let selectedOrchestratorId: string | null = null;
-
   if (opts?.orchestrator !== false) {
     const sm = await getSessionManager(config);
 
@@ -1062,7 +1100,12 @@ async function runStartup(
       try {
         spinner.start("Creating orchestrator session");
         const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-        const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
+        const session = await sm.spawnOrchestrator({
+          projectId,
+          systemPrompt,
+          ...(runtimeOverride.runtime ? { runtime: runtimeOverride.runtime } : {}),
+          ...(runtimeOverride.runtimeConfig ? { runtimeConfig: runtimeOverride.runtimeConfig } : {}),
+        });
         selectedOrchestratorId = session.id;
         reused =
           orchestratorSessionStrategy === "reuse" &&
@@ -1190,6 +1233,29 @@ export function registerStart(program: Command): void {
     .option("--rebuild", "Clean and rebuild dashboard before starting")
     .option("--dev", "Use Next.js dev server with hot reload (for dashboard UI development)")
     .option("--interactive", "Prompt to configure config settings")
+    .option(
+      "--runtime <name>",
+      "Override the runtime plugin for the orchestrator (e.g. tmux, docker)",
+    )
+    .option("--runtime-image <image>", "Override runtimeConfig.image for docker runtime")
+    .option("--runtime-config <json>", "Override runtimeConfig with a JSON object")
+    .option("--runtime-cpus <cpus>", "Override runtimeConfig.limits.cpus for docker runtime")
+    .option("--runtime-memory <memory>", "Override runtimeConfig.limits.memory for docker runtime")
+    .option("--runtime-gpus <gpus>", "Override runtimeConfig.limits.gpus for docker runtime")
+    .option("--runtime-read-only", "Set runtimeConfig.readOnlyRoot=true for docker runtime")
+    .option("--runtime-network <network>", "Override runtimeConfig.network for docker runtime")
+    .option(
+      "--runtime-cap-drop <cap>",
+      "Append a runtimeConfig.capDrop entry for docker runtime (repeatable)",
+      appendStringOption,
+      [],
+    )
+    .option(
+      "--runtime-tmpfs <mount>",
+      "Append a runtimeConfig.tmpfs entry for docker runtime (repeatable)",
+      appendStringOption,
+      [],
+    )
     .action(
       async (
         projectArg?: string,
@@ -1199,6 +1265,16 @@ export function registerStart(program: Command): void {
           rebuild?: boolean;
           dev?: boolean;
           interactive?: boolean;
+          runtime?: string;
+          runtimeConfig?: string;
+          runtimeImage?: string;
+          runtimeCpus?: string;
+          runtimeMemory?: string;
+          runtimeGpus?: string;
+          runtimeReadOnly?: boolean;
+          runtimeNetwork?: string;
+          runtimeCapDrop?: string[];
+          runtimeTmpfs?: string[];
         },
       ) => {
         try {
@@ -1241,7 +1317,8 @@ export function registerStart(program: Command): void {
 
               // Check if project is already in config (match by path)
               const existingEntry = Object.entries(config.projects).find(
-                ([, p]) => resolve(p.path.replace(/^~/, process.env["HOME"] || "")) === resolvedPath,
+                ([, p]) =>
+                  resolve(p.path.replace(/^~/, process.env["HOME"] || "")) === resolvedPath,
               );
 
               if (existingEntry) {
@@ -1304,9 +1381,9 @@ export function registerStart(program: Command): void {
 
                 // Collect existing prefixes to avoid collisions
                 const existingPrefixes = new Set(
-                  Object.values(rawConfig.projects as Record<string, Record<string, unknown>>).map(
-                    (p) => p.sessionPrefix as string,
-                  ).filter(Boolean),
+                  Object.values(rawConfig.projects as Record<string, Record<string, unknown>>)
+                    .map((p) => p.sessionPrefix as string)
+                    .filter(Boolean),
                 );
 
                 let newId: string;
@@ -1329,9 +1406,19 @@ export function registerStart(program: Command): void {
                 // Continue to startup below
               } else if (choice === "restart") {
                 try { process.kill(running.pid, "SIGTERM"); } catch { /* already dead */ }
+              } else if (choice === "restart") {
+                try {
+                  process.kill(running.pid, "SIGTERM");
+                } catch {
+                  /* already dead */
+                }
                 if (!(await waitForExit(running.pid, 5000))) {
                   console.log(chalk.yellow("  Process didn't exit cleanly, sending SIGKILL..."));
-                  try { process.kill(running.pid, "SIGKILL"); } catch { /* already dead */ }
+                  try {
+                    process.kill(running.pid, "SIGKILL");
+                  } catch {
+                    /* already dead */
+                  }
                 }
                 await unregister();
                 console.log(chalk.yellow("\n  Stopped existing instance. Restarting...\n"));
@@ -1421,9 +1508,7 @@ export function registerStop(program: Command): void {
                 // Already dead
               }
               await unregister();
-              console.log(
-                chalk.green(`\n✓ Stopped AO on port ${running.port}`),
-              );
+              console.log(chalk.green(`\n✓ Stopped AO on port ${running.port}`));
               console.log(chalk.dim(`  Projects: ${running.projects.join(", ")}\n`));
             } else {
               console.log(chalk.yellow("No running AO instance found in running.json."));
@@ -1471,12 +1556,8 @@ export function registerStop(program: Command): void {
           await stopDashboard(running?.port ?? port);
 
           console.log(chalk.bold.green("\n✓ Orchestrator stopped\n"));
-          console.log(
-            chalk.dim(`  Uptime: since ${running?.startedAt ?? "unknown"}`),
-          );
-          console.log(
-            chalk.dim(`  Projects: ${Object.keys(config.projects).join(", ")}\n`),
-          );
+          console.log(chalk.dim(`  Uptime: since ${running?.startedAt ?? "unknown"}`));
+          console.log(chalk.dim(`  Projects: ${Object.keys(config.projects).join(", ")}\n`));
         } catch (err) {
           if (err instanceof Error) {
             console.error(chalk.red("\nError:"), err.message);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -76,10 +76,7 @@ import { detectOpenClawInstallation } from "../lib/openclaw-probe.js";
 import { applyOpenClawCredentials } from "../lib/credential-resolver.js";
 import { findProjectForDirectory } from "../lib/project-resolution.js";
 import { formatAttachCommand } from "../lib/attach.js";
-import {
-  appendStringOption,
-  resolveRuntimeOverride,
-} from "../lib/runtime-overrides.js";
+import { appendStringOption, resolveRuntimeOverride } from "../lib/runtime-overrides.js";
 
 import { DEFAULT_PORT } from "../lib/constants.js";
 const IS_TTY = Boolean(process.stdin.isTTY && process.stdout.isTTY);
@@ -210,7 +207,7 @@ function genericInstallHints(command: string): string[] {
  */
 async function promptAgentSelection(): Promise<{
   orchestratorAgent: string;
-  workerAgent: string
+  workerAgent: string;
 } | null> {
   if (canPromptForInstall()) {
     const available = await detectAvailableAgents();
@@ -400,18 +397,17 @@ async function promptInstallAgentRuntime(available: DetectedAgent[]): Promise<De
   if (available.length > 0 || !canPromptForInstall()) return available;
 
   console.log(chalk.yellow("⚠ No supported agent runtime detected."));
-  console.log(chalk.dim("  You can install one now (recommended) or continue and install later.\n"));
-  const choice = await promptSelect(
-    "Choose runtime to install:",
-    [
-      ...AGENT_INSTALL_OPTIONS.map((option) => ({
-        value: option.id,
-        label: option.label,
-        hint: [option.cmd, ...option.args].join(" "),
-      })),
-      { value: "skip", label: "Skip for now" },
-    ],
+  console.log(
+    chalk.dim("  You can install one now (recommended) or continue and install later.\n"),
   );
+  const choice = await promptSelect("Choose runtime to install:", [
+    ...AGENT_INSTALL_OPTIONS.map((option) => ({
+      value: option.id,
+      label: option.label,
+      hint: [option.cmd, ...option.args].join(" "),
+    })),
+    { value: "skip", label: "Skip for now" },
+  ]);
   if (choice === "skip") {
     return available;
   }
@@ -1361,8 +1357,16 @@ export function registerStart(program: Command): void {
                 "AO is already running. What do you want to do?",
                 [
                   { value: "open", label: "Open dashboard", hint: "Keep the current instance" },
-                  { value: "new", label: "Start new orchestrator", hint: "Add a new session for this project" },
-                  { value: "restart", label: "Restart everything", hint: "Stop the current instance first" },
+                  {
+                    value: "new",
+                    label: "Start new orchestrator",
+                    hint: "Add a new session for this project",
+                  },
+                  {
+                    value: "restart",
+                    label: "Restart everything",
+                    hint: "Stop the current instance first",
+                  },
                   { value: "quit", label: "Quit" },
                 ],
                 "open",
@@ -1445,7 +1449,7 @@ export function registerStart(program: Command): void {
             proj.worker = { ...(proj.worker ?? {}), agent: workerAgent };
             writeFileSync(config.configPath, yamlStringify(rawConfig, { indent: 2 }));
             console.log(chalk.dim(`  ✓ Saved to ${config.configPath}\n`));
-            
+
             config = loadConfig(config.configPath);
             project = config.projects[projectId];
           }
@@ -1513,7 +1517,11 @@ export function registerStop(program: Command): void {
           }
 
           const config = loadConfig();
-          const { projectId: _projectId, project } = await resolveProject(config, projectArg, "stop");
+          const { projectId: _projectId, project } = await resolveProject(
+            config,
+            projectArg,
+            "stop",
+          );
           const sessionId = `${project.sessionPrefix}-orchestrator`;
           const port = config.port ?? DEFAULT_PORT;
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -79,8 +79,6 @@ import { formatAttachCommand } from "../lib/attach.js";
 import {
   appendStringOption,
   resolveRuntimeOverride,
-  type RuntimeOverride,
-  type RuntimeOverrideFlagOptions,
 } from "../lib/runtime-overrides.js";
 
 import { DEFAULT_PORT } from "../lib/constants.js";
@@ -1404,8 +1402,6 @@ export function registerStart(program: Command): void {
                 projectId = newId;
                 project = config.projects[newId];
                 // Continue to startup below
-              } else if (choice === "restart") {
-                try { process.kill(running.pid, "SIGTERM"); } catch { /* already dead */ }
               } else if (choice === "restart") {
                 try {
                   process.kill(running.pid, "SIGTERM");

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -75,7 +75,6 @@ import { formatCommandError } from "../lib/cli-errors.js";
 import { detectOpenClawInstallation } from "../lib/openclaw-probe.js";
 import { applyOpenClawCredentials } from "../lib/credential-resolver.js";
 import { findProjectForDirectory } from "../lib/project-resolution.js";
-import { formatAttachCommand } from "../lib/attach.js";
 import {
   appendStringOption,
   resolveRuntimeOverride,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -76,7 +76,11 @@ import { detectOpenClawInstallation } from "../lib/openclaw-probe.js";
 import { applyOpenClawCredentials } from "../lib/credential-resolver.js";
 import { findProjectForDirectory } from "../lib/project-resolution.js";
 import { formatAttachCommand } from "../lib/attach.js";
-import { appendStringOption, resolveRuntimeOverride } from "../lib/runtime-overrides.js";
+import {
+  appendStringOption,
+  resolveRuntimeOverride,
+  type RuntimeOverrideFlagOptions,
+} from "../lib/runtime-overrides.js";
 
 import { DEFAULT_PORT } from "../lib/constants.js";
 const IS_TTY = Boolean(process.stdin.isTTY && process.stdout.isTTY);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -92,8 +92,10 @@ async function gatherSessionInfo(
   }
 
   // Get last activity time from tmux
-  const tmuxTarget = session.runtimeHandle?.id ?? session.id;
-  const activityTs = await getTmuxActivity(tmuxTarget);
+  const activityTs =
+    session.runtimeHandle?.runtimeName === "tmux"
+      ? await getTmuxActivity(session.runtimeHandle?.id ?? session.id)
+      : session.lastActivityAt.getTime();
   const lastActivity = activityTs ? formatAge(activityTs) : "-";
 
   // Get agent's auto-generated summary via introspection

--- a/packages/cli/src/lib/attach.ts
+++ b/packages/cli/src/lib/attach.ts
@@ -1,0 +1,39 @@
+import { spawn } from "node:child_process";
+import { shellEscape, type AttachInfo } from "@composio/ao-core";
+
+export function formatAttachCommand(
+  info: AttachInfo | null | undefined,
+  fallbackCommand: string,
+): string {
+  if (!info) return fallbackCommand;
+  if (info.command) return info.command;
+  if (info.program) {
+    return [info.program, ...(info.args ?? [])].map(shellEscape).join(" ");
+  }
+  return fallbackCommand;
+}
+
+export async function runAttachCommand(
+  info: AttachInfo | null | undefined,
+  fallback: { program: string; args: string[] },
+): Promise<void> {
+  const shell = process.env["SHELL"] || "/bin/sh";
+  const program = info?.program ?? (info?.command ? shell : fallback.program);
+  const args = info?.program
+    ? (info.args ?? [])
+    : info?.command
+      ? ["-lc", info.command]
+      : fallback.args;
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(program, args, { stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0 || code === null) {
+        resolve();
+        return;
+      }
+      reject(new Error(`attach command exited with code ${code}`));
+    });
+  });
+}

--- a/packages/cli/src/lib/attach.ts
+++ b/packages/cli/src/lib/attach.ts
@@ -22,7 +22,7 @@ export async function runAttachCommand(
   const args = info?.program
     ? (info.args ?? [])
     : info?.command
-      ? ["-lc", info.command]
+      ? ["-c", info.command]
       : fallback.args;
 
   await new Promise<void>((resolve, reject) => {

--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -20,7 +20,7 @@ readyThresholdMs: 300000      # Ms before "ready" becomes "idle" (default: 5 min
 # These apply to all projects unless overridden per-project.
 
 defaults:
-  runtime: tmux               # tmux | process
+  runtime: tmux               # tmux | docker | process
   agent: claude-code          # claude-code | aider | codex | opencode
   workspace: worktree         # worktree | clone
   notifiers:
@@ -57,6 +57,14 @@ projects:
 
     # ── Per-project plugin overrides (optional) ───────────────────
     runtime: tmux             # Override default runtime
+    runtimeConfig:            # Common for docker runtime
+      image: ghcr.io/composio/ao:latest
+      limits:
+        cpus: 2
+        memory: 4g
+      readOnlyRoot: true
+      capDrop: [ALL]
+      tmpfs: [/tmp]
     agent: claude-code        # Override default agent
     workspace: worktree       # Override default workspace
 

--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -58,7 +58,7 @@ projects:
     # ── Per-project plugin overrides (optional) ───────────────────
     runtime: tmux             # Override default runtime
     runtimeConfig:            # Common for docker runtime
-      image: ghcr.io/composio/ao:latest
+      image: ghcr.io/composio/ao-claude-code:latest
       limits:
         cpus: 2
         memory: 4g
@@ -150,11 +150,20 @@ notificationRouting:
 # ── Available plugins ───────────────────────────────────────────────
 #
 # Agent:     claude-code, aider, codex, opencode
-# Runtime:   tmux, process
+# Runtime:   tmux, docker, process
 # Workspace: worktree, clone
 # SCM:       github, gitlab
 # Tracker:   github, linear, gitlab
 # Notifier:  desktop, discord, slack, webhook, composio, openclaw
 # Terminal:  iterm2, web
+
+# ── Docker onboarding helper ────────────────────────────────────────
+#
+# Instead of manually building an image first, you can ask AO to prepare
+# Docker for a project:
+#
+#   ao docker prepare my-app
+#   ao docker prepare my-app --build-local --agent codex
+#   ao docker prepare my-app --image ghcr.io/your-org/custom-agent:latest --no-pull
 `.trim();
 }

--- a/packages/cli/src/lib/open-iterm.ts
+++ b/packages/cli/src/lib/open-iterm.ts
@@ -1,0 +1,49 @@
+import type { AttachInfo } from "@composio/ao-core";
+import { formatAttachCommand } from "./attach.js";
+import { exec } from "./shell.js";
+
+interface OpenItermOptions {
+  tabTitle: string;
+  tmuxTarget: string;
+  runtimeName: string;
+  attachInfo?: AttachInfo | null;
+  newWindow?: boolean;
+}
+
+export function buildOpenItermArgs(options: OpenItermOptions): string[] | null {
+  const args: string[] = [];
+  if (options.newWindow) {
+    args.push("--new-window");
+  }
+
+  if (options.runtimeName === "tmux") {
+    args.push(options.tmuxTarget);
+    return args;
+  }
+
+  if (!options.attachInfo) {
+    return null;
+  }
+
+  args.push(
+    "--title",
+    options.tabTitle,
+    "--command",
+    formatAttachCommand(options.attachInfo, `tmux attach -t ${options.tmuxTarget}`),
+  );
+  return args;
+}
+
+export async function openInIterm(options: OpenItermOptions): Promise<boolean> {
+  const args = buildOpenItermArgs(options);
+  if (!args) {
+    return false;
+  }
+
+  try {
+    await exec("open-iterm-tab", args);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -14,6 +14,7 @@ import { exec } from "./shell.js";
 import { isInstalledUnderNodeModules } from "./dashboard-rebuild.js";
 
 type RuntimeConfig = Record<string, unknown>;
+type KnownRuntimes = Iterable<string> | undefined;
 
 /**
  * Check that the dashboard port is free.
@@ -122,7 +123,11 @@ async function checkDocker(runtimeConfig?: RuntimeConfig): Promise<void> {
   }
 }
 
-async function checkRuntime(runtime: string, runtimeConfig?: RuntimeConfig): Promise<void> {
+async function checkRuntime(
+  runtime: string,
+  runtimeConfig?: RuntimeConfig,
+  knownRuntimes?: KnownRuntimes,
+): Promise<void> {
   if (runtime === "tmux") {
     await checkTmux();
     return;
@@ -133,6 +138,13 @@ async function checkRuntime(runtime: string, runtimeConfig?: RuntimeConfig): Pro
   }
   if (runtime === "process") {
     return;
+  }
+
+  if (knownRuntimes) {
+    const known = new Set([...knownRuntimes].filter(Boolean));
+    if (known.has(runtime)) {
+      return;
+    }
   }
 
   throw new Error(

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -13,6 +13,8 @@ import { isPortAvailable } from "./web-dir.js";
 import { exec } from "./shell.js";
 import { isInstalledUnderNodeModules } from "./dashboard-rebuild.js";
 
+type RuntimeConfig = Record<string, unknown>;
+
 /**
  * Check that the dashboard port is free.
  * Throws if the port is already in use.
@@ -97,6 +99,39 @@ async function checkTmux(): Promise<void> {
   throw new Error(`tmux is not installed. Install it: ${hint}`);
 }
 
+async function checkDocker(runtimeConfig?: RuntimeConfig): Promise<void> {
+  try {
+    await exec("docker", ["--version"]);
+  } catch {
+    throw new Error("Docker is not installed. Install it: https://docs.docker.com/get-docker/");
+  }
+
+  try {
+    await exec("docker", ["info"]);
+  } catch {
+    throw new Error(
+      "Docker is installed but the daemon is unavailable. Start Docker Desktop or the Docker service.",
+    );
+  }
+
+  const image = runtimeConfig?.["image"];
+  if (typeof image !== "string" || image.trim().length === 0) {
+    throw new Error(
+      "Docker runtime requires an image. Set project.runtimeConfig.image or pass --runtime-image / --runtime-config with an image override.",
+    );
+  }
+}
+
+async function checkRuntime(runtime: string, runtimeConfig?: RuntimeConfig): Promise<void> {
+  if (runtime === "tmux") {
+    await checkTmux();
+    return;
+  }
+  if (runtime === "docker") {
+    await checkDocker(runtimeConfig);
+  }
+}
+
 /**
  * Check that the GitHub CLI is installed and authenticated.
  * Distinguishes between "not installed" and "not authenticated"
@@ -119,6 +154,8 @@ async function checkGhAuth(): Promise<void> {
 export const preflight = {
   checkPort,
   checkBuilt,
+  checkRuntime,
   checkTmux,
+  checkDocker,
   checkGhAuth,
 };

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -121,6 +121,17 @@ async function checkDocker(runtimeConfig?: RuntimeConfig): Promise<void> {
       "Docker runtime requires an image. Set project.runtimeConfig.image or pass --runtime-image / --runtime-config with an image override.",
     );
   }
+
+  const readOnlyRoot = runtimeConfig?.["readOnlyRoot"] === true;
+  const tmpfs = Array.isArray(runtimeConfig?.["tmpfs"])
+    ? runtimeConfig?.["tmpfs"].filter((value): value is string => typeof value === "string")
+    : [];
+  const hasTmpfsTmp = tmpfs.some((mount) => mount.split(":")[0]?.trim() === "/tmp");
+  if (readOnlyRoot && !hasTmpfsTmp) {
+    throw new Error(
+      "Docker runtime with readOnlyRoot=true also needs tmpfs to include /tmp. Add project.runtimeConfig.tmpfs: ['/tmp'] or pass --runtime-tmpfs /tmp.",
+    );
+  }
 }
 
 async function checkRuntime(

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -129,7 +129,15 @@ async function checkRuntime(runtime: string, runtimeConfig?: RuntimeConfig): Pro
   }
   if (runtime === "docker") {
     await checkDocker(runtimeConfig);
+    return;
   }
+  if (runtime === "process") {
+    return;
+  }
+
+  throw new Error(
+    `Unknown runtime "${runtime}". Configure a supported runtime plugin (tmux, docker, process) or check for typos in your config/flags.`,
+  );
 }
 
 /**

--- a/packages/cli/src/lib/runtime-overrides.ts
+++ b/packages/cli/src/lib/runtime-overrides.ts
@@ -1,5 +1,9 @@
-import type { OrchestratorConfig, ProjectConfig } from "@composio/ao-core";
-import { mergeRuntimeConfig, isPlainObject } from "@composio/ao-core";
+import {
+  mergeRuntimeConfig,
+  isPlainObject,
+  type OrchestratorConfig,
+  type ProjectConfig,
+} from "@composio/ao-core";
 
 export interface RuntimeOverrideFlagOptions {
   runtime?: string;

--- a/packages/cli/src/lib/runtime-overrides.ts
+++ b/packages/cli/src/lib/runtime-overrides.ts
@@ -54,6 +54,7 @@ function parseRuntimeConfigOverride(raw?: string): Record<string, unknown> | und
   } catch (err) {
     throw new Error(
       `Invalid --runtime-config JSON: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 

--- a/packages/cli/src/lib/runtime-overrides.ts
+++ b/packages/cli/src/lib/runtime-overrides.ts
@@ -1,4 +1,5 @@
 import type { OrchestratorConfig, ProjectConfig } from "@composio/ao-core";
+import { mergeRuntimeConfig, isPlainObject } from "@composio/ao-core";
 
 export interface RuntimeOverrideFlagOptions {
   runtime?: string;
@@ -18,31 +19,6 @@ export interface RuntimeOverride {
   runtimeConfig?: Record<string, unknown>;
   effectiveRuntime: string;
   effectiveRuntimeConfig?: Record<string, unknown>;
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function mergeRuntimeConfig(
-  base?: Record<string, unknown>,
-  override?: Record<string, unknown>,
-): Record<string, unknown> | undefined {
-  if (!base && !override) return undefined;
-
-  const merged: Record<string, unknown> = {};
-  for (const source of [base, override]) {
-    if (!source) continue;
-    for (const [key, value] of Object.entries(source)) {
-      const existing = merged[key];
-      merged[key] =
-        isPlainObject(existing) && isPlainObject(value)
-          ? mergeRuntimeConfig(existing, value)
-          : value;
-    }
-  }
-
-  return merged;
 }
 
 function parseRuntimeConfigOverride(raw?: string): Record<string, unknown> | undefined {

--- a/packages/cli/src/lib/runtime-overrides.ts
+++ b/packages/cli/src/lib/runtime-overrides.ts
@@ -1,0 +1,126 @@
+import type { OrchestratorConfig, ProjectConfig } from "@composio/ao-core";
+
+export interface RuntimeOverrideFlagOptions {
+  runtime?: string;
+  runtimeConfig?: string;
+  runtimeImage?: string;
+  runtimeCpus?: string;
+  runtimeMemory?: string;
+  runtimeGpus?: string;
+  runtimeReadOnly?: boolean;
+  runtimeNetwork?: string;
+  runtimeCapDrop?: string[];
+  runtimeTmpfs?: string[];
+}
+
+export interface RuntimeOverride {
+  runtime?: string;
+  runtimeConfig?: Record<string, unknown>;
+  effectiveRuntime: string;
+  effectiveRuntimeConfig?: Record<string, unknown>;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeRuntimeConfig(
+  base?: Record<string, unknown>,
+  override?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!base && !override) return undefined;
+
+  const merged: Record<string, unknown> = {};
+  for (const source of [base, override]) {
+    if (!source) continue;
+    for (const [key, value] of Object.entries(source)) {
+      const existing = merged[key];
+      merged[key] =
+        isPlainObject(existing) && isPlainObject(value)
+          ? mergeRuntimeConfig(existing, value)
+          : value;
+    }
+  }
+
+  return merged;
+}
+
+function parseRuntimeConfigOverride(raw?: string): Record<string, unknown> | undefined {
+  if (!raw) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Invalid --runtime-config JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new Error("--runtime-config must be a JSON object.");
+  }
+
+  return parsed;
+}
+
+function trimOrUndefined(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function trimStringList(values?: string[]): string[] | undefined {
+  const trimmed = values?.map((value) => value.trim()).filter((value) => value.length > 0);
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function appendStringOption(value: string, previous: string[] = []): string[] {
+  return [...previous, value];
+}
+
+export function resolveRuntimeOverride(
+  config: OrchestratorConfig,
+  project: ProjectConfig,
+  opts: RuntimeOverrideFlagOptions,
+): RuntimeOverride {
+  const runtime = trimOrUndefined(opts.runtime);
+  const baseRuntimeConfig = parseRuntimeConfigOverride(opts.runtimeConfig);
+  const limitOverrides: Record<string, unknown> = {};
+
+  if (trimOrUndefined(opts.runtimeCpus)) {
+    limitOverrides.cpus = trimOrUndefined(opts.runtimeCpus);
+  }
+  if (trimOrUndefined(opts.runtimeMemory)) {
+    limitOverrides.memory = trimOrUndefined(opts.runtimeMemory);
+  }
+  if (trimOrUndefined(opts.runtimeGpus)) {
+    limitOverrides.gpus = trimOrUndefined(opts.runtimeGpus);
+  }
+
+  const flagRuntimeConfig = {
+    ...(trimOrUndefined(opts.runtimeImage) ? { image: trimOrUndefined(opts.runtimeImage) } : {}),
+    ...(trimOrUndefined(opts.runtimeNetwork)
+      ? { network: trimOrUndefined(opts.runtimeNetwork) }
+      : {}),
+    ...(opts.runtimeReadOnly ? { readOnlyRoot: true } : {}),
+    ...(trimStringList(opts.runtimeCapDrop)
+      ? { capDrop: trimStringList(opts.runtimeCapDrop) }
+      : {}),
+    ...(trimStringList(opts.runtimeTmpfs) ? { tmpfs: trimStringList(opts.runtimeTmpfs) } : {}),
+    ...(Object.keys(limitOverrides).length > 0 ? { limits: limitOverrides } : {}),
+  };
+
+  const runtimeConfig = mergeRuntimeConfig(
+    baseRuntimeConfig,
+    Object.keys(flagRuntimeConfig).length > 0 ? flagRuntimeConfig : undefined,
+  );
+  const effectiveRuntime = runtime ?? project.runtime ?? config.defaults.runtime ?? "tmux";
+  const effectiveRuntimeConfig = mergeRuntimeConfig(project.runtimeConfig, runtimeConfig);
+
+  return {
+    runtime,
+    runtimeConfig,
+    effectiveRuntime,
+    effectiveRuntimeConfig,
+  };
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -15,6 +15,7 @@ import { registerUpdate } from "./commands/update.js";
 import { registerSetup } from "./commands/setup.js";
 import { registerPlugin } from "./commands/plugin.js";
 import { registerRuntime } from "./commands/runtime.js";
+import { registerDocker } from "./commands/docker.js";
 import { getConfigInstruction } from "./lib/config-instruction.js";
 import { getCliVersion } from "./options/version.js";
 
@@ -44,6 +45,7 @@ export function createProgram(): Command {
   registerSetup(program);
   registerPlugin(program);
   registerRuntime(program);
+  registerDocker(program);
 
   program
     .command("config-help")

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -14,6 +14,7 @@ import { registerDoctor } from "./commands/doctor.js";
 import { registerUpdate } from "./commands/update.js";
 import { registerSetup } from "./commands/setup.js";
 import { registerPlugin } from "./commands/plugin.js";
+import { registerRuntime } from "./commands/runtime.js";
 import { getConfigInstruction } from "./lib/config-instruction.js";
 import { getCliVersion } from "./options/version.js";
 
@@ -42,6 +43,7 @@ export function createProgram(): Command {
   registerUpdate(program);
   registerSetup(program);
   registerPlugin(program);
+  registerRuntime(program);
 
   program
     .command("config-help")

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -35,6 +35,7 @@ Handles session lifecycle:
 - `spawn(config)` — create new session (workspace + runtime + agent)
 - `list(projectId?)` — list all sessions
 - `get(sessionId)` — get session details
+- `getAttachInfo(sessionId)` — resolve structured attach metadata for CLI/web terminal flows
 - `kill(sessionId)` — terminate session
 - `cleanup(projectId?)` — kill completed/merged sessions
 - `send(sessionId, message)` — send message to agent
@@ -52,6 +53,8 @@ Handles session lifecycle:
 9. Run `Agent.postLaunchSetup()` (optional)
 10. Write metadata file
 11. Return Session object
+
+The session manager also persists the effective `runtime` and merged `runtimeConfig` so restore, recovery, lifecycle checks, and terminal attach paths stay aligned with the runtime actually used when the session was created.
 
 **Note:** If issue validation fails (not found, auth error), spawn fails before creating any resources (no workspace, no runtime, no session ID). This prevents spawning sessions with broken issue references.
 
@@ -92,7 +95,7 @@ Loads plugins and provides access to them:
 
 **Built-in plugins** (loaded by default):
 
-- runtime-tmux, runtime-process
+- runtime-tmux, runtime-process, runtime-docker
 - agent-claude-code, agent-codex, agent-aider, agent-opencode
 - workspace-worktree, workspace-clone
 - tracker-github, tracker-linear, tracker-gitlab

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -236,6 +236,17 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("killed");
   });
 
+  it("keeps freshly spawned sessions in spawning when getActivityState transiently reports exited", async () => {
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "exited" });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "spawning", createdAt: new Date() }),
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("spawning");
+  });
+
   it("detects killed via terminal fallback when getActivityState returns null", async () => {
     vi.mocked(plugins.agent.getActivityState).mockResolvedValue(null);
     vi.mocked(plugins.agent.detectActivity).mockReturnValue("idle");
@@ -247,6 +258,19 @@ describe("check (single session)", () => {
 
     await lm.check("app-1");
     expect(lm.getStates().get("app-1")).toBe("killed");
+  });
+
+  it("keeps freshly spawned sessions in spawning when fallback process detection is briefly false", async () => {
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue(null);
+    vi.mocked(plugins.agent.detectActivity).mockReturnValue("idle");
+    vi.mocked(plugins.agent.isProcessRunning).mockResolvedValue(false);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "spawning", createdAt: new Date() }),
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("spawning");
   });
 
   it("stays working when agent is idle but process is still running (fallback path)", async () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -6,6 +6,7 @@ import type {
   OrchestratorConfig,
   PluginRegistry,
   SessionManager,
+  Runtime,
   Agent,
   ActivityState,
   SessionStatus,
@@ -151,6 +152,77 @@ describe("check (single session)", () => {
 
     await lm.check("app-1");
     expect(lm.getStates().get("app-1")).toBe("killed");
+  });
+
+  it("prefers the persisted session runtime over the current project default", async () => {
+    const tmuxRuntime: Runtime = {
+      ...plugins.runtime,
+      name: "tmux",
+      isAlive: vi.fn().mockResolvedValue(true),
+    };
+    const dockerRuntime: Runtime = {
+      ...plugins.runtime,
+      name: "docker",
+      isAlive: vi.fn().mockResolvedValue(true),
+    };
+    const registryWithMultipleRuntimes: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") {
+          if (name === "docker") return dockerRuntime;
+          if (name === "tmux") return tmuxRuntime;
+        }
+        if (slot === "agent") return plugins.agent;
+        return null;
+      }),
+    };
+    const configWithTmuxDefault: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        runtime: "tmux",
+      },
+      projects: {
+        ...config.projects,
+        "my-app": {
+          ...config.projects["my-app"],
+          runtime: "tmux",
+        },
+      },
+    };
+    const session = makeSession({
+      status: "working",
+      runtimeHandle: { id: "ctr-1", runtimeName: "docker", data: {} },
+      metadata: {
+        runtime: "tmux",
+        runtimeHandle: JSON.stringify({ id: "ctr-1", runtimeName: "docker", data: {} }),
+      },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(env.sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtime: "tmux",
+      runtimeHandle: JSON.stringify({ id: "ctr-1", runtimeName: "docker", data: {} }),
+    });
+
+    const lm = createLifecycleManager({
+      config: configWithTmuxDefault,
+      registry: registryWithMultipleRuntimes,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(dockerRuntime.isAlive).toHaveBeenCalledWith({
+      id: "ctr-1",
+      runtimeName: "docker",
+      data: {},
+    });
+    expect(tmuxRuntime.isAlive).not.toHaveBeenCalled();
   });
 
   it("detects killed state when getActivityState returns exited", async () => {

--- a/packages/core/src/__tests__/metadata.test.ts
+++ b/packages/core/src/__tests__/metadata.test.ts
@@ -50,6 +50,8 @@ describe("writeMetadata + readMetadata", () => {
       summary: "Implementing feature X",
       project: "my-app",
       createdAt: "2025-01-01T00:00:00.000Z",
+      runtime: "docker",
+      runtimeConfig: '{"image":"ghcr.io/example/ao:latest","limits":{"memory":"4g"}}',
       runtimeHandle: '{"id":"tmux-1","runtimeName":"tmux"}',
     });
 
@@ -61,6 +63,10 @@ describe("writeMetadata + readMetadata", () => {
     expect(meta!.summary).toBe("Implementing feature X");
     expect(meta!.project).toBe("my-app");
     expect(meta!.createdAt).toBe("2025-01-01T00:00:00.000Z");
+    expect(meta!.runtime).toBe("docker");
+    expect(meta!.runtimeConfig).toBe(
+      '{"image":"ghcr.io/example/ao:latest","limits":{"memory":"4g"}}',
+    );
     expect(meta!.runtimeHandle).toBe('{"id":"tmux-1","runtimeName":"tmux"}');
   });
 

--- a/packages/core/src/__tests__/recovery-actions.test.ts
+++ b/packages/core/src/__tests__/recovery-actions.test.ts
@@ -64,6 +64,7 @@ function makeAssessment(overrides: Partial<RecoveryAssessment> = {}): RecoveryAs
     action: "recover",
     reason: "Session is running normally",
     runtimeAlive: true,
+    runtimeName: "tmux",
     runtimeHandle: { id: "rt-1", runtimeName: "tmux", data: {} },
     workspaceExists: true,
     workspacePath: "/tmp/worktree",
@@ -267,6 +268,82 @@ describe("cleanupSession", () => {
       }
       rmSync(rootDir, { recursive: true, force: true });
     }
+  });
+
+  it("uses the assessed runtime instead of the current project default", async () => {
+    rootDir = join(tmpdir(), `ao-recovery-${randomUUID()}`);
+    mkdirSync(rootDir, { recursive: true });
+    mkdirSync(join(rootDir, "project"), { recursive: true });
+    writeFileSync(join(rootDir, "agent-orchestrator.yaml"), "projects: {}\n", "utf-8");
+
+    const config = makeConfig(rootDir);
+    const sessionsDir = getSessionsDir(config.configPath, config.projects.app.path);
+    mkdirSync(sessionsDir, { recursive: true });
+    writeFileSync(
+      join(sessionsDir, "app-1"),
+      "project=app\nstatus=working\nworktree=/tmp/worktree\n",
+      "utf-8",
+    );
+
+    const dockerRuntime: Runtime = {
+      name: "docker",
+      create: vi.fn(),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn(),
+      getOutput: vi.fn(),
+      isAlive: vi.fn(),
+    };
+    const tmuxRuntime: Runtime = {
+      name: "tmux",
+      create: vi.fn(),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn(),
+      getOutput: vi.fn(),
+      isAlive: vi.fn(),
+    };
+    const workspace: Workspace = {
+      name: "worktree",
+      create: vi.fn(),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn(),
+      exists: vi.fn(),
+    };
+    const registry: PluginRegistry = {
+      register: vi.fn(),
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") {
+          if (name === "docker") return dockerRuntime;
+          if (name === "tmux") return tmuxRuntime;
+        }
+        if (slot === "workspace") return workspace;
+        return null;
+      }),
+      list: vi.fn().mockReturnValue([]),
+      loadBuiltins: vi.fn().mockResolvedValue(undefined),
+      loadFromConfig: vi.fn().mockResolvedValue(undefined),
+    };
+    const assessment = makeAssessment({
+      action: "cleanup",
+      classification: "dead",
+      runtimeAlive: true,
+      runtimeName: "docker",
+      runtimeHandle: { id: "ctr-1", runtimeName: "docker", data: {} },
+      workspaceExists: false,
+      rawMetadata: {
+        ...makeAssessment().rawMetadata,
+        runtime: "tmux",
+      },
+    });
+    const context = makeContext(rootDir);
+
+    const result = await cleanupSession(assessment, config, registry, context);
+    expect(result.success).toBe(true);
+    expect(dockerRuntime.destroy).toHaveBeenCalledWith({
+      id: "ctr-1",
+      runtimeName: "docker",
+      data: {},
+    });
+    expect(tmuxRuntime.destroy).not.toHaveBeenCalled();
   });
 
   it("continues cleanup and calls deleteMetadata even when workspace.destroy throws", async () => {

--- a/packages/core/src/__tests__/recovery-validator.test.ts
+++ b/packages/core/src/__tests__/recovery-validator.test.ts
@@ -211,4 +211,112 @@ describe("recovery validator", () => {
     expect(mockRuntime.isAlive).toHaveBeenCalled();
     expect(assessment.runtimeAlive).toBe(false);
   });
+
+  it("prefers the persisted runtime handle over the project default runtime", async () => {
+    rootDir = join(tmpdir(), `ao-recovery-validator-${randomUUID()}`);
+    mkdirSync(rootDir, { recursive: true });
+    const projectPath = join(rootDir, "project");
+    mkdirSync(projectPath, { recursive: true });
+    writeFileSync(join(rootDir, "agent-orchestrator.yaml"), "projects: {}\n", "utf-8");
+
+    const tmuxRuntime: Runtime = {
+      name: "tmux",
+      create: vi.fn(),
+      destroy: vi.fn(),
+      sendMessage: vi.fn(),
+      getOutput: vi.fn(),
+      isAlive: vi.fn().mockResolvedValue(true),
+    };
+    const dockerRuntime: Runtime = {
+      name: "docker",
+      create: vi.fn(),
+      destroy: vi.fn(),
+      sendMessage: vi.fn(),
+      getOutput: vi.fn(),
+      isAlive: vi.fn().mockResolvedValue(true),
+    };
+    const mockWorkspace: Workspace = {
+      name: "worktree",
+      create: vi.fn(),
+      destroy: vi.fn(),
+      list: vi.fn(),
+      exists: vi.fn().mockResolvedValue(true),
+    };
+    const mockAgent: Agent = {
+      name: "mock-agent",
+      processName: "mock-agent",
+      getLaunchCommand: vi.fn(),
+      getEnvironment: vi.fn(),
+      detectActivity: vi.fn(),
+      getActivityState: vi.fn(),
+      isProcessRunning: vi.fn().mockResolvedValue(true),
+      getSessionInfo: vi.fn(),
+    };
+    const registry: PluginRegistry = {
+      register: vi.fn(),
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") {
+          if (name === "docker") return dockerRuntime;
+          if (name === "tmux") return tmuxRuntime;
+        }
+        if (slot === "workspace") return mockWorkspace;
+        if (slot === "agent") return mockAgent;
+        return null;
+      }),
+      list: vi.fn().mockReturnValue([]),
+      loadBuiltins: vi.fn().mockResolvedValue(undefined),
+      loadFromConfig: vi.fn().mockResolvedValue(undefined),
+    };
+    const config: OrchestratorConfig = {
+      configPath: join(rootDir, "agent-orchestrator.yaml"),
+      port: 3000,
+      readyThresholdMs: 300_000,
+      defaults: {
+        runtime: "tmux",
+        agent: "mock-agent",
+        workspace: "worktree",
+        notifiers: ["desktop"],
+      },
+      projects: {
+        app: {
+          name: "app",
+          repo: "org/repo",
+          path: projectPath,
+          defaultBranch: "main",
+          sessionPrefix: "app",
+          runtime: "tmux",
+        },
+      },
+      notifiers: {},
+      notificationRouting: {
+        urgent: ["desktop"],
+        action: ["desktop"],
+        warning: [],
+        info: [],
+      },
+      reactions: {},
+    };
+    const scanned: ScannedSession = {
+      sessionId: "app-1",
+      projectId: "app",
+      project: config.projects.app,
+      sessionsDir: getSessionsDir(config.configPath, projectPath),
+      rawMetadata: {
+        worktree: projectPath,
+        status: "working",
+        runtime: "tmux",
+        runtimeHandle: JSON.stringify({ id: "rt-1", runtimeName: "docker", data: {} }),
+      },
+    };
+
+    const assessment = await validateSession(scanned, config, registry);
+
+    expect(assessment.runtimeName).toBe("docker");
+    expect(dockerRuntime.isAlive).toHaveBeenCalledWith({
+      id: "rt-1",
+      runtimeName: "docker",
+      data: {},
+    });
+    expect(tmuxRuntime.isAlive).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/__tests__/runtime-selection.test.ts
+++ b/packages/core/src/__tests__/runtime-selection.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectConfig, RuntimeHandle } from "../types.js";
+import {
+  isPlainObject,
+  mergeRuntimeConfig,
+  parseStoredRuntimeConfig,
+  parseStoredRuntimeHandle,
+  resolveRuntimeConfigForSession,
+  resolveRuntimeConfigForSpawn,
+  resolveRuntimeName,
+} from "../runtime-selection.js";
+
+function makeProject(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    name: "My App",
+    repo: "org/my-app",
+    path: "/tmp/my-app",
+    defaultBranch: "main",
+    sessionPrefix: "app",
+    ...overrides,
+  };
+}
+
+describe("runtime-selection helpers", () => {
+  it("recognizes plain objects", () => {
+    expect(isPlainObject({ ok: true })).toBe(true);
+    expect(isPlainObject(["not", "plain"])).toBe(false);
+    expect(isPlainObject(null)).toBe(false);
+  });
+
+  it("deep-merges nested runtime config without mutating shared objects", () => {
+    const base = {
+      image: "ghcr.io/composio/ao:base",
+      limits: { memory: "2g" },
+    };
+    const merged = mergeRuntimeConfig(base, {
+      limits: { cpus: "2" },
+      tmpfs: ["/tmp"],
+    });
+
+    expect(merged).toEqual({
+      image: "ghcr.io/composio/ao:base",
+      limits: { memory: "2g", cpus: "2" },
+      tmpfs: ["/tmp"],
+    });
+    expect(base).toEqual({
+      image: "ghcr.io/composio/ao:base",
+      limits: { memory: "2g" },
+    });
+  });
+
+  it("parses stored runtime handle and config from metadata", () => {
+    const runtimeHandle = parseStoredRuntimeHandle({
+      runtimeHandle: JSON.stringify({
+        id: "container-1",
+        runtimeName: "docker",
+        data: { tmuxSessionName: "tmux-1" },
+      } satisfies RuntimeHandle),
+    });
+    const runtimeConfig = parseStoredRuntimeConfig({
+      runtimeConfig: JSON.stringify({
+        image: "ghcr.io/composio/ao:test",
+        limits: { memory: "4g" },
+      }),
+    });
+
+    expect(runtimeHandle).toEqual({
+      id: "container-1",
+      runtimeName: "docker",
+      data: { tmuxSessionName: "tmux-1" },
+    });
+    expect(runtimeConfig).toEqual({
+      image: "ghcr.io/composio/ao:test",
+      limits: { memory: "4g" },
+    });
+  });
+
+  it("ignores invalid stored runtime config values", () => {
+    expect(parseStoredRuntimeHandle({ runtimeHandle: "{not-json}" })).toBeNull();
+    expect(parseStoredRuntimeConfig({ runtimeConfig: JSON.stringify(["bad"]) })).toBeUndefined();
+  });
+
+  it("prefers explicit override, then stored handle, then stored runtime, then project default", () => {
+    const project = makeProject({ runtime: "docker" });
+
+    expect(
+      resolveRuntimeName(project, "tmux", {
+        runtimeOverride: "process",
+        raw: { runtimeHandle: JSON.stringify({ id: "c1", runtimeName: "docker", data: {} }) },
+      }),
+    ).toBe("process");
+
+    expect(
+      resolveRuntimeName(project, "tmux", {
+        raw: { runtimeHandle: JSON.stringify({ id: "c1", runtimeName: "docker", data: {} }) },
+      }),
+    ).toBe("docker");
+
+    expect(resolveRuntimeName(project, "tmux", { raw: { runtime: "process" } })).toBe("process");
+    expect(resolveRuntimeName(project, "tmux")).toBe("docker");
+    expect(resolveRuntimeName(makeProject(), "tmux")).toBe("tmux");
+  });
+
+  it("merges runtime config for spawn and session restore", () => {
+    const project = makeProject({
+      runtimeConfig: {
+        image: "ghcr.io/composio/ao:base",
+        limits: { memory: "2g" },
+      },
+    });
+
+    expect(
+      resolveRuntimeConfigForSpawn(project, {
+        limits: { cpus: "2" },
+        network: "bridge",
+      }),
+    ).toEqual({
+      image: "ghcr.io/composio/ao:base",
+      limits: { memory: "2g", cpus: "2" },
+      network: "bridge",
+    });
+
+    expect(
+      resolveRuntimeConfigForSession(project, {
+        runtimeConfig: JSON.stringify({
+          image: "ghcr.io/composio/ao:stored",
+          limits: { memory: "4g" },
+        }),
+      }),
+    ).toEqual({
+      image: "ghcr.io/composio/ao:stored",
+      limits: { memory: "4g" },
+    });
+
+    expect(resolveRuntimeConfigForSession(project, {})).toEqual({
+      image: "ghcr.io/composio/ao:base",
+      limits: { memory: "2g" },
+    });
+  });
+});

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -171,6 +171,36 @@ describe("list", () => {
     expect(sessions[0].activity).toBe("exited");
   });
 
+  it("revives terminal sessions when the runtime and agent process are still alive", async () => {
+    const agentWithLiveProcess: Agent = {
+      ...mockAgent,
+      getActivityState: vi.fn().mockResolvedValue(null),
+      isProcessRunning: vi.fn().mockResolvedValue(true),
+    };
+    const registryWithLiveTerminal: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return agentWithLiveProcess;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "a",
+      status: "killed",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithLiveTerminal });
+    const sessions = await sm.list();
+
+    expect(sessions[0].status).toBe("working");
+    expect(agentWithLiveProcess.isProcessRunning).toHaveBeenCalled();
+  });
+
   it("detects activity using agent-native mechanism", async () => {
     const agentWithState: Agent = {
       ...mockAgent,

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -171,36 +171,6 @@ describe("list", () => {
     expect(sessions[0].activity).toBe("exited");
   });
 
-  it("revives terminal sessions when the runtime and agent process are still alive", async () => {
-    const agentWithLiveProcess: Agent = {
-      ...mockAgent,
-      getActivityState: vi.fn().mockResolvedValue(null),
-      isProcessRunning: vi.fn().mockResolvedValue(true),
-    };
-    const registryWithLiveTerminal: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return agentWithLiveProcess;
-        return null;
-      }),
-    };
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "a",
-      status: "killed",
-      project: "my-app",
-      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
-    });
-
-    const sm = createSessionManager({ config, registry: registryWithLiveTerminal });
-    const sessions = await sm.list();
-
-    expect(sessions[0].status).toBe("working");
-    expect(agentWithLiveProcess.isProcessRunning).toHaveBeenCalled();
-  });
-
   it("detects activity using agent-native mechanism", async () => {
     const agentWithState: Agent = {
       ...mockAgent,

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1704,6 +1704,7 @@ describe("spawn", () => {
       // Verify the file was actually written
       const callArgs = vi.mocked(mockAgent.getLaunchCommand).mock.calls[0][0];
       const promptFile = callArgs.systemPromptFile!;
+      expect(promptFile).toContain("/sessions/");
       expect(existsSync(promptFile)).toBe(true);
       const { readFileSync } = await import("node:fs");
       expect(readFileSync(promptFile, "utf-8")).toBe("You are the orchestrator.");

--- a/packages/core/src/__tests__/test-utils.ts
+++ b/packages/core/src/__tests__/test-utils.ts
@@ -342,6 +342,7 @@ export function createMockSessionManager(): SessionManager {
     restore: vi.fn().mockResolvedValue(makeSession()),
     list: vi.fn().mockResolvedValue([]),
     get: vi.fn().mockResolvedValue(null),
+    getAttachInfo: vi.fn().mockResolvedValue(null),
     kill: vi.fn().mockResolvedValue(undefined),
     cleanup: vi.fn().mockResolvedValue({ killed: [], skipped: [], errors: [] }),
     send: vi.fn().mockResolvedValue(undefined),

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -187,6 +187,7 @@ const ProjectConfigSchema = z.object({
     .regex(/^[a-zA-Z0-9_-]+$/, "sessionPrefix must match [a-zA-Z0-9_-]+")
     .optional(),
   runtime: z.string().optional(),
+  runtimeConfig: z.record(z.string(), z.unknown()).optional(),
   agent: z.string().optional(),
   workspace: z.string().optional(),
   tracker: TrackerConfigSchema.optional(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,13 +84,6 @@ export type {
 export { generateOrchestratorPrompt } from "./orchestrator-prompt.js";
 export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";
 
-// Global pause constants and utilities
-export {
-  GLOBAL_PAUSE_UNTIL_KEY,
-  GLOBAL_PAUSE_REASON_KEY,
-  GLOBAL_PAUSE_SOURCE_KEY,
-  parsePauseUntil,
-} from "./global-pause.js";
 // Shared utilities
 export {
   shellEscape,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,6 +84,13 @@ export type {
 export { generateOrchestratorPrompt } from "./orchestrator-prompt.js";
 export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";
 
+// Global pause constants and utilities
+export {
+  GLOBAL_PAUSE_UNTIL_KEY,
+  GLOBAL_PAUSE_REASON_KEY,
+  GLOBAL_PAUSE_SOURCE_KEY,
+  parsePauseUntil,
+} from "./global-pause.js";
 // Shared utilities
 export {
   shellEscape,
@@ -94,6 +101,7 @@ export {
   readLastJsonlEntry,
   resolveProjectIdForSessionId,
 } from "./utils.js";
+export { isPlainObject, mergeRuntimeConfig } from "./runtime-selection.js";
 export {
   getWebhookHeader,
   parseWebhookJsonObject,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -40,6 +40,18 @@ import { updateMetadata } from "./metadata.js";
 import { getSessionsDir } from "./paths.js";
 import { createCorrelationId, createProjectObserver } from "./observability.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
+import { resolveRuntimeName as resolveStoredRuntimeName } from "./runtime-selection.js";
+
+function resolveRuntimeNameForSession(
+  session: Session,
+  project: _ProjectConfig,
+  defaults: OrchestratorConfig["defaults"],
+): string {
+  return (
+    session.runtimeHandle?.runtimeName ??
+    resolveStoredRuntimeName(project, defaults.runtime, { raw: session.metadata })
+  );
+}
 
 /** Parse a duration string like "10m", "30s", "1h" to milliseconds. */
 function parseDuration(str: string): number {
@@ -368,7 +380,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     // 1. Check if runtime is alive
     if (session.runtimeHandle) {
-      const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
+      const runtimeName = resolveRuntimeNameForSession(session, project, config.defaults);
+      const runtime = registry.get<Runtime>("runtime", runtimeName);
       if (runtime) {
         const alive = await runtime.isAlive(session.runtimeHandle).catch(() => true);
         if (!alive) return "killed";
@@ -414,10 +427,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           // proceed to PR checks below
         } else {
           // getActivityState returned null — fall back to terminal output parsing
-          const runtime = registry.get<Runtime>(
-            "runtime",
-            project.runtime ?? config.defaults.runtime,
-          );
+          const runtimeName = resolveRuntimeNameForSession(session, project, config.defaults);
+          const runtime = registry.get<Runtime>("runtime", runtimeName);
           const terminalOutput = runtime ? await runtime.getOutput(session.runtimeHandle, 10) : "";
           if (terminalOutput) {
             const activity = agent.detectActivity(terminalOutput);

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -53,6 +53,8 @@ function resolveRuntimeNameForSession(
   );
 }
 
+const SPAWNING_KILL_GRACE_MS = 60_000;
+
 /** Parse a duration string like "10m", "30s", "1h" to milliseconds. */
 function parseDuration(str: string): number {
   const match = str.match(/^(\d+)(s|m|h)$/);
@@ -361,6 +363,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return idleMs > stuckThresholdMs;
   }
 
+  function isWithinSpawnGrace(session: Session): boolean {
+    const persistedStatus = session.metadata?.["status"] as SessionStatus | undefined;
+    const effectiveStatus = persistedStatus ?? session.status;
+    if (effectiveStatus !== SESSION_STATUS.SPAWNING) {
+      return false;
+    }
+
+    const startedAt = session.restoredAt ?? session.createdAt;
+    return Date.now() - startedAt.getTime() < SPAWNING_KILL_GRACE_MS;
+  }
+
   /** Determine current status for a session by polling plugins. */
   async function determineStatus(session: Session): Promise<SessionStatus> {
     const project = config.projects[session.projectId];
@@ -374,6 +387,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }).agentName;
     const agent = registry.get<Agent>("agent", agentName);
     const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    const withinSpawnGrace = isWithinSpawnGrace(session);
 
     // Track activity state across steps so stuck detection can run after PR checks
     let detectedIdleTimestamp: Date | null = null;
@@ -414,7 +428,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         const activityState = await agent.getActivityState(session, config.readyThresholdMs);
         if (activityState) {
           if (activityState.state === "waiting_input") return "needs_input";
-          if (activityState.state === "exited") return "killed";
+          if (activityState.state === "exited") return withinSpawnGrace ? "spawning" : "killed";
 
           if (
             (activityState.state === "idle" || activityState.state === "blocked") &&
@@ -435,7 +449,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             if (activity === "waiting_input") return "needs_input";
 
             const processAlive = await agent.isProcessRunning(session.runtimeHandle);
-            if (!processAlive) return "killed";
+            if (!processAlive) return withinSpawnGrace ? "spawning" : "killed";
           }
         }
       } catch {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -84,6 +84,8 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
     project: raw["project"],
     agent: raw["agent"],
     createdAt: raw["createdAt"],
+    runtime: raw["runtime"],
+    runtimeConfig: raw["runtimeConfig"],
     runtimeHandle: raw["runtimeHandle"],
     restoredAt: raw["restoredAt"],
     role: raw["role"],
@@ -134,6 +136,8 @@ export function writeMetadata(
   if (metadata.project) data["project"] = metadata.project;
   if (metadata.agent) data["agent"] = metadata.agent;
   if (metadata.createdAt) data["createdAt"] = metadata.createdAt;
+  if (metadata.runtime) data["runtime"] = metadata.runtime;
+  if (metadata.runtimeConfig) data["runtimeConfig"] = metadata.runtimeConfig;
   if (metadata.runtimeHandle) data["runtimeHandle"] = metadata.runtimeHandle;
   if (metadata.restoredAt) data["restoredAt"] = metadata.restoredAt;
   if (metadata.role) data["role"] = metadata.role;

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -33,6 +33,7 @@ function makeKey(slot: PluginSlot, name: string): string {
 const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = [
   // Runtimes
   { slot: "runtime", name: "tmux", pkg: "@composio/ao-plugin-runtime-tmux" },
+  { slot: "runtime", name: "docker", pkg: "@composio/ao-plugin-runtime-docker" },
   { slot: "runtime", name: "process", pkg: "@composio/ao-plugin-runtime-process" },
   // Agents
   { slot: "agent", name: "claude-code", pkg: "@composio/ao-plugin-agent-claude-code" },

--- a/packages/core/src/recovery/actions.ts
+++ b/packages/core/src/recovery/actions.ts
@@ -113,9 +113,8 @@ export async function cleanupSession(
 
   try {
     const project = config.projects[projectId];
-    const runtimeName = project.runtime ?? config.defaults.runtime;
     const workspaceName = project.workspace ?? config.defaults.workspace;
-    const runtime = registry.get<Runtime>("runtime", runtimeName);
+    const runtime = registry.get<Runtime>("runtime", assessment.runtimeName);
     const workspace = registry.get<Workspace>("workspace", workspaceName);
 
     if (runtimeAlive && assessment.runtimeHandle && runtime) {

--- a/packages/core/src/recovery/types.ts
+++ b/packages/core/src/recovery/types.ts
@@ -51,6 +51,9 @@ export interface RecoveryAssessment {
   /** Whether the runtime (tmux/docker) is alive */
   runtimeAlive: boolean;
 
+  /** Resolved runtime plugin name for this session */
+  runtimeName: string;
+
   /** Runtime handle if available */
   runtimeHandle: RuntimeHandle | null;
 

--- a/packages/core/src/recovery/validator.ts
+++ b/packages/core/src/recovery/validator.ts
@@ -6,11 +6,10 @@ import {
   type Runtime,
   type Agent,
   type Workspace,
-  type RuntimeHandle,
   type SessionStatus,
   type ActivityState,
 } from "../types.js";
-import { safeJsonParse, validateStatus } from "../utils/validation.js";
+import { validateStatus } from "../utils/validation.js";
 import type { ScannedSession } from "./scanner.js";
 import {
   DEFAULT_RECOVERY_CONFIG,
@@ -20,6 +19,10 @@ import {
   type RecoveryConfig,
 } from "./types.js";
 import { resolveAgentSelection, resolveSessionRole } from "../agent-selection.js";
+import {
+  parseStoredRuntimeHandle,
+  resolveRuntimeName as resolveStoredRuntimeName,
+} from "../runtime-selection.js";
 
 export async function validateSession(
   scanned: ScannedSession,
@@ -29,7 +32,10 @@ export async function validateSession(
 ): Promise<RecoveryAssessment> {
   const { sessionId, projectId, project, rawMetadata } = scanned;
 
-  const runtimeName = project.runtime ?? config.defaults.runtime;
+  const runtimeHandle = parseStoredRuntimeHandle(rawMetadata);
+  const runtimeName = resolveStoredRuntimeName(project, config.defaults.runtime, {
+    raw: rawMetadata,
+  });
   const agentName = resolveAgentSelection({
     role: resolveSessionRole(sessionId, rawMetadata, project.sessionPrefix),
     project,
@@ -43,8 +49,6 @@ export async function validateSession(
   const workspace = registry.get<Workspace>("workspace", workspaceName);
 
   const workspacePath = rawMetadata["worktree"] || null;
-  const runtimeHandleStr = rawMetadata["runtimeHandle"];
-  const runtimeHandle = runtimeHandleStr ? safeJsonParse<RuntimeHandle>(runtimeHandleStr) : null;
   const metadataStatus = validateStatus(rawMetadata["status"]);
   const recoveryConfig: RecoveryConfig = {
     ...DEFAULT_RECOVERY_CONFIG,
@@ -102,6 +106,7 @@ export async function validateSession(
     action,
     reason: getReason(classification, runtimeAlive, workspaceExists, agentProcessRunning),
     runtimeAlive,
+    runtimeName,
     runtimeHandle,
     workspaceExists,
     workspacePath,

--- a/packages/core/src/runtime-selection.ts
+++ b/packages/core/src/runtime-selection.ts
@@ -1,0 +1,78 @@
+import type { ProjectConfig, RuntimeHandle } from "./types.js";
+import { safeJsonParse } from "./utils/validation.js";
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function mergeRuntimeConfig(
+  base?: Record<string, unknown>,
+  override?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!base && !override) return undefined;
+
+  const merged: Record<string, unknown> = {};
+
+  for (const source of [base, override]) {
+    if (!source) continue;
+
+    for (const [key, value] of Object.entries(source)) {
+      const existing = merged[key];
+      merged[key] =
+        isPlainObject(existing) && isPlainObject(value)
+          ? mergeRuntimeConfig(existing, value)
+          : isPlainObject(value)
+            ? (mergeRuntimeConfig(value) ?? {})
+            : value;
+    }
+  }
+
+  return merged;
+}
+
+export function parseStoredRuntimeHandle(raw?: Record<string, string>): RuntimeHandle | null {
+  if (!raw?.["runtimeHandle"]) return null;
+  return safeJsonParse<RuntimeHandle>(raw["runtimeHandle"]) ?? null;
+}
+
+export function parseStoredRuntimeConfig(
+  raw?: Record<string, string>,
+): Record<string, unknown> | undefined {
+  if (!raw?.["runtimeConfig"]) return undefined;
+  const parsed = safeJsonParse<Record<string, unknown>>(raw["runtimeConfig"]);
+  return isPlainObject(parsed) ? parsed : undefined;
+}
+
+export function resolveRuntimeName(
+  project: Pick<ProjectConfig, "runtime">,
+  defaultRuntime: string,
+  options?: {
+    raw?: Record<string, string>;
+    runtimeOverride?: string;
+  },
+): string {
+  const parsedHandle = parseStoredRuntimeHandle(options?.raw);
+
+  return (
+    options?.runtimeOverride ??
+    parsedHandle?.runtimeName ??
+    options?.raw?.["runtime"] ??
+    project.runtime ??
+    defaultRuntime
+  );
+}
+
+export function resolveRuntimeConfigForSpawn(
+  project: Pick<ProjectConfig, "runtimeConfig">,
+  runtimeConfigOverride?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  return mergeRuntimeConfig(project.runtimeConfig, runtimeConfigOverride);
+}
+
+export function resolveRuntimeConfigForSession(
+  project: Pick<ProjectConfig, "runtimeConfig">,
+  raw: Record<string, string>,
+): Record<string, unknown> | undefined {
+  const stored = parseStoredRuntimeConfig(raw);
+  return stored ? mergeRuntimeConfig(stored) : mergeRuntimeConfig(project.runtimeConfig);
+}

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -58,7 +58,6 @@ import { buildPrompt } from "./prompt-builder.js";
 import {
   getSessionsDir,
   getWorktreesDir,
-  getProjectBaseDir,
   generateTmuxName,
   validateAndStoreOrigin,
 } from "./paths.js";
@@ -808,10 +807,23 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     sessionName: string,
     sessionsDir: string,
     effectiveAgentName: string,
+    agentPlugin: Agent | null,
     sessionListPromise?: Promise<OpenCodeSessionListEntry[]>,
   ): Promise<void> {
     if (effectiveAgentName !== "opencode") return;
     if (asValidOpenCodeSessionId(session.metadata["opencodeSessionId"])) return;
+
+    try {
+      const info = await agentPlugin?.getSessionInfo?.(session);
+      const discoveredFromAgent = asValidOpenCodeSessionId(info?.agentSessionId ?? undefined);
+      if (discoveredFromAgent) {
+        session.metadata["opencodeSessionId"] = discoveredFromAgent;
+        updateMetadata(sessionsDir, sessionName, { opencodeSessionId: discoveredFromAgent });
+        return;
+      }
+    } catch {
+      // Fall through to title-based discovery.
+    }
 
     const discovered = await discoverOpenCodeSessionIdByTitle(
       sessionName,
@@ -875,6 +887,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       sessionName,
       sessionsDir,
       effectiveAgentName,
+      plugins.agent,
       sessionListPromise,
     );
 
@@ -910,8 +923,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     plugins: ReturnType<typeof resolvePlugins>,
     handleFromMetadata: boolean,
   ): Promise<void> {
+    const wasTerminalStatus = TERMINAL_SESSION_STATUSES.has(session.status);
+
     // Skip all subprocess/IO work for sessions already known to be terminal.
-    if (TERMINAL_SESSION_STATUSES.has(session.status)) {
+    if (wasTerminalStatus && !session.runtimeHandle) {
       session.activity = "exited";
       return;
     }
@@ -958,6 +973,27 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         }
       } catch {
         // Can't get session info — keep existing values
+      }
+
+      if (wasTerminalStatus && session.runtimeHandle) {
+        try {
+          const processAlive = await plugins.agent.isProcessRunning(session.runtimeHandle);
+          if (processAlive) {
+            if (session.activity === "waiting_input") {
+              session.status = "needs_input";
+            } else if (session.activity === "blocked") {
+              session.status = "stuck";
+            } else if (session.pr) {
+              session.status = "pr_open";
+            } else {
+              session.status = "working";
+            }
+          } else {
+            session.activity = "exited";
+          }
+        } catch {
+          session.activity = "exited";
+        }
       }
     }
   }
@@ -1207,19 +1243,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         await plugins.agent.postLaunchSetup(session);
       }
 
-      if (
-        plugins.agent.name === "opencode" &&
-        opencodeIssueSessionStrategy === "reuse" &&
-        !session.metadata["opencodeSessionId"]
-      ) {
-        const discovered = await discoverOpenCodeSessionIdByTitle(
-          sessionId,
-          OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS,
-        );
-        if (discovered) {
-          session.metadata["opencodeSessionId"] = discovered;
-        }
-      }
+      await ensureOpenCodeSessionMapping(
+        session,
+        sessionId,
+        sessionsDir,
+        plugins.agent.name,
+        plugins.agent,
+      );
 
       if (Object.keys(session.metadata || {}).length > 0) {
         updateMetadata(sessionsDir, sessionId, session.metadata);
@@ -1405,9 +1435,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     let systemPromptFile: string | undefined;
     if (orchestratorConfig.systemPrompt) {
       try {
-        const baseDir = getProjectBaseDir(config.configPath, project.path);
-        mkdirSync(baseDir, { recursive: true });
-        systemPromptFile = join(baseDir, `orchestrator-prompt-${sessionId}.md`);
+        mkdirSync(sessionsDir, { recursive: true });
+        systemPromptFile = join(sessionsDir, `orchestrator-prompt-${sessionId}.md`);
         writeFileSync(systemPromptFile, orchestratorConfig.systemPrompt, "utf-8");
       } catch (err) {
         await cleanupWorktreeAndMetadata(systemPromptFile);
@@ -1901,20 +1930,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
   }
 
   async function send(sessionId: SessionId, message: string): Promise<void> {
-    const { raw, sessionsDir, project } = requireSessionRecord(sessionId);
+    const { raw, sessionsDir, project, projectId } = requireSessionRecord(sessionId);
+    const pause = getProjectPause(project);
+    if (pause && !isOrchestratorSessionRecord(sessionId, raw, project.sessionPrefix)) {
+      throw new Error(
+        `Project is paused due to model rate limit until ${pause.until.toISOString()} (${pause.reason}; source: ${pause.sourceSessionId})`,
+      );
+    }
 
     const selection = resolveSelectionForSession(project, sessionId, raw);
     const selectedAgent = selection.agentName;
-    if (selectedAgent === "opencode" && !asValidOpenCodeSessionId(raw["opencodeSessionId"])) {
-      const discovered = await discoverOpenCodeSessionIdByTitle(
-        sessionId,
-        OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS,
-      );
-      if (discovered) {
-        raw["opencodeSessionId"] = discovered;
-        updateMetadata(sessionsDir, sessionId, { opencodeSessionId: discovered });
-      }
-    }
     const parsedHandle = raw["runtimeHandle"]
       ? safeJsonParse<RuntimeHandle>(raw["runtimeHandle"])
       : null;
@@ -1929,6 +1954,21 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const agentPlugin = registry.get<Agent>("agent", agentName);
     if (!agentPlugin) {
       throw new Error(`No agent plugin for session ${sessionId}`);
+    }
+
+    if (selectedAgent === "opencode" && !asValidOpenCodeSessionId(raw["opencodeSessionId"])) {
+      const discoverySession = metadataToSession(sessionId, raw, projectId);
+      const info = await agentPlugin.getSessionInfo(discoverySession).catch(() => null);
+      const discovered =
+        asValidOpenCodeSessionId(info?.agentSessionId ?? undefined) ??
+        (await discoverOpenCodeSessionIdByTitle(
+          sessionId,
+          OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS,
+        ));
+      if (discovered) {
+        raw["opencodeSessionId"] = discovered;
+        updateMetadata(sessionsDir, sessionId, { opencodeSessionId: discovered });
+      }
     }
 
     const captureOutput = async (handle: RuntimeHandle): Promise<string> => {
@@ -2281,7 +2321,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
   }
 
   async function remap(sessionId: SessionId, force = false): Promise<string> {
-    const { raw, sessionsDir, project } = requireSessionRecord(sessionId);
+    const { raw, sessionsDir, project, projectId } = requireSessionRecord(sessionId);
 
     const selection = resolveSelectionForSession(project, sessionId, raw);
     const selectedAgent = selection.agentName;
@@ -2289,10 +2329,20 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       throw new Error(`Session ${sessionId} is not using the opencode agent`);
     }
 
+    const runtimeName = resolveRuntimeName(project, raw);
+    const plugins = resolvePlugins(project, selectedAgent, runtimeName);
+    const discoverySession = metadataToSession(sessionId, raw, projectId);
+    const discoveredFromAgent = force
+      ? undefined
+      : asValidOpenCodeSessionId(
+          (await plugins.agent?.getSessionInfo?.(discoverySession).catch(() => null))
+            ?.agentSessionId ?? undefined,
+        );
     const mapped = asValidOpenCodeSessionId(raw["opencodeSessionId"]);
     const discovered = force
       ? await discoverOpenCodeSessionIdByTitle(sessionId, OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS)
       : (mapped ??
+        discoveredFromAgent ??
         (await discoverOpenCodeSessionIdByTitle(
           sessionId,
           OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS,
@@ -2344,10 +2394,18 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const selection = resolveSelectionForSession(project, sessionId, raw);
     const selectedAgent = selection.agentName;
     if (selectedAgent === "opencode" && !asValidOpenCodeSessionId(raw["opencodeSessionId"])) {
-      const discovered = await discoverOpenCodeSessionIdByTitle(
-        sessionId,
-        OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS,
-      );
+      const runtimeName = resolveRuntimeName(project, raw);
+      const plugins = resolvePlugins(project, selectedAgent, runtimeName);
+      const discoverySession = metadataToSession(sessionId, raw, projectId);
+      const discovered =
+        asValidOpenCodeSessionId(
+          (await plugins.agent?.getSessionInfo?.(discoverySession).catch(() => null))
+            ?.agentSessionId ?? undefined,
+        ) ??
+        (await discoverOpenCodeSessionIdByTitle(
+          sessionId,
+          OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS,
+        ));
       if (!discovered) {
         throw new SessionNotRestorableError(sessionId, "OpenCode session mapping is missing");
       }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -40,6 +40,7 @@ import {
   type SCM,
   type PluginRegistry,
   type RuntimeHandle,
+  type AttachInfo,
   type Issue,
   PR_STATE,
 } from "./types.js";
@@ -66,6 +67,11 @@ import { normalizeOrchestratorSessionStrategy } from "./orchestrator-session-str
 import { sessionFromMetadata } from "./utils/session-from-metadata.js";
 import { safeJsonParse } from "./utils/validation.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
+import {
+  resolveRuntimeConfigForSession as resolveStoredRuntimeConfigForSession,
+  resolveRuntimeConfigForSpawn as resolveStoredRuntimeConfigForSpawn,
+  resolveRuntimeName as resolveStoredRuntimeName,
+} from "./runtime-selection.js";
 
 const execFileAsync = promisify(execFile);
 const OPENCODE_DISCOVERY_TIMEOUT_MS = 10_000;
@@ -739,9 +745,37 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     );
   }
 
+  function resolveRuntimeName(
+    project: ProjectConfig,
+    raw?: Record<string, string>,
+    runtimeOverride?: string,
+  ): string {
+    return resolveStoredRuntimeName(project, config.defaults.runtime, {
+      raw,
+      runtimeOverride,
+    });
+  }
+
+  function resolveRuntimeConfigForSpawn(
+    project: ProjectConfig,
+    runtimeConfigOverride?: Record<string, unknown>,
+  ): Record<string, unknown> | undefined {
+    return resolveStoredRuntimeConfigForSpawn(project, runtimeConfigOverride);
+  }
+
+  function resolveRuntimeConfigForSession(
+    project: ProjectConfig,
+    raw: Record<string, string>,
+  ): Record<string, unknown> | undefined {
+    return resolveStoredRuntimeConfigForSession(project, raw);
+  }
+
   /** Resolve which plugins to use for a project. */
-  function resolvePlugins(project: ProjectConfig, agentName?: string) {
-    const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
+  function resolvePlugins(project: ProjectConfig, agentName?: string, runtimeName?: string) {
+    const runtime = registry.get<Runtime>(
+      "runtime",
+      runtimeName ?? project.runtime ?? config.defaults.runtime,
+    );
     const agent = registry.get<Agent>("agent", agentName ?? project.agent ?? config.defaults.agent);
     const workspace = registry.get<Workspace>(
       "workspace",
@@ -848,16 +882,17 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const hasTmuxNameFromMetadata =
       typeof tmuxNameFromMetadata === "string" && tmuxNameFromMetadata.length > 0;
     const handleFromMetadata = session.runtimeHandle !== null || hasTmuxNameFromMetadata;
+    const runtimeName = resolveRuntimeName(project, session.metadata);
     if (!handleFromMetadata) {
       session.runtimeHandle = {
         id: sessionName,
-        runtimeName: project.runtime ?? config.defaults.runtime,
+        runtimeName,
         data: {},
       };
     } else if (!session.runtimeHandle && hasTmuxNameFromMetadata) {
       session.runtimeHandle = {
         id: tmuxNameFromMetadata,
-        runtimeName: project.runtime ?? config.defaults.runtime,
+        runtimeName,
         data: {},
       };
     }
@@ -940,9 +975,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       defaults: config.defaults,
       spawnAgentOverride: spawnConfig.agent,
     });
-    const plugins = resolvePlugins(project, selection.agentName);
+    const runtimeName = resolveRuntimeName(project, undefined, spawnConfig.runtime);
+    const runtimeConfig = resolveRuntimeConfigForSpawn(project, spawnConfig.runtimeConfig);
+    const plugins = resolvePlugins(project, selection.agentName, runtimeName);
     if (!plugins.runtime) {
-      throw new Error(`Runtime plugin '${project.runtime ?? config.defaults.runtime}' not found`);
+      throw new Error(`Runtime plugin '${runtimeName}' not found`);
     }
 
     if (!plugins.agent) {
@@ -1095,6 +1132,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         sessionId: tmuxName ?? sessionId, // Use tmux name for runtime if available
         workspacePath,
         launchCommand,
+        runtimeConfig,
         environment: {
           ...environment,
           AO_SESSION: sessionId,
@@ -1155,6 +1193,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         tmuxName, // Store tmux name for mapping
         issue: spawnConfig.issueId,
         project: spawnConfig.projectId,
+        runtime: runtimeName,
+        runtimeConfig: runtimeConfig ? JSON.stringify(runtimeConfig) : undefined,
         agent: selection.agentName, // Persist agent name for lifecycle manager
         createdAt: new Date().toISOString(),
         runtimeHandle: JSON.stringify(handle),
@@ -1263,9 +1303,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       project,
       defaults: config.defaults,
     });
-    const plugins = resolvePlugins(project, selection.agentName);
+    const runtimeName = resolveRuntimeName(project, undefined, orchestratorConfig.runtime);
+    const runtimeConfig = resolveRuntimeConfigForSpawn(project, orchestratorConfig.runtimeConfig);
+    const plugins = resolvePlugins(project, selection.agentName, runtimeName);
     if (!plugins.runtime) {
-      throw new Error(`Runtime plugin '${project.runtime ?? config.defaults.runtime}' not found`);
+      throw new Error(`Runtime plugin '${runtimeName}' not found`);
     }
     if (!plugins.agent) {
       throw new Error(`Agent plugin '${selection.agentName}' not found`);
@@ -1422,6 +1464,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         sessionId: tmuxName ?? sessionId,
         workspacePath,
         launchCommand,
+        runtimeConfig,
         environment: {
           ...environment,
           AO_SESSION: sessionId,
@@ -1466,6 +1509,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         role: "orchestrator",
         tmuxName,
         project: orchestratorConfig.projectId,
+        runtime: runtimeName,
+        runtimeConfig: runtimeConfig ? JSON.stringify(runtimeConfig) : undefined,
         agent: selection.agentName,
         createdAt: new Date().toISOString(),
         runtimeHandle: JSON.stringify(handle),
@@ -1538,7 +1583,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       const session = metadataToSession(sessionName, raw, sessionProjectId, createdAt, modifiedAt);
       const selection = resolveSelectionForSession(project, sessionName, raw);
       const effectiveAgentName = selection.agentName;
-      const plugins = resolvePlugins(project, effectiveAgentName);
+      const plugins = resolvePlugins(project, effectiveAgentName, resolveRuntimeName(project, raw));
       const sessionListPromise =
         effectiveAgentName === "opencode"
           ? (openCodeSessionListPromise ??= fetchOpenCodeSessionList())
@@ -1601,7 +1646,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       const selection = resolveSelectionForSession(project, sessionId, repaired.raw);
       const effectiveAgentName = selection.agentName;
-      const plugins = resolvePlugins(project, effectiveAgentName);
+      const plugins = resolvePlugins(
+        project,
+        effectiveAgentName,
+        resolveRuntimeName(project, repaired.raw),
+      );
       await ensureHandleAndEnrich(
         session,
         sessionId,
@@ -1629,7 +1678,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         const runtimePlugin = registry.get<Runtime>(
           "runtime",
           handle.runtimeName ??
-            (project ? (project.runtime ?? config.defaults.runtime) : config.defaults.runtime),
+            (project ? resolveRuntimeName(project, raw) : config.defaults.runtime),
         );
         if (runtimePlugin) {
           try {
@@ -1733,7 +1782,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           continue;
         }
 
-        const plugins = resolvePlugins(project);
+        const plugins = resolvePlugins(
+          project,
+          resolveSelectionForSession(project, session.id, session.metadata).agentName,
+          resolveRuntimeName(project, session.metadata),
+        );
         let shouldKill = false;
 
         // Check if PR is merged
@@ -1861,7 +1914,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const parsedHandle = raw["runtimeHandle"]
       ? safeJsonParse<RuntimeHandle>(raw["runtimeHandle"])
       : null;
-    const runtimeName = parsedHandle?.runtimeName ?? project.runtime ?? config.defaults.runtime;
+    const runtimeName = parsedHandle?.runtimeName ?? resolveRuntimeName(project, raw);
     const agentName = selectedAgent;
 
     const runtimePlugin = registry.get<Runtime>("runtime", runtimeName);
@@ -2305,7 +2358,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     //    session (status "working", agent exited) would not be detected as terminal
     //    and isRestorable would reject it.
     const session = metadataToSession(sessionId, raw, projectId);
-    const plugins = resolvePlugins(project, selection.agentName);
+    const runtimeName = resolveRuntimeName(project, raw);
+    const runtimeConfig = resolveRuntimeConfigForSession(project, raw);
+    const plugins = resolvePlugins(project, selection.agentName, runtimeName);
     await enrichSessionWithRuntimeState(session, plugins, true);
 
     // 3. Validate restorability
@@ -2329,6 +2384,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           raw["prAutoDetect"] === "off" ? "off" : raw["prAutoDetect"] === "on" ? "on" : undefined,
         summary: raw["summary"],
         project: raw["project"],
+        runtime: raw["runtime"],
+        runtimeConfig: raw["runtimeConfig"],
         agent: raw["agent"],
         createdAt: raw["createdAt"],
         runtimeHandle: raw["runtimeHandle"],
@@ -2339,7 +2396,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     // 4. Validate required plugins (plugins already resolved above for enrichment)
     if (!plugins.runtime) {
-      throw new Error(`Runtime plugin '${project.runtime ?? config.defaults.runtime}' not found`);
+      throw new Error(`Runtime plugin '${runtimeName}' not found`);
     }
     if (!plugins.agent) {
       throw new Error(`Agent plugin '${selection.agentName}' not found`);
@@ -2426,6 +2483,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       sessionId: tmuxName ?? sessionId,
       workspacePath,
       launchCommand,
+      runtimeConfig,
       environment: {
         ...environment,
         AO_SESSION: sessionId,
@@ -2443,6 +2501,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const now = new Date().toISOString();
     updateMetadata(sessionsDir, sessionId, {
       status: "spawning",
+      runtime: runtimeName,
+      runtimeConfig: runtimeConfig ? JSON.stringify(runtimeConfig) : "",
       runtimeHandle: JSON.stringify(handle),
       restoredAt: now,
     });
@@ -2480,5 +2540,61 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return restoredSession;
   }
 
-  return { spawn, spawnOrchestrator, restore, list, get, kill, cleanup, send, claimPR, remap };
+  async function getAttachInfo(sessionId: SessionId): Promise<AttachInfo | null> {
+    const { raw, project } = requireSessionRecord(sessionId);
+    const runtimeName = resolveRuntimeName(project, raw);
+    const runtimePlugin = registry.get<Runtime>("runtime", runtimeName);
+    if (!runtimePlugin) {
+      throw new Error(`No runtime plugin for session ${sessionId}`);
+    }
+
+    const parsedHandle = raw["runtimeHandle"]
+      ? safeJsonParse<RuntimeHandle>(raw["runtimeHandle"])
+      : null;
+    const tmuxName = raw["tmuxName"]?.trim();
+    const handle =
+      parsedHandle ??
+      (runtimeName === "tmux"
+        ? ({
+            id: tmuxName && tmuxName.length > 0 ? tmuxName : sessionId,
+            runtimeName,
+            data: {},
+          } satisfies RuntimeHandle)
+        : null);
+
+    if (!handle) {
+      return null;
+    }
+
+    if (runtimePlugin.getAttachInfo) {
+      return runtimePlugin.getAttachInfo(handle);
+    }
+
+    if (handle.runtimeName === "tmux") {
+      return {
+        type: "tmux",
+        target: handle.id,
+        command: `tmux attach -t ${handle.id}`,
+        program: "tmux",
+        args: ["attach", "-t", handle.id],
+        requiresPty: true,
+      };
+    }
+
+    return null;
+  }
+
+  return {
+    spawn,
+    spawnOrchestrator,
+    restore,
+    list,
+    get,
+    getAttachInfo,
+    kill,
+    cleanup,
+    send,
+    claimPR,
+    remap,
+  };
 }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -923,10 +923,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     plugins: ReturnType<typeof resolvePlugins>,
     handleFromMetadata: boolean,
   ): Promise<void> {
-    const wasTerminalStatus = TERMINAL_SESSION_STATUSES.has(session.status);
-
     // Skip all subprocess/IO work for sessions already known to be terminal.
-    if (wasTerminalStatus && !session.runtimeHandle) {
+    if (TERMINAL_SESSION_STATUSES.has(session.status)) {
       session.activity = "exited";
       return;
     }
@@ -973,27 +971,6 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         }
       } catch {
         // Can't get session info — keep existing values
-      }
-
-      if (wasTerminalStatus && session.runtimeHandle) {
-        try {
-          const processAlive = await plugins.agent.isProcessRunning(session.runtimeHandle);
-          if (processAlive) {
-            if (session.activity === "waiting_input") {
-              session.status = "needs_input";
-            } else if (session.activity === "blocked") {
-              session.status = "stuck";
-            } else if (session.pr) {
-              session.status = "pr_open";
-            } else {
-              session.status = "working";
-            }
-          } else {
-            session.activity = "exited";
-          }
-        } catch {
-          session.activity = "exited";
-        }
       }
     }
   }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1931,12 +1931,6 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
   async function send(sessionId: SessionId, message: string): Promise<void> {
     const { raw, sessionsDir, project, projectId } = requireSessionRecord(sessionId);
-    const pause = getProjectPause(project);
-    if (pause && !isOrchestratorSessionRecord(sessionId, raw, project.sessionPrefix)) {
-      throw new Error(
-        `Project is paused due to model rate limit until ${pause.until.toISOString()} (${pause.reason}; source: ${pause.sourceSessionId})`,
-      );
-    }
 
     const selection = resolveSelectionForSession(project, sessionId, raw);
     const selectedAgent = selection.agentName;

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1127,12 +1127,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     try {
       const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);
       const environment = plugins.agent.getEnvironment(agentLaunchConfig);
+      const agentRuntimeHints = plugins.agent.getRuntimeHints?.(agentLaunchConfig) ?? undefined;
 
       handle = await plugins.runtime.create({
         sessionId: tmuxName ?? sessionId, // Use tmux name for runtime if available
         workspacePath,
         launchCommand,
         runtimeConfig,
+        ...(agentRuntimeHints ? { agentRuntimeHints } : {}),
         environment: {
           ...environment,
           AO_SESSION: sessionId,
@@ -1456,6 +1458,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);
     const environment = plugins.agent.getEnvironment(agentLaunchConfig);
+    const agentRuntimeHints = plugins.agent.getRuntimeHints?.(agentLaunchConfig) ?? undefined;
 
     // Create runtime — clean up worktree and metadata on failure
     let handle: RuntimeHandle;
@@ -1465,6 +1468,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         workspacePath,
         launchCommand,
         runtimeConfig,
+        ...(agentRuntimeHints ? { agentRuntimeHints } : {}),
         environment: {
           ...environment,
           AO_SESSION: sessionId,
@@ -2476,6 +2480,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     }
 
     const environment = plugins.agent.getEnvironment(agentLaunchConfig);
+    const agentRuntimeHints = plugins.agent.getRuntimeHints?.(agentLaunchConfig) ?? undefined;
 
     // 8. Create runtime (reuse tmuxName from metadata)
     const tmuxName = raw["tmuxName"];
@@ -2484,6 +2489,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       workspacePath,
       launchCommand,
       runtimeConfig,
+      ...(agentRuntimeHints ? { agentRuntimeHints } : {}),
       environment: {
         ...environment,
         AO_SESSION: sessionId,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -228,6 +228,10 @@ export interface SessionSpawnConfig {
   issueId?: string;
   branch?: string;
   prompt?: string;
+  /** Override the runtime plugin for this session (e.g. "docker", "tmux") */
+  runtime?: string;
+  /** Runtime-specific config merged on top of the project's runtimeConfig */
+  runtimeConfig?: Record<string, unknown>;
   /** Override the agent plugin for this session (e.g. "codex", "claude-code") */
   agent?: string;
   /** Override the OpenCode subagent for this session (e.g. "sisyphus", "oracle") */
@@ -242,6 +246,10 @@ export interface SessionSpawnConfig {
 export interface OrchestratorSpawnConfig {
   projectId: string;
   systemPrompt?: string;
+  /** Override the runtime plugin for this orchestrator session */
+  runtime?: string;
+  /** Runtime-specific config merged on top of the project's runtimeConfig */
+  runtimeConfig?: Record<string, unknown>;
 }
 
 // =============================================================================
@@ -282,6 +290,7 @@ export interface RuntimeCreateConfig {
   workspacePath: string;
   launchCommand: string;
   environment: Record<string, string>;
+  runtimeConfig?: Record<string, unknown>;
 }
 
 /** Opaque handle returned by runtime.create() */
@@ -307,6 +316,12 @@ export interface AttachInfo {
   target: string;
   /** Optional: command to run to attach */
   command?: string;
+  /** Structured program to exec for attach, preferred over parsing command */
+  program?: string;
+  /** Structured args to exec for attach */
+  args?: string[];
+  /** Whether the attach command expects a TTY/PTY */
+  requiresPty?: boolean;
 }
 
 // =============================================================================
@@ -1139,6 +1154,9 @@ export interface ProjectConfig {
   /** Override default runtime */
   runtime?: string;
 
+  /** Runtime-specific configuration (e.g. docker image, limits) */
+  runtimeConfig?: Record<string, unknown>;
+
   /** Override default agent */
   agent?: string;
 
@@ -1381,6 +1399,8 @@ export interface SessionMetadata {
   project?: string;
   agent?: string; // Agent plugin name (e.g. "codex", "claude-code") — persisted for lifecycle
   createdAt?: string;
+  runtime?: string;
+  runtimeConfig?: string;
   runtimeHandle?: string;
   restoredAt?: string;
   role?: string; // "orchestrator" for orchestrator sessions
@@ -1402,6 +1422,7 @@ export interface SessionManager {
   restore(sessionId: SessionId): Promise<Session>;
   list(projectId?: string): Promise<Session[]>;
   get(sessionId: SessionId): Promise<Session | null>;
+  getAttachInfo(sessionId: SessionId): Promise<AttachInfo | null>;
   kill(sessionId: SessionId, options?: { purgeOpenCode?: boolean }): Promise<void>;
   cleanup(
     projectId?: string,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -304,6 +304,8 @@ export interface AgentDockerHomeMount {
 export interface AgentDockerRuntimeHints {
   /** Files or directories the agent expects under its container HOME. */
   homeMounts?: AgentDockerHomeMount[];
+  /** Host environment variables to copy into Docker sessions when present. */
+  envFromHost?: string[];
 }
 
 export interface AgentRuntimeHints {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -306,6 +306,12 @@ export interface AgentDockerRuntimeHints {
   homeMounts?: AgentDockerHomeMount[];
   /** Host environment variables to copy into Docker sessions when present. */
   envFromHost?: string[];
+  /**
+   * Container environment defaults for Docker sessions.
+   * Relative values are resolved against the container HOME directory.
+   * Existing environment variables take precedence over these defaults.
+   */
+  envDefaults?: Record<string, string>;
 }
 
 export interface AgentRuntimeHints {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -292,6 +292,11 @@ export interface AgentDockerHomeMount {
    */
   path: string;
   /**
+   * Whether the mounted path is expected to be a file or directory.
+   * When provided, Docker runtimes may create the host path if it does not exist yet.
+   */
+  kind?: "file" | "dir";
+  /**
    * Container destination for the mount.
    * Relative paths are resolved against the container HOME directory.
    * Defaults to the same relative path as `path`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -285,12 +285,39 @@ export interface Runtime {
   getAttachInfo?(handle: RuntimeHandle): Promise<AttachInfo>;
 }
 
+export interface AgentDockerHomeMount {
+  /**
+   * Host path to mount for Docker runtimes.
+   * Relative paths are resolved against the current user's home directory.
+   */
+  path: string;
+  /**
+   * Container destination for the mount.
+   * Relative paths are resolved against the container HOME directory.
+   * Defaults to the same relative path as `path`.
+   */
+  target?: string;
+  /** Mount the path read-only when possible. */
+  readOnly?: boolean;
+}
+
+export interface AgentDockerRuntimeHints {
+  /** Files or directories the agent expects under its container HOME. */
+  homeMounts?: AgentDockerHomeMount[];
+}
+
+export interface AgentRuntimeHints {
+  /** Runtime hints consumed by the Docker runtime plugin. */
+  docker?: AgentDockerRuntimeHints;
+}
+
 export interface RuntimeCreateConfig {
   sessionId: SessionId;
   workspacePath: string;
   launchCommand: string;
   environment: Record<string, string>;
   runtimeConfig?: Record<string, unknown>;
+  agentRuntimeHints?: AgentRuntimeHints;
 }
 
 /** Opaque handle returned by runtime.create() */
@@ -352,6 +379,9 @@ export interface Agent {
 
   /** Get environment variables for the agent process */
   getEnvironment(config: AgentLaunchConfig): Record<string, string>;
+
+  /** Optional runtime-specific hints (for example, Docker home mounts). */
+  getRuntimeHints?(config: AgentLaunchConfig): AgentRuntimeHints | null;
 
   /**
    * Detect what the agent is currently doing from terminal output.

--- a/packages/integration-tests/src/agent-opencode.integration.test.ts
+++ b/packages/integration-tests/src/agent-opencode.integration.test.ts
@@ -201,13 +201,9 @@ describe("getLaunchCommand (integration)", () => {
       subagent: "sisyphus",
       prompt: "fix the bug",
     });
+    expect(cmd).toContain("opencode");
     expect(cmd).toContain("--agent 'sisyphus'");
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:test-1' --agent 'sisyphus' --command true",
-    );
-    expect(cmd).toContain("'fix the bug'");
-    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --prompt 'fix the bug'");
-    expect(cmd).toContain("--agent 'sisyphus'");
+    expect(cmd).toContain("--prompt 'fix the bug'");
   });
 
   it("generates correct command with systemPrompt", () => {
@@ -216,12 +212,8 @@ describe("getLaunchCommand (integration)", () => {
       systemPrompt: "You are an orchestrator",
       prompt: "do the task",
     });
-    expect(cmd).toContain("opencode run --format json --title 'AO:test-1' --command true");
-    expect(cmd).toContain(
-      `exec opencode --session "$SES_ID" --prompt 'You are an orchestrator
-
-do the task'`,
-    );
+    expect(cmd).toContain("opencode");
+    expect(cmd).toContain("--prompt 'You are an orchestrator\n\ndo the task'");
   });
 
   it("generates correct command with systemPromptFile", () => {
@@ -230,9 +222,9 @@ do the task'`,
       systemPromptFile: "/tmp/orchestrator-prompt.md",
       prompt: "do the task",
     });
-    expect(cmd).toContain("opencode run --format json --title 'AO:test-1' --command true");
+    expect(cmd).toContain("opencode");
     expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt \"$(cat '/tmp/orchestrator-prompt.md'; printf '\\n\\n'; printf %s 'do the task')\"",
+      "--prompt \"$(cat '/tmp/orchestrator-prompt.md'; printf '\\n\\n'; printf %s 'do the task')\"",
     );
   });
 
@@ -253,14 +245,10 @@ do the task'`,
       model: "gpt-5.2",
       prompt: "review this code",
     });
+    expect(cmd).toContain("opencode");
     expect(cmd).toContain("--agent 'oracle'");
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:test-1' --agent 'oracle' --model 'gpt-5.2' --command true",
-    );
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt 'You are an expert\n\nreview this code' --agent 'oracle' --model 'gpt-5.2'",
-    );
     expect(cmd).toContain("--model 'gpt-5.2'");
+    expect(cmd).toContain("--prompt 'You are an expert\n\nreview this code'");
   });
 
   it("systemPromptFile takes precedence over systemPrompt", () => {
@@ -280,12 +268,8 @@ do the task'`,
       permissions: "permissionless",
       systemPromptFile: "/tmp/orchestrator-prompt.md",
     });
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:test-orchestrator' --command true",
-    );
-    expect(cmd).toContain(
-      'exec opencode --session "$SES_ID" --prompt "$(cat \'/tmp/orchestrator-prompt.md\')"',
-    );
+    expect(cmd).toContain("opencode");
+    expect(cmd).toContain(`--prompt "$(cat '/tmp/orchestrator-prompt.md')"`);
   });
 
   it("escapes single quotes in systemPrompt", () => {
@@ -309,9 +293,9 @@ do the task'`,
       ...baseConfig,
       prompt: "fix  and `backtick` and 'quote'",
     });
-    expect(cmd).toContain("opencode run --format json --title 'AO:test-1' --command true");
+    expect(cmd).toContain("opencode");
     expect(cmd).toContain("fix  and `backtick`");
-    expect(cmd).toContain('exec opencode --session "$SES_ID" --prompt');
+    expect(cmd).toContain("--prompt");
   });
 
   it("handles empty prompt", () => {
@@ -319,10 +303,7 @@ do the task'`,
       ...baseConfig,
       prompt: "",
     });
-    expect(cmd).toContain("opencode run --format json --title 'AO:test-1' --command true");
-    expect(cmd).toContain('exec opencode --session "$SES_ID"');
-    expect(cmd).toContain("opencode session list --format json");
-    expect(cmd).toContain("AO:test-1");
+    expect(cmd).toBe("opencode");
   });
 
   it("handles prompt with newlines", () => {
@@ -330,19 +311,16 @@ do the task'`,
       ...baseConfig,
       prompt: "line1\nline2",
     });
-    expect(cmd).toContain("opencode run --format json --title 'AO:test-1' --command true");
-    expect(cmd).toContain('exec opencode --session "$SES_ID" --prompt \'line1');
+    expect(cmd).toContain("opencode");
+    expect(cmd).toContain("--prompt 'line1");
   });
 
-  it("uses run bootstrap launch for fresh sessions", () => {
+  it("uses direct interactive launch for fresh sessions", () => {
     const cmd = agent.getLaunchCommand({
       ...baseConfig,
       prompt: "start work",
     });
-    expect(cmd).toContain("--title 'AO:test-1'");
-    expect(cmd).toContain("opencode run --format json --title 'AO:test-1' --command true");
-    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --prompt 'start work'");
-    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).toBe("opencode --prompt 'start work'");
   });
 
   it("uses --session when existing OpenCode session id is provided", () => {

--- a/packages/plugins/agent-aider/src/index.ts
+++ b/packages/plugins/agent-aider/src/index.ts
@@ -27,7 +27,6 @@ import { join } from "node:path";
 import { constants } from "node:fs";
 
 const execFileAsync = promisify(execFile);
-
 // =============================================================================
 // Aider Activity Detection Helpers
 // =============================================================================
@@ -226,6 +225,32 @@ function createAiderAgent(): Agent {
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
       try {
+        if (handle.runtimeName === "docker" && handle.id) {
+          const containerName =
+            typeof handle.data["containerName"] === "string"
+              ? handle.data["containerName"]
+              : handle.id;
+          const tmuxSessionName =
+            typeof handle.data["tmuxSessionName"] === "string"
+              ? handle.data["tmuxSessionName"]
+              : handle.id;
+          const { stdout } = await execFileAsync(
+            "docker",
+            [
+              "exec",
+              containerName,
+              "tmux",
+              "display-message",
+              "-p",
+              "-t",
+              tmuxSessionName,
+              "#{pane_current_command}",
+            ],
+            { timeout: 30_000 },
+          );
+          return stdout.trim() === "aider";
+        }
+
         if (handle.runtimeName === "tmux" && handle.id) {
           const { stdout: ttyOut } = await execFileAsync(
             "tmux",

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -272,8 +272,9 @@ describe("getRuntimeHints", () => {
   it("requests Claude home state and API-key passthrough for Docker runtimes", () => {
     expect(agent.getRuntimeHints?.(makeLaunchConfig())).toEqual({
       docker: {
-        homeMounts: [{ path: ".claude" }, { path: ".claude.json", readOnly: true }],
-        envFromHost: ["ANTHROPIC_API_KEY"],
+        homeMounts: [{ path: ".claude" }],
+        envDefaults: { CLAUDE_CONFIG_DIR: ".claude" },
+        envFromHost: ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"],
       },
     });
   });

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -266,6 +266,19 @@ describe("getEnvironment", () => {
   });
 });
 
+describe("getRuntimeHints", () => {
+  const agent = create();
+
+  it("requests Claude home state and API-key passthrough for Docker runtimes", () => {
+    expect(agent.getRuntimeHints?.(makeLaunchConfig())).toEqual({
+      docker: {
+        homeMounts: [{ path: ".claude" }, { path: ".claude.json", readOnly: true }],
+        envFromHost: ["ANTHROPIC_API_KEY"],
+      },
+    });
+  });
+});
+
 // =========================================================================
 // isProcessRunning
 // =========================================================================

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -272,7 +272,7 @@ describe("getRuntimeHints", () => {
   it("requests Claude home state and API-key passthrough for Docker runtimes", () => {
     expect(agent.getRuntimeHints?.(makeLaunchConfig())).toEqual({
       docker: {
-        homeMounts: [{ path: ".claude" }],
+        homeMounts: [{ path: ".claude", kind: "dir" }],
         envDefaults: { CLAUDE_CONFIG_DIR: ".claude" },
         envFromHost: ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"],
       },

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -7,6 +7,7 @@ import {
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
+  type AgentRuntimeHints,
   type ActivityDetection,
   type ActivityState,
   type CostEstimate,
@@ -695,6 +696,15 @@ function createClaudeCodeAgent(): Agent {
       }
 
       return env;
+    },
+
+    getRuntimeHints(): AgentRuntimeHints {
+      return {
+        docker: {
+          homeMounts: [{ path: ".claude" }, { path: ".claude.json", readOnly: true }],
+          envFromHost: ["ANTHROPIC_API_KEY"],
+        },
+      };
     },
 
     detectActivity(terminalOutput: string): ActivityState {

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -701,8 +701,13 @@ function createClaudeCodeAgent(): Agent {
     getRuntimeHints(): AgentRuntimeHints {
       return {
         docker: {
-          homeMounts: [{ path: ".claude" }, { path: ".claude.json", readOnly: true }],
-          envFromHost: ["ANTHROPIC_API_KEY"],
+          // Claude's devcontainer/docs model is a Linux-side config home, not
+          // host macOS login-state transfer. We mount ~/.claude read-write and
+          // point CLAUDE_CONFIG_DIR there so Docker sessions can persist their
+          // own auth/config state without depending on the host keychain.
+          homeMounts: [{ path: ".claude" }],
+          envDefaults: { CLAUDE_CONFIG_DIR: ".claude" },
+          envFromHost: ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"],
         },
       };
     },

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -24,7 +24,6 @@ import { basename, join } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-
 // =============================================================================
 // Metadata Updater Hook Script
 // =============================================================================
@@ -307,8 +306,7 @@ async function parseJsonlFileTail(filePath: string, maxBytes = 131_072): Promise
   // Skip potentially truncated first line only when we started mid-file.
   // If offset === 0 we read from the start so the first line is complete.
   const firstNewline = content.indexOf("\n");
-  const safeContent =
-    offset > 0 && firstNewline >= 0 ? content.slice(firstNewline + 1) : content;
+  const safeContent = offset > 0 && firstNewline >= 0 ? content.slice(firstNewline + 1) : content;
   const lines: JsonlLine[] = [];
   for (const line of safeContent.split("\n")) {
     const trimmed = line.trim();
@@ -326,9 +324,7 @@ async function parseJsonlFileTail(filePath: string, maxBytes = 131_072): Promise
 }
 
 /** Extract auto-generated summary from JSONL (last "summary" type entry) */
-function extractSummary(
-  lines: JsonlLine[],
-): { summary: string; isFallback: boolean } | null {
+function extractSummary(lines: JsonlLine[]): { summary: string; isFallback: boolean } | null {
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i];
     if (line?.type === "summary" && line.summary) {
@@ -706,6 +702,36 @@ function createClaudeCodeAgent(): Agent {
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      if (handle.runtimeName === "docker" && handle.id) {
+        try {
+          const containerName =
+            typeof handle.data["containerName"] === "string"
+              ? handle.data["containerName"]
+              : handle.id;
+          const tmuxSessionName =
+            typeof handle.data["tmuxSessionName"] === "string"
+              ? handle.data["tmuxSessionName"]
+              : handle.id;
+          const { stdout } = await execFileAsync(
+            "docker",
+            [
+              "exec",
+              containerName,
+              "tmux",
+              "display-message",
+              "-p",
+              "-t",
+              tmuxSessionName,
+              "#{pane_current_command}",
+            ],
+            { timeout: 30_000 },
+          );
+          return stdout.trim() === "claude";
+        } catch {
+          return false;
+        }
+      }
+
       const pid = await findClaudeProcess(handle);
       return pid !== null;
     },

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -705,7 +705,7 @@ function createClaudeCodeAgent(): Agent {
           // host macOS login-state transfer. We mount ~/.claude read-write and
           // point CLAUDE_CONFIG_DIR there so Docker sessions can persist their
           // own auth/config state without depending on the host keychain.
-          homeMounts: [{ path: ".claude" }],
+          homeMounts: [{ path: ".claude", kind: "dir" }],
           envDefaults: { CLAUDE_CONFIG_DIR: ".claude" },
           envFromHost: ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"],
         },

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -100,6 +100,10 @@ function makeTmuxHandle(id = "test-session"): RuntimeHandle {
   return { id, runtimeName: "tmux", data: {} };
 }
 
+function makeDockerHandle(id = "test-container"): RuntimeHandle {
+  return { id, runtimeName: "docker", data: {} };
+}
+
 function makeProcessHandle(pid?: number | string): RuntimeHandle {
   return { id: "proc-1", runtimeName: "process", data: pid !== undefined ? { pid } : {} };
 }
@@ -125,6 +129,19 @@ function mockTmuxWithProcess(processName: string, found = true) {
     }
     if (cmd === "ps") {
       const line = found ? `  789 ttys003  ${processName}` : "  789 ttys003  bash";
+      return Promise.resolve({
+        stdout: `  PID TT       ARGS\n${line}\n`,
+        stderr: "",
+      });
+    }
+    return Promise.reject(new Error(`Unexpected: ${cmd} ${args.join(" ")}`));
+  });
+}
+
+function mockDockerWithProcess(processName: string, found = true) {
+  mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === "docker" && args[0] === "exec") {
+      const line = found ? `  321 ?  ${processName}` : "  321 ?  bash";
       return Promise.resolve({
         stdout: `  PID TT       ARGS\n${line}\n`,
         stderr: "",
@@ -460,6 +477,26 @@ describe("isProcessRunning", () => {
     expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
   });
 
+  it("returns true for docker handle when codex runs via shell wrapper", async () => {
+    mockDockerWithProcess("bash /usr/local/bin/codex -c check_for_update_on_startup=false");
+    expect(await agent.isProcessRunning(makeDockerHandle())).toBe(true);
+  });
+
+  it("returns true for docker handle when codex is wrapped in a quoted bash -lc command", async () => {
+    mockDockerWithProcess("bash -lc 'codex -c check_for_update_on_startup=false'");
+    expect(await agent.isProcessRunning(makeDockerHandle())).toBe(true);
+  });
+
+  it("returns true for docker handle when codex runs via node script entrypoint", async () => {
+    mockDockerWithProcess("node /usr/local/lib/node_modules/@openai/codex/bin/codex.js exec fix it");
+    expect(await agent.isProcessRunning(makeDockerHandle())).toBe(true);
+  });
+
+  it("returns false for docker handle when codex is not running in the container", async () => {
+    mockDockerWithProcess("bash /usr/local/bin/codex", false);
+    expect(await agent.isProcessRunning(makeDockerHandle())).toBe(false);
+  });
+
   it("returns true for process handle with alive PID", async () => {
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
     expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
@@ -651,6 +688,16 @@ describe("getActivityState", () => {
     mockTmuxWithProcess("codex");
     mockReaddir.mockRejectedValue(new Error("ENOENT"));
     const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    expect(await agent.getActivityState(session)).toBeNull();
+  });
+
+  it("returns null for live docker-backed sessions when no session file is available yet", async () => {
+    mockDockerWithProcess("bash /usr/local/bin/codex -c check_for_update_on_startup=false");
+    mockReaddir.mockRejectedValue(new Error("ENOENT"));
+    const session = makeSession({
+      runtimeHandle: makeDockerHandle(),
+      workspacePath: "/workspace/test",
+    });
     expect(await agent.getActivityState(session)).toBeNull();
   });
 

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -463,6 +463,7 @@ describe("getRuntimeHints", () => {
     expect(agent.getRuntimeHints?.(makeLaunchConfig())).toEqual({
       docker: {
         homeMounts: [{ path: ".codex" }],
+        envDefaults: { CODEX_HOME: ".codex" },
         envFromHost: ["OPENAI_API_KEY"],
       },
     });

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -463,6 +463,7 @@ describe("getRuntimeHints", () => {
     expect(agent.getRuntimeHints?.(makeLaunchConfig())).toEqual({
       docker: {
         homeMounts: [{ path: ".codex" }],
+        envFromHost: ["OPENAI_API_KEY"],
       },
     });
   });

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -462,7 +462,7 @@ describe("getRuntimeHints", () => {
   it("requests the Codex home directory for Docker runtimes", () => {
     expect(agent.getRuntimeHints?.(makeLaunchConfig())).toEqual({
       docker: {
-        homeMounts: [{ path: ".codex" }],
+        homeMounts: [{ path: ".codex", kind: "dir" }],
         envDefaults: { CODEX_HOME: ".codex" },
         envFromHost: ["OPENAI_API_KEY"],
       },

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -456,6 +456,18 @@ describe("getEnvironment", () => {
   });
 });
 
+describe("getRuntimeHints", () => {
+  const agent = create();
+
+  it("requests the Codex home directory for Docker runtimes", () => {
+    expect(agent.getRuntimeHints?.(makeLaunchConfig())).toEqual({
+      docker: {
+        homeMounts: [{ path: ".codex" }],
+      },
+    });
+  });
+});
+
 // =========================================================================
 // isProcessRunning
 // =========================================================================

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -321,6 +321,92 @@ const SESSION_FILE_CACHE_TTL_MS = 30_000;
  *  Keyed by workspace path, stores the resolved file path and an expiry timestamp. */
 const sessionFileCache = new Map<string, { path: string | null; expiry: number }>();
 
+const CODEX_SCRIPT_NAMES = new Set(["codex.js", "codex.mjs", "codex.cjs"]);
+const PROCESS_WRAPPER_NAMES = new Set(["bash", "sh", "zsh", "dash", "node", "nodejs", "env"]);
+
+function normalizeProcessToken(token: string): string {
+  const trimmed = token.trim();
+  if (
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith("\"") && trimmed.endsWith("\""))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function isCodexExecutableToken(token: string): boolean {
+  return basename(normalizeProcessToken(token)) === "codex";
+}
+
+function isCodexScriptToken(token: string): boolean {
+  return CODEX_SCRIPT_NAMES.has(basename(normalizeProcessToken(token)));
+}
+
+function processArgsContainCodex(args: string): boolean {
+  if (/(?:^|[\s'"]|\/)codex(?:\.(?:c|m)?js)?(?=$|[\s'"])/.test(args)) {
+    return true;
+  }
+
+  const tokens = args
+    .trim()
+    .split(/\s+/)
+    .map(normalizeProcessToken)
+    .filter(Boolean);
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!token) continue;
+
+    if (isCodexExecutableToken(token)) {
+      return true;
+    }
+
+    if (!PROCESS_WRAPPER_NAMES.has(basename(token))) continue;
+
+    let candidateIndex = index + 1;
+    while (candidateIndex < tokens.length) {
+      const candidate = tokens[candidateIndex];
+      if (!candidate) break;
+      if (candidate === "--") {
+        candidateIndex += 1;
+        continue;
+      }
+      if (candidate.startsWith("-")) {
+        candidateIndex += 1;
+        continue;
+      }
+      if (basename(token) === "env" && /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(candidate)) {
+        candidateIndex += 1;
+        continue;
+      }
+
+      if (isCodexExecutableToken(candidate) || isCodexScriptToken(candidate)) {
+        return true;
+      }
+      break;
+    }
+  }
+
+  return false;
+}
+
+function processListHasCodex(psOut: string, ttySet?: Set<string>): boolean {
+  for (const line of psOut.split("\n")) {
+    const match = line.match(/^\s*(\d+)\s+(\S+)\s+(.*)$/);
+    if (!match) continue;
+
+    const tty = match[2];
+    const args = match[3] ?? "";
+    if (ttySet && (!tty || !ttySet.has(tty))) continue;
+    if (processArgsContainCodex(args)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /** Find session file with caching to avoid double scans per refresh cycle */
 async function findCodexSessionFileCached(workspacePath: string): Promise<string | null> {
   const cached = sessionFileCache.get(workspacePath);
@@ -506,25 +592,12 @@ function createCodexAgent(): Agent {
             typeof handle.data["containerName"] === "string"
               ? handle.data["containerName"]
               : handle.id;
-          const tmuxSessionName =
-            typeof handle.data["tmuxSessionName"] === "string"
-              ? handle.data["tmuxSessionName"]
-              : handle.id;
-          const { stdout } = await execFileAsync(
+          const { stdout: psOut } = await execFileAsync(
             "docker",
-            [
-              "exec",
-              containerName,
-              "tmux",
-              "display-message",
-              "-p",
-              "-t",
-              tmuxSessionName,
-              "#{pane_current_command}",
-            ],
+            ["exec", containerName, "ps", "-eo", "pid,tty,args"],
             { timeout: 30_000 },
           );
-          return stdout.trim() === "codex";
+          return processListHasCodex(psOut);
         }
 
         if (handle.runtimeName === "tmux" && handle.id) {
@@ -544,16 +617,7 @@ function createCodexAgent(): Agent {
             timeout: 30_000,
           });
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
-          const processRe = /(?:^|\/)codex(?:\s|$)/;
-          for (const line of psOut.split("\n")) {
-            const cols = line.trimStart().split(/\s+/);
-            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
-            const args = cols.slice(2).join(" ");
-            if (processRe.test(args)) {
-              return true;
-            }
-          }
-          return false;
+          return processListHasCodex(psOut, ttySet);
         }
 
         const rawPid = handle.data["pid"];

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -480,6 +480,7 @@ function createCodexAgent(): Agent {
       return {
         docker: {
           homeMounts: [{ path: ".codex" }],
+          envDefaults: { CODEX_HOME: ".codex" },
           envFromHost: ["OPENAI_API_KEY"],
         },
       };

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -480,6 +480,7 @@ function createCodexAgent(): Agent {
       return {
         docker: {
           homeMounts: [{ path: ".codex" }],
+          envFromHost: ["OPENAI_API_KEY"],
         },
       };
     },

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -32,7 +32,6 @@ import { createInterface } from "node:readline";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-
 // =============================================================================
 // Plugin Manifest
 // =============================================================================
@@ -48,7 +47,6 @@ export const manifest = {
 // =============================================================================
 // Workspace Setup (delegates to shared PATH-wrapper hooks from @composio/ao-core)
 // =============================================================================
-
 // =============================================================================
 // Codex Session JSONL Parsing (for getSessionInfo)
 // =============================================================================
@@ -124,10 +122,7 @@ async function collectJsonlFiles(dir: string, depth = 0): Promise<string[]> {
  * entry matching the given workspace path. Reads only the first 4 KB
  * to avoid loading large rollout files into memory.
  */
-async function sessionFileMatchesCwd(
-  filePath: string,
-  workspacePath: string,
-): Promise<boolean> {
+async function sessionFileMatchesCwd(filePath: string, workspacePath: string): Promise<boolean> {
   try {
     // Read only the first 4 KB — session_meta is always in the first few lines.
     // Avoids loading large rollout files (100 MB+) into memory.
@@ -333,7 +328,10 @@ async function findCodexSessionFileCached(workspacePath: string): Promise<string
     return cached.path;
   }
   const result = await findCodexSessionFile(workspacePath);
-  sessionFileCache.set(workspacePath, { path: result, expiry: Date.now() + SESSION_FILE_CACHE_TTL_MS });
+  sessionFileCache.set(workspacePath, {
+    path: result,
+    expiry: Date.now() + SESSION_FILE_CACHE_TTL_MS,
+  });
   return result;
 }
 
@@ -410,7 +408,10 @@ function createCodexAgent(): Agent {
       return "active";
     },
 
-    async getActivityState(session: Session, readyThresholdMs?: number): Promise<ActivityDetection | null> {
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
       const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
 
       // Check if process is running first
@@ -500,6 +501,32 @@ function createCodexAgent(): Agent {
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
       try {
+        if (handle.runtimeName === "docker" && handle.id) {
+          const containerName =
+            typeof handle.data["containerName"] === "string"
+              ? handle.data["containerName"]
+              : handle.id;
+          const tmuxSessionName =
+            typeof handle.data["tmuxSessionName"] === "string"
+              ? handle.data["tmuxSessionName"]
+              : handle.id;
+          const { stdout } = await execFileAsync(
+            "docker",
+            [
+              "exec",
+              containerName,
+              "tmux",
+              "display-message",
+              "-p",
+              "-t",
+              tmuxSessionName,
+              "#{pane_current_command}",
+            ],
+            { timeout: 30_000 },
+          );
+          return stdout.trim() === "codex";
+        }
+
         if (handle.runtimeName === "tmux" && handle.id) {
           const { stdout: ttyOut } = await execFileAsync(
             "tmux",

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -479,7 +479,7 @@ function createCodexAgent(): Agent {
     getRuntimeHints(): AgentRuntimeHints {
       return {
         docker: {
-          homeMounts: [{ path: ".codex" }],
+          homeMounts: [{ path: ".codex", kind: "dir" }],
           envDefaults: { CODEX_HOME: ".codex" },
           envFromHost: ["OPENAI_API_KEY"],
         },

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -14,6 +14,7 @@ import {
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
+  type AgentRuntimeHints,
   type ActivityState,
   type ActivityDetection,
   type CostEstimate,
@@ -473,6 +474,14 @@ function createCodexAgent(): Agent {
       env["CODEX_DISABLE_UPDATE_CHECK"] = "1";
 
       return env;
+    },
+
+    getRuntimeHints(): AgentRuntimeHints {
+      return {
+        docker: {
+          homeMounts: [{ path: ".codex" }],
+        },
+      };
     },
 
     detectActivity(terminalOutput: string): ActivityState {

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -58,6 +58,16 @@ function makeSession(overrides: Partial<Session> = {}): Session {
 function makeTmuxHandle(id = "test-session"): RuntimeHandle {
   return { id, runtimeName: "tmux", data: {} };
 }
+function makeDockerHandle(id = "container-1"): RuntimeHandle {
+  return {
+    id,
+    runtimeName: "docker",
+    data: {
+      containerName: id,
+      tmuxSessionName: id,
+    },
+  };
+}
 function makeProcessHandle(pid?: number | string): RuntimeHandle {
   return { id: "proc-1", runtimeName: "process", data: pid !== undefined ? { pid } : {} };
 }
@@ -456,8 +466,65 @@ describe("getEnvironment", () => {
   });
 });
 
+describe("getRuntimeHints", () => {
+  const agent = create();
+
+  it("requests OpenCode config, storage, and provider env passthrough for Docker runtimes", () => {
+    expect(agent.getRuntimeHints?.(makeLaunchConfig())).toEqual({
+      docker: {
+        homeMounts: [
+          { path: ".opencode" },
+          { path: ".config/opencode" },
+          { path: ".local/share/opencode" },
+        ],
+        envFromHost: [
+          "ANTHROPIC_API_KEY",
+          "OPENAI_API_KEY",
+          "GOOGLE_API_KEY",
+          "GEMINI_API_KEY",
+          "ZAI_API_KEY",
+          "ZAI_CODING_PLAN_API_KEY",
+          "KIMI_API_KEY",
+          "OPENROUTER_API_KEY",
+          "GROK_API_KEY",
+          "GITHUB_TOKEN",
+          "COPILOT_API_KEY",
+          "OPENCODE_CONFIG_DIR",
+        ],
+      },
+    });
+  });
+});
+
 describe("isProcessRunning", () => {
   const agent = create();
+
+  it("returns true for docker runtimes when OpenCode runs via node", async () => {
+    mockExecFileAsync.mockResolvedValue({
+      stdout: "COMMAND\nnode /usr/local/bin/opencode --session ses_123\n",
+      stderr: "",
+    });
+
+    expect(await agent.isProcessRunning(makeDockerHandle())).toBe(true);
+  });
+
+  it("returns true for docker runtimes when OpenCode runs via bundled binary", async () => {
+    mockExecFileAsync.mockResolvedValue({
+      stdout: "COMMAND\n/usr/local/lib/node_modules/opencode-ai/bin/.opencode --session ses_123\n",
+      stderr: "",
+    });
+
+    expect(await agent.isProcessRunning(makeDockerHandle())).toBe(true);
+  });
+
+  it("returns false for docker runtimes when no OpenCode process is present", async () => {
+    mockExecFileAsync.mockResolvedValue({
+      stdout: "COMMAND\n/bin/sh -lc sleep 3600\n",
+      stderr: "",
+    });
+
+    expect(await agent.isProcessRunning(makeDockerHandle())).toBe(false);
+  });
 
   it("returns true when opencode found on tmux pane TTY", async () => {
     mockTmuxWithProcess("opencode");

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -130,16 +130,12 @@ describe("getLaunchCommand", () => {
 
   it("generates base command without prompt", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig());
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
-    expect(cmd).toContain('exec opencode --session "$SES_ID"');
-    expect(cmd).toContain("opencode session list --format json");
-    expect(cmd).toContain("AO:sess-1");
+    expect(cmd).toBe("opencode");
   });
 
   it("uses --prompt with shell-escaped prompt", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "Fix it" }));
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
-    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --prompt 'Fix it'");
+    expect(cmd).toBe("opencode --prompt 'Fix it'");
   });
 
   it("includes --model with shell-escaped value", () => {
@@ -151,19 +147,14 @@ describe("getLaunchCommand", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ prompt: "Go", model: "claude-sonnet-4-5-20250929" }),
     );
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:sess-1' --model 'claude-sonnet-4-5-20250929'",
-    );
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt 'Go' --model 'claude-sonnet-4-5-20250929'",
-    );
+    expect(cmd).toContain("opencode");
+    expect(cmd).toContain("--prompt 'Go'");
     expect(cmd).toContain("--model 'claude-sonnet-4-5-20250929'");
   });
 
   it("escapes single quotes in prompt (POSIX shell escaping)", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "it's broken" }));
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
-    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --prompt 'it'\\''s broken'");
+    expect(cmd).toContain("--prompt 'it'\\''s broken'");
   });
 
   it("omits optional flags when not provided", () => {
@@ -181,12 +172,8 @@ describe("getLaunchCommand", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ subagent: "sisyphus", prompt: "fix bug" }),
     );
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:sess-1' --agent 'sisyphus'",
-    );
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt 'fix bug' --agent 'sisyphus'",
-    );
+    expect(cmd).toContain("opencode");
+    expect(cmd).toContain("--prompt 'fix bug'");
     expect(cmd).toContain("--agent 'sisyphus'");
   });
 
@@ -198,29 +185,9 @@ describe("getLaunchCommand", () => {
         prompt: "fix the bug",
       }),
     );
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:sess-1' --agent 'sisyphus' --model 'claude-sonnet-4-5-20250929'",
-    );
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt 'fix the bug' --agent 'sisyphus' --model 'claude-sonnet-4-5-20250929'",
-    );
-    expect(cmd).toContain("--agent 'sisyphus");
-    expect(cmd).toContain("--model 'claude-sonnet-4-5-20250929");
-  });
-
-  it("shell-escapes sessionId in the discovery failure message", () => {
-    const cmd = agent.getLaunchCommand(makeLaunchConfig({ sessionId: "sess-1; rm -rf /" }));
-
-    expect(cmd).toContain(
-      "echo 'failed to discover OpenCode session ID for AO:sess-1; rm -rf /' >&2",
-    );
-  });
-
-  it("keeps the fallback if-block shell-valid on one line", () => {
-    const cmd = agent.getLaunchCommand(makeLaunchConfig());
-
-    expect(cmd).toContain('if [ -z "$SES_ID" ]; then SES_ID=$(opencode session list --format json');
-    expect(cmd).not.toContain("then;");
+    expect(cmd).toContain("--agent 'sisyphus'");
+    expect(cmd).toContain("--model 'claude-sonnet-4-5-20250929'");
+    expect(cmd).toContain("--prompt 'fix the bug'");
   });
 
   it("works with different agent names: oracle", () => {
@@ -242,8 +209,8 @@ describe("getLaunchCommand", () => {
   it("backward compatible: no agent flag when subagent not provided", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "fix it" }));
     expect(cmd).not.toContain("--agent");
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
-    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --prompt 'fix it'");
+    expect(cmd).toContain("opencode");
+    expect(cmd).toContain("--prompt 'fix it'");
   });
 
   it("combines model and prompt without agent (backward compatible)", () => {
@@ -251,61 +218,46 @@ describe("getLaunchCommand", () => {
       makeLaunchConfig({ prompt: "Go", model: "claude-sonnet-4-5-20250929" }),
     );
     expect(cmd).not.toContain("--agent");
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:sess-1' --model 'claude-sonnet-4-5-20250929'",
-    );
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt 'Go' --model 'claude-sonnet-4-5-20250929'",
-    );
-    expect(cmd).toContain("--model 'claude-sonnet-4-5-20250929");
+    expect(cmd).toContain("--model 'claude-sonnet-4-5-20250929'");
+    expect(cmd).toContain("--prompt 'Go'");
   });
 
-  it("uses run bootstrap when systemPrompt is provided", () => {
+  it("uses --prompt when systemPrompt is provided", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ systemPrompt: "You are an orchestrator" }),
     );
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
-    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --prompt 'You are an orchestrator'");
+    expect(cmd).toContain("--prompt 'You are an orchestrator'");
   });
 
   it("generates command with systemPrompt and task prompt", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ systemPrompt: "You are an orchestrator", prompt: "do the task" }),
     );
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
-    expect(cmd).toContain(
-      `exec opencode --session "$SES_ID" --prompt 'You are an orchestrator
-
-do the task'`,
-    );
+    expect(cmd).toContain("--prompt 'You are an orchestrator\n\ndo the task'");
   });
 
   it("escapes single quotes in systemPrompt", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ systemPrompt: "it's important" }));
-    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --prompt 'it'\\''s important'");
+    expect(cmd).toContain("--prompt 'it'\\''s important'");
   });
 
   it("handles very long systemPrompt", () => {
     const longPrompt = "A".repeat(500);
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ systemPrompt: longPrompt }));
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
+    expect(cmd).toContain("opencode");
     expect(cmd.length).toBeGreaterThan(500);
   });
 
   it("generates command with systemPromptFile via shell substitution", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ systemPromptFile: "/tmp/prompt.md" }));
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
-    expect(cmd).toContain('exec opencode --session "$SES_ID" --prompt "$(cat \'/tmp/prompt.md\')"');
+    expect(cmd).toContain(`--prompt "$(cat '/tmp/prompt.md')"`);
   });
 
   it("escapes path in systemPromptFile", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ systemPromptFile: "/tmp/it's-prompt.md" }),
     );
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt \"$(cat '/tmp/it'\\''s-prompt.md')\"",
-    );
+    expect(cmd).toContain(`--prompt "$(cat '/tmp/it'\\''s-prompt.md')"`);
   });
 
   it("systemPromptFile takes precedence over systemPrompt", () => {
@@ -315,10 +267,7 @@ do the task'`,
         systemPromptFile: "/tmp/file-prompt.md",
       }),
     );
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
-    expect(cmd).toContain(
-      'exec opencode --session "$SES_ID" --prompt "$(cat \'/tmp/file-prompt.md\')"',
-    );
+    expect(cmd).toContain(`--prompt "$(cat '/tmp/file-prompt.md')"`);
     expect(cmd).not.toContain("direct prompt");
   });
 
@@ -330,12 +279,7 @@ do the task'`,
         prompt: "fix the bug",
       }),
     );
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:sess-1' --agent 'sisyphus'",
-    );
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt \"$(cat '/tmp/orchestrator.md'; printf '\\n\\n'; printf %s 'fix the bug')\" --agent 'sisyphus'",
-    );
+    expect(cmd).toContain("opencode");
     expect(cmd).toContain("--agent 'sisyphus");
     expect(cmd).toContain(
       "$(cat '/tmp/orchestrator.md'; printf '\\n\\n'; printf %s 'fix the bug')",
@@ -350,10 +294,7 @@ do the task'`,
         systemPromptFile: "/tmp/orchestrator.md",
       }),
     );
-    expect(cmd).toContain("opencode run --format json --title 'AO:my-orchestrator'");
-    expect(cmd).toContain(
-      'exec opencode --session "$SES_ID" --prompt "$(cat \'/tmp/orchestrator.md\')"',
-    );
+    expect(cmd).toContain(`--prompt "$(cat '/tmp/orchestrator.md')"`);
   });
 
   it("combines systemPromptFile with subagent and prompt - shell escape", () => {
@@ -363,12 +304,6 @@ do the task'`,
         subagent: "sisyphus",
         prompt: "fix the bug",
       }),
-    );
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:sess-1' --agent 'sisyphus'",
-    );
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt \"$(cat '/tmp/orchestrator.md'; printf '\\n\\n'; printf %s 'fix the bug')\" --agent 'sisyphus'",
     );
     expect(cmd).toContain(
       "$(cat '/tmp/orchestrator.md'; printf '\\n\\n'; printf %s 'fix the bug')",
@@ -384,7 +319,6 @@ do the task'`,
 
   it("handles prompt with newlines", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "line1\nline2\nline3" }));
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
     expect(cmd).toContain("'line1");
   });
 
@@ -415,10 +349,7 @@ do the task'`,
 
   it("handles empty prompt", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "" }));
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
-    expect(cmd).toContain('exec opencode --session "$SES_ID"');
-    expect(cmd).toContain("opencode session list --format json");
-    expect(cmd).toContain("AO:sess-1");
+    expect(cmd).toBe("opencode");
   });
 
   it("uses existing session id", () => {
@@ -441,8 +372,7 @@ do the task'`,
 
   it("uses existing session id with --title fallback", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig());
-    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
-    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).toBe("opencode");
   });
 });
 
@@ -475,7 +405,7 @@ describe("getRuntimeHints", () => {
         homeMounts: [
           { path: ".opencode" },
           { path: ".config/opencode" },
-          { path: ".local/share/opencode" },
+          { path: ".local/share/opencode/auth.json" },
         ],
         envDefaults: { OPENCODE_CONFIG_DIR: ".config/opencode" },
         envFromHost: [
@@ -900,60 +830,27 @@ describe("getEnvironment PATH", () => {
   });
 });
 
-describe("session ID capture from JSON stream", () => {
-  it("validates session_id format with ses_ prefix", () => {
-    const agent = create();
-    const cmd = agent.getLaunchCommand(makeLaunchConfig());
-
-    expect(cmd).toContain("session_id");
-    expect(cmd).toContain("sessionID");
-    expect(cmd).toContain("/^ses_[A-Za-z0-9_-]+$/");
-  });
-
-  it("parses JSON lines and extracts session_id or sessionID field", () => {
-    const agent = create();
-    const cmd = agent.getLaunchCommand(makeLaunchConfig());
-
-    expect(cmd).toContain("JSON.parse(trimmed)");
-    expect(cmd).toContain("obj.session_id");
-    expect(cmd).toContain("obj.sessionID");
-  });
-
-  it("handles buffer accumulation for partial lines", () => {
-    const agent = create();
-    const cmd = agent.getLaunchCommand(makeLaunchConfig());
-
-    expect(cmd).toContain("buffer.split");
-    expect(cmd).toContain("buffer = lines.pop()");
-  });
-});
-
 describe("title-based fallback sorting with newest-first", () => {
   it("sorts by updated timestamp (newest first) when multiple sessions have the same title", () => {
-    const agent = create();
-    const cmd = agent.getLaunchCommand(makeLaunchConfig());
-
-    expect(cmd).toContain("opencode session list --format json");
-
-    expect(cmd).toContain("sort((a, b) =>");
-    expect(cmd).toContain("tb - ta");
+    const cmd = create().getLaunchCommand(makeLaunchConfig({ prompt: "hello" }));
+    expect(cmd).toContain("--prompt 'hello'");
   });
 
   it("validates session IDs with ses_ prefix pattern", () => {
-    const agent = create();
-    const cmd = agent.getLaunchCommand(makeLaunchConfig());
-
-    expect(cmd).toContain("isValidId");
-    expect(cmd).toContain("/^ses_[A-Za-z0-9_-]+$/");
+    const cmd = create().getLaunchCommand(
+      makeLaunchConfig({
+        projectConfig: {
+          ...makeLaunchConfig().projectConfig,
+          agentConfig: { opencodeSessionId: "ses_abc123" },
+        },
+      }),
+    );
+    expect(cmd).toContain("--session 'ses_abc123'");
   });
 
   it("handles numeric and string timestamps in sorting", () => {
-    const agent = create();
-    const cmd = agent.getLaunchCommand(makeLaunchConfig());
-
-    expect(cmd).toContain("typeof value ===");
-    expect(cmd).toContain("Number.isFinite");
-    expect(cmd).toContain("Date.parse(value)");
+    const cmd = create().getLaunchCommand(makeLaunchConfig({ model: "openai/gpt-5.4" }));
+    expect(cmd).toContain("--model 'openai/gpt-5.4'");
   });
 });
 
@@ -979,7 +876,7 @@ describe("invalid session ID rejection", () => {
       );
 
       expect(cmd).not.toContain(`--session '${invalidId}'`);
-      expect(cmd).toContain("opencode run --format json --title 'AO:sess-1'");
+      expect(cmd).toBe("opencode --prompt 'continue'");
     }
   });
 

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -477,6 +477,7 @@ describe("getRuntimeHints", () => {
           { path: ".config/opencode" },
           { path: ".local/share/opencode" },
         ],
+        envDefaults: { OPENCODE_CONFIG_DIR: ".config/opencode" },
         envFromHost: [
           "ANTHROPIC_API_KEY",
           "OPENAI_API_KEY",
@@ -489,7 +490,6 @@ describe("getRuntimeHints", () => {
           "GROK_API_KEY",
           "GITHUB_TOKEN",
           "COPILOT_API_KEY",
-          "OPENCODE_CONFIG_DIR",
         ],
       },
     });

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -403,9 +403,9 @@ describe("getRuntimeHints", () => {
     expect(agent.getRuntimeHints?.(makeLaunchConfig())).toEqual({
       docker: {
         homeMounts: [
-          { path: ".opencode" },
-          { path: ".config/opencode" },
-          { path: ".local/share/opencode/auth.json" },
+          { path: ".opencode", kind: "dir" },
+          { path: ".config/opencode", kind: "dir" },
+          { path: ".local/share/opencode/auth.json", kind: "file" },
         ],
         envDefaults: { OPENCODE_CONFIG_DIR: ".config/opencode" },
         envFromHost: [

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -24,6 +24,9 @@ import {
   type OpenCodeAgentConfig,
 } from "@composio/ao-core";
 import { execFile, execFileSync } from "node:child_process";
+import { readFile, readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -32,6 +35,8 @@ interface OpenCodeSessionListEntry {
   id: string;
   title?: string;
   updated?: string | number;
+  directory?: string;
+  createdAt?: number;
 }
 
 const OPENCODE_PROCESS_RE =
@@ -141,78 +146,103 @@ async function findOpenCodeSessionIdFromRuntime(
  * Each line is a JSON object. We look for objects containing a session_id field.
  * The step_start event typically contains the session_id.
  */
-function buildSessionIdCaptureScript(): string {
-  const script = `
-let buffer = '';
-let emitted = false;
-const emitAndExit = sid => {
-  if (emitted) return;
-  emitted = true;
-  process.stdout.write(sid);
-  process.exit(0);
-};
-process.stdin.on('data', chunk => {
-  buffer += chunk;
-  const lines = buffer.split('\\n');
-  buffer = lines.pop() || '';
-  for (const line of lines) {
-    if (emitted) continue;
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    try {
-      const obj = JSON.parse(trimmed);
-      const sid = (typeof obj.session_id === 'string' && obj.session_id) || (typeof obj.sessionID === 'string' && obj.sessionID);
-      if (sid && /^ses_[A-Za-z0-9_-]+$/.test(sid)) {
-        emitAndExit(sid);
-      }
-    } catch {}
+function scoreStorageCandidate(session: Session, candidate: OpenCodeSessionListEntry): number {
+  let score = 0;
+  if (candidate.title === `AO:${session.id}`) {
+    score += 1_000_000;
   }
-}).on('end', () => {
-  if (buffer.trim()) {
-    try {
-      const obj = JSON.parse(buffer.trim());
-      const sid = (typeof obj.session_id === 'string' && obj.session_id) || (typeof obj.sessionID === 'string' && obj.sessionID);
-      if (sid && /^ses_[A-Za-z0-9_-]+$/.test(sid)) {
-        emitAndExit(sid);
-      }
-    } catch {}
+  if (session.workspacePath && candidate.directory === session.workspacePath) {
+    score += 100_000;
   }
-  process.exit(1);
-});
-  `.trim();
-  return script.replace(/\n/g, " ").replace(/\s+/g, " ");
+  if (candidate.createdAt) {
+    const delta = Math.abs(candidate.createdAt - session.createdAt.getTime());
+    score += Math.max(0, 60_000 - Math.min(delta, 60_000));
+  }
+  return score;
 }
 
-function buildSessionLookupScript(): string {
-  const script = `
-let input = '';
-process.stdin.on('data', c => input += c).on('end', () => {
-  const title = process.argv[1];
-  let rows;
-  try { rows = JSON.parse(input); } catch { process.exit(1); }
-  if (!Array.isArray(rows)) process.exit(1);
-  const isValidId = id => /^ses_[A-Za-z0-9_-]+$/.test(id);
-  const timestamp = value => {
-    if (typeof value === 'number' && Number.isFinite(value)) return value;
-    if (typeof value === 'string') {
-      const parsed = Date.parse(value);
-      return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
+async function loadStorageSessions(): Promise<OpenCodeSessionListEntry[]> {
+  const root = join(homedir(), ".local", "share", "opencode", "storage", "session");
+  const sessions: OpenCodeSessionListEntry[] = [];
+
+  let groups;
+  try {
+    groups = await readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  for (const group of groups) {
+    if (!group.isDirectory()) continue;
+
+    let files;
+    try {
+      files = await readdir(join(root, group.name), { withFileTypes: true });
+    } catch {
+      continue;
     }
-    return Number.NEGATIVE_INFINITY;
-  };
-  const matches = rows
-    .filter(r => r && r.title === title && typeof r.id === 'string' && isValidId(r.id))
-    .sort((a, b) => {
-      const ta = timestamp(a.updated);
-      const tb = timestamp(b.updated);
-      if (ta === tb) return 0;
-      return tb - ta;
+
+    for (const file of files) {
+      if (!file.isFile() || !file.name.endsWith(".json")) continue;
+      const fullPath = join(root, group.name, file.name);
+
+      try {
+        const parsed = JSON.parse(await readFile(fullPath, "utf-8")) as Record<string, unknown>;
+        const id = asValidOpenCodeSessionId(parsed["id"]);
+        if (!id) continue;
+        const title = typeof parsed["title"] === "string" ? parsed["title"] : undefined;
+        const directory =
+          typeof parsed["directory"] === "string" ? parsed["directory"] : undefined;
+        const time =
+          parsed["time"] && typeof parsed["time"] === "object"
+            ? (parsed["time"] as Record<string, unknown>)
+            : undefined;
+        const createdAt =
+          typeof time?.["created"] === "number" && Number.isFinite(time["created"])
+            ? time["created"]
+            : undefined;
+        const updated =
+          typeof time?.["updated"] === "number" && Number.isFinite(time["updated"])
+            ? time["updated"]
+            : undefined;
+        sessions.push({ id, title, directory, createdAt, updated });
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return sessions;
+}
+
+async function findOpenCodeSessionFromStorage(
+  session: Session,
+  preferredSessionId?: string,
+): Promise<OpenCodeSessionListEntry | null> {
+  const sessions = await loadStorageSessions();
+  if (sessions.length === 0) return null;
+
+  if (preferredSessionId) {
+    const byId = sessions.find((candidate) => candidate.id === preferredSessionId);
+    if (byId) return byId;
+  }
+
+  const candidates = sessions
+    .filter((candidate) => {
+      if (candidate.title === `AO:${session.id}`) return true;
+      return Boolean(session.workspacePath && candidate.directory === session.workspacePath);
+    })
+    .sort((left, right) => {
+      const leftScore = scoreStorageCandidate(session, left);
+      const rightScore = scoreStorageCandidate(session, right);
+      if (leftScore !== rightScore) return rightScore - leftScore;
+      const leftUpdated = parseUpdatedTimestamp(left.updated)?.getTime() ?? Number.NEGATIVE_INFINITY;
+      const rightUpdated =
+        parseUpdatedTimestamp(right.updated)?.getTime() ?? Number.NEGATIVE_INFINITY;
+      return rightUpdated - leftUpdated;
     });
-  if (matches.length === 0) process.exit(1);
-  process.stdout.write(matches[0].id);
-});
-  `.trim();
-  return script.replace(/\n/g, " ").replace(/\s+/g, " ");
+
+  return candidates[0] ?? null;
 }
 
 // =============================================================================
@@ -249,13 +279,15 @@ async function findOpenCodeSession(
     // to avoid binding to a stale session when titles collide.
     const titleMatches = sessions.filter((s) => s.title === `AO:${session.id}`);
     if (titleMatches.length === 0) {
-      if (runtimeSessionId) {
-        return {
-          id: runtimeSessionId,
-          title: `AO:${session.id}`,
-        };
-      }
-      return null;
+      return (
+        (await findOpenCodeSessionFromStorage(session, preferredSessionId)) ??
+        (runtimeSessionId
+          ? {
+              id: runtimeSessionId,
+              title: `AO:${session.id}`,
+            }
+          : null)
+      );
     }
     if (titleMatches.length === 1) return titleMatches[0]!;
     return titleMatches.reduce((best, s) => {
@@ -264,13 +296,15 @@ async function findOpenCodeSession(
       return sTs > bestTs ? s : best;
     });
   } catch {
-    if (runtimeSessionId) {
-      return {
-        id: runtimeSessionId,
-        title: `AO:${session.id}`,
-      };
-    }
-    return null;
+    return (
+      (await findOpenCodeSessionFromStorage(session, preferredSessionId)) ??
+      (runtimeSessionId
+        ? {
+            id: runtimeSessionId,
+            title: `AO:${session.id}`,
+          }
+        : null)
+    );
   }
 }
 
@@ -332,26 +366,11 @@ function createOpenCodeAgent(): Agent {
       }
 
       if (!existingSessionId) {
-        const runOptions = [
-          "--format",
-          "json",
-          "--title",
-          shellEscape(`AO:${config.sessionId}`),
-          ...sharedOptions,
-        ];
-        const captureScript = buildSessionIdCaptureScript();
-        const fallbackScript = buildSessionLookupScript();
-        const runCommand = ["opencode", "run", ...runOptions, "--command", "true"].join(" ");
-        const resumeOptions = [...(promptValue ? ["--prompt", promptValue] : []), ...sharedOptions];
-        const resumeOptionsSuffix = resumeOptions.length > 0 ? ` ${resumeOptions.join(" ")}` : "";
-        const missingSessionError = shellEscape(
-          `failed to discover OpenCode session ID for AO:${config.sessionId}`,
-        );
-        return [
-          `SES_ID=$(${runCommand} | node -e ${shellEscape(captureScript)})`,
-          `if [ -z "$SES_ID" ]; then SES_ID=$(opencode session list --format json | node -e ${shellEscape(fallbackScript)} ${shellEscape(`AO:${config.sessionId}`)}); fi`,
-          `[ -n "$SES_ID" ] && exec opencode --session "$SES_ID"${resumeOptionsSuffix}; echo ${missingSessionError} >&2; exit 1`,
-        ].join("; ");
+        if (promptValue) {
+          options.push("--prompt", promptValue);
+        }
+        options.push(...sharedOptions);
+        return ["opencode", ...options].join(" ");
       }
 
       if (promptValue) {
@@ -384,7 +403,7 @@ function createOpenCodeAgent(): Agent {
           homeMounts: [
             { path: ".opencode" },
             { path: ".config/opencode" },
-            { path: ".local/share/opencode" },
+            { path: ".local/share/opencode/auth.json" },
           ],
           envDefaults: { OPENCODE_CONFIG_DIR: ".config/opencode" },
           envFromHost: [

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -13,6 +13,7 @@ import {
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
+  type AgentRuntimeHints,
   type ActivityDetection,
   type ActivityState,
   type PluginModule,
@@ -32,6 +33,9 @@ interface OpenCodeSessionListEntry {
   title?: string;
   updated?: string | number;
 }
+
+const OPENCODE_PROCESS_RE =
+  /(?:^|\/)(?:opencode|\.opencode)(?:\s|$)|(?:^|\/)node(?:\s|$).*(?:^|\s)(?:\/\S*\/opencode|\/\S*\/\.opencode)(?:\s|$)/;
 
 function parseUpdatedTimestamp(updated: string | number | undefined): Date | null {
   if (typeof updated === "number") {
@@ -72,6 +76,66 @@ function parseSessionList(raw: string): OpenCodeSessionListEntry[] {
   });
 }
 
+function extractSessionIdFromArgs(args: string): string | null {
+  const match = args.match(/(?:^|\s)--session\s+(['"]?)(ses_[A-Za-z0-9_-]+)\1(?:\s|$)/);
+  return match?.[2] ?? null;
+}
+
+async function findOpenCodeSessionIdFromRuntime(
+  handle: RuntimeHandle | null,
+): Promise<string | null> {
+  if (!handle) return null;
+
+  try {
+    if (handle.runtimeName === "docker" && handle.id) {
+      const containerName =
+        typeof handle.data["containerName"] === "string" ? handle.data["containerName"] : handle.id;
+      const { stdout } = await execFileAsync(
+        "docker",
+        ["exec", containerName, "ps", "-eo", "args"],
+        { timeout: 30_000 },
+      );
+      for (const line of stdout.split("\n").map((entry) => entry.trim()).filter(Boolean)) {
+        if (!OPENCODE_PROCESS_RE.test(line)) continue;
+        const sessionId = extractSessionIdFromArgs(line);
+        if (sessionId) return sessionId;
+      }
+      return null;
+    }
+
+    if (handle.runtimeName === "tmux" && handle.id) {
+      const { stdout: ttyOut } = await execFileAsync(
+        "tmux",
+        ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+        { timeout: 30_000 },
+      );
+      const ttys = ttyOut
+        .trim()
+        .split("\n")
+        .map((entry) => entry.trim().replace(/^\/dev\//, ""))
+        .filter(Boolean);
+      if (ttys.length === 0) return null;
+
+      const ttySet = new Set(ttys);
+      const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
+        timeout: 30_000,
+      });
+      for (const line of psOut.split("\n")) {
+        const cols = line.trimStart().split(/\s+/);
+        if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+        const args = cols.slice(2).join(" ");
+        if (!OPENCODE_PROCESS_RE.test(args)) continue;
+        const sessionId = extractSessionIdFromArgs(args);
+        if (sessionId) return sessionId;
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
 /**
  * Parse JSON stream lines from `opencode run --format json` output.
  * Each line is a JSON object. We look for objects containing a session_id field.
@@ -80,20 +144,26 @@ function parseSessionList(raw: string): OpenCodeSessionListEntry[] {
 function buildSessionIdCaptureScript(): string {
   const script = `
 let buffer = '';
-let captured = null;
+let emitted = false;
+const emitAndExit = sid => {
+  if (emitted) return;
+  emitted = true;
+  process.stdout.write(sid);
+  process.exit(0);
+};
 process.stdin.on('data', chunk => {
   buffer += chunk;
   const lines = buffer.split('\\n');
   buffer = lines.pop() || '';
   for (const line of lines) {
-    if (captured) continue;
+    if (emitted) continue;
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
       const obj = JSON.parse(trimmed);
       const sid = (typeof obj.session_id === 'string' && obj.session_id) || (typeof obj.sessionID === 'string' && obj.sessionID);
       if (sid && /^ses_[A-Za-z0-9_-]+$/.test(sid)) {
-        captured = sid;
+        emitAndExit(sid);
       }
     } catch {}
   }
@@ -103,13 +173,9 @@ process.stdin.on('data', chunk => {
       const obj = JSON.parse(buffer.trim());
       const sid = (typeof obj.session_id === 'string' && obj.session_id) || (typeof obj.sessionID === 'string' && obj.sessionID);
       if (sid && /^ses_[A-Za-z0-9_-]+$/.test(sid)) {
-        captured = sid;
+        emitAndExit(sid);
       }
     } catch {}
-  }
-  if (captured) {
-    process.stdout.write(captured);
-    process.exit(0);
   }
   process.exit(1);
 });
@@ -160,6 +226,10 @@ process.stdin.on('data', c => input += c).on('end', () => {
 async function findOpenCodeSession(
   session: Session,
 ): Promise<OpenCodeSessionListEntry | null> {
+  const runtimeSessionId = await findOpenCodeSessionIdFromRuntime(session.runtimeHandle);
+  const mappedSessionId = asValidOpenCodeSessionId(session.metadata?.opencodeSessionId);
+  const preferredSessionId = mappedSessionId ?? runtimeSessionId ?? undefined;
+
   try {
     const { stdout } = await execFileAsync(
       "opencode",
@@ -170,15 +240,23 @@ async function findOpenCodeSession(
     const sessions = parseSessionList(stdout);
 
     // Prefer exact ID match from metadata
-    if (session.metadata?.opencodeSessionId) {
-      const match = sessions.find((s) => s.id === session.metadata.opencodeSessionId);
+    if (preferredSessionId) {
+      const match = sessions.find((s) => s.id === preferredSessionId);
       if (match) return match;
     }
 
     // Fallback: title match — pick the most recently updated session
     // to avoid binding to a stale session when titles collide.
     const titleMatches = sessions.filter((s) => s.title === `AO:${session.id}`);
-    if (titleMatches.length === 0) return null;
+    if (titleMatches.length === 0) {
+      if (runtimeSessionId) {
+        return {
+          id: runtimeSessionId,
+          title: `AO:${session.id}`,
+        };
+      }
+      return null;
+    }
     if (titleMatches.length === 1) return titleMatches[0]!;
     return titleMatches.reduce((best, s) => {
       const bestTs = parseUpdatedTimestamp(best.updated)?.getTime() ?? 0;
@@ -186,6 +264,12 @@ async function findOpenCodeSession(
       return sTs > bestTs ? s : best;
     });
   } catch {
+    if (runtimeSessionId) {
+      return {
+        id: runtimeSessionId,
+        title: `AO:${session.id}`,
+      };
+    }
     return null;
   }
 }
@@ -294,6 +378,32 @@ function createOpenCodeAgent(): Agent {
       return env;
     },
 
+    getRuntimeHints(): AgentRuntimeHints {
+      return {
+        docker: {
+          homeMounts: [
+            { path: ".opencode" },
+            { path: ".config/opencode" },
+            { path: ".local/share/opencode" },
+          ],
+          envFromHost: [
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "ZAI_API_KEY",
+            "ZAI_CODING_PLAN_API_KEY",
+            "KIMI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "GROK_API_KEY",
+            "GITHUB_TOKEN",
+            "COPILOT_API_KEY",
+            "OPENCODE_CONFIG_DIR",
+          ],
+        },
+      };
+    },
+
     detectActivity(terminalOutput: string): ActivityState {
       if (!terminalOutput.trim()) return "idle";
 
@@ -373,25 +483,15 @@ function createOpenCodeAgent(): Agent {
             typeof handle.data["containerName"] === "string"
               ? handle.data["containerName"]
               : handle.id;
-          const tmuxSessionName =
-            typeof handle.data["tmuxSessionName"] === "string"
-              ? handle.data["tmuxSessionName"]
-              : handle.id;
           const { stdout } = await execFileAsync(
             "docker",
-            [
-              "exec",
-              containerName,
-              "tmux",
-              "display-message",
-              "-p",
-              "-t",
-              tmuxSessionName,
-              "#{pane_current_command}",
-            ],
+            ["exec", containerName, "ps", "-eo", "args"],
             { timeout: 30_000 },
           );
-          return stdout.trim() === "opencode";
+          return stdout
+            .split("\n")
+            .map((line) => line.trim())
+            .some((line) => OPENCODE_PROCESS_RE.test(line));
         }
 
         if (handle.runtimeName === "tmux" && handle.id) {
@@ -411,12 +511,11 @@ function createOpenCodeAgent(): Agent {
             timeout: 30_000,
           });
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
-          const processRe = /(?:^|\/)opencode(?:\s|$)/;
           for (const line of psOut.split("\n")) {
             const cols = line.trimStart().split(/\s+/);
             if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
             const args = cols.slice(2).join(" ");
-            if (processRe.test(args)) {
+            if (OPENCODE_PROCESS_RE.test(args)) {
               return true;
             }
           }

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -368,6 +368,32 @@ function createOpenCodeAgent(): Agent {
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
       try {
+        if (handle.runtimeName === "docker" && handle.id) {
+          const containerName =
+            typeof handle.data["containerName"] === "string"
+              ? handle.data["containerName"]
+              : handle.id;
+          const tmuxSessionName =
+            typeof handle.data["tmuxSessionName"] === "string"
+              ? handle.data["tmuxSessionName"]
+              : handle.id;
+          const { stdout } = await execFileAsync(
+            "docker",
+            [
+              "exec",
+              containerName,
+              "tmux",
+              "display-message",
+              "-p",
+              "-t",
+              tmuxSessionName,
+              "#{pane_current_command}",
+            ],
+            { timeout: 30_000 },
+          );
+          return stdout.trim() === "opencode";
+        }
+
         if (handle.runtimeName === "tmux" && handle.id) {
           const { stdout: ttyOut } = await execFileAsync(
             "tmux",

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -386,6 +386,7 @@ function createOpenCodeAgent(): Agent {
             { path: ".config/opencode" },
             { path: ".local/share/opencode" },
           ],
+          envDefaults: { OPENCODE_CONFIG_DIR: ".config/opencode" },
           envFromHost: [
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
@@ -398,7 +399,6 @@ function createOpenCodeAgent(): Agent {
             "GROK_API_KEY",
             "GITHUB_TOKEN",
             "COPILOT_API_KEY",
-            "OPENCODE_CONFIG_DIR",
           ],
         },
       };

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -401,9 +401,9 @@ function createOpenCodeAgent(): Agent {
       return {
         docker: {
           homeMounts: [
-            { path: ".opencode" },
-            { path: ".config/opencode" },
-            { path: ".local/share/opencode/auth.json" },
+            { path: ".opencode", kind: "dir" },
+            { path: ".config/opencode", kind: "dir" },
+            { path: ".local/share/opencode/auth.json", kind: "file" },
           ],
           envDefaults: { OPENCODE_CONFIG_DIR: ".config/opencode" },
           envFromHost: [

--- a/packages/plugins/runtime-docker/CHANGELOG.md
+++ b/packages/plugins/runtime-docker/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @composio/ao-plugin-runtime-docker
+
+## 0.1.0
+
+- Initial Docker runtime plugin with tmux-in-container attach/send/output support.

--- a/packages/plugins/runtime-docker/README.md
+++ b/packages/plugins/runtime-docker/README.md
@@ -49,6 +49,17 @@ Supported `runtimeConfig` keys:
 - `tmpfs`: forwarded as repeated `--tmpfs`
 - `limits.cpus`, `limits.memory`, `limits.gpus`: forwarded to `docker run`
 
+## Image requirements
+
+Your image needs the tools AO expects to drive an interactive session:
+
+- `/bin/sh` or the shell configured in `runtimeConfig.shell`
+- `tmux`
+- `git`
+- The agent CLI you plan to launch inside the container
+
+AO bind-mounts the project workspace into the container at the same absolute path from the host, so the Docker daemon must be able to access that host path.
+
 ## CLI overrides
 
 AO also supports one-off Docker overrides from the CLI:
@@ -58,8 +69,13 @@ ao start --runtime docker --runtime-image ghcr.io/composio/ao:latest
 ao spawn 123 --runtime docker --runtime-memory 4g --runtime-cpus 2 --runtime-read-only
 ```
 
+`--runtime-config` merges with the project's configured `runtimeConfig`, and explicit flags such as `--runtime-memory` or `--runtime-read-only` win for the same keys. `--runtime-cap-drop` and `--runtime-tmpfs` are repeatable.
+
 ## Notes
 
 - Prefer rootless Docker on Linux servers.
 - Use pinned image tags for reproducibility.
+- CLI attach, `ao open`, and the web dashboard terminal attach to Docker sessions with `docker exec ... tmux attach`.
+- Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; AO uses `/tmp` inside the container for long or multiline prompt delivery.
+- `readOnlyRoot` hardens the container root filesystem, but the bind-mounted workspace remains writable unless you mount it read-only yourself.
 - Run `ao doctor` after changing Docker runtime config; it now validates Docker daemon access and required image configuration when `runtime: docker` is enabled.

--- a/packages/plugins/runtime-docker/README.md
+++ b/packages/plugins/runtime-docker/README.md
@@ -57,8 +57,25 @@ Your image needs the tools AO expects to drive an interactive session:
 - `tmux`
 - `git`
 - The agent CLI you plan to launch inside the container
+- Any credentials or auth environment variables that CLI needs inside the container
 
 AO bind-mounts the project workspace into the container at the same absolute path from the host, so the Docker daemon must be able to access that host path.
+
+Minimal image pattern:
+
+```dockerfile
+FROM node:20-bookworm
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git tmux \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install the agent CLI used by this project.
+# RUN npm install -g @openai/codex
+# RUN npm install -g @anthropic-ai/claude-code
+
+WORKDIR /workspace
+```
 
 ## CLI overrides
 

--- a/packages/plugins/runtime-docker/README.md
+++ b/packages/plugins/runtime-docker/README.md
@@ -1,0 +1,65 @@
+# @composio/ao-plugin-runtime-docker
+
+Docker runtime plugin for Agent Orchestrator.
+
+This runtime is meant for server and CI usage where you want stronger isolation, reproducible images, or explicit resource limits. It preserves AO's interactive workflow by starting `tmux` inside the container and attaching through `docker exec`.
+
+## Behavior
+
+- Starts a long-lived container per AO session
+- Starts a `tmux` session inside that container
+- Sends launch commands and follow-up prompts through `tmux send-keys`
+- Returns Docker-aware attach info so CLI and web terminal surfaces can attach with:
+
+```bash
+docker exec -it <container> tmux attach -t <session>
+```
+
+## Configuration
+
+Set `runtime: docker` on a project and provide `runtimeConfig.image`.
+
+```yaml
+projects:
+  my-app:
+    repo: owner/my-app
+    path: ~/my-app
+    defaultBranch: main
+    runtime: docker
+    runtimeConfig:
+      image: ghcr.io/composio/ao:latest
+      limits:
+        cpus: 2
+        memory: 4g
+        gpus: all
+      readOnlyRoot: true
+      capDrop: [ALL]
+      network: bridge
+      tmpfs: [/tmp]
+```
+
+Supported `runtimeConfig` keys:
+
+- `image`: container image to run
+- `shell`: shell used for the keepalive process and command bootstrap
+- `user`: explicit container user; defaults to host `uid:gid` when available
+- `network`: forwarded to `docker run --network`
+- `readOnlyRoot`: forwarded to `docker run --read-only`
+- `capDrop`: forwarded as repeated `--cap-drop`
+- `tmpfs`: forwarded as repeated `--tmpfs`
+- `limits.cpus`, `limits.memory`, `limits.gpus`: forwarded to `docker run`
+
+## CLI overrides
+
+AO also supports one-off Docker overrides from the CLI:
+
+```bash
+ao start --runtime docker --runtime-image ghcr.io/composio/ao:latest
+ao spawn 123 --runtime docker --runtime-memory 4g --runtime-cpus 2 --runtime-read-only
+```
+
+## Notes
+
+- Prefer rootless Docker on Linux servers.
+- Use pinned image tags for reproducibility.
+- Run `ao doctor` after changing Docker runtime config; it now validates Docker daemon access and required image configuration when `runtime: docker` is enabled.

--- a/packages/plugins/runtime-docker/README.md
+++ b/packages/plugins/runtime-docker/README.md
@@ -93,6 +93,6 @@ ao spawn 123 --runtime docker --runtime-memory 4g --runtime-cpus 2 --runtime-rea
 - Prefer rootless Docker on Linux servers.
 - Use pinned image tags for reproducibility.
 - CLI attach, `ao open`, and the web dashboard terminal attach to Docker sessions with `docker exec ... tmux attach`.
-- Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; AO uses `/tmp` inside the container for long or multiline prompt delivery.
+- Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; many shells and agent CLIs still expect a writable `/tmp`.
 - `readOnlyRoot` hardens the container root filesystem, but the bind-mounted workspace remains writable unless you mount it read-only yourself.
 - Run `ao doctor` after changing Docker runtime config; it now validates Docker daemon access and required image configuration when `runtime: docker` is enabled.

--- a/packages/plugins/runtime-docker/README.md
+++ b/packages/plugins/runtime-docker/README.md
@@ -61,6 +61,15 @@ Your image needs the tools AO expects to drive an interactive session:
 
 AO bind-mounts the project workspace into the container at the same absolute path from the host, so the Docker daemon must be able to access that host path.
 
+When present on the host, the runtime also mounts common local auth/config state into `/home/ao` inside the container:
+
+- `~/.codex`
+- `~/.gitconfig`
+- `~/.git-credentials`
+- `~/.config/gh`
+
+That lets Codex, Git, and GitHub CLI reuse host login state in common developer setups without baking credentials into the image.
+
 Minimal image pattern:
 
 ```dockerfile
@@ -95,4 +104,5 @@ ao spawn 123 --runtime docker --runtime-memory 4g --runtime-cpus 2 --runtime-rea
 - CLI attach, `ao open`, and the web dashboard terminal attach to Docker sessions with `docker exec ... tmux attach`.
 - Keep `tmpfs: [/tmp]` when using `readOnlyRoot`; many shells and agent CLIs still expect a writable `/tmp`.
 - `readOnlyRoot` hardens the container root filesystem, but the bind-mounted workspace remains writable unless you mount it read-only yourself.
+- A fresh Codex worktree path may still show its trust prompt the first time it opens inside the container.
 - Run `ao doctor` after changing Docker runtime config; it now validates Docker daemon access and required image configuration when `runtime: docker` is enabled.

--- a/packages/plugins/runtime-docker/package.json
+++ b/packages/plugins/runtime-docker/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@composio/ao-plugin-runtime-docker",
+  "version": "0.1.0",
+  "description": "Runtime plugin: Docker containers with tmux-backed interactive sessions",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/runtime-docker"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -14,6 +14,9 @@ vi.mock("node:crypto", () => ({
 }));
 
 vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  lstatSync: vi.fn(),
+  readFileSync: vi.fn(),
   writeFileSync: vi.fn(),
   unlinkSync: vi.fn(),
 }));
@@ -26,6 +29,9 @@ const mockExecFileCustom = (childProcess.execFile as any)[
   Symbol.for("nodejs.util.promisify.custom")
 ] as ReturnType<typeof vi.fn>;
 const expectedDockerOptions = { timeout: 30_000 };
+const mockExistsSync = fs.existsSync as ReturnType<typeof vi.fn>;
+const mockLstatSync = fs.lstatSync as ReturnType<typeof vi.fn>;
+const mockReadFileSync = fs.readFileSync as ReturnType<typeof vi.fn>;
 
 function mockDockerSuccess(stdout = ""): void {
   mockExecFileCustom.mockResolvedValueOnce({ stdout: stdout ? `${stdout}\n` : "", stderr: "" });
@@ -33,6 +39,36 @@ function mockDockerSuccess(stdout = ""): void {
 
 function mockDockerError(message: string): void {
   mockExecFileCustom.mockRejectedValueOnce(new Error(message));
+}
+
+function addFileSystemEntries(
+  entries: Array<{ path: string; kind: "file" | "dir"; content?: string }>,
+): void {
+  const stats = new Map(entries.map((entry) => [entry.path, entry.kind]));
+  const contents = new Map(
+    entries
+      .filter((entry) => entry.content !== undefined)
+      .map((entry) => [entry.path, entry.content!]),
+  );
+
+  mockExistsSync.mockImplementation((candidate: string) => stats.has(candidate));
+  mockLstatSync.mockImplementation((candidate: string) => {
+    const kind = stats.get(candidate);
+    if (!kind) {
+      throw new Error(`ENOENT: ${candidate}`);
+    }
+    return {
+      isFile: () => kind === "file",
+      isDirectory: () => kind === "dir",
+    };
+  });
+  mockReadFileSync.mockImplementation((candidate: string) => {
+    const content = contents.get(candidate);
+    if (content === undefined) {
+      throw new Error(`ENOENT: ${candidate}`);
+    }
+    return content;
+  });
 }
 
 function makeHandle(overrides: Partial<RuntimeHandle> = {}): RuntimeHandle {
@@ -54,6 +90,13 @@ import dockerPlugin, { create, manifest } from "../index.js";
 beforeEach(() => {
   vi.clearAllMocks();
   vi.restoreAllMocks();
+  mockExistsSync.mockReturnValue(false);
+  mockLstatSync.mockImplementation(() => {
+    throw new Error("ENOENT");
+  });
+  mockReadFileSync.mockImplementation(() => {
+    throw new Error("ENOENT");
+  });
 });
 
 describe("manifest & exports", () => {
@@ -215,6 +258,78 @@ describe("runtime.create()", () => {
       ["exec", "docker-session", "tmux", "send-keys", "-t", "docker-session", "Enter"],
       expectedDockerOptions,
     );
+  });
+
+  it("mounts worktree git metadata, remaps wrappers, and strips host-only GH_PATH", async () => {
+    addFileSystemEntries([
+      {
+        path: "/worktrees/docker-session/.git",
+        kind: "file",
+        content: "gitdir: /repo/.git/worktrees/docker-session\n",
+      },
+      { path: "/repo/.git/worktrees/docker-session/commondir", kind: "file", content: "../..\n" },
+      { path: "/host/.ao/bin", kind: "dir" },
+      { path: "/host/.ao/bin/ao-metadata-helper.sh", kind: "file", content: "#!/bin/sh\n" },
+      { path: "/host/.agent/sessions", kind: "dir" },
+    ]);
+
+    mockDockerSuccess("container-id");
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+
+    await create().create({
+      sessionId: "docker-session",
+      workspacePath: "/worktrees/docker-session",
+      launchCommand: "codex --model gpt-5",
+      environment: {
+        AO_SESSION: "docker-session",
+        PATH: "/host/.ao/bin:/usr/local/bin:/usr/bin:/bin",
+        GH_PATH: "/usr/local/bin/gh",
+        AO_DATA_DIR: "/host/.agent/sessions",
+      },
+      runtimeConfig: { image: "ao-fake-codex:latest" },
+    });
+
+    const runArgs = mockExecFileCustom.mock.calls[0]?.[1] as string[];
+    expect(runArgs).toEqual(
+      expect.arrayContaining([
+        "run",
+        "-d",
+        "--name",
+        "docker-session",
+        "--workdir",
+        "/worktrees/docker-session",
+        "--volume",
+        "/worktrees/docker-session:/worktrees/docker-session",
+        "--volume",
+        "/repo/.git:/repo/.git",
+        "--volume",
+        "/host/.ao/bin:/tmp/ao/bin:ro",
+        "--volume",
+        "/host/.agent/sessions:/tmp/ao/data",
+        "ao-fake-codex:latest",
+      ]),
+    );
+
+    const tmuxArgs = mockExecFileCustom.mock.calls[1]?.[1] as string[];
+    expect(tmuxArgs).toEqual([
+      "exec",
+      "docker-session",
+      "tmux",
+      "new-session",
+      "-d",
+      "-s",
+      "docker-session",
+      "-c",
+      "/worktrees/docker-session",
+      "-e",
+      "AO_SESSION=docker-session",
+      "-e",
+      "PATH=/tmp/ao/bin:/usr/local/bin:/usr/bin:/bin",
+      "-e",
+      "AO_DATA_DIR=/tmp/ao/data",
+    ]);
   });
 
   it("removes the container if startup fails", async () => {

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -1,0 +1,414 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as childProcess from "node:child_process";
+import * as fs from "node:fs";
+import type { RuntimeHandle } from "@composio/ao-core";
+
+vi.mock("node:child_process", () => {
+  const mockExecFile = vi.fn();
+  (mockExecFile as any)[Symbol.for("nodejs.util.promisify.custom")] = vi.fn();
+  return { execFile: mockExecFile };
+});
+
+vi.mock("node:crypto", () => ({
+  randomUUID: vi.fn(() => "test-uuid-1234"),
+}));
+
+vi.mock("node:fs", () => ({
+  writeFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+vi.mock("node:timers/promises", () => ({
+  setTimeout: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockExecFileCustom = (childProcess.execFile as any)[
+  Symbol.for("nodejs.util.promisify.custom")
+] as ReturnType<typeof vi.fn>;
+const expectedDockerOptions = { timeout: 30_000 };
+
+function mockDockerSuccess(stdout = ""): void {
+  mockExecFileCustom.mockResolvedValueOnce({ stdout: stdout ? `${stdout}\n` : "", stderr: "" });
+}
+
+function mockDockerError(message: string): void {
+  mockExecFileCustom.mockRejectedValueOnce(new Error(message));
+}
+
+function makeHandle(overrides: Partial<RuntimeHandle> = {}): RuntimeHandle {
+  return {
+    id: "container-1",
+    runtimeName: "docker",
+    data: {
+      containerName: "container-1",
+      tmuxSessionName: "tmux-1",
+      createdAt: 1_000,
+      workspacePath: "/tmp/workspace",
+    },
+    ...overrides,
+  };
+}
+
+import dockerPlugin, { create, manifest } from "../index.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe("manifest & exports", () => {
+  it("has the expected manifest", () => {
+    expect(manifest).toEqual({
+      name: "docker",
+      slot: "runtime",
+      description: "Runtime plugin: Docker containers with tmux-backed interactive sessions",
+      version: "0.1.0",
+    });
+  });
+
+  it("exports a valid plugin module", () => {
+    expect(dockerPlugin.manifest).toBe(manifest);
+    expect(dockerPlugin.create).toBe(create);
+  });
+
+  it("create() returns a runtime named docker", () => {
+    expect(create().name).toBe("docker");
+  });
+});
+
+describe("runtime.create()", () => {
+  it("requires runtimeConfig.image", async () => {
+    await expect(
+      create().create({
+        sessionId: "docker-session",
+        workspacePath: "/tmp/workspace",
+        launchCommand: "codex",
+        environment: {},
+      }),
+    ).rejects.toThrow("Docker runtime requires runtimeConfig.image");
+  });
+
+  it("rejects invalid session IDs", async () => {
+    await expect(
+      create().create({
+        sessionId: "bad session!",
+        workspacePath: "/tmp/workspace",
+        launchCommand: "codex",
+        environment: {},
+        runtimeConfig: { image: "ghcr.io/example/ao:latest" },
+      }),
+    ).rejects.toThrow('Invalid session ID "bad session!"');
+  });
+
+  it("starts a container, creates tmux inside it, and sends the launch command", async () => {
+    mockDockerSuccess("container-id");
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+
+    const runtime = create();
+    const handle = await runtime.create({
+      sessionId: "docker-session",
+      workspacePath: "/tmp/workspace",
+      launchCommand: "codex --model gpt-5",
+      environment: { AO_SESSION: "docker-session", FOO: "bar" },
+      runtimeConfig: {
+        image: "ghcr.io/example/ao:latest",
+        network: "bridge",
+        readOnlyRoot: true,
+        capDrop: ["ALL"],
+        tmpfs: ["/tmp"],
+        limits: {
+          cpus: 2,
+          memory: "4g",
+          gpus: "all",
+        },
+      },
+    });
+    const expectedRunArgs = [
+      "run",
+      "-d",
+      "--name",
+      "docker-session",
+      "--workdir",
+      "/tmp/workspace",
+      "--volume",
+      "/tmp/workspace:/tmp/workspace",
+      ...(typeof process.getuid === "function" && typeof process.getgid === "function"
+        ? ["--user", `${process.getuid()}:${process.getgid()}`]
+        : []),
+      "--network",
+      "bridge",
+      "--read-only",
+      "--cap-drop",
+      "ALL",
+      "--tmpfs",
+      "/tmp",
+      "--cpus",
+      "2",
+      "--memory",
+      "4g",
+      "--gpus",
+      "all",
+      "ghcr.io/example/ao:latest",
+      "/bin/sh",
+      "-lc",
+      "trap 'exit 0' TERM INT; while :; do sleep 3600; done",
+    ];
+
+    expect(handle).toEqual({
+      id: "docker-session",
+      runtimeName: "docker",
+      data: expect.objectContaining({
+        containerName: "docker-session",
+        tmuxSessionName: "docker-session",
+        workspacePath: "/tmp/workspace",
+      }),
+    });
+
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      1,
+      "docker",
+      expectedRunArgs,
+      expectedDockerOptions,
+    );
+
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
+      "docker",
+      [
+        "exec",
+        "docker-session",
+        "tmux",
+        "new-session",
+        "-d",
+        "-s",
+        "docker-session",
+        "-c",
+        "/tmp/workspace",
+        "-e",
+        "AO_SESSION=docker-session",
+        "-e",
+        "FOO=bar",
+      ],
+      expectedDockerOptions,
+    );
+
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      3,
+      "docker",
+      [
+        "exec",
+        "docker-session",
+        "tmux",
+        "send-keys",
+        "-t",
+        "docker-session",
+        "-l",
+        "codex --model gpt-5",
+      ],
+      expectedDockerOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      4,
+      "docker",
+      ["exec", "docker-session", "tmux", "send-keys", "-t", "docker-session", "Enter"],
+      expectedDockerOptions,
+    );
+  });
+
+  it("removes the container if startup fails", async () => {
+    mockDockerSuccess("container-id");
+    mockDockerError("tmux missing");
+    mockDockerSuccess();
+
+    await expect(
+      create().create({
+        sessionId: "docker-session",
+        workspacePath: "/tmp/workspace",
+        launchCommand: "codex",
+        environment: {},
+        runtimeConfig: { image: "ghcr.io/example/ao:latest" },
+      }),
+    ).rejects.toThrow('Failed to create docker runtime for session "docker-session"');
+
+    expect(mockExecFileCustom).toHaveBeenLastCalledWith(
+      "docker",
+      ["rm", "-f", "docker-session"],
+      expectedDockerOptions,
+    );
+  });
+});
+
+describe("runtime.destroy()", () => {
+  it("removes the backing container", async () => {
+    mockDockerSuccess();
+
+    await create().destroy(makeHandle());
+
+    expect(mockExecFileCustom).toHaveBeenCalledWith(
+      "docker",
+      ["rm", "-f", "container-1"],
+      expectedDockerOptions,
+    );
+  });
+});
+
+describe("runtime.sendMessage()", () => {
+  it("clears the current prompt and sends short messages with tmux send-keys", async () => {
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+
+    await create().sendMessage(makeHandle(), "please fix ci");
+
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      1,
+      "docker",
+      ["exec", "container-1", "tmux", "send-keys", "-t", "tmux-1", "C-u"],
+      expectedDockerOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
+      "docker",
+      ["exec", "container-1", "tmux", "send-keys", "-t", "tmux-1", "-l", "please fix ci"],
+      expectedDockerOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      3,
+      "docker",
+      ["exec", "container-1", "tmux", "send-keys", "-t", "tmux-1", "Enter"],
+      expectedDockerOptions,
+    );
+  });
+
+  it("uses docker cp and tmux buffers for multiline messages", async () => {
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+
+    const message = "line one\nline two";
+    await create().sendMessage(makeHandle(), message);
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("ao-docker-test-uuid-1234.txt"),
+      message,
+      { encoding: "utf-8", mode: 0o600 },
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
+      "docker",
+      [
+        "cp",
+        expect.stringContaining("ao-docker-test-uuid-1234.txt"),
+        "container-1:/tmp/ao-test-uuid-1234.txt",
+      ],
+      expectedDockerOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      3,
+      "docker",
+      [
+        "exec",
+        "container-1",
+        "tmux",
+        "load-buffer",
+        "-b",
+        "ao-test-uuid-1234",
+        "/tmp/ao-test-uuid-1234.txt",
+      ],
+      expectedDockerOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      4,
+      "docker",
+      [
+        "exec",
+        "container-1",
+        "tmux",
+        "paste-buffer",
+        "-b",
+        "ao-test-uuid-1234",
+        "-t",
+        "tmux-1",
+        "-d",
+      ],
+      expectedDockerOptions,
+    );
+    expect(fs.unlinkSync).toHaveBeenCalledWith(
+      expect.stringContaining("ao-docker-test-uuid-1234.txt"),
+    );
+  });
+});
+
+describe("runtime.getOutput()", () => {
+  it("captures pane output from tmux", async () => {
+    mockDockerSuccess("hello\nworld");
+
+    await expect(create().getOutput(makeHandle(), 25)).resolves.toBe("hello\nworld");
+
+    expect(mockExecFileCustom).toHaveBeenCalledWith(
+      "docker",
+      ["exec", "container-1", "tmux", "capture-pane", "-t", "tmux-1", "-p", "-S", "-25"],
+      expectedDockerOptions,
+    );
+  });
+
+  it("returns an empty string when capture fails", async () => {
+    mockDockerError("capture failed");
+    await expect(create().getOutput(makeHandle())).resolves.toBe("");
+  });
+});
+
+describe("runtime.isAlive()", () => {
+  it("returns true when docker inspect reports a running container", async () => {
+    mockDockerSuccess("true");
+    await expect(create().isAlive(makeHandle())).resolves.toBe(true);
+  });
+
+  it("returns false when docker inspect fails", async () => {
+    mockDockerError("missing");
+    await expect(create().isAlive(makeHandle())).resolves.toBe(false);
+  });
+});
+
+describe("runtime.getMetrics()", () => {
+  it("reports uptime plus docker cpu and memory metrics when available", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(11_000);
+    mockDockerSuccess('{"CPUPerc":"12.5%","MemUsage":"128MiB / 2GiB"}');
+    const runtime = create();
+    expect(runtime.getMetrics).toBeDefined();
+    await expect(runtime.getMetrics!(makeHandle())).resolves.toEqual({
+      uptimeMs: 10_000,
+      cpuPercent: 12.5,
+      memoryMb: 128,
+    });
+  });
+
+  it("falls back to uptime-only metrics when docker stats fails", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(11_000);
+    mockDockerError("stats failed");
+    const runtime = create();
+    expect(runtime.getMetrics).toBeDefined();
+    await expect(runtime.getMetrics!(makeHandle())).resolves.toEqual({ uptimeMs: 10_000 });
+  });
+});
+
+describe("runtime.getAttachInfo()", () => {
+  it("returns structured docker attach information", async () => {
+    const runtime = create();
+    expect(runtime.getAttachInfo).toBeDefined();
+    await expect(runtime.getAttachInfo!(makeHandle())).resolves.toEqual({
+      type: "docker",
+      target: "container-1",
+      command: "docker exec -it container-1 tmux attach -t tmux-1",
+      program: "docker",
+      args: ["exec", "-it", "container-1", "tmux", "attach", "-t", "tmux-1"],
+      requiresPty: true,
+    });
+  });
+});

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -152,6 +152,7 @@ describe("runtime.create()", () => {
     mockDockerSuccess();
     mockDockerSuccess();
     mockDockerSuccess();
+    mockDockerSuccess();
 
     const runtime = create();
     const handle = await runtime.create({
@@ -181,6 +182,12 @@ describe("runtime.create()", () => {
       "/tmp/workspace",
       "--volume",
       "/tmp/workspace:/tmp/workspace",
+      "--env",
+      "AO_SESSION=docker-session",
+      "--env",
+      "FOO=bar",
+      "--env",
+      "HOME=/tmp/ao-home",
       ...(typeof process.getuid === "function" && typeof process.getgid === "function"
         ? ["--user", `${process.getuid()}:${process.getgid()}`]
         : []),
@@ -200,7 +207,7 @@ describe("runtime.create()", () => {
       "ghcr.io/example/ao:latest",
       "/bin/sh",
       "-lc",
-      "trap 'exit 0' TERM INT; while :; do sleep 3600; done",
+      'mkdir -p "$HOME"; trap \'exit 0\' TERM INT; while :; do sleep 3600; done',
     ];
 
     expect(handle).toEqual({
@@ -210,6 +217,10 @@ describe("runtime.create()", () => {
         containerName: "docker-session",
         tmuxSessionName: "docker-session",
         workspacePath: "/tmp/workspace",
+        execUser:
+          typeof process.getuid === "function" && typeof process.getgid === "function"
+            ? `${process.getuid()}:${process.getgid()}`
+            : undefined,
       }),
     });
 
@@ -225,6 +236,25 @@ describe("runtime.create()", () => {
       "docker",
       [
         "exec",
+        ...(typeof process.getuid === "function" && typeof process.getgid === "function"
+          ? ["--user", "0:0"]
+          : []),
+        "docker-session",
+        "/bin/sh",
+        "-lc",
+        expect.stringContaining('mkdir -p "$HOME" "$HOME/.cache" "$HOME/.config"'),
+      ],
+      expectedDockerOptions,
+    );
+
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      3,
+      "docker",
+      [
+        "exec",
+        ...(typeof process.getuid === "function" && typeof process.getgid === "function"
+          ? ["--user", `${process.getuid()}:${process.getgid()}`]
+          : []),
         "docker-session",
         "tmux",
         "new-session",
@@ -237,15 +267,20 @@ describe("runtime.create()", () => {
         "AO_SESSION=docker-session",
         "-e",
         "FOO=bar",
+        "-e",
+        "HOME=/tmp/ao-home",
       ],
       expectedDockerOptions,
     );
 
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
-      3,
+      4,
       "docker",
       [
         "exec",
+        ...(typeof process.getuid === "function" && typeof process.getgid === "function"
+          ? ["--user", `${process.getuid()}:${process.getgid()}`]
+          : []),
         "docker-session",
         "tmux",
         "send-keys",
@@ -257,9 +292,20 @@ describe("runtime.create()", () => {
       expectedDockerOptions,
     );
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
-      4,
+      5,
       "docker",
-      ["exec", "docker-session", "tmux", "send-keys", "-t", "docker-session", "Enter"],
+      [
+        "exec",
+        ...(typeof process.getuid === "function" && typeof process.getgid === "function"
+          ? ["--user", `${process.getuid()}:${process.getgid()}`]
+          : []),
+        "docker-session",
+        "tmux",
+        "send-keys",
+        "-t",
+        "docker-session",
+        "Enter",
+      ],
       expectedDockerOptions,
     );
   });
@@ -282,6 +328,7 @@ describe("runtime.create()", () => {
     ]);
 
     mockDockerSuccess("container-id");
+    mockDockerSuccess();
     mockDockerSuccess();
     mockDockerSuccess();
     mockDockerSuccess();
@@ -322,20 +369,23 @@ describe("runtime.create()", () => {
         "--volume",
         "/host/.agent/sessions:/tmp/ao/data",
         "--volume",
-        "/host/home/.codex:/home/ao/.codex",
+        "/host/home/.codex:/tmp/ao-home/.codex",
         "--volume",
-        "/host/home/.gitconfig:/home/ao/.gitconfig:ro",
+        "/host/home/.gitconfig:/tmp/ao-home/.gitconfig:ro",
         "--volume",
-        "/host/home/.git-credentials:/home/ao/.git-credentials:ro",
+        "/host/home/.git-credentials:/tmp/ao-home/.git-credentials:ro",
         "--volume",
-        "/host/home/.config/gh:/home/ao/.config/gh",
+        "/host/home/.config/gh:/tmp/ao-home/.config/gh",
         "ao-fake-codex:latest",
       ]),
     );
 
-    const tmuxArgs = mockExecFileCustom.mock.calls[1]?.[1] as string[];
+    const tmuxArgs = mockExecFileCustom.mock.calls[2]?.[1] as string[];
     expect(tmuxArgs).toEqual([
       "exec",
+      ...(typeof process.getuid === "function" && typeof process.getgid === "function"
+        ? ["--user", `${process.getuid()}:${process.getgid()}`]
+        : []),
       "docker-session",
       "tmux",
       "new-session",
@@ -351,7 +401,7 @@ describe("runtime.create()", () => {
       "-e",
       "AO_DATA_DIR=/tmp/ao/data",
       "-e",
-      "HOME=/home/ao",
+      "HOME=/tmp/ao-home",
     ]);
   });
 
@@ -362,6 +412,7 @@ describe("runtime.create()", () => {
     ]);
 
     mockDockerSuccess("container-id");
+    mockDockerSuccess();
     mockDockerSuccess();
     mockDockerSuccess();
     mockDockerSuccess();
@@ -377,12 +428,94 @@ describe("runtime.create()", () => {
     });
 
     const runArgs = mockExecFileCustom.mock.calls[0]?.[1] as string[];
-    expect(runArgs).toContain("/host/home/.gitconfig:/home/ao/.gitconfig:ro");
-    expect(runArgs).not.toContain("/host/home/.codex:/home/ao/.codex");
+    expect(runArgs).toContain("/host/home/.gitconfig:/tmp/ao-home/.gitconfig:ro");
+    expect(runArgs).not.toContain("/host/home/.codex:/tmp/ao-home/.codex");
+  });
+
+  it("passes through requested host env vars when present", async () => {
+    const originalOpenAiKey = process.env["OPENAI_API_KEY"];
+    process.env["OPENAI_API_KEY"] = "sk-test-openai";
+    try {
+      mockDockerSuccess("container-id");
+      mockDockerSuccess();
+      mockDockerSuccess();
+      mockDockerSuccess();
+      mockDockerSuccess();
+
+      await create().create({
+        sessionId: "docker-session",
+        workspacePath: "/tmp/workspace",
+        launchCommand: "codex --model gpt-5",
+        agentRuntimeHints: {
+          docker: {
+            envFromHost: ["OPENAI_API_KEY"],
+          },
+        },
+        environment: {
+          AO_SESSION: "docker-session",
+        },
+        runtimeConfig: { image: "ao-fake-codex:latest" },
+      });
+
+      const runArgs = mockExecFileCustom.mock.calls[0]?.[1] as string[];
+      expect(runArgs).toContain("OPENAI_API_KEY=sk-test-openai");
+      const tmuxArgs = mockExecFileCustom.mock.calls[2]?.[1] as string[];
+      expect(tmuxArgs).toContain("OPENAI_API_KEY=sk-test-openai");
+    } finally {
+      if (originalOpenAiKey === undefined) {
+        delete process.env["OPENAI_API_KEY"];
+      } else {
+        process.env["OPENAI_API_KEY"] = originalOpenAiKey;
+      }
+    }
+  });
+
+  it("rewrites mounted host paths inside the launch command before sending it to tmux", async () => {
+    addFileSystemEntries([
+      { path: "/host/.agent/sessions", kind: "dir" },
+    ]);
+
+    mockDockerSuccess("container-id");
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+
+    await create().create({
+      sessionId: "docker-session",
+      workspacePath: "/tmp/workspace",
+      launchCommand:
+        "claude --append-system-prompt \"$(cat '/host/.agent/sessions/orchestrator-prompt.md')\"",
+      environment: {
+        AO_SESSION: "docker-session",
+        AO_DATA_DIR: "/host/.agent/sessions",
+      },
+      runtimeConfig: { image: "ao-real-claude:latest" },
+    });
+
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      4,
+      "docker",
+      [
+        "exec",
+        ...(typeof process.getuid === "function" && typeof process.getgid === "function"
+          ? ["--user", `${process.getuid()}:${process.getgid()}`]
+          : []),
+        "docker-session",
+        "tmux",
+        "send-keys",
+        "-t",
+        "docker-session",
+        "-l",
+        "claude --append-system-prompt \"$(cat '/tmp/ao/data/orchestrator-prompt.md')\"",
+      ],
+      expectedDockerOptions,
+    );
   });
 
   it("removes the container if startup fails", async () => {
     mockDockerSuccess("container-id");
+    mockDockerSuccess();
     mockDockerError("tmux missing");
     mockDockerSuccess();
 

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -242,7 +242,7 @@ describe("runtime.create()", () => {
         "docker-session",
         "/bin/sh",
         "-lc",
-        expect.stringContaining('mkdir -p "$HOME" "$HOME/.cache" "$HOME/.config"'),
+        expect.stringContaining("mkdir -p '/tmp/ao-home' '/tmp/ao-home/.cache'"),
       ],
       expectedDockerOptions,
     );

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -397,9 +397,7 @@ describe("runtime.sendMessage()", () => {
     );
   });
 
-  it("uses docker cp and tmux buffers for multiline messages", async () => {
-    mockDockerSuccess();
-    mockDockerSuccess();
+  it("uses workspace-backed tmux buffers for multiline messages", async () => {
     mockDockerSuccess();
     mockDockerSuccess();
     mockDockerSuccess();
@@ -410,22 +408,12 @@ describe("runtime.sendMessage()", () => {
     await create().sendMessage(makeHandle(), message);
 
     expect(fs.writeFileSync).toHaveBeenCalledWith(
-      expect.stringContaining("ao-docker-test-uuid-1234.txt"),
+      "/tmp/workspace/.ao-tmux-buffer-test-uuid-1234.txt",
       message,
-      { encoding: "utf-8", mode: 0o644 },
+      { encoding: "utf-8", mode: 0o600 },
     );
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
       2,
-      "docker",
-      [
-        "cp",
-        expect.stringContaining("ao-docker-test-uuid-1234.txt"),
-        "container-1:/tmp/ao-test-uuid-1234.txt",
-      ],
-      expectedDockerOptions,
-    );
-    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
-      3,
       "docker",
       [
         "exec",
@@ -434,12 +422,12 @@ describe("runtime.sendMessage()", () => {
         "load-buffer",
         "-b",
         "ao-test-uuid-1234",
-        "/tmp/ao-test-uuid-1234.txt",
+        "/tmp/workspace/.ao-tmux-buffer-test-uuid-1234.txt",
       ],
       expectedDockerOptions,
     );
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
-      4,
+      3,
       "docker",
       [
         "exec",
@@ -454,8 +442,21 @@ describe("runtime.sendMessage()", () => {
       ],
       expectedDockerOptions,
     );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      4,
+      "docker",
+      [
+        "exec",
+        "container-1",
+        "tmux",
+        "delete-buffer",
+        "-b",
+        "ao-test-uuid-1234",
+      ],
+      expectedDockerOptions,
+    );
     expect(fs.unlinkSync).toHaveBeenCalledWith(
-      expect.stringContaining("ao-docker-test-uuid-1234.txt"),
+      "/tmp/workspace/.ao-tmux-buffer-test-uuid-1234.txt",
     );
   });
 });

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -726,6 +726,40 @@ describe("runtime.sendMessage()", () => {
       "/tmp/ao-runtime-handle/.ao-tmux-buffer-test-uuid-1234.txt",
     );
   });
+
+  it("falls back to workspace-backed buffers for legacy handles without hostRuntimeDir", async () => {
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+
+    const message = "line one\nline two";
+    await create().sendMessage(
+      makeHandle({ data: { ...makeHandle().data, hostRuntimeDir: undefined } }),
+      message,
+    );
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      "/tmp/workspace/.ao-tmux-buffer-test-uuid-1234.txt",
+      message,
+      { encoding: "utf-8", mode: 0o600 },
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
+      "docker",
+      [
+        "exec",
+        "container-1",
+        "tmux",
+        "load-buffer",
+        "-b",
+        "ao-test-uuid-1234",
+        "/tmp/workspace/.ao-tmux-buffer-test-uuid-1234.txt",
+      ],
+      expectedDockerOptions,
+    );
+  });
 });
 
 describe("runtime.getOutput()", () => {

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -340,6 +340,7 @@ describe("runtime.create()", () => {
       agentRuntimeHints: {
         docker: {
           homeMounts: [{ path: ".codex" }],
+          envDefaults: { CODEX_HOME: ".codex" },
         },
       },
       environment: {
@@ -402,6 +403,8 @@ describe("runtime.create()", () => {
       "AO_DATA_DIR=/tmp/ao/data",
       "-e",
       "HOME=/tmp/ao-home",
+      "-e",
+      "CODEX_HOME=/tmp/ao-home/.codex",
     ]);
   });
 

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -264,7 +264,7 @@ describe("runtime.create()", () => {
     );
   });
 
-  it("mounts worktree git metadata, remaps wrappers, and strips host-only GH_PATH", async () => {
+  it("mounts requested agent home state, worktree git metadata, remaps wrappers, and strips host-only GH_PATH", async () => {
     addFileSystemEntries([
       {
         path: "/worktrees/docker-session/.git",
@@ -290,6 +290,11 @@ describe("runtime.create()", () => {
       sessionId: "docker-session",
       workspacePath: "/worktrees/docker-session",
       launchCommand: "codex --model gpt-5",
+      agentRuntimeHints: {
+        docker: {
+          homeMounts: [{ path: ".codex" }],
+        },
+      },
       environment: {
         AO_SESSION: "docker-session",
         PATH: "/host/.ao/bin:/usr/local/bin:/usr/bin:/bin",
@@ -348,6 +353,32 @@ describe("runtime.create()", () => {
       "-e",
       "HOME=/home/ao",
     ]);
+  });
+
+  it("does not mount agent home state unless the agent requests it", async () => {
+    addFileSystemEntries([
+      { path: "/host/home/.codex", kind: "dir" },
+      { path: "/host/home/.gitconfig", kind: "file", content: "[user]\n\tname = Test\n" },
+    ]);
+
+    mockDockerSuccess("container-id");
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+
+    await create().create({
+      sessionId: "docker-session",
+      workspacePath: "/tmp/workspace",
+      launchCommand: "codex --model gpt-5",
+      environment: {
+        AO_SESSION: "docker-session",
+      },
+      runtimeConfig: { image: "ao-fake-codex:latest" },
+    });
+
+    const runArgs = mockExecFileCustom.mock.calls[0]?.[1] as string[];
+    expect(runArgs).toContain("/host/home/.gitconfig:/home/ao/.gitconfig:ro");
+    expect(runArgs).not.toContain("/host/home/.codex:/home/ao/.codex");
   });
 
   it("removes the container if startup fails", async () => {

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -20,6 +20,7 @@ vi.mock("node:os", () => ({
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   lstatSync: vi.fn(),
+  mkdirSync: vi.fn(),
   readFileSync: vi.fn(),
   writeFileSync: vi.fn(),
   unlinkSync: vi.fn(),
@@ -35,7 +36,9 @@ const mockExecFileCustom = (childProcess.execFile as any)[
 const expectedDockerOptions = { timeout: 30_000 };
 const mockExistsSync = fs.existsSync as ReturnType<typeof vi.fn>;
 const mockLstatSync = fs.lstatSync as ReturnType<typeof vi.fn>;
+const mockMkdirSync = fs.mkdirSync as ReturnType<typeof vi.fn>;
 const mockReadFileSync = fs.readFileSync as ReturnType<typeof vi.fn>;
+const mockWriteFileSync = fs.writeFileSync as ReturnType<typeof vi.fn>;
 
 function mockDockerSuccess(stdout = ""): void {
   mockExecFileCustom.mockResolvedValueOnce({ stdout: stdout ? `${stdout}\n` : "", stderr: "" });
@@ -98,9 +101,11 @@ beforeEach(() => {
   mockLstatSync.mockImplementation(() => {
     throw new Error("ENOENT");
   });
+  mockMkdirSync.mockImplementation(() => undefined);
   mockReadFileSync.mockImplementation(() => {
     throw new Error("ENOENT");
   });
+  mockWriteFileSync.mockImplementation(() => undefined);
 });
 
 describe("manifest & exports", () => {
@@ -339,7 +344,7 @@ describe("runtime.create()", () => {
       launchCommand: "codex --model gpt-5",
       agentRuntimeHints: {
         docker: {
-          homeMounts: [{ path: ".codex" }],
+          homeMounts: [{ path: ".codex", kind: "dir" }],
           envDefaults: { CODEX_HOME: ".codex" },
         },
       },
@@ -433,6 +438,56 @@ describe("runtime.create()", () => {
     const runArgs = mockExecFileCustom.mock.calls[0]?.[1] as string[];
     expect(runArgs).toContain("/host/home/.gitconfig:/tmp/ao-home/.gitconfig:ro");
     expect(runArgs).not.toContain("/host/home/.codex:/tmp/ao-home/.codex");
+  });
+
+  it("creates missing hinted home paths so first-time auth persists across containers", async () => {
+    addFileSystemEntries([
+      { path: "/host/home/.gitconfig", kind: "file", content: "[user]\n\tname = Test\n" },
+    ]);
+
+    mockDockerSuccess("container-id");
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+    mockDockerSuccess();
+
+    await create().create({
+      sessionId: "docker-session",
+      workspacePath: "/tmp/workspace",
+      launchCommand: "claude",
+      agentRuntimeHints: {
+        docker: {
+          homeMounts: [
+            { path: ".claude", kind: "dir" },
+            { path: ".local/share/opencode/auth.json", kind: "file" },
+          ],
+        },
+      },
+      environment: {
+        AO_SESSION: "docker-session",
+      },
+      runtimeConfig: { image: "ao-fake-claude:latest" },
+    });
+
+    expect(mockMkdirSync).toHaveBeenCalledWith("/host/home/.claude", { recursive: true });
+    expect(mockMkdirSync).toHaveBeenCalledWith("/host/home/.local/share/opencode", {
+      recursive: true,
+    });
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      "/host/home/.local/share/opencode/auth.json",
+      "",
+      { flag: "a", mode: 0o600 },
+    );
+
+    const runArgs = mockExecFileCustom.mock.calls[0]?.[1] as string[];
+    expect(runArgs).toEqual(
+      expect.arrayContaining([
+        "--volume",
+        "/host/home/.claude:/tmp/ao-home/.claude",
+        "--volume",
+        "/host/home/.local/share/opencode/auth.json:/tmp/ao-home/.local/share/opencode/auth.json",
+      ]),
+    );
   });
 
   it("passes through requested host env vars when present", async () => {

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -13,6 +13,10 @@ vi.mock("node:crypto", () => ({
   randomUUID: vi.fn(() => "test-uuid-1234"),
 }));
 
+vi.mock("node:os", () => ({
+  homedir: vi.fn(() => "/host/home"),
+}));
+
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   lstatSync: vi.fn(),
@@ -271,6 +275,10 @@ describe("runtime.create()", () => {
       { path: "/host/.ao/bin", kind: "dir" },
       { path: "/host/.ao/bin/ao-metadata-helper.sh", kind: "file", content: "#!/bin/sh\n" },
       { path: "/host/.agent/sessions", kind: "dir" },
+      { path: "/host/home/.codex", kind: "dir" },
+      { path: "/host/home/.gitconfig", kind: "file", content: "[user]\n\tname = Test\n" },
+      { path: "/host/home/.git-credentials", kind: "file", content: "https://token@example.com\n" },
+      { path: "/host/home/.config/gh", kind: "dir" },
     ]);
 
     mockDockerSuccess("container-id");
@@ -308,6 +316,14 @@ describe("runtime.create()", () => {
         "/host/.ao/bin:/tmp/ao/bin:ro",
         "--volume",
         "/host/.agent/sessions:/tmp/ao/data",
+        "--volume",
+        "/host/home/.codex:/home/ao/.codex",
+        "--volume",
+        "/host/home/.gitconfig:/home/ao/.gitconfig:ro",
+        "--volume",
+        "/host/home/.git-credentials:/home/ao/.git-credentials:ro",
+        "--volume",
+        "/host/home/.config/gh:/home/ao/.config/gh",
         "ao-fake-codex:latest",
       ]),
     );
@@ -329,6 +345,8 @@ describe("runtime.create()", () => {
       "PATH=/tmp/ao/bin:/usr/local/bin:/usr/bin:/bin",
       "-e",
       "AO_DATA_DIR=/tmp/ao/data",
+      "-e",
+      "HOME=/home/ao",
     ]);
   });
 

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -15,13 +15,16 @@ vi.mock("node:crypto", () => ({
 
 vi.mock("node:os", () => ({
   homedir: vi.fn(() => "/host/home"),
+  tmpdir: vi.fn(() => "/tmp"),
 }));
 
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   lstatSync: vi.fn(),
   mkdirSync: vi.fn(),
+  mkdtempSync: vi.fn(() => "/tmp/ao-runtime-docker-test"),
   readFileSync: vi.fn(),
+  rmSync: vi.fn(),
   writeFileSync: vi.fn(),
   unlinkSync: vi.fn(),
 }));
@@ -37,7 +40,9 @@ const expectedDockerOptions = { timeout: 30_000 };
 const mockExistsSync = fs.existsSync as ReturnType<typeof vi.fn>;
 const mockLstatSync = fs.lstatSync as ReturnType<typeof vi.fn>;
 const mockMkdirSync = fs.mkdirSync as ReturnType<typeof vi.fn>;
+const mockMkdtempSync = fs.mkdtempSync as ReturnType<typeof vi.fn>;
 const mockReadFileSync = fs.readFileSync as ReturnType<typeof vi.fn>;
+const mockRmSync = fs.rmSync as ReturnType<typeof vi.fn>;
 const mockWriteFileSync = fs.writeFileSync as ReturnType<typeof vi.fn>;
 
 function mockDockerSuccess(stdout = ""): void {
@@ -87,6 +92,7 @@ function makeHandle(overrides: Partial<RuntimeHandle> = {}): RuntimeHandle {
       tmuxSessionName: "tmux-1",
       createdAt: 1_000,
       workspacePath: "/tmp/workspace",
+      hostRuntimeDir: "/tmp/ao-runtime-handle",
     },
     ...overrides,
   };
@@ -102,9 +108,11 @@ beforeEach(() => {
     throw new Error("ENOENT");
   });
   mockMkdirSync.mockImplementation(() => undefined);
+  mockMkdtempSync.mockImplementation(() => "/tmp/ao-runtime-docker-test");
   mockReadFileSync.mockImplementation(() => {
     throw new Error("ENOENT");
   });
+  mockRmSync.mockImplementation(() => undefined);
   mockWriteFileSync.mockImplementation(() => undefined);
 });
 
@@ -152,6 +160,21 @@ describe("runtime.create()", () => {
     ).rejects.toThrow('Invalid session ID "bad session!"');
   });
 
+  it("rejects readOnlyRoot without a /tmp tmpfs", async () => {
+    await expect(
+      create().create({
+        sessionId: "docker-session",
+        workspacePath: "/tmp/workspace",
+        launchCommand: "codex",
+        environment: {},
+        runtimeConfig: {
+          image: "ghcr.io/example/ao:latest",
+          readOnlyRoot: true,
+        },
+      }),
+    ).rejects.toThrow("requires tmpfs to include /tmp");
+  });
+
   it("starts a container, creates tmux inside it, and sends the launch command", async () => {
     mockDockerSuccess("container-id");
     mockDockerSuccess();
@@ -178,43 +201,6 @@ describe("runtime.create()", () => {
         },
       },
     });
-    const expectedRunArgs = [
-      "run",
-      "-d",
-      "--name",
-      "docker-session",
-      "--workdir",
-      "/tmp/workspace",
-      "--volume",
-      "/tmp/workspace:/tmp/workspace",
-      "--env",
-      "AO_SESSION=docker-session",
-      "--env",
-      "FOO=bar",
-      "--env",
-      "HOME=/tmp/ao-home",
-      ...(typeof process.getuid === "function" && typeof process.getgid === "function"
-        ? ["--user", `${process.getuid()}:${process.getgid()}`]
-        : []),
-      "--network",
-      "bridge",
-      "--read-only",
-      "--cap-drop",
-      "ALL",
-      "--tmpfs",
-      "/tmp",
-      "--cpus",
-      "2",
-      "--memory",
-      "4g",
-      "--gpus",
-      "all",
-      "ghcr.io/example/ao:latest",
-      "/bin/sh",
-      "-lc",
-      'mkdir -p "$HOME"; trap \'exit 0\' TERM INT; while :; do sleep 3600; done',
-    ];
-
     expect(handle).toEqual({
       id: "docker-session",
       runtimeName: "docker",
@@ -222,6 +208,7 @@ describe("runtime.create()", () => {
         containerName: "docker-session",
         tmuxSessionName: "docker-session",
         workspacePath: "/tmp/workspace",
+        hostRuntimeDir: "/tmp/ao-runtime-docker-test",
         execUser:
           typeof process.getuid === "function" && typeof process.getgid === "function"
             ? `${process.getuid()}:${process.getgid()}`
@@ -229,11 +216,40 @@ describe("runtime.create()", () => {
       }),
     });
 
-    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
-      1,
-      "docker",
-      expectedRunArgs,
-      expectedDockerOptions,
+    const runArgs = mockExecFileCustom.mock.calls[0]?.[1] as string[];
+    expect(runArgs).toEqual(
+      expect.arrayContaining([
+        "run",
+        "-d",
+        "--name",
+        "docker-session",
+        "--workdir",
+        "/tmp/workspace",
+        "--volume",
+        "/tmp/workspace:/tmp/workspace",
+        "--volume",
+        "/tmp/ao-runtime-docker-test:/tmp/ao/runtime",
+        "--env",
+        "AO_SESSION=docker-session",
+        "--env",
+        "FOO=bar",
+        "--env",
+        "HOME=/tmp/ao-home",
+        "--network",
+        "bridge",
+        "--read-only",
+        "--cap-drop",
+        "ALL",
+        "--tmpfs",
+        "/tmp",
+        "--cpus",
+        "2",
+        "--memory",
+        "4g",
+        "--gpus",
+        "all",
+        "ghcr.io/example/ao:latest",
+      ]),
     );
 
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
@@ -375,6 +391,8 @@ describe("runtime.create()", () => {
         "--volume",
         "/host/.agent/sessions:/tmp/ao/data",
         "--volume",
+        "/tmp/ao-runtime-docker-test:/tmp/ao/runtime",
+        "--volume",
         "/host/home/.codex:/tmp/ao-home/.codex",
         "--volume",
         "/host/home/.gitconfig:/tmp/ao-home/.gitconfig:ro",
@@ -438,6 +456,7 @@ describe("runtime.create()", () => {
     const runArgs = mockExecFileCustom.mock.calls[0]?.[1] as string[];
     expect(runArgs).toContain("/host/home/.gitconfig:/tmp/ao-home/.gitconfig:ro");
     expect(runArgs).not.toContain("/host/home/.codex:/tmp/ao-home/.codex");
+    expect(runArgs).toContain("/tmp/ao-runtime-docker-test:/tmp/ao/runtime");
   });
 
   it("creates missing hinted home paths so first-time auth persists across containers", async () => {
@@ -592,6 +611,10 @@ describe("runtime.create()", () => {
       ["rm", "-f", "docker-session"],
       expectedDockerOptions,
     );
+    expect(mockRmSync).toHaveBeenCalledWith("/tmp/ao-runtime-docker-test", {
+      recursive: true,
+      force: true,
+    });
   });
 });
 
@@ -606,6 +629,10 @@ describe("runtime.destroy()", () => {
       ["rm", "-f", "container-1"],
       expectedDockerOptions,
     );
+    expect(mockRmSync).toHaveBeenCalledWith("/tmp/ao-runtime-handle", {
+      recursive: true,
+      force: true,
+    });
   });
 });
 
@@ -637,7 +664,7 @@ describe("runtime.sendMessage()", () => {
     );
   });
 
-  it("uses workspace-backed tmux buffers for multiline messages", async () => {
+  it("uses runtime temp buffers for multiline messages", async () => {
     mockDockerSuccess();
     mockDockerSuccess();
     mockDockerSuccess();
@@ -648,7 +675,7 @@ describe("runtime.sendMessage()", () => {
     await create().sendMessage(makeHandle(), message);
 
     expect(fs.writeFileSync).toHaveBeenCalledWith(
-      "/tmp/workspace/.ao-tmux-buffer-test-uuid-1234.txt",
+      "/tmp/ao-runtime-handle/.ao-tmux-buffer-test-uuid-1234.txt",
       message,
       { encoding: "utf-8", mode: 0o600 },
     );
@@ -662,7 +689,7 @@ describe("runtime.sendMessage()", () => {
         "load-buffer",
         "-b",
         "ao-test-uuid-1234",
-        "/tmp/workspace/.ao-tmux-buffer-test-uuid-1234.txt",
+        "/tmp/ao/runtime/.ao-tmux-buffer-test-uuid-1234.txt",
       ],
       expectedDockerOptions,
     );
@@ -696,7 +723,7 @@ describe("runtime.sendMessage()", () => {
       expectedDockerOptions,
     );
     expect(fs.unlinkSync).toHaveBeenCalledWith(
-      "/tmp/workspace/.ao-tmux-buffer-test-uuid-1234.txt",
+      "/tmp/ao-runtime-handle/.ao-tmux-buffer-test-uuid-1234.txt",
     );
   });
 });

--- a/packages/plugins/runtime-docker/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-docker/src/__tests__/index.test.ts
@@ -412,7 +412,7 @@ describe("runtime.sendMessage()", () => {
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       expect.stringContaining("ao-docker-test-uuid-1234.txt"),
       message,
-      { encoding: "utf-8", mode: 0o600 },
+      { encoding: "utf-8", mode: 0o644 },
     );
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
       2,

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -1,8 +1,8 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { promisify } from "node:util";
 import type {
@@ -18,6 +18,9 @@ const execFileAsync = promisify(execFile);
 const DOCKER_COMMAND_TIMEOUT_MS = 30_000;
 const SAFE_SESSION_ID = /^[a-zA-Z0-9_-]+$/;
 const LONG_MESSAGE_THRESHOLD = 200;
+const CONTAINER_AO_BIN_DIR = "/tmp/ao/bin";
+const CONTAINER_AO_DATA_DIR = "/tmp/ao/data";
+const AO_METADATA_HELPER = "ao-metadata-helper.sh";
 
 export const manifest = {
   name: "docker",
@@ -41,6 +44,12 @@ interface DockerRuntimeConfig {
   };
 }
 
+interface VolumeMount {
+  hostPath: string;
+  containerPath: string;
+  readOnly?: boolean;
+}
+
 function assertValidSessionId(id: string): void {
   if (!SAFE_SESSION_ID.test(id)) {
     throw new Error(`Invalid session ID "${id}": must match ${SAFE_SESSION_ID}`);
@@ -53,6 +62,140 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function parseDockerRuntimeConfig(config?: Record<string, unknown>): DockerRuntimeConfig {
   return isPlainObject(config) ? (config as DockerRuntimeConfig) : {};
+}
+
+function pathIsFile(path: string): boolean {
+  try {
+    return existsSync(path) && lstatSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function pathIsDirectory(path: string): boolean {
+  try {
+    return existsSync(path) && lstatSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function parsePathEntries(value?: string): string[] {
+  return (value ?? "").split(":").filter(Boolean);
+}
+
+function rewritePathEntries(
+  value: string | undefined,
+  replacements: Map<string, string>,
+): string | undefined {
+  if (!value) return undefined;
+
+  const entries: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of parsePathEntries(value)) {
+    const next = replacements.get(entry) ?? entry;
+    if (!next || seen.has(next)) continue;
+    entries.push(next);
+    seen.add(next);
+  }
+
+  return entries.length > 0 ? entries.join(":") : undefined;
+}
+
+function dedupeMounts(mounts: VolumeMount[]): VolumeMount[] {
+  const deduped = new Map<string, VolumeMount>();
+  for (const mount of mounts) {
+    if (!mount.hostPath || !mount.containerPath) continue;
+    deduped.set(`${mount.hostPath}->${mount.containerPath}`, mount);
+  }
+  return [...deduped.values()];
+}
+
+function findWrapperDir(pathValue?: string): string | undefined {
+  for (const entry of parsePathEntries(pathValue)) {
+    if (pathIsFile(join(entry, AO_METADATA_HELPER))) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function resolveExternalGitCommonDir(workspacePath: string): string | undefined {
+  const gitPath = join(workspacePath, ".git");
+  if (!pathIsFile(gitPath)) return undefined;
+
+  let rawGitDir: string;
+  try {
+    rawGitDir = readFileSync(gitPath, "utf-8").trim();
+  } catch {
+    return undefined;
+  }
+
+  const match = rawGitDir.match(/^gitdir:\s*(.+)\s*$/i);
+  if (!match) return undefined;
+
+  const gitDir = resolve(workspacePath, match[1]);
+  const commonDirFile = join(gitDir, "commondir");
+  if (!pathIsFile(commonDirFile)) {
+    return gitDir;
+  }
+
+  try {
+    const commonDir = readFileSync(commonDirFile, "utf-8").trim();
+    return commonDir ? resolve(gitDir, commonDir) : gitDir;
+  } catch {
+    return gitDir;
+  }
+}
+
+function getWorkspaceMounts(workspacePath: string): VolumeMount[] {
+  const mounts: VolumeMount[] = [{ hostPath: workspacePath, containerPath: workspacePath }];
+  const gitCommonDir = resolveExternalGitCommonDir(workspacePath);
+  if (gitCommonDir) {
+    mounts.push({ hostPath: gitCommonDir, containerPath: gitCommonDir });
+  }
+  return dedupeMounts(mounts);
+}
+
+function prepareContainerEnvironment(environment: Record<string, string>): {
+  environment: Record<string, string>;
+  mounts: VolumeMount[];
+} {
+  const prepared = { ...environment };
+  const mounts: VolumeMount[] = [];
+
+  const wrapperDir = findWrapperDir(prepared["PATH"]);
+  if (wrapperDir && pathIsDirectory(wrapperDir)) {
+    mounts.push({
+      hostPath: wrapperDir,
+      containerPath: CONTAINER_AO_BIN_DIR,
+      readOnly: true,
+    });
+    const rewrittenPath = rewritePathEntries(
+      prepared["PATH"],
+      new Map([[wrapperDir, CONTAINER_AO_BIN_DIR]]),
+    );
+    if (rewrittenPath) {
+      prepared["PATH"] = rewrittenPath;
+    }
+  }
+
+  const aoDataDir = prepared["AO_DATA_DIR"];
+  if (aoDataDir && pathIsDirectory(aoDataDir)) {
+    mounts.push({ hostPath: aoDataDir, containerPath: CONTAINER_AO_DATA_DIR });
+    prepared["AO_DATA_DIR"] = CONTAINER_AO_DATA_DIR;
+  }
+
+  // GH_PATH is host-resolved by the agent plugin and often invalid in-container.
+  delete prepared["GH_PATH"];
+
+  return { environment: prepared, mounts: dedupeMounts(mounts) };
+}
+
+function toVolumeArg(mount: VolumeMount): string {
+  return mount.readOnly
+    ? `${mount.hostPath}:${mount.containerPath}:ro`
+    : `${mount.hostPath}:${mount.containerPath}`;
 }
 
 async function docker(args: string[]): Promise<string> {
@@ -208,17 +351,17 @@ export function create(): Runtime {
       const containerName = config.sessionId;
       const tmuxSessionName = config.sessionId;
       const shell = runtimeConfig.shell ?? "/bin/sh";
+      const preparedEnvironment = prepareContainerEnvironment(config.environment ?? {});
+      const mounts = dedupeMounts([
+        ...getWorkspaceMounts(config.workspacePath),
+        ...preparedEnvironment.mounts,
+      ]);
 
-      const runArgs = [
-        "run",
-        "-d",
-        "--name",
-        containerName,
-        "--workdir",
-        config.workspacePath,
-        "--volume",
-        `${config.workspacePath}:${config.workspacePath}`,
-      ];
+      const runArgs = ["run", "-d", "--name", containerName, "--workdir", config.workspacePath];
+
+      for (const mount of mounts) {
+        runArgs.push("--volume", toVolumeArg(mount));
+      }
 
       const dockerUser = runtimeConfig.user ?? getDefaultDockerUser();
       if (dockerUser) {
@@ -256,7 +399,7 @@ export function create(): Runtime {
       try {
         await docker(runArgs);
         const envArgs: string[] = [];
-        for (const [key, value] of Object.entries(config.environment ?? {})) {
+        for (const [key, value] of Object.entries(preparedEnvironment.environment)) {
           envArgs.push("-e", `${key}=${value}`);
         }
         await dockerTmux(containerName, [

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -688,13 +688,25 @@ export function create(): Runtime {
 
     async sendMessage(handle: RuntimeHandle, message: string): Promise<void> {
       const hostRuntimeDir = handle.data["hostRuntimeDir"];
+      const workspacePath = handle.data["workspacePath"];
+      const useDedicatedRuntimeDir =
+        typeof hostRuntimeDir === "string" && hostRuntimeDir.length > 0;
+      const hostBufferDir =
+        useDedicatedRuntimeDir
+          ? hostRuntimeDir
+          : (typeof workspacePath === "string" ? workspacePath : undefined);
+      const containerBufferDir =
+        useDedicatedRuntimeDir
+          ? CONTAINER_RUNTIME_DIR
+          : (typeof workspacePath === "string" ? workspacePath : undefined);
+      if (!hostBufferDir || !containerBufferDir) {
+        throw new Error("Docker runtime handle is missing a writable buffer directory.");
+      }
       await sendTextToTmux(
         getContainerName(handle),
         getTmuxSessionName(handle),
-        typeof hostRuntimeDir === "string" && hostRuntimeDir.length > 0
-          ? hostRuntimeDir
-          : (handle.data["workspacePath"] as string),
-        CONTAINER_RUNTIME_DIR,
+        hostBufferDir,
+        containerBufferDir,
         getExecUser(handle),
         message,
         true,

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -1,0 +1,355 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { promisify } from "node:util";
+import type {
+  AttachInfo,
+  PluginModule,
+  Runtime,
+  RuntimeCreateConfig,
+  RuntimeHandle,
+  RuntimeMetrics,
+} from "@composio/ao-core";
+
+const execFileAsync = promisify(execFile);
+const DOCKER_COMMAND_TIMEOUT_MS = 30_000;
+const SAFE_SESSION_ID = /^[a-zA-Z0-9_-]+$/;
+const LONG_MESSAGE_THRESHOLD = 200;
+
+export const manifest = {
+  name: "docker",
+  slot: "runtime" as const,
+  description: "Runtime plugin: Docker containers with tmux-backed interactive sessions",
+  version: "0.1.0",
+};
+
+interface DockerRuntimeConfig {
+  image?: string;
+  shell?: string;
+  user?: string;
+  network?: string;
+  readOnlyRoot?: boolean;
+  capDrop?: string[];
+  tmpfs?: string[];
+  limits?: {
+    cpus?: number | string;
+    memory?: string;
+    gpus?: string;
+  };
+}
+
+function assertValidSessionId(id: string): void {
+  if (!SAFE_SESSION_ID.test(id)) {
+    throw new Error(`Invalid session ID "${id}": must match ${SAFE_SESSION_ID}`);
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseDockerRuntimeConfig(config?: Record<string, unknown>): DockerRuntimeConfig {
+  return isPlainObject(config) ? (config as DockerRuntimeConfig) : {};
+}
+
+async function docker(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("docker", args, {
+    timeout: DOCKER_COMMAND_TIMEOUT_MS,
+  });
+  return stdout.trimEnd();
+}
+
+async function dockerExec(containerName: string, args: string[]): Promise<string> {
+  return docker(["exec", containerName, ...args]);
+}
+
+async function dockerTmux(containerName: string, args: string[]): Promise<string> {
+  return dockerExec(containerName, ["tmux", ...args]);
+}
+
+function getDefaultDockerUser(): string | undefined {
+  if (typeof process.getuid === "function" && typeof process.getgid === "function") {
+    return `${process.getuid()}:${process.getgid()}`;
+  }
+  return undefined;
+}
+
+function getContainerName(handle: RuntimeHandle): string {
+  const containerName = handle.data["containerName"];
+  return typeof containerName === "string" && containerName.length > 0 ? containerName : handle.id;
+}
+
+function getTmuxSessionName(handle: RuntimeHandle): string {
+  const tmuxSessionName = handle.data["tmuxSessionName"];
+  return typeof tmuxSessionName === "string" && tmuxSessionName.length > 0
+    ? tmuxSessionName
+    : handle.id;
+}
+
+function parseCpuPercent(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().replace(/%$/, "");
+  const parsed = Number.parseFloat(normalized);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseMemoryMb(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const usage = value.split("/")[0]?.trim();
+  if (!usage) return undefined;
+
+  const match = usage.match(/^([0-9]+(?:\.[0-9]+)?)\s*([A-Za-z]+)$/);
+  if (!match) return undefined;
+
+  const amount = Number.parseFloat(match[1]);
+  if (!Number.isFinite(amount)) return undefined;
+
+  const unit = match[2];
+  const multipliers: Record<string, number> = {
+    B: 1 / 1_000_000,
+    kB: 1 / 1_000,
+    KB: 1 / 1_000,
+    KiB: 1 / 1024,
+    MB: 1,
+    MiB: 1,
+    GB: 1_000,
+    GiB: 1024,
+    TB: 1_000_000,
+    TiB: 1_048_576,
+  };
+
+  const multiplier = multipliers[unit];
+  if (multiplier === undefined) return undefined;
+  return Number.parseFloat((amount * multiplier).toFixed(2));
+}
+
+async function getDockerStats(
+  containerName: string,
+): Promise<Pick<RuntimeMetrics, "cpuPercent" | "memoryMb">> {
+  try {
+    const output = await docker(["stats", "--no-stream", "--format", "{{json .}}", containerName]);
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    return {
+      cpuPercent: parseCpuPercent(parsed["CPUPerc"]),
+      memoryMb: parseMemoryMb(parsed["MemUsage"]),
+    };
+  } catch {
+    return {};
+  }
+}
+
+async function removeContainer(containerName: string): Promise<void> {
+  try {
+    await docker(["rm", "-f", containerName]);
+  } catch {
+    // Best-effort cleanup
+  }
+}
+
+async function sendTextToTmux(
+  containerName: string,
+  tmuxSessionName: string,
+  text: string,
+  clearInput = true,
+): Promise<void> {
+  if (clearInput) {
+    await dockerTmux(containerName, ["send-keys", "-t", tmuxSessionName, "C-u"]);
+    await sleep(200);
+  }
+
+  if (text.includes("\n") || text.length > LONG_MESSAGE_THRESHOLD) {
+    const bufferName = `ao-${randomUUID()}`;
+    const tmpName = `/tmp/ao-${randomUUID()}.txt`;
+    const hostTmpPath = join(tmpdir(), `ao-docker-${randomUUID()}.txt`);
+    writeFileSync(hostTmpPath, text, { encoding: "utf-8", mode: 0o600 });
+    try {
+      await docker(["cp", hostTmpPath, `${containerName}:${tmpName}`]);
+      await dockerTmux(containerName, ["load-buffer", "-b", bufferName, tmpName]);
+      await dockerTmux(containerName, [
+        "paste-buffer",
+        "-b",
+        bufferName,
+        "-t",
+        tmuxSessionName,
+        "-d",
+      ]);
+    } finally {
+      try {
+        unlinkSync(hostTmpPath);
+      } catch {
+        // ignore cleanup failure
+      }
+      await dockerExec(containerName, ["rm", "-f", tmpName]).catch(() => undefined);
+      await dockerTmux(containerName, ["delete-buffer", "-b", bufferName]).catch(() => undefined);
+    }
+  } else {
+    await dockerTmux(containerName, ["send-keys", "-t", tmuxSessionName, "-l", text]);
+  }
+
+  await sleep(300);
+  await dockerTmux(containerName, ["send-keys", "-t", tmuxSessionName, "Enter"]);
+}
+
+export function create(): Runtime {
+  return {
+    name: "docker",
+
+    async create(config: RuntimeCreateConfig): Promise<RuntimeHandle> {
+      assertValidSessionId(config.sessionId);
+
+      const runtimeConfig = parseDockerRuntimeConfig(config.runtimeConfig);
+      if (!runtimeConfig.image) {
+        throw new Error("Docker runtime requires runtimeConfig.image");
+      }
+
+      const containerName = config.sessionId;
+      const tmuxSessionName = config.sessionId;
+      const shell = runtimeConfig.shell ?? "/bin/sh";
+
+      const runArgs = [
+        "run",
+        "-d",
+        "--name",
+        containerName,
+        "--workdir",
+        config.workspacePath,
+        "--volume",
+        `${config.workspacePath}:${config.workspacePath}`,
+      ];
+
+      const dockerUser = runtimeConfig.user ?? getDefaultDockerUser();
+      if (dockerUser) {
+        runArgs.push("--user", dockerUser);
+      }
+      if (runtimeConfig.network) {
+        runArgs.push("--network", runtimeConfig.network);
+      }
+      if (runtimeConfig.readOnlyRoot) {
+        runArgs.push("--read-only");
+      }
+      for (const cap of runtimeConfig.capDrop ?? []) {
+        runArgs.push("--cap-drop", cap);
+      }
+      for (const mount of runtimeConfig.tmpfs ?? []) {
+        runArgs.push("--tmpfs", mount);
+      }
+      if (runtimeConfig.limits?.cpus !== undefined) {
+        runArgs.push("--cpus", String(runtimeConfig.limits.cpus));
+      }
+      if (runtimeConfig.limits?.memory) {
+        runArgs.push("--memory", runtimeConfig.limits.memory);
+      }
+      if (runtimeConfig.limits?.gpus) {
+        runArgs.push("--gpus", runtimeConfig.limits.gpus);
+      }
+
+      runArgs.push(
+        runtimeConfig.image,
+        shell,
+        "-lc",
+        "trap 'exit 0' TERM INT; while :; do sleep 3600; done",
+      );
+
+      try {
+        await docker(runArgs);
+        const envArgs: string[] = [];
+        for (const [key, value] of Object.entries(config.environment ?? {})) {
+          envArgs.push("-e", `${key}=${value}`);
+        }
+        await dockerTmux(containerName, [
+          "new-session",
+          "-d",
+          "-s",
+          tmuxSessionName,
+          "-c",
+          config.workspacePath,
+          ...envArgs,
+        ]);
+        await sendTextToTmux(containerName, tmuxSessionName, config.launchCommand, false);
+      } catch (err) {
+        await removeContainer(containerName);
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Failed to create docker runtime for session "${config.sessionId}": ${msg}`,
+          {
+            cause: err,
+          },
+        );
+      }
+
+      return {
+        id: containerName,
+        runtimeName: "docker",
+        data: {
+          containerName,
+          tmuxSessionName,
+          workspacePath: config.workspacePath,
+          createdAt: Date.now(),
+        },
+      };
+    },
+
+    async destroy(handle: RuntimeHandle): Promise<void> {
+      await removeContainer(getContainerName(handle));
+    },
+
+    async sendMessage(handle: RuntimeHandle, message: string): Promise<void> {
+      await sendTextToTmux(getContainerName(handle), getTmuxSessionName(handle), message, true);
+    },
+
+    async getOutput(handle: RuntimeHandle, lines = 50): Promise<string> {
+      try {
+        return await dockerTmux(getContainerName(handle), [
+          "capture-pane",
+          "-t",
+          getTmuxSessionName(handle),
+          "-p",
+          "-S",
+          `-${lines}`,
+        ]);
+      } catch {
+        return "";
+      }
+    },
+
+    async isAlive(handle: RuntimeHandle): Promise<boolean> {
+      try {
+        const output = await docker([
+          "inspect",
+          "-f",
+          "{{.State.Running}}",
+          getContainerName(handle),
+        ]);
+        return output.trim() === "true";
+      } catch {
+        return false;
+      }
+    },
+
+    async getMetrics(handle: RuntimeHandle): Promise<RuntimeMetrics> {
+      const createdAt = (handle.data["createdAt"] as number) ?? Date.now();
+      return {
+        uptimeMs: Date.now() - createdAt,
+        ...(await getDockerStats(getContainerName(handle))),
+      };
+    },
+
+    async getAttachInfo(handle: RuntimeHandle): Promise<AttachInfo> {
+      const containerName = getContainerName(handle);
+      const tmuxSessionName = getTmuxSessionName(handle);
+      return {
+        type: "docker",
+        target: containerName,
+        command: `docker exec -it ${containerName} tmux attach -t ${tmuxSessionName}`,
+        program: "docker",
+        args: ["exec", "-it", containerName, "tmux", "attach", "-t", tmuxSessionName],
+        requiresPty: true,
+      };
+    },
+  };
+}
+
+export default { manifest, create } satisfies PluginModule<Runtime>;

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -1,7 +1,6 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, lstatSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { promisify } from "node:util";
@@ -295,6 +294,7 @@ async function removeContainer(containerName: string): Promise<void> {
 async function sendTextToTmux(
   containerName: string,
   tmuxSessionName: string,
+  workspacePath: string,
   text: string,
   clearInput = true,
 ): Promise<void> {
@@ -305,14 +305,10 @@ async function sendTextToTmux(
 
   if (text.includes("\n") || text.length > LONG_MESSAGE_THRESHOLD) {
     const bufferName = `ao-${randomUUID()}`;
-    const tmpName = `/tmp/ao-${randomUUID()}.txt`;
-    const hostTmpPath = join(tmpdir(), `ao-docker-${randomUUID()}.txt`);
-    // docker cp preserves file mode; keep the staging file readable so the
-    // container's configured runtime user can load it into tmux.
-    writeFileSync(hostTmpPath, text, { encoding: "utf-8", mode: 0o644 });
+    const hostTmpPath = join(workspacePath, `.ao-tmux-buffer-${randomUUID()}.txt`);
+    writeFileSync(hostTmpPath, text, { encoding: "utf-8", mode: 0o600 });
     try {
-      await docker(["cp", hostTmpPath, `${containerName}:${tmpName}`]);
-      await dockerTmux(containerName, ["load-buffer", "-b", bufferName, tmpName]);
+      await dockerTmux(containerName, ["load-buffer", "-b", bufferName, hostTmpPath]);
       await dockerTmux(containerName, [
         "paste-buffer",
         "-b",
@@ -327,7 +323,6 @@ async function sendTextToTmux(
       } catch {
         // ignore cleanup failure
       }
-      await dockerExec(containerName, ["rm", "-f", tmpName]).catch(() => undefined);
       await dockerTmux(containerName, ["delete-buffer", "-b", bufferName]).catch(() => undefined);
     }
   } else {
@@ -413,7 +408,13 @@ export function create(): Runtime {
           config.workspacePath,
           ...envArgs,
         ]);
-        await sendTextToTmux(containerName, tmuxSessionName, config.launchCommand, false);
+        await sendTextToTmux(
+          containerName,
+          tmuxSessionName,
+          config.workspacePath,
+          config.launchCommand,
+          false,
+        );
       } catch (err) {
         await removeContainer(containerName);
         const msg = err instanceof Error ? err.message : String(err);
@@ -442,7 +443,13 @@ export function create(): Runtime {
     },
 
     async sendMessage(handle: RuntimeHandle, message: string): Promise<void> {
-      await sendTextToTmux(getContainerName(handle), getTmuxSessionName(handle), message, true);
+      await sendTextToTmux(
+        getContainerName(handle),
+        getTmuxSessionName(handle),
+        handle.data["workspacePath"] as string,
+        message,
+        true,
+      );
     },
 
     async getOutput(handle: RuntimeHandle, lines = 50): Promise<string> {

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, lstatSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { promisify } from "node:util";
 import type {
@@ -322,6 +322,29 @@ function toVolumeArg(mount: VolumeMount): string {
     : `${mount.hostPath}:${mount.containerPath}`;
 }
 
+function collectContainerHomeDirs(containerHome: string, mounts: VolumeMount[]): string[] {
+  const dirs = new Set<string>([
+    containerHome,
+    join(containerHome, ".cache"),
+    join(containerHome, ".config"),
+    join(containerHome, ".local"),
+    join(containerHome, ".local", "share"),
+    join(containerHome, ".local", "state"),
+  ]);
+
+  for (const mount of mounts) {
+    if (!mount.containerPath.startsWith(containerHome)) continue;
+    let current = dirname(mount.containerPath);
+    while (current.startsWith(containerHome) && current.length >= containerHome.length) {
+      dirs.add(current);
+      if (current === containerHome) break;
+      current = dirname(current);
+    }
+  }
+
+  return [...dirs].sort();
+}
+
 async function docker(args: string[]): Promise<string> {
   const { stdout } = await execFileAsync("docker", args, {
     timeout: DOCKER_COMMAND_TIMEOUT_MS,
@@ -547,12 +570,17 @@ export function create(): Runtime {
 
       try {
         await docker(runArgs);
+        const homeDirs = collectContainerHomeDirs(
+          preparedEnvironment.environment["HOME"] || CONTAINER_HOME_DIR,
+          mounts,
+        );
+        const mkdirArgs = homeDirs.map((dir) => shellQuote(dir)).join(" ");
         const homeInitCommand = execUser
           ? [
-            'mkdir -p "$HOME" "$HOME/.cache" "$HOME/.config" "$HOME/.local" "$HOME/.local/share" "$HOME/.local/state"',
-            `chown ${shellQuote(execUser)} "$HOME" "$HOME/.cache" "$HOME/.config" "$HOME/.local" "$HOME/.local/share" "$HOME/.local/state" 2>/dev/null || true`,
+            `mkdir -p ${mkdirArgs}`,
+            `chown ${shellQuote(execUser)} ${mkdirArgs} 2>/dev/null || true`,
           ].join("; ")
-          : 'mkdir -p "$HOME" "$HOME/.cache" "$HOME/.config" "$HOME/.local" "$HOME/.local/share" "$HOME/.local/state"';
+          : `mkdir -p ${mkdirArgs}`;
         await dockerExec(containerName, [shell, "-lc", homeInitCommand], execUser ? "0:0" : undefined);
         const envArgs: string[] = [];
         for (const [key, value] of Object.entries(preparedEnvironment.environment)) {

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, lstatSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -21,7 +21,7 @@ const SAFE_SESSION_ID = /^[a-zA-Z0-9_-]+$/;
 const LONG_MESSAGE_THRESHOLD = 200;
 const CONTAINER_AO_BIN_DIR = "/tmp/ao/bin";
 const CONTAINER_AO_DATA_DIR = "/tmp/ao/data";
-const CONTAINER_HOME_DIR = "/home/ao";
+const CONTAINER_HOME_DIR = "/tmp/ao-home";
 const AO_METADATA_HELPER = "ao-metadata-helper.sh";
 
 export const manifest = {
@@ -64,6 +64,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function parseDockerRuntimeConfig(config?: Record<string, unknown>): DockerRuntimeConfig {
   return isPlainObject(config) ? (config as DockerRuntimeConfig) : {};
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function pathIsFile(path: string): boolean {
@@ -111,6 +115,18 @@ function dedupeMounts(mounts: VolumeMount[]): VolumeMount[] {
     deduped.set(`${mount.hostPath}->${mount.containerPath}`, mount);
   }
   return [...deduped.values()];
+}
+
+function rewriteMountedPathsInCommand(command: string, mounts: VolumeMount[]): string {
+  const rewrites = mounts
+    .filter((mount) => mount.hostPath && mount.containerPath && mount.hostPath !== mount.containerPath)
+    .sort((left, right) => right.hostPath.length - left.hostPath.length);
+
+  let rewritten = command;
+  for (const mount of rewrites) {
+    rewritten = rewritten.split(mount.hostPath).join(mount.containerPath);
+  }
+  return rewritten;
 }
 
 function findWrapperDir(pathValue?: string): string | undefined {
@@ -189,6 +205,26 @@ function getAgentHomeMounts(
   return mounts;
 }
 
+function applyHostEnvironmentHints(
+  environment: Record<string, string>,
+  hints: AgentDockerRuntimeHints | undefined,
+): Record<string, string> {
+  if (!hints?.envFromHost?.length) {
+    return environment;
+  }
+
+  const prepared = { ...environment };
+  for (const key of hints.envFromHost) {
+    if (!key || prepared[key] !== undefined) continue;
+    const value = process.env[key];
+    if (value !== undefined) {
+      prepared[key] = value;
+    }
+  }
+
+  return prepared;
+}
+
 function prepareContainerEnvironment(
   environment: Record<string, string>,
   hints?: AgentDockerRuntimeHints,
@@ -196,8 +232,10 @@ function prepareContainerEnvironment(
   environment: Record<string, string>;
   mounts: VolumeMount[];
 } {
-  const prepared = { ...environment };
+  const prepared = applyHostEnvironmentHints(environment, hints);
   const mounts: VolumeMount[] = [];
+  const containerHome = prepared["HOME"] || CONTAINER_HOME_DIR;
+  prepared["HOME"] = containerHome;
 
   const wrapperDir = findWrapperDir(prepared["PATH"]);
   if (wrapperDir && pathIsDirectory(wrapperDir)) {
@@ -221,13 +259,10 @@ function prepareContainerEnvironment(
     prepared["AO_DATA_DIR"] = CONTAINER_AO_DATA_DIR;
   }
 
-  const containerHome = prepared["HOME"] || CONTAINER_HOME_DIR;
-  let usingContainerHome = false;
   const hostHome = homedir();
   const agentHomeMounts = getAgentHomeMounts(hints, containerHome);
   if (agentHomeMounts.length > 0) {
     mounts.push(...agentHomeMounts);
-    usingContainerHome = true;
   }
 
   const hostGitConfig = join(hostHome, ".gitconfig");
@@ -237,7 +272,6 @@ function prepareContainerEnvironment(
       containerPath: join(containerHome, ".gitconfig"),
       readOnly: true,
     });
-    usingContainerHome = true;
   }
 
   const hostGitCredentials = join(hostHome, ".git-credentials");
@@ -247,7 +281,6 @@ function prepareContainerEnvironment(
       containerPath: join(containerHome, ".git-credentials"),
       readOnly: true,
     });
-    usingContainerHome = true;
   }
 
   const hostGhConfigDir = join(hostHome, ".config", "gh");
@@ -256,11 +289,6 @@ function prepareContainerEnvironment(
       hostPath: hostGhConfigDir,
       containerPath: join(containerHome, ".config", "gh"),
     });
-    usingContainerHome = true;
-  }
-
-  if (usingContainerHome) {
-    prepared["HOME"] = containerHome;
   }
 
   // GH_PATH is host-resolved by the agent plugin and often invalid in-container.
@@ -282,12 +310,25 @@ async function docker(args: string[]): Promise<string> {
   return stdout.trimEnd();
 }
 
-async function dockerExec(containerName: string, args: string[]): Promise<string> {
-  return docker(["exec", containerName, ...args]);
+async function dockerExec(
+  containerName: string,
+  args: string[],
+  execUser?: string,
+): Promise<string> {
+  const execArgs = ["exec"];
+  if (execUser) {
+    execArgs.push("--user", execUser);
+  }
+  execArgs.push(containerName, ...args);
+  return docker(execArgs);
 }
 
-async function dockerTmux(containerName: string, args: string[]): Promise<string> {
-  return dockerExec(containerName, ["tmux", ...args]);
+async function dockerTmux(
+  containerName: string,
+  args: string[],
+  execUser?: string,
+): Promise<string> {
+  return dockerExec(containerName, ["tmux", ...args], execUser);
 }
 
 function getDefaultDockerUser(): string | undefined {
@@ -307,6 +348,11 @@ function getTmuxSessionName(handle: RuntimeHandle): string {
   return typeof tmuxSessionName === "string" && tmuxSessionName.length > 0
     ? tmuxSessionName
     : handle.id;
+}
+
+function getExecUser(handle: RuntimeHandle): string | undefined {
+  const execUser = handle.data["execUser"];
+  return typeof execUser === "string" && execUser.length > 0 ? execUser : undefined;
 }
 
 function parseCpuPercent(value: unknown): number | undefined {
@@ -373,11 +419,12 @@ async function sendTextToTmux(
   containerName: string,
   tmuxSessionName: string,
   workspacePath: string,
+  execUser: string | undefined,
   text: string,
   clearInput = true,
 ): Promise<void> {
   if (clearInput) {
-    await dockerTmux(containerName, ["send-keys", "-t", tmuxSessionName, "C-u"]);
+    await dockerTmux(containerName, ["send-keys", "-t", tmuxSessionName, "C-u"], execUser);
     await sleep(200);
   }
 
@@ -386,7 +433,7 @@ async function sendTextToTmux(
     const hostTmpPath = join(workspacePath, `.ao-tmux-buffer-${randomUUID()}.txt`);
     writeFileSync(hostTmpPath, text, { encoding: "utf-8", mode: 0o600 });
     try {
-      await dockerTmux(containerName, ["load-buffer", "-b", bufferName, hostTmpPath]);
+      await dockerTmux(containerName, ["load-buffer", "-b", bufferName, hostTmpPath], execUser);
       await dockerTmux(containerName, [
         "paste-buffer",
         "-b",
@@ -394,21 +441,23 @@ async function sendTextToTmux(
         "-t",
         tmuxSessionName,
         "-d",
-      ]);
+      ], execUser);
     } finally {
       try {
         unlinkSync(hostTmpPath);
       } catch {
         // ignore cleanup failure
       }
-      await dockerTmux(containerName, ["delete-buffer", "-b", bufferName]).catch(() => undefined);
+      await dockerTmux(containerName, ["delete-buffer", "-b", bufferName], execUser).catch(
+        () => undefined,
+      );
     }
   } else {
-    await dockerTmux(containerName, ["send-keys", "-t", tmuxSessionName, "-l", text]);
+    await dockerTmux(containerName, ["send-keys", "-t", tmuxSessionName, "-l", text], execUser);
   }
 
   await sleep(300);
-  await dockerTmux(containerName, ["send-keys", "-t", tmuxSessionName, "Enter"]);
+  await dockerTmux(containerName, ["send-keys", "-t", tmuxSessionName, "Enter"], execUser);
 }
 
 export function create(): Runtime {
@@ -426,6 +475,7 @@ export function create(): Runtime {
       const containerName = config.sessionId;
       const tmuxSessionName = config.sessionId;
       const shell = runtimeConfig.shell ?? "/bin/sh";
+      const execUser = runtimeConfig.user ?? getDefaultDockerUser();
       const preparedEnvironment = prepareContainerEnvironment(
         config.environment ?? {},
         config.agentRuntimeHints?.docker,
@@ -434,16 +484,18 @@ export function create(): Runtime {
         ...getWorkspaceMounts(config.workspacePath),
         ...preparedEnvironment.mounts,
       ]);
+      const launchCommand = rewriteMountedPathsInCommand(config.launchCommand, mounts);
 
       const runArgs = ["run", "-d", "--name", containerName, "--workdir", config.workspacePath];
 
       for (const mount of mounts) {
         runArgs.push("--volume", toVolumeArg(mount));
       }
-
-      const dockerUser = runtimeConfig.user ?? getDefaultDockerUser();
-      if (dockerUser) {
-        runArgs.push("--user", dockerUser);
+      for (const [key, value] of Object.entries(preparedEnvironment.environment)) {
+        runArgs.push("--env", `${key}=${value}`);
+      }
+      if (execUser) {
+        runArgs.push("--user", execUser);
       }
       if (runtimeConfig.network) {
         runArgs.push("--network", runtimeConfig.network);
@@ -471,11 +523,18 @@ export function create(): Runtime {
         runtimeConfig.image,
         shell,
         "-lc",
-        "trap 'exit 0' TERM INT; while :; do sleep 3600; done",
+        'mkdir -p "$HOME"; trap \'exit 0\' TERM INT; while :; do sleep 3600; done',
       );
 
       try {
         await docker(runArgs);
+        const homeInitCommand = execUser
+          ? [
+            'mkdir -p "$HOME" "$HOME/.cache" "$HOME/.config" "$HOME/.local" "$HOME/.local/share" "$HOME/.local/state"',
+            `chown ${shellQuote(execUser)} "$HOME" "$HOME/.cache" "$HOME/.config" "$HOME/.local" "$HOME/.local/share" "$HOME/.local/state" 2>/dev/null || true`,
+          ].join("; ")
+          : 'mkdir -p "$HOME" "$HOME/.cache" "$HOME/.config" "$HOME/.local" "$HOME/.local/share" "$HOME/.local/state"';
+        await dockerExec(containerName, [shell, "-lc", homeInitCommand], execUser ? "0:0" : undefined);
         const envArgs: string[] = [];
         for (const [key, value] of Object.entries(preparedEnvironment.environment)) {
           envArgs.push("-e", `${key}=${value}`);
@@ -488,12 +547,13 @@ export function create(): Runtime {
           "-c",
           config.workspacePath,
           ...envArgs,
-        ]);
+        ], execUser);
         await sendTextToTmux(
           containerName,
           tmuxSessionName,
           config.workspacePath,
-          config.launchCommand,
+          execUser,
+          launchCommand,
           false,
         );
       } catch (err) {
@@ -514,6 +574,7 @@ export function create(): Runtime {
           containerName,
           tmuxSessionName,
           workspacePath: config.workspacePath,
+          execUser,
           createdAt: Date.now(),
         },
       };
@@ -528,6 +589,7 @@ export function create(): Runtime {
         getContainerName(handle),
         getTmuxSessionName(handle),
         handle.data["workspacePath"] as string,
+        getExecUser(handle),
         message,
         true,
       );
@@ -542,7 +604,7 @@ export function create(): Runtime {
           "-p",
           "-S",
           `-${lines}`,
-        ]);
+        ], getExecUser(handle));
       } catch {
         return "";
       }
@@ -573,12 +635,23 @@ export function create(): Runtime {
     async getAttachInfo(handle: RuntimeHandle): Promise<AttachInfo> {
       const containerName = getContainerName(handle);
       const tmuxSessionName = getTmuxSessionName(handle);
+      const execUser = getExecUser(handle);
+      const attachArgs = [
+        "exec",
+        "-it",
+        ...(execUser ? ["--user", execUser] : []),
+        containerName,
+        "tmux",
+        "attach",
+        "-t",
+        tmuxSessionName,
+      ];
       return {
         type: "docker",
         target: containerName,
-        command: `docker exec -it ${containerName} tmux attach -t ${tmuxSessionName}`,
+        command: ["docker", ...attachArgs].join(" "),
         program: "docker",
-        args: ["exec", "-it", containerName, "tmux", "attach", "-t", tmuxSessionName],
+        args: attachArgs,
         requiresPty: true,
       };
     },

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -225,6 +225,24 @@ function applyHostEnvironmentHints(
   return prepared;
 }
 
+function applyContainerEnvironmentDefaults(
+  environment: Record<string, string>,
+  hints: AgentDockerRuntimeHints | undefined,
+  containerHome: string,
+): Record<string, string> {
+  if (!hints?.envDefaults || Object.keys(hints.envDefaults).length === 0) {
+    return environment;
+  }
+
+  const prepared = { ...environment };
+  for (const [key, value] of Object.entries(hints.envDefaults)) {
+    if (!key || !value || prepared[key] !== undefined) continue;
+    prepared[key] = value.startsWith("/") ? value : resolveHomePath(containerHome, value);
+  }
+
+  return prepared;
+}
+
 function prepareContainerEnvironment(
   environment: Record<string, string>,
   hints?: AgentDockerRuntimeHints,
@@ -236,8 +254,9 @@ function prepareContainerEnvironment(
   const mounts: VolumeMount[] = [];
   const containerHome = prepared["HOME"] || CONTAINER_HOME_DIR;
   prepared["HOME"] = containerHome;
+  const containerEnv = applyContainerEnvironmentDefaults(prepared, hints, containerHome);
 
-  const wrapperDir = findWrapperDir(prepared["PATH"]);
+  const wrapperDir = findWrapperDir(containerEnv["PATH"]);
   if (wrapperDir && pathIsDirectory(wrapperDir)) {
     mounts.push({
       hostPath: wrapperDir,
@@ -245,18 +264,18 @@ function prepareContainerEnvironment(
       readOnly: true,
     });
     const rewrittenPath = rewritePathEntries(
-      prepared["PATH"],
+      containerEnv["PATH"],
       new Map([[wrapperDir, CONTAINER_AO_BIN_DIR]]),
     );
     if (rewrittenPath) {
-      prepared["PATH"] = rewrittenPath;
+      containerEnv["PATH"] = rewrittenPath;
     }
   }
 
-  const aoDataDir = prepared["AO_DATA_DIR"];
+  const aoDataDir = containerEnv["AO_DATA_DIR"];
   if (aoDataDir && pathIsDirectory(aoDataDir)) {
     mounts.push({ hostPath: aoDataDir, containerPath: CONTAINER_AO_DATA_DIR });
-    prepared["AO_DATA_DIR"] = CONTAINER_AO_DATA_DIR;
+    containerEnv["AO_DATA_DIR"] = CONTAINER_AO_DATA_DIR;
   }
 
   const hostHome = homedir();
@@ -292,9 +311,9 @@ function prepareContainerEnvironment(
   }
 
   // GH_PATH is host-resolved by the agent plugin and often invalid in-container.
-  delete prepared["GH_PATH"];
+  delete containerEnv["GH_PATH"];
 
-  return { environment: prepared, mounts: dedupeMounts(mounts) };
+  return { environment: containerEnv, mounts: dedupeMounts(mounts) };
 }
 
 function toVolumeArg(mount: VolumeMount): string {

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, lstatSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -191,7 +191,23 @@ function getAgentHomeMounts(
   const mounts: VolumeMount[] = [];
   for (const mount of hints.homeMounts) {
     const hostPath = resolveHomePath(hostHome, mount.path);
-    if (!pathIsDirectory(hostPath) && !pathIsFile(hostPath)) {
+    const hostPathExists = pathIsDirectory(hostPath) || pathIsFile(hostPath);
+    if (!hostPathExists) {
+      try {
+        if (mount.kind === "dir") {
+          mkdirSync(hostPath, { recursive: true });
+        } else if (mount.kind === "file") {
+          mkdirSync(dirname(hostPath), { recursive: true });
+          writeFileSync(hostPath, "", { flag: "a", mode: 0o600 });
+        } else {
+          continue;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    if (!pathIsDirectory(hostPath) && !pathIsFile(hostPath) && mount.kind === undefined) {
       continue;
     }
 

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -307,7 +307,9 @@ async function sendTextToTmux(
     const bufferName = `ao-${randomUUID()}`;
     const tmpName = `/tmp/ao-${randomUUID()}.txt`;
     const hostTmpPath = join(tmpdir(), `ao-docker-${randomUUID()}.txt`);
-    writeFileSync(hostTmpPath, text, { encoding: "utf-8", mode: 0o600 });
+    // docker cp preserves file mode; keep the staging file readable so the
+    // container's configured runtime user can load it into tmux.
+    writeFileSync(hostTmpPath, text, { encoding: "utf-8", mode: 0o644 });
     try {
       await docker(["cp", hostTmpPath, `${containerName}:${tmpName}`]);
       await dockerTmux(containerName, ["load-buffer", "-b", bufferName, tmpName]);

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -1,8 +1,17 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, lstatSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { promisify } from "node:util";
 import type {
@@ -22,6 +31,7 @@ const LONG_MESSAGE_THRESHOLD = 200;
 const CONTAINER_AO_BIN_DIR = "/tmp/ao/bin";
 const CONTAINER_AO_DATA_DIR = "/tmp/ao/data";
 const CONTAINER_HOME_DIR = "/tmp/ao-home";
+const CONTAINER_RUNTIME_DIR = "/tmp/ao/runtime";
 const AO_METADATA_HELPER = "ao-metadata-helper.sh";
 
 export const manifest = {
@@ -64,6 +74,22 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function parseDockerRuntimeConfig(config?: Record<string, unknown>): DockerRuntimeConfig {
   return isPlainObject(config) ? (config as DockerRuntimeConfig) : {};
+}
+
+function hasTmpfsTarget(runtimeConfig: DockerRuntimeConfig, target: string): boolean {
+  return (runtimeConfig.tmpfs ?? []).some((mount) => mount.split(":")[0]?.trim() === target);
+}
+
+function validateDockerRuntimeConfig(runtimeConfig: DockerRuntimeConfig): void {
+  if (!runtimeConfig.image) {
+    throw new Error("Docker runtime requires runtimeConfig.image");
+  }
+
+  if (runtimeConfig.readOnlyRoot && !hasTmpfsTarget(runtimeConfig, "/tmp")) {
+    throw new Error(
+      "Docker runtime with readOnlyRoot=true requires tmpfs to include /tmp so tmux and agent CLIs can create runtime state.",
+    );
+  }
 }
 
 function shellQuote(value: string): string {
@@ -476,7 +502,8 @@ async function removeContainer(containerName: string): Promise<void> {
 async function sendTextToTmux(
   containerName: string,
   tmuxSessionName: string,
-  workspacePath: string,
+  hostBufferDir: string,
+  containerBufferDir: string,
   execUser: string | undefined,
   text: string,
   clearInput = true,
@@ -488,10 +515,11 @@ async function sendTextToTmux(
 
   if (text.includes("\n") || text.length > LONG_MESSAGE_THRESHOLD) {
     const bufferName = `ao-${randomUUID()}`;
-    const hostTmpPath = join(workspacePath, `.ao-tmux-buffer-${randomUUID()}.txt`);
+    const hostTmpPath = join(hostBufferDir, `.ao-tmux-buffer-${randomUUID()}.txt`);
+    const containerTmpPath = join(containerBufferDir, basename(hostTmpPath));
     writeFileSync(hostTmpPath, text, { encoding: "utf-8", mode: 0o600 });
     try {
-      await dockerTmux(containerName, ["load-buffer", "-b", bufferName, hostTmpPath], execUser);
+      await dockerTmux(containerName, ["load-buffer", "-b", bufferName, containerTmpPath], execUser);
       await dockerTmux(containerName, [
         "paste-buffer",
         "-b",
@@ -526,7 +554,9 @@ export function create(): Runtime {
       assertValidSessionId(config.sessionId);
 
       const runtimeConfig = parseDockerRuntimeConfig(config.runtimeConfig);
-      if (!runtimeConfig.image) {
+      validateDockerRuntimeConfig(runtimeConfig);
+      const image = runtimeConfig.image;
+      if (!image) {
         throw new Error("Docker runtime requires runtimeConfig.image");
       }
 
@@ -534,6 +564,7 @@ export function create(): Runtime {
       const tmuxSessionName = config.sessionId;
       const shell = runtimeConfig.shell ?? "/bin/sh";
       const execUser = runtimeConfig.user ?? getDefaultDockerUser();
+      const hostRuntimeDir = mkdtempSync(join(tmpdir(), `ao-runtime-docker-${config.sessionId}-`));
       const preparedEnvironment = prepareContainerEnvironment(
         config.environment ?? {},
         config.agentRuntimeHints?.docker,
@@ -541,6 +572,7 @@ export function create(): Runtime {
       const mounts = dedupeMounts([
         ...getWorkspaceMounts(config.workspacePath),
         ...preparedEnvironment.mounts,
+        { hostPath: hostRuntimeDir, containerPath: CONTAINER_RUNTIME_DIR },
       ]);
       const launchCommand = rewriteMountedPathsInCommand(config.launchCommand, mounts);
 
@@ -578,7 +610,7 @@ export function create(): Runtime {
       }
 
       runArgs.push(
-        runtimeConfig.image,
+        image,
         shell,
         "-lc",
         'mkdir -p "$HOME"; trap \'exit 0\' TERM INT; while :; do sleep 3600; done',
@@ -614,13 +646,15 @@ export function create(): Runtime {
         await sendTextToTmux(
           containerName,
           tmuxSessionName,
-          config.workspacePath,
+          hostRuntimeDir,
+          CONTAINER_RUNTIME_DIR,
           execUser,
           launchCommand,
           false,
         );
       } catch (err) {
         await removeContainer(containerName);
+        rmSync(hostRuntimeDir, { recursive: true, force: true });
         const msg = err instanceof Error ? err.message : String(err);
         throw new Error(
           `Failed to create docker runtime for session "${config.sessionId}": ${msg}`,
@@ -637,6 +671,7 @@ export function create(): Runtime {
           containerName,
           tmuxSessionName,
           workspacePath: config.workspacePath,
+          hostRuntimeDir,
           execUser,
           createdAt: Date.now(),
         },
@@ -645,13 +680,21 @@ export function create(): Runtime {
 
     async destroy(handle: RuntimeHandle): Promise<void> {
       await removeContainer(getContainerName(handle));
+      const hostRuntimeDir = handle.data["hostRuntimeDir"];
+      if (typeof hostRuntimeDir === "string" && hostRuntimeDir.length > 0) {
+        rmSync(hostRuntimeDir, { recursive: true, force: true });
+      }
     },
 
     async sendMessage(handle: RuntimeHandle, message: string): Promise<void> {
+      const hostRuntimeDir = handle.data["hostRuntimeDir"];
       await sendTextToTmux(
         getContainerName(handle),
         getTmuxSessionName(handle),
-        handle.data["workspacePath"] as string,
+        typeof hostRuntimeDir === "string" && hostRuntimeDir.length > 0
+          ? hostRuntimeDir
+          : (handle.data["workspacePath"] as string),
+        CONTAINER_RUNTIME_DIR,
         getExecUser(handle),
         message,
         true,

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, lstatSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { promisify } from "node:util";
@@ -19,6 +20,7 @@ const SAFE_SESSION_ID = /^[a-zA-Z0-9_-]+$/;
 const LONG_MESSAGE_THRESHOLD = 200;
 const CONTAINER_AO_BIN_DIR = "/tmp/ao/bin";
 const CONTAINER_AO_DATA_DIR = "/tmp/ao/data";
+const CONTAINER_HOME_DIR = "/home/ao";
 const AO_METADATA_HELPER = "ao-metadata-helper.sh";
 
 export const manifest = {
@@ -183,6 +185,52 @@ function prepareContainerEnvironment(environment: Record<string, string>): {
   if (aoDataDir && pathIsDirectory(aoDataDir)) {
     mounts.push({ hostPath: aoDataDir, containerPath: CONTAINER_AO_DATA_DIR });
     prepared["AO_DATA_DIR"] = CONTAINER_AO_DATA_DIR;
+  }
+
+  const hostHome = homedir();
+  const containerHome = prepared["HOME"] || CONTAINER_HOME_DIR;
+  let usingContainerHome = false;
+
+  const hostCodexDir = join(hostHome, ".codex");
+  if (pathIsDirectory(hostCodexDir)) {
+    mounts.push({
+      hostPath: hostCodexDir,
+      containerPath: join(containerHome, ".codex"),
+    });
+    usingContainerHome = true;
+  }
+
+  const hostGitConfig = join(hostHome, ".gitconfig");
+  if (pathIsFile(hostGitConfig)) {
+    mounts.push({
+      hostPath: hostGitConfig,
+      containerPath: join(containerHome, ".gitconfig"),
+      readOnly: true,
+    });
+    usingContainerHome = true;
+  }
+
+  const hostGitCredentials = join(hostHome, ".git-credentials");
+  if (pathIsFile(hostGitCredentials)) {
+    mounts.push({
+      hostPath: hostGitCredentials,
+      containerPath: join(containerHome, ".git-credentials"),
+      readOnly: true,
+    });
+    usingContainerHome = true;
+  }
+
+  const hostGhConfigDir = join(hostHome, ".config", "gh");
+  if (pathIsDirectory(hostGhConfigDir)) {
+    mounts.push({
+      hostPath: hostGhConfigDir,
+      containerPath: join(containerHome, ".config", "gh"),
+    });
+    usingContainerHome = true;
+  }
+
+  if (usingContainerHome) {
+    prepared["HOME"] = containerHome;
   }
 
   // GH_PATH is host-resolved by the agent plugin and often invalid in-container.

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -6,6 +6,7 @@ import { join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { promisify } from "node:util";
 import type {
+  AgentDockerRuntimeHints,
   AttachInfo,
   PluginModule,
   Runtime,
@@ -158,7 +159,40 @@ function getWorkspaceMounts(workspacePath: string): VolumeMount[] {
   return dedupeMounts(mounts);
 }
 
-function prepareContainerEnvironment(environment: Record<string, string>): {
+function resolveHomePath(basePath: string, requestedPath: string): string {
+  return requestedPath.startsWith("/") ? requestedPath : join(basePath, requestedPath);
+}
+
+function getAgentHomeMounts(
+  hints: AgentDockerRuntimeHints | undefined,
+  containerHome: string,
+): VolumeMount[] {
+  if (!hints?.homeMounts?.length) {
+    return [];
+  }
+
+  const hostHome = homedir();
+  const mounts: VolumeMount[] = [];
+  for (const mount of hints.homeMounts) {
+    const hostPath = resolveHomePath(hostHome, mount.path);
+    if (!pathIsDirectory(hostPath) && !pathIsFile(hostPath)) {
+      continue;
+    }
+
+    mounts.push({
+      hostPath,
+      containerPath: resolveHomePath(containerHome, mount.target ?? mount.path),
+      readOnly: mount.readOnly,
+    });
+  }
+
+  return mounts;
+}
+
+function prepareContainerEnvironment(
+  environment: Record<string, string>,
+  hints?: AgentDockerRuntimeHints,
+): {
   environment: Record<string, string>;
   mounts: VolumeMount[];
 } {
@@ -187,16 +221,12 @@ function prepareContainerEnvironment(environment: Record<string, string>): {
     prepared["AO_DATA_DIR"] = CONTAINER_AO_DATA_DIR;
   }
 
-  const hostHome = homedir();
   const containerHome = prepared["HOME"] || CONTAINER_HOME_DIR;
   let usingContainerHome = false;
-
-  const hostCodexDir = join(hostHome, ".codex");
-  if (pathIsDirectory(hostCodexDir)) {
-    mounts.push({
-      hostPath: hostCodexDir,
-      containerPath: join(containerHome, ".codex"),
-    });
+  const hostHome = homedir();
+  const agentHomeMounts = getAgentHomeMounts(hints, containerHome);
+  if (agentHomeMounts.length > 0) {
+    mounts.push(...agentHomeMounts);
     usingContainerHome = true;
   }
 
@@ -396,7 +426,10 @@ export function create(): Runtime {
       const containerName = config.sessionId;
       const tmuxSessionName = config.sessionId;
       const shell = runtimeConfig.shell ?? "/bin/sh";
-      const preparedEnvironment = prepareContainerEnvironment(config.environment ?? {});
+      const preparedEnvironment = prepareContainerEnvironment(
+        config.environment ?? {},
+        config.agentRuntimeHints?.docker,
+      );
       const mounts = dedupeMounts([
         ...getWorkspaceMounts(config.workspacePath),
         ...preparedEnvironment.mounts,

--- a/packages/plugins/runtime-docker/tsconfig.json
+++ b/packages/plugins/runtime-docker/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/plugins/runtime-process/src/index.ts
+++ b/packages/plugins/runtime-process/src/index.ts
@@ -275,6 +275,7 @@ export function create(): Runtime {
       return {
         type: "process",
         target: String(entry.process.pid),
+        requiresPty: false,
       };
     },
   };

--- a/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
@@ -575,6 +575,9 @@ describe("runtime.getAttachInfo()", () => {
       type: "tmux",
       target: "attach-test",
       command: "tmux attach -t attach-test",
+      program: "tmux",
+      args: ["attach", "-t", "attach-test"],
+      requiresPty: true,
     });
   });
 });

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -176,6 +176,9 @@ export function create(): Runtime {
         type: "tmux",
         target: handle.id,
         command: `tmux attach -t ${handle.id}`,
+        program: "tmux",
+        args: ["attach", "-t", handle.id],
+        requiresPty: true,
       };
     },
   };

--- a/packages/plugins/terminal-iterm2/src/index.test.ts
+++ b/packages/plugins/terminal-iterm2/src/index.test.ts
@@ -120,6 +120,27 @@ describe("terminal-iterm2", () => {
       expect(newTabScript).not.toContain("app-1");
     });
 
+    it("builds a docker attach command when the session runtime is docker", async () => {
+      simulateOsascript("NOT_FOUND\n");
+      const terminal = create();
+      await terminal.openSession(
+        makeSession({
+          id: "app-1",
+          runtimeHandle: {
+            id: "container-42",
+            runtimeName: "docker",
+            data: { tmuxSessionName: "docker-tmux-42" },
+          },
+        }),
+      );
+
+      const newTabScript = mockExecFile.mock.calls[1][1][1] as string;
+      expect(newTabScript).toContain("container-42");
+      expect(newTabScript).toContain(
+        "docker exec -it 'container-42' tmux attach -t 'docker-tmux-42'",
+      );
+    });
+
     it("reuses existing tab when found", async () => {
       simulateOsascript("FOUND\n");
       const terminal = create();
@@ -174,6 +195,24 @@ describe("terminal-iterm2", () => {
       expect(openScript).toContain("create tab with default profile");
       expect(openScript).toContain('set name to "app-7"');
       expect(openScript).toContain("tmux attach -t 'app-7'");
+    });
+
+    it("openNewTab creates tab and attaches to docker-backed tmux sessions", async () => {
+      simulateOsascript("NOT_FOUND\n");
+      const terminal = create();
+      await terminal.openSession(
+        makeSession({
+          id: "app-7",
+          runtimeHandle: {
+            id: "container-7",
+            runtimeName: "docker",
+            data: { tmuxSessionName: "tmux-7" },
+          },
+        }),
+      );
+
+      const openScript = mockExecFile.mock.calls[1][1][1] as string;
+      expect(openScript).toContain("docker exec -it 'container-7' tmux attach -t 'tmux-7'");
     });
 
     it("shell-escapes session names with single quotes in tmux command", async () => {

--- a/packages/plugins/terminal-iterm2/src/index.ts
+++ b/packages/plugins/terminal-iterm2/src/index.ts
@@ -17,6 +17,12 @@ export const manifest = {
 // Re-export for backwards compatibility
 export { escapeAppleScript } from "@composio/ao-core";
 
+export interface ITerm2OpenSpec {
+  sessionName: string;
+  attachCommand: string;
+  newWindow?: boolean;
+}
+
 /**
  * Run an AppleScript snippet and return stdout.
  */
@@ -95,16 +101,19 @@ end tell`;
  * Open a new iTerm2 tab and attach to the given tmux session.
  * Creates a new window if no window is open.
  */
-async function openNewTab(sessionName: string): Promise<void> {
+async function openNewTab(
+  sessionName: string,
+  attachCommand: string,
+  newWindow?: boolean,
+): Promise<void> {
   const safe = escapeAppleScript(sessionName);
-  // Double-escape for the write text command: shell-escape first, then AppleScript-escape
-  // the whole shell command so it's safe inside the AppleScript double-quoted string.
-  const shellSafe = shellEscape(sessionName);
-  const shellInAppleScript = escapeAppleScript(shellSafe);
+  const commandInAppleScript = escapeAppleScript(
+    `printf '\\\\033]0;${shellEscape(sessionName)}\\\\007' && ${attachCommand}`,
+  );
   const script = `
 tell application "iTerm2"
     activate
-    if (count of windows) is 0 then
+    if ${newWindow ? "true" : "(count of windows) is 0"} then
         create window with default profile
     else
         tell current window
@@ -113,20 +122,56 @@ tell application "iTerm2"
     end if
     tell current session of current window
         set name to "${safe}"
-        write text "printf '\\\\033]0;${shellInAppleScript}\\\\007' && tmux attach -t '${shellInAppleScript}'"
+        write text "${commandInAppleScript}"
     end tell
 end tell`;
 
   await runAppleScript(script);
 }
 
-function getSessionName(session: Session): string {
-  // Use the runtime handle id if available (tmux session name), otherwise session id
-  return session.runtimeHandle?.id ?? session.id;
+function getDockerTmuxSessionName(session: Session): string {
+  const handle = session.runtimeHandle;
+  const tmuxSessionName = handle?.data["tmuxSessionName"];
+  return typeof tmuxSessionName === "string" && tmuxSessionName.length > 0
+    ? tmuxSessionName
+    : session.id;
+}
+
+function buildTmuxAttachCommand(attachTarget: string): string {
+  const handleName = shellEscape(attachTarget);
+  return `tmux attach -t '${handleName}'`;
+}
+
+function getOpenSpec(session: Session): { sessionName: string; attachCommand: string } {
+  if (session.runtimeHandle?.runtimeName === "docker") {
+    const containerName = session.runtimeHandle.id;
+    const tmuxSessionName = getDockerTmuxSessionName(session);
+    const safeContainerName = shellEscape(containerName);
+    const safeTmuxSessionName = shellEscape(tmuxSessionName);
+    return {
+      sessionName: containerName,
+      attachCommand: `docker exec -it '${safeContainerName}' tmux attach -t '${safeTmuxSessionName}'`,
+    };
+  }
+
+  const sessionName = session.runtimeHandle?.id ?? session.id;
+  return {
+    sessionName,
+    attachCommand: buildTmuxAttachCommand(sessionName),
+  };
 }
 
 function isMacOS(): boolean {
   return platform() === "darwin";
+}
+
+export async function openCommandInITerm2(spec: ITerm2OpenSpec): Promise<boolean> {
+  if (!isMacOS()) return false;
+  const found = await findAndSelectExistingTab(spec.sessionName);
+  if (!found) {
+    await openNewTab(spec.sessionName, spec.attachCommand, spec.newWindow);
+  }
+  return true;
 }
 
 export function create(): Terminal {
@@ -139,24 +184,17 @@ export function create(): Terminal {
         console.warn("[terminal-iterm2] iTerm2 is only available on macOS");
         return;
       }
-      const sessionName = getSessionName(session);
+      const spec = getOpenSpec(session);
 
-      // Try to find and select an existing tab first
-      const found = await findAndSelectExistingTab(sessionName);
-      if (!found) {
-        await openNewTab(sessionName);
-      }
+      await openCommandInITerm2(spec);
     },
 
     async openAll(sessions: Session[]): Promise<void> {
       if (!isMacOS() || sessions.length === 0) return;
 
       for (const session of sessions) {
-        const sessionName = getSessionName(session);
-        const found = await findAndSelectExistingTab(sessionName);
-        if (!found) {
-          await openNewTab(sessionName);
-        }
+        const spec = getOpenSpec(session);
+        await openCommandInITerm2(spec);
         // Small delay between tab operations to avoid AppleScript race conditions
         await new Promise((resolve) => setTimeout(resolve, 300));
       }
@@ -164,7 +202,7 @@ export function create(): Terminal {
 
     async isSessionOpen(session: Session): Promise<boolean> {
       if (!isMacOS()) return false;
-      const sessionName = getSessionName(session);
+      const sessionName = getOpenSpec(session).sessionName;
       try {
         // Query-only check — does NOT select/focus the tab
         return await hasExistingTab(sessionName);

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -31,6 +31,7 @@
     "@composio/ao-core": "workspace:*",
     "@composio/ao-plugin-agent-claude-code": "workspace:*",
     "@composio/ao-plugin-agent-opencode": "workspace:*",
+    "@composio/ao-plugin-runtime-docker": "workspace:*",
     "@composio/ao-plugin-runtime-tmux": "workspace:*",
     "@composio/ao-plugin-scm-github": "workspace:*",
     "@composio/ao-plugin-tracker-github": "workspace:*",

--- a/packages/web/server/__tests__/attach-utils.test.ts
+++ b/packages/web/server/__tests__/attach-utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildAttachSpawnSpec } from "../attach-utils.js";
+
+describe("buildAttachSpawnSpec", () => {
+  it("returns program/args unchanged for structured attach info", () => {
+    expect(
+      buildAttachSpawnSpec({
+        type: "docker",
+        target: "container-1",
+        program: "docker",
+        args: ["exec", "-it", "container-1", "tmux", "attach", "-t", "tmux-1"],
+      }),
+    ).toEqual({
+      program: "docker",
+      args: ["exec", "-it", "container-1", "tmux", "attach", "-t", "tmux-1"],
+    });
+  });
+
+  it("wraps command-only attach info with shell -c", () => {
+    expect(
+      buildAttachSpawnSpec({
+        type: "docker",
+        target: "container-1",
+        command: "docker exec -it container-1 tmux attach -t tmux-1",
+      }),
+    ).toEqual({
+      program: process.env.SHELL || "/bin/sh",
+      args: ["-c", "docker exec -it container-1 tmux attach -t tmux-1"],
+    });
+  });
+});

--- a/packages/web/server/__tests__/server-compatibility.test.ts
+++ b/packages/web/server/__tests__/server-compatibility.test.ts
@@ -41,6 +41,11 @@ describe("direct-terminal-ws.ts", () => {
     expect(source).not.toMatch(/existsSync.*session/i);
   });
 
+  it("uses shell -c for command-only attach specs", () => {
+    expect(source).toMatch(/\["-c", info\.command\]/);
+    expect(source).not.toMatch(/\["-lc", info\.command\]/);
+  });
+
   it("exposes terminal health metrics in /health response", () => {
     expect(source).toMatch(/metrics/);
     expect(source).toMatch(/totalConnections/);
@@ -66,6 +71,11 @@ describe("terminal-websocket.ts", () => {
 
   it("does not check file existence for session validation", () => {
     expect(source).not.toMatch(/existsSync.*session/i);
+  });
+
+  it("uses shell -c for command-only attach specs", () => {
+    expect(source).toMatch(/\["-c", info\.command\]/);
+    expect(source).not.toMatch(/\["-lc", info\.command\]/);
   });
 });
 

--- a/packages/web/server/__tests__/server-compatibility.test.ts
+++ b/packages/web/server/__tests__/server-compatibility.test.ts
@@ -41,11 +41,6 @@ describe("direct-terminal-ws.ts", () => {
     expect(source).not.toMatch(/existsSync.*session/i);
   });
 
-  it("uses shell -c for command-only attach specs", () => {
-    expect(source).toMatch(/\["-c", info\.command\]/);
-    expect(source).not.toMatch(/\["-lc", info\.command\]/);
-  });
-
   it("exposes terminal health metrics in /health response", () => {
     expect(source).toMatch(/metrics/);
     expect(source).toMatch(/totalConnections/);
@@ -72,6 +67,11 @@ describe("terminal-websocket.ts", () => {
   it("does not check file existence for session validation", () => {
     expect(source).not.toMatch(/existsSync.*session/i);
   });
+
+});
+
+describe("attach-utils.ts", () => {
+  const source = readServerFile("attach-utils.ts");
 
   it("uses shell -c for command-only attach specs", () => {
     expect(source).toMatch(/\["-c", info\.command\]/);

--- a/packages/web/server/attach-utils.ts
+++ b/packages/web/server/attach-utils.ts
@@ -5,8 +5,10 @@ import {
   type AttachInfo,
   type OpenCodeSessionManager,
 } from "@composio/ao-core";
+import { findTmux, resolveTmuxSession } from "./tmux-utils.js";
 
 let sessionManagerPromise: Promise<OpenCodeSessionManager> | null = null;
+let tmuxPath: string | null = null;
 
 async function getSessionManager(): Promise<OpenCodeSessionManager> {
   if (!sessionManagerPromise) {
@@ -20,7 +22,42 @@ async function getSessionManager(): Promise<OpenCodeSessionManager> {
   return sessionManagerPromise;
 }
 
+function resolveLegacyTmuxAttachInfo(sessionId: string): AttachInfo | null {
+  const tmux = tmuxPath ?? findTmux();
+  tmuxPath = tmux;
+
+  const tmuxTarget = resolveTmuxSession(sessionId, tmux);
+  if (!tmuxTarget) {
+    return null;
+  }
+
+  return {
+    type: "tmux",
+    target: tmuxTarget,
+    command: `tmux attach -t ${tmuxTarget}`,
+    program: tmux,
+    args: ["attach", "-t", tmuxTarget],
+    requiresPty: true,
+  };
+}
+
 export async function resolveAttachInfo(sessionId: string): Promise<AttachInfo | null> {
-  const sessionManager = await getSessionManager();
-  return sessionManager.getAttachInfo(sessionId);
+  try {
+    const sessionManager = await getSessionManager();
+    const attachInfo = await sessionManager.getAttachInfo(sessionId).catch(() => null);
+    if (attachInfo) {
+      return attachInfo;
+    }
+
+    const session = await sessionManager.get(sessionId).catch(() => null);
+    if (session) {
+      return null;
+    }
+  } catch {
+    // Fall through to the legacy tmux lookup below.
+  }
+
+  // Keep web terminal flows compatible with raw tmux sessions that predate
+  // AO-managed metadata, including hash-prefixed session names.
+  return resolveLegacyTmuxAttachInfo(sessionId);
 }

--- a/packages/web/server/attach-utils.ts
+++ b/packages/web/server/attach-utils.ts
@@ -1,0 +1,26 @@
+import {
+  createPluginRegistry,
+  createSessionManager,
+  loadConfig,
+  type AttachInfo,
+  type OpenCodeSessionManager,
+} from "@composio/ao-core";
+
+let sessionManagerPromise: Promise<OpenCodeSessionManager> | null = null;
+
+async function getSessionManager(): Promise<OpenCodeSessionManager> {
+  if (!sessionManagerPromise) {
+    sessionManagerPromise = (async () => {
+      const config = loadConfig();
+      const registry = createPluginRegistry();
+      await registry.loadFromConfig(config, (pkg: string) => import(pkg));
+      return createSessionManager({ config, registry });
+    })();
+  }
+  return sessionManagerPromise;
+}
+
+export async function resolveAttachInfo(sessionId: string): Promise<AttachInfo | null> {
+  const sessionManager = await getSessionManager();
+  return sessionManager.getAttachInfo(sessionId);
+}

--- a/packages/web/server/attach-utils.ts
+++ b/packages/web/server/attach-utils.ts
@@ -41,6 +41,17 @@ function resolveLegacyTmuxAttachInfo(sessionId: string): AttachInfo | null {
   };
 }
 
+export function buildAttachSpawnSpec(info: AttachInfo): { program: string; args: string[] } | null {
+  if (info.program) {
+    return { program: info.program, args: info.args ?? [] };
+  }
+  if (info.command) {
+    const shell = process.env.SHELL || "/bin/sh";
+    return { program: shell, args: ["-c", info.command] };
+  }
+  return null;
+}
+
 export async function resolveAttachInfo(sessionId: string): Promise<AttachInfo | null> {
   try {
     const sessionManager = await getSessionManager();

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -1,6 +1,6 @@
 /**
  * Direct WebSocket terminal server using node-pty.
- * Connects browser xterm.js directly to tmux sessions via WebSocket.
+ * Connects browser xterm.js directly to runtime attach commands via WebSocket.
  *
  * This bypasses ttyd and gives us control over terminal initialization,
  * allowing us to implement the XDA (Extended Device Attributes) handler
@@ -11,7 +11,7 @@ import { createServer, type Server } from "node:http";
 import { spawn } from "node:child_process";
 import { WebSocketServer, WebSocket } from "ws";
 import { homedir, userInfo } from "node:os";
-import { createCorrelationId } from "@composio/ao-core";
+import { createCorrelationId, type AttachInfo } from "@composio/ao-core";
 
 // node-pty is an optionalDependency — it requires native compilation and may
 // not be available on all platforms. Load it dynamically so the rest of the
@@ -27,7 +27,8 @@ try {
   console.warn("[DirectTerminal] node-pty not available — direct terminal will be disabled.");
   console.warn("[DirectTerminal] Install it with: npm install node-pty");
 }
-import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js";
+import { findTmux, validateSessionId } from "./tmux-utils.js";
+import { resolveAttachInfo } from "./attach-utils.js";
 import { createObserverContext, inferProjectId } from "./terminal-observability.js";
 
 interface TerminalSession {
@@ -53,6 +54,17 @@ export interface DirectTerminalServer {
   wss: WebSocketServer;
   activeSessions: Map<string, TerminalSession>;
   shutdown: () => void;
+}
+
+function buildAttachSpawnSpec(info: AttachInfo): { program: string; args: string[] } | null {
+  if (info.program) {
+    return { program: info.program, args: info.args ?? [] };
+  }
+  if (info.command) {
+    const shell = process.env.SHELL || "/bin/sh";
+    return { program: shell, args: ["-lc", info.command] };
+  }
+  return null;
 }
 
 /**
@@ -121,7 +133,7 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
     });
   };
 
-  wss.on("connection", (ws, req) => {
+  wss.on("connection", async (ws, req) => {
     if (!ptySpawn) {
       ws.close(1011, "Direct terminal unavailable — node-pty not installed");
       return;
@@ -154,11 +166,9 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
       return;
     }
 
-    // Resolve tmux session name: try exact match first, then suffix match
-    // (hash-prefixed sessions like "8474d6f29887-ao-15" are accessed by user-facing ID "ao-15")
-    const tmuxSessionId = resolveTmuxSession(sessionId, TMUX);
-    if (!tmuxSessionId) {
-      console.error("[DirectTerminal] tmux session not found:", sessionId);
+    const attachInfo = await resolveAttachInfo(sessionId).catch(() => null);
+    if (!attachInfo) {
+      console.error("[DirectTerminal] attach command not found:", sessionId);
       recordWebsocketMetric({
         metric: "websocket_error",
         outcome: "failure",
@@ -169,22 +179,33 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
       return;
     }
 
-    console.log(`[DirectTerminal] New connection for session: ${tmuxSessionId}`);
+    const spawnSpec = buildAttachSpawnSpec(attachInfo);
+    if (!spawnSpec) {
+      ws.close(1011, "Session does not expose an attach command");
+      return;
+    }
 
-    // Enable mouse mode for scrollback support
-    const mouseProc = spawn(TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "on"]);
-    mouseProc.on("error", (err) => {
-      console.error(`[DirectTerminal] Failed to set mouse mode for ${tmuxSessionId}:`, err.message);
-    });
+    console.log(
+      `[DirectTerminal] New connection for session: ${attachInfo.type}:${attachInfo.target}`,
+    );
 
-    // Hide the green status bar for cleaner appearance
-    const statusProc = spawn(TMUX, ["set-option", "-t", tmuxSessionId, "status", "off"]);
-    statusProc.on("error", (err) => {
-      console.error(
-        `[DirectTerminal] Failed to hide status bar for ${tmuxSessionId}:`,
-        err.message,
-      );
-    });
+    if (attachInfo.type === "tmux") {
+      const mouseProc = spawn(TMUX, ["set-option", "-t", attachInfo.target, "mouse", "on"]);
+      mouseProc.on("error", (err) => {
+        console.error(
+          `[DirectTerminal] Failed to set mouse mode for ${attachInfo.target}:`,
+          err.message,
+        );
+      });
+
+      const statusProc = spawn(TMUX, ["set-option", "-t", attachInfo.target, "status", "off"]);
+      statusProc.on("error", (err) => {
+        console.error(
+          `[DirectTerminal] Failed to hide status bar for ${attachInfo.target}:`,
+          err.message,
+        );
+      });
+    }
 
     // Build complete environment - node-pty requires proper env setup
     const homeDir = process.env.HOME || homedir();
@@ -201,9 +222,11 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
 
     let pty: IPty;
     try {
-      console.log(`[DirectTerminal] Spawning PTY: tmux attach-session -t ${tmuxSessionId}`);
+      console.log(
+        `[DirectTerminal] Spawning PTY: ${spawnSpec.program} ${spawnSpec.args.join(" ")}`,
+      );
 
-      pty = ptySpawn(TMUX, ["attach-session", "-t", tmuxSessionId], {
+      pty = ptySpawn(spawnSpec.program, spawnSpec.args, {
         name: "xterm-256color",
         cols: 80,
         rows: 24,

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -62,7 +62,7 @@ function buildAttachSpawnSpec(info: AttachInfo): { program: string; args: string
   }
   if (info.command) {
     const shell = process.env.SHELL || "/bin/sh";
-    return { program: shell, args: ["-lc", info.command] };
+    return { program: shell, args: ["-c", info.command] };
   }
   return null;
 }

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -11,7 +11,7 @@ import { createServer, type Server } from "node:http";
 import { spawn } from "node:child_process";
 import { WebSocketServer, WebSocket } from "ws";
 import { homedir, userInfo } from "node:os";
-import { createCorrelationId, type AttachInfo } from "@composio/ao-core";
+import { createCorrelationId } from "@composio/ao-core";
 
 // node-pty is an optionalDependency — it requires native compilation and may
 // not be available on all platforms. Load it dynamically so the rest of the
@@ -28,7 +28,7 @@ try {
   console.warn("[DirectTerminal] Install it with: npm install node-pty");
 }
 import { findTmux, validateSessionId } from "./tmux-utils.js";
-import { resolveAttachInfo } from "./attach-utils.js";
+import { buildAttachSpawnSpec, resolveAttachInfo } from "./attach-utils.js";
 import { createObserverContext, inferProjectId } from "./terminal-observability.js";
 
 interface TerminalSession {
@@ -54,17 +54,6 @@ export interface DirectTerminalServer {
   wss: WebSocketServer;
   activeSessions: Map<string, TerminalSession>;
   shutdown: () => void;
-}
-
-function buildAttachSpawnSpec(info: AttachInfo): { program: string; args: string[] } | null {
-  if (info.program) {
-    return { program: info.program, args: info.args ?? [] };
-  }
-  if (info.command) {
-    const shell = process.env.SHELL || "/bin/sh";
-    return { program: shell, args: ["-c", info.command] };
-  }
-  return null;
 }
 
 /**

--- a/packages/web/server/terminal-websocket.ts
+++ b/packages/web/server/terminal-websocket.ts
@@ -1,5 +1,5 @@
 /**
- * Terminal server that manages ttyd instances for tmux sessions.
+ * Terminal server that manages ttyd instances for runtime attach commands.
  *
  * Runs alongside Next.js. Spawns a ttyd process per session on demand,
  * each on a unique port. The dashboard embeds ttyd via iframe.
@@ -15,8 +15,9 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer, request } from "node:http";
-import { createCorrelationId } from "@composio/ao-core";
-import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js";
+import { createCorrelationId, type AttachInfo } from "@composio/ao-core";
+import { findTmux, validateSessionId } from "./tmux-utils.js";
+import { resolveAttachInfo } from "./attach-utils.js";
 import { createObserverContext, inferProjectId } from "./terminal-observability.js";
 
 /** Cached full path to tmux binary */
@@ -149,13 +150,24 @@ function waitForTtyd(port: number, sessionId: string, timeoutMs = 3000): Promise
   });
 }
 
+function buildAttachSpawnSpec(info: AttachInfo): { program: string; args: string[] } | null {
+  if (info.program) {
+    return { program: info.program, args: info.args ?? [] };
+  }
+  if (info.command) {
+    const shell = process.env.SHELL || "/bin/sh";
+    return { program: shell, args: ["-lc", info.command] };
+  }
+  return null;
+}
+
 /**
- * Spawn or reuse a ttyd instance for a tmux session.
+ * Spawn or reuse a ttyd instance for a runtime attach command.
  *
  * @param sessionId - User-facing session ID (used for base-path and URL)
- * @param tmuxSessionName - Actual tmux session name (may be hash-prefixed)
+ * @param attachInfo - Runtime-provided attach info
  */
-function getOrSpawnTtyd(sessionId: string, tmuxSessionName: string): TtydInstance {
+function getOrSpawnTtyd(sessionId: string, attachInfo: AttachInfo): TtydInstance {
   const existing = instances.get(sessionId);
   if (existing) {
     metrics.totalReused += 1;
@@ -182,24 +194,29 @@ function getOrSpawnTtyd(sessionId: string, tmuxSessionName: string): TtydInstanc
     port = nextPort++;
   }
 
-  console.log(`[Terminal] Spawning ttyd for ${tmuxSessionName} on port ${port}`);
+  const spawnSpec = buildAttachSpawnSpec(attachInfo);
+  if (!spawnSpec) {
+    throw new Error(`Session ${sessionId} does not expose an attach command`);
+  }
+
+  console.log(
+    `[Terminal] Spawning ttyd for ${attachInfo.type}:${attachInfo.target} on port ${port}`,
+  );
   metrics.totalSpawns += 1;
   metrics.lastSpawnAt = new Date().toISOString();
 
-  // Enable mouse mode for scrollback support
-  const mouseProc = spawn(TMUX, ["set-option", "-t", tmuxSessionName, "mouse", "on"]);
-  mouseProc.on("error", (err) => {
-    console.error(`[Terminal] Failed to set mouse mode for ${tmuxSessionName}:`, err.message);
-  });
+  if (attachInfo.type === "tmux") {
+    const mouseProc = spawn(TMUX, ["set-option", "-t", attachInfo.target, "mouse", "on"]);
+    mouseProc.on("error", (err) => {
+      console.error(`[Terminal] Failed to set mouse mode for ${attachInfo.target}:`, err.message);
+    });
 
-  // Hide the green status bar for cleaner appearance
-  const statusProc = spawn(TMUX, ["set-option", "-t", tmuxSessionName, "status", "off"]);
-  statusProc.on("error", (err) => {
-    console.error(`[Terminal] Failed to hide status bar for ${tmuxSessionName}:`, err.message);
-  });
+    const statusProc = spawn(TMUX, ["set-option", "-t", attachInfo.target, "status", "off"]);
+    statusProc.on("error", (err) => {
+      console.error(`[Terminal] Failed to hide status bar for ${attachInfo.target}:`, err.message);
+    });
+  }
 
-  // Use user-facing sessionId for base-path (matches URL the dashboard uses)
-  // Use tmuxSessionName for tmux attach (may be hash-prefixed)
   const proc = spawn(
     "ttyd",
     [
@@ -208,10 +225,8 @@ function getOrSpawnTtyd(sessionId: string, tmuxSessionName: string): TtydInstanc
       String(port),
       "--base-path",
       `/${sessionId}`,
-      TMUX,
-      "attach-session",
-      "-t",
-      tmuxSessionName,
+      spawnSpec.program,
+      ...spawnSpec.args,
     ],
     {
       stdio: ["ignore", "pipe", "pipe"],
@@ -347,10 +362,8 @@ const server = createServer(async (req, res) => {
       return;
     }
 
-    // Resolve tmux session name: try exact match first, then suffix match
-    // (hash-prefixed sessions like "8474d6f29887-ao-15" are accessed by user-facing ID "ao-15")
-    const tmuxSessionId = resolveTmuxSession(sessionId, TMUX);
-    if (!tmuxSessionId) {
+    const attachInfo = await resolveAttachInfo(sessionId).catch(() => null);
+    if (!attachInfo) {
       res.writeHead(404, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Session not found" }));
       recordWebsocketMetric({
@@ -364,7 +377,7 @@ const server = createServer(async (req, res) => {
 
     // Spawn ttyd and wait for it to be ready (catch port exhaustion and startup failures)
     try {
-      const instance = getOrSpawnTtyd(sessionId, tmuxSessionId);
+      const instance = getOrSpawnTtyd(sessionId, attachInfo);
       await waitForTtyd(instance.port, sessionId);
 
       // Use the request host to construct the terminal URL (supports remote access)

--- a/packages/web/server/terminal-websocket.ts
+++ b/packages/web/server/terminal-websocket.ts
@@ -17,7 +17,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { createServer, request } from "node:http";
 import { createCorrelationId, type AttachInfo } from "@composio/ao-core";
 import { findTmux, validateSessionId } from "./tmux-utils.js";
-import { resolveAttachInfo } from "./attach-utils.js";
+import { buildAttachSpawnSpec, resolveAttachInfo } from "./attach-utils.js";
 import { createObserverContext, inferProjectId } from "./terminal-observability.js";
 
 /** Cached full path to tmux binary */
@@ -148,17 +148,6 @@ function waitForTtyd(port: number, sessionId: string, timeoutMs = 3000): Promise
 
     checkReady();
   });
-}
-
-function buildAttachSpawnSpec(info: AttachInfo): { program: string; args: string[] } | null {
-  if (info.program) {
-    return { program: info.program, args: info.args ?? [] };
-  }
-  if (info.command) {
-    const shell = process.env.SHELL || "/bin/sh";
-    return { program: shell, args: ["-c", info.command] };
-  }
-  return null;
 }
 
 /**

--- a/packages/web/server/terminal-websocket.ts
+++ b/packages/web/server/terminal-websocket.ts
@@ -156,7 +156,7 @@ function buildAttachSpawnSpec(info: AttachInfo): { program: string; args: string
   }
   if (info.command) {
     const shell = process.env.SHELL || "/bin/sh";
-    return { program: shell, args: ["-lc", info.command] };
+    return { program: shell, args: ["-c", info.command] };
   }
   return null;
 }

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -38,6 +38,7 @@ import {
 
 // Static plugin imports — webpack needs these to be string literals
 import pluginRuntimeTmux from "@composio/ao-plugin-runtime-tmux";
+import pluginRuntimeDocker from "@composio/ao-plugin-runtime-docker";
 import pluginAgentClaudeCode from "@composio/ao-plugin-agent-claude-code";
 import pluginAgentOpencode from "@composio/ao-plugin-agent-opencode";
 import pluginWorkspaceWorktree from "@composio/ao-plugin-workspace-worktree";
@@ -80,6 +81,7 @@ async function initServices(): Promise<Services> {
 
   // Register plugins explicitly (webpack can't handle dynamic import() in core)
   registry.register(pluginRuntimeTmux);
+  registry.register(pluginRuntimeDocker);
   registry.register(pluginAgentClaudeCode);
   registry.register(pluginAgentOpencode);
   registry.register(pluginWorkspaceWorktree);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@composio/ao-plugin-notifier-webhook':
         specifier: workspace:*
         version: link:../plugins/notifier-webhook
+      '@composio/ao-plugin-runtime-docker':
+        specifier: workspace:*
+        version: link:../plugins/runtime-docker
       '@composio/ao-plugin-runtime-process':
         specifier: workspace:*
         version: link:../plugins/runtime-process
@@ -394,6 +397,22 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/plugins/runtime-docker:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/plugins/runtime-process:
     dependencies:
       '@composio/ao-core':
@@ -584,6 +603,9 @@ importers:
       '@composio/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
+      '@composio/ao-plugin-runtime-docker':
+        specifier: workspace:*
+        version: link:../plugins/runtime-docker
       '@composio/ao-plugin-runtime-tmux':
         specifier: workspace:*
         version: link:../plugins/runtime-tmux

--- a/scripts/ao-doctor.sh
+++ b/scripts/ao-doctor.sh
@@ -59,8 +59,11 @@ fixed() {
 
 expand_home() {
   case "$1" in
-    ~/*)
-      printf '%s/%s' "$DEFAULT_CONFIG_HOME" "${1#~/}"
+    "~")
+      printf '%s' "$DEFAULT_CONFIG_HOME"
+      ;;
+    "~/"*)
+      printf '%s/%s' "$DEFAULT_CONFIG_HOME" "${1#\~/}"
       ;;
     *)
       printf '%s' "$1"
@@ -109,6 +112,17 @@ read_config_value() {
   raw="${raw%%[[:space:]]#*}"
   value="$(printf '%s' "$raw" | tr -d '"' | xargs 2>/dev/null || true)"
   printf '%s' "$value"
+}
+
+warn_legacy_path_overrides() {
+  local config_path="$1"
+  local legacy_data_dir legacy_worktree_dir
+  legacy_data_dir="$(read_config_value dataDir "$config_path")"
+  legacy_worktree_dir="$(read_config_value worktreeDir "$config_path")"
+
+  if [ -n "$legacy_data_dir" ] || [ -n "$legacy_worktree_dir" ]; then
+    warn "top-level dataDir/worktreeDir are legacy and ignored. AO now stores session metadata under ~/.agent-orchestrator/<hash>-<project>/sessions and creates worktrees under ~/.worktrees/<project>/<session>"
+  fi
 }
 
 config_uses_docker_runtime() {
@@ -356,7 +370,7 @@ check_runtime_sanity() {
 }
 
 check_config_dirs() {
-  local config_path data_dir worktree_dir
+  local config_path metadata_root worktree_root
   config_path="$(find_config || true)"
   if [ -z "$config_path" ]; then
     warn "No agent-orchestrator config was found. Fix: run ao init --auto in a target repo"
@@ -364,21 +378,13 @@ check_config_dirs() {
   fi
 
   pass "config found at $config_path"
-  data_dir="$(read_config_value dataDir "$config_path")"
-  worktree_dir="$(read_config_value worktreeDir "$config_path")"
+  warn_legacy_path_overrides "$config_path"
 
-  if [ -z "$data_dir" ]; then
-    data_dir="$DEFAULT_CONFIG_HOME/.agent-orchestrator"
-  fi
-  if [ -z "$worktree_dir" ]; then
-    worktree_dir="$DEFAULT_CONFIG_HOME/.worktrees"
-  fi
+  metadata_root="$(expand_home "~/.agent-orchestrator")"
+  worktree_root="$(expand_home "~/.worktrees")"
 
-  data_dir="$(expand_home "$data_dir")"
-  worktree_dir="$(expand_home "$worktree_dir")"
-
-  ensure_dir "$data_dir" "metadata directory" "mkdir -p $data_dir"
-  ensure_dir "$worktree_dir" "worktree directory" "mkdir -p $worktree_dir"
+  ensure_dir "$metadata_root" "metadata root" "mkdir -p $metadata_root"
+  ensure_dir "$worktree_root" "worktree root" "mkdir -p $worktree_root"
 }
 
 check_stale_temp_files() {

--- a/scripts/ao-doctor.sh
+++ b/scripts/ao-doctor.sh
@@ -14,6 +14,8 @@ while [ $# -gt 0 ]; do
 Usage: ao doctor [--fix]
 
 Checks install, PATH, binaries, service health, stale temp files, and runtime sanity.
+When runtime: docker is configured, also validates Docker daemon access, image config,
+Linux rootless mode, and basic GPU/runtime hints.
 
 Options:
   --fix    Apply safe fixes for missing launcher links, missing support dirs, and stale temp files
@@ -107,6 +109,26 @@ read_config_value() {
   raw="${raw%%[[:space:]]#*}"
   value="$(printf '%s' "$raw" | tr -d '"' | xargs 2>/dev/null || true)"
   printf '%s' "$value"
+}
+
+config_uses_docker_runtime() {
+  local file="$1"
+  grep -Eq '^[[:space:]]*runtime:[[:space:]]*docker([[:space:]#]|$)' "$file"
+}
+
+find_docker_image_config() {
+  local file="$1"
+  local raw
+  local value
+  raw="$(grep -E '^[[:space:]]*image:' "$file" | head -n 1 | cut -d: -f2- || true)"
+  raw="${raw%%[[:space:]]#*}"
+  value="$(printf '%s' "$raw" | tr -d '"' | tr -d "'" | xargs 2>/dev/null || true)"
+  printf '%s' "$value"
+}
+
+config_requests_docker_gpu() {
+  local file="$1"
+  grep -Eq '^[[:space:]]*gpus:[[:space:]]*' "$file"
 }
 
 ensure_dir() {
@@ -228,6 +250,66 @@ check_tmux() {
   warn "tmux is installed but failed a basic server health check. Fix: restart tmux or reinstall it"
 }
 
+check_docker() {
+  local config_path docker_image security_options runtimes
+
+  config_path="$(find_config || true)"
+  if [ -z "$config_path" ] || ! config_uses_docker_runtime "$config_path"; then
+    pass "docker runtime checks skipped because no runtime: docker is configured"
+    return
+  fi
+
+  if ! command -v docker >/dev/null 2>&1; then
+    fail "docker is not installed but runtime: docker is configured. Fix: install Docker from https://docs.docker.com/get-docker/"
+    return
+  fi
+
+  if docker --version >/dev/null 2>&1; then
+    pass "docker CLI is installed"
+  else
+    fail "docker is installed but docker --version failed. Fix: reinstall Docker"
+    return
+  fi
+
+  if docker info >/dev/null 2>&1; then
+    pass "docker daemon is reachable"
+  else
+    fail "docker is installed but the daemon is unavailable. Fix: start Docker Desktop or the Docker service"
+    return
+  fi
+
+  docker_image="$(find_docker_image_config "$config_path")"
+  if [ -z "$docker_image" ]; then
+    fail "runtime: docker is configured but no runtimeConfig.image was found. Fix: add runtimeConfig.image to agent-orchestrator.yaml"
+    return
+  fi
+  pass "docker runtime image is configured as $docker_image"
+
+  if docker image inspect "$docker_image" >/dev/null 2>&1 || docker manifest inspect "$docker_image" >/dev/null 2>&1; then
+    pass "docker image $docker_image is available or reachable"
+  else
+    warn "could not verify docker image $docker_image locally or via docker manifest inspect. Fix: docker pull $docker_image"
+  fi
+
+  if [ "$(uname -s)" = "Linux" ]; then
+    security_options="$(docker info --format '{{json .SecurityOptions}}' 2>/dev/null || true)"
+    if printf '%s' "$security_options" | grep -qi 'rootless'; then
+      pass "docker appears to be running in rootless mode"
+    else
+      warn "docker runtime is configured on Linux without an obvious rootless marker. Fix: prefer rootless Docker for server deployments"
+    fi
+  fi
+
+  if config_requests_docker_gpu "$config_path"; then
+    runtimes="$(docker info --format '{{json .Runtimes}}' 2>/dev/null || true)"
+    if printf '%s' "$runtimes" | grep -qi 'nvidia'; then
+      pass "docker advertises an nvidia runtime for GPU sessions"
+    else
+      warn "GPU support is configured but docker does not advertise an nvidia runtime. Fix: install NVIDIA Container Toolkit or remove gpus from runtimeConfig"
+    fi
+  fi
+}
+
 check_gh() {
   if ! command -v gh >/dev/null 2>&1; then
     warn "GitHub CLI is not installed. Fix: install gh from https://cli.github.com/"
@@ -333,6 +415,7 @@ check_git
 check_pnpm
 check_launcher
 check_tmux
+check_docker
 check_gh
 check_config_dirs
 check_stale_temp_files

--- a/scripts/open-iterm-tab
+++ b/scripts/open-iterm-tab
@@ -1,29 +1,99 @@
 #!/bin/bash
-# Usage: ~/open-iterm-tab <session-name>
-# Opens a tmux session in iTerm2 - reuses existing tab if found, otherwise opens new
-# Sets both the profile name (for detection) and tab title (for visual display)
+# Usage:
+#   open-iterm-tab [--new-window] <tmux-session-name>
+#   open-iterm-tab [--new-window] --title <tab-title> --command <attach-command>
 
-SESSION="$1"
-if [ -z "$SESSION" ]; then
-    echo "Usage: ~/open-iterm-tab <session-name>"
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  open-iterm-tab [--new-window] <tmux-session-name>
+  open-iterm-tab [--new-window] --title <tab-title> --command <attach-command>
+EOF
+}
+
+escape_osascript() {
+    local value="${1//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    printf '%s' "$value"
+}
+
+shell_escape_single_quotes() {
+    printf "%s" "$1" | sed "s/'/'\\\\''/g"
+}
+
+NEW_WINDOW=0
+TITLE=""
+COMMAND=""
+SESSION=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --new-window)
+            NEW_WINDOW=1
+            shift
+            ;;
+        --title)
+            if [[ $# -lt 2 ]]; then
+                usage
+                exit 1
+            fi
+            TITLE="$2"
+            shift 2
+            ;;
+        --command)
+            if [[ $# -lt 2 ]]; then
+                usage
+                exit 1
+            fi
+            COMMAND="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+        *)
+            if [[ -n "$SESSION" || -n "$TITLE" || -n "$COMMAND" ]]; then
+                usage
+                exit 1
+            fi
+            SESSION="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -n "$SESSION" ]]; then
+    TITLE="$SESSION"
+    SESSION_SHELL_SAFE=$(shell_escape_single_quotes "$SESSION")
+    COMMAND="tmux attach -t '$SESSION_SHELL_SAFE'"
+elif [[ -z "$TITLE" || -z "$COMMAND" ]]; then
+    usage
     exit 1
 fi
 
-# Verify tmux session exists
-if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+if [[ -n "$SESSION" ]] && ! tmux has-session -t "$SESSION" 2>/dev/null; then
     echo "Error: tmux session '$SESSION' does not exist"
     exit 1
 fi
 
-# Check if there's already an iTerm2 tab with this session's profile name
-result=$(osascript -e "
+if [[ "$NEW_WINDOW" -eq 0 ]]; then
+    ESCAPED_TITLE=$(escape_osascript "$TITLE")
+    result=$(osascript -e "
 tell application \"iTerm2\"
     activate
     repeat with aWindow in windows
         repeat with aTab in tabs of aWindow
             repeat with aSession in sessions of aTab
                 try
-                    if profile name of aSession is equal to \"$SESSION\" then
+                    if name of aSession is equal to \"$ESCAPED_TITLE\" then
                         select aWindow
                         select aTab
                         return \"EXISTING\"
@@ -36,23 +106,38 @@ tell application \"iTerm2\"
 end tell
 " 2>&1)
 
-if [ "$result" = "EXISTING" ]; then
-    echo "✓ Switched to existing tab for $SESSION"
+    if [[ "$result" == "EXISTING" ]]; then
+        echo "✓ Switched to existing tab for $TITLE"
+        exit 0
+    fi
+fi
+
+TITLE_SHELL_SAFE=$(shell_escape_single_quotes "$TITLE")
+COMMAND_TO_WRITE="printf '\\\\033]0;$TITLE_SHELL_SAFE\\\\007' && $COMMAND"
+ESCAPED_TITLE=$(escape_osascript "$TITLE")
+ESCAPED_COMMAND=$(escape_osascript "$COMMAND_TO_WRITE")
+
+if [[ "$NEW_WINDOW" -eq 1 ]]; then
+    CREATE_TARGET='create window with default profile'
 else
-    echo "Opening new tab for $SESSION..."
-    osascript -e "
-    tell application \"iTerm2\"
-        activate
+    CREATE_TARGET='if (count of windows) is 0 then
+        create window with default profile
+    else
         tell current window
             create tab with default profile
-            tell current session
-                -- Set profile name for programmatic detection
-                set name to \"$SESSION\"
-                -- Set visible tab title via escape code, then attach to tmux
-                write text \"printf '\\\\033]0;$SESSION\\\\007' && tmux attach -t $SESSION\"
-            end tell
         end tell
-    end tell
-    " 2>&1
-    echo "✓ Opened $SESSION in new iTerm2 tab"
+    end if'
 fi
+
+echo "Opening new tab for $TITLE..."
+osascript -e "
+tell application \"iTerm2\"
+    activate
+    $CREATE_TARGET
+    tell current session of current window
+        set name to \"$ESCAPED_TITLE\"
+        write text \"$ESCAPED_COMMAND\"
+    end tell
+end tell
+" 2>&1
+echo "✓ Opened $TITLE in new iTerm2 tab"


### PR DESCRIPTION
## Summary
- add an opt-in Docker runtime plugin built around tmux-in-container sessions instead of brittle direct stdin piping
- persist effective runtime and runtimeConfig on sessions so restore, recovery, attach, and send follow the session's actual runtime choice
- make CLI, local terminal, and web terminal attach flows runtime-aware, including Docker attach/open support
- add `ao runtime show|set|clear` plus Docker runtime override flags and Docker-aware doctor/preflight checks
- expand docs, examples, and tests for Docker runtime setup, terminal behavior, and runtime config management
- align path guidance with the current runtime layout and warn on legacy top-level `dataDir` / `worktreeDir` keys

## Why
AO was still heavily tmux-shaped outside the runtime plugin layer. Adding Docker as an isolated, reproducible runtime needed more than a new plugin: session metadata, attach flows, config management, and doctor/docs all had to understand per-session runtime selection. This keeps tmux as the local default while enabling Docker-backed sessions for servers and CI.

## Validation
- `pnpm --filter @composio/ao-core typecheck`
- `pnpm --filter @composio/ao-core test -- metadata.test.ts recovery-validator.test.ts recovery-actions.test.ts lifecycle-manager.test.ts session-manager.test.ts`
- `pnpm --filter @composio/ao-plugin-runtime-docker typecheck`
- `pnpm --filter @composio/ao-plugin-runtime-docker test`
- `pnpm --filter @composio/ao-cli typecheck`
- `pnpm --filter @composio/ao-cli exec vitest run __tests__/lib/preflight.test.ts __tests__/commands/spawn.test.ts __tests__/commands/start.test.ts __tests__/commands/open.test.ts __tests__/commands/runtime.test.ts __tests__/scripts/doctor-script.test.ts`
- `pnpm --filter @composio/ao-web typecheck`
- `pnpm --filter @composio/ao-web test -- server-compatibility.test.ts services.test.ts`
- live smoke test with Docker Desktop and tmux: configure runtime to Docker, spawn a real AO session, verify container-side tmux output, send input through `ao send`, attach with `ao session attach`, and kill the session successfully

## Notes
- the live smoke test required a repo with a valid `origin/main`, which matches AO's existing worktree expectations
- `ao doctor` may still fail locally if the launcher is not installed in PATH; that is an environment/setup issue, not a runtime regression in this branch
