### PR TITLE
fix: persist session model and permissions for restore

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "pnpm -r typecheck",
+    "typecheck": "pnpm -r build && pnpm -r typecheck",
     "test": "pnpm -r --filter '!@composio/ao-web' test",
     "test:integration": "pnpm --filter @composio/ao-integration-tests test:integration",
     "clean": "pnpm -r clean",

--- a/packages/core/src/__tests__/metadata.test.ts
+++ b/packages/core/src/__tests__/metadata.test.ts
@@ -49,6 +49,8 @@ describe("writeMetadata + readMetadata", () => {
       prAutoDetect: "off",
       summary: "Implementing feature X",
       project: "my-app",
+      permissions: "auto-edit",
+      model: "claude-sonnet-4-20250514",
       createdAt: "2025-01-01T00:00:00.000Z",
       runtimeHandle: '{"id":"tmux-1","runtimeName":"tmux"}',
     });
@@ -60,6 +62,8 @@ describe("writeMetadata + readMetadata", () => {
     expect(meta!.prAutoDetect).toBe("off");
     expect(meta!.summary).toBe("Implementing feature X");
     expect(meta!.project).toBe("my-app");
+    expect(meta!.permissions).toBe("auto-edit");
+    expect(meta!.model).toBe("claude-sonnet-4-20250514");
     expect(meta!.createdAt).toBe("2025-01-01T00:00:00.000Z");
     expect(meta!.runtimeHandle).toBe('{"id":"tmux-1","runtimeName":"tmux"}');
   });

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -83,6 +83,8 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
     summary: raw["summary"],
     project: raw["project"],
     agent: raw["agent"],
+    permissions: raw["permissions"],
+    model: raw["model"],
     createdAt: raw["createdAt"],
     runtimeHandle: raw["runtimeHandle"],
     restoredAt: raw["restoredAt"],
@@ -132,6 +134,8 @@ export function writeMetadata(
   if (metadata.summary) data["summary"] = metadata.summary;
   if (metadata.project) data["project"] = metadata.project;
   if (metadata.agent) data["agent"] = metadata.agent;
+  if (metadata.permissions) data["permissions"] = metadata.permissions;
+  if (metadata.model) data["model"] = metadata.model;
   if (metadata.createdAt) data["createdAt"] = metadata.createdAt;
   if (metadata.runtimeHandle) data["runtimeHandle"] = metadata.runtimeHandle;
   if (metadata.restoredAt) data["restoredAt"] = metadata.restoredAt;

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1073,7 +1073,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           AO_CALLER_TYPE: "agent",
           AO_PROJECT_ID: spawnConfig.projectId,
           AO_CONFIG_PATH: config.configPath,
-          ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) }),
+          ...(config.port !== undefined &&
+            config.port !== null && { AO_PORT: String(config.port) }),
         },
       });
     } catch (err) {
@@ -1124,6 +1125,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         issue: spawnConfig.issueId,
         project: spawnConfig.projectId,
         agent: selection.agentName, // Persist agent name for lifecycle manager
+        permissions: selection.permissions,
+        model: selection.model,
         createdAt: new Date().toISOString(),
         runtimeHandle: JSON.stringify(handle),
         opencodeSessionId: reusedOpenCodeSessionId,
@@ -1372,7 +1375,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         AO_CALLER_TYPE: "orchestrator",
         AO_PROJECT_ID: orchestratorConfig.projectId,
         AO_CONFIG_PATH: config.configPath,
-        ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) })
+        ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) }),
       },
     });
 
@@ -1404,6 +1407,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         tmuxName,
         project: orchestratorConfig.projectId,
         agent: selection.agentName,
+        permissions: "permissionless",
+        model: selection.model,
         createdAt: new Date().toISOString(),
         runtimeHandle: JSON.stringify(handle),
         opencodeSessionId: reusableOpenCodeSessionId,
@@ -2278,8 +2283,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         summary: raw["summary"],
         project: raw["project"],
         agent: raw["agent"],
+        permissions: raw["permissions"],
+        model: raw["model"],
         createdAt: raw["createdAt"],
         runtimeHandle: raw["runtimeHandle"],
+        restoredAt: raw["restoredAt"],
         opencodeSessionId: raw["opencodeSessionId"],
       });
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -608,7 +608,10 @@ export interface SCM {
    * @param observer - Optional observer for batch operation metrics
    * @returns Map keyed by "${owner}/${repo}#${number}" containing enrichment data
    */
-  enrichSessionsPRBatch?(prs: PRInfo[], observer?: BatchObserver): Promise<Map<string, PREnrichmentData>>;
+  enrichSessionsPRBatch?(
+    prs: PRInfo[],
+    observer?: BatchObserver,
+  ): Promise<Map<string, PREnrichmentData>>;
 }
 
 // --- PR Types ---
@@ -1245,6 +1248,8 @@ export interface SessionMetadata {
   summary?: string;
   project?: string;
   agent?: string; // Agent plugin name (e.g. "codex", "claude-code") — persisted for lifecycle
+  permissions?: string;
+  model?: string;
   createdAt?: string;
   runtimeHandle?: string;
   restoredAt?: string;

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Session, RuntimeHandle, AgentLaunchConfig, WorkspaceHooksConfig } from "@composio/ao-core";
+import type {
+  Session,
+  RuntimeHandle,
+  AgentLaunchConfig,
+  WorkspaceHooksConfig,
+} from "@composio/ao-core";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — available inside vi.mock factories
@@ -50,7 +55,13 @@ vi.mock("node:os", () => ({
   homedir: mockHomedir,
 }));
 
-import { create, manifest, default as defaultExport, resetPsCache, METADATA_UPDATER_SCRIPT } from "./index.js";
+import {
+  create,
+  manifest,
+  default as defaultExport,
+  resetPsCache,
+  METADATA_UPDATER_SCRIPT,
+} from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -263,6 +274,72 @@ describe("getEnvironment", () => {
   it("does not set AO_ISSUE_ID when not provided", () => {
     const env = agent.getEnvironment(makeLaunchConfig());
     expect(env["AO_ISSUE_ID"]).toBeUndefined();
+  });
+});
+
+// =========================================================================
+// getRestoreCommand
+// =========================================================================
+describe("getRestoreCommand", () => {
+  const agent = create();
+
+  beforeEach(() => {
+    mockJsonlFiles("{}\n", ["session-abc123.jsonl"]);
+  });
+
+  it("prefers persisted metadata over current project config", async () => {
+    const session = makeSession({
+      metadata: {
+        permissions: "permissionless",
+        model: "claude-opus-4-6",
+      },
+    });
+
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeLaunchConfig({
+        projectConfig: {
+          name: "my-project",
+          repo: "owner/repo",
+          path: "/workspace/repo",
+          defaultBranch: "main",
+          sessionPrefix: "my",
+          agentConfig: {
+            permissions: "default",
+            model: "claude-sonnet-4-20250514",
+          },
+        },
+      }).projectConfig,
+    );
+
+    expect(cmd).toBe(
+      "claude --resume 'session-abc123' --dangerously-skip-permissions --model 'claude-opus-4-6'",
+    );
+  });
+
+  it("falls back to current project config for older sessions without persisted metadata", async () => {
+    const session = makeSession();
+
+    const cmd = await agent.getRestoreCommand!(
+      session,
+      makeLaunchConfig({
+        projectConfig: {
+          name: "my-project",
+          repo: "owner/repo",
+          path: "/workspace/repo",
+          defaultBranch: "main",
+          sessionPrefix: "my",
+          agentConfig: {
+            permissions: "auto-edit",
+            model: "claude-sonnet-4-20250514",
+          },
+        },
+      }).projectConfig,
+    );
+
+    expect(cmd).toBe(
+      "claude --resume 'session-abc123' --dangerously-skip-permissions --model 'claude-sonnet-4-20250514'",
+    );
   });
 });
 
@@ -720,12 +797,8 @@ describe("METADATA_UPDATER_SCRIPT content", () => {
   it("does NOT use ^-anchored regexes directly on $command for gh/git detection", () => {
     // The old buggy patterns matched $command with ^ anchor.
     // After the fix, ^ is still used but on $clean_command (which has cd stripped).
-    expect(METADATA_UPDATER_SCRIPT).not.toMatch(
-      /"\$command"\s*=~\s*\^gh/,
-    );
-    expect(METADATA_UPDATER_SCRIPT).not.toMatch(
-      /"\$command"\s*=~\s*\^git/,
-    );
+    expect(METADATA_UPDATER_SCRIPT).not.toMatch(/"\$command"\s*=~\s*\^gh/);
+    expect(METADATA_UPDATER_SCRIPT).not.toMatch(/"\$command"\s*=~\s*\^git/);
   });
 
   it("strips cd prefixes with both && and ; delimiters", () => {
@@ -737,21 +810,15 @@ describe("METADATA_UPDATER_SCRIPT content", () => {
   });
 
   it("detects gh pr create on clean_command", () => {
-    expect(METADATA_UPDATER_SCRIPT).toMatch(
-      /"\$clean_command"\s*=~\s*\^gh\[/,
-    );
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/"\$clean_command"\s*=~\s*\^gh\[/);
   });
 
   it("detects git checkout -b on clean_command", () => {
-    expect(METADATA_UPDATER_SCRIPT).toMatch(
-      /"\$clean_command"\s*=~\s*\^git\[.*checkout/,
-    );
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/"\$clean_command"\s*=~\s*\^git\[.*checkout/);
   });
 
   it("detects gh pr merge on clean_command", () => {
-    expect(METADATA_UPDATER_SCRIPT).toMatch(
-      /"\$clean_command"\s*=~\s*\^gh\[.*merge/,
-    );
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/"\$clean_command"\s*=~\s*\^gh\[.*merge/);
   });
 });
 

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -23,10 +23,17 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-function normalizePermissionMode(mode: string | undefined): "permissionless" | "default" | "auto-edit" | "suggest" | undefined {
+function normalizePermissionMode(
+  mode: string | undefined,
+): "permissionless" | "default" | "auto-edit" | "suggest" | undefined {
   if (!mode) return undefined;
   if (mode === "skip") return "permissionless";
-  if (mode === "permissionless" || mode === "default" || mode === "auto-edit" || mode === "suggest") {
+  if (
+    mode === "permissionless" ||
+    mode === "default" ||
+    mode === "auto-edit" ||
+    mode === "suggest"
+  ) {
     return mode;
   }
   return undefined;
@@ -314,8 +321,7 @@ async function parseJsonlFileTail(filePath: string, maxBytes = 131_072): Promise
   // Skip potentially truncated first line only when we started mid-file.
   // If offset === 0 we read from the start so the first line is complete.
   const firstNewline = content.indexOf("\n");
-  const safeContent =
-    offset > 0 && firstNewline >= 0 ? content.slice(firstNewline + 1) : content;
+  const safeContent = offset > 0 && firstNewline >= 0 ? content.slice(firstNewline + 1) : content;
   const lines: JsonlLine[] = [];
   for (const line of safeContent.split("\n")) {
     const trimmed = line.trim();
@@ -333,9 +339,7 @@ async function parseJsonlFileTail(filePath: string, maxBytes = 131_072): Promise
 }
 
 /** Extract auto-generated summary from JSONL (last "summary" type entry) */
-function extractSummary(
-  lines: JsonlLine[],
-): { summary: string; isFallback: boolean } | null {
+function extractSummary(lines: JsonlLine[]): { summary: string; isFallback: boolean } | null {
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i];
     if (line?.type === "summary" && line.summary) {
@@ -821,13 +825,16 @@ function createClaudeCodeAgent(): Agent {
       // Build resume command
       const parts: string[] = ["claude", "--resume", shellEscape(sessionUuid)];
 
-      const permissionMode = normalizePermissionMode(project.agentConfig?.permissions);
+      const permissionMode =
+        normalizePermissionMode(session.metadata["permissions"]) ??
+        normalizePermissionMode(project.agentConfig?.permissions);
       if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
         parts.push("--dangerously-skip-permissions");
       }
 
-      if (project.agentConfig?.model) {
-        parts.push("--model", shellEscape(project.agentConfig.model as string));
+      const model = session.metadata["model"] ?? (project.agentConfig?.model as string | undefined);
+      if (model) {
+        parts.push("--model", shellEscape(model));
       }
 
       return parts.join(" ");


### PR DESCRIPTION
## Summary
- persist session `permissions` and `model` in flat-file metadata and restore archived sessions with those fields intact
- make Claude restore prefer persisted session settings over current project config, with fallback for older sessions
- build workspace packages before `pnpm -r typecheck` so package export dependencies exist during CI typecheck

## Testing
- `pnpm exec vitest run src/__tests__/metadata.test.ts`
- `pnpm exec vitest run src/index.test.ts`
- `pnpm typecheck`

Closes #129