### PR TITLE
fix(cli): ao start fails with "Dependencies not installed" due to npm hoisting of @composio/ao-core

### DIFF
--- a/packages/cli/__tests__/lib/preflight.test.ts
+++ b/packages/cli/__tests__/lib/preflight.test.ts
@@ -18,12 +18,22 @@ vi.mock("node:fs", () => ({
   existsSync: mockExistsSync,
 }));
 
+vi.mock("node:module", () => ({
+  createRequire: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(),
+  })),
+}));
+
 import { preflight } from "../../src/lib/preflight.js";
+import { createRequire } from "node:module";
+
+const mockCreateRequire = createRequire as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   mockExec.mockReset();
   mockIsPortAvailable.mockReset();
   mockExistsSync.mockReset();
+  mockCreateRequire.mockClear();
 });
 
 describe("preflight.checkPort", () => {
@@ -35,9 +45,7 @@ describe("preflight.checkPort", () => {
 
   it("throws when port is in use", async () => {
     mockIsPortAvailable.mockResolvedValue(false);
-    await expect(preflight.checkPort(3000)).rejects.toThrow(
-      "Port 3000 is already in use",
-    );
+    await expect(preflight.checkPort(3000)).rejects.toThrow("Port 3000 is already in use");
   });
 
   it("includes port number in error message", async () => {
@@ -47,46 +55,56 @@ describe("preflight.checkPort", () => {
 });
 
 describe("preflight.checkBuilt", () => {
-  it("passes when ao-core and dist exist at webDir level (pnpm layout)", async () => {
-    // findPackageUp finds ao-core on first check (pnpm symlink in webDir/node_modules)
+  it("passes when ao-core and dist exist (pnpm symlink or npm hoisted)", async () => {
+    mockCreateRequire.mockReturnValue({
+      resolve: vi.fn().mockReturnValue("/path/to/ao-core/dist/index.js"),
+    });
     mockExistsSync.mockReturnValue(true);
     await expect(preflight.checkBuilt("/web")).resolves.toBeUndefined();
-    expect(mockExistsSync).toHaveBeenCalled();
+    const mockReq = mockCreateRequire.mock.results[0].value;
+    expect(mockReq.resolve).toHaveBeenCalledWith("@composio/ao-core");
   });
 
-  it("finds ao-core when hoisted one level up (npm global install layout)", async () => {
-    // /web/node_modules/@composio/ao-core     — miss
-    // /node_modules/@composio/ao-core         — hit
-    // /node_modules/@composio/ao-core/dist/index.js — exists
-    mockExistsSync
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true);
-    await expect(preflight.checkBuilt("/web")).resolves.toBeUndefined();
+  it("finds ao-core when hoisted to parent node_modules (npm global install)", async () => {
+    mockCreateRequire.mockReturnValue({
+      resolve: vi
+        .fn()
+        .mockReturnValue("/usr/local/lib/node_modules/@composio/ao-core/dist/index.js"),
+    });
+    mockExistsSync.mockReturnValue(true);
+    await expect(
+      preflight.checkBuilt("/usr/local/lib/node_modules/@composio/ao-web"),
+    ).resolves.toBeUndefined();
   });
 
   it("throws npm hint when ao-core not found in global install", async () => {
-    mockExistsSync.mockReturnValue(false);
+    mockCreateRequire.mockReturnValue({
+      resolve: vi.fn().mockImplementation(() => {
+        throw new Error("Cannot find module");
+      }),
+    });
     await expect(
       preflight.checkBuilt("/usr/local/lib/node_modules/@composio/ao-web"),
     ).rejects.toThrow("npm install -g @composio/ao@latest");
   });
 
   it("throws pnpm hint when ao-core not found in monorepo", async () => {
-    mockExistsSync.mockReturnValue(false);
+    mockCreateRequire.mockReturnValue({
+      resolve: vi.fn().mockImplementation(() => {
+        throw new Error("Cannot find module");
+      }),
+    });
     await expect(
       preflight.checkBuilt("/home/user/agent-orchestrator/packages/web"),
     ).rejects.toThrow("pnpm install && pnpm build");
   });
 
-  it("throws 'pnpm build' when ao-core exists but dist is missing", async () => {
-    // findPackageUp finds ao-core, but dist/index.js is missing
-    mockExistsSync
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(false);
-    await expect(preflight.checkBuilt("/web")).rejects.toThrow(
-      "Packages not built",
-    );
+  it("throws 'pnpm build' when ao-core dist/index.js is missing", async () => {
+    mockCreateRequire.mockReturnValue({
+      resolve: vi.fn().mockReturnValue("/path/to/ao-core/dist/index.js"),
+    });
+    mockExistsSync.mockReturnValue(false);
+    await expect(preflight.checkBuilt("/web")).rejects.toThrow("Packages not built");
   });
 });
 
@@ -118,34 +136,25 @@ describe("preflight.checkGhAuth", () => {
 
   it("throws 'not installed' when gh is missing (ENOENT)", async () => {
     mockExec.mockRejectedValue(new Error("ENOENT"));
-    await expect(preflight.checkGhAuth()).rejects.toThrow(
-      "GitHub CLI (gh) is not installed",
-    );
-    // Should only call --version, not auth status
+    await expect(preflight.checkGhAuth()).rejects.toThrow("GitHub CLI (gh) is not installed");
     expect(mockExec).toHaveBeenCalledTimes(1);
     expect(mockExec).toHaveBeenCalledWith("gh", ["--version"]);
   });
 
   it("throws 'not authenticated' when gh exists but auth fails", async () => {
     mockExec
-      .mockResolvedValueOnce({ stdout: "gh version 2.40", stderr: "" }) // --version succeeds
-      .mockRejectedValueOnce(new Error("not logged in")); // auth status fails
-    await expect(preflight.checkGhAuth()).rejects.toThrow(
-      "GitHub CLI is not authenticated",
-    );
+      .mockResolvedValueOnce({ stdout: "gh version 2.40", stderr: "" })
+      .mockRejectedValueOnce(new Error("not logged in"));
+    await expect(preflight.checkGhAuth()).rejects.toThrow("GitHub CLI is not authenticated");
     expect(mockExec).toHaveBeenCalledTimes(2);
   });
 
   it("includes correct fix instructions for each failure", async () => {
-    // Not installed → install link
     mockExec.mockRejectedValue(new Error("ENOENT"));
-    await expect(preflight.checkGhAuth()).rejects.toThrow(
-      "https://cli.github.com/",
-    );
+    await expect(preflight.checkGhAuth()).rejects.toThrow("https://cli.github.com/");
 
     mockExec.mockReset();
 
-    // Not authenticated → auth login
     mockExec
       .mockResolvedValueOnce({ stdout: "gh version 2.40", stderr: "" })
       .mockRejectedValueOnce(new Error("not logged in"));

--- a/packages/cli/__tests__/lib/preflight.test.ts
+++ b/packages/cli/__tests__/lib/preflight.test.ts
@@ -55,26 +55,43 @@ describe("preflight.checkPort", () => {
 });
 
 describe("preflight.checkBuilt", () => {
-  it("passes when ao-core and dist exist (pnpm symlink or npm hoisted)", async () => {
+  it("returns immediately when require.resolve succeeds (package installed and built)", async () => {
     mockCreateRequire.mockReturnValue({
       resolve: vi.fn().mockReturnValue("/path/to/ao-core/dist/index.js"),
     });
-    mockExistsSync.mockReturnValue(true);
     await expect(preflight.checkBuilt("/web")).resolves.toBeUndefined();
     const mockReq = mockCreateRequire.mock.results[0].value;
     expect(mockReq.resolve).toHaveBeenCalledWith("@composio/ao-core");
+    // existsSync should NOT be called — require.resolve success proves the file exists
+    expect(mockExistsSync).not.toHaveBeenCalled();
   });
 
-  it("finds ao-core when hoisted to parent node_modules (npm global install)", async () => {
+  it("works for npm global install with hoisted ao-core", async () => {
     mockCreateRequire.mockReturnValue({
       resolve: vi
         .fn()
         .mockReturnValue("/usr/local/lib/node_modules/@composio/ao-core/dist/index.js"),
     });
-    mockExistsSync.mockReturnValue(true);
     await expect(
       preflight.checkBuilt("/usr/local/lib/node_modules/@composio/ao-web"),
     ).resolves.toBeUndefined();
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+
+  it("throws 'not built' when require.resolve fails but package dir exists without dist", async () => {
+    mockCreateRequire.mockReturnValue({
+      resolve: vi.fn().mockImplementation(() => {
+        throw new Error("Cannot find module");
+      }),
+    });
+    // findPackageUp checks node_modules/@composio/ao-core — found
+    // then existsSync checks dist/index.js inside it — not found
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p.endsWith("/web/node_modules/@composio/ao-core")) return true;
+      if (p.endsWith("/dist/index.js")) return false;
+      return false;
+    });
+    await expect(preflight.checkBuilt("/web")).rejects.toThrow("Packages not built");
   });
 
   it("throws npm hint when ao-core not found in global install", async () => {
@@ -83,6 +100,7 @@ describe("preflight.checkBuilt", () => {
         throw new Error("Cannot find module");
       }),
     });
+    mockExistsSync.mockReturnValue(false);
     await expect(
       preflight.checkBuilt("/usr/local/lib/node_modules/@composio/ao-web"),
     ).rejects.toThrow("npm install -g @composio/ao@latest");
@@ -94,17 +112,25 @@ describe("preflight.checkBuilt", () => {
         throw new Error("Cannot find module");
       }),
     });
+    mockExistsSync.mockReturnValue(false);
     await expect(
       preflight.checkBuilt("/home/user/agent-orchestrator/packages/web"),
     ).rejects.toThrow("pnpm install && pnpm build");
   });
 
-  it("throws 'pnpm build' when ao-core dist/index.js is missing", async () => {
+  it("passes when require.resolve fails but findPackageUp finds dir with dist", async () => {
     mockCreateRequire.mockReturnValue({
-      resolve: vi.fn().mockReturnValue("/path/to/ao-core/dist/index.js"),
+      resolve: vi.fn().mockImplementation(() => {
+        throw new Error("Cannot find module");
+      }),
     });
-    mockExistsSync.mockReturnValue(false);
-    await expect(preflight.checkBuilt("/web")).rejects.toThrow("Packages not built");
+    // findPackageUp finds the directory, and dist/index.js exists inside it
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p.endsWith("/web/node_modules/@composio/ao-core")) return true;
+      if (p.endsWith("/dist/index.js")) return true;
+      return false;
+    });
+    await expect(preflight.checkBuilt("/web")).resolves.toBeUndefined();
   });
 });
 

--- a/packages/cli/__tests__/lib/preflight.test.ts
+++ b/packages/cli/__tests__/lib/preflight.test.ts
@@ -18,22 +18,12 @@ vi.mock("node:fs", () => ({
   existsSync: mockExistsSync,
 }));
 
-vi.mock("node:module", () => ({
-  createRequire: vi.fn().mockImplementation(() => ({
-    resolve: vi.fn(),
-  })),
-}));
-
 import { preflight } from "../../src/lib/preflight.js";
-import { createRequire } from "node:module";
-
-const mockCreateRequire = createRequire as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   mockExec.mockReset();
   mockIsPortAvailable.mockReset();
   mockExistsSync.mockReset();
-  mockCreateRequire.mockClear();
 });
 
 describe("preflight.checkPort", () => {
@@ -55,37 +45,47 @@ describe("preflight.checkPort", () => {
 });
 
 describe("preflight.checkBuilt", () => {
-  it("returns immediately when require.resolve succeeds (package installed and built)", async () => {
-    mockCreateRequire.mockReturnValue({
-      resolve: vi.fn().mockReturnValue("/path/to/ao-core/dist/index.js"),
+  it("passes when ao-core dir and dist/index.js both exist (pnpm layout)", async () => {
+    // findPackageUp finds /web/node_modules/@composio/ao-core
+    // then existsSync confirms dist/index.js inside it
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p.endsWith("/web/node_modules/@composio/ao-core")) return true;
+      if (p.endsWith("/dist/index.js")) return true;
+      return false;
     });
     await expect(preflight.checkBuilt("/web")).resolves.toBeUndefined();
-    const mockReq = mockCreateRequire.mock.results[0].value;
-    expect(mockReq.resolve).toHaveBeenCalledWith("@composio/ao-core");
-    // existsSync should NOT be called — require.resolve success proves the file exists
-    expect(mockExistsSync).not.toHaveBeenCalled();
   });
 
-  it("works for npm global install with hoisted ao-core", async () => {
-    mockCreateRequire.mockReturnValue({
-      resolve: vi
-        .fn()
-        .mockReturnValue("/usr/local/lib/node_modules/@composio/ao-core/dist/index.js"),
+  it("finds ao-core when hoisted to parent node_modules (npm global install)", async () => {
+    // /usr/local/lib/node_modules/@composio/ao-web/node_modules/@composio/ao-core — miss
+    // /usr/local/lib/node_modules/@composio/node_modules/@composio/ao-core — miss
+    // /usr/local/lib/node_modules/node_modules/@composio/ao-core — miss
+    // /usr/local/lib/node_modules/@composio/ao-core — hit (hoisted)
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p === "/usr/local/lib/node_modules/@composio/ao-core") return true;
+      if (p === "/usr/local/lib/node_modules/@composio/ao-core/dist/index.js") return true;
+      return false;
     });
     await expect(
       preflight.checkBuilt("/usr/local/lib/node_modules/@composio/ao-web"),
     ).resolves.toBeUndefined();
-    expect(mockExistsSync).not.toHaveBeenCalled();
   });
 
-  it("throws 'not built' when require.resolve fails but package dir exists without dist", async () => {
-    mockCreateRequire.mockReturnValue({
-      resolve: vi.fn().mockImplementation(() => {
-        throw new Error("Cannot find module");
-      }),
-    });
-    // findPackageUp checks node_modules/@composio/ao-core — found
-    // then existsSync checks dist/index.js inside it — not found
+  it("throws npm hint when ao-core not found in global install", async () => {
+    mockExistsSync.mockReturnValue(false);
+    await expect(
+      preflight.checkBuilt("/usr/local/lib/node_modules/@composio/ao-web"),
+    ).rejects.toThrow("npm install -g @composio/ao@latest");
+  });
+
+  it("throws pnpm hint when ao-core not found in monorepo", async () => {
+    mockExistsSync.mockReturnValue(false);
+    await expect(
+      preflight.checkBuilt("/home/user/agent-orchestrator/packages/web"),
+    ).rejects.toThrow("pnpm install && pnpm build");
+  });
+
+  it("throws 'Packages not built' when ao-core exists but dist/index.js is missing", async () => {
     mockExistsSync.mockImplementation((p: string) => {
       if (p.endsWith("/web/node_modules/@composio/ao-core")) return true;
       if (p.endsWith("/dist/index.js")) return false;
@@ -94,43 +94,18 @@ describe("preflight.checkBuilt", () => {
     await expect(preflight.checkBuilt("/web")).rejects.toThrow("Packages not built");
   });
 
-  it("throws npm hint when ao-core not found in global install", async () => {
-    mockCreateRequire.mockReturnValue({
-      resolve: vi.fn().mockImplementation(() => {
-        throw new Error("Cannot find module");
-      }),
-    });
-    mockExistsSync.mockReturnValue(false);
-    await expect(
-      preflight.checkBuilt("/usr/local/lib/node_modules/@composio/ao-web"),
-    ).rejects.toThrow("npm install -g @composio/ao@latest");
-  });
-
-  it("throws pnpm hint when ao-core not found in monorepo", async () => {
-    mockCreateRequire.mockReturnValue({
-      resolve: vi.fn().mockImplementation(() => {
-        throw new Error("Cannot find module");
-      }),
-    });
-    mockExistsSync.mockReturnValue(false);
-    await expect(
-      preflight.checkBuilt("/home/user/agent-orchestrator/packages/web"),
-    ).rejects.toThrow("pnpm install && pnpm build");
-  });
-
-  it("passes when require.resolve fails but findPackageUp finds dir with dist", async () => {
-    mockCreateRequire.mockReturnValue({
-      resolve: vi.fn().mockImplementation(() => {
-        throw new Error("Cannot find module");
-      }),
-    });
-    // findPackageUp finds the directory, and dist/index.js exists inside it
+  it("only checks scoped @composio/ao-core path, never unscoped ao-core", async () => {
+    // Ensure findPackageUp never looks for node_modules/ao-core (unscoped)
+    const checkedPaths: string[] = [];
     mockExistsSync.mockImplementation((p: string) => {
-      if (p.endsWith("/web/node_modules/@composio/ao-core")) return true;
-      if (p.endsWith("/dist/index.js")) return true;
+      checkedPaths.push(p);
       return false;
     });
-    await expect(preflight.checkBuilt("/web")).resolves.toBeUndefined();
+    await expect(preflight.checkBuilt("/web")).rejects.toThrow();
+    const unscopedChecks = checkedPaths.filter(
+      (p) => p.includes("node_modules/ao-core") && !p.includes("@composio"),
+    );
+    expect(unscopedChecks).toHaveLength(0);
   });
 });
 

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -9,6 +9,7 @@
 
 import { existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
+import { createRequire } from "node:module";
 import { isPortAvailable } from "./web-dir.js";
 import { exec } from "./shell.js";
 
@@ -26,19 +27,57 @@ async function checkPort(port: number): Promise<void> {
 }
 
 /**
+ * Find @composio/ao-core package directory by walking up from webDir.
+ * Handles npm hoisting by checking both nested and hoisted locations.
+ */
+function findPackageUp(startDir: string): string | null {
+  let dir = resolve(startDir);
+  while (true) {
+    const scopedCore = resolve(dir, "node_modules", "@composio", "ao-core");
+    if (existsSync(scopedCore)) return scopedCore;
+    const hoistedCore = resolve(dir, "node_modules", "ao-core");
+    if (existsSync(hoistedCore)) return hoistedCore;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
  * Check that workspace packages have been compiled (TypeScript → JavaScript).
- * Locates @composio/ao-core by walking up from webDir, handling both pnpm
- * workspaces (symlinked deps in webDir/node_modules) and npm/yarn global
- * installs (hoisted to a parent node_modules).
+ * Uses Node's module resolution to locate @composio/ao-core, which correctly
+ * handles npm/yarn hoisting in global installs.
  */
 async function checkBuilt(webDir: string): Promise<void> {
-  const corePkgDir = findPackageUp(webDir, "@composio", "ao-core");
+  let corePkgDir: string | null;
+  let needsBuild = false;
+
+  try {
+    const require = createRequire(resolve(webDir, "package.json"));
+    const coreEntry = require.resolve("@composio/ao-core");
+    corePkgDir = resolve(coreEntry, "..");
+  } catch {
+    corePkgDir = findPackageUp(webDir);
+    if (corePkgDir) {
+      needsBuild = true;
+    }
+  }
+
   if (!corePkgDir) {
     const hint = webDir.includes("node_modules")
       ? "Run: npm install -g @composio/ao@latest"
       : "Run: pnpm install && pnpm build";
     throw new Error(`Dependencies not installed. ${hint}`);
   }
+
+  if (needsBuild) {
+    const hint = webDir.includes("node_modules")
+      ? "Run: npm install -g @composio/ao@latest"
+      : "Run: pnpm build";
+    throw new Error(`Packages not built. ${hint}`);
+  }
+
   const coreEntry = resolve(corePkgDir, "dist", "index.js");
   if (!existsSync(coreEntry)) {
     const hint = webDir.includes("node_modules")
@@ -46,23 +85,6 @@ async function checkBuilt(webDir: string): Promise<void> {
       : "Run: pnpm build";
     throw new Error(`Packages not built. ${hint}`);
   }
-}
-
-/**
- * Walk up from startDir looking for node_modules/<segments>.
- * Mirrors Node's module resolution: checks each ancestor directory until
- * the package is found or the filesystem root is reached.
- */
-function findPackageUp(startDir: string, ...segments: string[]): string | null {
-  let dir = resolve(startDir);
-  while (true) {
-    const candidate = resolve(dir, "node_modules", ...segments);
-    if (existsSync(candidate)) return candidate;
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return null;
 }
 
 /**

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -50,19 +50,21 @@ function findPackageUp(startDir: string): string | null {
  * handles npm/yarn hoisting in global installs.
  */
 async function checkBuilt(webDir: string): Promise<void> {
-  let corePkgDir: string | null;
-  let needsBuild = false;
-
+  // Primary: use Node's module resolution. require.resolve() both locates the
+  // package AND verifies the entry file exists on disk — if it returns without
+  // throwing, the package is installed and built.
   try {
     const require = createRequire(resolve(webDir, "package.json"));
-    const coreEntry = require.resolve("@composio/ao-core");
-    corePkgDir = resolve(coreEntry, "..");
+    require.resolve("@composio/ao-core");
+    return;
   } catch {
-    corePkgDir = findPackageUp(webDir);
-    if (corePkgDir) {
-      needsBuild = true;
-    }
+    // Fall through to manual lookup
   }
+
+  // Fallback: walk up from webDir looking for the package directory.
+  // This handles the case where require.resolve throws MODULE_NOT_FOUND
+  // because dist/index.js doesn't exist yet (installed but not built).
+  const corePkgDir = findPackageUp(webDir);
 
   if (!corePkgDir) {
     const hint = webDir.includes("node_modules")
@@ -71,13 +73,7 @@ async function checkBuilt(webDir: string): Promise<void> {
     throw new Error(`Dependencies not installed. ${hint}`);
   }
 
-  if (needsBuild) {
-    const hint = webDir.includes("node_modules")
-      ? "Run: npm install -g @composio/ao@latest"
-      : "Run: pnpm build";
-    throw new Error(`Packages not built. ${hint}`);
-  }
-
+  // Package directory exists but require.resolve failed — check if it needs building
   const coreEntry = resolve(corePkgDir, "dist", "index.js");
   if (!existsSync(coreEntry)) {
     const hint = webDir.includes("node_modules")
@@ -85,6 +81,9 @@ async function checkBuilt(webDir: string): Promise<void> {
       : "Run: pnpm build";
     throw new Error(`Packages not built. ${hint}`);
   }
+
+  // Package exists and dist exists but require.resolve still failed — unusual
+  // but not a blocker. The package is usable.
 }
 
 /**

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -9,7 +9,6 @@
 
 import { existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
-import { createRequire } from "node:module";
 import { isPortAvailable } from "./web-dir.js";
 import { exec } from "./shell.js";
 
@@ -27,16 +26,17 @@ async function checkPort(port: number): Promise<void> {
 }
 
 /**
- * Find @composio/ao-core package directory by walking up from webDir.
- * Handles npm hoisting by checking both nested and hoisted locations.
+ * Walk up from startDir looking for node_modules/@composio/ao-core.
+ * Mirrors Node's module resolution: checks each ancestor's node_modules
+ * until the package is found or the filesystem root is reached.
+ * This handles both pnpm symlinks (found in webDir/node_modules) and
+ * npm/yarn hoisting (found in a parent node_modules).
  */
 function findPackageUp(startDir: string): string | null {
   let dir = resolve(startDir);
   while (true) {
-    const scopedCore = resolve(dir, "node_modules", "@composio", "ao-core");
-    if (existsSync(scopedCore)) return scopedCore;
-    const hoistedCore = resolve(dir, "node_modules", "ao-core");
-    if (existsSync(hoistedCore)) return hoistedCore;
+    const candidate = resolve(dir, "node_modules", "@composio", "ao-core");
+    if (existsSync(candidate)) return candidate;
     const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;
@@ -46,24 +46,15 @@ function findPackageUp(startDir: string): string | null {
 
 /**
  * Check that workspace packages have been compiled (TypeScript → JavaScript).
- * Uses Node's module resolution to locate @composio/ao-core, which correctly
- * handles npm/yarn hoisting in global installs.
+ * Locates @composio/ao-core by walking up from webDir, handling both pnpm
+ * workspaces (symlinked deps in webDir/node_modules) and npm/yarn global
+ * installs (hoisted to a parent node_modules).
+ *
+ * Note: we cannot use createRequire().resolve() here because @composio/ao-core
+ * is ESM-only (its exports map defines "import" but not "require"/"default"),
+ * so CJS require.resolve always throws ERR_PACKAGE_PATH_NOT_EXPORTED.
  */
 async function checkBuilt(webDir: string): Promise<void> {
-  // Primary: use Node's module resolution. require.resolve() both locates the
-  // package AND verifies the entry file exists on disk — if it returns without
-  // throwing, the package is installed and built.
-  try {
-    const require = createRequire(resolve(webDir, "package.json"));
-    require.resolve("@composio/ao-core");
-    return;
-  } catch {
-    // Fall through to manual lookup
-  }
-
-  // Fallback: walk up from webDir looking for the package directory.
-  // This handles the case where require.resolve throws MODULE_NOT_FOUND
-  // because dist/index.js doesn't exist yet (installed but not built).
   const corePkgDir = findPackageUp(webDir);
 
   if (!corePkgDir) {
@@ -73,7 +64,6 @@ async function checkBuilt(webDir: string): Promise<void> {
     throw new Error(`Dependencies not installed. ${hint}`);
   }
 
-  // Package directory exists but require.resolve failed — check if it needs building
   const coreEntry = resolve(corePkgDir, "dist", "index.js");
   if (!existsSync(coreEntry)) {
     const hint = webDir.includes("node_modules")
@@ -81,9 +71,6 @@ async function checkBuilt(webDir: string): Promise<void> {
       : "Run: pnpm build";
     throw new Error(`Packages not built. ${hint}`);
   }
-
-  // Package exists and dist exists but require.resolve still failed — unusual
-  // but not a blocker. The package is usable.
 }
 
 /**


### PR DESCRIPTION
fix(cli): ao start fails with "Dependencies not installed" due to npm hoisting of @composio/ao-core

  Closes [#640](https://github.com/perfect7613/agent-orchestrator/issues/640)

  Problem

  ao start fails with "Dependencies not installed. Run: pnpm install && pnpm build" even after a successful install — both in global npm installs and monorepo setups.

  The original checkBuilt() in preflight.ts had multiple issues:

  1. Hardcoded nested path assumption: It only looked for @composio/ao-core directly under webDir/node_modules/, but npm/yarn hoist scoped packages to a parent
  node_modules/@composio/ao-core. The check always failed in global installs.
  2. findPackageUp was generic but never walked up: The original accepted variadic ...segments but was only called once with the nested path — it didn't actually help with hoisting.

  What this PR does

  Rewrites checkBuilt() with a dedicated findPackageUp that walks up the directory tree checking node_modules/@composio/ao-core at each level, correctly handling both:
  - pnpm workspaces: symlinked in webDir/node_modules
  - npm/yarn global installs: hoisted to a parent node_modules