### PR TITLE
chore: supply chain security hardening

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - "packages/*"
   - "packages/plugins/*"
+
+minimumReleaseAge: 2880


### PR DESCRIPTION
 supply-chain-security-hardening
 
Since the Composio team is using this package in production, all dependencies should ideally be pinned. Alternatively, since we are using pnpm, we should configure minimumReleaseAge. This ensures that if a newer version of a package is released, we won’t use it until at least 2 days have passed. This helps reduce the risk of adopting versions with undisclosed vulnerabilities.