### PR TITLE
fix(web): fix jest-dom matchers not extending vitest expect in test setup

### DIFF
--- a/packages/web/src/__tests__/setup.ts
+++ b/packages/web/src/__tests__/setup.ts
@@ -1,4 +1,6 @@
-import "@testing-library/jest-dom/vitest";
+import { expect } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+expect.extend(matchers);
 
 // jsdom does not implement window.matchMedia. Provide a minimal stub so
 // components that call useMediaQuery (e.g. Dashboard) work in unit tests.


### PR DESCRIPTION
## Summary

- Fixes 83 failing component tests in the web package that used `toBeInTheDocument`, `toHaveAttribute`, `toHaveClass`, and other jest-dom matchers
- Root cause: `import "@testing-library/jest-dom/vitest"` was not reliably extending vitest's `expect` object (the ESM side-effect module resolved to `[Module: null prototype] {}`)
- Fix: explicitly import matchers from `@testing-library/jest-dom/matchers` and call `expect.extend(matchers)` directly — the documented approach for vitest 2.x

## Test plan

- [x] `pnpm --filter @composio/ao-web test` — all 513 tests pass (previously 83 failures)
- [x] `pnpm typecheck` — passes
- [x] `pnpm build` — passes

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)