### PR TITLE
[codex] fix(cli): show worker issues in status output

### DIFF
--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -24,6 +24,7 @@ const {
   mockGetActivityState,
   mockDetectPR,
   mockGetCISummary,
+  mockIssueUrl,
   mockGetReviewDecision,
   mockGetPendingComments,
   mockSessionManager,
@@ -37,6 +38,7 @@ const {
   mockGetActivityState: vi.fn(),
   mockDetectPR: vi.fn(),
   mockGetCISummary: vi.fn(),
+  mockIssueUrl: vi.fn(),
   mockGetReviewDecision: vi.fn(),
   mockGetPendingComments: vi.fn(),
   mockSessionManager: {
@@ -276,6 +278,8 @@ beforeEach(() => {
   mockDetectPR.mockResolvedValue(null);
   mockGetCISummary.mockReset();
   mockGetCISummary.mockResolvedValue("none");
+  mockIssueUrl.mockReset();
+  mockIssueUrl.mockImplementation((issueId: string) => `https://tracker.example/issues/${issueId}`);
   mockGetReviewDecision.mockReset();
   mockGetReviewDecision.mockResolvedValue("none");
   mockGetPendingComments.mockReset();
@@ -426,10 +430,55 @@ describe("status command", () => {
 
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain("Session");
+    expect(output).toContain("Issue");
     expect(output).toContain("Branch");
     expect(output).toContain("PR");
     expect(output).toContain("CI");
     expect(output).toContain("Activity");
+  });
+
+  it("shows the issue identifier for worker sessions in the table", async () => {
+    mockConfigRef.current = {
+      ...(mockConfigRef.current as Record<string, unknown>),
+      projects: {
+        "my-app": {
+          name: "My App",
+          repo: "org/my-app",
+          path: join(tmpDir, "main-repo"),
+          defaultBranch: "main",
+          sessionPrefix: "app",
+          tracker: { plugin: "linear" },
+          scm: { plugin: "github" },
+        },
+      },
+    } as Record<string, unknown>;
+
+    writeFileSync(
+      join(sessionsDir, "app-1"),
+      "worktree=/tmp/wt\nbranch=feat/status\nstatus=working\nissue=ENG-1633\n",
+    );
+
+    mockGetPluginRegistry.mockResolvedValue({
+      get: vi.fn((slot: string) => {
+        if (slot === "tracker") {
+          return { issueUrl: mockIssueUrl };
+        }
+        return null;
+      }),
+      list: vi.fn(),
+      register: vi.fn(),
+    });
+    mockTmux.mockImplementation(async (...args: string[]) => {
+      if (args[0] === "list-sessions") return "app-1";
+      if (args[0] === "display-message") return null;
+      return null;
+    });
+    mockGit.mockResolvedValue("feat/status");
+
+    await program.parseAsync(["node", "test", "status"]);
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("ENG-1633");
   });
 
   it("shows PR number, CI status, review decision, and threads", async () => {
@@ -579,6 +628,52 @@ describe("status command", () => {
     expect(parsed[0].ciStatus).toBe("passing");
     expect(parsed[0].reviewDecision).toBe("pending");
     expect(parsed[0].pendingThreads).toBe(0);
+  });
+
+  it("includes issueUrl in JSON output when a tracker is configured", async () => {
+    mockConfigRef.current = {
+      ...(mockConfigRef.current as Record<string, unknown>),
+      projects: {
+        "my-app": {
+          name: "My App",
+          repo: "org/my-app",
+          path: join(tmpDir, "main-repo"),
+          defaultBranch: "main",
+          sessionPrefix: "app",
+          tracker: { plugin: "linear" },
+          scm: { plugin: "github" },
+        },
+      },
+    } as Record<string, unknown>;
+
+    writeFileSync(
+      join(sessionsDir, "app-1"),
+      "worktree=/tmp/wt\nbranch=feat/json\nstatus=working\nissue=ENG-1633\n",
+    );
+
+    mockGetPluginRegistry.mockResolvedValue({
+      get: vi.fn((slot: string) => {
+        if (slot === "tracker") {
+          return { issueUrl: mockIssueUrl };
+        }
+        return null;
+      }),
+      list: vi.fn(),
+      register: vi.fn(),
+    });
+    mockTmux.mockImplementation(async (...args: string[]) => {
+      if (args[0] === "list-sessions") return "app-1";
+      if (args[0] === "display-message") return String(Math.floor(Date.now() / 1000));
+      return null;
+    });
+    mockGit.mockResolvedValue("feat/json");
+
+    await program.parseAsync(["node", "test", "status", "--json"]);
+
+    const jsonCalls = consoleSpy.mock.calls.map((c) => c[0]).join("");
+    const parsed = JSON.parse(jsonCalls);
+    expect(parsed[0].issue).toBe("ENG-1633");
+    expect(parsed[0].issueUrl).toBe("https://tracker.example/issues/ENG-1633");
   });
 
   it("rejects --watch with --json", async () => {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -29,6 +29,7 @@ import { getPluginRegistry, getSessionManager } from "../lib/create-session-mana
 interface SessionInfo {
   name: string;
   role: "worker" | "orchestrator";
+  issueUrl: string | null;
   branch: string | null;
   status: string | null;
   summary: string | null;
@@ -72,6 +73,7 @@ async function gatherSessionInfo(
   session: Session,
   agent: Agent,
   scm: SCM,
+  tracker: Tracker | null,
   projectConfig: ReturnType<typeof loadConfig>,
 ): Promise<SessionInfo> {
   const sessionPrefix = projectConfig.projects[session.projectId]?.sessionPrefix ?? session.projectId;
@@ -84,6 +86,7 @@ async function gatherSessionInfo(
   const summary = session.metadata["summary"] ?? null;
   const prUrl = suppressPROwnership ? null : (session.metadata["pr"] ?? null);
   const issue = session.issueId;
+  const issueUrl = issue && tracker ? tracker.issueUrl(issue, projectConfig.projects[session.projectId]) : null;
 
   // Get live branch from worktree if available
   if (session.workspacePath) {
@@ -149,6 +152,7 @@ async function gatherSessionInfo(
   return {
     name: session.id,
     role: isOrchestratorSession(session, sessionPrefix, allSessionPrefixes) ? "orchestrator" : "worker",
+    issueUrl,
     branch,
     status,
     summary,
@@ -168,6 +172,7 @@ async function gatherSessionInfo(
 // Column widths for the table
 const COL = {
   session: 14,
+  issue: 12,
   branch: 24,
   pr: 6,
   ci: 6,
@@ -180,6 +185,7 @@ const COL = {
 function printTableHeader(): void {
   const hdr =
     padCol("Session", COL.session) +
+    padCol("Issue", COL.issue) +
     padCol("Branch", COL.branch) +
     padCol("PR", COL.pr) +
     padCol("CI", COL.ci) +
@@ -189,7 +195,15 @@ function printTableHeader(): void {
     "Age";
   console.log(chalk.dim(`  ${hdr}`));
   const totalWidth =
-    COL.session + COL.branch + COL.pr + COL.ci + COL.review + COL.threads + COL.activity + 3;
+    COL.session +
+    COL.issue +
+    COL.branch +
+    COL.pr +
+    COL.ci +
+    COL.review +
+    COL.threads +
+    COL.activity +
+    3;
   console.log(chalk.dim(`  ${"─".repeat(totalWidth)}`));
 }
 
@@ -198,6 +212,7 @@ function printSessionRow(info: SessionInfo): void {
 
   const row =
     padCol(chalk.green(info.name), COL.session) +
+    padCol(info.issue ? chalk.magenta(info.issue) : chalk.dim("-"), COL.issue) +
     padCol(info.branch ? chalk.cyan(info.branch) : chalk.dim("-"), COL.branch) +
     padCol(info.prNumber ? chalk.blue(prStr) : chalk.dim(prStr), COL.pr) +
     padCol(ciStatusIcon(info.ciStatus), COL.ci) +
@@ -321,6 +336,9 @@ export function registerStatus(program: Command): void {
           const agentName = projectConfig.agent ?? config.defaults.agent;
           const agent = getAgentByNameFromRegistry(registry, agentName);
           const scm = getSCMFromRegistry(registry, config, projectId);
+          const tracker = projectConfig.tracker?.plugin
+            ? registry.get<Tracker>("tracker", projectConfig.tracker.plugin)
+            : null;
 
           if (!opts.json) {
             console.log(header(projectConfig.name || projectId));
@@ -335,7 +353,9 @@ export function registerStatus(program: Command): void {
           }
 
           // Gather all session info in parallel
-          const infoPromises = projectSessions.map((s) => gatherSessionInfo(s, agent, scm, config));
+          const infoPromises = projectSessions.map((s) =>
+            gatherSessionInfo(s, agent, scm, tracker, config),
+          );
           const sessionInfos = await Promise.all(infoPromises);
 
           const orchestrators = sessionInfos.filter((info) => info.role === "orchestrator");


### PR DESCRIPTION
## Summary

Closes #303.

`ao status` was already reading `session.issueId` for worker sessions, but the CLI never rendered it. This change surfaces that missing context in both the table output and JSON output.

### What changed

- adds an `Issue` column to the worker-session table in `ao status`
- includes `issueUrl` in `ao status --json` when the project has a tracker plugin configured
- resolves the tracker plugin once per project and reuses it while gathering session info
- adds focused CLI tests for the table output and JSON issue URL behavior

## Root cause

`packages/cli/src/commands/status.ts` populated `SessionInfo.issue` but dropped it during rendering. The command also never asked the tracker plugin for the canonical issue URL.

## Validation

- `pnpm build`
- `pnpm --filter @composio/ao-cli exec vitest run __tests__/commands/status.test.ts`
- `pnpm --filter @composio/ao-cli typecheck`
- `pnpm --filter @composio/ao-cli exec eslint src/commands/status.ts __tests__/commands/status.test.ts`
