### PR TITLE
[codex] fix: enforce maxConcurrentSessions for worker spawns

### DIFF
--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -15,14 +15,15 @@ port: 3000
 
 # Default plugins (these are the defaults — you can omit this section)
 defaults:
-  runtime: tmux           # tmux | process
-  agent: claude-code      # claude-code | codex | aider | opencode
+  runtime: tmux # tmux | process
+  agent: claude-code # claude-code | codex | aider | opencode
+  # maxConcurrentSessions: 4
   # orchestrator:
   #   agent: claude-code
   # worker:
   #   agent: codex
-  workspace: worktree     # worktree | clone
-  notifiers: [desktop]    # desktop | slack | discord | webhook | composio | openclaw
+  workspace: worktree # worktree | clone
+  notifiers: [desktop] # desktop | slack | discord | webhook | composio | openclaw
 
 # Installer-managed external plugins (optional)
 # plugins:
@@ -45,6 +46,7 @@ projects:
     path: ~/my-app
     defaultBranch: main
     sessionPrefix: app
+    # maxConcurrentSessions: 3
 
     # Issue tracker (defaults to github issues)
     # tracker:
@@ -94,7 +96,7 @@ projects:
 
     # Rules for the orchestrator agent (reserved for future use)
     # orchestratorRules: |
-    #   Prefer to batch-spawn related issues together.
+    #   Prefer to batch-spawn related issues together, but respect maxConcurrentSessions.
 
     # OpenCode issue session strategy (only for agent: opencode)
     # opencodeIssueSessionStrategy: reuse   # reuse | delete | ignore

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -69,7 +69,7 @@ let configPath: string;
 let cwdSpy: ReturnType<typeof vi.spyOn> | undefined;
 
 import { Command } from "commander";
-import { registerSpawn } from "../../src/commands/spawn.js";
+import { registerBatchSpawn, registerSpawn } from "../../src/commands/spawn.js";
 
 let program: Command;
 let consoleSpy: ReturnType<typeof vi.spyOn>;
@@ -107,12 +107,15 @@ beforeEach(() => {
   program = new Command();
   program.exitOverride();
   registerSpawn(program);
+  registerBatchSpawn(program);
   consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   vi.spyOn(console, "error").mockImplementation(() => {});
   vi.spyOn(process, "exit").mockImplementation((code) => {
     throw new Error(`process.exit(${code})`);
   });
 
+  mockSessionManager.list.mockReset();
+  mockSessionManager.list.mockResolvedValue([]);
   mockSessionManager.spawn.mockReset();
   mockSessionManager.claimPR.mockReset();
   mockExec.mockReset();
@@ -378,9 +381,7 @@ describe("spawn command", () => {
   it("reports error when spawn fails", async () => {
     mockSessionManager.spawn.mockRejectedValue(new Error("worktree creation failed"));
 
-    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow(
-      "process.exit(1)",
-    );
+    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow("process.exit(1)");
   });
 
   it("claims a PR for the spawned session when --claim-pr is provided", async () => {
@@ -471,14 +472,7 @@ describe("spawn command", () => {
       takenOverFrom: ["app-9"],
     });
 
-    await program.parseAsync([
-      "node",
-      "test",
-      "spawn",
-      "--claim-pr",
-      "123",
-      "--assign-on-github",
-    ]);
+    await program.parseAsync(["node", "test", "spawn", "--claim-pr", "123", "--assign-on-github"]);
 
     expect(mockSessionManager.claimPR).toHaveBeenCalledWith("app-1", "123", {
       assignOnGithub: true,
@@ -537,9 +531,7 @@ describe("spawn pre-flight checks", () => {
   it("fails with clear error when tmux is not installed (default runtime)", async () => {
     mockExec.mockRejectedValue(new Error("ENOENT"));
 
-    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow(
-      "process.exit(1)",
-    );
+    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow("process.exit(1)");
 
     const errors = vi
       .mocked(console.error)
@@ -596,9 +588,7 @@ describe("spawn pre-flight checks", () => {
       .mockResolvedValueOnce({ stdout: "gh version 2.40", stderr: "" }) // gh --version
       .mockRejectedValueOnce(new Error("not logged in")); // gh auth status
 
-    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow(
-      "process.exit(1)",
-    );
+    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow("process.exit(1)");
 
     const errors = vi
       .mocked(console.error)
@@ -739,9 +729,7 @@ describe("spawn pre-flight checks", () => {
       .mockResolvedValueOnce({ stdout: "tmux 3.3a", stderr: "" }) // tmux -V
       .mockRejectedValueOnce(new Error("ENOENT")); // gh --version fails
 
-    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow(
-      "process.exit(1)",
-    );
+    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow("process.exit(1)");
 
     const errors = vi
       .mocked(console.error)
@@ -749,5 +737,64 @@ describe("spawn pre-flight checks", () => {
       .join("\n");
     expect(errors).toContain("not installed");
     expect(errors).not.toContain("not authenticated");
+  });
+});
+
+describe("batch-spawn command", () => {
+  it("stops spawning when maxConcurrentSessions is reached", async () => {
+    (mockConfigRef.current as Record<string, unknown>).defaults = {
+      runtime: "tmux",
+      agent: "claude-code",
+      workspace: "worktree",
+      notifiers: ["desktop"],
+      maxConcurrentSessions: 2,
+    };
+
+    const existingSession: Session = {
+      id: "app-1",
+      projectId: "my-app",
+      status: "working",
+      activity: "working",
+      branch: "feat/existing",
+      issueId: "INT-0",
+      pr: null,
+      workspacePath: "/tmp/wt-1",
+      runtimeHandle: { id: "hash-app-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+    const createdSession: Session = {
+      id: "app-2",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: "feat/INT-1",
+      issueId: "INT-1",
+      pr: null,
+      workspacePath: "/tmp/wt-2",
+      runtimeHandle: { id: "hash-app-2", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.list.mockResolvedValue([existingSession]);
+    mockSessionManager.spawn.mockResolvedValue(createdSession);
+
+    await program.parseAsync(["node", "test", "batch-spawn", "INT-1", "INT-2", "INT-3"]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledTimes(1);
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: "INT-1",
+    });
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("INT-2");
+    expect(output).toContain("INT-3");
+    expect(output).toContain("maxConcurrentSessions=2 reached (2 active sessions)");
   });
 });

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -82,6 +82,14 @@ async function runSpawnPreflight(
   }
 }
 
+function resolveMaxConcurrentSessions(
+  config: OrchestratorConfig,
+  projectId: string,
+): number | undefined {
+  const project = config.projects[projectId];
+  return project?.maxConcurrentSessions ?? config.defaults.maxConcurrentSessions;
+}
+
 async function spawnSession(
   config: OrchestratorConfig,
   projectId: string,
@@ -344,25 +352,29 @@ export function registerBatchSpawn(program: Command): void {
 
       const sm = await getSessionManager(config);
       const created: Array<{ session: string; issue: string }> = [];
-      const skipped: Array<{ issue: string; existing: string }> = [];
+      const skipped: Array<{ issue: string; reason: string }> = [];
       const failed: Array<{ issue: string; error: string }> = [];
       const spawnedIssues = new Set<string>();
+      const maxConcurrentSessions = resolveMaxConcurrentSessions(config, projectId);
 
       // Load existing sessions once before the loop to avoid repeated reads + enrichment.
       // Exclude terminal sessions so completed/merged sessions don't block respawning
       // (e.g. when an issue is reopened after its PR was merged).
       const existingSessions = await sm.list(projectId);
+      let activeSessionCount = existingSessions.filter(
+        (s) => !TERMINAL_STATUSES.has(s.status),
+      ).length;
       const existingIssueMap = new Map(
         existingSessions
           .filter((s) => s.issueId && !TERMINAL_STATUSES.has(s.status))
           .map((s) => [s.issueId!.toLowerCase(), s.id]),
       );
 
-      for (const issue of issues) {
+      for (const [index, issue] of issues.entries()) {
         // Duplicate detection — check both existing sessions and same-run duplicates
         if (spawnedIssues.has(issue.toLowerCase())) {
           console.log(chalk.yellow(`  Skip ${issue} — duplicate in this batch`));
-          skipped.push({ issue, existing: "(this batch)" });
+          skipped.push({ issue, reason: "duplicate in this batch" });
           continue;
         }
 
@@ -370,14 +382,24 @@ export function registerBatchSpawn(program: Command): void {
         const existingSessionId = existingIssueMap.get(issue.toLowerCase());
         if (existingSessionId) {
           console.log(chalk.yellow(`  Skip ${issue} — already has session ${existingSessionId}`));
-          skipped.push({ issue, existing: existingSessionId });
+          skipped.push({ issue, reason: `already has session ${existingSessionId}` });
           continue;
+        }
+
+        if (maxConcurrentSessions !== undefined && activeSessionCount >= maxConcurrentSessions) {
+          const reason = `maxConcurrentSessions=${maxConcurrentSessions} reached (${activeSessionCount} active sessions)`;
+          for (const remainingIssue of issues.slice(index)) {
+            console.log(chalk.yellow(`  Skip ${remainingIssue} — ${reason}`));
+            skipped.push({ issue: remainingIssue, reason });
+          }
+          break;
         }
 
         try {
           const session = await sm.spawn({ projectId, issueId: issue });
           created.push({ session: session.id, issue });
           spawnedIssues.add(issue.toLowerCase());
+          activeSessionCount += 1;
           console.log(chalk.green(`  Created ${session.id} for ${issue}`));
 
           if (opts.open) {
@@ -406,7 +428,7 @@ export function registerBatchSpawn(program: Command): void {
       }
       if (skipped.length > 0) {
         console.log(chalk.yellow(`Skipped ${skipped.length} issues:`));
-        for (const item of skipped) console.log(`  ${item.issue} (existing: ${item.existing})`);
+        for (const item of skipped) console.log(`  ${item.issue} (${item.reason})`);
       }
       if (failed.length > 0) {
         console.log(chalk.red(`Failed ${failed.length} issues:`));

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -482,6 +482,56 @@ describe("Config Schema Validation", () => {
 });
 
 describe("Config Defaults", () => {
+  it("accepts maxConcurrentSessions at defaults and project scope", () => {
+    const config = {
+      defaults: {
+        maxConcurrentSessions: 4,
+      },
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          maxConcurrentSessions: 2,
+        },
+      },
+    };
+
+    const validated = validateConfig(config);
+    expect(validated.defaults.maxConcurrentSessions).toBe(4);
+    expect(validated.projects.proj1.maxConcurrentSessions).toBe(2);
+  });
+
+  it("rejects non-positive maxConcurrentSessions", () => {
+    expect(() =>
+      validateConfig({
+        defaults: {
+          maxConcurrentSessions: 0,
+        },
+        projects: {
+          proj1: {
+            path: "/repos/test",
+            repo: "org/test",
+            defaultBranch: "main",
+          },
+        },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      validateConfig({
+        projects: {
+          proj1: {
+            path: "/repos/test",
+            repo: "org/test",
+            defaultBranch: "main",
+            maxConcurrentSessions: -1,
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
   it("applies default session prefix from project ID", () => {
     const config = {
       projects: {

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -3,12 +3,7 @@ import { mkdirSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { createSessionManager } from "../../session-manager.js";
 import { validateConfig } from "../../config.js";
-import {
-  writeMetadata,
-  readMetadata,
-  readMetadataRaw,
-  updateMetadata,
-} from "../../metadata.js";
+import { writeMetadata, readMetadata, readMetadataRaw, updateMetadata } from "../../metadata.js";
 import type {
   OrchestratorConfig,
   PluginRegistry,
@@ -93,6 +88,63 @@ describe("spawn", () => {
       "Project is paused due to model rate limit until",
     );
     expect(mockRuntime.create).not.toHaveBeenCalled();
+  });
+
+  it("blocks spawn when default maxConcurrentSessions is reached", async () => {
+    writeMetadata(sessionsDir, "app-9", {
+      worktree: join(tmpDir, "my-app"),
+      branch: "feat/existing",
+      status: "working",
+    });
+
+    const configWithLimit: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        maxConcurrentSessions: 1,
+      },
+    };
+
+    const sm = createSessionManager({ config: configWithLimit, registry: mockRegistry });
+
+    await expect(sm.spawn({ projectId: "my-app" })).rejects.toThrow(
+      "maxConcurrentSessions=1 reached (1 active sessions)",
+    );
+    expect(mockRuntime.create).not.toHaveBeenCalled();
+  });
+
+  it("uses project maxConcurrentSessions override and ignores terminal sessions", async () => {
+    writeMetadata(sessionsDir, "app-4", {
+      worktree: join(tmpDir, "my-app"),
+      branch: "feat/existing",
+      status: "working",
+    });
+    writeMetadata(sessionsDir, "app-5", {
+      worktree: join(tmpDir, "my-app"),
+      branch: "feat/completed",
+      status: "merged",
+    });
+
+    const configWithProjectLimit: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        maxConcurrentSessions: 1,
+      },
+      projects: {
+        ...config.projects,
+        "my-app": {
+          ...config.projects["my-app"],
+          maxConcurrentSessions: 2,
+        },
+      },
+    };
+
+    const sm = createSessionManager({ config: configWithProjectLimit, registry: mockRegistry });
+    const session = await sm.spawn({ projectId: "my-app" });
+
+    expect(session.id).toBe("app-6");
+    expect(mockRuntime.create).toHaveBeenCalledOnce();
   });
 
   it("uses issue ID to derive branch name", async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -15,7 +15,11 @@ import { resolve, join, basename } from "node:path";
 import { homedir } from "node:os";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
-import { ConfigNotFoundError, type ExternalPluginEntryRef, type OrchestratorConfig } from "./types.js";
+import {
+  ConfigNotFoundError,
+  type ExternalPluginEntryRef,
+  type OrchestratorConfig,
+} from "./types.js";
 import { generateSessionPrefix } from "./paths.js";
 
 function inferScmPlugin(project: {
@@ -189,6 +193,7 @@ const ProjectConfigSchema = z.object({
   runtime: z.string().optional(),
   agent: z.string().optional(),
   workspace: z.string().optional(),
+  maxConcurrentSessions: z.number().int().positive().optional(),
   tracker: TrackerConfigSchema.optional(),
   scm: SCMConfigSchema.optional(),
   symlinks: z.array(z.string()).optional(),
@@ -212,6 +217,7 @@ const DefaultPluginsSchema = z.object({
   agent: z.string().default("claude-code"),
   workspace: z.string().default("worktree"),
   notifiers: z.array(z.string()).default(["composio", "desktop"]),
+  maxConcurrentSessions: z.number().int().positive().optional(),
   orchestrator: RoleAgentDefaultsSchema,
   worker: RoleAgentDefaultsSchema,
 });
@@ -304,7 +310,9 @@ function generateTempPluginName(pkg?: string, path?: string): string {
     const packageName = slashParts[slashParts.length - 1] ?? pkg;
 
     // Extract plugin name after ao-plugin-{slot}- prefix, preserving multi-word names like "jira-cloud"
-    const prefixMatch = packageName.match(/^ao-plugin-(?:runtime|agent|workspace|tracker|scm|notifier|terminal)-(.+)$/);
+    const prefixMatch = packageName.match(
+      /^ao-plugin-(?:runtime|agent|workspace|tracker|scm|notifier|terminal)-(.+)$/,
+    );
     if (prefixMatch?.[1]) {
       return prefixMatch[1];
     }
@@ -438,8 +446,7 @@ function mergeExternalPlugins(
       // If the existing plugin is disabled but there's an inline reference, enable it
       const existingPlugin = plugins.find(
         (p) =>
-          (entry.package && p.package === entry.package) ||
-          (entry.path && p.path === entry.path),
+          (entry.package && p.package === entry.package) || (entry.path && p.path === entry.path),
       );
       if (existingPlugin && existingPlugin.enabled === false) {
         existingPlugin.enabled = true;

--- a/packages/core/src/orchestrator-prompt.ts
+++ b/packages/core/src/orchestrator-prompt.ts
@@ -46,7 +46,11 @@ Your role is to coordinate and manage worker agent sessions. You do NOT write co
 - **Default Branch**: ${project.defaultBranch}
 - **Session Prefix**: ${project.sessionPrefix}
 - **Local Path**: ${project.path}
-- **Dashboard Port**: ${config.port ?? 3000}`);
+- **Dashboard Port**: ${config.port ?? 3000}${
+    (project.maxConcurrentSessions ?? config.defaults.maxConcurrentSessions)
+      ? `\n- **Max Concurrent Sessions**: ${project.maxConcurrentSessions ?? config.defaults.maxConcurrentSessions}`
+      : ""
+  }`);
 
   // Quick Start
   sections.push(`## Quick Start
@@ -220,7 +224,7 @@ When an agent needs human judgment:
   // Tips
   sections.push(`## Tips
 
-1. **Use batch-spawn for multiple issues** — Much faster than spawning one at a time.
+1. **Use batch-spawn for multiple issues** — It's faster than spawning one at a time, but respect the configured session cap.
 
 2. **Check status before spawning** — Avoid creating duplicate sessions for issues already being worked on.
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -11,7 +11,15 @@
  * Reference: scripts/claude-ao-session, scripts/send-to-session
  */
 
-import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync, utimesSync, unlinkSync } from "node:fs";
+import {
+  statSync,
+  existsSync,
+  readdirSync,
+  writeFileSync,
+  mkdirSync,
+  utimesSync,
+  unlinkSync,
+} from "node:fs";
 import { execFile } from "node:child_process";
 import { basename, join, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -22,6 +30,7 @@ import {
   NON_RESTORABLE_STATUSES,
   SessionNotFoundError,
   SessionNotRestorableError,
+  TERMINAL_STATUSES,
   WorkspaceMissingError,
   type OpenCodeSessionManager,
   type Session,
@@ -297,7 +306,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     // ({prefix}-orchestrator-N) it will rarely exist, and pre-seeding it would
     // cause an unconditional extra readMetadataRaw on every hot-path invocation.
     const canonicalOrchestratorId = `${project.sessionPrefix}-orchestrator`;
-    const orchestratorPattern = new RegExp(`^${escapeRegex(project.sessionPrefix)}-orchestrator-(\\d+)$`);
+    const orchestratorPattern = new RegExp(
+      `^${escapeRegex(project.sessionPrefix)}-orchestrator-(\\d+)$`,
+    );
     const candidateIds = new Set<string>();
     for (const id of listMetadata(sessionsDir)) {
       if (id === canonicalOrchestratorId || orchestratorPattern.test(id)) {
@@ -324,6 +335,18 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     }
 
     return best;
+  }
+
+  function getMaxConcurrentSessions(project: ProjectConfig): number | undefined {
+    return project.maxConcurrentSessions ?? config.defaults.maxConcurrentSessions;
+  }
+
+  function countActiveSessionRecords(project: ProjectConfig): number {
+    return loadActiveSessionRecords(project).filter(({ raw }) => {
+      const status = raw["status"];
+      if (!status) return true;
+      return !TERMINAL_STATUSES.has(status as Session["status"]);
+    }).length;
   }
 
   function normalizePath(path: string): string {
@@ -797,8 +820,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     );
     // After config validation, plugin is always set if tracker/scm exists
     // (either from user config or auto-generated from package/path)
-    const tracker =
-      project.tracker?.plugin ? registry.get<Tracker>("tracker", project.tracker.plugin) : null;
+    const tracker = project.tracker?.plugin
+      ? registry.get<Tracker>("tracker", project.tracker.plugin)
+      : null;
     const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
 
     return { runtime, agent, workspace, tracker, scm };
@@ -987,6 +1011,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       throw new Error(
         `Project is paused due to model rate limit until ${pause.until.toISOString()} (${pause.reason}; source: ${pause.sourceSessionId})`,
       );
+    }
+
+    const maxConcurrentSessions = getMaxConcurrentSessions(project);
+    if (maxConcurrentSessions !== undefined) {
+      const activeSessionCount = countActiveSessionRecords(project);
+      if (activeSessionCount >= maxConcurrentSessions) {
+        throw new Error(
+          `Cannot spawn session for ${spawnConfig.projectId}: maxConcurrentSessions=${maxConcurrentSessions} reached (${activeSessionCount} active sessions). Wait for a session to finish or raise the limit.`,
+        );
+      }
     }
 
     const selection = resolveAgentSelection({
@@ -1493,7 +1527,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           AO_CALLER_TYPE: "orchestrator",
           AO_PROJECT_ID: orchestratorConfig.projectId,
           AO_CONFIG_PATH: config.configPath,
-          ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) }),
+          ...(config.port !== undefined &&
+            config.port !== null && { AO_PORT: String(config.port) }),
         },
       });
     } catch (err) {
@@ -2227,7 +2262,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     );
 
     for (const { sessionName, raw: otherRaw } of activeRecords) {
-      if (!otherRaw || isOrchestratorSessionRecord(sessionName, otherRaw, project.sessionPrefix)) continue;
+      if (!otherRaw || isOrchestratorSessionRecord(sessionName, otherRaw, project.sessionPrefix))
+        continue;
 
       const samePr = otherRaw["pr"] === pr.url;
       const sameBranch =

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -210,11 +210,7 @@ export function isOrchestratorSession(
   if (allSessionPrefixes) {
     for (const prefix of allSessionPrefixes) {
       if (prefix === sessionPrefix) continue;
-      if (
-        new RegExp(
-          `^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-\\d+$`,
-        ).test(session.id)
-      ) {
+      if (new RegExp(`^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-\\d+$`).test(session.id)) {
         return false;
       }
     }
@@ -662,7 +658,10 @@ export interface SCM {
    * @param observer - Optional observer for batch operation metrics
    * @returns Map keyed by "${owner}/${repo}#${number}" containing enrichment data
    */
-  enrichSessionsPRBatch?(prs: PRInfo[], observer?: BatchObserver): Promise<Map<string, PREnrichmentData>>;
+  enrichSessionsPRBatch?(
+    prs: PRInfo[],
+    observer?: BatchObserver,
+  ): Promise<Map<string, PREnrichmentData>>;
 }
 
 // --- PR Types ---
@@ -1083,6 +1082,7 @@ export interface DefaultPlugins {
   agent: string;
   workspace: string;
   notifiers: string[];
+  maxConcurrentSessions?: number;
   orchestrator?: {
     agent?: string;
   };
@@ -1142,6 +1142,9 @@ export interface ProjectConfig {
 
   /** Override default workspace */
   workspace?: string;
+
+  /** Maximum number of active non-terminal sessions allowed for this project */
+  maxConcurrentSessions?: number;
 
   /** Issue tracker configuration */
   tracker?: TrackerConfig;


### PR DESCRIPTION
## Summary
- add `maxConcurrentSessions` config support at the global defaults and per-project levels
- enforce the cap in core worker spawning before workspaces and runtimes are created
- stop `ao batch-spawn` once the active-session cap is reached and report skipped issues clearly
- surface the cap in the orchestrator prompt/example config and add regression coverage

## Why
AO currently encourages `ao batch-spawn`, but there is no hard limit on concurrent worker sessions. On resource-constrained machines, aggressive spawning can exhaust RAM and destabilize the host.

This change adds an explicit concurrency guard so the configured limit is enforced in the core spawn path and respected by the batch CLI flow.

## Validation
- `pnpm install`
- `pnpm --filter @composio/ao-core test -- src/__tests__/session-manager/spawn.test.ts src/__tests__/config-validation.test.ts src/__tests__/orchestrator-prompt.test.ts`
- `pnpm --filter @composio/ao-core build`
- `pnpm --filter @composio/ao-cli test -- __tests__/commands/spawn.test.ts`

Closes #916
