### PR TITLE
[codex] fix(cli): show tracker issues in status output

### DIFF
--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -432,6 +432,27 @@ describe("status command", () => {
     expect(output).toContain("Activity");
   });
 
+  it("shows tracker issue identifiers in the status table", async () => {
+    writeFileSync(
+      join(sessionsDir, "app-1"),
+      "worktree=/tmp/wt\nbranch=feat/status-column\nstatus=working\nissue=INT-123\n",
+    );
+
+    mockTmux.mockImplementation(async (...args: string[]) => {
+      if (args[0] === "list-sessions") return "app-1";
+      if (args[0] === "display-message") return String(Math.floor(Date.now() / 1000) - 60);
+      return null;
+    });
+    mockGit.mockResolvedValue("feat/status-column");
+
+    await program.parseAsync(["node", "test", "status"]);
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    const plainOutput = output.replace(/\u001b\[[0-9;]*m/g, "");
+    expect(plainOutput).toContain("Issue");
+    expect(plainOutput).toMatch(/app-1\s+INT-123\s+feat\/status-column/);
+  });
+
   it("shows PR number, CI status, review decision, and threads", async () => {
     writeFileSync(
       join(sessionsDir, "app-1"),
@@ -579,6 +600,55 @@ describe("status command", () => {
     expect(parsed[0].ciStatus).toBe("passing");
     expect(parsed[0].reviewDecision).toBe("pending");
     expect(parsed[0].pendingThreads).toBe(0);
+  });
+
+  it("includes issueUrl in JSON output when a tracker is configured", async () => {
+    writeFileSync(
+      join(sessionsDir, "app-1"),
+      "worktree=/tmp/wt\nbranch=feat/json-issue\nstatus=working\nissue=INT-123\n",
+    );
+
+    mockConfigRef.current = {
+      ...(mockConfigRef.current as Record<string, unknown>),
+      projects: {
+        "my-app": {
+          ...((mockConfigRef.current as { projects: Record<string, unknown> }).projects["my-app"] as Record<
+            string,
+            unknown
+          >),
+          tracker: { plugin: "linear", workspaceSlug: "acme" },
+        },
+      },
+    } as Record<string, unknown>;
+
+    const mockTracker = {
+      issueUrl: vi.fn().mockReturnValue("https://linear.app/acme/issue/INT-123"),
+    };
+    mockGetPluginRegistry.mockResolvedValueOnce({
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "tracker" && name === "linear") return mockTracker;
+        return null;
+      }),
+      list: vi.fn(),
+      register: vi.fn(),
+    });
+
+    mockTmux.mockImplementation(async (...args: string[]) => {
+      if (args[0] === "list-sessions") return "app-1";
+      if (args[0] === "display-message") return String(Math.floor(Date.now() / 1000));
+      return null;
+    });
+    mockGit.mockResolvedValue("feat/json-issue");
+
+    await program.parseAsync(["node", "test", "status", "--json"]);
+
+    const parsed = JSON.parse(consoleSpy.mock.calls.map((c) => c[0]).join(""));
+    expect(parsed[0].issue).toBe("INT-123");
+    expect(parsed[0].issueUrl).toBe("https://linear.app/acme/issue/INT-123");
+    expect(mockTracker.issueUrl).toHaveBeenCalledWith(
+      "INT-123",
+      expect.objectContaining({ tracker: { plugin: "linear", workspaceSlug: "acme" } }),
+    );
   });
 
   it("rejects --watch with --json", async () => {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -36,6 +36,7 @@ interface SessionInfo {
   pr: string | null;
   prNumber: number | null;
   issue: string | null;
+  issueUrl: string | null;
   lastActivity: string;
   project: string | null;
   ciStatus: CIStatus | null;
@@ -72,9 +73,11 @@ async function gatherSessionInfo(
   session: Session,
   agent: Agent,
   scm: SCM,
+  tracker: Tracker | null,
   projectConfig: ReturnType<typeof loadConfig>,
 ): Promise<SessionInfo> {
-  const sessionPrefix = projectConfig.projects[session.projectId]?.sessionPrefix ?? session.projectId;
+  const project = projectConfig.projects[session.projectId];
+  const sessionPrefix = project?.sessionPrefix ?? session.projectId;
   const allSessionPrefixes = Object.entries(projectConfig.projects).map(
     ([id, p]) => p.sessionPrefix ?? id,
   );
@@ -84,11 +87,20 @@ async function gatherSessionInfo(
   const summary = session.metadata["summary"] ?? null;
   const prUrl = suppressPROwnership ? null : (session.metadata["pr"] ?? null);
   const issue = session.issueId;
+  let issueUrl: string | null = null;
 
   // Get live branch from worktree if available
   if (session.workspacePath) {
     const liveBranch = await git(["branch", "--show-current"], session.workspacePath);
     if (liveBranch) branch = liveBranch;
+  }
+
+  if (issue && tracker && project) {
+    try {
+      issueUrl = tracker.issueUrl(issue, project);
+    } catch {
+      // Tracker URL generation failed — not critical
+    }
   }
 
   // Get last activity time from tmux
@@ -124,7 +136,6 @@ async function gatherSessionInfo(
 
   if (branch && !suppressPROwnership) {
     try {
-      const project = projectConfig.projects[session.projectId];
       if (project) {
         const prInfo: PRInfo | null = await scm.detectPR(session, project);
         if (prInfo) {
@@ -156,6 +167,7 @@ async function gatherSessionInfo(
     pr: prUrl,
     prNumber,
     issue,
+    issueUrl,
     lastActivity,
     project: session.projectId,
     ciStatus,
@@ -168,7 +180,8 @@ async function gatherSessionInfo(
 // Column widths for the table
 const COL = {
   session: 14,
-  branch: 24,
+  issue: 12,
+  branch: 22,
   pr: 6,
   ci: 6,
   review: 6,
@@ -180,6 +193,7 @@ const COL = {
 function printTableHeader(): void {
   const hdr =
     padCol("Session", COL.session) +
+    padCol("Issue", COL.issue) +
     padCol("Branch", COL.branch) +
     padCol("PR", COL.pr) +
     padCol("CI", COL.ci) +
@@ -189,7 +203,15 @@ function printTableHeader(): void {
     "Age";
   console.log(chalk.dim(`  ${hdr}`));
   const totalWidth =
-    COL.session + COL.branch + COL.pr + COL.ci + COL.review + COL.threads + COL.activity + 3;
+    COL.session +
+    COL.issue +
+    COL.branch +
+    COL.pr +
+    COL.ci +
+    COL.review +
+    COL.threads +
+    COL.activity +
+    3;
   console.log(chalk.dim(`  ${"─".repeat(totalWidth)}`));
 }
 
@@ -198,6 +220,7 @@ function printSessionRow(info: SessionInfo): void {
 
   const row =
     padCol(chalk.green(info.name), COL.session) +
+    padCol(info.issue ? chalk.yellow(info.issue) : chalk.dim("-"), COL.issue) +
     padCol(info.branch ? chalk.cyan(info.branch) : chalk.dim("-"), COL.branch) +
     padCol(info.prNumber ? chalk.blue(prStr) : chalk.dim(prStr), COL.pr) +
     padCol(ciStatusIcon(info.ciStatus), COL.ci) +
@@ -321,6 +344,9 @@ export function registerStatus(program: Command): void {
           const agentName = projectConfig.agent ?? config.defaults.agent;
           const agent = getAgentByNameFromRegistry(registry, agentName);
           const scm = getSCMFromRegistry(registry, config, projectId);
+          const tracker = projectConfig.tracker?.plugin
+            ? registry.get<Tracker>("tracker", projectConfig.tracker.plugin)
+            : null;
 
           if (!opts.json) {
             console.log(header(projectConfig.name || projectId));
@@ -335,7 +361,9 @@ export function registerStatus(program: Command): void {
           }
 
           // Gather all session info in parallel
-          const infoPromises = projectSessions.map((s) => gatherSessionInfo(s, agent, scm, config));
+          const infoPromises = projectSessions.map((s) =>
+            gatherSessionInfo(s, agent, scm, tracker, config),
+          );
           const sessionInfos = await Promise.all(infoPromises);
 
           const orchestrators = sessionInfos.filter((info) => info.role === "orchestrator");


### PR DESCRIPTION
## Summary
- add an `Issue` column to `ao status` so active sessions show their tracker identifier inline
- include `issueUrl` in `ao status --json` by resolving it through the configured tracker plugin
- add focused status-command tests for both terminal and JSON output

## Why
`gatherSessionInfo()` already captured `session.issueId`, but the status renderer never surfaced it. That made it hard to map a running session back to its GitHub or Linear issue without inspecting raw session metadata files.

## Validation
- `pnpm --filter @composio/ao-cli test -- __tests__/commands/status.test.ts`
- `pnpm --filter @composio/ao-cli typecheck`

Closes #303
