### PR TITLE
docs: add Hermes plugin install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,26 @@ Seven plugin slots. Lifecycle stays in core.
 
 All interfaces defined in [`packages/core/src/types.ts`](packages/core/src/types.ts). A plugin implements one interface and exports a `PluginModule`. That's it.
 
+## Integrations
+
+### Hermes (Discord / Telegram)
+
+Control Agent Orchestrator from chat using the [Hermes](https://github.com/NousResearch/hermes-agent) plugin — spawn agents, check status, manage issues, and merge PRs without leaving Discord or Telegram.
+
+```bash
+hermes plugins install illegalcall/hermes-plugin-agent-orchestrator
+```
+
+Add to `~/.hermes/.env`:
+
+```env
+AO_CWD=/path/to/your/agent-orchestrator   # repo root with agent-orchestrator.yaml
+```
+
+Restart the gateway and you're set. 17 tools available — say "what's happening?" to see live sessions, "spawn #42" to start an agent, or "doctor" to run health checks.
+
+See the [plugin repo](https://github.com/illegalcall/hermes-plugin-agent-orchestrator) for the full tool list and configuration options.
+
 ## Why Agent Orchestrator?
 
 Running one AI agent in a terminal is easy. Running 30 across different issues, branches, and PRs is a coordination problem.

--- a/README.md
+++ b/README.md
@@ -158,21 +158,25 @@ All interfaces defined in [`packages/core/src/types.ts`](packages/core/src/types
 
 ### Hermes (Discord / Telegram)
 
-Control Agent Orchestrator from chat using the [Hermes](https://github.com/NousResearch/hermes-agent) plugin — spawn agents, check status, manage issues, and merge PRs without leaving Discord or Telegram.
+Control Agent Orchestrator from chat using the [Hermes](https://github.com/NousResearch/hermes-agent) plugin — spawn agents, check status, manage issues, and merge PRs without leaving Discord or Telegram. 17 tools + 1 context-injection hook.
+
+**Install:**
 
 ```bash
-hermes plugins install illegalcall/hermes-plugin-agent-orchestrator
+pip install hermes-ao
 ```
 
-Add to `~/.hermes/.env`:
+**Configure** (add to your shell profile or `~/.hermes/.env`):
 
-```env
-AO_CWD=/path/to/your/agent-orchestrator   # repo root with agent-orchestrator.yaml
+```bash
+export AO_CWD=/path/to/your/project          # where agent-orchestrator.yaml lives (required)
+export AO_API_URL=http://localhost:3000        # AO server URL (default: http://127.0.0.1:3000)
+export AO_PUBLIC_URL=http://your-server:3000   # public dashboard URL for links (optional)
 ```
 
-Restart the gateway and you're set. 17 tools available — say "what's happening?" to see live sessions, "spawn #42" to start an agent, or "doctor" to run health checks.
+**Restart Hermes** and you're set. Say "what's happening?" to see live sessions, "spawn #42" to start an agent, or "doctor" to run health checks.
 
-See the [plugin repo](https://github.com/illegalcall/hermes-plugin-agent-orchestrator) for the full tool list and configuration options.
+See the [plugin repo](https://github.com/illegalcall/hermes-plugin-agent-orchestrator) for the full tool list, architecture details, and alternative install methods.
 
 ## Why Agent Orchestrator?
 


### PR DESCRIPTION
## Summary
- Updates the **Integrations** section in the README with install instructions for the Hermes AO plugin
- Primary install method: `pip install hermes-ao` ([PyPI](https://pypi.org/project/hermes-ao/))
- Includes env var configuration (`AO_CWD`, `AO_API_URL`, `AO_PUBLIC_URL`)
- Links to the [plugin repo](https://github.com/illegalcall/hermes-plugin-agent-orchestrator) for full docs, tool list, and alternative install methods

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Confirm plugin repo link resolves
- [x] Confirm PyPI package link resolves
- [x] Plugin repo restructured as pip-installable package with 115 passing tests

Generated with [Claude Code](https://claude.com/claude-code)