### PR TITLE
fix(web): guard fit.fit() calls against undefined dimensions

### DIFF
--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -341,7 +341,7 @@ export function DirectTerminal({
         }
 
         // Fit terminal to container
-        fit.fit();
+        try { fit.fit(); } catch { /* dimensions not ready yet */ }
 
         // Deferred fit to handle cases where container wasn't sized yet
         const deferredFitTimeout = setTimeout(() => {
@@ -516,7 +516,7 @@ export function DirectTerminal({
         // Handle window resize
         const handleResize = () => {
           if (fit) {
-            fit.fit();
+            try { fit.fit(); } catch { /* dimensions not ready yet */ }
             resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
           }
         };
@@ -648,7 +648,7 @@ export function DirectTerminal({
 
       // Container is at target size, now resize terminal
       terminal.refresh(0, terminal.rows - 1);
-      fit.fit();
+      try { fit.fit(); } catch { /* dimensions not ready yet */ }
       terminal.refresh(0, terminal.rows - 1);
 
       // Send new size to server via mux

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -70,6 +70,19 @@ function getStoredFontSize(): number {
   return FONT_SIZE_DEFAULT;
 }
 
+/**
+ * Call fit.fit() and return true on success, false if the terminal's render
+ * service hasn't initialised its dimensions yet (xterm race condition).
+ */
+export function safeFit(fit: FitAddonType): boolean {
+  try {
+    fit.fit();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 interface DirectTerminalProps {
   sessionId: string;
   startFullscreen?: boolean;
@@ -341,7 +354,7 @@ export function DirectTerminal({
         }
 
         // Fit terminal to container
-        try { fit.fit(); } catch { /* dimensions not ready yet */ }
+        safeFit(fit);
 
         // Deferred fit to handle cases where container wasn't sized yet
         const deferredFitTimeout = setTimeout(() => {
@@ -516,7 +529,7 @@ export function DirectTerminal({
         // Handle window resize
         const handleResize = () => {
           if (fit) {
-            try { fit.fit(); } catch { /* dimensions not ready yet */ }
+            if (!safeFit(fit)) return; // dimensions not ready — skip sending stale size
             resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
           }
         };
@@ -583,7 +596,7 @@ export function DirectTerminal({
     const fit = fitAddon.current;
     const terminal = terminalInstance.current;
     if (!fit || !terminal) return;
-    fit.fit();
+    if (!safeFit(fit)) return; // dimensions not ready — skip sending stale size
     resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
   }, [muxStatus, sessionId, resizeTerminalMux]);
 
@@ -611,7 +624,7 @@ export function DirectTerminal({
     // Without the mux resize, the shell keeps wrapping at the old dimensions
     // and the rendered output stops matching the visible grid until the
     // next resize event (window resize, tab switch, etc.).
-    fit.fit();
+    if (!safeFit(fit)) return; // dimensions not ready — skip sending stale size
     resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
   }, [fontSize, sessionId, resizeTerminalMux]);
 
@@ -648,7 +661,7 @@ export function DirectTerminal({
 
       // Container is at target size, now resize terminal
       terminal.refresh(0, terminal.rows - 1);
-      try { fit.fit(); } catch { /* dimensions not ready yet */ }
+      if (!safeFit(fit)) return; // dimensions not ready — skip sending stale size
       terminal.refresh(0, terminal.rows - 1);
 
       // Send new size to server via mux

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -186,4 +186,37 @@ describe("DirectTerminal render", () => {
     expect(terminalShell).toHaveClass("relative");
     expect(terminalShell).not.toHaveClass("fixed");
   });
+
+  it("handles window resize without throwing when terminal is initialised", async () => {
+    render(<DirectTerminal sessionId="resize-test" variant="agent" />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Connected")).toBeInTheDocument(),
+    );
+
+    // Let the async terminal setup (Promise.all + terminal.open) complete
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    // Dispatch resize — exercises the handleResize → safeFit path
+    expect(() => window.dispatchEvent(new Event("resize"))).not.toThrow();
+  });
+
+  it("handles window resize gracefully when fit throws", async () => {
+    const fitSpy = vi.spyOn(MockFitAddon.prototype, "fit").mockImplementation(() => {
+      throw new TypeError("Cannot read properties of undefined (reading 'dimensions')");
+    });
+
+    render(<DirectTerminal sessionId="resize-throw-test" variant="agent" />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Connected")).toBeInTheDocument(),
+    );
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    // Resize must not propagate the TypeError
+    expect(() => window.dispatchEvent(new Event("resize"))).not.toThrow();
+
+    fitSpy.mockRestore();
+  });
 });

--- a/packages/web/src/components/__tests__/DirectTerminal.test.ts
+++ b/packages/web/src/components/__tests__/DirectTerminal.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it, expect } from "vitest";
-import { buildTerminalThemes, resolveMonoFontFamily } from "@/components/DirectTerminal";
+import { buildTerminalThemes, resolveMonoFontFamily, safeFit } from "@/components/DirectTerminal";
+import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
 
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 const ANSI_KEYS = [
@@ -118,5 +119,19 @@ describe("resolveMonoFontFamily", () => {
       "__JetBrains_Mono_abc123",
     );
     expect(resolveMonoFontFamily()).not.toMatch(/var\(/);
+  });
+});
+
+describe("safeFit", () => {
+  it("returns true when fit() succeeds", () => {
+    const addon = { fit: () => {} } as unknown as FitAddonType;
+    expect(safeFit(addon)).toBe(true);
+  });
+
+  it("returns false when fit() throws (dimensions not ready)", () => {
+    const addon = {
+      fit: () => { throw new TypeError("Cannot read properties of undefined (reading 'dimensions')"); },
+    } as unknown as FitAddonType;
+    expect(safeFit(addon)).toBe(false);
   });
 });

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,7 +1,11 @@
 import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const xtermDir = dirname(require.resolve("@xterm/xterm/package.json"));
 
 export default defineConfig({
   plugins: [
@@ -68,6 +72,7 @@ export default defineConfig({
         find: "@aoagents/ao-plugin-tracker-linear",
         replacement: resolve(__dirname, "../plugins/tracker-linear/src/index.ts"),
       },
+      { find: "@xterm/xterm", replacement: xtermDir },
       { find: "server-only", replacement: resolve(__dirname, "./src/__tests__/server-only-mock.ts") },
       { find: "@", replacement: resolve(__dirname, "./src") },
     ],


### PR DESCRIPTION
## Summary
- Wraps all three `fit.fit()` calls in `DirectTerminal.tsx` with try-catch to prevent the runtime TypeError "Cannot read properties of undefined (reading 'dimensions')"
- The xterm.js FitAddon's `fit()` method accesses the terminal's internal render service dimensions, which may not be initialized during initial open, window resize, or fullscreen transitions
- The fix gracefully catches and ignores this transient error — the next resize/fit cycle will succeed once dimensions are available

Closes #936

## Test plan
- [ ] Open a session detail page and verify the terminal renders without errors
- [ ] Resize the browser window and confirm no console errors
- [ ] Toggle fullscreen on the terminal and confirm no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)