### PR TITLE
fix(web): handle network TypeError in SessionPage fetch

### DIFF
--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -196,6 +196,7 @@ export default function SessionPage() {
   const resolvedProjectSessionsKeyRef = useRef<string | null>(null);
   const prefixByProjectRef = useRef<Map<string, string>>(new Map());
   const hasLoadedSessionRef = useRef(cachedSession !== null);
+  const fetchFailCountRef = useRef(0);
   const pendingMuxSessionsRef = useRef<SessionPatch[] | null>(null);
   // In-flight guards — prevent concurrent duplicate fetches
   const fetchingSessionRef = useRef(false);
@@ -260,13 +261,14 @@ export default function SessionPage() {
   const fetchSession = useCallback(async () => {
     if (fetchingSessionRef.current) return;
     fetchingSessionRef.current = true;
+    let keepLoading = false;
     try {
       const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`);
       if (res.status === 404) {
+        fetchFailCountRef.current = 0;
         if (!hasLoadedSessionRef.current) {
           setSessionMissing(true);
         }
-        setLoading(false);
         return;
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -275,13 +277,29 @@ export default function SessionPage() {
       setRouteError(null);
       setSessionMissing(false);
       hasLoadedSessionRef.current = true;
+      fetchFailCountRef.current = 0;
     } catch (err) {
-      console.error("Failed to fetch session:", err);
+      const isNetworkError = err instanceof TypeError;
+      fetchFailCountRef.current++;
+      // Only log the first consecutive failure to avoid console spam during polling
+      if (fetchFailCountRef.current === 1) {
+        console.error("Failed to fetch session:", err);
+      }
       if (!hasLoadedSessionRef.current) {
-        setRouteError(err instanceof Error ? err : new Error("Failed to load session"));
+        // For network errors (e.g. proxy misconfiguration, offline), give the
+        // polling loop a few attempts before surfacing a fatal error — the
+        // failure may be transient. Keep loading=true so the render shows the
+        // spinner instead of hitting the final throw guard.
+        if (isNetworkError && fetchFailCountRef.current < 4) {
+          keepLoading = true;
+        } else {
+          setRouteError(err instanceof Error ? err : new Error("Failed to load session"));
+        }
       }
     } finally {
-      setLoading(false);
+      if (!keepLoading) {
+        setLoading(false);
+      }
       fetchingSessionRef.current = false;
     }
   }, [id]);


### PR DESCRIPTION
## Summary
- Fixes `TypeError: Failed to fetch` console spam in `SessionPage` when the Next.js server is behind a reverse proxy (e.g. Caddy) that causes relative-URL `fetch()` calls to fail with a network error
- Only logs the **first** consecutive fetch failure instead of every 5-second poll
- For network errors (`TypeError`) during initial page load, gives the polling loop **3 attempts** before surfacing a fatal error — transient failures (proxy restart, brief network blip) now self-heal
- Resets the failure counter on any successful fetch

## Test plan
- [x] Build passes (`pnpm build`)
- [ ] Open a session detail page — verify it loads normally
- [ ] Simulate network failure (e.g. DevTools offline mode) — verify only one console error appears, not continuous spam
- [ ] Restore network — verify the page recovers on next poll without requiring a refresh

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)