### PR TITLE
fix: restore PR details, CI checks, and comments on session detail page (#940)

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1300,6 +1300,90 @@ describe("reactions", () => {
     expect(metadata?.["lastMergeConflictDispatched"]).toBeFalsy();
   });
 
+  it("checkSession skips PR reaction dispatches for sessions with prOwnership='stale'", async () => {
+    config.reactions = {
+      "changes-requested": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Handle review comments.",
+      },
+      "merge-conflicts": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Resolve merge conflicts.",
+      },
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        message: "CI is failing.",
+        retries: 3,
+        escalateAfter: 3,
+      },
+    };
+
+    const mockSCM = createMockSCM({
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIChecks: vi.fn().mockResolvedValue([
+        { name: "lint", status: "failed", conclusion: "FAILURE" },
+      ]),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please fix this",
+          path: "src/index.ts",
+          line: 10,
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: false,
+        ciPassing: false,
+        approved: false,
+        noConflicts: false,
+        blockers: ["Merge conflicts"],
+      }),
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    // First poll without stale — establishes the pr_open state
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    const lm = setupCheck("app-1", { session, registry });
+    await lm.check("app-1");
+
+    // Transition reaction fires for the ci_failed transition, which is expected.
+    // Clear send calls so we can isolate the dispatch guard behavior.
+    vi.mocked(mockSessionManager.send).mockClear();
+
+    // Now update the session to have prOwnership='stale' and re-mock get()
+    const staleSession = makeSession({
+      status: "ci_failed",
+      pr: makePR(),
+      metadata: { prOwnership: "stale" },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(staleSession);
+
+    // Second poll: session stays ci_failed — dispatch functions would normally fire
+    // (e.g., CI failure details, review backlog, merge conflicts)
+    // but prOwnership='stale' should suppress all of them.
+    await lm.check("app-1");
+
+    // Status is still tracked correctly
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+
+    // None of the dispatch functions should have sent messages
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
+  });
+
   it("notifies humans on significant transitions without reaction config", async () => {
     const notifier = createMockNotifier();
     const mockSCM = createMockSCM({ getPRState: vi.fn().mockResolvedValue("merged") });

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createSessionManager } from "../session-manager.js";
-import { writeMetadata } from "../metadata.js";
+import { writeMetadata, readMetadataRaw } from "../metadata.js";
 import type { OrchestratorConfig, PluginRegistry, Agent } from "../types.js";
 import { setupTestContext, teardownTestContext, makeHandle, type TestContext } from "./test-utils.js";
 
@@ -279,5 +279,160 @@ describe("deleteSession retry loop", () => {
 
     // Verify delete was called only once - no retries for "not found" errors
     expect(deleteCallCount).toBe(1);
+  });
+});
+
+describe("prOwnership duplicate PR repair", () => {
+  it("duplicate PR dedup sets prOwnership='stale' on non-owner session", async () => {
+    const prUrl = "https://github.com/org/my-app/pull/99";
+
+    // Session app-1 has pr_open status — should be the owner
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp/ws1",
+      branch: "feat/a",
+      status: "pr_open",
+      project: "my-app",
+      agent: "opencode",
+      pr: prUrl,
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    // Session app-2 has working status and same PR — should become stale
+    writeMetadata(sessionsDir, "app-2", {
+      worktree: "/tmp/ws2",
+      branch: "feat/b",
+      status: "working",
+      project: "my-app",
+      agent: "opencode",
+      pr: prUrl,
+      runtimeHandle: JSON.stringify(makeHandle("rt-2")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const sessions = await sm.list("my-app");
+
+    // The stale session (app-2) should have prOwnership='stale' in metadata
+    const staleSession = sessions.find((s) => s.id === "app-2");
+    expect(staleSession).toBeDefined();
+    expect(staleSession!.metadata["prOwnership"]).toBe("stale");
+
+    // Also verify on disk
+    const rawOnDisk = readMetadataRaw(sessionsDir, "app-2");
+    expect(rawOnDisk).not.toBeNull();
+    expect(rawOnDisk!["prOwnership"]).toBe("stale");
+
+    // The owner session (app-1) should NOT have prOwnership set
+    const ownerSession = sessions.find((s) => s.id === "app-1");
+    expect(ownerSession).toBeDefined();
+    expect(ownerSession!.metadata["prOwnership"]).toBeUndefined();
+  });
+
+  it("stale session preserves pr URL in metadata after dedup", async () => {
+    const prUrl = "https://github.com/org/my-app/pull/100";
+
+    // Session app-1 has pr_open status — owner
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp/ws1",
+      branch: "feat/a",
+      status: "pr_open",
+      project: "my-app",
+      agent: "opencode",
+      pr: prUrl,
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    // Session app-2 has working status and same PR — will become stale
+    writeMetadata(sessionsDir, "app-2", {
+      worktree: "/tmp/ws2",
+      branch: "feat/b",
+      status: "working",
+      project: "my-app",
+      agent: "opencode",
+      pr: prUrl,
+      runtimeHandle: JSON.stringify(makeHandle("rt-2")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.list("my-app");
+
+    // The stale session's PR URL must be preserved (not erased)
+    const rawOnDisk = readMetadataRaw(sessionsDir, "app-2");
+    expect(rawOnDisk).not.toBeNull();
+    expect(rawOnDisk!["pr"]).toBe(prUrl);
+  });
+
+  it("sole session with prOwnership='stale' gets promoted", async () => {
+    const prUrl = "https://github.com/org/my-app/pull/101";
+
+    // A single session that has a PR URL but was previously marked stale
+    // (the original owner was killed/cleaned up)
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp/ws1",
+      branch: "feat/a",
+      status: "working",
+      project: "my-app",
+      agent: "opencode",
+      pr: prUrl,
+      prOwnership: "stale",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const sessions = await sm.list("my-app");
+
+    // The sole session should have prOwnership cleared (promoted)
+    const session = sessions.find((s) => s.id === "app-1");
+    expect(session).toBeDefined();
+    expect(session!.metadata["prOwnership"]).toBeUndefined();
+
+    // Verify on disk: prOwnership key should be removed
+    const rawOnDisk = readMetadataRaw(sessionsDir, "app-1");
+    expect(rawOnDisk).not.toBeNull();
+    expect(rawOnDisk!["prOwnership"]).toBeUndefined();
+  });
+
+  it("status reset to working for stale sessions in tracking statuses", async () => {
+    const prUrl = "https://github.com/org/my-app/pull/102";
+
+    // Session app-1 has pr_open and more recent timestamp — should be owner
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp/ws1",
+      branch: "feat/a",
+      status: "pr_open",
+      project: "my-app",
+      agent: "opencode",
+      pr: prUrl,
+      createdAt: new Date().toISOString(),
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    // Session app-2 also has pr_open and same PR — the stale one should be
+    // reset to "working" since pr_open is a PR tracking status
+    writeMetadata(sessionsDir, "app-2", {
+      worktree: "/tmp/ws2",
+      branch: "feat/b",
+      status: "pr_open",
+      project: "my-app",
+      agent: "opencode",
+      pr: prUrl,
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+      runtimeHandle: JSON.stringify(makeHandle("rt-2")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const sessions = await sm.list("my-app");
+
+    // Find the stale session (the one with prOwnership='stale')
+    const staleSession = sessions.find((s) => s.metadata["prOwnership"] === "stale");
+    expect(staleSession).toBeDefined();
+
+    // The stale session's status should have been reset to "working"
+    expect(staleSession!.status).toBe("working");
+
+    // Verify on disk
+    const rawOnDisk = readMetadataRaw(sessionsDir, staleSession!.id);
+    expect(rawOnDisk).not.toBeNull();
+    expect(rawOnDisk!["status"]).toBe("working");
+    expect(rawOnDisk!["prOwnership"]).toBe("stale");
   });
 });

--- a/packages/core/src/__tests__/session-manager/claim-pr.test.ts
+++ b/packages/core/src/__tests__/session-manager/claim-pr.test.ts
@@ -214,8 +214,9 @@ describe("claimPR", () => {
     expect(orchestrator!["status"]).toBe("working");
 
     const staleWorker = readMetadataRaw(sessionsDir, "app-1");
-    expect(staleWorker!["pr"]).toBeUndefined();
-    expect(staleWorker!["prAutoDetect"]).toBe("off");
+    // Stale sessions preserve PR URL but get prOwnership="stale" (non-destructive repair)
+    expect(staleWorker!["pr"]).toBe("https://github.com/org/my-app/pull/42");
+    expect(staleWorker!["prOwnership"]).toBe("stale");
     expect(staleWorker!["status"]).toBe("working");
 
     const activeWorker = readMetadataRaw(sessionsDir, "app-2");
@@ -261,8 +262,9 @@ describe("claimPR", () => {
     expect(result.takenOverFrom).toEqual(["app-2"]);
 
     const staleWorker = readMetadataRaw(sessionsDir, "app-1");
-    expect(staleWorker!["pr"]).toBeUndefined();
-    expect(staleWorker!["prAutoDetect"]).toBe("off");
+    // Stale sessions preserve PR URL but get prOwnership="stale" (non-destructive repair)
+    expect(staleWorker!["pr"]).toBe("https://github.com/org/my-app/pull/42");
+    expect(staleWorker!["prOwnership"]).toBe("stale");
 
     const activeWorker = readMetadataRaw(sessionsDir, "app-2");
     expect(activeWorker!["pr"]).toBeUndefined();

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1229,8 +1229,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
         if (reactionKey) {
           const reactionConfig = getReactionConfigForSession(session, reactionKey);
+          // Skip automated reactions for stale PR owners — they don't own
+          // the PR and shouldn't send messages to agents or trigger auto-merge.
+          // Human notifications still fire below so operators see the transition.
+          const skipReaction = session.metadata["prOwnership"] === "stale";
 
-          if (reactionConfig && reactionConfig.action) {
+          if (reactionConfig && reactionConfig.action && !skipReaction) {
             // auto: false skips automated agent actions but still allows notifications
             if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
               const reactionResult = await executeReaction(
@@ -1268,11 +1272,21 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       states.set(session.id, newStatus);
     }
 
-    await Promise.allSettled([
-      maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction),
-      maybeDispatchCIFailureDetails(session, oldStatus, newStatus, transitionReaction),
-      maybeDispatchMergeConflicts(session, newStatus),
-    ]);
+    // For stale PR owners: skip dispatches for non-terminal states (no duplicate
+    // notifications), but allow terminal transitions (merged/killed) through so
+    // dispatch helpers can run their cleanup paths (clearing CI fingerprints,
+    // merge conflict tracking, etc.).
+    const isStaleOwner = session.metadata["prOwnership"] === "stale";
+    const isTerminal = newStatus === "merged" || newStatus === "killed";
+    if (isStaleOwner && !isTerminal) {
+      // Non-terminal stale session: skip dispatches entirely (no cleanup needed)
+    } else {
+      await Promise.allSettled([
+        maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction),
+        maybeDispatchCIFailureDetails(session, oldStatus, newStatus, transitionReaction),
+        maybeDispatchMergeConflicts(session, newStatus),
+      ]);
+    }
   }
 
   /** Run one polling cycle across all sessions. */

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -478,12 +478,26 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       for (const record of staleRecords) {
         const updates: Partial<Record<string, string>> = {
-          pr: "",
-          prAutoDetect: "off",
+          prOwnership: "stale",
           ...(PR_TRACKING_STATUSES.has(record.raw["status"] ?? "") ? { status: "working" } : {}),
         };
         updateMetadataPreservingMtime(sessionsDir, record.sessionName, updates, record.modifiedAt);
         record.raw = applyMetadataUpdatesToRaw(record.raw, updates);
+      }
+    }
+
+    // Promote stale sessions that are now the sole owner of their PR
+    // (original owner was killed/cleaned up, metadata deleted)
+    for (const attachedRecords of duplicatePRAttachments.values()) {
+      if (attachedRecords.length === 1 && attachedRecords[0].raw["prOwnership"] === "stale") {
+        const updates = { prOwnership: "" };
+        updateMetadataPreservingMtime(
+          sessionsDir,
+          attachedRecords[0].sessionName,
+          updates,
+          attachedRecords[0].modifiedAt,
+        );
+        attachedRecords[0].raw = applyMetadataUpdatesToRaw(attachedRecords[0].raw, updates);
       }
     }
 
@@ -2160,6 +2174,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     for (const { sessionName, raw: otherRaw } of activeRecords) {
       if (!otherRaw || isOrchestratorSessionRecord(sessionName, otherRaw, project.sessionPrefix)) continue;
+      // Skip sessions already marked as stale PR owners — they don't actively own the PR
+      if (otherRaw["prOwnership"] === "stale") continue;
 
       const samePr = otherRaw["pr"] === pr.url;
       const sameBranch =
@@ -2184,6 +2200,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       status: "pr_open",
       branch: pr.branch,
       prAutoDetect: "",
+      prOwnership: "", // Clear stale flag if this session was previously marked stale
     });
 
     for (const previousSessionId of takenOverFrom) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1377,6 +1377,7 @@ export interface SessionMetadata {
   issue?: string;
   pr?: string;
   prAutoDetect?: "on" | "off";
+  prOwnership?: "stale" | "";
   summary?: string;
   project?: string;
   agent?: string; // Agent plugin name (e.g. "codex", "claude-code") — persisted for lifecycle

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -203,6 +203,7 @@ import { POST as killPOST } from "@/app/api/sessions/[id]/kill/route";
 import { POST as restorePOST } from "@/app/api/sessions/[id]/restore/route";
 import { POST as remapPOST } from "@/app/api/sessions/[id]/remap/route";
 import { POST as mergePOST } from "@/app/api/prs/[id]/merge/route";
+import { GET as sessionDetailGET } from "@/app/api/sessions/[id]/route";
 import { GET as eventsGET } from "@/app/api/events/route";
 import { GET as observabilityGET } from "@/app/api/observability/route";
 import { GET as runtimeTerminalGET } from "@/app/api/runtime/terminal/route";
@@ -361,6 +362,82 @@ describe("API Routes", () => {
       await vi.advanceTimersByTimeAsync(5_000);
       const res = await responsePromise;
       expect(res.status).toBe(200);
+
+      metadataSpy.mockRestore();
+      enrichSpy.mockRestore();
+      vi.useRealTimers();
+    });
+  });
+
+  // ── GET /api/sessions/:id ─────────────────────────────────────────
+
+  describe("GET /api/sessions/[id]", () => {
+    it("returns basic session data when metadata enrichment hangs", async () => {
+      vi.useFakeTimers();
+
+      const metadataSpy = vi
+        .spyOn(serialize, "enrichSessionsMetadata")
+        .mockImplementation(() => new Promise<void>(() => {}));
+
+      const responsePromise = sessionDetailGET(
+        makeRequest("http://localhost:3000/api/sessions/backend-9"),
+        { params: Promise.resolve({ id: "backend-9" }) },
+      );
+
+      // Advance past the 3s metadata enrichment timeout
+      await vi.advanceTimersByTimeAsync(3_000);
+      const res = await responsePromise;
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.id).toBe("backend-9");
+      expect(data.projectId).toBe("my-app");
+      expect(data.status).toBe("working");
+      expect(data.activity).toBe("active");
+
+      metadataSpy.mockRestore();
+      vi.useRealTimers();
+    });
+
+    it("returns basic PR data when PR enrichment hangs", async () => {
+      vi.useFakeTimers();
+
+      const metadataSpy = vi
+        .spyOn(serialize, "enrichSessionsMetadata")
+        .mockResolvedValue(undefined);
+
+      // enrichSessionPR: cacheOnly call returns false (no cache), live call hangs
+      const enrichSpy = vi
+        .spyOn(serialize, "enrichSessionPR")
+        .mockImplementation(
+          async (
+            _dashboard: Parameters<typeof serialize.enrichSessionPR>[0],
+            _scm: Parameters<typeof serialize.enrichSessionPR>[1],
+            _pr: Parameters<typeof serialize.enrichSessionPR>[2],
+            opts?: { cacheOnly?: boolean },
+          ) => {
+            if (opts?.cacheOnly) return false;
+            // Live enrichment: never resolves (simulates hang)
+            return new Promise<boolean>(() => {});
+          },
+        );
+
+      const responsePromise = sessionDetailGET(
+        makeRequest("http://localhost:3000/api/sessions/backend-7"),
+        { params: Promise.resolve({ id: "backend-7" }) },
+      );
+
+      // Advance past both the metadata (3s) and PR enrichment (4s) timeouts
+      await vi.advanceTimersByTimeAsync(4_000);
+      const res = await responsePromise;
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.id).toBe("backend-7");
+      expect(data.pr).toBeDefined();
+      expect(data.pr.number).toBe(432);
+      expect(data.pr.url).toBe("https://github.com/acme/my-app/pull/432");
+      expect(data.pr.enriched).toBe(false);
 
       metadataSpy.mockRestore();
       enrichSpy.mockRestore();

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -7,6 +7,10 @@ import {
   enrichSessionsMetadata,
 } from "@/lib/serialize";
 import { getCorrelationId, jsonWithCorrelation, recordApiObservation } from "@/lib/observability";
+import { settlesWithin } from "@/lib/async-utils";
+
+const METADATA_ENRICH_TIMEOUT_MS = 3_000;
+const PR_ENRICH_TIMEOUT_MS = 4_000;
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const correlationId = getCorrelationId(_request);
@@ -23,20 +27,35 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     const dashboardSession = sessionToDashboard(coreSession);
 
     // Enrich metadata (issue labels, agent summaries, issue titles)
-    await enrichSessionsMetadata([coreSession], [dashboardSession], config, registry);
+    // Non-blocking: timeout ensures basic session data is always returned
+    await settlesWithin(
+      enrichSessionsMetadata([coreSession], [dashboardSession], config, registry),
+      METADATA_ENRICH_TIMEOUT_MS,
+    );
 
-    // Enrich PR — serve cache immediately, refresh in background if stale
+    // Enrich PR — serve cache immediately, timeout on cold-cache fetch
     if (coreSession.pr) {
-      const project = resolveProject(coreSession, config.projects);
-      const scm = getSCM(registry, project);
-      if (scm) {
-        const cached = await enrichSessionPR(dashboardSession, scm, coreSession.pr, {
-          cacheOnly: true,
-        });
-        if (!cached) {
-          // Nothing cached yet — block once to populate, then future calls use cache
-          await enrichSessionPR(dashboardSession, scm, coreSession.pr);
+      try {
+        const project = resolveProject(coreSession, config.projects);
+        const scm = getSCM(registry, project);
+        if (scm) {
+          const cached = await enrichSessionPR(dashboardSession, scm, coreSession.pr, {
+            cacheOnly: true,
+          });
+          if (!cached) {
+            await settlesWithin(
+              enrichSessionPR(dashboardSession, scm, coreSession.pr),
+              PR_ENRICH_TIMEOUT_MS,
+            );
+          }
         }
+      } catch (prError) {
+        // resolveProject/getSCM may throw synchronously on bad config
+        // dashboard.pr still has basic data from basicPRToDashboard()
+        console.warn(
+          `[GET /api/sessions/${id}] PR enrichment failed:`,
+          prError instanceof Error ? prError.message : String(prError),
+        );
       }
     }
 

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -523,10 +523,14 @@ function SessionDetailPRCard({ pr, sessionId, metadata }: { pr: DashboardPR; ses
           PR #{pr.number}: {pr.title}
         </a>
         <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[11px]">
-          <span>
-            <span className="text-[var(--color-status-ready)]">+{pr.additions}</span>{" "}
-            <span className="text-[var(--color-status-error)]">-{pr.deletions}</span>
-          </span>
+          {pr.enriched ? (
+            <span>
+              <span className="text-[var(--color-status-ready)]">+{pr.additions}</span>{" "}
+              <span className="text-[var(--color-status-error)]">-{pr.deletions}</span>
+            </span>
+          ) : (
+            <span className="text-[var(--color-text-tertiary)]">loading…</span>
+          )}
           {pr.isDraft && (
             <>
               <span className="text-[var(--color-text-tertiary)]">&middot;</span>
@@ -568,8 +572,12 @@ function SessionDetailPRCard({ pr, sessionId, metadata }: { pr: DashboardPR; ses
               Ready to merge
             </span>
           </div>
-        ) : (
+        ) : pr.enriched || metadata["status"] === "ci_failed" || metadata["status"] === "changes_requested" ? (
           <IssuesList pr={pr} metadata={metadata} />
+        ) : (
+          <div className="text-[11px] text-[var(--color-text-tertiary)]">
+            Fetching CI and review status…
+          </div>
         )}
 
         {/* CI Checks */}

--- a/packages/web/src/components/__tests__/SessionDetail.enrichment.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.enrichment.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SessionDetail } from "../SessionDetail";
+import { makePR, makeSession } from "../../__tests__/helpers";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("../DirectTerminal", () => ({
+  DirectTerminal: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="direct-terminal">{sessionId}</div>
+  ),
+}));
+
+describe("SessionDetailPRCard enrichment gating", () => {
+  it("shows loading text for additions/deletions when PR is not enriched", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "enrich-1",
+          projectId: "my-app",
+          pr: makePR({
+            number: 200,
+            title: "Unenriched PR",
+            enriched: false,
+            additions: 0,
+            deletions: 0,
+          }),
+        })}
+      />,
+    );
+
+    expect(screen.getByText("loading…")).toBeInTheDocument();
+    expect(screen.queryByText("+0")).not.toBeInTheDocument();
+    expect(screen.queryByText("-0")).not.toBeInTheDocument();
+  });
+
+  it("shows fetching message instead of IssuesList when PR is not enriched", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "enrich-2",
+          projectId: "my-app",
+          pr: makePR({
+            number: 201,
+            title: "Unenriched blockers",
+            enriched: false,
+            mergeability: {
+              mergeable: false,
+              ciPassing: false,
+              approved: false,
+              noConflicts: true,
+              blockers: [],
+            },
+            ciStatus: "failing",
+            reviewDecision: "none",
+          }),
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Fetching CI and review status…")).toBeInTheDocument();
+    expect(screen.queryByText(/Not approved/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Not mergeable/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Blockers")).not.toBeInTheDocument();
+  });
+
+  it("shows normal IssuesList when PR is enriched", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "enrich-3",
+          projectId: "my-app",
+          pr: makePR({
+            number: 202,
+            title: "Enriched with CI failure",
+            enriched: true,
+            ciStatus: "failing",
+            ciChecks: [
+              { name: "build", status: "failed", url: "https://ci.example/build" },
+            ],
+            mergeability: {
+              mergeable: false,
+              ciPassing: false,
+              approved: true,
+              noConflicts: true,
+              blockers: ["CI failing"],
+            },
+          }),
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/CI failing/)).toBeInTheDocument();
+    expect(screen.queryByText("Fetching CI and review status…")).not.toBeInTheDocument();
+    expect(screen.queryByText("loading…")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #940 — PR details, CI details, and pending comments were not showing on the session detail page.

**Root cause:** The duplicate-PR repair in `repairSessionMetadataOnRead()` destructively erased PR metadata (`pr=""`, `prAutoDetect="off"`) for sessions it deemed "stale." Once erased, the session detail API returned `pr: null` and the PR card never rendered. Secondary: the detail API had no timeout protection, so slow GitHub API calls could block indefinitely.

**Core fix — prOwnership flag:**
- Replace destructive PR erasure with non-destructive `prOwnership: "stale"` flag
- Stale sessions preserve PR URL for dashboard visibility
- Lifecycle manager gates reaction dispatches (send-to-agent, auto-merge) on ownership
- Promotion check: sole stale sessions automatically regain ownership
- `claimPR` skips stale sessions in conflict detection and clears flag on claimant

**Web fix — timeout + UI gating:**
- Session detail API wraps enrichment in `settlesWithin(3s/4s)` matching list endpoint
- PR card shows "loading..." for additions/deletions when unenriched
- PR card shows "Fetching CI and review status..." instead of fake blockers
- Preserves IssuesList when lifecycle status is ci_failed/changes_requested

## Test Coverage
- 4 session-manager tests (dedup flag, PR preservation, promotion, status reset)
- 1 lifecycle-manager test (dispatch guard for stale sessions)
- 2 api-routes tests (metadata/PR enrichment timeout behavior)
- 3 SessionDetail tests (enrichment gating loading states)
- Updated claim-pr tests for non-destructive repair

**578 core tests + 58 web API tests pass.**

## Pre-Landing Review
Pre-Landing Review: 3 issues — 2 auto-fixed, 1 fixed with user approval
- [AUTO-FIXED] lifecycle-manager.ts:1271 — Misleading comment → updated
- [AUTO-FIXED] route.ts:52 — Silent catch → added console.warn
- [FIXED] lifecycle-manager.ts:1230 — Stale sessions firing transition reactions → gated executeReaction

## Adversarial Review
Cross-model adversarial review (Claude + Codex):
- HIGH (both found): Stale sessions firing transition reactions → fixed
- 3 Codex implementation findings → all fixed (claimPR prOwnership clearing, lifecycle fallback, cleanup paths)

## Test plan
- [x] All core tests pass (578 tests)
- [x] All web API tests pass (58 tests)
- [x] Typecheck passes (core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)