### PR TITLE
fix(web): fix 'Ask to Post' button action message to be agent-actionable

### DIFF
--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -819,7 +819,7 @@ function getAlerts(session: DashboardSession): Alert[] {
       color: "var(--color-alert-review)",
       url: pr.url,
       actionLabel: "ask to post",
-      actionMessage: `Post ${pr.url} on slack asking for a review.`,
+      actionMessage: `Please request a code review for ${pr.url}. Use 'gh pr request-review --reviewer @username' to add reviewers, or notify the team through any available channel.`,
       actionClassName: "bg-[var(--color-alert-review-bg)] text-white hover:brightness-110",
     });
   }

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -819,7 +819,7 @@ function getAlerts(session: DashboardSession): Alert[] {
       color: "var(--color-alert-review)",
       url: pr.url,
       actionLabel: "ask to post",
-      actionMessage: `Please request a code review for ${pr.url}. Use 'gh pr request-review --reviewer @username' to add reviewers, or notify the team through any available channel.`,
+      actionMessage: `Please request a code review for ${pr.url}. Add reviewers using 'gh pr request-review' with the appropriate team members, or notify the team through any available channel.`,
       actionClassName: "bg-[var(--color-alert-review-bg)] text-white hover:brightness-110",
     });
   }


### PR DESCRIPTION
## Summary

- The 'Ask to Post' button on the "needs review" kanban card was sending `"Post {pr.url} on slack asking for a review."` to the coding agent terminal
- Coding agents (Claude Code, Codex, Aider, OpenCode) don't have Slack access by default, so the button effectively did nothing
- Also inconsistent with all other action messages which start with "Please"

## Fix

Changed the `actionMessage` to instruct the agent to request reviewers via `gh pr request-review` — something all coding agents can actually execute — with a fallback to team channels (Slack/Composio) if those integrations are available.

## Test plan

- [ ] Verify the button label still shows "ask to post" on a card with a PR in "needs review" state
- [ ] Click the button — agent terminal should receive the new message with the `gh pr request-review` instruction
- [ ] Typecheck passes: `pnpm --filter @composio/ao-web typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)