### PR TITLE
fix: stop dead-session terminal reconnect storms

### DIFF
--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -342,7 +342,7 @@ describe("WebSocket connection validation", () => {
     const ws = new WebSocket(`ws://localhost:${port}/ws?session=ao-nonexistent-999`);
     const result = await waitForWsClose(ws);
 
-    expect(result.code).toBe(1008);
+    expect(result.code).toBe(4004);
     expect(result.reason).toContain("Session not found");
   });
 
@@ -351,7 +351,7 @@ describe("WebSocket connection validation", () => {
     const ws = new WebSocket(`ws://localhost:${port}/ws?session=definitely-not-real-${Date.now()}`);
     const result = await waitForWsClose(ws);
 
-    expect(result.code).toBe(1008);
+    expect(result.code).toBe(4004);
     expect(result.reason).toContain("Session not found");
   });
 });
@@ -570,7 +570,7 @@ describe("hash-prefixed session resolution", () => {
       const ws = new WebSocket(`ws://localhost:${port}/ws?session=${session1}`);
       const result = await waitForWsClose(ws);
 
-      expect(result.code).toBe(1008);
+      expect(result.code).toBe(4004);
       expect(result.reason).toContain("Session not found");
     } finally {
       try {

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -30,6 +30,8 @@ try {
 import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js";
 import { createObserverContext, inferProjectId } from "./terminal-observability.js";
 
+const WS_CLOSE_CODE_SESSION_NOT_FOUND = 4004;
+
 interface TerminalSession {
   sessionId: string;
   pty: IPty;
@@ -165,7 +167,7 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
         sessionId,
         reason: "Session not found",
       });
-      ws.close(1008, "Session not found");
+      ws.close(WS_CLOSE_CODE_SESSION_NOT_FOUND, "Session not found");
       return;
     }
 

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -26,6 +26,29 @@ export async function GET(request: Request): Promise<Response> {
   let updates: ReturnType<typeof setInterval> | undefined;
   let observerProjectId: string | undefined;
   let observer: ProjectObserver | null = null;
+  let closed = false;
+
+  const clearStreamIntervals = (): void => {
+    if (heartbeat) clearInterval(heartbeat);
+    if (updates) clearInterval(updates);
+    heartbeat = undefined;
+    updates = undefined;
+  };
+
+  const safeEnqueue = (controller: ReadableStreamDefaultController, payload: string): boolean => {
+    if (closed) {
+      return false;
+    }
+
+    try {
+      controller.enqueue(encoder.encode(payload));
+      return true;
+    } catch {
+      closed = true;
+      clearStreamIntervals();
+      return false;
+    }
+  };
 
   const ensureObserver = (config: ServicesConfig): ProjectObserver | null => {
     if (!observerProjectId) {
@@ -93,7 +116,9 @@ export async function GET(request: Request): Promise<Response> {
               lastActivityAt: s.lastActivityAt,
             })),
           };
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify(initialEvent)}\n\n`));
+          if (!safeEnqueue(controller, `data: ${JSON.stringify(initialEvent)}\n\n`)) {
+            return;
+          }
           if (projectObserver && observerProjectId) {
             projectObserver.recordOperation({
               metric: "sse_snapshot",
@@ -107,22 +132,16 @@ export async function GET(request: Request): Promise<Response> {
           }
         } catch {
           // If services aren't available, send empty snapshot
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ type: "snapshot", correlationId, emittedAt: new Date().toISOString(), sessions: [] })}\n\n`,
-            ),
+          safeEnqueue(
+            controller,
+            `data: ${JSON.stringify({ type: "snapshot", correlationId, emittedAt: new Date().toISOString(), sessions: [] })}\n\n`,
           );
         }
       })();
 
       // Send periodic heartbeat
       heartbeat = setInterval(() => {
-        try {
-          controller.enqueue(encoder.encode(`: heartbeat\n\n`));
-        } catch {
-          clearInterval(heartbeat);
-          clearInterval(updates);
-        }
+        safeEnqueue(controller, `: heartbeat\n\n`);
       }, 15000);
 
       // Poll for session state changes every 5 seconds
@@ -167,7 +186,9 @@ export async function GET(request: Request): Promise<Response> {
                   lastActivityAt: s.lastActivityAt,
                 })),
               };
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+              if (!safeEnqueue(controller, `data: ${JSON.stringify(event)}\n\n`)) {
+                return;
+              }
               if (projectObserver && observerProjectId) {
                 projectObserver.recordOperation({
                   metric: "sse_snapshot",
@@ -180,9 +201,7 @@ export async function GET(request: Request): Promise<Response> {
                 });
               }
             } catch {
-              // enqueue failure means the stream is closed — clean up both intervals
-              clearInterval(updates);
-              clearInterval(heartbeat);
+              // Observer recording is best-effort; stream delivery was already attempted above.
             }
           } catch {
             // Transient service error — skip this poll, retry on next interval
@@ -192,8 +211,8 @@ export async function GET(request: Request): Promise<Response> {
       }, 5000);
     },
     cancel() {
-      clearInterval(heartbeat);
-      clearInterval(updates);
+      closed = true;
+      clearStreamIntervals();
       void (async () => {
         try {
           const { config } = await getServices();

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1031,6 +1031,52 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   --color-text-tertiary: #5c5c66;
 }
 
+.session-detail-terminal-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-border-default);
+  background:
+    radial-gradient(circle at top, color-mix(in srgb, var(--color-accent) 10%, transparent), transparent 58%),
+    var(--detail-card-bg);
+  box-shadow: var(--detail-card-shadow);
+}
+
+.session-detail-terminal-placeholder__panel {
+  width: min(100%, 32rem);
+  padding: 1.75rem;
+  text-align: center;
+}
+
+.session-detail-terminal-placeholder__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--color-status-error) 25%, var(--color-border-default));
+  color: var(--color-status-error);
+  background: color-mix(in srgb, var(--color-status-error) 10%, transparent);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.session-detail-terminal-placeholder__title {
+  margin-top: 1rem;
+  color: var(--color-text-primary);
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+}
+
+.session-detail-terminal-placeholder__copy {
+  margin-top: 0.65rem;
+  color: var(--color-text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
 /* ── Session cards — flat, Linear-style ──────────────────────────────── */
 
 .session-card {

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -12,6 +12,18 @@ import "xterm/css/xterm.css";
 import type { ITheme, Terminal as TerminalType } from "xterm";
 import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
 
+const PERMANENT_CLOSE_CODES = new Set([4001, 4004]); // auth failure, session not found
+const MAX_RECONNECT_DELAY = 15_000;
+const MAX_RECONNECT_ATTEMPTS = 8;
+
+export function getDirectTerminalReconnectDelay(attempt: number): number | null {
+  if (attempt >= MAX_RECONNECT_ATTEMPTS) {
+    return null;
+  }
+
+  return Math.min(1000 * Math.pow(2, attempt), MAX_RECONNECT_DELAY);
+}
+
 interface DirectTerminalProps {
   sessionId: string;
   startFullscreen?: boolean;
@@ -257,9 +269,6 @@ export function DirectTerminal({
     let mounted = true;
     let cleanup: (() => void) | null = null;
     let inputDisposable: { dispose(): void } | null = null;
-
-    const PERMANENT_CLOSE_CODES = new Set([4001, 4004]); // auth failure, session not found
-    const MAX_RECONNECT_DELAY = 15_000;
 
     Promise.all([
       import("xterm").then((mod) => mod.Terminal),
@@ -518,6 +527,9 @@ export function DirectTerminal({
 
           websocket.onclose = (event) => {
             console.log("[DirectTerminal] WebSocket closed:", event.code, event.reason);
+            if (ws.current === websocket) {
+              ws.current = null;
+            }
 
             if (!mounted) return;
 
@@ -531,7 +543,16 @@ export function DirectTerminal({
 
             // Transient failure — schedule reconnect with exponential backoff
             const attempt = reconnectAttemptRef.current;
-            const delay = Math.min(1000 * Math.pow(2, attempt), MAX_RECONNECT_DELAY);
+            const delay = getDirectTerminalReconnectDelay(attempt);
+            if (delay === null) {
+              permanentErrorRef.current = true;
+              setStatus("error");
+              setError(
+                `Unable to reconnect after ${MAX_RECONNECT_ATTEMPTS} attempts. Refresh to try again.`,
+              );
+              return;
+            }
+
             reconnectAttemptRef.current = attempt + 1;
 
             console.log(`[DirectTerminal] Reconnecting in ${delay}ms (attempt ${attempt + 1})`);
@@ -539,6 +560,7 @@ export function DirectTerminal({
             setError(null);
 
             reconnectTimerRef.current = setTimeout(() => {
+              reconnectTimerRef.current = null;
               void connectWebSocket();
             }, delay);
           };
@@ -557,7 +579,9 @@ export function DirectTerminal({
             clearTimeout(reconnectTimerRef.current);
             reconnectTimerRef.current = null;
           }
-          ws.current?.close();
+          const currentWs = ws.current;
+          ws.current = null;
+          currentWs?.close();
           terminal.dispose();
         };
       })

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -3,7 +3,13 @@
 import { useState, useEffect, useRef, useMemo, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 import { useMediaQuery, MOBILE_BREAKPOINT } from "@/hooks/useMediaQuery";
-import { type DashboardSession, type DashboardPR, isPRMergeReady } from "@/lib/types";
+import {
+  type DashboardSession,
+  type DashboardPR,
+  isPRMergeReady,
+  TERMINAL_STATUSES,
+  TERMINAL_ACTIVITIES,
+} from "@/lib/types";
 import { CI_STATUS } from "@composio/ao-core/types";
 import { cn } from "@/lib/cn";
 import { CICheckList } from "./CIBadge";
@@ -69,6 +75,29 @@ function activityStateClass(activityLabel: string): string {
     return "session-detail-status-pill--error";
   }
   return "session-detail-status-pill--neutral";
+}
+
+function SessionTerminalEndedPlaceholder({
+  session,
+  terminalHeight,
+}: {
+  session: DashboardSession;
+  terminalHeight: string;
+}) {
+  const reason =
+    session.activity === "exited"
+      ? "The agent process has exited, so the live terminal is no longer available."
+      : "This session is in a terminal state, so the live terminal is no longer available.";
+
+  return (
+    <div className="session-detail-terminal-placeholder" style={{ minHeight: terminalHeight }}>
+      <div className="session-detail-terminal-placeholder__panel">
+        <span className="session-detail-terminal-placeholder__eyebrow">Session ended</span>
+        <h2 className="session-detail-terminal-placeholder__title">Terminal unavailable</h2>
+        <p className="session-detail-terminal-placeholder__copy">{reason}</p>
+      </div>
+    </div>
+  );
 }
 
 function SessionTopStrip({
@@ -335,6 +364,9 @@ export function SessionDetail({
   const terminalVariant = isOrchestrator ? "orchestrator" : "agent";
 
   const terminalHeight = isOrchestrator ? "clamp(560px, 76vh, 920px)" : "clamp(520px, 72vh, 860px)";
+  const showTerminalPlaceholder =
+    TERMINAL_STATUSES.has(session.status) ||
+    (session.activity !== null && TERMINAL_ACTIVITIES.has(session.activity));
   const isOpenCodeSession = session.metadata["agent"] === "opencode";
   const opencodeSessionId =
     typeof session.metadata["opencodeSessionId"] === "string" &&
@@ -397,14 +429,21 @@ export function SessionDetail({
                 Live Terminal
               </span>
             </div>
-            <DirectTerminal
-              sessionId={session.id}
-              startFullscreen={startFullscreen}
-              variant={terminalVariant}
-              height={terminalHeight}
-              isOpenCodeSession={isOpenCodeSession}
-              reloadCommand={isOpenCodeSession ? reloadCommand : undefined}
-            />
+            {showTerminalPlaceholder ? (
+              <SessionTerminalEndedPlaceholder
+                session={session}
+                terminalHeight={terminalHeight}
+              />
+            ) : (
+              <DirectTerminal
+                sessionId={session.id}
+                startFullscreen={startFullscreen}
+                variant={terminalVariant}
+                height={terminalHeight}
+                isOpenCodeSession={isOpenCodeSession}
+                reloadCommand={isOpenCodeSession ? reloadCommand : undefined}
+              />
+            )}
           </section>
 
           {pr ? (

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -59,6 +59,7 @@ function MockWebLinksAddon() {
 
 class MockWebSocket {
   static OPEN = 1;
+  static CLOSED = 3;
   static instances: MockWebSocket[] = [];
   readyState = MockWebSocket.OPEN;
   binaryType = "arraybuffer";
@@ -73,7 +74,9 @@ class MockWebSocket {
   }
 
   send() {}
-  close() {}
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+  }
 }
 
 vi.mock("xterm", () => ({
@@ -112,6 +115,7 @@ describe("DirectTerminal render", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("renders the shared accent chrome for orchestrator terminals", async () => {

--- a/packages/web/src/components/__tests__/DirectTerminal.test.ts
+++ b/packages/web/src/components/__tests__/DirectTerminal.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { buildDirectTerminalWsUrl, buildTerminalThemes } from "@/components/DirectTerminal";
+import {
+  buildDirectTerminalWsUrl,
+  buildTerminalThemes,
+  getDirectTerminalReconnectDelay,
+} from "@/components/DirectTerminal";
 
 describe("buildDirectTerminalWsUrl", () => {
   it("keeps non-standard port when proxy path override is set", () => {
@@ -145,5 +149,23 @@ describe("buildTerminalThemes", () => {
   it("selection colors differ between dark and light themes", () => {
     const { dark, light } = buildTerminalThemes("agent");
     expect(dark.selectionBackground).not.toBe(light.selectionBackground);
+  });
+});
+
+describe("getDirectTerminalReconnectDelay", () => {
+  it("uses exponential backoff for the first reconnect attempts", () => {
+    expect(getDirectTerminalReconnectDelay(0)).toBe(1000);
+    expect(getDirectTerminalReconnectDelay(1)).toBe(2000);
+    expect(getDirectTerminalReconnectDelay(2)).toBe(4000);
+  });
+
+  it("caps the reconnect delay at 15 seconds", () => {
+    expect(getDirectTerminalReconnectDelay(4)).toBe(15000);
+    expect(getDirectTerminalReconnectDelay(7)).toBe(15000);
+  });
+
+  it("stops reconnecting after eight failed attempts", () => {
+    expect(getDirectTerminalReconnectDelay(8)).toBeNull();
+    expect(getDirectTerminalReconnectDelay(9)).toBeNull();
   });
 });

--- a/packages/web/src/components/__tests__/SessionDetail.mobile.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.mobile.test.tsx
@@ -205,4 +205,22 @@ describe("SessionDetail mobile navbar", () => {
       background: "var(--color-chip-bg)",
     });
   });
+
+  it("shows a session-ended placeholder instead of mounting the terminal for exited sessions", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "worker-exited",
+          projectId: "my-app",
+          summary: "Exited session",
+          activity: "exited",
+        })}
+        projectOrchestratorId="my-app-orchestrator"
+      />,
+    );
+
+    expect(screen.getByText("Session ended")).toBeInTheDocument();
+    expect(screen.getByText("Terminal unavailable")).toBeInTheDocument();
+    expect(screen.queryByTestId("direct-terminal")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- cap direct terminal reconnects with exponential backoff and stop retrying after 8 failed attempts
- return WebSocket close code `4004` for missing tmux sessions and show a terminal-ended placeholder for exited sessions
- guard SSE enqueue calls after stream cancellation and cover the new behavior with web + websocket tests

Closes #964.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @composio/ao-web test -- src/components/__tests__/DirectTerminal.test.ts src/components/__tests__/DirectTerminal.render.test.tsx src/components/__tests__/SessionDetail.mobile.test.tsx src/__tests__/api-routes.test.ts server/__tests__/direct-terminal-ws.integration.test.ts`

## Notes
- `pnpm build` still fails on the existing Next.js prerender error for `/404` (`<Html> should not be imported outside of pages/_document`). This predates this fix and is unchanged by this PR.