### PR TITLE
fix(web): eliminate session page layout shift on orchestrator pages

### DIFF
--- a/packages/cli/__tests__/index.test.ts
+++ b/packages/cli/__tests__/index.test.ts
@@ -21,7 +21,7 @@ describe("cli entrypoint", () => {
   });
 
   it("prints a clean message and exits 1 on ConfigNotFoundError", async () => {
-    const { ConfigNotFoundError } = await import("@composio/ao-core");
+    const { ConfigNotFoundError } = await import("@aoagents/ao-core");
     const error = new ConfigNotFoundError();
     let rejectionHandler:
       | ((reason: unknown) => unknown)

--- a/packages/cli/__tests__/scripts/doctor-script.test.ts
+++ b/packages/cli/__tests__/scripts/doctor-script.test.ts
@@ -79,7 +79,7 @@ function createHealthyPath(binDir: string): void {
 }
 
 describe("scripts/ao-doctor.sh", () => {
-  it("reports a healthy install as PASS", () => {
+  it("reports a healthy install as PASS", { timeout: 30_000 }, () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-script-"));
     const fakeRepo = createHealthyRepo(tempRoot);
     const binDir = join(tempRoot, "bin");
@@ -113,7 +113,7 @@ describe("scripts/ao-doctor.sh", () => {
     expect(result.stdout).toContain("Environment looks healthy");
   });
 
-  it("applies safe fixes for missing launcher, missing dirs, and stale temp files", () => {
+  it("applies safe fixes for missing launcher, missing dirs, and stale temp files", { timeout: 45_000 }, () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-fix-"));
     const fakeRepo = createHealthyRepo(tempRoot);
     const binDir = join(tempRoot, "bin");

--- a/packages/cli/__tests__/scripts/update-script.test.ts
+++ b/packages/cli/__tests__/scripts/update-script.test.ts
@@ -18,7 +18,7 @@ function createFakeBinary(binDir: string, name: string, body: string): void {
 }
 
 describe("scripts/ao-update.sh", () => {
-  it("runs the expected fetch, rebuild, and launcher refresh flow", () => {
+  it("runs the expected fetch, rebuild, and launcher refresh flow", { timeout: 30_000 }, () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "ao-update-script-"));
     const fakeRepo = join(tempRoot, "repo");
     mkdirSync(join(fakeRepo, "packages", "cli"), { recursive: true });
@@ -176,7 +176,7 @@ exit 0`,
     expect(result.stderr).toContain("Conflicting options");
   });
 
-  it("reports when the update itself dirties the checkout", () => {
+  it("reports when the update itself dirties the checkout", { timeout: 30_000 }, () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "ao-update-post-dirty-"));
     const fakeRepo = join(tempRoot, "repo");
     mkdirSync(join(fakeRepo, "packages", "cli"), { recursive: true });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { ConfigNotFoundError } from "@composio/ao-core";
+import { ConfigNotFoundError } from "@aoagents/ao-core";
 import { createProgram } from "./program.js";
 
 createProgram()

--- a/packages/web/src/app/sessions/[id]/loading.test.tsx
+++ b/packages/web/src/app/sessions/[id]/loading.test.tsx
@@ -1,17 +1,17 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import SessionLoading from "./loading";
 
 describe("SessionLoading", () => {
-  it("renders the session loading text", () => {
-    render(<SessionLoading />);
-    expect(screen.getByText("Loading session…")).toBeInTheDocument();
+  it("renders the skeleton shell with a stable header placeholder", () => {
+    const { container } = render(<SessionLoading />);
+    expect(container.querySelector(".session-page-header")).toBeInTheDocument();
   });
 
-  it("renders a spinning indicator", () => {
+  it("renders animated skeleton bones instead of a spinner", () => {
     const { container } = render(<SessionLoading />);
-    const spinner = container.querySelector(".animate-spin");
-    expect(spinner).toBeInTheDocument();
-    expect(spinner?.tagName.toLowerCase()).toBe("svg");
+    const bones = container.querySelectorAll(".animate-pulse");
+    expect(bones.length).toBeGreaterThanOrEqual(4);
+    expect(container.querySelector(".animate-spin")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/sessions/[id]/loading.tsx
+++ b/packages/web/src/app/sessions/[id]/loading.tsx
@@ -1,20 +1,5 @@
+import { SessionDetailSkeleton } from "@/components/SessionDetailSkeleton";
+
 export default function SessionLoading() {
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-[var(--color-bg-base)]">
-      <div className="flex flex-col items-center gap-3">
-        <svg
-          className="h-5 w-5 animate-spin text-[var(--color-text-tertiary)]"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          viewBox="0 0 24 24"
-        >
-          <path d="M12 3a9 9 0 1 0 9 9" />
-        </svg>
-        <p className="text-[13px] text-[var(--color-text-tertiary)]">
-          Loading session…
-        </p>
-      </div>
-    </div>
-  );
+  return <SessionDetailSkeleton />;
 }

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -9,6 +9,7 @@ import { activityIcon } from "@/lib/activity-icons";
 import type { ProjectInfo } from "@/lib/project-name";
 import { getSessionTitle } from "@/lib/format";
 import { useSSESessionActivity } from "@/hooks/useSSESessionActivity";
+import { SessionDetailSkeleton } from "@/components/SessionDetailSkeleton";
 
 function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max) + "..." : s;
@@ -225,11 +226,7 @@ export default function SessionPage() {
   }, [fetchSession, fetchProjectSessions, fetchSidebarSessions]);
 
   if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-[var(--color-bg-base)]">
-        <div className="text-[13px] text-[var(--color-text-tertiary)]">Loading session…</div>
-      </div>
-    );
+    return <SessionDetailSkeleton />;
   }
 
   if (sessionMissing) {

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -362,79 +362,77 @@ function _OrchestratorStatusStrip({
     : null;
 
   return (
-    <div className="mx-auto max-w-[1180px] px-5 pt-5 lg:px-8">
-      <SessionTopStrip
-        headline={headline}
-        crumbId={headline}
-        activityLabel={activityLabel}
-        activityColor={activityColor}
-        branch={branch}
-        pr={pr}
-        isOrchestrator
-        crumbHref={crumbHref}
-        crumbLabel={crumbLabel}
-        rightSlot={
-          <div className="flex flex-wrap items-center gap-3 lg:justify-end">
-            {total !== null ? (
-              <>
-                <div className="flex items-baseline gap-1.5 mr-2">
-                  <span className="text-[22px] font-bold leading-none tabular-nums text-[var(--color-text-primary)]">
-                    {total}
-                  </span>
-                  <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
-                </div>
+    <SessionTopStrip
+      headline={headline}
+      crumbId={headline}
+      activityLabel={activityLabel}
+      activityColor={activityColor}
+      branch={branch}
+      pr={pr}
+      isOrchestrator
+      crumbHref={crumbHref}
+      crumbLabel={crumbLabel}
+      rightSlot={
+        <div className="flex flex-wrap items-center gap-3 lg:justify-end">
+          {total !== null ? (
+            <>
+              <div className="flex items-baseline gap-1.5 mr-2">
+                <span className="text-[22px] font-bold leading-none tabular-nums text-[var(--color-text-primary)]">
+                  {total}
+                </span>
+                <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
+              </div>
 
-                <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
+              <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
 
-                {/* Per-zone pills */}
-                {stats && stats.length > 0 ? (
-                  stats.map((s) => (
-                    <div
-                      key={s.label}
-                      className="flex items-center gap-1.5 px-2.5 py-1"
-                      style={{ background: s.bg }}
+              {/* Per-zone pills */}
+              {stats && stats.length > 0 ? (
+                stats.map((s) => (
+                  <div
+                    key={s.label}
+                    className="flex items-center gap-1.5 px-2.5 py-1"
+                    style={{ background: s.bg }}
+                  >
+                    <span
+                      className="text-[15px] font-bold leading-none tabular-nums"
+                      style={{ color: s.color }}
                     >
-                      <span
-                        className="text-[15px] font-bold leading-none tabular-nums"
-                        style={{ color: s.color }}
-                      >
-                        {s.value}
-                      </span>
-                      <span
-                        className="text-[10px] font-medium"
-                        style={{ color: s.color, opacity: 0.8 }}
-                      >
-                        {s.label}
-                      </span>
-                    </div>
-                  ))
-                ) : (
-                  <span className="text-[12px] text-[var(--color-text-tertiary)]">
-                    no active agents
-                  </span>
-                )}
+                      {s.value}
+                    </span>
+                    <span
+                      className="text-[10px] font-medium"
+                      style={{ color: s.color, opacity: 0.8 }}
+                    >
+                      {s.label}
+                    </span>
+                  </div>
+                ))
+              ) : (
+                <span className="text-[12px] text-[var(--color-text-tertiary)]">
+                  no active agents
+                </span>
+              )}
 
-                {uptime && (
-                  <span className="ml-auto font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
-                    up {uptime}
-                  </span>
-                )}
-              </>
-            ) : (
-              <>
-                <div className="flex items-baseline gap-1.5 mr-2">
-                  <div className="h-5 w-6 animate-pulse rounded bg-[var(--color-bg-subtle)]" />
-                  <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
-                </div>
-                <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
-                <div className="h-5 w-20 animate-pulse rounded bg-[var(--color-bg-subtle)]" />
-                <div className="h-5 w-16 animate-pulse rounded bg-[var(--color-bg-subtle)]" />
-              </>
-            )}
-          </div>
-        }
-      />
-    </div>
+              {uptime && (
+                <span className="ml-auto font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
+                  up {uptime}
+                </span>
+              )}
+            </>
+          ) : (
+            <>
+              <div className="flex items-baseline gap-1.5 mr-2">
+                <div className="h-5 w-6 animate-pulse rounded bg-[var(--color-bg-subtle)]" />
+                <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
+              </div>
+              <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
+              <div className="h-5 w-20 animate-pulse rounded bg-[var(--color-bg-subtle)]" />
+              <div className="h-5 w-16 animate-pulse rounded bg-[var(--color-bg-subtle)]" />
+            </>
+          )}
+        </div>
+      }
+    />
   );
 }
 

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -292,7 +292,7 @@ function _OrchestratorStatusStrip({
   crumbHref,
   crumbLabel,
 }: {
-  zones: OrchestratorZones;
+  zones?: OrchestratorZones;
   createdAt: string;
   headline: string;
   activityLabel: string;
@@ -316,47 +316,50 @@ function _OrchestratorStatusStrip({
     return () => clearInterval(id);
   }, [createdAt]);
 
-  const stats: Array<{ value: number; label: string; color: string; bg: string }> = [
-    {
-      value: zones.merge,
-      label: "merge-ready",
-      color: "var(--color-status-ready)",
-      bg: "color-mix(in srgb, var(--color-status-ready) 10%, transparent)",
-    },
-    {
-      value: zones.respond,
-      label: "responding",
-      color: "var(--color-status-error)",
-      bg: "color-mix(in srgb, var(--color-status-error) 10%, transparent)",
-    },
-    {
-      value: zones.review,
-      label: "review",
-      color: "var(--color-accent-orange)",
-      bg: "color-mix(in srgb, var(--color-accent-orange) 10%, transparent)",
-    },
-    {
-      value: zones.working,
-      label: "working",
-      color: "var(--color-accent-blue)",
-      bg: "color-mix(in srgb, var(--color-accent-blue) 10%, transparent)",
-    },
-    {
-      value: zones.pending,
-      label: "pending",
-      color: "var(--color-status-attention)",
-      bg: "color-mix(in srgb, var(--color-status-attention) 10%, transparent)",
-    },
-    {
-      value: zones.done,
-      label: "done",
-      color: "var(--color-text-tertiary)",
-      bg: "color-mix(in srgb, var(--color-text-tertiary) 14%, transparent)",
-    },
-  ].filter((s) => s.value > 0);
+  const stats: Array<{ value: number; label: string; color: string; bg: string }> | null = zones
+    ? [
+        {
+          value: zones.merge,
+          label: "merge-ready",
+          color: "var(--color-status-ready)",
+          bg: "color-mix(in srgb, var(--color-status-ready) 10%, transparent)",
+        },
+        {
+          value: zones.respond,
+          label: "responding",
+          color: "var(--color-status-error)",
+          bg: "color-mix(in srgb, var(--color-status-error) 10%, transparent)",
+        },
+        {
+          value: zones.review,
+          label: "review",
+          color: "var(--color-accent-orange)",
+          bg: "color-mix(in srgb, var(--color-accent-orange) 10%, transparent)",
+        },
+        {
+          value: zones.working,
+          label: "working",
+          color: "var(--color-accent-blue)",
+          bg: "color-mix(in srgb, var(--color-accent-blue) 10%, transparent)",
+        },
+        {
+          value: zones.pending,
+          label: "pending",
+          color: "var(--color-status-attention)",
+          bg: "color-mix(in srgb, var(--color-status-attention) 10%, transparent)",
+        },
+        {
+          value: zones.done,
+          label: "done",
+          color: "var(--color-text-tertiary)",
+          bg: "color-mix(in srgb, var(--color-text-tertiary) 14%, transparent)",
+        },
+      ].filter((s) => s.value > 0)
+    : null;
 
-  const total =
-    zones.merge + zones.respond + zones.review + zones.working + zones.pending + zones.done;
+  const total = zones
+    ? zones.merge + zones.respond + zones.review + zones.working + zones.pending + zones.done
+    : null;
 
   return (
     <div className="mx-auto max-w-[1180px] px-5 pt-5 lg:px-8">
@@ -372,47 +375,61 @@ function _OrchestratorStatusStrip({
         crumbLabel={crumbLabel}
         rightSlot={
           <div className="flex flex-wrap items-center gap-3 lg:justify-end">
-            <div className="flex items-baseline gap-1.5 mr-2">
-              <span className="text-[22px] font-bold leading-none tabular-nums text-[var(--color-text-primary)]">
-                {total}
-              </span>
-              <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
-            </div>
-
-            <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
-
-            {/* Per-zone pills */}
-            {stats.length > 0 ? (
-              stats.map((s) => (
-                <div
-                  key={s.label}
-                  className="flex items-center gap-1.5 px-2.5 py-1"
-                  style={{ background: s.bg }}
-                >
-                  <span
-                    className="text-[15px] font-bold leading-none tabular-nums"
-                    style={{ color: s.color }}
-                  >
-                    {s.value}
+            {total !== null ? (
+              <>
+                <div className="flex items-baseline gap-1.5 mr-2">
+                  <span className="text-[22px] font-bold leading-none tabular-nums text-[var(--color-text-primary)]">
+                    {total}
                   </span>
-                  <span
-                    className="text-[10px] font-medium"
-                    style={{ color: s.color, opacity: 0.8 }}
-                  >
-                    {s.label}
-                  </span>
+                  <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
                 </div>
-              ))
-            ) : (
-              <span className="text-[12px] text-[var(--color-text-tertiary)]">
-                no active agents
-              </span>
-            )}
 
-            {uptime && (
-              <span className="ml-auto font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
-                up {uptime}
-              </span>
+                <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
+
+                {/* Per-zone pills */}
+                {stats && stats.length > 0 ? (
+                  stats.map((s) => (
+                    <div
+                      key={s.label}
+                      className="flex items-center gap-1.5 px-2.5 py-1"
+                      style={{ background: s.bg }}
+                    >
+                      <span
+                        className="text-[15px] font-bold leading-none tabular-nums"
+                        style={{ color: s.color }}
+                      >
+                        {s.value}
+                      </span>
+                      <span
+                        className="text-[10px] font-medium"
+                        style={{ color: s.color, opacity: 0.8 }}
+                      >
+                        {s.label}
+                      </span>
+                    </div>
+                  ))
+                ) : (
+                  <span className="text-[12px] text-[var(--color-text-tertiary)]">
+                    no active agents
+                  </span>
+                )}
+
+                {uptime && (
+                  <span className="ml-auto font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
+                    up {uptime}
+                  </span>
+                )}
+              </>
+            ) : (
+              <>
+                <div className="flex items-baseline gap-1.5 mr-2">
+                  <div className="h-5 w-6 animate-pulse rounded bg-[var(--color-bg-subtle)]" />
+                  <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
+                </div>
+                <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
+                <div className="h-5 w-20 animate-pulse rounded bg-[var(--color-bg-subtle)]" />
+                <div className="h-5 w-16 animate-pulse rounded bg-[var(--color-bg-subtle)]" />
+              </>
             )}
           </div>
         }
@@ -562,7 +579,19 @@ export function SessionDetail({
             <main className="session-detail-page min-h-0 flex-1 overflow-y-auto bg-[var(--color-bg-base)]">
               <div className="session-detail-layout">
                 <main className="min-w-0">
-                  {(!isOrchestrator || (isOrchestrator && orchestratorZones)) && (
+                  {isOrchestrator ? (
+                    <_OrchestratorStatusStrip
+                      zones={orchestratorZones}
+                      createdAt={session.createdAt}
+                      headline={headline}
+                      activityLabel={activity.label}
+                      activityColor={activity.color}
+                      branch={session.branch}
+                      pr={pr}
+                      crumbHref={crumbHref}
+                      crumbLabel={crumbLabel}
+                    />
+                  ) : (
                     <SessionTopStrip
                       headline={headline}
                       crumbId={session.id}

--- a/packages/web/src/components/SessionDetailSkeleton.tsx
+++ b/packages/web/src/components/SessionDetailSkeleton.tsx
@@ -1,0 +1,55 @@
+/**
+ * Skeleton shell for the session detail page.
+ *
+ * Renders a stable layout placeholder (breadcrumb, header, terminal frame)
+ * so the page doesn't shift when async data arrives. Used by both the
+ * route-level loading.tsx and the client-side loading branch in page.tsx.
+ */
+
+function Bone({ className }: { className?: string }) {
+  return (
+    <div
+      className={`animate-pulse rounded bg-[var(--color-bg-subtle)] ${className ?? ""}`}
+    />
+  );
+}
+
+export function SessionDetailSkeleton() {
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-base)]">
+      <div className="mx-auto max-w-[1180px] px-5 py-5 lg:px-8">
+        <main className="min-w-0">
+          {/* Header skeleton matching .session-page-header */}
+          <section className="session-page-header">
+            {/* Breadcrumb row */}
+            <div className="session-page-header__crumbs">
+              <Bone className="h-3 w-16" />
+              <span className="text-[var(--color-border-strong)]">/</span>
+              <Bone className="h-3 w-24" />
+            </div>
+
+            {/* Main row: title + status pill */}
+            <div className="session-page-header__main">
+              <div className="session-page-header__identity">
+                <Bone className="h-5 w-48" />
+                <div className="session-page-header__meta">
+                  <Bone className="h-6 w-16 rounded-full" />
+                  <Bone className="h-5 w-28" />
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* Terminal section skeleton */}
+          <section className="mt-5">
+            <div className="mb-3 flex items-center gap-2">
+              <Bone className="h-3 w-0.5" />
+              <Bone className="h-3 w-20" />
+            </div>
+            <Bone className="h-[440px] w-full rounded" />
+          </section>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/SessionDetailSkeleton.tsx
+++ b/packages/web/src/components/SessionDetailSkeleton.tsx
@@ -6,10 +6,12 @@
  * route-level loading.tsx and the client-side loading branch in page.tsx.
  */
 
+import { cn } from "@/lib/cn";
+
 function Bone({ className }: { className?: string }) {
   return (
     <div
-      className={`animate-pulse rounded bg-[var(--color-bg-subtle)] ${className ?? ""}`}
+      className={cn("animate-pulse rounded bg-[var(--color-bg-subtle)]", className)}
     />
   );
 }

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -255,4 +255,30 @@ describe("SessionDetail desktop layout", () => {
     expect(screen.getByText("review")).toBeInTheDocument();
     expect(screen.getByText("working")).toBeInTheDocument();
   });
+
+  it("keeps the orchestrator header aligned and shows an empty state when all zones are zero", () => {
+    const { container } = render(
+      <SessionDetail
+        session={makeSession({
+          id: "my-app-orchestrator",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          summary: "Idle orchestrator",
+          branch: null,
+          createdAt: new Date().toISOString(),
+        })}
+        isOrchestrator
+        orchestratorZones={{ merge: 0, respond: 0, review: 0, pending: 0, working: 0, done: 0 }}
+        projectOrchestratorId="my-app-orchestrator"
+      />,
+    );
+
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("no active agents")).toBeInTheDocument();
+
+    const contentMain = container.querySelector(".session-detail-layout > main");
+    const topStrip = container.querySelector(".session-detail-top-strip");
+    expect(contentMain).toContainElement(topStrip);
+    expect(topStrip?.parentElement).toBe(contentMain);
+  });
 });

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -186,4 +186,73 @@ describe("SessionDetail desktop layout", () => {
     expect(screen.getByText(/Terminal session has ended/i)).toBeInTheDocument();
     expect(screen.queryByTestId("direct-terminal")).not.toBeInTheDocument();
   });
+
+  it("renders the orchestrator header immediately even when zones are undefined", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "my-app-orchestrator",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          summary: "Orchestrator session",
+          branch: null,
+          createdAt: new Date().toISOString(),
+        })}
+        isOrchestrator
+        orchestratorZones={undefined}
+        projectOrchestratorId="my-app-orchestrator"
+      />,
+    );
+
+    expect(screen.getAllByText("Orchestrator session").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("agents")).toBeInTheDocument();
+    expect(screen.getByText("Live Terminal")).toBeInTheDocument();
+  });
+
+  it("shows skeleton placeholders for orchestrator zones while loading", () => {
+    const { container } = render(
+      <SessionDetail
+        session={makeSession({
+          id: "my-app-orchestrator",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          summary: "Loading zones test",
+          branch: null,
+          createdAt: new Date().toISOString(),
+        })}
+        isOrchestrator
+        orchestratorZones={undefined}
+        projectOrchestratorId="my-app-orchestrator"
+      />,
+    );
+
+    const headerSide = container.querySelector(".session-detail-identity__actions--custom");
+    expect(headerSide).toBeInTheDocument();
+    const bones = headerSide?.querySelectorAll(".animate-pulse");
+    expect(bones?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  it("fills in orchestrator zone counts when data arrives", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "my-app-orchestrator",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          summary: "Zones loaded test",
+          branch: null,
+          createdAt: new Date().toISOString(),
+        })}
+        isOrchestrator
+        orchestratorZones={{ merge: 1, respond: 0, review: 2, pending: 0, working: 3, done: 0 }}
+        projectOrchestratorId="my-app-orchestrator"
+      />,
+    );
+
+    expect(screen.getByText("6")).toBeInTheDocument();
+    expect(screen.getByText("agents")).toBeInTheDocument();
+    expect(screen.getByText("merge-ready")).toBeInTheDocument();
+    expect(screen.getByText("review")).toBeInTheDocument();
+    expect(screen.getByText("working")).toBeInTheDocument();
+  });
 });

--- a/packages/web/src/components/__tests__/SessionDetailSkeleton.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetailSkeleton.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SessionDetailSkeleton } from "../SessionDetailSkeleton";
+
+describe("SessionDetailSkeleton", () => {
+  it("renders a stable page shell with header and terminal placeholders", () => {
+    const { container } = render(<SessionDetailSkeleton />);
+
+    // Header section with breadcrumb separator
+    expect(screen.getByText("/")).toBeInTheDocument();
+
+    // Should have the session-page-header class for layout stability
+    expect(container.querySelector(".session-page-header")).toBeInTheDocument();
+
+    // Should have multiple animated skeleton bones
+    const bones = container.querySelectorAll(".animate-pulse");
+    expect(bones.length).toBeGreaterThanOrEqual(4);
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: The orchestrator header was gated on zone-count data that loads 2s after mount (`setTimeout(fetchProjectSessions, 2000)`), leaving no header at all for desktop orchestrator sessions until the async fetch resolved. The terminal rendered immediately, then jumped down when the header popped in.
- **Fix**: Decouple the `OrchestratorStatusStrip` from zone-count availability — render it immediately with skeleton placeholders for agent counts, fill in real data when the fetch resolves
- **Bonus**: Replace the spinner-only `loading.tsx` and the inline `page.tsx` loading branch with a proper `SessionDetailSkeleton` shell so both route-level and client-side loading states show a stable layout instead of a centered spinner

### Files changed
| File | What changed |
|------|-------------|
| `SessionDetailSkeleton.tsx` | **New** — reusable skeleton shell (breadcrumb, header, terminal frame) |
| `SessionDetail.tsx` | Removed `orchestratorZones` gate from render condition; `OrchestratorStatusStrip` accepts optional zones and shows skeleton placeholders while loading |
| `loading.tsx` | Renders skeleton shell instead of spinner |
| `page.tsx` | Loading branch uses skeleton shell |
| `SessionDetail.desktop.test.tsx` | **New** — verifies header renders immediately without zone data |
| `SessionDetailSkeleton.test.tsx` | **New** — verifies skeleton renders stable layout |
| `loading.test.tsx` | Updated to match skeleton instead of spinner |

### Overlap with #980
PR #980 touches the same files for mobile terminal deferral. This PR avoids those areas — focused purely on stable shell rendering + header skeleton behavior. No conflicts expected.

Closes #988

## Test plan

- [x] `pnpm --filter @composio/ao-web test` — all 554 tests pass (46 files)
- [x] Pre-existing typecheck errors in `services.ts` / `session-project.ts` — not introduced by this PR
- [x] New tests verify: skeleton shell layout, desktop orchestrator header without zones, zone data fill-in
- [x] Existing mobile tests remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)