### PR TITLE
[codex] fix self-hosted GitLab host propagation for glab

### DIFF
--- a/packages/plugins/scm-gitlab/src/glab-utils.ts
+++ b/packages/plugins/scm-gitlab/src/glab-utils.ts
@@ -8,11 +8,13 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export async function glab(args: string[], hostname?: string): Promise<string> {
-  if (hostname && args[0] === "api") {
-    args = [args[0], "--hostname", hostname, ...args.slice(1)];
-  }
+  // glab resolves self-hosted instances via GITLAB_HOST; most subcommands do
+  // not accept a per-command --hostname flag.
+  const env = hostname ? { ...process.env, GITLAB_HOST: hostname } : process.env;
+
   try {
     const { stdout } = await execFileAsync("glab", args, {
+      env,
       maxBuffer: 10 * 1024 * 1024,
       timeout: 30_000,
     });

--- a/packages/plugins/scm-gitlab/test/index.test.ts
+++ b/packages/plugins/scm-gitlab/test/index.test.ts
@@ -589,25 +589,25 @@ describe("scm-gitlab plugin", () => {
       expect(checks[0].status).toBe("failed");
     });
 
-    it("passes --hostname to glab api for self-hosted GitLab", async () => {
+    it("passes GITLAB_HOST env to glab for self-hosted GitLab", async () => {
       const selfHosted = create({ host: "gitlab.corp.com" });
       mockGlab([{ id: 100 }]);
       mockGlab([]);
       await selfHosted.getCIChecks(pr);
       const firstCallArgs = glabMock.mock.calls[0][1] as string[];
+      const firstCallOptions = glabMock.mock.calls[0][2] as { env?: NodeJS.ProcessEnv };
       expect(firstCallArgs[0]).toBe("api");
-      expect(firstCallArgs[1]).toBe("--hostname");
-      expect(firstCallArgs[2]).toBe("gitlab.corp.com");
+      expect(firstCallOptions.env?.["GITLAB_HOST"]).toBe("gitlab.corp.com");
     });
 
-    it("strips hostname from project ID and infers --hostname from pr.owner", async () => {
+    it("strips hostname from project ID and infers GITLAB_HOST from pr.owner", async () => {
       const selfHostedPr = { ...pr, owner: "gitlab.corp.com/acme", repo: "repo" };
       mockGlab([{ id: 100 }]);
       mockGlab([]);
       await scm.getCIChecks(selfHostedPr);
       const firstCallArgs = glabMock.mock.calls[0][1] as string[];
-      expect(firstCallArgs).toContain("--hostname");
-      expect(firstCallArgs).toContain("gitlab.corp.com");
+      const firstCallOptions = glabMock.mock.calls[0][2] as { env?: NodeJS.ProcessEnv };
+      expect(firstCallOptions.env?.["GITLAB_HOST"]).toBe("gitlab.corp.com");
       expect(firstCallArgs).toContain("projects/acme%2Frepo/merge_requests/42/pipelines");
     });
 
@@ -617,7 +617,8 @@ describe("scm-gitlab plugin", () => {
       mockGlab([]);
       await scm.getCIChecks(dottedGroupPr);
       const firstCallArgs = glabMock.mock.calls[0][1] as string[];
-      expect(firstCallArgs).not.toContain("--hostname");
+      const firstCallOptions = glabMock.mock.calls[0][2] as { env?: NodeJS.ProcessEnv };
+      expect(firstCallOptions.env?.["GITLAB_HOST"]).toBeUndefined();
       expect(firstCallArgs).toContain("projects/my.company%2Frepo/merge_requests/42/pipelines");
     });
   });
@@ -885,14 +886,14 @@ describe("scm-gitlab plugin", () => {
       expect(await scm.getReviewDecision(pr)).toBe("none");
     });
 
-    it("passes --hostname to glab api for self-hosted GitLab", async () => {
+    it("passes GITLAB_HOST env to glab for self-hosted GitLab", async () => {
       const selfHosted = create({ host: "gitlab.corp.com" });
       mockGlab({ approved: true, approvals_left: 0 });
       await selfHosted.getReviewDecision(pr);
       const args = glabMock.mock.calls[0][1] as string[];
+      const options = glabMock.mock.calls[0][2] as { env?: NodeJS.ProcessEnv };
       expect(args[0]).toBe("api");
-      expect(args[1]).toBe("--hostname");
-      expect(args[2]).toBe("gitlab.corp.com");
+      expect(options.env?.["GITLAB_HOST"]).toBe("gitlab.corp.com");
     });
   });
 

--- a/packages/plugins/tracker-gitlab/test/index.test.ts
+++ b/packages/plugins/tracker-gitlab/test/index.test.ts
@@ -123,6 +123,14 @@ describe("tracker-gitlab plugin", () => {
       await expect(tracker.getIssue("999", project)).rejects.toThrow("issue not found");
     });
 
+    it("passes GITLAB_HOST env to glab for self-hosted GitLab", async () => {
+      const selfHosted = create({ host: "gitlab.corp.com" });
+      mockGlab(sampleIssue);
+      await selfHosted.getIssue("123", project);
+      const options = glabMock.mock.calls[0][2] as { env?: NodeJS.ProcessEnv };
+      expect(options.env?.["GITLAB_HOST"]).toBe("gitlab.corp.com");
+    });
+
     it("throws on malformed JSON response", async () => {
       glabMock.mockResolvedValueOnce({ stdout: "not json{" });
       await expect(tracker.getIssue("123", project)).rejects.toThrow();


### PR DESCRIPTION
## Summary

- pass the configured self-hosted GitLab host to every `glab` invocation via `GITLAB_HOST`
- keep SCM self-hosted expectations aligned with the actual CLI behavior instead of relying on unsupported per-command flags
- cover the regression in both the SCM and tracker GitLab plugin tests

## Why

Self-hosted GitLab support only applied the configured host to `glab api` calls. Commands like `glab issue view`, `glab mr view`, and `glab mr list` ignored the project host, so AO could query the wrong GitLab instance from non-GitLab worktrees.

## Impact

AO GitLab tracker and SCM operations now resolve against the intended self-hosted host consistently, including issue lookup during session spawn.

## Validation

- `pnpm --filter @composio/ao-core --filter @composio/ao-plugin-scm-gitlab --filter @composio/ao-plugin-tracker-gitlab build`
- `pnpm --filter @composio/ao-plugin-scm-gitlab test`
- `pnpm --filter @composio/ao-plugin-tracker-gitlab test`
