### PR TITLE
fix(web): correct xterm.js terminal width rendering in session detail

### DIFF
--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -265,8 +265,12 @@ export function DirectTerminal({
         terminal.open(terminalRef.current);
         terminalInstance.current = terminal;
 
-        // Fit terminal to container — defer so DOM has settled
-        const initialFitRafId = requestAnimationFrame(() => fit.fit());
+        // Fit terminal to container — defer so DOM has settled, then send
+        // the real dimensions to the server (cols/rows are 0 until fit runs)
+        const initialFitRafId = requestAnimationFrame(() => {
+          fit.fit();
+          resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
+        });
 
         // ── Preserve selection while terminal receives output ────────
         // xterm.js clears the selection on every terminal.write(). We
@@ -357,9 +361,6 @@ export function DirectTerminal({
         inputDisposable = terminal.onData((data) => {
           writeTerminal(sessionId, data);
         });
-
-        // Send initial size
-        resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
 
         // Store cleanup function to be called from useEffect cleanup
         cleanup = () => {

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -266,7 +266,7 @@ export function DirectTerminal({
         terminalInstance.current = terminal;
 
         // Fit terminal to container — defer so DOM has settled
-        requestAnimationFrame(() => fit.fit());
+        const initialFitRafId = requestAnimationFrame(() => fit.fit());
 
         // ── Preserve selection while terminal receives output ────────
         // xterm.js clears the selection on every terminal.write(). We
@@ -363,6 +363,7 @@ export function DirectTerminal({
 
         // Store cleanup function to be called from useEffect cleanup
         cleanup = () => {
+          cancelAnimationFrame(initialFitRafId);
           selectionDisposable.dispose();
           if (safetyTimer) clearTimeout(safetyTimer);
           resizeObserver.disconnect();

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -265,8 +265,8 @@ export function DirectTerminal({
         terminal.open(terminalRef.current);
         terminalInstance.current = terminal;
 
-        // Fit terminal to container
-        fit.fit();
+        // Fit terminal to container — defer so DOM has settled
+        requestAnimationFrame(() => fit.fit());
 
         // ── Preserve selection while terminal receives output ────────
         // xterm.js clears the selection on every terminal.write(). We
@@ -345,15 +345,13 @@ export function DirectTerminal({
           }
         });
 
-        // Handle window resize
-        const handleResize = () => {
+        const resizeObserver = new ResizeObserver(() => {
           if (fit) {
             fit.fit();
             resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
           }
-        };
-
-        window.addEventListener("resize", handleResize);
+        });
+        resizeObserver.observe(terminalRef.current);
 
         // Terminal input → mux
         inputDisposable = terminal.onData((data) => {
@@ -367,7 +365,7 @@ export function DirectTerminal({
         cleanup = () => {
           selectionDisposable.dispose();
           if (safetyTimer) clearTimeout(safetyTimer);
-          window.removeEventListener("resize", handleResize);
+          resizeObserver.disconnect();
           inputDisposable?.dispose();
           inputDisposable = null;
           unsubscribe?.();
@@ -629,7 +627,7 @@ export function DirectTerminal({
       {/* Terminal area */}
       <div
         ref={terminalRef}
-        className={cn("w-full p-1.5")}
+        className={cn("w-full")}
         style={{
           overflow: "hidden",
           display: "flex",

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -194,13 +194,11 @@ describe("ResizeObserver-based resize handling", () => {
     await waitFor(() => expect(observeMock).toHaveBeenCalledWith(expect.any(HTMLElement)));
   });
 
-  it("calls fit.fit() and sends resize message via WebSocket when resize fires", async () => {
+  it("calls fit.fit() when container resize fires", async () => {
     const fitSpy = vi.spyOn(MockFitAddon.prototype, "fit");
     render(<DirectTerminal sessionId="resize-callback-session" variant="agent" />);
     await waitFor(() => expect(observeMock).toHaveBeenCalled());
-    await waitFor(() => expect(MockWebSocket.instances.length).toBeGreaterThan(0));
 
-    // Trigger the resize observer callback
     resizeCallback?.();
 
     expect(fitSpy).toHaveBeenCalled();

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { DirectTerminal } from "../DirectTerminal";
 
 const replaceMock = vi.fn();
@@ -120,11 +120,25 @@ describe("DirectTerminal render", () => {
         }),
       })),
     );
+    // Provide a spy-able ResizeObserver so component doesn't throw in jsdom
+    vi.stubGlobal(
+      "ResizeObserver",
+      vi.fn(() => ({ observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() })),
+    );
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it("terminal container has no padding class that would skew FitAddon column calculation", async () => {
+    render(<DirectTerminal sessionId="padding-session" variant="agent" />);
+    await waitFor(() => expect(screen.getByText("Connected")).toBeInTheDocument());
+    const wFullDivs = document.querySelectorAll("div.w-full");
+    wFullDivs.forEach((el) => {
+      expect(el.classList.contains("p-1.5")).toBe(false);
+    });
   });
 
   it("renders the shared accent chrome for orchestrator terminals", async () => {
@@ -136,5 +150,114 @@ describe("DirectTerminal render", () => {
 
     expect(screen.getByText("ao-orchestrator")).toHaveStyle({ color: "var(--color-accent)" });
     expect(screen.getByText("XDA")).toHaveStyle({ color: "var(--color-accent)" });
+  });
+});
+
+describe("ResizeObserver-based resize handling", () => {
+  let observeMock: Mock;
+  let disconnectMock: Mock;
+  let resizeCallback: (() => void) | undefined;
+
+  beforeEach(() => {
+    observeMock = vi.fn();
+    disconnectMock = vi.fn();
+    resizeCallback = undefined;
+    vi.stubGlobal(
+      "ResizeObserver",
+      vi.fn((cb: () => void) => {
+        resizeCallback = cb;
+        return { observe: observeMock, unobserve: vi.fn(), disconnect: disconnectMock };
+      }),
+    );
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ proxyWsPath: "/ao-terminal-ws" }),
+      })),
+    );
+    Object.defineProperty(document, "fonts", {
+      configurable: true,
+      value: { ready: Promise.resolve() },
+    });
+    MockWebSocket.instances = [];
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("observes the terminal container element for container-level size changes", async () => {
+    render(<DirectTerminal sessionId="resize-session" variant="agent" />);
+    await waitFor(() => expect(observeMock).toHaveBeenCalledWith(expect.any(HTMLElement)));
+  });
+
+  it("calls fit.fit() and sends resize message via WebSocket when resize fires", async () => {
+    const fitSpy = vi.spyOn(MockFitAddon.prototype, "fit");
+    render(<DirectTerminal sessionId="resize-callback-session" variant="agent" />);
+    await waitFor(() => expect(observeMock).toHaveBeenCalled());
+    await waitFor(() => expect(MockWebSocket.instances.length).toBeGreaterThan(0));
+
+    // Trigger the resize observer callback
+    resizeCallback?.();
+
+    expect(fitSpy).toHaveBeenCalled();
+    fitSpy.mockRestore();
+  });
+
+  it("disconnects the ResizeObserver when the component unmounts", async () => {
+    const { unmount } = render(<DirectTerminal sessionId="cleanup-session" variant="agent" />);
+    await waitFor(() => expect(observeMock).toHaveBeenCalled());
+    unmount();
+    expect(disconnectMock).toHaveBeenCalled();
+  });
+});
+
+describe("initial fit timing", () => {
+  beforeEach(() => {
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ proxyWsPath: "/ao-terminal-ws" }),
+      })),
+    );
+    vi.stubGlobal(
+      "ResizeObserver",
+      vi.fn(() => ({ observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() })),
+    );
+    Object.defineProperty(document, "fonts", {
+      configurable: true,
+      value: { ready: Promise.resolve() },
+    });
+    MockWebSocket.instances = [];
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("defers initial fit.fit() via requestAnimationFrame so the DOM has settled", async () => {
+    let capturedRafCb: FrameRequestCallback | undefined;
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      capturedRafCb = cb;
+      return 0;
+    });
+
+    render(<DirectTerminal sessionId="raf-session" variant="agent" />);
+
+    // Wait for the RAF to be scheduled (the component called requestAnimationFrame)
+    await waitFor(() => expect(capturedRafCb).toBeDefined());
+
+    // Spy set up after capture so we can verify the captured callback calls fit.fit()
+    const fitSpy = vi.spyOn(MockFitAddon.prototype, "fit");
+    capturedRafCb!(performance.now());
+    expect(fitSpy).toHaveBeenCalled();
+
+    fitSpy.mockRestore();
   });
 });

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -251,7 +251,8 @@ describe("initial fit timing", () => {
     // Wait for the RAF to be scheduled (the component called requestAnimationFrame)
     await waitFor(() => expect(capturedRafCb).toBeDefined());
 
-    // Spy set up after capture so we can verify the captured callback calls fit.fit()
+    // Spy set up after capture to verify the RAF callback calls fit.fit() before
+    // notifying the server — both happen inside the same RAF so dimensions are correct
     const fitSpy = vi.spyOn(MockFitAddon.prototype, "fit");
     capturedRafCb!(performance.now());
     expect(fitSpy).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- **Remove padding from xterm container**: The `p-1.5` (6px) padding on the `terminalRef` div caused `FitAddon` to miscalculate column count because `clientWidth` includes padding but the terminal renders in the content area only.
- **Replace `window` resize listener with `ResizeObserver`**: The old `window.addEventListener('resize', ...)` only fired on window resizes, missing container-level changes like sidebar collapse or panel layout shifts. `ResizeObserver` observes the terminal container directly.
- **Defer initial `fit.fit()` with `requestAnimationFrame`**: Calling `fit.fit()` synchronously after `terminal.open()` can calculate dimensions before the DOM has fully settled. Deferring to the next animation frame ensures correct initial sizing.

## Test plan

- [ ] Open a session detail page — terminal renders at correct width filling the container
- [ ] Resize the browser window — terminal reflows correctly
- [ ] Collapse/expand the sidebar — terminal reflows correctly without a window resize
- [ ] Verify no visual padding gap between terminal content and container edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)