### PR TITLE
Fix fail-open health probes in send readiness and lifecycle status detection

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -153,6 +153,17 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("killed");
   });
 
+  it("detects killed state when the runtime health probe throws", async () => {
+    vi.mocked(plugins.runtime.isAlive).mockRejectedValue(new Error("probe failed"));
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("killed");
+  });
+
   it("detects killed state when getActivityState returns exited", async () => {
     vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "exited" });
 

--- a/packages/core/src/__tests__/session-manager/communication.test.ts
+++ b/packages/core/src/__tests__/session-manager/communication.test.ts
@@ -86,6 +86,49 @@ describe("send", () => {
     );
   });
 
+  it("treats initial send health probe failures as unhealthy and restores before sending", async () => {
+    const wsPath = join(tmpDir, "ws-app-probe-failure");
+    mkdirSync(wsPath, { recursive: true });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: wsPath,
+      branch: "feat/TEST-1",
+      status: "working",
+      project: "my-app",
+      issue: "TEST-1",
+      runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+    });
+
+    let isAliveCalls = 0;
+    vi.mocked(mockRuntime.isAlive).mockImplementation(async (handle) => {
+      if (handle.id === "rt-restored") return true;
+
+      isAliveCalls += 1;
+      if (isAliveCalls === 1) return true;
+      if (isAliveCalls === 2) throw new Error("runtime probe failed");
+      return false;
+    });
+
+    vi.mocked(mockAgent.isProcessRunning)
+      .mockRejectedValueOnce(new Error("process probe failed"))
+      .mockResolvedValueOnce(true);
+
+    vi.mocked(mockRuntime.create).mockResolvedValue(makeHandle("rt-restored"));
+    vi.mocked(mockRuntime.getOutput)
+      .mockResolvedValueOnce("restored prompt")
+      .mockResolvedValueOnce("before send")
+      .mockResolvedValueOnce("after send");
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.send("app-1", "Recover from failed health probes");
+
+    expect(mockRuntime.create).toHaveBeenCalled();
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      makeHandle("rt-restored"),
+      "Recover from failed health probes",
+    );
+  });
+
   it("waits for restored session health probes to recover before sending", async () => {
     const wsPath = join(tmpDir, "ws-app-1");
     mkdirSync(wsPath, { recursive: true });
@@ -128,6 +171,59 @@ describe("send", () => {
     expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
       makeHandle("rt-restored"),
       "Please resume",
+    );
+  });
+
+  it("restores spawning sessions when readiness probes fail after bootstrap", async () => {
+    const wsPath = join(tmpDir, "ws-app-spawning");
+    mkdirSync(wsPath, { recursive: true });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: wsPath,
+      branch: "feat/TEST-1",
+      status: "spawning",
+      project: "my-app",
+      issue: "TEST-1",
+      runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+    });
+
+    let isAliveCalls = 0;
+    vi.mocked(mockRuntime.isAlive).mockImplementation(async (handle) => {
+      if (handle.id === "rt-restored") return true;
+
+      isAliveCalls += 1;
+      if (isAliveCalls === 1) return true;
+      if (isAliveCalls === 2) return true;
+      if (isAliveCalls === 3) throw new Error("bootstrap runtime probe failed");
+      if (isAliveCalls === 4 || isAliveCalls === 5) return true;
+      if (isAliveCalls === 6) throw new Error("post-bootstrap runtime probe failed");
+      return false;
+    });
+
+    vi.mocked(mockAgent.isProcessRunning)
+      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(new Error("bootstrap process probe failed"))
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(new Error("post-bootstrap process probe failed"))
+      .mockResolvedValueOnce(true);
+
+    vi.mocked(mockRuntime.create).mockResolvedValue(makeHandle("rt-restored"));
+    vi.mocked(mockRuntime.getOutput)
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("Press up to edit queued messages")
+      .mockResolvedValueOnce("Press up to edit queued messages")
+      .mockResolvedValueOnce("restored prompt")
+      .mockResolvedValueOnce("before send")
+      .mockResolvedValueOnce("after send");
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.send("app-1", "Resume after bootstrap probe failure");
+
+    expect(mockRuntime.create).toHaveBeenCalled();
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      makeHandle("rt-restored"),
+      "Resume after bootstrap probe failure",
     );
   });
 

--- a/packages/core/src/__tests__/session-manager/communication.test.ts
+++ b/packages/core/src/__tests__/session-manager/communication.test.ts
@@ -86,6 +86,92 @@ describe("send", () => {
     );
   });
 
+  it("waits for restored session health probes to recover before sending", async () => {
+    const wsPath = join(tmpDir, "ws-app-1");
+    mkdirSync(wsPath, { recursive: true });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: wsPath,
+      branch: "feat/TEST-1",
+      status: "killed",
+      project: "my-app",
+      issue: "TEST-1",
+      runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+    });
+
+    vi.mocked(mockRuntime.isAlive).mockImplementation(async (handle) => {
+      if (handle.id === "rt-restored" && vi.mocked(mockRuntime.isAlive).mock.calls.length === 1) {
+        throw new Error("runtime probe failed");
+      }
+      return true;
+    });
+    vi.mocked(mockAgent.isProcessRunning).mockImplementation(async (handle) => {
+      if (
+        handle.id === "rt-restored" &&
+        vi.mocked(mockAgent.isProcessRunning).mock.calls.length === 1
+      ) {
+        throw new Error("process probe failed");
+      }
+      return true;
+    });
+    vi.mocked(mockRuntime.create).mockResolvedValue(makeHandle("rt-restored"));
+    vi.mocked(mockRuntime.getOutput)
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("restored prompt")
+      .mockResolvedValueOnce("before send")
+      .mockResolvedValueOnce("after send");
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.send("app-1", "Please resume");
+
+    expect(mockRuntime.create).toHaveBeenCalled();
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      makeHandle("rt-restored"),
+      "Please resume",
+    );
+  });
+
+  it("throws when a restored session never becomes ready", async () => {
+    vi.useFakeTimers();
+    try {
+      const wsPath = join(tmpDir, "ws-app-timeout");
+      mkdirSync(wsPath, { recursive: true });
+
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: wsPath,
+        branch: "feat/TEST-1",
+        status: "working",
+        project: "my-app",
+        issue: "TEST-1",
+        runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+      });
+
+      vi.mocked(mockRuntime.isAlive).mockImplementation(async (handle) => {
+        if (handle.id === "rt-old") return false;
+        throw new Error("runtime probe failed");
+      });
+      vi.mocked(mockAgent.isProcessRunning).mockImplementation(async (handle) => {
+        if (handle.id === "rt-old") return false;
+        throw new Error("process probe failed");
+      });
+      vi.mocked(mockRuntime.create).mockResolvedValue(makeHandle("rt-restored"));
+      vi.mocked(mockRuntime.getOutput).mockResolvedValue("");
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const sendPromise = sm.send("app-1", "This should not be delivered");
+      const sendAssertion = expect(sendPromise).rejects.toThrow(
+        "Timed out waiting for restored session app-1 to become ready",
+      );
+
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      await sendAssertion;
+      expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("waits for spawning sessions to become interactive before considering restore", async () => {
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp",

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -370,7 +370,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     if (session.runtimeHandle) {
       const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
       if (runtime) {
-        const alive = await runtime.isAlive(session.runtimeHandle).catch(() => true);
+        const alive = await runtime.isAlive(session.runtimeHandle).catch(() => false);
         if (!alive) return "killed";
       }
     }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1920,8 +1920,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       while (true) {
         const [runtimeAlive, processRunning, output, foregroundCommand] = await Promise.all([
-          runtimePlugin.isAlive(handle).catch(() => true),
-          agentPlugin.isProcessRunning(handle).catch(() => true),
+          runtimePlugin.isAlive(handle).catch(() => false),
+          agentPlugin.isProcessRunning(handle).catch(() => false),
           captureOutput(handle),
           handle.runtimeName === "tmux"
             ? getTmuxForegroundCommand(handle.id)
@@ -1967,8 +1967,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       const deadline = Date.now() + SEND_RESTORE_READY_TIMEOUT_MS;
       while (true) {
         const [runtimeAlive, processRunning, output, foregroundCommand] = await Promise.all([
-          runtimePlugin.isAlive(handle).catch(() => true),
-          agentPlugin.isProcessRunning(handle).catch(() => true),
+          runtimePlugin.isAlive(handle).catch(() => false),
+          agentPlugin.isProcessRunning(handle).catch(() => false),
           captureOutput(handle),
           handle.runtimeName === "tmux"
             ? getTmuxForegroundCommand(handle.id)
@@ -1983,7 +1983,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         }
 
         if (Date.now() >= deadline) {
-          return;
+          throw new Error(`Timed out waiting for restored session ${restoredSession.id} to become ready`);
         }
 
         await sleep(SEND_RESTORE_READY_POLL_MS);
@@ -2032,15 +2032,15 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
 
       let [runtimeAlive, processRunning] = await Promise.all([
-        runtimePlugin.isAlive(handle).catch(() => true),
-        agentPlugin.isProcessRunning(handle).catch(() => true),
+        runtimePlugin.isAlive(handle).catch(() => false),
+        agentPlugin.isProcessRunning(handle).catch(() => false),
       ]);
 
       if (normalized.status === "spawning" && runtimeAlive) {
         await waitForInteractiveReadiness(normalized, SEND_BOOTSTRAP_READY_TIMEOUT_MS);
         [runtimeAlive, processRunning] = await Promise.all([
-          runtimePlugin.isAlive(handle).catch(() => true),
-          agentPlugin.isProcessRunning(handle).catch(() => true),
+          runtimePlugin.isAlive(handle).catch(() => false),
+          agentPlugin.isProcessRunning(handle).catch(() => false),
         ]);
       }
 


### PR DESCRIPTION


### Summary
This PR fixes a fail-open health-check pattern where runtime/agent probe errors were treated as success.  
In multiple paths, probe exceptions were converted to alive/running = true, which could hide broken checks and produce false confidence.

### Problem
Health probes in two critical paths used catch(() => true):

1. Send/readiness path in session manager:
- Runtime and process probe failures were treated as healthy during readiness checks.
- Result: send flow could proceed even when health checks were broken.

2. Lifecycle status detection:
- Runtime probe failures were treated as alive.
- Result: dead/unreachable sessions could avoid transition to killed.

### Root Cause
Promise rejection from probe methods was mapped to true instead of false.  
That made probe failures indistinguishable from real healthy states.

### Changes
1. Updated probe fallback behavior to fail closed:
- Changed catch(() => true) to catch(() => false) in send/readiness and lifecycle liveness checks.

2. Preserved existing positive behavior:
- Real successful probes still behave exactly the same.
- Only rejection behavior changed.

3. Strengthened readiness semantics:
- Readiness now requires verified liveness, not masked probe failures.

4. (If included in your branch) Improved restored-session timeout behavior:
- Timeout now surfaces as explicit failure instead of silently returning when readiness cannot be confirmed.

### Files Changed
- session-manager.ts
- lifecycle-manager.ts

### Why This Is Safe
- This change only affects exception paths.
- Healthy sessions with successful probes are unaffected.
- It prevents false positives and aligns with fail-closed behavior for control-plane checks.

### Behavioral Impact
Before:
- Probe error could be interpreted as healthy.
- Send/lifecycle decisions could continue on unverified state.

After:
- Probe error is treated as not healthy.
- Send path waits/restores/fails safely.
- Lifecycle can correctly classify unreachable sessions as killed.

### Test Plan
1. Session manager:
- When runtime probe throws, send path does not treat session as healthy.
- When process probe throws, send path does not treat session as healthy.
- Readiness path no longer advances due to masked probe exceptions.

2. Lifecycle manager:
- When runtime probe throws during determine status, session transitions to killed path.

3. Regression checks:
- Normal healthy sessions still pass readiness and lifecycle checks.
- No behavior change when probes resolve true/false normally.

### Risk / Rollback
Risk is low and localized to failure handling.  
Rollback is straightforward by reverting these fallback changes in the two files above.

---


Closes #1067