### PR TITLE
fix: open orchestrator picker on ao start

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -757,7 +757,7 @@ describe("start command — non-interactive install safety", () => {
 // ---------------------------------------------------------------------------
 
 describe("start command — browser open waits for port", () => {
-  it("calls waitForPortAndOpen with orchestrator URL and AbortSignal", async () => {
+  it("calls waitForPortAndOpen with the orchestrator picker URL and AbortSignal", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
     // Mock findWebDir to return tmpDir and create package.json for existsSync
@@ -765,15 +765,12 @@ describe("start command — browser open waits for port", () => {
     vi.mocked(findWebDir).mockReturnValue(tmpDir);
     writeFileSync(join(tmpDir, "package.json"), "{}");
 
-    mockSessionManager.get.mockResolvedValue(null);
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
+    await program.parseAsync(["node", "test", "start"]);
 
-    await program.parseAsync(["node", "test", "start", "--no-orchestrator"]);
-
-    // waitForPortAndOpen should have been called with orchestrator URL and AbortSignal
+    // waitForPortAndOpen should have been called with orchestrator picker URL and AbortSignal
     expect(mockWaitForPortAndOpen).toHaveBeenCalledTimes(1);
     const args = mockWaitForPortAndOpen.mock.calls[0];
-    expect(args[1]).toContain("/sessions/app-orchestrator");
+    expect(args[1]).toContain("/orchestrators?project=my-app");
     expect(args[2]).toBeInstanceOf(AbortSignal);
     expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
       expect.objectContaining({ configPath: expect.any(String) }),
@@ -908,7 +905,7 @@ describe("start command — orchestrator session strategy display", () => {
     expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
   });
 
-  it("navigates directly to session page when one existing orchestrator found with dashboard enabled", async () => {
+  it("opens the orchestrator picker when dashboard is enabled", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
     // Mock findWebDir and port availability for dashboard-enabled test
@@ -924,31 +921,16 @@ describe("start command — orchestrator session strategy display", () => {
     };
     mockSpawn.mockReturnValue(fakeDashboard);
 
-    // Return a single existing orchestrator session
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator",
-        projectId: "my-app",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(),
-        runtimeHandle: { id: "tmux-session-existing" },
-      },
-    ]);
-
     await program.parseAsync(["node", "test", "start"]);
 
     const output = getLoggedOutput();
-    // With one orchestrator and dashboard enabled, shows the session URL instead of tmux attach
-    expect(output).toContain("http://localhost:3000/sessions/app-orchestrator");
+    expect(output).toContain("http://localhost:3000/orchestrators?project=my-app");
     expect(output).not.toContain("tmux attach");
-    expect(output).not.toContain("multiple sessions found");
-    expect(output).not.toContain("select one in the dashboard");
-
-    // Should NOT spawn a new orchestrator when existing one exists
+    expect(mockSessionManager.list).not.toHaveBeenCalled();
     expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
   });
 
-  it("opens orchestrator selection page when multiple existing orchestrators found with dashboard enabled", async () => {
+  it("skips orchestrator lookup and spawn when dashboard is enabled", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
     // Mock findWebDir
@@ -962,37 +944,16 @@ describe("start command — orchestrator session strategy display", () => {
       emit: vi.fn(),
     };
     mockSpawn.mockReturnValue(fakeDashboard);
-
-    const now = new Date();
-    // Return two existing orchestrator sessions
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator-1",
-        projectId: "my-app",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(now.getTime() - 1000),
-        runtimeHandle: { id: "tmux-session-1" },
-      },
-      {
-        id: "app-orchestrator-2",
-        projectId: "my-app",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: now,
-        runtimeHandle: { id: "tmux-session-2" },
-      },
-    ]);
 
     await program.parseAsync(["node", "test", "start"]);
 
     const output = getLoggedOutput();
-    // With multiple orchestrators, shows selection message so user can choose or spawn a new one
-    expect(output).toContain("multiple sessions found — select one in the dashboard");
-
-    // Should NOT spawn a new orchestrator when existing ones exist
+    expect(output).toContain("/orchestrators?project=my-app");
+    expect(mockSessionManager.list).not.toHaveBeenCalled();
     expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
   });
 
-  it("fails and cleans up dashboard when orchestrator setup throws", async () => {
+  it("does not attempt orchestrator setup during dashboard startup", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
     // Mock findWebDir
@@ -1007,19 +968,16 @@ describe("start command — orchestrator session strategy display", () => {
     };
     mockSpawn.mockReturnValue(fakeDashboard);
 
-    mockSessionManager.list.mockResolvedValue([]);
-    mockSessionManager.spawnOrchestrator.mockRejectedValue(new Error("Spawn failed"));
-
-    await expect(program.parseAsync(["node", "test", "start"])).rejects.toThrow("process.exit(1)");
+    await program.parseAsync(["node", "test", "start"]);
 
     const errors = vi
       .mocked(console.error)
       .mock.calls.map((c) => c.join(" "))
       .join("\n");
-    expect(errors).toContain("Failed to setup orchestrator: Spawn failed");
-
-    // Should have killed the dashboard
-    expect(fakeDashboard.kill).toHaveBeenCalled();
+    expect(errors).not.toContain("Spawn failed");
+    expect(mockSessionManager.list).not.toHaveBeenCalled();
+    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+    expect(fakeDashboard.kill).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1008,11 +1008,13 @@ async function runStartup(
     }
   }
 
-  // Create orchestrator session (unless --no-orchestrator or existing orchestrators found)
-  let hasExistingOrchestrators = false;
+  // When the dashboard is enabled, always send the user to the orchestrator picker
+  // and let the web app handle resume/spawn. This avoids auto-opening stale
+  // sessions and keeps startup off the session enumeration path.
+  const hasExistingOrchestrators = false;
   let selectedOrchestratorId: string | null = null;
 
-  if (opts?.orchestrator !== false) {
+  if (opts?.orchestrator !== false && opts?.dashboard === false) {
     const sm = await getSessionManager(config);
 
     // Check for existing orchestrator sessions for this project
@@ -1039,19 +1041,13 @@ async function runStartup(
     );
 
     if (existingOrchestrators.length > 0) {
-      // Existing orchestrators found — always auto-select the most recently active one.
-      // With a single orchestrator, navigate directly to its session page.
-      // With multiple orchestrators, keep the selection page so the user can choose or spawn a
-      // new one — the dashboard only links to one orchestrator per project, so the selection page
-      // is the only startup path for multi-orchestrator projects.
+      // Without the dashboard we still need a concrete session to attach to, so
+      // auto-select the most recently active orchestrator.
       const sortedOrchestrators = [...existingOrchestrators].sort(
         (a, b) => (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0),
       );
       const selected = sortedOrchestrators[0];
       selectedOrchestratorId = selected.id;
-      if (opts?.dashboard !== false && existingOrchestrators.length > 1) {
-        hasExistingOrchestrators = true;
-      }
       spinner.succeed(
         `Using existing orchestrator session: ${selected.id}` +
           (existingOrchestrators.length > 1
@@ -1096,7 +1092,12 @@ async function runStartup(
     console.log(chalk.cyan("Lifecycle:"), lifecycleTarget);
   }
 
-  if (hasExistingOrchestrators) {
+  if (opts?.dashboard !== false && opts?.orchestrator !== false) {
+    console.log(
+      chalk.cyan("Orchestrator:"),
+      `http://localhost:${port}/orchestrators?project=${projectId}`,
+    );
+  } else if (hasExistingOrchestrators) {
     console.log(
       chalk.cyan("Orchestrator:"),
       "multiple sessions found — select one in the dashboard",
@@ -1121,17 +1122,17 @@ async function runStartup(
   console.log(chalk.dim(`Config: ${config.configPath}`));
 
   // Auto-open browser once the server is ready.
-  // With a single orchestrator (or a newly created one), navigate directly to the session page.
-  // With multiple existing orchestrators, open the selection page so the user can choose or
-  // spawn a new one — the dashboard only links one orchestrator per project.
+  // When the dashboard is enabled, always land on the orchestrator picker so the
+  // user can choose a live session or start a new one.
   // Polls the port instead of using a fixed delay — deterministic and works regardless of
   // how long Next.js takes to compile. AbortController cancels polling on early exit.
   let openAbort: AbortController | undefined;
   if (opts?.dashboard !== false) {
     openAbort = new AbortController();
-    const orchestratorUrl = hasExistingOrchestrators
-      ? `http://localhost:${port}/orchestrators?project=${projectId}`
-      : `http://localhost:${port}/sessions/${selectedOrchestratorId ?? sessionId}`;
+    const orchestratorUrl =
+      opts?.orchestrator !== false
+        ? `http://localhost:${port}/orchestrators?project=${projectId}`
+        : `http://localhost:${port}`;
     void waitForPortAndOpen(port, orchestratorUrl, openAbort.signal);
   }
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1011,7 +1011,6 @@ async function runStartup(
   // When the dashboard is enabled, always send the user to the orchestrator picker
   // and let the web app handle resume/spawn. This avoids auto-opening stale
   // sessions and keeps startup off the session enumeration path.
-  const hasExistingOrchestrators = false;
   let selectedOrchestratorId: string | null = null;
 
   if (opts?.orchestrator !== false && opts?.dashboard === false) {
@@ -1097,24 +1096,12 @@ async function runStartup(
       chalk.cyan("Orchestrator:"),
       `http://localhost:${port}/orchestrators?project=${projectId}`,
     );
-  } else if (hasExistingOrchestrators) {
-    console.log(
-      chalk.cyan("Orchestrator:"),
-      "multiple sessions found — select one in the dashboard",
-    );
   } else if (opts?.orchestrator !== false && !reused) {
     const orchSessionId = selectedOrchestratorId ?? sessionId;
-    if (opts?.dashboard !== false) {
-      console.log(
-        chalk.cyan("Orchestrator:"),
-        `http://localhost:${port}/sessions/${orchSessionId}`,
-      );
-    } else {
-      console.log(
-        chalk.cyan("Orchestrator:"),
-        `ao session attach ${orchSessionId}`,
-      );
-    }
+    console.log(
+      chalk.cyan("Orchestrator:"),
+      `ao session attach ${orchSessionId}`,
+    );
   } else if (reused) {
     console.log(chalk.cyan("Orchestrator:"), `reused existing session (${sessionId})`);
   }

--- a/packages/web/src/components/OrchestratorSelector.tsx
+++ b/packages/web/src/components/OrchestratorSelector.tsx
@@ -170,12 +170,21 @@ export function OrchestratorSelector({
           {/* Info banner */}
           <div className="mb-6 rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
             <p className="text-sm text-[var(--color-text-secondary)]">
-              Found{" "}
-              <span className="font-medium text-[var(--color-text-primary)]">
-                {orchestrators.length}
-              </span>{" "}
-              existing orchestrator session{orchestrators.length !== 1 ? "s" : ""}. You can resume
-              an existing session or start a new one.
+              {orchestrators.length > 0 ? (
+                <>
+                  Found{" "}
+                  <span className="font-medium text-[var(--color-text-primary)]">
+                    {orchestrators.length}
+                  </span>{" "}
+                  active orchestrator session{orchestrators.length !== 1 ? "s" : ""}. Resume one
+                  below or start a new one.
+                </>
+              ) : (
+                "No active orchestrator sessions found. Start a new one below."
+              )}
+            </p>
+            <p className="mt-2 text-xs text-[var(--color-text-tertiary)]">
+              Inactive or exited orchestrators are hidden from this list.
             </p>
           </div>
 

--- a/packages/web/src/components/__tests__/OrchestratorSelector.test.tsx
+++ b/packages/web/src/components/__tests__/OrchestratorSelector.test.tsx
@@ -59,9 +59,8 @@ describe("OrchestratorSelector", () => {
   it("shows count of existing sessions", () => {
     render(<OrchestratorSelector {...defaultProps} />);
 
-    expect(screen.getByText(/existing orchestrator sessions/)).toBeInTheDocument();
-    // The count "2" appears in multiple places, so we check the full info banner text
-    expect(screen.getByText(/Found/)).toBeInTheDocument();
+    expect(screen.getByText(/active orchestrator sessions/)).toBeInTheDocument();
+    expect(screen.getByText(/inactive or exited orchestrators are hidden/i)).toBeInTheDocument();
   });
 
   it("shows error state", () => {


### PR DESCRIPTION


Closes #1102

### Problem

`ao start` navigated directly to `/sessions/{slug}-orchestrator` instead of the orchestrator picker. If the previous orchestrator had been killed (no active tmux), the session page errored with _"tmux not found"_ and offered no way to reach an active session or start a new one.

### Fix

When the dashboard is enabled, `ao start` now always opens the orchestrator picker (`/orchestrators?project=<id>`). The picker shows only active orchestrators and lets the user resume or start a new one. Killed/inactive orchestrators are hidden from the list.

The `--no-dashboard` flow is unchanged.

### Changes

- **`packages/cli/src/commands/start.ts`** — Orchestrator session lookup now only runs when `--no-dashboard` is set. Dashboard flow always opens the picker URL.
- **`packages/web/src/components/OrchestratorSelector.tsx`** — Handles the zero-sessions case. Inactive/exited orchestrators hidden from list.
- **Tests** — Removed auto-selection branches. Updated to match the simpler startup contract.

### Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`