### PR TITLE
fix(web): register codex agent plugin in web services registry

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,6 +30,7 @@
     "@aoagents/ao-core": "workspace:*",
     "@aoagents/ao-plugin-agent-claude-code": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
+    "@aoagents/ao-plugin-agent-codex": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
     "@aoagents/ao-plugin-runtime-tmux": "workspace:*",
     "@aoagents/ao-plugin-scm-github": "workspace:*",

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -34,6 +34,7 @@ import {
 import pluginRuntimeTmux from "@aoagents/ao-plugin-runtime-tmux";
 import pluginAgentClaudeCode from "@aoagents/ao-plugin-agent-claude-code";
 import pluginAgentCursor from "@aoagents/ao-plugin-agent-cursor";
+import pluginAgentCodex from "@aoagents/ao-plugin-agent-codex";
 import pluginAgentOpencode from "@aoagents/ao-plugin-agent-opencode";
 import pluginWorkspaceWorktree from "@aoagents/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@aoagents/ao-plugin-scm-github";
@@ -77,6 +78,7 @@ async function initServices(): Promise<Services> {
   registry.register(pluginRuntimeTmux);
   registry.register(pluginAgentClaudeCode);
   registry.register(pluginAgentCursor);
+  registry.register(pluginAgentCodex);
   registry.register(pluginAgentOpencode);
   registry.register(pluginWorkspaceWorktree);
   registry.register(pluginScmGithub);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -600,6 +600,9 @@ importers:
       '@aoagents/ao-plugin-agent-claude-code':
         specifier: workspace:*
         version: link:../plugins/agent-claude-code
+      '@aoagents/ao-plugin-agent-codex':
+        specifier: workspace:*
+        version: link:../plugins/agent-codex
       '@aoagents/ao-plugin-agent-cursor':
         specifier: workspace:*
         version: link:../plugins/agent-cursor


### PR DESCRIPTION
## Summary

- Adds the missing `@aoagents/ao-plugin-agent-codex` dependency to `packages/web/package.json`
- Adds the static import and `registry.register()` call in `packages/web/src/lib/services.ts`
- This fixes `POST /api/orchestrators` returning `"Agent plugin 'codex' not found"` for codex-based projects

The codex plugin was simply omitted when the web services registry was assembled. The CLI path (`ao start`) was unaffected because it uses dynamic `import()` via `loadBuiltins()`, but the web server requires explicit static imports for Next.js webpack compatibility.

Closes #1137

## Test plan

- [x] `pnpm build` passes (all packages including web)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm --filter @aoagents/ao-web test` passes (52 files, 594 tests)
- [ ] Manual: configure a project with `agent: codex`, call `POST /api/orchestrators` — verify new orchestrator spawns successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)