### PR TITLE
feat(web): add /api/health endpoint

### DIFF
--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -208,6 +208,7 @@ import { GET as observabilityGET } from "@/app/api/observability/route";
 import { GET as runtimeTerminalGET } from "@/app/api/runtime/terminal/route";
 import { GET as verifyGET, POST as verifyPOST } from "@/app/api/verify/route";
 import { GET as patchesGET } from "@/app/api/sessions/patches/route";
+import { GET as healthGET } from "@/app/api/health/route";
 
 function makeRequest(url: string, init?: RequestInit): NextRequest {
   return new NextRequest(
@@ -1022,6 +1023,29 @@ describe("API Routes", () => {
       expect(res.status).toBe(500);
       const data = await res.json();
       expect(data.error).toBe("db down");
+    });
+  });
+
+  // ── /api/health ──────────────────────────────────────────────────────
+
+  describe("GET /api/health", () => {
+    it("returns 200 with status ok and project count", async () => {
+      const res = await healthGET();
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.status).toBe("ok");
+      expect(typeof data.timestamp).toBe("string");
+      expect(data.projects).toBe(Object.keys(mockConfig.projects).length);
+    });
+
+    it("returns 503 when getServices throws", async () => {
+      const { getServices } = await import("@/lib/services");
+      vi.mocked(getServices).mockRejectedValueOnce(new Error("config missing"));
+      const res = await healthGET();
+      expect(res.status).toBe(503);
+      const data = await res.json();
+      expect(data.status).toBe("error");
+      expect(data.error).toBe("config missing");
     });
   });
 });

--- a/packages/web/src/app/api/health/route.ts
+++ b/packages/web/src/app/api/health/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getServices } from "@/lib/services";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/health — Health check endpoint
+ *
+ * Returns 200 when the server is running and core services are available.
+ * Returns 503 when services fail to initialize.
+ */
+export async function GET() {
+  try {
+    const { config } = await getServices();
+    const projectCount = Object.keys(config.projects).length;
+
+    return NextResponse.json({
+      status: "ok",
+      timestamp: new Date().toISOString(),
+      projects: projectCount,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        status: "error",
+        timestamp: new Date().toISOString(),
+        error: err instanceof Error ? err.message : "Services unavailable",
+      },
+      { status: 503 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `GET /api/health` endpoint that returns `200` with `{ status: "ok", timestamp, projects }` when the server is healthy
- Returns `503` with `{ status: "error", timestamp, error }` when core services fail to initialize
- Adds tests for both the success and failure paths

Closes: assigned task (add health check endpoint to web server)

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm lint` passes (0 errors, only pre-existing warnings)
- [x] `pnpm --filter @aoagents/ao-web test` passes (596/596 tests, including 2 new health check tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)