### PR TITLE
feat(cli): auto-offer to register cwd when ao start finds no matching project

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -53,6 +53,16 @@ const { mockProcessCwd } = vi.hoisted(() => ({
   mockProcessCwd: vi.fn<[], string>(),
 }));
 
+const { mockPromptSelect, mockPromptConfirm } = vi.hoisted(() => ({
+  mockPromptSelect: vi.fn(),
+  mockPromptConfirm: vi.fn(),
+}));
+
+vi.mock("../../src/lib/prompts.js", () => ({
+  promptSelect: mockPromptSelect,
+  promptConfirm: mockPromptConfirm,
+}));
+
 vi.mock("../../src/lib/shell.js", () => ({
   tmux: vi.fn(),
   exec: mockExec,
@@ -192,6 +202,7 @@ vi.mock("node:process", async (importOriginal) => {
 
 import { Command } from "commander";
 import { registerStart, registerStop, createConfigOnly } from "../../src/commands/start.js";
+import { isHumanCaller } from "../../src/lib/caller-context.js";
 
 let tmpDir: string;
 let program: Command;
@@ -252,6 +263,17 @@ beforeEach(() => {
   });
   mockSpawn.mockClear();
   mockProcessCwd.mockReset();
+
+  mockPromptSelect.mockReset();
+  mockPromptConfirm.mockReset();
+  // Default: return the first option's value (picks first project in multi-project prompts).
+  mockPromptSelect.mockImplementation(
+    async (_message: string, options: Array<{ value: string }>) => options[0]?.value,
+  );
+  mockPromptConfirm.mockResolvedValue(false);
+
+  // Reset isHumanCaller to its module-level default — tests can override locally.
+  vi.mocked(isHumanCaller).mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -371,11 +393,14 @@ describe("start command — project resolution", () => {
     expect(errors).toContain("not found");
   });
 
-  it("errors when multiple projects and no arg", async () => {
+  it("errors when multiple projects and no arg in non-interactive mode", async () => {
     mockConfigRef.current = makeConfig({
       frontend: makeProject({ name: "Frontend" }),
       backend: makeProject({ name: "Backend" }),
     });
+
+    // Non-interactive caller (CI, agent) — no prompt, just fail with guidance.
+    vi.mocked(isHumanCaller).mockReturnValue(false);
 
     await expect(
       program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
@@ -400,6 +425,150 @@ describe("start command — project resolution", () => {
       .mock.calls.map((c) => c.join(" "))
       .join("\n");
     expect(errors).toContain("No projects configured");
+  });
+
+  it("offers register-cwd option when cwd is a git repo and no project matches", async () => {
+    // Create a real git repo on disk so addProjectToConfig can detect it.
+    const cwdRepo = join(tmpDir, "agent-orchestrator");
+    createFakeRepo(cwdRepo, "https://github.com/ComposioHQ/agent-orchestrator.git");
+    mockCwd(cwdRepo);
+    mockProcessCwd.mockReturnValue(cwdRepo);
+
+    // Write a real yaml to disk so loadConfig() can re-read after the append.
+    const configPath = join(tmpDir, "agent-orchestrator.yaml");
+    writeFileSync(
+      configPath,
+      [
+        "port: 3000",
+        "defaults:",
+        "  runtime: tmux",
+        "  agent: claude-code",
+        "  workspace: worktree",
+        "  notifiers: []",
+        "projects:",
+        "  frontend:",
+        "    name: Frontend",
+        "    repo: org/frontend",
+        "    path: /some/other/frontend",
+        "    defaultBranch: main",
+        "    sessionPrefix: fe",
+        "  backend:",
+        "    name: Backend",
+        "    repo: org/backend",
+        "    path: /some/other/backend",
+        "    defaultBranch: main",
+        "    sessionPrefix: be",
+      ].join("\n"),
+    );
+    mockConfigRef.current = {
+      configPath,
+      port: 3000,
+      defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+      projects: {
+        frontend: {
+          name: "Frontend",
+          repo: "org/frontend",
+          path: "/some/other/frontend",
+          defaultBranch: "main",
+          sessionPrefix: "fe",
+        },
+        backend: {
+          name: "Backend",
+          repo: "org/backend",
+          path: "/some/other/backend",
+          defaultBranch: "main",
+          sessionPrefix: "be",
+        },
+      },
+      notifiers: {},
+      notificationRouting: {},
+      reactions: {},
+    };
+
+    // Mock shell `git` to report cwd as a git repo and surface the origin remote.
+    const { git } = await import("../../src/lib/shell.js");
+    vi.mocked(git).mockImplementation(async (args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--git-dir") return ".git";
+      if (args[0] === "remote" && args[1] === "get-url") {
+        return "https://github.com/ComposioHQ/agent-orchestrator.git";
+      }
+      return null;
+    });
+
+    // vi.restoreAllMocks() in afterEach wipes vi.fn() return values — re-establish.
+    const { detectProjectType, generateRulesFromTemplates, formatProjectTypeForDisplay } =
+      await import("../../src/lib/project-detection.js");
+    vi.mocked(detectProjectType).mockReturnValue({ languages: [], frameworks: [] });
+    vi.mocked(generateRulesFromTemplates).mockReturnValue(null);
+    vi.mocked(formatProjectTypeForDisplay).mockReturnValue("");
+
+    // Capture the options passed to promptSelect, then pick the register option.
+    let capturedOptions: Array<{ value: string; label: string; hint?: string }> | null = null;
+    mockPromptSelect.mockImplementationOnce(
+      async (_message: string, options: Array<{ value: string; label: string; hint?: string }>) => {
+        capturedOptions = options;
+        return "__register_cwd__";
+      },
+    );
+
+    await program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]);
+
+    // Register option should be offered as the first choice, with cwd as hint.
+    expect(capturedOptions).not.toBeNull();
+    expect(capturedOptions![0]).toMatchObject({
+      value: "__register_cwd__",
+      hint: cwdRepo,
+    });
+    // Existing projects still shown after register.
+    expect(capturedOptions!.slice(1).map((o) => o.value)).toEqual(["frontend", "backend"]);
+
+    // Yaml should now contain the new project pointing at cwdRepo.
+    const updated = parseYaml(readFileSync(configPath, "utf-8")) as {
+      projects: Record<string, { path: string; repo: string; defaultBranch: string }>;
+    };
+    expect(updated.projects).toHaveProperty("agent-orchestrator");
+    expect(updated.projects["agent-orchestrator"].path).toBe(cwdRepo);
+    expect(updated.projects["agent-orchestrator"].repo).toBe("ComposioHQ/agent-orchestrator");
+    // frontend/backend untouched.
+    expect(updated.projects).toHaveProperty("frontend");
+    expect(updated.projects).toHaveProperty("backend");
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain(`Added "agent-orchestrator"`);
+    expect(output).toContain("Startup complete");
+  });
+
+  it("does not offer register-cwd option when cwd is not a git repo", async () => {
+    const nonRepo = join(tmpDir, "not-a-repo");
+    mkdirSync(nonRepo, { recursive: true });
+    mockCwd(nonRepo);
+    mockProcessCwd.mockReturnValue(nonRepo);
+
+    mockConfigRef.current = makeConfig({
+      frontend: makeProject({ name: "Frontend" }),
+      backend: makeProject({ name: "Backend", sessionPrefix: "be" }),
+    });
+
+    // Mock shell `git` — `rev-parse --git-dir` fails (not a git repo).
+    const { git } = await import("../../src/lib/shell.js");
+    vi.mocked(git).mockResolvedValue(null);
+
+    let capturedOptions: Array<{ value: string }> | null = null;
+    mockPromptSelect.mockImplementationOnce(
+      async (_message: string, options: Array<{ value: string }>) => {
+        capturedOptions = options;
+        return "frontend";
+      },
+    );
+
+    await program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]);
+
+    expect(capturedOptions).not.toBeNull();
+    expect(capturedOptions!.map((o) => o.value)).toEqual(["frontend", "backend"]);
+    expect(capturedOptions!.some((o) => o.value === "__register_cwd__")).toBe(false);
   });
 });
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -73,16 +73,24 @@ const IS_TTY = Boolean(process.stdin.isTTY && process.stdout.isTTY);
 // HELPERS
 // =============================================================================
 
+const REGISTER_CWD_CHOICE = "__register_cwd__";
+
 /**
  * Resolve project from config.
  * If projectArg is provided, use it. If only one project exists, use that.
  * Otherwise, error with helpful message.
+ *
+ * When multiple projects are configured and cwd doesn't match any of them,
+ * interactive callers also see a "Register current directory" option at the
+ * top of the prompt (if cwd is a git repo). Selecting it appends a new
+ * project entry to the yaml via `addProjectToConfig` and returns a reloaded
+ * config so the caller picks up the new entry.
  */
 async function resolveProject(
   config: OrchestratorConfig,
   projectArg?: string,
   action = "start",
-): Promise<{ projectId: string; project: ProjectConfig }> {
+): Promise<{ projectId: string; project: ProjectConfig; config: OrchestratorConfig }> {
   const projectIds = Object.keys(config.projects);
 
   if (projectIds.length === 0) {
@@ -97,13 +105,13 @@ async function resolveProject(
         `Project "${projectArg}" not found. Available projects:\n  ${projectIds.join(", ")}`,
       );
     }
-    return { projectId: projectArg, project };
+    return { projectId: projectArg, project, config };
   }
 
   // Only one project — use it
   if (projectIds.length === 1) {
     const projectId = projectIds[0];
-    return { projectId, project: config.projects[projectId] };
+    return { projectId, project: config.projects[projectId], config };
   }
 
   // Multiple projects — try matching cwd to a project path
@@ -111,20 +119,52 @@ async function resolveProject(
   const currentDir = resolve(cwd());
   const matchedProjectId = findProjectForDirectory(config.projects, currentDir);
   if (matchedProjectId) {
-    return { projectId: matchedProjectId, project: config.projects[matchedProjectId] };
+    return {
+      projectId: matchedProjectId,
+      project: config.projects[matchedProjectId],
+      config,
+    };
   }
 
   // No match — prompt if interactive, otherwise error
   if (isHumanCaller()) {
-    const projectId = await promptSelect(
-      `Choose project to ${action}:`,
-      projectIds.map((id) => ({
+    // If cwd is a git repo, let the user register it as a new project inline
+    // rather than forcing them to pick one of the existing (wrong) projects.
+    const cwdIsGitRepo = (await git(["rev-parse", "--git-dir"], currentDir)) !== null;
+
+    const options: Array<{ value: string; label: string; hint?: string }> = [];
+    if (cwdIsGitRepo) {
+      options.push({
+        value: REGISTER_CWD_CHOICE,
+        label: "Register current directory as a new project",
+        hint: currentDir,
+      });
+    }
+    for (const id of projectIds) {
+      options.push({
         value: id,
         label: config.projects[id].name ?? id,
         hint: id,
-      })),
-    );
-    return { projectId, project: config.projects[projectId] };
+      });
+    }
+
+    const message = cwdIsGitRepo
+      ? `Choose a project to ${action} (or register the current directory):`
+      : `Choose project to ${action}:`;
+
+    const choice = await promptSelect(message, options);
+
+    if (choice === REGISTER_CWD_CHOICE) {
+      const addedId = await addProjectToConfig(config, currentDir);
+      const reloaded = loadConfig(config.configPath);
+      return {
+        projectId: addedId,
+        project: reloaded.projects[addedId],
+        config: reloaded,
+      };
+    }
+
+    return { projectId: choice, project: config.projects[choice], config };
   } else {
     throw new Error(
       `Multiple projects configured. Specify which one to ${action}:\n  ${projectIds.map((id) => `ao ${action} ${id}`).join("\n  ")}`,
@@ -143,14 +183,14 @@ async function resolveProject(
 async function resolveProjectByRepo(
   config: OrchestratorConfig,
   parsed: ParsedRepoUrl,
-): Promise<{ projectId: string; project: ProjectConfig }> {
+): Promise<{ projectId: string; project: ProjectConfig; config: OrchestratorConfig }> {
   const projectIds = Object.keys(config.projects);
 
   // Try to match by repo field (e.g. "owner/repo")
   for (const id of projectIds) {
     const project = config.projects[id];
     if (project.repo === parsed.ownerRepo) {
-      return { projectId: id, project };
+      return { projectId: id, project, config };
     }
   }
 
@@ -1211,7 +1251,7 @@ export function registerStart(program: Command): void {
             console.log(chalk.bold.cyan("\n  Agent Orchestrator — Quick Start\n"));
             const result = await handleUrlStart(projectArg);
             config = result.config;
-            ({ projectId, project } = await resolveProjectByRepo(config, result.parsed));
+            ({ projectId, project, config } = await resolveProjectByRepo(config, result.parsed));
           } else if (projectArg && isLocalPath(projectArg)) {
             // ── Path argument: add project if new, then start ──
             const resolvedPath = resolve(projectArg.replace(/^~/, process.env["HOME"] || ""));
@@ -1234,7 +1274,7 @@ export function registerStart(program: Command): void {
                 projectId = addedId;
                 project = config.projects[projectId];
               } else {
-                ({ projectId, project } = await resolveProject(config));
+                ({ projectId, project, config } = await resolveProject(config));
               }
             } else {
               config = loadConfig(configPath);
@@ -1270,7 +1310,7 @@ export function registerStart(program: Command): void {
               }
             }
             config = loadedConfig;
-            ({ projectId, project } = await resolveProject(config, projectArg));
+            ({ projectId, project, config } = await resolveProject(config, projectArg));
           }
 
           // ── Already-running detection (Step 9) ──


### PR DESCRIPTION
## Summary
- When `ao start` (no args) is run from a git repo that isn't registered in the config, the interactive prompt now shows **"Register current directory as a new project"** as the first option — eliminating the dead-end where only unrelated projects were offered.
- Selecting it calls the existing `addProjectToConfig` helper, reloads the config, and proceeds to start the newly-registered project.
- Non-interactive mode (CI/agents) is unchanged — still errors with the same guidance message.
- `resolveProject` return type now includes `config` so the reloaded config propagates to all call sites.

Closes #1141

## Test plan
- [x] New test: register-cwd option appears first with cwd hint when cwd is a git repo and no project matches; selecting it writes yaml and starts the project
- [x] New test: non-git cwd does not see the register option
- [x] Existing test updated: "errors when multiple projects" now explicitly tests non-interactive mode (`isHumanCaller=false`)
- [x] All 35 start command tests pass
- [x] Typecheck clean
- [x] Lint clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)