### PR TITLE
feat(core): add hello world utility

### DIFF
--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -3,12 +3,19 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  helloWorld,
   isGitBranchNameSafe,
   isRetryableHttpStatus,
   normalizeRetryConfig,
   readLastJsonlEntry,
 } from "../utils.js";
 import { parsePrFromUrl } from "../utils/pr.js";
+
+describe("helloWorld", () => {
+  it("returns the canonical greeting", () => {
+    expect(helloWorld()).toBe("Hello, world!");
+  });
+});
 
 describe("readLastJsonlEntry", () => {
   let tmpDir: string;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -24,6 +24,13 @@ export function escapeAppleScript(s: string): string {
 }
 
 /**
+ * Minimal hello world helper for TypeScript consumers.
+ */
+export function helloWorld(): string {
+  return "Hello, world!";
+}
+
+/**
  * Validate that a URL starts with http:// or https://.
  * Throws with a descriptive error including the plugin label if invalid.
  */


### PR DESCRIPTION
## Summary
- add a typed `helloWorld()` helper in `@aoagents/ao-core` shared utilities
- cover the helper with a focused unit test in the core utils test suite

## Testing
- pnpm --filter @aoagents/ao-core test -- utils.test.ts
- pnpm --filter @aoagents/ao-core typecheck

No tracker issue was provided for auto-closing.