### PR TITLE
fix(lifecycle): refresh stale PR enrichment before CI/conflict alerts

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1216,6 +1216,41 @@ describe("reactions", () => {
     );
   });
 
+  it("does not dispatch merge conflict notification when GitHub mergeability is unknown", async () => {
+    config.reactions = {
+      "merge-conflicts": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Resolve merge conflicts.",
+      },
+    };
+
+    const mockSCM = createMockSCM({
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: false,
+        ciPassing: true,
+        approved: false,
+        noConflicts: false,
+        blockers: ["Merge status unknown (GitHub is computing)"],
+      }),
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
+  });
+
   it("does not re-dispatch merge conflict notification when already dispatched", async () => {
     config.reactions = {
       "merge-conflicts": {
@@ -1318,6 +1353,76 @@ describe("reactions", () => {
     });
     await lm.check("app-1");
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-dispatches merge conflict notification when the same conflict persists on a new head SHA", async () => {
+    config.reactions = {
+      "merge-conflicts": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Resolve merge conflicts.",
+      },
+    };
+
+    const pr = makePR({ owner: "org", repo: "my-app" });
+    const mockSCM = createMockSCM({
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      enrichSessionsPRBatch: vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Map([
+            [
+              `${pr.owner}/${pr.repo}#${pr.number}`,
+              {
+                state: "open" as const,
+                headSha: "sha-1",
+                ciStatus: "passing" as const,
+                reviewDecision: "none" as const,
+                mergeable: false,
+                hasConflicts: true,
+              },
+            ],
+          ]),
+        )
+        .mockResolvedValueOnce(
+          new Map([
+            [
+              `${pr.owner}/${pr.repo}#${pr.number}`,
+              {
+                state: "open" as const,
+                headSha: "sha-2",
+                ciStatus: "passing" as const,
+                reviewDecision: "none" as const,
+                mergeable: false,
+                hasConflicts: true,
+              },
+            ],
+          ]),
+        ),
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const session = makeSession({ id: "s-head", status: "pr_open", pr });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    vi.useFakeTimers();
+    const lm = createLifecycleManager({ config, registry, sessionManager: mockSessionManager });
+    lm.start(60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    vi.mocked(mockSessionManager.send).mockClear();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+
+    lm.stop();
+    vi.useRealTimers();
   });
 
   it("clears merge conflict tracking when PR is merged", async () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -946,6 +946,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return lines.join("\n");
   }
 
+  function addHeadShaToFingerprint(fingerprint: string, headSha?: string): string {
+    return headSha ? `${headSha}:${fingerprint}` : fingerprint;
+  }
+
   /**
    * Dispatch CI failure details to the agent session when new or changed
    * failures are detected. Follows the same fingerprinting/deduplication
@@ -1014,8 +1018,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     );
     if (failedChecks.length === 0) return;
 
-    const ciFingerprint = makeFingerprint(
+    const failureFingerprint = makeFingerprint(
       failedChecks.map((c) => `${c.name}:${c.status}:${c.conclusion ?? ""}`),
+    );
+    const ciFingerprint = addHeadShaToFingerprint(
+      failureFingerprint,
+      cachedEnrichment?.headSha,
     );
     const lastCIFingerprint = session.metadata["lastCIFailureFingerprint"] ?? "";
     const lastCIDispatchHash = session.metadata["lastCIFailureDispatchHash"] ?? "";
@@ -1118,31 +1126,35 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     // Check for conflicts using cached enrichment data or fallback to individual call.
-    // When batch enrichment ran (cachedData is present), use its hasConflicts value
-    // to avoid 3 redundant REST calls from getMergeability() — the batch already
-    // fetched the mergeable/mergeStateStatus fields via GraphQL.
+    // Only trust cached hasConflicts when GitHub returned an authoritative mergeable
+    // state. UNKNOWN / computing should fall back to a live getMergeability() check
+    // rather than being treated as conflict-free.
     const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
     const cachedData = prEnrichmentCache.get(prKey);
 
     let hasConflicts: boolean;
-    if (cachedData) {
-      // Batch ran — trust its data (undefined means CONFLICTING wasn't set → no conflicts)
-      hasConflicts = cachedData.hasConflicts ?? false;
+    if (cachedData?.hasConflicts !== undefined) {
+      hasConflicts = cachedData.hasConflicts;
     } else {
-      // Batch didn't run this cycle — fall back to individual API call
+      // Batch did not run this cycle, or GitHub returned an indeterminate mergeability
+      // state. Fall back to a live per-PR mergeability check.
       try {
         const mergeReadiness = await scm.getMergeability(session.pr);
-        hasConflicts = !mergeReadiness.noConflicts;
+        hasConflicts = mergeReadiness.blockers.includes("Merge conflicts");
       } catch {
         return;
       }
     }
 
     const lastDispatched = session.metadata["lastMergeConflictDispatched"] ?? "";
+    const conflictFingerprint = addHeadShaToFingerprint(
+      "merge-conflicts",
+      cachedData?.headSha,
+    );
 
     if (hasConflicts) {
       // Already dispatched for current conflict state — skip
-      if (lastDispatched === "true") return;
+      if (lastDispatched === conflictFingerprint) return;
 
       const reactionConfig = getReactionConfigForSession(session, conflictReactionKey);
       if (
@@ -1166,13 +1178,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           }
 
           updateSessionMetadata(session, {
-            lastMergeConflictDispatched: "true",
+            lastMergeConflictDispatched: conflictFingerprint,
           });
         } catch {
           // Send failed — will retry on next poll cycle
         }
       }
-    } else if (lastDispatched === "true") {
+    } else if (lastDispatched) {
       // Conflicts resolved — clear so we can re-dispatch if they recur
       clearReactionTracker(session.id, conflictReactionKey);
       updateSessionMetadata(session, {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -793,6 +793,8 @@ export interface MergeReadiness {
 export interface PREnrichmentData {
   /** Current PR state */
   state: PRState;
+  /** Head commit SHA used to derive this enrichment snapshot */
+  headSha?: string;
   /** Overall CI status */
   ciStatus: CIStatus;
   /** Review decision */

--- a/packages/plugins/scm-github/src/graphql-batch.ts
+++ b/packages/plugins/scm-github/src/graphql-batch.ts
@@ -33,6 +33,7 @@ export function setExecFileAsync(fn: typeof execFileAsync): void {
  * LRU cache automatically evicts oldest entries when these limits are reached.
  */
 const MAX_PR_LIST_ETAGS = 100;  // Number of repos to cache
+const MAX_PR_DETAIL_ETAGS = 500;  // Number of PRs to cache
 const MAX_COMMIT_STATUS_ETAGS = 500;  // Number of commits to cache
 const MAX_PR_METADATA = 200;  // Number of PRs to cache full data
 
@@ -46,6 +47,7 @@ const MAX_PR_METADATA = 200;  // Number of PRs to cache full data
  */
 interface ETagCache {
   prList: LRUCache<string, string>; // Key: "owner/repo", Value: ETag
+  prDetail: LRUCache<string, string>; // Key: "owner/repo#number", Value: ETag
   commitStatus: LRUCache<string, string>; // Key: "owner/repo#sha", Value: ETag
 }
 
@@ -58,6 +60,7 @@ interface ETagCache {
  */
 const etagCache: ETagCache = {
   prList: new LRUCache(MAX_PR_LIST_ETAGS),
+  prDetail: new LRUCache(MAX_PR_DETAIL_ETAGS),
   commitStatus: new LRUCache(MAX_COMMIT_STATUS_ETAGS),
 };
 
@@ -75,6 +78,7 @@ interface ETagGuardResult {
  */
 export function clearETagCache(): void {
   etagCache.prList.clear();
+  etagCache.prDetail.clear();
   etagCache.commitStatus.clear();
 }
 
@@ -83,6 +87,17 @@ export function clearETagCache(): void {
  */
 export function getPRListETag(owner: string, repo: string): string | undefined {
   return etagCache.prList.get(`${owner}/${repo}`);
+}
+
+/**
+ * Get PR detail ETag for a specific PR.
+ */
+export function getPRDetailETag(
+  owner: string,
+  repo: string,
+  number: number,
+): string | undefined {
+  return etagCache.prDetail.get(`${owner}/${repo}#${number}`);
 }
 
 /**
@@ -102,6 +117,19 @@ export function getCommitStatusETag(
  */
 export function setPRListETag(owner: string, repo: string, etag: string): void {
   etagCache.prList.set(`${owner}/${repo}`, etag);
+}
+
+/**
+ * Set PR detail ETag for a specific PR.
+ * Exported for testing.
+ */
+export function setPRDetailETag(
+  owner: string,
+  repo: string,
+  number: number,
+  etag: string,
+): void {
+  etagCache.prDetail.set(`${owner}/${repo}#${number}`, etag);
 }
 
 /**
@@ -157,7 +185,7 @@ function updatePRMetadataCache(
 }
 
 /**
- * 2-Guard ETag Strategy: Check if PR enrichment cache needs refreshing.
+ * 3-Guard ETag Strategy: Check if PR enrichment cache needs refreshing.
  *
  * Before running expensive GraphQL batch queries, use two lightweight REST API
  * ETag checks to detect if anything actually changed:
@@ -166,7 +194,11 @@ function updatePRMetadataCache(
  *   - Detects: New commits, PR title/body edits, labels changes, reviews, PR state changes
  *   - Misses: CI status changes
  *
- * Guard 2: Commit Status ETag Check (per PR with cached metadata)
+ * Guard 2: PR Detail ETag Check (per tracked PR)
+ *   - Detects: Head SHA changes, review changes, mergeability changes, draft/state updates
+ *   - Closes the stale-head window that repo-level PR-list ETags can miss
+ *
+ * Guard 3: Commit Status ETag Check (per PR with cached metadata)
  *   - Checks ALL PRs with cached metadata and head SHA
  *   - Detects: CI check starts, passes, fails, or external status updates
  *   - Critical for catching CI transitions (failing -> passing, passing -> failing, etc.)
@@ -210,19 +242,27 @@ export async function shouldRefreshPREnrichment(
     }
   }
 
-  // Guard 2: Check commit status ETag only when Guard 1 didn't detect changes
+  // Guard 2 + Guard 3: when Guard 1 did not detect changes, validate each tracked
+  // PR directly before trusting cached enrichment. Repo-level PR list ETags can miss
+  // updates on a tracked PR that is not the most recently updated PR in the repo.
   // We check ALL PRs (not just pending) to catch CI status transitions:
   // - failing -> passing (PR becomes merge-ready)
   // - passing -> failing (PR becomes unmergeable)
   // - pending -> passing/failing (CI completes)
   // - passing -> pending (new CI run starts)
   //
-  // Guard 2 is only needed when Guard 1 returns 304 (no PR list changes).
+  // These guards are only needed when Guard 1 returns 304 (no repo-level PR list changes).
   // If Guard 1 detected changes, we're going to refresh all PRs anyway.
   if (!guard1DetectedChanges) {
     for (const pr of prs) {
       const prKey = `${pr.owner}/${pr.repo}#${pr.number}`;
       const cached = prMetadataCache.get(prKey);
+
+      if (!cached) {
+        shouldRefresh = true;
+        details.push(`First time seeing PR #${pr.number} (Guard 2: no cached metadata)`);
+        continue;
+      }
 
       // Check for incomplete cache (cached but no headSha)
       // This happens when PR was cached but headSha wasn't captured
@@ -233,22 +273,30 @@ export async function shouldRefreshPREnrichment(
         continue;
       }
 
-      // Only check commit status ETag if we have cached data with a non-null head SHA
-      if (!cached || !cached.headSha) {
-        // No cached metadata - skip Guard 2. Since Guard 1 didn't detect changes
-        // and we have no cached data, there's nothing to check.
+      const prDetailChanged = await checkPRDetailETag(pr.owner, pr.repo, pr.number);
+      if (prDetailChanged) {
+        shouldRefresh = true;
+        details.push(`PR metadata changed for ${pr.owner}/${pr.repo}#${pr.number} (Guard 2)`);
         continue;
       }
 
+      const headSha = cached.headSha;
+      if (!headSha) {
+        shouldRefresh = true;
+        details.push(`First time seeing PR #${pr.number} (Guard 3: no cached head SHA)`);
+        continue;
+      }
+
+      // Only check commit status ETag if we have cached data with a non-null head SHA
       const statusChanged = await checkCommitStatusETag(
         pr.owner,
         pr.repo,
-        cached.headSha,
+        headSha,
       );
       if (statusChanged) {
         shouldRefresh = true;
         details.push(
-          `CI status changed for ${pr.owner}/${pr.repo}#${pr.number} (Guard 2)`,
+          `CI status changed for ${pr.owner}/${pr.repo}#${pr.number} (Guard 3)`,
         );
       }
     }
@@ -381,14 +429,58 @@ async function checkPRListETag(
 }
 
 /**
- * Guard 2: Commit Status ETag Check (per PR with pending CI)
+ * Guard 2: PR Detail ETag Check (per PR)
+ *
+ * Detects if a tracked PR changed using its own REST ETag. This catches stale head
+ * SHA / mergeability / review state windows that a repo-level PR-list ETag can miss.
+ *
+ * @returns true if PR details changed (200 OK), false if unchanged (304 Not Modified)
+ */
+async function checkPRDetailETag(
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<boolean> {
+  const prKey = `${owner}/${repo}#${number}`;
+  const cachedETag = etagCache.prDetail.get(prKey);
+
+  const url = `repos/${owner}/${repo}/pulls/${number}`;
+  const args = ["api", "--method", "GET", url, "-i"];
+
+  if (cachedETag) {
+    args.push("-H", `If-None-Match: ${cachedETag}`);
+  }
+
+  try {
+    const { stdout } = await execFileAsync("gh", args, { timeout: 10_000 });
+    const output = stdout.trim();
+
+    if (output.includes("HTTP/1.1 304") || output.includes("HTTP/2 304")) {
+      return false;
+    }
+
+    const etagMatch = output.match(/etag:\s*(.+)/i);
+    if (etagMatch) {
+      const newETag = etagMatch[1].trim();
+      setPRDetailETag(owner, repo, number, newETag);
+    }
+
+    return true;
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    // eslint-disable-next-line no-console -- Observability logging for ETag errors
+    console.warn(`[ETag Guard 2] PR detail check failed for ${prKey}: ${errorMsg}`);
+    return true;
+  }
+}
+
+/**
+ * Guard 3: Commit Status ETag Check (per PR with cached head SHA)
  *
  * Detects if CI status has changed for a specific commit using REST ETag.
  *
  * - Endpoint: GET /repos/{owner}/{repo}/commits/{head_sha}/status
  * - Detects: CI check starts, passes, fails, or external status updates
- * - Only checked for PRs with ciStatus === "pending" to minimize calls
- *
  * @returns true if CI status has changed (200 OK), false if unchanged (304 Not Modified)
  */
 async function checkCommitStatusETag(
@@ -788,7 +880,12 @@ function extractPREnrichment(
     typeof pr["mergeStateStatus"] === "string"
       ? pr["mergeStateStatus"].toUpperCase()
       : "";
-  const hasConflicts = mergeable === "CONFLICTING";
+  const hasConflicts =
+    mergeable === "CONFLICTING"
+      ? true
+      : mergeable === "MERGEABLE"
+        ? false
+        : undefined;
   const isBehind = mergeStateStatus === "BEHIND";
 
   // Extract review decision
@@ -825,7 +922,7 @@ function extractPREnrichment(
   if (reviewDecision === "changes_requested")
     blockers.push("Changes requested in review");
   if (reviewDecision === "pending") blockers.push("Review required");
-  if (hasConflicts) blockers.push("Merge conflicts");
+  if (hasConflicts === true) blockers.push("Merge conflicts");
   if (isBehind) blockers.push("Branch is behind base branch");
   if (isDraft) blockers.push("PR is still a draft");
 
@@ -844,6 +941,7 @@ function extractPREnrichment(
 
   const data: PREnrichmentData = {
     state,
+    ...(headSha ? { headSha } : {}),
     ciStatus,
     reviewDecision,
     mergeable: mergeReady,
@@ -1016,6 +1114,7 @@ export {
   parsePRState,
   extractPREnrichment,
   checkPRListETag,
+  checkPRDetailETag,
   checkCommitStatusETag,
   // shouldRefreshPREnrichment is already exported as async function
   updatePRMetadataCache,

--- a/packages/plugins/scm-github/src/graphql-batch.ts
+++ b/packages/plugins/scm-github/src/graphql-batch.ts
@@ -941,7 +941,6 @@ function extractPREnrichment(
 
   const data: PREnrichmentData = {
     state,
-    ...(headSha ? { headSha } : {}),
     ciStatus,
     reviewDecision,
     mergeable: mergeReady,
@@ -954,22 +953,29 @@ function extractPREnrichment(
     blockers,
     ...(ciChecks !== undefined ? { ciChecks } : {}),
   };
+  if (headSha) {
+    data.headSha = headSha;
+  }
 
   return { data, headSha };
 }
 
 /**
- * Main batch enrichment function with 2-Guard ETag Strategy.
+ * Main batch enrichment function with 3-Guard ETag Strategy.
  *
- * Before running expensive GraphQL batch queries, uses two lightweight REST API
+ * Before running expensive GraphQL batch queries, uses three lightweight REST API
  * ETag checks to detect if anything actually changed:
  *
  * 1. Guard 1: PR List ETag Check (per repo)
  *    - Detects PR metadata changes (commits, reviews, labels, state)
  *    - Cost: 1 REST point if changed, 0 if unchanged (304)
  *
- * 2. Guard 2: Commit Status ETag Check (per PR with pending CI)
- *    - Detects CI status changes for PRs with pending CI
+ * 2. Guard 2: PR Detail ETag Check (per tracked PR)
+ *    - Detects head SHA, mergeability, review, and draft/state changes on the specific PR
+ *    - Cost: 1 REST point if changed, 0 if unchanged (304)
+ *
+ * 3. Guard 3: Commit Status ETag Check (per cached head SHA)
+ *    - Detects CI status changes for the exact cached head commit
  *    - Cost: 1 REST point if changed, 0 if unchanged (304)
  *
  * If guards indicate no changes, skips GraphQL entirely (saves ~50 points per batch).
@@ -987,7 +993,7 @@ export async function enrichSessionsPRBatch(
     return result;
   }
 
-  // Step 1: Check if we need to refresh using 2-Guard ETag Strategy
+  // Step 1: Check if we need to refresh using 3-Guard ETag Strategy
   const guardResult = await shouldRefreshPREnrichment(prs);
 
   if (!guardResult.shouldRefresh) {

--- a/packages/plugins/scm-github/test/graphql-batch.test.ts
+++ b/packages/plugins/scm-github/test/graphql-batch.test.ts
@@ -19,8 +19,10 @@ import {
   extractPREnrichment,
   clearETagCache,
   getPRListETag,
+  getPRDetailETag,
   getCommitStatusETag,
   setPRListETag,
+  setPRDetailETag,
   setCommitStatusETag,
   setPRMetadata,
   getPRMetadataCache,
@@ -518,6 +520,38 @@ describe("PR Enrichment Data Extraction", () => {
     expect(result?.blockers).toContain("Merge conflicts");
   });
 
+  it("should leave hasConflicts undefined when GitHub mergeability is UNKNOWN", () => {
+    const pullRequest = {
+      title: "Recomputing mergeability",
+      state: "OPEN",
+      additions: 1,
+      deletions: 1,
+      isDraft: false,
+      mergeable: "UNKNOWN",
+      mergeStateStatus: "CLEAN",
+      reviewDecision: "NONE",
+      reviews: { nodes: [] },
+      commits: {
+        nodes: [
+          {
+            commit: {
+              statusCheckRollup: {
+                state: "SUCCESS",
+                contexts: { nodes: [] },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const extracted = extractPREnrichment(pullRequest);
+
+    expect(extracted).not.toBeNull();
+    expect(extracted?.data.hasConflicts).toBeUndefined();
+    expect(extracted?.data.blockers).not.toContain("Merge conflicts");
+  });
+
   it("should extract PR that is behind base", () => {
     const pullRequest = {
       title: "Sync branch",
@@ -857,7 +891,7 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
       expect(mockExecFileImpl).toHaveBeenCalledTimes(1);
     });
 
-    it("should not refresh when PR list ETag returns 304 Not Modified", async () => {
+    it("should refresh when PR list ETag returns 304 but the PR has no cached metadata yet", async () => {
       const prs = [
         {
           owner: "owner",
@@ -879,9 +913,8 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
 
       const result = await shouldRefreshPREnrichment(prs);
 
-      expect(result.shouldRefresh).toBe(false);
-      // When no changes detected, details may be empty (only changes add to details)
-      expect(result.details).toHaveLength(0);
+      expect(result.shouldRefresh).toBe(true);
+      expect(result.details).toContain("First time seeing PR #123 (Guard 2: no cached metadata)");
     });
 
     it("should refresh on error and log warning", async () => {
@@ -911,7 +944,7 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
   });
 
   describe("Guard 2: Commit Status ETag - Pending CI PRs", () => {
-    it("should refresh when commit status ETag check returns 200", async () => {
+    it("should refresh when PR detail ETag check returns 200", async () => {
       // Set up cached PR with pending CI
       setPRMetadata("owner/repo#123", { headSha: "abc123", ciStatus: "pending" });
 
@@ -935,18 +968,18 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
           stderr: "",
         })
         .mockResolvedValueOnce({
-          stdout: 'HTTP/2 200\neTag: "xyz789"', // Guard 2: CI changed
+          stdout: 'HTTP/2 200\neTag: "xyz789"', // Guard 2: PR metadata changed
           stderr: "",
         });
 
       const result = await shouldRefreshPREnrichment(prs);
 
       expect(result.shouldRefresh).toBe(true);
-      expect(result.details).toContain("CI status changed for owner/repo#123 (Guard 2)");
+      expect(result.details).toContain("PR metadata changed for owner/repo#123 (Guard 2)");
       expect(mockExecFileImpl).toHaveBeenCalledTimes(2);
     });
 
-    it("should not refresh when commit status ETag returns 304", async () => {
+    it("should refresh when commit status ETag check returns 200 after PR detail 304", async () => {
       // Set up cached PR with pending CI
       setPRMetadata("owner/repo#123", { headSha: "abc123", ciStatus: "pending" });
 
@@ -963,8 +996,50 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
         },
       ];
 
-      // Mock both guards return 304 (no change)
+      // Mock: Guard 1 returns 304, Guard 2 returns 304, Guard 3 returns 200
       mockExecFileImpl
+        .mockResolvedValueOnce({
+          stdout: 'HTTP/2 304',
+          stderr: "",
+        })
+        .mockResolvedValueOnce({
+          stdout: 'HTTP/2 304',
+          stderr: "",
+        })
+        .mockResolvedValueOnce({
+          stdout: 'HTTP/2 200\neTag: "xyz789"',
+          stderr: "",
+        });
+
+      const result = await shouldRefreshPREnrichment(prs);
+
+      expect(result.shouldRefresh).toBe(true);
+      expect(result.details).toContain("CI status changed for owner/repo#123 (Guard 3)");
+      expect(mockExecFileImpl).toHaveBeenCalledTimes(3);
+    });
+
+    it("should not refresh when PR detail and commit status ETags return 304", async () => {
+      // Set up cached PR with pending CI
+      setPRMetadata("owner/repo#123", { headSha: "abc123", ciStatus: "pending" });
+
+      const prs = [
+        {
+          owner: "owner",
+          repo: "repo",
+          number: 123,
+          url: "https://github.com/owner/repo/pull/123",
+          title: "Test PR",
+          branch: "feature",
+          baseBranch: "main",
+          isDraft: false,
+        },
+      ];
+
+      mockExecFileImpl
+        .mockResolvedValueOnce({
+          stdout: 'HTTP/2 304',
+          stderr: "",
+        })
         .mockResolvedValueOnce({
           stdout: 'HTTP/2 304',
           stderr: "",
@@ -977,7 +1052,7 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
       const result = await shouldRefreshPREnrichment(prs);
 
       expect(result.shouldRefresh).toBe(false);
-      expect(mockExecFileImpl).toHaveBeenCalledTimes(2);
+      expect(mockExecFileImpl).toHaveBeenCalledTimes(3);
     });
 
     it("should check Guard 2 for ALL PRs with cached metadata", async () => {
@@ -997,8 +1072,12 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
         },
       ];
 
-      // Mock both guards return 304 (no change)
+      // Mock all three guards return 304 (no change)
       mockExecFileImpl
+        .mockResolvedValueOnce({
+          stdout: 'HTTP/2 304',
+          stderr: "",
+        })
         .mockResolvedValueOnce({
           stdout: 'HTTP/2 304',
           stderr: "",
@@ -1011,7 +1090,7 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
       const result = await shouldRefreshPREnrichment(prs);
 
       expect(result.shouldRefresh).toBe(false);
-      expect(mockExecFileImpl).toHaveBeenCalledTimes(2); // Guard 1 + Guard 2 called
+      expect(mockExecFileImpl).toHaveBeenCalledTimes(3); // Guard 1 + Guard 2 + Guard 3
     });
 
     it("should refresh when PR has no cached head SHA", async () => {
@@ -1041,7 +1120,7 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
 
       expect(result.shouldRefresh).toBe(true);
       expect(result.details).toContain("First time seeing PR #123 (Guard 2: no cached head SHA)");
-      // Guard 1 called for PR list, Guard 2 skipped (no head SHA to check)
+      // Guard 1 called for PR list, Guard 2/3 skipped (no head SHA to check)
       expect(mockExecFileImpl).toHaveBeenCalledTimes(1);
     });
   });
@@ -1090,11 +1169,11 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
       const result = await shouldRefreshPREnrichment(prs);
 
       expect(result.shouldRefresh).toBe(true);
-      // Guard 1 adds 2 details (one per repo), Guard 2 skipped (304 = no change, no detail)
+      // Guard 1 adds 2 details (one per repo); per-PR guards are skipped because refresh is already required
       expect(result.details).toHaveLength(2);
       expect(result.details).toContain("PR list changed for owner1/repo1 (Guard 1)");
       expect(result.details).toContain("PR list changed for owner2/repo2 (Guard 1)");
-      // 2 Guard 1 calls only (Guard 2 calls return 304, no details added)
+      // 2 Guard 1 calls only
       expect(mockExecFileImpl).toHaveBeenCalledTimes(2);
     });
   });
@@ -1126,10 +1205,15 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
       // Cache metadata and ETags after first poll so Guard 2 has data for second poll
       setPRMetadata("owner/repo#123", { headSha: "abc123", ciStatus: "passing" });
       setPRListETag("owner", "repo", "cached-etag");
+      setPRDetailETag("owner", "repo", 123, "pr-detail-etag");
       setCommitStatusETag("owner", "repo", "abc123", "commit-status-etag");
 
-      // Second call - should use cached ETag in If-None-Match headers (Guard 1 + Guard 2)
+      // Second call - should use cached ETag in If-None-Match headers (Guard 1 + Guard 2 + Guard 3)
       mockExecFileImpl
+        .mockResolvedValueOnce({
+          stdout: 'HTTP/2 304',
+          stderr: "",
+        })
         .mockResolvedValueOnce({
           stdout: 'HTTP/2 304',
           stderr: "",
@@ -1142,11 +1226,15 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
       const result2 = await shouldRefreshPREnrichment(prs);
       expect(result2.shouldRefresh).toBe(false);
 
-      // Cache metadata after first poll so Guard 2 has data for second poll
+      // Cache metadata after first poll so later polls also have guard data
       setPRMetadata("owner/repo#123", { headSha: "abc123", ciStatus: "passing" });
 
-      // Second poll - should use cached ETag in If-None-Match headers (Guard 1 + Guard 2)
+      // Third poll - should use cached ETag in If-None-Match headers (Guard 1 + Guard 2 + Guard 3)
       mockExecFileImpl
+        .mockResolvedValueOnce({
+          stdout: 'HTTP/2 304',
+          stderr: "",
+        })
         .mockResolvedValueOnce({
           stdout: 'HTTP/2 304',
           stderr: "",
@@ -1162,13 +1250,17 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
       // Verify the second poll included If-None-Match headers
       // Get all call arguments and find those with -H flag
       const allCalls = mockExecFileImpl.mock.calls;
-      // Second poll has 2 calls: Guard 1 (index 1) and Guard 2 (index 2)
-      const secondPollCalls = allCalls.slice(1, 3);
+      // Second poll has 3 calls: Guard 1 (index 1), Guard 2 (index 2), Guard 3 (index 3)
+      const secondPollCalls = allCalls.slice(1, 4);
       // Mock call format: [file, args, options], so check call[1] for args
       const callsWithHeader = secondPollCalls.filter((call) =>
         Array.isArray(call) && call[1] && call[1].includes("-H")
       );
-      expect(callsWithHeader).toHaveLength(2); // Both Guard 1 and Guard 2
+      expect(callsWithHeader).toHaveLength(3); // Guard 1, Guard 2, and Guard 3
+
+      expect(getPRListETag("owner", "repo")).toBe("cached-etag");
+      expect(getPRDetailETag("owner", "repo", 123)).toBe("pr-detail-etag");
+      expect(getCommitStatusETag("owner", "repo", "abc123")).toBe("commit-status-etag");
     });
   });
 });


### PR DESCRIPTION
Closes #1122.

## Summary

This hardens lifecycle alerting against stale PR enrichment snapshots so workers do not receive CI-failing or merge-conflict guidance for an older head commit after a newer head has already fixed the problem.

## Problem

The lifecycle manager trusted cached PR enrichment too aggressively. In the bad path:

1. head A is failing or conflicting
2. lifecycle caches that state
3. head B is pushed and fixes the issue
4. repo-level freshness checks say "304 unchanged"
5. lifecycle reuses the stale snapshot from head A and fires the wrong alert

This was especially risky for merge-conflict alerts because the suggested action is destructive.

## Fix

- add `headSha` to `PREnrichmentData` so lifecycle can tie alert fingerprints to the exact head commit
- extend GitHub batch enrichment freshness from a repo-level PR-list ETag plus commit-status ETag to a three-step guard:
  - repo PR-list ETag
  - per-PR detail ETag
  - commit-status ETag for the cached head SHA
- make CI failure detail fingerprints head-aware
- make merge-conflict dispatch fingerprints head-aware
- stop treating indeterminate mergeability (`UNKNOWN` / computing) as a real conflict signal
- when batch enrichment cannot prove conflicts authoritatively, fall back to live `getMergeability()` and only alert on an actual `"Merge conflicts"` blocker

## Live Reproduction

I reproduced the stale CI path against a real PR on a personal fork using real GitHub Actions check-runs on two different heads.

Old head had a failing Actions run; new head had a passing Actions run. With a simulated stale cache pointing at the old head:

```json
{
  "old_guard": {
    "repo_list_http_status": 304,
    "old_commit_status_http_status": 304,
    "should_refresh": false,
    "result_if_cache_reused": "would keep stale failing snapshot from the old Actions run"
  },
  "new_guard": {
    "repo_list_http_status": 304,
    "pr_detail_http_status": 200,
    "should_refresh": true,
    "result_if_refreshed": "refreshes and sees the new head plus passing Actions check-run"
  }
}
```

I also reproduced the merge-conflict path against a real PR on a temporary base branch:

- old head: `mergeable=CONFLICTING`, `mergeStateStatus=DIRTY`
- new head after resolving the conflict: `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`

With a stale cache still pointing at the old conflicting head:

```json
{
  "old_guard": {
    "repo_list_http_status": 304,
    "old_commit_status_http_status": 304,
    "should_refresh": false,
    "result_if_cache_reused": "would keep stale conflict snapshot from the old head"
  },
  "new_guard": {
    "repo_list_http_status": 304,
    "pr_detail_http_status": 200,
    "should_refresh": true,
    "result_if_refreshed": "refreshes and sees the new mergeable head"
  }
}
```

Both temporary repro PRs and branches were cleaned up after validation.

## Tests

Focused regressions added/updated in:

- `packages/plugins/scm-github/test/graphql-batch.test.ts`
- `packages/core/src/__tests__/lifecycle-manager.test.ts`

Verified with:

- `pnpm --filter @aoagents/ao-plugin-scm-github test -- graphql-batch.test.ts`
- `pnpm --filter @aoagents/ao-core test -- lifecycle-manager.test.ts`
