### PR TITLE
fix(web): resolve worker session orchestrator links

### DIFF
--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -86,6 +86,29 @@ const multiProjectSessions: Session[] = [
   }),
 ];
 
+const multiOrchestratorProjectSessions: Session[] = [
+  makeSession({
+    id: "ao-orchestrator-1",
+    projectId: "my-app",
+    metadata: { role: "orchestrator" },
+    createdAt: new Date("2026-04-12T09:00:00Z"),
+    lastActivityAt: new Date("2026-04-12T09:15:00Z"),
+  }),
+  makeSession({
+    id: "ao-orchestrator-5",
+    projectId: "my-app",
+    metadata: { role: "orchestrator" },
+    createdAt: new Date("2026-04-12T10:00:00Z"),
+    lastActivityAt: new Date("2026-04-12T10:30:00Z"),
+  }),
+  makeSession({
+    id: "worker-1",
+    projectId: "my-app",
+    status: "working",
+    activity: "active",
+  }),
+];
+
 // ── Mock Services ─────────────────────────────────────────────────────
 
 const mockSessionManager: SessionManager = {
@@ -317,6 +340,29 @@ describe("API Routes", () => {
       ]);
       expect(data.sessions.map((session: { id: string }) => session.id)).toEqual(["docs-2"]);
       expect(mockSessionManager.list).toHaveBeenCalledWith("docs-app");
+    });
+
+    it("returns the current project orchestrator when multiple orchestrators exist", async () => {
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        async (projectId?: string) =>
+          multiOrchestratorProjectSessions.filter(
+            (session) => !projectId || session.projectId === projectId,
+          ),
+      );
+
+      const res = await sessionsGET(
+        makeRequest("http://localhost:3000/api/sessions?project=my-app&orchestratorOnly=true"),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+
+      expect(data.orchestratorId).toBe("ao-orchestrator-5");
+      expect(data.orchestrators).toEqual([
+        { id: "ao-orchestrator-1", projectId: "my-app", projectName: "My App" },
+        { id: "ao-orchestrator-5", projectId: "my-app", projectName: "My App" },
+      ]);
+      expect(data.sessions).toEqual([]);
+      expect(mockSessionManager.list).toHaveBeenCalledWith("my-app");
     });
 
     it("enriches all PRs concurrently, not sequentially", async () => {

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -7,6 +7,7 @@ import {
   enrichSessionsMetadata,
   computeStats,
   listDashboardOrchestrators,
+  resolveCurrentProjectOrchestratorId,
 } from "@/lib/serialize";
 import { getCorrelationId, jsonWithCorrelation, recordApiObservation } from "@/lib/observability";
 import { filterProjectSessions } from "@/lib/project-utils";
@@ -33,7 +34,9 @@ export async function GET(request: Request) {
     const coreSessions = await sessionManager.list(requestedProjectId);
     const visibleSessions = filterProjectSessions(coreSessions, projectFilter, config.projects);
     const orchestrators = listDashboardOrchestrators(visibleSessions, config.projects);
-    const orchestratorId = orchestrators.length === 1 ? (orchestrators[0]?.id ?? null) : null;
+    const orchestratorId = requestedProjectId
+      ? resolveCurrentProjectOrchestratorId(visibleSessions, requestedProjectId, config.projects)
+      : (orchestrators.length === 1 ? (orchestrators[0]?.id ?? null) : null);
 
     if (orchestratorOnly) {
       recordApiObservation({

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -95,11 +95,27 @@ describe("SessionPage project polling", () => {
 
     global.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
+      if (url === "/api/projects") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ projects: [{ id: "my-app", name: "My App", path: "/tmp/my-app" }] }),
+        } as Response;
+      }
+
       if (url === "/api/sessions/worker-1") {
         return {
           ok: true,
           status: 200,
           json: async () => workerSession,
+        } as Response;
+      }
+
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ sessions: [] }),
         } as Response;
       }
 
@@ -136,6 +152,9 @@ describe("SessionPage project polling", () => {
     await flushAsyncWork();
 
     expect(fetch).toHaveBeenCalledWith("/api/sessions?project=my-app&orchestratorOnly=true");
+    expect(sessionDetailSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ projectOrchestratorId: "my-app-orchestrator" }),
+    );
 
     expect(
       vi.mocked(fetch).mock.calls.filter(
@@ -153,6 +172,67 @@ describe("SessionPage project polling", () => {
         ([url]) => url === "/api/sessions?project=my-app&orchestratorOnly=true",
       ),
     ).toHaveLength(1);
+  });
+
+  it("uses the API-selected current orchestrator instead of the first sorted orchestrator", async () => {
+    const workerSession = makeWorkerSession();
+
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ projects: [{ id: "my-app", name: "My App", path: "/tmp/my-app" }] }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions/worker-1") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => workerSession,
+        } as Response;
+      }
+
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ sessions: [] }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            orchestratorId: "ao-orchestrator-5",
+            orchestrators: [
+              { id: "ao-orchestrator-1", projectId: "my-app", projectName: "My App" },
+              { id: "ao-orchestrator-5", projectId: "my-app", projectName: "My App" },
+            ],
+          }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const { default: SessionPage } = await import("./page");
+
+    render(<SessionPage />);
+    await flushAsyncWork();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    await flushAsyncWork();
+
+    expect(sessionDetailSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ projectOrchestratorId: "ao-orchestrator-5" }),
+    );
   });
 
   it("routes 404 responses through notFound()", async () => {

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -157,10 +157,7 @@ export default function SessionPage() {
       if (!res.ok) return;
       const body = (await res.json()) as ProjectSessionsBody;
       const sessions = body.sessions ?? [];
-      const orchestratorId =
-        body.orchestratorId ??
-        body.orchestrators?.find((orchestrator) => orchestrator.projectId === projectId)?.id ??
-        null;
+      const orchestratorId = body.orchestratorId ?? null;
       setProjectOrchestratorId((current) => (current === orchestratorId ? current : orchestratorId));
 
       if (!isOrchestrator) {

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -16,6 +16,7 @@ import type {
 import {
   sessionToDashboard,
   resolveProject,
+  resolveCurrentProjectOrchestratorId,
   enrichSessionPR,
   enrichSessionAgentSummary,
   enrichSessionIssueTitle,
@@ -313,6 +314,87 @@ describe("resolveProject", () => {
     // session id starts with "app" (matches lib's prefix), but projectId is "app" (direct match)
     const session = createCoreSession({ id: "app-1", projectId: "app" });
     expect(resolveProject(session, projects)).toBe(projects.app);
+  });
+});
+
+describe("resolveCurrentProjectOrchestratorId", () => {
+  function makeProject(overrides?: Partial<ProjectConfig>): ProjectConfig {
+    return {
+      name: "test",
+      repo: "test/repo",
+      path: "/test",
+      defaultBranch: "main",
+      sessionPrefix: "test",
+      ...overrides,
+    };
+  }
+
+  it("returns the most recently active orchestrator for the project", () => {
+    const projects = {
+      "my-app": makeProject({ name: "My App", sessionPrefix: "ao-orchestrator" }),
+    };
+    const sessions = [
+      createCoreSession({
+        id: "ao-orchestrator-1",
+        projectId: "my-app",
+        metadata: { role: "orchestrator" },
+        createdAt: new Date("2026-04-12T09:00:00Z"),
+        lastActivityAt: new Date("2026-04-12T09:15:00Z"),
+      }),
+      createCoreSession({
+        id: "ao-orchestrator-5",
+        projectId: "my-app",
+        metadata: { role: "orchestrator" },
+        createdAt: new Date("2026-04-12T10:00:00Z"),
+        lastActivityAt: new Date("2026-04-12T10:30:00Z"),
+      }),
+      createCoreSession({
+        id: "worker-2",
+        projectId: "my-app",
+        createdAt: new Date("2026-04-12T11:00:00Z"),
+        lastActivityAt: new Date("2026-04-12T11:30:00Z"),
+      }),
+    ];
+
+    expect(resolveCurrentProjectOrchestratorId(sessions, "my-app", projects)).toBe(
+      "ao-orchestrator-5",
+    );
+  });
+
+  it("uses a numeric id tie-breaker when timestamps match", () => {
+    const projects = {
+      "my-app": makeProject({ name: "My App", sessionPrefix: "ao-orchestrator" }),
+    };
+    const timestamp = new Date("2026-04-12T10:00:00Z");
+    const sessions = [
+      createCoreSession({
+        id: "ao-orchestrator-2",
+        projectId: "my-app",
+        metadata: { role: "orchestrator" },
+        createdAt: timestamp,
+        lastActivityAt: timestamp,
+      }),
+      createCoreSession({
+        id: "ao-orchestrator-10",
+        projectId: "my-app",
+        metadata: { role: "orchestrator" },
+        createdAt: timestamp,
+        lastActivityAt: timestamp,
+      }),
+    ];
+
+    expect(resolveCurrentProjectOrchestratorId(sessions, "my-app", projects)).toBe(
+      "ao-orchestrator-10",
+    );
+  });
+
+  it("returns null when the project has no orchestrator sessions", () => {
+    const projects = {
+      "my-app": makeProject({ name: "My App", sessionPrefix: "ao-orchestrator" }),
+    };
+    const sessions = [createCoreSession({ id: "worker-1", projectId: "my-app" })];
+
+    expect(resolveCurrentProjectOrchestratorId(sessions, "my-app", projects)).toBeNull();
   });
 });
 

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -94,6 +94,47 @@ export function listDashboardOrchestrators(
     .sort((a, b) => a.projectName.localeCompare(b.projectName) || a.id.localeCompare(b.id));
 }
 
+function getSessionRecencyTimestamp(session: Session): number {
+  const lastActivityAt = session.lastActivityAt.getTime();
+  if (!Number.isNaN(lastActivityAt)) return lastActivityAt;
+
+  const createdAt = session.createdAt.getTime();
+  if (!Number.isNaN(createdAt)) return createdAt;
+
+  return -Infinity;
+}
+
+function compareSessionsByRecency(a: Session, b: Session): number {
+  const timestampDiff = getSessionRecencyTimestamp(b) - getSessionRecencyTimestamp(a);
+  if (timestampDiff !== 0) return timestampDiff;
+
+  const createdAtDiff = b.createdAt.getTime() - a.createdAt.getTime();
+  if (createdAtDiff !== 0) return createdAtDiff;
+
+  return b.id.localeCompare(a.id, undefined, { numeric: true });
+}
+
+export function resolveCurrentProjectOrchestratorId(
+  sessions: Session[],
+  projectId: string,
+  projects: Record<string, ProjectConfig>,
+): string | null {
+  const allSessionPrefixes = Object.entries(projects).map(
+    ([entryProjectId, p]) => p.sessionPrefix ?? entryProjectId,
+  );
+  const projectPrefix = projects[projectId]?.sessionPrefix ?? projectId;
+
+  const currentOrchestrator = sessions
+    .filter(
+      (session) =>
+        session.projectId === projectId &&
+        isOrchestratorSession(session, projectPrefix, allSessionPrefixes),
+    )
+    .sort(compareSessionsByRecency)[0];
+
+  return currentOrchestrator?.id ?? null;
+}
+
 /**
  * Convert minimal PRInfo to a DashboardPR with default values for enriched fields.
  * These defaults indicate "data not yet loaded" rather than "failing".


### PR DESCRIPTION
## Summary
- compute the current project orchestrator from orchestrator session recency instead of display ordering
- return that canonical orchestratorId from /api/sessions for project-scoped worker and orchestrator detail lookups
- stop the worker session page from guessing from the sorted orchestrator list and add regressions for multi-orchestrator projects

## Validation
- pnpm --filter @aoagents/ao-web test -- src/lib/__tests__/serialize.test.ts
- pnpm --filter @aoagents/ao-web test -- src/__tests__/api-routes.test.ts
- pnpm --filter @aoagents/ao-web test -- "src/app/sessions/[id]/page.test.tsx"
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test