### PR TITLE
fix(lifecycle): treat null/empty reviewDecision as 'none' for auto-merge

### DIFF
--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -503,8 +503,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           // Check reviews
           if (cachedData.reviewDecision === "changes_requested")
             return "changes_requested";
-          if (cachedData.reviewDecision === "approved" || cachedData.reviewDecision === "none") {
-            // Check merge readiness — treat "none" (no reviewers required)
+          if (cachedData.reviewDecision === "approved" || cachedData.reviewDecision === "none" || !cachedData.reviewDecision) {
+            // Check merge readiness — treat "none" or null/empty (no reviewers required)
             // as "approved" so CI-green PRs reach "mergeable" status
             // and fire the merge.ready event / approved-and-green reaction.
             if (cachedData.mergeable) return "mergeable";
@@ -536,8 +536,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         // Check reviews
         const reviewDecision = await scm.getReviewDecision(session.pr);
         if (reviewDecision === "changes_requested") return "changes_requested";
-        if (reviewDecision === "approved" || reviewDecision === "none") {
-          // Check merge readiness — treat "none" (no reviewers required)
+        if (reviewDecision === "approved" || reviewDecision === "none" || !reviewDecision) {
+          // Check merge readiness — treat "none" or null/empty (no reviewers required)
           // as "approved" so CI-green PRs reach "mergeable" status
           // and fire the merge.ready event / approved-and-green reaction.
           const mergeReady = await scm.getMergeability(session.pr);


### PR DESCRIPTION
## Summary

Fixes #1173 — auto-merge not triggered when branch protection doesn't require reviews.

GitHub GraphQL returns `reviewDecision: null` (not `"none"`) when no reviews are configured. The `gh` CLI converts this to an empty string. Adding `!reviewDecision` to the merge-readiness check catches null, undefined, and empty string.

## Changes

`packages/core/src/lifecycle-manager.ts` — both cached and fallback code paths:

```diff
- if (reviewDecision === "approved" || reviewDecision === "none") {
+ if (reviewDecision === "approved" || reviewDecision === "none" || !reviewDecision) {
```

## Test plan

- [ ] Repo with `required_approving_review_count: 0` → PR with CI green should reach `mergeable` status
- [ ] Repo with required reviews → behavior unchanged (pending/approved/changes_requested still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)