### PR TITLE
fix(web): include orchestrator activity fields in dashboard dto

### DIFF
--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -289,8 +289,24 @@ describe("API Routes", () => {
 
       expect(data.orchestratorId).toBeNull();
       expect(data.orchestrators).toEqual([
-        { id: "docs-orchestrator", projectId: "docs-app", projectName: "Docs App" },
-        { id: "app-orchestrator", projectId: "my-app", projectName: "My App" },
+        expect.objectContaining({
+          id: "docs-orchestrator",
+          projectId: "docs-app",
+          projectName: "Docs App",
+          status: "working",
+          activity: "active",
+          createdAt: expect.any(String),
+          lastActivityAt: expect.any(String),
+        }),
+        expect.objectContaining({
+          id: "app-orchestrator",
+          projectId: "my-app",
+          projectName: "My App",
+          status: "working",
+          activity: "active",
+          createdAt: expect.any(String),
+          lastActivityAt: expect.any(String),
+        }),
       ]);
       expect(data.sessions.map((session: { id: string }) => session.id)).toEqual([
         "backend-3",
@@ -313,7 +329,15 @@ describe("API Routes", () => {
 
       expect(data.orchestratorId).toBe("docs-orchestrator");
       expect(data.orchestrators).toEqual([
-        { id: "docs-orchestrator", projectId: "docs-app", projectName: "Docs App" },
+        expect.objectContaining({
+          id: "docs-orchestrator",
+          projectId: "docs-app",
+          projectName: "Docs App",
+          status: "working",
+          activity: "active",
+          createdAt: expect.any(String),
+          lastActivityAt: expect.any(String),
+        }),
       ]);
       expect(data.sessions.map((session: { id: string }) => session.id)).toEqual(["docs-2"]);
       expect(mockSessionManager.list).toHaveBeenCalledWith("docs-app");

--- a/packages/web/src/lib/__tests__/dashboard-page-data.fast-path.test.ts
+++ b/packages/web/src/lib/__tests__/dashboard-page-data.fast-path.test.ts
@@ -56,7 +56,17 @@ describe("getDashboardPageData fast path", () => {
     hoisted.getPrimaryProjectIdMock.mockReturnValue("docs");
     hoisted.getProjectNameMock.mockReturnValue("Docs");
     hoisted.resolveGlobalPauseMock.mockReturnValue({ reason: "paused" });
-    hoisted.listDashboardOrchestratorsMock.mockReturnValue([{ id: "orch-1", projectId: "docs", projectName: "Docs" }]);
+    hoisted.listDashboardOrchestratorsMock.mockReturnValue([
+      {
+        id: "orch-1",
+        projectId: "docs",
+        projectName: "Docs",
+        status: "working",
+        activity: "active",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastActivityAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
     hoisted.enrichSessionsMetadataFastMock.mockResolvedValue(undefined);
   });
 

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -90,6 +90,10 @@ export function listDashboardOrchestrators(
       id: session.id,
       projectId: session.projectId,
       projectName: projects[session.projectId]?.name ?? session.projectId,
+      status: session.status,
+      activity: session.activity,
+      createdAt: session.createdAt.toISOString(),
+      lastActivityAt: session.lastActivityAt.toISOString(),
     }))
     .sort((a, b) => a.projectName.localeCompare(b.projectName) || a.id.localeCompare(b.id));
 }

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -135,6 +135,10 @@ export interface DashboardOrchestratorLink {
   id: string;
   projectId: string;
   projectName: string;
+  status: SessionStatus;
+  activity: ActivityState | null;
+  createdAt: string;
+  lastActivityAt: string;
 }
 
 /** SSE snapshot event from /api/events */


### PR DESCRIPTION
## Summary
- extend the dashboard orchestrator DTO to include session status, activity, and timestamps
- update the web type contract so the dashboard can rely on those fields
- add regression coverage for API and dashboard fast-path serialization

## Problem
The dashboard orchestrator serialization path only exposed minimal identity fields (`id`, `projectId`, `projectName`). The underlying orchestrator session already had runtime state, but the DTO dropped:
- `status`
- `activity`
- `createdAt`
- `lastActivityAt`

That meant the dashboard could not render orchestrator activity/state consistently even when the session manager had the data.

Closes #1177.

## Solution
- update `listDashboardOrchestrators()` to serialize `status`, `activity`, `createdAt`, and `lastActivityAt`
- extend `DashboardOrchestratorLink` with the same fields
- update API route tests to assert the richer orchestrator payload shape
- update dashboard fast-path tests to reflect the expanded DTO contract

## Testing
- `pnpm --filter @aoagents/ao-web test -- src/__tests__/api-routes.test.ts src/lib/__tests__/dashboard-page-data.fast-path.test.ts`
