### PR TITLE
fix(codex): improve dashboard activity integration and native session matching

### DIFF
--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -141,9 +141,12 @@ function mockTmuxWithProcess(processName: string, found = true) {
 function makeFakeFileHandle(content: string) {
   const buf = Buffer.from(content, "utf-8");
   return {
-    read: vi.fn().mockImplementation((buffer: Buffer, offset: number, length: number, _position: number) => {
-      const bytesToCopy = Math.min(length, buf.length);
-      buf.copy(buffer, offset, 0, bytesToCopy);
+    read: vi.fn().mockImplementation((buffer: Buffer, offset: number, length: number, position: number) => {
+      const start = typeof position === "number" ? position : 0;
+      const bytesToCopy = Math.max(0, Math.min(length, buf.length - start));
+      if (bytesToCopy > 0) {
+        buf.copy(buffer, offset, start, start + bytesToCopy);
+      }
       return Promise.resolve({ bytesRead: bytesToCopy, buffer });
     }),
     close: vi.fn().mockResolvedValue(undefined),
@@ -567,11 +570,18 @@ describe("detectActivity", () => {
     expect(agent.detectActivity("some output\n# ")).toBe("idle");
   });
 
+  it("returns idle when last line is a Codex interactive prompt", () => {
+    expect(agent.detectActivity("some output\n› Summarize recent commits")).toBe("idle");
+  });
+
   it("returns idle when prompt follows historical activity indicators", () => {
     // Key regression test: historical active output in the buffer
     // should NOT override an idle prompt on the last line.
     expect(agent.detectActivity("✶ Reading files\nDone.\n> ")).toBe("idle");
     expect(agent.detectActivity("Working on task (esc to interrupt)\nFinished.\n$ ")).toBe("idle");
+    expect(
+      agent.detectActivity("• Updated Plan\n  └ Finished work\n\n› Summarize recent commits"),
+    ).toBe("idle");
   });
 
   // -- Waiting input states --
@@ -656,7 +666,7 @@ describe("getActivityState", () => {
 
   it("returns active when session file was recently modified", async () => {
     mockTmuxWithProcess("codex");
-    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    const content = '{"type":"session_meta","payload":{"cwd":"/workspace/test"}}\n';
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     setupMockOpen(content);
     mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
@@ -672,9 +682,32 @@ describe("getActivityState", () => {
     expect(result?.timestamp).toBeInstanceOf(Date);
   });
 
+  it("matches session files when session_meta exceeds the initial 4 KB read", async () => {
+    mockTmuxWithProcess("codex");
+    const oversizedMeta = JSON.stringify({
+      type: "session_meta",
+      payload: {
+        cwd: "/workspace/test",
+        base_instructions: { text: "x".repeat(5000) },
+      },
+    }) + "\n";
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(oversizedMeta);
+    const staleTime = Date.now() - 600_000;
+    mockStat.mockResolvedValue({ mtimeMs: staleTime, mtime: new Date(staleTime) });
+    mockReadLastJsonlEntry.mockResolvedValue({
+      lastType: "assistant_message",
+      modifiedAt: new Date(staleTime),
+    });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const result = await agent.getActivityState(session);
+    expect(result?.state).toBe("idle");
+  });
+
   it("returns idle when session file is stale", async () => {
     mockTmuxWithProcess("codex");
-    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    const content = '{"type":"session_meta","payload":{"cwd":"/workspace/test"}}\n';
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     setupMockOpen(content);
     const staleTime = Date.now() - 600_000;
@@ -693,7 +726,7 @@ describe("getActivityState", () => {
 
   it("returns waiting_input for approval_request entry type", async () => {
     mockTmuxWithProcess("codex");
-    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    const content = '{"type":"session_meta","payload":{"cwd":"/workspace/test"}}\n';
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     setupMockOpen(content);
     mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
@@ -709,7 +742,7 @@ describe("getActivityState", () => {
 
   it("returns blocked for error entry type", async () => {
     mockTmuxWithProcess("codex");
-    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    const content = '{"type":"session_meta","payload":{"cwd":"/workspace/test"}}\n';
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     setupMockOpen(content);
     mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
@@ -725,7 +758,7 @@ describe("getActivityState", () => {
 
   it("returns ready for assistant_message entry type", async () => {
     mockTmuxWithProcess("codex");
-    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    const content = '{"type":"session_meta","payload":{"cwd":"/workspace/test"}}\n';
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     setupMockOpen(content);
     mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
@@ -782,7 +815,10 @@ describe("getSessionInfo", () => {
 
   it("returns null when no session files match the workspace cwd", async () => {
     mockReaddir.mockResolvedValue(["session-abc.jsonl"]);
-    const content = jsonl({ type: "session_meta", cwd: "/other/workspace", model: "gpt-4o" });
+    const content = jsonl({
+      type: "session_meta",
+      payload: { cwd: "/other/workspace", model: "gpt-4o" },
+    });
     setupMockOpen(content);
     mockReadFile.mockResolvedValue(content);
     expect(await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }))).toBeNull();
@@ -790,9 +826,31 @@ describe("getSessionInfo", () => {
 
   it("returns session info with cost and model when matching session found", async () => {
     const sessionContent = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "o3-mini" },
-      { type: "event_msg", msg: { type: "token_count", input_tokens: 1000, output_tokens: 500, cached_tokens: 200, reasoning_tokens: 100 } },
-      { type: "event_msg", msg: { type: "token_count", input_tokens: 2000, output_tokens: 300, cached_tokens: 0, reasoning_tokens: 0 } },
+      { type: "session_meta", payload: { cwd: "/workspace/test", model: "o3-mini" } },
+      {
+        type: "event_msg",
+        payload: {
+          msg: {
+            type: "token_count",
+            input_tokens: 1000,
+            output_tokens: 500,
+            cached_tokens: 200,
+            reasoning_tokens: 100,
+          },
+        },
+      },
+      {
+        type: "event_msg",
+        payload: {
+          msg: {
+            type: "token_count",
+            input_tokens: 2000,
+            output_tokens: 300,
+            cached_tokens: 0,
+            reasoning_tokens: 0,
+          },
+        },
+      },
     );
 
     mockReaddir.mockResolvedValue(["session-123.jsonl"]);
@@ -818,10 +876,10 @@ describe("getSessionInfo", () => {
 
   it("picks the most recently modified matching session file", async () => {
     const oldContent = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
+      { type: "session_meta", payload: { cwd: "/workspace/test", model: "gpt-4o" } },
     );
     const newContent = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "o3" },
+      { type: "session_meta", payload: { cwd: "/workspace/test", model: "o3" } },
     );
 
     mockReaddir.mockResolvedValue(["old-session.jsonl", "new-session.jsonl"]);
@@ -854,9 +912,9 @@ describe("getSessionInfo", () => {
   });
 
   it("handles corrupt/malformed JSONL lines gracefully", async () => {
-    const content = '{"type":"session_meta","cwd":"/workspace/test","model":"gpt-4o"}\n' +
+    const content = '{"type":"session_meta","payload":{"cwd":"/workspace/test","model":"gpt-4o"}}\n' +
       "not valid json\n" +
-      '{"type":"event_msg","msg":{"type":"token_count","input_tokens":500,"output_tokens":200}}\n';
+      '{"type":"event_msg","payload":{"msg":{"type":"token_count","input_tokens":500,"output_tokens":200}}}\n';
 
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     setupMockOpen(content);
@@ -873,8 +931,8 @@ describe("getSessionInfo", () => {
 
   it("returns null summary when no model in session_meta", async () => {
     const content = jsonl(
-      { type: "session_meta", cwd: "/workspace/test" },
-      { type: "event_msg", msg: { type: "token_count", input_tokens: 100, output_tokens: 50 } },
+      { type: "session_meta", payload: { cwd: "/workspace/test" } },
+      { type: "event_msg", payload: { msg: { type: "token_count", input_tokens: 100, output_tokens: 50 } } },
     );
 
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
@@ -894,8 +952,8 @@ describe("getSessionInfo", () => {
 
   it("returns undefined cost when no token_count events", async () => {
     const content = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
-      { type: "event_msg", msg: { type: "other_event" } },
+      { type: "session_meta", payload: { cwd: "/workspace/test", model: "gpt-4o" } },
+      { type: "event_msg", payload: { msg: { type: "other_event" } } },
     );
 
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
@@ -914,7 +972,7 @@ describe("getSessionInfo", () => {
   it("handles unreadable session files gracefully", async () => {
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     // open() finds matching session_meta, but readFile fails for full parse
-    setupMockOpen(jsonl({ type: "session_meta", cwd: "/workspace/test" }));
+    setupMockOpen(jsonl({ type: "session_meta", payload: { cwd: "/workspace/test" } }));
     mockStat.mockResolvedValue({ mtimeMs: 1000 });
     mockReadFile.mockRejectedValue(new Error("EACCES"));
     mockCreateReadStream.mockImplementation(() => { throw new Error("EACCES"); });
@@ -924,7 +982,7 @@ describe("getSessionInfo", () => {
 
   it("skips session files when stat throws", async () => {
     const content = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "gpt-4o" },
+      { type: "session_meta", payload: { cwd: "/workspace/test", model: "gpt-4o" } },
     );
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     setupMockOpen(content);
@@ -939,7 +997,7 @@ describe("getSessionInfo", () => {
   it("returns null when session JSONL has only empty/malformed lines", async () => {
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
     // open() finds matching session_meta for cwd check
-    setupMockOpen(jsonl({ type: "session_meta", cwd: "/workspace/test" }));
+    setupMockOpen(jsonl({ type: "session_meta", payload: { cwd: "/workspace/test" } }));
     // readFile (full parse) returns only garbage
     mockReadFile.mockResolvedValue("not json\n\n   \n");
     setupMockStream("not json\n\n   \n");
@@ -967,7 +1025,7 @@ describe("getSessionInfo", () => {
     // stat is used by findCodexSessionFile to get mtimeMs of matching JSONL files
     mockStat.mockResolvedValue({ mtimeMs: 2000 });
     const content = jsonl(
-      { type: "session_meta", cwd: "/workspace/test", model: "o3-mini" },
+      { type: "session_meta", payload: { cwd: "/workspace/test", model: "o3-mini" } },
     );
     setupMockOpen(content);
     setupMockStream(content);
@@ -977,6 +1035,50 @@ describe("getSessionInfo", () => {
     expect(result).not.toBeNull();
     expect(result!.agentSessionId).toBe("rollout-abc");
     expect(result!.summary).toBe("Codex session (o3-mini)");
+  });
+
+  it("matches native JSONL when cwd is nested under payload", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","payload":{"cwd":"/workspace/test"}}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+    mockReadLastJsonlEntry.mockResolvedValue({
+      lastType: "assistant_message",
+      modifiedAt: new Date(),
+    });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const result = await agent.getActivityState(session);
+    expect(result?.state).toBe("ready");
+  });
+
+  it("parses token usage from nested payload info total_token_usage", async () => {
+    const content = jsonl(
+      { type: "session_meta", payload: { cwd: "/workspace/test", model: "gpt-4o" } },
+      {
+        type: "event_msg",
+        payload: {
+          info: {
+            total_token_usage: {
+              input_tokens: 123,
+              output_tokens: 45,
+            },
+          },
+        },
+      },
+    );
+
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+    expect(result).not.toBeNull();
+    expect(result!.cost).toBeDefined();
+    expect(result!.cost!.inputTokens).toBe(123);
+    expect(result!.cost!.outputTokens).toBe(45);
   });
 
   it("ignores non-JSONL files in sessions directory", async () => {

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -63,6 +63,7 @@ interface CodexJsonlLine {
   model?: string;
   // Thread ID from thread_started notifications
   threadId?: string;
+  thread_id?: string;
   // User message content (from user input events)
   content?: string;
   role?: string;
@@ -74,6 +75,63 @@ interface CodexJsonlLine {
     cached_tokens?: number;
     reasoning_tokens?: number;
   };
+  payload?: {
+    cwd?: string;
+    model?: string;
+    threadId?: string;
+    thread_id?: string;
+    msg?: {
+      type?: string;
+      input_tokens?: number;
+      output_tokens?: number;
+      cached_tokens?: number;
+      reasoning_tokens?: number;
+    };
+    info?: {
+      total_token_usage?: {
+        input_tokens?: number;
+        output_tokens?: number;
+      };
+      last_token_usage?: {
+        input_tokens?: number;
+        output_tokens?: number;
+      };
+    };
+  };
+}
+
+function getCodexEntryCwd(entry: CodexJsonlLine): string | undefined {
+  return entry.payload?.cwd ?? entry.cwd;
+}
+
+function getCodexEntryModel(entry: CodexJsonlLine): string | null {
+  const model = entry.payload?.model ?? entry.model;
+  return typeof model === "string" && model.trim().length > 0 ? model : null;
+}
+
+function getCodexEntryThreadId(entry: CodexJsonlLine): string | null {
+  const threadId = entry.payload?.threadId ?? entry.payload?.thread_id ?? entry.threadId ?? entry.thread_id;
+  return typeof threadId === "string" && threadId.trim().length > 0 ? threadId : null;
+}
+
+function getCodexTokenUsage(entry: CodexJsonlLine): { inputTokens: number; outputTokens: number } | null {
+  const msg = entry.payload?.msg ?? entry.msg;
+  if (msg?.type === "token_count") {
+    return {
+      inputTokens: msg.input_tokens ?? 0,
+      outputTokens: msg.output_tokens ?? 0,
+    };
+  }
+
+  const usage = entry.payload?.info?.total_token_usage;
+  if (usage) {
+    return {
+      inputTokens: usage.input_tokens ?? 0,
+      outputTokens: usage.output_tokens ?? 0,
+    };
+  }
+
+  return null;
 }
 
 /**
@@ -129,14 +187,32 @@ async function sessionFileMatchesCwd(
   workspacePath: string,
 ): Promise<boolean> {
   try {
-    // Read only the first 4 KB — session_meta is always in the first few lines.
-    // Avoids loading large rollout files (100 MB+) into memory.
+    // Read until we have a complete first line (session_meta) instead of a
+    // fixed 4 KB slice. Orchestrator session_meta lines can exceed 4 KB
+    // because they embed large instruction payloads.
     const handle = await open(filePath, "r");
     let content: string;
     try {
-      const buffer = Buffer.allocUnsafe(4096);
-      const { bytesRead } = await handle.read(buffer, 0, 4096, 0);
-      content = buffer.subarray(0, bytesRead).toString("utf-8");
+      const chunkSize = 4096;
+      const maxBytes = 256 * 1024;
+      const chunks: Buffer[] = [];
+      let position = 0;
+      let bytesAccumulated = 0;
+
+      while (bytesAccumulated < maxBytes) {
+        const buffer = Buffer.allocUnsafe(chunkSize);
+        const { bytesRead } = await handle.read(buffer, 0, chunkSize, position);
+        if (bytesRead <= 0) break;
+
+        const chunk = buffer.subarray(0, bytesRead);
+        chunks.push(chunk);
+        bytesAccumulated += bytesRead;
+        position += bytesRead;
+
+        if (chunk.includes(0x0a)) break;
+      }
+
+      content = Buffer.concat(chunks, bytesAccumulated).toString("utf-8");
     } finally {
       await handle.close();
     }
@@ -151,7 +227,7 @@ async function sessionFileMatchesCwd(
           parsed !== null &&
           !Array.isArray(parsed) &&
           (parsed as CodexJsonlLine).type === "session_meta" &&
-          (parsed as CodexJsonlLine).cwd === workspacePath
+          getCodexEntryCwd(parsed as CodexJsonlLine) === workspacePath
         ) {
           return true;
         }
@@ -222,15 +298,22 @@ async function streamCodexSessionData(filePath: string): Promise<CodexSessionDat
         if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) continue;
         const entry = parsed as CodexJsonlLine;
 
-        if (entry.type === "session_meta" && typeof entry.model === "string") {
-          data.model = entry.model;
+        if (entry.type === "session_meta") {
+          const model = getCodexEntryModel(entry);
+          if (model) {
+            data.model = model;
+          }
         }
-        if (typeof entry.threadId === "string" && entry.threadId) {
-          data.threadId = entry.threadId;
+        const threadId = getCodexEntryThreadId(entry);
+        if (threadId) {
+          data.threadId = threadId;
         }
-        if (entry.type === "event_msg" && entry.msg?.type === "token_count") {
-          data.inputTokens += entry.msg.input_tokens ?? 0;
-          data.outputTokens += entry.msg.output_tokens ?? 0;
+        if (entry.type === "event_msg") {
+          const usage = getCodexTokenUsage(entry);
+          if (usage) {
+            data.inputTokens += usage.inputTokens;
+            data.outputTokens += usage.outputTokens;
+          }
         }
       } catch {
         // Skip malformed lines
@@ -397,8 +480,10 @@ function createCodexAgent(): Agent {
       const lines = terminalOutput.trim().split("\n");
       const lastLine = lines[lines.length - 1]?.trim() ?? "";
 
-      // If Codex is showing its input prompt, it's idle
+      // If Codex is showing its input prompt, it's idle. Codex uses both
+      // shell-like bare prompts and its own "› <placeholder>" prompt.
       if (/^[>$#]\s*$/.test(lastLine)) return "idle";
+      if (/^›(?:\s|$)/u.test(lastLine)) return "idle";
 
       // Check last few lines for approval prompts
       const tail = lines.slice(-5).join("\n");

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@aoagents/ao-core": "workspace:*",
     "@aoagents/ao-plugin-agent-claude-code": "workspace:*",
+    "@aoagents/ao-plugin-agent-codex": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
     "@aoagents/ao-plugin-runtime-tmux": "workspace:*",

--- a/packages/web/src/__tests__/services.test.ts
+++ b/packages/web/src/__tests__/services.test.ts
@@ -7,6 +7,7 @@ const {
   mockRegistry,
   tmuxPlugin,
   claudePlugin,
+  codexPlugin,
   opencodePlugin,
   worktreePlugin,
   scmPlugin,
@@ -31,6 +32,7 @@ const {
     mockRegistry,
     tmuxPlugin: { manifest: { name: "tmux" } },
     claudePlugin: { manifest: { name: "claude-code" } },
+    codexPlugin: { manifest: { name: "codex" } },
     opencodePlugin: { manifest: { name: "opencode" } },
     worktreePlugin: { manifest: { name: "worktree" } },
     scmPlugin: { manifest: { name: "github" } },
@@ -54,6 +56,7 @@ vi.mock("@aoagents/ao-core", () => ({
 
 vi.mock("@aoagents/ao-plugin-runtime-tmux", () => ({ default: tmuxPlugin }));
 vi.mock("@aoagents/ao-plugin-agent-claude-code", () => ({ default: claudePlugin }));
+vi.mock("@aoagents/ao-plugin-agent-codex", () => ({ default: codexPlugin }));
 vi.mock("@aoagents/ao-plugin-agent-opencode", () => ({ default: opencodePlugin }));
 vi.mock("@aoagents/ao-plugin-workspace-worktree", () => ({ default: worktreePlugin }));
 vi.mock("@aoagents/ao-plugin-scm-github", () => ({ default: scmPlugin }));
@@ -92,6 +95,14 @@ describe("services", () => {
     await getServices();
 
     expect(mockRegister).toHaveBeenCalledWith(opencodePlugin);
+  });
+
+  it("registers the Codex agent plugin with web services", async () => {
+    const { getServices } = await import("../lib/services");
+
+    await getServices();
+
+    expect(mockRegister).toHaveBeenCalledWith(codexPlugin);
   });
 
   it("caches initialized services across repeated calls", async () => {

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -33,6 +33,7 @@ import {
 // Static plugin imports — webpack needs these to be string literals
 import pluginRuntimeTmux from "@aoagents/ao-plugin-runtime-tmux";
 import pluginAgentClaudeCode from "@aoagents/ao-plugin-agent-claude-code";
+import pluginAgentCodex from "@aoagents/ao-plugin-agent-codex";
 import pluginAgentCursor from "@aoagents/ao-plugin-agent-cursor";
 import pluginAgentOpencode from "@aoagents/ao-plugin-agent-opencode";
 import pluginWorkspaceWorktree from "@aoagents/ao-plugin-workspace-worktree";
@@ -76,6 +77,7 @@ async function initServices(): Promise<Services> {
   // Register plugins explicitly (webpack can't handle dynamic import() in core)
   registry.register(pluginRuntimeTmux);
   registry.register(pluginAgentClaudeCode);
+  registry.register(pluginAgentCodex);
   registry.register(pluginAgentCursor);
   registry.register(pluginAgentOpencode);
   registry.register(pluginWorkspaceWorktree);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -600,6 +600,9 @@ importers:
       '@aoagents/ao-plugin-agent-claude-code':
         specifier: workspace:*
         version: link:../plugins/agent-claude-code
+      '@aoagents/ao-plugin-agent-codex':
+        specifier: workspace:*
+        version: link:../plugins/agent-codex
       '@aoagents/ao-plugin-agent-cursor':
         specifier: workspace:*
         version: link:../plugins/agent-cursor


### PR DESCRIPTION
## Summary
- register the Codex plugin in the web service layer so dashboard session enrichment can run for Codex sessions
- update the Codex plugin to parse modern native JSONL payload shapes and match oversized `session_meta` lines reliably
- improve fallback terminal activity detection so idle Codex prompt states are not misclassified as active

## Problem
Codex-backed sessions were hitting multiple integration gaps across the web and plugin layers:
- the web backend never registered the Codex plugin, so dashboard-side session managers could not enrich Codex activity at all
- native Codex JSONL parsing still assumed older flat fields instead of nested `payload.*` fields
- native session matching only read the first 4 KB of `session_meta`, which fails for large orchestrator session metadata lines
- fallback terminal parsing treated Codex prompt lines like `› ...` as active work

Together these issues caused missing dashboard activity, incorrect `active` states, and fallback behavior even when a valid native Codex session log existed.

Closes #1178.

## Solution
### Web integration
- add `@aoagents/ao-plugin-agent-codex` as a web dependency
- register the Codex plugin in `packages/web/src/lib/services.ts`
- add a regression test asserting the web service registry includes the Codex plugin

### Native Codex JSONL parsing
- support nested native fields such as `payload.cwd`, `payload.model`, `payload.threadId`, `payload.thread_id`, `payload.msg`, and `payload.info.total_token_usage`
- centralize nested field extraction helpers for cwd, model, thread id, and token usage

### Native session matching
- change `sessionFileMatchesCwd()` to read until it has a complete first JSONL line instead of truncating at a fixed 4 KB slice
- keep the read bounded while allowing oversized `session_meta` lines from orchestrator sessions to parse correctly

### Fallback terminal activity detection
- treat Codex interactive prompt lines starting with `›` as idle
- preserve existing waiting-input and active detection behavior for real in-progress output

## Testing
- `pnpm --filter @aoagents/ao-plugin-agent-codex test -- src/index.test.ts`
- `pnpm --filter @aoagents/ao-web test -- src/__tests__/services.test.ts`
