### PR TITLE
fix(web): upgrade xterm.js to v6 for DEC 2026 synchronized output support

### DIFF
--- a/packages/cli/__tests__/commands/dashboard.test.ts
+++ b/packages/cli/__tests__/commands/dashboard.test.ts
@@ -43,7 +43,7 @@ describe("cleanNextCache", () => {
     mkdirSync(webDir, { recursive: true });
     mkdirSync(join(webDir, ".next", "server", "vendor-chunks"), { recursive: true });
     writeFileSync(
-      join(webDir, ".next", "server", "vendor-chunks", "xterm@5.3.0.js"),
+      join(webDir, ".next", "server", "vendor-chunks", "@xterm+xterm@6.0.0.js"),
       "module.exports = {}",
     );
 
@@ -187,7 +187,7 @@ describe("looksLikeStaleBuild pattern matching", () => {
   it("detects vendor-chunks module not found (the actual bug)", () => {
     // This is the exact error from the bug report
     const stderr =
-      "Error: Cannot find module '/path/to/.next/server/vendor-chunks/xterm@5.3.0.js'";
+      "Error: Cannot find module '/path/to/.next/server/vendor-chunks/@xterm+xterm@6.0.0.js'";
     expect(looksLikeStaleBuild(stderr)).toBe(true);
   });
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^19.0.0",
     "server-only": "^0.0.1",
     "ws": "^8.19.0",
-    "xterm": "^5.3.0"
+    "@xterm/xterm": "^6.0.0"
   },
   "optionalDependencies": {
     "node-pty": "^1.1.0"

--- a/packages/web/src/app/dev/terminal-test/page.tsx
+++ b/packages/web/src/app/dev/terminal-test/page.tsx
@@ -610,7 +610,7 @@ function TerminalTestPageContent() {
         {/* Footer */}
         <div className="mt-8 border-t border-[var(--color-border-default)] pt-4 text-center text-xs text-[var(--color-text-secondary)]">
           <p>Investigation: Feb 15-16, 2026 • Duration: 12+ hours • Status: ✅ Resolved</p>
-          <p className="mt-1">Node 20.20.0 • node-pty 1.1.0 • xterm.js 5.3.0</p>
+          <p className="mt-1">Node 20.20.0 • node-pty 1.1.0 • @xterm/xterm 6.0.0</p>
         </div>
       </div>
     </div>

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -217,7 +217,6 @@ export function DirectTerminal({
           minimumContrastRatio: isDark ? 1 : 7,
           scrollback: 10000,
           allowProposedApi: true,
-          fastScrollModifier: "alt",
           fastScrollSensitivity: 3,
           scrollSensitivity: 1,
         });

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/cn";
 import { useMux } from "@/hooks/useMux";
 
 // Import xterm CSS (must be imported in client component)
-import "xterm/css/xterm.css";
+import "@xterm/xterm/css/xterm.css";
 
 // Dynamically import xterm types for TypeScript
 import type { ITheme, Terminal as TerminalType } from "xterm";

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -10,7 +10,7 @@ import { useMux } from "@/hooks/useMux";
 import "@xterm/xterm/css/xterm.css";
 
 // Dynamically import xterm types for TypeScript
-import type { ITheme, Terminal as TerminalType } from "xterm";
+import type { ITheme, Terminal as TerminalType } from "@xterm/xterm";
 import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
 
 interface DirectTerminalProps {
@@ -194,7 +194,7 @@ export function DirectTerminal({
     let unsubscribe: (() => void) | null = null;
 
     Promise.all([
-      import("xterm").then((mod) => mod.Terminal),
+      import("@xterm/xterm").then((mod) => mod.Terminal),
       import("@xterm/addon-fit").then((mod) => mod.FitAddon),
       import("@xterm/addon-web-links").then((mod) => mod.WebLinksAddon),
       document.fonts.ready,

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -76,7 +76,7 @@ class MockWebSocket {
   close() {}
 }
 
-vi.mock("xterm", () => ({
+vi.mock("@xterm/xterm", () => ({
   Terminal: MockTerminal,
 }));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,9 @@ importers:
       '@xterm/addon-web-links':
         specifier: ^0.12.0
         version: 0.12.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       next:
         specifier: ^15.1.0
         version: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -648,9 +651,6 @@ importers:
       ws:
         specifier: ^8.19.0
         version: 8.20.0
-      xterm:
-        specifier: ^5.3.0
-        version: 5.3.0
     optionalDependencies:
       node-pty:
         specifier: ^1.1.0
@@ -2171,6 +2171,9 @@ packages:
 
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -4170,10 +4173,6 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  xterm@5.3.0:
-    resolution: {integrity: sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==}
-    deprecated: This package is now deprecated. Move to @xterm/xterm instead.
-
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -5674,6 +5673,8 @@ snapshots:
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   abbrev@4.0.0: {}
 
@@ -7617,8 +7618,6 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
-
-  xterm@5.3.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary

Upgrades xterm.js from v5.3.0 (Sep 2023) to @xterm/xterm v6.0.0 to fix garbled terminal rendering during agent streaming output.

Fixes #1197

## Why This Is Needed

**Root cause of the rendering bug:** AO's xterm.js v5.3.0 lacks DEC 2026 (synchronized output) support. Agent CLIs (claude-code, codex, copilot-cli) emit `\x1b[?2026h/l` sequences during streaming redraws. Without support, ED2 clear-screen commands inside sync blocks yank the viewport and produce garbled intermediate states. Tracked upstream at **xtermjs/xterm.js#5801** — the #1 rendering complaint for claude-code users (677+ reactions on anthropics/claude-code#826).

v6.0.0 also includes 8+ rendering fixes absent from v5.3.0, notably **#5328** (refresh viewport after clear/ED — directly addresses our garbling).

## Previous Attempt

Gaurav previously attempted this migration on the `gb-personal` branch (commit `8f8231fe`) but it was never merged — it sat on an orphaned branch. This PR incorporates the same changes plus fixes identified in Gaurav's migration plan (`docs/plans/xterm-v6-migration-plan.md`).

## Changes

### 1. Package rename (`packages/web/package.json`)
- `xterm: ^5.3.0` → `@xterm/xterm: ^6.0.0`
- Addons (`@xterm/addon-fit`, `@xterm/addon-web-links`) unchanged — v6.0.0 tag uses same versions

### 2. Import updates (`DirectTerminal.tsx`)
- `import "xterm/css/xterm.css"` → `import "@xterm/xterm/css/xterm.css"`
- `import type { ... } from "xterm"` → `from "@xterm/xterm"`
- `import("xterm")` → `import("@xterm/xterm")`

### 3. Breaking change: `fastScrollModifier` removed (#5462)
- Removed `fastScrollModifier: "alt"` from Terminal options — this option does not exist in v6 and would cause a TS/build error

### 4. CLI test fixture (`dashboard.test.ts`)
- Updated vendor chunk name from `xterm@5.3.0.js` to `@xterm+xterm@6.0.0.js` (Next.js bundles scoped packages as `@scope+name`)

### 5. Test mocks (`DirectTerminal.render.test.tsx`)
- Updated `vi.mock("xterm")` → `vi.mock("@xterm/xterm")`

### 6. Dev page (`terminal-test/page.tsx`)
- Updated version string from "xterm.js 5.3.0" to "@xterm/xterm 6.0.0"

## Not Changed (verified safe)

- **CSS (`globals.css`)** — `.xterm .xterm-viewport` scrollbar rules: v6's viewport rewrite may affect these, but they're cosmetic auto-hide rules that degrade gracefully. Should be re-tested visually but won't break anything.
- **`node-pty`** — Not an xterm dependency, no changes needed.
- **OSC 52 handler** — Our custom `registerOscHandler(52, ...)` is still needed for tmux clipboard. v6 added OSC 52 support (#4220) but our tmux XDA flow is different from the standard path.

## Test Plan

- [ ] `pnpm install && pnpm build` — verify no TS errors
- [ ] `pnpm --filter @aoagents/ao-web test` — verify tests pass
- [ ] `pnpm --filter @aoagents/ao-cli test` — CLI tests pass with new vendor chunk name
- [ ] Open dashboard, spawn session with claude-code or codex
- [ ] Verify terminal renders correctly during streaming output
- [ ] Verify no viewport yanking when scrolling during streaming
- [ ] Verify Alt+scroll still works (fast scroll via `fastScrollSensitivity`)
- [ ] Verify Cmd+C clipboard still works (XDA + OSC 52 path)
- [ ] Check scrollbar styling on terminal (`.xterm-viewport` CSS)
