### PR TITLE
fix(web): hyperlink passing CI check chips in session kanban card

### DIFF
--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -571,14 +571,30 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
 
         {visiblePassingChecks.length > 0 && (
           <div className="card__ci">
-            {visiblePassingChecks.map((check) => (
-              <span key={check.name} className="ci-chip ci-chip--pass">
-                <svg width="8" height="8" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M20 6 9 17l-5-5" />
-                </svg>
-                {check.name}
-              </span>
-            ))}
+            {visiblePassingChecks.map((check) => {
+              const chip = (
+                <span className="ci-chip ci-chip--pass">
+                  <svg width="8" height="8" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M20 6 9 17l-5-5" />
+                  </svg>
+                  {check.name}
+                </span>
+              );
+              return check.url ? (
+                <a
+                  key={check.name}
+                  href={check.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="no-underline"
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                >
+                  {chip}
+                </a>
+              ) : (
+                <span key={check.name}>{chip}</span>
+              );
+            })}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Passing CI check chips in `SessionCard.tsx` were rendered as plain `<span>` elements, ignoring the `check.url` field. The `CICheckList` component already handles this correctly, but the inline chip rendering on the kanban card did not.

**Before:** Check names (e.g., "lint-and-type-checks", "checks", "tests") were non-interactive text.

**After:** Each chip wraps in an `<a>` tag linking to the check run URL on GitHub (when `check.url` is available). Falls back to plain `<span>` when no URL exists. Includes `e.stopPropagation()` to prevent card click-through.

## Changed

- `packages/web/src/components/SessionCard.tsx` — passing check chip rendering now conditionally wraps in `<a href={check.url}>` 

## Test

1. Open the web dashboard with active sessions that have passing CI checks
2. Verify each green chip is a clickable link that opens the GitHub check run
3. Verify clicking a chip does NOT navigate to the session detail page
4. Verify chips without URLs still render as plain text (no broken links)