### PR TITLE
fix(web): orchestrator button links to wrong parent session

### DIFF
--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1173,6 +1173,21 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         userPrompt: spawnConfig.prompt,
       });
 
+      // Record the parent orchestrator session so the dashboard can link back.
+      // Find the most recent non-exited orchestrator for this project.
+      const existingRecords = loadActiveSessionRecords(project);
+      const orchestratorRecord = existingRecords
+        .filter((rec) => isOrchestratorSessionRecord(rec.sessionName, rec.raw, project.sessionPrefix))
+        .filter((rec) => {
+          const status = rec.raw["status"] ?? "";
+          return status !== "exited" && status !== "killed" && status !== "done" && status !== "terminated" && status !== "cleanup";
+        })
+        .sort((a, b) => sessionMetadataTimestamp(b) - sessionMetadataTimestamp(a))[0];
+      if (orchestratorRecord) {
+        updateMetadata(sessionsDir, sessionId, { parentOrchestratorId: orchestratorRecord.sessionName });
+        session.metadata["parentOrchestratorId"] = orchestratorRecord.sessionName;
+      }
+
       if (plugins.agent.postLaunchSetup) {
         await plugins.agent.postLaunchSetup(session);
       }

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -33,7 +33,9 @@ export async function GET(request: Request) {
     const coreSessions = await sessionManager.list(requestedProjectId);
     const visibleSessions = filterProjectSessions(coreSessions, projectFilter, config.projects);
     const orchestrators = listDashboardOrchestrators(visibleSessions, config.projects);
-    const orchestratorId = orchestrators.length === 1 ? (orchestrators[0]?.id ?? null) : null;
+    // Pick the first orchestrator as the default — the list is sorted by
+    // recency (active first, then newest) so this is the best candidate.
+    const orchestratorId = orchestrators.length > 0 ? (orchestrators[0]?.id ?? null) : null;
 
     if (orchestratorOnly) {
       recordApiObservation({

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -49,7 +49,7 @@ interface ZoneCounts {
 interface ProjectSessionsBody {
   sessions?: DashboardSession[];
   orchestratorId?: string | null;
-  orchestrators?: Array<{ id: string; projectId: string; projectName: string }>;
+  orchestrators?: Array<{ id: string; projectId: string; projectName: string; status: string; createdAt: string }>;
 }
 
 export default function SessionPage() {
@@ -75,6 +75,7 @@ export default function SessionPage() {
   const resolvedProjectSessionsKeyRef = useRef<string | null>(null);
   const prefixByProjectRef = useRef<Map<string, string>>(new Map());
   const hasLoadedSessionRef = useRef(false);
+  const parentOrchestratorIdRef = useRef<string | null>(null);
 
   // Keep prefixByProjectRef in sync so fetchProjectSessions (stable [] dep) reads latest map
   useEffect(() => {
@@ -115,6 +116,11 @@ export default function SessionPage() {
   useEffect(() => {
     sessionIsOrchestratorRef.current = sessionIsOrchestrator;
   }, [sessionIsOrchestrator]);
+
+  // Keep parentOrchestratorIdRef in sync so fetchProjectSessions reads the latest value
+  useEffect(() => {
+    parentOrchestratorIdRef.current = session?.metadata?.["parentOrchestratorId"] ?? null;
+  }, [session]);
 
   // Fetch session data (memoized to avoid recreating on every render)
   const fetchSession = useCallback(async () => {
@@ -158,6 +164,7 @@ export default function SessionPage() {
       const body = (await res.json()) as ProjectSessionsBody;
       const sessions = body.sessions ?? [];
       const orchestratorId =
+        parentOrchestratorIdRef.current ??
         body.orchestratorId ??
         body.orchestrators?.find((orchestrator) => orchestrator.projectId === projectId)?.id ??
         null;

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -91,8 +91,21 @@ export function listDashboardOrchestrators(
       id: session.id,
       projectId: session.projectId,
       projectName: projects[session.projectId]?.name ?? session.projectId,
+      status: session.status,
+      createdAt: session.createdAt.toISOString(),
     }))
-    .sort((a, b) => a.projectName.localeCompare(b.projectName) || a.id.localeCompare(b.id));
+    .sort((a, b) => {
+      // Prefer non-exited/active sessions first
+      const aExited = a.status === "exited" || a.status === "killed" || a.status === "done" || a.status === "terminated" || a.status === "cleanup";
+      const bExited = b.status === "exited" || b.status === "killed" || b.status === "done" || b.status === "terminated" || b.status === "cleanup";
+      if (aExited !== bExited) return aExited ? 1 : -1;
+      // Then sort by most recent createdAt descending
+      const aTime = new Date(a.createdAt).getTime();
+      const bTime = new Date(b.createdAt).getTime();
+      if (bTime !== aTime) return bTime - aTime;
+      // Final tie-break by id
+      return a.id.localeCompare(b.id);
+    });
 }
 
 /**

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -136,6 +136,8 @@ export interface DashboardOrchestratorLink {
   id: string;
   projectId: string;
   projectName: string;
+  status: string;
+  createdAt: string;
 }
 
 /** SSE snapshot event from /api/events */


### PR DESCRIPTION
## Problem

The orchestrator button on a worker session page (top-right of `/sessions/ao-8?project=...`) links to the wrong orchestrator — e.g., `/sessions/ao-orchestrator-1` instead of the correct `/sessions/ao-orchestrator-9`.

## Root Cause

**Stale closure.** `fetchProjectSessions` is a `useCallback(fn, [])` that reads `session?.metadata?.["parentOrchestratorId"]`. Since the dep array is `[]`, it captures `session` from the initial render — when it is `null`. So `parentOrchestratorId` is **always `undefined`**.

The code falls through to `body.orchestratorId`, which picks `orchestrators[0]` — the first in an alphabetically-sorted list. With multiple orchestrators (`ao-orchestrator-1` and `ao-orchestrator-9`), it always picks `-1` regardless of which one actually spawned the worker.

## Fix (5 files, +42/-3)

| File | Change |
|------|--------|
| `packages/web/src/app/sessions/[id]/page.tsx` | Add `parentOrchestratorIdRef` + `useEffect` sync (same ref pattern already used for `sessionProjectIdRef`, `sessionIsOrchestratorRef`). Read ref first in the orchestrator ID fallback chain. |
| `packages/core/src/session-manager.ts` | Record `parentOrchestratorId` in session metadata at spawn time by finding the active orchestrator for the project. |
| `packages/web/src/lib/serialize.ts` | Better orchestrator sort: active sessions first, then by recency (newest first), then alphabetical as tiebreaker. |
| `packages/web/src/app/api/sessions/route.ts` | Pick first orchestrator as default when multiple exist (was only picking when exactly 1). |
| `packages/web/src/lib/types.ts` | Add `status` and `createdAt` to `DashboardOrchestratorLink`. |

Closes #1211