### PR TITLE
fix(web): eliminate xterm terminal right-side text clipping

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -476,7 +476,8 @@ a:hover {
 /* ── xterm.js terminal viewport scrollbar — macOS-style auto-hide ──── */
 
 .xterm .xterm-viewport {
-  overflow-y: overlay !important;
+  overflow-y: scroll !important;
+  scrollbar-width: none !important;
 }
 
 .xterm .xterm-viewport::-webkit-scrollbar {


### PR DESCRIPTION
Fixes #1023

## Problem

Text in the xterm terminal (session details page) is clipped on the right side. The last character's rightmost pixels are cut off, both when the scrollbar is visible and when it's hidden.

## Root Cause

The `xterm-viewport` element is absolutely positioned over the `xterm-screen` element (where text is rendered):

```css
/* xterm.css default */
.xterm-viewport {
  position: absolute;
  right: 0; left: 0; top: 0; bottom: 0;
  overflow-y: scroll;
}
```

Our override used `overflow-y: overlay !important` which is **deprecated since Chrome 115** — it now behaves as `overflow-y: auto`. This means Chrome allocates a native scrollbar gutter (5-15px depending on OS) that overlaps the rightmost text pixels.

Additionally, the FitAddon (`@xterm/addon-fit@0.11.0`) reserves 14px for scrollbar width by default (`overviewRulerWidth || 14`), but this deduction only affects column count — it doesn't prevent the native scrollbar gutter from overlapping rendered text.

## Fix

Replace `overflow-y: overlay` with `overflow-y: scroll` + `scrollbar-width: none`:

- **`overflow-y: scroll`** — consistent behavior across all browsers (no deprecated values)
- **`scrollbar-width: none`** — completely removes the scrollbar gutter (no pixels stolen from text)
- Scrolling still works because xterm.js handles scrolling internally via its Viewport class (JavaScript `scrollTop` manipulation), not native scroll events

The existing webkit-scrollbar rules below (5px width, transparent thumb) are kept as a secondary fallback but effectively become no-ops since `scrollbar-width: none` hides the scrollbar entirely.

## Test Plan

1. Open a session detail page in non-fullscreen mode
2. Type or observe a line that fills the full terminal width
3. Verify the last character is fully visible (not clipped)
4. Scroll through terminal output — verify scrolling still works
5. Test on macOS (overlay scrollbar) and Linux/Windows (classic scrollbar)