### PR TITLE
fix(scm-github): handle HTTP 304 correctly in ETag guard catch blocks

### DIFF
--- a/packages/plugins/scm-github/src/graphql-batch.ts
+++ b/packages/plugins/scm-github/src/graphql-batch.ts
@@ -371,8 +371,12 @@ async function checkPRListETag(
     // PR list changed - cost: 1 REST point
     return true;
   } catch (err) {
-    // On error, assume change to ensure we don't miss anything
     const errorMsg = err instanceof Error ? err.message : String(err);
+    // gh CLI exits non-zero on HTTP 304 — that means "not modified", not an error
+    if (errorMsg.includes("HTTP 304")) {
+      return false; // Not modified — skip batch, use cache (intended behavior)
+    }
+    // On other errors, assume change to ensure we don't miss anything
     // Log but don't throw - allow GraphQL batch to proceed
     // eslint-disable-next-line no-console -- Observability logging for ETag errors
     console.warn(`[ETag Guard 1] PR list check failed for ${repoKey}: ${errorMsg}`);
@@ -429,8 +433,12 @@ async function checkCommitStatusETag(
     // CI status changed - cost: 1 REST point
     return true;
   } catch (err) {
-    // On error, assume change to ensure we don't miss anything
     const errorMsg = err instanceof Error ? err.message : String(err);
+    // gh CLI exits non-zero on HTTP 304 — that means "not modified", not an error
+    if (errorMsg.includes("HTTP 304")) {
+      return false; // Not modified — skip batch, use cache (intended behavior)
+    }
+    // On other errors, assume change to ensure we don't miss anything
     // eslint-disable-next-line no-console -- Observability logging for ETag errors
     console.warn(
       `[ETag Guard 2] Commit status check failed for ${commitKey}: ${errorMsg}`,


### PR DESCRIPTION
## Summary

Resolves #1191 — ETag Guard treats HTTP 304 as failure, defeats caching optimization

## Root Cause

The `gh` CLI exits with a non-zero exit code on HTTP 304 responses. This caused `execFileAsync` to throw before the `try`-block 304-detection code could run (dead code). Both catch blocks in `checkPRListETag` and `checkCommitStatusETag` were treating every HTTP 304 as a failure — logging a warning and returning `true` ("assume changed"). As a result, the full GraphQL batch ran every 30 seconds instead of being skipped when nothing had changed.

## Changes Made

- `packages/plugins/scm-github/src/graphql-batch.ts` — Added an early `if (errorMsg.includes("HTTP 304")) return false` check at the top of both catch blocks (Guard 1 in `checkPRListETag`, Guard 2 in `checkCommitStatusETag`). When the error is a 304, the function now correctly returns `false` (not modified — skip batch, use cache). All other errors fall through to the existing warn-and-return-true path unchanged.

## Testing

- All 140 tests pass (`pnpm --filter @aoagents/ao-plugin-scm-github test`)
- The two test files that cover `graphql-batch.ts` directly (`graphql-batch.test.ts` — 65 tests, `graphql-batch.integration.test.ts` — 8 tests) pass with no changes needed

## Notes

The fix matches on `"HTTP 304"` as a substring in the error message, which matches the standard `gh` CLI output format (`gh: HTTP 304`). The existing dead code in the `try` block (checking `stdout` for `"HTTP/1.1 304"` or `"HTTP/2 304"`) is left untouched — removing it would be out of scope for this fix.

Fixes #1191
