### PR TITLE
fix: preserve terminal selection and focus across controls

### DIFF
--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState, useMemo } from "react";
+import { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/cn";
-import { useMux } from "@/hooks/useMux";
+import { useMuxSession, useMuxTerminal } from "@/hooks/useMux";
 
 // Import xterm CSS (must be imported in client component)
 import "xterm/css/xterm.css";
@@ -119,7 +119,9 @@ export function DirectTerminal({
   const searchParams = useSearchParams();
   const { resolvedTheme } = useTheme();
   const terminalThemes = useMemo(() => buildTerminalThemes(variant), [variant]);
-  const { subscribeTerminal, writeTerminal, resizeTerminal: resizeTerminalMux, openTerminal, closeTerminal, status: muxStatus } = useMux();
+  const { subscribeTerminal, writeTerminal, resizeTerminal: resizeTerminalMux, openTerminal, closeTerminal } =
+    useMuxTerminal();
+  const { status: muxStatus } = useMuxSession();
 
   const terminalRef = useRef<HTMLDivElement>(null);
   const terminalInstance = useRef<TerminalType | null>(null);
@@ -130,6 +132,18 @@ export function DirectTerminal({
   const [error, setError] = useState<string | null>(null);
   const [reloading, setReloading] = useState(false);
   const [reloadError, setReloadError] = useState<string | null>(null);
+
+  const restoreTerminalFocus = useCallback((trigger?: HTMLButtonElement | null) => {
+    trigger?.blur();
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        const textarea = terminalRef.current?.querySelector("textarea");
+        if (textarea instanceof HTMLTextAreaElement) {
+          textarea.focus();
+        }
+      });
+    });
+  }, []);
 
   // Update URL when fullscreen changes
   useEffect(() => {
@@ -145,7 +159,7 @@ export function DirectTerminal({
     router.replace(newUrl, { scroll: false });
   }, [fullscreen, pathname, router, searchParams]);
 
-  async function handleReload(): Promise<void> {
+  async function handleReload(trigger?: HTMLButtonElement | null): Promise<void> {
     if (!isOpenCodeSession || reloading) return;
     setReloadError(null);
     setReloading(true);
@@ -181,8 +195,14 @@ export function DirectTerminal({
       setReloadError(err instanceof Error ? err.message : "Failed to reload OpenCode session");
     } finally {
       setReloading(false);
+      restoreTerminalFocus(trigger);
     }
   }
+
+  const toggleFullscreen = useCallback((trigger?: HTMLButtonElement | null) => {
+    setFullscreen((current) => !current);
+    restoreTerminalFocus(trigger);
+  }, [restoreTerminalFocus]);
 
   useEffect(() => {
     if (!terminalRef.current) return;
@@ -532,7 +552,8 @@ export function DirectTerminal({
   const isDarkChrome = appearance === "dark" || resolvedTheme !== "light";
   const fullscreenButton = (
     <button
-      onClick={() => setFullscreen(!fullscreen)}
+      type="button"
+      onClick={(event) => toggleFullscreen(event.currentTarget)}
       className={cn(
         "flex items-center gap-1 px-2 py-0.5 text-[11px] text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-text-primary)]",
         !isOpenCodeSession && !chromeless && "ml-auto",
@@ -600,7 +621,10 @@ export function DirectTerminal({
           </span>
           {isOpenCodeSession ? (
             <button
-              onClick={handleReload}
+              type="button"
+              onClick={(event) => {
+                void handleReload(event.currentTarget);
+              }}
               disabled={reloading || muxStatus !== "connected"}
               title="Restart OpenCode session (/exit then resume mapped session)"
               aria-label="Restart OpenCode session"
@@ -651,7 +675,10 @@ export function DirectTerminal({
         <div className="absolute right-3 top-3 z-10 flex items-center gap-1 rounded-[6px] border border-[var(--color-border-subtle)] bg-[color-mix(in_srgb,var(--color-bg-elevated)_92%,transparent)] px-1.5 py-1 shadow-[0_8px_24px_rgba(0,0,0,0.18)] backdrop-blur-sm">
           {isOpenCodeSession ? (
             <button
-              onClick={handleReload}
+              type="button"
+              onClick={(event) => {
+                void handleReload(event.currentTarget);
+              }}
               disabled={reloading || muxStatus !== "connected"}
               title="Restart OpenCode session (/exit then resume mapped session)"
               aria-label="Restart OpenCode session"

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -23,16 +23,25 @@ class MockTerminal {
   };
   cols = 80;
   rows = 24;
+  private textarea: HTMLTextAreaElement | null = null;
 
   constructor(options: Record<string, unknown>) {
     this.options = options;
   }
 
   loadAddon() {}
-  open() {}
+  open(container: Element) {
+    const textarea = document.createElement("textarea");
+    textarea.className = "xterm-helper-textarea";
+    container.appendChild(textarea);
+    this.textarea = textarea;
+  }
   write() {}
   refresh() {}
-  dispose() {}
+  dispose() {
+    this.textarea?.remove();
+    this.textarea = null;
+  }
   hasSelection() {
     return false;
   }
@@ -89,15 +98,16 @@ vi.mock("@xterm/addon-web-links", () => ({
 }));
 
 vi.mock("@/hooks/useMux", () => ({
-  useMux: () => ({
+  useMuxTerminal: () => ({
     subscribeTerminal: vi.fn(() => vi.fn()),
     writeTerminal: vi.fn(),
     openTerminal: vi.fn(),
     closeTerminal: vi.fn(),
     resizeTerminal: vi.fn(),
+  }),
+  useMuxSession: () => ({
     status: "connected",
     sessions: [],
-    terminals: [],
   }),
 }));
 
@@ -109,6 +119,10 @@ describe("DirectTerminal render", () => {
     Object.defineProperty(document, "fonts", {
       configurable: true,
       value: { ready: Promise.resolve() },
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: vi.fn(() => ({})),
     });
     vi.stubGlobal("WebSocket", MockWebSocket);
     vi.stubGlobal(
@@ -178,5 +192,61 @@ describe("DirectTerminal render", () => {
     expect(screen.getByRole("button", { name: "fullscreen" })).toBeInTheDocument();
     expect(terminalShell).toHaveClass("relative");
     expect(terminalShell).not.toHaveClass("fixed");
+  });
+
+  it("returns focus to the terminal after toggling fullscreen", async () => {
+    render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "fullscreen" })).toBeInTheDocument(),
+    );
+
+    const fullscreenButton = screen.getByRole("button", { name: "fullscreen" });
+    fullscreenButton.focus();
+    fireEvent.click(fullscreenButton);
+
+    await waitFor(() => {
+      expect(document.activeElement).toBeInstanceOf(HTMLTextAreaElement);
+      expect(fullscreenButton).not.toHaveFocus();
+    });
+  });
+
+  it("returns focus to the terminal after restarting an OpenCode session", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/runtime/terminal") {
+          return {
+            ok: true,
+            json: async () => ({ proxyWsPath: "/ao-terminal-ws" }),
+          };
+        }
+        if (url.includes("/remap")) {
+          return {
+            ok: true,
+            json: async () => ({ opencodeSessionId: "mapped-session" }),
+          };
+        }
+        if (url.includes("/send")) {
+          return {
+            ok: true,
+            json: async () => ({}),
+          };
+        }
+        throw new Error(`Unexpected fetch call: ${url}`);
+      }),
+    );
+
+    render(<DirectTerminal sessionId="ao-opencode" chromeless isOpenCodeSession />);
+
+    const restartButton = await screen.findByRole("button", { name: "Restart OpenCode session" });
+    restartButton.focus();
+    fireEvent.click(restartButton);
+
+    await waitFor(() => {
+      expect(document.activeElement).toBeInstanceOf(HTMLTextAreaElement);
+      expect(restartButton).not.toHaveFocus();
+    });
   });
 });

--- a/packages/web/src/hooks/useMux.ts
+++ b/packages/web/src/hooks/useMux.ts
@@ -1,1 +1,1 @@
-export { useMux } from "@/providers/MuxProvider";
+export { useMux, useMuxOptional, useMuxSession, useMuxTerminal } from "@/providers/MuxProvider";

--- a/packages/web/src/providers/MuxProvider.tsx
+++ b/packages/web/src/providers/MuxProvider.tsx
@@ -3,29 +3,69 @@
 import React, { useEffect, useRef, useState, useMemo, useCallback, type ReactNode } from "react";
 import type { ClientMessage, ServerMessage, SessionPatch } from "@/lib/mux-protocol";
 
-interface MuxContextValue {
+type MuxStatus = "connecting" | "connected" | "reconnecting" | "disconnected";
+
+interface MuxTerminalContextValue {
   subscribeTerminal: (id: string, callback: (data: string) => void) => () => void;
   writeTerminal: (id: string, data: string) => void;
   openTerminal: (id: string) => void;
   closeTerminal: (id: string) => void;
   resizeTerminal: (id: string, cols: number, rows: number) => void;
-  status: "connecting" | "connected" | "reconnecting" | "disconnected";
+}
+
+interface MuxSessionContextValue {
+  status: MuxStatus;
   sessions: SessionPatch[];
 }
 
-const MuxContext = React.createContext<MuxContextValue | undefined>(undefined);
+interface MuxContextValue extends MuxTerminalContextValue, MuxSessionContextValue {}
 
-export function useMux(): MuxContextValue {
-  const context = React.useContext(MuxContext);
+const MuxTerminalContext = React.createContext<MuxTerminalContextValue | undefined>(undefined);
+const MuxSessionContext = React.createContext<MuxSessionContextValue | undefined>(undefined);
+
+export function useMuxTerminal(): MuxTerminalContextValue {
+  const context = React.useContext(MuxTerminalContext);
   if (!context) {
-    throw new Error("useMux() must be used within <MuxProvider>");
+    throw new Error("useMuxTerminal() must be used within <MuxProvider>");
   }
   return context;
 }
 
+export function useMuxSession(): MuxSessionContextValue {
+  const context = React.useContext(MuxSessionContext);
+  if (!context) {
+    throw new Error("useMuxSession() must be used within <MuxProvider>");
+  }
+  return context;
+}
+
+export function useMux(): MuxContextValue {
+  const terminalContext = React.useContext(MuxTerminalContext);
+  const sessionContext = React.useContext(MuxSessionContext);
+
+  if (!terminalContext || !sessionContext) {
+    throw new Error("useMux() must be used within <MuxProvider>");
+  }
+
+  return {
+    ...terminalContext,
+    ...sessionContext,
+  };
+}
+
 /** Like useMux() but returns undefined when outside a MuxProvider (safe for tests). */
 export function useMuxOptional(): MuxContextValue | undefined {
-  return React.useContext(MuxContext);
+  const terminalContext = React.useContext(MuxTerminalContext);
+  const sessionContext = React.useContext(MuxSessionContext);
+
+  if (!terminalContext || !sessionContext) {
+    return undefined;
+  }
+
+  return {
+    ...terminalContext,
+    ...sessionContext,
+  };
 }
 
 interface RuntimeTerminalConfig {
@@ -72,9 +112,7 @@ export function MuxProvider({ children }: { children: ReactNode }) {
   const wsRef = useRef<WebSocket | null>(null);
   const subscribersRef = useRef(new Map<string, Set<(data: string) => void>>());
   const openedTerminalsRef = useRef(new Set<string>());
-  const [status, setStatus] = useState<"connecting" | "connected" | "reconnecting" | "disconnected">(
-    "connecting",
-  );
+  const [status, setStatus] = useState<MuxStatus>("connecting");
   const [sessions, setSessions] = useState<SessionPatch[]>([]);
   const reconnectAttempt = useRef(0);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -306,18 +344,28 @@ export function MuxProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const contextValue: MuxContextValue = useMemo(
+  const terminalContextValue: MuxTerminalContextValue = useMemo(
     () => ({
       subscribeTerminal,
       writeTerminal,
       openTerminal,
       closeTerminal,
       resizeTerminal,
+    }),
+    [subscribeTerminal, writeTerminal, openTerminal, closeTerminal, resizeTerminal],
+  );
+
+  const sessionContextValue: MuxSessionContextValue = useMemo(
+    () => ({
       status,
       sessions,
     }),
-    [subscribeTerminal, writeTerminal, openTerminal, closeTerminal, resizeTerminal, status, sessions],
+    [status, sessions],
   );
 
-  return <MuxContext.Provider value={contextValue}>{children}</MuxContext.Provider>;
+  return (
+    <MuxTerminalContext.Provider value={terminalContextValue}>
+      <MuxSessionContext.Provider value={sessionContextValue}>{children}</MuxSessionContext.Provider>
+    </MuxTerminalContext.Provider>
+  );
 }

--- a/packages/web/src/providers/__tests__/MuxProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/MuxProvider.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { MuxProvider, useMux, useMuxOptional } from "../MuxProvider";
+import { MuxProvider, useMux, useMuxOptional, useMuxSession, useMuxTerminal } from "../MuxProvider";
 
 // ---------------------------------------------------------------------------
 // Mock WebSocket
@@ -117,6 +117,18 @@ afterEach(() => {
 describe("useMux outside provider", () => {
   it("throws when used outside MuxProvider", () => {
     expect(() => renderHook(() => useMux())).toThrow("useMux() must be used within <MuxProvider>");
+  });
+
+  it("throws when terminal hook is used outside MuxProvider", () => {
+    expect(() => renderHook(() => useMuxTerminal())).toThrow(
+      "useMuxTerminal() must be used within <MuxProvider>",
+    );
+  });
+
+  it("throws when session hook is used outside MuxProvider", () => {
+    expect(() => renderHook(() => useMuxSession())).toThrow(
+      "useMuxSession() must be used within <MuxProvider>",
+    );
   });
 });
 
@@ -424,6 +436,31 @@ describe("MuxProvider message handling", () => {
 
     expect(result.current.sessions.length).toBe(1);
     expect(result.current.sessions[0].id).toBe("s1");
+  });
+
+  it("keeps terminal context stable across session snapshots", async () => {
+    const { result } = renderHook(
+      () => ({
+        terminal: useMuxTerminal(),
+        session: useMuxSession(),
+      }),
+      { wrapper },
+    );
+    await flushInit();
+
+    const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+    act(() => ws.simulateOpen());
+
+    const terminalBeforeSnapshot = result.current.terminal;
+
+    act(() => ws.simulateMessage({
+      ch: "sessions",
+      type: "snapshot",
+      sessions: [{ id: "s1", status: "working", activity: null, attentionLevel: "none", lastActivityAt: "" }],
+    }));
+
+    expect(result.current.session.sessions).toHaveLength(1);
+    expect(result.current.terminal).toBe(terminalBeforeSnapshot);
   });
 
   it("handles malformed JSON message without crashing", async () => {


### PR DESCRIPTION
## Summary
- split mux state into stable terminal operations and reactive session state so session snapshots do not recreate xterm
- restore focus to the terminal textarea after fullscreen toggles and OpenCode restart actions
- add provider and terminal render coverage for stable context references and focus restoration

## Testing
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test  <!-- fails in packages/integration-tests/src/agent-claude-code.integration.test.ts:153 on an unrelated Claude message-type expectation -->
- pnpm --filter @aoagents/ao-web test

Closes #1248
Closes #1249