### PR TITLE
fix(web): eliminate sidebar flash and redundant re-renders on session detail page (#1230)

### DIFF
--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -60,7 +60,7 @@ export default function SessionPage() {
   const [zoneCounts, setZoneCounts] = useState<ZoneCounts | null>(null);
   const [projectOrchestratorId, setProjectOrchestratorId] = useState<string | null | undefined>(undefined);
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
-  const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[]>([]);
+  const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [routeError, setRouteError] = useState<Error | null>(null);
   const [sessionMissing, setSessionMissing] = useState(false);
@@ -75,6 +75,7 @@ export default function SessionPage() {
   const resolvedProjectSessionsKeyRef = useRef<string | null>(null);
   const prefixByProjectRef = useRef<Map<string, string>>(new Map());
   const hasLoadedSessionRef = useRef(false);
+  const sidebarSessionsRef = useRef<DashboardSession[] | null>(null);
 
   // Keep prefixByProjectRef in sync so fetchProjectSessions (stable [] dep) reads latest map
   useEffect(() => {
@@ -193,7 +194,25 @@ export default function SessionPage() {
       const res = await fetch("/api/sessions");
       if (!res.ok) return;
       const body = (await res.json()) as { sessions?: DashboardSession[] } | null;
-      setSidebarSessions(body?.sessions ?? []);
+      const next = body?.sessions ?? [];
+      const prev = sidebarSessionsRef.current;
+      // Skip re-render if nothing meaningful changed
+      const changed =
+        prev === null ||
+        prev.length !== next.length ||
+        next.some((s, i) => {
+          const p = prev[i];
+          return (
+            p.id !== s.id ||
+            p.status !== s.status ||
+            p.activity !== s.activity ||
+            p.lastActivityAt !== s.lastActivityAt
+          );
+        });
+      if (changed) {
+        sidebarSessionsRef.current = next;
+        setSidebarSessions(next);
+      }
     } catch {
       // non-critical
     }
@@ -205,10 +224,9 @@ export default function SessionPage() {
     }
   }, [sessionIsOrchestrator]);
 
-  // Initial fetch — session first, zone counts after (avoids blocking on slow /api/sessions)
+  // Initial fetch — session + sidebar in parallel; zone counts deferred to avoid contention
   useEffect(() => {
-    fetchSession();
-    fetchSidebarSessions();
+    void Promise.all([fetchSession(), fetchSidebarSessions()]);
     // Delay zone counts so the heavy /api/sessions call doesn't contend with session load
     const t = setTimeout(fetchProjectSessions, 2000);
     return () => clearTimeout(t);
@@ -252,7 +270,8 @@ export default function SessionPage() {
       orchestratorZones={zoneCounts ?? undefined}
       projectOrchestratorId={projectOrchestratorId}
       projects={projects}
-      sidebarSessions={sidebarSessions}
+      sidebarSessions={sidebarSessions ?? []}
+      sidebarLoading={sidebarSessions === null}
     />
   );
 }

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -18,6 +18,7 @@ interface ProjectSidebarProps {
   onToggleCollapsed?: () => void;
   mobileOpen?: boolean;
   onMobileClose?: () => void;
+  loading?: boolean;
 }
 
 type SessionDotLevel = "respond" | "review" | "pending" | "working" | "merge" | "done";
@@ -50,6 +51,19 @@ export function ProjectSidebar(props: ProjectSidebarProps) {
   return <ProjectSidebarInner {...props} />;
 }
 
+function SessionSkeleton() {
+  return (
+    <div className="project-sidebar__sessions">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="project-sidebar__sess-row project-sidebar__sess-row--skeleton" aria-hidden="true">
+          <div className="sidebar-session-dot shrink-0 rounded-full opacity-30" data-level="working" />
+          <div className="project-sidebar__sess-label project-sidebar__sess-label--skeleton" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function ProjectSidebarInner({
   projects,
   sessions,
@@ -59,6 +73,7 @@ function ProjectSidebarInner({
   onToggleCollapsed: _onToggleCollapsed,
   mobileOpen = false,
   onMobileClose,
+  loading = false,
 }: ProjectSidebarProps) {
   const router = useRouter();
 
@@ -196,47 +211,51 @@ function ProjectSidebarInner({
 
                 {/* Sessions */}
                 {isExpanded && (
-                  <div className="project-sidebar__sessions">
-                    {visibleSessions.length > 0 ? (
-                      visibleSessions.map((session) => {
-                        const level = getAttentionLevel(session);
-                        const isSessionActive = activeSessionId === session.id;
-                        const title = session.branch ?? getSessionTitle(session);
-                        return (
-                          <button
-                            key={session.id}
-                            type="button"
-                            onClick={() =>
-                              navigate(
-                                `/sessions/${encodeURIComponent(session.id)}?project=${encodeURIComponent(project.id)}`,
-                              )
-                            }
-                            className={cn(
-                              "project-sidebar__sess-row",
-                              isSessionActive && "project-sidebar__sess-row--active",
-                            )}
-                            aria-current={isSessionActive ? "page" : undefined}
-                            aria-label={`Open ${title}`}
-                          >
-                            <SessionDot level={level} />
-                            <span
+                  loading ? (
+                    <SessionSkeleton />
+                  ) : (
+                    <div className="project-sidebar__sessions">
+                      {visibleSessions.length > 0 ? (
+                        visibleSessions.map((session) => {
+                          const level = getAttentionLevel(session);
+                          const isSessionActive = activeSessionId === session.id;
+                          const title = session.branch ?? getSessionTitle(session);
+                          return (
+                            <button
+                              key={session.id}
+                              type="button"
+                              onClick={() =>
+                                navigate(
+                                  `/sessions/${encodeURIComponent(session.id)}?project=${encodeURIComponent(project.id)}`,
+                                )
+                              }
                               className={cn(
-                                "project-sidebar__sess-label",
-                                isSessionActive && "project-sidebar__sess-label--active",
+                                "project-sidebar__sess-row",
+                                isSessionActive && "project-sidebar__sess-row--active",
                               )}
+                              aria-current={isSessionActive ? "page" : undefined}
+                              aria-label={`Open ${title}`}
                             >
-                              {title}
-                            </span>
-                            <span className="project-sidebar__sess-status">
-                              {LEVEL_LABELS[level]}
-                            </span>
-                          </button>
-                        );
-                      })
-                    ) : (
-                      <div className="project-sidebar__empty">No active sessions</div>
-                    )}
-                  </div>
+                              <SessionDot level={level} />
+                              <span
+                                className={cn(
+                                  "project-sidebar__sess-label",
+                                  isSessionActive && "project-sidebar__sess-label--active",
+                                )}
+                              >
+                                {title}
+                              </span>
+                              <span className="project-sidebar__sess-status">
+                                {LEVEL_LABELS[level]}
+                              </span>
+                            </button>
+                          );
+                        })
+                      ) : (
+                        <div className="project-sidebar__empty">No active sessions</div>
+                      )}
+                    </div>
+                  )
                 )}
               </div>
             );

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -47,6 +47,7 @@ interface SessionDetailProps {
   projectOrchestratorId?: string | null;
   projects?: ProjectInfo[];
   sidebarSessions?: DashboardSession[];
+  sidebarLoading?: boolean;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -451,6 +452,7 @@ export function SessionDetail({
   projectOrchestratorId = null,
   projects = [],
   sidebarSessions = [],
+  sidebarLoading = false,
 }: SessionDetailProps) {
   const searchParams = useSearchParams();
   const isMobile = useMediaQuery(MOBILE_BREAKPOINT);
@@ -597,6 +599,7 @@ export function SessionDetail({
               activeSessionId={session.id}
               collapsed={sidebarCollapsed}
               onToggleCollapsed={() => setSidebarCollapsed((current) => !current)}
+              loading={sidebarLoading}
             />
           ) : null}
 


### PR DESCRIPTION
## Summary

Resolves #1230 — web: sidebar flashes 'No active sessions' on /sessions/[id] and re-renders every 5s

## Root Cause

`packages/web/src/app/sessions/[id]/page.tsx` is a pure client component with no SSR, so `sidebarSessions` was initialized to `[]` (empty array). This caused the `ProjectSidebar` to show "No active sessions" on every navigation — a permanent empty-state message used as a transient loading placeholder — before the `/api/sessions` fetch resolved and filled the list. Additionally, `fetchSidebarSessions` unconditionally called `setSidebarSessions(...)` every 5 seconds with a fresh array reference, forcing `ProjectSidebar` and all its `useMemo` computations to re-run even when no session data had changed.

## Changes Made

- `packages/web/src/app/sessions/[id]/page.tsx` — Changed `sidebarSessions` initial state from `[]` to `null`; added a `sidebarSessionsRef` for diffing; updated `fetchSidebarSessions` to compare incoming sessions by `id + status + activity + lastActivityAt` and skip `setSidebarSessions` when nothing changed; parallelized the initial `fetchSession` + `fetchSidebarSessions` calls via `Promise.all`; passes `sidebarLoading={sidebarSessions === null}` to `SessionDetail`
- `packages/web/src/components/SessionDetail.tsx` — Added optional `sidebarLoading?: boolean` prop (defaults `false`); forwards it to `ProjectSidebar`
- `packages/web/src/components/ProjectSidebar.tsx` — Added optional `loading?: boolean` prop; added `SessionSkeleton` component that renders 3 placeholder rows with a dimmed dot; renders skeleton rows in place of the sessions list (including "No active sessions") while loading

## Testing

- [x] Existing tests pass (`pnpm test` — 443 tests across all packages; pre-existing `tracker-gitlab` failure unrelated to this change)
- [x] Manually verified: `sidebarSessions === null` on first paint triggers skeleton rows, not "No active sessions"
- [x] Diff check verified: `setSidebarSessions` only fires when `id`, `status`, `activity`, or `lastActivityAt` changes

## Notes

The `SessionSkeleton` rows use two new BEM modifier classes (`--skeleton`) that currently render as unstyled placeholder divs. A follow-up can add a shimmer/pulse animation in `globals.css` if desired — the flash elimination works without it.

The long-term fix (from `ashish/feat/multi-dashboard-final`) replaces this entire route with a server-rendered layout. This patch is intentionally minimal and zero-conflict with that branch since it only touches code that branch deletes.

Fixes #1230