### PR TITLE
fix(runtime-tmux): multiline ao send leaves message unsubmitted (#1110)

### DIFF
--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -111,10 +111,14 @@ export function create(): Runtime {
     async sendMessage(handle: RuntimeHandle, message: string): Promise<void> {
       // Clear any partial input
       await tmux("send-keys", "-t", handle.id, "C-u");
+      // Small delay to ensure C-u is processed before pasting begins.
+      // Without this, load-buffer + paste-buffer can collide with the clear.
+      await sleep(200);
 
       // For long or multiline messages, use load-buffer + paste-buffer
       // Use randomUUID to avoid temp file collisions on concurrent sends
-      if (message.includes("\n") || message.length > 200) {
+      const isLongOrMultiline = message.includes("\n") || message.length > 200;
+      if (isLongOrMultiline) {
         const bufferName = `ao-${randomUUID()}`;
         const tmpPath = join(tmpdir(), `ao-send-${randomUUID()}.txt`);
         writeFileSync(tmpPath, message, { encoding: "utf-8", mode: 0o600 });
@@ -141,9 +145,10 @@ export function create(): Runtime {
         await tmux("send-keys", "-t", handle.id, "-l", message);
       }
 
-      // Small delay to let tmux process the pasted text before pressing Enter.
-      // Without this, Enter can arrive before the text is fully rendered.
-      await sleep(300);
+      // Delay before Enter to let tmux finish rendering the pasted text.
+      // Multiline/long pastes via paste-buffer need more time than short
+      // send-keys text — 1 s matches the reference delay in core/src/tmux.ts.
+      await sleep(isLongOrMultiline ? 1000 : 300);
       await tmux("send-keys", "-t", handle.id, "Enter");
     },
 


### PR DESCRIPTION
## Problem

`ao send` with multi-line or long messages places the text in the tmux input buffer but never submits it. The agent session sits idle at the `❯` prompt with the message visible — no Enter keypress is delivered. Users had to manually run `tmux send-keys -t <session> Enter` after every `ao send` call.

## Root Cause

Two timing gaps in `runtime-tmux`'s `sendMessage` (the path taken when a session is registered with the session manager):

1. **No delay after `C-u`** — `load-buffer + paste-buffer` started immediately after the clear keypress, before the terminal application had processed it. Short messages are unaffected since they go through `send-keys -l`, but the buffer path is used for all multiline/long content.

2. **Flat 300 ms pre-Enter delay for all messages** — `paste-buffer` is asynchronous; tmux returns from the command before the target application has consumed all pasted keystrokes. 300 ms is enough for short pastes but not for multiline heredocs. `core/src/tmux.ts:sendKeys` already used 1 000 ms for the identical scenario — `sendMessage` was inconsistent.

## Fix

| Change | Before | After |
|--------|--------|-------|
| Delay after `C-u` | 0 ms | 200 ms (matches `send.ts:sendViaTmux`) |
| Pre-Enter delay (multiline/long) | 300 ms | 1 000 ms (matches `core/src/tmux.ts:sendKeys`) |
| Pre-Enter delay (short text) | 300 ms | 300 ms (unchanged) |

Single file changed: `packages/plugins/runtime-tmux/src/index.ts`.

## Testing

All 26 existing `runtime-tmux` tests pass (the multiline tests now correctly reflect the 1 s delay in their runtimes).

```
✓ src/__tests__/index.test.ts (26 tests)
  ✓ runtime.sendMessage() > sends short text with send-keys -l (literal) + Enter
  ✓ runtime.sendMessage() > uses load-buffer + paste-buffer for long text (> 200 chars)
  ✓ runtime.sendMessage() > uses load-buffer for multiline text
```

Fixes #1110

🤖 Generated with [Claude Code](https://claude.ai/code)