### PR TITLE
feat(core): add validated greet utility

### DIFF
--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -3,12 +3,28 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  greet,
   isGitBranchNameSafe,
   isRetryableHttpStatus,
   normalizeRetryConfig,
   readLastJsonlEntry,
 } from "../utils.js";
 import { parsePrFromUrl } from "../utils/pr.js";
+
+describe("greet", () => {
+  it("returns a hello greeting for the provided name", () => {
+    expect(greet("Halcyon")).toBe("Hello, Halcyon!");
+  });
+
+  it("trims surrounding whitespace from the provided name", () => {
+    expect(greet("  Halcyon  ")).toBe("Hello, Halcyon!");
+  });
+
+  it("throws for an empty name", () => {
+    expect(() => greet("")).toThrow("Name must not be empty");
+    expect(() => greet("   ")).toThrow("Name must not be empty");
+  });
+});
 
 describe("readLastJsonlEntry", () => {
   let tmpDir: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,7 @@ export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";
 
 // Shared utilities
 export {
+  greet,
   shellEscape,
   escapeAppleScript,
   validateUrl,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -6,6 +6,17 @@ import { open, stat } from "node:fs/promises";
 import type { OrchestratorConfig } from "./types.js";
 
 /**
+ * Return a stable greeting string for a given name.
+ */
+export function greet(name: string): string {
+  const normalizedName = name.trim();
+  if (!normalizedName) {
+    throw new Error("Name must not be empty");
+  }
+  return `Hello, ${normalizedName}!`;
+}
+
+/**
  * POSIX-safe shell escaping: wraps value in single quotes,
  * escaping any embedded single quotes as '\\'' .
  *


### PR DESCRIPTION
## Summary
- add `greet(name)` to `packages/core/src/utils.ts`
- validate and trim the provided name before returning the greeting
- export the helper from the core package entrypoint and cover success/error cases in unit tests

## Testing
- `pnpm --filter @aoagents/ao-core test -- src/__tests__/utils.test.ts`
- `pnpm --filter @aoagents/ao-core typecheck`

## Notes
- A broader `pnpm --filter @aoagents/ao-core test` run still hits pre-existing unrelated failures in `packages/core/__tests__/config.test.ts`.