### PR TITLE
feat(web): add GET /api/health endpoint

### DIFF
--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -208,6 +208,7 @@ import { GET as observabilityGET } from "@/app/api/observability/route";
 import { GET as runtimeTerminalGET } from "@/app/api/runtime/terminal/route";
 import { GET as verifyGET, POST as verifyPOST } from "@/app/api/verify/route";
 import { GET as patchesGET } from "@/app/api/sessions/patches/route";
+import { GET as healthGET } from "@/app/api/health/route";
 
 function makeRequest(url: string, init?: RequestInit): NextRequest {
   return new NextRequest(
@@ -1022,6 +1023,19 @@ describe("API Routes", () => {
       expect(res.status).toBe(500);
       const data = await res.json();
       expect(data.error).toBe("db down");
+    });
+  });
+
+  // ── GET /api/health ──────────────────────────────────────────────────
+
+  describe("GET /api/health", () => {
+    it("returns status ok with a valid ISO timestamp", async () => {
+      const res = await healthGET();
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.status).toBe("ok");
+      expect(typeof data.timestamp).toBe("string");
+      expect(new Date(data.timestamp).toISOString()).toBe(data.timestamp);
     });
   });
 });

--- a/packages/web/src/app/api/health/route.ts
+++ b/packages/web/src/app/api/health/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/health — Basic health check endpoint
+ */
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
+    timestamp: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/health` endpoint at `packages/web/src/app/api/health/route.ts` returning `{ status: 'ok', timestamp: '<ISO string>' }`
- Add test coverage in the existing `api-routes.test.ts` test suite

## Test plan
- [x] New test verifies 200 status, `status: 'ok'`, and valid ISO timestamp
- [x] All 61 API route tests pass (`pnpm --filter @aoagents/ao-web test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>