### PR TITLE
feat: add GET /api/health endpoint

### DIFF
--- a/packages/web/src/app/api/health/route.ts
+++ b/packages/web/src/app/api/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/health — Health check endpoint
+ */
+export async function GET() {
+  return NextResponse.json({ status: "ok", timestamp: new Date().toISOString() });
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/health` endpoint at `packages/web/src/app/api/health/route.ts`
- Returns `{ status: 'ok', timestamp: <ISO string> }` with `force-dynamic` to ensure fresh timestamps

## Test plan

- [ ] `curl http://localhost:3000/api/health` returns `{"status":"ok","timestamp":"..."}` with HTTP 200