### PR TITLE
fix(web): cap terminal reconnects, guard SSE enqueue, custom 4004 code

### DIFF
--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -30,7 +30,7 @@ type ServerMessage =
   | { ch: "terminal"; id: string; type: "data"; data: string }
   | { ch: "terminal"; id: string; type: "exited"; code: number }
   | { ch: "terminal"; id: string; type: "opened" }
-  | { ch: "terminal"; id: string; type: "error"; message: string }
+  | { ch: "terminal"; id: string; type: "error"; message: string; code?: number }
   | { ch: "sessions"; type: "snapshot"; sessions: SessionPatch[] }
   | { ch: "system"; type: "pong" }
   | { ch: "system"; type: "error"; message: string };
@@ -229,6 +229,14 @@ interface ManagedTerminal {
 
 const RING_BUFFER_MAX = 50 * 1024; // 50KB max per terminal
 const MAX_REATTACH_ATTEMPTS = 3;
+
+/**
+ * Custom close code for "session not found" — mirrors
+ * TERMINAL_CLOSE_SESSION_NOT_FOUND in src/lib/mux-protocol.ts. Kept duplicated
+ * because tsconfig.server.json isolates the server tree from src/.
+ */
+const TERMINAL_CLOSE_SESSION_NOT_FOUND = 4004;
+const SESSION_NOT_FOUND_PREFIX = "Session not found:";
 
 /**
  * TerminalManager manages PTY processes independently of WebSocket connections.
@@ -557,11 +565,14 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
             }
           } catch (err) {
             if (ws.readyState === WebSocket.OPEN) {
+              const message = err instanceof Error ? err.message : String(err);
+              const isNotFound = message.startsWith(SESSION_NOT_FOUND_PREFIX);
               const errorMsg: ServerMessage = {
                 ch: "terminal",
                 id,
                 type: "error",
-                message: err instanceof Error ? err.message : String(err),
+                message,
+                ...(isNotFound ? { code: TERMINAL_CLOSE_SESSION_NOT_FOUND } : {}),
               };
               ws.send(JSON.stringify(errorMsg));
             }

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -946,6 +946,69 @@ describe("API Routes", () => {
       expect(event.sessions[0]).toHaveProperty("id");
       expect(event.sessions[0]).toHaveProperty("attentionLevel");
     });
+
+    it("guards controller.enqueue after stream is cancelled", async () => {
+      // No unhandled errors should escape once the reader cancels — the
+      // route must set its internal `closed` flag and short-circuit all
+      // later enqueue paths (heartbeat, poll, observer-triggered snapshot).
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on("unhandledRejection", onUnhandled);
+
+      try {
+        const req = makeRequest("/api/events", { method: "GET" });
+        const res = await eventsGET(req);
+        const reader = res.body!.getReader();
+        // Consume the initial snapshot, then cancel mid-flight.
+        await reader.read();
+        await reader.cancel();
+
+        // Give any queued microtasks / pending setInterval ticks a chance
+        // to run. Without the `closed` flag and interval cleanup this is
+        // where the old code threw "Controller is already closed".
+        await new Promise((r) => setTimeout(r, 50));
+      } finally {
+        process.off("unhandledRejection", onUnhandled);
+      }
+
+      expect(unhandled).toEqual([]);
+    });
+
+    it("clears heartbeat and update intervals on cancel", async () => {
+      // Track all setInterval ids created during GET so we can verify they
+      // are cleared when the stream is cancelled.
+      const liveIntervals = new Set<ReturnType<typeof setInterval>>();
+      const origSet = globalThis.setInterval;
+      const origClear = globalThis.clearInterval;
+      globalThis.setInterval = ((handler: () => void, ms?: number) => {
+        const id = origSet(handler, ms);
+        liveIntervals.add(id);
+        return id;
+      }) as typeof setInterval;
+      globalThis.clearInterval = ((id: ReturnType<typeof setInterval> | undefined) => {
+        if (id !== undefined) liveIntervals.delete(id);
+        return origClear(id);
+      }) as typeof clearInterval;
+
+      try {
+        const req = makeRequest("/api/events", { method: "GET" });
+        const res = await eventsGET(req);
+        const reader = res.body!.getReader();
+        await reader.read();
+
+        // Both heartbeat + updates should be registered by now.
+        expect(liveIntervals.size).toBeGreaterThanOrEqual(2);
+
+        await reader.cancel();
+        // Allow the async cancel() callback to run.
+        await new Promise((r) => setTimeout(r, 20));
+
+        expect(liveIntervals.size).toBe(0);
+      } finally {
+        globalThis.setInterval = origSet;
+        globalThis.clearInterval = origClear;
+      }
+    });
   });
 
   describe("GET /api/observability", () => {

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -947,66 +947,179 @@ describe("API Routes", () => {
       expect(event.sessions[0]).toHaveProperty("attentionLevel");
     });
 
-    it("guards controller.enqueue after stream is cancelled", async () => {
-      // No unhandled errors should escape once the reader cancels — the
-      // route must set its internal `closed` flag and short-circuit all
-      // later enqueue paths (heartbeat, poll, observer-triggered snapshot).
-      const unhandled: unknown[] = [];
-      const onUnhandled = (reason: unknown) => unhandled.push(reason);
-      process.on("unhandledRejection", onUnhandled);
+    // ── Helpers for the SSE cancel / closed-flag tests ─────────────────
+    //
+    // Intercepts the ReadableStream constructor the route uses so the test
+    // can reach the actual controller and spy on .enqueue(), and wraps
+    // setInterval/clearInterval to capture the two specific handles the
+    // route schedules (heartbeat at 15s, poll at 5s) and their callbacks.
+    interface SseInstrumentation {
+      enqueueSpy: ReturnType<typeof vi.fn>;
+      intervals: Array<{
+        id: ReturnType<typeof setInterval>;
+        handler: () => void;
+        ms: number;
+        cleared: boolean;
+      }>;
+      restore: () => void;
+    }
 
-      try {
-        const req = makeRequest("/api/events", { method: "GET" });
-        const res = await eventsGET(req);
-        const reader = res.body!.getReader();
-        // Consume the initial snapshot, then cancel mid-flight.
-        await reader.read();
-        await reader.cancel();
-
-        // Give any queued microtasks / pending setInterval ticks a chance
-        // to run. Without the `closed` flag and interval cleanup this is
-        // where the old code threw "Controller is already closed".
-        await new Promise((r) => setTimeout(r, 50));
-      } finally {
-        process.off("unhandledRejection", onUnhandled);
-      }
-
-      expect(unhandled).toEqual([]);
-    });
-
-    it("clears heartbeat and update intervals on cancel", async () => {
-      // Track all setInterval ids created during GET so we can verify they
-      // are cleared when the stream is cancelled.
-      const liveIntervals = new Set<ReturnType<typeof setInterval>>();
+    function instrumentSse(): SseInstrumentation {
+      const origRS = globalThis.ReadableStream;
       const origSet = globalThis.setInterval;
       const origClear = globalThis.clearInterval;
+
+      const intervals: SseInstrumentation["intervals"] = [];
+      const enqueueSpy = vi.fn();
+
+      class TrackedRS<R = Uint8Array> extends (origRS as unknown as {
+        new <T>(source?: UnderlyingSource<T>): ReadableStream<T>;
+      })<R> {
+        constructor(source?: UnderlyingSource<R>) {
+          const wrapped: UnderlyingSource<R> = {
+            ...(source ?? {}),
+            start(controller) {
+              const realEnqueue = controller.enqueue.bind(controller);
+              controller.enqueue = ((chunk: R) => {
+                enqueueSpy(chunk);
+                return realEnqueue(chunk);
+              }) as typeof controller.enqueue;
+              return source?.start?.(controller);
+            },
+          };
+          super(wrapped);
+        }
+      }
+
+      (globalThis as unknown as { ReadableStream: typeof ReadableStream }).ReadableStream =
+        TrackedRS as unknown as typeof ReadableStream;
+
       globalThis.setInterval = ((handler: () => void, ms?: number) => {
         const id = origSet(handler, ms);
-        liveIntervals.add(id);
+        intervals.push({ id, handler, ms: ms ?? 0, cleared: false });
         return id;
       }) as typeof setInterval;
+
       globalThis.clearInterval = ((id: ReturnType<typeof setInterval> | undefined) => {
-        if (id !== undefined) liveIntervals.delete(id);
+        const entry = intervals.find((e) => e.id === id);
+        if (entry) entry.cleared = true;
         return origClear(id);
       }) as typeof clearInterval;
 
+      return {
+        enqueueSpy,
+        intervals,
+        restore() {
+          (globalThis as unknown as { ReadableStream: typeof ReadableStream }).ReadableStream =
+            origRS;
+          globalThis.setInterval = origSet;
+          globalThis.clearInterval = origClear;
+        },
+      };
+    }
+
+    /** Flush microtasks while fake timers are active. */
+    async function flushMicrotasks() {
+      // Multiple ticks — the route awaits getServices() twice before enqueue.
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+    }
+
+    it("makes no enqueue calls after cancel, even when heartbeat and update timers fire", async () => {
+      vi.useFakeTimers();
+      const sse = instrumentSse();
       try {
         const req = makeRequest("/api/events", { method: "GET" });
         const res = await eventsGET(req);
         const reader = res.body!.getReader();
+
+        // Flush the async init so the initial snapshot is enqueued.
+        await flushMicrotasks();
         await reader.read();
 
-        // Both heartbeat + updates should be registered by now.
-        expect(liveIntervals.size).toBeGreaterThanOrEqual(2);
+        // Cancel mid-flight. After this the closed flag must short-circuit
+        // any further enqueue from heartbeat / update / observer callbacks.
+        await reader.cancel();
+        await flushMicrotasks();
+
+        const callsAtCancel = sse.enqueueSpy.mock.calls.length;
+
+        // Drive the heartbeat interval (15s) and update interval (5s)
+        // several cycles past cancel. Without the closed flag this is where
+        // the old code attempted to enqueue into a cancelled controller.
+        await vi.advanceTimersByTimeAsync(60_000);
+        await flushMicrotasks();
+
+        expect(sse.enqueueSpy.mock.calls.length).toBe(callsAtCancel);
+      } finally {
+        sse.restore();
+        vi.useRealTimers();
+      }
+    });
+
+    it("clears the specific heartbeat and update interval handles on cancel", async () => {
+      vi.useFakeTimers();
+      const sse = instrumentSse();
+      try {
+        const req = makeRequest("/api/events", { method: "GET" });
+        const res = await eventsGET(req);
+        const reader = res.body!.getReader();
+
+        await flushMicrotasks();
+        await reader.read();
+
+        // Exactly two intervals are scheduled by the route: the 15s
+        // heartbeat and the 5s session-state poll. Grab them by their ms.
+        const heartbeat = sse.intervals.find((e) => e.ms === 15_000);
+        const update = sse.intervals.find((e) => e.ms === 5_000);
+        expect(heartbeat).toBeDefined();
+        expect(update).toBeDefined();
+        expect(heartbeat!.cleared).toBe(false);
+        expect(update!.cleared).toBe(false);
 
         await reader.cancel();
-        // Allow the async cancel() callback to run.
-        await new Promise((r) => setTimeout(r, 20));
+        await flushMicrotasks();
 
-        expect(liveIntervals.size).toBe(0);
+        expect(heartbeat!.cleared).toBe(true);
+        expect(update!.cleared).toBe(true);
       } finally {
-        globalThis.setInterval = origSet;
-        globalThis.clearInterval = origClear;
+        sse.restore();
+        vi.useRealTimers();
+      }
+    });
+
+    it("short-circuits the poll callback post-cancel (closed flag, not swallow)", async () => {
+      vi.useFakeTimers();
+      const sse = instrumentSse();
+      try {
+        const req = makeRequest("/api/events", { method: "GET" });
+        const res = await eventsGET(req);
+        const reader = res.body!.getReader();
+
+        await flushMicrotasks();
+        await reader.read();
+
+        const update = sse.intervals.find((e) => e.ms === 5_000);
+        const heartbeat = sse.intervals.find((e) => e.ms === 15_000);
+        expect(update).toBeDefined();
+        expect(heartbeat).toBeDefined();
+
+        await reader.cancel();
+        await flushMicrotasks();
+
+        const callsAtCancel = sse.enqueueSpy.mock.calls.length;
+
+        // Directly invoke the captured callbacks as if a lingering timer
+        // fired. The `closed` flag must short-circuit BOTH paths — they
+        // must not even attempt to enqueue (which would otherwise be
+        // caught by safeEnqueue, masking a bug where the path still ran).
+        update!.handler();
+        heartbeat!.handler();
+        await flushMicrotasks();
+
+        expect(sse.enqueueSpy.mock.calls.length).toBe(callsAtCancel);
+      } finally {
+        sse.restore();
+        vi.useRealTimers();
       }
     });
   });

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -26,6 +26,23 @@ export async function GET(request: Request): Promise<Response> {
   let updates: ReturnType<typeof setInterval> | undefined;
   let observerProjectId: string | undefined;
   let observer: ProjectObserver | null = null;
+  let closed = false;
+
+  const safeEnqueue = (
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    chunk: Uint8Array,
+  ): boolean => {
+    if (closed) return false;
+    try {
+      controller.enqueue(chunk);
+      return true;
+    } catch {
+      closed = true;
+      if (heartbeat) clearInterval(heartbeat);
+      if (updates) clearInterval(updates);
+      return false;
+    }
+  };
 
   const ensureObserver = (config: ServicesConfig): ProjectObserver | null => {
     if (!observerProjectId) {
@@ -94,7 +111,7 @@ export async function GET(request: Request): Promise<Response> {
               lastActivityAt: s.lastActivityAt,
             })),
           };
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify(initialEvent)}\n\n`));
+          safeEnqueue(controller, encoder.encode(`data: ${JSON.stringify(initialEvent)}\n\n`));
           if (projectObserver && observerProjectId) {
             projectObserver.recordOperation({
               metric: "sse_snapshot",
@@ -108,7 +125,8 @@ export async function GET(request: Request): Promise<Response> {
           }
         } catch {
           // If services aren't available, send empty snapshot
-          controller.enqueue(
+          safeEnqueue(
+            controller,
             encoder.encode(
               `data: ${JSON.stringify({ type: "snapshot", correlationId, emittedAt: new Date().toISOString(), sessions: [] })}\n\n`,
             ),
@@ -118,16 +136,21 @@ export async function GET(request: Request): Promise<Response> {
 
       // Send periodic heartbeat
       heartbeat = setInterval(() => {
-        try {
-          controller.enqueue(encoder.encode(`: heartbeat\n\n`));
-        } catch {
+        if (closed) {
           clearInterval(heartbeat);
           clearInterval(updates);
+          return;
         }
+        safeEnqueue(controller, encoder.encode(`: heartbeat\n\n`));
       }, 15000);
 
       // Poll for session state changes every 5 seconds
       updates = setInterval(() => {
+        if (closed) {
+          clearInterval(heartbeat);
+          clearInterval(updates);
+          return;
+        }
         void (async () => {
           let dashboardSessions;
           try {
@@ -155,36 +178,33 @@ export async function GET(request: Request): Promise<Response> {
               });
             }
 
-            try {
-              const attentionZones = config.dashboard?.attentionZones ?? "simple";
-              const event = {
-                type: "snapshot",
+            const attentionZones = config.dashboard?.attentionZones ?? "simple";
+            const event = {
+              type: "snapshot",
+              correlationId,
+              emittedAt: new Date().toISOString(),
+              sessions: dashboardSessions.map((s) => ({
+                id: s.id,
+                status: s.status,
+                activity: s.activity,
+                attentionLevel: getAttentionLevel(s, attentionZones),
+                lastActivityAt: s.lastActivityAt,
+              })),
+            };
+            const delivered = safeEnqueue(
+              controller,
+              encoder.encode(`data: ${JSON.stringify(event)}\n\n`),
+            );
+            if (delivered && projectObserver && observerProjectId) {
+              projectObserver.recordOperation({
+                metric: "sse_snapshot",
+                operation: "sse.snapshot",
+                outcome: "success",
                 correlationId,
-                emittedAt: new Date().toISOString(),
-                sessions: dashboardSessions.map((s) => ({
-                  id: s.id,
-                  status: s.status,
-                  activity: s.activity,
-                  attentionLevel: getAttentionLevel(s, attentionZones),
-                  lastActivityAt: s.lastActivityAt,
-                })),
-              };
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
-              if (projectObserver && observerProjectId) {
-                projectObserver.recordOperation({
-                  metric: "sse_snapshot",
-                  operation: "sse.snapshot",
-                  outcome: "success",
-                  correlationId,
-                  projectId: observerProjectId,
-                  data: { sessionCount: dashboardSessions.length, initial: false },
-                  level: "info",
-                });
-              }
-            } catch {
-              // enqueue failure means the stream is closed — clean up both intervals
-              clearInterval(updates);
-              clearInterval(heartbeat);
+                projectId: observerProjectId,
+                data: { sessionCount: dashboardSessions.length, initial: false },
+                level: "info",
+              });
             }
           } catch {
             // Transient service error — skip this poll, retry on next interval
@@ -194,6 +214,7 @@ export async function GET(request: Request): Promise<Response> {
       }, 5000);
     },
     cancel() {
+      closed = true;
       clearInterval(heartbeat);
       clearInterval(updates);
       void (async () => {

--- a/packages/web/src/lib/mux-protocol.ts
+++ b/packages/web/src/lib/mux-protocol.ts
@@ -16,10 +16,17 @@ export type ServerMessage =
   | { ch: "terminal"; id: string; type: "data"; data: string }
   | { ch: "terminal"; id: string; type: "exited"; code: number }
   | { ch: "terminal"; id: string; type: "opened" }
-  | { ch: "terminal"; id: string; type: "error"; message: string }
+  | { ch: "terminal"; id: string; type: "error"; message: string; code?: number }
   | { ch: "sessions"; type: "snapshot"; sessions: SessionPatch[] }
   | { ch: "system"; type: "pong" }
   | { ch: "system"; type: "error"; message: string };
+
+/**
+ * Custom WebSocket-style application close code for "session not found".
+ * Used on per-terminal error messages so the client can distinguish this
+ * from a generic policy violation (1008) and stop reconnecting for good.
+ */
+export const TERMINAL_CLOSE_SESSION_NOT_FOUND = 4004;
 
 export interface SessionPatch {
   id: string;

--- a/packages/web/src/providers/MuxProvider.tsx
+++ b/packages/web/src/providers/MuxProvider.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import React, { useEffect, useRef, useState, useMemo, useCallback, type ReactNode } from "react";
-import type { ClientMessage, ServerMessage, SessionPatch } from "@/lib/mux-protocol";
+import {
+  TERMINAL_CLOSE_SESSION_NOT_FOUND,
+  type ClientMessage,
+  type ServerMessage,
+  type SessionPatch,
+} from "@/lib/mux-protocol";
 
 interface MuxContextValue {
   subscribeTerminal: (id: string, callback: (data: string) => void) => () => void;
@@ -46,6 +51,9 @@ function normalizePathValue(value: unknown): string | undefined {
   if (!trimmed.startsWith("/")) return undefined;
   return trimmed;
 }
+
+/** Cap on reconnect attempts before giving up and surfacing a permanent error. */
+const MAX_RECONNECT_ATTEMPTS = 8;
 
 function buildMuxWsUrl(runtimeConfig: { directTerminalPort?: string; proxyWsPath?: string }): string {
   const loc = window.location;
@@ -151,6 +159,19 @@ export function MuxProvider({ children }: { children: ReactNode }) {
               }
             } else if (msg.type === "error") {
               console.error(`[MuxProvider] Terminal error for ${msg.id}:`, msg.message);
+              // "Session not found" is a permanent condition — don't re-open this
+              // terminal on reconnect, and surface a terminal-level notice so the
+              // DirectTerminal component can stop trying.
+              if (msg.code === TERMINAL_CLOSE_SESSION_NOT_FOUND) {
+                openedTerminalsRef.current.delete(msg.id);
+                const subs = subscribersRef.current.get(msg.id);
+                if (subs) {
+                  const notice = `\r\n\x1b[31m[Session not found — terminal unavailable]\x1b[0m\r\n`;
+                  for (const callback of subs) {
+                    callback(notice);
+                  }
+                }
+              }
             }
           } else if (msg.ch === "sessions" && msg.type === "snapshot") {
             setSessions(msg.sessions);
@@ -170,6 +191,16 @@ export function MuxProvider({ children }: { children: ReactNode }) {
 
         // Don't reconnect if the provider has been unmounted
         if (isDestroyedRef.current) return;
+
+        // Cap reconnect attempts to avoid an infinite loop after the server
+        // (or individual session) has gone away for good.
+        if (reconnectAttempt.current >= MAX_RECONNECT_ATTEMPTS) {
+          console.warn(
+            `[MuxProvider] Reached ${MAX_RECONNECT_ATTEMPTS} reconnect attempts, giving up`,
+          );
+          setStatus("disconnected");
+          return;
+        }
 
         // Reconnect with exponential backoff
         const delayMs = Math.min(1000 * Math.pow(2, reconnectAttempt.current), 30_000);

--- a/packages/web/src/providers/__tests__/MuxProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/MuxProvider.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MuxProvider, useMux, useMuxOptional } from "../MuxProvider";
+import { TERMINAL_CLOSE_SESSION_NOT_FOUND } from "@/lib/mux-protocol";
 
 // ---------------------------------------------------------------------------
 // Mock WebSocket
@@ -527,6 +528,206 @@ describe("MuxProvider terminal operations", () => {
 // ---------------------------------------------------------------------------
 // buildMuxWsUrl — via provider behaviour
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Reconnect cap + session-not-found handling
+// ---------------------------------------------------------------------------
+
+describe("MuxProvider reconnect cap", () => {
+  it("caps reconnects at 8 attempts and transitions to disconnected", async () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useMux(), { wrapper });
+      await flushInit();
+
+      // Drive 8 close events through failing reconnect cycles. The very
+      // first close increments reconnectAttempt → 1 and schedules attempt 1.
+      // Subsequent closes on each new instance do the same. After 8 closes
+      // we've used all attempts and the 9th close must transition to
+      // "disconnected" with NO further socket being created.
+      for (let i = 0; i < 8; i++) {
+        expect(MockWebSocket.instances.length).toBe(i + 1);
+        const ws = MockWebSocket.instances[i];
+        act(() => ws.simulateClose());
+        expect(result.current.status).toBe("reconnecting");
+        // Advance past the backoff delay so the next socket is constructed.
+        act(() => vi.advanceTimersByTime(60_000));
+        await flushInit();
+      }
+
+      // 9th socket now exists; closing it exceeds the cap.
+      expect(MockWebSocket.instances.length).toBe(9);
+      const lastWs = MockWebSocket.instances[8];
+      const countBeforeFinalClose = MockWebSocket.instances.length;
+      act(() => lastWs.simulateClose());
+
+      expect(result.current.status).toBe("disconnected");
+
+      // Advance well past any backoff — no new socket should be scheduled.
+      act(() => vi.advanceTimersByTime(120_000));
+      await flushInit();
+      expect(MockWebSocket.instances.length).toBe(countBeforeFinalClose);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets reconnect attempt counter after a successful open", async () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useMux(), { wrapper });
+      await flushInit();
+
+      // Burn through a handful of failed reconnects.
+      for (let i = 0; i < 5; i++) {
+        const ws = MockWebSocket.instances[i];
+        act(() => ws.simulateClose());
+        act(() => vi.advanceTimersByTime(60_000));
+        await flushInit();
+      }
+
+      // The next socket succeeds — this must reset reconnectAttempt to 0.
+      const okWs = MockWebSocket.instances[5];
+      act(() => okWs.simulateOpen());
+      expect(result.current.status).toBe("connected");
+
+      // Now fail 8 more times; because the counter reset, we should get
+      // 8 fresh reconnect instances (not hit the cap after a handful).
+      const baseline = MockWebSocket.instances.length;
+      for (let i = 0; i < 8; i++) {
+        const ws = MockWebSocket.instances[baseline - 1 + i];
+        act(() => ws.simulateClose());
+        expect(result.current.status).toBe("reconnecting");
+        act(() => vi.advanceTimersByTime(60_000));
+        await flushInit();
+      }
+      expect(MockWebSocket.instances.length).toBe(baseline + 8);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("MuxProvider session-not-found (code 4004) handling", () => {
+  async function setupConnected() {
+    const { result } = renderHook(() => useMux(), { wrapper });
+    await flushInit();
+    const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+    act(() => ws.simulateOpen());
+    return { result, ws };
+  }
+
+  it("dispatches the unavailable notice to subscribers on 4004 error", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result, ws } = await setupConnected();
+
+    const received: string[] = [];
+    act(() => {
+      result.current.subscribeTerminal("s-gone", (d) => received.push(d));
+    });
+
+    act(() =>
+      ws.simulateMessage({
+        ch: "terminal",
+        id: "s-gone",
+        type: "error",
+        message: "Session not found: s-gone",
+        code: TERMINAL_CLOSE_SESSION_NOT_FOUND,
+      }),
+    );
+
+    expect(received.some((m) => m.includes("Session not found"))).toBe(true);
+    expect(received.some((m) => m.includes("terminal unavailable"))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("does not re-open the terminal on reconnect after a 4004 error", async () => {
+    vi.useFakeTimers();
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { result } = renderHook(() => useMux(), { wrapper });
+      await flushInit();
+
+      const ws1 = MockWebSocket.instances[0];
+      act(() => ws1.simulateOpen());
+
+      // Mark the terminal as opened on this connection, then the server
+      // reports it vanished with the custom 4004 code.
+      act(() => {
+        result.current.openTerminal("s-gone");
+      });
+      act(() => ws1.simulateMessage({ ch: "terminal", id: "s-gone", type: "opened" }));
+      act(() =>
+        ws1.simulateMessage({
+          ch: "terminal",
+          id: "s-gone",
+          type: "error",
+          message: "Session not found: s-gone",
+          code: TERMINAL_CLOSE_SESSION_NOT_FOUND,
+        }),
+      );
+
+      // Force a reconnect and confirm s-gone is NOT in the re-open set.
+      act(() => ws1.simulateClose());
+      act(() => vi.advanceTimersByTime(1_100));
+      await flushInit();
+
+      const ws2 = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+      act(() => ws2.simulateOpen());
+
+      const reopened = ws2.sentMessages.some((m) => {
+        const p = JSON.parse(m) as Record<string, unknown>;
+        return p.ch === "terminal" && p.type === "open" && p.id === "s-gone";
+      });
+      expect(reopened).toBe(false);
+    } finally {
+      spy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores generic terminal errors (no code) without clearing the opened set", async () => {
+    vi.useFakeTimers();
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { result } = renderHook(() => useMux(), { wrapper });
+      await flushInit();
+
+      const ws1 = MockWebSocket.instances[0];
+      act(() => ws1.simulateOpen());
+
+      act(() => {
+        result.current.openTerminal("s-ok");
+      });
+      act(() => ws1.simulateMessage({ ch: "terminal", id: "s-ok", type: "opened" }));
+      // Generic error — no 4004 code — should NOT remove the terminal.
+      act(() =>
+        ws1.simulateMessage({
+          ch: "terminal",
+          id: "s-ok",
+          type: "error",
+          message: "PTY failed",
+        }),
+      );
+
+      act(() => ws1.simulateClose());
+      act(() => vi.advanceTimersByTime(1_100));
+      await flushInit();
+
+      const ws2 = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+      act(() => ws2.simulateOpen());
+
+      const reopened = ws2.sentMessages.some((m) => {
+        const p = JSON.parse(m) as Record<string, unknown>;
+        return p.ch === "terminal" && p.type === "open" && p.id === "s-ok";
+      });
+      expect(reopened).toBe(true);
+    } finally {
+      spy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});
 
 describe("buildMuxWsUrl", () => {
   it("uses directTerminalPort from runtime config when on a custom port", async () => {


### PR DESCRIPTION
Fixes #964.

## Summary
- **Cap MuxProvider reconnects** at 8 attempts (exponential backoff retained). Once exhausted the provider transitions to a permanent `disconnected` state instead of spamming WebSocket connects forever after a session exits.
- **Guard SSE enqueue** in `/api/events` with a `closed` flag set in `cancel()` (and on any enqueue failure). Heartbeat, poller, and initial snapshot paths now short-circuit cleanly after the client disconnects instead of throwing unhandled `controller.enqueue()` errors.
- **Custom close code `4004` for "session not found"** — added `TERMINAL_CLOSE_SESSION_NOT_FOUND` in `mux-protocol.ts` and mirrored it in the server (tsconfig rootDir prevents shared import). The server now tags the terminal error message with `code: 4004` so the client can distinguish it from a generic policy violation (1008). On receipt, MuxProvider drops the terminal from its re-open set and pushes a visible notice line to subscribers.
- The exited-session placeholder in `SessionDetail` already covers the "session ended" UI path via `TERMINAL_STATUSES` — no change needed there.

## Test plan
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint` (no new errors; pre-existing warnings only)
- [x] `pnpm --filter @aoagents/ao-web test` — 599 tests pass
- [ ] Manual: kill a session in the dashboard and confirm the terminal no longer reconnects in a loop
- [ ] Manual: close a browser tab mid-SSE and confirm no `enqueue after close` errors in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)