### PR TITLE
feat(core): automatic cleanup of dead/terminal worker sessions

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -596,6 +596,35 @@ describe("check (single session)", () => {
     await expect(lm.check("nonexistent")).rejects.toThrow("not found");
   });
 
+  it("auto-archives session on transition to terminal status (merged)", async () => {
+    const mockSCM = createMockSCM({ getPRState: vi.fn().mockResolvedValue("merged") });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "approved", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("merged");
+    expect(mockSessionManager.archiveTerminalSession).toHaveBeenCalledWith("app-1");
+  });
+
+  it("does not auto-archive session on transition to errored status", async () => {
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "errored" }),
+    });
+
+    await lm.check("app-1");
+
+    expect(mockSessionManager.archiveTerminalSession).not.toHaveBeenCalled();
+  });
+
   it("does not change state when status is unchanged", async () => {
     const lm = setupCheck("app-1", {
       session: makeSession({ status: "working" }),

--- a/packages/core/src/__tests__/session-manager/lifecycle.test.ts
+++ b/packages/core/src/__tests__/session-manager/lifecycle.test.ts
@@ -228,6 +228,81 @@ describe("kill", () => {
   }, 15000);
 });
 
+describe("archiveTerminalSession", () => {
+  it("destroys runtime and archives metadata but preserves workspace", async () => {
+    const managedWorktree = join(
+      getWorktreesDir(config.configPath, config.projects["my-app"]!.path),
+      "app-1",
+    );
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: managedWorktree,
+      branch: "main",
+      status: "merged",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const archived = await sm.archiveTerminalSession("app-1");
+
+    expect(archived).toBe(true);
+    expect(mockRuntime.destroy).toHaveBeenCalledWith(makeHandle("rt-1"));
+    expect(mockWorkspace.destroy).not.toHaveBeenCalled();
+    expect(readMetadata(sessionsDir, "app-1")).toBeNull();
+    expect(existsSync(join(sessionsDir, "archive"))).toBe(true);
+  });
+
+  it("skips orchestrator sessions", async () => {
+    writeMetadata(sessionsDir, "app-orchestrator", {
+      worktree: config.projects["my-app"]!.path,
+      branch: "main",
+      status: "done",
+      project: "my-app",
+      role: "orchestrator",
+      runtimeHandle: JSON.stringify(makeHandle("rt-orch")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const archived = await sm.archiveTerminalSession("app-orchestrator");
+
+    expect(archived).toBe(false);
+    expect(mockRuntime.destroy).not.toHaveBeenCalled();
+    expect(readMetadata(sessionsDir, "app-orchestrator")).not.toBeNull();
+  });
+
+  it("returns false for unknown session", async () => {
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.archiveTerminalSession("missing")).resolves.toBe(false);
+  });
+
+  it("archives even when runtime destroy throws", async () => {
+    const failRuntime: Runtime = {
+      ...mockRuntime,
+      destroy: vi.fn().mockRejectedValue(new Error("already gone")),
+    };
+    const registryWithFail: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return failRuntime;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp/ws",
+      branch: "main",
+      status: "killed",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithFail });
+    await expect(sm.archiveTerminalSession("app-1")).resolves.toBe(true);
+    expect(readMetadata(sessionsDir, "app-1")).toBeNull();
+  });
+});
+
 describe("cleanup", () => {
   it("kills sessions with merged PRs", async () => {
     const mockSCM: SCM = {

--- a/packages/core/src/__tests__/test-utils.ts
+++ b/packages/core/src/__tests__/test-utils.ts
@@ -345,6 +345,7 @@ export function createMockSessionManager(): SessionManager {
     list: vi.fn().mockResolvedValue([]),
     get: vi.fn().mockResolvedValue(null),
     kill: vi.fn().mockResolvedValue(undefined),
+    archiveTerminalSession: vi.fn().mockResolvedValue(true),
     cleanup: vi.fn().mockResolvedValue({ killed: [], skipped: [], errors: [] }),
     send: vi.fn().mockResolvedValue(undefined),
     claimPR: vi.fn().mockResolvedValue({

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -16,6 +16,7 @@ import {
   PR_STATE,
   CI_STATUS,
   TERMINAL_STATUSES,
+  AUTO_ARCHIVE_STATUSES,
   type LifecycleManager,
   type SessionManager,
   type SessionId,
@@ -198,6 +199,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   const states = new Map<SessionId, SessionStatus>();
   const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
+  const archivedSessions = new Set<SessionId>(); // guard against repeated archive attempts
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
@@ -1316,6 +1318,32 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       maybeDispatchCIFailureDetails(session, oldStatus, newStatus, transitionReaction),
       maybeDispatchMergeConflicts(session, newStatus),
     ]);
+
+    // Auto-archive sessions that have entered a terminal state. This kills
+    // the tmux session and moves metadata to archive/ so `ao status` and
+    // `ao session ls` stop showing stale entries. Run after notifications
+    // and reactions so they see the live session state first. See issue #536.
+    if (AUTO_ARCHIVE_STATUSES.has(newStatus) && !archivedSessions.has(session.id)) {
+      archivedSessions.add(session.id);
+      try {
+        await sessionManager.archiveTerminalSession(session.id);
+      } catch (err) {
+        archivedSessions.delete(session.id); // allow retry on next poll
+        observer.recordOperation({
+          metric: "lifecycle_poll",
+          operation: "lifecycle.archive",
+          outcome: "failure",
+          correlationId: createCorrelationId("lifecycle-archive"),
+          projectId: session.projectId,
+          sessionId: session.id,
+          data: {
+            status: newStatus,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          level: "error",
+        });
+      }
+    }
   }
 
   /** Run one polling cycle across all sessions. */
@@ -1344,6 +1372,36 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
       // Poll all sessions concurrently
       await Promise.allSettled(sessionsToCheck.map((s) => checkSession(s)));
+
+      // Sweep any terminal sessions that didn't go through a transition this
+      // cycle (e.g., sessions already in terminal state at lifecycle startup,
+      // or set terminal by an external process). Keeps active sessions dir
+      // clean across restarts. See issue #536.
+      await Promise.allSettled(
+        sessions
+          .filter((s) => AUTO_ARCHIVE_STATUSES.has(s.status) && !archivedSessions.has(s.id))
+          .map(async (s) => {
+            archivedSessions.add(s.id);
+            try {
+              await sessionManager.archiveTerminalSession(s.id);
+            } catch (err) {
+              archivedSessions.delete(s.id);
+              observer.recordOperation({
+                metric: "lifecycle_poll",
+                operation: "lifecycle.archive",
+                outcome: "failure",
+                correlationId: createCorrelationId("lifecycle-archive"),
+                projectId: s.projectId,
+                sessionId: s.id,
+                data: {
+                  status: s.status,
+                  error: err instanceof Error ? err.message : String(err),
+                },
+                level: "error",
+              });
+            }
+          }),
+      );
 
       // Prune stale entries from states, reactionTrackers, and lastReviewBacklogCheckAt
       // for sessions that no longer appear in the session list (e.g., after kill/cleanup)

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1708,6 +1708,46 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     }
   }
 
+  /**
+   * Archive a session that has reached a terminal state.
+   *
+   * Destroys the runtime (kills the tmux session) and moves metadata to
+   * `archive/` so `ao status` / `ao session ls` stop showing stale entries.
+   * Unlike `kill()`, this preserves the workspace/worktree — the issue is
+   * already done and the worktree may still be useful for human inspection.
+   *
+   * Orchestrator sessions are protected from auto-archive.
+   */
+  async function archiveTerminalSession(sessionId: SessionId): Promise<boolean> {
+    const located = findSessionRecord(sessionId);
+    if (!located) return false;
+    const { raw, sessionsDir, project } = located;
+
+    if (isCleanupProtectedSession(project, sessionId, raw)) {
+      return false;
+    }
+
+    if (raw["runtimeHandle"]) {
+      const handle = safeJsonParse<RuntimeHandle>(raw["runtimeHandle"]);
+      if (handle) {
+        const runtimePlugin = registry.get<Runtime>(
+          "runtime",
+          handle.runtimeName ?? project.runtime ?? config.defaults.runtime,
+        );
+        if (runtimePlugin) {
+          try {
+            await runtimePlugin.destroy(handle);
+          } catch {
+            // Runtime may already be gone — archiving is still valuable.
+          }
+        }
+      }
+    }
+
+    deleteMetadata(sessionsDir, sessionId, true);
+    return true;
+  }
+
   async function cleanup(
     projectId?: string,
     options?: { dryRun?: boolean; purgeOpenCode?: boolean },
@@ -2523,5 +2563,17 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return restoredSession;
   }
 
-  return { spawn, spawnOrchestrator, restore, list, get, kill, cleanup, send, claimPR, remap };
+  return {
+    spawn,
+    spawnOrchestrator,
+    restore,
+    list,
+    get,
+    kill,
+    archiveTerminalSession,
+    cleanup,
+    send,
+    claimPR,
+    remap,
+  };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -119,6 +119,19 @@ export const TERMINAL_STATUSES: ReadonlySet<SessionStatus> = new Set([
   "merged",
 ]);
 
+/**
+ * Statuses that trigger automatic archiving (metadata moved to archive/, tmux killed).
+ * Excludes "errored" because errored sessions may still be recovered via the
+ * recovery manager and should stay in the active sessions directory until then.
+ */
+export const AUTO_ARCHIVE_STATUSES: ReadonlySet<SessionStatus> = new Set([
+  "killed",
+  "terminated",
+  "done",
+  "cleanup",
+  "merged",
+]);
+
 /** Activity states that indicate the session is no longer running. */
 export const TERMINAL_ACTIVITIES: ReadonlySet<ActivityState> = new Set(["exited"]);
 
@@ -1405,6 +1418,14 @@ export interface SessionManager {
   list(projectId?: string): Promise<Session[]>;
   get(sessionId: SessionId): Promise<Session | null>;
   kill(sessionId: SessionId, options?: { purgeOpenCode?: boolean }): Promise<void>;
+  /**
+   * Archive a session that has entered a terminal state.
+   * Kills the runtime (tmux) and moves metadata to `archive/`, but preserves
+   * the workspace/worktree so users can still inspect the completed work.
+   * Returns true if archived, false if the session was missing, protected
+   * (orchestrator), or had no active metadata to archive.
+   */
+  archiveTerminalSession(sessionId: SessionId): Promise<boolean>;
   cleanup(
     projectId?: string,
     options?: { dryRun?: boolean; purgeOpenCode?: boolean },


### PR DESCRIPTION
## Summary

- Add `SessionManager.archiveTerminalSession()` which kills the runtime (tmux) and moves metadata to `archive/` while preserving the worktree for human inspection.
- Lifecycle manager now calls it on transitions into `killed`/`done`/`merged`/`terminated`/`cleanup`, plus a sweep over already-terminal sessions each poll so stale entries clean up across restarts.
- `errored` is intentionally excluded so sessions remain available to the recovery manager. Orchestrator sessions are protected from auto-archive.

Closes #536.

## Test plan

- [x] Unit tests for `archiveTerminalSession` (success, orchestrator protection, missing session, runtime destroy failure)
- [x] Lifecycle tests: archives on merged transition, skips archive on `errored`
- [x] `pnpm build && pnpm typecheck && pnpm lint && pnpm test` — all 1000+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)