### PR TITLE
fix(web): refresh orchestrator links from SSE to prevent stale dashboard navigation

### DIFF
--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -248,7 +248,7 @@ function DashboardInner({
     }
     return levels;
   }, [initialSessions]);
-  const { sessions, connectionStatus, sseAttentionLevels } = useSessionEvents(
+  const { sessions, connectionStatus, sseAttentionLevels, orchestrators: refreshedOrchestrators } = useSessionEvents(
     initialSessions,
     projectId,
     mux?.status === "connected" ? mux.sessions : undefined,
@@ -338,8 +338,15 @@ function DashboardInner({
   }, [sheetSession, sheetSessionOverride]);
 
   useEffect(() => {
-    setActiveOrchestrators((current) => mergeOrchestrators(current, orchestratorLinks));
-  }, [orchestratorLinks]);
+    setActiveOrchestrators((current) => {
+      // Prefer live orchestrators from SSE/API refresh (includes killed session pruning)
+      if (refreshedOrchestrators && refreshedOrchestrators.length > 0) {
+        return mergeOrchestrators(current, refreshedOrchestrators);
+      }
+      // Fallback to SSR orchestrator links
+      return mergeOrchestrators(current, orchestratorLinks);
+    });
+  }, [orchestratorLinks, refreshedOrchestrators]);
 
   // Update document title with live attention counts from SSE
   useEffect(() => {

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -5,6 +5,7 @@ import {
   getAttentionLevel,
   type AttentionLevel,
   type DashboardSession,
+  type DashboardOrchestratorLink,
   type SSESnapshotEvent,
 } from "@/lib/types";
 
@@ -26,10 +27,12 @@ interface State {
   connectionStatus: ConnectionStatus;
   /** Attention levels from the latest SSE snapshot (server-computed, includes PR state). */
   sseAttentionLevels: SSEAttentionMap;
+  /** Orchestrator links from the latest /api/sessions refresh. */
+  orchestrators: DashboardOrchestratorLink[];
 }
 
 type Action =
-  | { type: "reset"; sessions: DashboardSession[]; sseAttentionLevels?: SSEAttentionMap }
+  | { type: "reset"; sessions: DashboardSession[]; sseAttentionLevels?: SSEAttentionMap; orchestrators?: DashboardOrchestratorLink[] }
   | { type: "snapshot"; patches: SSESnapshotEvent["sessions"] }
   | { type: "setConnection"; status: ConnectionStatus };
 
@@ -41,6 +44,9 @@ function reducer(state: State, action: Action): State {
         sessions: action.sessions,
         ...(action.sseAttentionLevels !== undefined
           ? { sseAttentionLevels: action.sseAttentionLevels }
+          : {}),
+        ...(action.orchestrators !== undefined
+          ? { orchestrators: action.orchestrators }
           : {}),
       };
     case "setConnection":
@@ -104,6 +110,7 @@ export function useSessionEvents(
     sessions: initialSessions,
     connectionStatus: "connected" as ConnectionStatus,
     sseAttentionLevels: initialAttentionLevels ?? ({} as SSEAttentionMap),
+    orchestrators: [],
   });
   const sessionsRef = useRef(state.sessions);
   const initialAttentionLevelsRef = useRef(initialAttentionLevels);
@@ -150,7 +157,7 @@ export function useSessionEvents(
       void fetch(sessionsUrl, { signal: refreshController.signal })
         .then((res) => (res.ok ? res.json() : null))
         .then(
-          (updated: { sessions?: DashboardSession[] } | null) => {
+          (updated: { sessions?: DashboardSession[]; orchestrators?: DashboardOrchestratorLink[] } | null) => {
             if (refreshController.signal.aborted || !updated?.sessions) {
               // Update timestamp even for non-OK responses to prevent retry storms
               if (!refreshController.signal.aborted) {
@@ -167,6 +174,7 @@ export function useSessionEvents(
               type: "reset",
               sessions: updated.sessions,
               sseAttentionLevels,
+              orchestrators: updated.orchestrators,
             });
           },
         )


### PR DESCRIPTION
Fixes #1103

## Problem

The "Orchestrator" button on the Dashboard linked to killed/stale orchestrator sessions. After an orchestrator was killed and potentially re-spawned with a new ID, clicking the button would navigate to the dead session.

Reported by @Atul Pandey in [Discord](https://discord.com/channels/1491735678156013588/1494703600293908731).

## Root Cause

`activeOrchestrators` state in `Dashboard.tsx` was frozen at SSR time and only grew via `mergeOrchestrators()` (which adds/replaces by `projectId` but never prunes dead entries). The SSE/refresh cycle in `useSessionEvents` called `/api/sessions` — which **does** include fresh `orchestrators` data in its response — but `useSessionEvents` only extracted `sessions`, discarding the orchestrator data.

## Fix

1. **`useSessionEvents.ts`** — Extract `orchestrators` from `/api/sessions` refresh responses and include them in the reducer state alongside sessions.

2. **`Dashboard.tsx`** — Consume `refreshedOrchestrators` from `useSessionEvents` and use it to update `activeOrchestrators`, so killed orchestrator IDs get replaced with current ones on every SSE refresh cycle (~15s max stale window).

## Test Plan

- [ ] Start an orchestrator session
- [ ] Verify "Orchestrator" button links to the active session
- [ ] Kill the orchestrator
- [ ] Verify the "Orchestrator" button updates (within ~15s) to reflect the killed session being gone, or links to a new orchestrator if one is spawned
- [ ] Verify no regressions on single-project and multi-project dashboard views