### PR TITLE
fix(web): propagate wheel events to page when terminal reaches scroll limit

### DIFF
--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -331,6 +331,19 @@ export function DirectTerminal({
           return true;
         });
 
+        // Propagate wheel events to the page when terminal is at scroll limits.
+        // xterm.js consumes all wheel events, so when the user scrolls past the
+        // end of the scrollback buffer the page never receives them.
+        const handleWheel = (e: WheelEvent) => {
+          const buf = terminal.buffer.active;
+          const atBottom = buf.viewportY >= buf.length - terminal.rows;
+          const atTop = buf.viewportY === 0;
+          if ((e.deltaY > 0 && atBottom) || (e.deltaY < 0 && atTop)) {
+            window.scrollBy({ top: e.deltaY, behavior: "auto" });
+          }
+        };
+        terminalRef.current?.addEventListener("wheel", handleWheel, { passive: true });
+
         // Open terminal via mux
         openTerminal(sessionId);
 
@@ -369,6 +382,7 @@ export function DirectTerminal({
 
         // Store cleanup function to be called from useEffect cleanup
         cleanup = () => {
+          terminalRef.current?.removeEventListener("wheel", handleWheel);
           selectionDisposable.dispose();
           if (safetyTimer) clearTimeout(safetyTimer);
           window.removeEventListener("resize", handleResize);


### PR DESCRIPTION
## Summary

- xterm.js captures all wheel events for its own scrollback, so when the scrollback buffer is exhausted the page never receives the scroll signal
- Added a passive `wheel` listener on the terminal container that calls `window.scrollBy()` when the user scrolls past the bottom (or top) of the xterm scrollback buffer
- Cleaned up the listener on unmount

Closes #1292

## How to test locally

1. `pnpm dev` to start the web dashboard
2. Open any session with a terminal
3. Scroll inside the terminal — terminal scrollback should work as before
4. Scroll to the **very end** of the terminal's output (bottom of scrollback), then keep scrolling down — the **dashboard page** should now continue scrolling
5. Scroll to the **top** of the terminal and keep scrolling up — the dashboard page should scroll up

🤖 Generated with [Claude Code](https://claude.com/claude-code)