### PR TITLE
fix(web): keep terminal selection until user interacts

### DIFF
--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -276,18 +276,15 @@ export function DirectTerminal({
         // xterm.js clears the selection on every terminal.write(). We
         // buffer incoming data while a selection is active so the
         // highlight stays visible for Cmd+C. The buffer is flushed
-        // when the selection is cleared (click, keypress, etc.).
+        // when the selection is cleared (click, keypress, etc.) — the
+        // selection stays until the user interacts, matching native
+        // browser copy-paste behavior.
         const writeBuffer: string[] = [];
         let selectionActive = false;
-        let safetyTimer: ReturnType<typeof setTimeout> | null = null;
         let bufferBytes = 0;
         const MAX_BUFFER_BYTES = 1_048_576; // 1 MB
 
         const flushWriteBuffer = () => {
-          if (safetyTimer) {
-            clearTimeout(safetyTimer);
-            safetyTimer = null;
-          }
           if (writeBuffer.length > 0) {
             terminal.write(writeBuffer.join(""));
             writeBuffer.length = 0;
@@ -298,13 +295,6 @@ export function DirectTerminal({
         const selectionDisposable = terminal.onSelectionChange(() => {
           if (terminal.hasSelection()) {
             selectionActive = true;
-            // Safety: flush after 5s to prevent unbounded buffering
-            if (!safetyTimer) {
-              safetyTimer = setTimeout(() => {
-                selectionActive = false;
-                flushWriteBuffer();
-              }, 5_000);
-            }
           } else {
             selectionActive = false;
             flushWriteBuffer();
@@ -370,7 +360,6 @@ export function DirectTerminal({
         // Store cleanup function to be called from useEffect cleanup
         cleanup = () => {
           selectionDisposable.dispose();
-          if (safetyTimer) clearTimeout(safetyTimer);
           window.removeEventListener("resize", handleResize);
           inputDisposable?.dispose();
           inputDisposable = null;


### PR DESCRIPTION
## Summary
- Terminal text selection on the dashboard was being cleared ~5 s after it was made, making Cmd+C unreliable.
- Cause: a safety timer in `DirectTerminal` unconditionally flushed the write buffer after 5 s, and each `terminal.write()` clears the xterm selection.
- Fix: remove the timer. The buffered writes now flush only when the user dismisses the selection (click, keypress) — selection persists indefinitely, matching native browser behavior. The 1 MB buffer cap is still in place as the safety valve.

Fixes #1295

## Test plan
- [ ] \`pnpm install && pnpm build && pnpm dev\`
- [ ] Open a session with active agent output on the dashboard
- [ ] Click-drag to select terminal text while output is still streaming
- [ ] Verify the highlight stays indefinitely (previously disappeared after ~5 s)
- [ ] Press Cmd+C (mac) / Ctrl+Shift+C (linux/win) — selection is copied to clipboard
- [ ] Click elsewhere in the terminal — selection clears and buffered output flushes
- [ ] \`pnpm --filter @aoagents/ao-web test -- --run DirectTerminal\` — all 10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)