### PR TITLE
fix(web): chain wheel scroll from terminal to page at boundary

### DIFF
--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -331,6 +331,31 @@ export function DirectTerminal({
           return true;
         });
 
+        // ── Scroll chaining ───────────────────────────────────────────
+        // xterm.js's viewport consumes all wheel events, which prevents
+        // the page from scrolling once the terminal hits its scroll
+        // boundary. Intercept wheel in the capture phase: if the terminal
+        // buffer is at the boundary in the event's direction, stop xterm's
+        // handler and let the page scroll instead.
+        const handleWheelCapture = (e: WheelEvent) => {
+          const buf = terminal.buffer.active;
+          const atTop = buf.viewportY <= 0;
+          const atBottom = buf.viewportY >= buf.baseY;
+          const goingDown = e.deltaY > 0;
+          const goingUp = e.deltaY < 0;
+          if ((goingDown && atBottom) || (goingUp && atTop)) {
+            e.stopPropagation();
+            const scroller =
+              document.scrollingElement ?? document.documentElement;
+            scroller.scrollBy({ top: e.deltaY, left: e.deltaX, behavior: "auto" });
+          }
+        };
+        const wheelTarget = terminalRef.current;
+        wheelTarget.addEventListener("wheel", handleWheelCapture, {
+          capture: true,
+          passive: true,
+        });
+
         // Open terminal via mux
         openTerminal(sessionId);
 
@@ -371,6 +396,9 @@ export function DirectTerminal({
         cleanup = () => {
           selectionDisposable.dispose();
           if (safetyTimer) clearTimeout(safetyTimer);
+          wheelTarget.removeEventListener("wheel", handleWheelCapture, {
+            capture: true,
+          } as EventListenerOptions);
           window.removeEventListener("resize", handleResize);
           inputDisposable?.dispose();
           inputDisposable = null;


### PR DESCRIPTION
## Summary
- When the cursor was inside the dashboard terminal, xterm.js consumed all wheel events, so the dashboard page stopped scrolling once the terminal buffer reached its top or bottom.
- Fix: add a capture-phase wheel listener on the xterm container. When the terminal buffer is at the boundary in the event's direction (\`viewportY <= 0\` going up, \`viewportY >= baseY\` going down), stop xterm's handler and scroll the document with \`scrollBy()\`. Mid-buffer scrolls still scroll the terminal as before.

Fixes #1292

## Test plan
- [ ] \`pnpm install && pnpm build && pnpm dev\`
- [ ] Open a dashboard session whose terminal has enough scrollback and whose page has content below/above the terminal
- [ ] With the cursor inside the terminal, scroll down to the end of terminal content — continued scrolling should move the page
- [ ] Scroll up to the top of terminal scrollback — continued scrolling up should move the page
- [ ] Mid-buffer: scrolling only moves the terminal (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)