### PR TITLE
fix(cli): probe ::1 in isPortAvailable to match its own documented contract

### DIFF
--- a/packages/cli/src/lib/web-dir.ts
+++ b/packages/cli/src/lib/web-dir.ts
@@ -28,14 +28,15 @@ const DEFAULT_TERMINAL_PORT = 14800;
  * 0.0.0.0, or :: (IPv6 wildcard).
  */
 export function isPortAvailable(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
+  const probe = (host: string) => new Promise<boolean>((resolve) => {
     const s = new Socket();
     s.setTimeout(300);
     s.once("connect", () => { s.destroy(); resolve(false); }); // something listening → in use
     s.once("error", () => { s.destroy(); resolve(true); });    // ECONNREFUSED → free
     s.once("timeout", () => { s.destroy(); resolve(true); });  // no response → free
-    s.connect(port, "127.0.0.1");
+    s.connect(port, host);
   });
+  return Promise.all([probe("127.0.0.1"), probe("::1")]).then(([v4, v6]) => v4 && v6);
 }
 
 /** How many consecutive ports to scan before giving up. */


### PR DESCRIPTION
### What changed and why                                                          
                      
`isPortAvailable` had a comment claiming it worked "regardless of whether the occupying process is bound to
`127.0.0.1, ::1, 0.0.0.0, or ::"` 
but the implementation only probed 127.0.0.1. 

  The fix adds a local probe arrow and checks both 127.0.0.1 and ::1 via Promise.all.
   A port is only considered free when both return clear making the implementation
  match what the comment always claimed.                                             
                  
###   How to test

  1. Start any process on port 3000 bound to IPv6 (e.g. node -e                      
  "require('net').createServer().listen(3000, '::1')")
  2. Run ao start — should print Port 3000 is busy — using 3001 instead. and start   
  successfully                                                                       
  3. Run ao start with port 3000 free — behaviour unchanged