### PR TITLE
fix(webhooks): restore killed sessions and auto-spawn on CI failure

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1511,6 +1511,7 @@ export interface SCMWebhookConfig {
   eventHeader?: string;
   deliveryHeader?: string;
   maxBodyBytes?: number;
+  autoSpawnOnCIFailure?: boolean;
 }
 
 export interface NotifierConfig {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1511,6 +1511,7 @@ export interface SCMWebhookConfig {
   eventHeader?: string;
   deliveryHeader?: string;
   maxBodyBytes?: number;
+  /** When true, automatically spawn a new agent session when CI fails on a PR and no active or restorable session exists for that PR. */
   autoSpawnOnCIFailure?: boolean;
 }
 

--- a/packages/web/src/app/api/webhooks/[...slug]/route.ts
+++ b/packages/web/src/app/api/webhooks/[...slug]/route.ts
@@ -1,12 +1,30 @@
 import { NextResponse } from "next/server";
+import type { SCMWebhookEvent } from "@aoagents/ao-core";
 import { getServices } from "@/lib/services";
 import {
   buildWebhookRequest,
   eventMatchesProject,
   findAffectedSessions,
-  findRestorableSessions,
+  findRestorableSessionsForCI,
   findWebhookProjects,
 } from "@/lib/scm-webhooks";
+
+function buildCISpawnPrompt(event: SCMWebhookEvent): string {
+  const base = `CI failed on PR #${event.prNumber} (branch: ${event.branch}).`;
+  try {
+    const checkRun = (event.data as Record<string, unknown>)[event.rawEventType] as Record<string, unknown> | undefined;
+    const name = typeof checkRun?.["name"] === "string" ? checkRun["name"] : undefined;
+    const conclusion = typeof checkRun?.["conclusion"] === "string" ? checkRun["conclusion"] : undefined;
+    const url = typeof checkRun?.["html_url"] === "string" ? checkRun["html_url"] : undefined;
+    if (name) {
+      const detail = [name, conclusion, url].filter(Boolean).join(" — ");
+      return `${base} Failed check: ${detail}. Investigate the failure, fix the root cause, and push a fix to this branch.`;
+    }
+  } catch {
+    // fall through to generic prompt
+  }
+  return `${base} Investigate the failure, fix the root cause, and push a fix to this branch.`;
+}
 
 export const dynamic = "force-dynamic";
 
@@ -78,11 +96,11 @@ export async function POST(request: Request): Promise<Response> {
       projectIds.add(candidate.projectId);
       const affectedSessions = findAffectedSessions(sessions, candidate.projectId, event);
 
-      const lifecycle = services.lifecycleManager;
 
       if (affectedSessions.length === 0) {
+        const lifecycle = services.lifecycleManager;
         // Gap 1: session exists but is terminal — restore it, then let existing reaction engine handle ci-failed
-        const restorable = findRestorableSessions(sessions, candidate.projectId, event);
+        const restorable = findRestorableSessionsForCI(sessions, candidate.projectId, event);
         for (const session of restorable) {
           sessionIds.add(session.id);
           try {
@@ -97,12 +115,15 @@ export async function POST(request: Request): Promise<Response> {
         // Gap 2: no session at all — auto-spawn if project opts in
         if (restorable.length === 0) {
           const autoSpawn = candidate.project.scm?.webhook?.autoSpawnOnCIFailure ?? false;
-          if (autoSpawn && event.kind === "ci" && event.prNumber !== undefined && event.branch) {
+          const alreadyExists = sessions.some(
+            (s) => s.projectId === candidate.projectId && s.pr?.number === event.prNumber,
+          );
+          if (autoSpawn && !alreadyExists && event.kind === "ci" && event.prNumber !== undefined && event.branch) {
             try {
               const spawned = await services.sessionManager.spawn({
                 projectId: candidate.projectId,
                 branch: event.branch,
-                prompt: `CI failed on PR #${event.prNumber}. Investigate the failure, fix the root cause, and push a fix to this branch.`,
+                prompt: buildCISpawnPrompt(event),
               });
               sessionIds.add(spawned.id);
               await lifecycle.check(spawned.id);
@@ -116,6 +137,7 @@ export async function POST(request: Request): Promise<Response> {
         continue;
       }
 
+      const lifecycle = services.lifecycleManager;
       for (const session of affectedSessions) {
         sessionIds.add(session.id);
         try {

--- a/packages/web/src/app/api/webhooks/[...slug]/route.ts
+++ b/packages/web/src/app/api/webhooks/[...slug]/route.ts
@@ -4,6 +4,7 @@ import {
   buildWebhookRequest,
   eventMatchesProject,
   findAffectedSessions,
+  findRestorableSessions,
   findWebhookProjects,
 } from "@/lib/scm-webhooks";
 
@@ -76,11 +77,45 @@ export async function POST(request: Request): Promise<Response> {
 
       projectIds.add(candidate.projectId);
       const affectedSessions = findAffectedSessions(sessions, candidate.projectId, event);
+
+      const lifecycle = services.lifecycleManager;
+
       if (affectedSessions.length === 0) {
+        // Gap 1: session exists but is terminal — restore it, then let existing reaction engine handle ci-failed
+        const restorable = findRestorableSessions(sessions, candidate.projectId, event);
+        for (const session of restorable) {
+          sessionIds.add(session.id);
+          try {
+            await services.sessionManager.restore(session.id);
+            await lifecycle.check(session.id);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : "Restore failed";
+            lifecycleErrors.push(`restore ${session.id}: ${message}`);
+          }
+        }
+
+        // Gap 2: no session at all — auto-spawn if project opts in
+        if (restorable.length === 0) {
+          const autoSpawn = candidate.project.scm?.webhook?.autoSpawnOnCIFailure ?? false;
+          if (autoSpawn && event.kind === "ci" && event.prNumber !== undefined && event.branch) {
+            try {
+              const spawned = await services.sessionManager.spawn({
+                projectId: candidate.projectId,
+                branch: event.branch,
+                prompt: `CI failed on PR #${event.prNumber}. Investigate the failure, fix the root cause, and push a fix to this branch.`,
+              });
+              sessionIds.add(spawned.id);
+              await lifecycle.check(spawned.id);
+            } catch (err) {
+              const message = err instanceof Error ? err.message : "Spawn failed";
+              lifecycleErrors.push(`auto-spawn PR #${event.prNumber}: ${message}`);
+            }
+          }
+        }
+
         continue;
       }
 
-      const lifecycle = services.lifecycleManager;
       for (const session of affectedSessions) {
         sessionIds.add(session.id);
         try {

--- a/packages/web/src/lib/scm-webhooks.test.ts
+++ b/packages/web/src/lib/scm-webhooks.test.ts
@@ -6,7 +6,7 @@ import {
   type SCMWebhookEvent,
   type Session,
 } from "@aoagents/ao-core";
-import { eventMatchesProject, findAffectedSessions, findRestorableSessions } from "./scm-webhooks";
+import { eventMatchesProject, findAffectedSessions, findRestorableSessionsForCI } from "./scm-webhooks";
 
 const project: ProjectConfig = {
   name: "my-app",
@@ -166,10 +166,10 @@ describe("findAffectedSessions", () => {
 });
 
 
-describe("findRestorableSessions", () => {
+describe("findRestorableSessionsForCI", () => {
   const killedLifecycle = createInitialCanonicalLifecycle("worker", new Date());
   killedLifecycle.session.state = "terminated";
-  killedLifecycle.session.reason = "kill_requested";
+  killedLifecycle.session.reason = "manually_killed";
   killedLifecycle.session.startedAt = killedLifecycle.session.lastTransitionAt;
   killedLifecycle.runtime.state = "exited";
   killedLifecycle.runtime.reason = "process_missing";
@@ -232,7 +232,7 @@ describe("findRestorableSessions", () => {
       provider: "github", kind: "pull_request", action: "synchronize",
       rawEventType: "pull_request", prNumber: 42, data: {},
     };
-    expect(findRestorableSessions([killedSession], "my-app", event)).toEqual([]);
+    expect(findRestorableSessionsForCI([killedSession], "my-app", event)).toEqual([]);
   });
 
   it("returns empty for ci events without prNumber", () => {
@@ -240,7 +240,7 @@ describe("findRestorableSessions", () => {
       provider: "github", kind: "ci", action: "completed",
       rawEventType: "workflow_run", data: {},
     };
-    expect(findRestorableSessions([killedSession], "my-app", event)).toEqual([]);
+    expect(findRestorableSessionsForCI([killedSession], "my-app", event)).toEqual([]);
   });
 
   it("matches a killed session by pr number", () => {
@@ -248,7 +248,7 @@ describe("findRestorableSessions", () => {
       provider: "github", kind: "ci", action: "completed",
       rawEventType: "workflow_run", prNumber: 42, data: {},
     };
-    expect(findRestorableSessions([killedSession, mergedSession], "my-app", event)).toEqual([killedSession]);
+    expect(findRestorableSessionsForCI([killedSession, mergedSession], "my-app", event)).toEqual([killedSession]);
   });
 
   it("skips merged sessions even when pr number matches", () => {
@@ -256,6 +256,6 @@ describe("findRestorableSessions", () => {
       provider: "github", kind: "ci", action: "completed",
       rawEventType: "workflow_run", prNumber: 42, data: {},
     };
-    expect(findRestorableSessions([mergedSession], "my-app", event)).toEqual([]);
+    expect(findRestorableSessionsForCI([mergedSession], "my-app", event)).toEqual([]);
   });
 });

--- a/packages/web/src/lib/scm-webhooks.test.ts
+++ b/packages/web/src/lib/scm-webhooks.test.ts
@@ -6,7 +6,7 @@ import {
   type SCMWebhookEvent,
   type Session,
 } from "@aoagents/ao-core";
-import { eventMatchesProject, findAffectedSessions } from "./scm-webhooks";
+import { eventMatchesProject, findAffectedSessions, findRestorableSessions } from "./scm-webhooks";
 
 const project: ProjectConfig = {
   name: "my-app",
@@ -162,5 +162,100 @@ describe("findAffectedSessions", () => {
 
     const affected = findAffectedSessions(sessions, "my-app", event);
     expect(affected.map((s) => s.id)).toEqual(["s1"]);
+  });
+});
+
+
+describe("findRestorableSessions", () => {
+  const killedLifecycle = createInitialCanonicalLifecycle("worker", new Date());
+  killedLifecycle.session.state = "terminated";
+  killedLifecycle.session.reason = "kill_requested";
+  killedLifecycle.session.startedAt = killedLifecycle.session.lastTransitionAt;
+  killedLifecycle.runtime.state = "exited";
+  killedLifecycle.runtime.reason = "process_missing";
+
+  const mergedLifecycle = createInitialCanonicalLifecycle("worker", new Date());
+  mergedLifecycle.session.state = "idle";
+  mergedLifecycle.session.reason = "merged_waiting_decision";
+  mergedLifecycle.session.startedAt = mergedLifecycle.session.lastTransitionAt;
+  mergedLifecycle.pr.state = "merged";
+  mergedLifecycle.pr.reason = "merged";
+  mergedLifecycle.runtime.state = "exited";
+  mergedLifecycle.runtime.reason = "process_missing";
+
+  const killedSession: Session = {
+    id: "s-killed",
+    projectId: "my-app",
+    status: "killed",
+    activity: "exited",
+    activitySignal: createActivitySignal("valid", {
+      activity: "exited",
+      timestamp: new Date(),
+      source: "runtime",
+    }),
+    lifecycle: killedLifecycle,
+    branch: "feat/fix",
+    issueId: null,
+    pr: { number: 42, url: "u", title: "t", owner: "acme", repo: "my-app", branch: "feat/fix", baseBranch: "main", isDraft: false },
+    workspacePath: null,
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+  };
+
+  const mergedSession: Session = {
+    id: "s-merged",
+    projectId: "my-app",
+    status: "merged",
+    activity: "exited",
+    activitySignal: createActivitySignal("valid", {
+      activity: "exited",
+      timestamp: new Date(),
+      source: "runtime",
+    }),
+    lifecycle: mergedLifecycle,
+    branch: "feat/fix",
+    issueId: null,
+    pr: { number: 42, url: "u", title: "t", owner: "acme", repo: "my-app", branch: "feat/fix", baseBranch: "main", isDraft: false },
+    workspacePath: null,
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+  };
+
+  it("returns empty for non-ci events", () => {
+    const event: SCMWebhookEvent = {
+      provider: "github", kind: "pull_request", action: "synchronize",
+      rawEventType: "pull_request", prNumber: 42, data: {},
+    };
+    expect(findRestorableSessions([killedSession], "my-app", event)).toEqual([]);
+  });
+
+  it("returns empty for ci events without prNumber", () => {
+    const event: SCMWebhookEvent = {
+      provider: "github", kind: "ci", action: "completed",
+      rawEventType: "workflow_run", data: {},
+    };
+    expect(findRestorableSessions([killedSession], "my-app", event)).toEqual([]);
+  });
+
+  it("matches a killed session by pr number", () => {
+    const event: SCMWebhookEvent = {
+      provider: "github", kind: "ci", action: "completed",
+      rawEventType: "workflow_run", prNumber: 42, data: {},
+    };
+    expect(findRestorableSessions([killedSession, mergedSession], "my-app", event)).toEqual([killedSession]);
+  });
+
+  it("skips merged sessions even when pr number matches", () => {
+    const event: SCMWebhookEvent = {
+      provider: "github", kind: "ci", action: "completed",
+      rawEventType: "workflow_run", prNumber: 42, data: {},
+    };
+    expect(findRestorableSessions([mergedSession], "my-app", event)).toEqual([]);
   });
 });

--- a/packages/web/src/lib/scm-webhooks.ts
+++ b/packages/web/src/lib/scm-webhooks.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import {
   TERMINAL_STATUSES,
+  isRestorable,
   type OrchestratorConfig,
   type PluginRegistry,
   type ProjectConfig,
@@ -82,4 +83,19 @@ export function buildWebhookRequest(
     path: url.pathname,
     query: Object.fromEntries(url.searchParams.entries()),
   };
+}
+
+export function findRestorableSessions(
+  sessions: Session[],
+  projectId: string,
+  event: SCMWebhookEvent,
+): Session[] {
+  if (event.kind !== "ci" || event.prNumber === undefined) return [];
+  return sessions.filter((session) => {
+    if (session.projectId !== projectId) return false;
+    if (!isRestorable(session)) return false;
+    if (event.prNumber !== undefined && session.pr?.number === event.prNumber) return true;
+    if (event.branch && session.branch === event.branch) return true;
+    return false;
+  });
 }

--- a/packages/web/src/lib/scm-webhooks.ts
+++ b/packages/web/src/lib/scm-webhooks.ts
@@ -85,7 +85,7 @@ export function buildWebhookRequest(
   };
 }
 
-export function findRestorableSessions(
+export function findRestorableSessionsForCI(
   sessions: Session[],
   projectId: string,
   event: SCMWebhookEvent,


### PR DESCRIPTION
## Summary

Fixes #1290

When a CI webhook fires for a PR, `findAffectedSessions` only matches sessions in non-terminal states. If the session was previously killed or errored, the event was silently dropped with a bare `continue`. This means the CI failure signal never reached the agent.

- Add `findRestorableSessions()` in `scm-webhooks.ts` using the existing `isRestorable()` predicate from `ao-core` (covers killed/terminated/done/errored, excludes merged)
- In the webhook route handler, when `findAffectedSessions` returns empty for a CI event, restore any matching terminal sessions and re-run `lifecycle.check()` so the existing reaction engine handles the `ci-failed` signal
- If no restorable session exists and `autoSpawnOnCIFailure` is enabled in project config, spawn a new session with a targeted prompt to investigate and fix the CI failure
- Add `autoSpawnOnCIFailure?: boolean` to `SCMWebhookConfig` in `types.ts`
- Add 4 unit tests for `findRestorableSessions` covering: non-CI events, CI events without prNumber, matched killed session, and skipping merged sessions

## Test plan

- All 601 web package tests pass
- All 432 non-web tests pass
- Typecheck and build clean across all packages
- New tests in `scm-webhooks.test.ts` cover the added function directly
