### PR TITLE
fix: clean up tmux pane processes on session kill

### DIFF
--- a/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
@@ -17,6 +17,10 @@ vi.mock("node:crypto", () => ({
   randomUUID: () => "test-uuid-1234",
 }));
 
+vi.mock("node:timers/promises", () => ({
+  setTimeout: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Mock node:fs for writeFileSync / unlinkSync
 vi.mock("node:fs", () => ({
   writeFileSync: vi.fn(),
@@ -55,6 +59,7 @@ function makeHandle(id: string, createdAt?: number): RuntimeHandle {
 import tmuxPlugin, { manifest, create } from "../index.js";
 
 beforeEach(() => {
+  mockExecFileCustom.mockReset();
   vi.clearAllMocks();
 });
 
@@ -278,25 +283,79 @@ describe("runtime.create()", () => {
 });
 
 describe("runtime.destroy()", () => {
-  it("calls kill-session with the handle id", async () => {
+  it("falls back to kill-session when pane tty lookup fails", async () => {
     const runtime = create();
     const handle = makeHandle("destroy-test");
 
+    mockTmuxError("list-panes failed");
     mockTmuxSuccess();
 
     await runtime.destroy(handle);
 
-    expect(mockExecFileCustom).toHaveBeenCalledWith(
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      1,
+      "tmux",
+      ["list-panes", "-t", "destroy-test", "-F", "#{pane_tty}"],
+      expectedTmuxOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
       "tmux",
       ["kill-session", "-t", "destroy-test"],
       expectedTmuxOptions,
     );
   });
 
+  it("terminates remaining pane processes after killing the tmux session", async () => {
+    const runtime = create();
+    const handle = makeHandle("destroy-test");
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    mockExecFileCustom
+      .mockResolvedValueOnce({ stdout: "/dev/ttys004\n", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "101\n102\n", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "102\n", stderr: "" });
+
+    await runtime.destroy(handle);
+
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      1,
+      "tmux",
+      ["list-panes", "-t", "destroy-test", "-F", "#{pane_tty}"],
+      expectedTmuxOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
+      "tmux",
+      ["kill-session", "-t", "destroy-test"],
+      expectedTmuxOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      3,
+      "ps",
+      ["-t", "ttys004", "-o", "pid="],
+      expectedTmuxOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      4,
+      "ps",
+      ["-t", "ttys004", "-o", "pid="],
+      expectedTmuxOptions,
+    );
+
+    expect(killSpy).toHaveBeenNthCalledWith(1, 101, "SIGTERM");
+    expect(killSpy).toHaveBeenNthCalledWith(2, 102, "SIGTERM");
+    expect(killSpy).toHaveBeenNthCalledWith(3, 102, "SIGKILL");
+
+    killSpy.mockRestore();
+  });
+
   it("does not throw if session is already gone", async () => {
     const runtime = create();
     const handle = makeHandle("already-dead");
 
+    mockTmuxError("list-panes failed");
     mockTmuxError("session not found: already-dead");
 
     // Should not throw

--- a/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
@@ -295,7 +295,7 @@ describe("runtime.destroy()", () => {
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
       1,
       "tmux",
-      ["list-panes", "-t", "destroy-test", "-F", "#{pane_tty}"],
+      ["list-panes", "-s", "-t", "destroy-test", "-F", "#{pane_tty}"],
       expectedTmuxOptions,
     );
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
@@ -306,47 +306,54 @@ describe("runtime.destroy()", () => {
     );
   });
 
-  it("terminates remaining pane processes after killing the tmux session", async () => {
+  it("snapshots pane processes before kill-session and only signals matching TTY PIDs", async () => {
     const runtime = create();
     const handle = makeHandle("destroy-test");
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
     mockExecFileCustom
-      .mockResolvedValueOnce({ stdout: "/dev/ttys004\n", stderr: "" })
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "/dev/ttys004\n/dev/ttys005\n/dev/ttys004\n", stderr: "" })
       .mockResolvedValueOnce({ stdout: "101\n102\n", stderr: "" })
-      .mockResolvedValueOnce({ stdout: "102\n", stderr: "" });
+      .mockResolvedValueOnce({ stdout: "201\n", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "ttys004\n", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "ttys004\n", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "ttys005\n", stderr: "" })
+      .mockRejectedValueOnce(new Error("process exited"))
+      .mockResolvedValueOnce({ stdout: "ttys004\n", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "ttys006\n", stderr: "" });
 
     await runtime.destroy(handle);
 
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
       1,
       "tmux",
-      ["list-panes", "-t", "destroy-test", "-F", "#{pane_tty}"],
+      ["list-panes", "-s", "-t", "destroy-test", "-F", "#{pane_tty}"],
       expectedTmuxOptions,
     );
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
       2,
-      "tmux",
-      ["kill-session", "-t", "destroy-test"],
+      "ps",
+      ["-t", "ttys004", "-o", "pid="],
       expectedTmuxOptions,
     );
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
       3,
       "ps",
-      ["-t", "ttys004", "-o", "pid="],
+      ["-t", "ttys005", "-o", "pid="],
       expectedTmuxOptions,
     );
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
       4,
-      "ps",
-      ["-t", "ttys004", "-o", "pid="],
+      "tmux",
+      ["kill-session", "-t", "destroy-test"],
       expectedTmuxOptions,
     );
 
     expect(killSpy).toHaveBeenNthCalledWith(1, 101, "SIGTERM");
     expect(killSpy).toHaveBeenNthCalledWith(2, 102, "SIGTERM");
-    expect(killSpy).toHaveBeenNthCalledWith(3, 102, "SIGKILL");
+    expect(killSpy).toHaveBeenNthCalledWith(3, 201, "SIGTERM");
+    expect(killSpy).toHaveBeenNthCalledWith(4, 102, "SIGKILL");
 
     killSpy.mockRestore();
   });

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -17,6 +17,7 @@ import {
 
 const execFileAsync = promisify(execFile);
 const TMUX_COMMAND_TIMEOUT_MS = 5_000;
+const PROCESS_CLEANUP_GRACE_MS = 1_000;
 
 export const manifest = {
   name: "tmux",
@@ -47,6 +48,64 @@ async function tmux(...args: string[]): Promise<string> {
     timeout: TMUX_COMMAND_TIMEOUT_MS,
   });
   return stdout.trimEnd();
+}
+
+async function getPaneTTY(sessionName: string): Promise<string | null> {
+  try {
+    const output = await tmux("list-panes", "-t", sessionName, "-F", "#{pane_tty}");
+    const tty = output
+      .split("\n")
+      .map((line) => line.trim())
+      .find(Boolean);
+    return tty ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeTTY(tty: string): string {
+  return tty.startsWith("/dev/") ? tty.slice("/dev/".length) : tty;
+}
+
+async function getProcessIdsForTTY(tty: string): Promise<number[]> {
+  try {
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-t", normalizeTTY(tty), "-o", "pid="],
+      { timeout: TMUX_COMMAND_TIMEOUT_MS },
+    );
+    return stdout
+      .split("\n")
+      .map((line) => Number.parseInt(line.trim(), 10))
+      .filter((pid) => Number.isInteger(pid) && pid > 0);
+  } catch {
+    return [];
+  }
+}
+
+function signalProcesses(pids: number[], signal: NodeJS.Signals): void {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Best-effort cleanup: a process may have already exited between polls.
+    }
+  }
+}
+
+async function cleanupTTYProcesses(tty: string): Promise<void> {
+  let remaining = await getProcessIdsForTTY(tty);
+  if (remaining.length === 0) {
+    return;
+  }
+
+  signalProcesses(remaining, "SIGTERM");
+  await sleep(PROCESS_CLEANUP_GRACE_MS);
+
+  remaining = await getProcessIdsForTTY(tty);
+  if (remaining.length > 0) {
+    signalProcesses(remaining, "SIGKILL");
+  }
 }
 
 export function create(): Runtime {
@@ -101,10 +160,15 @@ export function create(): Runtime {
     },
 
     async destroy(handle: RuntimeHandle): Promise<void> {
+      const paneTTY = await getPaneTTY(handle.id);
       try {
         await tmux("kill-session", "-t", handle.id);
       } catch {
         // Session may already be dead — that's fine
+      }
+
+      if (paneTTY) {
+        await cleanupTTYProcesses(paneTTY);
       }
     },
 

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -19,6 +19,11 @@ const execFileAsync = promisify(execFile);
 const TMUX_COMMAND_TIMEOUT_MS = 5_000;
 const PROCESS_CLEANUP_GRACE_MS = 1_000;
 
+interface ProcessSnapshot {
+  pid: number;
+  tty: string;
+}
+
 export const manifest = {
   name: "tmux",
   slot: "runtime" as const,
@@ -50,16 +55,12 @@ async function tmux(...args: string[]): Promise<string> {
   return stdout.trimEnd();
 }
 
-async function getPaneTTY(sessionName: string): Promise<string | null> {
+async function getPaneTTYs(sessionName: string): Promise<string[]> {
   try {
-    const output = await tmux("list-panes", "-t", sessionName, "-F", "#{pane_tty}");
-    const tty = output
-      .split("\n")
-      .map((line) => line.trim())
-      .find(Boolean);
-    return tty ?? null;
+    const output = await tmux("list-panes", "-s", "-t", sessionName, "-F", "#{pane_tty}");
+    return [...new Set(output.split("\n").map((line) => line.trim()).filter(Boolean))];
   } catch {
-    return null;
+    return [];
   }
 }
 
@@ -83,6 +84,23 @@ async function getProcessIdsForTTY(tty: string): Promise<number[]> {
   }
 }
 
+async function getTTYForPID(pid: number): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-p", String(pid), "-o", "tty="],
+      { timeout: TMUX_COMMAND_TIMEOUT_MS },
+    );
+    const tty = stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .find(Boolean);
+    return tty ? normalizeTTY(tty) : null;
+  } catch {
+    return null;
+  }
+}
+
 function signalProcesses(pids: number[], signal: NodeJS.Signals): void {
   for (const pid of pids) {
     try {
@@ -93,8 +111,29 @@ function signalProcesses(pids: number[], signal: NodeJS.Signals): void {
   }
 }
 
-async function cleanupTTYProcesses(tty: string): Promise<void> {
-  let remaining = await getProcessIdsForTTY(tty);
+async function snapshotSessionProcesses(sessionName: string): Promise<ProcessSnapshot[]> {
+  const paneTTYs = await getPaneTTYs(sessionName);
+  const snapshots = await Promise.all(
+    paneTTYs.map(async (tty) => {
+      const normalizedTTY = normalizeTTY(tty);
+      const pids = await getProcessIdsForTTY(normalizedTTY);
+      return pids.map((pid) => ({ pid, tty: normalizedTTY }));
+    }),
+  );
+
+  return [...new Map(snapshots.flat().map((snapshot) => [snapshot.pid, snapshot])).values()];
+}
+
+async function getLiveSnapshotPIDs(snapshots: ProcessSnapshot[]): Promise<number[]> {
+  const livePIDs = await Promise.all(
+    snapshots.map(async ({ pid, tty }) => ((await getTTYForPID(pid)) === tty ? pid : null)),
+  );
+
+  return livePIDs.filter((pid): pid is number => pid !== null);
+}
+
+async function cleanupSnapshotProcesses(snapshots: ProcessSnapshot[]): Promise<void> {
+  let remaining = await getLiveSnapshotPIDs(snapshots);
   if (remaining.length === 0) {
     return;
   }
@@ -102,7 +141,7 @@ async function cleanupTTYProcesses(tty: string): Promise<void> {
   signalProcesses(remaining, "SIGTERM");
   await sleep(PROCESS_CLEANUP_GRACE_MS);
 
-  remaining = await getProcessIdsForTTY(tty);
+  remaining = await getLiveSnapshotPIDs(snapshots);
   if (remaining.length > 0) {
     signalProcesses(remaining, "SIGKILL");
   }
@@ -160,15 +199,15 @@ export function create(): Runtime {
     },
 
     async destroy(handle: RuntimeHandle): Promise<void> {
-      const paneTTY = await getPaneTTY(handle.id);
+      const processSnapshots = await snapshotSessionProcesses(handle.id);
       try {
         await tmux("kill-session", "-t", handle.id);
       } catch {
         // Session may already be dead — that's fine
       }
 
-      if (paneTTY) {
-        await cleanupTTYProcesses(paneTTY);
+      if (processSnapshots.length > 0) {
+        await cleanupSnapshotProcesses(processSnapshots);
       }
     },
 


### PR DESCRIPTION
Fixes #1234

## Summary

- capture the tmux pane TTY before destroying the session
- terminate leftover TTY-bound processes with `SIGTERM` and escalate stragglers to `SIGKILL`
- cover the cleanup path and no-TTY fallback with runtime plugin tests

## Testing

- `pnpm exec eslint packages/plugins/runtime-tmux/src/index.ts packages/plugins/runtime-tmux/src/__tests__/index.test.ts`
- `pnpm --filter @aoagents/ao-plugin-runtime-tmux build`
- `pnpm --filter @aoagents/ao-plugin-runtime-tmux typecheck`
- `pnpm --filter @aoagents/ao-plugin-runtime-tmux test`
