### PR TITLE
fix: add audit trail for session kills (#1073)

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -459,6 +459,31 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("killed");
   });
 
+  it("records killReason and killSource in observability data for killed transitions", async () => {
+    vi.mocked(plugins.runtime.isAlive).mockResolvedValue(false);
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "idle" });
+    vi.mocked(plugins.agent.isProcessRunning).mockResolvedValue(false);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("killed");
+
+    const summary = readObservabilitySummary(config);
+    const trace = summary.projects["my-app"]?.recentTraces.find(
+      (entry) => entry.operation === "lifecycle.transition" && entry.sessionId === "app-1",
+    );
+
+    expect(trace?.data).toMatchObject({
+      oldStatus: "working",
+      newStatus: "killed",
+      killReason: expect.stringContaining("runtime_lost"),
+      killSource: expect.stringContaining("runtime_dead"),
+    });
+  });
+
   it("detects killed state when getActivityState returns exited", async () => {
     vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "exited" });
     vi.mocked(plugins.runtime.isAlive).mockResolvedValue(true);
@@ -1063,6 +1088,46 @@ describe("check (single session)", () => {
     expect(meta?.["statePayload"]).toContain('"state":"closed"');
     expect(meta?.["statePayload"]).toContain('"reason":"pr_closed_waiting_decision"');
     expect(notifier.notify).toHaveBeenCalledWith(expect.objectContaining({ type: "pr.closed" }));
+  });
+
+  it("emits session.killed notification with kill reason and evidence", async () => {
+    vi.mocked(plugins.runtime.isAlive).mockResolvedValue(false);
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "idle" });
+    vi.mocked(plugins.agent.isProcessRunning).mockResolvedValue(false);
+    const notifier = createMockNotifier();
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      notifier,
+    });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
+      registry,
+      configOverride: {
+        ...config,
+        notificationRouting: {
+          ...config.notificationRouting,
+          info: ["desktop"],
+        },
+      },
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("killed");
+
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session.killed",
+        message: expect.stringContaining("killed"),
+        data: expect.objectContaining({
+          oldStatus: "working",
+          newStatus: "killed",
+          killReason: expect.stringContaining("runtime_lost"),
+          evidence: expect.any(String),
+        }),
+      }),
+    );
   });
 
   it("routes closed PR transitions through the pr-closed reaction key", async () => {

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -224,6 +224,46 @@ describe("list", () => {
     expect(sessions[0].activity).toBe("exited");
   });
 
+  it("emits observer log with kill reason when marking dead runtime as killed", async () => {
+    const { readObservabilitySummary } = await import("../../observability.js");
+    const deadRuntime: Runtime = {
+      ...mockRuntime,
+      isAlive: vi.fn().mockResolvedValue(false),
+    };
+    const registryWithDead: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return deadRuntime;
+        if (slot === "agent") return mockAgent;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "a",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithDead });
+    await sm.list();
+
+    const summary = readObservabilitySummary(config);
+    const trace = summary.projects["my-app"]?.recentTraces.find(
+      (entry) => entry.operation === "session.killed" && entry.sessionId === "app-1",
+    );
+
+    expect(trace).toBeDefined();
+    expect(trace?.reason).toContain("runtime_lost");
+    expect(trace?.data).toMatchObject({
+      previousStatus: "working",
+      runtimeState: "missing",
+      sessionState: "detecting",
+    });
+  });
+
   it("detects activity using agent-native mechanism", async () => {
     const agentWithState: Agent = {
       ...mockAgent,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -266,7 +266,7 @@ function buildTransitionObservabilityData(
   statusTransition: boolean,
   reaction?: { key: string; result: ReactionResult | null },
 ): Record<string, unknown> {
-  return {
+  const data: Record<string, unknown> = {
     oldStatus,
     newStatus,
     statusTransition,
@@ -291,6 +291,18 @@ function buildTransitionObservabilityData(
     reactionSuccess: reaction?.result?.success ?? null,
     escalated: reaction?.result?.escalated ?? null,
   };
+
+  if (newStatus === "killed") {
+    const reasons: string[] = [];
+    if (next.session.reason) reasons.push(next.session.reason);
+    if (next.runtime.reason && next.runtime.reason !== "process_running") {
+      reasons.push(next.runtime.reason);
+    }
+    data.killReason = reasons.length > 0 ? reasons.join("; ") : "unknown";
+    data.killSource = evidence;
+  }
+
+  return data;
 }
 
 export interface LifecycleManagerDeps {
@@ -1771,11 +1783,19 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         // so the config controls which notifiers receive each priority level.
         if (!reactionHandledNotify) {
           const priority = inferPriority(eventType);
+          const eventData: Record<string, unknown> = { oldStatus, newStatus };
+          if (newStatus === "killed") {
+            eventData.killReason = primaryLifecycleReason(session.lifecycle);
+            eventData.evidence = assessment.evidence;
+          }
           const event = createEvent(eventType, {
             sessionId: session.id,
             projectId: session.projectId,
-            message: `${session.id}: ${oldStatus} → ${newStatus}`,
-            data: { oldStatus, newStatus },
+            message:
+              newStatus === "killed"
+                ? `${session.id}: ${oldStatus} → killed (${primaryLifecycleReason(session.lifecycle)})`
+                : `${session.id}: ${oldStatus} → ${newStatus}`,
+            data: eventData,
           });
           await notifyHuman(event, priority);
         }

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -256,6 +256,15 @@ function primaryLifecycleReason(lifecycle: CanonicalSessionLifecycle): string {
   return lifecycle.session.reason;
 }
 
+function synthesizeKillReason(lifecycle: CanonicalSessionLifecycle): string {
+  const reasons: string[] = [];
+  if (lifecycle.session.reason) reasons.push(lifecycle.session.reason);
+  if (lifecycle.runtime.reason && lifecycle.runtime.reason !== "process_running") {
+    reasons.push(lifecycle.runtime.reason);
+  }
+  return reasons.length > 0 ? reasons.join("; ") : "unknown";
+}
+
 function buildTransitionObservabilityData(
   previous: CanonicalSessionLifecycle,
   next: CanonicalSessionLifecycle,
@@ -293,12 +302,7 @@ function buildTransitionObservabilityData(
   };
 
   if (newStatus === "killed") {
-    const reasons: string[] = [];
-    if (next.session.reason) reasons.push(next.session.reason);
-    if (next.runtime.reason && next.runtime.reason !== "process_running") {
-      reasons.push(next.runtime.reason);
-    }
-    data.killReason = reasons.length > 0 ? reasons.join("; ") : "unknown";
+    data.killReason = synthesizeKillReason(next);
     data.killSource = evidence;
   }
 
@@ -1785,7 +1789,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const priority = inferPriority(eventType);
           const eventData: Record<string, unknown> = { oldStatus, newStatus };
           if (newStatus === "killed") {
-            eventData.killReason = primaryLifecycleReason(session.lifecycle);
+            eventData.killReason = synthesizeKillReason(session.lifecycle);
             eventData.evidence = assessment.evidence;
           }
           const event = createEvent(eventType, {
@@ -1793,7 +1797,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             projectId: session.projectId,
             message:
               newStatus === "killed"
-                ? `${session.id}: ${oldStatus} → killed (${primaryLifecycleReason(session.lifecycle)})`
+                ? `${session.id}: ${oldStatus} → killed (${synthesizeKillReason(session.lifecycle)})`
                 : `${session.id}: ${oldStatus} → ${newStatus}`,
             data: eventData,
           });

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -64,6 +64,7 @@ import {
 } from "./lifecycle-state.js";
 import { buildPrompt } from "./prompt-builder.js";
 import { classifyActivitySignal, createActivitySignal } from "./activity-signal.js";
+import { createCorrelationId, createProjectObserver } from "./observability.js";
 import {
   getSessionsDir,
   getWorktreesDir,
@@ -280,6 +281,7 @@ export interface SessionManagerDeps {
 /** Create a SessionManager instance. */
 export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionManager {
   const { config, registry } = deps;
+  const observer = createProjectObserver(config, "session-manager");
 
   interface LocatedSession {
     raw: Record<string, string>;
@@ -1024,7 +1026,26 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           // Process is confirmed dead — set activity to exited.
           // Only update status to "killed" if not already in a terminal state.
           if (!TERMINAL_SESSION_STATUSES.has(session.status)) {
+            const previousStatus = session.status;
+            const killReason = `${session.lifecycle.session.reason}; ${session.lifecycle.runtime.reason}`;
             session.status = "killed";
+            observer.recordOperation({
+              metric: "lifecycle_poll",
+              operation: "session.killed",
+              outcome: "success",
+              correlationId: createCorrelationId("session-killed"),
+              projectId: session.projectId,
+              sessionId: session.id,
+              reason: killReason,
+              data: {
+                previousStatus,
+                runtimeState: session.lifecycle.runtime.state,
+                runtimeReason: session.lifecycle.runtime.reason,
+                sessionState: session.lifecycle.session.state,
+                sessionReason: session.lifecycle.session.reason,
+              },
+              level: "warn",
+            });
           }
           session.activity = "exited";
           session.activitySignal = createActivitySignal("valid", {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1030,7 +1030,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
             const killReason = `${session.lifecycle.session.reason}; ${session.lifecycle.runtime.reason}`;
             session.status = "killed";
             observer.recordOperation({
-              metric: "lifecycle_poll",
+              metric: "kill",
               operation: "session.killed",
               outcome: "success",
               correlationId: createCorrelationId("session-killed"),


### PR DESCRIPTION
## Summary
- Adds `killReason` and `killSource` fields to the transition observability data when a session transitions to `killed` status, synthesizing session and runtime reasons (e.g. `"runtime_lost; tmux_missing"`)
- Enriches the notification event dispatched to Slack/Discord with kill reason and human-readable message for killed sessions
- Adds an observer log in `enrichSessionWithRuntimeState` (session-manager) so the silent kill (runtime death detection) now emits a structured log with session ID, reasons, and previous status

## Test plan
- [x] All 801 core unit tests pass
- [x] All 137 lifecycle-manager tests pass
- [x] All 187 session-manager tests pass
- [x] Type checking clean (`pnpm typecheck`)
- [x] Linting clean (`pnpm lint`)
- [x] Pre-existing integration test failure (`permission-mode` type) confirmed on main — not introduced by this PR

Closes #1073

🤖 Generated with [Claude Code](https://claude.com/claude-code)