### PR TITLE
feat(plugin): add kimi-2-6-code agent plugin

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "@aoagents/ao-plugin-agent-claude-code": "workspace:*",
     "@aoagents/ao-plugin-agent-codex": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
+    "@aoagents/ao-plugin-agent-kimi-2-6-code": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
     "@aoagents/ao-plugin-notifier-composio": "workspace:*",
     "@aoagents/ao-plugin-notifier-desktop": "workspace:*",

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -385,6 +385,12 @@ const AGENT_INSTALL_OPTIONS: AgentInstallOption[] = [
     cmd: "npm",
     args: ["install", "-g", "opencode-ai"],
   },
+  {
+    id: "kimi-2-6-code",
+    label: "Kimi 2.6 Code",
+    cmd: "bun",
+    args: ["install", "-g", "@moonshot-ai/kimi-code"],
+  },
 ];
 
 async function promptInstallAgentRuntime(available: DetectedAgent[]): Promise<DetectedAgent[]> {

--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -21,7 +21,7 @@ readyThresholdMs: 300000      # Ms before "ready" becomes "idle" (default: 5 min
 
 defaults:
   runtime: tmux               # tmux | process
-  agent: claude-code          # claude-code | aider | codex | cursor | opencode
+  agent: claude-code          # claude-code | aider | codex | cursor | opencode | kimi-2-6-code
   workspace: worktree         # worktree | clone
   notifiers:
     - desktop                 # desktop | discord | slack | webhook | composio | openclaw
@@ -134,7 +134,7 @@ notificationRouting:
 
 # ── Available plugins ───────────────────────────────────────────────
 #
-# Agent:     claude-code, aider, codex, cursor, opencode
+# Agent:     claude-code, aider, codex, cursor, opencode, kimi-2-6-code
 # Runtime:   tmux, process
 # Workspace: worktree, clone
 # SCM:       github, gitlab

--- a/packages/cli/src/lib/detect-agent.ts
+++ b/packages/cli/src/lib/detect-agent.ts
@@ -20,6 +20,7 @@ const AGENT_PLUGINS: Array<{ name: string; pkg: string }> = [
   { name: "codex", pkg: "@aoagents/ao-plugin-agent-codex" },
   { name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { name: "kimi-2-6-code", pkg: "@aoagents/ao-plugin-agent-kimi-2-6-code" },
 ];
 
 /**

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -3,6 +3,7 @@ import claudeCodePlugin from "@aoagents/ao-plugin-agent-claude-code";
 import codexPlugin from "@aoagents/ao-plugin-agent-codex";
 import aiderPlugin from "@aoagents/ao-plugin-agent-aider";
 import cursorPlugin from "@aoagents/ao-plugin-agent-cursor";
+import kimi26CodePlugin from "@aoagents/ao-plugin-agent-kimi-2-6-code";
 import opencodePlugin from "@aoagents/ao-plugin-agent-opencode";
 import githubSCMPlugin from "@aoagents/ao-plugin-scm-github";
 
@@ -11,6 +12,7 @@ const agentPlugins: Record<string, { create(): Agent }> = {
   codex: codexPlugin,
   aider: aiderPlugin,
   cursor: cursorPlugin,
+  "kimi-2-6-code": kimi26CodePlugin,
   opencode: opencodePlugin,
 };
 

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -45,6 +45,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "aider", pkg: "@aoagents/ao-plugin-agent-aider" },
   { slot: "agent", name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { slot: "agent", name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { slot: "agent", name: "kimi-2-6-code", pkg: "@aoagents/ao-plugin-agent-kimi-2-6-code" },
   // Workspaces
   { slot: "workspace", name: "worktree", pkg: "@aoagents/ao-plugin-workspace-worktree" },
   { slot: "workspace", name: "clone", pkg: "@aoagents/ao-plugin-workspace-clone" },

--- a/packages/plugins/agent-kimi-2-6-code/package.json
+++ b/packages/plugins/agent-kimi-2-6-code/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@aoagents/ao-plugin-agent-kimi-2-6-code",
+  "version": "0.1.0",
+  "description": "Agent plugin: Kimi 2.6 Code CLI",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-kimi-2-6-code"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-kimi-2-6-code/src/__tests__/activity-detection.test.ts
+++ b/packages/plugins/agent-kimi-2-6-code/src/__tests__/activity-detection.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { toKimiProjectPath, create } from "../index.js";
+import { createActivitySignal, type Session, type RuntimeHandle } from "@aoagents/ao-core";
+
+// Mock homedir() so getActivityState looks in our temp dir
+vi.mock("node:os", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    homedir: () => fakeHome,
+  };
+});
+
+let fakeHome: string;
+let workspacePath: string;
+let projectDir: string;
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  const handle: RuntimeHandle = { id: "test-1", runtimeName: "tmux", data: {} };
+  return {
+    id: "test-1",
+    projectId: "test",
+    status: "working",
+    activity: "idle",
+    activitySignal: createActivitySignal("valid", {
+      activity: "idle",
+      timestamp: new Date(),
+      source: "native",
+    }),
+    branch: "main",
+    issueId: null,
+    pr: null,
+    workspacePath,
+    runtimeHandle: handle,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function writeJsonl(
+  entries: Array<{ type: string; [key: string]: unknown }>,
+  ageMs = 0,
+  filename = "session-abc.jsonl",
+): void {
+  const content = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  const filePath = join(projectDir, filename);
+  writeFileSync(filePath, content);
+  if (ageMs > 0) {
+    const past = new Date(Date.now() - ageMs);
+    utimesSync(filePath, past, past);
+  }
+}
+
+// =============================================================================
+// toKimiProjectPath
+// =============================================================================
+
+describe("Kimi 2.6 Code Activity Detection", () => {
+  describe("toKimiProjectPath", () => {
+    it("encodes paths with leading dash", () => {
+      expect(toKimiProjectPath("/Users/dev/.worktrees/ao")).toBe("-Users-dev--worktrees-ao");
+    });
+
+    it("preserves leading slash as leading dash", () => {
+      expect(toKimiProjectPath("/tmp/test")).toBe("-tmp-test");
+    });
+
+    it("replaces dots with dashes", () => {
+      expect(toKimiProjectPath("/path/to/.hidden")).toBe("-path-to--hidden");
+    });
+
+    it("handles Windows paths (no leading slash)", () => {
+      expect(toKimiProjectPath("C:\\Users\\dev\\project")).toBe("C--Users-dev-project");
+    });
+
+    it("handles consecutive dots and slashes", () => {
+      expect(toKimiProjectPath("/a/../b/./c")).toBe("-a----b---c");
+    });
+
+    it("handles paths with multiple dot-directories", () => {
+      expect(toKimiProjectPath("/Users/dev/.config/.local/share")).toBe(
+        "-Users-dev--config--local-share",
+      );
+    });
+  });
+
+  // =============================================================================
+  // getActivityState — integration tests with real JSONL files on disk
+  // =============================================================================
+
+  describe("getActivityState", () => {
+    const agent = create();
+
+    beforeEach(() => {
+      fakeHome = mkdtempSync(join(tmpdir(), "ao-activity-test-"));
+      workspacePath = join(fakeHome, "workspace");
+      mkdirSync(workspacePath, { recursive: true });
+
+      const encoded = toKimiProjectPath(workspacePath);
+      projectDir = join(fakeHome, ".kimi", "projects", encoded);
+      mkdirSync(projectDir, { recursive: true });
+
+      vi.spyOn(agent, "isProcessRunning").mockResolvedValue(true);
+    });
+
+    afterEach(() => {
+      rmSync(fakeHome, { recursive: true, force: true });
+      vi.restoreAllMocks();
+    });
+
+    it("returns 'exited' when process is not running", async () => {
+      vi.spyOn(agent, "isProcessRunning").mockResolvedValue(false);
+      writeJsonl([{ type: "assistant" }]);
+      expect((await agent.getActivityState(makeSession()))?.state).toBe("exited");
+    });
+
+    it("returns 'exited' when no runtimeHandle", async () => {
+      expect((await agent.getActivityState(makeSession({ runtimeHandle: undefined })))?.state).toBe(
+        "exited",
+      );
+    });
+
+    it("returns 'exited' when runtimeHandle is null", async () => {
+      expect((await agent.getActivityState(makeSession({ runtimeHandle: null })))?.state).toBe("exited");
+    });
+
+    it("returns 'idle' when no session file exists yet", async () => {
+      const session = makeSession();
+      const result = await agent.getActivityState(session);
+      expect(result?.state).toBe("idle");
+      expect(result?.timestamp).toBe(session.createdAt);
+    });
+
+    it("returns null when no workspacePath", async () => {
+      expect(await agent.getActivityState(makeSession({ workspacePath: null }))).toBeNull();
+    });
+
+    it("returns 'idle' when project directory does not exist", async () => {
+      const badPath = join(fakeHome, "nonexistent-workspace");
+      expect((await agent.getActivityState(makeSession({ workspacePath: badPath })))?.state).toBe("idle");
+    });
+
+    describe("real Kimi Code entry types", () => {
+      it("returns 'active' for recent 'progress' entry (streaming)", async () => {
+        writeJsonl([{ type: "progress", status: "running tool" }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("active");
+      });
+
+      it("returns 'active' for recent 'user' entry", async () => {
+        writeJsonl([{ type: "user", message: { content: "fix the bug" } }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("active");
+      });
+
+      it("returns 'ready' for recent 'assistant' entry", async () => {
+        writeJsonl([{ type: "assistant", message: { content: "Done!" } }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("ready");
+      });
+
+      it("returns 'ready' for recent 'system' entry", async () => {
+        writeJsonl([{ type: "system", summary: "session started" }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("ready");
+      });
+
+      it("returns 'active' for recent 'file-history-snapshot' (bookkeeping)", async () => {
+        writeJsonl([{ type: "file-history-snapshot" }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("active");
+      });
+
+      it("returns 'active' for recent 'queue-operation' (bookkeeping)", async () => {
+        writeJsonl([{ type: "queue-operation" }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("active");
+      });
+
+      it("returns 'active' for recent 'pr-link' (bookkeeping)", async () => {
+        writeJsonl([{ type: "pr-link" }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("active");
+      });
+    });
+
+    describe("agent interface spec types", () => {
+      it("returns 'active' for recent 'tool_use' entry", async () => {
+        writeJsonl([{ type: "tool_use" }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("active");
+      });
+
+      it("returns 'waiting_input' for 'permission_request'", async () => {
+        writeJsonl([{ type: "permission_request" }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("waiting_input");
+      });
+
+      it("returns 'blocked' for 'error'", async () => {
+        writeJsonl([{ type: "error" }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("blocked");
+      });
+
+      it("returns 'ready' for recent 'summary' entry", async () => {
+        writeJsonl([{ type: "summary", summary: "Implemented login feature" }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("ready");
+      });
+
+      it("returns 'ready' for recent 'result' entry", async () => {
+        writeJsonl([{ type: "result" }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("ready");
+      });
+    });
+
+    describe("staleness threshold", () => {
+      it("returns 'idle' for stale 'assistant' entry (> threshold)", async () => {
+        writeJsonl([{ type: "assistant" }], 400_000);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("idle");
+      });
+
+      it("returns 'idle' for stale 'user' entry (> threshold)", async () => {
+        writeJsonl([{ type: "user" }], 400_000);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("idle");
+      });
+
+      it("returns 'idle' for stale 'progress' entry (> threshold)", async () => {
+        writeJsonl([{ type: "progress" }], 400_000);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("idle");
+      });
+
+      it("returns 'idle' for stale bookkeeping entry (> threshold)", async () => {
+        writeJsonl([{ type: "file-history-snapshot" }], 400_000);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("idle");
+      });
+
+      it("'permission_request' ignores staleness (always waiting_input)", async () => {
+        writeJsonl([{ type: "permission_request" }], 400_000);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("waiting_input");
+      });
+
+      it("'error' ignores staleness (always blocked)", async () => {
+        writeJsonl([{ type: "error" }], 400_000);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("blocked");
+      });
+
+      it("respects custom readyThresholdMs", async () => {
+        writeJsonl([{ type: "assistant" }], 120_000);
+
+        expect((await agent.getActivityState(makeSession(), 60_000))?.state).toBe("idle");
+        expect((await agent.getActivityState(makeSession(), 300_000))?.state).toBe("ready");
+      });
+
+      it("custom threshold applies to active types too", async () => {
+        writeJsonl([{ type: "user" }], 120_000);
+
+        expect((await agent.getActivityState(makeSession(), 60_000))?.state).toBe("idle");
+        expect((await agent.getActivityState(makeSession(), 300_000))?.state).toBe("ready");
+      });
+
+      it("active types within 30s window return active", async () => {
+        writeJsonl([{ type: "user" }], 10_000);
+
+        expect((await agent.getActivityState(makeSession(), 300_000))?.state).toBe("active");
+      });
+    });
+
+    describe("JSONL file selection", () => {
+      it("picks the most recently modified JSONL file", async () => {
+        writeJsonl([{ type: "assistant" }], 10_000, "old-session.jsonl");
+        writeJsonl([{ type: "user" }], 0, "new-session.jsonl");
+
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("active");
+      });
+
+      it("ignores agent- prefixed JSONL files", async () => {
+        writeJsonl([{ type: "user" }], 0, "agent-toolkit.jsonl");
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("idle");
+      });
+
+      it("reads last entry from multi-entry JSONL (not first)", async () => {
+        writeJsonl([
+          { type: "user", message: { content: "fix bug" } },
+          { type: "progress", status: "thinking" },
+          { type: "assistant", message: { content: "Done!" } },
+        ]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("ready");
+      });
+
+      it("returns null for empty JSONL file", async () => {
+        writeFileSync(join(projectDir, "empty-session.jsonl"), "");
+        expect(await agent.getActivityState(makeSession())).toBeNull();
+      });
+
+      it("returns null for JSONL with only whitespace", async () => {
+        writeFileSync(join(projectDir, "whitespace-session.jsonl"), "\n\n  \n");
+        expect(await agent.getActivityState(makeSession())).toBeNull();
+      });
+
+      it("ignores non-JSONL files in project directory", async () => {
+        writeFileSync(join(projectDir, "config.json"), '{"type": "user"}');
+        writeFileSync(join(projectDir, "notes.txt"), "some notes");
+        writeJsonl([{ type: "assistant" }]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("ready");
+      });
+    });
+
+    describe("realistic session sequences", () => {
+      it("detects agent mid-work (progress is last entry)", async () => {
+        writeJsonl([
+          { type: "user", message: { content: "implement auth" } },
+          { type: "assistant", message: { content: "I'll implement..." } },
+          { type: "progress", status: "Reading file" },
+          { type: "progress", status: "Writing file" },
+          { type: "progress", status: "Running tool" },
+        ]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("active");
+      });
+
+      it("detects agent done and waiting (assistant is last entry)", async () => {
+        writeJsonl([
+          { type: "user", message: { content: "implement auth" } },
+          { type: "progress", status: "thinking" },
+          { type: "progress", status: "writing" },
+          { type: "assistant", message: { content: "I've implemented the auth feature." } },
+        ]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("ready");
+      });
+
+      it("detects agent done with system summary", async () => {
+        writeJsonl([
+          { type: "user", message: { content: "fix tests" } },
+          { type: "progress", status: "thinking" },
+          { type: "assistant", message: { content: "Fixed!" } },
+          { type: "system", summary: "Fixed failing tests" },
+        ]);
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("ready");
+      });
+
+      it("detects stale finished session", async () => {
+        writeJsonl(
+          [
+            { type: "user", message: { content: "implement auth" } },
+            { type: "assistant", message: { content: "Done" } },
+          ],
+          600_000,
+        );
+        expect((await agent.getActivityState(makeSession()))?.state).toBe("idle");
+      });
+    });
+  });
+});

--- a/packages/plugins/agent-kimi-2-6-code/src/__tests__/hook-script.integration.test.ts
+++ b/packages/plugins/agent-kimi-2-6-code/src/__tests__/hook-script.integration.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { METADATA_UPDATER_SCRIPT } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Integration tests for the metadata-updater.sh hook script.
+// These execute the actual bash script with various inputs and verify that
+// session metadata files are updated correctly.
+// ---------------------------------------------------------------------------
+
+let testDir: string;
+let hookScriptPath: string;
+
+beforeAll(() => {
+  testDir = mkdtempSync(join(tmpdir(), "ao-hook-test-"));
+  hookScriptPath = join(testDir, "metadata-updater.sh");
+  writeFileSync(hookScriptPath, METADATA_UPDATER_SCRIPT, { mode: 0o755 });
+});
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+/**
+ * Run the hook script with given parameters and return the script's
+ * stdout plus the updated metadata file contents.
+ */
+function runHook(opts: {
+  command: string;
+  toolName?: string;
+  output?: string;
+  exitCode?: number;
+  metadataContent?: string;
+}): { stdout: string; metadata: string } {
+  const sessionId = `test-session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const sessionsDir = join(testDir, "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  const metadataFile = join(sessionsDir, sessionId);
+  writeFileSync(metadataFile, opts.metadataContent ?? "status=spawning\n");
+
+  const input = JSON.stringify({
+    tool_name: opts.toolName ?? "Bash",
+    tool_input: { command: opts.command },
+    tool_response: opts.output ?? "",
+    exit_code: opts.exitCode ?? 0,
+  });
+
+  let stdout: string;
+  try {
+    stdout = execSync(`bash "${hookScriptPath}"`, {
+      input,
+      env: {
+        ...process.env,
+        AO_SESSION: sessionId,
+        AO_DATA_DIR: sessionsDir,
+        HOME: testDir,
+      },
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+  } catch (err: unknown) {
+    const e = err as { stdout?: string };
+    stdout = e.stdout ?? "";
+  }
+
+  let metadata: string;
+  try {
+    metadata = readFileSync(metadataFile, "utf-8");
+  } catch {
+    metadata = "";
+  }
+
+  return { stdout, metadata };
+}
+
+// =========================================================================
+// gh pr create detection
+// =========================================================================
+describe("hook script: gh pr create", () => {
+  const prUrl = "https://github.com/owner/repo/pull/42";
+
+  it("detects plain gh pr create", () => {
+    const { metadata } = runHook({
+      command: 'gh pr create --title "fix" --body "test" --base master',
+      output: `Creating pull request...\n${prUrl}\n`,
+    });
+    expect(metadata).toContain(`pr=${prUrl}`);
+    expect(metadata).toContain("status=pr_open");
+  });
+
+  it("detects gh pr create with cd && prefix", () => {
+    const { metadata } = runHook({
+      command: `cd ~/.worktrees/mercury/cleanup && gh pr create --title "fix" --base master`,
+      output: `${prUrl}`,
+    });
+    expect(metadata).toContain(`pr=${prUrl}`);
+    expect(metadata).toContain("status=pr_open");
+  });
+
+  it("detects gh pr create with cd ; prefix", () => {
+    const { metadata } = runHook({
+      command: `cd /some/path ; gh pr create --title "test" --body "body"`,
+      output: prUrl,
+    });
+    expect(metadata).toContain(`pr=${prUrl}`);
+    expect(metadata).toContain("status=pr_open");
+  });
+
+  it("detects gh pr create with multiple chained cd prefixes", () => {
+    const { metadata } = runHook({
+      command: `cd /tmp && cd ~/.worktrees/mercury && gh pr create --title "fix" --base master`,
+      output: prUrl,
+    });
+    expect(metadata).toContain(`pr=${prUrl}`);
+    expect(metadata).toContain("status=pr_open");
+  });
+
+  it("does NOT update metadata when PR URL is missing from output", () => {
+    const { metadata } = runHook({
+      command: 'gh pr create --title "fix"',
+      output: "Error: something went wrong",
+    });
+    expect(metadata).not.toContain("pr=");
+    expect(metadata).toContain("status=spawning");
+  });
+});
+
+// =========================================================================
+// git checkout -b / git switch -c detection
+// =========================================================================
+describe("hook script: git checkout -b / git switch -c", () => {
+  it("detects plain git checkout -b", () => {
+    const { metadata } = runHook({
+      command: "git checkout -b feat/my-feature",
+    });
+    expect(metadata).toContain("branch=feat/my-feature");
+  });
+
+  it("detects plain git switch -c", () => {
+    const { metadata } = runHook({
+      command: "git switch -c fix/bug-123",
+    });
+    expect(metadata).toContain("branch=fix/bug-123");
+  });
+
+  it("detects git checkout -b with cd && prefix", () => {
+    const { metadata } = runHook({
+      command: "cd /some/project && git checkout -b feat/new-feature",
+    });
+    expect(metadata).toContain("branch=feat/new-feature");
+  });
+
+  it("detects git switch -c with cd && prefix", () => {
+    const { metadata } = runHook({
+      command: "cd ~/.worktrees/project && git switch -c fix/issue-456",
+    });
+    expect(metadata).toContain("branch=fix/issue-456");
+  });
+
+  it("detects git checkout -b with cd ; prefix", () => {
+    const { metadata } = runHook({
+      command: "cd /project ; git checkout -b feat/semicolon-test",
+    });
+    expect(metadata).toContain("branch=feat/semicolon-test");
+  });
+
+  it("detects git checkout -b with multiple cd prefixes", () => {
+    const { metadata } = runHook({
+      command: "cd /tmp && cd /project && git checkout -b feat/chained",
+    });
+    expect(metadata).toContain("branch=feat/chained");
+  });
+});
+
+// =========================================================================
+// gh pr merge detection
+// =========================================================================
+describe("hook script: gh pr merge", () => {
+  it("detects plain gh pr merge", () => {
+    const { metadata } = runHook({
+      command: "gh pr merge 123 --squash",
+    });
+    expect(metadata).toContain("status=merged");
+  });
+
+  it("detects gh pr merge with cd && prefix", () => {
+    const { metadata } = runHook({
+      command: "cd ~/.worktrees/project && gh pr merge 42 --squash",
+    });
+    expect(metadata).toContain("status=merged");
+  });
+
+  it("detects gh pr merge with cd ; prefix", () => {
+    const { metadata } = runHook({
+      command: "cd /project ; gh pr merge --rebase",
+    });
+    expect(metadata).toContain("status=merged");
+  });
+});
+
+// =========================================================================
+// git checkout <existing-branch> detection (feature branches)
+// =========================================================================
+describe("hook script: git checkout existing branch", () => {
+  it("detects plain git checkout of a feature branch", () => {
+    const { metadata } = runHook({
+      command: "git checkout feat/existing-branch",
+    });
+    expect(metadata).toContain("branch=feat/existing-branch");
+  });
+
+  it("detects git checkout of a feature branch with cd prefix", () => {
+    const { metadata } = runHook({
+      command: "cd /project && git checkout feat/existing-branch",
+    });
+    expect(metadata).toContain("branch=feat/existing-branch");
+  });
+});
+
+// =========================================================================
+// Non-matching commands (should NOT modify metadata)
+// =========================================================================
+describe("hook script: non-matching commands", () => {
+  it("ignores plain ls command", () => {
+    const { metadata } = runHook({
+      command: "ls -la",
+    });
+    expect(metadata).toBe("status=spawning\n");
+  });
+
+  it("ignores non-Bash tool calls", () => {
+    const { metadata } = runHook({
+      command: 'gh pr create --title "test"',
+      toolName: "Read",
+      output: "https://github.com/owner/repo/pull/1",
+    });
+    expect(metadata).toBe("status=spawning\n");
+  });
+
+  it("ignores commands with non-zero exit code", () => {
+    const { metadata } = runHook({
+      command: 'gh pr create --title "test"',
+      exitCode: 1,
+      output: "https://github.com/owner/repo/pull/1",
+    });
+    expect(metadata).toBe("status=spawning\n");
+  });
+
+  it("ignores cd-only commands (no chained git/gh)", () => {
+    const { metadata } = runHook({
+      command: "cd /some/directory",
+    });
+    expect(metadata).toBe("status=spawning\n");
+  });
+
+  it("ignores git status", () => {
+    const { metadata } = runHook({
+      command: "cd /project && git status",
+    });
+    expect(metadata).toBe("status=spawning\n");
+  });
+});
+
+// =========================================================================
+// Metadata file update mechanics
+// =========================================================================
+describe("hook script: metadata file updates", () => {
+  it("updates an existing key in the metadata file", () => {
+    const { metadata } = runHook({
+      command: "gh pr merge 10 --squash",
+      metadataContent: "status=pr_open\nbranch=feat/test\n",
+    });
+    expect(metadata).toContain("status=merged");
+    expect(metadata).toContain("branch=feat/test");
+    expect(metadata).not.toContain("status=pr_open");
+  });
+
+  it("appends a new key to the metadata file", () => {
+    const { metadata } = runHook({
+      command: 'gh pr create --title "test"',
+      output: "https://github.com/owner/repo/pull/99",
+      metadataContent: "branch=feat/test\n",
+    });
+    expect(metadata).toContain("branch=feat/test");
+    expect(metadata).toContain("pr=https://github.com/owner/repo/pull/99");
+    expect(metadata).toContain("status=pr_open");
+  });
+
+  it("returns systemMessage JSON on successful detection", () => {
+    const { stdout } = runHook({
+      command: "gh pr merge 1 --squash",
+    });
+    expect(stdout).toContain("systemMessage");
+    expect(stdout).toContain("merged");
+  });
+
+  it("returns empty JSON for non-matching commands", () => {
+    const { stdout } = runHook({
+      command: "echo hello",
+    });
+    expect(stdout.trim()).toBe("{}");
+  });
+});

--- a/packages/plugins/agent-kimi-2-6-code/src/__tests__/index.test.ts
+++ b/packages/plugins/agent-kimi-2-6-code/src/__tests__/index.test.ts
@@ -1,0 +1,888 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createActivitySignal,
+  type Session,
+  type RuntimeHandle,
+  type AgentLaunchConfig,
+  type WorkspaceHooksConfig,
+} from "@aoagents/ao-core";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — available inside vi.mock factories
+// ---------------------------------------------------------------------------
+const {
+  mockExecFileAsync,
+  mockReaddir,
+  mockReadFile,
+  mockStat,
+  mockHomedir,
+  mockWriteFile,
+  mockMkdir,
+  mockChmod,
+  mockExistsSync,
+} = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(),
+  mockReaddir: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockStat: vi.fn(),
+  mockHomedir: vi.fn(() => "/mock/home"),
+  mockWriteFile: vi.fn().mockResolvedValue(undefined),
+  mockMkdir: vi.fn().mockResolvedValue(undefined),
+  mockChmod: vi.fn().mockResolvedValue(undefined),
+  mockExistsSync: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("node:child_process", () => {
+  const fn = Object.assign((..._args: unknown[]) => {}, {
+    [Symbol.for("nodejs.util.promisify.custom")]: mockExecFileAsync,
+  });
+  return { execFile: fn };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readdir: mockReaddir,
+  readFile: mockReadFile,
+  stat: mockStat,
+  writeFile: mockWriteFile,
+  mkdir: mockMkdir,
+  chmod: mockChmod,
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+}));
+
+vi.mock("node:os", () => ({
+  homedir: mockHomedir,
+}));
+
+import {
+  create,
+  manifest,
+  default as defaultExport,
+  resetPsCache,
+  METADATA_UPDATER_SCRIPT,
+} from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "test-1",
+    projectId: "test-project",
+    status: "working",
+    activity: "active",
+    activitySignal: createActivitySignal("valid", {
+      activity: "active",
+      timestamp: new Date(),
+      source: "native",
+    }),
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/workspace/test-project",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeTmuxHandle(id = "test-session"): RuntimeHandle {
+  return { id, runtimeName: "tmux", data: {} };
+}
+
+function makeProcessHandle(pid?: number): RuntimeHandle {
+  return { id: "proc-1", runtimeName: "process", data: pid !== undefined ? { pid } : {} };
+}
+
+function makeLaunchConfig(overrides: Partial<AgentLaunchConfig> = {}): AgentLaunchConfig {
+  return {
+    sessionId: "sess-1",
+    projectConfig: {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/repo",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+    },
+    ...overrides,
+  };
+}
+
+function mockTmuxWithProcess(processName = "kimi-code", tty = "/dev/ttys001", pid = 12345) {
+  mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === "tmux" && args[0] === "list-panes") {
+      return Promise.resolve({ stdout: `${tty}\n`, stderr: "" });
+    }
+    if (cmd === "ps") {
+      const ttyShort = tty.replace(/^\/dev\//, "");
+      // Matches `ps -eo pid,tty,args` output format
+      return Promise.resolve({
+        stdout: `  PID TT       ARGS\n  ${pid} ${ttyShort}  ${processName}\n`,
+        stderr: "",
+      });
+    }
+    return Promise.reject(new Error(`Unexpected: ${cmd} ${args.join(" ")}`));
+  });
+}
+
+function mockJsonlFiles(
+  jsonlContent: string,
+  files = ["session-abc123.jsonl"],
+  mtime = new Date(1700000000000),
+) {
+  mockReaddir.mockResolvedValue(files);
+  mockStat.mockResolvedValue({ mtimeMs: mtime.getTime(), mtime });
+  mockReadFile.mockResolvedValue(jsonlContent);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetPsCache();
+  mockHomedir.mockReturnValue("/mock/home");
+});
+
+describe("plugin manifest & exports", () => {
+  it("has correct manifest", () => {
+    expect(manifest).toEqual({
+      name: "kimi-2-6-code",
+      slot: "agent",
+      description: "Agent plugin: Kimi 2.6 Code CLI",
+      version: "0.1.0",
+      displayName: "Kimi 2.6 Code",
+    });
+  });
+
+  it("create() returns an agent with correct name and processName", () => {
+    const agent = create();
+    expect(agent.name).toBe("kimi-2-6-code");
+    expect(agent.processName).toBe("kimi-code");
+    expect(agent.promptDelivery).toBe("post-launch");
+  });
+
+  it("default export is a valid PluginModule", () => {
+    expect(defaultExport.manifest).toBe(manifest);
+    expect(typeof defaultExport.create).toBe("function");
+  });
+});
+
+// =========================================================================
+// getLaunchCommand
+// =========================================================================
+describe("getLaunchCommand", () => {
+  const agent = create();
+
+  it("generates base command without shell syntax", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "default" }));
+    expect(cmd).toBe("kimi-code");
+    // Must not contain shell operators (execFile-safe)
+    expect(cmd).not.toContain("&&");
+    expect(cmd).not.toContain("unset");
+  });
+
+  it("includes --dangerously-skip-permissions when permissions=permissionless", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "permissionless" }));
+    expect(cmd).toContain("--dangerously-skip-permissions");
+  });
+
+  it("treats legacy permissions=skip as permissionless", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "skip" as unknown as AgentLaunchConfig["permissions"] }),
+    );
+    expect(cmd).toContain("--dangerously-skip-permissions");
+  });
+
+  it("maps permissions=auto-edit to no-prompt mode on Kimi", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "auto-edit" }));
+    expect(cmd).toContain("--dangerously-skip-permissions");
+  });
+
+  it("shell-escapes model argument", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ model: "kimi-k2-6" }));
+    expect(cmd).toContain("--model 'kimi-k2-6'");
+  });
+
+  it("does not include -p flag (prompt delivered post-launch)", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "Fix the bug" }));
+    expect(cmd).not.toContain("-p");
+    expect(cmd).not.toContain("Fix the bug");
+  });
+
+  it("combines all options without prompt", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ permissions: "permissionless", model: "opus", prompt: "Hello" }),
+    );
+    expect(cmd).toBe("kimi-code --dangerously-skip-permissions --model 'opus'");
+  });
+
+  it("omits --dangerously-skip-permissions when permissions=default", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "default" }));
+    expect(cmd).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("omits optional flags when not provided", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig());
+    expect(cmd).not.toContain("--model");
+    expect(cmd).not.toContain("-p");
+  });
+
+  it("includes --append-system-prompt alongside omitted -p", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ systemPrompt: "You are a helper", prompt: "Do the task" }),
+    );
+    expect(cmd).toContain("--append-system-prompt");
+    expect(cmd).toContain("You are a helper");
+    // -p as a standalone flag (not substring of --append-system-prompt)
+    expect(cmd).not.toMatch(/\s-p\s/);
+    expect(cmd).not.toContain("Do the task");
+  });
+
+  it("uses systemPromptFile via shell substitution alongside omitted -p", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ systemPromptFile: "/tmp/prompt.md", prompt: "Do the task" }),
+    );
+    expect(cmd).toContain('--append-system-prompt "$(cat');
+    expect(cmd).toContain("/tmp/prompt.md");
+    expect(cmd).not.toMatch(/\s-p\s/);
+    expect(cmd).not.toContain("Do the task");
+  });
+});
+
+// =========================================================================
+// getEnvironment
+// =========================================================================
+describe("getEnvironment", () => {
+  const agent = create();
+
+  it("sets CLAUDECODE to empty string (replaces unset in command)", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["CLAUDECODE"]).toBe("");
+    expect(env["CLAUDE_CONFIG_DIR"]).toBe("/mock/home/.kimi");
+  });
+
+  it("sets AO_SESSION_ID but not AO_PROJECT_ID (caller's responsibility)", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["AO_SESSION_ID"]).toBe("sess-1");
+    expect(env["AO_PROJECT_ID"]).toBeUndefined();
+  });
+
+  it("sets AO_ISSUE_ID when provided", () => {
+    const env = agent.getEnvironment(makeLaunchConfig({ issueId: "INT-100" }));
+    expect(env["AO_ISSUE_ID"]).toBe("INT-100");
+  });
+
+  it("does not set AO_ISSUE_ID when not provided", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["AO_ISSUE_ID"]).toBeUndefined();
+  });
+});
+
+// =========================================================================
+// isProcessRunning
+// =========================================================================
+describe("isProcessRunning", () => {
+  const agent = create();
+
+  it("returns true when kimi-code is found on tmux pane TTY", async () => {
+    mockTmuxWithProcess("kimi-code");
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("returns false when no kimi-code on tmux pane TTY", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys002\n", stderr: "" });
+      if (cmd === "ps")
+        return Promise.resolve({
+          stdout: "  PID TT       ARGS\n  999 ttys002  bash\n",
+          stderr: "",
+        });
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns false when tmux list-panes returns empty", async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: "", stderr: "" });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns true for process runtime with alive PID", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    expect(await agent.isProcessRunning(makeProcessHandle(999))).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(999, 0);
+    killSpy.mockRestore();
+  });
+
+  it("returns false for process runtime with dead PID", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(999))).toBe(false);
+    killSpy.mockRestore();
+  });
+
+  it("returns false for unknown runtime without PID (no pgrep fallback)", async () => {
+    const handle: RuntimeHandle = { id: "x", runtimeName: "other", data: {} };
+    expect(await agent.isProcessRunning(handle)).toBe(false);
+    // Must NOT call pgrep — could match wrong session
+    expect(mockExecFileAsync).not.toHaveBeenCalled();
+  });
+
+  it("returns false when tmux command fails", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("fail"));
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns true when PID exists but throws EPERM", async () => {
+    const epermErr = Object.assign(new Error("EPERM"), { code: "EPERM" });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw epermErr;
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(789))).toBe(true);
+    killSpy.mockRestore();
+  });
+
+  it("finds kimi-code on any pane in multi-pane session", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "list-panes") {
+        return Promise.resolve({ stdout: "/dev/ttys001\n/dev/ttys002\n", stderr: "" });
+      }
+      if (cmd === "ps") {
+        return Promise.resolve({
+          stdout: "  PID TT ARGS\n  100 ttys001  bash\n  200 ttys002  kimi-code -p test\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("does not match similar process names like kimi-2-6-code", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "list-panes") {
+        return Promise.resolve({ stdout: "/dev/ttys001\n", stderr: "" });
+      }
+      if (cmd === "ps") {
+        return Promise.resolve({
+          stdout: "  PID TT ARGS\n  100 ttys001  /usr/bin/kimi-2-6-code\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+});
+
+// =========================================================================
+// detectActivity — terminal output classification
+// =========================================================================
+describe("detectActivity", () => {
+  const agent = create();
+
+  it("returns idle for empty terminal output", () => {
+    expect(agent.detectActivity("")).toBe("idle");
+  });
+
+  it("returns idle for whitespace-only terminal output", () => {
+    expect(agent.detectActivity("   \n  \n  ")).toBe("idle");
+  });
+
+  it("returns active when 'esc to interrupt' is visible", () => {
+    expect(agent.detectActivity("Working... esc to interrupt\n")).toBe("active");
+  });
+
+  it("returns active when Thinking indicator is visible", () => {
+    expect(agent.detectActivity("Thinking...\n")).toBe("active");
+  });
+
+  it("returns active when Reading indicator is visible", () => {
+    expect(agent.detectActivity("Reading file src/index.ts\n")).toBe("active");
+  });
+
+  it("returns active when Writing indicator is visible", () => {
+    expect(agent.detectActivity("Writing to src/main.ts\n")).toBe("active");
+  });
+
+  it("returns active when Searching indicator is visible", () => {
+    expect(agent.detectActivity("Searching codebase...\n")).toBe("active");
+  });
+
+  it("returns waiting_input for permission prompt (Y/N)", () => {
+    expect(agent.detectActivity("Do you want to proceed? (Y)es / (N)o\n")).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for 'Do you want to proceed?' prompt", () => {
+    expect(agent.detectActivity("Do you want to proceed?\n")).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for bypass permissions prompt", () => {
+    expect(agent.detectActivity("bypass all future permissions for this session\n")).toBe(
+      "waiting_input",
+    );
+  });
+
+  it("returns active when queued message indicator is visible", () => {
+    expect(agent.detectActivity("Press up to edit queued messages\n")).toBe("active");
+  });
+
+  it("returns idle when shell prompt is visible", () => {
+    expect(agent.detectActivity("some output\n> ")).toBe("idle");
+    expect(agent.detectActivity("some output\n$ ")).toBe("idle");
+  });
+
+  it("returns idle when prompt follows historical activity indicators", () => {
+    // Key regression test: historical "Reading file..." output in the buffer
+    // should NOT override an idle prompt on the last line.
+    expect(agent.detectActivity("Reading file src/index.ts\nWriting to out.ts\n❯ ")).toBe("idle");
+    expect(agent.detectActivity("Thinking...\nSearching codebase...\n$ ")).toBe("idle");
+  });
+
+  it("returns waiting_input when permission prompt follows historical activity", () => {
+    // Permission prompt at the bottom should NOT be overridden by historical
+    // "Reading"/"Thinking" output higher in the buffer.
+    expect(
+      agent.detectActivity("Reading file src/index.ts\nThinking...\nDo you want to proceed?\n"),
+    ).toBe("waiting_input");
+    expect(agent.detectActivity("Searching codebase...\n(Y)es / (N)o\n")).toBe("waiting_input");
+    expect(
+      agent.detectActivity("Writing to out.ts\nbypass all future permissions for this session\n"),
+    ).toBe("waiting_input");
+  });
+
+  it("returns active for non-empty output with no special patterns", () => {
+    expect(agent.detectActivity("some random terminal output\n")).toBe("active");
+  });
+});
+
+// =========================================================================
+// getSessionInfo — JSONL parsing
+// =========================================================================
+describe("getSessionInfo", () => {
+  const agent = create();
+
+  it("returns null when workspacePath is null", async () => {
+    expect(await agent.getSessionInfo(makeSession({ workspacePath: null }))).toBeNull();
+  });
+
+  it("returns null when project directory does not exist", async () => {
+    mockReaddir.mockRejectedValue(new Error("ENOENT"));
+    expect(await agent.getSessionInfo(makeSession())).toBeNull();
+  });
+
+  it("returns null when no JSONL files in project dir", async () => {
+    mockReaddir.mockResolvedValue(["readme.txt", "config.yaml"]);
+    expect(await agent.getSessionInfo(makeSession())).toBeNull();
+  });
+
+  it("filters out agent- prefixed JSONL files", async () => {
+    mockReaddir.mockResolvedValue(["agent-toolkit.jsonl"]);
+    expect(await agent.getSessionInfo(makeSession())).toBeNull();
+  });
+
+  it("returns null when JSONL file is empty", async () => {
+    mockJsonlFiles("");
+    expect(await agent.getSessionInfo(makeSession())).toBeNull();
+  });
+
+  it("returns null when JSONL has only malformed lines", async () => {
+    mockJsonlFiles("not json\nalso not json\n");
+    expect(await agent.getSessionInfo(makeSession())).toBeNull();
+  });
+
+  describe("path conversion", () => {
+    it("converts workspace path to Kimi project dir path", async () => {
+      mockJsonlFiles('{"type":"user","message":{"content":"hello"}}');
+      await agent.getSessionInfo(makeSession({ workspacePath: "/Users/dev/.worktrees/ao/ao-3" }));
+      expect(mockReaddir).toHaveBeenCalledWith(
+        "/mock/home/.kimi/projects/-Users-dev--worktrees-ao-ao-3",
+      );
+    });
+  });
+
+  describe("summary extraction", () => {
+    it("extracts summary from last summary event and marks as not fallback", async () => {
+      const jsonl = [
+        '{"type":"summary","summary":"First summary"}',
+        '{"type":"user","message":{"content":"do something"}}',
+        '{"type":"summary","summary":"Latest summary"}',
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.summary).toBe("Latest summary");
+      expect(result?.summaryIsFallback).toBe(false);
+    });
+
+    it("falls back to first user message and marks as fallback", async () => {
+      const jsonl = [
+        '{"type":"user","message":{"content":"Implement the login feature"}}',
+        '{"type":"assistant","message":{"content":"I will implement..."}}',
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.summary).toBe("Implement the login feature");
+      expect(result?.summaryIsFallback).toBe(true);
+    });
+
+    it("truncates long user message to 120 chars", async () => {
+      const longMsg = "A".repeat(200);
+      const jsonl = `{"type":"user","message":{"content":"${longMsg}"}}`;
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.summary).toBe("A".repeat(120) + "...");
+      expect(result!.summary!.length).toBe(123);
+      expect(result?.summaryIsFallback).toBe(true);
+    });
+
+    it("returns null summary when no summary and no user messages", async () => {
+      const jsonl = '{"type":"assistant","message":{"content":"Hello"}}';
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.summary).toBeNull();
+      expect(result?.summaryIsFallback).toBeUndefined();
+    });
+
+    it("skips user messages with empty content", async () => {
+      const jsonl = [
+        '{"type":"user","message":{"content":"   "}}',
+        '{"type":"user","message":{"content":"Real content"}}',
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.summary).toBe("Real content");
+      expect(result?.summaryIsFallback).toBe(true);
+    });
+  });
+
+  describe("session ID extraction", () => {
+    it("extracts session ID from filename", async () => {
+      mockJsonlFiles('{"type":"user","message":{"content":"hi"}}', ["abc-def-123.jsonl"]);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.agentSessionId).toBe("abc-def-123");
+    });
+  });
+
+  describe("cost estimation", () => {
+    it("aggregates usage.input_tokens and usage.output_tokens", async () => {
+      const jsonl = [
+        '{"type":"user","message":{"content":"hi"}}',
+        '{"type":"assistant","usage":{"input_tokens":1000,"output_tokens":500}}',
+        '{"type":"assistant","usage":{"input_tokens":2000,"output_tokens":300}}',
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.cost?.inputTokens).toBe(3000);
+      expect(result?.cost?.outputTokens).toBe(800);
+      expect(result?.cost?.estimatedCostUsd).toBeCloseTo(0.009 + 0.012, 6);
+    });
+
+    it("includes cache tokens in input count", async () => {
+      const jsonl = [
+        '{"type":"user","message":{"content":"hi"}}',
+        '{"type":"assistant","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":500,"cache_creation_input_tokens":200}}',
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.cost?.inputTokens).toBe(800);
+      expect(result?.cost?.outputTokens).toBe(50);
+    });
+
+    it("uses model-aware pricing when cached tokens are present", async () => {
+      const jsonl = [
+        '{"type":"assistant","model":"claude-sonnet-4-5","usage":{"input_tokens":1000,"output_tokens":100,"cache_read_input_tokens":10000,"cache_creation_input_tokens":2000}}',
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.cost?.inputTokens).toBe(13000);
+      expect(result?.cost?.outputTokens).toBe(100);
+      expect(result?.cost?.estimatedCostUsd).toBeGreaterThan(0);
+    });
+
+    it("uses costUSD field when present", async () => {
+      const jsonl = [
+        '{"type":"user","message":{"content":"hi"}}',
+        '{"costUSD":0.05}',
+        '{"costUSD":0.03}',
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.cost?.estimatedCostUsd).toBeCloseTo(0.08);
+    });
+
+    it("prefers costUSD over estimatedCostUsd to avoid double-counting", async () => {
+      const jsonl = [
+        '{"type":"user","message":{"content":"hi"}}',
+        '{"costUSD":0.10,"estimatedCostUsd":0.10}',
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      // Should use costUSD only, not sum both
+      expect(result?.cost?.estimatedCostUsd).toBeCloseTo(0.1);
+    });
+
+    it("falls back to estimatedCostUsd when costUSD is absent", async () => {
+      const jsonl = [
+        '{"type":"user","message":{"content":"hi"}}',
+        '{"estimatedCostUsd":0.12}',
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.cost?.estimatedCostUsd).toBeCloseTo(0.12);
+    });
+
+    it("uses direct inputTokens/outputTokens fields", async () => {
+      const jsonl = [
+        '{"type":"user","message":{"content":"hi"}}',
+        '{"inputTokens":5000,"outputTokens":1000}',
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.cost?.inputTokens).toBe(5000);
+      expect(result?.cost?.outputTokens).toBe(1000);
+    });
+
+    it("returns undefined cost when no usage data", async () => {
+      const jsonl = '{"type":"user","message":{"content":"hi"}}';
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.cost).toBeUndefined();
+    });
+  });
+
+  describe("file selection", () => {
+    it("picks the most recently modified JSONL file", async () => {
+      mockReaddir.mockResolvedValue(["old.jsonl", "new.jsonl"]);
+      mockStat.mockImplementation((path: string) => {
+        if (path.endsWith("old.jsonl")) {
+          return Promise.resolve({ mtimeMs: 1000, mtime: new Date(1000) });
+        }
+        return Promise.resolve({ mtimeMs: 2000, mtime: new Date(2000) });
+      });
+      mockReadFile.mockResolvedValue('{"type":"user","message":{"content":"hi"}}');
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.agentSessionId).toBe("new");
+    });
+
+    it("skips JSONL files that fail stat", async () => {
+      mockReaddir.mockResolvedValue(["broken.jsonl", "good.jsonl"]);
+      mockStat.mockImplementation((path: string) => {
+        if (path.endsWith("broken.jsonl")) {
+          return Promise.reject(new Error("ENOENT"));
+        }
+        return Promise.resolve({ mtimeMs: 1000, mtime: new Date(1000) });
+      });
+      mockReadFile.mockResolvedValue('{"type":"user","message":{"content":"hi"}}');
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.agentSessionId).toBe("good");
+    });
+  });
+
+  describe("malformed JSONL handling", () => {
+    it("skips malformed lines and parses valid ones", async () => {
+      const jsonl = [
+        "not valid json",
+        '{"type":"summary","summary":"Good summary"}',
+        "{truncated",
+        "",
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.summary).toBe("Good summary");
+    });
+
+    it("skips JSON null, array, and primitive values", async () => {
+      const jsonl = [
+        "null",
+        "42",
+        '"just a string"',
+        "[1,2,3]",
+        '{"type":"summary","summary":"Valid object"}',
+      ].join("\n");
+      mockJsonlFiles(jsonl);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result?.summary).toBe("Valid object");
+    });
+
+    it("handles readFile failure gracefully", async () => {
+      mockReaddir.mockResolvedValue(["session.jsonl"]);
+      mockStat.mockResolvedValue({ mtimeMs: 1000, mtime: new Date(1000) });
+      mockReadFile.mockRejectedValue(new Error("EACCES"));
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result).toBeNull();
+    });
+  });
+});
+
+// =========================================================================
+// METADATA_UPDATER_SCRIPT — content verification (unit tests)
+// =========================================================================
+describe("METADATA_UPDATER_SCRIPT content", () => {
+  it("contains clean_command stripping logic for cd prefixes", () => {
+    expect(METADATA_UPDATER_SCRIPT).toContain('clean_command="$command"');
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/while.*clean_command.*cd/);
+  });
+
+  it("uses $clean_command (not $command) for all regex-based command detection", () => {
+    const lines = METADATA_UPDATER_SCRIPT.split("\n");
+    for (const line of lines) {
+      // Skip comment lines, the initial assignment, and the stripping logic itself
+      if (line.trim().startsWith("#")) continue;
+      if (line.includes('clean_command="$command"')) continue;
+      if (line.includes("while") && line.includes("clean_command")) continue;
+
+      // Any regex match line (=~) should use $clean_command, NOT $command
+      if (line.includes("=~") && line.includes("command")) {
+        expect(line).toContain("clean_command");
+        expect(line).not.toMatch(/"\$command"/);
+      }
+    }
+  });
+
+  it("does NOT use ^-anchored regexes directly on $command for gh/git detection", () => {
+    // The old buggy patterns matched $command with ^ anchor.
+    // After the fix, ^ is still used but on $clean_command (which has cd stripped).
+    expect(METADATA_UPDATER_SCRIPT).not.toMatch(/"\$command"\s*=~\s*\^gh/);
+    expect(METADATA_UPDATER_SCRIPT).not.toMatch(/"\$command"\s*=~\s*\^git/);
+  });
+
+  it("strips cd prefixes with both && and ; delimiters", () => {
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/&&\|;/);
+  });
+
+  it("handles multiple chained cd commands via while loop", () => {
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/while.*clean_command/);
+  });
+
+  it("detects gh pr create on clean_command", () => {
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/"\$clean_command"\s*=~\s*\^gh\[/);
+  });
+
+  it("detects git checkout -b on clean_command", () => {
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/"\$clean_command"\s*=~\s*\^git\[.*checkout/);
+  });
+
+  it("detects gh pr merge on clean_command", () => {
+    expect(METADATA_UPDATER_SCRIPT).toMatch(/"\$clean_command"\s*=~\s*\^gh\[.*merge/);
+  });
+});
+
+// =========================================================================
+// setupWorkspaceHooks / postLaunchSetup — hook path (symlink safety)
+// =========================================================================
+describe("hook setup — relative path (symlink-safe)", () => {
+  const agent = create();
+
+  /** Extract the hook command from the settings.json that was written */
+  function getWrittenHookCommand(): string {
+    const settingsWrite = mockWriteFile.mock.calls.find(
+      ([path]: unknown[]) => typeof path === "string" && path.endsWith("settings.json"),
+    );
+    expect(settingsWrite).toBeDefined();
+    const parsed = JSON.parse(settingsWrite![1] as string);
+    return parsed.hooks.PostToolUse[0].hooks[0].command;
+  }
+
+  it("setupWorkspaceHooks writes a relative hook command (not absolute)", async () => {
+    await agent.setupWorkspaceHooks!(
+      "/Users/equinox/.worktrees/integrator/integrator-5",
+      {} as WorkspaceHooksConfig,
+    );
+
+    const hookCommand = getWrittenHookCommand();
+    expect(hookCommand).toBe(".claude/metadata-updater.sh");
+    expect(hookCommand).not.toMatch(/^\//);
+  });
+
+  it("postLaunchSetup writes a relative hook command (not absolute)", async () => {
+    await agent.postLaunchSetup!(
+      makeSession({ workspacePath: "/Users/equinox/.worktrees/integrator/integrator-10" }),
+    );
+
+    const hookCommand = getWrittenHookCommand();
+    expect(hookCommand).toBe(".claude/metadata-updater.sh");
+    expect(hookCommand).not.toMatch(/^\//);
+  });
+
+  it("different worktree paths produce identical settings.json content", async () => {
+    await agent.setupWorkspaceHooks!(
+      "/Users/equinox/.worktrees/integrator/integrator-5",
+      {} as WorkspaceHooksConfig,
+    );
+    const settingsWrite1 = mockWriteFile.mock.calls.find(
+      ([path]: unknown[]) => typeof path === "string" && path.endsWith("settings.json"),
+    );
+    const content1 = settingsWrite1![1] as string;
+
+    mockWriteFile.mockClear();
+
+    await agent.setupWorkspaceHooks!(
+      "/Users/equinox/.worktrees/integrator/integrator-10",
+      {} as WorkspaceHooksConfig,
+    );
+    const settingsWrite2 = mockWriteFile.mock.calls.find(
+      ([path]: unknown[]) => typeof path === "string" && path.endsWith("settings.json"),
+    );
+    const content2 = settingsWrite2![1] as string;
+
+    expect(content1).toBe(content2);
+  });
+
+  it("updates an existing absolute hook path to relative", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [
+                {
+                  type: "command",
+                  command:
+                    "/Users/equinox/.worktrees/integrator/integrator-5/.claude/metadata-updater.sh",
+                  timeout: 5000,
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    await agent.setupWorkspaceHooks!(
+      "/Users/equinox/.worktrees/integrator/integrator-10",
+      {} as WorkspaceHooksConfig,
+    );
+
+    const hookCommand = getWrittenHookCommand();
+    expect(hookCommand).toBe(".claude/metadata-updater.sh");
+  });
+
+  it("still writes the script file to the correct absolute filesystem path", async () => {
+    await agent.setupWorkspaceHooks!(
+      "/Users/equinox/.worktrees/integrator/integrator-5",
+      {} as WorkspaceHooksConfig,
+    );
+
+    const scriptWrite = mockWriteFile.mock.calls.find(
+      ([path]: unknown[]) => typeof path === "string" && path.endsWith("metadata-updater.sh"),
+    );
+    expect(scriptWrite).toBeDefined();
+    expect(scriptWrite![0]).toBe(
+      "/Users/equinox/.worktrees/integrator/integrator-5/.claude/metadata-updater.sh",
+    );
+  });
+
+  it("skips postLaunchSetup when workspacePath is null", async () => {
+    await agent.postLaunchSetup!(makeSession({ workspacePath: null }));
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/agent-kimi-2-6-code/src/index.ts
+++ b/packages/plugins/agent-kimi-2-6-code/src/index.ts
@@ -1,0 +1,860 @@
+import {
+  shellEscape,
+  readLastJsonlEntry,
+  normalizeAgentPermissionMode,
+  DEFAULT_READY_THRESHOLD_MS,
+  DEFAULT_ACTIVE_WINDOW_MS,
+  type Agent,
+  type AgentSessionInfo,
+  type AgentLaunchConfig,
+  type ActivityDetection,
+  type ActivityState,
+  type CostEstimate,
+  type PluginModule,
+  type ProjectConfig,
+  type RuntimeHandle,
+  type Session,
+  type WorkspaceHooksConfig,
+} from "@aoagents/ao-core";
+import { execFile, execFileSync } from "node:child_process";
+import { readdir, readFile, stat, open, writeFile, mkdir, chmod } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// =============================================================================
+// Metadata Updater Hook Script
+// =============================================================================
+
+/** Hook script content that updates session metadata on git/gh commands.
+ *  Exported for integration testing. */
+export const METADATA_UPDATER_SCRIPT = `#!/usr/bin/env bash
+# Metadata Updater Hook for Agent Orchestrator
+#
+# This PostToolUse hook automatically updates session metadata when:
+# - gh pr create: extracts PR URL and writes to metadata
+# - git checkout -b / git switch -c: extracts branch name and writes to metadata
+# - gh pr merge: updates status to "merged"
+
+set -euo pipefail
+
+# Configuration
+AO_DATA_DIR="\${AO_DATA_DIR:-$HOME/.ao-sessions}"
+
+# Read hook input from stdin
+input=$(cat)
+
+# Extract fields from JSON (using jq if available, otherwise basic parsing)
+if command -v jq &>/dev/null; then
+  tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+  command=$(echo "$input" | jq -r '.tool_input.command // empty')
+  output=$(echo "$input" | jq -r '.tool_response // empty')
+  exit_code=$(echo "$input" | jq -r '.exit_code // 0')
+else
+  # Fallback: basic JSON parsing without jq
+  tool_name=$(echo "$input" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4 || echo "")
+  command=$(echo "$input" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4 || echo "")
+  output=$(echo "$input" | grep -o '"tool_response"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4 || echo "")
+  exit_code=$(echo "$input" | grep -o '"exit_code"[[:space:]]*:[[:space:]]*[0-9]*' | grep -o '[0-9]*$' || echo "0")
+fi
+
+# Only process successful commands (exit code 0)
+if [[ "$exit_code" -ne 0 ]]; then
+  echo '{}'
+  exit 0
+fi
+
+# Only process Bash tool calls
+if [[ "$tool_name" != "Bash" ]]; then
+  echo '{}' # Empty JSON output
+  exit 0
+fi
+
+# Validate AO_SESSION is set
+if [[ -z "\${AO_SESSION:-}" ]]; then
+  echo '{"systemMessage": "AO_SESSION environment variable not set, skipping metadata update"}'
+  exit 0
+fi
+
+# Construct metadata file path
+# AO_DATA_DIR is already set to the project-specific sessions directory
+metadata_file="$AO_DATA_DIR/$AO_SESSION"
+
+# Ensure metadata file exists
+if [[ ! -f "$metadata_file" ]]; then
+  echo '{"systemMessage": "Metadata file not found: '"$metadata_file"'"}'
+  exit 0
+fi
+
+# Update a single key in metadata
+update_metadata_key() {
+  local key="$1"
+  local value="$2"
+
+  # Create temp file
+  local temp_file="\${metadata_file}.tmp"
+
+  # Escape special sed characters in value (& | / \\)
+  local escaped_value=$(echo "$value" | sed 's/[&|\\/]/\\\\&/g')
+
+  # Check if key already exists
+  if grep -q "^$key=" "$metadata_file" 2>/dev/null; then
+    # Update existing key
+    sed "s|^$key=.*|$key=$escaped_value|" "$metadata_file" > "$temp_file"
+  else
+    # Append new key
+    cp "$metadata_file" "$temp_file"
+    echo "$key=$value" >> "$temp_file"
+  fi
+
+  # Atomic replace
+  mv "$temp_file" "$metadata_file"
+}
+
+# ============================================================================
+# Command Detection and Parsing
+# ============================================================================
+
+# Strip leading directory-change prefixes so that commands like
+#   cd ~/.worktrees/project && gh pr create ...
+# are correctly detected. Agents frequently cd into a worktree first.
+# Store the regex pattern in a variable for clarity (avoids shell quoting confusion).
+# Uses space-padded (&&|;) to avoid breaking on paths containing & or ; chars.
+cd_prefix_pattern='^[[:space:]]*cd[[:space:]]+.*[[:space:]]+(&&|;)[[:space:]]+(.*)'
+clean_command="$command"
+while [[ "$clean_command" =~ ^[[:space:]]*cd[[:space:]] ]]; do
+  if [[ "$clean_command" =~ $cd_prefix_pattern ]]; then
+    clean_command="\${BASH_REMATCH[2]}"
+  else
+    break
+  fi
+done
+
+# Detect: gh pr create
+if [[ "$clean_command" =~ ^gh[[:space:]]+pr[[:space:]]+create ]]; then
+  # Extract PR URL from output
+  pr_url=$(echo "$output" | grep -Eo 'https://github[.]com/[^/]+/[^/]+/pull/[0-9]+' | head -1)
+
+  if [[ -n "$pr_url" ]]; then
+    update_metadata_key "pr" "$pr_url"
+    update_metadata_key "status" "pr_open"
+    echo '{"systemMessage": "Updated metadata: PR created at '"$pr_url"'"}'
+    exit 0
+  fi
+fi
+
+# Detect: git checkout -b <branch> or git switch -c <branch>
+if [[ "$clean_command" =~ ^git[[:space:]]+checkout[[:space:]]+-b[[:space:]]+([^[:space:]]+) ]] || \\
+   [[ "$clean_command" =~ ^git[[:space:]]+switch[[:space:]]+-c[[:space:]]+([^[:space:]]+) ]]; then
+  branch="\${BASH_REMATCH[1]}"
+
+  if [[ -n "$branch" ]]; then
+    update_metadata_key "branch" "$branch"
+    echo '{"systemMessage": "Updated metadata: branch = '"$branch"'"}'
+    exit 0
+  fi
+fi
+
+# Detect: git checkout <branch> (without -b) or git switch <branch> (without -c)
+# Only update if the branch name looks like a feature branch (contains / or -)
+if [[ "$clean_command" =~ ^git[[:space:]]+checkout[[:space:]]+([^[:space:]-]+[/-][^[:space:]]+) ]] || \\
+   [[ "$clean_command" =~ ^git[[:space:]]+switch[[:space:]]+([^[:space:]-]+[/-][^[:space:]]+) ]]; then
+  branch="\${BASH_REMATCH[1]}"
+
+  # Avoid updating for checkout of commits/tags
+  if [[ -n "$branch" && "$branch" != "HEAD" ]]; then
+    update_metadata_key "branch" "$branch"
+    echo '{"systemMessage": "Updated metadata: branch = '"$branch"'"}'
+    exit 0
+  fi
+fi
+
+# Detect: gh pr merge
+if [[ "$clean_command" =~ ^gh[[:space:]]+pr[[:space:]]+merge ]]; then
+  update_metadata_key "status" "merged"
+  echo '{"systemMessage": "Updated metadata: status = merged"}'
+  exit 0
+fi
+
+# No matching command, exit silently
+echo '{}'
+exit 0
+`;
+
+// =============================================================================
+// Plugin Manifest
+// =============================================================================
+
+export const manifest = {
+  name: "kimi-2-6-code",
+  slot: "agent" as const,
+  description: "Agent plugin: Kimi 2.6 Code CLI",
+  version: "0.1.0",
+  displayName: "Kimi 2.6 Code",
+};
+
+// =============================================================================
+// JSONL Helpers
+// =============================================================================
+
+/**
+ * Convert a workspace path to Kimi's project directory path.
+ * Kimi stores sessions at ~/.kimi/projects/{sanitized-path}/
+ *
+ * Exported for testing purposes.
+ */
+export function toKimiProjectPath(workspacePath: string): string {
+  const normalized = workspacePath.replace(/\\/g, "/");
+  const sanitized = normalized.replace(/[^a-zA-Z0-9]/g, "-");
+  return sanitized.length > 200 ? sanitized.slice(0, 200) : sanitized;
+}
+
+/** Find the most recently modified .jsonl session file in a directory */
+async function findLatestSessionFile(projectDir: string): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(projectDir);
+  } catch {
+    return null;
+  }
+
+  const jsonlFiles = entries.filter((f) => f.endsWith(".jsonl") && !f.startsWith("agent-"));
+  if (jsonlFiles.length === 0) return null;
+
+  // Sort by mtime descending
+  const withStats = await Promise.all(
+    jsonlFiles.map(async (f) => {
+      const fullPath = join(projectDir, f);
+      try {
+        const s = await stat(fullPath);
+        return { path: fullPath, mtime: s.mtimeMs };
+      } catch {
+        return { path: fullPath, mtime: 0 };
+      }
+    }),
+  );
+  withStats.sort((a, b) => b.mtime - a.mtime);
+  return withStats[0]?.path ?? null;
+}
+
+interface JsonlLine {
+  type?: string;
+  summary?: string;
+  message?: { content?: string; role?: string };
+  // Cost/usage fields
+  costUSD?: number;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+  inputTokens?: number;
+  outputTokens?: number;
+  estimatedCostUsd?: number;
+}
+
+/**
+ * Read only the last chunk of a JSONL file to extract the last entry's type
+ * and the file's modification time. This is optimized for polling — it avoids
+ * reading the entire file (which `getSessionInfo()` does for full cost/summary).
+ * Now uses the shared readLastJsonlEntry utility from @aoagents/ao-core.
+ */
+
+/**
+ * Parse only the last `maxBytes` of a JSONL file.
+ * Summaries and recent activity are always near the end, so reading the whole
+ * file (which can be 100MB+) is wasteful. For files smaller than maxBytes,
+ * readFile is used directly. For large files, only the tail is read via a
+ * file handle to avoid loading the entire file into memory.
+ */
+async function parseJsonlFileTail(filePath: string, maxBytes = 131_072): Promise<JsonlLine[]> {
+  let content: string;
+  let offset: number;
+  try {
+    const { size = 0 } = await stat(filePath);
+    offset = Math.max(0, size - maxBytes);
+    if (offset === 0) {
+      // Small file (or unknown size) — read it whole
+      content = await readFile(filePath, "utf-8");
+    } else {
+      // Large file — read only the tail via a file handle
+      const handle = await open(filePath, "r");
+      try {
+        const length = size - offset;
+        const buffer = Buffer.allocUnsafe(length);
+        await handle.read(buffer, 0, length, offset);
+        content = buffer.toString("utf-8");
+      } finally {
+        await handle.close();
+      }
+    }
+  } catch {
+    return [];
+  }
+  // Skip potentially truncated first line only when we started mid-file.
+  // If offset === 0 we read from the start so the first line is complete.
+  const firstNewline = content.indexOf("\n");
+  const safeContent = offset > 0 && firstNewline >= 0 ? content.slice(firstNewline + 1) : content;
+  const lines: JsonlLine[] = [];
+  for (const line of safeContent.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        lines.push(parsed as JsonlLine);
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+  return lines;
+}
+
+/** Extract auto-generated summary from JSONL (last "summary" type entry) */
+function extractSummary(lines: JsonlLine[]): { summary: string; isFallback: boolean } | null {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (line?.type === "summary" && line.summary) {
+      return { summary: line.summary, isFallback: false };
+    }
+  }
+  // Fallback: first user message truncated to 120 chars
+  for (const line of lines) {
+    if (
+      line?.type === "user" &&
+      line.message?.content &&
+      typeof line.message.content === "string"
+    ) {
+      const msg = line.message.content.trim();
+      if (msg.length > 0) {
+        return {
+          summary: msg.length > 120 ? msg.substring(0, 120) + "..." : msg,
+          isFallback: true,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+/** Aggregate cost estimate from JSONL usage events */
+function extractCost(lines: JsonlLine[]): CostEstimate | undefined {
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cachedReadTokens = 0;
+  let cacheCreationTokens = 0;
+  let totalCost = 0;
+
+  for (const line of lines) {
+    // Handle direct cost fields — prefer costUSD; only use estimatedCostUsd
+    // as fallback to avoid double-counting when both are present.
+    if (typeof line.costUSD === "number") {
+      totalCost += line.costUSD;
+    } else if (typeof line.estimatedCostUsd === "number") {
+      totalCost += line.estimatedCostUsd;
+    }
+    // Handle token counts — prefer the structured `usage` object when present;
+    // only fall back to flat `inputTokens`/`outputTokens` fields to avoid
+    // double-counting if a line contains both.
+    if (line.usage) {
+      inputTokens += line.usage.input_tokens ?? 0;
+      cachedReadTokens += line.usage.cache_read_input_tokens ?? 0;
+      cacheCreationTokens += line.usage.cache_creation_input_tokens ?? 0;
+      outputTokens += line.usage.output_tokens ?? 0;
+    } else {
+      if (typeof line.inputTokens === "number") {
+        inputTokens += line.inputTokens;
+      }
+      if (typeof line.outputTokens === "number") {
+        outputTokens += line.outputTokens;
+      }
+    }
+  }
+
+  if (
+    inputTokens === 0 &&
+    outputTokens === 0 &&
+    totalCost === 0 &&
+    cachedReadTokens === 0 &&
+    cacheCreationTokens === 0
+  ) {
+    return undefined;
+  }
+
+  if (totalCost === 0) {
+    totalCost =
+      (inputTokens / 1_000_000) * 3.0 +
+      (outputTokens / 1_000_000) * 15.0 +
+      (cachedReadTokens / 1_000_000) * 0.3 +
+      (cacheCreationTokens / 1_000_000) * 3.75;
+  }
+
+  return {
+    inputTokens: inputTokens + cachedReadTokens + cacheCreationTokens,
+    outputTokens,
+    estimatedCostUsd: totalCost,
+  };
+}
+
+// =============================================================================
+// Process Detection
+// =============================================================================
+
+/**
+ * TTL cache for `ps -eo pid,tty,args` output. Without this, listing N sessions
+ * would spawn N concurrent `ps` processes, each taking 30+ seconds on machines
+ * with many processes. The cache ensures `ps` is called at most once per TTL
+ * window regardless of how many sessions are being enriched.
+ */
+let psCache: { output: string; timestamp: number; promise?: Promise<string> } | null = null;
+const PS_CACHE_TTL_MS = 5_000;
+
+/** Reset the ps cache. Exported for testing only. */
+export function resetPsCache(): void {
+  psCache = null;
+}
+
+async function getCachedProcessList(): Promise<string> {
+  const now = Date.now();
+  if (psCache && now - psCache.timestamp < PS_CACHE_TTL_MS) {
+    // Cache hit — return resolved output or wait for in-flight request
+    if (psCache.promise) return psCache.promise;
+    return psCache.output;
+  }
+
+  // Cache miss or expired — start a single `ps` call and share the promise.
+  // Guard both callbacks so they only update psCache if it still belongs to
+  // this request — a newer request may have replaced it while we were waiting.
+  const promise = execFileAsync("ps", ["-eo", "pid,tty,args"], {
+    timeout: 5_000,
+  }).then(({ stdout }) => {
+    if (psCache?.promise === promise) {
+      psCache = { output: stdout, timestamp: Date.now() };
+    }
+    return stdout;
+  });
+
+  // Store the in-flight promise so concurrent callers share it
+  psCache = { output: "", timestamp: now, promise };
+
+  try {
+    return await promise;
+  } catch {
+    // On failure, clear cache so the next caller retries — but only if
+    // psCache still points to this request (avoid clobbering a newer entry)
+    if (psCache?.promise === promise) {
+      psCache = null;
+    }
+    return "";
+  }
+}
+
+/**
+ * Check if a process named "kimi-code" is running in the given runtime handle's context.
+ * Uses ps to find processes by TTY (for tmux) or by PID.
+ */
+async function findKimiProcess(handle: RuntimeHandle): Promise<number | null> {
+  try {
+    // For tmux runtime, get the pane TTY and find kimi-code on it
+    if (handle.runtimeName === "tmux" && handle.id) {
+      const { stdout: ttyOut } = await execFileAsync(
+        "tmux",
+        ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+        { timeout: 5_000 },
+      );
+      // Iterate all pane TTYs (multi-pane sessions) — succeed on any match
+      const ttys = ttyOut
+        .trim()
+        .split("\n")
+        .map((t) => t.trim())
+        .filter(Boolean);
+      if (ttys.length === 0) return null;
+
+      const psOut = await getCachedProcessList();
+      if (!psOut) return null;
+
+      const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
+      const processRe = /(?:^|\/)\.?kimi-code(?:\s|$)/;
+      for (const line of psOut.split("\n")) {
+        const cols = line.trimStart().split(/\s+/);
+        if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+        const args = cols.slice(2).join(" ");
+        if (processRe.test(args)) {
+          return parseInt(cols[0] ?? "0", 10);
+        }
+      }
+      return null;
+    }
+
+    // For process runtime, check if the PID stored in handle data is alive
+    const rawPid = handle.data["pid"];
+    const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+    if (Number.isFinite(pid) && pid > 0) {
+      try {
+        process.kill(pid, 0); // Signal 0 = check existence
+        return pid;
+      } catch (err: unknown) {
+        // EPERM means the process exists but we lack permission to signal it
+        if (err instanceof Error && "code" in err && err.code === "EPERM") {
+          return pid;
+        }
+        return null;
+      }
+    }
+
+    // No reliable way to identify the correct process for this session
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// =============================================================================
+// Terminal Output Patterns for detectActivity
+// =============================================================================
+
+/** Classify Kimi Code's activity state from terminal output (pure, sync). */
+function classifyTerminalOutput(terminalOutput: string): ActivityState {
+  // Empty output — can't determine state
+  if (!terminalOutput.trim()) return "idle";
+
+  const lines = terminalOutput.trim().split("\n");
+  const lastLine = lines[lines.length - 1]?.trim() ?? "";
+
+  // Check the last line FIRST — if the prompt is visible, the agent is idle
+  // regardless of historical output (e.g. "Reading file..." from earlier).
+  // The ❯ is Claude Code's prompt character.
+  if (/^[❯>$#]\s*$/.test(lastLine)) return "idle";
+
+  // Check the bottom of the buffer for permission prompts BEFORE checking
+  // full-buffer active indicators. Historical "Thinking"/"Reading" text in
+  // the buffer must not override a current permission prompt at the bottom.
+  const tail = lines.slice(-5).join("\n");
+  if (/Do you want to proceed\?/i.test(tail)) return "waiting_input";
+  if (/\(Y\)es.*\(N\)o/i.test(tail)) return "waiting_input";
+  if (/bypass.*permissions/i.test(tail)) return "waiting_input";
+
+  // Everything else is "active" — the agent is processing, waiting for
+  // output, or showing content. Specific patterns (e.g. "esc to interrupt",
+  // "Thinking", "Reading") all map to "active" so no need to check them
+  // individually.
+  return "active";
+}
+
+// =============================================================================
+// Hook Setup Helper
+// =============================================================================
+
+/**
+ * Shared helper to setup PostToolUse hooks in a workspace.
+ * Writes metadata-updater.sh script and updates settings.json.
+ *
+ * @param workspacePath - Path to the workspace directory
+ * @param hookCommand - Command string for the hook (can use variables like $CLAUDE_PROJECT_DIR)
+ */
+async function setupHookInWorkspace(workspacePath: string, hookCommand: string): Promise<void> {
+  const claudeDir = join(workspacePath, ".claude");
+  const settingsPath = join(claudeDir, "settings.json");
+  const hookScriptPath = join(claudeDir, "metadata-updater.sh");
+
+  // Create .claude directory if it doesn't exist
+  try {
+    await mkdir(claudeDir, { recursive: true });
+  } catch {
+    // Directory might already exist
+  }
+
+  // Write the metadata updater script
+  await writeFile(hookScriptPath, METADATA_UPDATER_SCRIPT, "utf-8");
+  await chmod(hookScriptPath, 0o755); // Make executable
+
+  // Read existing settings if present
+  let existingSettings: Record<string, unknown> = {};
+  if (existsSync(settingsPath)) {
+    try {
+      const content = await readFile(settingsPath, "utf-8");
+      existingSettings = JSON.parse(content) as Record<string, unknown>;
+    } catch {
+      // Invalid JSON or read error — start fresh
+    }
+  }
+
+  // Merge hooks configuration
+  const hooks = (existingSettings["hooks"] as Record<string, unknown>) ?? {};
+  const postToolUse = (hooks["PostToolUse"] as Array<unknown>) ?? [];
+
+  // Check if our hook is already configured
+  let hookIndex = -1;
+  let hookDefIndex = -1;
+  for (let i = 0; i < postToolUse.length; i++) {
+    const hook = postToolUse[i];
+    if (typeof hook !== "object" || hook === null || Array.isArray(hook)) continue;
+    const h = hook as Record<string, unknown>;
+    const hooksList = h["hooks"];
+    if (!Array.isArray(hooksList)) continue;
+    for (let j = 0; j < hooksList.length; j++) {
+      const hDef = hooksList[j];
+      if (typeof hDef !== "object" || hDef === null || Array.isArray(hDef)) continue;
+      const def = hDef as Record<string, unknown>;
+      if (typeof def["command"] === "string" && def["command"].includes("metadata-updater.sh")) {
+        hookIndex = i;
+        hookDefIndex = j;
+        break;
+      }
+    }
+    if (hookIndex >= 0) break;
+  }
+
+  // Add or update our hook
+  if (hookIndex === -1) {
+    // No metadata hook exists, add it
+    postToolUse.push({
+      matcher: "Bash",
+      hooks: [
+        {
+          type: "command",
+          command: hookCommand,
+          timeout: 5000,
+        },
+      ],
+    });
+  } else {
+    // Hook exists, update the command
+    const hook = postToolUse[hookIndex] as Record<string, unknown>;
+    const hooksList = hook["hooks"] as Array<Record<string, unknown>>;
+    hooksList[hookDefIndex]["command"] = hookCommand;
+  }
+
+  hooks["PostToolUse"] = postToolUse;
+  existingSettings["hooks"] = hooks;
+
+  // Write updated settings
+  await writeFile(settingsPath, JSON.stringify(existingSettings, null, 2) + "\n", "utf-8");
+}
+
+// =============================================================================
+// Agent Implementation
+// =============================================================================
+
+function createKimi26CodeAgent(): Agent {
+  return {
+    name: "kimi-2-6-code",
+    processName: "kimi-code",
+    promptDelivery: "post-launch",
+
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      // Note: CLAUDECODE is unset via getEnvironment() (set to ""), not here.
+      // This command must be safe for both shell and execFile contexts.
+      const parts: string[] = ["kimi-code"];
+
+      const permissionMode = normalizeAgentPermissionMode(config.permissions);
+      if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
+        parts.push("--dangerously-skip-permissions");
+      }
+
+      if (config.model) {
+        parts.push("--model", shellEscape(config.model));
+      }
+
+      if (config.systemPromptFile) {
+        // Use shell command substitution to read from file at launch time.
+        // This avoids tmux truncation when inlining 2000+ char prompts.
+        // The double quotes allow $() expansion; inner path is single-quoted for safety.
+        parts.push("--append-system-prompt", `"$(cat ${shellEscape(config.systemPromptFile)})"`);
+      } else if (config.systemPrompt) {
+        parts.push("--append-system-prompt", shellEscape(config.systemPrompt));
+      }
+
+      // NOTE: prompt is NOT included here — it's delivered post-launch via
+      // runtime.sendMessage() to keep Claude in interactive mode.
+      // Using -p causes one-shot mode (Claude exits after responding).
+
+      return parts.join(" ");
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      const env: Record<string, string> = {};
+
+      env["CLAUDE_CONFIG_DIR"] = join(homedir(), ".kimi");
+
+      // Unset CLAUDECODE to avoid nested agent conflicts
+      env["CLAUDECODE"] = "";
+
+      // Set session info for introspection
+      env["AO_SESSION_ID"] = config.sessionId;
+
+      // NOTE: AO_PROJECT_ID is NOT set here - it's the caller's responsibility
+      // to set it based on their metadata path scheme:
+      // - spawn.ts sets it to projectId for project-specific directories
+      // - start.ts omits it for orchestrator (flat directories)
+      // - session manager omits it (flat directories)
+
+      if (config.issueId) {
+        env["AO_ISSUE_ID"] = config.issueId;
+      }
+
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      return classifyTerminalOutput(terminalOutput);
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      const pid = await findKimiProcess(handle);
+      return pid !== null;
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
+      const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
+
+      // Check if process is running first
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (!running) return { state: "exited", timestamp: exitedAt };
+
+      // Process is running - check JSONL session file for activity
+      if (!session.workspacePath) {
+        // No workspace path — cannot determine activity without it
+        return null;
+      }
+
+      const projectPath = toKimiProjectPath(session.workspacePath);
+      const projectDir = join(homedir(), ".kimi", "projects", projectPath);
+
+      const sessionFile = await findLatestSessionFile(projectDir);
+      if (!sessionFile) {
+        // No session file yet — process is running but no conversation started.
+        // Treat as idle (waiting for first task).
+        return { state: "idle", timestamp: session.createdAt };
+      }
+
+      const entry = await readLastJsonlEntry(sessionFile);
+      if (!entry) {
+        // Empty file or read error — cannot determine activity
+        return null;
+      }
+
+      const ageMs = Date.now() - entry.modifiedAt.getTime();
+      const timestamp = entry.modifiedAt;
+
+      const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
+      switch (entry.lastType) {
+        case "user":
+        case "tool_use":
+        case "progress":
+          if (ageMs <= activeWindowMs) return { state: "active", timestamp };
+          return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+
+        case "assistant":
+        case "system":
+        case "summary":
+        case "result":
+          return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+
+        case "permission_request":
+          return { state: "waiting_input", timestamp };
+
+        case "error":
+          return { state: "blocked", timestamp };
+
+        default:
+          if (ageMs <= activeWindowMs) return { state: "active", timestamp };
+          return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+      }
+    },
+
+    async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {
+      if (!session.workspacePath) return null;
+
+      const projectPath = toKimiProjectPath(session.workspacePath);
+      const projectDir = join(homedir(), ".kimi", "projects", projectPath);
+
+      const sessionFile = await findLatestSessionFile(projectDir);
+      if (!sessionFile) return null;
+
+      const lines = await parseJsonlFileTail(sessionFile);
+      if (lines.length === 0) return null;
+
+      const agentSessionId = basename(sessionFile, ".jsonl");
+
+      const summaryResult = extractSummary(lines);
+      return {
+        summary: summaryResult?.summary ?? null,
+        summaryIsFallback: summaryResult?.isFallback,
+        agentSessionId,
+        cost: extractCost(lines),
+      };
+    },
+
+    async getRestoreCommand(session: Session, project: ProjectConfig): Promise<string | null> {
+      if (!session.workspacePath) return null;
+
+      const projectPath = toKimiProjectPath(session.workspacePath);
+      const projectDir = join(homedir(), ".kimi", "projects", projectPath);
+
+      const sessionFile = await findLatestSessionFile(projectDir);
+      if (!sessionFile) return null;
+
+      const sessionUuid = basename(sessionFile, ".jsonl");
+      if (!sessionUuid) return null;
+
+      const parts: string[] = ["kimi-code", "--resume", shellEscape(sessionUuid)];
+
+      const permissionMode = normalizeAgentPermissionMode(project.agentConfig?.permissions);
+      const isOrchestrator = session.metadata?.["role"] === "orchestrator";
+      if (
+        isOrchestrator &&
+        (permissionMode === "permissionless" || permissionMode === "auto-edit")
+      ) {
+        parts.push("--dangerously-skip-permissions");
+      }
+
+      if (project.agentConfig?.model) {
+        parts.push("--model", shellEscape(project.agentConfig.model as string));
+      }
+
+      return parts.join(" ");
+    },
+
+    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+      // Relative path so that symlinked .claude/ dirs across worktrees
+      // all produce the same settings.json (last writer doesn't clobber).
+      await setupHookInWorkspace(workspacePath, ".claude/metadata-updater.sh");
+    },
+
+    async postLaunchSetup(session: Session): Promise<void> {
+      if (!session.workspacePath) return;
+
+      await setupHookInWorkspace(session.workspacePath, ".claude/metadata-updater.sh");
+    },
+  };
+}
+
+// =============================================================================
+// Plugin Export
+// =============================================================================
+
+export function create(): Agent {
+  return createKimi26CodeAgent();
+}
+
+export function detect(): boolean {
+  try {
+    execFileSync("kimi-code", ["--help"], { stdio: "ignore", timeout: 3_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-kimi-2-6-code/tsconfig.json
+++ b/packages/plugins/agent-kimi-2-6-code/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@aoagents/ao-plugin-agent-cursor':
         specifier: workspace:*
         version: link:../plugins/agent-cursor
+      '@aoagents/ao-plugin-agent-kimi-2-6-code':
+        specifier: workspace:*
+        version: link:../plugins/agent-kimi-2-6-code
       '@aoagents/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
@@ -298,6 +301,22 @@ importers:
         version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/plugins/agent-cursor:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/plugins/agent-kimi-2-6-code:
     dependencies:
       '@aoagents/ao-core':
         specifier: workspace:*


### PR DESCRIPTION
Adds a new built-in kimi-2-6-code agent plugin by copying the existing Claude Code plugin.

Also wires the plugin into CLI/core registration and adds matching tests so Kimi is available as a standard AO agent runtime.

closes #1393 
