### PR TITLE
fix: setup workspace hooks before launching agent to prevent trust prompt

### DIFF
--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1297,6 +1297,33 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       subagent: spawnConfig.subagent ?? selection.subagent,
     };
 
+    // Setup agent hooks BEFORE launching the runtime so the workspace is
+    // trusted (e.g. .claude/settings.json exists) when the agent process starts.
+    // Without this, Claude Code shows a trust prompt and blocks.
+    try {
+      if (plugins.agent.setupWorkspaceHooks) {
+        await plugins.agent.setupWorkspaceHooks(workspacePath, { dataDir: sessionsDir });
+      }
+    } catch (err) {
+      // Clean up workspace and metadata on hook setup failure
+      if (
+        plugins.workspace &&
+        shouldDestroyWorkspacePath(project, spawnConfig.projectId, workspacePath)
+      ) {
+        try {
+          await plugins.workspace.destroy(workspacePath);
+        } catch {
+          /* best effort */
+        }
+      }
+      try {
+        deleteMetadata(sessionsDir, sessionId, false);
+      } catch {
+        /* best effort */
+      }
+      throw err;
+    }
+
     let handle: RuntimeHandle;
     try {
       const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);
@@ -1571,16 +1598,6 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     };
 
-    // Setup agent hooks for automatic metadata updates
-    try {
-      if (plugins.agent.setupWorkspaceHooks) {
-        await plugins.agent.setupWorkspaceHooks(workspacePath, { dataDir: sessionsDir });
-      }
-    } catch (err) {
-      await cleanupWorktreeAndMetadata();
-      throw err;
-    }
-
     // Write system prompt to a file to avoid shell/tmux truncation.
     // Long prompts (2000+ chars) get mangled when inlined in shell commands
     // via tmux send-keys or paste-buffer. File-based approach is reliable.
@@ -1649,6 +1666,18 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);
     const environment = plugins.agent.getEnvironment(agentLaunchConfig);
+
+    // Setup agent hooks BEFORE launching the runtime so the workspace is
+    // trusted (e.g. .claude/settings.json exists) when the agent process starts.
+    // Without this, Claude Code shows a trust prompt and blocks.
+    try {
+      if (plugins.agent.setupWorkspaceHooks) {
+        await plugins.agent.setupWorkspaceHooks(workspacePath, { dataDir: sessionsDir });
+      }
+    } catch (err) {
+      await cleanupWorktreeAndMetadata(systemPromptFile);
+      throw err;
+    }
 
     // Create runtime — clean up worktree and metadata on failure
     let handle: RuntimeHandle;


### PR DESCRIPTION
## Summary

- Moved `setupWorkspaceHooks` call before `runtime.create()` in both `spawnSession` and `spawnOrchestrator` flows
- Without this, Claude Code shows an interactive trust prompt in fresh worktrees and the agent never receives its task prompt, causing workers to idle and die

## Root Cause

Claude Code displays "Is this a project you trust?" on first launch in an untrusted directory. The spawn flow was:
1. Launch agent in tmux (triggers trust prompt)
2. Create `.claude/settings.json` via `setupWorkspaceHooks` (too late)

The agent sat at the trust prompt indefinitely, never reaching the task prompt. ~80% of spawns failed (4 out of 5 consecutive attempts).

## Fix

Reorder so `setupWorkspaceHooks` runs **before** `runtime.create()`:
1. Create `.claude/settings.json` (marks workspace as trusted)
2. Launch agent in tmux (skips trust prompt)
3. Deliver task prompt

## Test plan

- [x] `pnpm --filter @aoagents/ao-core typecheck` passes
- [x] `pnpm --filter @aoagents/ao-core test` — 801/801 pass
- [x] `pnpm build` passes
- [ ] Spawn a new worker session and verify it starts working immediately
- [ ] Verify no regression in orchestrator session spawning

Closes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)