### PR TITLE
Move orchestrator uniqueness into core

### DIFF
--- a/.changeset/canonical-orchestrator-migration.md
+++ b/.changeset/canonical-orchestrator-migration.md
@@ -1,0 +1,12 @@
+"@aoagents/ao-core": patch
+"@aoagents/ao-cli": patch
+"@aoagents/ao-web": patch
+---
+
+Move orchestrator uniqueness into core and begin the migration to a canonical per-project orchestrator session.
+
+- add `ensureOrchestrator()` in core so orchestrator create/reuse/restore behavior is owned by one deterministic code path
+- make fresh projects create a canonical `{sessionPrefix}-orchestrator` session without allocating an orchestrator worktree
+- keep backward compatibility with historical numbered orchestrators like `{sessionPrefix}-orchestrator-1` during the migration window
+- switch CLI and web callers to the core ensure path, including migration-safe stop behavior for legacy orchestrators
+- harden web orchestrator/session flows with safer event-stream cleanup, explicit session-detail error states, and restore UX fixes

--- a/.changeset/canonical-orchestrator-migration.md
+++ b/.changeset/canonical-orchestrator-migration.md
@@ -1,6 +1,6 @@
-"@aoagents/ao-core": patch
-"@aoagents/ao-cli": patch
-"@aoagents/ao-web": patch
+"@aoagents/ao-core": minor
+"@aoagents/ao-cli": minor
+"@aoagents/ao-web": minor
 ---
 
 Move orchestrator uniqueness into core with a single canonical per-project orchestrator session.
@@ -10,3 +10,9 @@ Move orchestrator uniqueness into core with a single canonical per-project orche
 - remove support for historical numbered orchestrators so callers only operate on the canonical session id
 - switch CLI and web callers to the core ensure path and canonical orchestrator id
 - harden web orchestrator/session flows with safer event-stream cleanup, explicit session-detail error states, and restore UX fixes
+
+If you still have legacy numbered orchestrators like `{sessionPrefix}-orchestrator-1`, clean them up after upgrading:
+
+- run `ao session ls -p <project>`
+- kill any legacy numbered orchestrator sessions with `ao session kill <session-id>`
+- restart with `ao stop && ao start` so AO recreates or reuses the canonical `{sessionPrefix}-orchestrator` session

--- a/.changeset/canonical-orchestrator-migration.md
+++ b/.changeset/canonical-orchestrator-migration.md
@@ -3,10 +3,10 @@
 "@aoagents/ao-web": patch
 ---
 
-Move orchestrator uniqueness into core and begin the migration to a canonical per-project orchestrator session.
+Move orchestrator uniqueness into core with a single canonical per-project orchestrator session.
 
 - add `ensureOrchestrator()` in core so orchestrator create/reuse/restore behavior is owned by one deterministic code path
 - make fresh projects create a canonical `{sessionPrefix}-orchestrator` session without allocating an orchestrator worktree
-- keep backward compatibility with historical numbered orchestrators like `{sessionPrefix}-orchestrator-1` during the migration window
-- switch CLI and web callers to the core ensure path, including migration-safe stop behavior for legacy orchestrators
+- remove support for historical numbered orchestrators so callers only operate on the canonical session id
+- switch CLI and web callers to the core ensure path and canonical orchestrator id
 - harden web orchestrator/session flows with safer event-stream cleanup, explicit session-detail error states, and restore UX fixes

--- a/SETUP.md
+++ b/SETUP.md
@@ -826,7 +826,7 @@ Yes! Each orchestrator instance should have:
 
 AO derives runtime directories from the config location, so separate config locations already produce separate hash-scoped runtime paths under `~/.agent-orchestrator/`. Terminal WebSocket ports are auto-detected by default, so you typically only need to set `port:` differently. If you need explicit control, you can also set `terminalPort:` and `directTerminalPort:` per config.
 
-Orchestrator IDs are now deterministic per project: new projects create `{sessionPrefix}-orchestrator`. During the migration window, AO still tolerates and reuses historical numbered orchestrators like `{sessionPrefix}-orchestrator-1` when they already exist, instead of creating duplicates.
+Orchestrator IDs are deterministic per project: AO uses exactly one orchestrator session per project, named `{sessionPrefix}-orchestrator`.
 
 Useful for:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -826,6 +826,8 @@ Yes! Each orchestrator instance should have:
 
 AO derives runtime directories from the config location, so separate config locations already produce separate hash-scoped runtime paths under `~/.agent-orchestrator/`. Terminal WebSocket ports are auto-detected by default, so you typically only need to set `port:` differently. If you need explicit control, you can also set `terminalPort:` and `directTerminalPort:` per config.
 
+Orchestrator IDs are now deterministic per project: new projects create `{sessionPrefix}-orchestrator`. During the migration window, AO still tolerates and reuses historical numbered orchestrators like `{sessionPrefix}-orchestrator-1` when they already exist, instead of creating duplicates.
+
 Useful for:
 
 - Separating projects

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -108,6 +108,8 @@ cd packages/web && pnpm dev
 # Open http://localhost:3000
 ```
 
+When dogfooding the CLI from this checkout with `pnpm exec ao ...`, rebuild `@aoagents/ao-core` and `@aoagents/ao-cli` first if you changed session-manager or CLI code. The launcher runs compiled `dist` output, so stale builds can make local smoke tests exercise old orchestrator behavior even when `src/` is already updated.
+
 ### Project structure
 
 ```
@@ -172,6 +174,8 @@ ao update
 `ao update` is intentionally conservative: it fast-forwards the local install checkout from `origin/main`, runs `pnpm install`, clean-rebuilds `@aoagents/ao-core`, `@aoagents/ao-cli`, and `@aoagents/ao-web`, refreshes the global launcher with `npm link`, and ends with CLI smoke tests. Use `ao update --skip-smoke` to stop after the rebuild, or `ao update --smoke-only` to rerun the smoke checks without fetching or rebuilding.
 
 If your branch has drift from `main`, update the install checkout first and then return to your feature worktree. That keeps CLI behavior and generated docs aligned with the version contributors are expected to run.
+
+This matters for orchestrator dogfooding in particular: fresh project identities now create a canonical `{sessionPrefix}-orchestrator` session, while older projects may still reuse historical numbered orchestrators such as `{sessionPrefix}-orchestrator-1` during the migration window.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -175,7 +175,7 @@ ao update
 
 If your branch has drift from `main`, update the install checkout first and then return to your feature worktree. That keeps CLI behavior and generated docs aligned with the version contributors are expected to run.
 
-This matters for orchestrator dogfooding in particular: fresh project identities now create a canonical `{sessionPrefix}-orchestrator` session, while older projects may still reuse historical numbered orchestrators such as `{sessionPrefix}-orchestrator-1` during the migration window.
+This matters for orchestrator dogfooding in particular: the canonical orchestrator session is always `{sessionPrefix}-orchestrator`.
 
 ---
 

--- a/packages/cli/__tests__/commands/session.test.ts
+++ b/packages/cli/__tests__/commands/session.test.ts
@@ -393,7 +393,7 @@ describe("session ls", () => {
     expect(parsed.meta.hiddenTerminatedCount).toBe(1);
   });
 
-  it("marks metadata-based orchestrators correctly in JSON output", async () => {
+  it("does not mark legacy sessions as orchestrators from metadata alone in JSON output", async () => {
     writeFileSync(
       join(sessionsDir, "app-control"),
       "branch=control\nstatus=working\nrole=orchestrator\n",
@@ -411,7 +411,7 @@ describe("session ls", () => {
           id: "app-control",
           projectId: "my-app",
           projectName: "My App",
-          role: "orchestrator",
+          role: "worker",
           branch: "control",
           status: "working",
           issueId: null,

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -35,6 +35,7 @@ const {
     cleanup: vi.fn(),
     get: vi.fn(),
     spawn: vi.fn(),
+    ensureOrchestrator: vi.fn(),
     spawnOrchestrator: vi.fn(),
     send: vi.fn(),
     claimPR: vi.fn(),
@@ -112,7 +113,11 @@ vi.mock("@aoagents/ao-core", async (importOriginal) => {
 });
 
 vi.mock("../../src/lib/create-session-manager.js", () => ({
-  getSessionManager: async (): Promise<SessionManager> => mockSessionManager as SessionManager,
+  getSessionManager: async (): Promise<SessionManager> =>
+    ({
+      ...mockSessionManager,
+      ensureOrchestrator: mockSessionManager.ensureOrchestrator,
+    }) as SessionManager,
 }));
 
 vi.mock("../../src/lib/lifecycle-service.js", () => ({
@@ -257,6 +262,8 @@ beforeEach(async () => {
   mockSessionManager.restore.mockReset();
   mockSessionManager.restore.mockResolvedValue({ id: "app-orchestrator-restored" });
   mockSessionManager.get.mockReset();
+  mockSessionManager.ensureOrchestrator.mockReset();
+  mockSessionManager.ensureOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
   mockSessionManager.spawnOrchestrator.mockReset();
   mockSessionManager.kill.mockReset();
   mockExec.mockReset();
@@ -814,11 +821,8 @@ describe("start command — browser open waits for port", () => {
     vi.mocked(findWebDir).mockReturnValue(tmpDir);
     writeFileSync(join(tmpDir, "package.json"), "{}");
 
-    // No existing orchestrators on disk → spawnOrchestrator runs and returns
-    // a numbered id which must end up in the auto-opened browser URL.
-    mockSessionManager.list.mockResolvedValue([]);
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({
-      id: "app-orchestrator-1",
+    mockSessionManager.ensureOrchestrator.mockResolvedValue({
+      id: "app-orchestrator",
       projectId: "my-app",
       status: "working",
       activity: "active",
@@ -830,7 +834,7 @@ describe("start command — browser open waits for port", () => {
     // waitForPortAndOpen should have been called with orchestrator URL and AbortSignal
     expect(mockWaitForPortAndOpen).toHaveBeenCalledTimes(1);
     const args = mockWaitForPortAndOpen.mock.calls[0];
-    expect(args[1]).toContain("/projects/my-app/sessions/app-orchestrator-1");
+    expect(args[1]).toContain("/projects/my-app/sessions/app-orchestrator");
     expect(args[2]).toBeInstanceOf(AbortSignal);
     expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
       expect.objectContaining({ configPath: expect.any(String) }),
@@ -850,8 +854,7 @@ describe("start command — browser open waits for port", () => {
   it("skips browser open but still starts lifecycle with --no-dashboard alone", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
-    mockSessionManager.get.mockResolvedValue(null);
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
+    mockSessionManager.ensureOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
 
     await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
 
@@ -863,7 +866,7 @@ describe("start command — browser open waits for port", () => {
   });
 });
 
-describe("start command — orchestrator session strategy display", () => {
+describe("start command — canonical orchestrator startup", () => {
   function getLoggedOutput(): string {
     return vi
       .mocked(console.log)
@@ -871,195 +874,20 @@ describe("start command — orchestrator session strategy display", () => {
       .join("\n");
   }
 
-  it("shows reused messaging when strategy is reuse and metadata marks the session reused", async () => {
-    mockConfigRef.current = makeConfig({
-      "my-app": makeProject({ orchestratorSessionStrategy: "reuse" }),
-    });
-
-    mockSessionManager.get.mockResolvedValue({
-      id: "app-orchestrator",
-      runtimeHandle: { id: "tmux-session-1" },
-    });
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({
-      id: "app-orchestrator",
-      runtimeHandle: { id: "tmux-session-1" },
-      metadata: { orchestratorSessionReused: "true" },
-    });
-
-    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
-
-    const output = getLoggedOutput();
-    expect(output).toContain("reused existing session (app-orchestrator)");
-    expect(output).not.toContain("tmux attach -t tmux-session-1");
-  });
-
-  it("falls back to attach messaging when strategy is reuse but metadata is missing", async () => {
-    mockConfigRef.current = makeConfig({
-      "my-app": makeProject({ orchestratorSessionStrategy: "reuse" }),
-    });
-
-    mockSessionManager.get.mockResolvedValue({
-      id: "app-orchestrator",
-      runtimeHandle: { id: "tmux-session-1" },
-    });
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({
-      id: "app-orchestrator",
-      runtimeHandle: { id: "tmux-session-1" },
-    });
-
-    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
-
-    const output = getLoggedOutput();
-    expect(output).toContain("ao session attach app-orchestrator");
-    expect(output).not.toContain("reused existing session");
-  });
-
-  it.each(["delete", "ignore", "delete-new", "ignore-new", "kill-previous"] as const)(
-    "uses ao session attach when strategy is %s and --no-dashboard",
-    async (orchestratorSessionStrategy) => {
-      mockConfigRef.current = makeConfig({
-        "my-app": makeProject({ orchestratorSessionStrategy }),
-      });
-
-      mockSessionManager.get.mockResolvedValue({
-        id: "app-orchestrator",
-        runtimeHandle: { id: "tmux-session-1" },
-      });
-      mockSessionManager.spawnOrchestrator.mockResolvedValue({
-        id: "app-orchestrator",
-        runtimeHandle: { id: "tmux-session-1" },
-        metadata: { orchestratorSessionReused: "true" },
-      });
-
-      await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
-
-      const output = getLoggedOutput();
-      expect(output).toContain("ao session attach app-orchestrator");
-      expect(output).not.toContain("reused existing session");
-    },
-  );
-
-  it("handles existing orchestrator sessions by auto-selecting when --no-dashboard", async () => {
+  it("prints the direct attach target when dashboard is disabled", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-
-    // Return an existing orchestrator session
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator",
-        projectId: "my-app",
-        status: "working",
-        activity: "active",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(),
-        runtimeHandle: { id: "tmux-session-existing" },
-      },
-    ]);
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({
-      id: "app-orchestrator-2",
-      runtimeHandle: { id: "tmux-session-new" },
-    });
+    mockSessionManager.ensureOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
 
     await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
 
     const output = getLoggedOutput();
-    expect(mockSessionManager.kill).not.toHaveBeenCalled();
-    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+    expect(mockSessionManager.ensureOrchestrator).toHaveBeenCalledTimes(1);
     expect(output).toContain("ao session attach app-orchestrator");
   });
 
-  it("restores the latest restorable orchestrator when tmux is gone", async () => {
-    mockConfigRef.current = makeConfig({
-      "my-app": makeProject({ orchestratorSessionStrategy: "reuse" }),
-    });
-
-    const now = new Date();
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator-1",
-        projectId: "my-app",
-        status: "killed",
-        activity: "exited",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(now.getTime() - 1000),
-        lifecycle: {
-          version: 2,
-          session: {
-            kind: "orchestrator",
-            state: "working",
-            reason: "task_in_progress",
-            startedAt: now.toISOString(),
-            completedAt: null,
-            terminatedAt: null,
-            lastTransitionAt: now.toISOString(),
-          },
-          pr: {
-            state: "none",
-            reason: "not_created",
-            number: null,
-            url: null,
-            lastObservedAt: null,
-          },
-          runtime: {
-            state: "missing",
-            reason: "tmux_missing",
-            lastObservedAt: now.toISOString(),
-            handle: null,
-            tmuxName: "tmux-old-1",
-          },
-        },
-      },
-      {
-        id: "app-orchestrator-2",
-        projectId: "my-app",
-        status: "killed",
-        activity: "exited",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: now,
-        lifecycle: {
-          version: 2,
-          session: {
-            kind: "orchestrator",
-            state: "working",
-            reason: "task_in_progress",
-            startedAt: now.toISOString(),
-            completedAt: null,
-            terminatedAt: null,
-            lastTransitionAt: now.toISOString(),
-          },
-          pr: {
-            state: "none",
-            reason: "not_created",
-            number: null,
-            url: null,
-            lastObservedAt: null,
-          },
-          runtime: {
-            state: "missing",
-            reason: "tmux_missing",
-            lastObservedAt: now.toISOString(),
-            handle: null,
-            tmuxName: "tmux-old-2",
-          },
-        },
-      },
-    ]);
-    mockSessionManager.restore.mockResolvedValue({
-      id: "app-orchestrator-2",
-      runtimeHandle: { id: "tmux-restored-2" },
-    });
-
-    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
-
-    const output = getLoggedOutput();
-    expect(output).toContain("ao session attach app-orchestrator-2");
-    expect(mockSessionManager.restore).toHaveBeenCalledWith("app-orchestrator-2");
-    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
-  });
-
-  it("navigates directly to session page when one existing orchestrator found with dashboard enabled", async () => {
+  it("navigates directly to the canonical session page when dashboard is enabled", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
-    // Mock findWebDir and port availability for dashboard-enabled test
     const webDir = await import("../../src/lib/web-dir.js");
     vi.mocked(webDir.findWebDir).mockReturnValue(tmpDir);
     vi.mocked(webDir.isPortAvailable).mockResolvedValue(true);
@@ -1072,251 +900,13 @@ describe("start command — orchestrator session strategy display", () => {
     };
     mockSpawn.mockReturnValue(fakeDashboard);
 
-    // Return a single existing orchestrator session
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator",
-        projectId: "my-app",
-        status: "working",
-        activity: "active",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(),
-        runtimeHandle: { id: "tmux-session-existing" },
-      },
-    ]);
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({
-      id: "app-orchestrator-2",
-      runtimeHandle: { id: "tmux-session-new" },
-    });
+    mockSessionManager.ensureOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
 
     await program.parseAsync(["node", "test", "start"]);
 
     const output = getLoggedOutput();
-    expect(mockSessionManager.kill).not.toHaveBeenCalled();
-    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
     expect(output).toContain("http://localhost:3000/projects/my-app/sessions/app-orchestrator");
     expect(output).not.toContain("tmux attach");
-  });
-
-  it("opens orchestrator selection page when multiple existing orchestrators found with dashboard enabled and reuse is explicit", async () => {
-    mockConfigRef.current = makeConfig({
-      "my-app": makeProject({ orchestratorSessionStrategy: "reuse" }),
-    });
-
-    // Mock findWebDir
-    const { findWebDir } = await import("../../src/lib/web-dir.js");
-    vi.mocked(findWebDir).mockReturnValue(tmpDir);
-    writeFileSync(join(tmpDir, "package.json"), "{}");
-
-    const fakeDashboard = {
-      on: vi.fn(),
-      kill: vi.fn(),
-      emit: vi.fn(),
-    };
-    mockSpawn.mockReturnValue(fakeDashboard);
-
-    const now = new Date();
-    // Return two existing orchestrator sessions
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator-1",
-        projectId: "my-app",
-        status: "working",
-        activity: "active",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(now.getTime() - 1000),
-        runtimeHandle: { id: "tmux-session-1" },
-      },
-      {
-        id: "app-orchestrator-2",
-        projectId: "my-app",
-        status: "working",
-        activity: "active",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: now,
-        runtimeHandle: { id: "tmux-session-2" },
-      },
-    ]);
-
-    await program.parseAsync(["node", "test", "start"]);
-
-    const output = getLoggedOutput();
-    // With multiple orchestrators, the CLI auto-selects the most recent and tells the user
-    // how many other sessions are available so they can pick a different one in the dashboard.
-    expect(output).toContain("/projects/my-app/sessions/app-orchestrator-2");
-    expect(output).toContain("1 other session(s) available");
-
-    // The browser auto-open should land on the dashboard's orchestrator-selection page
-    // (not a direct session URL) so the user can pick a different one if desired.
-    expect(mockWaitForPortAndOpen).toHaveBeenCalledTimes(1);
-    const args = mockWaitForPortAndOpen.mock.calls[0];
-    expect(args[1]).toContain("/orchestrators?project=my-app");
-
-    // Should NOT spawn a new orchestrator when existing ones exist
-    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
-  });
-
-  // ----- Issue #1048: stable orchestrator reuse -----------------------------
-  // The next block of tests pins down the new lookup contract that runStartup
-  // must follow when deciding whether to reuse, restore, or spawn fresh.
-
-  it("restores the most-recently-active killed orchestrator instead of spawning", async () => {
-    mockConfigRef.current = makeConfig({
-      "my-app": makeProject({ orchestratorSessionStrategy: "reuse" }),
-    });
-
-    // Only orchestrator on disk is killed (its tmux pane was destroyed) but
-    // still restorable — runStartup must call sm.restore() and reuse its id.
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator-3",
-        projectId: "my-app",
-        status: "killed",
-        activity: "exited",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(),
-        runtimeHandle: { id: "tmux-session-3" },
-      },
-    ]);
-    mockSessionManager.restore.mockResolvedValue({
-      id: "app-orchestrator-3",
-      projectId: "my-app",
-      status: "spawning",
-      activity: "active",
-      metadata: { role: "orchestrator" },
-      lastActivityAt: new Date(),
-      runtimeHandle: { id: "tmux-session-3" },
-    });
-
-    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
-
-    expect(mockSessionManager.restore).toHaveBeenCalledWith("app-orchestrator-3");
-    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
-
-    const output = getLoggedOutput();
-    // Restored id is preserved (no fresh -N allocation) and the user sees an
-    // explicit "(restored)" marker so the resurfaced id isn't a surprise.
-    expect(output).toContain("ao session attach app-orchestrator-3");
-    expect(output).toContain("(restored)");
-  });
-
-  it("ignores stale bare {projectId}-orchestrator records that lack role metadata", async () => {
-    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-
-    // Legacy bare-named record from a pre-numbered AO version with no role
-    // metadata — must NOT be treated as an orchestrator, so spawnOrchestrator
-    // still gets called and the user gets a fresh numbered id.
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "my-app-orchestrator",
-        projectId: "my-app",
-        status: "working",
-        activity: "active",
-        metadata: {},
-        lastActivityAt: new Date(),
-        runtimeHandle: null,
-      },
-    ]);
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({
-      id: "app-orchestrator-1",
-      projectId: "my-app",
-      status: "working",
-      activity: "active",
-      metadata: { role: "orchestrator" },
-    });
-
-    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
-
-    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledTimes(1);
-    expect(mockSessionManager.restore).not.toHaveBeenCalled();
-
-    const output = getLoggedOutput();
-    expect(output).toContain("ao session attach app-orchestrator-1");
-    expect(output).not.toContain("/sessions/my-app-orchestrator");
-  });
-
-  it("prefers a live orchestrator over a more-recently-active restorable one", async () => {
-    // Regression guard for PR #1075 review comment: an earlier version of
-    // runStartup merged live + restorable into one bucket and sorted by
-    // lastActivityAt, which could pick a newer *killed* record over an older
-    // but still-running one. sm.restore() would then spin up the killed
-    // record while the live one kept running, leaving two orchestrators
-    // alive. The fix prefers live unconditionally.
-    mockConfigRef.current = makeConfig({
-      "my-app": makeProject({ orchestratorSessionStrategy: "reuse" }),
-    });
-
-    const now = Date.now();
-    mockSessionManager.list.mockResolvedValue([
-      // Live but older — this is the one we must pick.
-      {
-        id: "app-orchestrator-2",
-        projectId: "my-app",
-        status: "working",
-        activity: "active",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(now - 60_000),
-        runtimeHandle: { id: "tmux-2" },
-      },
-      // Killed but newer — the old buggy sort would have picked this one.
-      {
-        id: "app-orchestrator-3",
-        projectId: "my-app",
-        status: "killed",
-        activity: "exited",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(now),
-        runtimeHandle: { id: "tmux-3" },
-      },
-    ]);
-
-    await program.parseAsync(["node", "test", "start"]);
-
-    // The live -2 is reused in place; the killed -3 is NOT restored.
-    expect(mockSessionManager.restore).not.toHaveBeenCalled();
-    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
-
-    const output = getLoggedOutput();
-    expect(output).toContain("/projects/my-app/sessions/app-orchestrator-2");
-    expect(output).not.toContain("/projects/my-app/sessions/app-orchestrator-3");
-  });
-
-  it("reuses the most-recently-active live orchestrator when multiple are running", async () => {
-    mockConfigRef.current = makeConfig({
-      "my-app": makeProject({ orchestratorSessionStrategy: "reuse" }),
-    });
-
-    const now = Date.now();
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator-1",
-        projectId: "my-app",
-        status: "working",
-        activity: "active",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(now - 30_000),
-        runtimeHandle: { id: "tmux-1" },
-      },
-      {
-        id: "app-orchestrator-2",
-        projectId: "my-app",
-        status: "working",
-        activity: "active",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(now),
-        runtimeHandle: { id: "tmux-2" },
-      },
-    ]);
-
-    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
-
-    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
-    expect(mockSessionManager.restore).not.toHaveBeenCalled();
-
-    const output = getLoggedOutput();
-    // The newer one (-2) is auto-selected for attach.
-    expect(output).toContain("ao session attach app-orchestrator-2");
-    expect(output).toContain("1 other session(s) available");
   });
 
   it("fails and cleans up dashboard when orchestrator setup throws", async () => {
@@ -1334,8 +924,7 @@ describe("start command — orchestrator session strategy display", () => {
     };
     mockSpawn.mockReturnValue(fakeDashboard);
 
-    mockSessionManager.list.mockResolvedValue([]);
-    mockSessionManager.spawnOrchestrator.mockRejectedValue(new Error("Spawn failed"));
+    mockSessionManager.ensureOrchestrator.mockRejectedValue(new Error("Spawn failed"));
 
     await expect(program.parseAsync(["node", "test", "start"])).rejects.toThrow("process.exit(1)");
 
@@ -1369,53 +958,11 @@ describe("start command — orchestrator session strategy display", () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
     const releaseStartupLock = vi.fn();
     mockAcquireStartupLock.mockResolvedValueOnce(releaseStartupLock);
-    mockSessionManager.list.mockResolvedValue([]);
-    mockSessionManager.spawnOrchestrator.mockRejectedValue(new Error("Spawn failed"));
+    mockSessionManager.ensureOrchestrator.mockRejectedValue(new Error("Spawn failed"));
 
     await expect(program.parseAsync(["node", "test", "start"])).rejects.toThrow("process.exit(1)");
 
     expect(releaseStartupLock).toHaveBeenCalledTimes(1);
-  });
-
-  it("fails and cleans up dashboard when sm.restore throws on a killed orchestrator", async () => {
-    mockConfigRef.current = makeConfig({
-      "my-app": makeProject({ orchestratorSessionStrategy: "reuse" }),
-    });
-
-    const { findWebDir } = await import("../../src/lib/web-dir.js");
-    vi.mocked(findWebDir).mockReturnValue(tmpDir);
-    writeFileSync(join(tmpDir, "package.json"), "{}");
-
-    const fakeDashboard = { on: vi.fn(), kill: vi.fn(), emit: vi.fn() };
-    mockSpawn.mockReturnValue(fakeDashboard);
-
-    // Only candidate is restorable. sm.restore throws — runStartup must
-    // surface the error, kill the dashboard, and never fall through to
-    // spawnOrchestrator (which would silently allocate a fresh -N).
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator-3",
-        projectId: "my-app",
-        status: "killed",
-        activity: "exited",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(),
-        runtimeHandle: { id: "tmux-3" },
-      },
-    ]);
-    mockSessionManager.restore.mockRejectedValue(new Error("workspace gone"));
-
-    await expect(program.parseAsync(["node", "test", "start"])).rejects.toThrow("process.exit(1)");
-
-    const errors = vi
-      .mocked(console.error)
-      .mock.calls.map((c) => c.join(" "))
-      .join("\n");
-    expect(errors).toContain("Failed to restore orchestrator session app-orchestrator-3");
-    expect(errors).toContain("workspace gone");
-
-    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
-    expect(fakeDashboard.kill).toHaveBeenCalled();
   });
 
   it("opens the bare dashboard URL when --no-orchestrator skips the orchestrator block", async () => {
@@ -1433,7 +980,7 @@ describe("start command — orchestrator session strategy display", () => {
     const args = mockWaitForPortAndOpen.mock.calls[0];
     expect(args[1]).toBe("http://localhost:3000");
     expect(args[1]).not.toContain("/sessions/");
-    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+    expect(mockSessionManager.ensureOrchestrator).not.toHaveBeenCalled();
   });
 });
 
@@ -1455,27 +1002,14 @@ describe("stop command", () => {
     });
   }
 
-  it("stops the actual numbered orchestrator session and dashboard", async () => {
+  it("stops the canonical orchestrator session and dashboard", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-    // Issue #1048: ao stop must look up the real numbered orchestrator id
-    // (e.g. app-orchestrator-3) via sm.list — never the phantom `${prefix}-orchestrator`.
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator-3",
-        projectId: "my-app",
-        status: "working",
-        activity: "active",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(),
-        runtimeHandle: { id: "tmux-3" },
-      },
-    ]);
     mockSessionManager.kill.mockResolvedValue(undefined);
     mockDashboardOnPort(3000);
 
     await program.parseAsync(["node", "test", "stop"]);
 
-    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-3", {
+    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator", {
       purgeOpenCode: false,
     });
     const output = vi
@@ -1483,49 +1017,20 @@ describe("stop command", () => {
       .mock.calls.map((c) => c.join(" "))
       .join("\n");
     expect(output).toContain("Orchestrator stopped");
-    expect(output).toContain("app-orchestrator-3");
-  });
-
-  it("kills the most-recently-active orchestrator when multiple exist", async () => {
-    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-    const now = Date.now();
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator-1",
-        projectId: "my-app",
-        status: "working",
-        activity: "active",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(now - 10_000),
-        runtimeHandle: { id: "tmux-1" },
-      },
-      {
-        id: "app-orchestrator-2",
-        projectId: "my-app",
-        status: "working",
-        activity: "active",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(now),
-        runtimeHandle: { id: "tmux-2" },
-      },
-    ]);
-    mockSessionManager.kill.mockResolvedValue(undefined);
-
-    await program.parseAsync(["node", "test", "stop"]);
-
-    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-2", {
-      purgeOpenCode: false,
-    });
+    expect(output).toContain("app-orchestrator");
   });
 
   it("handles missing orchestrator session gracefully", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockSessionManager.kill.mockRejectedValue(new Error("session not found"));
     mockSessionManager.list.mockResolvedValue([]);
     mockExec.mockRejectedValue(new Error("no process"));
 
     await program.parseAsync(["node", "test", "stop"]);
 
-    expect(mockSessionManager.kill).not.toHaveBeenCalled();
+    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator", {
+      purgeOpenCode: false,
+    });
     const output = vi
       .mocked(console.log)
       .mock.calls.map((c) => c.join(" "))
@@ -1533,25 +1038,46 @@ describe("stop command", () => {
     expect(output).toContain("No running orchestrator session found");
   });
 
-  it("passes purge flag when stopping orchestrator with --purge-session", async () => {
+  it("falls back to a legacy numbered orchestrator during migration", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockSessionManager.kill
+      .mockRejectedValueOnce(new Error("session not found"))
+      .mockResolvedValueOnce(undefined);
     mockSessionManager.list.mockResolvedValue([
       {
         id: "app-orchestrator-1",
-        projectId: "my-app",
         status: "working",
         activity: "active",
         metadata: { role: "orchestrator" },
-        lastActivityAt: new Date(),
-        runtimeHandle: { id: "tmux-1" },
       },
     ]);
+    mockDashboardOnPort(3000);
+
+    await program.parseAsync(["node", "test", "stop"]);
+
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(1, "app-orchestrator", {
+      purgeOpenCode: false,
+    });
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(2, "app-orchestrator-1", {
+      purgeOpenCode: false,
+    });
+    expect(mockSessionManager.list).toHaveBeenCalledWith("my-app");
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("app-orchestrator-1");
+    expect(output).toContain("Orchestrator stopped");
+  });
+
+  it("passes purge flag when stopping orchestrator with --purge-session", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
     mockSessionManager.kill.mockResolvedValue(undefined);
     mockDashboardOnPort(3000);
 
     await program.parseAsync(["node", "test", "stop", "--purge-session"]);
 
-    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-1", {
+    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator", {
       purgeOpenCode: true,
     });
   });

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -1038,38 +1038,6 @@ describe("stop command", () => {
     expect(output).toContain("No running orchestrator session found");
   });
 
-  it("falls back to a legacy numbered orchestrator during migration", async () => {
-    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-    mockSessionManager.kill
-      .mockRejectedValueOnce(new Error("session not found"))
-      .mockResolvedValueOnce(undefined);
-    mockSessionManager.list.mockResolvedValue([
-      {
-        id: "app-orchestrator-1",
-        status: "working",
-        activity: "active",
-        metadata: { role: "orchestrator" },
-      },
-    ]);
-    mockDashboardOnPort(3000);
-
-    await program.parseAsync(["node", "test", "stop"]);
-
-    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(1, "app-orchestrator", {
-      purgeOpenCode: false,
-    });
-    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(2, "app-orchestrator-1", {
-      purgeOpenCode: false,
-    });
-    expect(mockSessionManager.list).toHaveBeenCalledWith("my-app");
-    const output = vi
-      .mocked(console.log)
-      .mock.calls.map((c) => c.join(" "))
-      .join("\n");
-    expect(output).toContain("app-orchestrator-1");
-    expect(output).toContain("Orchestrator stopped");
-  });
-
   it("passes purge flag when stopping orchestrator with --purge-session", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
     mockSessionManager.kill.mockResolvedValue(undefined);

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -10,7 +10,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync,
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { parse as parseYaml } from "yaml";
-import type { SessionManager } from "@aoagents/ao-core";
+import { SessionNotFoundError, type SessionManager } from "@aoagents/ao-core";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -1022,7 +1022,7 @@ describe("stop command", () => {
 
   it("handles missing orchestrator session gracefully", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-    mockSessionManager.kill.mockRejectedValue(new Error("session not found"));
+    mockSessionManager.kill.mockRejectedValue(new SessionNotFoundError("app-orchestrator"));
     mockSessionManager.list.mockResolvedValue([]);
     mockExec.mockRejectedValue(new Error("no process"));
 
@@ -1036,6 +1036,19 @@ describe("stop command", () => {
       .mock.calls.map((c) => c.join(" "))
       .join("\n");
     expect(output).toContain("No running orchestrator session found");
+  });
+
+  it("does not swallow unrelated errors that happen to contain 'not found'", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockSessionManager.kill.mockRejectedValue(new Error("metadata file not found"));
+
+    await expect(program.parseAsync(["node", "test", "stop"])).rejects.toThrow("process.exit(1)");
+
+    const errors = vi
+      .mocked(console.error)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(errors).toContain("metadata file not found");
   });
 
   it("passes purge flag when stopping orchestrator with --purge-session", async () => {

--- a/packages/cli/__tests__/lib/session-utils.test.ts
+++ b/packages/cli/__tests__/lib/session-utils.test.ts
@@ -130,7 +130,7 @@ describe("findProjectForSession", () => {
   it("matches orchestrator session names to their project", () => {
     const config = makeConfig({ "my-app": { sessionPrefix: "app" } });
     expect(findProjectForSession(config, "app-orchestrator")).toBe("my-app");
-    expect(findProjectForSession(config, "app-orchestrator-2")).toBe("my-app");
+    expect(findProjectForSession(config, "app-orchestrator-2")).toBeNull();
   });
 });
 
@@ -162,9 +162,9 @@ describe("isOrchestratorSessionName", () => {
     expect(isOrchestratorSessionName(config, "app-orchestrator")).toBe(true);
   });
 
-  it("falls back to suffix detection for legacy orchestrator names", () => {
+  it("does not fall back to suffix detection for non-configured orchestrator names", () => {
     const config = makeConfig({ "my-app": { sessionPrefix: "app" } });
-    expect(isOrchestratorSessionName(config, "legacy-orchestrator")).toBe(true);
+    expect(isOrchestratorSessionName(config, "legacy-orchestrator")).toBe(false);
   });
 
   it("does not classify worker session IDs as orchestrators", () => {
@@ -172,15 +172,15 @@ describe("isOrchestratorSessionName", () => {
     expect(isOrchestratorSessionName(config, "app-12", "my-app")).toBe(false);
   });
 
-  it("matches worktree orchestrator IDs (orchestrator-N) for a known project", () => {
+  it("does not match numbered orchestrator ids for a known project", () => {
     const config = makeConfig({ "my-app": { sessionPrefix: "app" } });
-    expect(isOrchestratorSessionName(config, "app-orchestrator-1", "my-app")).toBe(true);
-    expect(isOrchestratorSessionName(config, "app-orchestrator-42", "my-app")).toBe(true);
+    expect(isOrchestratorSessionName(config, "app-orchestrator-1", "my-app")).toBe(false);
+    expect(isOrchestratorSessionName(config, "app-orchestrator-42", "my-app")).toBe(false);
   });
 
-  it("matches worktree orchestrator IDs without an explicit project", () => {
+  it("does not match numbered orchestrator ids without an explicit project", () => {
     const config = makeConfig({ "my-app": { sessionPrefix: "app" } });
-    expect(isOrchestratorSessionName(config, "app-orchestrator-1")).toBe(true);
+    expect(isOrchestratorSessionName(config, "app-orchestrator-1")).toBe(false);
   });
 
   it("does not false-positive on a worker when prefix ends with -orchestrator", () => {
@@ -191,7 +191,7 @@ describe("isOrchestratorSessionName", () => {
     expect(isOrchestratorSessionName(config, "my-orchestrator-orchestrator", "my-app")).toBe(true);
   });
 
-  it("does not cross-project false-positive when one prefix is another's {prefix}-orchestrator", () => {
+  it("still recognizes the canonical orchestrator when one prefix is another's {prefix}-orchestrator", () => {
     // project A prefix "app", project B prefix "app-orchestrator"
     // "app-orchestrator-1" is a worker of B, NOT an orchestrator of A
     const config = makeConfig({
@@ -199,8 +199,7 @@ describe("isOrchestratorSessionName", () => {
       "project-b": { sessionPrefix: "app-orchestrator" },
     });
     expect(isOrchestratorSessionName(config, "app-orchestrator-1")).toBe(false);
-    // "app-orchestrator-orchestrator-1" IS an orchestrator of B
-    expect(isOrchestratorSessionName(config, "app-orchestrator-orchestrator-1")).toBe(true);
+    expect(isOrchestratorSessionName(config, "app-orchestrator-orchestrator")).toBe(true);
   });
 
   it("does not cross-project false-positive when projectId is provided", () => {

--- a/packages/cli/__tests__/lib/update-check.test.ts
+++ b/packages/cli/__tests__/lib/update-check.test.ts
@@ -139,8 +139,14 @@ describe("update-check", () => {
 
     it("returns 'npm-global' for Windows global path", () => {
       expect(
-        classifyInstallPath("C:\\Users\\test\\AppData\\Roaming\\npm\\lib\\node_modules\\@aoagents\\ao-cli\\dist\\lib\\update-check.js"),
+        classifyInstallPath("C:\\Users\\test\\AppData\\Roaming\\npm\\node_modules\\@aoagents\\ao-cli\\dist\\lib\\update-check.js"),
       ).toBe("npm-global");
+    });
+
+    it("returns 'unknown' for Windows local project node_modules", () => {
+      expect(
+        classifyInstallPath("C:\\Users\\test\\projects\\ao\\node_modules\\@aoagents\\ao-cli\\dist\\lib\\update-check.js"),
+      ).toBe("unknown");
     });
 
     it("returns 'pnpm-global' for pnpm global store path", () => {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1599,7 +1599,8 @@ export function registerStop(program: Command): void {
           const sessionPrefix = project.sessionPrefix ?? _projectId;
           const orchestratorId = `${sessionPrefix}-orchestrator`;
           const allSessionPrefixes = Object.entries(config.projects).map(
-            ([projectId, configuredProject]) => configuredProject.sessionPrefix ?? projectId,
+            ([, configuredProject]) =>
+              configuredProject.sessionPrefix ?? generateSessionPrefix(configuredProject.name ?? ""),
           );
           try {
             const spinner = ora("Stopping orchestrator session").start();

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -22,16 +22,14 @@ import {
   generateSessionPrefix,
   findConfigFile,
   getGlobalConfigPath,
+  isOrchestratorSession,
   isRepoUrl,
+  isTerminalSession,
   parseRepoUrl,
   resolveCloneTarget,
   isRepoAlreadyCloned,
   generateConfigFromUrl,
   configToYaml,
-  normalizeOrchestratorSessionStrategy,
-  isOrchestratorSession,
-  isTerminalSession,
-  isRestorable,
   ConfigNotFoundError,
   loadLocalProjectConfigDetailed,
   registerProjectInGlobalConfig,
@@ -39,7 +37,6 @@ import {
   type LocalProjectConfig,
   type ProjectConfig,
   type ParsedRepoUrl,
-  type Session,
   writeLocalProjectConfig,
 } from "@aoagents/ao-core";
 import { parse as yamlParse, stringify as yamlStringify } from "yaml";
@@ -1060,16 +1057,11 @@ async function runStartup(
   const shouldStartLifecycle = opts?.dashboard !== false || opts?.orchestrator !== false;
   let lifecycleStatus: Awaited<ReturnType<typeof ensureLifecycleWorker>> | null = null;
   let port = config.port ?? DEFAULT_PORT;
-  const orchestratorSessionStrategy = normalizeOrchestratorSessionStrategy(
-    project.orchestratorSessionStrategy,
-  );
 
   console.log(chalk.bold(`\nStarting orchestrator for ${chalk.cyan(project.name)}\n`));
 
   const spinner = ora();
   let dashboardProcess: ChildProcess | null = null;
-  let reused = false;
-  let restored = false;
 
   // Start dashboard (unless --no-dashboard)
   if (opts?.dashboard !== false) {
@@ -1129,144 +1121,26 @@ async function runStartup(
     }
   }
 
-  // Create orchestrator session (unless --no-orchestrator or existing orchestrators found)
-  let hasMultipleReusable = false;
+  // Ensure the project's single canonical orchestrator session.
   let selectedOrchestratorId: string | null = null;
-  let otherCandidateCount = 0;
 
   if (opts?.orchestrator !== false) {
     const sm = await getSessionManager(config);
-
-    // Check for existing orchestrator sessions for this project.
-    let allSessions;
     try {
-      allSessions = await sm.list(projectId);
+      spinner.start("Ensuring orchestrator session");
+      const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
+      const session = await sm.ensureOrchestrator({ projectId, systemPrompt });
+      selectedOrchestratorId = session.id;
+      spinner.succeed(`Orchestrator session ready: ${session.id}`);
     } catch (err) {
-      spinner.fail("Failed to list sessions");
+      spinner.fail("Orchestrator setup failed");
       if (dashboardProcess) {
         dashboardProcess.kill();
       }
       throw new Error(
-        `Failed to list sessions: ${err instanceof Error ? err.message : String(err)}`,
+        `Failed to setup orchestrator: ${err instanceof Error ? err.message : String(err)}`,
         { cause: err },
       );
-    }
-    const allSessionPrefixes = Object.entries(config.projects).map(
-      ([, p]) => p.sessionPrefix ?? generateSessionPrefix(p.name ?? ""),
-    );
-    const orchestrators = allSessions.filter((s) =>
-      isOrchestratorSession(s, project.sessionPrefix ?? projectId, allSessionPrefixes),
-    );
-
-    // Partition into two reuse buckets so we never spawn a new numbered id when
-    // an existing one is still usable:
-    //   - live:       runtime is still running, attach in place.
-    //   - restorable: status is terminal but the session can be restarted via
-    //                 sm.restore() (workspace + branch + handle still on disk).
-    //                 Restoring keeps the original numbered id rather than
-    //                 allocating a fresh one.
-    //
-    // IMPORTANT: live MUST be preferred unconditionally over restorable. A
-    // previous version sorted both buckets together by `lastActivityAt`, which
-    // could pick a newer killed record over an older-but-still-running one —
-    // sm.restore() would then spin up the killed record while the live one
-    // kept running, leaving two orchestrators alive for the project. Only fall
-    // back to restorable when the live bucket is empty.
-    const live = orchestrators.filter((s) => !isTerminalSession(s));
-    // isRestorable already requires isTerminalSession internally, so no need
-    // to repeat that guard here.
-    const restorable = orchestrators.filter((s) => isRestorable(s));
-    type OrchestratorCandidate = { session: Session; mode: "live" | "restore" };
-    const byMostRecent = (a: Session, b: Session): number =>
-      (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0);
-    const candidates: OrchestratorCandidate[] =
-      live.length > 0
-        ? [...live]
-            .sort(byMostRecent)
-            .map<OrchestratorCandidate>((session) => ({ session, mode: "live" }))
-        : [...restorable]
-            .sort(byMostRecent)
-            .map<OrchestratorCandidate>((session) => ({ session, mode: "restore" }));
-
-    if (candidates.length > 0 && orchestratorSessionStrategy === "reuse") {
-      const chosen = candidates[0];
-      // Multiple candidates → CLI auto-picks the most recent, but the dashboard
-      // surfaces all of them via the orchestrator-selection page. Only meaningful
-      // when the dashboard is running.
-      otherCandidateCount = candidates.length - 1;
-      if (opts?.dashboard !== false && candidates.length > 1) {
-        hasMultipleReusable = true;
-      }
-
-      const otherSuffix =
-        otherCandidateCount > 0 ? ` (${otherCandidateCount} other session(s) available)` : "";
-
-      if (chosen.mode === "live") {
-        selectedOrchestratorId = chosen.session.id;
-        spinner.succeed(`Using existing orchestrator session: ${chosen.session.id}${otherSuffix}`);
-      } else {
-        try {
-          spinner.start(`Restoring orchestrator session: ${chosen.session.id}`);
-          const restoredSession = await sm.restore(chosen.session.id);
-          selectedOrchestratorId = restoredSession.id;
-          restored = true;
-          spinner.succeed(
-            `Restored orchestrator session: ${restoredSession.id}${otherSuffix}`,
-          );
-        } catch (err) {
-          spinner.fail(`Failed to restore orchestrator session: ${chosen.session.id}`);
-          if (dashboardProcess) {
-            dashboardProcess.kill();
-          }
-          throw new Error(
-            `Failed to restore orchestrator session ${chosen.session.id}: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-            { cause: err },
-          );
-        }
-      }
-    } else {
-      if (orchestratorSessionStrategy === "delete") {
-        const liveOrchestrators = orchestrators.filter((s) => !isTerminalSession(s));
-        for (const orchestrator of liveOrchestrators) {
-          try {
-            await sm.kill(orchestrator.id);
-          } catch (err) {
-            spinner.fail(`Failed to replace existing orchestrator: ${orchestrator.id}`);
-            if (dashboardProcess) {
-              dashboardProcess.kill();
-            }
-            throw new Error(
-              `Failed to kill existing orchestrator ${orchestrator.id}: ${
-                err instanceof Error ? err.message : String(err)
-              }`,
-              { cause: err },
-            );
-          }
-        }
-      }
-
-      // No reusable orchestrators — spawn a fresh numbered one.
-      try {
-        spinner.start("Creating orchestrator session");
-        const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-        const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
-        selectedOrchestratorId = session.id;
-        reused =
-          orchestratorSessionStrategy === "reuse" &&
-          session.metadata?.["orchestratorSessionReused"] === "true";
-        spinner.succeed(reused ? "Orchestrator session reused" : "Orchestrator session created");
-      } catch (err) {
-        spinner.fail("Orchestrator setup failed");
-        if (dashboardProcess) {
-          dashboardProcess.kill();
-        }
-        throw new Error(
-          `Failed to setup orchestrator: ${err instanceof Error ? err.message : String(err)}`,
-          { cause: err },
-        );
-      }
     }
   }
 
@@ -1283,43 +1157,24 @@ async function runStartup(
   }
 
   if (opts?.orchestrator !== false && selectedOrchestratorId) {
-    const restoreNote = restored ? " (restored)" : "";
-    const otherSummarySuffix =
-      otherCandidateCount > 0 ? ` — ${otherCandidateCount} other session(s) available` : "";
     const target =
       opts?.dashboard !== false
         ? projectSessionUrl(port, projectId, selectedOrchestratorId)
         : `ao session attach ${selectedOrchestratorId}`;
-
-    if (reused) {
-      console.log(
-        chalk.cyan("Orchestrator:"),
-        `reused existing session (${selectedOrchestratorId})${otherSummarySuffix}`,
-      );
-    } else {
-      console.log(
-        chalk.cyan("Orchestrator:"),
-        `${target}${restoreNote}${otherSummarySuffix}`,
-      );
-    }
+    console.log(chalk.cyan("Orchestrator:"), target);
   }
 
   console.log(chalk.dim(`Config: ${config.configPath}`));
 
   // Auto-open browser once the server is ready.
-  // With a single chosen orchestrator (live, restored, or newly spawned), navigate directly to
-  // its session page. With multiple reusable orchestrators, open the selection page so the user
-  // can choose or spawn a new one — the dashboard only links one orchestrator per project.
   // Polls the port instead of using a fixed delay — deterministic and works regardless of
   // how long Next.js takes to compile. AbortController cancels polling on early exit.
   let openAbort: AbortController | undefined;
   if (opts?.dashboard !== false) {
     openAbort = new AbortController();
-    const orchestratorUrl = hasMultipleReusable
-      ? `http://localhost:${port}/orchestrators?project=${projectId}`
-      : selectedOrchestratorId
-        ? projectSessionUrl(port, projectId, selectedOrchestratorId)
-        : `http://localhost:${port}`;
+    const orchestratorUrl = selectedOrchestratorId
+      ? projectSessionUrl(port, projectId, selectedOrchestratorId)
+      : `http://localhost:${port}`;
     void waitForPortAndOpen(port, orchestratorUrl, openAbort.signal);
   }
 
@@ -1740,54 +1595,53 @@ export function registerStop(program: Command): void {
 
           console.log(chalk.bold(`\nStopping orchestrator for ${chalk.cyan(project.name)}\n`));
 
-          // Resolve the actual orchestrator session id by listing the project's sessions
-          // and finding the most-recently-active orchestrator. This avoids relying on the
-          // legacy `${prefix}-orchestrator` (no-N) phantom id, which never matches a real
-          // numbered session and causes ao stop to silently no-op.
           const sm = await getSessionManager(config);
+          const sessionPrefix = project.sessionPrefix ?? _projectId;
+          const orchestratorId = `${sessionPrefix}-orchestrator`;
           const allSessionPrefixes = Object.entries(config.projects).map(
-            ([, p]) => p.sessionPrefix ?? generateSessionPrefix(p.name ?? ""),
+            ([projectId, configuredProject]) => configuredProject.sessionPrefix ?? projectId,
           );
-          let orchestratorToKill: { id: string } | null = null;
-          let lookupFailed = false;
           try {
-            const projectSessions = await sm.list(_projectId);
-            const orchestrators = projectSessions
-              .filter((s) =>
-                isOrchestratorSession(s, project.sessionPrefix ?? _projectId, allSessionPrefixes),
-              )
-              .filter((s) => !isTerminalSession(s));
-            const sorted = [...orchestrators].sort(
-              (a, b) =>
-                (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0),
-            );
-            orchestratorToKill = sorted[0] ?? null;
-          } catch (err) {
-            lookupFailed = true;
-            console.log(
-              chalk.yellow(
-                `  Could not list sessions to locate orchestrator: ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
-              ),
-            );
-          }
-
-          if (orchestratorToKill) {
             const spinner = ora("Stopping orchestrator session").start();
             const purgeOpenCode = opts?.purgeSession === true;
-            await sm.kill(orchestratorToKill.id, { purgeOpenCode });
-            spinner.succeed(`Orchestrator session stopped (${orchestratorToKill.id})`);
+            let stoppedSessionId = orchestratorId;
+
+            try {
+              await sm.kill(orchestratorId, { purgeOpenCode });
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              if (!message.includes("not found")) {
+                throw err;
+              }
+
+              const legacyOrchestrator = (await sm.list(_projectId)).find(
+                (session) =>
+                  session.id !== orchestratorId &&
+                  isOrchestratorSession(session, sessionPrefix, allSessionPrefixes) &&
+                  !isTerminalSession(session),
+              );
+
+              if (!legacyOrchestrator) {
+                throw err;
+              }
+
+              stoppedSessionId = legacyOrchestrator.id;
+              await sm.kill(stoppedSessionId, { purgeOpenCode });
+            }
+
+            spinner.succeed(`Orchestrator session stopped (${stoppedSessionId})`);
             // Also log to console.log so the killed id is visible in non-TTY callers
             // (CI, scripts) and in test capture, since spinner output is suppressed.
-            console.log(chalk.green(`  Stopped orchestrator session: ${orchestratorToKill.id}`));
-          } else if (!lookupFailed) {
-            // Suppress the "no orchestrator found" message when sm.list threw —
-            // the catch above already explained the real reason and adding a
-            // second message would falsely imply the lookup succeeded.
-            console.log(
-              chalk.yellow(`No running orchestrator session found for "${project.name}"`),
-            );
+            console.log(chalk.green(`  Stopped orchestrator session: ${stoppedSessionId}`));
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (message.includes("not found")) {
+              console.log(
+                chalk.yellow(`No running orchestrator session found for "${project.name}"`),
+              );
+            } else {
+              throw err;
+            }
           }
 
           // Lifecycle polling runs in-process inside the `ao start` process

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -29,6 +29,7 @@ import {
   generateConfigFromUrl,
   configToYaml,
   ConfigNotFoundError,
+  SessionNotFoundError,
   loadLocalProjectConfigDetailed,
   registerProjectInGlobalConfig,
   type OrchestratorConfig,
@@ -1605,8 +1606,7 @@ export function registerStop(program: Command): void {
             // (CI, scripts) and in test capture, since spinner output is suppressed.
             console.log(chalk.green(`  Stopped orchestrator session: ${orchestratorId}`));
           } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            if (message.includes("not found")) {
+            if (err instanceof SessionNotFoundError) {
               console.log(
                 chalk.yellow(`No running orchestrator session found for "${project.name}"`),
               );

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -22,9 +22,7 @@ import {
   generateSessionPrefix,
   findConfigFile,
   getGlobalConfigPath,
-  isOrchestratorSession,
   isRepoUrl,
-  isTerminalSession,
   parseRepoUrl,
   resolveCloneTarget,
   isRepoAlreadyCloned,
@@ -1598,42 +1596,14 @@ export function registerStop(program: Command): void {
           const sm = await getSessionManager(config);
           const sessionPrefix = project.sessionPrefix ?? _projectId;
           const orchestratorId = `${sessionPrefix}-orchestrator`;
-          const allSessionPrefixes = Object.entries(config.projects).map(
-            ([, configuredProject]) =>
-              configuredProject.sessionPrefix ?? generateSessionPrefix(configuredProject.name ?? ""),
-          );
           try {
             const spinner = ora("Stopping orchestrator session").start();
             const purgeOpenCode = opts?.purgeSession === true;
-            let stoppedSessionId = orchestratorId;
-
-            try {
-              await sm.kill(orchestratorId, { purgeOpenCode });
-            } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
-              if (!message.includes("not found")) {
-                throw err;
-              }
-
-              const legacyOrchestrator = (await sm.list(_projectId)).find(
-                (session) =>
-                  session.id !== orchestratorId &&
-                  isOrchestratorSession(session, sessionPrefix, allSessionPrefixes) &&
-                  !isTerminalSession(session),
-              );
-
-              if (!legacyOrchestrator) {
-                throw err;
-              }
-
-              stoppedSessionId = legacyOrchestrator.id;
-              await sm.kill(stoppedSessionId, { purgeOpenCode });
-            }
-
-            spinner.succeed(`Orchestrator session stopped (${stoppedSessionId})`);
+            await sm.kill(orchestratorId, { purgeOpenCode });
+            spinner.succeed(`Orchestrator session stopped (${orchestratorId})`);
             // Also log to console.log so the killed id is visible in non-TTY callers
             // (CI, scripts) and in test capture, since spinner output is suppressed.
-            console.log(chalk.green(`  Stopped orchestrator session: ${stoppedSessionId}`));
+            console.log(chalk.green(`  Stopped orchestrator session: ${orchestratorId}`));
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             if (message.includes("not found")) {

--- a/packages/cli/src/lib/session-utils.ts
+++ b/packages/cli/src/lib/session-utils.ts
@@ -43,27 +43,11 @@ export function isOrchestratorSessionName(
 ): boolean {
   const normalizedName = stripHashPrefix(sessionName);
 
-  // If sessionName is a numbered worker for any configured project, it is not an orchestrator.
-  // This guard runs first to prevent cross-project false positives: e.g. prefix "app" would
-  // match "app-orchestrator-1" as an orchestrator pattern, but if another project has prefix
-  // "app-orchestrator" then "app-orchestrator-1" is a worker, not an orchestrator.
-  for (const [id, project] of Object.entries(config.projects) as Array<
-    [string, OrchestratorConfig["projects"][string]]
-  >) {
-    const prefix = project.sessionPrefix || id;
-    if (matchesPrefix(normalizedName, prefix)) return false;
-  }
-
   if (projectId) {
     const project = config.projects[projectId];
     if (project) {
       const prefix = project.sessionPrefix || projectId;
-      if (
-        normalizedName === `${prefix}-orchestrator` ||
-        new RegExp(`^${escapeRegex(prefix)}-orchestrator-\\d+$`).test(normalizedName)
-      ) {
-        return true;
-      }
+      return normalizedName === `${prefix}-orchestrator`;
     }
   }
 
@@ -71,13 +55,10 @@ export function isOrchestratorSessionName(
     [string, OrchestratorConfig["projects"][string]]
   >) {
     const prefix = project.sessionPrefix || id;
-    if (
-      normalizedName === `${prefix}-orchestrator` ||
-      new RegExp(`^${escapeRegex(prefix)}-orchestrator-\\d+$`).test(normalizedName)
-    ) {
+    if (normalizedName === `${prefix}-orchestrator`) {
       return true;
     }
   }
 
-  return normalizedName.endsWith("-orchestrator");
+  return false;
 }

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -53,9 +53,9 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
  * the resolved `import.meta.url` path.
  *
  * Distinguishes global npm installs (e.g. /usr/local/lib/node_modules,
- * ~/.nvm/.../lib/node_modules, pnpm global store) from local project
- * node_modules by checking for `lib/node_modules` (global) vs a bare
- * `node_modules` that sits inside a project directory (local/npx).
+ * ~/.nvm/.../lib/node_modules, %AppData%/npm/node_modules, pnpm global store)
+ * from local project node_modules by checking for known global-install
+ * layouts rather than treating every node_modules path as global.
  */
 export function classifyInstallPath(resolvedPath: string): InstallMethod {
   const hasNodeModules =
@@ -75,9 +75,14 @@ export function classifyInstallPath(resolvedPath: string): InstallMethod {
       return "pnpm-global";
     }
 
+    const isWindowsNpmGlobal =
+      resolvedPath.includes("/AppData/Roaming/npm/node_modules/") ||
+      resolvedPath.includes("\\AppData\\Roaming\\npm\\node_modules\\");
+
     const isNpmGlobal =
       resolvedPath.includes("/lib/node_modules/") ||
-      resolvedPath.includes("\\lib\\node_modules\\");
+      resolvedPath.includes("\\lib\\node_modules\\") ||
+      isWindowsNpmGlobal;
 
     if (isNpmGlobal) {
       return "npm-global";

--- a/packages/core/src/__tests__/session-manager/lifecycle.test.ts
+++ b/packages/core/src/__tests__/session-manager/lifecycle.test.ts
@@ -512,7 +512,7 @@ describe("cleanup", () => {
     expect(result.skipped).toContain("app-1");
   });
 
-  it("skips orchestrator sessions by role metadata", async () => {
+  it("does not protect legacy sessions by role metadata alone", async () => {
     const deadRuntime: Runtime = {
       ...mockRuntime,
       isAlive: vi.fn().mockResolvedValue(false),
@@ -527,8 +527,8 @@ describe("cleanup", () => {
       }),
     };
 
-    // Session with role=orchestrator but a name that does NOT end in "-orchestrator"
-    // so only the role metadata check can protect it (not the name fallback)
+    // A non-canonical session that still carries stale orchestrator metadata should
+    // now be treated like any other cleanup candidate.
     writeMetadata(sessionsDir, "app-99", {
       worktree: "/tmp",
       branch: "main",
@@ -541,8 +541,8 @@ describe("cleanup", () => {
     const sm = createSessionManager({ config, registry: registryWithDead });
     const result = await sm.cleanup();
 
-    expect(result.killed).toHaveLength(0);
-    expect(result.skipped).toContain("app-99");
+    expect(result.killed).toContain("app-99");
+    expect(result.skipped).not.toContain("app-99");
   });
 
   it("skips orchestrator sessions by name fallback (no role metadata)", async () => {

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { createSessionManager } from "../../session-manager.js";
+import { createInitialCanonicalLifecycle } from "../../lifecycle-state.js";
 import { getWorkspaceAgentsMdPath } from "../../opencode-agents-md.js";
 import {
   writeMetadata,
@@ -1665,6 +1666,118 @@ describe("spawn", () => {
       const session = await sm.spawnOrchestrator({ projectId: "my-app" });
 
       expect(session.runtimeHandle).toEqual(makeHandle("rt-1"));
+    });
+  });
+
+  describe("ensureOrchestrator", () => {
+    function makeDeadOrchestratorLifecycle(timestamp: string) {
+      const lifecycle = createInitialCanonicalLifecycle("orchestrator", new Date(timestamp));
+      lifecycle.session.state = "terminated";
+      lifecycle.session.reason = "runtime_missing";
+      lifecycle.session.startedAt = timestamp;
+      lifecycle.session.terminatedAt = timestamp;
+      lifecycle.session.lastTransitionAt = timestamp;
+      lifecycle.runtime.state = "missing";
+      lifecycle.runtime.reason = "process_missing";
+      lifecycle.runtime.lastObservedAt = timestamp;
+      return lifecycle;
+    }
+
+    it("prefers a live canonical orchestrator over a newer legacy restorable record", async () => {
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: config.projects["my-app"]!.path,
+        branch: "",
+        status: "working",
+        project: "my-app",
+        role: "orchestrator",
+        createdAt: "2026-04-20T10:00:00.000Z",
+      });
+      writeMetadata(sessionsDir, "app-orchestrator-9", {
+        worktree: "/tmp/dead",
+        branch: "",
+        status: "killed",
+        project: "my-app",
+        role: "orchestrator",
+        createdAt: "2026-04-21T10:00:00.000Z",
+        statePayload: JSON.stringify(makeDeadOrchestratorLifecycle("2026-04-21T10:00:00.000Z")),
+      });
+
+      const session = await sm.ensureOrchestrator({ projectId: "my-app", systemPrompt: "test" });
+
+      expect(session.id).toBe("app-orchestrator");
+      expect(mockRuntime.create).not.toHaveBeenCalled();
+    });
+
+    it("reuses the most recently active live legacy orchestrator", async () => {
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      writeMetadata(sessionsDir, "app-orchestrator-1", {
+        worktree: config.projects["my-app"]!.path,
+        branch: "",
+        status: "working",
+        project: "my-app",
+        role: "orchestrator",
+        createdAt: "2026-04-19T10:00:00.000Z",
+      });
+      writeMetadata(sessionsDir, "app-orchestrator-2", {
+        worktree: config.projects["my-app"]!.path,
+        branch: "",
+        status: "working",
+        project: "my-app",
+        role: "orchestrator",
+        createdAt: "2026-04-21T10:00:00.000Z",
+      });
+
+      const session = await sm.ensureOrchestrator({ projectId: "my-app", systemPrompt: "test" });
+
+      expect(session.id).toBe("app-orchestrator-2");
+      expect(mockRuntime.create).not.toHaveBeenCalled();
+    });
+
+    it("falls through to create when restore fails for a legacy orchestrator", async () => {
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockAgent.getRestoreCommand = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("restore command failed"));
+
+      writeMetadata(sessionsDir, "app-orchestrator-3", {
+        worktree: config.projects["my-app"]!.path,
+        branch: "",
+        status: "killed",
+        project: "my-app",
+        role: "orchestrator",
+        createdAt: "2026-04-21T10:00:00.000Z",
+        statePayload: JSON.stringify(makeDeadOrchestratorLifecycle("2026-04-21T10:00:00.000Z")),
+      });
+
+      const session = await sm.ensureOrchestrator({ projectId: "my-app", systemPrompt: "test" });
+
+      expect(session.id).toBe("app-orchestrator");
+      expect(mockRuntime.create).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Failed to restore orchestrator session during ensure; falling back",
+        expect.objectContaining({ orchestratorId: "app-orchestrator-3" }),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("throws a clear error when the canonical orchestrator id collides with another project prefix", async () => {
+      config.projects["other-app"] = {
+        ...config.projects["my-app"]!,
+        name: "Other App",
+        storageKey: `${ctx.storageKey}-other`,
+        path: join(tmpDir, "other-app"),
+        sessionPrefix: "app-orchestrator",
+      };
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      await expect(
+        sm.ensureOrchestrator({ projectId: "my-app", systemPrompt: "test" }),
+      ).rejects.toThrow(/collides with sessionPrefix of project "other-app"/);
     });
   });
 });

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1673,7 +1673,7 @@ describe("spawn", () => {
     function makeDeadOrchestratorLifecycle(timestamp: string) {
       const lifecycle = createInitialCanonicalLifecycle("orchestrator", new Date(timestamp));
       lifecycle.session.state = "terminated";
-      lifecycle.session.reason = "runtime_missing";
+      lifecycle.session.reason = "runtime_lost";
       lifecycle.session.startedAt = timestamp;
       lifecycle.session.terminatedAt = timestamp;
       lifecycle.session.lastTransitionAt = timestamp;

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1162,128 +1162,101 @@ describe("spawn", () => {
   });
 
   describe("spawnOrchestrator", () => {
-    it("throws when no workspace plugin is configured", async () => {
+    const projectPath = () => config.projects["my-app"]!.path;
+
+    it("does not require a workspace plugin and runs from the project path", async () => {
       const registryNoWorkspace: PluginRegistry = {
         ...mockRegistry,
         get: vi.fn().mockImplementation((slot: string) => {
           if (slot === "runtime") return mockRuntime;
           if (slot === "agent") return mockAgent;
-          return null; // no workspace plugin
+          return null;
         }),
       };
       const sm = createSessionManager({ config, registry: registryNoWorkspace });
 
-      await expect(sm.spawnOrchestrator({ projectId: "my-app" })).rejects.toThrow(
-        "spawnOrchestrator requires a workspace plugin",
-      );
-
-      // Reserved session metadata should be cleaned up
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")).toBeNull();
-      expect(mockRuntime.create).not.toHaveBeenCalled();
-    });
-
-    it("creates orchestrator session with correct ID", async () => {
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
       const session = await sm.spawnOrchestrator({ projectId: "my-app" });
 
-      expect(session.id).toBe("app-orchestrator-1");
-      expect(session.status).toBe("working");
-      expect(session.projectId).toBe("my-app");
-      expect(session.branch).toBe("orchestrator/app-orchestrator-1");
-      expect(session.issueId).toBeNull();
-      expect(session.workspacePath).toBe("/tmp/ws");
+      expect(session.id).toBe("app-orchestrator");
+      expect(session.workspacePath).toBe(projectPath());
+      expect(session.branch).toBeNull();
+      expect(mockRuntime.create).toHaveBeenCalled();
     });
 
-    it("creates a worktree with an orchestrator branch", async () => {
+    it("creates the canonical orchestrator session and reuses it on later calls", async () => {
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      const first = await sm.spawnOrchestrator({ projectId: "my-app" });
+      const second = await sm.spawnOrchestrator({ projectId: "my-app" });
+
+      expect(first.id).toBe("app-orchestrator");
+      expect(second.id).toBe("app-orchestrator");
+      expect(mockRuntime.create).toHaveBeenCalledTimes(1);
+      expect(mockWorkspace.create).not.toHaveBeenCalled();
+    });
+
+    it("writes metadata with canonical orchestrator fields", async () => {
       const sm = createSessionManager({ config, registry: mockRegistry });
 
       await sm.spawnOrchestrator({ projectId: "my-app" });
 
-      expect(mockWorkspace.create).toHaveBeenCalledWith(
+      const meta = readMetadata(sessionsDir, "app-orchestrator");
+      const raw = readMetadataRaw(sessionsDir, "app-orchestrator");
+      expect(meta).not.toBeNull();
+      expect(meta!.status).toBe("working");
+      expect(meta!.project).toBe("my-app");
+      expect(meta!.branch).toBe("");
+      expect(meta!.tmuxName).toBeDefined();
+      expect(meta!.runtimeHandle).toBeDefined();
+      expect(raw?.["role"]).toBe("orchestrator");
+      expect(raw?.["agent"]).toBe("mock-agent");
+      expect(raw?.["worktree"]).toBe(projectPath());
+    });
+
+    it("calls agent.setupWorkspaceHooks on the project path", async () => {
+      const agentWithHooks: Agent = {
+        ...mockAgent,
+        setupWorkspaceHooks: vi.fn().mockResolvedValue(undefined),
+      };
+      const registryWithHooks: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return agentWithHooks;
+          if (slot === "workspace") return mockWorkspace;
+          return null;
+        }),
+      };
+
+      const sm = createSessionManager({ config, registry: registryWithHooks });
+      await sm.spawnOrchestrator({ projectId: "my-app" });
+
+      expect(agentWithHooks.setupWorkspaceHooks).toHaveBeenCalledWith(
+        projectPath(),
+        expect.objectContaining({ dataDir: sessionsDir }),
+      );
+    });
+
+    it("calls runtime.create with the project path and canonical session id", async () => {
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      await sm.spawnOrchestrator({ projectId: "my-app" });
+
+      expect(mockRuntime.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          sessionId: "app-orchestrator-1",
-          branch: "orchestrator/app-orchestrator-1",
-          projectId: "my-app",
+          sessionId: expect.stringContaining("-app-orchestrator"),
+          workspacePath: projectPath(),
+          launchCommand: "mock-agent --start",
+          environment: expect.objectContaining({
+            AO_SESSION: "app-orchestrator",
+            AO_SESSION_NAME: "app-orchestrator",
+            AO_PROJECT_ID: "my-app",
+          }),
         }),
       );
     });
 
-    it("uses the worktree path returned by the workspace plugin", async () => {
-      const worktreePath = join(tmpDir, "orchestrator-ws");
-      (mockWorkspace.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        path: worktreePath,
-        branch: "orchestrator/app-orchestrator-1",
-        sessionId: "app-orchestrator-1",
-        projectId: "my-app",
-      });
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      const session = await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(session.workspacePath).toBe(worktreePath);
-      expect(session.branch).toBe("orchestrator/app-orchestrator-1");
-    });
-
-    it("writes metadata with proper fields", async () => {
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      const meta = readMetadata(sessionsDir, "app-orchestrator-1");
-      expect(meta).not.toBeNull();
-      expect(meta!.status).toBe("working");
-      expect(meta!.project).toBe("my-app");
-      expect(meta!.branch).toBe("orchestrator/app-orchestrator-1");
-      expect(meta!.tmuxName).toBeDefined();
-      expect(meta!.runtimeHandle).toBeDefined();
-    });
-
-    it("writes metadata with worktree path and orchestrator role", async () => {
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
-      expect(meta?.["role"]).toBe("orchestrator");
-      expect(meta?.["branch"]).toBe("orchestrator/app-orchestrator-1");
-      expect(meta?.["status"]).toBe("working");
-      expect(meta?.["project"]).toBe("my-app");
-    });
-
-    it("increments the orchestrator counter for each new session", async () => {
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      const s1 = await sm.spawnOrchestrator({ projectId: "my-app" });
-      const s2 = await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(s1.id).toBe("app-orchestrator-1");
-      expect(s2.id).toBe("app-orchestrator-2");
-      expect(mockWorkspace.create).toHaveBeenCalledTimes(2);
-    });
-
-    it("cleans up reserved metadata on workspace creation failure", async () => {
-      (mockWorkspace.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-        new Error("workspace creation failed"),
-      );
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      await expect(sm.spawnOrchestrator({ projectId: "my-app" })).rejects.toThrow(
-        "workspace creation failed",
-      );
-
-      // Reserved session file should be cleaned up
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")).toBeNull();
-    });
-
-    it("destroys the worktree and metadata when runtime creation fails", async () => {
-      const worktreePath = join(tmpDir, "orchestrator-ws-rt-fail");
-      (mockWorkspace.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        path: worktreePath,
-        branch: "orchestrator/app-orchestrator-1",
-        sessionId: "app-orchestrator-1",
-        projectId: "my-app",
-      });
+    it("cleans up metadata when runtime creation fails", async () => {
       (mockRuntime.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
         new Error("runtime creation failed"),
       );
@@ -1293,18 +1266,11 @@ describe("spawn", () => {
         "runtime creation failed",
       );
 
-      expect(mockWorkspace.destroy).toHaveBeenCalledWith(worktreePath);
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")).toBeNull();
+      expect(mockWorkspace.destroy).not.toHaveBeenCalled();
+      expect(readMetadataRaw(sessionsDir, "app-orchestrator")).toBeNull();
     });
 
-    it("destroys the worktree when post-launch setup fails", async () => {
-      const worktreePath = join(tmpDir, "orchestrator-ws-postlaunch-fail");
-      (mockWorkspace.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        path: worktreePath,
-        branch: "orchestrator/app-orchestrator-1",
-        sessionId: "app-orchestrator-1",
-        projectId: "my-app",
-      });
+    it("cleans up metadata and runtime when post-launch setup fails", async () => {
       const postLaunchError = new Error("post-launch setup failed");
       const agentWithPostLaunch: typeof mockAgent = {
         ...mockAgent,
@@ -1326,8 +1292,8 @@ describe("spawn", () => {
       );
 
       expect(mockRuntime.destroy).toHaveBeenCalled();
-      expect(mockWorkspace.destroy).toHaveBeenCalledWith(worktreePath);
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")).toBeNull();
+      expect(mockWorkspace.destroy).not.toHaveBeenCalled();
+      expect(readMetadataRaw(sessionsDir, "app-orchestrator")).toBeNull();
     });
 
     it("deletes previous OpenCode orchestrator sessions before starting", async () => {
@@ -1335,17 +1301,14 @@ describe("spawn", () => {
       const mockBin = installMockOpencode(
         tmpDir,
         JSON.stringify([
-          { id: "ses_old", title: "AO:app-orchestrator-1", updated: "2025-01-01T00:00:00.000Z" },
-          { id: "ses_new", title: "AO:app-orchestrator-1", updated: "2025-01-02T00:00:00.000Z" },
+          { id: "ses_old", title: "AO:app-orchestrator", updated: "2025-01-01T00:00:00.000Z" },
+          { id: "ses_new", title: "AO:app-orchestrator", updated: "2025-01-02T00:00:00.000Z" },
         ]),
         deleteLogPath,
       );
       process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
 
-      const opencodeAgent: Agent = {
-        ...mockAgent,
-        name: "opencode",
-      };
+      const opencodeAgent: Agent = { ...mockAgent, name: "opencode" };
       const registryWithOpenCode: PluginRegistry = {
         ...mockRegistry,
         get: vi.fn().mockImplementation((slot: string) => {
@@ -1355,7 +1318,6 @@ describe("spawn", () => {
           return null;
         }),
       };
-
       const configWithDelete: OrchestratorConfig = {
         ...config,
         defaults: { ...config.defaults, agent: "opencode" },
@@ -1375,29 +1337,28 @@ describe("spawn", () => {
       const deleteLog = readFileSync(deleteLogPath, "utf-8");
       expect(deleteLog).toContain("session delete ses_old");
       expect(deleteLog).toContain("session delete ses_new");
-
       expect(opencodeAgent.getLaunchCommand).toHaveBeenCalledWith(
         expect.objectContaining({
-          sessionId: "app-orchestrator-1",
+          sessionId: "app-orchestrator",
           projectConfig: expect.objectContaining({
             agentConfig: expect.not.objectContaining({ opencodeSessionId: expect.any(String) }),
           }),
         }),
       );
 
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
+      const meta = readMetadataRaw(sessionsDir, "app-orchestrator");
       expect(meta?.["agent"]).toBe("opencode");
       expect(meta?.["opencodeSessionId"]).toBeUndefined();
     });
 
-    it("discovers and persists OpenCode session id by title when strategy is reuse", async () => {
-      const deleteLogPath = join(tmpDir, "opencode-delete-orchestrator-reuse-discovery.log");
+    it("discovers and persists OpenCode session ids by canonical title when strategy is reuse", async () => {
+      const deleteLogPath = join(tmpDir, "opencode-delete-orchestrator-reuse.log");
       const mockBin = installMockOpencode(
         tmpDir,
         JSON.stringify([
           {
             id: "ses_discovered_orchestrator",
-            title: "AO:app-orchestrator-1",
+            title: "AO:app-orchestrator",
             updated: 1_772_777_000_000,
           },
         ]),
@@ -1405,10 +1366,7 @@ describe("spawn", () => {
       );
       process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
 
-      const opencodeAgent: Agent = {
-        ...mockAgent,
-        name: "opencode",
-      };
+      const opencodeAgent: Agent = { ...mockAgent, name: "opencode" };
       const registryWithOpenCode: PluginRegistry = {
         ...mockRegistry,
         get: vi.fn().mockImplementation((slot: string) => {
@@ -1418,7 +1376,6 @@ describe("spawn", () => {
           return null;
         }),
       };
-
       const configWithReuse: OrchestratorConfig = {
         ...config,
         defaults: { ...config.defaults, agent: "opencode" },
@@ -1435,268 +1392,17 @@ describe("spawn", () => {
       const sm = createSessionManager({ config: configWithReuse, registry: registryWithOpenCode });
       await sm.spawnOrchestrator({ projectId: "my-app" });
 
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
+      expect(opencodeAgent.getLaunchCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectConfig: expect.objectContaining({
+            agentConfig: expect.objectContaining({
+              opencodeSessionId: "ses_discovered_orchestrator",
+            }),
+          }),
+        }),
+      );
+      const meta = readMetadataRaw(sessionsDir, "app-orchestrator");
       expect(meta?.["opencodeSessionId"]).toBe("ses_discovered_orchestrator");
-    });
-
-    it("reuses mapped OpenCode session id when strategy is reuse and opencode lists it by title", async () => {
-      const deleteLogPath = join(tmpDir, "opencode-delete-orchestrator-reuse-restart.log");
-      const mockBin = installMockOpencode(
-        tmpDir,
-        JSON.stringify([
-          {
-            id: "ses_existing",
-            title: "AO:app-orchestrator-1",
-            updated: 1_772_777_000_000,
-          },
-        ]),
-        deleteLogPath,
-      );
-      process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
-
-      const opencodeAgent: Agent = {
-        ...mockAgent,
-        name: "opencode",
-      };
-      const registryWithOpenCode: PluginRegistry = {
-        ...mockRegistry,
-        get: vi.fn().mockImplementation((slot: string) => {
-          if (slot === "runtime") return mockRuntime;
-          if (slot === "agent") return opencodeAgent;
-          if (slot === "workspace") return mockWorkspace;
-          return null;
-        }),
-      };
-
-      const configWithReuse: OrchestratorConfig = {
-        ...config,
-        defaults: { ...config.defaults, agent: "opencode" },
-        projects: {
-          ...config.projects,
-          "my-app": {
-            ...config.projects["my-app"],
-            agent: "opencode",
-            orchestratorSessionStrategy: "reuse",
-          },
-        },
-      };
-
-      const sm = createSessionManager({ config: configWithReuse, registry: registryWithOpenCode });
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(opencodeAgent.getLaunchCommand).toHaveBeenCalledWith(
-        expect.objectContaining({
-          projectConfig: expect.objectContaining({
-            agentConfig: expect.objectContaining({ opencodeSessionId: "ses_existing" }),
-          }),
-        }),
-      );
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
-      expect(meta?.["opencodeSessionId"]).toBe("ses_existing");
-    });
-
-    it("discovers OpenCode mapping by title when no archived mapping exists for new session id", async () => {
-      const deleteLogPath = join(tmpDir, "opencode-delete-orchestrator-reuse-title-fallback.log");
-      const mockBin = installMockOpencode(
-        tmpDir,
-        JSON.stringify([
-          { id: "ses_existing", title: "AO:app-orchestrator-1", updated: 1_772_777_000_000 },
-        ]),
-        deleteLogPath,
-      );
-      process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
-
-      const opencodeAgent: Agent = {
-        ...mockAgent,
-        name: "opencode",
-      };
-      const registryWithOpenCode: PluginRegistry = {
-        ...mockRegistry,
-        get: vi.fn().mockImplementation((slot: string) => {
-          if (slot === "runtime") return mockRuntime;
-          if (slot === "agent") return opencodeAgent;
-          if (slot === "workspace") return mockWorkspace;
-          return null;
-        }),
-      };
-
-      const configWithReuse: OrchestratorConfig = {
-        ...config,
-        defaults: { ...config.defaults, agent: "opencode" },
-        projects: {
-          ...config.projects,
-          "my-app": {
-            ...config.projects["my-app"],
-            agent: "opencode",
-            orchestratorSessionStrategy: "reuse",
-          },
-        },
-      };
-
-      const sm = createSessionManager({ config: configWithReuse, registry: registryWithOpenCode });
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(opencodeAgent.getLaunchCommand).toHaveBeenCalledWith(
-        expect.objectContaining({
-          projectConfig: expect.objectContaining({
-            agentConfig: expect.objectContaining({ opencodeSessionId: "ses_existing" }),
-          }),
-        }),
-      );
-    });
-
-    it("reuses OpenCode session by title when orchestrator mapping is missing", async () => {
-      const deleteLogPath = join(tmpDir, "opencode-delete-orchestrator-reuse-title.log");
-      const mockBin = installMockOpencode(
-        tmpDir,
-        JSON.stringify([
-          { id: "ses_title_match", title: "AO:app-orchestrator-1", updated: 1_772_777_000_000 },
-        ]),
-        deleteLogPath,
-      );
-      process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
-
-      const opencodeAgent: Agent = {
-        ...mockAgent,
-        name: "opencode",
-      };
-      const registryWithOpenCode: PluginRegistry = {
-        ...mockRegistry,
-        get: vi.fn().mockImplementation((slot: string) => {
-          if (slot === "runtime") return mockRuntime;
-          if (slot === "agent") return opencodeAgent;
-          if (slot === "workspace") return mockWorkspace;
-          return null;
-        }),
-      };
-
-      const configWithReuse: OrchestratorConfig = {
-        ...config,
-        defaults: { ...config.defaults, agent: "opencode" },
-        projects: {
-          ...config.projects,
-          "my-app": {
-            ...config.projects["my-app"],
-            agent: "opencode",
-            orchestratorSessionStrategy: "reuse",
-          },
-        },
-      };
-
-      const sm = createSessionManager({ config: configWithReuse, registry: registryWithOpenCode });
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(opencodeAgent.getLaunchCommand).toHaveBeenCalledWith(
-        expect.objectContaining({
-          projectConfig: expect.objectContaining({
-            agentConfig: expect.objectContaining({ opencodeSessionId: "ses_title_match" }),
-          }),
-        }),
-      );
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
-      expect(meta?.["opencodeSessionId"]).toBe("ses_title_match");
-    });
-
-    it("calls agent.setupWorkspaceHooks on worktree path", async () => {
-      const agentWithHooks: Agent = {
-        ...mockAgent,
-        setupWorkspaceHooks: vi.fn().mockResolvedValue(undefined),
-      };
-      const registryWithHooks: PluginRegistry = {
-        ...mockRegistry,
-        get: vi.fn().mockImplementation((slot: string) => {
-          if (slot === "runtime") return mockRuntime;
-          if (slot === "agent") return agentWithHooks;
-          if (slot === "workspace") return mockWorkspace;
-          return null;
-        }),
-      };
-
-      const sm = createSessionManager({ config, registry: registryWithHooks });
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(agentWithHooks.setupWorkspaceHooks).toHaveBeenCalledWith(
-        "/tmp/ws",
-        expect.objectContaining({ dataDir: sessionsDir }),
-      );
-    });
-
-    it("calls runtime.create with proper config", async () => {
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(mockRuntime.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          workspacePath: "/tmp/ws",
-          launchCommand: "mock-agent --start",
-        }),
-      );
-    });
-
-    it("does not persist orchestratorSessionReused metadata on newly created sessions", async () => {
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
-      expect(meta?.["orchestratorSessionReused"]).toBeUndefined();
-    });
-
-    it("uses orchestratorModel when configured", async () => {
-      const configWithOrchestratorModel: OrchestratorConfig = {
-        ...config,
-        projects: {
-          ...config.projects,
-          "my-app": {
-            ...config.projects["my-app"],
-            agentConfig: {
-              model: "worker-model",
-              orchestratorModel: "orchestrator-model",
-            },
-          },
-        },
-      };
-
-      const sm = createSessionManager({
-        config: configWithOrchestratorModel,
-        registry: mockRegistry,
-      });
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
-        expect.objectContaining({ model: "orchestrator-model" }),
-      );
-    });
-
-    it("keeps orchestrator launch permissionless even when shared config sets permissions", async () => {
-      const configWithSharedPermissions: OrchestratorConfig = {
-        ...config,
-        projects: {
-          ...config.projects,
-          "my-app": {
-            ...config.projects["my-app"],
-            agentConfig: {
-              permissions: "suggest",
-            },
-          },
-        },
-      };
-
-      const sm = createSessionManager({
-        config: configWithSharedPermissions,
-        registry: mockRegistry,
-      });
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
-        expect.objectContaining({
-          permissions: "permissionless",
-          projectConfig: expect.objectContaining({
-            agentConfig: expect.objectContaining({ permissions: "permissionless" }),
-          }),
-        }),
-      );
     });
 
     it("uses project orchestrator agent when configured", async () => {
@@ -1726,9 +1432,7 @@ describe("spawn", () => {
           "my-app": {
             ...config.projects["my-app"],
             agent: "mock-agent",
-            orchestrator: {
-              agent: "codex",
-            },
+            orchestrator: { agent: "codex" },
           },
         },
       };
@@ -1741,7 +1445,7 @@ describe("spawn", () => {
 
       expect(mockCodexAgent.getLaunchCommand).toHaveBeenCalled();
       expect(mockAgent.getLaunchCommand).not.toHaveBeenCalled();
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")?.["agent"]).toBe("codex");
+      expect(readMetadataRaw(sessionsDir, "app-orchestrator")?.["agent"]).toBe("codex");
     });
 
     it("uses defaults orchestrator agent when project agent is not set", async () => {
@@ -1768,9 +1472,7 @@ describe("spawn", () => {
         ...config,
         defaults: {
           ...config.defaults,
-          orchestrator: {
-            agent: "codex",
-          },
+          orchestrator: { agent: "codex" },
         },
         projects: {
           ...config.projects,
@@ -1788,11 +1490,11 @@ describe("spawn", () => {
       await sm.spawnOrchestrator({ projectId: "my-app" });
 
       expect(mockCodexAgent.getLaunchCommand).toHaveBeenCalled();
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")?.["agent"]).toBe("codex");
+      expect(readMetadataRaw(sessionsDir, "app-orchestrator")?.["agent"]).toBe("codex");
     });
 
-    it("keeps shared worker permissions when role-specific config only overrides model", async () => {
-      const configWithSharedPermissions: OrchestratorConfig = {
+    it("uses orchestratorModel and remains permissionless", async () => {
+      const configWithOrchestratorModel: OrchestratorConfig = {
         ...config,
         projects: {
           ...config.projects,
@@ -1800,57 +1502,27 @@ describe("spawn", () => {
             ...config.projects["my-app"],
             agentConfig: {
               permissions: "suggest",
-            },
-            worker: {
-              agentConfig: {
-                model: "worker-model",
-              },
-            },
-          },
-        },
-      };
-
-      const validatedConfig = validateConfig(configWithSharedPermissions);
-      validatedConfig.configPath = config.configPath;
-      const sm = createSessionManager({
-        config: validatedConfig,
-        registry: mockRegistry,
-      });
-      await sm.spawn({ projectId: "my-app" });
-
-      expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
-        expect.objectContaining({ permissions: "suggest", model: "worker-model" }),
-      );
-    });
-
-    it("uses role-specific orchestratorModel when configured", async () => {
-      const configWithRoleOrchestratorModel: OrchestratorConfig = {
-        ...config,
-        projects: {
-          ...config.projects,
-          "my-app": {
-            ...config.projects["my-app"],
-            agentConfig: {
               model: "worker-model",
-              orchestratorModel: "shared-orchestrator-model",
-            },
-            orchestrator: {
-              agentConfig: {
-                orchestratorModel: "role-orchestrator-model",
-              },
+              orchestratorModel: "orchestrator-model",
             },
           },
         },
       };
 
       const sm = createSessionManager({
-        config: configWithRoleOrchestratorModel,
+        config: configWithOrchestratorModel,
         registry: mockRegistry,
       });
       await sm.spawnOrchestrator({ projectId: "my-app" });
 
       expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
-        expect.objectContaining({ model: "role-orchestrator-model" }),
+        expect.objectContaining({
+          permissions: "permissionless",
+          model: "orchestrator-model",
+          projectConfig: expect.objectContaining({
+            agentConfig: expect.objectContaining({ permissions: "permissionless" }),
+          }),
+        }),
       );
     });
 
@@ -1861,9 +1533,7 @@ describe("spawn", () => {
           ...config.projects,
           "my-app": {
             ...config.projects["my-app"],
-            agentConfig: {
-              subagent: "oracle",
-            },
+            agentConfig: { subagent: "oracle" },
           },
         },
       };
@@ -1887,19 +1557,16 @@ describe("spawn", () => {
         systemPrompt: "You are the orchestrator.",
       });
 
-      // Should pass systemPromptFile (not inline systemPrompt) to avoid tmux truncation
       expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
         expect.objectContaining({
-          sessionId: "app-orchestrator-1",
-          systemPromptFile: expect.stringContaining("orchestrator-prompt-app-orchestrator-1.md"),
+          sessionId: "app-orchestrator",
+          systemPromptFile: expect.stringContaining("orchestrator-prompt-app-orchestrator.md"),
         }),
       );
 
-      // Verify the file was actually written
       const callArgs = vi.mocked(mockAgent.getLaunchCommand).mock.calls[0][0];
       const promptFile = callArgs.systemPromptFile!;
       expect(existsSync(promptFile)).toBe(true);
-      const { readFileSync } = await import("node:fs");
       expect(readFileSync(promptFile, "utf-8")).toBe("You are the orchestrator.");
     });
 
@@ -1911,7 +1578,7 @@ describe("spawn", () => {
         systemPrompt: "Audit test coverage for session-manager and open PRs for gaps",
       });
 
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
+      const meta = readMetadataRaw(sessionsDir, "app-orchestrator");
       expect(meta?.["displayName"]).toBe(
         "Audit test coverage for session-manager and open PRs for gaps",
       );
@@ -1922,15 +1589,12 @@ describe("spawn", () => {
 
       await sm.spawnOrchestrator({ projectId: "my-app" });
 
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
+      const meta = readMetadataRaw(sessionsDir, "app-orchestrator");
       expect(meta?.["displayName"]).toBeUndefined();
     });
 
-    it("writes the orchestrator AGENTS.md block for OpenCode orchestrators", async () => {
-      const opencodeAgent: Agent = {
-        ...mockAgent,
-        name: "opencode",
-      };
+    it("writes the orchestrator AGENTS.md block into the project workspace for OpenCode", async () => {
+      const opencodeAgent: Agent = { ...mockAgent, name: "opencode" };
       const registryWithOpenCode: PluginRegistry = {
         ...mockRegistry,
         get: vi.fn().mockImplementation((slot: string) => {
@@ -1962,7 +1626,7 @@ describe("spawn", () => {
         systemPrompt: "You are the orchestrator.",
       });
 
-      const agentsMdPath = getWorkspaceAgentsMdPath("/tmp/ws");
+      const agentsMdPath = getWorkspaceAgentsMdPath(projectPath());
       expect(existsSync(agentsMdPath)).toBe(true);
       expect(readFileSync(agentsMdPath, "utf-8")).toBe(
         "<!-- AO_ORCHESTRATOR_PROMPT_START -->\n## Agent Orchestrator\n\nYou are the orchestrator.\n<!-- AO_ORCHESTRATOR_PROMPT_END -->\n",
@@ -2003,6 +1667,5 @@ describe("spawn", () => {
 
       expect(session.runtimeHandle).toEqual(makeHandle("rt-1"));
     });
-
   });
 });

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1748,6 +1748,27 @@ describe("spawn", () => {
       warnSpy.mockRestore();
     });
 
+    it("reuses the canonical orchestrator when concurrent ensure calls race to create it", async () => {
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      const results = await Promise.allSettled([
+        sm.ensureOrchestrator({ projectId: "my-app", systemPrompt: "test" }),
+        sm.ensureOrchestrator({ projectId: "my-app", systemPrompt: "test" }),
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]?.status).toBe("fulfilled");
+      expect(results[1]?.status).toBe("fulfilled");
+
+      if (results[0]?.status !== "fulfilled" || results[1]?.status !== "fulfilled") {
+        throw new Error("Expected both ensureOrchestrator calls to fulfill");
+      }
+
+      expect(results[0].value.id).toBe("app-orchestrator");
+      expect(results[1].value.id).toBe("app-orchestrator");
+      expect(mockRuntime.create).toHaveBeenCalledTimes(1);
+    });
+
     it("throws a clear error when the canonical orchestrator id collides with another project prefix", async () => {
       config.projects["other-app"] = {
         ...config.projects["my-app"]!,

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1683,6 +1683,31 @@ describe("spawn", () => {
       return lifecycle;
     }
 
+    it("warns when legacy numbered orchestrator sessions still exist", async () => {
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      writeMetadata(sessionsDir, "app-orchestrator-2", {
+        worktree: config.projects["my-app"]!.path,
+        branch: "",
+        status: "working",
+        project: "my-app",
+        role: "orchestrator",
+      });
+
+      await sm.ensureOrchestrator({ projectId: "my-app", systemPrompt: "test" });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Legacy numbered orchestrator sessions detected"),
+        expect.objectContaining({
+          projectId: "my-app",
+          legacySessionIds: ["app-orchestrator-2"],
+        }),
+      );
+
+      warnSpy.mockRestore();
+    });
+
     it("reuses the live canonical orchestrator when it already exists", async () => {
       const sm = createSessionManager({ config, registry: mockRegistry });
 

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { createSessionManager } from "../../session-manager.js";
-import { validateConfig } from "../../config.js";
 import { getWorkspaceAgentsMdPath } from "../../opencode-agents-md.js";
 import {
   writeMetadata,

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1683,7 +1683,7 @@ describe("spawn", () => {
       return lifecycle;
     }
 
-    it("prefers a live canonical orchestrator over a newer legacy restorable record", async () => {
+    it("reuses the live canonical orchestrator when it already exists", async () => {
       const sm = createSessionManager({ config, registry: mockRegistry });
 
       writeMetadata(sessionsDir, "app-orchestrator", {
@@ -1694,8 +1694,18 @@ describe("spawn", () => {
         role: "orchestrator",
         createdAt: "2026-04-20T10:00:00.000Z",
       });
-      writeMetadata(sessionsDir, "app-orchestrator-9", {
-        worktree: "/tmp/dead",
+
+      const session = await sm.ensureOrchestrator({ projectId: "my-app", systemPrompt: "test" });
+
+      expect(session.id).toBe("app-orchestrator");
+      expect(mockRuntime.create).not.toHaveBeenCalled();
+    });
+
+    it("restores the canonical orchestrator when it is terminal but restorable", async () => {
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: config.projects["my-app"]!.path,
         branch: "",
         status: "killed",
         project: "my-app",
@@ -1707,43 +1717,17 @@ describe("spawn", () => {
       const session = await sm.ensureOrchestrator({ projectId: "my-app", systemPrompt: "test" });
 
       expect(session.id).toBe("app-orchestrator");
-      expect(mockRuntime.create).not.toHaveBeenCalled();
+      expect(mockRuntime.create).toHaveBeenCalledTimes(1);
     });
 
-    it("reuses the most recently active live legacy orchestrator", async () => {
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      writeMetadata(sessionsDir, "app-orchestrator-1", {
-        worktree: config.projects["my-app"]!.path,
-        branch: "",
-        status: "working",
-        project: "my-app",
-        role: "orchestrator",
-        createdAt: "2026-04-19T10:00:00.000Z",
-      });
-      writeMetadata(sessionsDir, "app-orchestrator-2", {
-        worktree: config.projects["my-app"]!.path,
-        branch: "",
-        status: "working",
-        project: "my-app",
-        role: "orchestrator",
-        createdAt: "2026-04-21T10:00:00.000Z",
-      });
-
-      const session = await sm.ensureOrchestrator({ projectId: "my-app", systemPrompt: "test" });
-
-      expect(session.id).toBe("app-orchestrator-2");
-      expect(mockRuntime.create).not.toHaveBeenCalled();
-    });
-
-    it("falls through to create when restore fails for a legacy orchestrator", async () => {
+    it("falls through to create when restoring the canonical orchestrator fails", async () => {
       const sm = createSessionManager({ config, registry: mockRegistry });
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       mockAgent.getRestoreCommand = vi
         .fn()
         .mockRejectedValueOnce(new Error("restore command failed"));
 
-      writeMetadata(sessionsDir, "app-orchestrator-3", {
+      writeMetadata(sessionsDir, "app-orchestrator", {
         worktree: config.projects["my-app"]!.path,
         branch: "",
         status: "killed",
@@ -1759,7 +1743,7 @@ describe("spawn", () => {
       expect(mockRuntime.create).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
         "Failed to restore orchestrator session during ensure; falling back",
-        expect.objectContaining({ orchestratorId: "app-orchestrator-3" }),
+        expect.objectContaining({ orchestratorId: "app-orchestrator" }),
       );
       warnSpy.mockRestore();
     });

--- a/packages/core/src/__tests__/test-utils.ts
+++ b/packages/core/src/__tests__/test-utils.ts
@@ -426,6 +426,9 @@ export function teardownTestContext(ctx: TestContext): void {
 export function createMockSessionManager(): OpenCodeSessionManager {
   return {
     spawn: vi.fn().mockResolvedValue(makeSession()),
+    ensureOrchestrator: vi
+      .fn()
+      .mockResolvedValue(makeSession({ id: "app-orchestrator", metadata: { role: "orchestrator" } })),
     spawnOrchestrator: vi.fn().mockResolvedValue(makeSession({ id: "app-orchestrator", metadata: { role: "orchestrator" } })),
     restore: vi.fn().mockResolvedValue(makeSession()),
     list: vi.fn().mockResolvedValue([]),

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -2,30 +2,24 @@ import { describe, expect, it } from "vitest";
 import { isOrchestratorSession, isIssueNotFoundError } from "../types.js";
 
 describe("isOrchestratorSession", () => {
-  it("detects orchestrators by explicit role metadata", () => {
-    expect(
-      isOrchestratorSession({ id: "app-control", metadata: { role: "orchestrator" } }, "app"),
-    ).toBe(true);
+  it("detects the canonical orchestrator id for a project", () => {
+    expect(isOrchestratorSession({ id: "app-orchestrator", metadata: {} }, "app")).toBe(true);
   });
 
-  it("detects numbered worktree orchestrators by prefix pattern", () => {
-    expect(isOrchestratorSession({ id: "app-orchestrator-1", metadata: {} }, "app")).toBe(true);
-    expect(isOrchestratorSession({ id: "app-orchestrator-42", metadata: {} }, "app")).toBe(true);
+  it("does not accept numbered orchestrator ids anymore", () => {
+    expect(isOrchestratorSession({ id: "app-orchestrator-1", metadata: {} }, "app")).toBe(false);
+    expect(isOrchestratorSession({ id: "app-orchestrator-42", metadata: {} }, "app")).toBe(false);
   });
 
   it("does not false-positive on worker sessions", () => {
     expect(isOrchestratorSession({ id: "app-7", metadata: { role: "worker" } }, "app")).toBe(false);
   });
 
-  it("does not false-positive when prefix ends with -orchestrator", () => {
-    // my-orchestrator-1 is a worker when prefix is "my-orchestrator"
-    expect(
-      isOrchestratorSession({ id: "my-orchestrator-1", metadata: {} }, "my-orchestrator"),
-    ).toBe(false);
-    // my-orchestrator-orchestrator-1 is the real worktree orchestrator
+  it("still handles prefixes that end with -orchestrator", () => {
+    expect(isOrchestratorSession({ id: "my-orchestrator-1", metadata: {} }, "my-orchestrator")).toBe(false);
     expect(
       isOrchestratorSession(
-        { id: "my-orchestrator-orchestrator-1", metadata: {} },
+        { id: "my-orchestrator-orchestrator", metadata: {} },
         "my-orchestrator",
       ),
     ).toBe(true);
@@ -44,11 +38,11 @@ describe("isOrchestratorSession", () => {
     ).toBe(false);
   });
 
-  it("accepts bare legacy ids when role metadata is explicitly stamped", () => {
+  it("only falls back to role metadata when no prefix is available", () => {
     expect(
       isOrchestratorSession(
         { id: "integrator-orchestrator", metadata: { role: "orchestrator" } },
-        "int",
+        undefined,
       ),
     ).toBe(true);
   });

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -20,6 +20,7 @@ import {
   isTerminalSession,
   isIssueNotFoundError,
   isRestorable,
+  selectPreferredOrchestratorSession,
   SessionNotFoundError,
   SessionNotRestorableError,
   WorkspaceMissingError,
@@ -70,6 +71,7 @@ import {
   getWorktreesDir,
   getProjectBaseDir,
   generateTmuxName,
+  generateSessionPrefix,
   validateAndStoreOrigin,
 } from "./paths.js";
 import { asValidOpenCodeSessionId } from "./opencode-session-id.js";
@@ -852,48 +854,28 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     );
   }
 
-  function getCanonicalOrchestratorId(project: ProjectConfig): string {
-    return `${project.sessionPrefix}-orchestrator`;
+  function getCanonicalOrchestratorId(projectId: string, project: ProjectConfig): string {
+    const canonicalSessionId = `${project.sessionPrefix}-orchestrator`;
+    const conflictingProject = Object.entries(config.projects).find(
+      ([otherProjectId, otherProject]) =>
+        otherProjectId !== projectId &&
+        (otherProject.sessionPrefix ?? generateSessionPrefix(otherProject.name ?? "")) ===
+          canonicalSessionId,
+    );
+
+    if (conflictingProject) {
+      throw new Error(
+        `Canonical orchestrator ID "${canonicalSessionId}" for project "${projectId}" collides with sessionPrefix of project "${conflictingProject[0]}". Rename one project's sessionPrefix to continue.`,
+      );
+    }
+
+    return canonicalSessionId;
   }
 
   function getCanonicalOrchestratorTmuxName(project: ProjectConfig): string | undefined {
     return project.storageKey
       ? `${project.storageKey}-${project.sessionPrefix}-orchestrator`
       : undefined;
-  }
-
-  function compareOrchestratorRecency(a: Session, b: Session): number {
-    return (
-      (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0) ||
-      (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0) ||
-      a.id.localeCompare(b.id)
-    );
-  }
-
-  function selectPreferredOrchestratorSession(
-    sessions: Session[],
-    canonicalSessionId: string,
-  ): Session | null {
-    const exact = sessions.find((session) => session.id === canonicalSessionId) ?? null;
-    if (exact && !isTerminalSession(exact)) {
-      return exact;
-    }
-
-    const live = sessions
-      .filter((session) => !isTerminalSession(session))
-      .sort(compareOrchestratorRecency);
-    if (live.length > 0) {
-      return live[0] ?? null;
-    }
-
-    if (exact) {
-      return exact;
-    }
-
-    const restorable = sessions
-      .filter((session) => isRestorable(session))
-      .sort(compareOrchestratorRecency);
-    return restorable[0] ?? null;
   }
 
   /** Resolve which plugins to use for a project. */
@@ -1511,7 +1493,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       validateAndStoreOrigin(config.configPath, project.storageKey!);
     }
 
-    const sessionId = getCanonicalOrchestratorId(project);
+    const sessionId = getCanonicalOrchestratorId(orchestratorConfig.projectId, project);
     const tmuxName = getCanonicalOrchestratorTmuxName(project);
     const branch = null;
 
@@ -1751,7 +1733,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       throw new Error(`Unknown project: ${orchestratorConfig.projectId}`);
     }
 
-    const canonicalSessionId = getCanonicalOrchestratorId(project);
+    const canonicalSessionId = getCanonicalOrchestratorId(orchestratorConfig.projectId, project);
     const projectSessions = (await list(orchestratorConfig.projectId)).filter((session) =>
       isOrchestratorSessionRecord(session.id, session.metadata, project.sessionPrefix),
     );
@@ -1764,7 +1746,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     if (existing && isRestorable(existing)) {
       try {
         return await restore(existing.id);
-      } catch {
+      } catch (error) {
+        console.warn("Failed to restore orchestrator session during ensure; falling back", {
+          projectId: orchestratorConfig.projectId,
+          orchestratorId: existing.id,
+          error,
+        });
         if (existing.id === canonicalSessionId) {
           return createCanonicalOrchestrator(orchestratorConfig, { replaceExisting: true });
         }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -414,17 +414,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     sessionPrefix?: string,
   ): boolean {
     if (!raw) return false;
-    if (raw["role"] === "orchestrator") return true;
-    // Check the -orchestrator-N pattern only when the prefix is known so the
-    // regex is anchored to the project prefix, preventing false-positives when
-    // the user-configured sessionPrefix itself ends with "-orchestrator".
-    if (sessionPrefix) {
-      if (sessionId === `${sessionPrefix}-orchestrator`) {
-        return true;
-      }
-      return new RegExp(`^${escapeRegex(sessionPrefix)}-orchestrator-\\d+$`).test(sessionId);
-    }
-    return false;
+    if (!sessionPrefix) return raw["role"] === "orchestrator";
+    return sessionId === `${sessionPrefix}-orchestrator`;
   }
 
   function isCleanupProtectedSession(

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -17,6 +17,7 @@ import { basename, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { promisify } from "node:util";
 import {
+  isTerminalSession,
   isIssueNotFoundError,
   isRestorable,
   SessionNotFoundError,
@@ -313,7 +314,10 @@ function metadataToSession(
   const sessionKind =
     meta["role"] === "orchestrator" ||
     (sessionPrefix
-      ? new RegExp(`^${escapeRegex(sessionPrefix)}-orchestrator-\\d+$`).test(sessionId)
+      ? (
+          sessionId === `${sessionPrefix}-orchestrator` ||
+          new RegExp(`^${escapeRegex(sessionPrefix)}-orchestrator-\\d+$`).test(sessionId)
+        )
       : false)
       ? "orchestrator"
       : "worker";
@@ -848,64 +852,48 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     );
   }
 
-  /**
-   * Reserve a unique orchestrator identity ({prefix}-orchestrator-N) for a worktree-based orchestrator.
-   * Unlike worker sessions, orchestrator IDs are assigned locally without remote branch checks.
-   */
-  function reserveNextOrchestratorIdentity(
-    project: ProjectConfig,
-    sessionsDir: string,
-  ): { num: number; sessionId: string; tmuxName: string | undefined } {
-    const orchestratorPrefix = `${project.sessionPrefix}-orchestrator`;
-    const usedNumbers = new Set<number>();
+  function getCanonicalOrchestratorId(project: ProjectConfig): string {
+    return `${project.sessionPrefix}-orchestrator`;
+  }
 
-    const orchestratorPattern = new RegExp(`^${escapeRegex(orchestratorPrefix)}-(\\d+)$`);
-    for (const sessionName of [
-      ...listMetadata(sessionsDir),
-      ...listArchivedSessionIds(sessionsDir),
-    ]) {
-      const match = sessionName.match(orchestratorPattern);
-      if (match) {
-        const parsed = Number.parseInt(match[1], 10);
-        if (!Number.isNaN(parsed)) usedNumbers.add(parsed);
-      }
-    }
+  function getCanonicalOrchestratorTmuxName(project: ProjectConfig): string | undefined {
+    return project.storageKey
+      ? `${project.storageKey}-${project.sessionPrefix}-orchestrator`
+      : undefined;
+  }
 
-    // Build worker-ID patterns for all other projects. If another project has
-    // sessionPrefix === orchestratorPrefix (e.g. project B has prefix "app-orchestrator"),
-    // then its workers are named "app-orchestrator-1", "app-orchestrator-2", etc. — which
-    // would collide with our orchestrator IDs. Detect this impossible configuration early.
-    for (const [otherProjectId, otherProject] of Object.entries(config.projects)) {
-      const otherPrefix = otherProject.sessionPrefix ?? otherProjectId;
-      if (otherPrefix === project.sessionPrefix) continue;
-      if (otherPrefix === orchestratorPrefix) {
-        // Another project's workers are "{otherPrefix}-\d+" which equals "{orchestratorPrefix}-\d+".
-        // Every candidate ID we would generate collides — fail immediately with a clear message.
-        throw new Error(
-          `Cannot spawn orchestrator for project "${project.sessionPrefix}": the orchestrator ID prefix "${orchestratorPrefix}" ` +
-            `conflicts with the session prefix of project "${otherProjectId}" ("${otherPrefix}"). ` +
-            `Rename one of the project sessionPrefix values to avoid this overlap.`,
-        );
-      }
-    }
-
-    let num = 1;
-    for (let attempts = 0; attempts < 10_000; attempts++) {
-      if (!usedNumbers.has(num)) {
-        const sessionId = `${orchestratorPrefix}-${num}`;
-        const tmuxName = config.configPath
-          ? generateTmuxName(project.storageKey, orchestratorPrefix, num)
-          : undefined;
-        if (reserveSessionId(sessionsDir, sessionId)) {
-          return { num, sessionId, tmuxName };
-        }
-      }
-      num += 1;
-    }
-
-    throw new Error(
-      `Failed to reserve orchestrator session ID after 10000 attempts (prefix: ${orchestratorPrefix})`,
+  function compareOrchestratorRecency(a: Session, b: Session): number {
+    return (
+      (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0) ||
+      (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0) ||
+      a.id.localeCompare(b.id)
     );
+  }
+
+  function selectPreferredOrchestratorSession(
+    sessions: Session[],
+    canonicalSessionId: string,
+  ): Session | null {
+    const exact = sessions.find((session) => session.id === canonicalSessionId) ?? null;
+    if (exact && !isTerminalSession(exact)) {
+      return exact;
+    }
+
+    const live = sessions
+      .filter((session) => !isTerminalSession(session))
+      .sort(compareOrchestratorRecency);
+    if (live.length > 0) {
+      return live[0] ?? null;
+    }
+
+    if (exact) {
+      return exact;
+    }
+
+    const restorable = sessions
+      .filter((session) => isRestorable(session))
+      .sort(compareOrchestratorRecency);
+    return restorable[0] ?? null;
   }
 
   /** Resolve which plugins to use for a project. */
@@ -1487,7 +1475,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return session;
   }
 
-  async function spawnOrchestrator(orchestratorConfig: OrchestratorSpawnConfig): Promise<Session> {
+  async function createCanonicalOrchestrator(
+    orchestratorConfig: OrchestratorSpawnConfig,
+    options: { replaceExisting?: boolean } = {},
+  ): Promise<Session> {
     const project = config.projects[orchestratorConfig.projectId];
     if (!project) {
       throw new Error(`Unknown project: ${orchestratorConfig.projectId}`);
@@ -1520,52 +1511,29 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       validateAndStoreOrigin(config.configPath, project.storageKey!);
     }
 
-    // Reserve a new unique orchestrator identity (e.g. {prefix}-orchestrator-1, -2, …).
-    // Each spawnOrchestrator call gets its own numbered session and isolated worktree.
-    const identity = reserveNextOrchestratorIdentity(project, sessionsDir);
-    const sessionId = identity.sessionId;
-    const tmuxName = identity.tmuxName;
+    const sessionId = getCanonicalOrchestratorId(project);
+    const tmuxName = getCanonicalOrchestratorTmuxName(project);
+    const branch = null;
 
-    // Each orchestrator gets an isolated worktree on its own branch.
-    const branch = `orchestrator/${sessionId}`;
-
-    if (!plugins.workspace) {
-      try {
-        deleteMetadata(sessionsDir, sessionId, false);
-      } catch {
-        /* best effort */
-      }
-      throw new Error(
-        `spawnOrchestrator requires a workspace plugin but none is configured for project '${orchestratorConfig.projectId}'`,
-      );
+    if (options.replaceExisting && readMetadataRaw(sessionsDir, sessionId)) {
+      deleteMetadata(sessionsDir, sessionId);
     }
 
-    let workspacePath: string;
-    try {
-      const wsInfo = await plugins.workspace.create({
-        projectId: orchestratorConfig.projectId,
-        project,
-        sessionId,
-        branch,
-      });
-      workspacePath = wsInfo.path;
-    } catch (err) {
-      try {
-        deleteMetadata(sessionsDir, sessionId, false);
-      } catch {
-        /* best effort */
-      }
-      throw err;
+    if (!reserveSessionId(sessionsDir, sessionId)) {
+      throw new Error(`Orchestrator session '${sessionId}' already exists`);
     }
+
+    const workspacePath = project.path;
 
     // Helper: undo worktree + metadata if anything between workspace creation
     // and a fully-written metadata record fails.
     const cleanupWorktreeAndMetadata = async (promptFile?: string): Promise<void> => {
-      try {
-        // plugins.workspace is guaranteed non-null here: we threw above if it was null
-        await plugins.workspace!.destroy(workspacePath);
-      } catch {
-        /* best effort */
+      if (shouldDestroyWorkspacePath(project, orchestratorConfig.projectId, workspacePath)) {
+        try {
+          await plugins.workspace?.destroy?.(workspacePath);
+        } catch {
+          /* best effort */
+        }
       }
       try {
         deleteMetadata(sessionsDir, sessionId, false);
@@ -1728,7 +1696,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     try {
       writeMetadata(sessionsDir, sessionId, {
         worktree: workspacePath,
-        branch,
+        branch: "",
         status: deriveLegacyStatus(lifecycle),
         ...buildLifecycleMetadataPatch(lifecycle),
         role: "orchestrator",
@@ -1775,6 +1743,41 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     }
 
     return session;
+  }
+
+  async function ensureOrchestrator(orchestratorConfig: OrchestratorSpawnConfig): Promise<Session> {
+    const project = config.projects[orchestratorConfig.projectId];
+    if (!project) {
+      throw new Error(`Unknown project: ${orchestratorConfig.projectId}`);
+    }
+
+    const canonicalSessionId = getCanonicalOrchestratorId(project);
+    const projectSessions = (await list(orchestratorConfig.projectId)).filter((session) =>
+      isOrchestratorSessionRecord(session.id, session.metadata, project.sessionPrefix),
+    );
+    const existing = selectPreferredOrchestratorSession(projectSessions, canonicalSessionId);
+
+    if (existing && !isTerminalSession(existing)) {
+      return existing;
+    }
+
+    if (existing && isRestorable(existing)) {
+      try {
+        return await restore(existing.id);
+      } catch {
+        if (existing.id === canonicalSessionId) {
+          return createCanonicalOrchestrator(orchestratorConfig, { replaceExisting: true });
+        }
+      }
+    }
+
+    return createCanonicalOrchestrator(orchestratorConfig, {
+      replaceExisting: existing?.id === canonicalSessionId,
+    });
+  }
+
+  async function spawnOrchestrator(orchestratorConfig: OrchestratorSpawnConfig): Promise<Session> {
+    return ensureOrchestrator(orchestratorConfig);
   }
 
   async function list(projectId?: string): Promise<Session[]> {
@@ -2887,6 +2890,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
   return {
     spawn,
+    ensureOrchestrator,
     spawnOrchestrator,
     restore,
     list,

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -869,6 +869,17 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       : undefined;
   }
 
+  function listLegacyNumberedOrchestrators(project: ProjectConfig): SessionId[] {
+    const sessionsDir = getProjectSessionsDir(project);
+    if (!existsSync(sessionsDir)) return [];
+
+    const numberedPattern = new RegExp(
+      `^${escapeRegex(project.sessionPrefix)}-orchestrator-\\d+$`,
+    );
+
+    return listMetadata(sessionsDir).filter((sessionId) => numberedPattern.test(sessionId));
+  }
+
   /** Resolve which plugins to use for a project. */
   function resolvePlugins(project: ProjectConfig, agentName?: string) {
     const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
@@ -1722,6 +1733,17 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const project = config.projects[orchestratorConfig.projectId];
     if (!project) {
       throw new Error(`Unknown project: ${orchestratorConfig.projectId}`);
+    }
+
+    const legacyNumberedOrchestrators = listLegacyNumberedOrchestrators(project);
+    if (legacyNumberedOrchestrators.length > 0) {
+      console.warn(
+        "Legacy numbered orchestrator sessions detected; AO now uses a single canonical orchestrator session. Clean up the legacy sessions with `ao session kill <session-id>` and restart with `ao stop && ao start`.",
+        {
+          projectId: orchestratorConfig.projectId,
+          legacySessionIds: legacyNumberedOrchestrators,
+        },
+      );
     }
 
     const canonicalSessionId = getCanonicalOrchestratorId(orchestratorConfig.projectId, project);

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1725,6 +1725,28 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     }
 
     const canonicalSessionId = getCanonicalOrchestratorId(orchestratorConfig.projectId, project);
+    const createOrReuseCanonical = async (replaceExisting: boolean): Promise<Session> => {
+      try {
+        return await createCanonicalOrchestrator(orchestratorConfig, { replaceExisting });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "";
+        if (message !== `Orchestrator session '${canonicalSessionId}' already exists`) {
+          throw error;
+        }
+
+        const canonical = selectPreferredOrchestratorSession(
+          (await list(orchestratorConfig.projectId)).filter((session) =>
+            isOrchestratorSessionRecord(session.id, session.metadata, project.sessionPrefix),
+          ),
+          canonicalSessionId,
+        );
+        if (canonical) {
+          return canonical;
+        }
+
+        throw error;
+      }
+    };
     const projectSessions = (await list(orchestratorConfig.projectId)).filter((session) =>
       isOrchestratorSessionRecord(session.id, session.metadata, project.sessionPrefix),
     );
@@ -1743,15 +1765,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           orchestratorId: existing.id,
           error,
         });
-        if (existing.id === canonicalSessionId) {
-          return createCanonicalOrchestrator(orchestratorConfig, { replaceExisting: true });
-        }
+        return createOrReuseCanonical(true);
       }
     }
 
-    return createCanonicalOrchestrator(orchestratorConfig, {
-      replaceExisting: existing?.id === canonicalSessionId,
-    });
+    return createOrReuseCanonical(existing?.id === canonicalSessionId);
   }
 
   async function spawnOrchestrator(orchestratorConfig: OrchestratorSpawnConfig): Promise<Session> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -333,6 +333,43 @@ export interface Session {
   metadata: Record<string, string>;
 }
 
+function compareOrchestratorRecency(
+  a: Pick<Session, "id" | "lastActivityAt" | "createdAt">,
+  b: Pick<Session, "id" | "lastActivityAt" | "createdAt">,
+): number {
+  return (
+    (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0) ||
+    (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0) ||
+    a.id.localeCompare(b.id)
+  );
+}
+
+export function selectPreferredOrchestratorSession(
+  sessions: Session[],
+  canonicalSessionId: string,
+): Session | null {
+  const exact = sessions.find((session) => session.id === canonicalSessionId) ?? null;
+  if (exact && !isTerminalSession(exact)) {
+    return exact;
+  }
+
+  const live = sessions
+    .filter((session) => !isTerminalSession(session))
+    .sort(compareOrchestratorRecency);
+  if (live.length > 0) {
+    return live[0] ?? null;
+  }
+
+  if (exact) {
+    return exact;
+  }
+
+  const restorable = sessions
+    .filter((session) => isRestorable(session))
+    .sort(compareOrchestratorRecency);
+  return restorable[0] ?? null;
+}
+
 export function isOrchestratorSession(
   session: { id: SessionId; metadata?: Record<string, string> },
   sessionPrefix?: string,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -345,7 +345,10 @@ export function isOrchestratorSession(
     return false;
   }
   const escaped = sessionPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  if (!new RegExp(`^${escaped}-orchestrator-\\d+$`).test(session.id)) {
+  if (
+    session.id !== `${sessionPrefix}-orchestrator` &&
+    !new RegExp(`^${escaped}-orchestrator-\\d+$`).test(session.id)
+  ) {
     return false;
   }
   // Guard against cross-project false positives: if the session ID is a plain
@@ -1694,6 +1697,7 @@ export interface KillOptions {
 /** Session manager — CRUD for sessions */
 export interface SessionManager {
   spawn(config: SessionSpawnConfig): Promise<Session>;
+  ensureOrchestrator(config: OrchestratorSpawnConfig): Promise<Session>;
   spawnOrchestrator(config: OrchestratorSpawnConfig): Promise<Session>;
   restore(sessionId: SessionId): Promise<Session>;
   list(projectId?: string): Promise<Session[]>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -333,41 +333,11 @@ export interface Session {
   metadata: Record<string, string>;
 }
 
-function compareOrchestratorRecency(
-  a: Pick<Session, "id" | "lastActivityAt" | "createdAt">,
-  b: Pick<Session, "id" | "lastActivityAt" | "createdAt">,
-): number {
-  return (
-    (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0) ||
-    (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0) ||
-    a.id.localeCompare(b.id)
-  );
-}
-
 export function selectPreferredOrchestratorSession(
   sessions: Session[],
   canonicalSessionId: string,
 ): Session | null {
-  const exact = sessions.find((session) => session.id === canonicalSessionId) ?? null;
-  if (exact && !isTerminalSession(exact)) {
-    return exact;
-  }
-
-  const live = sessions
-    .filter((session) => !isTerminalSession(session))
-    .sort(compareOrchestratorRecency);
-  if (live.length > 0) {
-    return live[0] ?? null;
-  }
-
-  if (exact) {
-    return exact;
-  }
-
-  const restorable = sessions
-    .filter((session) => isRestorable(session))
-    .sort(compareOrchestratorRecency);
-  return restorable[0] ?? null;
+  return sessions.find((session) => session.id === canonicalSessionId) ?? null;
 }
 
 export function isOrchestratorSession(
@@ -375,35 +345,11 @@ export function isOrchestratorSession(
   sessionPrefix?: string,
   allSessionPrefixes?: string[],
 ): boolean {
-  if (session.metadata?.["role"] === "orchestrator") {
-    return true;
-  }
   if (!sessionPrefix) {
-    return false;
+    return session.metadata?.["role"] === "orchestrator";
   }
-  const escaped = sessionPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  if (
-    session.id !== `${sessionPrefix}-orchestrator` &&
-    !new RegExp(`^${escaped}-orchestrator-\\d+$`).test(session.id)
-  ) {
-    return false;
-  }
-  // Guard against cross-project false positives: if the session ID is a plain
-  // numbered worker for any other known prefix (e.g. prefix "app-orchestrator"
-  // matches "app-orchestrator-1" as a worker), it is not an orchestrator.
-  if (allSessionPrefixes) {
-    for (const prefix of allSessionPrefixes) {
-      if (prefix === sessionPrefix) continue;
-      if (
-        new RegExp(
-          `^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-\\d+$`,
-        ).test(session.id)
-      ) {
-        return false;
-      }
-    }
-  }
-  return true;
+  void allSessionPrefixes;
+  return session.id === `${sessionPrefix}-orchestrator`;
 }
 
 /** Config for creating a new session */

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -894,13 +894,22 @@ describe("API Routes", () => {
     it("reuses the live canonical orchestrator instead of spawning another one", async () => {
       (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
         makeSession({
-          id: "my-app-orchestrator-30",
+          id: "my-app-orchestrator",
           projectId: "my-app",
           metadata: { role: "orchestrator" },
           status: "working",
           activity: "active",
         }),
       ]);
+      (mockSessionManager.ensureOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        makeSession({
+          id: "my-app-orchestrator",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          status: "working",
+          activity: "active",
+        }),
+      );
 
       const req = makeRequest("/api/orchestrators", {
         method: "POST",
@@ -910,10 +919,10 @@ describe("API Routes", () => {
       const res = await orchestratorsPOST(req);
 
       expect(res.status).toBe(200);
-      expect(mockSessionManager.ensureOrchestrator).not.toHaveBeenCalled();
+      expect(mockSessionManager.ensureOrchestrator).toHaveBeenCalledTimes(1);
       const data = await res.json();
       expect(data.reusedExisting).toBe(true);
-      expect(data.orchestrator.id).toBe("my-app-orchestrator-30");
+      expect(data.orchestrator.id).toBe("my-app-orchestrator");
     });
 
     it("restores the canonical dead orchestrator instead of spawning another one", async () => {
@@ -928,7 +937,7 @@ describe("API Routes", () => {
 
       (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
         makeSession({
-          id: "my-app-orchestrator-30",
+          id: "my-app-orchestrator",
           projectId: "my-app",
           metadata: { role: "orchestrator" },
           status: "killed",
@@ -936,13 +945,14 @@ describe("API Routes", () => {
           lifecycle: deadLifecycle,
         }),
       ]);
-      (mockSessionManager.restore as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      (mockSessionManager.ensureOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
         makeSession({
-          id: "my-app-orchestrator-30",
+          id: "my-app-orchestrator",
           projectId: "my-app",
           metadata: { role: "orchestrator" },
           status: "spawning",
           activity: "active",
+          restoredAt: new Date("2026-04-21T11:00:00.000Z"),
         }),
       );
 
@@ -954,11 +964,10 @@ describe("API Routes", () => {
       const res = await orchestratorsPOST(req);
 
       expect(res.status).toBe(200);
-      expect(mockSessionManager.restore).toHaveBeenCalledWith("my-app-orchestrator-30");
-      expect(mockSessionManager.ensureOrchestrator).not.toHaveBeenCalled();
+      expect(mockSessionManager.ensureOrchestrator).toHaveBeenCalledTimes(1);
       const data = await res.json();
       expect(data.restoredExisting).toBe(true);
-      expect(data.orchestrator.id).toBe("my-app-orchestrator-30");
+      expect(data.orchestrator.id).toBe("my-app-orchestrator");
     });
 
     it("spawns a fresh orchestrator when canonical restore fails", async () => {
@@ -973,7 +982,7 @@ describe("API Routes", () => {
 
       (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
         makeSession({
-          id: "my-app-orchestrator-30",
+          id: "my-app-orchestrator",
           projectId: "my-app",
           metadata: { role: "orchestrator" },
           status: "killed",
@@ -981,12 +990,9 @@ describe("API Routes", () => {
           lifecycle: deadLifecycle,
         }),
       ]);
-      (mockSessionManager.restore as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-        new Error("workspace missing"),
-      );
       (mockSessionManager.ensureOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
         makeSession({
-          id: "my-app-orchestrator-31",
+          id: "my-app-orchestrator",
           projectId: "my-app",
           metadata: { role: "orchestrator" },
           status: "spawning",
@@ -1002,10 +1008,9 @@ describe("API Routes", () => {
       const res = await orchestratorsPOST(req);
 
       expect(res.status).toBe(201);
-      expect(mockSessionManager.restore).toHaveBeenCalledWith("my-app-orchestrator-30");
       expect(mockSessionManager.ensureOrchestrator).toHaveBeenCalledTimes(1);
       const data = await res.json();
-      expect(data.orchestrator.id).toBe("my-app-orchestrator-31");
+      expect(data.orchestrator.id).toBe("my-app-orchestrator");
     });
 
     it("returns 404 for an unknown project", async () => {

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -322,16 +322,16 @@ describe("API Routes", () => {
       expect(res.status).toBe(200);
       const data = await res.json();
 
-      expect(data.orchestratorId).toBeNull();
+      expect(data.orchestratorId).toBe("docs-orchestrator");
       expect(data.orchestrators).toEqual([
         { id: "docs-orchestrator", projectId: "docs-app", projectName: "Docs App" },
-        { id: "app-orchestrator", projectId: "my-app", projectName: "My App" },
       ]);
       expect(data.sessions.map((session: { id: string }) => session.id)).toEqual([
+        "app-orchestrator",
         "backend-3",
         "docs-2",
       ]);
-      expect(data.stats.totalSessions).toBe(2);
+      expect(data.stats.totalSessions).toBe(3);
     });
 
     it("supports project-scoped session queries for orchestrator detail views", async () => {
@@ -375,38 +375,21 @@ describe("API Routes", () => {
     it("prefers the most recently active live orchestrator for project-scoped worker navigation", async () => {
       const deadLifecycle = createInitialCanonicalLifecycle("orchestrator", new Date("2026-04-19T11:00:00.000Z"));
       deadLifecycle.session.state = "terminated";
-      deadLifecycle.session.reason = "runtime_missing";
+      deadLifecycle.session.reason = "runtime_lost";
       deadLifecycle.session.terminatedAt = "2026-04-19T11:00:00.000Z";
       deadLifecycle.session.lastTransitionAt = "2026-04-19T11:00:00.000Z";
       deadLifecycle.runtime.state = "missing";
       deadLifecycle.runtime.reason = "process_missing";
       deadLifecycle.runtime.lastObservedAt = "2026-04-19T11:00:00.000Z";
 
-      const olderLive = makeSession({
-        id: "my-app-orchestrator-1",
-        projectId: "my-app",
-        metadata: { role: "orchestrator" },
-        lastActivityAt: new Date("2026-04-19T09:00:00.000Z"),
-      });
-      const newerLive = makeSession({
-        id: "my-app-orchestrator-2",
+      const canonical = makeSession({
+        id: "my-app-orchestrator",
         projectId: "my-app",
         metadata: { role: "orchestrator" },
         lastActivityAt: new Date("2026-04-19T10:00:00.000Z"),
       });
-      const deadOlder = makeSession({
-        id: "my-app-orchestrator-0",
-        projectId: "my-app",
-        metadata: { role: "orchestrator" },
-        status: "killed",
-        activity: "exited",
-        lastActivityAt: new Date("2026-04-19T11:00:00.000Z"),
-        lifecycle: deadLifecycle,
-      });
       (mockSessionManager.listCached as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
-        deadOlder,
-        olderLive,
-        newerLive,
+        canonical,
         makeSession({
           id: "backend-3",
           projectId: "my-app",
@@ -421,9 +404,9 @@ describe("API Routes", () => {
       expect(res.status).toBe(200);
       const data = await res.json();
 
-      expect(data.orchestratorId).toBe("my-app-orchestrator-2");
+      expect(data.orchestratorId).toBe("my-app-orchestrator");
       expect(data.orchestrators.map((session: { id: string }) => session.id)).toEqual([
-        "my-app-orchestrator-2",
+        "my-app-orchestrator",
       ]);
       expect(data.sessions).toEqual([]);
       expect(mockSessionManager.listCached).toHaveBeenCalledWith("my-app");
@@ -432,7 +415,7 @@ describe("API Routes", () => {
     it("keeps dead orchestrators as the fallback project-scoped payload when none are live", async () => {
       const deadLifecycle = createInitialCanonicalLifecycle("orchestrator", new Date("2026-04-19T11:00:00.000Z"));
       deadLifecycle.session.state = "terminated";
-      deadLifecycle.session.reason = "runtime_missing";
+      deadLifecycle.session.reason = "runtime_lost";
       deadLifecycle.session.terminatedAt = "2026-04-19T11:00:00.000Z";
       deadLifecycle.session.lastTransitionAt = "2026-04-19T11:00:00.000Z";
       deadLifecycle.runtime.state = "missing";
@@ -441,7 +424,7 @@ describe("API Routes", () => {
 
       (mockSessionManager.listCached as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
         makeSession({
-          id: "my-app-orchestrator-0",
+          id: "my-app-orchestrator",
           projectId: "my-app",
           metadata: { role: "orchestrator" },
           status: "killed",
@@ -457,62 +440,9 @@ describe("API Routes", () => {
       expect(res.status).toBe(200);
       const data = await res.json();
 
-      expect(data.orchestratorId).toBe("my-app-orchestrator-0");
+      expect(data.orchestratorId).toBe("my-app-orchestrator");
       expect(data.orchestrators).toEqual([
-        { id: "my-app-orchestrator-0", projectId: "my-app", projectName: "My App" },
-      ]);
-      expect(data.sessions).toEqual([]);
-    });
-
-    it("prefers the most recently active dead orchestrator when no live project orchestrator exists", async () => {
-      const olderDeadLifecycle = createInitialCanonicalLifecycle("orchestrator", new Date("2026-04-19T10:00:00.000Z"));
-      olderDeadLifecycle.session.state = "terminated";
-      olderDeadLifecycle.session.reason = "runtime_missing";
-      olderDeadLifecycle.session.terminatedAt = "2026-04-19T10:00:00.000Z";
-      olderDeadLifecycle.session.lastTransitionAt = "2026-04-19T10:00:00.000Z";
-      olderDeadLifecycle.runtime.state = "missing";
-      olderDeadLifecycle.runtime.reason = "process_missing";
-      olderDeadLifecycle.runtime.lastObservedAt = "2026-04-19T10:00:00.000Z";
-
-      const newerDeadLifecycle = createInitialCanonicalLifecycle("orchestrator", new Date("2026-04-19T11:00:00.000Z"));
-      newerDeadLifecycle.session.state = "terminated";
-      newerDeadLifecycle.session.reason = "runtime_missing";
-      newerDeadLifecycle.session.terminatedAt = "2026-04-19T11:00:00.000Z";
-      newerDeadLifecycle.session.lastTransitionAt = "2026-04-19T11:00:00.000Z";
-      newerDeadLifecycle.runtime.state = "missing";
-      newerDeadLifecycle.runtime.reason = "process_missing";
-      newerDeadLifecycle.runtime.lastObservedAt = "2026-04-19T11:00:00.000Z";
-
-      (mockSessionManager.listCached as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
-        makeSession({
-          id: "my-app-orchestrator-0",
-          projectId: "my-app",
-          metadata: { role: "orchestrator" },
-          status: "killed",
-          activity: "exited",
-          lastActivityAt: new Date("2026-04-19T10:00:00.000Z"),
-          lifecycle: olderDeadLifecycle,
-        }),
-        makeSession({
-          id: "my-app-orchestrator-9",
-          projectId: "my-app",
-          metadata: { role: "orchestrator" },
-          status: "killed",
-          activity: "exited",
-          lastActivityAt: new Date("2026-04-19T11:00:00.000Z"),
-          lifecycle: newerDeadLifecycle,
-        }),
-      ]);
-
-      const res = await sessionsGET(
-        makeRequest("http://localhost:3000/api/sessions?project=my-app&orchestratorOnly=true"),
-      );
-      expect(res.status).toBe(200);
-      const data = await res.json();
-
-      expect(data.orchestratorId).toBe("my-app-orchestrator-9");
-      expect(data.orchestrators).toEqual([
-        { id: "my-app-orchestrator-9", projectId: "my-app", projectName: "My App" },
+        { id: "my-app-orchestrator", projectId: "my-app", projectName: "My App" },
       ]);
       expect(data.sessions).toEqual([]);
     });
@@ -928,7 +858,7 @@ describe("API Routes", () => {
     it("restores the canonical dead orchestrator instead of spawning another one", async () => {
       const deadLifecycle = createInitialCanonicalLifecycle("orchestrator", new Date("2026-04-19T11:00:00.000Z"));
       deadLifecycle.session.state = "terminated";
-      deadLifecycle.session.reason = "runtime_missing";
+      deadLifecycle.session.reason = "runtime_lost";
       deadLifecycle.session.terminatedAt = "2026-04-19T11:00:00.000Z";
       deadLifecycle.session.lastTransitionAt = "2026-04-19T11:00:00.000Z";
       deadLifecycle.runtime.state = "missing";
@@ -973,7 +903,7 @@ describe("API Routes", () => {
     it("spawns a fresh orchestrator when canonical restore fails", async () => {
       const deadLifecycle = createInitialCanonicalLifecycle("orchestrator", new Date("2026-04-19T11:00:00.000Z"));
       deadLifecycle.session.state = "terminated";
-      deadLifecycle.session.reason = "runtime_missing";
+      deadLifecycle.session.reason = "runtime_lost";
       deadLifecycle.session.terminatedAt = "2026-04-19T11:00:00.000Z";
       deadLifecycle.session.lastTransitionAt = "2026-04-19T11:00:00.000Z";
       deadLifecycle.runtime.state = "missing";
@@ -1074,7 +1004,7 @@ describe("API Routes", () => {
       (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
       (mockSessionManager.ensureOrchestrator as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
         new Error(
-          'Worktree path "/Users/test/.worktrees/my-app/my-app-orchestrator-1" already exists and is still registered with git',
+          'Worktree path "/Users/test/.worktrees/my-app/my-app-orchestrator" already exists and is still registered with git',
         ),
       );
 
@@ -1116,18 +1046,10 @@ describe("API Routes", () => {
       expect(data.projectName).toBe("My App");
     });
 
-    it("returns only the canonical orchestrator when multiple historical sessions exist", async () => {
+    it("returns only the canonical orchestrator", async () => {
       (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
         makeSession({
-          id: "my-app-orchestrator-1",
-          projectId: "my-app",
-          metadata: { role: "orchestrator" },
-          status: "killed",
-          activity: "exited",
-          lastActivityAt: new Date("2026-04-19T10:00:00.000Z"),
-        }),
-        makeSession({
-          id: "my-app-orchestrator-7",
+          id: "my-app-orchestrator",
           projectId: "my-app",
           metadata: { role: "orchestrator" },
           status: "working",
@@ -1142,7 +1064,7 @@ describe("API Routes", () => {
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(data.orchestrators).toEqual([
-        expect.objectContaining({ id: "my-app-orchestrator-7" }),
+        expect.objectContaining({ id: "my-app-orchestrator" }),
       ]);
     });
 

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -943,6 +943,53 @@ describe("API Routes", () => {
       expect(data.orchestrator.id).toBe("my-app-orchestrator-30");
     });
 
+    it("spawns a fresh orchestrator when canonical restore fails", async () => {
+      const deadLifecycle = createInitialCanonicalLifecycle("orchestrator", new Date("2026-04-19T11:00:00.000Z"));
+      deadLifecycle.session.state = "terminated";
+      deadLifecycle.session.reason = "runtime_missing";
+      deadLifecycle.session.terminatedAt = "2026-04-19T11:00:00.000Z";
+      deadLifecycle.session.lastTransitionAt = "2026-04-19T11:00:00.000Z";
+      deadLifecycle.runtime.state = "missing";
+      deadLifecycle.runtime.reason = "process_missing";
+      deadLifecycle.runtime.lastObservedAt = "2026-04-19T11:00:00.000Z";
+
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+        makeSession({
+          id: "my-app-orchestrator-30",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          status: "killed",
+          activity: "exited",
+          lifecycle: deadLifecycle,
+        }),
+      ]);
+      (mockSessionManager.restore as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("workspace missing"),
+      );
+      (mockSessionManager.spawnOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        makeSession({
+          id: "my-app-orchestrator-31",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          status: "spawning",
+          activity: "active",
+        }),
+      );
+
+      const req = makeRequest("/api/orchestrators", {
+        method: "POST",
+        body: JSON.stringify({ projectId: "my-app" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      const res = await orchestratorsPOST(req);
+
+      expect(res.status).toBe(201);
+      expect(mockSessionManager.restore).toHaveBeenCalledWith("my-app-orchestrator-30");
+      expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledTimes(1);
+      const data = await res.json();
+      expect(data.orchestrator.id).toBe("my-app-orchestrator-31");
+    });
+
     it("returns 404 for an unknown project", async () => {
       const req = makeRequest("/api/orchestrators", {
         method: "POST",

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -405,7 +405,6 @@ describe("API Routes", () => {
 
       expect(data.orchestratorId).toBe("my-app-orchestrator-2");
       expect(data.orchestrators.map((session: { id: string }) => session.id)).toEqual([
-        "my-app-orchestrator-1",
         "my-app-orchestrator-2",
       ]);
       expect(data.sessions).toEqual([]);
@@ -495,7 +494,6 @@ describe("API Routes", () => {
 
       expect(data.orchestratorId).toBe("my-app-orchestrator-9");
       expect(data.orchestrators).toEqual([
-        { id: "my-app-orchestrator-0", projectId: "my-app", projectName: "My App" },
         { id: "my-app-orchestrator-9", projectId: "my-app", projectName: "My App" },
       ]);
       expect(data.sessions).toEqual([]);
@@ -841,6 +839,7 @@ describe("API Routes", () => {
 
   describe("POST /api/orchestrators", () => {
     it("creates a per-project orchestrator with the generated prompt", async () => {
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
       (mockSessionManager.spawnOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
         makeSession({
           id: "my-app-orchestrator",
@@ -867,7 +866,81 @@ describe("API Routes", () => {
         id: "my-app-orchestrator",
         projectId: "my-app",
         projectName: "My App",
+        status: "working",
+        activity: "active",
+        createdAt: expect.any(String),
+        lastActivityAt: expect.any(String),
       });
+    });
+
+    it("reuses the live canonical orchestrator instead of spawning another one", async () => {
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+        makeSession({
+          id: "my-app-orchestrator-30",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          status: "working",
+          activity: "active",
+        }),
+      ]);
+
+      const req = makeRequest("/api/orchestrators", {
+        method: "POST",
+        body: JSON.stringify({ projectId: "my-app" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      const res = await orchestratorsPOST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+      const data = await res.json();
+      expect(data.reusedExisting).toBe(true);
+      expect(data.orchestrator.id).toBe("my-app-orchestrator-30");
+    });
+
+    it("restores the canonical dead orchestrator instead of spawning another one", async () => {
+      const deadLifecycle = createInitialCanonicalLifecycle("orchestrator", new Date("2026-04-19T11:00:00.000Z"));
+      deadLifecycle.session.state = "terminated";
+      deadLifecycle.session.reason = "runtime_missing";
+      deadLifecycle.session.terminatedAt = "2026-04-19T11:00:00.000Z";
+      deadLifecycle.session.lastTransitionAt = "2026-04-19T11:00:00.000Z";
+      deadLifecycle.runtime.state = "missing";
+      deadLifecycle.runtime.reason = "process_missing";
+      deadLifecycle.runtime.lastObservedAt = "2026-04-19T11:00:00.000Z";
+
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+        makeSession({
+          id: "my-app-orchestrator-30",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          status: "killed",
+          activity: "exited",
+          lifecycle: deadLifecycle,
+        }),
+      ]);
+      (mockSessionManager.restore as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        makeSession({
+          id: "my-app-orchestrator-30",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          status: "spawning",
+          activity: "active",
+        }),
+      );
+
+      const req = makeRequest("/api/orchestrators", {
+        method: "POST",
+        body: JSON.stringify({ projectId: "my-app" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      const res = await orchestratorsPOST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockSessionManager.restore).toHaveBeenCalledWith("my-app-orchestrator-30");
+      expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+      const data = await res.json();
+      expect(data.restoredExisting).toBe(true);
+      expect(data.orchestrator.id).toBe("my-app-orchestrator-30");
     });
 
     it("returns 404 for an unknown project", async () => {
@@ -910,6 +983,7 @@ describe("API Routes", () => {
     });
 
     it("returns 500 when orchestrator spawn fails", async () => {
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
       (mockSessionManager.spawnOrchestrator as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
         new Error("boom"),
       );
@@ -927,6 +1001,7 @@ describe("API Routes", () => {
     });
 
     it("returns a guided recovery message for registered orchestrator worktree collisions", async () => {
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
       (mockSessionManager.spawnOrchestrator as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
         new Error(
           'Worktree path "/Users/test/.worktrees/my-app/my-app-orchestrator-1" already exists and is still registered with git',
@@ -969,6 +1044,36 @@ describe("API Routes", () => {
       expect(data.orchestrators).toHaveLength(1);
       expect(data.orchestrators[0].id).toBe("my-app-orchestrator");
       expect(data.projectName).toBe("My App");
+    });
+
+    it("returns only the canonical orchestrator when multiple historical sessions exist", async () => {
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+        makeSession({
+          id: "my-app-orchestrator-1",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          status: "killed",
+          activity: "exited",
+          lastActivityAt: new Date("2026-04-19T10:00:00.000Z"),
+        }),
+        makeSession({
+          id: "my-app-orchestrator-7",
+          projectId: "my-app",
+          metadata: { role: "orchestrator" },
+          status: "working",
+          activity: "active",
+          lastActivityAt: new Date("2026-04-19T11:00:00.000Z"),
+        }),
+      ]);
+
+      const res = await orchestratorsGET(
+        makeRequest("http://localhost:3000/api/orchestrators?project=my-app"),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.orchestrators).toEqual([
+        expect.objectContaining({ id: "my-app-orchestrator-7" }),
+      ]);
     });
 
     it("returns 400 when project parameter is missing", async () => {
@@ -1284,6 +1389,27 @@ describe("API Routes", () => {
       expect(event.sessions.length).toBeGreaterThan(0);
       expect(event.sessions[0]).toHaveProperty("id");
       expect(event.sessions[0]).toHaveProperty("attentionLevel");
+    });
+
+    it("stops enqueuing cleanly after the client aborts the SSE request", async () => {
+      vi.useFakeTimers();
+      const abortController = new AbortController();
+      const req = {
+        url: "http://localhost:3000/api/events",
+        signal: abortController.signal,
+      } as Request;
+      const res = await eventsGET(req);
+      const reader = res.body!.getReader();
+
+      await reader.read();
+      abortController.abort();
+
+      await expect(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      }).not.toThrow();
+
+      await reader.cancel();
+      vi.useRealTimers();
     });
   });
 

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -126,6 +126,15 @@ const mockSessionManager: SessionManager = {
     }
   }),
   cleanup: vi.fn(async () => ({ killed: [], skipped: [], errors: [] })),
+  ensureOrchestrator: vi.fn(async (config) =>
+    makeSession({
+      id: "my-app-orchestrator",
+      projectId: config.projectId,
+      metadata: { role: "orchestrator" },
+      status: "working",
+      activity: "active",
+    }),
+  ),
   spawnOrchestrator: vi.fn(),
   remap: vi.fn(async () => "ses_mock"),
   restore: vi.fn(async (id: string) => {
@@ -237,6 +246,15 @@ beforeEach(() => {
   // Re-set default return values
   (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValue(testSessions);
   (mockSessionManager.listCached as ReturnType<typeof vi.fn>).mockResolvedValue(testSessions);
+  (mockSessionManager.ensureOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValue(
+    makeSession({
+      id: "my-app-orchestrator",
+      projectId: "my-app",
+      metadata: { role: "orchestrator" },
+      status: "working",
+      activity: "active",
+    }),
+  );
   (mockSessionManager.get as ReturnType<typeof vi.fn>).mockImplementation(
     async (id: string) => testSessions.find((s) => s.id === id) ?? null,
   );
@@ -840,7 +858,7 @@ describe("API Routes", () => {
   describe("POST /api/orchestrators", () => {
     it("creates a per-project orchestrator with the generated prompt", async () => {
       (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
-      (mockSessionManager.spawnOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      (mockSessionManager.ensureOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
         makeSession({
           id: "my-app-orchestrator",
           projectId: "my-app",
@@ -856,7 +874,7 @@ describe("API Routes", () => {
       const res = await orchestratorsPOST(req);
 
       expect(res.status).toBe(201);
-      expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith({
+      expect(mockSessionManager.ensureOrchestrator).toHaveBeenCalledWith({
         projectId: "my-app",
         systemPrompt: expect.stringContaining("# My App Orchestrator"),
       });
@@ -892,7 +910,7 @@ describe("API Routes", () => {
       const res = await orchestratorsPOST(req);
 
       expect(res.status).toBe(200);
-      expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+      expect(mockSessionManager.ensureOrchestrator).not.toHaveBeenCalled();
       const data = await res.json();
       expect(data.reusedExisting).toBe(true);
       expect(data.orchestrator.id).toBe("my-app-orchestrator-30");
@@ -937,7 +955,7 @@ describe("API Routes", () => {
 
       expect(res.status).toBe(200);
       expect(mockSessionManager.restore).toHaveBeenCalledWith("my-app-orchestrator-30");
-      expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+      expect(mockSessionManager.ensureOrchestrator).not.toHaveBeenCalled();
       const data = await res.json();
       expect(data.restoredExisting).toBe(true);
       expect(data.orchestrator.id).toBe("my-app-orchestrator-30");
@@ -966,7 +984,7 @@ describe("API Routes", () => {
       (mockSessionManager.restore as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
         new Error("workspace missing"),
       );
-      (mockSessionManager.spawnOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      (mockSessionManager.ensureOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
         makeSession({
           id: "my-app-orchestrator-31",
           projectId: "my-app",
@@ -985,7 +1003,7 @@ describe("API Routes", () => {
 
       expect(res.status).toBe(201);
       expect(mockSessionManager.restore).toHaveBeenCalledWith("my-app-orchestrator-30");
-      expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledTimes(1);
+      expect(mockSessionManager.ensureOrchestrator).toHaveBeenCalledTimes(1);
       const data = await res.json();
       expect(data.orchestrator.id).toBe("my-app-orchestrator-31");
     });
@@ -1031,7 +1049,7 @@ describe("API Routes", () => {
 
     it("returns 500 when orchestrator spawn fails", async () => {
       (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
-      (mockSessionManager.spawnOrchestrator as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      (mockSessionManager.ensureOrchestrator as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
         new Error("boom"),
       );
 
@@ -1049,7 +1067,7 @@ describe("API Routes", () => {
 
     it("returns a guided recovery message for registered orchestrator worktree collisions", async () => {
       (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
-      (mockSessionManager.spawnOrchestrator as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      (mockSessionManager.ensureOrchestrator as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
         new Error(
           'Worktree path "/Users/test/.worktrees/my-app/my-app-orchestrator-1" already exists and is still registered with git',
         ),

--- a/packages/web/src/__tests__/components.test.tsx
+++ b/packages/web/src/__tests__/components.test.tsx
@@ -204,6 +204,54 @@ describe("SessionCard", () => {
     expect(screen.getByText("feat/cool-thing")).toBeInTheDocument();
   });
 
+  it("does not render lifecycle guidance as a pill on kanban cards", () => {
+    const session = makeSession({
+      lifecycle: {
+        sessionState: "detecting",
+        sessionReason: "runtime_lost",
+        prState: "none",
+        prReason: "not_created",
+        runtimeState: "missing",
+        runtimeReason: "tmux_missing",
+        session: {
+          state: "detecting",
+          reason: "runtime_lost",
+          label: "detecting",
+          reasonLabel: "runtime lost",
+          startedAt: new Date().toISOString(),
+          completedAt: null,
+          terminatedAt: null,
+          lastTransitionAt: new Date().toISOString(),
+        },
+        pr: {
+          state: "none",
+          reason: "not_created",
+          label: "not created",
+          reasonLabel: "not created",
+          number: null,
+          url: null,
+          lastObservedAt: null,
+        },
+        runtime: {
+          state: "missing",
+          reason: "tmux_missing",
+          label: "missing",
+          reasonLabel: "tmux missing",
+          lastObservedAt: new Date().toISOString(),
+        },
+        legacyStatus: "detecting",
+        evidence: null,
+        detectingAttempts: 1,
+        detectingEscalatedAt: null,
+        summary: "Detecting runtime truth (runtime lost)",
+        guidance: "Checking runtime and process evidence now.",
+      },
+    });
+
+    render(<SessionCard session={session} />);
+    expect(screen.queryByText("Checking runtime and process evidence now.")).not.toBeInTheDocument();
+  });
+
   it("renders terminal link", () => {
     const session = makeSession({ id: "backend-5" });
     render(<SessionCard session={session} />);
@@ -215,7 +263,7 @@ describe("SessionCard", () => {
     const session = makeSession({ activity: "exited" });
     render(<SessionCard session={session} />);
     // Header shows compact "restore"; expanded panel shows "restore session"
-    expect(screen.getByText("restore")).toBeInTheDocument();
+    expect(screen.getByText("restore")).toHaveClass("session-card__restore-control");
   });
 
   it("does not show restore button when agent is active", () => {

--- a/packages/web/src/__tests__/orchestrators.test.tsx
+++ b/packages/web/src/__tests__/orchestrators.test.tsx
@@ -39,7 +39,7 @@ describe("Orchestrators Page (OrchestratorsRoute)", () => {
     const mockSessionManager = {
       list: vi.fn().mockResolvedValue([
         {
-          id: "app-orchestrator-1",
+          id: "app-orchestrator",
           projectId: "my-app",
           status: "working",
           activity: "active",
@@ -66,7 +66,7 @@ describe("Orchestrators Page (OrchestratorsRoute)", () => {
     render(jsx);
 
     expect(screen.getByText("My App")).toBeInTheDocument();
-    expect(screen.getByText("app-orchestrator-1")).toBeInTheDocument();
+    expect(screen.getByText("app-orchestrator")).toBeInTheDocument();
   });
 
   it("shows error when project is missing in searchParams", async () => {

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -28,6 +28,7 @@ export async function GET(request: Request): Promise<Response> {
   let updates: ReturnType<typeof setInterval> | undefined;
   let observerProjectId: string | undefined;
   let observer: ProjectObserver | null = null;
+  let streamClosed = false;
 
   const ensureObserver = (config: ServicesConfig): ProjectObserver | null => {
     if (!observerProjectId) {
@@ -44,8 +45,33 @@ export async function GET(request: Request): Promise<Response> {
     return observer;
   };
 
+  const stopIntervals = () => {
+    if (heartbeat) clearInterval(heartbeat);
+    if (updates) clearInterval(updates);
+    heartbeat = undefined;
+    updates = undefined;
+  };
+
+  const cleanup = () => {
+    streamClosed = true;
+    stopIntervals();
+  };
+
   const stream = new ReadableStream({
     start(controller) {
+      const safeEnqueue = (payload: string): boolean => {
+        if (streamClosed) return false;
+        try {
+          controller.enqueue(encoder.encode(payload));
+          return true;
+        } catch {
+          cleanup();
+          return false;
+        }
+      };
+
+      request.signal.addEventListener("abort", cleanup, { once: true });
+
       void (async () => {
         try {
           const { config } = await getServices();
@@ -96,7 +122,7 @@ export async function GET(request: Request): Promise<Response> {
               lastActivityAt: s.lastActivityAt,
             })),
           };
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify(initialEvent)}\n\n`));
+          safeEnqueue(`data: ${JSON.stringify(initialEvent)}\n\n`);
           if (projectObserver && observerProjectId) {
             projectObserver.recordOperation({
               metric: "sse_snapshot",
@@ -110,22 +136,15 @@ export async function GET(request: Request): Promise<Response> {
           }
         } catch {
           // If services aren't available, send empty snapshot
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ type: "snapshot", correlationId, emittedAt: new Date().toISOString(), sessions: [] })}\n\n`,
-            ),
+          safeEnqueue(
+            `data: ${JSON.stringify({ type: "snapshot", correlationId, emittedAt: new Date().toISOString(), sessions: [] })}\n\n`,
           );
         }
       })();
 
       // Send periodic heartbeat
       heartbeat = setInterval(() => {
-        try {
-          controller.enqueue(encoder.encode(`: heartbeat\n\n`));
-        } catch {
-          clearInterval(heartbeat);
-          clearInterval(updates);
-        }
+        safeEnqueue(`: heartbeat\n\n`);
       }, 15000);
 
       // Poll for session state changes frequently enough that new workers
@@ -172,7 +191,9 @@ export async function GET(request: Request): Promise<Response> {
                   lastActivityAt: s.lastActivityAt,
                 })),
               };
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+              if (!safeEnqueue(`data: ${JSON.stringify(event)}\n\n`)) {
+                return;
+              }
               if (projectObserver && observerProjectId) {
                 projectObserver.recordOperation({
                   metric: "sse_snapshot",
@@ -185,9 +206,7 @@ export async function GET(request: Request): Promise<Response> {
                 });
               }
             } catch {
-              // enqueue failure means the stream is closed — clean up both intervals
-              clearInterval(updates);
-              clearInterval(heartbeat);
+              cleanup();
             }
           } catch {
             // Transient service error — skip this poll, retry on next interval
@@ -197,8 +216,7 @@ export async function GET(request: Request): Promise<Response> {
       }, SESSION_EVENTS_POLL_INTERVAL_MS);
     },
     cancel() {
-      clearInterval(heartbeat);
-      clearInterval(updates);
+      cleanup();
       void (async () => {
         try {
           const { config } = await getServices();

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -10,7 +10,7 @@ import {
 
 export const dynamic = "force-dynamic";
 
-const SESSION_EVENTS_POLL_INTERVAL_MS = 2000;
+const SESSION_EVENTS_POLL_INTERVAL_MS = 5000;
 
 /**
  * GET /api/events — SSE stream for real-time lifecycle events

--- a/packages/web/src/app/api/orchestrators/route.ts
+++ b/packages/web/src/app/api/orchestrators/route.ts
@@ -101,46 +101,23 @@ export async function POST(request: NextRequest) {
       allSessionPrefixes,
     );
 
-    if (canonical) {
-      if (!isTerminalSession(canonical)) {
-        return NextResponse.json(
-          {
-            orchestrator: mapSessionToOrchestrator(canonical, project.name),
-            reusedExisting: true,
-          },
-          { status: 200 },
-        );
-      }
-
-      if (isRestorable(canonical)) {
-        try {
-          const restored = await sessionManager.restore(canonical.id);
-          return NextResponse.json(
-            {
-              orchestrator: mapSessionToOrchestrator(restored, project.name),
-              reusedExisting: true,
-              restoredExisting: true,
-            },
-            { status: 200 },
-          );
-        } catch (error) {
-          console.warn("Failed to restore canonical orchestrator, falling back to spawn", {
-            projectId,
-            orchestratorId: canonical.id,
-            error,
-          });
-        }
-      }
-    }
-
     const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
     const session = await sessionManager.ensureOrchestrator({ projectId, systemPrompt });
+    const reusedExisting =
+      canonical !== null && !isTerminalSession(canonical) && canonical.id === session.id;
+    const restoredExisting =
+      canonical !== null &&
+      isRestorable(canonical) &&
+      canonical.id === session.id &&
+      session.restoredAt !== undefined;
 
     return NextResponse.json(
       {
         orchestrator: mapSessionToOrchestrator(session, project.name),
+        ...(reusedExisting ? { reusedExisting: true } : {}),
+        ...(restoredExisting ? { reusedExisting: true, restoredExisting: true } : {}),
       },
-      { status: 201 },
+      { status: reusedExisting || restoredExisting ? 200 : 201 },
     );
   } catch (err) {
     const classified = classifySpawnError(body.projectId as string, err);

--- a/packages/web/src/app/api/orchestrators/route.ts
+++ b/packages/web/src/app/api/orchestrators/route.ts
@@ -1,8 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { generateOrchestratorPrompt, generateSessionPrefix } from "@aoagents/ao-core";
+import { generateOrchestratorPrompt, generateSessionPrefix, isRestorable, isTerminalSession } from "@aoagents/ao-core";
 import { getServices } from "@/lib/services";
 import { validateIdentifier, validateConfiguredProject } from "@/lib/validation";
-import { mapSessionsToOrchestrators } from "@/lib/orchestrator-utils";
+import { mapSessionToOrchestrator, mapSessionsToOrchestrators, selectCanonicalProjectOrchestrator } from "@/lib/orchestrator-utils";
 
 function classifySpawnError(projectId: string, error: unknown): {
   status: number;
@@ -90,17 +90,47 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: configProjectErr }, { status: 404 });
     }
     const project = config.projects[projectId];
+    const sessionPrefix = project.sessionPrefix ?? projectId;
+    const allSessions = await sessionManager.list(projectId);
+    const allSessionPrefixes = Object.entries(config.projects).map(
+      ([, p]) => p.sessionPrefix ?? generateSessionPrefix(p.name ?? ""),
+    );
+    const canonical = selectCanonicalProjectOrchestrator(
+      allSessions,
+      sessionPrefix,
+      allSessionPrefixes,
+    );
+
+    if (canonical) {
+      if (!isTerminalSession(canonical)) {
+        return NextResponse.json(
+          {
+            orchestrator: mapSessionToOrchestrator(canonical, project.name),
+            reusedExisting: true,
+          },
+          { status: 200 },
+        );
+      }
+
+      if (isRestorable(canonical)) {
+        const restored = await sessionManager.restore(canonical.id);
+        return NextResponse.json(
+          {
+            orchestrator: mapSessionToOrchestrator(restored, project.name),
+            reusedExisting: true,
+            restoredExisting: true,
+          },
+          { status: 200 },
+        );
+      }
+    }
 
     const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
     const session = await sessionManager.spawnOrchestrator({ projectId, systemPrompt });
 
     return NextResponse.json(
       {
-        orchestrator: {
-          id: session.id,
-          projectId,
-          projectName: project.name,
-        },
+        orchestrator: mapSessionToOrchestrator(session, project.name),
       },
       { status: 201 },
     );

--- a/packages/web/src/app/api/orchestrators/route.ts
+++ b/packages/web/src/app/api/orchestrators/route.ts
@@ -113,15 +113,23 @@ export async function POST(request: NextRequest) {
       }
 
       if (isRestorable(canonical)) {
-        const restored = await sessionManager.restore(canonical.id);
-        return NextResponse.json(
-          {
-            orchestrator: mapSessionToOrchestrator(restored, project.name),
-            reusedExisting: true,
-            restoredExisting: true,
-          },
-          { status: 200 },
-        );
+        try {
+          const restored = await sessionManager.restore(canonical.id);
+          return NextResponse.json(
+            {
+              orchestrator: mapSessionToOrchestrator(restored, project.name),
+              reusedExisting: true,
+              restoredExisting: true,
+            },
+            { status: 200 },
+          );
+        } catch (error) {
+          console.warn("Failed to restore canonical orchestrator, falling back to spawn", {
+            projectId,
+            orchestratorId: canonical.id,
+            error,
+          });
+        }
       }
     }
 

--- a/packages/web/src/app/api/orchestrators/route.ts
+++ b/packages/web/src/app/api/orchestrators/route.ts
@@ -134,7 +134,7 @@ export async function POST(request: NextRequest) {
     }
 
     const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-    const session = await sessionManager.spawnOrchestrator({ projectId, systemPrompt });
+    const session = await sessionManager.ensureOrchestrator({ projectId, systemPrompt });
 
     return NextResponse.json(
       {

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -12,6 +12,7 @@ import { getCorrelationId, jsonWithCorrelation, recordApiObservation } from "@/l
 import { filterProjectSessions } from "@/lib/project-utils";
 import { settlesWithin } from "@/lib/async-utils";
 import type { DashboardOrchestratorLink } from "@/lib/types";
+import { selectCanonicalProjectOrchestrator } from "@/lib/orchestrator-utils";
 
 const METADATA_ENRICH_TIMEOUT_MS = 3_000;
 const PR_ENRICH_TIMEOUT_MS = 4_000;
@@ -62,7 +63,7 @@ function selectPreferredOrchestratorId(
 function listPreferredProjectOrchestrators(
   sessions: Parameters<typeof listDashboardOrchestrators>[0],
   projects: Parameters<typeof listDashboardOrchestrators>[1],
-) : DashboardOrchestratorLink[] {
+): DashboardOrchestratorLink[] {
   const preferredOrchestrators = listProjectOrchestratorSessions(sessions, projects);
 
   return preferredOrchestrators
@@ -73,7 +74,6 @@ function listPreferredProjectOrchestrators(
     }))
     .sort((a, b) => a.projectName.localeCompare(b.projectName) || a.id.localeCompare(b.id));
 }
-
 export async function GET(request: Request) {
   const correlationId = getCorrelationId(request);
   const startedAt = Date.now();
@@ -93,12 +93,30 @@ export async function GET(request: Request) {
       ? await sessionManager.list(requestedProjectId)
       : await sessionManager.listCached(requestedProjectId);
     const visibleSessions = filterProjectSessions(coreSessions, projectFilter, config.projects);
+    const allSessionPrefixes = Object.entries(config.projects).map(
+      ([projectId, p]) => p.sessionPrefix ?? projectId,
+    );
     const orchestrators = requestedProjectId
-      ? listPreferredProjectOrchestrators(visibleSessions, config.projects)
+      ? (() => {
+          const project = config.projects[requestedProjectId];
+          const canonical = project
+            ? selectCanonicalProjectOrchestrator(
+                visibleSessions,
+                project.sessionPrefix ?? requestedProjectId,
+                allSessionPrefixes,
+              )
+            : null;
+          return canonical
+            ? [{
+                id: canonical.id,
+                projectId: canonical.projectId,
+                projectName: project?.name ?? canonical.projectId,
+              } satisfies DashboardOrchestratorLink]
+            : [];
+        })()
       : listDashboardOrchestrators(visibleSessions, config.projects);
-    const orchestratorId = requestedProjectId
-      ? selectPreferredOrchestratorId(visibleSessions, config.projects)
-      : (orchestrators.length === 1 ? (orchestrators[0]?.id ?? null) : null);
+    const orchestratorId =
+      requestedProjectId || orchestrators.length === 1 ? (orchestrators[0]?.id ?? null) : null;
 
     if (orchestratorOnly) {
       recordApiObservation({
@@ -123,9 +141,6 @@ export async function GET(request: Request) {
       );
     }
 
-    const allSessionPrefixes = Object.entries(config.projects).map(
-      ([projectId, p]) => p.sessionPrefix ?? projectId,
-    );
     let workerSessions = visibleSessions.filter(
       (session) =>
         !isOrchestratorSession(

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -1,4 +1,4 @@
-import { ACTIVITY_STATE, isOrchestratorSession, isTerminalSession } from "@aoagents/ao-core";
+import { ACTIVITY_STATE, isOrchestratorSession, type Session } from "@aoagents/ao-core";
 import { getServices, getSCM } from "@/lib/services";
 import {
   sessionToDashboard,
@@ -18,61 +18,9 @@ const METADATA_ENRICH_TIMEOUT_MS = 3_000;
 const PR_ENRICH_TIMEOUT_MS = 4_000;
 const PER_PR_ENRICH_TIMEOUT_MS = 1_500;
 
-function hasTerminalPRState(session: Parameters<typeof isTerminalSession>[0]): boolean {
+function hasTerminalPRState(session: Session): boolean {
   const prState = session.lifecycle?.pr.state;
   return prState === "merged" || prState === "closed";
-}
-
-function compareOrchestratorRecency(a: { lastActivityAt?: Date | null; createdAt?: Date | null; id: string }, b: { lastActivityAt?: Date | null; createdAt?: Date | null; id: string }): number {
-  return (
-    (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0) ||
-    (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0) ||
-    a.id.localeCompare(b.id)
-  );
-}
-
-function listProjectOrchestratorSessions(
-  sessions: Parameters<typeof listDashboardOrchestrators>[0],
-  projects: Parameters<typeof listDashboardOrchestrators>[1],
-): Parameters<typeof listDashboardOrchestrators>[0] {
-  const allSessionPrefixes = Object.entries(projects).map(
-    ([projectId, project]) => project.sessionPrefix ?? projectId,
-  );
-
-  const projectOrchestrators = sessions
-    .filter((session) =>
-      isOrchestratorSession(
-        session,
-        projects[session.projectId]?.sessionPrefix ?? session.projectId,
-        allSessionPrefixes,
-      ),
-    )
-    .sort(compareOrchestratorRecency);
-
-  const liveOrchestrators = projectOrchestrators.filter((session) => !isTerminalSession(session));
-  return liveOrchestrators.length > 0 ? liveOrchestrators : projectOrchestrators;
-}
-
-function selectPreferredOrchestratorId(
-  sessions: Parameters<typeof listDashboardOrchestrators>[0],
-  projects: Parameters<typeof listDashboardOrchestrators>[1],
-): string | null {
-  return listProjectOrchestratorSessions(sessions, projects)[0]?.id ?? null;
-}
-
-function listPreferredProjectOrchestrators(
-  sessions: Parameters<typeof listDashboardOrchestrators>[0],
-  projects: Parameters<typeof listDashboardOrchestrators>[1],
-): DashboardOrchestratorLink[] {
-  const preferredOrchestrators = listProjectOrchestratorSessions(sessions, projects);
-
-  return preferredOrchestrators
-    .map((session) => ({
-      id: session.id,
-      projectId: session.projectId,
-      projectName: projects[session.projectId]?.name ?? session.projectId,
-    }))
-    .sort((a, b) => a.projectName.localeCompare(b.projectName) || a.id.localeCompare(b.id));
 }
 export async function GET(request: Request) {
   const correlationId = getCorrelationId(request);

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -980,6 +980,23 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   transform: scale(0.97);
 }
 
+.topbar-action-icon {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+}
+
+.dashboard-app-btn--restore {
+  border-radius: 4px;
+  color: var(--color-text-secondary);
+}
+
+.dashboard-app-btn--restore:hover {
+  background: color-mix(in srgb, var(--color-accent-amber) 4%, transparent);
+  border-color: var(--color-accent-amber-border);
+  color: var(--color-accent-amber);
+}
+
 .dashboard-app-btn--amber {
   border-color: var(--color-accent-amber-border);
   background: var(--color-accent-amber-dim);
@@ -2659,6 +2676,23 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   border-color: var(--color-accent-amber-border);
   color: var(--color-accent-amber);
   text-decoration: none;
+}
+
+.session-card__restore-control {
+  font-size: 10.5px;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  padding: 2px 8px 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-text-secondary);
+}
+
+.session-card__restore-control:hover {
+  background: color-mix(in srgb, var(--color-accent-amber) 4%, transparent);
+  border-color: var(--color-accent-amber-border);
+  color: var(--color-accent-amber);
 }
 
 .btn--danger {

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -26,6 +26,9 @@
 
 /* ── Light mode (default) ─────────────────────────────────────────── */
 :root {
+  --font-geist-sans: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-jetbrains-mono: "SF Mono", "Menlo", "Consolas", "Liberation Mono", monospace;
+
   /* Base surfaces — design-system light palette */
   --color-bg-base: #f5f3f0;
   --color-bg-surface: #ffffff;
@@ -4620,9 +4623,12 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 /* ── Kanban board ────────────────────────────────────────────────────── */
 
 .kanban-board {
+  --kanban-column-count: 5;
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(var(--kanban-column-count), minmax(0, 1fr));
   gap: 8px;
+  width: 100%;
+  min-width: 0;
   height: calc(100vh - 240px);
   height: calc(100dvh - 240px);
   overflow-x: auto;

--- a/packages/web/src/app/layout.test.ts
+++ b/packages/web/src/app/layout.test.ts
@@ -4,11 +4,6 @@ vi.mock("@/lib/project-name", () => ({
   getProjectName: () => "Agent Orchestrator",
 }));
 
-vi.mock("next/font/google", () => ({
-  Geist: () => ({ variable: "--font-geist-sans" }),
-  JetBrains_Mono: () => ({ variable: "--font-jetbrains-mono" }),
-}));
-
 describe("app layout metadata", () => {
   it("exports the themed mobile viewport colors", async () => {
     const { viewport } = await import("./layout");

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,23 +1,9 @@
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
-import { Geist, JetBrains_Mono } from "next/font/google";
 import { getProjectName } from "@/lib/project-name";
 import { ServiceWorkerRegistrar } from "@/components/ServiceWorkerRegistrar";
 import { Providers } from "@/app/providers";
 import "./globals.css";
-
-const geistSans = Geist({
-  subsets: ["latin"],
-  variable: "--font-geist-sans",
-  display: "swap",
-});
-
-const jetbrainsMono = JetBrains_Mono({
-  subsets: ["latin"],
-  variable: "--font-jetbrains-mono",
-  display: "swap",
-  weight: ["400", "500"],
-});
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -49,7 +35,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`dark ${geistSans.variable} ${jetbrainsMono.variable}`}
+      className="dark"
       suppressHydrationWarning
     >
       <body className="h-screen overflow-hidden bg-[var(--color-bg-base)] text-[var(--color-text-primary)] antialiased">

--- a/packages/web/src/app/orchestrators/page.tsx
+++ b/packages/web/src/app/orchestrators/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata(props: {
       projectName = project.name;
     }
   }
-  return { title: { absolute: `ao | ${projectName} - Select Orchestrator` } };
+  return { title: { absolute: `ao | ${projectName} - Orchestrator` } };
 }
 
 export default async function OrchestratorsRoute(props: {

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -1,14 +1,9 @@
-import React, { type ReactNode } from "react";
 import { act, render, screen, cleanup } from "@testing-library/react";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { DashboardSession } from "@/lib/types";
 import type { SessionPatch } from "@/lib/mux-protocol";
 
 const sessionDetailSpy = vi.fn();
-const notFoundError = new Error("NEXT_NOT_FOUND");
-const notFoundSpy = vi.fn(() => {
-  throw notFoundError;
-});
 const replaceSpy = vi.fn();
 let mockPathname = "/projects/my-app/sessions/worker-1";
 let mockParams: Record<string, string> = { id: "worker-1" };
@@ -20,7 +15,6 @@ vi.mock("next/navigation", () => ({
   useParams: () => mockParams,
   usePathname: () => mockPathname,
   useRouter: () => ({ replace: replaceSpy }),
-  notFound: notFoundSpy,
 }));
 
 vi.mock("@/providers/MuxProvider", () => ({
@@ -60,27 +54,6 @@ async function flushAsyncWork(): Promise<void> {
   });
 }
 
-class TestErrorBoundary extends React.Component<
-  { children: ReactNode },
-  { error: Error | null }
-> {
-  constructor(props: { children: ReactNode }) {
-    super(props);
-    this.state = { error: null };
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { error };
-  }
-
-  render() {
-    if (this.state.error) {
-      return <div data-testid="route-error">{this.state.error.message}</div>;
-    }
-    return this.props.children;
-  }
-}
-
 describe("SessionPage project polling", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -108,7 +81,6 @@ describe("SessionPage project polling", () => {
     cleanup();
     vi.useRealTimers();
     vi.restoreAllMocks();
-    notFoundSpy.mockReset();
   });
 
   it("resolves orchestrator nav once for non-orchestrator pages and skips repeated project polling", async () => {
@@ -168,11 +140,14 @@ describe("SessionPage project polling", () => {
     render(<SessionPage />);
     await flushAsyncWork();
 
-    expect(fetch).toHaveBeenCalledWith("/api/projects");
-    expect(fetch).toHaveBeenCalledWith("/api/sessions/worker-1");
-    expect(fetch).toHaveBeenCalledWith("/api/sessions?fresh=true");
+    expect(fetch).toHaveBeenCalledWith("/api/projects", expect.any(Object));
+    expect(fetch).toHaveBeenCalledWith("/api/sessions/worker-1", expect.any(Object));
+    expect(fetch).toHaveBeenCalledWith("/api/sessions?fresh=true", expect.any(Object));
 
-    expect(fetch).toHaveBeenCalledWith("/api/sessions?project=my-app&orchestratorOnly=true&fresh=true");
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true",
+      expect.any(Object),
+    );
 
     expect(
       vi.mocked(fetch).mock.calls.filter(
@@ -261,10 +236,10 @@ describe("SessionPage project polling", () => {
     });
     await flushAsyncWork();
 
-    expect(fetch).toHaveBeenCalledWith("/api/sessions?project=my-app&fresh=true");
+    expect(fetch).toHaveBeenCalledWith("/api/sessions?project=my-app&fresh=true", expect.any(Object));
   });
 
-  it("routes 404 responses through notFound()", async () => {
+  it("renders an inline missing-session state instead of blanking the shell", async () => {
     global.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url === "/api/projects") {
@@ -291,11 +266,12 @@ describe("SessionPage project polling", () => {
     render(<SessionPage />);
     await flushAsyncWork();
 
-    expect(notFoundSpy).toHaveBeenCalled();
+    expect(screen.getByText("Session not found")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Toggle sidebar" })).toBeInTheDocument();
     expect(screen.queryByTestId("session-detail")).not.toBeInTheDocument();
   });
 
-  it("throws non-404 session fetch failures to the route error boundary", async () => {
+  it("renders an inline error state instead of throwing the route away", async () => {
     global.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url === "/api/projects") {
@@ -319,15 +295,12 @@ describe("SessionPage project polling", () => {
 
     const { default: SessionPage } = await import("./page");
 
-    render(
-      <TestErrorBoundary>
-        <SessionPage />
-      </TestErrorBoundary>,
-    );
-
+    render(<SessionPage />);
     await flushAsyncWork();
 
-    expect(screen.getByTestId("route-error")).toHaveTextContent("HTTP 500");
+    expect(screen.getByText("Failed to load session")).toBeInTheDocument();
+    expect(screen.getByText(/internal error/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Toggle sidebar" })).toBeInTheDocument();
   });
 
   it("marks sidebar data as loading until the sessions list resolves", async () => {
@@ -517,6 +490,62 @@ describe("SessionPage project polling", () => {
     expect(latestProps.sidebarLoading).toBe(false);
     expect(latestProps.sidebarError).toBe(true);
     expect(latestProps.sidebarSessions).toEqual([]);
+  });
+
+  it("times out a stuck session fetch and replaces the infinite loader with an error state", async () => {
+    global.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/projects") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [{ id: "my-app", name: "My App", sessionPrefix: "my-app" }],
+          }),
+        } as Response);
+      }
+
+      if (url === "/api/sessions/worker-1") {
+        return new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        });
+      }
+
+      if (url === "/api/sessions?fresh=true") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ sessions: [] }),
+        } as Response);
+      }
+
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ orchestratorId: "my-app-orchestrator" }),
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    }) as typeof fetch;
+
+    const { default: SessionPage } = await import("./page");
+
+    render(<SessionPage />);
+
+    expect(screen.getByText("Loading session…")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Failed to load session")).toBeInTheDocument();
+    expect(screen.getByText(/taking too long/i)).toBeInTheDocument();
+    expect(screen.queryByText("Loading session…")).not.toBeInTheDocument();
   });
 
   it("applies mux snapshots that arrive before the initial sidebar fetch resolves", async () => {

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -85,7 +85,15 @@ describe("SessionPage project polling", () => {
 
   it("resolves orchestrator nav once for non-orchestrator pages and skips repeated project polling", async () => {
     const workerSession = makeWorkerSession();
-    const sidebarSessions = [workerSession];
+    const sidebarSessions = [
+      workerSession,
+      {
+        ...workerSession,
+        id: "docs-2",
+        projectId: "docs-app",
+        summary: "Docs session",
+      },
+    ];
 
     global.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -68,7 +68,7 @@ interface ProjectSessionsBody {
 }
 
 let cachedProjects: ProjectInfo[] | null = null;
-let cachedSidebarSessions: DashboardSession[] | null = null;
+const cachedSidebarSessionsByScope = new Map<string, DashboardSession[]>();
 const SESSION_PAGE_REFRESH_INTERVAL_MS = 2000;
 const SESSION_PAGE_FETCH_TIMEOUT_MS = 10_000;
 const validSessionStatuses = new Set<string>(Object.values(SESSION_STATUS));
@@ -106,6 +106,10 @@ function areSidebarSessionsEqual(
     const candidate = next[index];
     return JSON.stringify(session) === JSON.stringify(candidate);
   });
+}
+
+function getSidebarScopeKey(projectId?: string | null): string {
+  return projectId ? `project:${projectId}` : "all";
 }
 
 async function fetchWithTimeout(input: string, timeoutMs = SESSION_PAGE_FETCH_TIMEOUT_MS): Promise<Response> {
@@ -334,6 +338,7 @@ export default function SessionPage() {
         ? params.projectId[0]
         : null;
   const mux = useMuxOptional();
+  const initialSidebarScopeKey = getSidebarScopeKey(expectedProjectId);
 
   // Read optimistic session data written by sidebar navigation (instant render, no white screen)
   const cachedSession = (() => {
@@ -353,13 +358,17 @@ export default function SessionPage() {
   const [projectOrchestratorId, setProjectOrchestratorId] = useState<string | null | undefined>(undefined);
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
   const [projectsLoading, setProjectsLoading] = useState(cachedProjects === null);
-  const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[] | null>(() => cachedSidebarSessions);
+  const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[] | null>(
+    () => cachedSidebarSessionsByScope.get(initialSidebarScopeKey) ?? null,
+  );
   const [loading, setLoading] = useState(cachedSession === null);
   const [routeError, setRouteError] = useState<Error | null>(null);
   const [sessionMissing, setSessionMissing] = useState(false);
   const [sidebarError, setSidebarError] = useState(false);
   const [prefixByProject, setPrefixByProject] = useState<Map<string, string>>(new Map());
   const sessionProjectId = session?.projectId ?? null;
+  const sidebarProjectId = null;
+  const sidebarScopeKey = getSidebarScopeKey(sidebarProjectId);
   const allPrefixes = [...prefixByProject.values()];
   const sessionIsOrchestrator = session
     ? isOrchestratorSession(session, prefixByProject.get(session.projectId), allPrefixes)
@@ -450,6 +459,11 @@ export default function SessionPage() {
     sessionIsOrchestratorRef.current = sessionIsOrchestrator;
   }, [sessionIsOrchestrator]);
 
+  useEffect(() => {
+    const cachedSessions = cachedSidebarSessionsByScope.get(sidebarScopeKey) ?? null;
+    setSidebarSessions(cachedSessions);
+  }, [sidebarScopeKey]);
+
   // Fetch session data (memoized to avoid recreating on every render)
   const fetchSession = useCallback(async () => {
     if (fetchingSessionRef.current) return;
@@ -539,8 +553,11 @@ export default function SessionPage() {
   const fetchSidebarSessions = useCallback(async () => {
     if (fetchingSidebarRef.current) return;
     fetchingSidebarRef.current = true;
+    const projectId = null;
+    const scopeKey = getSidebarScopeKey(projectId);
+    const query = "/api/sessions?fresh=true";
     try {
-      const res = await fetchWithTimeout("/api/sessions?fresh=true");
+      const res = await fetchWithTimeout(query);
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }
@@ -548,7 +565,7 @@ export default function SessionPage() {
       const restSessions = body?.sessions ?? [];
       const nextSessions =
         applyMuxSessionPatches(restSessions, pendingMuxSessionsRef.current ?? []) ?? restSessions;
-      cachedSidebarSessions = nextSessions;
+      cachedSidebarSessionsByScope.set(scopeKey, nextSessions);
       setSidebarError(false);
       setSidebarSessions((current) => (
         areSidebarSessionsEqual(current, nextSessions) ? current : nextSessions
@@ -578,13 +595,18 @@ export default function SessionPage() {
     // Read current sessions via the module-level cache so this effect reacts to
     // new mux data only — keeping `sidebarSessions` out of the dep array avoids
     // re-running on every state change that the effect itself produces.
-    const next = applyMuxSessionPatches(cachedSidebarSessions, mux.sessions);
+    const cachedSidebarSessions = cachedSidebarSessionsByScope.get(sidebarScopeKey) ?? null;
+    if (cachedSidebarSessions === null) {
+      return;
+    }
+
+    const next = applyMuxSessionPatches(cachedSidebarSessions, mux.sessions) ?? cachedSidebarSessions;
     if (next !== cachedSidebarSessions) {
-      cachedSidebarSessions = next;
+      cachedSidebarSessionsByScope.set(sidebarScopeKey, next);
       setSidebarSessions(next);
     }
 
-    if (mux.sessions.length === 0 || !cachedSidebarSessions) {
+    if (mux.sessions.length === 0) {
       return;
     }
 
@@ -601,7 +623,7 @@ export default function SessionPage() {
         return;
       }
     }
-  }, [fetchSidebarSessions, mux?.sessions, mux?.status]);
+  }, [fetchSidebarSessions, mux?.sessions, mux?.status, sidebarScopeKey]);
 
   useEffect(() => {
     if (!sessionIsOrchestrator) {

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef } from "react";
-import { notFound, useParams, usePathname, useRouter } from "next/navigation";
+import { useEffect, useState, useCallback, useRef, type ReactNode } from "react";
+import { useParams, usePathname, useRouter } from "next/navigation";
 import { ACTIVITY_STATE, SESSION_STATUS, isOrchestratorSession } from "@aoagents/ao-core/types";
 import { SessionDetail } from "@/components/SessionDetail";
+import { ErrorDisplay } from "@/components/ErrorDisplay";
+import { ProjectSidebar } from "@/components/ProjectSidebar";
+import { useMediaQuery, MOBILE_BREAKPOINT } from "@/hooks/useMediaQuery";
 import { type DashboardSession, type ActivityState, getAttentionLevel } from "@/lib/types";
 import { activityIcon } from "@/lib/activity-icons";
 import type { ProjectInfo } from "@/lib/project-name";
@@ -67,6 +70,7 @@ interface ProjectSessionsBody {
 let cachedProjects: ProjectInfo[] | null = null;
 let cachedSidebarSessions: DashboardSession[] | null = null;
 const SESSION_PAGE_REFRESH_INTERVAL_MS = 2000;
+const SESSION_PAGE_FETCH_TIMEOUT_MS = 10_000;
 const validSessionStatuses = new Set<string>(Object.values(SESSION_STATUS));
 const validActivityStates = new Set<string>(Object.values(ACTIVITY_STATE));
 const warnedMuxPatchValues = new Set<string>();
@@ -102,6 +106,161 @@ function areSidebarSessionsEqual(
     const candidate = next[index];
     return JSON.stringify(session) === JSON.stringify(candidate);
   });
+}
+
+async function fetchWithTimeout(input: string, timeoutMs = SESSION_PAGE_FETCH_TIMEOUT_MS): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(input, { signal: controller.signal });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error(`Request timed out after ${Math.round(timeoutMs / 1000)}s`, {
+        cause: error,
+      });
+    }
+    throw error;
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
+
+function getSessionLoadErrorMessage(error: Error): string {
+  const normalized = error.message.toLowerCase();
+  if (normalized.includes("timed out")) {
+    return "The session request is taking too long, so the page stopped waiting instead of spinning forever. You can retry, or return to the project and reopen a different session.";
+  }
+  if (normalized.includes("network")) {
+    return "The session request failed before the dashboard got a response. Check the local server connection and try again.";
+  }
+  if (normalized.includes("404")) {
+    return "This session is no longer available. It may have been removed while the page was open.";
+  }
+  if (normalized.includes("500")) {
+    return "The server returned an internal error while loading this session. Try again to re-fetch the latest state.";
+  }
+  return "The dashboard could not load this session cleanly. Try again to re-fetch the latest state.";
+}
+
+function SidebarPlaceholder({ message }: { message: string }) {
+  return (
+    <div className="project-sidebar h-full">
+      <div className="space-y-3 px-3 py-4">
+        <div className="text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--color-text-tertiary)]">
+          Projects
+        </div>
+        <div className="space-y-2">
+          {Array.from({ length: 3 }, (_, index) => (
+            <div
+              key={`sidebar-placeholder-${index}`}
+              className="h-10 animate-pulse border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)]"
+            />
+          ))}
+        </div>
+        <div className="pt-2 text-[12px] text-[var(--color-text-tertiary)]">{message}</div>
+      </div>
+    </div>
+  );
+}
+
+function SessionPageShell({
+  projects,
+  projectsLoading,
+  sidebarSessions,
+  sidebarLoading,
+  sidebarError,
+  onRetrySidebar,
+  activeProjectId,
+  activeSessionId,
+  children,
+}: {
+  projects: ProjectInfo[];
+  projectsLoading: boolean;
+  sidebarSessions: DashboardSession[] | null;
+  sidebarLoading: boolean;
+  sidebarError: boolean;
+  onRetrySidebar: () => void;
+  activeProjectId?: string;
+  activeSessionId?: string;
+  children: ReactNode;
+}) {
+  const isMobile = useMediaQuery(MOBILE_BREAKPOINT);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const showSidebar = true;
+
+  const handleToggleSidebar = useCallback(() => {
+    if (isMobile) {
+      setMobileSidebarOpen((current) => !current);
+      return;
+    }
+    setSidebarCollapsed((current) => !current);
+  }, [isMobile]);
+
+  return (
+    <div className="dashboard-app-shell">
+      <header className="dashboard-app-header">
+        {showSidebar ? (
+          <button
+            type="button"
+            className="dashboard-app-sidebar-toggle"
+            onClick={handleToggleSidebar}
+            aria-label="Toggle sidebar"
+          >
+            {isMobile ? (
+              <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            ) : (
+              <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="2" />
+                <path d="M9 3v18" />
+              </svg>
+            )}
+          </button>
+        ) : null}
+        <div className="dashboard-app-header__brand">
+          <span>Agent Orchestrator</span>
+        </div>
+        <div className="dashboard-app-header__spacer" />
+      </header>
+
+      <div
+        className={`dashboard-shell dashboard-shell--desktop${sidebarCollapsed ? " dashboard-shell--sidebar-collapsed" : ""}`}
+      >
+        {showSidebar ? (
+          <div className={`sidebar-wrapper${mobileSidebarOpen ? " sidebar-wrapper--mobile-open" : ""}`}>
+            {projects.length > 0 ? (
+              <ProjectSidebar
+                projects={projects}
+                sessions={sidebarSessions}
+                loading={sidebarLoading}
+                error={sidebarError}
+                onRetry={onRetrySidebar}
+                activeProjectId={activeProjectId}
+                activeSessionId={activeSessionId}
+                collapsed={sidebarCollapsed}
+                onToggleCollapsed={() => setSidebarCollapsed((current) => !current)}
+                onMobileClose={() => setMobileSidebarOpen(false)}
+              />
+            ) : (
+              <SidebarPlaceholder message={projectsLoading ? "Loading projects..." : "Projects unavailable."} />
+            )}
+          </div>
+        ) : null}
+        {mobileSidebarOpen && (
+          <div className="sidebar-mobile-backdrop" onClick={() => setMobileSidebarOpen(false)} />
+        )}
+
+        <div className="dashboard-main dashboard-main--desktop">
+          <main className="session-detail-page flex-1 min-h-0 flex flex-col bg-[var(--color-bg-base)]">
+            <div className="flex-1 min-h-0">{children}</div>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function applyMuxSessionPatches(current: DashboardSession[] | null, patches: SessionPatch[]): DashboardSession[] | null {
@@ -193,6 +352,7 @@ export default function SessionPage() {
   const [zoneCounts, setZoneCounts] = useState<ZoneCounts | null>(null);
   const [projectOrchestratorId, setProjectOrchestratorId] = useState<string | null | undefined>(undefined);
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
+  const [projectsLoading, setProjectsLoading] = useState(cachedProjects === null);
   const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[] | null>(() => cachedSidebarSessions);
   const [loading, setLoading] = useState(cachedSession === null);
   const [routeError, setRouteError] = useState<Error | null>(null);
@@ -227,10 +387,11 @@ export default function SessionPage() {
       setPrefixByProject(
         new Map(cachedProjects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
       );
+      setProjectsLoading(false);
     }
 
     try {
-      const res = await fetch("/api/projects");
+      const res = await fetchWithTimeout("/api/projects");
       if (!res.ok) {
         console.error("Failed to fetch projects:", new Error(`HTTP ${res.status}`));
         return;
@@ -246,6 +407,8 @@ export default function SessionPage() {
       }
     } catch (err) {
       console.error("Failed to fetch projects:", err);
+    } finally {
+      setProjectsLoading(false);
     }
   }, []);
 
@@ -292,7 +455,7 @@ export default function SessionPage() {
     if (fetchingSessionRef.current) return;
     fetchingSessionRef.current = true;
     try {
-      const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`);
+      const res = await fetchWithTimeout(`/api/sessions/${encodeURIComponent(id)}`);
       if (res.status === 404) {
         if (!hasLoadedSessionRef.current) {
           setSessionMissing(true);
@@ -329,7 +492,7 @@ export default function SessionPage() {
       const query = isOrchestrator
         ? `/api/sessions?project=${encodeURIComponent(projectId)}&fresh=true`
         : `/api/sessions?project=${encodeURIComponent(projectId)}&orchestratorOnly=true&fresh=true`;
-      const res = await fetch(query);
+      const res = await fetchWithTimeout(query);
       if (!res.ok) {
         console.error("Failed to fetch project sessions for", projectId, new Error(`HTTP ${res.status}`));
         return;
@@ -377,7 +540,7 @@ export default function SessionPage() {
     if (fetchingSidebarRef.current) return;
     fetchingSidebarRef.current = true;
     try {
-      const res = await fetch("/api/sessions?fresh=true");
+      const res = await fetchWithTimeout("/api/sessions?fresh=true");
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }
@@ -473,19 +636,91 @@ export default function SessionPage() {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[var(--color-bg-base)]">
-        <div className="text-[13px] text-[var(--color-text-tertiary)]">Loading session…</div>
-      </div>
+      <SessionPageShell
+        projects={projects}
+        projectsLoading={projectsLoading}
+        sidebarSessions={sidebarSessions}
+        sidebarLoading={sidebarSessions === null}
+        sidebarError={sidebarError}
+        onRetrySidebar={fetchSidebarSessions}
+        activeProjectId={expectedProjectId ?? undefined}
+        activeSessionId={id}
+      >
+        <div className="flex h-full min-h-screen items-center justify-center bg-[var(--color-bg-base)]">
+          <div className="flex flex-col items-center gap-3">
+            <svg
+              className="h-5 w-5 animate-spin text-[var(--color-text-tertiary)]"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+            >
+              <path d="M12 3a9 9 0 1 0 9 9" />
+            </svg>
+            <div className="text-[13px] text-[var(--color-text-tertiary)]">Loading session…</div>
+          </div>
+        </div>
+      </SessionPageShell>
     );
   }
 
   if (sessionMissing) {
-    notFound();
-    return null;
+    return (
+      <SessionPageShell
+        projects={projects}
+        projectsLoading={projectsLoading}
+        sidebarSessions={sidebarSessions}
+        sidebarLoading={sidebarSessions === null}
+        sidebarError={sidebarError}
+        onRetrySidebar={fetchSidebarSessions}
+        activeProjectId={expectedProjectId ?? undefined}
+        activeSessionId={id}
+      >
+        <ErrorDisplay
+          title="Session not found"
+          message="This session is no longer available. It may have been removed, renamed, or already cleaned up."
+          tone="not-found"
+          primaryAction={{ label: "Back to dashboard", href: expectedProjectId ? `/projects/${expectedProjectId}` : "/" }}
+          secondaryAction={{ label: "Retry", onClick: () => void fetchSession() }}
+          compact
+          chrome="card"
+        />
+      </SessionPageShell>
+    );
   }
 
   if (routeError) {
-    throw routeError;
+    return (
+      <SessionPageShell
+        projects={projects}
+        projectsLoading={projectsLoading}
+        sidebarSessions={sidebarSessions}
+        sidebarLoading={sidebarSessions === null}
+        sidebarError={sidebarError}
+        onRetrySidebar={fetchSidebarSessions}
+        activeProjectId={session?.projectId ?? expectedProjectId ?? undefined}
+        activeSessionId={id}
+      >
+        <ErrorDisplay
+          title="Failed to load session"
+          message={getSessionLoadErrorMessage(routeError)}
+          tone="error"
+          primaryAction={{
+            label: "Try again",
+            onClick: () => {
+              setRouteError(null);
+              setSessionMissing(false);
+              setLoading(true);
+              void Promise.all([fetchProjects(), fetchSession(), fetchSidebarSessions()]);
+            },
+          }}
+          secondaryAction={{ label: "Back to dashboard", href: session?.projectId ? `/projects/${session.projectId}` : "/" }}
+          error={routeError}
+          compact
+          chrome="card"
+        />
+      </SessionPageShell>
+    );
   }
 
   if (!session) {

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useMediaQuery, MOBILE_BREAKPOINT } from "@/hooks/useMediaQuery";
 import {
   NON_RESTORABLE_STATUSES,
@@ -160,6 +160,7 @@ function DashboardInner({
   const recoveredFromLoadError = Boolean(dashboardLoadError) && liveSessionsResolved;
   const visibleDashboardLoadError = recoveredFromLoadError ? undefined : dashboardLoadError;
   const searchParams = useSearchParams();
+  const router = useRouter();
   const activeSessionId = searchParams.get("session") ?? undefined;
   const [rateLimitDismissed, setRateLimitDismissed] = useState(false);
   const [activeOrchestrators, setActiveOrchestrators] =
@@ -375,13 +376,14 @@ function DashboardInner({
           showToast(`Restore failed: ${text}`, "error");
         } else {
           showToast("Session restored", "success");
+          router.refresh();
         }
       } catch (error) {
         console.error(`Network error restoring ${sessionId}:`, error);
         showToast("Network error while restoring session", "error");
       }
     },
-    [showToast],
+    [router, showToast],
   );
 
   const handleSpawnOrchestrator = async (project: ProjectInfo) => {
@@ -634,7 +636,15 @@ function DashboardInner({
 
                 {!allProjectsView && hasAnySessions && (
                   <div className="kanban-board-wrap">
-                    <div className="kanban-board">
+                    <div
+                      className="kanban-board"
+                      data-columns={kanbanLevels.length}
+                      style={
+                        {
+                          "--kanban-column-count": kanbanLevels.length,
+                        } as React.CSSProperties
+                      }
+                    >
                       {kanbanLevels.map((level) => (
                         <AttentionZone
                           key={level}

--- a/packages/web/src/components/OrchestratorSelector.tsx
+++ b/packages/web/src/components/OrchestratorSelector.tsx
@@ -154,7 +154,7 @@ export function OrchestratorSelector({
             <h1 className="text-lg font-semibold text-[var(--color-text-primary)]">
               {projectName}
             </h1>
-            <p className="text-sm text-[var(--color-text-secondary)]">Select an orchestrator</p>
+            <p className="text-sm text-[var(--color-text-secondary)]">Project orchestrator</p>
           </div>
           <Link
             href={projectDashboardPath(projectId)}
@@ -171,19 +171,15 @@ export function OrchestratorSelector({
           {/* Info banner */}
           <div className="mb-6 rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
             <p className="text-sm text-[var(--color-text-secondary)]">
-              Found{" "}
-              <span className="font-medium text-[var(--color-text-primary)]">
-                {orchestrators.length}
-              </span>{" "}
-              existing orchestrator session{orchestrators.length !== 1 ? "s" : ""}. You can resume
-              an existing session or start a new one.
+              AO keeps one main orchestrator per project. Opening or spawning here reuses that
+              canonical session instead of creating another duplicate.
             </p>
           </div>
 
           {/* Existing orchestrators */}
           <div className="mb-6">
             <h2 className="mb-3 text-sm font-medium text-[var(--color-text-secondary)]">
-              Existing Sessions
+              Main Session
             </h2>
             <div className="space-y-2">
               {orchestrators.map((orch) => (
@@ -227,7 +223,7 @@ export function OrchestratorSelector({
           {/* Start new section */}
           <div className="border-t border-[var(--color-border-subtle)] pt-6">
             <h2 className="mb-3 text-sm font-medium text-[var(--color-text-secondary)]">
-              Or Start Fresh
+              Open Orchestrator
             </h2>
             <button
               type="button"
@@ -260,10 +256,10 @@ export function OrchestratorSelector({
                       d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                     />
                   </svg>
-                  Creating new orchestrator...
+                  Opening orchestrator...
                 </span>
               ) : (
-                "Start New Orchestrator"
+                "Open Orchestrator"
               )}
             </button>
             {spawnError && (

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -10,7 +10,6 @@ import {
   getSessionTruthLabel,
   getPRTruthLabel,
   getRuntimeTruthLabel,
-  getLifecycleGuidance,
   isDashboardSessionDone,
   isDashboardSessionTerminal,
   isDashboardSessionRestorable,
@@ -201,7 +200,6 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
         `Runtime ${getRuntimeTruthLabel(session)}`,
       ].join(" · ")
     : null;
-  const lifecycleGuidance = getLifecycleGuidance(session);
   const secondaryText = session.issueLabel
     ? `${session.issueLabel}${session.issueTitle ? ` · ${session.issueTitle}` : ""}`
     : (session.issueTitle ??
@@ -483,17 +481,19 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
               e.stopPropagation();
               onRestore?.(session.id);
             }}
-            className="inline-flex items-center gap-1 border border-[color-mix(in_srgb,var(--color-accent)_35%,transparent)] px-2 py-0.5 text-[11px] text-[var(--color-accent)] transition-colors hover:bg-[var(--color-tint-blue)]"
+            className="session-card__control session-card__restore-control"
           >
             <svg
+              className="session-card__control-icon"
               fill="none"
               stroke="currentColor"
               strokeWidth="2"
               viewBox="0 0 24 24"
-              className="h-3 w-3"
             >
-              <polyline points="1 4 1 10 7 10" />
-              <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+              <path d="M20 11a8 8 0 0 0-14.9-3.98" />
+              <path d="M4 5v4h4" />
+              <path d="M4 13a8 8 0 0 0 14.9 3.98" />
+              <path d="M20 19v-4h-4" />
             </svg>
             restore
           </button>
@@ -586,14 +586,6 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
           <div className="px-[10px] pb-[5px]">
             <p className="text-[10px] leading-relaxed text-[var(--color-text-tertiary)]">
               {truthLine}
-            </p>
-          </div>
-        )}
-
-        {lifecycleGuidance && (
-          <div className="px-[10px] pb-[6px]">
-            <p className="inline-flex items-center gap-1 rounded-full border border-[color-mix(in_srgb,var(--color-status-attention)_35%,transparent)] bg-[color-mix(in_srgb,var(--color-status-attention)_9%,transparent)] px-2 py-1 text-[10px] leading-none text-[var(--color-status-attention)]">
-              {lifecycleGuidance}
             </p>
           </div>
         )}

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -428,11 +428,11 @@ export function SessionDetail({
         const message = await res.text().catch(() => "");
         throw new Error(message || `HTTP ${res.status}`);
       }
-      router.refresh();
+      window.location.reload();
     } catch (err) {
       console.error("Failed to restore session:", err);
     }
-  }, [router, session.id]);
+  }, [session.id]);
 
   const allGreen = pr ? isPRMergeReady(pr) : false;
   const [prPopoverOpen, setPrPopoverOpen] = useState(false);
@@ -610,10 +610,12 @@ export function SessionDetail({
 
           {/* Restore is available for any restorable session; Kill stays worker-only. */}
           {isRestorable ? (
-            <button type="button" className="dashboard-app-btn" onClick={handleRestore}>
-              <svg className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                <polyline points="1 4 1 10 7 10" />
-                <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+            <button type="button" className="dashboard-app-btn dashboard-app-btn--restore" onClick={handleRestore}>
+              <svg className="topbar-action-icon" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path d="M20 11a8 8 0 0 0-14.9-3.98" />
+                <path d="M4 5v4h4" />
+                <path d="M4 13a8 8 0 0 0 14.9 3.98" />
+                <path d="M20 19v-4h-4" />
               </svg>
               <span className="topbar-btn-label">Restore</span>
             </button>

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -424,12 +424,15 @@ export function SessionDetail({
   const handleRestore = useCallback(async () => {
     try {
       const res = await fetch(`/api/sessions/${encodeURIComponent(session.id)}/restore`, { method: "POST" });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      window.location.reload();
+      if (!res.ok) {
+        const message = await res.text().catch(() => "");
+        throw new Error(message || `HTTP ${res.status}`);
+      }
+      router.refresh();
     } catch (err) {
       console.error("Failed to restore session:", err);
     }
-  }, [session.id]);
+  }, [router, session.id]);
 
   const allGreen = pr ? isPRMergeReady(pr) : false;
   const [prPopoverOpen, setPrPopoverOpen] = useState(false);

--- a/packages/web/src/components/__tests__/Dashboard.kanbanLayout.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.kanbanLayout.test.tsx
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Dashboard } from "@/components/Dashboard";
+import { makePR, makeSession } from "@/__tests__/helpers";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("Dashboard kanban layout", () => {
+  beforeEach(() => {
+    global.EventSource = vi.fn(
+      () =>
+        ({
+          onmessage: null,
+          onerror: null,
+          close: vi.fn(),
+        }) as unknown as EventSource,
+    );
+    global.fetch = vi.fn();
+  });
+
+  it("uses four board columns in simple attention mode", () => {
+    render(
+      <Dashboard
+        initialSessions={[
+          makeSession({
+            id: "respond-1",
+            status: "waiting_input",
+            activity: "waiting_input",
+            summary: "Needs a reply",
+          }),
+        ]}
+      />,
+    );
+
+    const board = document.querySelector(".kanban-board");
+    expect(board).toHaveAttribute("data-columns", "4");
+    expect(board).toHaveStyle({ "--kanban-column-count": "4" });
+    expect(screen.getByText("Action")).toBeInTheDocument();
+    expect(screen.queryByText("Respond")).not.toBeInTheDocument();
+  });
+
+  it("uses five board columns in detailed attention mode", () => {
+    render(
+      <Dashboard
+        initialSessions={[
+          makeSession({
+            id: "review-1",
+            status: "reviewing",
+            pr: makePR({
+              number: 42,
+              reviewDecision: "changes_requested",
+            }),
+          }),
+        ]}
+        attentionZones="detailed"
+      />,
+    );
+
+    const board = document.querySelector(".kanban-board");
+    expect(board).toHaveAttribute("data-columns", "5");
+    expect(board).toHaveStyle({ "--kanban-column-count": "5" });
+    expect(screen.getByText("Respond")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/__tests__/Dashboard.mobile.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.mobile.test.tsx
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Dashboard } from "../Dashboard";
 import { makePR, makeSession } from "../../__tests__/helpers";
 
+const refreshMock = vi.fn();
+
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: refreshMock }),
   usePathname: () => "/",
   useSearchParams: () => new URLSearchParams(),
 }));
@@ -27,6 +29,7 @@ function mockMobileViewport() {
 
 describe("Dashboard unified layout (mobile viewport)", () => {
   beforeEach(() => {
+    refreshMock.mockReset();
     mockMobileViewport();
     Element.prototype.scrollIntoView = vi.fn();
     const eventSourceMock = {
@@ -216,6 +219,7 @@ describe("Dashboard unified layout (mobile viewport)", () => {
     expect(global.fetch).toHaveBeenCalledWith("/api/sessions/done-1/restore", {
       method: "POST",
     });
+    expect(refreshMock).toHaveBeenCalledTimes(1);
   });
 
   it("kill button requires a two-click confirmation before firing", async () => {

--- a/packages/web/src/components/__tests__/OrchestratorSelector.test.tsx
+++ b/packages/web/src/components/__tests__/OrchestratorSelector.test.tsx
@@ -9,22 +9,13 @@ vi.mock("next/navigation", () => ({
 
 const mockOrchestrators = [
   {
-    id: "app-orchestrator-1",
+    id: "app-orchestrator",
     projectId: "my-project",
     projectName: "My Project",
     status: "working",
     activity: "active",
     createdAt: new Date(Date.now() - 3600000).toISOString(), // 1 hour ago
     lastActivityAt: new Date(Date.now() - 300000).toISOString(), // 5 min ago
-  },
-  {
-    id: "app-orchestrator-2",
-    projectId: "my-project",
-    projectName: "My Project",
-    status: "spawning",
-    activity: null,
-    createdAt: new Date(Date.now() - 7200000).toISOString(), // 2 hours ago
-    lastActivityAt: null,
   },
 ];
 
@@ -45,8 +36,7 @@ describe("OrchestratorSelector", () => {
   it("renders orchestrator list", () => {
     render(<OrchestratorSelector {...defaultProps} />);
 
-    expect(screen.getByText("app-orchestrator-1")).toBeInTheDocument();
-    expect(screen.getByText("app-orchestrator-2")).toBeInTheDocument();
+    expect(screen.getByText("app-orchestrator")).toBeInTheDocument();
   });
 
   it("displays project name in header", () => {
@@ -87,7 +77,7 @@ describe("OrchestratorSelector", () => {
       ok: true,
       json: () =>
         Promise.resolve({
-          orchestrator: { id: "app-orchestrator-3" },
+          orchestrator: { id: "app-orchestrator" },
         }),
     });
     global.fetch = mockFetch;
@@ -102,7 +92,7 @@ describe("OrchestratorSelector", () => {
     });
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith("/projects/my-project/sessions/app-orchestrator-3");
+      expect(mockPush).toHaveBeenCalledWith("/projects/my-project/sessions/app-orchestrator");
     });
   });
 
@@ -142,8 +132,8 @@ describe("OrchestratorSelector", () => {
   it("links to orchestrator session page", () => {
     render(<OrchestratorSelector {...defaultProps} />);
 
-    const link = screen.getByRole("link", { name: /app-orchestrator-1/i });
-    expect(link).toHaveAttribute("href", "/projects/my-project/sessions/app-orchestrator-1");
+    const link = screen.getByRole("link", { name: /app-orchestrator/i });
+    expect(link).toHaveAttribute("href", "/projects/my-project/sessions/app-orchestrator");
   });
 
   it("displays status and activity for each orchestrator", () => {
@@ -151,7 +141,6 @@ describe("OrchestratorSelector", () => {
 
     expect(screen.getByText("working")).toBeInTheDocument();
     expect(screen.getByText("Active")).toBeInTheDocument();
-    expect(screen.getByText("spawning")).toBeInTheDocument();
   });
 
   it("covers relative time for days and status colors/labels", () => {

--- a/packages/web/src/components/__tests__/OrchestratorSelector.test.tsx
+++ b/packages/web/src/components/__tests__/OrchestratorSelector.test.tsx
@@ -53,16 +53,14 @@ describe("OrchestratorSelector", () => {
     render(<OrchestratorSelector {...defaultProps} />);
 
     expect(screen.getByText("My Project")).toBeInTheDocument();
-    expect(screen.getByText("Select an orchestrator")).toBeInTheDocument();
+    expect(screen.getByText("Project orchestrator")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Dashboard" })).toHaveAttribute("href", "/projects/my-project");
   });
 
-  it("shows count of existing sessions", () => {
+  it("explains that orchestrator opening reuses the canonical session", () => {
     render(<OrchestratorSelector {...defaultProps} />);
 
-    expect(screen.getByText(/existing orchestrator sessions/)).toBeInTheDocument();
-    // The count "2" appears in multiple places, so we check the full info banner text
-    expect(screen.getByText(/Found/)).toBeInTheDocument();
+    expect(screen.getByText(/one main orchestrator per project/i)).toBeInTheDocument();
   });
 
   it("shows error state", () => {
@@ -78,10 +76,10 @@ describe("OrchestratorSelector", () => {
     expect(screen.getByText("Project not found")).toBeInTheDocument();
   });
 
-  it("shows start new orchestrator button", () => {
+  it("shows open orchestrator button", () => {
     render(<OrchestratorSelector {...defaultProps} />);
 
-    expect(screen.getByRole("button", { name: /start new orchestrator/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /open orchestrator/i })).toBeInTheDocument();
   });
 
   it("spawns new orchestrator on button click and navigates", async () => {
@@ -96,7 +94,7 @@ describe("OrchestratorSelector", () => {
 
     render(<OrchestratorSelector {...defaultProps} />);
 
-    const button = screen.getByRole("button", { name: /start new orchestrator/i });
+    const button = screen.getByRole("button", { name: /open orchestrator/i });
     fireEvent.click(button);
 
     await waitFor(() => {
@@ -116,11 +114,11 @@ describe("OrchestratorSelector", () => {
 
     render(<OrchestratorSelector {...defaultProps} />);
 
-    const button = screen.getByRole("button", { name: /start new orchestrator/i });
+    const button = screen.getByRole("button", { name: /open orchestrator/i });
     fireEvent.click(button);
 
     await waitFor(() => {
-      expect(screen.getByText(/creating new orchestrator/i)).toBeInTheDocument();
+      expect(screen.getByText(/opening orchestrator/i)).toBeInTheDocument();
     });
   });
 
@@ -133,7 +131,7 @@ describe("OrchestratorSelector", () => {
 
     render(<OrchestratorSelector {...defaultProps} />);
 
-    const button = screen.getByRole("button", { name: /start new orchestrator/i });
+    const button = screen.getByRole("button", { name: /open orchestrator/i });
     fireEvent.click(button);
 
     await waitFor(() => {

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -237,6 +237,28 @@ describe("SessionDetail desktop layout", () => {
     expect(within(screen.getByRole("banner")).queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
   });
 
+  it("refreshes the route after restoring a terminated session", async () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "worker-restore",
+          projectId: "my-app",
+          status: "terminated",
+          activity: "exited",
+          pr: null,
+        })}
+        projects={[{ id: "my-app", name: "My App", path: "/tmp/my-app" }]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+
+    await act(async () => {});
+
+    expect(global.fetch).toHaveBeenCalledWith("/api/sessions/worker-restore/restore", { method: "POST" });
+    expect(routerRefreshMock).toHaveBeenCalledTimes(1);
+  });
+
   it("hides the desktop orchestrator button on orchestrator session pages", () => {
     render(
       <SessionDetail

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -233,11 +233,13 @@ describe("SessionDetail desktop layout", () => {
       />,
     );
 
-    expect(within(screen.getByRole("banner")).getByRole("button", { name: "Restore" })).toBeInTheDocument();
+    expect(within(screen.getByRole("banner")).getByRole("button", { name: "Restore" })).toHaveClass(
+      "dashboard-app-btn--restore",
+    );
     expect(within(screen.getByRole("banner")).queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
   });
 
-  it("refreshes the route after restoring a terminated session", async () => {
+  it("restores without using router refresh on the client-only session page", async () => {
     render(
       <SessionDetail
         session={makeSession({
@@ -256,7 +258,7 @@ describe("SessionDetail desktop layout", () => {
     await act(async () => {});
 
     expect(global.fetch).toHaveBeenCalledWith("/api/sessions/worker-restore/restore", { method: "POST" });
-    expect(routerRefreshMock).toHaveBeenCalledTimes(1);
+    expect(routerRefreshMock).not.toHaveBeenCalled();
   });
 
   it("hides the desktop orchestrator button on orchestrator session pages", () => {

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -167,7 +167,7 @@ describe("sessionToDashboard", () => {
     expect(dashboard.attentionLevel).toBe("working");
   });
 
-  it("should expose detecting guidance and evidence from legacy metadata", () => {
+  it("should expose detecting evidence from legacy metadata without card guidance copy", () => {
     const lifecycle = createInitialCanonicalLifecycle("worker", new Date("2025-01-01T00:00:00Z"));
     lifecycle.session.state = "detecting";
     lifecycle.session.reason = "probe_failure";
@@ -184,7 +184,7 @@ describe("sessionToDashboard", () => {
 
     const dashboard = sessionToDashboard(coreSession);
 
-    expect(dashboard.lifecycle?.guidance).toContain("Retry 2");
+    expect(dashboard.lifecycle?.guidance).toBeNull();
     expect(dashboard.lifecycle?.evidence).toContain("signal_disagreement");
     expect(dashboard.attentionLevel).toBe("respond");
   });

--- a/packages/web/src/lib/orchestrator-utils.ts
+++ b/packages/web/src/lib/orchestrator-utils.ts
@@ -1,46 +1,22 @@
-import type { Session } from "@aoagents/ao-core";
-import { isOrchestratorSession, isTerminalSession } from "@aoagents/ao-core/types";
+import {
+  type Session,
+  isOrchestratorSession,
+  selectPreferredOrchestratorSession,
+} from "@aoagents/ao-core";
 import type { Orchestrator } from "@/components/OrchestratorSelector";
-
-/**
- * Filter and map sessions to orchestrator DTOs.
- * Shared between page.tsx and API route to ensure consistent orchestrator listing.
- */
-function compareOrchestratorRecency(
-  a: Pick<Session, "id" | "lastActivityAt" | "createdAt">,
-  b: Pick<Session, "id" | "lastActivityAt" | "createdAt">,
-): number {
-  return (
-    (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0) ||
-    (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0) ||
-    a.id.localeCompare(b.id)
-  );
-}
-
-function listProjectOrchestratorSessions(
-  sessions: Session[],
-  sessionPrefix: string,
-  allSessionPrefixes?: string[],
-): Session[] {
-  const projectOrchestrators = sessions
-    .filter((s) => isOrchestratorSession(s, sessionPrefix, allSessionPrefixes) && !isTerminalSession(s))
-    .sort(compareOrchestratorRecency);
-
-  if (projectOrchestrators.length > 0) {
-    return projectOrchestrators;
-  }
-
-  return sessions
-    .filter((s) => isOrchestratorSession(s, sessionPrefix, allSessionPrefixes))
-    .sort(compareOrchestratorRecency);
-}
 
 export function selectCanonicalProjectOrchestrator(
   sessions: Session[],
   sessionPrefix: string,
   allSessionPrefixes?: string[],
 ): Session | null {
-  return listProjectOrchestratorSessions(sessions, sessionPrefix, allSessionPrefixes)[0] ?? null;
+  const projectOrchestrators = sessions.filter((session) =>
+    isOrchestratorSession(session, sessionPrefix, allSessionPrefixes),
+  );
+  return selectPreferredOrchestratorSession(
+    projectOrchestrators,
+    `${sessionPrefix}-orchestrator`,
+  );
 }
 
 export function mapSessionToOrchestrator(

--- a/packages/web/src/lib/orchestrator-utils.ts
+++ b/packages/web/src/lib/orchestrator-utils.ts
@@ -6,21 +6,64 @@ import type { Orchestrator } from "@/components/OrchestratorSelector";
  * Filter and map sessions to orchestrator DTOs.
  * Shared between page.tsx and API route to ensure consistent orchestrator listing.
  */
+function compareOrchestratorRecency(
+  a: Pick<Session, "id" | "lastActivityAt" | "createdAt">,
+  b: Pick<Session, "id" | "lastActivityAt" | "createdAt">,
+): number {
+  return (
+    (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0) ||
+    (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0) ||
+    a.id.localeCompare(b.id)
+  );
+}
+
+function listProjectOrchestratorSessions(
+  sessions: Session[],
+  sessionPrefix: string,
+  allSessionPrefixes?: string[],
+): Session[] {
+  const projectOrchestrators = sessions
+    .filter((s) => isOrchestratorSession(s, sessionPrefix, allSessionPrefixes) && !isTerminalSession(s))
+    .sort(compareOrchestratorRecency);
+
+  if (projectOrchestrators.length > 0) {
+    return projectOrchestrators;
+  }
+
+  return sessions
+    .filter((s) => isOrchestratorSession(s, sessionPrefix, allSessionPrefixes))
+    .sort(compareOrchestratorRecency);
+}
+
+export function selectCanonicalProjectOrchestrator(
+  sessions: Session[],
+  sessionPrefix: string,
+  allSessionPrefixes?: string[],
+): Session | null {
+  return listProjectOrchestratorSessions(sessions, sessionPrefix, allSessionPrefixes)[0] ?? null;
+}
+
+export function mapSessionToOrchestrator(
+  session: Session,
+  projectName: string,
+): Orchestrator {
+  return {
+    id: session.id,
+    projectId: session.projectId,
+    projectName,
+    status: session.status,
+    activity: session.activity,
+    createdAt: session.createdAt?.toISOString() ?? null,
+    lastActivityAt: session.lastActivityAt?.toISOString() ?? null,
+  };
+}
+
 export function mapSessionsToOrchestrators(
   sessions: Session[],
   sessionPrefix: string,
   projectName: string,
   allSessionPrefixes?: string[],
 ): Orchestrator[] {
-  return sessions
-    .filter((s) => isOrchestratorSession(s, sessionPrefix, allSessionPrefixes) && !isTerminalSession(s))
-    .map((s) => ({
-      id: s.id,
-      projectId: s.projectId,
-      projectName,
-      status: s.status,
-      activity: s.activity,
-      createdAt: s.createdAt?.toISOString() ?? null,
-      lastActivityAt: s.lastActivityAt?.toISOString() ?? null,
-    }));
+  const canonical = selectCanonicalProjectOrchestrator(sessions, sessionPrefix, allSessionPrefixes);
+  return canonical ? [mapSessionToOrchestrator(canonical, projectName)] : [];
 }

--- a/packages/web/src/lib/orchestrator-utils.ts
+++ b/packages/web/src/lib/orchestrator-utils.ts
@@ -1,7 +1,6 @@
 import {
   type Session,
   isOrchestratorSession,
-  selectPreferredOrchestratorSession,
 } from "@aoagents/ao-core";
 import type { Orchestrator } from "@/components/OrchestratorSelector";
 
@@ -10,12 +9,12 @@ export function selectCanonicalProjectOrchestrator(
   sessionPrefix: string,
   allSessionPrefixes?: string[],
 ): Session | null {
-  const projectOrchestrators = sessions.filter((session) =>
-    isOrchestratorSession(session, sessionPrefix, allSessionPrefixes),
-  );
-  return selectPreferredOrchestratorSession(
-    projectOrchestrators,
-    `${sessionPrefix}-orchestrator`,
+  return (
+    sessions.find(
+      (session) =>
+        session.id === `${sessionPrefix}-orchestrator` &&
+        isOrchestratorSession(session, sessionPrefix, allSessionPrefixes),
+    ) ?? null
   );
 }
 

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -105,22 +105,6 @@ function buildLifecycleSummary(session: Session): string {
   return `Session ${humanizeLifecycleToken(lifecycle.session.state)} (${humanizeLifecycleToken(lifecycle.session.reason)})`;
 }
 
-function buildLifecycleGuidance(session: Session): string | null {
-  const { lifecycle, metadata } = session;
-  if (lifecycle.session.state !== "detecting") {
-    return null;
-  }
-  const attempts = Number.parseInt(metadata["detectingAttempts"] ?? "0", 10);
-  const normalizedAttempts = Number.isFinite(attempts) ? attempts : 0;
-  if (metadata["detectingEscalatedAt"]) {
-    return "Detection retries exhausted. Inspect runtime evidence or restore the session manually.";
-  }
-  if (normalizedAttempts > 0) {
-    return `Checking runtime and process evidence now. Retry ${normalizedAttempts} is in progress.`;
-  }
-  return "Checking runtime and process evidence now.";
-}
-
 function buildDashboardLifecycle(session: Session): NonNullable<DashboardSession["lifecycle"]> {
   const lifecycle = session.lifecycle;
   return {
@@ -161,7 +145,7 @@ function buildDashboardLifecycle(session: Session): NonNullable<DashboardSession
     detectingAttempts: Number.parseInt(session.metadata["detectingAttempts"] ?? "0", 10) || 0,
     detectingEscalatedAt: session.metadata["detectingEscalatedAt"] ?? null,
     summary: buildLifecycleSummary(session),
-    guidance: buildLifecycleGuidance(session),
+    guidance: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- move orchestrator uniqueness into core with `ensureOrchestrator()` and a single deterministic per-project orchestrator id: `{sessionPrefix}-orchestrator`
- simplify CLI and web callers to use the core ensure path and the canonical orchestrator id directly
- remove legacy numbered-orchestrator compatibility so orchestrator selection, startup, stop, and cleanup all operate on the canonical session only
- keep the web hardening from this branch: safer SSE disconnect cleanup, restore fallback behavior, and more resilient session-detail loading/error states

## Behavior change
- each project now has exactly one supported orchestrator session id: `{sessionPrefix}-orchestrator`
- historical numbered orchestrators like `{sessionPrefix}-orchestrator-1` are no longer recognized as valid orchestrator sessions
- this is an intentional breaking simplification, not a migration-safe compatibility window

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @aoagents/ao-core test`
- `pnpm --filter @aoagents/ao-cli test -- __tests__/commands/start.test.ts __tests__/lib/session-utils.test.ts`
- `pnpm --filter @aoagents/ao-web test -- src/__tests__/api-routes.test.ts src/__tests__/orchestrators.test.tsx src/components/__tests__/OrchestratorSelector.test.tsx`
- `pnpm build`
