### PR TITLE
fix: session detail CI chip shows failing when CI is passing

### DIFF
--- a/packages/plugins/scm-github/src/graphql-batch.ts
+++ b/packages/plugins/scm-github/src/graphql-batch.ts
@@ -224,19 +224,17 @@ export async function shouldRefreshPREnrichment(
       const prKey = `${pr.owner}/${pr.repo}#${pr.number}`;
       const cached = prMetadataCache.get(prKey);
 
-      // Check for incomplete cache (cached but no headSha)
-      // This happens when PR was cached but headSha wasn't captured
-      // We need to refresh to get complete data including headSha
-      if (cached && cached.headSha === null) {
-        shouldRefresh = true;
-        details.push(`First time seeing PR #${pr.number} (Guard 2: no cached head SHA)`);
+      // No cached metadata — skip Guard 2. Since Guard 1 didn't detect changes
+      // and we have no cached data, there's nothing to check.
+      if (!cached) {
         continue;
       }
 
-      // Only check commit status ETag if we have cached data with a non-null head SHA
-      if (!cached || !cached.headSha) {
-        // No cached metadata - skip Guard 2. Since Guard 1 didn't detect changes
-        // and we have no cached data, there's nothing to check.
+      // Cached with null headSha — must refresh to get complete data.
+      // Re-check every poll since we can't do ETag comparison without a SHA.
+      if (cached.headSha === null) {
+        shouldRefresh = true;
+        details.push(`PR #${pr.number} needs refresh (Guard 2: cached with no head SHA)`);
         continue;
       }
 

--- a/packages/plugins/scm-github/test/graphql-batch.test.ts
+++ b/packages/plugins/scm-github/test/graphql-batch.test.ts
@@ -1040,7 +1040,7 @@ describe("shouldRefreshPREnrichment - ETag Guard Strategy", () => {
       const result = await shouldRefreshPREnrichment(prs);
 
       expect(result.shouldRefresh).toBe(true);
-      expect(result.details).toContain("First time seeing PR #123 (Guard 2: no cached head SHA)");
+      expect(result.details).toContain("PR #123 needs refresh (Guard 2: cached with no head SHA)");
       // Guard 1 called for PR list, Guard 2 skipped (no head SHA to check)
       expect(mockExecFileImpl).toHaveBeenCalledTimes(1);
     });

--- a/packages/web/src/components/SessionDetailPRCard.tsx
+++ b/packages/web/src/components/SessionDetailPRCard.tsx
@@ -36,10 +36,7 @@ function buildBlockerChips(
   const reviewNotified = Boolean(metadata["lastPendingReviewDispatchHash"]);
   const lifecycleStatus = metadata["status"];
 
-  const ciIsFailing =
-    pr.ciStatus === CI_STATUS.FAILING ||
-    lifecyclePrReason === "ci_failing" ||
-    lifecycleStatus === "ci_failed";
+  const ciIsFailing = pr.ciStatus === CI_STATUS.FAILING;
   const hasChangesRequested =
     pr.reviewDecision === "changes_requested" ||
     lifecyclePrReason === "changes_requested" ||

--- a/packages/web/src/lib/cache.ts
+++ b/packages/web/src/lib/cache.ts
@@ -2,7 +2,7 @@
  * Simple in-memory TTL cache for SCM API data.
  *
  * Reduces GitHub API rate limit exhaustion by caching PR enrichment data.
- * Default TTL: 60 seconds (data is fresh enough for dashboard refresh).
+ * Default TTL: 5 minutes (balances freshness with API rate limits).
  */
 
 interface CacheEntry<T> {
@@ -50,6 +50,11 @@ export class TTLCache<T> {
       value,
       expiresAt: Date.now() + (ttlMs ?? this.ttlMs),
     });
+  }
+
+  /** Delete a specific cache entry */
+  delete(key: string): boolean {
+    return this.cache.delete(key);
   }
 
   /** Evict all expired entries */
@@ -105,7 +110,7 @@ export interface PREnrichmentData {
   }>;
 }
 
-/** Global PR enrichment cache (60s TTL) */
+/** Global PR enrichment cache (5 min TTL) */
 export const prCache = new TTLCache<PREnrichmentData>();
 
 /** Generate cache key for a PR: `owner/repo#123` */

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -279,9 +279,15 @@ export async function enrichSessionPR(
 
   const cacheKey = prCacheKey(pr.owner, pr.repo, pr.number);
 
-  // Check cache first
+  // Check cache first — but bypass if CI state is stale (lifecycle recovered but cache still says failing)
   const cached = prCache.get(cacheKey);
-  if (cached && dashboard.pr) {
+  const lifecycleCIRecovered =
+    dashboard.lifecycle?.prReason !== "ci_failing" &&
+    cached?.ciStatus === "failing";
+  if (lifecycleCIRecovered) {
+    prCache.delete(cacheKey);
+  }
+  if (cached && !lifecycleCIRecovered && dashboard.pr) {
     dashboard.pr.state = cached.state;
     dashboard.pr.title = cached.title;
     dashboard.pr.additions = cached.additions;


### PR DESCRIPTION
## Summary

Fixes #1360 — the session detail page's PR card showed a red "CI failing" blocker chip when CI on the actual PR was passing. Three independent sources fed the chip via an OR, and a single stale source kept the chip up.

Four fixes:

1. **Narrow the OR** — `buildBlockerChips` now trusts only `pr.ciStatus` (live SCM signal), removing `lifecyclePrReason` and `lifecycleStatus` from the CI check
2. **Fix TTL comment mismatch** — cache.ts comments said 60s but `DEFAULT_TTL_MS` was 5 min; updated comments to match reality
3. **Invalidate prCache on CI recovery** — `enrichSessionPR` now detects when lifecycle says CI recovered but cached data still shows failing, and bypasses the stale entry
4. **Simplify Guard 2 null-headSha logic** — restructured graphql-batch to check `!cached` first, then null headSha, eliminating confusing fallthrough

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` — all tests pass (2 pre-existing failures in web unrelated to this change)
- [x] Updated graphql-batch test expectation to match new detail message string
- [ ] Manual: verify CI chip shows green when CI passes, red when CI fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)