### PR TITLE
refactor(core): consolidate duplicate PREnrichmentData and BatchObserver declarations

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -835,6 +835,8 @@ export interface PREnrichmentData {
   isBehind?: boolean;
   /** List of blockers preventing merge */
   blockers?: string[];
+  /** Individual CI check results (populated from batch enrichment when available) */
+  ciChecks?: CICheck[];
 }
 
 /**
@@ -985,60 +987,6 @@ export interface MergeReadiness {
   blockers: string[];
 }
 
-/**
- * Batch enrichment data returned by SCM plugins.
- * Contains all the information the orchestrator needs for status detection.
- */
-export interface PREnrichmentData {
-  /** Current PR state */
-  state: PRState;
-  /** Overall CI status */
-  ciStatus: CIStatus;
-  /** Review decision */
-  reviewDecision: ReviewDecision;
-  /** Whether the PR is mergeable based on CI, reviews, and merge state */
-  mergeable: boolean;
-  /** PR title */
-  title?: string;
-  /** Number of additions */
-  additions?: number;
-  /** Number of deletions */
-  deletions?: number;
-  /** Whether PR is a draft */
-  isDraft?: boolean;
-  /** Whether PR has merge conflicts */
-  hasConflicts?: boolean;
-  /** Whether PR is behind base branch */
-  isBehind?: boolean;
-  /** List of blockers preventing merge */
-  blockers?: string[];
-  /** Individual CI check results (populated from batch enrichment when available) */
-  ciChecks?: CICheck[];
-}
-
-/**
- * Observer for GraphQL batch PR enrichment operations.
- * Used by SCM plugins to report batch success/failure to the observability system.
- */
-export interface BatchObserver {
-  /** Record a successful batch enrichment */
-  recordSuccess(data: {
-    batchIndex: number;
-    totalBatches: number;
-    prCount: number;
-    durationMs: number;
-  }): void;
-  /** Record a failed batch enrichment */
-  recordFailure(data: {
-    batchIndex: number;
-    totalBatches: number;
-    prCount: number;
-    error: string;
-    durationMs: number;
-  }): void;
-  /** Log a message at a specific level */
-  log(level: ObservabilityLevel, message: string): void;
-}
 // =============================================================================
 // NOTIFIER — Plugin Slot 6 (PRIMARY INTERFACE)
 // =============================================================================


### PR DESCRIPTION
## Summary
- Merged the two `PREnrichmentData` declarations in `packages/core/src/types.ts` into one, keeping the `ciChecks` field that was added via the second declaration.
- Removed the redundant `BatchObserver` duplicate declaration (the two sites were identical).
- Relying on TypeScript interface merging across widely-separated lines in a single file was a maintenance trap — a single declaration site is easier to keep coherent.

Closes #1413

## Test plan
- [x] `pnpm --filter @aoagents/ao-core typecheck` passes
- [x] `pnpm typecheck` passes across all workspace packages (plugins, web, cli, integration-tests)
- [x] Pre-existing core test failure (`recovery-actions.test.ts`) confirmed unrelated — fails on main too

🤖 Generated with [Claude Code](https://claude.com/claude-code)