### PR TITLE
refactor(core): split lifecycle-manager.ts into focused modules

### DIFF
--- a/packages/core/src/__tests__/lifecycle-backlog.test.ts
+++ b/packages/core/src/__tests__/lifecycle-backlog.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createBacklogDispatchers,
+  formatCIFailureMessage,
+} from "../lifecycle-backlog.js";
+import { createReactionEngine } from "../reaction-engine.js";
+import type {
+  OrchestratorConfig,
+  PluginRegistry,
+  OpenCodeSessionManager,
+  ReactionConfig,
+  Session,
+  SCM,
+  CICheck,
+  ReviewComment,
+  OrchestratorEvent,
+  EventPriority,
+} from "../types.js";
+import type { PREnrichmentCache } from "../pr-enrichment-cache.js";
+import {
+  createMockSCM,
+  createMockSessionManager,
+  makePR,
+  makeSession,
+} from "./test-utils.js";
+
+function makeOpenPRSession(overrides: Partial<Session> = {}): Session {
+  const session = makeSession({ pr: makePR(), ...overrides });
+  session.lifecycle.pr.state = "open";
+  session.lifecycle.pr.reason = "in_progress";
+  session.lifecycle.pr.number = session.pr!.number;
+  session.lifecycle.pr.url = session.pr!.url;
+  return session;
+}
+
+function makeConfig(reactions: Record<string, ReactionConfig> = {}): OrchestratorConfig {
+  return {
+    configPath: "/tmp/ao.yaml",
+    port: 3000,
+    power: { preventIdleSleep: false },
+    defaults: { runtime: "mock", agent: "mock-agent", workspace: "mock-ws", notifiers: [] },
+    projects: {
+      "my-app": {
+        name: "My App",
+        repo: "org/my-app",
+        path: "/tmp/my-app",
+        storageKey: "111111111111",
+        defaultBranch: "main",
+        sessionPrefix: "app",
+        scm: { plugin: "github" },
+      },
+    },
+    notifiers: {},
+    notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+    reactions,
+    readyThresholdMs: 300_000,
+  };
+}
+
+function makeRegistry(scm: SCM): PluginRegistry {
+  return {
+    register: vi.fn(),
+    get: vi.fn().mockImplementation((slot: string) => (slot === "scm" ? scm : null)),
+    list: vi.fn().mockReturnValue([]),
+    loadBuiltins: vi.fn(),
+    loadFromConfig: vi.fn(),
+  };
+}
+
+function makeCache(
+  overrides: Partial<PREnrichmentCache> = {},
+): PREnrichmentCache {
+  return {
+    get: vi.fn().mockReturnValue(undefined),
+    populate: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function reviewComment(id: string): ReviewComment {
+  return {
+    id,
+    author: "reviewer",
+    body: "please fix",
+    isResolved: false,
+    createdAt: new Date(),
+    url: `https://example.com/${id}`,
+  };
+}
+
+interface Harness {
+  dispatchers: ReturnType<typeof createBacklogDispatchers>;
+  updates: Array<{ session: Session; updates: Record<string, string> }>;
+  notified: Array<{ event: OrchestratorEvent; priority: EventPriority }>;
+  sessionManager: OpenCodeSessionManager;
+}
+
+function makeHarness(opts: {
+  scm: SCM;
+  reactions?: Record<string, ReactionConfig>;
+  cache?: PREnrichmentCache;
+}): Harness {
+  const config = makeConfig(opts.reactions);
+  const registry = makeRegistry(opts.scm);
+  const sessionManager = createMockSessionManager();
+  const updates: Harness["updates"] = [];
+  const notified: Harness["notified"] = [];
+  const notifyHuman = async (event: OrchestratorEvent, priority: EventPriority) => {
+    notified.push({ event, priority });
+  };
+  const reactionEngine = createReactionEngine({
+    config,
+    sessionManager,
+    notifyHuman,
+  });
+  const dispatchers = createBacklogDispatchers({
+    config,
+    registry,
+    sessionManager,
+    reactionEngine,
+    prEnrichmentCache: opts.cache ?? makeCache(),
+    updateSessionMetadata: (session, u) => {
+      updates.push({ session, updates: u as Record<string, string> });
+      // Emulate persistence so throttle/fingerprint checks see latest values
+      Object.assign(session.metadata, u);
+    },
+    notifyHuman,
+  });
+  return { dispatchers, updates, notified, sessionManager };
+}
+
+describe("formatCIFailureMessage", () => {
+  it("renders each failed check as a bullet with status and link", () => {
+    const checks: CICheck[] = [
+      { name: "unit", status: "failed", conclusion: "FAILURE", url: "https://ci/1" },
+      { name: "lint", status: "failed" },
+    ];
+    const msg = formatCIFailureMessage(checks);
+    expect(msg).toContain("- **unit**: FAILURE — https://ci/1");
+    expect(msg).toContain("- **lint**: failed");
+    expect(msg.startsWith("CI checks are failing")).toBe(true);
+  });
+});
+
+describe("maybeDispatchReviewBacklog", () => {
+  it("dispatches review comments via send-to-agent when fingerprint changes", async () => {
+    const scm = createMockSCM({
+      getPendingComments: vi.fn().mockResolvedValue([reviewComment("c-1")]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+    });
+    const { dispatchers, sessionManager, updates } = makeHarness({
+      scm,
+      reactions: {
+        "changes-requested": {
+          auto: true,
+          action: "send-to-agent",
+          message: "Address review comments",
+        },
+      },
+    });
+    const session = makeOpenPRSession({ status: "changes_requested" });
+
+    // Subsequent poll after the initial transition — backlog dispatch fires
+    // when comments arrive while already in changes_requested.
+    await dispatchers.maybeDispatchReviewBacklog(
+      session,
+      "changes_requested",
+      "changes_requested",
+    );
+
+    expect(sessionManager.send).toHaveBeenCalledWith(session.id, "Address review comments");
+    const flat = Object.assign({}, ...updates.map((u) => u.updates));
+    expect(flat.lastPendingReviewDispatchHash).toBeTruthy();
+  });
+
+  it("does not dispatch a second time when fingerprint is unchanged", async () => {
+    const scm = createMockSCM({
+      getPendingComments: vi.fn().mockResolvedValue([reviewComment("c-1")]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+    });
+    const { dispatchers, sessionManager } = makeHarness({
+      scm,
+      reactions: {
+        "changes-requested": {
+          auto: true,
+          action: "send-to-agent",
+          message: "m",
+        },
+      },
+    });
+    const session = makeOpenPRSession({ status: "changes_requested" });
+
+    await dispatchers.maybeDispatchReviewBacklog(
+      session,
+      "changes_requested",
+      "changes_requested",
+    );
+    expect(sessionManager.send).toHaveBeenCalledTimes(1);
+
+    // Second poll: same comments -> throttle + matching fingerprint skip
+    (scm.getPendingComments as ReturnType<typeof vi.fn>).mockClear();
+    await dispatchers.maybeDispatchReviewBacklog(
+      session,
+      "changes_requested",
+      "changes_requested",
+    );
+    expect(sessionManager.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears trackers and metadata when PR is no longer open", async () => {
+    const scm = createMockSCM();
+    const { dispatchers, updates } = makeHarness({ scm });
+    const session = makeSession({
+      pr: makePR(),
+      status: "merged",
+      metadata: {
+        lastPendingReviewFingerprint: "abc",
+        lastPendingReviewDispatchHash: "abc",
+      },
+    });
+
+    await dispatchers.maybeDispatchReviewBacklog(session, "approved", "merged");
+
+    expect(scm.getPendingComments).not.toHaveBeenCalled();
+    const flat = Object.assign({}, ...updates.map((u) => u.updates));
+    expect(flat.lastPendingReviewFingerprint).toBe("");
+    expect(flat.lastPendingReviewDispatchHash).toBe("");
+  });
+});
+
+describe("maybeDispatchCIFailureDetails", () => {
+  it("uses cached CI checks from the enrichment cache when available", async () => {
+    const checks: CICheck[] = [{ name: "unit", status: "failed", url: "https://ci/1" }];
+    const cache = makeCache({
+      get: vi.fn().mockReturnValue({
+        state: "open",
+        ciStatus: "failing",
+        reviewDecision: "none",
+        mergeable: false,
+        ciChecks: checks,
+      }),
+    });
+    const scm = createMockSCM();
+    const { dispatchers, sessionManager } = makeHarness({
+      scm,
+      cache,
+      reactions: {
+        "ci-failed": { auto: true, action: "send-to-agent", message: "ignored" },
+      },
+    });
+    const session = makeOpenPRSession({ status: "ci_failed" });
+
+    await dispatchers.maybeDispatchCIFailureDetails(session, "pr_open", "ci_failed");
+
+    expect(scm.getCIChecks).not.toHaveBeenCalled();
+    expect(sessionManager.send).toHaveBeenCalledTimes(1);
+    const [, message] = (sessionManager.send as ReturnType<typeof vi.fn>).mock.calls[0] ?? [];
+    expect(message).toContain("unit");
+  });
+
+  it("falls back to scm.getCIChecks when the cache is empty", async () => {
+    const checks: CICheck[] = [{ name: "lint", status: "failed" }];
+    const scm = createMockSCM({ getCIChecks: vi.fn().mockResolvedValue(checks) });
+    const { dispatchers, sessionManager } = makeHarness({
+      scm,
+      reactions: {
+        "ci-failed": { auto: true, action: "send-to-agent", message: "m" },
+      },
+    });
+    const session = makeOpenPRSession({ status: "ci_failed" });
+
+    await dispatchers.maybeDispatchCIFailureDetails(session, "pr_open", "ci_failed");
+
+    expect(scm.getCIChecks).toHaveBeenCalledTimes(1);
+    expect(sessionManager.send).toHaveBeenCalled();
+  });
+
+  it("clears CI tracking when status is no longer ci_failed", async () => {
+    const scm = createMockSCM();
+    const { dispatchers, updates } = makeHarness({ scm });
+    const session = makeSession({
+      pr: makePR(),
+      status: "approved",
+      metadata: {
+        lastCIFailureFingerprint: "abc",
+        lastCIFailureDispatchHash: "abc",
+      },
+    });
+
+    await dispatchers.maybeDispatchCIFailureDetails(session, "ci_failed", "approved");
+
+    expect(scm.getCIChecks).not.toHaveBeenCalled();
+    const flat = Object.assign({}, ...updates.map((u) => u.updates));
+    expect(flat.lastCIFailureFingerprint).toBe("");
+  });
+});
+
+describe("maybeDispatchMergeConflicts", () => {
+  it("sends a conflict message once, then dedupes on the next poll", async () => {
+    const cache = makeCache({
+      get: vi.fn().mockReturnValue({
+        state: "open",
+        ciStatus: "passing",
+        reviewDecision: "none",
+        mergeable: false,
+        hasConflicts: true,
+      }),
+    });
+    const scm = createMockSCM();
+    const { dispatchers, sessionManager } = makeHarness({
+      scm,
+      cache,
+      reactions: {
+        "merge-conflicts": { auto: true, action: "send-to-agent", message: "rebase please" },
+      },
+    });
+    const session = makeOpenPRSession({ status: "ci_failed" });
+
+    await dispatchers.maybeDispatchMergeConflicts(session, "ci_failed");
+    expect(sessionManager.send).toHaveBeenCalledTimes(1);
+
+    await dispatchers.maybeDispatchMergeConflicts(session, "ci_failed");
+    expect(sessionManager.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to scm.getMergeability when cache is empty", async () => {
+    const scm = createMockSCM({
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: false,
+        ciPassing: true,
+        approved: true,
+        noConflicts: false,
+        blockers: [],
+      }),
+    });
+    const { dispatchers, sessionManager } = makeHarness({
+      scm,
+      reactions: {
+        "merge-conflicts": { auto: true, action: "send-to-agent", message: "rebase" },
+      },
+    });
+    const session = makeOpenPRSession({ status: "mergeable" });
+
+    await dispatchers.maybeDispatchMergeConflicts(session, "mergeable");
+
+    expect(scm.getMergeability).toHaveBeenCalledTimes(1);
+    expect(sessionManager.send).toHaveBeenCalled();
+  });
+
+  it("clears the dispatched flag once conflicts resolve", async () => {
+    const get = vi
+      .fn()
+      .mockReturnValueOnce({
+        state: "open",
+        ciStatus: "passing",
+        reviewDecision: "none",
+        mergeable: false,
+        hasConflicts: true,
+      })
+      .mockReturnValueOnce({
+        state: "open",
+        ciStatus: "passing",
+        reviewDecision: "none",
+        mergeable: true,
+        hasConflicts: false,
+      });
+    const cache = makeCache({ get });
+    const { dispatchers, updates } = makeHarness({
+      scm: createMockSCM(),
+      cache,
+      reactions: {
+        "merge-conflicts": { auto: true, action: "send-to-agent", message: "m" },
+      },
+    });
+    const session = makeOpenPRSession({ status: "ci_failed" });
+
+    await dispatchers.maybeDispatchMergeConflicts(session, "ci_failed");
+    await dispatchers.maybeDispatchMergeConflicts(session, "approved");
+
+    const clearingUpdate = updates.find((u) => u.updates.lastMergeConflictDispatched === "");
+    expect(clearingUpdate).toBeDefined();
+  });
+});

--- a/packages/core/src/__tests__/lifecycle-events.test.ts
+++ b/packages/core/src/__tests__/lifecycle-events.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseDuration,
+  inferPriority,
+  createEvent,
+  statusToEventType,
+  prStateToEventType,
+  eventToReactionKey,
+  transitionLogLevel,
+  splitEvidenceSignals,
+  makeFingerprint,
+} from "../lifecycle-events.js";
+
+describe("lifecycle-events", () => {
+  describe("parseDuration", () => {
+    it("parses seconds, minutes, hours", () => {
+      expect(parseDuration("30s")).toBe(30_000);
+      expect(parseDuration("10m")).toBe(600_000);
+      expect(parseDuration("2h")).toBe(7_200_000);
+    });
+
+    it("returns 0 for malformed input", () => {
+      expect(parseDuration("")).toBe(0);
+      expect(parseDuration("10")).toBe(0);
+      expect(parseDuration("abc")).toBe(0);
+      expect(parseDuration("10d")).toBe(0);
+    });
+  });
+
+  describe("inferPriority", () => {
+    it("returns urgent for stuck/needs_input/errored", () => {
+      expect(inferPriority("session.stuck")).toBe("urgent");
+      expect(inferPriority("session.needs_input")).toBe("urgent");
+      expect(inferPriority("session.errored")).toBe("urgent");
+    });
+
+    it("returns action for merge/ready events", () => {
+      expect(inferPriority("merge.ready")).toBe("action");
+      expect(inferPriority("merge.completed")).toBe("action");
+      expect(inferPriority("review.approved")).toBe("action");
+    });
+
+    it("returns warning for failures and changes_requested", () => {
+      expect(inferPriority("ci.failing")).toBe("warning");
+      expect(inferPriority("review.changes_requested")).toBe("warning");
+      expect(inferPriority("merge.conflicts")).toBe("warning");
+    });
+
+    it("returns info for summary and miscellaneous events", () => {
+      expect(inferPriority("summary.all_complete")).toBe("info");
+      expect(inferPriority("pr.created")).toBe("info");
+    });
+  });
+
+  describe("createEvent", () => {
+    it("fills in timestamp, id, inferred priority", () => {
+      const event = createEvent("ci.failing", {
+        sessionId: "s-1",
+        projectId: "my-app",
+        message: "CI is broken",
+      });
+      expect(event.type).toBe("ci.failing");
+      expect(event.priority).toBe("warning");
+      expect(event.sessionId).toBe("s-1");
+      expect(event.projectId).toBe("my-app");
+      expect(event.message).toBe("CI is broken");
+      expect(event.timestamp).toBeInstanceOf(Date);
+      expect(event.data).toEqual({});
+      expect(event.id).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it("honors explicit priority override", () => {
+      const event = createEvent("pr.created", {
+        sessionId: "s-1",
+        projectId: "my-app",
+        message: "m",
+        priority: "urgent",
+      });
+      expect(event.priority).toBe("urgent");
+    });
+  });
+
+  describe("statusToEventType", () => {
+    it("maps known statuses to event types", () => {
+      expect(statusToEventType(undefined, "working")).toBe("session.working");
+      expect(statusToEventType(undefined, "pr_open")).toBe("pr.created");
+      expect(statusToEventType(undefined, "ci_failed")).toBe("ci.failing");
+      expect(statusToEventType(undefined, "merged")).toBe("merge.completed");
+      expect(statusToEventType(undefined, "stuck")).toBe("session.stuck");
+    });
+
+    it("returns null for statuses without a transition event", () => {
+      expect(statusToEventType(undefined, "spawning")).toBeNull();
+      expect(statusToEventType(undefined, "cleanup")).toBeNull();
+    });
+  });
+
+  describe("prStateToEventType", () => {
+    it("emits pr.closed when transitioning to closed", () => {
+      expect(prStateToEventType("open", "closed")).toBe("pr.closed");
+    });
+
+    it("returns null when state did not change", () => {
+      expect(prStateToEventType("open", "open")).toBeNull();
+    });
+
+    it("returns null for merged transitions (handled via status map)", () => {
+      expect(prStateToEventType("open", "merged")).toBeNull();
+    });
+  });
+
+  describe("eventToReactionKey", () => {
+    it("maps known events to reaction keys", () => {
+      expect(eventToReactionKey("ci.failing")).toBe("ci-failed");
+      expect(eventToReactionKey("review.changes_requested")).toBe("changes-requested");
+      expect(eventToReactionKey("automated_review.found")).toBe("bugbot-comments");
+      expect(eventToReactionKey("merge.conflicts")).toBe("merge-conflicts");
+      expect(eventToReactionKey("session.stuck")).toBe("agent-stuck");
+    });
+
+    it("returns null for events without a reaction", () => {
+      expect(eventToReactionKey("pr.created")).toBeNull();
+      expect(eventToReactionKey("session.working")).toBeNull();
+    });
+  });
+
+  describe("transitionLogLevel", () => {
+    it("escalates urgent priorities to error level", () => {
+      expect(transitionLogLevel("stuck")).toBe("error");
+      expect(transitionLogLevel("needs_input")).toBe("error");
+    });
+
+    it("maps warning priorities to warn level", () => {
+      expect(transitionLogLevel("ci_failed")).toBe("warn");
+      expect(transitionLogLevel("changes_requested")).toBe("warn");
+    });
+
+    it("defaults to info", () => {
+      expect(transitionLogLevel("working")).toBe("info");
+      expect(transitionLogLevel("merged")).toBe("info");
+    });
+  });
+
+  describe("splitEvidenceSignals", () => {
+    it("splits on whitespace and drops empties", () => {
+      expect(splitEvidenceSignals("  a  b\tc\nd  ")).toEqual(["a", "b", "c", "d"]);
+      expect(splitEvidenceSignals("")).toEqual([]);
+    });
+  });
+
+  describe("makeFingerprint", () => {
+    it("is order-independent", () => {
+      expect(makeFingerprint(["b", "a", "c"])).toBe(makeFingerprint(["c", "a", "b"]));
+    });
+
+    it("differs when the set changes", () => {
+      expect(makeFingerprint(["a", "b"])).not.toBe(makeFingerprint(["a", "b", "c"]));
+    });
+  });
+});

--- a/packages/core/src/__tests__/pr-enrichment-cache.test.ts
+++ b/packages/core/src/__tests__/pr-enrichment-cache.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from "vitest";
+import { createPREnrichmentCache } from "../pr-enrichment-cache.js";
+import type {
+  OrchestratorConfig,
+  PluginRegistry,
+  PREnrichmentData,
+  SCM,
+} from "../types.js";
+import { createMockSCM, makePR, makeSession } from "./test-utils.js";
+
+function makeConfig(): OrchestratorConfig {
+  return {
+    configPath: "/tmp/ao.yaml",
+    port: 3000,
+    power: { preventIdleSleep: false },
+    defaults: { runtime: "mock", agent: "mock-agent", workspace: "mock-ws", notifiers: [] },
+    projects: {
+      "my-app": {
+        name: "My App",
+        repo: "org/my-app",
+        path: "/tmp/my-app",
+        storageKey: "111111111111",
+        defaultBranch: "main",
+        sessionPrefix: "app",
+        scm: { plugin: "github" },
+      },
+    },
+    notifiers: {},
+    notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+    reactions: {},
+    readyThresholdMs: 300_000,
+  };
+}
+
+function makeRegistry(scm: SCM | null): PluginRegistry {
+  return {
+    register: vi.fn(),
+    get: vi.fn().mockImplementation((slot: string) => (slot === "scm" ? scm : null)),
+    list: vi.fn().mockReturnValue([]),
+    loadBuiltins: vi.fn(),
+    loadFromConfig: vi.fn(),
+  };
+}
+
+const enrichment: PREnrichmentData = {
+  state: "open",
+  ciStatus: "passing",
+  reviewDecision: "approved",
+  mergeable: true,
+};
+
+describe("pr-enrichment-cache", () => {
+  it("populates from SCM batch and exposes get() by PR key", async () => {
+    const scm = createMockSCM({
+      enrichSessionsPRBatch: vi.fn().mockResolvedValue(
+        new Map([["org/repo#42", enrichment]]),
+      ),
+    });
+    const cache = createPREnrichmentCache({
+      config: makeConfig(),
+      registry: makeRegistry(scm),
+      observer: undefined,
+    });
+    const session = makeSession({ pr: makePR({ owner: "org", repo: "repo", number: 42 }) });
+
+    await cache.populate([session]);
+
+    expect(scm.enrichSessionsPRBatch).toHaveBeenCalledTimes(1);
+    expect(cache.get("org/repo#42")).toEqual(enrichment);
+    expect(cache.get("unknown")).toBeUndefined();
+  });
+
+  it("dedupes PRs across sessions so the SCM sees each PR once", async () => {
+    const batch = vi.fn().mockResolvedValue(new Map());
+    const scm = createMockSCM({ enrichSessionsPRBatch: batch });
+    const cache = createPREnrichmentCache({
+      config: makeConfig(),
+      registry: makeRegistry(scm),
+      observer: undefined,
+    });
+    const pr = makePR({ owner: "org", repo: "repo", number: 42 });
+    const sessions = [
+      makeSession({ id: "s-1", pr }),
+      makeSession({ id: "s-2", pr }),
+    ];
+
+    await cache.populate(sessions);
+
+    expect(batch).toHaveBeenCalledTimes(1);
+    const [prs] = batch.mock.calls[0]!;
+    expect(prs).toHaveLength(1);
+  });
+
+  it("clears stale entries on re-populate", async () => {
+    const scm = createMockSCM({
+      enrichSessionsPRBatch: vi
+        .fn()
+        .mockResolvedValueOnce(new Map([["org/repo#42", enrichment]]))
+        .mockResolvedValueOnce(new Map()),
+    });
+    const cache = createPREnrichmentCache({
+      config: makeConfig(),
+      registry: makeRegistry(scm),
+      observer: undefined,
+    });
+    const session = makeSession({ pr: makePR({ owner: "org", repo: "repo", number: 42 }) });
+
+    await cache.populate([session]);
+    expect(cache.get("org/repo#42")).toEqual(enrichment);
+
+    await cache.populate([session]);
+    expect(cache.get("org/repo#42")).toBeUndefined();
+  });
+
+  it("skips sessions whose project has no SCM plugin configured", async () => {
+    const batch = vi.fn().mockResolvedValue(new Map());
+    const scm = createMockSCM({ enrichSessionsPRBatch: batch });
+    const config = makeConfig();
+    delete config.projects["my-app"]!.scm;
+
+    const cache = createPREnrichmentCache({
+      config,
+      registry: makeRegistry(scm),
+      observer: undefined,
+    });
+    await cache.populate([makeSession({ pr: makePR() })]);
+
+    expect(batch).not.toHaveBeenCalled();
+  });
+
+  it("swallows batch errors so a failure doesn't break the poll", async () => {
+    const scm = createMockSCM({
+      enrichSessionsPRBatch: vi.fn().mockRejectedValue(new Error("GraphQL down")),
+    });
+    const cache = createPREnrichmentCache({
+      config: makeConfig(),
+      registry: makeRegistry(scm),
+      observer: undefined,
+    });
+    const session = makeSession({ pr: makePR({ owner: "org", repo: "repo", number: 42 }) });
+
+    await expect(cache.populate([session])).resolves.toBeUndefined();
+    expect(cache.get("org/repo#42")).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/pr-enrichment-cache.test.ts
+++ b/packages/core/src/__tests__/pr-enrichment-cache.test.ts
@@ -6,7 +6,14 @@ import type {
   PREnrichmentData,
   SCM,
 } from "../types.js";
+import type { ProjectObserver } from "../observability.js";
 import { createMockSCM, makePR, makeSession } from "./test-utils.js";
+
+const noopObserver: ProjectObserver = {
+  component: "test",
+  recordOperation: () => {},
+  setHealth: () => {},
+};
 
 function makeConfig(): OrchestratorConfig {
   return {
@@ -59,7 +66,7 @@ describe("pr-enrichment-cache", () => {
     const cache = createPREnrichmentCache({
       config: makeConfig(),
       registry: makeRegistry(scm),
-      observer: undefined,
+      observer: noopObserver,
     });
     const session = makeSession({ pr: makePR({ owner: "org", repo: "repo", number: 42 }) });
 
@@ -76,7 +83,7 @@ describe("pr-enrichment-cache", () => {
     const cache = createPREnrichmentCache({
       config: makeConfig(),
       registry: makeRegistry(scm),
-      observer: undefined,
+      observer: noopObserver,
     });
     const pr = makePR({ owner: "org", repo: "repo", number: 42 });
     const sessions = [
@@ -101,7 +108,7 @@ describe("pr-enrichment-cache", () => {
     const cache = createPREnrichmentCache({
       config: makeConfig(),
       registry: makeRegistry(scm),
-      observer: undefined,
+      observer: noopObserver,
     });
     const session = makeSession({ pr: makePR({ owner: "org", repo: "repo", number: 42 }) });
 
@@ -121,7 +128,7 @@ describe("pr-enrichment-cache", () => {
     const cache = createPREnrichmentCache({
       config,
       registry: makeRegistry(scm),
-      observer: undefined,
+      observer: noopObserver,
     });
     await cache.populate([makeSession({ pr: makePR() })]);
 
@@ -135,7 +142,7 @@ describe("pr-enrichment-cache", () => {
     const cache = createPREnrichmentCache({
       config: makeConfig(),
       registry: makeRegistry(scm),
-      observer: undefined,
+      observer: noopObserver,
     });
     const session = makeSession({ pr: makePR({ owner: "org", repo: "repo", number: 42 }) });
 

--- a/packages/core/src/__tests__/reaction-engine.test.ts
+++ b/packages/core/src/__tests__/reaction-engine.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createReactionEngine } from "../reaction-engine.js";
+import type {
+  OrchestratorConfig,
+  ReactionConfig,
+  OpenCodeSessionManager,
+  OrchestratorEvent,
+  EventPriority,
+} from "../types.js";
+import { createMockSessionManager, makeSession } from "./test-utils.js";
+
+function makeConfig(
+  reactions: Record<string, ReactionConfig> = {},
+  projectReactions: Record<string, ReactionConfig> = {},
+): OrchestratorConfig {
+  return {
+    configPath: "/tmp/ao.yaml",
+    port: 3000,
+    power: { preventIdleSleep: false },
+    defaults: { runtime: "mock", agent: "mock-agent", workspace: "mock-ws", notifiers: [] },
+    projects: {
+      "my-app": {
+        name: "My App",
+        repo: "org/my-app",
+        path: "/tmp/my-app",
+        storageKey: "111111111111",
+        defaultBranch: "main",
+        sessionPrefix: "app",
+        reactions: projectReactions,
+      },
+    },
+    notifiers: {},
+    notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+    reactions,
+    readyThresholdMs: 300_000,
+  };
+}
+
+describe("reaction-engine", () => {
+  let sessionManager: OpenCodeSessionManager;
+  let notified: Array<{ event: OrchestratorEvent; priority: EventPriority }>;
+  let notifyHuman: (event: OrchestratorEvent, priority: EventPriority) => Promise<void>;
+
+  beforeEach(() => {
+    sessionManager = createMockSessionManager();
+    notified = [];
+    notifyHuman = async (event, priority) => {
+      notified.push({ event, priority });
+    };
+  });
+
+  describe("executeReaction — actions", () => {
+    it("sends a message to the agent when action=send-to-agent", async () => {
+      const engine = createReactionEngine({
+        config: makeConfig(),
+        sessionManager,
+        notifyHuman,
+      });
+      const result = await engine.executeReaction("s-1", "my-app", "ci-failed", {
+        auto: true,
+        action: "send-to-agent",
+        message: "Fix CI please",
+      });
+      expect(result).toEqual({
+        reactionType: "ci-failed",
+        success: true,
+        action: "send-to-agent",
+        message: "Fix CI please",
+        escalated: false,
+      });
+      expect(sessionManager.send).toHaveBeenCalledWith("s-1", "Fix CI please");
+    });
+
+    it("notifies the human when action=notify", async () => {
+      const engine = createReactionEngine({
+        config: makeConfig(),
+        sessionManager,
+        notifyHuman,
+      });
+      const result = await engine.executeReaction("s-1", "my-app", "agent-stuck", {
+        auto: true,
+        action: "notify",
+        priority: "urgent",
+      });
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("notify");
+      expect(notified).toHaveLength(1);
+      expect(notified[0]?.priority).toBe("urgent");
+      expect(notified[0]?.event.type).toBe("reaction.triggered");
+    });
+
+    it("returns success=false when send-to-agent throws", async () => {
+      sessionManager.send = vi.fn().mockRejectedValue(new Error("boom"));
+      const engine = createReactionEngine({
+        config: makeConfig(),
+        sessionManager,
+        notifyHuman,
+      });
+      const result = await engine.executeReaction("s-1", "my-app", "ci-failed", {
+        auto: true,
+        action: "send-to-agent",
+        message: "Fix CI",
+      });
+      expect(result.success).toBe(false);
+      expect(result.escalated).toBe(false);
+    });
+  });
+
+  describe("executeReaction — retry/escalation", () => {
+    it("escalates after retries are exceeded", async () => {
+      const engine = createReactionEngine({
+        config: makeConfig(),
+        sessionManager,
+        notifyHuman,
+      });
+      const cfg: ReactionConfig = {
+        auto: true,
+        action: "send-to-agent",
+        message: "retry me",
+        retries: 2,
+      };
+      // attempts 1, 2 -> within retries budget
+      await engine.executeReaction("s-1", "my-app", "ci-failed", cfg);
+      await engine.executeReaction("s-1", "my-app", "ci-failed", cfg);
+      // attempt 3 -> escalated
+      const result = await engine.executeReaction("s-1", "my-app", "ci-failed", cfg);
+      expect(result.escalated).toBe(true);
+      expect(result.action).toBe("escalated");
+      expect(notified).toHaveLength(1);
+      expect(notified[0]?.event.type).toBe("reaction.escalated");
+    });
+
+    it("escalates after numeric escalateAfter threshold", async () => {
+      const engine = createReactionEngine({
+        config: makeConfig(),
+        sessionManager,
+        notifyHuman,
+      });
+      const cfg: ReactionConfig = {
+        auto: true,
+        action: "send-to-agent",
+        message: "m",
+        escalateAfter: 1,
+      };
+      // attempt 1 -> not yet (1 > 1 is false)
+      await engine.executeReaction("s-1", "my-app", "k", cfg);
+      // attempt 2 -> escalated (2 > 1)
+      const result = await engine.executeReaction("s-1", "my-app", "k", cfg);
+      expect(result.escalated).toBe(true);
+    });
+
+    it("escalates after duration-based escalateAfter elapses", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+        const engine = createReactionEngine({
+          config: makeConfig(),
+          sessionManager,
+          notifyHuman,
+        });
+        const cfg: ReactionConfig = {
+          auto: true,
+          action: "send-to-agent",
+          message: "m",
+          escalateAfter: "30m",
+        };
+        await engine.executeReaction("s-1", "my-app", "k", cfg);
+        // Jump forward 31 minutes
+        vi.setSystemTime(new Date("2026-01-01T00:31:00Z"));
+        const result = await engine.executeReaction("s-1", "my-app", "k", cfg);
+        expect(result.escalated).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("tracker lifecycle", () => {
+    it("clearTracker resets the attempt count", async () => {
+      const engine = createReactionEngine({
+        config: makeConfig(),
+        sessionManager,
+        notifyHuman,
+      });
+      const cfg: ReactionConfig = {
+        auto: true,
+        action: "send-to-agent",
+        message: "m",
+        retries: 2,
+      };
+      await engine.executeReaction("s-1", "my-app", "k", cfg);
+      await engine.executeReaction("s-1", "my-app", "k", cfg);
+      engine.clearTracker("s-1", "k");
+      // Cleared — should not escalate on next attempt
+      const result = await engine.executeReaction("s-1", "my-app", "k", cfg);
+      expect(result.escalated).toBe(false);
+    });
+
+    it("pruneTrackers drops state for sessions no longer present", async () => {
+      const engine = createReactionEngine({
+        config: makeConfig(),
+        sessionManager,
+        notifyHuman,
+      });
+      const cfg: ReactionConfig = {
+        auto: true,
+        action: "send-to-agent",
+        message: "m",
+        retries: 1,
+      };
+      // s-1 reaches retries budget
+      await engine.executeReaction("s-1", "my-app", "k", cfg);
+      await engine.executeReaction("s-1", "my-app", "k", cfg);
+      // Prune removes s-1 because it's not in the active set
+      engine.pruneTrackers(new Set(["s-2"]));
+      // After pruning, a fresh execution should not be escalated
+      const result = await engine.executeReaction("s-1", "my-app", "k", cfg);
+      expect(result.escalated).toBe(false);
+    });
+
+    it("handles session IDs containing ':' without ambiguity", async () => {
+      const engine = createReactionEngine({
+        config: makeConfig(),
+        sessionManager,
+        notifyHuman,
+      });
+      const cfg: ReactionConfig = {
+        auto: true,
+        action: "send-to-agent",
+        message: "m",
+        retries: 1,
+      };
+      // Session IDs that would collide if a compound "sessionId:reactionKey"
+      // key were split on the first ":".
+      await engine.executeReaction("sess:abc", "my-app", "ci-failed", cfg);
+      await engine.executeReaction("sess:abc", "my-app", "ci-failed", cfg);
+      // Pruning with "sess:abc" in the active set must NOT wipe it.
+      engine.pruneTrackers(new Set(["sess:abc"]));
+      const result = await engine.executeReaction("sess:abc", "my-app", "ci-failed", cfg);
+      expect(result.escalated).toBe(true);
+    });
+  });
+
+  describe("getReactionConfigForSession", () => {
+    it("returns null when no config is defined anywhere", () => {
+      const engine = createReactionEngine({
+        config: makeConfig(),
+        sessionManager,
+        notifyHuman,
+      });
+      const session = makeSession({ projectId: "my-app" });
+      expect(engine.getReactionConfigForSession(session, "missing")).toBeNull();
+    });
+
+    it("returns the global reaction when no project override exists", () => {
+      const global: ReactionConfig = { auto: true, action: "notify" };
+      const engine = createReactionEngine({
+        config: makeConfig({ "ci-failed": global }),
+        sessionManager,
+        notifyHuman,
+      });
+      const session = makeSession({ projectId: "my-app" });
+      expect(engine.getReactionConfigForSession(session, "ci-failed")).toEqual(global);
+    });
+
+    it("merges project reaction on top of global reaction", () => {
+      const global: ReactionConfig = {
+        auto: true,
+        action: "send-to-agent",
+        message: "global",
+        retries: 3,
+      };
+      const project: ReactionConfig = {
+        auto: true,
+        action: "send-to-agent",
+        message: "project override",
+      };
+      const engine = createReactionEngine({
+        config: makeConfig({ "ci-failed": global }, { "ci-failed": project }),
+        sessionManager,
+        notifyHuman,
+      });
+      const session = makeSession({ projectId: "my-app" });
+      const merged = engine.getReactionConfigForSession(session, "ci-failed");
+      expect(merged).toMatchObject({
+        action: "send-to-agent",
+        message: "project override",
+        retries: 3,
+      });
+    });
+  });
+});

--- a/packages/core/src/lifecycle-backlog.ts
+++ b/packages/core/src/lifecycle-backlog.ts
@@ -1,0 +1,551 @@
+/**
+ * Backlog dispatchers — review comments, CI failures, and merge conflicts.
+ *
+ * These fire once per poll cycle after the primary lifecycle transition has
+ * been handled. Each dispatcher deduplicates on a fingerprint of the fetched
+ * items so that repeated polls don't spam the agent; when the batch
+ * enrichment cache has relevant data, it is preferred over individual REST
+ * calls.
+ */
+
+import {
+  TERMINAL_STATUSES,
+  type CICheck,
+  type EventPriority,
+  type OpenCodeSessionManager,
+  type OrchestratorConfig,
+  type OrchestratorEvent,
+  type PluginRegistry,
+  type ReactionConfig,
+  type ReactionResult,
+  type SCM,
+  type Session,
+  type SessionStatus,
+} from "./types.js";
+import { createEvent, makeFingerprint } from "./lifecycle-events.js";
+import { formatAutomatedCommentsMessage } from "./format-automated-comments.js";
+import { DEFAULT_BUGBOT_COMMENTS_MESSAGE } from "./config.js";
+import type { ReactionEngine } from "./reaction-engine.js";
+import type { PREnrichmentCache } from "./pr-enrichment-cache.js";
+
+export type NotifyHuman = (event: OrchestratorEvent, priority: EventPriority) => Promise<void>;
+export type UpdateSessionMetadata = (
+  session: Session,
+  updates: Partial<Record<string, string>>,
+) => void;
+
+export interface BacklogDispatchers {
+  maybeDispatchReviewBacklog(
+    session: Session,
+    oldStatus: SessionStatus,
+    newStatus: SessionStatus,
+    transitionReaction?: { key: string; result: ReactionResult | null },
+  ): Promise<void>;
+  maybeDispatchCIFailureDetails(
+    session: Session,
+    oldStatus: SessionStatus,
+    newStatus: SessionStatus,
+    transitionReaction?: { key: string; result: ReactionResult | null },
+  ): Promise<void>;
+  maybeDispatchMergeConflicts(session: Session, newStatus: SessionStatus): Promise<void>;
+  /** Drop throttle entries for sessions no longer present. */
+  pruneReviewBacklogThrottle(currentSessionIds: Set<string>): void;
+  /** Clear throttle entry for a single session. */
+  clearReviewBacklogThrottle(sessionId: string): void;
+}
+
+export interface BacklogDispatchersDeps {
+  config: OrchestratorConfig;
+  registry: PluginRegistry;
+  sessionManager: OpenCodeSessionManager;
+  reactionEngine: ReactionEngine;
+  prEnrichmentCache: PREnrichmentCache;
+  updateSessionMetadata: UpdateSessionMetadata;
+  notifyHuman: NotifyHuman;
+}
+
+/** Throttle interval for review backlog API calls (2 minutes). */
+const REVIEW_BACKLOG_THROTTLE_MS = 2 * 60 * 1000;
+
+/**
+ * Format CI check failures into a human-readable message for the agent.
+ * Includes check names, statuses, and links for debugging.
+ */
+export function formatCIFailureMessage(failedChecks: CICheck[]): string {
+  const lines = ["CI checks are failing on your PR. Here are the failed checks:", ""];
+  for (const check of failedChecks) {
+    const status = check.conclusion ?? check.status;
+    const link = check.url ? ` — ${check.url}` : "";
+    lines.push(`- **${check.name}**: ${status}${link}`);
+  }
+  lines.push("", "Investigate the failures, fix the issues, and push again.");
+  return lines.join("\n");
+}
+
+export function createBacklogDispatchers(deps: BacklogDispatchersDeps): BacklogDispatchers {
+  const {
+    config,
+    registry,
+    sessionManager,
+    reactionEngine,
+    prEnrichmentCache,
+    updateSessionMetadata,
+    notifyHuman,
+  } = deps;
+
+  /**
+   * Per-session timestamp of last review backlog API check.
+   * Used to throttle getPendingComments/getAutomatedComments to at most once per 2 minutes.
+   * In-memory only — resets on restart (acceptable since it's a rate-limit hint, not state).
+   */
+  const lastReviewBacklogCheckAt = new Map<string, number>();
+
+  async function maybeDispatchReviewBacklog(
+    session: Session,
+    oldStatus: SessionStatus,
+    newStatus: SessionStatus,
+    transitionReaction?: { key: string; result: ReactionResult | null },
+  ): Promise<void> {
+    const project = config.projects[session.projectId];
+    if (!project || !session.pr) return;
+
+    const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    if (!scm) return;
+
+    const humanReactionKey = "changes-requested";
+    const automatedReactionKey = "bugbot-comments";
+
+    if (TERMINAL_STATUSES.has(newStatus) || session.lifecycle.pr.state !== "open") {
+      reactionEngine.clearTracker(session.id, humanReactionKey);
+      reactionEngine.clearTracker(session.id, automatedReactionKey);
+      lastReviewBacklogCheckAt.delete(session.id);
+      updateSessionMetadata(session, {
+        lastPendingReviewFingerprint: "",
+        lastPendingReviewDispatchHash: "",
+        lastPendingReviewDispatchAt: "",
+        lastAutomatedReviewFingerprint: "",
+        lastAutomatedReviewDispatchHash: "",
+        lastAutomatedReviewDispatchAt: "",
+      });
+      return;
+    }
+
+    // Throttle review backlog API calls to at most once per 2 minutes.
+    // Comments don't change faster than this in practice, and the SCM calls
+    // (getPendingComments + getAutomatedComments) consume API quota on every poll.
+    //
+    // Exception: bypass throttle when a transition reaction just fired for a
+    // review reaction key. The transitionReaction branch records
+    // lastPendingReviewDispatchHash, which requires the current fingerprint from
+    // the API. If we throttle here, that metadata never gets written and the
+    // next unthrottled poll sees a "new" fingerprint, clears the reaction tracker,
+    // and fires a duplicate dispatch.
+    const hasRelevantTransition =
+      transitionReaction?.key === humanReactionKey ||
+      transitionReaction?.key === automatedReactionKey;
+    if (!hasRelevantTransition) {
+      const lastCheckAt = lastReviewBacklogCheckAt.get(session.id) ?? 0;
+      if (Date.now() - lastCheckAt < REVIEW_BACKLOG_THROTTLE_MS) {
+        return;
+      }
+    }
+    lastReviewBacklogCheckAt.set(session.id, Date.now());
+
+    const [pendingResult, automatedResult] = await Promise.allSettled([
+      scm.getPendingComments(session.pr),
+      scm.getAutomatedComments(session.pr),
+    ]);
+
+    // null means "failed to fetch" — preserve existing metadata.
+    // [] means "confirmed no comments" — safe to clear.
+    const pendingComments =
+      pendingResult.status === "fulfilled" && Array.isArray(pendingResult.value)
+        ? pendingResult.value
+        : null;
+    const automatedComments =
+      automatedResult.status === "fulfilled" && Array.isArray(automatedResult.value)
+        ? automatedResult.value
+        : null;
+
+    // --- Pending (human) review comments ---
+    // null = SCM fetch failed; skip processing to preserve existing metadata.
+    if (pendingComments !== null) {
+      const pendingFingerprint = makeFingerprint(pendingComments.map((comment) => comment.id));
+      const lastPendingFingerprint = session.metadata["lastPendingReviewFingerprint"] ?? "";
+      const lastPendingDispatchHash = session.metadata["lastPendingReviewDispatchHash"] ?? "";
+
+      if (
+        pendingFingerprint !== lastPendingFingerprint &&
+        transitionReaction?.key !== humanReactionKey
+      ) {
+        reactionEngine.clearTracker(session.id, humanReactionKey);
+      }
+      if (pendingFingerprint !== lastPendingFingerprint) {
+        updateSessionMetadata(session, {
+          lastPendingReviewFingerprint: pendingFingerprint,
+        });
+      }
+
+      if (!pendingFingerprint) {
+        reactionEngine.clearTracker(session.id, humanReactionKey);
+        updateSessionMetadata(session, {
+          lastPendingReviewFingerprint: "",
+          lastPendingReviewDispatchHash: "",
+          lastPendingReviewDispatchAt: "",
+        });
+      } else if (
+        transitionReaction?.key === humanReactionKey &&
+        transitionReaction.result?.success
+      ) {
+        if (lastPendingDispatchHash !== pendingFingerprint) {
+          updateSessionMetadata(session, {
+            lastPendingReviewDispatchHash: pendingFingerprint,
+            lastPendingReviewDispatchAt: new Date().toISOString(),
+          });
+        }
+      } else if (
+        !(oldStatus !== newStatus && newStatus === "changes_requested") &&
+        pendingFingerprint !== lastPendingDispatchHash
+      ) {
+        const reactionConfig = reactionEngine.getReactionConfigForSession(session, humanReactionKey);
+        if (
+          reactionConfig &&
+          reactionConfig.action &&
+          (reactionConfig.auto !== false || reactionConfig.action === "notify")
+        ) {
+          const result = await reactionEngine.executeReaction(
+            session.id,
+            session.projectId,
+            humanReactionKey,
+            reactionConfig,
+          );
+          if (result.success) {
+            updateSessionMetadata(session, {
+              lastPendingReviewDispatchHash: pendingFingerprint,
+              lastPendingReviewDispatchAt: new Date().toISOString(),
+            });
+          }
+        }
+      }
+    }
+
+    // --- Automated (bot) review comments ---
+    if (automatedComments !== null) {
+      const automatedFingerprint = makeFingerprint(
+        automatedComments.map((comment) => comment.id),
+      );
+      const lastAutomatedFingerprint = session.metadata["lastAutomatedReviewFingerprint"] ?? "";
+      const lastAutomatedDispatchHash =
+        session.metadata["lastAutomatedReviewDispatchHash"] ?? "";
+
+      if (automatedFingerprint !== lastAutomatedFingerprint) {
+        reactionEngine.clearTracker(session.id, automatedReactionKey);
+        updateSessionMetadata(session, {
+          lastAutomatedReviewFingerprint: automatedFingerprint,
+        });
+      }
+
+      if (!automatedFingerprint) {
+        reactionEngine.clearTracker(session.id, automatedReactionKey);
+        updateSessionMetadata(session, {
+          lastAutomatedReviewFingerprint: "",
+          lastAutomatedReviewDispatchHash: "",
+          lastAutomatedReviewDispatchAt: "",
+        });
+      } else if (automatedFingerprint !== lastAutomatedDispatchHash) {
+        const reactionConfig = reactionEngine.getReactionConfigForSession(
+          session,
+          automatedReactionKey,
+        );
+        if (
+          reactionConfig &&
+          reactionConfig.action &&
+          (reactionConfig.auto !== false || reactionConfig.action === "notify")
+        ) {
+          // Inject the detailed comment listing + correct-API guidance into the
+          // message so the agent doesn't re-fetch with stale or unpaginated calls
+          // (see #895 — fixes the pagination + stale `gh pr checks` failure modes).
+          // Only override when the message is the built-in sentinel — a user who
+          // customized `reactions.bugbot-comments.message` in their YAML gets
+          // exactly what they wrote, nothing more.
+          const usingDefaultMessage =
+            reactionConfig.message === DEFAULT_BUGBOT_COMMENTS_MESSAGE;
+          const detailedConfig: ReactionConfig =
+            reactionConfig.action === "send-to-agent" && usingDefaultMessage
+              ? {
+                  ...reactionConfig,
+                  message: formatAutomatedCommentsMessage(automatedComments, session.pr),
+                }
+              : reactionConfig;
+          const result = await reactionEngine.executeReaction(
+            session.id,
+            session.projectId,
+            automatedReactionKey,
+            detailedConfig,
+          );
+          if (result.success) {
+            updateSessionMetadata(session, {
+              lastAutomatedReviewDispatchHash: automatedFingerprint,
+              lastAutomatedReviewDispatchAt: new Date().toISOString(),
+            });
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Dispatch CI failure details to the agent session when new or changed
+   * failures are detected. Follows the same fingerprinting/deduplication
+   * pattern as maybeDispatchReviewBacklog().
+   */
+  async function maybeDispatchCIFailureDetails(
+    session: Session,
+    _oldStatus: SessionStatus,
+    newStatus: SessionStatus,
+    transitionReaction?: { key: string; result: ReactionResult | null },
+  ): Promise<void> {
+    const project = config.projects[session.projectId];
+    if (!project || !session.pr) return;
+
+    const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    if (!scm) return;
+
+    const ciReactionKey = "ci-failed";
+
+    // Clear tracking when PR is closed/merged
+    if (newStatus === "merged" || newStatus === "killed") {
+      reactionEngine.clearTracker(session.id, ciReactionKey);
+      updateSessionMetadata(session, {
+        lastCIFailureFingerprint: "",
+        lastCIFailureDispatchHash: "",
+        lastCIFailureDispatchAt: "",
+      });
+      return;
+    }
+
+    // Only dispatch CI details when in ci_failed state
+    if (newStatus !== "ci_failed") {
+      // CI is no longer failing — clear tracking so next failure is dispatched fresh
+      const lastFingerprint = session.metadata["lastCIFailureFingerprint"] ?? "";
+      if (lastFingerprint) {
+        reactionEngine.clearTracker(session.id, ciReactionKey);
+        updateSessionMetadata(session, {
+          lastCIFailureFingerprint: "",
+          lastCIFailureDispatchHash: "",
+          lastCIFailureDispatchAt: "",
+        });
+      }
+      return;
+    }
+
+    // Fetch individual CI checks for failure details.
+    // Use batch enrichment data when available to avoid an extra REST call;
+    // fall back to getCIChecks() when the batch didn't run this cycle.
+    const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
+    const cachedEnrichment = prEnrichmentCache.get(prKey);
+
+    let checks: CICheck[];
+    if (cachedEnrichment?.ciChecks !== undefined) {
+      checks = cachedEnrichment.ciChecks;
+    } else {
+      try {
+        checks = await scm.getCIChecks(session.pr);
+      } catch {
+        // Failed to fetch checks — skip this cycle
+        return;
+      }
+    }
+
+    const failedChecks = checks.filter(
+      (c) => c.status === "failed" || c.conclusion?.toUpperCase() === "FAILURE",
+    );
+    if (failedChecks.length === 0) return;
+
+    const ciFingerprint = makeFingerprint(
+      failedChecks.map((c) => `${c.name}:${c.status}:${c.conclusion ?? ""}`),
+    );
+    const lastCIFingerprint = session.metadata["lastCIFailureFingerprint"] ?? "";
+    const lastCIDispatchHash = session.metadata["lastCIFailureDispatchHash"] ?? "";
+
+    // Reset reaction tracker when failure set changes
+    if (ciFingerprint !== lastCIFingerprint && transitionReaction?.key !== ciReactionKey) {
+      reactionEngine.clearTracker(session.id, ciReactionKey);
+    }
+    if (ciFingerprint !== lastCIFingerprint) {
+      updateSessionMetadata(session, {
+        lastCIFailureFingerprint: ciFingerprint,
+      });
+    }
+
+    // If transition already sent a ci-failed reaction with the static message,
+    // skip this cycle but do NOT record dispatch hash — the next poll will send
+    // the detailed CI failure info with check names and URLs.
+    if (transitionReaction?.key === ciReactionKey && transitionReaction.result?.success) {
+      return;
+    }
+
+    // Skip if we already dispatched this exact failure set
+    if (ciFingerprint === lastCIDispatchHash) return;
+
+    // Dispatch CI failure details directly via sessionManager.send() rather than
+    // executeReaction() to avoid consuming the ci-failed reaction's retry budget.
+    // The transition reaction owns escalation; this is a follow-up info delivery.
+    const reactionConfig = reactionEngine.getReactionConfigForSession(session, ciReactionKey);
+    if (
+      reactionConfig &&
+      reactionConfig.action &&
+      (reactionConfig.auto !== false || reactionConfig.action === "notify")
+    ) {
+      const detailedMessage = formatCIFailureMessage(failedChecks);
+
+      try {
+        if (reactionConfig.action === "send-to-agent") {
+          await sessionManager.send(session.id, detailedMessage);
+        } else {
+          // For "notify" action, send to human notifiers instead
+          const event = createEvent("ci.failing", {
+            sessionId: session.id,
+            projectId: session.projectId,
+            message: detailedMessage,
+            data: { failedChecks: failedChecks.map((c) => c.name) },
+          });
+          await notifyHuman(event, reactionConfig.priority ?? "warning");
+        }
+
+        updateSessionMetadata(session, {
+          lastCIFailureDispatchHash: ciFingerprint,
+          lastCIFailureDispatchAt: new Date().toISOString(),
+        });
+      } catch {
+        // Send failed — will retry on next poll cycle
+      }
+    }
+  }
+
+  /**
+   * Dispatch merge conflict notifications to the agent session.
+   * Conflicts are detected from the PR enrichment cache or getMergeability()
+   * and dispatched independently of the session status (conflicts can coexist
+   * with ci_failed, changes_requested, etc.).
+   */
+  async function maybeDispatchMergeConflicts(
+    session: Session,
+    newStatus: SessionStatus,
+  ): Promise<void> {
+    const project = config.projects[session.projectId];
+    if (!project || !session.pr) return;
+
+    const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    if (!scm) return;
+
+    const conflictReactionKey = "merge-conflicts";
+
+    // Clear tracking when PR is no longer open.
+    if (session.lifecycle.pr.state !== "open" || newStatus === "killed") {
+      reactionEngine.clearTracker(session.id, conflictReactionKey);
+      updateSessionMetadata(session, {
+        lastMergeConflictDispatched: "",
+      });
+      return;
+    }
+
+    // Only check for conflicts on open PRs
+    if (
+      newStatus !== "pr_open" &&
+      newStatus !== "ci_failed" &&
+      newStatus !== "review_pending" &&
+      newStatus !== "changes_requested" &&
+      newStatus !== "approved" &&
+      newStatus !== "mergeable"
+    ) {
+      return;
+    }
+
+    // Check for conflicts using cached enrichment data or fallback to individual call.
+    // When batch enrichment ran (cachedData is present), use its hasConflicts value
+    // to avoid 3 redundant REST calls from getMergeability() — the batch already
+    // fetched the mergeable/mergeStateStatus fields via GraphQL.
+    const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
+    const cachedData = prEnrichmentCache.get(prKey);
+
+    let hasConflicts: boolean;
+    if (cachedData) {
+      // Batch ran — trust its data (undefined means CONFLICTING wasn't set → no conflicts)
+      hasConflicts = cachedData.hasConflicts ?? false;
+    } else {
+      // Batch didn't run this cycle — fall back to individual API call
+      try {
+        const mergeReadiness = await scm.getMergeability(session.pr);
+        hasConflicts = !mergeReadiness.noConflicts;
+      } catch {
+        return;
+      }
+    }
+
+    const lastDispatched = session.metadata["lastMergeConflictDispatched"] ?? "";
+
+    if (hasConflicts) {
+      // Already dispatched for current conflict state — skip
+      if (lastDispatched === "true") return;
+
+      const reactionConfig = reactionEngine.getReactionConfigForSession(
+        session,
+        conflictReactionKey,
+      );
+      if (
+        reactionConfig &&
+        reactionConfig.action &&
+        (reactionConfig.auto !== false || reactionConfig.action === "notify")
+      ) {
+        try {
+          if (reactionConfig.action === "send-to-agent") {
+            const message =
+              reactionConfig.message ??
+              "Your branch has merge conflicts. Rebase on the default branch and resolve them.";
+            await sessionManager.send(session.id, message);
+          } else {
+            const event = createEvent("merge.conflicts", {
+              sessionId: session.id,
+              projectId: session.projectId,
+              message: `${session.id}: PR has merge conflicts`,
+            });
+            await notifyHuman(event, reactionConfig.priority ?? "warning");
+          }
+
+          updateSessionMetadata(session, {
+            lastMergeConflictDispatched: "true",
+          });
+        } catch {
+          // Send failed — will retry on next poll cycle
+        }
+      }
+    } else if (lastDispatched === "true") {
+      // Conflicts resolved — clear so we can re-dispatch if they recur
+      reactionEngine.clearTracker(session.id, conflictReactionKey);
+      updateSessionMetadata(session, {
+        lastMergeConflictDispatched: "",
+      });
+    }
+  }
+
+  function pruneReviewBacklogThrottle(currentSessionIds: Set<string>): void {
+    for (const sessionId of lastReviewBacklogCheckAt.keys()) {
+      if (!currentSessionIds.has(sessionId)) {
+        lastReviewBacklogCheckAt.delete(sessionId);
+      }
+    }
+  }
+
+  function clearReviewBacklogThrottle(sessionId: string): void {
+    lastReviewBacklogCheckAt.delete(sessionId);
+  }
+
+  return {
+    maybeDispatchReviewBacklog,
+    maybeDispatchCIFailureDetails,
+    maybeDispatchMergeConflicts,
+    pruneReviewBacklogThrottle,
+    clearReviewBacklogThrottle,
+  };
+}

--- a/packages/core/src/lifecycle-backlog.ts
+++ b/packages/core/src/lifecycle-backlog.ts
@@ -50,8 +50,6 @@ export interface BacklogDispatchers {
   maybeDispatchMergeConflicts(session: Session, newStatus: SessionStatus): Promise<void>;
   /** Drop throttle entries for sessions no longer present. */
   pruneReviewBacklogThrottle(currentSessionIds: Set<string>): void;
-  /** Clear throttle entry for a single session. */
-  clearReviewBacklogThrottle(sessionId: string): void;
 }
 
 export interface BacklogDispatchersDeps {
@@ -537,15 +535,10 @@ export function createBacklogDispatchers(deps: BacklogDispatchersDeps): BacklogD
     }
   }
 
-  function clearReviewBacklogThrottle(sessionId: string): void {
-    lastReviewBacklogCheckAt.delete(sessionId);
-  }
-
   return {
     maybeDispatchReviewBacklog,
     maybeDispatchCIFailureDetails,
     maybeDispatchMergeConflicts,
     pruneReviewBacklogThrottle,
-    clearReviewBacklogThrottle,
   };
 }

--- a/packages/core/src/lifecycle-events.ts
+++ b/packages/core/src/lifecycle-events.ts
@@ -1,0 +1,232 @@
+/**
+ * Lifecycle event helpers — pure functions shared by the lifecycle manager.
+ *
+ * These are mechanical helpers for translating between statuses, events, and
+ * reaction keys, plus small formatting utilities used when recording lifecycle
+ * transitions. No I/O, no dependencies on the orchestrator runtime.
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  CanonicalSessionLifecycle,
+  EventPriority,
+  EventType,
+  OrchestratorEvent,
+  ReactionResult,
+  Session,
+  SessionId,
+  SessionStatus,
+} from "./types.js";
+
+/** Parse a duration string like "10m", "30s", "1h" to milliseconds. */
+export function parseDuration(str: string): number {
+  const match = str.match(/^(\d+)(s|m|h)$/);
+  if (!match) return 0;
+  const value = parseInt(match[1], 10);
+  switch (match[2]) {
+    case "s":
+      return value * 1000;
+    case "m":
+      return value * 60_000;
+    case "h":
+      return value * 3_600_000;
+    default:
+      return 0;
+  }
+}
+
+/** Infer a reasonable priority from event type. */
+export function inferPriority(type: EventType): EventPriority {
+  if (type.includes("stuck") || type.includes("needs_input") || type.includes("errored")) {
+    return "urgent";
+  }
+  if (type.startsWith("summary.")) {
+    return "info";
+  }
+  if (
+    type.includes("approved") ||
+    type.includes("ready") ||
+    type.includes("merged") ||
+    type.includes("completed")
+  ) {
+    return "action";
+  }
+  if (type.includes("fail") || type.includes("changes_requested") || type.includes("conflicts")) {
+    return "warning";
+  }
+  return "info";
+}
+
+/** Create an OrchestratorEvent with defaults filled in. */
+export function createEvent(
+  type: EventType,
+  opts: {
+    sessionId: SessionId;
+    projectId: string;
+    message: string;
+    priority?: EventPriority;
+    data?: Record<string, unknown>;
+  },
+): OrchestratorEvent {
+  return {
+    id: randomUUID(),
+    type,
+    priority: opts.priority ?? inferPriority(type),
+    sessionId: opts.sessionId,
+    projectId: opts.projectId,
+    timestamp: new Date(),
+    message: opts.message,
+    data: opts.data ?? {},
+  };
+}
+
+/** Determine which event type corresponds to a status transition. */
+export function statusToEventType(
+  _from: SessionStatus | undefined,
+  to: SessionStatus,
+): EventType | null {
+  switch (to) {
+    case "working":
+      return "session.working";
+    case "pr_open":
+      return "pr.created";
+    case "ci_failed":
+      return "ci.failing";
+    case "review_pending":
+      return "review.pending";
+    case "changes_requested":
+      return "review.changes_requested";
+    case "approved":
+      return "review.approved";
+    case "mergeable":
+      return "merge.ready";
+    case "merged":
+      return "merge.completed";
+    case "needs_input":
+      return "session.needs_input";
+    case "stuck":
+      return "session.stuck";
+    case "errored":
+      return "session.errored";
+    case "killed":
+      return "session.killed";
+    default:
+      return null;
+  }
+}
+
+export function prStateToEventType(
+  from: Session["lifecycle"]["pr"]["state"],
+  to: Session["lifecycle"]["pr"]["state"],
+): EventType | null {
+  if (from === to) return null;
+  switch (to) {
+    case "closed":
+      return "pr.closed";
+    default:
+      return null;
+  }
+}
+
+/** Map event type to reaction config key. */
+export function eventToReactionKey(eventType: EventType): string | null {
+  switch (eventType) {
+    case "pr.closed":
+      return "pr-closed";
+    case "ci.failing":
+      return "ci-failed";
+    case "review.changes_requested":
+      return "changes-requested";
+    case "automated_review.found":
+      return "bugbot-comments";
+    case "merge.conflicts":
+      return "merge-conflicts";
+    case "merge.ready":
+      return "approved-and-green";
+    case "session.stuck":
+      return "agent-stuck";
+    case "session.needs_input":
+      return "agent-needs-input";
+    case "session.killed":
+      return "agent-exited";
+    case "summary.all_complete":
+      return "all-complete";
+    default:
+      return null;
+  }
+}
+
+export function transitionLogLevel(status: SessionStatus): "info" | "warn" | "error" {
+  const eventType = statusToEventType(undefined, status);
+  if (!eventType) {
+    return "info";
+  }
+  const priority = inferPriority(eventType);
+  if (priority === "urgent") {
+    return "error";
+  }
+  if (priority === "warning") {
+    return "warn";
+  }
+  return "info";
+}
+
+export function splitEvidenceSignals(evidence: string): string[] {
+  return evidence
+    .split(/\s+/)
+    .map((signal) => signal.trim())
+    .filter((signal) => signal.length > 0);
+}
+
+export function primaryLifecycleReason(lifecycle: CanonicalSessionLifecycle): string {
+  if (lifecycle.session.state === "detecting") return lifecycle.session.reason;
+  if (lifecycle.pr.reason !== "not_created" && lifecycle.pr.reason !== "in_progress") {
+    return lifecycle.pr.reason;
+  }
+  if (lifecycle.runtime.reason !== "process_running") {
+    return lifecycle.runtime.reason;
+  }
+  return lifecycle.session.reason;
+}
+
+export function buildTransitionObservabilityData(
+  previous: CanonicalSessionLifecycle,
+  next: CanonicalSessionLifecycle,
+  oldStatus: SessionStatus,
+  newStatus: SessionStatus,
+  evidence: string,
+  detectingAttempts: number,
+  statusTransition: boolean,
+  reaction?: { key: string; result: ReactionResult | null },
+): Record<string, unknown> {
+  return {
+    oldStatus,
+    newStatus,
+    statusTransition,
+    previousSessionState: previous.session.state,
+    newSessionState: next.session.state,
+    previousSessionReason: previous.session.reason,
+    newSessionReason: next.session.reason,
+    previousPRState: previous.pr.state,
+    newPRState: next.pr.state,
+    previousPRReason: previous.pr.reason,
+    newPRReason: next.pr.reason,
+    previousRuntimeState: previous.runtime.state,
+    newRuntimeState: next.runtime.state,
+    previousRuntimeReason: previous.runtime.reason,
+    newRuntimeReason: next.runtime.reason,
+    primaryReason: primaryLifecycleReason(next),
+    evidence,
+    signalsConsulted: splitEvidenceSignals(evidence),
+    detectingAttempts,
+    recoveryAction: reaction?.result?.action ?? null,
+    reactionKey: reaction?.key ?? null,
+    reactionSuccess: reaction?.result?.success ?? null,
+    escalated: reaction?.result?.escalated ?? null,
+  };
+}
+
+/** Fingerprint builder for comment/check lists — stable hash via sort+join. */
+export function makeFingerprint(ids: string[]): string {
+  return [...ids].sort().join(",");
+}

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1,16 +1,15 @@
 /**
- * Lifecycle Manager — state machine + polling loop + reaction engine.
+ * Lifecycle Manager — polling loop + state machine + event dispatch.
  *
  * Periodically polls all sessions and:
  * 1. Detects state transitions (spawning → working → pr_open → etc.)
  * 2. Emits events on transitions
- * 3. Triggers reactions (auto-handle CI failures, review comments, etc.)
- * 4. Escalates to human notification when auto-handling fails
+ * 3. Delegates reactions, PR enrichment caching, and backlog dispatch to
+ *    focused modules (reaction-engine, pr-enrichment-cache, lifecycle-backlog).
  *
  * Reference: scripts/claude-session-status, scripts/claude-review-check
  */
 
-import { randomUUID } from "node:crypto";
 import {
   SESSION_STATUS,
   ACTIVITY_STATE,
@@ -21,7 +20,6 @@ import {
   type OpenCodeSessionManager,
   type SessionId,
   type SessionStatus,
-  type EventType,
   type OrchestratorEvent,
   type OrchestratorConfig,
   type ReactionConfig,
@@ -32,14 +30,9 @@ import {
   type SCM,
   type Notifier,
   type Session,
-  type CanonicalSessionLifecycle,
   type EventPriority,
   type ProjectConfig as _ProjectConfig,
-  type PREnrichmentData,
-  type CICheck,
 } from "./types.js";
-import { formatAutomatedCommentsMessage } from "./format-automated-comments.js";
-import { DEFAULT_BUGBOT_COMMENTS_MESSAGE } from "./config.js";
 import { buildLifecycleMetadataPatch, cloneLifecycle, deriveLegacyStatus } from "./lifecycle-state.js";
 import { updateMetadata } from "./metadata.js";
 import { getSessionsDir } from "./paths.js";
@@ -74,156 +67,20 @@ import {
   resolveProbeDecision,
   type LifecycleDecision,
 } from "./lifecycle-status-decisions.js";
-
-/** Parse a duration string like "10m", "30s", "1h" to milliseconds. */
-function parseDuration(str: string): number {
-  const match = str.match(/^(\d+)(s|m|h)$/);
-  if (!match) return 0;
-  const value = parseInt(match[1], 10);
-  switch (match[2]) {
-    case "s":
-      return value * 1000;
-    case "m":
-      return value * 60_000;
-    case "h":
-      return value * 3_600_000;
-    default:
-      return 0;
-  }
-}
-
-/** Infer a reasonable priority from event type. */
-function inferPriority(type: EventType): EventPriority {
-  if (type.includes("stuck") || type.includes("needs_input") || type.includes("errored")) {
-    return "urgent";
-  }
-  if (type.startsWith("summary.")) {
-    return "info";
-  }
-  if (
-    type.includes("approved") ||
-    type.includes("ready") ||
-    type.includes("merged") ||
-    type.includes("completed")
-  ) {
-    return "action";
-  }
-  if (type.includes("fail") || type.includes("changes_requested") || type.includes("conflicts")) {
-    return "warning";
-  }
-  return "info";
-}
-
-/** Create an OrchestratorEvent with defaults filled in. */
-function createEvent(
-  type: EventType,
-  opts: {
-    sessionId: SessionId;
-    projectId: string;
-    message: string;
-    priority?: EventPriority;
-    data?: Record<string, unknown>;
-  },
-): OrchestratorEvent {
-  return {
-    id: randomUUID(),
-    type,
-    priority: opts.priority ?? inferPriority(type),
-    sessionId: opts.sessionId,
-    projectId: opts.projectId,
-    timestamp: new Date(),
-    message: opts.message,
-    data: opts.data ?? {},
-  };
-}
-
-/** Determine which event type corresponds to a status transition. */
-function statusToEventType(_from: SessionStatus | undefined, to: SessionStatus): EventType | null {
-  switch (to) {
-    case "working":
-      return "session.working";
-    case "pr_open":
-      return "pr.created";
-    case "ci_failed":
-      return "ci.failing";
-    case "review_pending":
-      return "review.pending";
-    case "changes_requested":
-      return "review.changes_requested";
-    case "approved":
-      return "review.approved";
-    case "mergeable":
-      return "merge.ready";
-    case "merged":
-      return "merge.completed";
-    case "needs_input":
-      return "session.needs_input";
-    case "stuck":
-      return "session.stuck";
-    case "errored":
-      return "session.errored";
-    case "killed":
-      return "session.killed";
-    default:
-      return null;
-  }
-}
-
-function prStateToEventType(
-  from: Session["lifecycle"]["pr"]["state"],
-  to: Session["lifecycle"]["pr"]["state"],
-): EventType | null {
-  if (from === to) return null;
-  switch (to) {
-    case "closed":
-      return "pr.closed";
-    default:
-      return null;
-  }
-}
-
-/** Map event type to reaction config key. */
-function eventToReactionKey(eventType: EventType): string | null {
-  switch (eventType) {
-    case "pr.closed":
-      return "pr-closed";
-    case "ci.failing":
-      return "ci-failed";
-    case "review.changes_requested":
-      return "changes-requested";
-    case "automated_review.found":
-      return "bugbot-comments";
-    case "merge.conflicts":
-      return "merge-conflicts";
-    case "merge.ready":
-      return "approved-and-green";
-    case "session.stuck":
-      return "agent-stuck";
-    case "session.needs_input":
-      return "agent-needs-input";
-    case "session.killed":
-      return "agent-exited";
-    case "summary.all_complete":
-      return "all-complete";
-    default:
-      return null;
-  }
-}
-
-function transitionLogLevel(status: SessionStatus): "info" | "warn" | "error" {
-  const eventType = statusToEventType(undefined, status);
-  if (!eventType) {
-    return "info";
-  }
-  const priority = inferPriority(eventType);
-  if (priority === "urgent") {
-    return "error";
-  }
-  if (priority === "warning") {
-    return "warn";
-  }
-  return "info";
-}
+import {
+  buildTransitionObservabilityData,
+  createEvent,
+  eventToReactionKey,
+  inferPriority,
+  parseDuration,
+  prStateToEventType,
+  primaryLifecycleReason,
+  statusToEventType,
+  transitionLogLevel,
+} from "./lifecycle-events.js";
+import { createPREnrichmentCache } from "./pr-enrichment-cache.js";
+import { createReactionEngine } from "./reaction-engine.js";
+import { createBacklogDispatchers } from "./lifecycle-backlog.js";
 
 interface DeterminedStatus {
   status: SessionStatus;
@@ -240,61 +97,6 @@ interface ProbeResult {
   failed: boolean;
 }
 
-function splitEvidenceSignals(evidence: string): string[] {
-  return evidence
-    .split(/\s+/)
-    .map((signal) => signal.trim())
-    .filter((signal) => signal.length > 0);
-}
-
-function primaryLifecycleReason(lifecycle: CanonicalSessionLifecycle): string {
-  if (lifecycle.session.state === "detecting") return lifecycle.session.reason;
-  if (lifecycle.pr.reason !== "not_created" && lifecycle.pr.reason !== "in_progress") {
-    return lifecycle.pr.reason;
-  }
-  if (lifecycle.runtime.reason !== "process_running") {
-    return lifecycle.runtime.reason;
-  }
-  return lifecycle.session.reason;
-}
-
-function buildTransitionObservabilityData(
-  previous: CanonicalSessionLifecycle,
-  next: CanonicalSessionLifecycle,
-  oldStatus: SessionStatus,
-  newStatus: SessionStatus,
-  evidence: string,
-  detectingAttempts: number,
-  statusTransition: boolean,
-  reaction?: { key: string; result: ReactionResult | null },
-): Record<string, unknown> {
-  return {
-    oldStatus,
-    newStatus,
-    statusTransition,
-    previousSessionState: previous.session.state,
-    newSessionState: next.session.state,
-    previousSessionReason: previous.session.reason,
-    newSessionReason: next.session.reason,
-    previousPRState: previous.pr.state,
-    newPRState: next.pr.state,
-    previousPRReason: previous.pr.reason,
-    newPRReason: next.pr.reason,
-    previousRuntimeState: previous.runtime.state,
-    newRuntimeState: next.runtime.state,
-    previousRuntimeReason: previous.runtime.reason,
-    newRuntimeReason: next.runtime.reason,
-    primaryReason: primaryLifecycleReason(next),
-    evidence,
-    signalsConsulted: splitEvidenceSignals(evidence),
-    detectingAttempts,
-    recoveryAction: reaction?.result?.action ?? null,
-    reactionKey: reaction?.key ?? null,
-    reactionSuccess: reaction?.result?.success ?? null,
-    escalated: reaction?.result?.escalated ?? null,
-  };
-}
-
 export interface LifecycleManagerDeps {
   config: OrchestratorConfig;
   registry: PluginRegistry;
@@ -303,153 +105,42 @@ export interface LifecycleManagerDeps {
   projectId?: string;
 }
 
-/** Track attempt counts for reactions per session. */
-interface ReactionTracker {
-  attempts: number;
-  firstTriggered: Date;
-}
-
 /** Create a LifecycleManager instance. */
 export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleManager {
   const { config, registry, sessionManager, projectId: scopedProjectId } = deps;
   const observer = createProjectObserver(config, "lifecycle-manager");
 
   const states = new Map<SessionId, SessionStatus>();
-  const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
 
-  /**
-   * Cache for PR enrichment data within a single poll cycle.
-   * Cleared at the start of each pollAll() call.
-   * Key format: "${owner}/${repo}#${number}"
-   */
-  const prEnrichmentCache = new Map<string, PREnrichmentData>();
+  const prEnrichmentCache = createPREnrichmentCache({
+    config,
+    registry,
+    observer,
+    scopedProjectId,
+  });
 
-  /**
-   * Per-session timestamp of last review backlog API check.
-   * Used to throttle getPendingComments/getAutomatedComments to at most once per 2 minutes.
-   * In-memory only — resets on restart (acceptable since it's a rate-limit hint, not state).
-   */
-  const lastReviewBacklogCheckAt = new Map<SessionId, number>();
+  const reactionEngine = createReactionEngine({
+    config,
+    sessionManager,
+    notifyHuman,
+  });
 
-  /** Throttle interval for review backlog API calls (2 minutes). */
-  const REVIEW_BACKLOG_THROTTLE_MS = 2 * 60 * 1000;
+  const backlog = createBacklogDispatchers({
+    config,
+    registry,
+    sessionManager,
+    reactionEngine,
+    prEnrichmentCache,
+    updateSessionMetadata,
+    notifyHuman,
+  });
 
-  /**
-   * Populate the PR enrichment cache using batch GraphQL queries.
-   * This is called once per poll cycle to fetch data for all PRs efficiently.
-   */
-  async function populatePREnrichmentCache(sessions: Session[]): Promise<void> {
-    // Clear previous cache
-    prEnrichmentCache.clear();
-
-    // Collect all unique PRs keyed by their owning session's project/plugin.
-    const prsByPlugin = new Map<string, Array<NonNullable<Session["pr"]>>>();
-    const seenPRKeys = new Set<string>();
-    for (const session of sessions) {
-      if (!session.pr) continue;
-      const project = config.projects[session.projectId];
-      if (!project?.scm?.plugin) continue;
-
-      const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
-      if (seenPRKeys.has(prKey)) continue;
-      seenPRKeys.add(prKey);
-
-      const pluginKey = project.scm.plugin;
-      if (!prsByPlugin.has(pluginKey)) {
-        prsByPlugin.set(pluginKey, []);
-      }
-      const pluginPRs = prsByPlugin.get(pluginKey);
-      if (pluginPRs) {
-        pluginPRs.push(session.pr);
-      }
-    }
-
-    // Fetch enrichment data for each plugin's PRs
-    for (const [pluginKey, pluginPRs] of prsByPlugin) {
-      const scm = registry.get<SCM>("scm", pluginKey);
-      if (!scm?.enrichSessionsPRBatch) continue;
-
-      const batchStartTime = Date.now();
-      try {
-        const enrichmentData = await scm.enrichSessionsPRBatch(
-          pluginPRs,
-          {
-            recordSuccess(_data) {
-              const batchDuration = Date.now() - batchStartTime;
-              observer?.recordOperation({
-                metric: "graphql_batch",
-                operation: "batch_enrichment",
-                correlationId: createCorrelationId("graphql-batch"),
-                outcome: "success",
-                projectId: scopedProjectId,
-                durationMs: batchDuration,
-                data: {
-                  plugin: pluginKey,
-                  prCount: pluginPRs.length,
-                  prKeys: pluginPRs.map((pr) => `${pr.owner}/${pr.repo}#${pr.number}`),
-                },
-                level: "info",
-              });
-            },
-            recordFailure(data) {
-              const batchDuration = Date.now() - batchStartTime;
-              observer?.recordOperation({
-                metric: "graphql_batch",
-                operation: "batch_enrichment",
-                correlationId: createCorrelationId("graphql-batch"),
-                outcome: "failure",
-                reason: data.error,
-                level: "warn",
-                data: {
-                  plugin: pluginKey,
-                  prCount: pluginPRs.length,
-                  error: data.error,
-                  durationMs: batchDuration,
-                },
-              });
-            },
-            log(level, message) {
-              observer?.recordDiagnostic?.({
-                operation: "batch_enrichment.log",
-                correlationId: createCorrelationId("graphql-batch"),
-                projectId: scopedProjectId,
-                message,
-                level,
-                data: {
-                  plugin: pluginKey,
-                  source: "ao-graphql-batch",
-                },
-              });
-            },
-          },
-        );
-
-        // Merge into cache
-        for (const [key, data] of enrichmentData) {
-          prEnrichmentCache.set(key, data);
-        }
-      } catch (err) {
-        // Batch fetch failed - individual calls will still work
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        const batchCorrelationId = createCorrelationId("batch-enrichment");
-        observer?.recordOperation?.({
-          metric: "lifecycle_poll",
-          operation: "batch_enrichment",
-          correlationId: batchCorrelationId,
-          outcome: "failure",
-          reason: errorMsg,
-          level: "warn",
-          data: { plugin: pluginKey, prCount: pluginPRs.length },
-        });
-      }
-    }
-  }
   /** Check if idle time exceeds the agent-stuck threshold. */
   function isIdleBeyondThreshold(session: Session, idleTimestamp: Date): boolean {
-    const stuckReaction = getReactionConfigForSession(session, "agent-stuck");
+    const stuckReaction = reactionEngine.getReactionConfigForSession(session, "agent-stuck");
     const thresholdStr = stuckReaction?.threshold;
     if (typeof thresholdStr !== "string") return false;
     const stuckThresholdMs = parseDuration(thresholdStr);
@@ -910,150 +601,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     });
   }
 
-  /** Execute a reaction for a session. */
-  async function executeReaction(
-    sessionId: SessionId,
-    projectId: string,
-    reactionKey: string,
-    reactionConfig: ReactionConfig,
-  ): Promise<ReactionResult> {
-    const trackerKey = `${sessionId}:${reactionKey}`;
-    let tracker = reactionTrackers.get(trackerKey);
-
-    if (!tracker) {
-      tracker = { attempts: 0, firstTriggered: new Date() };
-      reactionTrackers.set(trackerKey, tracker);
-    }
-
-    // Increment attempts before checking escalation
-    tracker.attempts++;
-
-    // Check if we should escalate
-    const maxRetries = reactionConfig.retries ?? Infinity;
-    const escalateAfter = reactionConfig.escalateAfter;
-    let shouldEscalate = false;
-
-    if (tracker.attempts > maxRetries) {
-      shouldEscalate = true;
-    }
-
-    if (typeof escalateAfter === "string") {
-      const durationMs = parseDuration(escalateAfter);
-      if (durationMs > 0 && Date.now() - tracker.firstTriggered.getTime() > durationMs) {
-        shouldEscalate = true;
-      }
-    }
-
-    if (typeof escalateAfter === "number" && tracker.attempts > escalateAfter) {
-      shouldEscalate = true;
-    }
-
-    if (shouldEscalate) {
-      // Escalate to human
-      const event = createEvent("reaction.escalated", {
-        sessionId,
-        projectId,
-        message: `Reaction '${reactionKey}' escalated after ${tracker.attempts} attempts`,
-        data: { reactionKey, attempts: tracker.attempts },
-      });
-      await notifyHuman(event, reactionConfig.priority ?? "urgent");
-      return {
-        reactionType: reactionKey,
-        success: true,
-        action: "escalated",
-        escalated: true,
-      };
-    }
-
-    // Execute the reaction action
-    const action = reactionConfig.action ?? "notify";
-
-    switch (action) {
-      case "send-to-agent": {
-        if (reactionConfig.message) {
-          try {
-            await sessionManager.send(sessionId, reactionConfig.message);
-
-            return {
-              reactionType: reactionKey,
-              success: true,
-              action: "send-to-agent",
-              message: reactionConfig.message,
-              escalated: false,
-            };
-          } catch {
-            // Send failed — allow retry on next poll cycle (don't escalate immediately)
-            return {
-              reactionType: reactionKey,
-              success: false,
-              action: "send-to-agent",
-              escalated: false,
-            };
-          }
-        }
-        break;
-      }
-
-      case "notify": {
-        const event = createEvent("reaction.triggered", {
-          sessionId,
-          projectId,
-          message: `Reaction '${reactionKey}' triggered notification`,
-          data: { reactionKey },
-        });
-        await notifyHuman(event, reactionConfig.priority ?? "info");
-        return {
-          reactionType: reactionKey,
-          success: true,
-          action: "notify",
-          escalated: false,
-        };
-      }
-
-      case "auto-merge": {
-        // Auto-merge is handled by the SCM plugin
-        // For now, just notify
-        const event = createEvent("reaction.triggered", {
-          sessionId,
-          projectId,
-          message: `Reaction '${reactionKey}' triggered auto-merge`,
-          data: { reactionKey },
-        });
-        await notifyHuman(event, "action");
-        return {
-          reactionType: reactionKey,
-          success: true,
-          action: "auto-merge",
-          escalated: false,
-        };
-      }
-    }
-
-    return {
-      reactionType: reactionKey,
-      success: false,
-      action,
-      escalated: false,
-    };
-  }
-
-  function clearReactionTracker(sessionId: SessionId, reactionKey: string): void {
-    reactionTrackers.delete(`${sessionId}:${reactionKey}`);
-  }
-
-  function getReactionConfigForSession(
-    session: Session,
-    reactionKey: string,
-  ): ReactionConfig | null {
-    const project = config.projects[session.projectId];
-    const globalReaction = config.reactions[reactionKey];
-    const projectReaction = project?.reactions?.[reactionKey];
-    const reactionConfig = projectReaction
-      ? { ...globalReaction, ...projectReaction }
-      : globalReaction;
-    return reactionConfig ? (reactionConfig as ReactionConfig) : null;
-  }
-
   function updateSessionMetadata(
     session: Session,
     updates: Partial<Record<string, string>>,
@@ -1082,457 +629,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
     session.metadata = cleaned;
     session.status = deriveLegacyStatus(session.lifecycle, session.status);
-  }
-
-  function makeFingerprint(ids: string[]): string {
-    return [...ids].sort().join(",");
-  }
-
-  async function maybeDispatchReviewBacklog(
-    session: Session,
-    oldStatus: SessionStatus,
-    newStatus: SessionStatus,
-    transitionReaction?: { key: string; result: ReactionResult | null },
-  ): Promise<void> {
-    const project = config.projects[session.projectId];
-    if (!project || !session.pr) return;
-
-    const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
-    if (!scm) return;
-
-    const humanReactionKey = "changes-requested";
-    const automatedReactionKey = "bugbot-comments";
-
-    if (TERMINAL_STATUSES.has(newStatus) || session.lifecycle.pr.state !== "open") {
-      clearReactionTracker(session.id, humanReactionKey);
-      clearReactionTracker(session.id, automatedReactionKey);
-      lastReviewBacklogCheckAt.delete(session.id);
-      updateSessionMetadata(session, {
-        lastPendingReviewFingerprint: "",
-        lastPendingReviewDispatchHash: "",
-        lastPendingReviewDispatchAt: "",
-        lastAutomatedReviewFingerprint: "",
-        lastAutomatedReviewDispatchHash: "",
-        lastAutomatedReviewDispatchAt: "",
-      });
-      return;
-    }
-
-    // Throttle review backlog API calls to at most once per 2 minutes.
-    // Comments don't change faster than this in practice, and the SCM calls
-    // (getPendingComments + getAutomatedComments) consume API quota on every poll.
-    //
-    // Exception: bypass throttle when a transition reaction just fired for a
-    // review reaction key. The transitionReaction branch records
-    // lastPendingReviewDispatchHash, which requires the current fingerprint from
-    // the API. If we throttle here, that metadata never gets written and the
-    // next unthrottled poll sees a "new" fingerprint, clears the reaction tracker,
-    // and fires a duplicate dispatch.
-    const hasRelevantTransition =
-      transitionReaction?.key === humanReactionKey ||
-      transitionReaction?.key === automatedReactionKey;
-    if (!hasRelevantTransition) {
-      const lastCheckAt = lastReviewBacklogCheckAt.get(session.id) ?? 0;
-      if (Date.now() - lastCheckAt < REVIEW_BACKLOG_THROTTLE_MS) {
-        return;
-      }
-    }
-    lastReviewBacklogCheckAt.set(session.id, Date.now());
-
-    const [pendingResult, automatedResult] = await Promise.allSettled([
-      scm.getPendingComments(session.pr),
-      scm.getAutomatedComments(session.pr),
-    ]);
-
-    // null means "failed to fetch" — preserve existing metadata.
-    // [] means "confirmed no comments" — safe to clear.
-    const pendingComments =
-      pendingResult.status === "fulfilled" && Array.isArray(pendingResult.value)
-        ? pendingResult.value
-        : null;
-    const automatedComments =
-      automatedResult.status === "fulfilled" && Array.isArray(automatedResult.value)
-        ? automatedResult.value
-        : null;
-
-    // --- Pending (human) review comments ---
-    // null = SCM fetch failed; skip processing to preserve existing metadata.
-    if (pendingComments !== null) {
-      const pendingFingerprint = makeFingerprint(pendingComments.map((comment) => comment.id));
-      const lastPendingFingerprint = session.metadata["lastPendingReviewFingerprint"] ?? "";
-      const lastPendingDispatchHash = session.metadata["lastPendingReviewDispatchHash"] ?? "";
-
-      if (
-        pendingFingerprint !== lastPendingFingerprint &&
-        transitionReaction?.key !== humanReactionKey
-      ) {
-        clearReactionTracker(session.id, humanReactionKey);
-      }
-      if (pendingFingerprint !== lastPendingFingerprint) {
-        updateSessionMetadata(session, {
-          lastPendingReviewFingerprint: pendingFingerprint,
-        });
-      }
-
-      if (!pendingFingerprint) {
-        clearReactionTracker(session.id, humanReactionKey);
-        updateSessionMetadata(session, {
-          lastPendingReviewFingerprint: "",
-          lastPendingReviewDispatchHash: "",
-          lastPendingReviewDispatchAt: "",
-        });
-      } else if (
-        transitionReaction?.key === humanReactionKey &&
-        transitionReaction.result?.success
-      ) {
-        if (lastPendingDispatchHash !== pendingFingerprint) {
-          updateSessionMetadata(session, {
-            lastPendingReviewDispatchHash: pendingFingerprint,
-            lastPendingReviewDispatchAt: new Date().toISOString(),
-          });
-        }
-      } else if (
-        !(oldStatus !== newStatus && newStatus === "changes_requested") &&
-        pendingFingerprint !== lastPendingDispatchHash
-      ) {
-        const reactionConfig = getReactionConfigForSession(session, humanReactionKey);
-        if (
-          reactionConfig &&
-          reactionConfig.action &&
-          (reactionConfig.auto !== false || reactionConfig.action === "notify")
-        ) {
-          const result = await executeReaction(
-            session.id,
-            session.projectId,
-            humanReactionKey,
-            reactionConfig,
-          );
-          if (result.success) {
-            updateSessionMetadata(session, {
-              lastPendingReviewDispatchHash: pendingFingerprint,
-              lastPendingReviewDispatchAt: new Date().toISOString(),
-            });
-          }
-        }
-      }
-    }
-
-    // --- Automated (bot) review comments ---
-    if (automatedComments !== null) {
-      const automatedFingerprint = makeFingerprint(
-        automatedComments.map((comment) => comment.id),
-      );
-      const lastAutomatedFingerprint = session.metadata["lastAutomatedReviewFingerprint"] ?? "";
-      const lastAutomatedDispatchHash =
-        session.metadata["lastAutomatedReviewDispatchHash"] ?? "";
-
-      if (automatedFingerprint !== lastAutomatedFingerprint) {
-        clearReactionTracker(session.id, automatedReactionKey);
-        updateSessionMetadata(session, {
-          lastAutomatedReviewFingerprint: automatedFingerprint,
-        });
-      }
-
-      if (!automatedFingerprint) {
-        clearReactionTracker(session.id, automatedReactionKey);
-        updateSessionMetadata(session, {
-          lastAutomatedReviewFingerprint: "",
-          lastAutomatedReviewDispatchHash: "",
-          lastAutomatedReviewDispatchAt: "",
-        });
-      } else if (automatedFingerprint !== lastAutomatedDispatchHash) {
-        const reactionConfig = getReactionConfigForSession(session, automatedReactionKey);
-        if (
-          reactionConfig &&
-          reactionConfig.action &&
-          (reactionConfig.auto !== false || reactionConfig.action === "notify")
-        ) {
-          // Inject the detailed comment listing + correct-API guidance into the
-          // message so the agent doesn't re-fetch with stale or unpaginated calls
-          // (see #895 — fixes the pagination + stale `gh pr checks` failure modes).
-          // Only override when the message is the built-in sentinel — a user who
-          // customized `reactions.bugbot-comments.message` in their YAML gets
-          // exactly what they wrote, nothing more.
-          const usingDefaultMessage =
-            reactionConfig.message === DEFAULT_BUGBOT_COMMENTS_MESSAGE;
-          const detailedConfig: ReactionConfig =
-            reactionConfig.action === "send-to-agent" && usingDefaultMessage
-              ? {
-                  ...reactionConfig,
-                  message: formatAutomatedCommentsMessage(automatedComments, session.pr),
-                }
-              : reactionConfig;
-          const result = await executeReaction(
-            session.id,
-            session.projectId,
-            automatedReactionKey,
-            detailedConfig,
-          );
-          if (result.success) {
-            updateSessionMetadata(session, {
-              lastAutomatedReviewDispatchHash: automatedFingerprint,
-              lastAutomatedReviewDispatchAt: new Date().toISOString(),
-            });
-          }
-        }
-      }
-    }
-  }
-
-  /**
-   * Format CI check failures into a human-readable message for the agent.
-   * Includes check names, statuses, and links for debugging.
-   */
-  function formatCIFailureMessage(failedChecks: CICheck[]): string {
-    const lines = [
-      "CI checks are failing on your PR. Here are the failed checks:",
-      "",
-    ];
-    for (const check of failedChecks) {
-      const status = check.conclusion ?? check.status;
-      const link = check.url ? ` — ${check.url}` : "";
-      lines.push(`- **${check.name}**: ${status}${link}`);
-    }
-    lines.push(
-      "",
-      "Investigate the failures, fix the issues, and push again.",
-    );
-    return lines.join("\n");
-  }
-
-  /**
-   * Dispatch CI failure details to the agent session when new or changed
-   * failures are detected. Follows the same fingerprinting/deduplication
-   * pattern as maybeDispatchReviewBacklog().
-   */
-  async function maybeDispatchCIFailureDetails(
-    session: Session,
-    _oldStatus: SessionStatus,
-    newStatus: SessionStatus,
-    transitionReaction?: { key: string; result: ReactionResult | null },
-  ): Promise<void> {
-    const project = config.projects[session.projectId];
-    if (!project || !session.pr) return;
-
-    const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
-    if (!scm) return;
-
-    const ciReactionKey = "ci-failed";
-
-    // Clear tracking when PR is closed/merged
-    if (newStatus === "merged" || newStatus === "killed") {
-      clearReactionTracker(session.id, ciReactionKey);
-      updateSessionMetadata(session, {
-        lastCIFailureFingerprint: "",
-        lastCIFailureDispatchHash: "",
-        lastCIFailureDispatchAt: "",
-      });
-      return;
-    }
-
-    // Only dispatch CI details when in ci_failed state
-    if (newStatus !== "ci_failed") {
-      // CI is no longer failing — clear tracking so next failure is dispatched fresh
-      const lastFingerprint = session.metadata["lastCIFailureFingerprint"] ?? "";
-      if (lastFingerprint) {
-        clearReactionTracker(session.id, ciReactionKey);
-        updateSessionMetadata(session, {
-          lastCIFailureFingerprint: "",
-          lastCIFailureDispatchHash: "",
-          lastCIFailureDispatchAt: "",
-        });
-      }
-      return;
-    }
-
-    // Fetch individual CI checks for failure details.
-    // Use batch enrichment data when available to avoid an extra REST call;
-    // fall back to getCIChecks() when the batch didn't run this cycle.
-    const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
-    const cachedEnrichment = prEnrichmentCache.get(prKey);
-
-    let checks: CICheck[];
-    if (cachedEnrichment?.ciChecks !== undefined) {
-      checks = cachedEnrichment.ciChecks;
-    } else {
-      try {
-        checks = await scm.getCIChecks(session.pr);
-      } catch {
-        // Failed to fetch checks — skip this cycle
-        return;
-      }
-    }
-
-    const failedChecks = checks.filter(
-      (c) => c.status === "failed" || c.conclusion?.toUpperCase() === "FAILURE",
-    );
-    if (failedChecks.length === 0) return;
-
-    const ciFingerprint = makeFingerprint(
-      failedChecks.map((c) => `${c.name}:${c.status}:${c.conclusion ?? ""}`),
-    );
-    const lastCIFingerprint = session.metadata["lastCIFailureFingerprint"] ?? "";
-    const lastCIDispatchHash = session.metadata["lastCIFailureDispatchHash"] ?? "";
-
-    // Reset reaction tracker when failure set changes
-    if (ciFingerprint !== lastCIFingerprint && transitionReaction?.key !== ciReactionKey) {
-      clearReactionTracker(session.id, ciReactionKey);
-    }
-    if (ciFingerprint !== lastCIFingerprint) {
-      updateSessionMetadata(session, {
-        lastCIFailureFingerprint: ciFingerprint,
-      });
-    }
-
-    // If transition already sent a ci-failed reaction with the static message,
-    // skip this cycle but do NOT record dispatch hash — the next poll will send
-    // the detailed CI failure info with check names and URLs.
-    if (
-      transitionReaction?.key === ciReactionKey &&
-      transitionReaction.result?.success
-    ) {
-      return;
-    }
-
-    // Skip if we already dispatched this exact failure set
-    if (ciFingerprint === lastCIDispatchHash) return;
-
-    // Dispatch CI failure details directly via sessionManager.send() rather than
-    // executeReaction() to avoid consuming the ci-failed reaction's retry budget.
-    // The transition reaction owns escalation; this is a follow-up info delivery.
-    const reactionConfig = getReactionConfigForSession(session, ciReactionKey);
-    if (
-      reactionConfig &&
-      reactionConfig.action &&
-      (reactionConfig.auto !== false || reactionConfig.action === "notify")
-    ) {
-      const detailedMessage = formatCIFailureMessage(failedChecks);
-
-      try {
-        if (reactionConfig.action === "send-to-agent") {
-          await sessionManager.send(session.id, detailedMessage);
-        } else {
-          // For "notify" action, send to human notifiers instead
-          const event = createEvent("ci.failing", {
-            sessionId: session.id,
-            projectId: session.projectId,
-            message: detailedMessage,
-            data: { failedChecks: failedChecks.map((c) => c.name) },
-          });
-          await notifyHuman(event, reactionConfig.priority ?? "warning");
-        }
-
-        updateSessionMetadata(session, {
-          lastCIFailureDispatchHash: ciFingerprint,
-          lastCIFailureDispatchAt: new Date().toISOString(),
-        });
-      } catch {
-        // Send failed — will retry on next poll cycle
-      }
-    }
-  }
-
-  /**
-   * Dispatch merge conflict notifications to the agent session.
-   * Conflicts are detected from the PR enrichment cache or getMergeability()
-   * and dispatched independently of the session status (conflicts can coexist
-   * with ci_failed, changes_requested, etc.).
-   */
-  async function maybeDispatchMergeConflicts(
-    session: Session,
-    newStatus: SessionStatus,
-  ): Promise<void> {
-    const project = config.projects[session.projectId];
-    if (!project || !session.pr) return;
-
-    const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
-    if (!scm) return;
-
-    const conflictReactionKey = "merge-conflicts";
-
-    // Clear tracking when PR is no longer open.
-    if (session.lifecycle.pr.state !== "open" || newStatus === "killed") {
-      clearReactionTracker(session.id, conflictReactionKey);
-      updateSessionMetadata(session, {
-        lastMergeConflictDispatched: "",
-      });
-      return;
-    }
-
-    // Only check for conflicts on open PRs
-    if (
-      newStatus !== "pr_open" &&
-      newStatus !== "ci_failed" &&
-      newStatus !== "review_pending" &&
-      newStatus !== "changes_requested" &&
-      newStatus !== "approved" &&
-      newStatus !== "mergeable"
-    ) {
-      return;
-    }
-
-    // Check for conflicts using cached enrichment data or fallback to individual call.
-    // When batch enrichment ran (cachedData is present), use its hasConflicts value
-    // to avoid 3 redundant REST calls from getMergeability() — the batch already
-    // fetched the mergeable/mergeStateStatus fields via GraphQL.
-    const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
-    const cachedData = prEnrichmentCache.get(prKey);
-
-    let hasConflicts: boolean;
-    if (cachedData) {
-      // Batch ran — trust its data (undefined means CONFLICTING wasn't set → no conflicts)
-      hasConflicts = cachedData.hasConflicts ?? false;
-    } else {
-      // Batch didn't run this cycle — fall back to individual API call
-      try {
-        const mergeReadiness = await scm.getMergeability(session.pr);
-        hasConflicts = !mergeReadiness.noConflicts;
-      } catch {
-        return;
-      }
-    }
-
-    const lastDispatched = session.metadata["lastMergeConflictDispatched"] ?? "";
-
-    if (hasConflicts) {
-      // Already dispatched for current conflict state — skip
-      if (lastDispatched === "true") return;
-
-      const reactionConfig = getReactionConfigForSession(session, conflictReactionKey);
-      if (
-        reactionConfig &&
-        reactionConfig.action &&
-        (reactionConfig.auto !== false || reactionConfig.action === "notify")
-      ) {
-        try {
-          if (reactionConfig.action === "send-to-agent") {
-            const message =
-              reactionConfig.message ??
-              "Your branch has merge conflicts. Rebase on the default branch and resolve them.";
-            await sessionManager.send(session.id, message);
-          } else {
-            const event = createEvent("merge.conflicts", {
-              sessionId: session.id,
-              projectId: session.projectId,
-              message: `${session.id}: PR has merge conflicts`,
-            });
-            await notifyHuman(event, reactionConfig.priority ?? "warning");
-          }
-
-          updateSessionMetadata(session, {
-            lastMergeConflictDispatched: "true",
-          });
-        } catch {
-          // Send failed — will retry on next poll cycle
-        }
-      }
-    } else if (lastDispatched === "true") {
-      // Conflicts resolved — clear so we can re-dispatch if they recur
-      clearReactionTracker(session.id, conflictReactionKey);
-      updateSessionMetadata(session, {
-        lastMergeConflictDispatched: "",
-      });
-    }
   }
 
   /** Send a notification to all configured notifiers. */
@@ -1731,7 +827,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       if (oldEventType) {
         const oldReactionKey = eventToReactionKey(oldEventType);
         if (oldReactionKey) {
-          clearReactionTracker(session.id, oldReactionKey);
+          reactionEngine.clearTracker(session.id, oldReactionKey);
         }
       }
 
@@ -1742,12 +838,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         const reactionKey = eventToReactionKey(eventType);
 
         if (reactionKey) {
-          const reactionConfig = getReactionConfigForSession(session, reactionKey);
+          const reactionConfig = reactionEngine.getReactionConfigForSession(session, reactionKey);
 
           if (reactionConfig && reactionConfig.action) {
             // auto: false skips automated agent actions but still allows notifications
             if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
-              const reactionResult = await executeReaction(
+              const reactionResult = await reactionEngine.executeReaction(
                 session.id,
                 session.projectId,
                 reactionKey,
@@ -1830,10 +926,15 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       const reactionKey = eventToReactionKey(prEventType);
 
       if (reactionKey) {
-        const reactionConfig = getReactionConfigForSession(session, reactionKey);
+        const reactionConfig = reactionEngine.getReactionConfigForSession(session, reactionKey);
         if (reactionConfig && reactionConfig.action) {
           if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
-            await executeReaction(session.id, session.projectId, reactionKey, reactionConfig);
+            await reactionEngine.executeReaction(
+              session.id,
+              session.projectId,
+              reactionKey,
+              reactionConfig,
+            );
             reactionHandledNotify = true;
           }
         }
@@ -1872,9 +973,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     await Promise.allSettled([
-      maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction),
-      maybeDispatchCIFailureDetails(session, oldStatus, newStatus, transitionReaction),
-      maybeDispatchMergeConflicts(session, newStatus),
+      backlog.maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction),
+      backlog.maybeDispatchCIFailureDetails(session, oldStatus, newStatus, transitionReaction),
+      backlog.maybeDispatchMergeConflicts(session, newStatus),
     ]);
 
     // Report watcher: audit agent reports for issues (#140)
@@ -1909,7 +1010,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     const reactionKey = getReactionKeyForTrigger(auditResult.trigger);
-    const reactionConfig = getReactionConfigForSession(session, reactionKey);
+    const reactionConfig = reactionEngine.getReactionConfigForSession(session, reactionKey);
 
     // Update audit metadata
     const currentTriggerCount = parseInt(
@@ -1951,7 +1052,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     // Execute reaction if configured
     if (isNewTrigger && reactionConfig && reactionConfig.auto !== false) {
-      await executeReaction(session.id, session.projectId, reactionKey, reactionConfig);
+      await reactionEngine.executeReaction(session.id, session.projectId, reactionKey, reactionConfig);
     }
   }
 
@@ -1977,12 +1078,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
       // Prime the per-poll PR enrichment cache before session checks so
       // downstream status/reaction logic can reuse batch GraphQL data.
-      await populatePREnrichmentCache(sessionsToCheck);
+      await prEnrichmentCache.populate(sessionsToCheck);
 
       // Poll all sessions concurrently
       await Promise.allSettled(sessionsToCheck.map((s) => checkSession(s)));
 
-      // Prune stale entries from states, reactionTrackers, and lastReviewBacklogCheckAt
+      // Prune stale entries from states, reactionTrackers, and the review-backlog throttle
       // for sessions that no longer appear in the session list (e.g., after kill/cleanup)
       const currentSessionIds = new Set(sessions.map((s) => s.id));
       for (const trackedId of states.keys()) {
@@ -1990,17 +1091,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           states.delete(trackedId);
         }
       }
-      for (const trackerKey of reactionTrackers.keys()) {
-        const sessionId = trackerKey.split(":")[0];
-        if (sessionId && !currentSessionIds.has(sessionId)) {
-          reactionTrackers.delete(trackerKey);
-        }
-      }
-      for (const sessionId of lastReviewBacklogCheckAt.keys()) {
-        if (!currentSessionIds.has(sessionId)) {
-          lastReviewBacklogCheckAt.delete(sessionId);
-        }
-      }
+      reactionEngine.pruneTrackers(currentSessionIds);
+      backlog.pruneReviewBacklogThrottle(currentSessionIds);
 
       // Check if all sessions are complete (trigger reaction only once)
       const activeSessions = sessions.filter((s) => !TERMINAL_STATUSES.has(s.status));
@@ -2013,7 +1105,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const reactionConfig = config.reactions[reactionKey];
           if (reactionConfig && reactionConfig.action) {
             if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
-              await executeReaction("system", "all", reactionKey, reactionConfig as ReactionConfig);
+              await reactionEngine.executeReaction(
+                "system",
+                "all",
+                reactionKey,
+                reactionConfig as ReactionConfig,
+              );
             }
           }
         }

--- a/packages/core/src/pr-enrichment-cache.ts
+++ b/packages/core/src/pr-enrichment-cache.ts
@@ -20,7 +20,6 @@ type Observer = ProjectObserver;
 
 export interface PREnrichmentCache {
   get(key: string): PREnrichmentData | undefined;
-  clear(): void;
   populate(sessions: Session[]): Promise<void>;
 }
 
@@ -138,7 +137,6 @@ export function createPREnrichmentCache(deps: PREnrichmentCacheDeps): PREnrichme
 
   return {
     get: (key) => cache.get(key),
-    clear: () => cache.clear(),
     populate,
   };
 }

--- a/packages/core/src/pr-enrichment-cache.ts
+++ b/packages/core/src/pr-enrichment-cache.ts
@@ -1,0 +1,144 @@
+/**
+ * Per-poll-cycle cache of PR enrichment data.
+ *
+ * The lifecycle manager populates this cache once at the top of each poll via
+ * the SCM's batch GraphQL endpoint. Downstream status and reaction logic read
+ * from it (instead of issuing their own REST calls) to avoid redundant API
+ * traffic. Keys are formatted as `${owner}/${repo}#${number}`.
+ */
+
+import type {
+  OrchestratorConfig,
+  PluginRegistry,
+  PREnrichmentData,
+  SCM,
+  Session,
+} from "./types.js";
+import { createCorrelationId, type ProjectObserver } from "./observability.js";
+
+type Observer = ProjectObserver;
+
+export interface PREnrichmentCache {
+  get(key: string): PREnrichmentData | undefined;
+  clear(): void;
+  populate(sessions: Session[]): Promise<void>;
+}
+
+export interface PREnrichmentCacheDeps {
+  config: OrchestratorConfig;
+  registry: PluginRegistry;
+  observer: Observer;
+  scopedProjectId?: string;
+}
+
+export function createPREnrichmentCache(deps: PREnrichmentCacheDeps): PREnrichmentCache {
+  const { config, registry, observer, scopedProjectId } = deps;
+  const cache = new Map<string, PREnrichmentData>();
+
+  async function populate(sessions: Session[]): Promise<void> {
+    cache.clear();
+
+    // Collect all unique PRs keyed by their owning session's project/plugin.
+    const prsByPlugin = new Map<string, Array<NonNullable<Session["pr"]>>>();
+    const seenPRKeys = new Set<string>();
+    for (const session of sessions) {
+      if (!session.pr) continue;
+      const project = config.projects[session.projectId];
+      if (!project?.scm?.plugin) continue;
+
+      const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
+      if (seenPRKeys.has(prKey)) continue;
+      seenPRKeys.add(prKey);
+
+      const pluginKey = project.scm.plugin;
+      if (!prsByPlugin.has(pluginKey)) {
+        prsByPlugin.set(pluginKey, []);
+      }
+      const pluginPRs = prsByPlugin.get(pluginKey);
+      if (pluginPRs) {
+        pluginPRs.push(session.pr);
+      }
+    }
+
+    for (const [pluginKey, pluginPRs] of prsByPlugin) {
+      const scm = registry.get<SCM>("scm", pluginKey);
+      if (!scm?.enrichSessionsPRBatch) continue;
+
+      const batchStartTime = Date.now();
+      try {
+        const enrichmentData = await scm.enrichSessionsPRBatch(pluginPRs, {
+          recordSuccess(_data) {
+            const batchDuration = Date.now() - batchStartTime;
+            observer?.recordOperation({
+              metric: "graphql_batch",
+              operation: "batch_enrichment",
+              correlationId: createCorrelationId("graphql-batch"),
+              outcome: "success",
+              projectId: scopedProjectId,
+              durationMs: batchDuration,
+              data: {
+                plugin: pluginKey,
+                prCount: pluginPRs.length,
+                prKeys: pluginPRs.map((pr) => `${pr.owner}/${pr.repo}#${pr.number}`),
+              },
+              level: "info",
+            });
+          },
+          recordFailure(data) {
+            const batchDuration = Date.now() - batchStartTime;
+            observer?.recordOperation({
+              metric: "graphql_batch",
+              operation: "batch_enrichment",
+              correlationId: createCorrelationId("graphql-batch"),
+              outcome: "failure",
+              reason: data.error,
+              level: "warn",
+              data: {
+                plugin: pluginKey,
+                prCount: pluginPRs.length,
+                error: data.error,
+                durationMs: batchDuration,
+              },
+            });
+          },
+          log(level, message) {
+            observer?.recordDiagnostic?.({
+              operation: "batch_enrichment.log",
+              correlationId: createCorrelationId("graphql-batch"),
+              projectId: scopedProjectId,
+              message,
+              level,
+              data: {
+                plugin: pluginKey,
+                source: "ao-graphql-batch",
+              },
+            });
+          },
+        });
+
+        for (const [key, data] of enrichmentData) {
+          cache.set(key, data);
+        }
+      } catch (err) {
+        // Batch fetch failed - individual calls will still work
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        const batchCorrelationId = createCorrelationId("batch-enrichment");
+        observer?.recordOperation?.({
+          metric: "lifecycle_poll",
+          operation: "batch_enrichment",
+          correlationId: batchCorrelationId,
+          outcome: "failure",
+          reason: errorMsg,
+          level: "warn",
+          data: { plugin: pluginKey, prCount: pluginPRs.length },
+        });
+      }
+    }
+  }
+
+  return {
+    get: (key) => cache.get(key),
+    clear: () => cache.clear(),
+    populate,
+  };
+}

--- a/packages/core/src/reaction-engine.ts
+++ b/packages/core/src/reaction-engine.ts
@@ -1,0 +1,205 @@
+/**
+ * Reaction engine — runs configured reactions, tracks retry attempts, and
+ * escalates to human notification when limits are exceeded.
+ *
+ * The lifecycle manager owns state transitions; this module owns the "event
+ * happened -> run the configured reaction" side of the loop.
+ */
+
+import type {
+  EventPriority,
+  OpenCodeSessionManager,
+  OrchestratorConfig,
+  OrchestratorEvent,
+  ReactionConfig,
+  ReactionResult,
+  Session,
+  SessionId,
+} from "./types.js";
+import { createEvent, parseDuration } from "./lifecycle-events.js";
+
+/** Per-session, per-reaction retry/escalation tracker. */
+interface ReactionTracker {
+  attempts: number;
+  firstTriggered: Date;
+}
+
+export interface ReactionEngine {
+  executeReaction(
+    sessionId: SessionId,
+    projectId: string,
+    reactionKey: string,
+    reactionConfig: ReactionConfig,
+  ): Promise<ReactionResult>;
+  clearTracker(sessionId: SessionId, reactionKey: string): void;
+  getReactionConfigForSession(session: Session, reactionKey: string): ReactionConfig | null;
+  /** Drop trackers for sessions no longer present. */
+  pruneTrackers(currentSessionIds: Set<SessionId>): void;
+}
+
+export interface ReactionEngineDeps {
+  config: OrchestratorConfig;
+  sessionManager: OpenCodeSessionManager;
+  notifyHuman(event: OrchestratorEvent, priority: EventPriority): Promise<void>;
+}
+
+export function createReactionEngine(deps: ReactionEngineDeps): ReactionEngine {
+  const { config, sessionManager, notifyHuman } = deps;
+  const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
+
+  async function executeReaction(
+    sessionId: SessionId,
+    projectId: string,
+    reactionKey: string,
+    reactionConfig: ReactionConfig,
+  ): Promise<ReactionResult> {
+    const trackerKey = `${sessionId}:${reactionKey}`;
+    let tracker = reactionTrackers.get(trackerKey);
+
+    if (!tracker) {
+      tracker = { attempts: 0, firstTriggered: new Date() };
+      reactionTrackers.set(trackerKey, tracker);
+    }
+
+    // Increment attempts before checking escalation
+    tracker.attempts++;
+
+    const maxRetries = reactionConfig.retries ?? Infinity;
+    const escalateAfter = reactionConfig.escalateAfter;
+    let shouldEscalate = false;
+
+    if (tracker.attempts > maxRetries) {
+      shouldEscalate = true;
+    }
+
+    if (typeof escalateAfter === "string") {
+      const durationMs = parseDuration(escalateAfter);
+      if (durationMs > 0 && Date.now() - tracker.firstTriggered.getTime() > durationMs) {
+        shouldEscalate = true;
+      }
+    }
+
+    if (typeof escalateAfter === "number" && tracker.attempts > escalateAfter) {
+      shouldEscalate = true;
+    }
+
+    if (shouldEscalate) {
+      const event = createEvent("reaction.escalated", {
+        sessionId,
+        projectId,
+        message: `Reaction '${reactionKey}' escalated after ${tracker.attempts} attempts`,
+        data: { reactionKey, attempts: tracker.attempts },
+      });
+      await notifyHuman(event, reactionConfig.priority ?? "urgent");
+      return {
+        reactionType: reactionKey,
+        success: true,
+        action: "escalated",
+        escalated: true,
+      };
+    }
+
+    const action = reactionConfig.action ?? "notify";
+
+    switch (action) {
+      case "send-to-agent": {
+        if (reactionConfig.message) {
+          try {
+            await sessionManager.send(sessionId, reactionConfig.message);
+
+            return {
+              reactionType: reactionKey,
+              success: true,
+              action: "send-to-agent",
+              message: reactionConfig.message,
+              escalated: false,
+            };
+          } catch {
+            // Send failed — allow retry on next poll cycle (don't escalate immediately)
+            return {
+              reactionType: reactionKey,
+              success: false,
+              action: "send-to-agent",
+              escalated: false,
+            };
+          }
+        }
+        break;
+      }
+
+      case "notify": {
+        const event = createEvent("reaction.triggered", {
+          sessionId,
+          projectId,
+          message: `Reaction '${reactionKey}' triggered notification`,
+          data: { reactionKey },
+        });
+        await notifyHuman(event, reactionConfig.priority ?? "info");
+        return {
+          reactionType: reactionKey,
+          success: true,
+          action: "notify",
+          escalated: false,
+        };
+      }
+
+      case "auto-merge": {
+        // Auto-merge is handled by the SCM plugin
+        // For now, just notify
+        const event = createEvent("reaction.triggered", {
+          sessionId,
+          projectId,
+          message: `Reaction '${reactionKey}' triggered auto-merge`,
+          data: { reactionKey },
+        });
+        await notifyHuman(event, "action");
+        return {
+          reactionType: reactionKey,
+          success: true,
+          action: "auto-merge",
+          escalated: false,
+        };
+      }
+    }
+
+    return {
+      reactionType: reactionKey,
+      success: false,
+      action,
+      escalated: false,
+    };
+  }
+
+  function clearTracker(sessionId: SessionId, reactionKey: string): void {
+    reactionTrackers.delete(`${sessionId}:${reactionKey}`);
+  }
+
+  function getReactionConfigForSession(
+    session: Session,
+    reactionKey: string,
+  ): ReactionConfig | null {
+    const project = config.projects[session.projectId];
+    const globalReaction = config.reactions[reactionKey];
+    const projectReaction = project?.reactions?.[reactionKey];
+    const reactionConfig = projectReaction
+      ? { ...globalReaction, ...projectReaction }
+      : globalReaction;
+    return reactionConfig ? (reactionConfig as ReactionConfig) : null;
+  }
+
+  function pruneTrackers(currentSessionIds: Set<SessionId>): void {
+    for (const trackerKey of reactionTrackers.keys()) {
+      const sessionId = trackerKey.split(":")[0];
+      if (sessionId && !currentSessionIds.has(sessionId)) {
+        reactionTrackers.delete(trackerKey);
+      }
+    }
+  }
+
+  return {
+    executeReaction,
+    clearTracker,
+    getReactionConfigForSession,
+    pruneTrackers,
+  };
+}

--- a/packages/core/src/reaction-engine.ts
+++ b/packages/core/src/reaction-engine.ts
@@ -45,7 +45,9 @@ export interface ReactionEngineDeps {
 
 export function createReactionEngine(deps: ReactionEngineDeps): ReactionEngine {
   const { config, sessionManager, notifyHuman } = deps;
-  const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
+  // Nested so we can prune/clear by sessionId without parsing a compound key —
+  // SessionId is an unconstrained string and could contain ":".
+  const reactionTrackers = new Map<SessionId, Map<string, ReactionTracker>>();
 
   async function executeReaction(
     sessionId: SessionId,
@@ -53,12 +55,15 @@ export function createReactionEngine(deps: ReactionEngineDeps): ReactionEngine {
     reactionKey: string,
     reactionConfig: ReactionConfig,
   ): Promise<ReactionResult> {
-    const trackerKey = `${sessionId}:${reactionKey}`;
-    let tracker = reactionTrackers.get(trackerKey);
-
+    let sessionTrackers = reactionTrackers.get(sessionId);
+    if (!sessionTrackers) {
+      sessionTrackers = new Map();
+      reactionTrackers.set(sessionId, sessionTrackers);
+    }
+    let tracker = sessionTrackers.get(reactionKey);
     if (!tracker) {
       tracker = { attempts: 0, firstTriggered: new Date() };
-      reactionTrackers.set(trackerKey, tracker);
+      sessionTrackers.set(reactionKey, tracker);
     }
 
     // Increment attempts before checking escalation
@@ -171,7 +176,12 @@ export function createReactionEngine(deps: ReactionEngineDeps): ReactionEngine {
   }
 
   function clearTracker(sessionId: SessionId, reactionKey: string): void {
-    reactionTrackers.delete(`${sessionId}:${reactionKey}`);
+    const sessionTrackers = reactionTrackers.get(sessionId);
+    if (!sessionTrackers) return;
+    sessionTrackers.delete(reactionKey);
+    if (sessionTrackers.size === 0) {
+      reactionTrackers.delete(sessionId);
+    }
   }
 
   function getReactionConfigForSession(
@@ -188,10 +198,9 @@ export function createReactionEngine(deps: ReactionEngineDeps): ReactionEngine {
   }
 
   function pruneTrackers(currentSessionIds: Set<SessionId>): void {
-    for (const trackerKey of reactionTrackers.keys()) {
-      const sessionId = trackerKey.split(":")[0];
-      if (sessionId && !currentSessionIds.has(sessionId)) {
-        reactionTrackers.delete(trackerKey);
+    for (const sessionId of reactionTrackers.keys()) {
+      if (!currentSessionIds.has(sessionId)) {
+        reactionTrackers.delete(sessionId);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Splits `packages/core/src/lifecycle-manager.ts` (2077 lines) into four focused modules behind the existing `createLifecycleManager` factory. Mechanical refactor — no behavior change, public API unchanged.
- `lifecycle-manager.ts` shrinks from **2077 → 1191 lines** (-43%) and now owns only the polling loop, state machine (`determineStatus`, `checkSession`), merge auto-cleanup, and report-watcher audit; reactions/caching/backlog dispatch live in their own files.
- New modules:
  - `lifecycle-events.ts` (232) — pure helpers (`parseDuration`, `inferPriority`, `createEvent`, `statusToEventType`, `prStateToEventType`, `eventToReactionKey`, `transitionLogLevel`, `primaryLifecycleReason`, `buildTransitionObservabilityData`, `makeFingerprint`).
  - `pr-enrichment-cache.ts` (144) — per-poll-cycle batch GraphQL cache with `populate/get/clear`.
  - `reaction-engine.ts` (205) — `executeReaction`, retry trackers, escalation logic, and reaction config resolution.
  - `lifecycle-backlog.ts` (533) — review backlog, CI failure details, and merge conflict dispatchers plus throttle state.

Closes #1417.

## Test plan

- [x] `pnpm --filter @aoagents/ao-core typecheck` passes
- [x] `pnpm --filter @aoagents/ao-core test` — 806/808 tests pass; the 2 failures (`plugin-registry.loadBuiltins` timeout and `orchestrator-prompt.dist` requiring `pnpm build`) are pre-existing on `main` and unrelated to this refactor
- [x] `npx vitest run src/__tests__/lifecycle-manager.test.ts` — 89/89 pass
- [x] `npx vitest run src/__tests__/plugin-integration.test.ts` — 13/13 pass
- [x] ESLint clean on the 5 touched files