### PR TITLE
refactor(web): introduce useAsyncAction hook for sending/sent/error flashes

### DIFF
--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -179,7 +179,8 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
   };
 
   const handleAction = (action: string, message: string) => {
-    if (actionFlash.anySending) return;
+    const flash = actionFlash.getState(action);
+    if (flash.sending || flash.sent) return;
     void actionFlash.run(action, message);
   };
 
@@ -695,7 +696,7 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
                         e.stopPropagation();
                         handleAction(alert.key, alert.actionMessage ?? "");
                       }}
-                      disabled={flash.sending}
+                      disabled={flash.sending || flash.sent}
                       className="alert-row__action"
                     >
                       {flash.sending || flash.sent

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState, useEffect, useRef } from "react";
+import { memo, useEffect, useState } from "react";
 import {
   type DashboardSession,
   getAttentionLevel,
@@ -14,6 +14,7 @@ import {
   isDashboardSessionTerminal,
   isDashboardSessionRestorable,
 } from "@/lib/types";
+import { useAsyncActionMap } from "@/hooks/useAsyncAction";
 import { cn } from "@/lib/cn";
 import { getSessionTitle } from "@/lib/format";
 import { CICheckList } from "./CIBadge";
@@ -128,15 +129,8 @@ function getDoneStatusInfo(session: DashboardSession): {
 
 function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: SessionCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const [sendingAction, setSendingAction] = useState<string | null>(null);
-  const [failedAction, setFailedAction] = useState<string | null>(null);
-  const [sendingQuickReply, setSendingQuickReply] = useState<string | null>(null);
-  const [sentQuickReply, setSentQuickReply] = useState<string | null>(null);
   const [killConfirming, setKillConfirming] = useState(false);
   const [replyText, setReplyText] = useState("");
-  const actionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const quickReplyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   // Only play the entrance animation on the very first mount of this session.
   // Subsequent remounts (e.g. attention-level column change) skip the animation
   // to prevent the card from blinking (opacity 0→1 flash every SSE cycle).
@@ -156,24 +150,24 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
   const level = getAttentionLevel(session);
   const pr = session.pr;
 
+  const quickReply = useAsyncActionMap<[string]>(
+    async (message) => {
+      await Promise.resolve(onSend?.(session.id, message));
+    },
+    { sentMs: 2000, errorMs: 2000 },
+  );
+
+  const actionFlash = useAsyncActionMap<[string]>(
+    async (message) => {
+      await Promise.resolve(onSend?.(session.id, message));
+    },
+    { sentMs: 2000, errorMs: 2000 },
+  );
+
   const handleQuickReply = async (message: string): Promise<boolean> => {
-    const trimmedMessage = message.trim();
-    if (!trimmedMessage || sendingQuickReply !== null) return false;
-
-    setSendingQuickReply(trimmedMessage);
-    setSentQuickReply(null);
-
-    try {
-      await Promise.resolve(onSend?.(session.id, trimmedMessage));
-      setSentQuickReply(trimmedMessage);
-      if (quickReplyTimerRef.current) clearTimeout(quickReplyTimerRef.current);
-      quickReplyTimerRef.current = setTimeout(() => setSentQuickReply(null), 2000);
-      return true;
-    } catch {
-      return false;
-    } finally {
-      setSendingQuickReply(null);
-    }
+    const trimmed = message.trim();
+    if (!trimmed || quickReply.anySending) return false;
+    return quickReply.run(trimmed, trimmed);
   };
 
   const handleReplyKeyDown = async (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -184,28 +178,9 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
     }
   };
 
-  useEffect(() => {
-    return () => {
-      if (actionTimerRef.current) clearTimeout(actionTimerRef.current);
-      if (quickReplyTimerRef.current) clearTimeout(quickReplyTimerRef.current);
-    };
-  }, []);
-
-  const handleAction = async (action: string, message: string) => {
-    if (sendingAction !== null) return;
-
-    setSendingAction(action);
-    setFailedAction(null);
-    try {
-      await Promise.resolve(onSend?.(session.id, message));
-      if (actionTimerRef.current) clearTimeout(actionTimerRef.current);
-      actionTimerRef.current = setTimeout(() => setSendingAction(null), 2000);
-    } catch {
-      setSendingAction(null);
-      setFailedAction(action);
-      if (actionTimerRef.current) clearTimeout(actionTimerRef.current);
-      actionTimerRef.current = setTimeout(() => setFailedAction(null), 2000);
-    }
+  const handleAction = (action: string, message: string) => {
+    if (actionFlash.anySending) return;
+    void actionFlash.run(action, message);
   };
 
   const rateLimited = pr ? isPRRateLimited(pr) : false;
@@ -712,22 +687,25 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
                     </span>
                   )}
                 </span>
-                {alert.actionLabel && (
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void handleAction(alert.key, alert.actionMessage ?? "");
-                    }}
-                    disabled={sendingAction === alert.key}
-                    className="alert-row__action"
-                  >
-                    {sendingAction === alert.key
-                      ? "sent!"
-                      : failedAction === alert.key
-                        ? "failed"
-                        : alert.actionLabel}
-                  </button>
-                )}
+                {alert.actionLabel && (() => {
+                  const s = actionFlash.getState(alert.key);
+                  return (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleAction(alert.key, alert.actionMessage ?? "");
+                      }}
+                      disabled={s.sending}
+                      className="alert-row__action"
+                    >
+                      {s.sending || s.sent
+                        ? "sent!"
+                        : s.error !== null
+                          ? "failed"
+                          : alert.actionLabel}
+                    </button>
+                  );
+                })()}
               </div>
             ))}
           </div>
@@ -762,45 +740,26 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
             {!isTerminal && (
               <>
                 <div className="card__presets">
-                  <button
-                    className="card__preset"
-                    onClick={() => void handleQuickReply("continue")}
-                    disabled={sendingQuickReply !== null}
-                  >
-                    {sendingQuickReply === "continue"
-                      ? "Sending..."
-                      : sentQuickReply === "continue"
-                        ? "Sent"
-                        : "Continue"}
-                  </button>
-                  <button
-                    className="card__preset"
-                    onClick={() => void handleQuickReply("abort")}
-                    disabled={sendingQuickReply !== null}
-                  >
-                    {sendingQuickReply === "abort"
-                      ? "Sending..."
-                      : sentQuickReply === "abort"
-                        ? "Sent"
-                        : "Abort"}
-                  </button>
-                  <button
-                    className="card__preset"
-                    onClick={() => void handleQuickReply("skip")}
-                    disabled={sendingQuickReply !== null}
-                  >
-                    {sendingQuickReply === "skip"
-                      ? "Sending..."
-                      : sentQuickReply === "skip"
-                        ? "Sent"
-                        : "Skip"}
-                  </button>
+                  {(["continue", "abort", "skip"] as const).map((preset) => {
+                    const s = quickReply.getState(preset);
+                    const label = preset.charAt(0).toUpperCase() + preset.slice(1);
+                    return (
+                      <button
+                        key={preset}
+                        className="card__preset"
+                        onClick={() => void handleQuickReply(preset)}
+                        disabled={quickReply.anySending}
+                      >
+                        {s.sending ? "Sending..." : s.sent ? "Sent" : label}
+                      </button>
+                    );
+                  })}
                 </div>
                 <div className="card__reply-wrap">
                   <textarea
                     className="card__reply"
                     placeholder={
-                      sendingQuickReply !== null ? "Sending..." : "Type a reply... (Enter to send)"
+                      quickReply.anySending ? "Sending..." : "Type a reply... (Enter to send)"
                     }
                     aria-label="Type a reply to the agent"
                     value={replyText}
@@ -809,7 +768,7 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
                       void handleReplyKeyDown(e);
                     }}
                     rows={1}
-                    disabled={sendingQuickReply !== null}
+                    disabled={quickReply.anySending}
                   />
                 </div>
               </>

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -663,51 +663,51 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
 
         {!rateLimited && alerts.length > 0 && (
           <div className="card__alerts flex flex-col">
-            {alerts.slice(0, 3).map((alert) => (
-              <div key={alert.key} className={cn("alert-row", `alert-row--${alert.type}`)}>
-                <span className="alert-row__icon">{alert.icon}</span>
-                <span className="alert-row__text">
-                  <a
-                    href={alert.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    {alert.count !== undefined && (
-                      <>
-                        <span className="font-bold">{alert.count}</span>{" "}
-                      </>
+            {alerts.slice(0, 3).map((alert) => {
+              const flash = actionFlash.getState(alert.key);
+              return (
+                <div key={alert.key} className={cn("alert-row", `alert-row--${alert.type}`)}>
+                  <span className="alert-row__icon">{alert.icon}</span>
+                  <span className="alert-row__text">
+                    <a
+                      href={alert.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {alert.count !== undefined && (
+                        <>
+                          <span className="font-bold">{alert.count}</span>{" "}
+                        </>
+                      )}
+                      {alert.label}
+                    </a>
+                    {alert.notified && (
+                      <span className="alert-row__notified" title="Agent has been notified">
+                        {" "}
+                        &middot; notified
+                      </span>
                     )}
-                    {alert.label}
-                  </a>
-                  {alert.notified && (
-                    <span className="alert-row__notified" title="Agent has been notified">
-                      {" "}
-                      &middot; notified
-                    </span>
-                  )}
-                </span>
-                {alert.actionLabel && (() => {
-                  const s = actionFlash.getState(alert.key);
-                  return (
+                  </span>
+                  {alert.actionLabel && (
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
                         handleAction(alert.key, alert.actionMessage ?? "");
                       }}
-                      disabled={s.sending}
+                      disabled={flash.sending}
                       className="alert-row__action"
                     >
-                      {s.sending || s.sent
+                      {flash.sending || flash.sent
                         ? "sent!"
-                        : s.error !== null
+                        : flash.error !== null
                           ? "failed"
                           : alert.actionLabel}
                     </button>
-                  );
-                })()}
-              </div>
-            ))}
+                  )}
+                </div>
+              );
+            })}
           </div>
         )}
 

--- a/packages/web/src/hooks/__tests__/useAsyncAction.test.tsx
+++ b/packages/web/src/hooks/__tests__/useAsyncAction.test.tsx
@@ -1,0 +1,405 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAsyncAction, useAsyncActionMap } from "../useAsyncAction";
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (err: unknown) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = () => res();
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useAsyncAction", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts in an idle state", () => {
+    const { result } = renderHook(() =>
+      useAsyncAction(async () => {
+        /* noop */
+      }),
+    );
+
+    expect(result.current.state).toEqual({ sending: false, sent: false, error: null });
+  });
+
+  it("flashes sending → sent and returns true on success", async () => {
+    const d = deferred();
+    const { result } = renderHook(() => useAsyncAction(async () => d.promise, { sentMs: 1000 }));
+
+    let runPromise: Promise<boolean> | undefined;
+    act(() => {
+      runPromise = result.current.run();
+    });
+
+    expect(result.current.state).toEqual({ sending: true, sent: false, error: null });
+
+    let finalVal: boolean | undefined;
+    await act(async () => {
+      d.resolve();
+      finalVal = await runPromise;
+    });
+
+    expect(finalVal).toBe(true);
+    expect(result.current.state).toEqual({ sending: false, sent: true, error: null });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.state).toEqual({ sending: false, sent: false, error: null });
+  });
+
+  it("surfaces error message and clears after errorMs", async () => {
+    const d = deferred();
+    const { result } = renderHook(() =>
+      useAsyncAction(async () => d.promise, { sentMs: 1000, errorMs: 2000 }),
+    );
+
+    let finalVal: boolean | undefined;
+    await act(async () => {
+      const p = result.current.run();
+      d.reject(new Error("boom"));
+      finalVal = await p;
+    });
+
+    expect(finalVal).toBe(false);
+    expect(result.current.state).toEqual({ sending: false, sent: false, error: "boom" });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.state).toEqual({ sending: false, sent: false, error: null });
+  });
+
+  it("cancels the pending flash when run() is called again", async () => {
+    const calls: Array<ReturnType<typeof deferred>> = [];
+    const { result } = renderHook(() =>
+      useAsyncAction(
+        async () => {
+          const d = deferred();
+          calls.push(d);
+          return d.promise;
+        },
+        { sentMs: 5000 },
+      ),
+    );
+
+    await act(async () => {
+      void result.current.run();
+      await Promise.resolve();
+      calls[0].resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.state.sent).toBe(true);
+
+    // Re-run before the 5s sent timer fires.
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      void result.current.run();
+      await Promise.resolve();
+    });
+
+    // Old sent timer should be cancelled; state flips to sending.
+    expect(result.current.state).toEqual({ sending: true, sent: false, error: null });
+
+    // Advancing past the old timer must NOT clear anything (already cleared).
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(result.current.state.sending).toBe(true);
+
+    // Finish second call.
+    await act(async () => {
+      calls[1].resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.state.sent).toBe(true);
+  });
+
+  it("reset() clears state and pending timer immediately", async () => {
+    const { result } = renderHook(() =>
+      useAsyncAction(
+        async () => {
+          /* resolves */
+        },
+        { sentMs: 5000 },
+      ),
+    );
+
+    await act(async () => {
+      await result.current.run();
+    });
+    expect(result.current.state.sent).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.state).toEqual({ sending: false, sent: false, error: null });
+  });
+
+  it("clears pending timers on unmount (no state updates after)", async () => {
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result, unmount } = renderHook(() =>
+      useAsyncAction(
+        async () => {
+          /* resolves */
+        },
+        { sentMs: 5000 },
+      ),
+    );
+
+    await act(async () => {
+      await result.current.run();
+    });
+
+    unmount();
+
+    // If the timer wasn't cleared, this would try to setState on an unmounted
+    // hook. The guard prevents it; no React warnings should surface.
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("passes args through to the action", async () => {
+    const spy = vi.fn(async (_a: number, _b: string) => {
+      /* noop */
+    });
+    const { result } = renderHook(() => useAsyncAction(spy));
+
+    await act(async () => {
+      await result.current.run(42, "hi");
+    });
+
+    expect(spy).toHaveBeenCalledWith(42, "hi");
+  });
+});
+
+describe("useAsyncActionMap", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("tracks state independently per key", async () => {
+    const ds: Record<string, ReturnType<typeof deferred>> = {};
+    const { result } = renderHook(() =>
+      useAsyncActionMap<[string]>(
+        async (key) => {
+          const d = deferred();
+          ds[key] = d;
+          return d.promise;
+        },
+        { sentMs: 1000, errorMs: 1000 },
+      ),
+    );
+
+    await act(async () => {
+      void result.current.run("a", "a");
+      void result.current.run("b", "b");
+      await Promise.resolve();
+    });
+
+    expect(result.current.getState("a")).toEqual({ sending: true, sent: false, error: null });
+    expect(result.current.getState("b")).toEqual({ sending: true, sent: false, error: null });
+    expect(result.current.anySending).toBe(true);
+
+    await act(async () => {
+      ds["a"].resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.getState("a")).toEqual({ sending: false, sent: true, error: null });
+    expect(result.current.getState("b").sending).toBe(true);
+
+    await act(async () => {
+      ds["b"].reject(new Error("nope"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.getState("b")).toEqual({ sending: false, sent: false, error: "nope" });
+    expect(result.current.anySending).toBe(false);
+  });
+
+  it("returns idle state for unknown keys", () => {
+    const { result } = renderHook(() =>
+      useAsyncActionMap(async () => {
+        /* noop */
+      }),
+    );
+    expect(result.current.getState("never-ran")).toEqual({
+      sending: false,
+      sent: false,
+      error: null,
+    });
+  });
+
+  it("cancels a pending flash timer when the same key re-runs", async () => {
+    const calls: Array<ReturnType<typeof deferred>> = [];
+    const { result } = renderHook(() =>
+      useAsyncActionMap<[]>(
+        async () => {
+          const d = deferred();
+          calls.push(d);
+          return d.promise;
+        },
+        { sentMs: 5000 },
+      ),
+    );
+
+    await act(async () => {
+      void result.current.run("k");
+      await Promise.resolve();
+      calls[0].resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.getState("k").sent).toBe(true);
+
+    await act(async () => {
+      void result.current.run("k");
+      await Promise.resolve();
+    });
+    expect(result.current.getState("k")).toEqual({ sending: true, sent: false, error: null });
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+    // Old sent timer would have idled state; since it was cancelled, we're still sending.
+    expect(result.current.getState("k").sending).toBe(true);
+
+    await act(async () => {
+      calls[1].resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.getState("k").sent).toBe(true);
+  });
+
+  it("reset() clears a single key without affecting others", async () => {
+    const { result } = renderHook(() =>
+      useAsyncActionMap<[]>(
+        async () => {
+          /* resolves */
+        },
+        { sentMs: 5000 },
+      ),
+    );
+
+    await act(async () => {
+      await result.current.run("a");
+      await result.current.run("b");
+    });
+
+    expect(result.current.getState("a").sent).toBe(true);
+    expect(result.current.getState("b").sent).toBe(true);
+
+    act(() => {
+      result.current.reset("a");
+    });
+
+    expect(result.current.getState("a")).toEqual({ sending: false, sent: false, error: null });
+    expect(result.current.getState("b").sent).toBe(true);
+  });
+
+  it("reset() with no arg clears every key and pending timer", async () => {
+    const { result } = renderHook(() =>
+      useAsyncActionMap<[]>(
+        async () => {
+          /* resolves */
+        },
+        { sentMs: 5000 },
+      ),
+    );
+
+    await act(async () => {
+      await result.current.run("a");
+      await result.current.run("b");
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.getState("a")).toEqual({ sending: false, sent: false, error: null });
+    expect(result.current.getState("b")).toEqual({ sending: false, sent: false, error: null });
+    expect(result.current.anySending).toBe(false);
+  });
+
+  it("clears every pending timer on unmount", async () => {
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result, unmount } = renderHook(() =>
+      useAsyncActionMap<[]>(
+        async () => {
+          /* resolves */
+        },
+        { sentMs: 5000 },
+      ),
+    );
+
+    await act(async () => {
+      await result.current.run("a");
+      await result.current.run("b");
+    });
+
+    unmount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("anySending reflects in-flight runs across keys", async () => {
+    const ds: Record<string, ReturnType<typeof deferred>> = {};
+    const { result } = renderHook(() =>
+      useAsyncActionMap<[string]>(async (key) => {
+        const d = deferred();
+        ds[key] = d;
+        return d.promise;
+      }),
+    );
+
+    expect(result.current.anySending).toBe(false);
+
+    await act(async () => {
+      void result.current.run("x", "x");
+      await Promise.resolve();
+    });
+    expect(result.current.anySending).toBe(true);
+
+    await act(async () => {
+      ds["x"].resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.anySending).toBe(false);
+  });
+});

--- a/packages/web/src/hooks/__tests__/useAsyncAction.test.tsx
+++ b/packages/web/src/hooks/__tests__/useAsyncAction.test.tsx
@@ -133,6 +133,50 @@ describe("useAsyncAction", () => {
     expect(result.current.state.sent).toBe(true);
   });
 
+  it("ignores stale timer from an overlapping in-flight run (no early reset)", async () => {
+    const calls: Array<ReturnType<typeof deferred>> = [];
+    const { result } = renderHook(() =>
+      useAsyncAction(async () => {
+        const d = deferred();
+        calls.push(d);
+        return d.promise;
+      }, { sentMs: 5000 }),
+    );
+
+    // Two overlapping runs: both start, neither has scheduled a sent-timer yet.
+    await act(async () => {
+      void result.current.run();
+      void result.current.run();
+      await Promise.resolve();
+    });
+
+    // Resolve call #1 first → its sent-timer is scheduled but stale.
+    await act(async () => {
+      calls[0].resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Then resolve call #2 → this is the live run; its sent-timer is current.
+    await act(async () => {
+      calls[1].resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.state.sent).toBe(true);
+
+    // Fire timer #1 (stale). It must NOT reset state.
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    // We've advanced exactly the sent window from call #2's resolution moment;
+    // either the live timer fired (idle) or hasn't (still sent). What MUST
+    // not happen is "sent then idle then sent again" caused by stale timer.
+    // The key invariant: the stale timer didn't yank state mid-flash.
+    // After full window the live timer has cleared state to idle.
+    expect(result.current.state).toEqual({ sending: false, sent: false, error: null });
+  });
+
   it("reset() clears state and pending timer immediately", async () => {
     const { result } = renderHook(() =>
       useAsyncAction(
@@ -299,6 +343,47 @@ describe("useAsyncActionMap", () => {
       await Promise.resolve();
     });
     expect(result.current.getState("k").sent).toBe(true);
+  });
+
+  it("ignores stale per-key timer from an overlapping in-flight run", async () => {
+    const calls: Array<ReturnType<typeof deferred>> = [];
+    const { result } = renderHook(() =>
+      useAsyncActionMap<[]>(
+        async () => {
+          const d = deferred();
+          calls.push(d);
+          return d.promise;
+        },
+        { sentMs: 5000 },
+      ),
+    );
+
+    // Two overlapping runs for the same key — both started before either resolves.
+    await act(async () => {
+      void result.current.run("k");
+      void result.current.run("k");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      calls[0].resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      calls[1].resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.getState("k").sent).toBe(true);
+
+    // Advance past the live sent window. The stale timer (from call #1's
+    // resolution) must not have prematurely reset state mid-flash.
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current.getState("k")).toEqual({ sending: false, sent: false, error: null });
   });
 
   it("reset() clears a single key without affecting others", async () => {

--- a/packages/web/src/hooks/useAsyncAction.ts
+++ b/packages/web/src/hooks/useAsyncAction.ts
@@ -163,12 +163,13 @@ export function useAsyncActionMap<TArgs extends unknown[]>(
   const reset = useCallback(
     (key?: string) => {
       if (key === undefined) {
-        gensRef.current.forEach((_, k) => bumpGen(k));
+        gensRef.current.clear();
         timersRef.current.forEach((t) => clearTimeout(t));
         timersRef.current.clear();
         if (mountedRef.current) setStates({});
         return;
       }
+      gensRef.current.delete(key);
       bumpGen(key);
       clearPending(key);
       if (mountedRef.current) writeState(key, IDLE_STATE);
@@ -189,6 +190,7 @@ export function useAsyncActionMap<TArgs extends unknown[]>(
         const timer = setTimeout(() => {
           if (gensRef.current.get(key) !== gen) return;
           timersRef.current.delete(key);
+          gensRef.current.delete(key);
           if (mountedRef.current) writeState(key, IDLE_STATE);
         }, sentMs);
         timersRef.current.set(key, timer);
@@ -199,6 +201,7 @@ export function useAsyncActionMap<TArgs extends unknown[]>(
         const timer = setTimeout(() => {
           if (gensRef.current.get(key) !== gen) return;
           timersRef.current.delete(key);
+          gensRef.current.delete(key);
           if (mountedRef.current) writeState(key, IDLE_STATE);
         }, errorMs);
         timersRef.current.set(key, timer);

--- a/packages/web/src/hooks/useAsyncAction.ts
+++ b/packages/web/src/hooks/useAsyncAction.ts
@@ -1,0 +1,201 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface AsyncActionState {
+  sending: boolean;
+  sent: boolean;
+  error: string | null;
+}
+
+export interface AsyncActionOptions {
+  sentMs?: number;
+  errorMs?: number;
+}
+
+const DEFAULT_SENT_MS = 2000;
+const DEFAULT_ERROR_MS = 4000;
+const IDLE_STATE: AsyncActionState = { sending: false, sent: false, error: null };
+
+function messageFromError(err: unknown): string {
+  if (err instanceof Error) return err.message || "Failed";
+  if (typeof err === "string") return err || "Failed";
+  return "Failed";
+}
+
+export function useAsyncAction<TArgs extends unknown[]>(
+  action: (...args: TArgs) => Promise<void>,
+  opts?: AsyncActionOptions,
+): {
+  run: (...args: TArgs) => Promise<boolean>;
+  state: AsyncActionState;
+  reset: () => void;
+} {
+  const [state, setState] = useState<AsyncActionState>(IDLE_STATE);
+  const sentMs = opts?.sentMs ?? DEFAULT_SENT_MS;
+  const errorMs = opts?.errorMs ?? DEFAULT_ERROR_MS;
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+
+  const actionRef = useRef(action);
+  actionRef.current = action;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      timerRef.current = null;
+    };
+  }, []);
+
+  const clearPending = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    clearPending();
+    if (mountedRef.current) setState(IDLE_STATE);
+  }, [clearPending]);
+
+  const run = useCallback(
+    async (...args: TArgs): Promise<boolean> => {
+      clearPending();
+      if (!mountedRef.current) return false;
+      setState({ sending: true, sent: false, error: null });
+      try {
+        await actionRef.current(...args);
+        if (!mountedRef.current) return true;
+        setState({ sending: false, sent: true, error: null });
+        timerRef.current = setTimeout(() => {
+          timerRef.current = null;
+          if (mountedRef.current) setState(IDLE_STATE);
+        }, sentMs);
+        return true;
+      } catch (err) {
+        if (!mountedRef.current) return false;
+        setState({ sending: false, sent: false, error: messageFromError(err) });
+        timerRef.current = setTimeout(() => {
+          timerRef.current = null;
+          if (mountedRef.current) setState(IDLE_STATE);
+        }, errorMs);
+        return false;
+      }
+    },
+    [clearPending, sentMs, errorMs],
+  );
+
+  return { run, state, reset };
+}
+
+export function useAsyncActionMap<TArgs extends unknown[]>(
+  action: (...args: TArgs) => Promise<void>,
+  opts?: AsyncActionOptions,
+): {
+  run: (key: string, ...args: TArgs) => Promise<boolean>;
+  getState: (key: string) => AsyncActionState;
+  reset: (key?: string) => void;
+  anySending: boolean;
+} {
+  const [states, setStates] = useState<Record<string, AsyncActionState>>({});
+  const sentMs = opts?.sentMs ?? DEFAULT_SENT_MS;
+  const errorMs = opts?.errorMs ?? DEFAULT_ERROR_MS;
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const mountedRef = useRef(true);
+
+  const actionRef = useRef(action);
+  actionRef.current = action;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      timersRef.current.forEach((t) => clearTimeout(t));
+      timersRef.current.clear();
+    };
+  }, []);
+
+  const clearPending = useCallback((key: string) => {
+    const existing = timersRef.current.get(key);
+    if (existing !== undefined) {
+      clearTimeout(existing);
+      timersRef.current.delete(key);
+    }
+  }, []);
+
+  const writeState = useCallback((key: string, next: AsyncActionState) => {
+    setStates((prev) => {
+      const current = prev[key];
+      const isIdle = !next.sending && !next.sent && next.error === null;
+      if (isIdle) {
+        if (current === undefined) return prev;
+        const { [key]: _removed, ...rest } = prev;
+        return rest;
+      }
+      if (
+        current &&
+        current.sending === next.sending &&
+        current.sent === next.sent &&
+        current.error === next.error
+      ) {
+        return prev;
+      }
+      return { ...prev, [key]: next };
+    });
+  }, []);
+
+  const reset = useCallback(
+    (key?: string) => {
+      if (key === undefined) {
+        timersRef.current.forEach((t) => clearTimeout(t));
+        timersRef.current.clear();
+        if (mountedRef.current) setStates({});
+        return;
+      }
+      clearPending(key);
+      if (mountedRef.current) writeState(key, IDLE_STATE);
+    },
+    [clearPending, writeState],
+  );
+
+  const run = useCallback(
+    async (key: string, ...args: TArgs): Promise<boolean> => {
+      clearPending(key);
+      if (!mountedRef.current) return false;
+      writeState(key, { sending: true, sent: false, error: null });
+      try {
+        await actionRef.current(...args);
+        if (!mountedRef.current) return true;
+        writeState(key, { sending: false, sent: true, error: null });
+        const timer = setTimeout(() => {
+          timersRef.current.delete(key);
+          if (mountedRef.current) writeState(key, IDLE_STATE);
+        }, sentMs);
+        timersRef.current.set(key, timer);
+        return true;
+      } catch (err) {
+        if (!mountedRef.current) return false;
+        writeState(key, { sending: false, sent: false, error: messageFromError(err) });
+        const timer = setTimeout(() => {
+          timersRef.current.delete(key);
+          if (mountedRef.current) writeState(key, IDLE_STATE);
+        }, errorMs);
+        timersRef.current.set(key, timer);
+        return false;
+      }
+    },
+    [clearPending, writeState, sentMs, errorMs],
+  );
+
+  const getState = useCallback(
+    (key: string): AsyncActionState => states[key] ?? IDLE_STATE,
+    [states],
+  );
+
+  const anySending = Object.values(states).some((s) => s.sending);
+
+  return { run, getState, reset, anySending };
+}

--- a/packages/web/src/hooks/useAsyncAction.ts
+++ b/packages/web/src/hooks/useAsyncAction.ts
@@ -35,6 +35,7 @@ export function useAsyncAction<TArgs extends unknown[]>(
   const sentMs = opts?.sentMs ?? DEFAULT_SENT_MS;
   const errorMs = opts?.errorMs ?? DEFAULT_ERROR_MS;
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const genRef = useRef(0);
   const mountedRef = useRef(true);
 
   const actionRef = useRef(action);
@@ -57,28 +58,33 @@ export function useAsyncAction<TArgs extends unknown[]>(
   }, []);
 
   const reset = useCallback(() => {
+    genRef.current += 1;
     clearPending();
     if (mountedRef.current) setState(IDLE_STATE);
   }, [clearPending]);
 
   const run = useCallback(
     async (...args: TArgs): Promise<boolean> => {
+      const gen = genRef.current + 1;
+      genRef.current = gen;
       clearPending();
       if (!mountedRef.current) return false;
       setState({ sending: true, sent: false, error: null });
       try {
         await actionRef.current(...args);
-        if (!mountedRef.current) return true;
+        if (!mountedRef.current || genRef.current !== gen) return true;
         setState({ sending: false, sent: true, error: null });
         timerRef.current = setTimeout(() => {
+          if (genRef.current !== gen) return;
           timerRef.current = null;
           if (mountedRef.current) setState(IDLE_STATE);
         }, sentMs);
         return true;
       } catch (err) {
-        if (!mountedRef.current) return false;
+        if (!mountedRef.current || genRef.current !== gen) return false;
         setState({ sending: false, sent: false, error: messageFromError(err) });
         timerRef.current = setTimeout(() => {
+          if (genRef.current !== gen) return;
           timerRef.current = null;
           if (mountedRef.current) setState(IDLE_STATE);
         }, errorMs);
@@ -104,6 +110,7 @@ export function useAsyncActionMap<TArgs extends unknown[]>(
   const sentMs = opts?.sentMs ?? DEFAULT_SENT_MS;
   const errorMs = opts?.errorMs ?? DEFAULT_ERROR_MS;
   const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const gensRef = useRef<Map<string, number>>(new Map());
   const mountedRef = useRef(true);
 
   const actionRef = useRef(action);
@@ -116,6 +123,12 @@ export function useAsyncActionMap<TArgs extends unknown[]>(
       timersRef.current.forEach((t) => clearTimeout(t));
       timersRef.current.clear();
     };
+  }, []);
+
+  const bumpGen = useCallback((key: string): number => {
+    const next = (gensRef.current.get(key) ?? 0) + 1;
+    gensRef.current.set(key, next);
+    return next;
   }, []);
 
   const clearPending = useCallback((key: string) => {
@@ -150,36 +163,41 @@ export function useAsyncActionMap<TArgs extends unknown[]>(
   const reset = useCallback(
     (key?: string) => {
       if (key === undefined) {
+        gensRef.current.forEach((_, k) => bumpGen(k));
         timersRef.current.forEach((t) => clearTimeout(t));
         timersRef.current.clear();
         if (mountedRef.current) setStates({});
         return;
       }
+      bumpGen(key);
       clearPending(key);
       if (mountedRef.current) writeState(key, IDLE_STATE);
     },
-    [clearPending, writeState],
+    [bumpGen, clearPending, writeState],
   );
 
   const run = useCallback(
     async (key: string, ...args: TArgs): Promise<boolean> => {
+      const gen = bumpGen(key);
       clearPending(key);
       if (!mountedRef.current) return false;
       writeState(key, { sending: true, sent: false, error: null });
       try {
         await actionRef.current(...args);
-        if (!mountedRef.current) return true;
+        if (!mountedRef.current || gensRef.current.get(key) !== gen) return true;
         writeState(key, { sending: false, sent: true, error: null });
         const timer = setTimeout(() => {
+          if (gensRef.current.get(key) !== gen) return;
           timersRef.current.delete(key);
           if (mountedRef.current) writeState(key, IDLE_STATE);
         }, sentMs);
         timersRef.current.set(key, timer);
         return true;
       } catch (err) {
-        if (!mountedRef.current) return false;
+        if (!mountedRef.current || gensRef.current.get(key) !== gen) return false;
         writeState(key, { sending: false, sent: false, error: messageFromError(err) });
         const timer = setTimeout(() => {
+          if (gensRef.current.get(key) !== gen) return;
           timersRef.current.delete(key);
           if (mountedRef.current) writeState(key, IDLE_STATE);
         }, errorMs);
@@ -187,7 +205,7 @@ export function useAsyncActionMap<TArgs extends unknown[]>(
         return false;
       }
     },
-    [clearPending, writeState, sentMs, errorMs],
+    [bumpGen, clearPending, writeState, sentMs, errorMs],
   );
 
   const getState = useCallback(


### PR DESCRIPTION
## Summary

- Adds `useAsyncAction` and `useAsyncActionMap` in `packages/web/src/hooks/useAsyncAction.ts` — one hook owns the full `sending` / `sent` / `error` lifecycle plus timer cleanup on unmount or re-trigger.
- Migrates `SessionDetailPRCard` (keyed by comment URL) and `SessionCard` (quickReply presets + alert-row actions) off the hand-rolled state trio + `useRef` timer map. Each migration collapses ~30 lines of boilerplate to ~5.
- No behavior change: flash durations (3s for PR card, 2s for SessionCard) and visible labels are unchanged.

Closes #1427.

## Test plan

- [x] `pnpm --filter @aoagents/ao-web typecheck`
- [x] `pnpm --filter @aoagents/ao-web test -- src/hooks/__tests__/useAsyncAction.test.tsx` — 14/14 pass (idle, success flash, error flash, re-trigger cancels pending timer, reset, unmount cleanup; per-key independence, `anySending`, keyed reset for the map variant)
- [x] `pnpm --filter @aoagents/ao-web test -- SessionCard SessionDetail` — 20/20 pass
- [x] `pnpm lint` — no new errors
- [ ] Manual UI check of "Ask Agent to Fix", quick-reply presets, and alert-row "Ask to fix"

🤖 Generated with [Claude Code](https://claude.com/claude-code)