### PR TITLE
refactor(core,plugins): consolidate recordActivity duplication via factory

### DIFF
--- a/.changeset/recordActivity-factory.md
+++ b/.changeset/recordActivity-factory.md
@@ -1,0 +1,9 @@
+---
+"@aoagents/ao-core": minor
+"@aoagents/ao-plugin-agent-aider": patch
+"@aoagents/ao-plugin-agent-codex": patch
+"@aoagents/ao-plugin-agent-cursor": patch
+"@aoagents/ao-plugin-agent-opencode": patch
+---
+
+Add `recordActivityViaTerminal(classifier)` factory to core and use it to replace the identical 5-line `recordActivity` wrapper in the aider, codex, cursor, and opencode plugins. Same behavior, less boilerplate for future AO-activity-JSONL plugins.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,7 @@ import {
   checkActivityLogState,        // Extract waiting_input/blocked from AO JSONL (with staleness cap)
   getActivityFallbackState,     // Last-resort fallback: entry state + age-based decay
   recordTerminalActivity,       // Shared recordActivity impl (classify + dedup + append)
+  recordActivityViaTerminal,    // Factory returning a standard recordActivity from a classifier
   classifyTerminalActivity,     // Classify terminal output via detectActivity
   appendActivityEntry,          // Low-level JSONL append
   setupPathWrapperWorkspace,    // Install ~/.ao/bin wrappers + .ao/AGENTS.md
@@ -458,21 +459,24 @@ async getActivityState(session, readyThresholdMs?): Promise<ActivityDetection | 
 | Pattern | Used by | How it works |
 |---------|---------|-------------|
 | **Native JSONL** | Claude Code, Codex | Agent writes its own JSONL with rich state (`permission_request`, `tool_call`, `error`, etc.). `getActivityState` reads the last entry and maps it to activity states. |
-| **AO Activity JSONL** | Aider, OpenCode, new agents | Agent implements `recordActivity`. Lifecycle manager calls it each poll cycle with terminal output. It calls `classifyTerminalActivity()` → `appendActivityEntry()` to write to `{workspacePath}/.ao/activity.jsonl`. `getActivityState` reads from this file. |
+| **AO Activity JSONL** | Aider, OpenCode, new agents | Agent wires `recordActivity` to the `recordActivityViaTerminal(classifier)` factory from core. Lifecycle manager calls it each poll cycle with terminal output. It classifies via the provided function, dedupes, and appends to `{workspacePath}/.ao/activity.jsonl`. `getActivityState` reads from this file. |
 
 **For agents using AO Activity JSONL (the common case for new plugins):**
 
-1. Implement `recordActivity` — delegate to the shared `recordTerminalActivity()`:
+1. Wire `recordActivity` to the shared `recordActivityViaTerminal()` factory — no custom wrapper needed:
 ```typescript
-async recordActivity(session: Session, terminalOutput: string): Promise<void> {
-  if (!session.workspacePath) return;
-  await recordTerminalActivity(session.workspacePath, terminalOutput, (output) =>
-    this.detectActivity(output),
-  );
-}
+import { recordActivityViaTerminal } from "@aoagents/ao-core";
+
+function detectMyAgentActivity(output: string): ActivityState { ... }
+
+const agent: Agent = {
+  detectActivity: detectMyAgentActivity,
+  recordActivity: recordActivityViaTerminal(detectMyAgentActivity),
+  // ...
+};
 ```
 
-`recordTerminalActivity` handles classification, deduplication (20s window for non-actionable states), and appending. You don't need to implement dedup yourself.
+The factory handles the `workspacePath` null-check and delegates to `recordTerminalActivity`, which classifies, dedupes (20s window for non-actionable states), and appends. Only write a custom `recordActivity` if you need different classification or a different location.
 
 2. Implement `detectActivity` with patterns specific to the agent's terminal output:
 ```typescript

--- a/packages/core/src/__tests__/activity-log.test.ts
+++ b/packages/core/src/__tests__/activity-log.test.ts
@@ -8,10 +8,11 @@ import {
   readLastActivityEntry,
   appendActivityEntry,
   recordTerminalActivity,
+  recordActivityViaTerminal,
   getActivityLogPath,
   ACTIVITY_INPUT_STALENESS_MS,
 } from "../activity-log.js";
-import type { ActivityState } from "../types.js";
+import type { ActivityState, Session } from "../types.js";
 
 describe("classifyTerminalActivity", () => {
   it("returns active state with no trigger", () => {
@@ -194,5 +195,39 @@ describe("recordTerminalActivity", () => {
     const content = await rf(getActivityLogPath(tmpDir), "utf-8");
     const lines = content.trim().split("\n").filter(Boolean);
     expect(lines).toHaveLength(2);
+  });
+});
+
+describe("recordActivityViaTerminal", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "ao-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns a function", () => {
+    const fn = recordActivityViaTerminal(() => "active" as ActivityState);
+    expect(typeof fn).toBe("function");
+  });
+
+  it("does nothing when session.workspacePath is null", async () => {
+    const fn = recordActivityViaTerminal(() => "active" as ActivityState);
+    await fn({ workspacePath: null } as unknown as Session, "some output");
+    const result = await readLastActivityEntry(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("delegates to recordTerminalActivity with provided classifier", async () => {
+    const classifier = () => "waiting_input" as ActivityState;
+    const fn = recordActivityViaTerminal(classifier);
+    await fn({ workspacePath: tmpDir } as unknown as Session, "prompt?");
+    const result = await readLastActivityEntry(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.entry.state).toBe("waiting_input");
+    expect(result!.entry.source).toBe("terminal");
   });
 });

--- a/packages/core/src/activity-log.ts
+++ b/packages/core/src/activity-log.ts
@@ -12,7 +12,7 @@
  */
 import { appendFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
-import type { ActivityState, ActivityLogEntry, ActivityDetection } from "./types.js";
+import type { ActivityState, ActivityLogEntry, ActivityDetection, Session } from "./types.js";
 
 /**
  * Maximum age (ms) for `waiting_input`/`blocked` entries before they're
@@ -250,4 +250,21 @@ export async function recordTerminalActivity(
   }
 
   await appendActivityEntry(workspacePath, state, "terminal", trigger);
+}
+
+/**
+ * Build a standard `Agent.recordActivity` implementation from a classifier.
+ *
+ * Agents that classify terminal output and write to the AO activity JSONL
+ * all share the same wrapper: null-check `session.workspacePath`, then
+ * delegate to `recordTerminalActivity`. This factory produces that wrapper
+ * so plugins don't have to duplicate it.
+ */
+export function recordActivityViaTerminal(
+  classifier: (output: string) => ActivityState,
+): (session: Session, terminalOutput: string) => Promise<void> {
+  return async (session, terminalOutput) => {
+    if (!session.workspacePath) return;
+    await recordTerminalActivity(session.workspacePath, terminalOutput, classifier);
+  };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -170,6 +170,7 @@ export {
   getActivityFallbackState,
   classifyTerminalActivity,
   recordTerminalActivity,
+  recordActivityViaTerminal,
 } from "./activity-log.js";
 export {
   ACTIVITY_STRONG_WINDOW_MS,

--- a/packages/plugins/agent-aider/src/index.test.ts
+++ b/packages/plugins/agent-aider/src/index.test.ts
@@ -11,11 +11,10 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 });
 
 // Mock activity log utilities from core
-const { mockAppendActivityEntry, mockReadLastActivityEntry, mockRecordTerminalActivity } =
+const { mockAppendActivityEntry, mockReadLastActivityEntry } =
   vi.hoisted(() => ({
     mockAppendActivityEntry: vi.fn().mockResolvedValue(undefined),
     mockReadLastActivityEntry: vi.fn().mockResolvedValue(null),
-    mockRecordTerminalActivity: vi.fn().mockResolvedValue(undefined),
   }));
 
 vi.mock("@aoagents/ao-core", async (importOriginal) => {
@@ -24,7 +23,6 @@ vi.mock("@aoagents/ao-core", async (importOriginal) => {
     ...actual,
     appendActivityEntry: mockAppendActivityEntry,
     readLastActivityEntry: mockReadLastActivityEntry,
-    recordTerminalActivity: mockRecordTerminalActivity,
   };
 });
 
@@ -421,31 +419,6 @@ describe("getEnvironment PATH", () => {
   it("does not set GH_PATH (injected by session-manager)", () => {
     const env = agent.getEnvironment(makeLaunchConfig());
     expect(env["GH_PATH"]).toBeUndefined();
-  });
-});
-
-// =========================================================================
-// recordActivity
-// =========================================================================
-describe("recordActivity", () => {
-  const agent = create();
-
-  it("is defined", () => {
-    expect(agent.recordActivity).toBeDefined();
-  });
-
-  it("does nothing when workspacePath is null", async () => {
-    await agent.recordActivity!(makeSession({ workspacePath: null }), "some output");
-    expect(mockRecordTerminalActivity).not.toHaveBeenCalled();
-  });
-
-  it("delegates to recordTerminalActivity", async () => {
-    await agent.recordActivity!(makeSession(), "aider is processing files");
-    expect(mockRecordTerminalActivity).toHaveBeenCalledWith(
-      "/workspace/test",
-      "aider is processing files",
-      expect.any(Function),
-    );
   });
 });
 

--- a/packages/plugins/agent-aider/src/index.ts
+++ b/packages/plugins/agent-aider/src/index.ts
@@ -4,7 +4,7 @@ import {
   readLastActivityEntry,
   checkActivityLogState,
   getActivityFallbackState,
-  recordTerminalActivity,
+  recordActivityViaTerminal,
   DEFAULT_READY_THRESHOLD_MS,
   DEFAULT_ACTIVE_WINDOW_MS,
   type Agent,
@@ -104,6 +104,28 @@ export const manifest = {
 // Agent Implementation
 // =============================================================================
 
+function detectAiderActivity(terminalOutput: string): ActivityState {
+  if (!terminalOutput.trim()) return "idle";
+
+  const lines = terminalOutput.trim().split("\n");
+  const lastLine = lines[lines.length - 1]?.trim() ?? "";
+
+  // Aider's input prompt — agent is idle, waiting for user command
+  if (/^[>$#]\s*$/.test(lastLine)) return "idle";
+  // Aider-specific prompt patterns
+  if (/^aider>\s*$/.test(lastLine)) return "idle";
+
+  // Check the last few lines for permission/confirmation prompts
+  const tail = lines.slice(-5).join("\n");
+  if (/\(Y\)es.*\(N\)o/i.test(tail)) return "waiting_input";
+  if (/Allow creation of/i.test(tail)) return "waiting_input";
+  if (/Add .+ to the chat\?/i.test(tail)) return "waiting_input";
+  if (/\[Yes\].*\[No\]/i.test(tail)) return "waiting_input";
+  if (/proceed\?/i.test(tail)) return "waiting_input";
+
+  return "active";
+}
+
 function createAiderAgent(): Agent {
   return {
     name: "aider",
@@ -147,27 +169,9 @@ function createAiderAgent(): Agent {
       return env;
     },
 
-    detectActivity(terminalOutput: string): ActivityState {
-      if (!terminalOutput.trim()) return "idle";
+    detectActivity: detectAiderActivity,
 
-      const lines = terminalOutput.trim().split("\n");
-      const lastLine = lines[lines.length - 1]?.trim() ?? "";
-
-      // Aider's input prompt — agent is idle, waiting for user command
-      if (/^[>$#]\s*$/.test(lastLine)) return "idle";
-      // Aider-specific prompt patterns
-      if (/^aider>\s*$/.test(lastLine)) return "idle";
-
-      // Check the last few lines for permission/confirmation prompts
-      const tail = lines.slice(-5).join("\n");
-      if (/\(Y\)es.*\(N\)o/i.test(tail)) return "waiting_input";
-      if (/Allow creation of/i.test(tail)) return "waiting_input";
-      if (/Add .+ to the chat\?/i.test(tail)) return "waiting_input";
-      if (/\[Yes\].*\[No\]/i.test(tail)) return "waiting_input";
-      if (/proceed\?/i.test(tail)) return "waiting_input";
-
-      return "active";
-    },
+    recordActivity: recordActivityViaTerminal(detectAiderActivity),
 
     async getActivityState(
       session: Session,
@@ -210,13 +214,6 @@ function createAiderAgent(): Agent {
       if (fallback) return fallback;
 
       return null;
-    },
-
-    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
-      if (!session.workspacePath) return;
-      await recordTerminalActivity(session.workspacePath, terminalOutput, (output) =>
-        this.detectActivity(output),
-      );
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -7,7 +7,7 @@ import {
   readLastActivityEntry,
   checkActivityLogState,
   getActivityFallbackState,
-  recordTerminalActivity,
+  recordActivityViaTerminal,
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
@@ -441,6 +441,25 @@ async function findCodexSessionFileCached(workspacePath: string): Promise<string
   return result;
 }
 
+function detectCodexActivity(terminalOutput: string): ActivityState {
+  if (!terminalOutput.trim()) return "idle";
+
+  const lines = terminalOutput.trim().split("\n");
+  const lastLine = lines[lines.length - 1]?.trim() ?? "";
+
+  // If Codex is showing its input prompt, it's idle
+  if (/^[>$#]\s*$/.test(lastLine)) return "idle";
+
+  // Check last few lines for approval prompts
+  const tail = lines.slice(-5).join("\n");
+  if (/approval required/i.test(tail)) return "waiting_input";
+  if (/\(y\)es.*\(n\)o/i.test(tail)) return "waiting_input";
+
+  // Default to active — specific patterns (esc to interrupt, spinner
+  // symbols) all map to "active" so no need to check them individually.
+  return "active";
+}
+
 function createCodexAgent(): Agent {
   /** Cached resolved binary path (populated by init or first getLaunchCommand) */
   let resolvedBinary: string | null = null;
@@ -491,24 +510,9 @@ function createCodexAgent(): Agent {
       return env;
     },
 
-    detectActivity(terminalOutput: string): ActivityState {
-      if (!terminalOutput.trim()) return "idle";
+    detectActivity: detectCodexActivity,
 
-      const lines = terminalOutput.trim().split("\n");
-      const lastLine = lines[lines.length - 1]?.trim() ?? "";
-
-      // If Codex is showing its input prompt, it's idle
-      if (/^[>$#]\s*$/.test(lastLine)) return "idle";
-
-      // Check last few lines for approval prompts
-      const tail = lines.slice(-5).join("\n");
-      if (/approval required/i.test(tail)) return "waiting_input";
-      if (/\(y\)es.*\(n\)o/i.test(tail)) return "waiting_input";
-
-      // Default to active — specific patterns (esc to interrupt, spinner
-      // symbols) all map to "active" so no need to check them individually.
-      return "active";
-    },
+    recordActivity: recordActivityViaTerminal(detectCodexActivity),
 
     async getActivityState(
       session: Session,
@@ -612,13 +616,6 @@ function createCodexAgent(): Agent {
       }
 
       return null;
-    },
-
-    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
-      if (!session.workspacePath) return;
-      await recordTerminalActivity(session.workspacePath, terminalOutput, (output) =>
-        this.detectActivity(output),
-      );
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {

--- a/packages/plugins/agent-cursor/src/index.test.ts
+++ b/packages/plugins/agent-cursor/src/index.test.ts
@@ -27,11 +27,10 @@ vi.mock("node:fs", async (importOriginal) => {
 });
 
 // Mock activity log utilities from core
-const { mockAppendActivityEntry, mockReadLastActivityEntry, mockRecordTerminalActivity } =
+const { mockAppendActivityEntry, mockReadLastActivityEntry } =
   vi.hoisted(() => ({
     mockAppendActivityEntry: vi.fn().mockResolvedValue(undefined),
     mockReadLastActivityEntry: vi.fn().mockResolvedValue(null),
-    mockRecordTerminalActivity: vi.fn().mockResolvedValue(undefined),
   }));
 
 vi.mock("@aoagents/ao-core", async (importOriginal) => {
@@ -40,7 +39,6 @@ vi.mock("@aoagents/ao-core", async (importOriginal) => {
     ...actual,
     appendActivityEntry: mockAppendActivityEntry,
     readLastActivityEntry: mockReadLastActivityEntry,
-    recordTerminalActivity: mockRecordTerminalActivity,
   };
 });
 
@@ -516,31 +514,6 @@ describe("getEnvironment PATH", () => {
   it("does not set GH_PATH (injected by session-manager)", () => {
     const env = agent.getEnvironment(makeLaunchConfig());
     expect(env["GH_PATH"]).toBeUndefined();
-  });
-});
-
-// =========================================================================
-// recordActivity
-// =========================================================================
-describe("recordActivity", () => {
-  const agent = create();
-
-  it("is defined", () => {
-    expect(agent.recordActivity).toBeDefined();
-  });
-
-  it("does nothing when workspacePath is null", async () => {
-    await agent.recordActivity!(makeSession({ workspacePath: null }), "some output");
-    expect(mockRecordTerminalActivity).not.toHaveBeenCalled();
-  });
-
-  it("delegates to recordTerminalActivity", async () => {
-    await agent.recordActivity!(makeSession(), "agent is processing files");
-    expect(mockRecordTerminalActivity).toHaveBeenCalledWith(
-      "/workspace/test",
-      "agent is processing files",
-      expect.any(Function),
-    );
   });
 });
 

--- a/packages/plugins/agent-cursor/src/index.ts
+++ b/packages/plugins/agent-cursor/src/index.ts
@@ -4,7 +4,7 @@ import {
   readLastActivityEntry,
   checkActivityLogState,
   getActivityFallbackState,
-  recordTerminalActivity,
+  recordActivityViaTerminal,
   DEFAULT_READY_THRESHOLD_MS,
   DEFAULT_ACTIVE_WINDOW_MS,
   type Agent,
@@ -149,6 +149,39 @@ export const manifest = {
 // Agent Implementation
 // =============================================================================
 
+function detectCursorActivity(terminalOutput: string): ActivityState {
+  if (!terminalOutput.trim()) return "idle";
+
+  const lines = terminalOutput.trim().split("\n");
+  const lastLine = lines[lines.length - 1]?.trim() ?? "";
+
+  // Check for permission/confirmation prompts FIRST (actionable states take priority)
+  // This must come before idle prompt detection to avoid false negatives when
+  // a permission prompt is followed by an input cursor on the next line
+  const tail = lines.slice(-5).join("\n");
+  if (/\(Y\)es.*\(N\)o/i.test(tail)) return "waiting_input";
+  if (/Approve.*changes\?/i.test(tail)) return "waiting_input";
+  if (/Continue\?/i.test(tail)) return "waiting_input";
+  if (/\[Yes\].*\[No\]/i.test(tail)) return "waiting_input";
+  if (/proceed\?/i.test(tail)) return "waiting_input";
+  if (/Press Enter to continue/i.test(tail)) return "waiting_input";
+
+  // Cursor agent's input prompt — agent is idle, waiting for user command
+  if (/^[>$#]\s*$/.test(lastLine)) return "idle";
+  // Cursor agent-specific prompt patterns
+  if (/^agent>\s*$/.test(lastLine)) return "idle";
+  if (/^\[agent\]\s*$/.test(lastLine)) return "idle";
+
+  // Note: "blocked" detection removed — compiler errors, test failures, and linter
+  // messages are extremely common in normal tool output. Unlike Claude Code (which
+  // has native JSONL with rich "error" types), terminal-based detection can't
+  // distinguish between actionable agent errors and normal tool output.
+  // If Cursor CLI provides native JSONL in the future, blocked detection can be
+  // added to getActivityState() based on JSONL entry types.
+
+  return "active";
+}
+
 function createCursorAgent(): Agent {
   return {
     name: "cursor",
@@ -231,38 +264,9 @@ function createCursorAgent(): Agent {
       return env;
     },
 
-    detectActivity(terminalOutput: string): ActivityState {
-      if (!terminalOutput.trim()) return "idle";
+    detectActivity: detectCursorActivity,
 
-      const lines = terminalOutput.trim().split("\n");
-      const lastLine = lines[lines.length - 1]?.trim() ?? "";
-
-      // Check for permission/confirmation prompts FIRST (actionable states take priority)
-      // This must come before idle prompt detection to avoid false negatives when
-      // a permission prompt is followed by an input cursor on the next line
-      const tail = lines.slice(-5).join("\n");
-      if (/\(Y\)es.*\(N\)o/i.test(tail)) return "waiting_input";
-      if (/Approve.*changes\?/i.test(tail)) return "waiting_input";
-      if (/Continue\?/i.test(tail)) return "waiting_input";
-      if (/\[Yes\].*\[No\]/i.test(tail)) return "waiting_input";
-      if (/proceed\?/i.test(tail)) return "waiting_input";
-      if (/Press Enter to continue/i.test(tail)) return "waiting_input";
-
-      // Cursor agent's input prompt — agent is idle, waiting for user command
-      if (/^[>$#]\s*$/.test(lastLine)) return "idle";
-      // Cursor agent-specific prompt patterns
-      if (/^agent>\s*$/.test(lastLine)) return "idle";
-      if (/^\[agent\]\s*$/.test(lastLine)) return "idle";
-
-      // Note: "blocked" detection removed — compiler errors, test failures, and linter
-      // messages are extremely common in normal tool output. Unlike Claude Code (which
-      // has native JSONL with rich "error" types), terminal-based detection can't
-      // distinguish between actionable agent errors and normal tool output.
-      // If Cursor CLI provides native JSONL in the future, blocked detection can be
-      // added to getActivityState() based on JSONL entry types.
-
-      return "active";
-    },
+    recordActivity: recordActivityViaTerminal(detectCursorActivity),
 
     async getActivityState(
       session: Session,
@@ -307,13 +311,6 @@ function createCursorAgent(): Agent {
       if (fallback) return fallback;
 
       return null;
-    },
-
-    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
-      if (!session.workspacePath) return;
-      await recordTerminalActivity(session.workspacePath, terminalOutput, (output: string) =>
-        this.detectActivity(output),
-      );
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createActivitySignal, type Session, type RuntimeHandle, type AgentLaunchConfig } from "@aoagents/ao-core";
 
-const { mockAppendActivityEntry, mockReadLastActivityEntry, mockRecordTerminalActivity } =
+const { mockAppendActivityEntry, mockReadLastActivityEntry } =
   vi.hoisted(() => ({
     mockAppendActivityEntry: vi.fn().mockResolvedValue(undefined),
     mockReadLastActivityEntry: vi.fn().mockResolvedValue(null),
-    mockRecordTerminalActivity: vi.fn().mockResolvedValue(undefined),
   }));
 
 const mockExecFileAsync = vi.fn();
@@ -16,7 +15,6 @@ vi.mock("@aoagents/ao-core", async (importOriginal) => {
     ...actual,
     appendActivityEntry: mockAppendActivityEntry,
     readLastActivityEntry: mockReadLastActivityEntry,
-    recordTerminalActivity: mockRecordTerminalActivity,
   };
 });
 
@@ -934,31 +932,6 @@ describe("invalid session ID rejection", () => {
 
       expect(cmd).toContain(`--session '${validId}'`);
     }
-  });
-});
-
-// =========================================================================
-// recordActivity
-// =========================================================================
-describe("recordActivity", () => {
-  const agent = create();
-
-  it("is defined", () => {
-    expect(agent.recordActivity).toBeDefined();
-  });
-
-  it("does nothing when workspacePath is null", async () => {
-    await agent.recordActivity!(makeSession({ workspacePath: null }), "some output");
-    expect(mockRecordTerminalActivity).not.toHaveBeenCalled();
-  });
-
-  it("delegates to recordTerminalActivity", async () => {
-    await agent.recordActivity!(makeSession(), "opencode is working");
-    expect(mockRecordTerminalActivity).toHaveBeenCalledWith(
-      "/workspace/test",
-      "opencode is working",
-      expect.any(Function),
-    );
   });
 });
 

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -5,7 +5,7 @@ import {
   readLastActivityEntry,
   checkActivityLogState,
   getActivityFallbackState,
-  recordTerminalActivity,
+  recordActivityViaTerminal,
   asValidOpenCodeSessionId,
   type Agent,
   type AgentSessionInfo,
@@ -203,6 +203,25 @@ export const manifest = {
 // Agent Implementation
 // =============================================================================
 
+function detectOpenCodeActivity(terminalOutput: string): ActivityState {
+  if (!terminalOutput.trim()) return "idle";
+
+  const lines = terminalOutput.trim().split("\n");
+  const lastLine = lines[lines.length - 1]?.trim() ?? "";
+
+  // OpenCode's input prompt — agent is idle
+  if (/^[>$#]\s*$/.test(lastLine)) return "idle";
+
+  // Check the last few lines for permission/confirmation prompts
+  const tail = lines.slice(-5).join("\n");
+  if (/\(Y\)es.*\(N\)o/i.test(tail)) return "waiting_input";
+  if (/approval required/i.test(tail)) return "waiting_input";
+  if (/Do you want to proceed\?/i.test(tail)) return "waiting_input";
+  if (/Allow .+\?/i.test(tail)) return "waiting_input";
+
+  return "active";
+}
+
 function createOpenCodeAgent(): Agent {
   return {
     name: "opencode",
@@ -278,24 +297,9 @@ function createOpenCodeAgent(): Agent {
       return env;
     },
 
-    detectActivity(terminalOutput: string): ActivityState {
-      if (!terminalOutput.trim()) return "idle";
+    detectActivity: detectOpenCodeActivity,
 
-      const lines = terminalOutput.trim().split("\n");
-      const lastLine = lines[lines.length - 1]?.trim() ?? "";
-
-      // OpenCode's input prompt — agent is idle
-      if (/^[>$#]\s*$/.test(lastLine)) return "idle";
-
-      // Check the last few lines for permission/confirmation prompts
-      const tail = lines.slice(-5).join("\n");
-      if (/\(Y\)es.*\(N\)o/i.test(tail)) return "waiting_input";
-      if (/approval required/i.test(tail)) return "waiting_input";
-      if (/Do you want to proceed\?/i.test(tail)) return "waiting_input";
-      if (/Allow .+\?/i.test(tail)) return "waiting_input";
-
-      return "active";
-    },
+    recordActivity: recordActivityViaTerminal(detectOpenCodeActivity),
 
     async getActivityState(
       session: Session,
@@ -341,13 +345,6 @@ function createOpenCodeAgent(): Agent {
       if (fallback) return fallback;
 
       return null;
-    },
-
-    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
-      if (!session.workspacePath) return;
-      await recordTerminalActivity(session.workspacePath, terminalOutput, (output) =>
-        this.detectActivity(output),
-      );
     },
 
     async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {


### PR DESCRIPTION
Closes #1424.

## Summary
- Add `recordActivityViaTerminal(classifier)` to `@aoagents/ao-core` — factory that returns the standard `recordActivity` implementation (null-check `workspacePath`, delegate to `recordTerminalActivity`).
- Replace the identical 5-line `recordActivity` wrapper in `agent-aider`, `agent-codex`, `agent-cursor`, and `agent-opencode` with a 1-line factory call.
- Same runtime behavior — the wrappers were pure forwards.
- Update `CLAUDE.md` plugin-authoring guide to point at the new factory.

## Why option (a), not option (b)
Issue #1424 proposed two options, with (b) (lifecycle-manager default) preferred. I went with (a) (factory) after discovering (b) changes behavior for agents that don't use AO activity JSONL:

- Claude Code uses its own native JSONL (`~/.claude/projects/`) and doesn't override `recordActivity`. Under (b), the lifecycle manager would start calling `recordTerminalActivity` for Claude Code every poll cycle, producing orphan `.ao/activity.jsonl` writes nothing reads.
- It also broke lifecycle-manager tests whose mock agent defines `detectActivity` but intentionally omits `recordActivity`.

Option (a) keeps opt-in semantics, leaves the lifecycle manager untouched, and is truly no behavior change for any existing agent. See https://github.com/ComposioHQ/agent-orchestrator/issues/1424#issuecomment-4291773453.

## Test plan
- [x] `pnpm --filter @aoagents/ao-core test` — 808 tests pass
- [x] `pnpm --filter @aoagents/ao-plugin-agent-{aider,codex,cursor,opencode} test` — all pass (404 tests)
- [x] `pnpm typecheck` — only pre-existing `tracker-gitlab` failure unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)