### PR TITLE
fix(core): preserve runtimeHandle and tmuxName across lifecycle writes

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -393,13 +393,16 @@ describe("check (single session)", () => {
 
     const metadata = readMetadataRaw(env.sessionsDir, "app-1");
     expect(metadata?.["pr"]).toBeUndefined();
-    expect(metadata?.["runtimeHandle"]).toBeUndefined();
-    expect(metadata?.["tmuxName"]).toBeUndefined();
     expect(metadata?.["role"]).toBeUndefined();
     expect(currentSession.metadata["pr"]).toBeUndefined();
-    expect(currentSession.metadata["runtimeHandle"]).toBeUndefined();
-    expect(currentSession.metadata["tmuxName"]).toBeUndefined();
     expect(currentSession.metadata["role"]).toBeUndefined();
+    // runtimeHandle / tmuxName intentionally preserved on disk across lifecycle
+    // writes — they are the routing address for `ao send` and dashboard
+    // attach, and must only be removed by explicit cleanup. See issue #1458.
+    expect(metadata?.["runtimeHandle"]).toBe(
+      JSON.stringify({ id: "stale", runtimeName: "mock", data: {} }),
+    );
+    expect(metadata?.["tmuxName"]).toBe("stale-tmux");
   });
 
   it("does not kill a spawning session when its runtime handle has not been persisted yet", async () => {

--- a/packages/core/src/__tests__/lifecycle-transition.test.ts
+++ b/packages/core/src/__tests__/lifecycle-transition.test.ts
@@ -9,7 +9,7 @@ import {
   createStateTransitionDecision,
 } from "../lifecycle-transition.js";
 import { createInitialCanonicalLifecycle } from "../lifecycle-state.js";
-import { readMetadataRaw } from "../metadata.js";
+import { readCanonicalLifecycle, readMetadataRaw } from "../metadata.js";
 import type { LifecycleDecision } from "../lifecycle-status-decisions.js";
 import type { CanonicalSessionLifecycle } from "../types.js";
 
@@ -196,7 +196,7 @@ describe("buildTransitionMetadataPatch", () => {
     expect(JSON.parse(patch["lifecycle"])).toHaveProperty("version", 2);
   });
 
-  it("clears stale PR, runtime, and role metadata when lifecycle no longer carries them", () => {
+  it("clears stale PR and role metadata when lifecycle no longer carries them", () => {
     const lifecycle = createInitialCanonicalLifecycle("worker");
     const decision: LifecycleDecision = {
       status: "working",
@@ -209,9 +209,45 @@ describe("buildTransitionMetadataPatch", () => {
     const patch = buildTransitionMetadataPatch(lifecycle, decision);
 
     expect(patch["pr"]).toBe("");
-    expect(patch["runtimeHandle"]).toBe("");
-    expect(patch["tmuxName"]).toBe("");
     expect(patch["role"]).toBe("");
+  });
+
+  it("omits runtimeHandle and tmuxName when lifecycle has no handle (preserves flat keys on disk)", () => {
+    const lifecycle = createInitialCanonicalLifecycle("worker");
+    lifecycle.session.state = "terminated";
+    lifecycle.session.reason = "runtime_lost";
+    const decision: LifecycleDecision = {
+      status: "terminated",
+      evidence: "runtime_dead process_dead",
+      detecting: { attempts: 0 },
+      sessionState: "terminated",
+      sessionReason: "runtime_lost",
+    };
+
+    const patch = buildTransitionMetadataPatch(lifecycle, decision);
+
+    // Not "" — an empty string would delete the key. Omitting the key leaves
+    // the existing disk value untouched. See issue #1458.
+    expect("runtimeHandle" in patch).toBe(false);
+    expect("tmuxName" in patch).toBe(false);
+  });
+
+  it("writes runtimeHandle and tmuxName when the lifecycle carries a handle", () => {
+    const lifecycle = createInitialCanonicalLifecycle("worker");
+    lifecycle.runtime.handle = { id: "tmux-1", runtimeName: "tmux", data: {} };
+    lifecycle.runtime.tmuxName = "tmux-1";
+    const decision: LifecycleDecision = {
+      status: "working",
+      evidence: "active",
+      detecting: { attempts: 0 },
+    };
+
+    const patch = buildTransitionMetadataPatch(lifecycle, decision);
+
+    expect(patch["runtimeHandle"]).toBe(
+      JSON.stringify({ id: "tmux-1", runtimeName: "tmux", data: {} }),
+    );
+    expect(patch["tmuxName"]).toBe("tmux-1");
   });
 });
 
@@ -308,7 +344,7 @@ describe("applyLifecycleDecision (integration)", () => {
     expect(meta?.["summary"]).toBe("worker reported PR creation");
   });
 
-  it("clears stale metadata fields that are absent from the next lifecycle", () => {
+  it("clears stale pr and role metadata but preserves runtimeHandle/tmuxName across transitions", () => {
     const lifecycle = createInitialCanonicalLifecycle("worker");
     lifecycle.session.state = "working";
     lifecycle.session.reason = "task_in_progress";
@@ -344,9 +380,68 @@ describe("applyLifecycleDecision (integration)", () => {
 
     const meta = readMetadataRaw(dataDir, "test-3");
     expect(meta?.["pr"]).toBeUndefined();
-    expect(meta?.["runtimeHandle"]).toBeUndefined();
-    expect(meta?.["tmuxName"]).toBeUndefined();
     expect(meta?.["role"]).toBeUndefined();
+    // Runtime address must survive — it's the only routing key for send/attach. See #1458.
+    expect(meta?.["runtimeHandle"]).toBe(
+      JSON.stringify({ id: "rt-1", runtimeName: "tmux", data: {} }),
+    );
+    expect(meta?.["tmuxName"]).toBe("tmux-1");
+  });
+
+  it("preserves runtimeHandle and tmuxName on disk when a terminated transition nulls the in-memory handle", () => {
+    // Regression for #1458: a probe disagreement trips `terminated + runtime_lost`.
+    // The in-memory lifecycle may end up with runtime.handle=null. Before the fix,
+    // the patch wrote `runtimeHandle=""` which deleted the flat key, permanently
+    // losing the tmux name even though the tmux session was still alive.
+    const priorLifecycle = createInitialCanonicalLifecycle("worker");
+    priorLifecycle.session.state = "working";
+    priorLifecycle.session.reason = "task_in_progress";
+    priorLifecycle.runtime.state = "alive";
+    priorLifecycle.runtime.reason = "process_running";
+    priorLifecycle.runtime.handle = { id: "host-ao-17", runtimeName: "tmux", data: {} };
+    priorLifecycle.runtime.tmuxName = "host-ao-17";
+
+    writeTestSession("test-1458", {
+      status: "working",
+      stateVersion: "2",
+      statePayload: JSON.stringify(priorLifecycle),
+      runtimeHandle: JSON.stringify({ id: "host-ao-17", runtimeName: "tmux", data: {} }),
+      tmuxName: "host-ao-17",
+      worktree: "/tmp/test",
+      branch: "main",
+    });
+
+    const result = applyLifecycleDecision({
+      dataDir,
+      sessionId: "test-1458",
+      decision: {
+        status: "terminated",
+        evidence: "runtime_dead process_dead",
+        detecting: { attempts: 0 },
+        sessionState: "terminated",
+        sessionReason: "runtime_lost",
+      },
+      source: "poll",
+    });
+
+    expect(result.success).toBe(true);
+
+    const meta = readMetadataRaw(dataDir, "test-1458");
+    // Flat keys preserved on disk.
+    expect(meta?.["runtimeHandle"]).toBe(
+      JSON.stringify({ id: "host-ao-17", runtimeName: "tmux", data: {} }),
+    );
+    expect(meta?.["tmuxName"]).toBe("host-ao-17");
+
+    // Re-parsing rehydrates the handle even if the payload ended up with
+    // runtime.handle/tmuxName = null.
+    const reparsed = readCanonicalLifecycle(dataDir, "test-1458");
+    expect(reparsed?.runtime.handle).toEqual({
+      id: "host-ao-17",
+      runtimeName: "tmux",
+      data: {},
+    });
+    expect(reparsed?.runtime.tmuxName).toBe("host-ao-17");
   });
 
   it("validates stored legacy status before deriving the previous status", () => {

--- a/packages/core/src/lifecycle-state.ts
+++ b/packages/core/src/lifecycle-state.ts
@@ -482,14 +482,23 @@ export function deriveLegacyStatus(
 export function buildLifecycleMetadataPatch(
   lifecycle: CanonicalSessionLifecycle,
 ): Partial<Record<string, string>> {
-  return {
+  const patch: Partial<Record<string, string>> = {
     lifecycle: JSON.stringify(lifecycle),
     // status is NOT persisted — computed on read via deriveLegacyStatus()
     pr: lifecycle.pr.url ?? "",
-    runtimeHandle: lifecycle.runtime.handle ? JSON.stringify(lifecycle.runtime.handle) : "",
-    tmuxName: lifecycle.runtime.tmuxName ?? "",
     role: lifecycle.session.kind === "orchestrator" ? "orchestrator" : "",
   };
+  // The runtime handle is the session's address (tmux target, PID, etc.).
+  // A transient terminated transition must not erase it; only explicit cleanup
+  // (archive) removes the flat keys. Omit the key when null so the disk value
+  // is left alone.
+  if (lifecycle.runtime.handle) {
+    patch.runtimeHandle = JSON.stringify(lifecycle.runtime.handle);
+  }
+  if (lifecycle.runtime.tmuxName) {
+    patch.tmuxName = lifecycle.runtime.tmuxName;
+  }
+  return patch;
 }
 
 export function cloneLifecycle(lifecycle: CanonicalSessionLifecycle): CanonicalSessionLifecycle {

--- a/packages/core/src/lifecycle-transition.ts
+++ b/packages/core/src/lifecycle-transition.ts
@@ -149,8 +149,16 @@ export function buildTransitionMetadataPatch(
 
   patch["pr"] = lifecycle.pr.url ?? "";
 
-  patch["runtimeHandle"] = lifecycle.runtime.handle ? JSON.stringify(lifecycle.runtime.handle) : "";
-  patch["tmuxName"] = lifecycle.runtime.tmuxName ?? "";
+  // Preserve the runtime address across terminated transitions — the handle is
+  // the only routing key for `ao send`, dashboard attach, and liveness probes.
+  // Omit the key when null so an earlier flat `runtimeHandle=` on disk survives.
+  // Explicit cleanup (archive) removes the keys through a different path. See #1458.
+  if (lifecycle.runtime.handle) {
+    patch["runtimeHandle"] = JSON.stringify(lifecycle.runtime.handle);
+  }
+  if (lifecycle.runtime.tmuxName) {
+    patch["tmuxName"] = lifecycle.runtime.tmuxName;
+  }
 
   patch["role"] = lifecycle.session.kind === "orchestrator" ? "orchestrator" : "";
 


### PR DESCRIPTION
## Summary

Fixes #1458 — a data-loss bug where `buildLifecycleMetadataPatch` (`lifecycle-state.ts`) and `buildTransitionMetadataPatch` (`lifecycle-transition.ts`) emitted empty-string values for `runtimeHandle` / `tmuxName` when the in-memory lifecycle had them null. `applyMetadataUpdates` treats empty strings as **deletions**, so a transient `terminated + runtime_lost` transition (from a probe disagreement — see #1063, #989) permanently wiped the session's routing address from disk while the tmux session was still alive.

- `ao send <id>` could no longer route (no handle)
- Dashboard terminal attach could not open (no tmux name)
- Even if the runtime came back alive on the next probe, AO had nothing to re-attach to

## The fix

Stop emitting the keys when the in-memory handle is null. Omitting the key in the patch leaves the existing disk value alone (`applyMetadataUpdates` skips `undefined`). Only explicit cleanup (archive) should ever delete the flat keys — and it already uses a different path.

No new handle-preservation subsystem, recovery layer, or rehydration logic. Just: if the handle is valuable metadata, stop destroying it.

## Changes

- `packages/core/src/lifecycle-state.ts` — `buildLifecycleMetadataPatch` emits `runtimeHandle`/`tmuxName` only when non-null
- `packages/core/src/lifecycle-transition.ts` — `buildTransitionMetadataPatch` same
- Tests updated to reflect the new contract
- New regression test: seeds a session with a valid handle, forces a `terminated + runtime_lost` decision, asserts the flat keys still exist on disk afterward and `readCanonicalLifecycle` rehydrates the original handle

## Test plan

- [x] `pnpm --filter @aoagents/ao-core test` — all 811 tests pass
- [x] `pnpm --filter @aoagents/ao-core typecheck` — clean
- [x] `pnpm lint` — no new warnings

## Related

- #1063, #989 — upstream triggers (transient mis-labeling) this bug makes permanent
- #1187 — zombie sessions from the opposite direction
- #1245 — sessions stuck in `working` with no recovery path
- #1454 — flicker issue; fixing this bug removes much of the visible damage
- #1456 — sibling to this one

Closes #1458

🤖 Generated with [Claude Code](https://claude.com/claude-code)