### PR TITLE
fix(core): stop single-shot dead probe from latching session to terminated

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -530,7 +530,7 @@ describe("check (single session)", () => {
     expect(plugins.agent.getActivityState).not.toHaveBeenCalled();
   });
 
-  it("detects killed state when runtime is dead", async () => {
+  it("routes a single dead probe through detecting (no terminal latch)", async () => {
     vi.mocked(plugins.runtime.isAlive).mockResolvedValue(false);
     vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "idle" });
     vi.mocked(plugins.agent.isProcessRunning).mockResolvedValue(false);
@@ -540,7 +540,13 @@ describe("check (single session)", () => {
     });
 
     await lm.check("app-1");
-    expect(lm.getStates().get("app-1")).toBe("killed");
+    // A single observation of dead+dead+no-fresh-activity must not latch the
+    // session to a terminal state — the next probe may disagree, and there's
+    // no inverse transition out of `terminated` (#1454). Route through
+    // detecting; the standard escalation surfaces persistent failures as stuck.
+    expect(lm.getStates().get("app-1")).toBe("detecting");
+    const meta = readMetadataRaw(env.sessionsDir, "app-1");
+    expect(meta?.["lifecycleEvidence"]).toContain("runtime_dead process_dead");
   });
 
   it("detects killed state when getActivityState returns exited", async () => {
@@ -555,7 +561,35 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("detecting");
   });
 
-  it("detects killed via terminal fallback when getActivityState returns null", async () => {
+  it("revives a previously-detecting session when probes recover (#1454 regression)", async () => {
+    // Reproduces the issue scenario: poll N sees dead+dead, poll N+1 sees the
+    // runtime alive again. Before the fix, poll N latched the session to
+    // `terminated`/`runtime_lost` and there was no inverse transition. Now
+    // poll N marks it `detecting` and poll N+1 walks back to a live state.
+    vi.mocked(plugins.runtime.isAlive).mockResolvedValueOnce(false);
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValueOnce({ state: "idle" });
+    vi.mocked(plugins.agent.isProcessRunning).mockResolvedValueOnce(false);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("detecting");
+
+    // Next poll: probes agree the session is alive again.
+    vi.mocked(plugins.runtime.isAlive).mockResolvedValue(true);
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({
+      state: "active",
+      timestamp: new Date(),
+    });
+    vi.mocked(plugins.agent.isProcessRunning).mockResolvedValue(true);
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("working");
+  });
+
+  it("routes terminal-fallback dead+dead through detecting (no terminal latch)", async () => {
     vi.mocked(plugins.agent.getActivityState).mockResolvedValue(null);
     vi.mocked(plugins.agent.detectActivity).mockReturnValue("idle");
     vi.mocked(plugins.runtime.isAlive).mockResolvedValue(false);
@@ -566,7 +600,9 @@ describe("check (single session)", () => {
     });
 
     await lm.check("app-1");
-    expect(lm.getStates().get("app-1")).toBe("killed");
+    // Same as above but via the terminal fallback path — single dead+dead
+    // observation must not be terminal (#1454).
+    expect(lm.getStates().get("app-1")).toBe("detecting");
   });
 
   it("enters detecting when runtime is dead but recent activity is still fresh", async () => {
@@ -688,9 +724,13 @@ describe("check (single session)", () => {
 
     await lm.check("app-1");
 
-    expect(lm.getStates().get("app-1")).toBe("killed");
+    // Stale activity correctly fails the recent-liveness check, so we land on
+    // the dead+dead branch — but that branch must not be terminal on a single
+    // observation (#1454). The evidence still carries the stale activity tag.
+    expect(lm.getStates().get("app-1")).toBe("detecting");
     const meta = readMetadataRaw(env.sessionsDir, "app-1");
     expect(meta?.["lifecycleEvidence"]).toContain("activity_signal=stale");
+    expect(meta?.["lifecycleEvidence"]).toContain("runtime_dead process_dead");
   });
 
   it("records explicit probe-failure activity evidence", async () => {

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -233,6 +233,42 @@ describe("list", () => {
     expect(sessions[0].activitySignal.state).toBe("unavailable");
   });
 
+  it("persists detecting (not terminated) to disk after single dead probe (#1454)", async () => {
+    // Regression: the persistence block that follows enrichSessionWithRuntimeState
+    // was writing `session.state = "terminated"` to disk, immediately overwriting
+    // the in-memory "detecting" fix. Verify the on-disk lifecycle is "detecting".
+    const deadRuntime: Runtime = {
+      ...mockRuntime,
+      isAlive: vi.fn().mockResolvedValue(false),
+    };
+    const registryWithDead: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return deadRuntime;
+        if (slot === "agent") return mockAgent;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "a",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: makeHandle("rt-1"),
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithDead });
+    await sm.list();
+
+    const raw = readMetadataRaw(sessionsDir, "app-1");
+    const lifecycle = JSON.parse(raw!["lifecycle"]);
+    expect(lifecycle.session.state).toBe("detecting");
+    expect(lifecycle.session.reason).toBe("runtime_lost");
+    expect(lifecycle.session.terminatedAt).toBeNull();
+    expect(lifecycle.runtime.state).toBe("missing");
+  });
+
   it("detects activity using agent-native mechanism", async () => {
     const agentWithState: Agent = {
       ...mockAgent,

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -194,7 +194,7 @@ describe("list", () => {
     vi.useRealTimers();
   });
 
-  it("marks dead runtimes as killed", async () => {
+  it("routes dead runtimes through detecting (no single-shot terminal latch)", async () => {
     const deadRuntime: Runtime = {
       ...mockRuntime,
       isAlive: vi.fn().mockResolvedValue(false),
@@ -219,8 +219,14 @@ describe("list", () => {
     const sm = createSessionManager({ config, registry: registryWithDead });
     const sessions = await sm.list();
 
-    expect(sessions[0].status).toBe("killed");
-    expect(sessions[0].activity).toBe("exited");
+    // A single dead probe must NOT latch to "killed" or "exited" — that
+    // destroys recoverable state when the next probe disagrees (#1454).
+    // Lifecycle is updated to detecting/runtime_lost and the lifecycle manager
+    // confirms with multiple observations before any escalation.
+    expect(sessions[0].status).toBe("detecting");
+    expect(sessions[0].lifecycle.session.state).toBe("detecting");
+    expect(sessions[0].lifecycle.session.reason).toBe("runtime_lost");
+    expect(sessions[0].lifecycle.runtime.state).toBe("missing");
   });
 
   it("detects activity using agent-native mechanism", async () => {
@@ -335,8 +341,9 @@ describe("list", () => {
 
     expect(sessions).toHaveLength(1);
     expect(sessions[0].runtimeHandle?.id).toBe(expectedTmuxName);
-    expect(sessions[0].status).toBe("killed");
-    expect(sessions[0].activity).toBe("exited");
+    // Single dead probe goes to detecting, not killed (#1454).
+    expect(sessions[0].status).toBe("detecting");
+    expect(sessions[0].lifecycle.session.reason).toBe("runtime_lost");
     expect(agentWithSpy.getActivityState).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -227,6 +227,10 @@ describe("list", () => {
     expect(sessions[0].lifecycle.session.state).toBe("detecting");
     expect(sessions[0].lifecycle.session.reason).toBe("runtime_lost");
     expect(sessions[0].lifecycle.runtime.state).toBe("missing");
+    // Stale activity signal must be cleared — once the runtime is missing,
+    // the cached "active"/"ready" is no longer trustworthy and would render
+    // misleadingly alongside `detecting` in the dashboard.
+    expect(sessions[0].activitySignal.state).toBe("unavailable");
   });
 
   it("detects activity using agent-native mechanism", async () => {

--- a/packages/core/src/lifecycle-status-decisions.ts
+++ b/packages/core/src/lifecycle-status-decisions.ts
@@ -335,12 +335,21 @@ export function resolveProbeDecision(input: ProbeDecisionInput): LifecycleDecisi
     input.processProbe.state === "dead" &&
     !recentActivitySupportsLiveness
   ) {
-    return createLifecycleDecision({
-      status: SESSION_STATUS.KILLED,
+    // Don't latch to a terminal state on a single poll. A transient probe miss
+    // (one missed `ps` window, one tmux race, one slow native API call) used to
+    // walk the session straight to `terminated`/`runtime_lost` with no inverse
+    // transition — leaving live sessions permanently dead in metadata. Route
+    // through `detecting` instead; the standard escalation will surface
+    // persistent failures as `stuck`, which is still recoverable. Manual kills
+    // (`ao session kill`) and the explicit `done` path remain the only ways to
+    // reach a terminal state.
+    return createDetectingDecision({
+      currentAttempts: input.currentAttempts,
+      idleWasBlocked: input.idleWasBlocked,
       evidence: `runtime_dead process_dead ${input.activityEvidence}`,
-      detecting: { attempts: 0 },
-      sessionState: "terminated",
-      sessionReason: "runtime_lost",
+      reason: "runtime_lost",
+      detectingStartedAt: input.detectingStartedAt,
+      previousEvidenceHash: input.previousEvidenceHash,
     });
   }
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1009,17 +1009,15 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
             session.lifecycle.session.state = "detecting";
             session.lifecycle.session.reason = "runtime_lost";
             session.lifecycle.session.lastTransitionAt = new Date().toISOString();
+            // Mirror the lifecycle into the legacy status so dashboard surfaces
+            // that still read `session.status` don't show a stale `working` /
+            // `pr_open`. Don't latch to "killed" — a single dead probe is not
+            // terminal evidence (#1454). The lifecycle manager confirms with
+            // multiple observations before any escalation.
+            if (!TERMINAL_SESSION_STATUSES.has(session.status)) {
+              session.status = "detecting";
+            }
           }
-          // Process is confirmed dead — set activity to exited.
-          // Only update status to "killed" if not already in a terminal state.
-          if (!TERMINAL_SESSION_STATUSES.has(session.status)) {
-            session.status = "killed";
-          }
-          session.activity = "exited";
-          session.activitySignal = createActivitySignal("valid", {
-            activity: "exited",
-            source: "runtime",
-          });
           return;
         }
       } catch {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1018,6 +1018,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
               session.status = "detecting";
             }
           }
+          // Clear any stale activity signal — once the runtime is missing,
+          // the previously-cached activity (e.g. "active") is no longer
+          // trustworthy and would render misleadingly alongside `detecting`.
+          session.activitySignal = createActivitySignal("unavailable");
           return;
         }
       } catch {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1913,7 +1913,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       // Persist lifecycle to disk when enrichment detected a dead runtime.
       // enrichSessionWithRuntimeState updates the in-memory lifecycle but
       // doesn't write to disk — without this, the stale "alive" state persists
-      // and the dashboard shows terminated sessions on the active sidebar.
+      // and the dashboard shows a stale working/pr_open status.
+      // Write "detecting" (not "terminated") — a single dead probe is not
+      // terminal evidence (#1454). The lifecycle manager confirms with multiple
+      // observations before any escalation.
       if (
         session.lifecycle &&
         (session.lifecycle.runtime.state === "missing" ||
@@ -1923,10 +1926,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       ) {
         try {
           const persisted = buildUpdatedLifecycle(sessionName, raw, (next) => {
-            next.session.state = "terminated";
+            next.session.state = "detecting";
             next.session.reason = "runtime_lost";
-            next.session.terminatedAt = new Date().toISOString();
-            next.session.lastTransitionAt = next.session.terminatedAt;
+            next.session.lastTransitionAt = new Date().toISOString();
             next.runtime.state = session.lifecycle!.runtime.state;
             next.runtime.reason = session.lifecycle!.runtime.reason;
             next.runtime.lastObservedAt = new Date().toISOString();


### PR DESCRIPTION
## Summary

Fixes #1454. A single transient probe miss used to walk a session straight to `session.state=terminated` with `reason=runtime_lost`. There was no inverse transition — once terminated, subsequent probes showing the runtime alive and active activity could not flip the session back. The dashboard then flickered `idle → killed → ready` as different surfaces read different fields.

Two single-shot terminal latches removed:

- **`lifecycle-status-decisions.ts:resolveProbeDecision`**: `runtime=dead && process=dead && !recentActivity` now routes through `detecting`/`runtime_lost` instead of `killed`/`terminated`. The standard `detecting → stuck` escalation already handles persistence; `stuck` is recoverable, `terminated` was not.
- **`session-manager.ts:enrichSessionWithRuntimeState`**: a single `isAlive=false` observation no longer overrides `session.status` to `"killed"` or `session.activity` to `"exited"`. Lifecycle is set to `detecting`/`runtime_lost` and the legacy status is mirrored to `"detecting"` so the dashboard stays aligned.

Manual kills (`ao session kill`) and the explicit `done` path remain the only ways to reach a terminal state.

## Why this approach (vs. adding a revive subsystem)

The issue suggested two options: harden the probe OR add a revive transition (preferably both). I went with hardening alone — the simpler fix that addresses the root cause. Adding a revive subsystem would have been new infrastructure to compensate for a bad terminal decision; this PR removes the bad terminal decision instead. Net diff is mostly deletions.

## Test plan

- [x] `pnpm --filter @aoagents/ao-core test` — 809/809 pass
- [x] `pnpm --filter @aoagents/ao-core typecheck` — clean
- [x] New regression test asserts: probe N sees dead+dead → `detecting`, probe N+1 sees runtime alive → session walks back to `working` (the exact scenario from the issue's metadata artifact)
- [x] Existing tests that asserted single-shot kill behavior updated to assert single-shot detecting behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
