### PR TITLE
Use stronger OSS-style issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -10,6 +10,14 @@ body:
         Use this template for user-visible breakage, regressions, incorrect state, or workflow failures.
         Please keep the scope concrete and include evidence that the bug is real.
         If this is a usage question or a feature request, open a different issue instead of forcing it into the bug flow.
+        
+        Repo-wide constraints to keep in mind:
+        - should not make the orchestrator feel laggier
+        - should not increase polling or hot-path overhead unless explicitly intended
+        - should not make session state more misleading
+        - should not change CLI behavior unless explicitly approved
+
+        Maintainers may refine scope, outcome, and done criteria during triage.
   - type: checkboxes
     id: verification
     attributes:
@@ -82,46 +90,32 @@ body:
     id: in_scope
     attributes:
       label: In scope
-      description: What work is allowed in this issue?
+      description: What work is allowed in this issue? Maintainers may refine this during triage.
       placeholder: Keep this to the smallest acceptable fix.
-    validations:
-      required: true
   - type: textarea
     id: out_of_scope
     attributes:
       label: Out of scope
-      description: What should not change as part of this issue?
+      description: What should not change as part of this issue? Maintainers may refine this during triage.
       placeholder: No CLI behavior changes, no design refresh, no new persistence model, etc.
-    validations:
-      required: true
   - type: textarea
     id: expected_outcome
     attributes:
       label: Expected outcome
-      description: What should be true when this is done?
+      description: What should be true when this is done? Maintainers may refine this during triage.
       placeholder: Describe the observable result after the fix.
-    validations:
-      required: true
   - type: textarea
-    id: constraints
+    id: issue_specific_risks
     attributes:
-      label: Constraints and risks
-      description: What must be protected?
-      value: |
-        - should not make the orchestrator feel laggier
-        - should not increase polling or hot-path overhead unless explicitly intended
-        - should not make session state more misleading
-        - should not change CLI behavior unless explicitly approved
-    validations:
-      required: true
+      label: Issue-specific risks or constraints
+      description: Optional. Call out anything unusual that maintainers should protect for this specific bug.
+      placeholder: Affects only tmux-backed sessions, only reproduces in the dashboard, must not alter retry timing, etc.
   - type: textarea
     id: definition_of_done
     attributes:
       label: Definition of done
-      description: How do we know this is complete?
+      description: How do we know this is complete? Maintainers may refine this during triage.
       placeholder: Regression test added, manual repro no longer fails, logs/state are correct, docs updated if needed, etc.
-    validations:
-      required: true
   - type: dropdown
     id: owner_area
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,143 @@
+name: Bug report
+description: Report a user-visible bug, regression, or incorrect behavior.
+title: "[bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for user-visible breakage, regressions, incorrect state, or workflow failures.
+        Please keep the scope concrete and include evidence that the bug is real.
+        If this is a usage question or a feature request, open a different issue instead of forcing it into the bug flow.
+  - type: checkboxes
+    id: verification
+    attributes:
+      label: Verification
+      description: Please confirm all of the following before filing.
+      options:
+        - label: I searched existing issues and PRs and did not find a duplicate.
+          required: true
+        - label: This is a bug or regression, not a usage question.
+          required: true
+        - label: I can reproduce this consistently or I have included concrete evidence that the problem is real.
+          required: true
+        - label: I included a minimal reproduction or exact reproduction steps.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is wrong today?
+      placeholder: Describe the visible symptom or incorrect behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: why_it_matters
+    attributes:
+      label: Why it matters
+      description: Who is affected, and how?
+      placeholder: Users, operators, maintainers, or contributors; what pain does this cause?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      description: What should have happened instead?
+      placeholder: Describe the correct or expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: How can we reproduce this as minimally and precisely as possible?
+      placeholder: Include exact commands, config, page flow, or file paths. Avoid screenshots when copy-pasteable text is possible.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Share the relevant environment details needed to investigate this bug.
+      placeholder: |
+        ao --version:
+        node --version:
+        pnpm --version:
+        OS:
+        Browser (if web-related):
+        Relevant config/plugins:
+    validations:
+      required: true
+  - type: textarea
+    id: current_evidence
+    attributes:
+      label: Current evidence
+      description: What evidence do we have that the problem is real?
+      placeholder: Reproduction steps, logs, screenshots, failing tests, exact file paths, linked PRs/issues.
+    validations:
+      required: true
+  - type: textarea
+    id: in_scope
+    attributes:
+      label: In scope
+      description: What work is allowed in this issue?
+      placeholder: Keep this to the smallest acceptable fix.
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What should not change as part of this issue?
+      placeholder: No CLI behavior changes, no design refresh, no new persistence model, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: expected_outcome
+    attributes:
+      label: Expected outcome
+      description: What should be true when this is done?
+      placeholder: Describe the observable result after the fix.
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and risks
+      description: What must be protected?
+      value: |
+        - should not make the orchestrator feel laggier
+        - should not increase polling or hot-path overhead unless explicitly intended
+        - should not make session state more misleading
+        - should not change CLI behavior unless explicitly approved
+    validations:
+      required: true
+  - type: textarea
+    id: definition_of_done
+    attributes:
+      label: Definition of done
+      description: How do we know this is complete?
+      placeholder: Regression test added, manual repro no longer fails, logs/state are correct, docs updated if needed, etc.
+    validations:
+      required: true
+  - type: dropdown
+    id: owner_area
+    attributes:
+      label: Suggested owner area
+      options:
+        - Core
+        - CLI
+        - Web
+        - Plugin system
+        - Infra / CI
+        - Docs / RFC
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes for implementers
+      description: Optional extra guidance for humans or agents.
+      placeholder: Prefer smallest fix, split behavior changes into a separate PR, close instead of stretching scope, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and general help
+    url: https://github.com/ComposioHQ/agent-orchestrator/discussions
+    about: Please use Discussions for usage questions, open-ended help, and general conversation.

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -9,6 +9,12 @@ body:
       value: |
         Use this template for refactors, cleanup, CI improvements, or maintenance work.
         Explain why the change is worth the churn; "duplicate code exists" is not enough by itself.
+        
+        Repo-wide constraints to keep in mind:
+        - should be behavior-preserving unless explicitly approved otherwise
+        - should not make the orchestrator feel laggier
+        - should not increase polling or hot-path overhead unless explicitly intended
+        - should not widen public API surface without clear need
   - type: checkboxes
     id: verification
     attributes:
@@ -80,17 +86,11 @@ body:
     validations:
       required: true
   - type: textarea
-    id: constraints
+    id: issue_specific_risks
     attributes:
-      label: Constraints and risks
-      description: What must be protected?
-      value: |
-        - should be behavior-preserving unless explicitly approved otherwise
-        - should not make the orchestrator feel laggier
-        - should not increase polling or hot-path overhead unless explicitly intended
-        - should not widen public API surface without clear need
-    validations:
-      required: true
+      label: Issue-specific risks or constraints
+      description: Optional. Call out anything unusual that maintainers should protect for this specific maintenance task.
+      placeholder: Must stay behavior-preserving, should not touch plugin contracts, avoid widening API surface, etc.
   - type: textarea
     id: definition_of_done
     attributes:

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,120 @@
+name: Maintenance / refactor
+description: Propose cleanup, refactoring, dead-code removal, or code health work.
+title: "[maintenance] "
+labels:
+  - maintenance
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for refactors, cleanup, CI improvements, or maintenance work.
+        Explain why the change is worth the churn; "duplicate code exists" is not enough by itself.
+  - type: checkboxes
+    id: verification
+    attributes:
+      label: Verification
+      description: Please confirm all of the following before filing.
+      options:
+        - label: I searched existing issues and PRs and did not find a duplicate.
+          required: true
+        - label: I included concrete evidence that this maintenance problem is real.
+          required: true
+        - label: I explained why this is worth doing now instead of later.
+          required: true
+        - label: I called out any intended behavior change explicitly rather than bundling it into cleanup.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What maintenance cost or repo problem exists today?
+      placeholder: Large hotspot file, repeated logic, dead code, confusing ownership, brittle tests, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: why_it_matters
+    attributes:
+      label: Why it matters
+      description: Why is this worth doing now?
+      placeholder: Contributor friction, risky future changes, repeated bugs, review burden, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other options exist, and why is this one preferred?
+      placeholder: Leave it alone for now, smaller surgical extraction, warn-only check instead of enforcement, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: current_evidence
+    attributes:
+      label: Current evidence
+      description: What evidence do we have that the problem is real?
+      placeholder: File paths, duplicate snippets, dead exports, flaky tests, linked incidents, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: in_scope
+    attributes:
+      label: In scope
+      description: What work is allowed in this issue?
+      placeholder: Extract one helper, split one file, remove one dead path, add warn-only CI visibility, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What should not change?
+      placeholder: No behavior changes, no unrelated formatting, no broad design cleanup, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: expected_outcome
+    attributes:
+      label: Expected outcome
+      description: What should be true when this is done?
+      placeholder: One source of truth, smaller hotspot, dead code removed, CI warning added, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and risks
+      description: What must be protected?
+      value: |
+        - should be behavior-preserving unless explicitly approved otherwise
+        - should not make the orchestrator feel laggier
+        - should not increase polling or hot-path overhead unless explicitly intended
+        - should not widen public API surface without clear need
+    validations:
+      required: true
+  - type: textarea
+    id: definition_of_done
+    attributes:
+      label: Definition of done
+      description: How do we know this is complete?
+      placeholder: Code moved or deleted, tests pass, behavior preserved, docs updated if needed.
+    validations:
+      required: true
+  - type: dropdown
+    id: owner_area
+    attributes:
+      label: Suggested owner area
+      options:
+        - Core
+        - CLI
+        - Web
+        - Plugin system
+        - Infra / CI
+        - Docs / RFC
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes for implementers
+      description: Optional extra guidance for humans or agents.
+      placeholder: Keep this surgical, prefer smallest change, close instead of stretching scope, etc.

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -9,6 +9,12 @@ body:
       value: |
         Use this template when the change affects product behavior, CLI behavior, public API shape, plugin contracts,
         lifecycle semantics, or contributor workflow. These should be agreed before implementation PRs are merged.
+        
+        Repo-wide constraints to keep in mind:
+        - should not make the orchestrator feel laggier unless that tradeoff is explicitly accepted
+        - should not increase polling or hot-path overhead without clear justification
+        - should not make session state or operator workflows more confusing
+        - should call out migration impact for CLI, plugin, or API changes
   - type: checkboxes
     id: verification
     attributes:
@@ -83,17 +89,11 @@ body:
     validations:
       required: true
   - type: textarea
-    id: constraints
+    id: issue_specific_risks
     attributes:
-      label: Constraints and risks
-      description: What must be protected?
-      value: |
-        - should not make the orchestrator feel laggier unless that tradeoff is explicitly accepted
-        - should not increase polling or hot-path overhead without clear justification
-        - should not make session state or operator workflows more confusing
-        - should call out migration impact for CLI, plugin, or API changes
-    validations:
-      required: true
+      label: Issue-specific risks or constraints
+      description: Optional. Call out anything unusual that this proposal must protect.
+      placeholder: Must preserve current CLI scripts, avoid new background polling, keep plugin contracts stable, etc.
   - type: textarea
     id: decision_criteria
     attributes:
@@ -115,3 +115,9 @@ body:
         - Docs / RFC
     validations:
       required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes for implementers
+      description: Optional extra guidance for humans or agents.
+      placeholder: Keep the implementation split from the decision work, phase this in, separate migration from behavior change, etc.

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,0 +1,117 @@
+name: Behavior change / RFC
+description: Propose a behavior change, workflow change, or design decision that should be agreed before code.
+title: "[rfc] "
+labels:
+  - rfc
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when the change affects product behavior, CLI behavior, public API shape, plugin contracts,
+        lifecycle semantics, or contributor workflow. These should be agreed before implementation PRs are merged.
+  - type: checkboxes
+    id: verification
+    attributes:
+      label: Verification
+      description: Please confirm all of the following before filing.
+      options:
+        - label: I searched existing issues, PRs, and RFCs and did not find an already-agreed solution.
+          required: true
+        - label: This change affects behavior, contracts, or workflow enough that it should be agreed before implementation.
+          required: true
+        - label: I described alternatives and tradeoffs, not just the preferred path.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What limitation or decision gap exists today?
+      placeholder: Describe the current behavior and why it is insufficient.
+    validations:
+      required: true
+  - type: textarea
+    id: why_it_matters
+    attributes:
+      label: Why it matters
+      description: Who benefits or is affected by this change?
+      placeholder: Users, operators, maintainers, plugin authors, contributors, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: current_evidence
+    attributes:
+      label: Current evidence
+      description: What evidence do we have that this is worth changing?
+      placeholder: Repeated confusion, linked bugs, prior PRs, incidents, support burden, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What change do you want to make?
+      placeholder: Describe the desired behavior or decision at a high level.
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: What is explicitly not part of this proposal?
+      placeholder: New plugin slot, migration automation, additional UI redesign, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: in_scope
+    attributes:
+      label: In scope
+      description: What work belongs under this proposal?
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What should not be bundled into this change?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other paths exist, and why is this one preferred?
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and risks
+      description: What must be protected?
+      value: |
+        - should not make the orchestrator feel laggier unless that tradeoff is explicitly accepted
+        - should not increase polling or hot-path overhead without clear justification
+        - should not make session state or operator workflows more confusing
+        - should call out migration impact for CLI, plugin, or API changes
+    validations:
+      required: true
+  - type: textarea
+    id: decision_criteria
+    attributes:
+      label: Done when
+      description: How do we know the proposal is agreed and ready for implementation?
+      placeholder: Decision recorded, constraints agreed, migration path clear, follow-up implementation PR can stay small, etc.
+    validations:
+      required: true
+  - type: dropdown
+    id: owner_area
+    attributes:
+      label: Suggested owner area
+      options:
+        - Core
+        - CLI
+        - Web
+        - Plugin system
+        - Infra / CI
+        - Docs / RFC
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,7 +47,7 @@ What did you test?
 Commands run:
 
 ## Linked Issue
-Closes #
+Closes #<!-- issue number, or remove this line if not applicable -->
 
 ## Notes For Reviewers
 Anything reviewers should pay special attention to?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+## Summary
+Briefly describe what this PR does and why.
+
+## Problem
+What problem does this PR solve?
+
+## Why This Change
+Why is this the right fix or refactor now?
+
+## Change Type
+- [ ] Bug fix
+- [ ] Maintenance / refactor
+- [ ] Behavior change
+- [ ] Docs / RFC
+
+## Scope
+What is intentionally in scope for this PR?
+
+## Behavior
+- [ ] This PR is behavior-preserving.
+- [ ] This PR changes behavior and is linked to an agreed issue or RFC.
+
+If behavior changes, describe the change clearly:
+
+## Risk
+What are the main risks in this PR?
+
+Please explicitly consider:
+- lag or responsiveness regressions
+- polling or hot-path overhead
+- session-state correctness
+- UI churn or operator confusion
+- CLI or plugin migration impact
+
+## Artifacts
+If this changes web UI, terminal output, or CLI UX, include screenshots, GIFs, or example command output where helpful.
+
+## Test Plan
+What did you test?
+
+- [ ] Automated tests added or updated
+- [ ] Existing relevant tests pass
+- [ ] Manual verification done where needed
+- [ ] I self-reviewed the code and kept the scope aligned to the linked issue/RFC
+- [ ] I checked whether docs or release notes need updates
+
+Commands run:
+
+## Linked Issue
+Closes #
+
+## Notes For Reviewers
+Anything reviewers should pay special attention to?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ Include:
 - What you expected vs. what happened
 - Relevant output from `ao doctor`
 
+GitHub issue templates are available for bugs, maintenance/refactors, and behavior-change RFCs. Please pick the one that best matches the work so reviewers and AI agents can tell whether the task is a bug fix, cleanup, or a product decision before code is written.
+
 ---
 
 ## Development Setup


### PR DESCRIPTION
I aligned the templates more closely with repos like `t3`, `emdash`, `trpc`, `LangGraph`, `Homebrew`, and `Kubernetes`.

What changed:
- required verification checkboxes up front
- minimal reproduction for bugs
- environment details for debugging
- explicit `in scope` / `out of scope`
- required `alternatives considered` for maintenance and RFCs
- a tighter PR template with summary, risk, artifacts, and self-review

If you want, I can further tighten this in one of two directions:
1. more `t3`-style and minimal
2. more `Homebrew`/`Kubernetes`-style and strict