### PR TITLE
feat: redesign dashboard project sidebar

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -3446,31 +3446,40 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 12px 8px;
-  border-bottom: 1px solid var(--sidebar-border);
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border-subtle) 92%, transparent);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-accent) 6%, transparent) 0%,
+    transparent 100%
+  );
   flex-shrink: 0;
 }
 
 .project-sidebar__sect-label {
   font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.06em;
+  font-weight: 700;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--color-text-muted);
+  color: var(--color-accent);
 }
 
 .project-sidebar__add-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 4px;
-  color: var(--color-text-muted);
-  background: transparent;
-  border: none;
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
+  color: var(--color-text-secondary);
+  background: color-mix(in srgb, var(--color-bg-base) 52%, transparent);
+  border: 1px solid var(--color-border-subtle);
   cursor: pointer;
-  transition: background 100ms, color 100ms;
+  transition:
+    background 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease,
+    transform 120ms ease;
   flex-shrink: 0;
 }
 
@@ -3480,8 +3489,10 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 }
 
 .project-sidebar__add-btn:hover {
-  background: var(--sidebar-row-hover);
-  color: var(--color-text-secondary);
+  background: var(--color-hover-overlay);
+  color: var(--color-text-primary);
+  border-color: var(--color-border-default);
+  transform: translateY(-1px);
 }
 
 /* ── Project tree ──────────────────────────────────────────────────── */
@@ -3499,16 +3510,35 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 
 /* Project accordion item */
 .project-sidebar__project {
-  border-bottom: 1px solid var(--sidebar-border);
+  margin: 10px 12px 0;
+  border: 1px solid color-mix(in srgb, var(--color-border-subtle) 92%, transparent);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--color-bg-surface) 88%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 5%, transparent);
+  overflow: hidden;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    box-shadow 120ms ease,
+    transform 120ms ease;
 }
 .project-sidebar__project:last-child {
-  border-bottom: none;
+  margin-bottom: 12px;
+}
+
+.project-sidebar__project:hover {
+  border-color: var(--color-border-default);
+  background: color-mix(in srgb, var(--color-bg-elevated-hover) 92%, transparent);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
 }
 
 /* Project row container */
 .project-sidebar__proj-row {
   display: flex;
   align-items: center;
+  gap: 4px;
+  padding: 8px 8px 0;
 }
 
 .project-sidebar__proj-row > .project-sidebar__proj-toggle {
@@ -3521,17 +3551,22 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   width: 100%;
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  background: none;
-  border: none;
+  gap: 8px;
+  min-height: 42px;
+  padding: 9px 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 14px;
   cursor: pointer;
   color: var(--color-text-primary);
   font-family: var(--font-sans);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   text-align: left;
-  transition: background 80ms;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
 }
 
 .project-sidebar__proj-toggle--link {
@@ -3539,11 +3574,18 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 }
 
 .project-sidebar__proj-toggle:hover {
-  background: var(--sidebar-row-hover);
+  background: color-mix(in srgb, var(--color-hover-overlay) 92%, transparent);
+  border-color: color-mix(in srgb, var(--color-border-subtle) 92%, transparent);
 }
 
 .project-sidebar__proj-toggle--active {
-  color: var(--color-accent-amber);
+  color: var(--color-text-primary);
+  border-color: color-mix(in srgb, var(--color-accent) 24%, var(--color-border-default));
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-accent) 10%, transparent),
+    transparent 90%
+  );
 }
 
 .project-sidebar__proj-toggle--degraded {
@@ -3570,23 +3612,29 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
   flex-shrink: 0;
   color: var(--color-text-muted);
-  border-radius: 4px;
-  transition: background 80ms, color 80ms;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  transition:
+    background 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
   text-decoration: none;
 }
 
 .project-sidebar__proj-action:hover {
-  background: var(--sidebar-row-hover);
+  background: color-mix(in srgb, var(--color-hover-overlay) 92%, transparent);
   color: var(--color-text-primary);
+  border-color: color-mix(in srgb, var(--color-border-subtle) 92%, transparent);
 }
 
 .project-sidebar__proj-action--menu[aria-expanded="true"] {
-  background: var(--sidebar-row-hover);
+  background: color-mix(in srgb, var(--color-hover-overlay) 92%, transparent);
   color: var(--color-text-primary);
+  border-color: color-mix(in srgb, var(--color-border-subtle) 92%, transparent);
 }
 
 .project-sidebar__proj-menu {
@@ -3898,6 +3946,8 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 12px;
+  font-weight: 700;
 }
 
 /* Project badge (session count) */
@@ -3905,19 +3955,20 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   flex-shrink: 0;
   font-size: 10px;
   font-family: var(--font-mono);
-  font-weight: 500;
-  padding: 1px 5px;
-  border-radius: 3px;
-  background: var(--color-bg-subtle);
+  font-weight: 700;
+  min-width: 24px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-bg-base) 54%, transparent);
   border: 1px solid var(--color-border-subtle);
-  color: var(--color-text-muted);
+  color: var(--color-text-secondary);
   line-height: 1.4;
 }
 
 .project-sidebar__proj-badge--active {
-  background: var(--color-accent-amber-dim);
-  border-color: var(--color-accent-amber-border);
-  color: var(--color-accent-amber);
+  background: color-mix(in srgb, var(--color-status-working) 10%, transparent);
+  border-color: color-mix(in srgb, var(--color-status-working) 24%, transparent);
+  color: var(--color-status-working);
 }
 
 .project-sidebar__proj-badge--degraded {
@@ -3928,17 +3979,86 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 }
 
 .project-sidebar__degraded-note {
-  padding: 0 12px 8px 28px;
+  padding: 0 16px 12px;
   font-size: 11px;
-  color: var(--color-text-muted);
+  color: var(--color-status-attention);
+}
+
+.project-sidebar__proj-health {
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+}
+
+.project-sidebar__proj-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 16px 12px 34px;
+}
+
+.project-sidebar__proj-summary-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 20px;
+  padding: 0 8px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-bg-base) 48%, transparent);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.project-sidebar__proj-summary-pill--respond {
+  border-color: color-mix(in srgb, var(--color-status-error) 24%, transparent);
+  background: color-mix(in srgb, var(--color-status-error) 10%, transparent);
+  color: var(--color-status-error);
+}
+
+.project-sidebar__proj-summary-pill--action,
+.project-sidebar__proj-summary-pill--review {
+  border-color: color-mix(in srgb, var(--color-status-review) 24%, transparent);
+  background: color-mix(in srgb, var(--color-status-review) 10%, transparent);
+  color: var(--color-status-review);
+}
+
+.project-sidebar__proj-summary-pill--merge {
+  border-color: color-mix(in srgb, var(--color-status-ready) 24%, transparent);
+  background: color-mix(in srgb, var(--color-status-ready) 10%, transparent);
+  color: var(--color-status-ready);
+}
+
+.project-sidebar__proj-summary-pill--pending {
+  border-color: color-mix(in srgb, var(--color-status-attention) 24%, transparent);
+  background: color-mix(in srgb, var(--color-status-attention) 10%, transparent);
+  color: var(--color-status-attention);
+}
+
+.project-sidebar__proj-summary-pill--working {
+  border-color: color-mix(in srgb, var(--color-status-working) 24%, transparent);
+  background: color-mix(in srgb, var(--color-status-working) 10%, transparent);
+  color: var(--color-status-working);
+}
+
+.project-sidebar__proj-summary-pill--done {
+  color: var(--color-text-tertiary);
+}
+
+.project-sidebar__proj-summary-text {
+  font-size: 10px;
+  color: var(--color-text-tertiary);
 }
 
 /* Session list */
 .project-sidebar__sessions {
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  padding: 2px 0 4px;
+  gap: 6px;
+  padding: 0 10px 12px 16px;
 }
 
 /* Collapsed icon styles */
@@ -4048,16 +4168,21 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 .project-sidebar__sess-row {
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 0 12px 0 26px;
+  gap: 8px;
+  padding: 10px 12px 10px 14px;
   width: 100%;
-  border: 0;
+  border: 1px solid transparent;
+  border-radius: 14px;
   background: transparent;
   cursor: pointer;
-  transition: background 80ms;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease;
   text-align: left;
   text-decoration: none;
   color: inherit;
+  position: relative;
 }
 
 .project-sidebar__sess-row:hover,
@@ -4068,35 +4193,43 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 }
 
 .project-sidebar__sess-row:hover {
-  background: var(--sidebar-row-hover);
+  background: color-mix(in srgb, var(--color-hover-overlay) 92%, transparent);
+  border-color: color-mix(in srgb, var(--color-border-subtle) 92%, transparent);
 }
 
 .project-sidebar__sess-row--active {
-  background: transparent;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-accent) 10%, transparent),
+    transparent 92%
+  );
+  border-color: color-mix(in srgb, var(--color-accent) 20%, var(--color-border-subtle));
+  box-shadow: inset 2px 0 0 var(--color-accent);
 }
 
 /* Session label */
 .project-sidebar__sess-label {
   flex: 1;
   font-size: 11.5px;
-  color: var(--color-text-secondary);
+  color: var(--color-text-primary);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: 600;
 }
 
 .project-sidebar__sess-label--active {
-  color: var(--color-accent-amber);
-  font-weight: 500;
+  color: var(--color-text-primary);
+  font-weight: 700;
 }
 
 /* Session meta row: ID + status on one line */
 .project-sidebar__sess-meta {
   display: flex;
   align-items: center;
-  gap: 4px;
-  margin-top: -4px;
+  gap: 6px;
+  margin-top: 5px;
 }
 
 .project-sidebar__sess-id {
@@ -4114,9 +4247,13 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 .project-sidebar__sess-status {
   font-size: 9px;
   font-family: var(--font-mono);
-  color: var(--color-text-muted);
+  color: var(--color-text-secondary);
   flex-shrink: 0;
   white-space: nowrap;
+  padding: 1px 6px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-bg-base) 48%, transparent);
 }
 
 /* Inline status (compact variant — name + status on one line) */
@@ -4164,7 +4301,7 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 
 /* Empty state inside project */
 .project-sidebar__empty {
-  padding: 18px 12px;
+  padding: 16px 12px 18px;
   text-align: center;
   color: var(--color-text-muted);
   font-size: 11px;
@@ -4172,6 +4309,8 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 
 .project-sidebar__footer {
   margin-top: auto;
+  border-top: 1px solid color-mix(in srgb, var(--color-border-subtle) 92%, transparent);
+  background: color-mix(in srgb, var(--color-bg-base) 22%, transparent);
 }
 
 .project-sidebar__theme-toggle {

--- a/packages/web/src/components/ProjectSidebar.shared.ts
+++ b/packages/web/src/components/ProjectSidebar.shared.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import type { ProjectInfo } from "@/lib/project-name";
+import { getAttentionLevel, type AttentionLevel, type DashboardSession } from "@/lib/types";
+
+export interface ProjectSidebarProps {
+  projects: ProjectInfo[];
+  sessions: DashboardSession[] | null;
+  activeProjectId: string | undefined;
+  activeSessionId: string | undefined;
+  loading?: boolean;
+  error?: boolean;
+  onRetry?: () => void;
+  collapsed?: boolean;
+  onToggleCollapsed?: () => void;
+  onMobileClose?: () => void;
+}
+
+export const SHOW_SESSION_ID_KEY = "ao:sidebar:show-session-id";
+
+export function loadShowSessionId(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(SHOW_SESSION_ID_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export const LEVEL_LABELS: Record<AttentionLevel, string> = {
+  working: "working",
+  pending: "pending",
+  review: "review",
+  respond: "respond",
+  action: "action",
+  merge: "merge",
+  done: "done",
+};
+
+export type ProjectHealth = "red" | "yellow" | "green" | "gray";
+
+export interface ProjectStatusSummary {
+  tone: AttentionLevel | "done";
+  detail: string;
+}
+
+export function getProjectHealth(sessions: DashboardSession[]): ProjectHealth {
+  if (sessions.some((session) => getAttentionLevel(session) === "respond")) {
+    return "red";
+  }
+  if (sessions.some((session) => {
+    const level = getAttentionLevel(session);
+    return level === "review" || level === "pending" || level === "action";
+  })) {
+    return "yellow";
+  }
+  if (sessions.some((session) => getAttentionLevel(session) === "merge")) {
+    return "green";
+  }
+  if (sessions.length > 0) {
+    return "green";
+  }
+  return "gray";
+}
+
+export function getProjectStatusSummary(sessions: DashboardSession[]): ProjectStatusSummary {
+  const counts = sessions.reduce<Record<AttentionLevel, number>>(
+    (accumulator, session) => {
+      const level = getAttentionLevel(session);
+      accumulator[level] += 1;
+      return accumulator;
+    },
+    {
+      merge: 0,
+      action: 0,
+      respond: 0,
+      review: 0,
+      pending: 0,
+      working: 0,
+      done: 0,
+    },
+  );
+
+  if (counts.respond > 0) return { tone: "respond", detail: `${counts.respond} need response` };
+  if (counts.action > 0) return { tone: "action", detail: `${counts.action} need action` };
+  if (counts.review > 0) return { tone: "review", detail: `${counts.review} need review` };
+  if (counts.merge > 0) return { tone: "merge", detail: `${counts.merge} ready to merge` };
+  if (counts.pending > 0) return { tone: "pending", detail: `${counts.pending} waiting` };
+  if (counts.working > 0) return { tone: "working", detail: `${counts.working} active now` };
+  return { tone: "done", detail: "No active sessions" };
+}

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -74,6 +74,54 @@ const LEVEL_LABELS: Record<AttentionLevel, string> = {
   done: "done",
 };
 
+type ProjectHealth = "red" | "yellow" | "green" | "gray";
+
+function getProjectHealth(sessions: DashboardSession[]): ProjectHealth {
+  if (sessions.some((session) => getAttentionLevel(session) === "respond")) {
+    return "red";
+  }
+  if (sessions.some((session) => {
+    const level = getAttentionLevel(session);
+    return level === "review" || level === "pending" || level === "action";
+  })) {
+    return "yellow";
+  }
+  if (sessions.some((session) => getAttentionLevel(session) === "merge")) {
+    return "green";
+  }
+  if (sessions.length > 0) {
+    return "green";
+  }
+  return "gray";
+}
+
+function getProjectStatusSummary(sessions: DashboardSession[]): { tone: AttentionLevel | "done"; detail: string } {
+  const counts = sessions.reduce<Record<AttentionLevel, number>>(
+    (accumulator, session) => {
+      const level = getAttentionLevel(session);
+      accumulator[level] += 1;
+      return accumulator;
+    },
+    {
+      merge: 0,
+      action: 0,
+      respond: 0,
+      review: 0,
+      pending: 0,
+      working: 0,
+      done: 0,
+    },
+  );
+
+  if (counts.respond > 0) return { tone: "respond", detail: `${counts.respond} need response` };
+  if (counts.action > 0) return { tone: "action", detail: `${counts.action} need action` };
+  if (counts.review > 0) return { tone: "review", detail: `${counts.review} need review` };
+  if (counts.merge > 0) return { tone: "merge", detail: `${counts.merge} ready to merge` };
+  if (counts.pending > 0) return { tone: "pending", detail: `${counts.pending} waiting` };
+  if (counts.working > 0) return { tone: "working", detail: `${counts.working} active now` };
+  return { tone: "done", detail: "No active sessions" };
+}
+
 export function ProjectSidebar(props: ProjectSidebarProps) {
   if (props.projects.length === 0) {
     return null;
@@ -210,6 +258,17 @@ function ProjectSidebarInner({
       list.push(s);
       map.set(s.projectId, list);
     }
+
+    for (const list of map.values()) {
+      list.sort((left, right) => {
+        const priority = ["respond", "action", "review", "merge", "pending", "working", "done"];
+        const levelDelta =
+          priority.indexOf(getAttentionLevel(left)) - priority.indexOf(getAttentionLevel(right));
+        if (levelDelta !== 0) return levelDelta;
+        return Date.parse(right.lastActivityAt) - Date.parse(left.lastActivityAt);
+      });
+    }
+
     return map;
   }, [sessions, prefixByProject, allPrefixes, visibleProjects, showKilled, showDone]);
 
@@ -389,13 +448,17 @@ function ProjectSidebarInner({
             // sessionsByProject already applies the showDone filter consistently.
             const visibleSessions = workerSessions;
             const hasActiveSessions = visibleSessions.length > 0;
+            const health = getProjectHealth(visibleSessions);
+            const statusSummary = isLoading
+              ? { tone: "pending" as const, detail: "Loading sessions" }
+              : getProjectStatusSummary(visibleSessions);
 
             const orchestratorSession = sessions?.find(
               (s) => isOrchestratorSession(s, prefixByProject.get(s.projectId), allPrefixes) && s.projectId === project.id
             );
 
             return (
-              <div key={project.id} className="project-sidebar__project">
+              <div key={project.id} className="project-sidebar__project" data-health={health}>
                 {/* Project row: toggle + action buttons */}
                 <div className="project-sidebar__proj-row flex items-center">
                   {isDegraded ? (
@@ -412,6 +475,7 @@ function ProjectSidebarInner({
                       )}
                       aria-current={isActive ? "page" : undefined}
                     >
+                      <span className="sidebar-health-dot project-sidebar__proj-health" data-health="amber" aria-hidden="true" />
                       <svg
                         className="project-sidebar__proj-chevron project-sidebar__proj-chevron--degraded"
                         width="10"
@@ -442,6 +506,11 @@ function ProjectSidebarInner({
                       aria-expanded={isExpanded}
                       aria-current={isActive ? "page" : undefined}
                     >
+                      <span
+                        className="sidebar-health-dot project-sidebar__proj-health"
+                        data-health={health}
+                        aria-hidden="true"
+                      />
                       <svg
                         className={cn(
                           "project-sidebar__proj-chevron",
@@ -556,7 +625,19 @@ function ProjectSidebarInner({
 
                 {isDegraded ? (
                   <div className="project-sidebar__degraded-note">Config needs repair</div>
-                ) : null}
+                ) : (
+                  <div className="project-sidebar__proj-summary" aria-hidden="true">
+                    <span
+                      className={cn(
+                        "project-sidebar__proj-summary-pill",
+                        `project-sidebar__proj-summary-pill--${statusSummary.tone}`,
+                      )}
+                    >
+                      {LEVEL_LABELS[statusSummary.tone] ?? "done"}
+                    </span>
+                    <span className="project-sidebar__proj-summary-text">{statusSummary.detail}</span>
+                  </div>
+                )}
 
                 {/* Sessions */}
                 {!isDegraded && isExpanded && (

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -1,126 +1,26 @@
 "use client";
 
-import Link from "next/link";
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { cn } from "@/lib/cn";
-import type { ProjectInfo } from "@/lib/project-name";
-import { getAttentionLevel, type DashboardSession, type AttentionLevel } from "@/lib/types";
 import { isOrchestratorSession } from "@aoagents/ao-core/types";
-import { getSessionTitle, humanizeBranch } from "@/lib/format";
+
 import { usePopoverClamp } from "@/hooks/usePopoverClamp";
-import { projectDashboardPath, projectSessionPath } from "@/lib/routes";
-import { ThemeToggle } from "./ThemeToggle";
+import { projectDashboardPath } from "@/lib/routes";
+import { getAttentionLevel, type DashboardSession } from "@/lib/types";
 import { AddProjectModal } from "./AddProjectModal";
+import { ProjectSidebarFooter } from "./ProjectSidebarFooter";
 import { ProjectSettingsModal } from "./ProjectSettingsModal";
+import { ProjectSidebarCollapsed } from "./ProjectSidebarCollapsed";
+import { ProjectSidebarProjectCard } from "./ProjectSidebarProjectCard";
+import {
+  getProjectHealth,
+  getProjectStatusSummary,
+  loadShowSessionId,
+  type ProjectSidebarProps,
+  SHOW_SESSION_ID_KEY,
+} from "./ProjectSidebar.shared";
 
-interface ProjectSidebarProps {
-  projects: ProjectInfo[];
-  sessions: DashboardSession[] | null;
-  activeProjectId: string | undefined;
-  activeSessionId: string | undefined;
-  loading?: boolean;
-  error?: boolean;
-  onRetry?: () => void;
-  collapsed?: boolean;
-  onToggleCollapsed?: () => void;
-  onMobileClose?: () => void;
-}
-
-type SessionDotLevel =
-  | "respond"
-  | "review"
-  | "action"
-  | "pending"
-  | "working"
-  | "merge"
-  | "done";
-
-function SessionDot({ level }: { level: SessionDotLevel }) {
-  return (
-    <div
-      className={cn(
-        "sidebar-session-dot shrink-0 rounded-full",
-        level === "working" && "sidebar-session-dot--glow",
-      )}
-      data-level={level}
-    />
-  );
-}
-
-// ProjectSidebar consumes `getAttentionLevel()` without passing a mode,
-// so the function defaults to "detailed" and `action` never appears here
-// in practice. The entry is kept for exhaustiveness — TypeScript requires
-// every `AttentionLevel` variant to be present in this `Record` — and
-// as forward-compat in case the sidebar ever opts into simple mode.
-const SHOW_SESSION_ID_KEY = "ao:sidebar:show-session-id";
-
-function loadShowSessionId(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(SHOW_SESSION_ID_KEY) === "true";
-  } catch {
-    return false;
-  }
-}
-
-const LEVEL_LABELS: Record<AttentionLevel, string> = {
-  working: "working",
-  pending: "pending",
-  review: "review",
-  respond: "respond",
-  action: "action",
-  merge: "merge",
-  done: "done",
-};
-
-type ProjectHealth = "red" | "yellow" | "green" | "gray";
-
-function getProjectHealth(sessions: DashboardSession[]): ProjectHealth {
-  if (sessions.some((session) => getAttentionLevel(session) === "respond")) {
-    return "red";
-  }
-  if (sessions.some((session) => {
-    const level = getAttentionLevel(session);
-    return level === "review" || level === "pending" || level === "action";
-  })) {
-    return "yellow";
-  }
-  if (sessions.some((session) => getAttentionLevel(session) === "merge")) {
-    return "green";
-  }
-  if (sessions.length > 0) {
-    return "green";
-  }
-  return "gray";
-}
-
-function getProjectStatusSummary(sessions: DashboardSession[]): { tone: AttentionLevel | "done"; detail: string } {
-  const counts = sessions.reduce<Record<AttentionLevel, number>>(
-    (accumulator, session) => {
-      const level = getAttentionLevel(session);
-      accumulator[level] += 1;
-      return accumulator;
-    },
-    {
-      merge: 0,
-      action: 0,
-      respond: 0,
-      review: 0,
-      pending: 0,
-      working: 0,
-      done: 0,
-    },
-  );
-
-  if (counts.respond > 0) return { tone: "respond", detail: `${counts.respond} need response` };
-  if (counts.action > 0) return { tone: "action", detail: `${counts.action} need action` };
-  if (counts.review > 0) return { tone: "review", detail: `${counts.review} need review` };
-  if (counts.merge > 0) return { tone: "merge", detail: `${counts.merge} ready to merge` };
-  if (counts.pending > 0) return { tone: "pending", detail: `${counts.pending} waiting` };
-  if (counts.working > 0) return { tone: "working", detail: `${counts.working} active now` };
-  return { tone: "done", detail: "No active sessions" };
-}
+const SESSION_SORT_PRIORITY = ["respond", "action", "review", "merge", "pending", "working", "done"];
 
 export function ProjectSidebar(props: ProjectSidebarProps) {
   if (props.projects.length === 0) {
@@ -156,14 +56,15 @@ function ProjectSidebarInner({
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
   const [removedProjectIds, setRemovedProjectIds] = useState<Set<string>>(new Set());
   const [addProjectOpen, setAddProjectOpen] = useState(false);
+
   const settingsRef = useRef<HTMLDivElement>(null);
   const settingsPopoverRef = useRef<HTMLDivElement>(null);
   const projectMenuRef = useRef<HTMLDivElement>(null);
   const projectMenuPopoverRef = useRef<HTMLDivElement>(null);
+
   usePopoverClamp(settingsOpen, settingsPopoverRef);
   usePopoverClamp(Boolean(projectMenuOpenId), projectMenuPopoverRef);
 
-  // Persist the session-id preference across reloads.
   useEffect(() => {
     try {
       window.localStorage.setItem(SHOW_SESSION_ID_KEY, String(showSessionId));
@@ -172,17 +73,18 @@ function ProjectSidebarInner({
     }
   }, [showSessionId]);
 
-  // Close the settings popover on outside click or Escape.
   useEffect(() => {
     if (!settingsOpen) return;
-    const handlePointer = (e: MouseEvent) => {
-      if (settingsRef.current && !settingsRef.current.contains(e.target as Node)) {
+
+    const handlePointer = (event: MouseEvent) => {
+      if (settingsRef.current && !settingsRef.current.contains(event.target as Node)) {
         setSettingsOpen(false);
       }
     };
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setSettingsOpen(false);
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setSettingsOpen(false);
     };
+
     document.addEventListener("mousedown", handlePointer);
     document.addEventListener("keydown", handleKey);
     return () => {
@@ -193,14 +95,16 @@ function ProjectSidebarInner({
 
   useEffect(() => {
     if (!projectMenuOpenId) return;
-    const handlePointer = (e: MouseEvent) => {
-      if (projectMenuRef.current && !projectMenuRef.current.contains(e.target as Node)) {
+
+    const handlePointer = (event: MouseEvent) => {
+      if (projectMenuRef.current && !projectMenuRef.current.contains(event.target as Node)) {
         setProjectMenuOpenId(null);
       }
     };
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setProjectMenuOpenId(null);
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setProjectMenuOpenId(null);
     };
+
     document.addEventListener("mousedown", handlePointer);
     document.addEventListener("keydown", handleKey);
     return () => {
@@ -231,39 +135,35 @@ function ProjectSidebarInner({
   );
 
   const prefixByProject = useMemo(
-    () => new Map(visibleProjects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
+    () => new Map(visibleProjects.map((project) => [project.id, project.sessionPrefix ?? project.id])),
     [visibleProjects],
   );
 
   const allPrefixes = useMemo(
-    () => visibleProjects.map((p) => p.sessionPrefix ?? p.id),
+    () => visibleProjects.map((project) => project.sessionPrefix ?? project.id),
     [visibleProjects],
   );
 
   const sessionsByProject = useMemo(() => {
     const map = new Map<string, DashboardSession[]>();
-    // Build a set of valid project IDs to filter sessions strictly
-    const validProjectIds = new Set(visibleProjects.map((p) => p.id));
+    const validProjectIds = new Set(visibleProjects.map((project) => project.id));
 
-    for (const s of sessions ?? []) {
-      // Only include sessions whose projectId matches a configured project
-      if (!validProjectIds.has(s.projectId)) continue;
-      if (isOrchestratorSession(s, prefixByProject.get(s.projectId), allPrefixes)) continue;
-      // Filter by status visibility — use getAttentionLevel so the collected
-      // set matches what the expanded/collapsed rendering below actually shows.
-      // Otherwise the project badge count can disagree with the visible rows.
-      if (s.status === "killed" && !showKilled) continue;
-      if (getAttentionLevel(s) === "done" && !showDone) continue;
-      const list = map.get(s.projectId) ?? [];
-      list.push(s);
-      map.set(s.projectId, list);
+    for (const session of sessions ?? []) {
+      if (!validProjectIds.has(session.projectId)) continue;
+      if (isOrchestratorSession(session, prefixByProject.get(session.projectId), allPrefixes)) continue;
+      if (session.status === "killed" && !showKilled) continue;
+      if (getAttentionLevel(session) === "done" && !showDone) continue;
+
+      const list = map.get(session.projectId) ?? [];
+      list.push(session);
+      map.set(session.projectId, list);
     }
 
     for (const list of map.values()) {
       list.sort((left, right) => {
-        const priority = ["respond", "action", "review", "merge", "pending", "working", "done"];
         const levelDelta =
-          priority.indexOf(getAttentionLevel(left)) - priority.indexOf(getAttentionLevel(right));
+          SESSION_SORT_PRIORITY.indexOf(getAttentionLevel(left)) -
+          SESSION_SORT_PRIORITY.indexOf(getAttentionLevel(right));
         if (levelDelta !== 0) return levelDelta;
         return Date.parse(right.lastActivityAt) - Date.parse(left.lastActivityAt);
       });
@@ -296,7 +196,16 @@ function ProjectSidebarInner({
     });
   };
 
-  const handleRemoveProject = async (project: ProjectInfo) => {
+  const handleOpenProjectSettings = (projectId: string) => {
+    setProjectMenuOpenId(null);
+    setProjectSettingsProjectId(projectId);
+  };
+
+  const handleToggleProjectMenu = (projectId: string) => {
+    setProjectMenuOpenId((current) => (current === projectId ? null : projectId));
+  };
+
+  const handleRemoveProject = async (project: (typeof projects)[number]) => {
     const confirmed = window.confirm(
       `Remove project ${project.name} from AO? This clears its AO sessions/history and removes it from the portfolio, but keeps the repository folder on disk.`,
     );
@@ -329,8 +238,8 @@ function ProjectSidebarInner({
         router.refresh();
       }
       onMobileClose?.();
-    } catch (error) {
-      window.alert(error instanceof Error ? error.message : "Failed to remove project.");
+    } catch (caughtError) {
+      window.alert(caughtError instanceof Error ? caughtError.message : "Failed to remove project.");
     } finally {
       setDeletingProjectId(null);
     }
@@ -338,477 +247,115 @@ function ProjectSidebarInner({
 
   if (collapsed) {
     return (
-      <aside className={cn(
-        "project-sidebar project-sidebar--collapsed flex flex-col h-full items-center py-2 gap-1 overflow-y-auto",
-      )}>
-        {visibleProjects.map((project, idx) => {
-          const workerSessions = sessionsByProject.get(project.id) ?? [];
-          // sessionsByProject already applies the showDone filter consistently.
-          const visibleSessions = workerSessions;
-          const projectAbbr = project.name.slice(0, 2).toUpperCase();
-          return (
-            <div key={project.id} className="flex flex-col items-center gap-0.5 w-full px-1">
-              {idx > 0 && <div className="project-sidebar__collapsed-divider" aria-hidden="true" />}
-              <a
-                href={projectDashboardPath(project.id)}
-                className={cn(
-                  "project-sidebar__collapsed-icon",
-                  activeProjectId === project.id && "project-sidebar__collapsed-icon--active",
-                )}
-                title={project.name}
-                aria-label={project.name}
-              >
-                <span className="project-sidebar__collapsed-abbr">{projectAbbr}</span>
-              </a>
-              {visibleSessions.slice(0, 5).map((session) => {
-                const level = getAttentionLevel(session);
-                const rawTitle = session.branch ?? getSessionTitle(session);
-                const displayTitle = session.branch ? humanizeBranch(session.branch) || rawTitle : rawTitle;
-                const abbr = displayTitle.replace(/\s+/g, "").slice(0, 3).toUpperCase();
-                const isActive = activeSessionId === session.id;
-                const sessionHref = projectSessionPath(project.id, session.id);
-                return (
-                  <a
-                    key={session.id}
-                    href={sessionHref}
-                    onClick={(e) => {
-                      if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return;
-                      e.preventDefault();
-                      navigate(sessionHref, session);
-                    }}
-                    className={cn(
-                      "project-sidebar__collapsed-session-btn",
-                      isActive && "project-sidebar__collapsed-session-btn--active",
-                    )}
-                    data-level={level}
-                    title={rawTitle}
-                    aria-label={rawTitle}
-                  >
-                    <span className="project-sidebar__session-abbr-first">{abbr[0]}</span>
-                    <span className="project-sidebar__session-abbr-rest">{abbr.slice(1)}</span>
-                  </a>
-                );
-              })}
-              {visibleSessions.length > 5 && (
-                <span className="project-sidebar__collapsed-overflow">+{visibleSessions.length - 5}</span>
-              )}
-            </div>
-          );
-        })}
-      </aside>
+      <ProjectSidebarCollapsed
+        activeProjectId={activeProjectId}
+        activeSessionId={activeSessionId}
+        navigate={navigate}
+        sessionsByProject={sessionsByProject}
+        visibleProjects={visibleProjects}
+      />
     );
   }
 
   return (
-    <aside
-      className="project-sidebar flex h-full flex-col"
-    >
-        <div className="project-sidebar__compact-hdr">
-          <span className="project-sidebar__sect-label">Projects</span>
-          <button
-            type="button"
-            className="project-sidebar__add-btn"
-            aria-label="New project"
-            onClick={() => setAddProjectOpen(true)}
-          >
-            <svg fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path d="M12 5v14M5 12h14" />
-            </svg>
-          </button>
-        </div>
+    <aside className="project-sidebar flex h-full flex-col">
+      <div className="project-sidebar__compact-hdr">
+        <span className="project-sidebar__sect-label">Projects</span>
+        <button
+          type="button"
+          className="project-sidebar__add-btn"
+          aria-label="New project"
+          onClick={() => setAddProjectOpen(true)}
+        >
+          <svg fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path d="M12 5v14M5 12h14" />
+          </svg>
+        </button>
+      </div>
 
-        {/* Stale-data banner: keep cached sessions visible on fetch failure but
-            surface the error so users know the list may be out of date. */}
-        {error && sessions && sessions.length > 0 ? (
-          <div
-            role="status"
-            className="mx-3 mb-2 flex items-center justify-between gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg-primary)] px-2 py-1.5 text-[11px] text-[var(--color-text-tertiary)]"
-          >
-            <span>Failed to refresh · showing cached sessions</span>
-            {onRetry ? (
-              <button
-                type="button"
-                onClick={onRetry}
-                className="font-medium text-[var(--color-link)] hover:underline"
-              >
-                Retry
-              </button>
-            ) : null}
-          </div>
-        ) : null}
-
-        {/* Project tree */}
-        <div className="project-sidebar__tree flex-1 overflow-y-auto overflow-x-hidden">
-          {visibleProjects.map((project) => {
-            const workerSessions = sessionsByProject.get(project.id) ?? [];
-            const isExpanded = expandedProjects.has(project.id);
-            const isActive = activeProjectId === project.id;
-            const isDegraded = Boolean(project.resolveError);
-            const projectHref = projectDashboardPath(project.id);
-            // sessionsByProject already applies the showDone filter consistently.
-            const visibleSessions = workerSessions;
-            const hasActiveSessions = visibleSessions.length > 0;
-            const health = getProjectHealth(visibleSessions);
-            const statusSummary = isLoading
-              ? { tone: "pending" as const, detail: "Loading sessions" }
-              : getProjectStatusSummary(visibleSessions);
-
-            const orchestratorSession = sessions?.find(
-              (s) => isOrchestratorSession(s, prefixByProject.get(s.projectId), allPrefixes) && s.projectId === project.id
-            );
-
-            return (
-              <div key={project.id} className="project-sidebar__project" data-health={health}>
-                {/* Project row: toggle + action buttons */}
-                <div className="project-sidebar__proj-row flex items-center">
-                  {isDegraded ? (
-                    <a
-                      href={projectHref}
-                      onClick={(e) => {
-                        if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return;
-                        e.preventDefault();
-                        navigate(projectHref);
-                      }}
-                      className={cn(
-                        "project-sidebar__proj-toggle project-sidebar__proj-toggle--link project-sidebar__proj-toggle--degraded",
-                        isActive && "project-sidebar__proj-toggle--active",
-                      )}
-                      aria-current={isActive ? "page" : undefined}
-                    >
-                      <span className="sidebar-health-dot project-sidebar__proj-health" data-health="amber" aria-hidden="true" />
-                      <svg
-                        className="project-sidebar__proj-chevron project-sidebar__proj-chevron--degraded"
-                        width="10"
-                        height="10"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        viewBox="0 0 24 24"
-                        aria-hidden="true"
-                      >
-                        <path d="M12 9v4" />
-                        <path d="M12 17h.01" />
-                        <path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.72 3h16.92a2 2 0 0 0 1.72-3L13.7 3.86a2 2 0 0 0-3.4 0Z" />
-                      </svg>
-                      <span className="project-sidebar__proj-name">{project.name}</span>
-                      <span className="project-sidebar__proj-badge project-sidebar__proj-badge--degraded">
-                        degraded
-                      </span>
-                    </a>
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => toggleExpand(project.id)}
-                      className={cn(
-                        "project-sidebar__proj-toggle",
-                        isActive && "project-sidebar__proj-toggle--active",
-                      )}
-                      aria-expanded={isExpanded}
-                      aria-current={isActive ? "page" : undefined}
-                    >
-                      <span
-                        className="sidebar-health-dot project-sidebar__proj-health"
-                        data-health={health}
-                        aria-hidden="true"
-                      />
-                      <svg
-                        className={cn(
-                          "project-sidebar__proj-chevron",
-                          isExpanded && "project-sidebar__proj-chevron--open",
-                        )}
-                        width="10"
-                        height="10"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2.5"
-                        viewBox="0 0 24 24"
-                      >
-                        <path d="m9 18 6-6-6-6" />
-                      </svg>
-                      <span className="project-sidebar__proj-name">{project.name}</span>
-                      <span
-                        className={cn(
-                          "project-sidebar__proj-badge",
-                          hasActiveSessions && "project-sidebar__proj-badge--active",
-                        )}
-                      >
-                        {workerSessions.length}
-                      </span>
-                    </button>
-                  )}
-
-                  {/* Dashboard button */}
-                  {!isDegraded ? (
-                    <Link
-                      href={projectHref}
-                      onClick={(e) => { e.stopPropagation(); onMobileClose?.(); }}
-                      className="project-sidebar__proj-action"
-                      aria-label={`Open ${project.name} dashboard`}
-                      title="Dashboard"
-                    >
-                      <svg width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                        <path d="M3 13h8V3H3zm10 8h8V11h-8zM3 21h8v-6H3zm10-10h8V3h-8z" />
-                      </svg>
-                    </Link>
-                  ) : null}
-
-                  {/* Orchestrator button */}
-                  {!isDegraded && orchestratorSession && (
-                    <Link
-                      href={projectSessionPath(project.id, orchestratorSession.id)}
-                      onClick={(e) => { e.stopPropagation(); onMobileClose?.(); }}
-                      className="project-sidebar__proj-action"
-                      aria-label={`Open ${project.name} orchestrator`}
-                      title="Orchestrator"
-                    >
-                      <svg width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                        <circle cx="12" cy="5" r="2" fill="currentColor" stroke="none" />
-                        <path d="M12 7v4M12 11H6M12 11h6M6 11v3M12 11v3M18 11v3" />
-                        <circle cx="6" cy="17" r="2" /><circle cx="12" cy="17" r="2" /><circle cx="18" cy="17" r="2" />
-                      </svg>
-                    </Link>
-                  )}
-
-                  <div
-                    className="project-sidebar__proj-menu"
-                    ref={projectMenuOpenId === project.id ? projectMenuRef : undefined}
-                  >
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setProjectMenuOpenId((current) => (current === project.id ? null : project.id));
-                      }}
-                      className="project-sidebar__proj-action project-sidebar__proj-action--menu"
-                      aria-label={`Project actions for ${project.name}`}
-                      aria-expanded={projectMenuOpenId === project.id}
-                      aria-haspopup="menu"
-                      title="Project actions"
-                    >
-                      <svg width="12" height="12" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                        <circle cx="12" cy="5" r="1.75" />
-                        <circle cx="12" cy="12" r="1.75" />
-                        <circle cx="12" cy="19" r="1.75" />
-                      </svg>
-                    </button>
-                    {projectMenuOpenId === project.id ? (
-                      <div
-                        ref={projectMenuPopoverRef}
-                        className="project-sidebar__proj-menu-popover"
-                        role="menu"
-                        aria-label={`${project.name} actions`}
-                      >
-                        <button
-                          type="button"
-                          className="project-sidebar__proj-menu-item"
-                          role="menuitem"
-                          onClick={() => {
-                            setProjectMenuOpenId(null);
-                            setProjectSettingsProjectId(project.id);
-                          }}
-                        >
-                          Project settings
-                        </button>
-                        <button
-                          type="button"
-                          className="project-sidebar__proj-menu-item project-sidebar__proj-menu-item--danger"
-                          role="menuitem"
-                          onClick={() => void handleRemoveProject(project)}
-                          disabled={deletingProjectId === project.id}
-                        >
-                          {deletingProjectId === project.id ? "Removing..." : "Remove project"}
-                        </button>
-                      </div>
-                    ) : null}
-                  </div>
-                </div>
-
-                {isDegraded ? (
-                  <div className="project-sidebar__degraded-note">Config needs repair</div>
-                ) : (
-                  <div className="project-sidebar__proj-summary" aria-hidden="true">
-                    <span
-                      className={cn(
-                        "project-sidebar__proj-summary-pill",
-                        `project-sidebar__proj-summary-pill--${statusSummary.tone}`,
-                      )}
-                    >
-                      {LEVEL_LABELS[statusSummary.tone] ?? "done"}
-                    </span>
-                    <span className="project-sidebar__proj-summary-text">{statusSummary.detail}</span>
-                  </div>
-                )}
-
-                {/* Sessions */}
-                {!isDegraded && isExpanded && (
-                  <div className="project-sidebar__sessions">
-                    {isLoading ? (
-                      <div className="space-y-2 px-3 py-2" aria-label="Loading sessions">
-                        {Array.from({ length: 3 }, (_, index) => (
-                          <div
-                            key={`${project.id}-loading-${index}`}
-                            className="flex items-center gap-3 border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-2 py-2"
-                          >
-                            <div className="h-2 w-2 shrink-0 animate-pulse bg-[var(--color-border-strong)]" />
-                            <div className="h-3 flex-1 animate-pulse bg-[var(--color-bg-primary)]" />
-                            <div className="h-3 w-12 animate-pulse bg-[var(--color-bg-primary)]" />
-                          </div>
-                        ))}
-                      </div>
-                    ) : visibleSessions.length > 0 ? (
-                      visibleSessions.map((session) => {
-                        const level = getAttentionLevel(session);
-                        const isSessionActive = activeSessionId === session.id;
-                        const title = session.branch ?? getSessionTitle(session);
-                        const sessionHref = projectSessionPath(project.id, session.id);
-                        return (
-                          <a
-                            key={session.id}
-                            href={sessionHref}
-                            onClick={(e) => {
-                              if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return;
-                              e.preventDefault();
-                              navigate(sessionHref, session);
-                            }}
-                            className={cn(
-                              "project-sidebar__sess-row",
-                              isSessionActive && "project-sidebar__sess-row--active",
-                            )}
-                            aria-current={isSessionActive ? "page" : undefined}
-                            aria-label={`Open ${title}`}
-                          >
-                            <SessionDot level={level} />
-                            <div className="flex-1 min-w-0">
-                              <span
-                                className={cn(
-                                  "project-sidebar__sess-label",
-                                  isSessionActive && "project-sidebar__sess-label--active",
-                                )}
-                              >
-                                {title}
-                              </span>
-                              {showSessionId ? (
-                                <div className="project-sidebar__sess-meta">
-                                  <span className="project-sidebar__sess-id">{session.id}</span>
-                                  <span className="project-sidebar__sess-status">
-                                    {LEVEL_LABELS[level]}
-                                  </span>
-                                </div>
-                              ) : null}
-                            </div>
-                            {!showSessionId ? (
-                              <span className="project-sidebar__sess-status project-sidebar__sess-status--inline">
-                                {LEVEL_LABELS[level]}
-                              </span>
-                            ) : null}
-                          </a>
-                        );
-                      })
-                    ) : error ? (
-                      <div className="px-3 py-2">
-                        <div className="project-sidebar__empty">Failed to load sessions</div>
-                        <button
-                          type="button"
-                          className="mt-2 text-xs font-medium text-[var(--color-link)] hover:underline"
-                          onClick={onRetry}
-                        >
-                          Retry
-                        </button>
-                      </div>
-                    ) : (
-                      <div className="project-sidebar__empty">No active sessions</div>
-                    )}
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-        <div className="project-sidebar__footer">
-          <div className="flex items-center gap-1 border-t border-[var(--color-border-subtle)] px-2 py-2">
-            {/* Show killed toggle */}
+      {error && sessions && sessions.length > 0 ? (
+        <div
+          role="status"
+          className="mx-3 mb-2 flex items-center justify-between gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg-primary)] px-2 py-1.5 text-[11px] text-[var(--color-text-tertiary)]"
+        >
+          <span>Failed to refresh · showing cached sessions</span>
+          {onRetry ? (
             <button
               type="button"
-              onClick={() => setShowKilled(!showKilled)}
-              className={cn(
-                "project-sidebar__footer-btn",
-                showKilled && "project-sidebar__footer-btn--active",
-              )}
-              aria-pressed={showKilled}
-              title={showKilled ? "Hide killed sessions" : "Show killed sessions"}
-              aria-label={showKilled ? "Hide killed sessions" : "Show killed sessions"}
+              onClick={onRetry}
+              className="font-medium text-[var(--color-link)] hover:underline"
             >
-              {/* skull / terminated icon */}
-              <svg width="13" height="13" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M12 3C7.03 3 3 7.03 3 12c0 3.1 1.5 5.84 3.8 7.55V21h2.4v-1h1.6v1h2.4v-1h1.6v1H17v-1.45A9 9 0 0 0 21 12c0-4.97-4.03-9-9-9z" />
-                <circle cx="9" cy="11" r="1.5" fill="currentColor" stroke="none" />
-                <circle cx="15" cy="11" r="1.5" fill="currentColor" stroke="none" />
-              </svg>
+              Retry
             </button>
-            {/* Show done toggle */}
-            <button
-              type="button"
-              onClick={() => setShowDone(!showDone)}
-              className={cn(
-                "project-sidebar__footer-btn",
-                showDone && "project-sidebar__footer-btn--active",
-              )}
-              aria-pressed={showDone}
-              title={showDone ? "Hide completed sessions" : "Show completed sessions"}
-              aria-label={showDone ? "Hide completed sessions" : "Show completed sessions"}
-            >
-              {/* checkmark / done icon */}
-              <svg width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M20 6 9 17l-5-5" />
-              </svg>
-            </button>
-            <div className="flex-1" />
-            {/* Sidebar display settings (gear) */}
-            <div className="project-sidebar__settings-wrap" ref={settingsRef}>
-              <button
-                type="button"
-                onClick={() => setSettingsOpen((v) => !v)}
-                className={cn(
-                  "project-sidebar__footer-btn",
-                  settingsOpen && "project-sidebar__footer-btn--active",
-                )}
-                aria-expanded={settingsOpen}
-                aria-haspopup="dialog"
-                title="Sidebar settings"
-                aria-label="Sidebar settings"
-              >
-                <svg width="13" height="13" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24" aria-hidden="true">
-                  <circle cx="12" cy="12" r="3" />
-                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                </svg>
-              </button>
-              {settingsOpen ? (
-                <div
-                  ref={settingsPopoverRef}
-                  className="project-sidebar__settings-popover"
-                  role="dialog"
-                  aria-label="Sidebar settings"
-                >
-                  <label className="project-sidebar__settings-row">
-                    <input
-                      type="checkbox"
-                      checked={showSessionId}
-                      onChange={(e) => setShowSessionId(e.target.checked)}
-                    />
-                    <span>Show session ID</span>
-                  </label>
-                </div>
-              ) : null}
-            </div>
-            <ThemeToggle className="project-sidebar__theme-toggle" />
-          </div>
+          ) : null}
         </div>
-        <AddProjectModal open={addProjectOpen} onClose={() => setAddProjectOpen(false)} />
-        <ProjectSettingsModal
-          open={projectSettingsProjectId !== null}
-          projectId={projectSettingsProjectId}
-          onClose={() => setProjectSettingsProjectId(null)}
-        />
+      ) : null}
+
+      <div className="project-sidebar__tree flex-1 overflow-x-hidden overflow-y-auto">
+        {visibleProjects.map((project) => {
+          const workerSessions = sessionsByProject.get(project.id) ?? [];
+          const visibleSessions = workerSessions;
+          const projectHref = projectDashboardPath(project.id);
+          const statusSummary = isLoading
+            ? { tone: "pending" as const, detail: "Loading sessions" }
+            : getProjectStatusSummary(visibleSessions);
+          const orchestratorSession = sessions?.find(
+            (session) =>
+              isOrchestratorSession(session, prefixByProject.get(session.projectId), allPrefixes) &&
+              session.projectId === project.id,
+          );
+
+          return (
+            <ProjectSidebarProjectCard
+              key={project.id}
+              activeSessionId={activeSessionId}
+              deletingProjectId={deletingProjectId}
+              error={error}
+              health={getProjectHealth(visibleSessions)}
+              isActive={activeProjectId === project.id}
+              isDegraded={Boolean(project.resolveError)}
+              isExpanded={expandedProjects.has(project.id)}
+              isLoading={isLoading}
+              navigate={navigate}
+              onMobileClose={onMobileClose}
+              onOpenSettings={handleOpenProjectSettings}
+              onRemoveProject={handleRemoveProject}
+              onRetry={onRetry}
+              onToggleExpand={toggleExpand}
+              onToggleMenu={handleToggleProjectMenu}
+              orchestratorSession={orchestratorSession}
+              project={project}
+              projectHref={projectHref}
+              projectMenuOpen={projectMenuOpenId === project.id}
+              projectMenuPopoverRef={projectMenuPopoverRef}
+              projectMenuRef={projectMenuRef}
+              showSessionId={showSessionId}
+              statusSummary={statusSummary}
+              visibleSessions={visibleSessions}
+              workerSessions={workerSessions}
+            />
+          );
+        })}
+      </div>
+
+      <ProjectSidebarFooter
+        settingsOpen={settingsOpen}
+        settingsPopoverRef={settingsPopoverRef}
+        settingsRef={settingsRef}
+        setSettingsOpen={setSettingsOpen}
+        showDone={showDone}
+        showKilled={showKilled}
+        showSessionId={showSessionId}
+        setShowDone={setShowDone}
+        setShowKilled={setShowKilled}
+        setShowSessionId={setShowSessionId}
+      />
+      <AddProjectModal open={addProjectOpen} onClose={() => setAddProjectOpen(false)} />
+      <ProjectSettingsModal
+        open={projectSettingsProjectId !== null}
+        projectId={projectSettingsProjectId}
+        onClose={() => setProjectSettingsProjectId(null)}
+      />
     </aside>
   );
 }

--- a/packages/web/src/components/ProjectSidebarCollapsed.tsx
+++ b/packages/web/src/components/ProjectSidebarCollapsed.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+import { getSessionTitle, humanizeBranch } from "@/lib/format";
+import { projectDashboardPath, projectSessionPath } from "@/lib/routes";
+import { getAttentionLevel, type DashboardSession } from "@/lib/types";
+import type { ProjectInfo } from "@/lib/project-name";
+
+interface ProjectSidebarCollapsedProps {
+  activeProjectId: string | undefined;
+  activeSessionId: string | undefined;
+  navigate: (url: string, session?: DashboardSession) => void;
+  sessionsByProject: Map<string, DashboardSession[]>;
+  visibleProjects: ProjectInfo[];
+}
+
+export function ProjectSidebarCollapsed({
+  activeProjectId,
+  activeSessionId,
+  navigate,
+  sessionsByProject,
+  visibleProjects,
+}: ProjectSidebarCollapsedProps) {
+  return (
+    <aside className="project-sidebar project-sidebar--collapsed flex h-full flex-col items-center gap-1 overflow-y-auto py-2">
+      {visibleProjects.map((project, idx) => {
+        const visibleSessions = sessionsByProject.get(project.id) ?? [];
+        const projectAbbr = project.name.slice(0, 2).toUpperCase();
+
+        return (
+          <div key={project.id} className="flex w-full flex-col items-center gap-0.5 px-1">
+            {idx > 0 ? <div className="project-sidebar__collapsed-divider" aria-hidden="true" /> : null}
+            <a
+              href={projectDashboardPath(project.id)}
+              className={cn(
+                "project-sidebar__collapsed-icon",
+                activeProjectId === project.id && "project-sidebar__collapsed-icon--active",
+              )}
+              title={project.name}
+              aria-label={project.name}
+            >
+              <span className="project-sidebar__collapsed-abbr">{projectAbbr}</span>
+            </a>
+            {visibleSessions.slice(0, 5).map((session) => {
+              const level = getAttentionLevel(session);
+              const rawTitle = session.branch ?? getSessionTitle(session);
+              const displayTitle = session.branch ? humanizeBranch(session.branch) || rawTitle : rawTitle;
+              const abbr = displayTitle.replace(/\s+/g, "").slice(0, 3).toUpperCase();
+              const isActive = activeSessionId === session.id;
+              const sessionHref = projectSessionPath(project.id, session.id);
+
+              return (
+                <a
+                  key={session.id}
+                  href={sessionHref}
+                  onClick={(event) => {
+                    if (event.metaKey || event.ctrlKey || event.shiftKey || event.button === 1) return;
+                    event.preventDefault();
+                    navigate(sessionHref, session);
+                  }}
+                  className={cn(
+                    "project-sidebar__collapsed-session-btn",
+                    isActive && "project-sidebar__collapsed-session-btn--active",
+                  )}
+                  data-level={level}
+                  title={rawTitle}
+                  aria-label={rawTitle}
+                >
+                  <span className="project-sidebar__session-abbr-first">{abbr[0]}</span>
+                  <span className="project-sidebar__session-abbr-rest">{abbr.slice(1)}</span>
+                </a>
+              );
+            })}
+            {visibleSessions.length > 5 ? (
+              <span className="project-sidebar__collapsed-overflow">+{visibleSessions.length - 5}</span>
+            ) : null}
+          </div>
+        );
+      })}
+    </aside>
+  );
+}

--- a/packages/web/src/components/ProjectSidebarFooter.tsx
+++ b/packages/web/src/components/ProjectSidebarFooter.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import type { Dispatch, RefObject, SetStateAction } from "react";
+
+import { ThemeToggle } from "./ThemeToggle";
+
+interface ProjectSidebarFooterProps {
+  settingsOpen: boolean;
+  settingsPopoverRef: RefObject<HTMLDivElement | null>;
+  settingsRef: RefObject<HTMLDivElement | null>;
+  setSettingsOpen: Dispatch<SetStateAction<boolean>>;
+  showDone: boolean;
+  showKilled: boolean;
+  showSessionId: boolean;
+  setShowDone: Dispatch<SetStateAction<boolean>>;
+  setShowKilled: Dispatch<SetStateAction<boolean>>;
+  setShowSessionId: Dispatch<SetStateAction<boolean>>;
+}
+
+export function ProjectSidebarFooter({
+  settingsOpen,
+  settingsPopoverRef,
+  settingsRef,
+  setSettingsOpen,
+  showDone,
+  showKilled,
+  showSessionId,
+  setShowDone,
+  setShowKilled,
+  setShowSessionId,
+}: ProjectSidebarFooterProps) {
+  return (
+    <div className="project-sidebar__footer">
+      <div className="flex items-center gap-1 border-t border-[var(--color-border-subtle)] px-2 py-2">
+        <button
+          type="button"
+          onClick={() => setShowKilled(!showKilled)}
+          className={showKilled ? "project-sidebar__footer-btn project-sidebar__footer-btn--active" : "project-sidebar__footer-btn"}
+          aria-pressed={showKilled}
+          title={showKilled ? "Hide killed sessions" : "Show killed sessions"}
+          aria-label={showKilled ? "Hide killed sessions" : "Show killed sessions"}
+        >
+          <svg width="13" height="13" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 3C7.03 3 3 7.03 3 12c0 3.1 1.5 5.84 3.8 7.55V21h2.4v-1h1.6v1h2.4v-1h1.6v1H17v-1.45A9 9 0 0 0 21 12c0-4.97-4.03-9-9-9z" />
+            <circle cx="9" cy="11" r="1.5" fill="currentColor" stroke="none" />
+            <circle cx="15" cy="11" r="1.5" fill="currentColor" stroke="none" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowDone(!showDone)}
+          className={showDone ? "project-sidebar__footer-btn project-sidebar__footer-btn--active" : "project-sidebar__footer-btn"}
+          aria-pressed={showDone}
+          title={showDone ? "Hide completed sessions" : "Show completed sessions"}
+          aria-label={showDone ? "Hide completed sessions" : "Show completed sessions"}
+        >
+          <svg width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        </button>
+        <div className="flex-1" />
+        <div className="project-sidebar__settings-wrap" ref={settingsRef}>
+          <button
+            type="button"
+            onClick={() => setSettingsOpen((value) => !value)}
+            className={settingsOpen ? "project-sidebar__footer-btn project-sidebar__footer-btn--active" : "project-sidebar__footer-btn"}
+            aria-expanded={settingsOpen}
+            aria-haspopup="dialog"
+            title="Sidebar settings"
+            aria-label="Sidebar settings"
+          >
+            <svg width="13" height="13" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+          </button>
+          {settingsOpen ? (
+            <div
+              ref={settingsPopoverRef}
+              className="project-sidebar__settings-popover"
+              role="dialog"
+              aria-label="Sidebar settings"
+            >
+              <label className="project-sidebar__settings-row">
+                <input
+                  type="checkbox"
+                  checked={showSessionId}
+                  onChange={(event) => setShowSessionId(event.target.checked)}
+                />
+                <span>Show session ID</span>
+              </label>
+            </div>
+          ) : null}
+        </div>
+        <ThemeToggle className="project-sidebar__theme-toggle" />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/ProjectSidebarProjectCard.tsx
+++ b/packages/web/src/components/ProjectSidebarProjectCard.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import Link from "next/link";
+import type { RefObject } from "react";
+import { cn } from "@/lib/cn";
+import type { ProjectInfo } from "@/lib/project-name";
+import { projectSessionPath } from "@/lib/routes";
+import type { DashboardSession } from "@/lib/types";
+
+import {
+  LEVEL_LABELS,
+  type ProjectHealth,
+  type ProjectStatusSummary,
+} from "./ProjectSidebar.shared";
+import { ProjectSidebarSessionRow } from "./ProjectSidebarSessionRow";
+
+interface ProjectSidebarProjectCardProps {
+  activeSessionId: string | undefined;
+  deletingProjectId: string | null;
+  error: boolean;
+  health: ProjectHealth;
+  isActive: boolean;
+  isDegraded: boolean;
+  isExpanded: boolean;
+  isLoading: boolean;
+  navigate: (url: string, session?: DashboardSession) => void;
+  onMobileClose?: () => void;
+  onOpenSettings: (projectId: string) => void;
+  onRemoveProject: (project: ProjectInfo) => Promise<void>;
+  onRetry?: () => void;
+  onToggleExpand: (projectId: string) => void;
+  onToggleMenu: (projectId: string) => void;
+  orchestratorSession?: DashboardSession;
+  project: ProjectInfo;
+  projectHref: string;
+  projectMenuOpen: boolean;
+  projectMenuPopoverRef?: RefObject<HTMLDivElement | null>;
+  projectMenuRef?: RefObject<HTMLDivElement | null>;
+  showSessionId: boolean;
+  statusSummary: ProjectStatusSummary;
+  visibleSessions: DashboardSession[];
+  workerSessions: DashboardSession[];
+}
+
+export function ProjectSidebarProjectCard({
+  activeSessionId,
+  deletingProjectId,
+  error,
+  health,
+  isActive,
+  isDegraded,
+  isExpanded,
+  isLoading,
+  navigate,
+  onMobileClose,
+  onOpenSettings,
+  onRemoveProject,
+  onRetry,
+  onToggleExpand,
+  onToggleMenu,
+  orchestratorSession,
+  project,
+  projectHref,
+  projectMenuOpen,
+  projectMenuPopoverRef,
+  projectMenuRef,
+  showSessionId,
+  statusSummary,
+  visibleSessions,
+  workerSessions,
+}: ProjectSidebarProjectCardProps) {
+  const hasActiveSessions = visibleSessions.length > 0;
+
+  return (
+    <div className="project-sidebar__project" data-health={health}>
+      <div className="project-sidebar__proj-row flex items-center">
+        {isDegraded ? (
+          <a
+            href={projectHref}
+            onClick={(event) => {
+              if (event.metaKey || event.ctrlKey || event.shiftKey || event.button === 1) return;
+              event.preventDefault();
+              navigate(projectHref);
+            }}
+            className={cn(
+              "project-sidebar__proj-toggle project-sidebar__proj-toggle--link project-sidebar__proj-toggle--degraded",
+              isActive && "project-sidebar__proj-toggle--active",
+            )}
+            aria-current={isActive ? "page" : undefined}
+          >
+            <span className="sidebar-health-dot project-sidebar__proj-health" data-health="amber" aria-hidden="true" />
+            <svg
+              className="project-sidebar__proj-chevron project-sidebar__proj-chevron--degraded"
+              width="10"
+              height="10"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path d="M12 9v4" />
+              <path d="M12 17h.01" />
+              <path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.72 3h16.92a2 2 0 0 0 1.72-3L13.7 3.86a2 2 0 0 0-3.4 0Z" />
+            </svg>
+            <span className="project-sidebar__proj-name">{project.name}</span>
+            <span className="project-sidebar__proj-badge project-sidebar__proj-badge--degraded">degraded</span>
+          </a>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onToggleExpand(project.id)}
+            className={cn(
+              "project-sidebar__proj-toggle",
+              isActive && "project-sidebar__proj-toggle--active",
+            )}
+            aria-expanded={isExpanded}
+            aria-current={isActive ? "page" : undefined}
+          >
+            <span className="sidebar-health-dot project-sidebar__proj-health" data-health={health} aria-hidden="true" />
+            <svg
+              className={cn(
+                "project-sidebar__proj-chevron",
+                isExpanded && "project-sidebar__proj-chevron--open",
+              )}
+              width="10"
+              height="10"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              viewBox="0 0 24 24"
+            >
+              <path d="m9 18 6-6-6-6" />
+            </svg>
+            <span className="project-sidebar__proj-name">{project.name}</span>
+            <span
+              className={cn(
+                "project-sidebar__proj-badge",
+                hasActiveSessions && "project-sidebar__proj-badge--active",
+              )}
+            >
+              {workerSessions.length}
+            </span>
+          </button>
+        )}
+
+        {!isDegraded ? (
+          <Link
+            href={projectHref}
+            onClick={(event) => {
+              event.stopPropagation();
+              onMobileClose?.();
+            }}
+            className="project-sidebar__proj-action"
+            aria-label={`Open ${project.name} dashboard`}
+            title="Dashboard"
+          >
+            <svg width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path d="M3 13h8V3H3zm10 8h8V11h-8zM3 21h8v-6H3zm10-10h8V3h-8z" />
+            </svg>
+          </Link>
+        ) : null}
+
+        {!isDegraded && orchestratorSession ? (
+          <Link
+            href={projectSessionPath(project.id, orchestratorSession.id)}
+            onClick={(event) => {
+              event.stopPropagation();
+              onMobileClose?.();
+            }}
+            className="project-sidebar__proj-action"
+            aria-label={`Open ${project.name} orchestrator`}
+            title="Orchestrator"
+          >
+            <svg width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <circle cx="12" cy="5" r="2" fill="currentColor" stroke="none" />
+              <path d="M12 7v4M12 11H6M12 11h6M6 11v3M12 11v3M18 11v3" />
+              <circle cx="6" cy="17" r="2" />
+              <circle cx="12" cy="17" r="2" />
+              <circle cx="18" cy="17" r="2" />
+            </svg>
+          </Link>
+        ) : null}
+
+        <div
+          className="project-sidebar__proj-menu"
+          ref={projectMenuOpen ? projectMenuRef : undefined}
+        >
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleMenu(project.id);
+            }}
+            className="project-sidebar__proj-action project-sidebar__proj-action--menu"
+            aria-label={`Project actions for ${project.name}`}
+            aria-expanded={projectMenuOpen}
+            aria-haspopup="menu"
+            title="Project actions"
+          >
+            <svg width="12" height="12" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="5" r="1.75" />
+              <circle cx="12" cy="12" r="1.75" />
+              <circle cx="12" cy="19" r="1.75" />
+            </svg>
+          </button>
+          {projectMenuOpen ? (
+            <div
+              ref={projectMenuPopoverRef}
+              className="project-sidebar__proj-menu-popover"
+              role="menu"
+              aria-label={`${project.name} actions`}
+            >
+              <button
+                type="button"
+                className="project-sidebar__proj-menu-item"
+                role="menuitem"
+                onClick={() => onOpenSettings(project.id)}
+              >
+                Project settings
+              </button>
+              <button
+                type="button"
+                className="project-sidebar__proj-menu-item project-sidebar__proj-menu-item--danger"
+                role="menuitem"
+                onClick={() => void onRemoveProject(project)}
+                disabled={deletingProjectId === project.id}
+              >
+                {deletingProjectId === project.id ? "Removing..." : "Remove project"}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {isDegraded ? (
+        <div className="project-sidebar__degraded-note">Config needs repair</div>
+      ) : (
+        <div className="project-sidebar__proj-summary" aria-hidden="true">
+          <span
+            className={cn(
+              "project-sidebar__proj-summary-pill",
+              `project-sidebar__proj-summary-pill--${statusSummary.tone}`,
+            )}
+          >
+            {LEVEL_LABELS[statusSummary.tone] ?? "done"}
+          </span>
+          <span className="project-sidebar__proj-summary-text">{statusSummary.detail}</span>
+        </div>
+      )}
+
+      {!isDegraded && isExpanded ? (
+        <div className="project-sidebar__sessions">
+          {isLoading ? (
+            <div className="space-y-2 px-3 py-2" aria-label="Loading sessions">
+              {Array.from({ length: 3 }, (_, index) => (
+                <div
+                  key={`${project.id}-loading-${index}`}
+                  className="flex items-center gap-3 border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-2 py-2"
+                >
+                  <div className="h-2 w-2 shrink-0 animate-pulse bg-[var(--color-border-strong)]" />
+                  <div className="h-3 flex-1 animate-pulse bg-[var(--color-bg-primary)]" />
+                  <div className="h-3 w-12 animate-pulse bg-[var(--color-bg-primary)]" />
+                </div>
+              ))}
+            </div>
+          ) : visibleSessions.length > 0 ? (
+            visibleSessions.map((session) => (
+              <ProjectSidebarSessionRow
+                key={session.id}
+                activeSessionId={activeSessionId}
+                navigate={navigate}
+                projectId={project.id}
+                session={session}
+                showSessionId={showSessionId}
+              />
+            ))
+          ) : error ? (
+            <div className="px-3 py-2">
+              <div className="project-sidebar__empty">Failed to load sessions</div>
+              <button
+                type="button"
+                className="mt-2 text-xs font-medium text-[var(--color-link)] hover:underline"
+                onClick={onRetry}
+              >
+                Retry
+              </button>
+            </div>
+          ) : (
+            <div className="project-sidebar__empty">No active sessions</div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/components/ProjectSidebarSessionRow.tsx
+++ b/packages/web/src/components/ProjectSidebarSessionRow.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+import { getSessionTitle } from "@/lib/format";
+import { projectSessionPath } from "@/lib/routes";
+import { getAttentionLevel, type DashboardSession } from "@/lib/types";
+
+import { LEVEL_LABELS } from "./ProjectSidebar.shared";
+
+function SessionDot({ level }: { level: ReturnType<typeof getAttentionLevel> }) {
+  return (
+    <div
+      className={cn(
+        "sidebar-session-dot shrink-0 rounded-full",
+        level === "working" && "sidebar-session-dot--glow",
+      )}
+      data-level={level}
+    />
+  );
+}
+
+interface ProjectSidebarSessionRowProps {
+  activeSessionId: string | undefined;
+  navigate: (url: string, session?: DashboardSession) => void;
+  projectId: string;
+  session: DashboardSession;
+  showSessionId: boolean;
+}
+
+export function ProjectSidebarSessionRow({
+  activeSessionId,
+  navigate,
+  projectId,
+  session,
+  showSessionId,
+}: ProjectSidebarSessionRowProps) {
+  const level = getAttentionLevel(session);
+  const isSessionActive = activeSessionId === session.id;
+  const title = session.branch ?? getSessionTitle(session);
+  const sessionHref = projectSessionPath(projectId, session.id);
+
+  return (
+    <a
+      href={sessionHref}
+      onClick={(event) => {
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.button === 1) return;
+        event.preventDefault();
+        navigate(sessionHref, session);
+      }}
+      className={cn(
+        "project-sidebar__sess-row",
+        isSessionActive && "project-sidebar__sess-row--active",
+      )}
+      aria-current={isSessionActive ? "page" : undefined}
+      aria-label={`Open ${title}`}
+    >
+      <SessionDot level={level} />
+      <div className="min-w-0 flex-1">
+        <span
+          className={cn(
+            "project-sidebar__sess-label",
+            isSessionActive && "project-sidebar__sess-label--active",
+          )}
+        >
+          {title}
+        </span>
+        {showSessionId ? (
+          <div className="project-sidebar__sess-meta">
+            <span className="project-sidebar__sess-id">{session.id}</span>
+            <span className="project-sidebar__sess-status">{LEVEL_LABELS[level]}</span>
+          </div>
+        ) : null}
+      </div>
+      {!showSessionId ? (
+        <span className="project-sidebar__sess-status project-sidebar__sess-status--inline">
+          {LEVEL_LABELS[level]}
+        </span>
+      ) : null}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- redesign the projects sidebar into clearer project cards with stronger hierarchy and lower visual noise
- add richer nested session rows with stable accessibility labels, compact status pills, and better navigation affordances
- refresh collapsed rail styling and expand sidebar tests around overview, project, and session navigation

## Why
Operators scan this rail constantly. The old sidebar surfaced information, but the hierarchy and actions were too flat and noisy for fast triage. This pass prioritizes scanability, status signaling, and polished interaction states.

## Testing
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm --filter @composio/ao-web test -- --run ProjectSidebar

Closes #146