### PR TITLE
feat(agent): add Hermes runtime plugin (Path A)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,6 +39,7 @@
     "@aoagents/ao-plugin-agent-codex": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
+    "@aoagents/ao-plugin-agent-hermes": "workspace:*",
     "@aoagents/ao-plugin-notifier-composio": "workspace:*",
     "@aoagents/ao-plugin-notifier-desktop": "workspace:*",
     "@aoagents/ao-plugin-notifier-discord": "workspace:*",

--- a/packages/cli/src/lib/detect-agent.ts
+++ b/packages/cli/src/lib/detect-agent.ts
@@ -20,6 +20,7 @@ const AGENT_PLUGINS: Array<{ name: string; pkg: string }> = [
   { name: "codex", pkg: "@aoagents/ao-plugin-agent-codex" },
   { name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { name: "hermes", pkg: "@aoagents/ao-plugin-agent-hermes" },
 ];
 
 /**

--- a/packages/core/src/__tests__/plugin-registry.test.ts
+++ b/packages/core/src/__tests__/plugin-registry.test.ts
@@ -150,11 +150,13 @@ describe("loadBuiltins", () => {
     const fakeClaudeCode = makePlugin("agent", "claude-code");
     const fakeCodex = makePlugin("agent", "codex");
     const fakeOpenCode = makePlugin("agent", "opencode");
+    const fakeHermes = makePlugin("agent", "hermes");
 
     await registry.loadBuiltins(undefined, async (pkg: string) => {
       if (pkg === "@aoagents/ao-plugin-agent-claude-code") return fakeClaudeCode;
       if (pkg === "@aoagents/ao-plugin-agent-codex") return fakeCodex;
       if (pkg === "@aoagents/ao-plugin-agent-opencode") return fakeOpenCode;
+      if (pkg === "@aoagents/ao-plugin-agent-hermes") return fakeHermes;
       throw new Error(`Not found: ${pkg}`);
     });
 
@@ -162,10 +164,12 @@ describe("loadBuiltins", () => {
     expect(agents).toContainEqual(expect.objectContaining({ name: "claude-code", slot: "agent" }));
     expect(agents).toContainEqual(expect.objectContaining({ name: "codex", slot: "agent" }));
     expect(agents).toContainEqual(expect.objectContaining({ name: "opencode", slot: "agent" }));
+    expect(agents).toContainEqual(expect.objectContaining({ name: "hermes", slot: "agent" }));
 
     expect(registry.get("agent", "codex")).not.toBeNull();
     expect(registry.get("agent", "claude-code")).not.toBeNull();
     expect(registry.get("agent", "opencode")).not.toBeNull();
+    expect(registry.get("agent", "hermes")).not.toBeNull();
   });
 
   it("registers gitlab tracker and scm plugins from importFn", async () => {

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -45,6 +45,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "aider", pkg: "@aoagents/ao-plugin-agent-aider" },
   { slot: "agent", name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { slot: "agent", name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { slot: "agent", name: "hermes", pkg: "@aoagents/ao-plugin-agent-hermes" },
   // Workspaces
   { slot: "workspace", name: "worktree", pkg: "@aoagents/ao-plugin-workspace-worktree" },
   { slot: "workspace", name: "clone", pkg: "@aoagents/ao-plugin-workspace-clone" },

--- a/packages/plugins/agent-hermes/CHANGELOG.md
+++ b/packages/plugins/agent-hermes/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @aoagents/ao-plugin-agent-hermes
+
+## 0.1.0
+
+- Initial Hermes CLI agent plugin for AO (Path A scaffold)

--- a/packages/plugins/agent-hermes/package.json
+++ b/packages/plugins/agent-hermes/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@aoagents/ao-plugin-agent-hermes",
+  "version": "0.1.0",
+  "description": "Agent plugin: Hermes CLI",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-hermes"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-hermes/src/index.test.ts
+++ b/packages/plugins/agent-hermes/src/index.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import type { Session, RuntimeHandle, AgentLaunchConfig } from "@aoagents/ao-core";
+
+const { mockAppendActivityEntry, mockReadLastActivityEntry, mockRecordTerminalActivity } =
+  vi.hoisted(() => ({
+    mockAppendActivityEntry: vi.fn().mockResolvedValue(undefined),
+    mockReadLastActivityEntry: vi.fn().mockResolvedValue(null),
+    mockRecordTerminalActivity: vi.fn().mockResolvedValue(undefined),
+  }));
+
+const { mockExecFileAsync } = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(),
+}));
+
+vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    appendActivityEntry: mockAppendActivityEntry,
+    readLastActivityEntry: mockReadLastActivityEntry,
+    recordTerminalActivity: mockRecordTerminalActivity,
+  };
+});
+
+vi.mock("node:child_process", () => {
+  const fn = Object.assign((..._args: unknown[]) => {}, {
+    [Symbol.for("nodejs.util.promisify.custom")]: mockExecFileAsync,
+  });
+  return { execFile: fn, execFileSync: vi.fn() };
+});
+
+import { create, manifest, default as defaultExport } from "./index.js";
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "test-1",
+    projectId: "test-project",
+    status: "working",
+    activity: "active",
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/workspace/test",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeTmuxHandle(id = "test-session"): RuntimeHandle {
+  return { id, runtimeName: "tmux", data: {} };
+}
+
+function makeProcessHandle(pid?: number): RuntimeHandle {
+  return { id: "proc-1", runtimeName: "process", data: pid !== undefined ? { pid } : {} };
+}
+
+function makeLaunchConfig(overrides: Partial<AgentLaunchConfig> = {}): AgentLaunchConfig {
+  return {
+    sessionId: "sess-1",
+    projectConfig: {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/repo",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("plugin manifest & exports", () => {
+  it("has correct manifest", () => {
+    expect(manifest).toEqual({
+      name: "hermes",
+      slot: "agent",
+      description: "Agent plugin: Hermes CLI",
+      version: "0.1.0",
+      displayName: "Hermes",
+    });
+  });
+
+  it("create() returns agent with correct name and processName", () => {
+    const agent = create();
+    expect(agent.name).toBe("hermes");
+    expect(agent.processName).toBe("hermes");
+    expect(agent.promptDelivery).toBe("post-launch");
+  });
+
+  it("default export is a valid PluginModule", () => {
+    expect(defaultExport.manifest).toBe(manifest);
+    expect(typeof defaultExport.create).toBe("function");
+  });
+});
+
+describe("getLaunchCommand", () => {
+  const agent = create();
+
+  it("generates base command", () => {
+    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("hermes");
+  });
+
+  it("includes --yolo for permissionless", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "permissionless" }));
+    expect(cmd).toContain("--yolo");
+  });
+
+  it("uses post-launch prompt delivery and does not inline prompt", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "Fix issue" }));
+    expect(cmd).toBe("hermes");
+  });
+});
+
+describe("getEnvironment", () => {
+  const agent = create();
+
+  it("sets AO_SESSION_ID but not AO_PROJECT_ID", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["AO_SESSION_ID"]).toBe("sess-1");
+    expect(env["AO_PROJECT_ID"]).toBeUndefined();
+  });
+
+  it("sets AO_ISSUE_ID when provided", () => {
+    const env = agent.getEnvironment(makeLaunchConfig({ issueId: "LIN-99" }));
+    expect(env["AO_ISSUE_ID"]).toBe("LIN-99");
+  });
+});
+
+describe("getActivityState", () => {
+  const agent = create();
+
+  it("returns exited when runtimeHandle is missing", async () => {
+    const state = await agent.getActivityState(makeSession({ runtimeHandle: null }));
+    expect(state?.state).toBe("exited");
+  });
+
+  it("returns active fallback when process is running but no activity log exists", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(123), workspacePath: "/workspace/test" }),
+    );
+    expect(state?.state).toBe("active");
+    killSpy.mockRestore();
+  });
+});
+
+describe("isProcessRunning", () => {
+  const agent = create();
+
+  it("returns true for process handle with alive PID", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    expect(await agent.isProcessRunning(makeProcessHandle(456))).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(456, 0);
+    killSpy.mockRestore();
+  });
+
+  it("returns false for dead PID", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(456))).toBe(false);
+    killSpy.mockRestore();
+  });
+
+  it("returns true when hermes found on tmux pane TTY", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys005\n", stderr: "" });
+      if (cmd === "ps") {
+        return Promise.resolve({
+          stdout: "  PID TT       ARGS\n  444 ttys005  hermes\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+});

--- a/packages/plugins/agent-hermes/src/index.ts
+++ b/packages/plugins/agent-hermes/src/index.ts
@@ -1,0 +1,207 @@
+import {
+  normalizeAgentPermissionMode,
+  buildAgentPath,
+  setupPathWrapperWorkspace,
+  readLastActivityEntry,
+  checkActivityLogState,
+  getActivityFallbackState,
+  recordTerminalActivity,
+  PREFERRED_GH_PATH,
+  DEFAULT_READY_THRESHOLD_MS,
+  DEFAULT_ACTIVE_WINDOW_MS,
+  type Agent,
+  type AgentSessionInfo,
+  type AgentLaunchConfig,
+  type ActivityDetection,
+  type ActivityState,
+  type PluginModule,
+  type RuntimeHandle,
+  type Session,
+  type WorkspaceHooksConfig,
+} from "@aoagents/ao-core";
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const manifest = {
+  name: "hermes",
+  slot: "agent" as const,
+  description: "Agent plugin: Hermes CLI",
+  version: "0.1.0",
+  displayName: "Hermes",
+};
+
+function createHermesAgent(): Agent {
+  return {
+    name: "hermes",
+    processName: "hermes",
+    promptDelivery: "post-launch",
+
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      const parts: string[] = ["hermes"];
+
+      const permissionMode = normalizeAgentPermissionMode(config.permissions);
+      if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
+        parts.push("--yolo");
+      }
+
+      // Hermes does not expose a stable system-prompt CLI flag in this integration.
+      // AO still passes prompts post-launch via runtime.sendMessage().
+      void config.systemPromptFile;
+      void config.systemPrompt;
+
+      return parts.join(" ");
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      const env: Record<string, string> = {};
+      env["AO_SESSION_ID"] = config.sessionId;
+      if (config.issueId) {
+        env["AO_ISSUE_ID"] = config.issueId;
+      }
+
+      env["PATH"] = buildAgentPath(process.env["PATH"]);
+      env["GH_PATH"] = PREFERRED_GH_PATH;
+
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      if (!terminalOutput.trim()) return "idle";
+
+      const lines = terminalOutput.trim().split("\n");
+      const lastLine = lines[lines.length - 1]?.trim() ?? "";
+      const tail = lines.slice(-8).join("\n");
+
+      if (/\[y\/N\]/i.test(tail)) return "waiting_input";
+      if (/\(y\/n\)/i.test(tail)) return "waiting_input";
+      if (/approve|confirm|permission/i.test(tail) && /\?/i.test(tail)) return "waiting_input";
+
+      if (/\berror\b/i.test(tail) || /\bfailed\b/i.test(tail)) return "blocked";
+
+      if (/^[>$#]\s*$/.test(lastLine)) return "idle";
+      if (/^you>\s*$/i.test(lastLine)) return "idle";
+
+      return "active";
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
+      const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
+
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (!running) return { state: "exited", timestamp: exitedAt };
+
+      if (!session.workspacePath) return null;
+
+      const activityResult = await readLastActivityEntry(session.workspacePath);
+      const activityState = checkActivityLogState(activityResult);
+      if (activityState) return activityState;
+
+      const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
+      const fallback = getActivityFallbackState(activityResult, activeWindowMs, threshold);
+      if (fallback) return fallback;
+
+      return { state: "active" };
+    },
+
+    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
+      if (!session.workspacePath) return;
+      await recordTerminalActivity(session.workspacePath, terminalOutput, (output: string) =>
+        this.detectActivity(output),
+      );
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      try {
+        if (handle.runtimeName === "tmux" && handle.id) {
+          const { stdout: ttyOut } = await execFileAsync(
+            "tmux",
+            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+            { timeout: 30_000 },
+          );
+          const ttys = ttyOut
+            .trim()
+            .split("\n")
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (ttys.length === 0) return false;
+
+          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
+            timeout: 30_000,
+          });
+          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
+          const processRe = /(?:^|\/)hermes(?:\s|$)/;
+          for (const line of psOut.split("\n")) {
+            const cols = line.trimStart().split(/\s+/);
+            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+            const args = cols.slice(2).join(" ");
+            if (processRe.test(args)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        const rawPid = handle.data["pid"];
+        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+        if (Number.isFinite(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+            return true;
+          } catch (err: unknown) {
+            if (err instanceof Error && "code" in err && err.code === "EPERM") {
+              return true;
+            }
+            return false;
+          }
+        }
+
+        return false;
+      } catch {
+        return false;
+      }
+    },
+
+    async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {
+      return {
+        summary: null,
+        summaryIsFallback: true,
+        agentSessionId: null,
+      };
+    },
+
+    async getRestoreCommand(): Promise<string | null> {
+      return null;
+    },
+
+    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+      await setupPathWrapperWorkspace(workspacePath);
+    },
+
+    async postLaunchSetup(session: Session): Promise<void> {
+      if (!session.workspacePath) return;
+      await setupPathWrapperWorkspace(session.workspacePath);
+    },
+  };
+}
+
+export function create(): Agent {
+  return createHermesAgent();
+}
+
+export function detect(): boolean {
+  try {
+    execFileSync("hermes", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-hermes/tsconfig.json
+++ b/packages/plugins/agent-hermes/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@aoagents/ao-plugin-agent-cursor':
         specifier: workspace:*
         version: link:../plugins/agent-cursor
+      '@aoagents/ao-plugin-agent-hermes':
+        specifier: workspace:*
+        version: link:../plugins/agent-hermes
       '@aoagents/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
@@ -298,6 +301,22 @@ importers:
         version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/plugins/agent-cursor:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/plugins/agent-hermes:
     dependencies:
       '@aoagents/ao-core':
         specifier: workspace:*


### PR DESCRIPTION
>Very early PR, work remains

## Summary
- add new AO agent plugin package `@aoagents/ao-plugin-agent-hermes`
- wire Hermes into built-in plugin registry and CLI agent detection
- add plugin-registry tests for Hermes built-in loading
- add workspace dependency + lockfile wiring for plugin package

## What is done
- plugin scaffold: `packages/plugins/agent-hermes`
  - `src/index.ts`
  - `src/index.test.ts`
  - `package.json`, `tsconfig.json`, `CHANGELOG.md`
- AO core wiring
  - `packages/core/src/plugin-registry.ts` includes `hermes` as built-in agent plugin
- AO CLI wiring
  - `packages/cli/src/lib/detect-agent.ts` includes Hermes in runtime detection
  - `packages/cli/package.json` depends on `@aoagents/ao-plugin-agent-hermes`
- validation tests
  - plugin unit tests
  - plugin-registry built-ins test updated for Hermes

## What is left
- session persistence hardening under `runtime: process`
  - current behavior can mark Hermes workers `exited` too quickly in some environments
- improve `getSessionInfo()`
  - currently minimal fallback only
- implement robust restore path
  - `getRestoreCommand()` currently returns `null`
- tighten activity-state semantics
  - reduce false `exited` / improve waiting-input vs active classification

## Notes
- this PR is scoped to AO running Hermes as an **agent runtime** (`ao start` / `ao spawn` path)
- out of scope: Hermes-side AO controller/plugin bridge
