### PR TITLE
Fix update flow for git installs and runnable binary validation

### DIFF
--- a/packages/cli/__tests__/commands/update.test.ts
+++ b/packages/cli/__tests__/commands/update.test.ts
@@ -96,6 +96,8 @@ describe("update command", () => {
   let program: Command;
   let origStdinTTY: boolean | undefined;
   let origStdoutTTY: boolean | undefined;
+  let origPlatform: NodeJS.Platform;
+  let origComSpec: string | undefined;
 
   beforeEach(() => {
     program = new Command();
@@ -114,6 +116,8 @@ describe("update command", () => {
     mockSpawn.mockReset();
     origStdinTTY = process.stdin.isTTY;
     origStdoutTTY = process.stdout.isTTY;
+    origPlatform = process.platform;
+    origComSpec = process.env.ComSpec;
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(process, "exit").mockImplementation((code) => {
@@ -125,6 +129,12 @@ describe("update command", () => {
     vi.restoreAllMocks();
     Object.defineProperty(process.stdin, "isTTY", { value: origStdinTTY, configurable: true });
     Object.defineProperty(process.stdout, "isTTY", { value: origStdoutTTY, configurable: true });
+    Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+    if (origComSpec === undefined) {
+      delete process.env.ComSpec;
+    } else {
+      process.env.ComSpec = origComSpec;
+    }
   });
 
   // -----------------------------------------------------------------------
@@ -306,6 +316,34 @@ describe("update command", () => {
       );
       expect(mockSpawn).toHaveBeenCalledWith("sh", ["-lc", "command -v ao"], expect.anything());
       expect(mockSpawn).toHaveBeenCalledWith("sh", ["-lc", "ao --version"], expect.anything());
+      expect(mockInvalidateCache).toHaveBeenCalled();
+    });
+
+    it("verifies the runnable ao binary through cmd.exe on Windows", async () => {
+      Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+      Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      process.env.ComSpec = "C:\\Windows\\System32\\cmd.exe";
+      mockPromptConfirm.mockResolvedValue(true);
+      mockSpawn
+        .mockReturnValueOnce(createMockChild(0))
+        .mockReturnValueOnce(
+          createMockChild(0, undefined, "C:\\Users\\test\\AppData\\Roaming\\npm\\ao.cmd\n"),
+        )
+        .mockReturnValueOnce(createMockChild(0, undefined, "0.3.0\n"));
+
+      await program.parseAsync(["node", "test", "update"]);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "C:\\Windows\\System32\\cmd.exe",
+        ["/d", "/s", "/c", "where ao"],
+        expect.anything(),
+      );
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "C:\\Windows\\System32\\cmd.exe",
+        ["/d", "/s", "/c", "ao --version"],
+        expect.anything(),
+      );
       expect(mockInvalidateCache).toHaveBeenCalled();
     });
 

--- a/packages/cli/__tests__/commands/update.test.ts
+++ b/packages/cli/__tests__/commands/update.test.ts
@@ -5,9 +5,7 @@ import { Command } from "commander";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const {
-  mockRunRepoScript,
-} = vi.hoisted(() => ({
+const { mockRunRepoScript } = vi.hoisted(() => ({
   mockRunRepoScript: vi.fn(),
 }));
 
@@ -83,9 +81,14 @@ function makeNpmUpdateInfo(overrides = {}) {
   };
 }
 
-function createMockChild(exitCode: number | null, signal?: NodeJS.Signals) {
+function createMockChild(exitCode: number | null, signal?: NodeJS.Signals, stdout = "") {
   const child = new EventEmitter();
-  setTimeout(() => child.emit("exit", exitCode, signal ?? null), 0);
+  const stdoutEmitter = new EventEmitter();
+  Object.assign(child, { stdout: stdoutEmitter });
+  setTimeout(() => {
+    if (stdout) stdoutEmitter.emit("data", Buffer.from(stdout));
+    child.emit("exit", exitCode, signal ?? null);
+  }, 0);
   return child;
 }
 
@@ -102,7 +105,9 @@ describe("update command", () => {
     mockRunRepoScript.mockResolvedValue(0);
     mockDetectInstallMethod.mockReturnValue("git");
     mockCheckForUpdate.mockReset();
-    mockCheckForUpdate.mockResolvedValue(makeNpmUpdateInfo({ installMethod: "git", recommendedCommand: "ao update" }));
+    mockCheckForUpdate.mockResolvedValue(
+      makeNpmUpdateInfo({ installMethod: "git", recommendedCommand: "ao update" }),
+    );
     mockInvalidateCache.mockReset();
     mockPromptConfirm.mockReset();
     mockPromptConfirm.mockResolvedValue(false);
@@ -187,9 +192,9 @@ describe("update command", () => {
         new Error("Script not found: ao-update.sh. Expected at: /tmp/ao-update.sh"),
       );
 
-      await expect(
-        program.parseAsync(["node", "test", "update"]),
-      ).rejects.toThrow("process.exit(1)");
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow(
+        "process.exit(1)",
+      );
 
       expect(mockSpawn).not.toHaveBeenCalled();
       expect(mockCheckForUpdate).not.toHaveBeenCalled();
@@ -234,7 +239,9 @@ describe("update command", () => {
     });
 
     it("prints already up to date when not outdated", async () => {
-      mockCheckForUpdate.mockResolvedValue(makeNpmUpdateInfo({ isOutdated: false, latestVersion: "0.2.2", currentVersion: "0.2.2" }));
+      mockCheckForUpdate.mockResolvedValue(
+        makeNpmUpdateInfo({ isOutdated: false, latestVersion: "0.2.2", currentVersion: "0.2.2" }),
+      );
 
       const logSpy = vi.mocked(console.log);
       await program.parseAsync(["node", "test", "update"]);
@@ -246,9 +253,9 @@ describe("update command", () => {
         makeNpmUpdateInfo({ latestVersion: null, isOutdated: false }),
       );
 
-      await expect(
-        program.parseAsync(["node", "test", "update"]),
-      ).rejects.toThrow("process.exit(1)");
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow(
+        "process.exit(1)",
+      );
       expect(vi.mocked(console.error)).toHaveBeenCalledWith(
         expect.stringContaining("Could not reach npm registry"),
       );
@@ -285,12 +292,43 @@ describe("update command", () => {
       Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
       Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
       mockPromptConfirm.mockResolvedValue(true);
-      mockSpawn.mockReturnValue(createMockChild(0));
+      mockSpawn
+        .mockReturnValueOnce(createMockChild(0))
+        .mockReturnValueOnce(createMockChild(0, undefined, "/usr/local/bin/ao\n"))
+        .mockReturnValueOnce(createMockChild(0, undefined, "0.3.0\n"));
 
       await program.parseAsync(["node", "test", "update"]);
 
-      expect(mockSpawn).toHaveBeenCalledWith("npm", expect.arrayContaining(["install"]), expect.anything());
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "npm",
+        expect.arrayContaining(["install"]),
+        expect.anything(),
+      );
+      expect(mockSpawn).toHaveBeenCalledWith("sh", ["-lc", "command -v ao"], expect.anything());
+      expect(mockSpawn).toHaveBeenCalledWith("ao", ["--version"], expect.anything());
       expect(mockInvalidateCache).toHaveBeenCalled();
+    });
+
+    it("exits non-zero when npm install succeeds but runnable ao remains old", async () => {
+      Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+      Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+      mockPromptConfirm.mockResolvedValue(true);
+      mockSpawn
+        .mockReturnValueOnce(createMockChild(0))
+        .mockReturnValueOnce(createMockChild(0, undefined, "/opt/homebrew/bin/ao\n"))
+        .mockReturnValueOnce(createMockChild(0, undefined, "0.2.2\n"));
+
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow(
+        "process.exit(1)",
+      );
+
+      expect(mockInvalidateCache).not.toHaveBeenCalled();
+      expect(vi.mocked(console.error)).toHaveBeenCalledWith(
+        expect.stringContaining("runnable `ao` binary did not update"),
+      );
+      expect(vi.mocked(console.error)).toHaveBeenCalledWith(
+        expect.stringContaining("/opt/homebrew/bin/ao"),
+      );
     });
 
     it("exits non-zero when npm install fails", async () => {
@@ -299,9 +337,9 @@ describe("update command", () => {
       mockPromptConfirm.mockResolvedValue(true);
       mockSpawn.mockReturnValue(createMockChild(1));
 
-      await expect(
-        program.parseAsync(["node", "test", "update"]),
-      ).rejects.toThrow("process.exit(1)");
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow(
+        "process.exit(1)",
+      );
       expect(mockInvalidateCache).not.toHaveBeenCalled();
     });
 
@@ -327,9 +365,9 @@ describe("update command", () => {
       mockPromptConfirm.mockResolvedValue(true);
       mockSpawn.mockReturnValue(createMockChild(null, "SIGTERM"));
 
-      await expect(
-        program.parseAsync(["node", "test", "update"]),
-      ).rejects.toThrow("process.exit(1)");
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow(
+        "process.exit(1)",
+      );
 
       expect(vi.mocked(console.error)).not.toHaveBeenCalledWith(
         expect.stringContaining("exited with code null"),
@@ -346,9 +384,7 @@ describe("update command", () => {
       mockSpawn.mockReturnValue(child);
       setTimeout(() => child.emit("error", new Error("ENOENT: npm not found")), 0);
 
-      await expect(
-        program.parseAsync(["node", "test", "update"]),
-      ).rejects.toThrow("ENOENT");
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow("ENOENT");
     });
 
     it("does nothing when user declines prompt", async () => {
@@ -378,7 +414,9 @@ describe("update command", () => {
 
       await program.parseAsync(["node", "test", "update"]);
 
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Could not detect install method"));
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not detect install method"),
+      );
       expect(mockRunRepoScript).not.toHaveBeenCalled();
     });
 

--- a/packages/cli/__tests__/commands/update.test.ts
+++ b/packages/cli/__tests__/commands/update.test.ts
@@ -295,7 +295,7 @@ describe("update command", () => {
       mockSpawn
         .mockReturnValueOnce(createMockChild(0))
         .mockReturnValueOnce(createMockChild(0, undefined, "/usr/local/bin/ao\n"))
-        .mockReturnValueOnce(createMockChild(0, undefined, "0.3.0\n"));
+        .mockReturnValueOnce(createMockChild(0, undefined, "@aoagents/ao 0.3.0\n"));
 
       await program.parseAsync(["node", "test", "update"]);
 
@@ -305,7 +305,7 @@ describe("update command", () => {
         expect.anything(),
       );
       expect(mockSpawn).toHaveBeenCalledWith("sh", ["-lc", "command -v ao"], expect.anything());
-      expect(mockSpawn).toHaveBeenCalledWith("ao", ["--version"], expect.anything());
+      expect(mockSpawn).toHaveBeenCalledWith("sh", ["-lc", "ao --version"], expect.anything());
       expect(mockInvalidateCache).toHaveBeenCalled();
     });
 

--- a/packages/cli/__tests__/lib/update-check.test.ts
+++ b/packages/cli/__tests__/lib/update-check.test.ts
@@ -13,6 +13,10 @@ const { mockExistsSync, mockReadFileSync, mockWriteFileSync, mockUnlinkSync, moc
     mockMkdirSync: vi.fn(),
   }));
 
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+}));
+
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual("node:fs");
   return {
@@ -22,6 +26,14 @@ vi.mock("node:fs", async () => {
     writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
     unlinkSync: (...args: unknown[]) => mockUnlinkSync(...args),
     mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+  };
+});
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual("node:child_process");
+  return {
+    ...actual,
+    execFile: mockExecFile,
   };
 });
 
@@ -45,6 +57,7 @@ import {
   getCacheDir,
   readCachedUpdateInfo,
   fetchLatestVersion,
+  fetchLatestGitVersion,
   invalidateCache,
   writeCache,
   checkForUpdate,
@@ -127,39 +140,51 @@ describe("update-check", () => {
   describe("classifyInstallPath", () => {
     it("returns 'npm-global' for /usr/local/lib/node_modules path", () => {
       expect(
-        classifyInstallPath("/usr/local/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/usr/local/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("npm-global");
     });
 
     it("returns 'npm-global' for nvm global path", () => {
       expect(
-        classifyInstallPath("/home/user/.nvm/versions/node/v20.0.0/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/.nvm/versions/node/v20.0.0/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("npm-global");
     });
 
     it("returns 'npm-global' for Windows global path", () => {
       expect(
-        classifyInstallPath("C:\\Users\\test\\AppData\\Roaming\\npm\\lib\\node_modules\\@aoagents\\ao-cli\\dist\\lib\\update-check.js"),
+        classifyInstallPath(
+          "C:\\Users\\test\\AppData\\Roaming\\npm\\lib\\node_modules\\@aoagents\\ao-cli\\dist\\lib\\update-check.js",
+        ),
       ).toBe("npm-global");
     });
 
     it("returns 'pnpm-global' for pnpm global store path", () => {
       expect(
-        classifyInstallPath("/home/user/.local/share/pnpm/global/5/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/.local/share/pnpm/global/5/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("pnpm-global");
     });
 
     it("returns 'unknown' for local pnpm node_modules/.pnpm (not global)", () => {
       mockExistsSync.mockReturnValue(false);
       expect(
-        classifyInstallPath("/home/user/my-project/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/my-project/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("unknown");
     });
 
     it("returns 'unknown' for local project node_modules (npx)", () => {
       mockExistsSync.mockReturnValue(false);
       expect(
-        classifyInstallPath("/home/user/my-project/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/my-project/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("unknown");
     });
 
@@ -189,9 +214,7 @@ describe("update-check", () => {
 
     it("returns 'unknown' when .git does not exist at the resolved repo root", () => {
       mockExistsSync.mockReturnValue(false);
-      expect(
-        classifyInstallPath("/tmp/random/path/update-check.ts"),
-      ).toBe("unknown");
+      expect(classifyInstallPath("/tmp/random/path/update-check.ts")).toBe("unknown");
     });
   });
 
@@ -293,6 +316,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: now,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
 
@@ -309,6 +333,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: old,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       expect(readCachedUpdateInfo()).toBeNull();
@@ -322,6 +347,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: recent,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       expect(readCachedUpdateInfo()).not.toBeNull();
@@ -334,8 +360,43 @@ describe("update-check", () => {
           latestVersion: "0.5.0",
           checkedAt: now,
           currentVersionAtCheck: "9.9.9",
+          installMethod: "unknown",
         }),
       );
+      expect(readCachedUpdateInfo()).toBeNull();
+    });
+
+    it("returns null for legacy cache entries when running from a git install", () => {
+      const now = new Date().toISOString();
+      const currentVersion = getCurrentVersion();
+      mockExistsSync.mockImplementation((path: string) => path.endsWith(".git"));
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("packages/ao/package.json")) {
+          return JSON.stringify({ name: "@aoagents/ao" });
+        }
+        return JSON.stringify({
+          latestVersion: "0.3.0",
+          checkedAt: now,
+          currentVersionAtCheck: currentVersion,
+        });
+      });
+
+      expect(readCachedUpdateInfo()).toBeNull();
+    });
+
+    it("returns null when cache install method differs from the current install method", () => {
+      const now = new Date().toISOString();
+      const currentVersion = getCurrentVersion();
+      mockExistsSync.mockReturnValue(false);
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          latestVersion: "0.3.0",
+          checkedAt: now,
+          currentVersionAtCheck: currentVersion,
+          installMethod: "git",
+        }),
+      );
+
       expect(readCachedUpdateInfo()).toBeNull();
     });
 
@@ -375,7 +436,9 @@ describe("update-check", () => {
         currentVersionAtCheck: "0.2.2",
       });
 
-      expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining("ao"), { recursive: true });
+      expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining("ao"), {
+        recursive: true,
+      });
       expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
       const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
       expect(written.latestVersion).toBe("0.3.0");
@@ -487,6 +550,82 @@ describe("update-check", () => {
   });
 
   // -----------------------------------------------------------------------
+  // fetchLatestGitVersion
+  // -----------------------------------------------------------------------
+
+  describe("fetchLatestGitVersion", () => {
+    it("returns the package version from the git update branch", async () => {
+      mockExistsSync.mockImplementation((path: string) => path.endsWith(".git"));
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("packages/ao/package.json")) {
+          return JSON.stringify({ name: "@aoagents/ao" });
+        }
+        throw new Error(`unexpected read: ${path}`);
+      });
+      mockExecFile.mockImplementation((cmd, args, _opts, cb) => {
+        const joined = args.join(" ");
+        if (joined === "remote get-url upstream") {
+          cb(new Error("no upstream"), "", "");
+          return;
+        }
+        if (joined === "fetch --quiet origin main") {
+          cb(null, "", "");
+          return;
+        }
+        if (joined === "show FETCH_HEAD:packages/ao/package.json") {
+          cb(null, JSON.stringify({ version: "0.2.5" }), "");
+          return;
+        }
+        cb(new Error(`unexpected git args: ${joined}`), "", "");
+      });
+
+      await expect(fetchLatestGitVersion()).resolves.toBe("0.2.5");
+    });
+
+    it("falls back to the remote tracking ref when fetch fails", async () => {
+      mockExistsSync.mockImplementation((path: string) => path.endsWith(".git"));
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("packages/ao/package.json")) {
+          return JSON.stringify({ name: "@aoagents/ao" });
+        }
+        throw new Error(`unexpected read: ${path}`);
+      });
+      const attemptedGitCommands: string[] = [];
+      mockExecFile.mockImplementation((cmd, args, _opts, cb) => {
+        const joined = args.join(" ");
+        attemptedGitCommands.push(joined);
+        if (joined === "remote get-url upstream") {
+          cb(null, "git@github.com:upstream/agent-orchestrator.git\n", "");
+          return;
+        }
+        if (joined === "fetch --quiet upstream main") {
+          cb(new Error("network unavailable"), "", "");
+          return;
+        }
+        if (joined === "show FETCH_HEAD:packages/ao/package.json") {
+          cb(new Error("missing FETCH_HEAD"), "", "");
+          return;
+        }
+        if (joined === "show upstream/main:packages/ao/package.json") {
+          cb(null, JSON.stringify({ version: "0.2.6" }), "");
+          return;
+        }
+        cb(new Error(`unexpected git args: ${joined}`), "", "");
+      });
+
+      await expect(fetchLatestGitVersion()).resolves.toBe("0.2.6");
+      expect(attemptedGitCommands).not.toContain("show FETCH_HEAD:packages/ao/package.json");
+    });
+
+    it("returns null outside a source checkout", async () => {
+      mockExistsSync.mockReturnValue(false);
+
+      await expect(fetchLatestGitVersion()).resolves.toBeNull();
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // invalidateCache
   // -----------------------------------------------------------------------
 
@@ -518,6 +657,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: now,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       mockExistsSync.mockReturnValue(false);
@@ -528,6 +668,46 @@ describe("update-check", () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
+    it("uses git branch version instead of npm latest for git installs", async () => {
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("update-check.json")) {
+          throw new Error("ENOENT");
+        }
+        if (path.endsWith("packages/ao/package.json")) {
+          return JSON.stringify({ name: "@aoagents/ao" });
+        }
+        throw new Error(`unexpected read: ${path}`);
+      });
+      mockExistsSync.mockImplementation((path: string) => path.endsWith(".git"));
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ version: "0.3.0" }),
+      });
+      mockExecFile.mockImplementation((cmd, args, _opts, cb) => {
+        const joined = args.join(" ");
+        if (joined === "remote get-url upstream") {
+          cb(new Error("no upstream"), "", "");
+          return;
+        }
+        if (joined === "fetch --quiet origin main") {
+          cb(null, "", "");
+          return;
+        }
+        if (joined === "show FETCH_HEAD:packages/ao/package.json") {
+          cb(null, JSON.stringify({ version: getCurrentVersion() }), "");
+          return;
+        }
+        cb(new Error(`unexpected git args: ${joined}`), "", "");
+      });
+
+      const info = await checkForUpdate({ force: true });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(info.installMethod).toBe("git");
+      expect(info.latestVersion).toBe(getCurrentVersion());
+      expect(info.isOutdated).toBe(false);
+    });
+
     it("bypasses cache when force: true", async () => {
       const now = new Date().toISOString();
       const currentVersion = getCurrentVersion();
@@ -536,6 +716,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: now,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       mockExistsSync.mockReturnValue(false);
@@ -574,12 +755,13 @@ describe("update-check", () => {
         json: async () => ({ version: "0.3.0" }),
       });
 
-      await checkForUpdate();
+      const info = await checkForUpdate();
 
       expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
       const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
       expect(written.latestVersion).toBe("0.3.0");
       expect(written.currentVersionAtCheck).toBe(getCurrentVersion());
+      expect(written.installMethod).toBe(info.installMethod);
     });
 
     it("does NOT write cache when fetch fails", async () => {
@@ -682,6 +864,7 @@ describe("update-check", () => {
           latestVersion: "99.0.0",
           checkedAt: new Date().toISOString(),
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
 
@@ -701,6 +884,7 @@ describe("update-check", () => {
           latestVersion: currentVersion,
           checkedAt: new Date().toISOString(),
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       maybeShowUpdateNotice();

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -188,20 +188,16 @@ interface RunnableAo {
 
 async function getRunnableAo(): Promise<RunnableAo> {
   const [path, version] = await Promise.all([
-    runCommand("command", ["-v", "ao"], { shell: true }),
-    runCommand("ao", ["--version"], { shell: true }),
+    runShellCommand(process.platform === "win32" ? "where ao" : "command -v ao"),
+    runShellCommand("ao --version"),
   ]);
   return { path, version: parseVersionOutput(version) };
 }
 
-function runCommand(
-  command: string,
-  args: string[],
-  opts?: { shell?: boolean },
-): Promise<string | null> {
+function runShellCommand(command: string): Promise<string | null> {
   return new Promise<string | null>((resolveOutput) => {
-    const spawnCommand = opts?.shell ? "sh" : command;
-    const spawnArgs = opts?.shell ? ["-lc", [command, ...args].join(" ")] : args;
+    const spawnCommand = process.platform === "win32" ? (process.env.ComSpec ?? "cmd.exe") : "sh";
+    const spawnArgs = process.platform === "win32" ? ["/d", "/s", "/c", command] : ["-lc", command];
     const child = spawn(spawnCommand, spawnArgs, {
       stdio: ["ignore", "pipe", "ignore"],
     });

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -23,37 +23,33 @@ export function registerUpdate(program: Command): void {
     .option("--skip-smoke", "Skip smoke tests after rebuilding (git installs only)")
     .option("--smoke-only", "Run smoke tests without fetching or rebuilding (git installs only)")
     .option("--check", "Print version info as JSON without upgrading")
-    .action(
-      async (opts: { skipSmoke?: boolean; smokeOnly?: boolean; check?: boolean }) => {
-        if (opts.skipSmoke && opts.smokeOnly) {
-          console.error(
-            "`ao update` does not allow `--skip-smoke` together with `--smoke-only`.",
-          );
-          process.exit(1);
-        }
+    .action(async (opts: { skipSmoke?: boolean; smokeOnly?: boolean; check?: boolean }) => {
+      if (opts.skipSmoke && opts.smokeOnly) {
+        console.error("`ao update` does not allow `--skip-smoke` together with `--smoke-only`.");
+        process.exit(1);
+      }
 
-        // --check: print JSON and exit
-        if (opts.check) {
-          await handleCheck();
-          return;
-        }
+      // --check: print JSON and exit
+      if (opts.check) {
+        await handleCheck();
+        return;
+      }
 
-        const method = detectInstallMethod();
+      const method = detectInstallMethod();
 
-        switch (method) {
-          case "git":
-            await handleGitUpdate(opts);
-            break;
-          case "npm-global":
-          case "pnpm-global":
-            await handleNpmUpdate(opts);
-            break;
-          case "unknown":
-            await handleUnknownUpdate();
-            break;
-        }
-      },
-    );
+      switch (method) {
+        case "git":
+          await handleGitUpdate(opts);
+          break;
+        case "npm-global":
+        case "pnpm-global":
+          await handleNpmUpdate(opts);
+          break;
+        case "unknown":
+          await handleUnknownUpdate();
+          break;
+      }
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -69,10 +65,7 @@ async function handleCheck(): Promise<void> {
 // git install
 // ---------------------------------------------------------------------------
 
-async function handleGitUpdate(opts: {
-  skipSmoke?: boolean;
-  smokeOnly?: boolean;
-}): Promise<void> {
+async function handleGitUpdate(opts: { skipSmoke?: boolean; smokeOnly?: boolean }): Promise<void> {
   const args: string[] = [];
   if (opts.skipSmoke) args.push("--skip-smoke");
   if (opts.smokeOnly) args.push("--smoke-only");
@@ -84,10 +77,7 @@ async function handleGitUpdate(opts: {
     }
     invalidateCache();
   } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message.includes("Script not found: ao-update.sh")
-    ) {
+    if (error instanceof Error && error.message.includes("Script not found: ao-update.sh")) {
       console.error(
         chalk.red(
           "ao-update.sh is missing from the bundled assets. " +
@@ -107,10 +97,7 @@ async function handleGitUpdate(opts: {
 // npm-global install
 // ---------------------------------------------------------------------------
 
-async function handleNpmUpdate(opts: {
-  skipSmoke?: boolean;
-  smokeOnly?: boolean;
-}): Promise<void> {
+async function handleNpmUpdate(opts: { skipSmoke?: boolean; smokeOnly?: boolean }): Promise<void> {
   if (opts.skipSmoke || opts.smokeOnly) {
     console.log(
       chalk.yellow("--skip-smoke and --smoke-only only apply to git source installs. Ignoring."),
@@ -147,6 +134,23 @@ async function handleNpmUpdate(opts: {
 
   const exitCode = await runNpmInstall(command);
   if (exitCode === 0) {
+    const runnable = await getRunnableAo();
+    if (runnable.version !== info.latestVersion) {
+      console.error(
+        chalk.red("\nUpdate command finished, but the runnable `ao` binary did not update."),
+      );
+      console.error(
+        `Expected ${chalk.green(info.latestVersion)}, got ${chalk.yellow(runnable.version ?? "unknown")}.`,
+      );
+      if (runnable.path) {
+        console.error(`Runnable path: ${chalk.cyan(runnable.path)}`);
+      }
+      console.error(
+        `Fix: check which \`ao\` your shell is running, then rerun ${chalk.cyan(command)} or reinstall with npm.`,
+      );
+      process.exit(1);
+    }
+
     invalidateCache();
     console.log(chalk.green("\nUpdate complete."));
   } else {
@@ -169,6 +173,44 @@ function runNpmInstall(command: string): Promise<number> {
         console.error(chalk.yellow(`\n${cmd} exited with code ${code}.`));
       }
       resolveExit(code ?? 1);
+    });
+  });
+}
+
+interface RunnableAo {
+  version: string | null;
+  path: string | null;
+}
+
+async function getRunnableAo(): Promise<RunnableAo> {
+  const [path, version] = await Promise.all([
+    runCommand("command", ["-v", "ao"]),
+    runCommand("ao", ["--version"]),
+  ]);
+  return { path, version: version?.split(/\s+/)[0] ?? null };
+}
+
+function runCommand(command: string, args: string[]): Promise<string | null> {
+  return new Promise<string | null>((resolveOutput) => {
+    const spawnCommand = command === "command" ? "sh" : command;
+    const spawnArgs = command === "command" ? ["-lc", [command, ...args].join(" ")] : args;
+    const child = spawn(spawnCommand, spawnArgs, {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    let output = "";
+
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      output += chunk.toString();
+    });
+    child.on("error", () => resolveOutput(null));
+    child.on("exit", (code, signal) => {
+      if (signal || code !== 0) {
+        resolveOutput(null);
+        return;
+      }
+
+      const trimmed = output.trim();
+      resolveOutput(trimmed || null);
     });
   });
 }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -177,6 +177,10 @@ function runNpmInstall(command: string): Promise<number> {
   });
 }
 
+function parseVersionOutput(output: string | null): string | null {
+  return output?.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/)?.[0] ?? null;
+}
+
 interface RunnableAo {
   version: string | null;
   path: string | null;
@@ -184,16 +188,20 @@ interface RunnableAo {
 
 async function getRunnableAo(): Promise<RunnableAo> {
   const [path, version] = await Promise.all([
-    runCommand("command", ["-v", "ao"]),
-    runCommand("ao", ["--version"]),
+    runCommand("command", ["-v", "ao"], { shell: true }),
+    runCommand("ao", ["--version"], { shell: true }),
   ]);
-  return { path, version: version?.split(/\s+/)[0] ?? null };
+  return { path, version: parseVersionOutput(version) };
 }
 
-function runCommand(command: string, args: string[]): Promise<string | null> {
+function runCommand(
+  command: string,
+  args: string[],
+  opts?: { shell?: boolean },
+): Promise<string | null> {
   return new Promise<string | null>((resolveOutput) => {
-    const spawnCommand = command === "command" ? "sh" : command;
-    const spawnArgs = command === "command" ? ["-lc", [command, ...args].join(" ")] : args;
+    const spawnCommand = opts?.shell ? "sh" : command;
+    const spawnArgs = opts?.shell ? ["-lc", [command, ...args].join(" ")] : args;
     const child = spawn(spawnCommand, spawnArgs, {
       stdio: ["ignore", "pipe", "ignore"],
     });

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -8,6 +8,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { execFile as execFileCb } from "node:child_process";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -33,6 +34,7 @@ interface CacheData {
   latestVersion: string;
   checkedAt: string;
   currentVersionAtCheck: string;
+  installMethod?: InstallMethod;
 }
 
 // ---------------------------------------------------------------------------
@@ -42,6 +44,8 @@ interface CacheData {
 const REGISTRY_URL = "https://registry.npmjs.org/@aoagents%2Fao/latest";
 const FETCH_TIMEOUT_MS = 3000;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const GIT_TIMEOUT_MS = 3000;
+const SOURCE_PACKAGE_JSON = "packages/ao/package.json";
 
 // ---------------------------------------------------------------------------
 // Install detection
@@ -95,16 +99,14 @@ export function classifyInstallPath(resolvedPath: string): InstallMethod {
     // Note: /.pnpm/ alone is NOT a global signal — pnpm creates node_modules/.pnpm/
     // for local installs too. Only pnpm/global paths indicate a global install.
     const isPnpmGlobal =
-      resolvedPath.includes("/pnpm/global/") ||
-      resolvedPath.includes("\\pnpm\\global\\");
+      resolvedPath.includes("/pnpm/global/") || resolvedPath.includes("\\pnpm\\global\\");
 
     if (isPnpmGlobal) {
       return "pnpm-global";
     }
 
     const isNpmGlobal =
-      resolvedPath.includes("/lib/node_modules/") ||
-      resolvedPath.includes("\\lib\\node_modules\\");
+      resolvedPath.includes("/lib/node_modules/") || resolvedPath.includes("\\lib\\node_modules\\");
 
     if (isNpmGlobal) {
       return "npm-global";
@@ -127,6 +129,45 @@ export function classifyInstallPath(resolvedPath: string): InstallMethod {
 /** Detect how the running `ao` binary was installed based on its file location. */
 export function detectInstallMethod(): InstallMethod {
   return classifyInstallPath(fileURLToPath(import.meta.url));
+}
+
+function getSourceRepoRoot(): string | null {
+  const resolvedPath = fileURLToPath(import.meta.url);
+  const repoRoot = resolve(dirname(resolvedPath), "../../../../");
+  return isAgentOrchestratorRepoRoot(repoRoot) ? repoRoot : null;
+}
+
+function getGitUpdateBranch(): string {
+  return process.env["AO_UPDATE_BRANCH"] || "main";
+}
+
+async function git(args: string[], cwd: string): Promise<string | null> {
+  return new Promise((resolveOutput) => {
+    execFileCb(
+      "git",
+      args,
+      {
+        cwd,
+        timeout: GIT_TIMEOUT_MS,
+        env: {
+          ...process.env,
+          GIT_TERMINAL_PROMPT: "0",
+        },
+      },
+      (error, stdout) => {
+        if (error) {
+          resolveOutput(null);
+          return;
+        }
+        resolveOutput(stdout.trim());
+      },
+    );
+  });
+}
+
+async function resolveUpdateRemote(repoRoot: string): Promise<string> {
+  const upstream = await git(["remote", "get-url", "upstream"], repoRoot);
+  return upstream ? "upstream" : "origin";
 }
 
 // ---------------------------------------------------------------------------
@@ -187,8 +228,15 @@ export function readCachedUpdateInfo(): CacheData | null {
 
     if (!data.latestVersion || !data.checkedAt) return null;
 
-    // Cache is stale if user upgraded since the check
+    // Cache is stale if user upgraded since the check, or if it was produced
+    // by another install type. Legacy cache entries have no install method, so
+    // reject them to avoid carrying old update-source assumptions forward.
     const currentVersion = getCurrentVersion();
+    const installMethod = detectInstallMethod();
+    if (!data.installMethod || data.installMethod !== installMethod) {
+      return null;
+    }
+
     if (data.currentVersionAtCheck && data.currentVersionAtCheck !== currentVersion) {
       return null;
     }
@@ -240,6 +288,31 @@ export async function fetchLatestVersion(): Promise<string | null> {
   }
 }
 
+/** Fetch the package version reachable by `ao update` for source installs. */
+export async function fetchLatestGitVersion(): Promise<string | null> {
+  const repoRoot = getSourceRepoRoot();
+  if (!repoRoot) return null;
+
+  const remote = await resolveUpdateRemote(repoRoot);
+  const branch = getGitUpdateBranch();
+  const ref = `${remote}/${branch}`;
+
+  const fetched = await git(["fetch", "--quiet", remote, branch], repoRoot);
+
+  const packageJson =
+    (fetched !== null
+      ? await git(["show", `FETCH_HEAD:${SOURCE_PACKAGE_JSON}`], repoRoot)
+      : null) ?? (await git(["show", `${ref}:${SOURCE_PACKAGE_JSON}`], repoRoot));
+  if (!packageJson) return null;
+
+  try {
+    const parsed = JSON.parse(packageJson) as { version?: unknown };
+    return typeof parsed.version === "string" ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Orchestrator
 // ---------------------------------------------------------------------------
@@ -265,8 +338,9 @@ export async function checkForUpdate(opts?: { force?: boolean }): Promise<Update
     }
   }
 
-  // Fetch from registry
-  const latestVersion = await fetchLatestVersion();
+  // Source installs update from the configured git branch, not npm latest.
+  const latestVersion =
+    installMethod === "git" ? await fetchLatestGitVersion() : await fetchLatestVersion();
   const now = new Date().toISOString();
 
   if (latestVersion) {
@@ -274,6 +348,7 @@ export async function checkForUpdate(opts?: { force?: boolean }): Promise<Update
       latestVersion,
       checkedAt: now,
       currentVersionAtCheck: currentVersion,
+      installMethod,
     });
   }
 

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -297,12 +297,11 @@ export async function fetchLatestGitVersion(): Promise<string | null> {
   const branch = getGitUpdateBranch();
   const ref = `${remote}/${branch}`;
 
-  const fetched = await git(["fetch", "--quiet", remote, branch], repoRoot);
+  const fetchSucceeded = (await git(["fetch", "--quiet", remote, branch], repoRoot)) !== null;
 
   const packageJson =
-    (fetched !== null
-      ? await git(["show", `FETCH_HEAD:${SOURCE_PACKAGE_JSON}`], repoRoot)
-      : null) ?? (await git(["show", `${ref}:${SOURCE_PACKAGE_JSON}`], repoRoot));
+    (fetchSucceeded ? await git(["show", `FETCH_HEAD:${SOURCE_PACKAGE_JSON}`], repoRoot) : null) ??
+    (await git(["show", `${ref}:${SOURCE_PACKAGE_JSON}`], repoRoot));
   if (!packageJson) return null;
 
   try {


### PR DESCRIPTION
## Summary
- Add git-backed update version checks for source installs instead of relying on npm registry data
- Track install method in update cache and invalidate legacy or mismatched cache entries
- Verify the runnable `ao` binary after npm-global updates and fail fast if the shell still resolves an old version
- Expand CLI tests for git version resolution, cache behavior, and post-install validation

## Testing
- Added unit coverage for git update version lookup and cache invalidation cases
- Added unit coverage for npm update verification when the resolved `ao` binary does not match the installed version