### PR TITLE
fix(core): randomize generated session branches

### DIFF
--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -329,13 +329,13 @@ describe("spawn", () => {
 
     const first = await sm.spawn({ projectId: "my-app" });
     expect(first.id).toBe("app-1");
-    expect(first.branch).toBe("session/app-1");
+    expect(first.branch).toMatch(/^session\/app-1-[a-z0-9]{5}$/);
 
     await sm.kill(first.id);
 
     const second = await sm.spawn({ projectId: "my-app" });
     expect(second.id).toBe("app-2");
-    expect(second.branch).toBe("session/app-2");
+    expect(second.branch).toMatch(/^session\/app-2-[a-z0-9]{5}$/);
   });
 
   it("skips remote session branches when allocating a fresh session id", async () => {
@@ -347,7 +347,31 @@ describe("spawn", () => {
     const session = await sm.spawn({ projectId: "my-app" });
 
     expect(session.id).toBe("app-23");
-    expect(session.branch).toBe("session/app-23");
+    expect(session.branch).toMatch(/^session\/app-23-[a-z0-9]{5}$/);
+  });
+
+  it("skips suffixed remote session branches when allocating a fresh session id", async () => {
+    const mockGitBin = installMockGit(tmpDir, ["session/app-22-k7f2m"]);
+    process.env.PATH = `${mockGitBin}:${originalPath ?? ""}`;
+    mkdirSync(config.projects["my-app"]!.path, { recursive: true });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const session = await sm.spawn({ projectId: "my-app" });
+
+    expect(session.id).toBe("app-23");
+    expect(session.branch).toMatch(/^session\/app-23-[a-z0-9]{5}$/);
+  });
+
+  it("parses the numeric prefix even when the remote session branch has a nonstandard suffix", async () => {
+    const mockGitBin = installMockGit(tmpDir, ["session/app-22-manual-branch-name"]);
+    process.env.PATH = `${mockGitBin}:${originalPath ?? ""}`;
+    mkdirSync(config.projects["my-app"]!.path, { recursive: true });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const session = await sm.spawn({ projectId: "my-app" });
+
+    expect(session.id).toBe("app-23");
+    expect(session.branch).toMatch(/^session\/app-23-[a-z0-9]{5}$/);
   });
 
   it("writes metadata file", async () => {
@@ -963,8 +987,8 @@ describe("spawn", () => {
     const session = await sm.spawn({ projectId: "my-app" });
 
     expect(session.issueId).toBeNull();
-    // Uses session/{sessionId} to avoid conflicts with default branch
-    expect(session.branch).toMatch(/^session\/app-\d+$/);
+    // Uses a session-scoped branch with a random suffix to avoid collisions.
+    expect(session.branch).toMatch(/^session\/app-\d+-[a-z0-9]{5}$/);
     expect(session.branch).not.toBe("main");
   });
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -95,6 +95,7 @@ import {
 const execFileAsync = promisify(execFile);
 const OPENCODE_DISCOVERY_TIMEOUT_MS = 10_000;
 const OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS = 10_000;
+const SESSION_BRANCH_RANDOM_SUFFIX_LENGTH = 5;
 
 function errorIncludesSessionNotFound(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -125,6 +126,14 @@ async function deleteOpenCodeSession(sessionId: string): Promise<void> {
     }
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+function createSessionBranchSuffix(length = SESSION_BRANCH_RANDOM_SUFFIX_LENGTH): string {
+  let suffix = "";
+  while (suffix.length < length) {
+    suffix += Math.random().toString(36).slice(2);
+  }
+  return suffix.slice(0, length);
 }
 
 interface OpenCodeSessionListEntry {
@@ -810,7 +819,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
           const ref = trimmed.split(/\s+/)[1] ?? "";
           const match = ref.match(
-            new RegExp(`refs/heads/session/${escapeRegex(project.sessionPrefix)}-(\\d+)$`),
+            new RegExp(`refs/heads/session/${escapeRegex(project.sessionPrefix)}-(\\d+)(?:-.+)?$`),
           );
           if (!match) return [];
 
@@ -1182,7 +1191,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
             .replace(/^-+|-+$/g, "");
       branch = `feat/${slug || sessionId}`;
     } else {
-      branch = `session/${sessionId}`;
+      branch = `session/${sessionId}-${createSessionBranchSuffix()}`;
     }
 
     // Create workspace (if workspace plugin is available)

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -13,6 +13,7 @@
 
 import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync, utimesSync, unlinkSync } from "node:fs";
 import { execFile } from "node:child_process";
+import { randomInt } from "node:crypto";
 import { basename, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { promisify } from "node:util";
@@ -96,6 +97,7 @@ const execFileAsync = promisify(execFile);
 const OPENCODE_DISCOVERY_TIMEOUT_MS = 10_000;
 const OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS = 10_000;
 const SESSION_BRANCH_RANDOM_SUFFIX_LENGTH = 5;
+const SESSION_BRANCH_SUFFIX_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
 
 function errorIncludesSessionNotFound(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -130,10 +132,10 @@ async function deleteOpenCodeSession(sessionId: string): Promise<void> {
 
 function createSessionBranchSuffix(length = SESSION_BRANCH_RANDOM_SUFFIX_LENGTH): string {
   let suffix = "";
-  while (suffix.length < length) {
-    suffix += Math.random().toString(36).slice(2);
+  for (let i = 0; i < length; i += 1) {
+    suffix += SESSION_BRANCH_SUFFIX_ALPHABET[randomInt(SESSION_BRANCH_SUFFIX_ALPHABET.length)];
   }
-  return suffix.slice(0, length);
+  return suffix;
 }
 
 interface OpenCodeSessionListEntry {

--- a/packages/web/src/lib/__tests__/format.test.ts
+++ b/packages/web/src/lib/__tests__/format.test.ts
@@ -77,6 +77,10 @@ describe("humanizeBranch", () => {
     expect(humanizeBranch("session/ao-42", "ao-42")).toBe("");
   });
 
+  it("returns empty when the branch is a suffixed session branch", () => {
+    expect(humanizeBranch("session/ao-42-k7f2m", "ao-42")).toBe("");
+  });
+
   it("returns empty when the branch is just the session ID (orchestrator/)", () => {
     expect(humanizeBranch("orchestrator/ao-orchestrator-8", "ao-orchestrator-8")).toBe("");
   });

--- a/packages/web/src/lib/__tests__/format.test.ts
+++ b/packages/web/src/lib/__tests__/format.test.ts
@@ -68,6 +68,11 @@ describe("humanizeBranch", () => {
     expect(humanizeBranch("session/ao-52")).toBe("Ao 52");
   });
 
+  it("hides suffixes on generated session branches even without a session id", () => {
+    expect(humanizeBranch("session/ao-52-k7f2m")).toBe("Ao 52");
+    expect(humanizeBranch("session/ao-52-manual-branch-name")).toBe("Ao 52");
+  });
+
   it("handles orchestrator/ prefix", () => {
     expect(humanizeBranch("orchestrator/ao-orchestrator-8")).toBe("Ao Orchestrator 8");
   });
@@ -79,6 +84,7 @@ describe("humanizeBranch", () => {
 
   it("returns empty when the branch is a suffixed session branch", () => {
     expect(humanizeBranch("session/ao-42-k7f2m", "ao-42")).toBe("");
+    expect(humanizeBranch("session/ao-42-manual-branch-name", "ao-42")).toBe("");
   });
 
   it("returns empty when the branch is just the session ID (orchestrator/)", () => {

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -24,6 +24,7 @@ import type { DashboardSession } from "./types.js";
  *   humanizeBranch("session/ao-52", "ao-52")          // → ""
  */
 export function humanizeBranch(branch: string, sessionId?: string): string {
+  const isSessionBranch = branch.startsWith("session/");
   // Remove common prefixes (keep in sync with actual branch-generation logic
   // in packages/core/src/session-manager.ts — `session/`, `orchestrator/`, and
   // `feat/` are produced by spawn()/spawnOrchestrator()).
@@ -32,12 +33,15 @@ export function humanizeBranch(branch: string, sessionId?: string): string {
     "",
   );
 
+  const displayText = isSessionBranch
+    ? withoutPrefix.replace(/^([A-Za-z0-9][A-Za-z0-9_-]*-\d+)-.+$/, "$1")
+    : withoutPrefix;
+
   const sessionBranchBase =
     sessionId &&
-    withoutPrefix.startsWith(`${sessionId}-`) &&
-    /^[a-z0-9]{5}$/.test(withoutPrefix.slice(sessionId.length + 1))
+    displayText === sessionId
       ? sessionId
-      : withoutPrefix;
+      : displayText;
 
   // If the remaining text is just the session ID (e.g. "ao-42" or
   // "ao-orchestrator-8"), there's no task signal here — return empty so the
@@ -47,7 +51,7 @@ export function humanizeBranch(branch: string, sessionId?: string): string {
   }
 
   // Replace hyphens and underscores with spaces, then title-case each word
-  return withoutPrefix
+  return displayText
     .replace(/[-_]/g, " ")
     .replace(/\b\w/g, (c) => c.toUpperCase())
     .trim();

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -32,10 +32,17 @@ export function humanizeBranch(branch: string, sessionId?: string): string {
     "",
   );
 
+  const sessionBranchBase =
+    sessionId &&
+    withoutPrefix.startsWith(`${sessionId}-`) &&
+    /^[a-z0-9]{5}$/.test(withoutPrefix.slice(sessionId.length + 1))
+      ? sessionId
+      : withoutPrefix;
+
   // If the remaining text is just the session ID (e.g. "ao-42" or
   // "ao-orchestrator-8"), there's no task signal here — return empty so the
   // caller can fall through to the next fallback (displayName, summary, …).
-  if (sessionId && withoutPrefix === sessionId) {
+  if (sessionId && sessionBranchBase === sessionId) {
     return "";
   }
 


### PR DESCRIPTION
Fixes #1529

This changes AO’s default freeform session branch naming from  to  so manually pushed  branches do not collide with AO-owned sessions. Remote session-number reservation remains backward-compatible by still recognizing legacy unsuffixed branches while allowing newly spawned sessions to use unique suffixed branch names. The dashboard branch formatter is also updated so generated suffixes do not show up as noisy titles.

Manual verification by @somewherelostt: with a remote  branch present, newly spawned sessions were created as  and , and no phantom local  session appeared.

<img width="1885" height="966" alt="image" src="https://github.com/user-attachments/assets/fc1e2e64-5690-41e0-9ad2-37b46cbe5885" />
