### PR TITLE
feat: add Zellij runtime plugin

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,7 @@
       "@aoagents/ao-cli",
       "@aoagents/ao",
       "@aoagents/ao-plugin-runtime-tmux",
+      "@aoagents/ao-plugin-runtime-zellij",
       "@aoagents/ao-plugin-runtime-process",
       "@aoagents/ao-plugin-agent-claude-code",
       "@aoagents/ao-plugin-agent-codex",

--- a/.changeset/zellij-runtime.md
+++ b/.changeset/zellij-runtime.md
@@ -1,0 +1,8 @@
+---
+"@aoagents/ao-plugin-runtime-zellij": minor
+"@aoagents/ao-core": patch
+"@aoagents/ao-cli": patch
+"@aoagents/ao-web": patch
+---
+
+Add a built-in Zellij runtime for launching, messaging, attaching to, and cleaning up agent sessions in detached Zellij sessions.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Spawn parallel AI coding agents, each in its own git worktree. Agents autonomous
 
 Agent Orchestrator manages fleets of AI coding agents working in parallel on your codebase. Each agent gets its own git worktree, its own branch, and its own PR. When CI fails, the agent fixes it. When reviewers leave comments, the agent addresses them. You only get pulled in when human judgment is needed.
 
-**Agent-agnostic** (Claude Code, Codex, Aider) · **Runtime-agnostic** (tmux, Docker) · **Tracker-agnostic** (GitHub, Linear)
+**Agent-agnostic** (Claude Code, Codex, Aider) · **Runtime-agnostic** (tmux, Zellij, Docker) · **Tracker-agnostic** (GitHub, Linear)
 
 <div align="center">
 
@@ -190,7 +190,7 @@ Seven plugin slots. Lifecycle stays in core.
 
 | Slot      | Default     | Alternatives             |
 | --------- | ----------- | ------------------------ |
-| Runtime   | tmux        | process                  |
+| Runtime   | tmux        | zellij, process          |
 | Agent     | claude-code | codex, aider, cursor, opencode   |
 | Workspace | worktree    | clone                    |
 | Tracker   | github      | linear, gitlab           |

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -32,7 +32,7 @@ port: 3000
 
 # Default plugins (these are the defaults — you can omit this section)
 defaults:
-  runtime: tmux           # tmux | process
+  runtime: tmux           # tmux | zellij | process
   agent: claude-code      # claude-code | codex | aider | opencode
   # orchestrator:
   #   agent: claude-code

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -22,7 +22,7 @@ Every abstraction is a swappable plugin. All interfaces are defined in [`package
 
 | Slot      | Interface   | Default       | Alternatives                             |
 | --------- | ----------- | ------------- | ---------------------------------------- |
-| Runtime   | `Runtime`   | `tmux`        | `process`, `docker`, `k8s`, `ssh`, `e2b` |
+| Runtime   | `Runtime`   | `tmux`        | `zellij`, `process`, `docker`, `k8s`, `ssh`, `e2b` |
 | Agent     | `Agent`     | `claude-code` | `codex`, `aider`, `opencode`             |
 | Workspace | `Workspace` | `worktree`    | `clone`                                  |
 | Tracker   | `Tracker`   | `github`      | `linear`                                 |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
     "@aoagents/ao-plugin-notifier-webhook": "workspace:*",
     "@aoagents/ao-plugin-runtime-process": "workspace:*",
     "@aoagents/ao-plugin-runtime-tmux": "workspace:*",
+    "@aoagents/ao-plugin-runtime-zellij": "workspace:*",
     "@aoagents/ao-plugin-scm-github": "workspace:*",
     "@aoagents/ao-plugin-terminal-iterm2": "workspace:*",
     "@aoagents/ao-plugin-terminal-web": "workspace:*",

--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -24,7 +24,7 @@ readyThresholdMs: 300000      # Ms before "ready" becomes "idle" (default: 5 min
 # These apply to all projects unless overridden per-project.
 
 defaults:
-  runtime: tmux               # tmux | process
+  runtime: tmux               # tmux | zellij | process
   agent: claude-code          # claude-code | aider | codex | cursor | opencode
   workspace: worktree         # worktree | clone
   notifiers:
@@ -139,7 +139,7 @@ notificationRouting:
 # ── Available plugins ───────────────────────────────────────────────
 #
 # Agent:     claude-code, aider, codex, cursor, opencode
-# Runtime:   tmux, process
+# Runtime:   tmux, zellij, process
 # Workspace: worktree, clone
 # SCM:       github, gitlab
 # Tracker:   github, linear, gitlab

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -95,7 +95,7 @@ Loads plugins and provides access to them:
 
 **Built-in plugins** (loaded by default):
 
-- runtime-tmux, runtime-process
+- runtime-tmux, runtime-zellij, runtime-process
 - agent-claude-code, agent-codex, agent-aider, agent-opencode
 - workspace-worktree, workspace-clone
 - tracker-github, tracker-linear, tracker-gitlab

--- a/packages/core/src/__tests__/plugin-registry.test.ts
+++ b/packages/core/src/__tests__/plugin-registry.test.ts
@@ -447,6 +447,12 @@ describe("loadBuiltins", () => {
           create: () => ({ name: "tmux" }),
         };
       }
+      if (pkg === "@aoagents/ao-plugin-runtime-zellij") {
+        return {
+          manifest: { name: "zellij", slot: "runtime", description: "test", version: "0.0.0" },
+          create: () => ({ name: "zellij" }),
+        };
+      }
       // Throw for everything else to simulate not-installed
       throw new Error(`Module not found: ${pkg}`);
     };
@@ -456,10 +462,13 @@ describe("loadBuiltins", () => {
     // importFn should have been called for all builtin plugins
     expect(importedPackages.length).toBeGreaterThan(0);
     expect(importedPackages).toContain("@aoagents/ao-plugin-runtime-tmux");
+    expect(importedPackages).toContain("@aoagents/ao-plugin-runtime-zellij");
 
     // The tmux plugin should be registered
     const tmux = registry.get("runtime", "tmux");
     expect(tmux).not.toBeNull();
+    const zellij = registry.get("runtime", "zellij");
+    expect(zellij).not.toBeNull();
   });
 });
 
@@ -514,6 +523,7 @@ describe("loadFromConfig", () => {
     // Should have attempted to import builtin plugins via the provided importFn
     expect(importedPackages.length).toBeGreaterThan(0);
     expect(importedPackages).toContain("@aoagents/ao-plugin-runtime-tmux");
+    expect(importedPackages).toContain("@aoagents/ao-plugin-runtime-zellij");
   });
 
   it("loads external package plugins from config.plugins", async () => {

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -38,6 +38,7 @@ function makeKey(slot: PluginSlot, name: string): string {
 const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = [
   // Runtimes
   { slot: "runtime", name: "tmux", pkg: "@aoagents/ao-plugin-runtime-tmux" },
+  { slot: "runtime", name: "zellij", pkg: "@aoagents/ao-plugin-runtime-zellij" },
   { slot: "runtime", name: "process", pkg: "@aoagents/ao-plugin-runtime-process" },
   // Agents
   { slot: "agent", name: "claude-code", pkg: "@aoagents/ao-plugin-agent-claude-code" },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -436,7 +436,7 @@ export interface RuntimeMetrics {
 
 export interface AttachInfo {
   /** How to connect: tmux attach, docker exec, SSH, web URL, etc. */
-  type: "tmux" | "docker" | "ssh" | "web" | "process";
+  type: "tmux" | "zellij" | "docker" | "ssh" | "web" | "process";
   /** For tmux: session name. For docker: container ID. For web: URL. */
   target: string;
   /** Optional: command to run to attach */

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -16,6 +16,7 @@
     "@aoagents/ao-plugin-agent-aider": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
     "@aoagents/ao-plugin-runtime-tmux": "workspace:*",
+    "@aoagents/ao-plugin-runtime-zellij": "workspace:*",
     "@aoagents/ao-plugin-runtime-process": "workspace:*",
     "@aoagents/ao-plugin-workspace-worktree": "workspace:*",
     "@aoagents/ao-plugin-workspace-clone": "workspace:*",

--- a/packages/integration-tests/src/helpers/zellij.ts
+++ b/packages/integration-tests/src/helpers/zellij.ts
@@ -1,0 +1,38 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export async function isZellijAvailable(): Promise<boolean> {
+  try {
+    await execFileAsync("zellij", ["--version"], { timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function killZellijSessionsByPrefix(prefix: string): Promise<void> {
+  let stdout = "";
+  try {
+    ({ stdout } = await execFileAsync("zellij", ["list-sessions", "--short", "--no-formatting"], {
+      timeout: 5_000,
+    }));
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((session) => session.startsWith(prefix))
+      .map(async (session) => {
+        try {
+          await execFileAsync("zellij", ["kill-session", session], { timeout: 5_000 });
+        } catch {
+          // Best-effort cleanup
+        }
+      }),
+  );
+}

--- a/packages/integration-tests/src/runtime-zellij.integration.test.ts
+++ b/packages/integration-tests/src/runtime-zellij.integration.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import zellijPlugin from "@aoagents/ao-plugin-runtime-zellij";
+import type { RuntimeHandle } from "@aoagents/ao-core";
+import { sleep } from "./helpers/polling.js";
+import { isZellijAvailable, killZellijSessionsByPrefix } from "./helpers/zellij.js";
+
+const zellijOk = await isZellijAvailable();
+const SESSION_PREFIX = "aoz-int-";
+
+describe.skipIf(!zellijOk)("runtime-zellij (integration)", () => {
+  const runtime = zellijPlugin.create();
+  const sessionId = `${SESSION_PREFIX}${Date.now().toString(36)}`;
+  let handle: RuntimeHandle;
+
+  beforeAll(async () => {
+    await killZellijSessionsByPrefix(SESSION_PREFIX);
+  }, 30_000);
+
+  afterAll(async () => {
+    try {
+      await runtime.destroy(handle);
+    } catch {
+      // Best-effort cleanup
+    }
+    await killZellijSessionsByPrefix(SESSION_PREFIX);
+  }, 30_000);
+
+  it("creates a Zellij session", async () => {
+    handle = await runtime.create({
+      sessionId,
+      workspacePath: "/tmp",
+      launchCommand: "cat",
+      environment: { AO_TEST: "1" },
+    });
+
+    expect(handle.id).toBe(sessionId);
+    expect(handle.runtimeName).toBe("zellij");
+    expect(handle.data.paneId).toMatch(/^terminal_\d+$/);
+  });
+
+  it("isAlive returns true for running session", async () => {
+    expect(await runtime.isAlive(handle)).toBe(true);
+  });
+
+  it("sendMessage sends text and getOutput captures it", async () => {
+    await runtime.sendMessage(handle, "hello from zellij");
+    await sleep(500);
+    const output = await runtime.getOutput(handle);
+    expect(output).toContain("hello from zellij");
+  });
+
+  it("getMetrics returns uptime", async () => {
+    const metrics = await runtime.getMetrics!(handle);
+    expect(metrics.uptimeMs).toBeGreaterThan(0);
+  });
+
+  it("getAttachInfo returns Zellij command", async () => {
+    const info = await runtime.getAttachInfo!(handle);
+    expect(info.type).toBe("zellij");
+    expect(info.target).toBe(sessionId);
+    expect(info.command).toContain("zellij attach");
+  });
+
+  it("destroy kills the session", async () => {
+    await runtime.destroy(handle);
+    expect(await runtime.isAlive(handle)).toBe(false);
+  });
+
+  it("destroy is idempotent", async () => {
+    await runtime.destroy(handle);
+  });
+});

--- a/packages/plugins/runtime-zellij/CHANGELOG.md
+++ b/packages/plugins/runtime-zellij/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @aoagents/ao-plugin-runtime-zellij
+
+## 0.2.5
+
+### Patch Changes
+
+- Initial Zellij runtime plugin.

--- a/packages/plugins/runtime-zellij/README.md
+++ b/packages/plugins/runtime-zellij/README.md
@@ -1,0 +1,59 @@
+# @aoagents/ao-plugin-runtime-zellij
+
+Runtime plugin for executing agent sessions in Zellij.
+
+## What This Does
+
+Creates one detached Zellij session per AO session and runs the agent in a named pane.
+
+## Requirements
+
+- Zellij must be installed and available on `PATH`
+- macOS or Linux
+
+## Configuration
+
+```yaml
+defaults:
+  runtime: zellij
+  agent: codex
+  workspace: worktree
+```
+
+## How It Works
+
+Creating a session:
+
+1. Validates `sessionId` with the same safe character set as the tmux runtime.
+2. Maps long AO session IDs to short deterministic Zellij session names when needed.
+3. Creates a detached Zellij session with `zellij attach --create-background <session>`.
+4. Writes a temporary launch script containing environment exports and the launch command.
+5. Starts the launch script in a named Zellij pane with `zellij --session <session> run`.
+6. Returns a handle containing the session name and pane ID.
+
+Sending a message:
+
+1. Sends `Ctrl u` to clear partial input.
+2. Pastes the message into the agent pane with `zellij action paste`.
+3. Sends `Enter`.
+
+Capturing output:
+
+Uses `zellij action dump-screen --full --pane-id <pane>`.
+
+Destroying:
+
+Kills the Zellij session with `zellij kill-session <session>`.
+
+## Attaching
+
+```bash
+zellij attach <session-id>
+```
+
+For long AO session IDs, use the `getAttachInfo()` command because the runtime stores a shorter Zellij session name in the handle.
+
+## Limitations
+
+- Zellij does not currently expose tmux-style per-command environment flags, so the runtime writes environment variables into a temporary launch script.
+- `getOutput()` depends on Zellij scrollback availability.

--- a/packages/plugins/runtime-zellij/package.json
+++ b/packages/plugins/runtime-zellij/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@aoagents/ao-plugin-runtime-zellij",
+  "version": "0.2.5",
+  "description": "Runtime plugin: Zellij sessions",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/runtime-zellij"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/runtime-zellij/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-zellij/src/__tests__/index.test.ts
@@ -1,0 +1,425 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as childProcess from "node:child_process";
+import * as fs from "node:fs";
+import type { RuntimeHandle } from "@aoagents/ao-core";
+
+vi.mock("node:child_process", () => {
+  const mockExecFile = vi.fn();
+  (mockExecFile as any)[Symbol.for("nodejs.util.promisify.custom")] = vi.fn();
+  return { execFile: mockExecFile };
+});
+
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:crypto")>();
+  return {
+    ...actual,
+    randomUUID: () => "test-uuid-1234",
+  };
+});
+
+vi.mock("node:fs", () => ({
+  writeFileSync: vi.fn(),
+}));
+
+const mockExecFileCustom = (childProcess.execFile as any)[
+  Symbol.for("nodejs.util.promisify.custom")
+] as ReturnType<typeof vi.fn>;
+const expectedZellijOptions = { timeout: 5_000 };
+
+function mockZellijSuccess(stdout = "") {
+  mockExecFileCustom.mockResolvedValueOnce({ stdout, stderr: "" });
+}
+
+function mockZellijError(message: string) {
+  mockExecFileCustom.mockRejectedValueOnce(new Error(message));
+}
+
+function makeHandle(
+  id = "test-session",
+  paneId = "terminal_1",
+  createdAt = 1000,
+  zellijSessionName?: string,
+): RuntimeHandle {
+  return {
+    id,
+    runtimeName: "zellij",
+    data: {
+      paneId,
+      createdAt,
+      workspacePath: "/tmp/workspace",
+      ...(zellijSessionName ? { zellijSessionName } : {}),
+    },
+  };
+}
+
+import zellijPlugin, { manifest, create } from "../index.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExecFileCustom.mockReset();
+});
+
+describe("manifest", () => {
+  it("has name 'zellij' and slot 'runtime'", () => {
+    expect(manifest.name).toBe("zellij");
+    expect(manifest.slot).toBe("runtime");
+    expect(manifest.version).toBe("0.1.0");
+    expect(manifest.description).toBe("Runtime plugin: Zellij sessions");
+  });
+
+  it("default export includes manifest and create", () => {
+    expect(zellijPlugin.manifest).toBe(manifest);
+    expect(zellijPlugin.create).toBe(create);
+  });
+});
+
+describe("create()", () => {
+  it("returns a Runtime with name 'zellij'", () => {
+    const runtime = create();
+    expect(runtime.name).toBe("zellij");
+  });
+});
+
+describe("runtime.create()", () => {
+  it("creates a background Zellij session and starts a command pane", async () => {
+    const runtime = create();
+
+    mockZellijSuccess("");
+    mockZellijSuccess("");
+    mockZellijSuccess("terminal_7\n");
+
+    const handle = await runtime.create({
+      sessionId: "test-session",
+      workspacePath: "/tmp/workspace",
+      launchCommand: "echo hello",
+      environment: { FOO: "bar" },
+    });
+
+    expect(handle).toEqual({
+      id: "test-session",
+      runtimeName: "zellij",
+      data: expect.objectContaining({
+        paneId: "terminal_7",
+        workspacePath: "/tmp/workspace",
+      }),
+    });
+
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      1,
+      "zellij",
+      ["list-sessions", "--short", "--no-formatting"],
+      expectedZellijOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
+      "zellij",
+      ["attach", "--create-background", "test-session"],
+      expectedZellijOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      3,
+      "zellij",
+      [
+        "--session",
+        "test-session",
+        "run",
+        "--name",
+        "test-session",
+        "--cwd",
+        "/tmp/workspace",
+        "--",
+        "bash",
+        expect.stringContaining("ao-zellij-launch-test-uuid-1234.sh"),
+      ],
+      expectedZellijOptions,
+    );
+  });
+
+  it("writes environment exports and launch command to a temp script", async () => {
+    const runtime = create();
+
+    mockZellijSuccess("");
+    mockZellijSuccess("");
+    mockZellijSuccess("terminal_1\n");
+
+    await runtime.create({
+      sessionId: "env-session",
+      workspacePath: "/tmp/ws",
+      launchCommand: "codex exec test",
+      environment: { FOO: "bar baz", QUOTED: "it's ok" },
+    });
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("ao-zellij-launch-test-uuid-1234.sh"),
+      expect.stringContaining("export FOO='bar baz'"),
+      { encoding: "utf-8", mode: 0o700 },
+    );
+    const script = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    expect(script).toContain("export QUOTED='it'\\''s ok'");
+    expect(script).toContain("codex exec test");
+  });
+
+  it("uses a short deterministic Zellij session name for long AO session IDs", async () => {
+    const runtime = create();
+    const sessionId = "ao-inttest-zellij-1234567890";
+
+    mockZellijSuccess("");
+    mockZellijSuccess("");
+    mockZellijSuccess("terminal_1\n");
+
+    const handle = await runtime.create({
+      sessionId,
+      workspacePath: "/tmp/ws",
+      launchCommand: "echo hi",
+      environment: {},
+    });
+
+    const zellijSessionName = handle.data.zellijSessionName as string;
+    expect(handle.id).toBe(sessionId);
+    expect(zellijSessionName).toMatch(/^ao-ao-intte-[a-f0-9]{12}$/);
+    expect(zellijSessionName.length).toBeLessThanOrEqual(25);
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
+      "zellij",
+      ["attach", "--create-background", zellijSessionName],
+      expectedZellijOptions,
+    );
+  });
+
+  it("rejects invalid session IDs", async () => {
+    const runtime = create();
+
+    await expect(
+      runtime.create({
+        sessionId: "bad session",
+        workspacePath: "/tmp/ws",
+        launchCommand: "echo hi",
+        environment: {},
+      }),
+    ).rejects.toThrow(/Invalid session ID/);
+  });
+
+  it("rejects invalid environment names", async () => {
+    const runtime = create();
+
+    mockZellijSuccess("");
+    mockZellijSuccess("");
+    mockZellijSuccess("");
+
+    await expect(
+      runtime.create({
+        sessionId: "bad-env",
+        workspacePath: "/tmp/ws",
+        launchCommand: "echo hi",
+        environment: { "BAD-NAME": "value" },
+      }),
+    ).rejects.toThrow(/Invalid environment variable name/);
+
+    expect(mockExecFileCustom).toHaveBeenCalledWith(
+      "zellij",
+      ["kill-session", "bad-env"],
+      expectedZellijOptions,
+    );
+  });
+
+  it("rejects duplicate session IDs", async () => {
+    const runtime = create();
+
+    mockZellijSuccess("dup-session\n");
+
+    await expect(
+      runtime.create({
+        sessionId: "dup-session",
+        workspacePath: "/tmp/ws",
+        launchCommand: "echo hi",
+        environment: {},
+      }),
+    ).rejects.toThrow(/already exists/);
+  });
+
+  it("cleans up the session if pane launch fails", async () => {
+    const runtime = create();
+
+    mockZellijSuccess("");
+    mockZellijSuccess("");
+    mockZellijError("run failed");
+    mockZellijSuccess("");
+
+    await expect(
+      runtime.create({
+        sessionId: "fail-session",
+        workspacePath: "/tmp/ws",
+        launchCommand: "bad-command",
+        environment: {},
+      }),
+    ).rejects.toThrow('Failed to start Zellij pane for session "fail-session"');
+
+    expect(mockExecFileCustom).toHaveBeenCalledWith(
+      "zellij",
+      ["kill-session", "fail-session"],
+      expectedZellijOptions,
+    );
+  });
+
+  it("throws when pane id cannot be parsed", async () => {
+    const runtime = create();
+
+    mockZellijSuccess("");
+    mockZellijSuccess("");
+    mockZellijSuccess("unexpected\n");
+    mockZellijSuccess("");
+
+    await expect(
+      runtime.create({
+        sessionId: "parse-fail",
+        workspacePath: "/tmp/ws",
+        launchCommand: "echo hi",
+        environment: {},
+      }),
+    ).rejects.toThrow(/Could not parse Zellij pane id/);
+  });
+});
+
+describe("runtime.destroy()", () => {
+  it("kills the Zellij session", async () => {
+    const runtime = create();
+    mockZellijSuccess("");
+
+    await runtime.destroy(makeHandle("dead-session"));
+
+    expect(mockExecFileCustom).toHaveBeenCalledWith(
+      "zellij",
+      ["kill-session", "dead-session"],
+      expectedZellijOptions,
+    );
+  });
+
+  it("uses stored Zellij session name when present", async () => {
+    const runtime = create();
+    mockZellijSuccess("");
+
+    await runtime.destroy(makeHandle("long-ao-session-id", "terminal_1", 1000, "ao-short-name"));
+
+    expect(mockExecFileCustom).toHaveBeenCalledWith(
+      "zellij",
+      ["kill-session", "ao-short-name"],
+      expectedZellijOptions,
+    );
+  });
+
+  it("is idempotent", async () => {
+    const runtime = create();
+    mockZellijError("not found");
+
+    await expect(runtime.destroy(makeHandle("missing"))).resolves.toBeUndefined();
+  });
+});
+
+describe("runtime.sendMessage()", () => {
+  it("clears input, pastes the message, and sends Enter", async () => {
+    const runtime = create();
+    mockZellijSuccess("");
+    mockZellijSuccess("");
+    mockZellijSuccess("");
+
+    await runtime.sendMessage(makeHandle("msg-session", "terminal_4"), "hello world");
+
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      1,
+      "zellij",
+      ["--session", "msg-session", "action", "send-keys", "--pane-id", "terminal_4", "Ctrl u"],
+      expectedZellijOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
+      "zellij",
+      [
+        "--session",
+        "msg-session",
+        "action",
+        "paste",
+        "--pane-id",
+        "terminal_4",
+        "--",
+        "hello world",
+      ],
+      expectedZellijOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      3,
+      "zellij",
+      ["--session", "msg-session", "action", "send-keys", "--pane-id", "terminal_4", "Enter"],
+      expectedZellijOptions,
+    );
+  });
+
+  it("throws when handle is missing a pane id", async () => {
+    const runtime = create();
+    await expect(runtime.sendMessage(makeHandle("msg-session", ""), "hello")).rejects.toThrow(
+      /Missing Zellij pane id/,
+    );
+  });
+});
+
+describe("runtime.getOutput()", () => {
+  it("dumps scrollback for the pane and returns the requested line count", async () => {
+    const runtime = create();
+    mockZellijSuccess("line1\nline2\nline3\n");
+
+    const output = await runtime.getOutput(makeHandle("out-session", "terminal_2"), 2);
+
+    expect(output).toBe("line2\nline3");
+    expect(mockExecFileCustom).toHaveBeenCalledWith(
+      "zellij",
+      ["--session", "out-session", "action", "dump-screen", "--pane-id", "terminal_2", "--full"],
+      expectedZellijOptions,
+    );
+  });
+
+  it("returns empty output on dump failure", async () => {
+    const runtime = create();
+    mockZellijError("dump failed");
+
+    await expect(runtime.getOutput(makeHandle("out-session"))).resolves.toBe("");
+  });
+});
+
+describe("runtime.isAlive()", () => {
+  it("returns true when the session is listed", async () => {
+    const runtime = create();
+    mockZellijSuccess("other\nalive-session\n");
+
+    expect(await runtime.isAlive(makeHandle("alive-session"))).toBe(true);
+  });
+
+  it("returns false when the session is not listed", async () => {
+    const runtime = create();
+    mockZellijSuccess("other\n");
+
+    expect(await runtime.isAlive(makeHandle("missing-session"))).toBe(false);
+  });
+});
+
+describe("runtime.getMetrics()", () => {
+  it("returns uptime", async () => {
+    const runtime = create();
+    const metrics = await runtime.getMetrics!(
+      makeHandle("metrics-session", "terminal_1", Date.now() - 10),
+    );
+
+    expect(metrics.uptimeMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("runtime.getAttachInfo()", () => {
+  it("returns a Zellij attach command", async () => {
+    const runtime = create();
+    const info = await runtime.getAttachInfo!(makeHandle("attach-session"));
+
+    expect(info).toEqual({
+      type: "zellij",
+      target: "attach-session",
+      command: "zellij attach attach-session",
+    });
+  });
+});

--- a/packages/plugins/runtime-zellij/src/index.ts
+++ b/packages/plugins/runtime-zellij/src/index.ts
@@ -1,0 +1,219 @@
+import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { promisify } from "node:util";
+import {
+  type AttachInfo,
+  type PluginModule,
+  type Runtime,
+  type RuntimeCreateConfig,
+  type RuntimeHandle,
+  type RuntimeMetrics,
+  shellEscape,
+} from "@aoagents/ao-core";
+
+const execFileAsync = promisify(execFile);
+const ZELLIJ_COMMAND_TIMEOUT_MS = 5_000;
+const ZELLIJ_SESSION_NAME_MAX_LENGTH = 25;
+
+export const manifest = {
+  name: "zellij",
+  slot: "runtime" as const,
+  description: "Runtime plugin: Zellij sessions",
+  version: "0.1.0",
+};
+
+const SAFE_SESSION_ID = /^[a-zA-Z0-9_-]+$/;
+const SAFE_ENV_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+function assertValidSessionId(id: string): void {
+  if (!SAFE_SESSION_ID.test(id)) {
+    throw new Error(`Invalid session ID "${id}": must match ${SAFE_SESSION_ID}`);
+  }
+}
+
+function envExportLines(environment: Record<string, string>): string {
+  return Object.entries(environment)
+    .map(([key, value]) => {
+      if (!SAFE_ENV_NAME.test(key)) {
+        throw new Error(`Invalid environment variable name "${key}"`);
+      }
+      return `export ${key}=${shellEscape(value)}`;
+    })
+    .join("\n");
+}
+
+function toZellijSessionName(sessionId: string): string {
+  if (sessionId.length <= ZELLIJ_SESSION_NAME_MAX_LENGTH) {
+    return sessionId;
+  }
+
+  const prefix = sessionId.slice(0, 8);
+  const hash = createHash("sha256").update(sessionId).digest("hex").slice(0, 12);
+  return `ao-${prefix}-${hash}`;
+}
+
+function getZellijSessionName(handle: RuntimeHandle): string {
+  return String(handle.data.zellijSessionName ?? handle.id);
+}
+
+function writeLaunchScript(command: string, environment: Record<string, string>): string {
+  const scriptPath = join(tmpdir(), `ao-zellij-launch-${randomUUID()}.sh`);
+  const exports = envExportLines(environment);
+  const content = ["#!/usr/bin/env bash", 'rm -- "$0" 2>/dev/null || true', exports, command, ""]
+    .filter(Boolean)
+    .join("\n");
+  writeFileSync(scriptPath, content, { encoding: "utf-8", mode: 0o700 });
+  return scriptPath;
+}
+
+async function zellij(...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("zellij", args, {
+    timeout: ZELLIJ_COMMAND_TIMEOUT_MS,
+  });
+  return stdout.trimEnd();
+}
+
+function parsePaneId(stdout: string): string {
+  const paneId = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => /^terminal_\d+$/.test(line));
+
+  if (!paneId) {
+    throw new Error(`Could not parse Zellij pane id from output: ${JSON.stringify(stdout)}`);
+  }
+
+  return paneId;
+}
+
+async function sessionExists(sessionName: string): Promise<boolean> {
+  try {
+    const stdout = await zellij("list-sessions", "--short", "--no-formatting");
+    return stdout.split(/\r?\n/).some((line) => line.trim() === sessionName);
+  } catch {
+    return false;
+  }
+}
+
+export function create(): Runtime {
+  return {
+    name: "zellij",
+
+    async create(config: RuntimeCreateConfig): Promise<RuntimeHandle> {
+      assertValidSessionId(config.sessionId);
+      const sessionName = toZellijSessionName(config.sessionId);
+
+      if (await sessionExists(sessionName)) {
+        throw new Error(`Session "${sessionName}" already exists — destroy it before re-creating`);
+      }
+
+      await zellij("attach", "--create-background", sessionName);
+
+      try {
+        const scriptPath = writeLaunchScript(config.launchCommand, config.environment ?? {});
+        const paneStdout = await zellij(
+          "--session",
+          sessionName,
+          "run",
+          "--name",
+          sessionName,
+          "--cwd",
+          config.workspacePath,
+          "--",
+          "bash",
+          scriptPath,
+        );
+        const paneId = parsePaneId(paneStdout);
+
+        return {
+          id: config.sessionId,
+          runtimeName: "zellij",
+          data: {
+            createdAt: Date.now(),
+            workspacePath: config.workspacePath,
+            zellijSessionName: sessionName,
+            paneId,
+          },
+        };
+      } catch (err: unknown) {
+        try {
+          await zellij("kill-session", sessionName);
+        } catch {
+          // Best-effort cleanup
+        }
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to start Zellij pane for session "${sessionName}": ${msg}`, {
+          cause: err,
+        });
+      }
+    },
+
+    async destroy(handle: RuntimeHandle): Promise<void> {
+      try {
+        await zellij("kill-session", getZellijSessionName(handle));
+      } catch {
+        // Session may already be gone.
+      }
+    },
+
+    async sendMessage(handle: RuntimeHandle, message: string): Promise<void> {
+      const paneId = String(handle.data.paneId ?? "");
+      if (!paneId) {
+        throw new Error(`Missing Zellij pane id for session ${handle.id}`);
+      }
+      const sessionName = getZellijSessionName(handle);
+
+      await zellij("--session", sessionName, "action", "send-keys", "--pane-id", paneId, "Ctrl u");
+      await zellij("--session", sessionName, "action", "paste", "--pane-id", paneId, "--", message);
+      await sleep(300);
+      await zellij("--session", sessionName, "action", "send-keys", "--pane-id", paneId, "Enter");
+    },
+
+    async getOutput(handle: RuntimeHandle, lines = 50): Promise<string> {
+      const paneId = String(handle.data.paneId ?? "");
+      if (!paneId) return "";
+
+      try {
+        const output = await zellij(
+          "--session",
+          getZellijSessionName(handle),
+          "action",
+          "dump-screen",
+          "--pane-id",
+          paneId,
+          "--full",
+        );
+        const allLines = output.split(/\r?\n/);
+        return allLines.slice(Math.max(0, allLines.length - lines)).join("\n");
+      } catch {
+        return "";
+      }
+    },
+
+    async isAlive(handle: RuntimeHandle): Promise<boolean> {
+      return sessionExists(getZellijSessionName(handle));
+    },
+
+    async getMetrics(handle: RuntimeHandle): Promise<RuntimeMetrics> {
+      const createdAt = (handle.data.createdAt as number) ?? Date.now();
+      return {
+        uptimeMs: Date.now() - createdAt,
+      };
+    },
+
+    async getAttachInfo(handle: RuntimeHandle): Promise<AttachInfo> {
+      const sessionName = getZellijSessionName(handle);
+      return {
+        type: "zellij",
+        target: sessionName,
+        command: `zellij attach ${sessionName}`,
+      };
+    },
+  };
+}
+
+export default { manifest, create } satisfies PluginModule<Runtime>;

--- a/packages/plugins/runtime-zellij/tsconfig.json
+++ b/packages/plugins/runtime-zellij/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -12,6 +12,7 @@ const nextConfig = {
     "@aoagents/ao-plugin-agent-codex",
     "@aoagents/ao-plugin-agent-opencode",
     "@aoagents/ao-plugin-runtime-tmux",
+    "@aoagents/ao-plugin-runtime-zellij",
     "@aoagents/ao-plugin-scm-github",
     "@aoagents/ao-plugin-tracker-github",
     "@aoagents/ao-plugin-tracker-linear",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,6 +34,7 @@
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
     "@aoagents/ao-plugin-runtime-tmux": "workspace:*",
+    "@aoagents/ao-plugin-runtime-zellij": "workspace:*",
     "@aoagents/ao-plugin-scm-github": "workspace:*",
     "@aoagents/ao-plugin-tracker-github": "workspace:*",
     "@aoagents/ao-plugin-tracker-linear": "workspace:*",

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -96,7 +96,7 @@ const isMainModule =
 
 if (isMainModule) {
   const TMUX = findTmux();
-  console.log(`[DirectTerminal] Using tmux: ${TMUX}`);
+  console.log(`[DirectTerminal] Using tmux fallback: ${TMUX}`);
 
   const { server, shutdown } = createDirectTerminalServer(TMUX);
   const PORT = parseInt(process.env.DIRECT_TERMINAL_PORT ?? "14801", 10);

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -9,7 +9,7 @@
 
 import { WebSocketServer, WebSocket } from "ws";
 import { homedir, userInfo } from "node:os";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js";
 
 // These types mirror src/lib/mux-protocol.ts exactly.
@@ -17,10 +17,14 @@ import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js
 // across the boundary. Keep both in sync when updating the protocol.
 
 // ── Client → Server ──
+type TerminalTarget =
+  | { runtime: "tmux"; sessionName?: string }
+  | { runtime: "zellij"; sessionName: string };
+
 type ClientMessage =
   | { ch: "terminal"; id: string; type: "data"; data: string }
   | { ch: "terminal"; id: string; type: "resize"; cols: number; rows: number }
-  | { ch: "terminal"; id: string; type: "open"; tmuxName?: string }
+  | { ch: "terminal"; id: string; type: "open"; tmuxName?: string; target?: TerminalTarget }
   | { ch: "terminal"; id: string; type: "close" }
   | { ch: "system"; type: "ping" }
   | { ch: "subscribe"; topics: ("sessions")[] };
@@ -216,9 +220,37 @@ try {
   console.warn("[MuxServer] node-pty not available — mux server will be disabled.", err);
 }
 
+function findZellij(): string {
+  const candidates = [
+    process.env.ZELLIJ_PATH,
+    "/opt/homebrew/bin/zellij",
+    "/usr/local/bin/zellij",
+    "/usr/bin/zellij",
+  ].filter((candidate): candidate is string => !!candidate);
+
+  for (const candidate of candidates) {
+    const result = spawnSync(candidate, ["--version"], {
+      stdio: "ignore",
+      timeout: 5000,
+    });
+    if (!result.error) {
+      return candidate;
+    }
+  }
+
+  return "zellij";
+}
+
+interface ResolvedTerminalTarget {
+  runtime: "tmux" | "zellij";
+  sessionName: string;
+  command: string;
+  args: string[];
+}
+
 interface ManagedTerminal {
   id: string;
-  tmuxSessionId: string;
+  target: ResolvedTerminalTarget;
   pty: IPty | null;
   subscribers: Set<(data: string) => void>;
   exitCallbacks: Set<(exitCode: number) => void>;
@@ -236,35 +268,82 @@ const MAX_REATTACH_ATTEMPTS = 3;
  */
 class TerminalManager {
   private terminals = new Map<string, ManagedTerminal>();
-  private TMUX: string;
+  private readonly TMUX: string;
+  private readonly ZELLIJ: string;
 
   constructor(tmuxPath?: string) {
     this.TMUX = tmuxPath ?? findTmux();
+    this.ZELLIJ = findZellij();
+  }
+
+  private resolveTarget(
+    id: string,
+    requestedTarget?: TerminalTarget,
+    existing?: ManagedTerminal,
+  ): ResolvedTerminalTarget {
+    if (!requestedTarget && existing) {
+      return existing.target;
+    }
+
+    if (requestedTarget?.runtime === "zellij") {
+      if (!validateSessionId(requestedTarget.sessionName)) {
+        throw new Error(`Invalid Zellij session name: ${requestedTarget.sessionName}`);
+      }
+      return {
+        runtime: "zellij",
+        sessionName: requestedTarget.sessionName,
+        command: this.ZELLIJ,
+        args: ["attach", requestedTarget.sessionName],
+      };
+    }
+
+    const tmuxSessionId =
+      requestedTarget?.runtime === "tmux" && requestedTarget.sessionName
+        ? requestedTarget.sessionName
+        : resolveTmuxSession(id, this.TMUX);
+    if (!tmuxSessionId) {
+      throw new Error(`Session not found: ${id}`);
+    }
+
+    return {
+      runtime: "tmux",
+      sessionName: tmuxSessionId,
+      command: this.TMUX,
+      args: ["attach-session", "-t", tmuxSessionId],
+    };
+  }
+
+  private enableTmuxUi(sessionName: string): void {
+    const mouseProc = spawn(this.TMUX, ["set-option", "-t", sessionName, "mouse", "on"]);
+    mouseProc.on("error", (err) => {
+      console.error(`[MuxServer] Failed to set mouse mode for ${sessionName}:`, err.message);
+    });
+
+    const statusProc = spawn(this.TMUX, ["set-option", "-t", sessionName, "status", "off"]);
+    statusProc.on("error", (err) => {
+      console.error(`[MuxServer] Failed to hide status bar for ${sessionName}:`, err.message);
+    });
   }
 
   /**
    * Open/attach to a terminal. If already open, just return.
    * If has subscribers but PTY crashed, re-attach.
    */
-  open(id: string, tmuxName?: string): string {
+  open(id: string, requestedTarget?: TerminalTarget): ResolvedTerminalTarget {
     // Validate and resolve
     if (!validateSessionId(id)) {
       throw new Error(`Invalid session ID: ${id}`);
     }
 
-    // Use provided tmuxName, or reuse from existing terminal entry, or resolve
     const existing = this.terminals.get(id);
-    const tmuxSessionId = tmuxName ?? existing?.tmuxSessionId ?? resolveTmuxSession(id, this.TMUX);
-    if (!tmuxSessionId) {
-      throw new Error(`Session not found: ${id}`);
-    }
+    const target = this.resolveTarget(id, requestedTarget, existing);
 
     // Get or create terminal entry
     let terminal = this.terminals.get(id);
     if (!terminal) {
       terminal = {
         id,
-        tmuxSessionId,
+        target,
         pty: null,
         subscribers: new Set(),
         exitCallbacks: new Set(),
@@ -277,20 +356,12 @@ class TerminalManager {
 
     // If PTY is already attached, we're done
     if (terminal.pty) {
-      return tmuxSessionId;
+      return terminal.target;
     }
 
-    // Enable mouse mode
-    const mouseProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "on"]);
-    mouseProc.on("error", (err) => {
-      console.error(`[MuxServer] Failed to set mouse mode for ${tmuxSessionId}:`, err.message);
-    });
-
-    // Hide the status bar
-    const statusProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "status", "off"]);
-    statusProc.on("error", (err) => {
-      console.error(`[MuxServer] Failed to hide status bar for ${tmuxSessionId}:`, err.message);
-    });
+    if (target.runtime === "tmux") {
+      this.enableTmuxUi(target.sessionName);
+    }
 
     // Build environment
     const homeDir = process.env.HOME || homedir();
@@ -310,7 +381,7 @@ class TerminalManager {
     }
 
     // Spawn PTY
-    const pty = ptySpawn(this.TMUX, ["attach-session", "-t", tmuxSessionId], {
+    const pty = ptySpawn(target.command, target.args, {
       name: "xterm-256color",
       cols: 80,
       rows: 24,
@@ -319,6 +390,7 @@ class TerminalManager {
     });
 
     terminal.pty = pty;
+    terminal.target = target;
 
     // Wire up data events
     pty.onData((data: string) => {
@@ -371,8 +443,8 @@ class TerminalManager {
       }
     });
 
-    console.log(`[MuxServer] Opened terminal ${id} (tmux: ${tmuxSessionId})`);
-    return tmuxSessionId;
+    console.log(`[MuxServer] Opened terminal ${id} (${target.runtime}: ${target.sessionName})`);
+    return target;
   }
 
   /**
@@ -501,7 +573,13 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
           try {
             if (type === "open") {
               // Validate session exists
-              terminalManager.open(id, "tmuxName" in msg ? msg.tmuxName : undefined);
+              const target =
+                "target" in msg && msg.target
+                  ? msg.target
+                  : "tmuxName" in msg && msg.tmuxName
+                    ? { runtime: "tmux" as const, sessionName: msg.tmuxName }
+                    : undefined;
+              terminalManager.open(id, target);
 
               // Send opened confirmation (idempotent — safe to send on re-open)
               const openedMsg: ServerMessage = { ch: "terminal", id, type: "opened" };

--- a/packages/web/src/__tests__/services.test.ts
+++ b/packages/web/src/__tests__/services.test.ts
@@ -8,6 +8,7 @@ const {
   mockCreateSessionManager,
   mockRegistry,
   tmuxPlugin,
+  zellijPlugin,
   claudePlugin,
   codexPlugin,
   opencodePlugin,
@@ -42,6 +43,7 @@ const {
     mockCreateSessionManager,
     mockRegistry,
     tmuxPlugin: { manifest: { name: "tmux" } },
+    zellijPlugin: { manifest: { name: "zellij" } },
     claudePlugin: { manifest: { name: "claude-code" } },
     codexPlugin: { manifest: { name: "codex" } },
     opencodePlugin: { manifest: { name: "opencode" } },
@@ -68,6 +70,7 @@ vi.mock("@aoagents/ao-core", () => ({
 }));
 
 vi.mock("@aoagents/ao-plugin-runtime-tmux", () => ({ default: tmuxPlugin }));
+vi.mock("@aoagents/ao-plugin-runtime-zellij", () => ({ default: zellijPlugin }));
 vi.mock("@aoagents/ao-plugin-agent-claude-code", () => ({ default: claudePlugin }));
 vi.mock("@aoagents/ao-plugin-agent-codex", () => ({ default: codexPlugin }));
 vi.mock("@aoagents/ao-plugin-agent-opencode", () => ({ default: opencodePlugin }));

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/cn";
+import type { TerminalTarget } from "@/lib/mux-protocol";
 
 import { getStoredFontSize } from "./terminal/terminal-font";
 import { TerminalControls } from "./terminal/TerminalControls";
@@ -18,6 +19,8 @@ interface DirectTerminalProps {
   sessionId: string;
   /** Actual tmux session name. When provided, the terminal server uses it directly instead of resolving from sessionId. */
   tmuxName?: string;
+  /** Runtime-specific terminal attachment target. Prefer this over tmuxName for non-tmux runtimes. */
+  terminalTarget?: TerminalTarget;
   startFullscreen?: boolean;
   /** Visual variant. Orchestrator keeps the same design-system blue accent as the rest of the app. */
   variant?: "agent" | "orchestrator";
@@ -39,6 +42,7 @@ interface DirectTerminalProps {
 export function DirectTerminal({
   sessionId,
   tmuxName,
+  terminalTarget,
   startFullscreen = false,
   variant = "agent",
   appearance = "theme",
@@ -69,7 +73,7 @@ export function DirectTerminal({
     variant,
     fontSize,
     autoFocus,
-    tmuxName,
+    terminalTarget: terminalTarget ?? (tmuxName ? { runtime: "tmux", sessionName: tmuxName } : undefined),
   });
 
   useFullscreenResize(fullscreen, sessionId, terminalInstance, fitAddon, terminalRef);

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -5,9 +5,11 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useMediaQuery, MOBILE_BREAKPOINT } from "@/hooks/useMediaQuery";
 import {
   type DashboardSession,
+  type RuntimeHandle,
   TERMINAL_STATUSES,
   NON_RESTORABLE_STATUSES,
 } from "@/lib/types";
+import type { TerminalTarget } from "@/lib/mux-protocol";
 import dynamic from "next/dynamic";
 import { getSessionTitle } from "@/lib/format";
 import type { ProjectInfo } from "@/lib/project-name";
@@ -36,6 +38,53 @@ const DirectTerminal = dynamic(
     ),
   },
 );
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseRuntimeHandle(raw: string | undefined): RuntimeHandle | null {
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed) || !isRecord(parsed.data)) return null;
+    if (typeof parsed.id !== "string" || typeof parsed.runtimeName !== "string") return null;
+    return {
+      id: parsed.id,
+      runtimeName: parsed.runtimeName,
+      data: parsed.data,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getTerminalTarget(session: DashboardSession): TerminalTarget | undefined {
+  const runtimeHandle =
+    session.runtimeHandle ?? parseRuntimeHandle(session.metadata["runtimeHandle"]);
+
+  if (runtimeHandle?.runtimeName === "zellij") {
+    const zellijSessionName = runtimeHandle.data["zellijSessionName"];
+    return {
+      runtime: "zellij",
+      sessionName:
+        typeof zellijSessionName === "string" && zellijSessionName.length > 0
+          ? zellijSessionName
+          : runtimeHandle.id,
+    };
+  }
+
+  if (runtimeHandle?.runtimeName === "tmux") {
+    return {
+      runtime: "tmux",
+      sessionName: session.metadata["tmuxName"] ?? runtimeHandle.id,
+    };
+  }
+
+  const tmuxName = session.metadata["tmuxName"];
+  return tmuxName ? { runtime: "tmux", sessionName: tmuxName } : undefined;
+}
 
 interface SessionDetailProps {
   session: DashboardSession;
@@ -77,6 +126,7 @@ export function SessionDetail({
   const headline = getSessionTitle(session);
 
   const terminalVariant = isOrchestrator ? "orchestrator" : "agent";
+  const terminalTarget = getTerminalTarget(session);
 
   const isOpenCodeSession = session.metadata["agent"] === "opencode";
   const opencodeSessionId =
@@ -209,6 +259,7 @@ export function SessionDetail({
                   <DirectTerminal
                     sessionId={session.id}
                     tmuxName={session.metadata?.tmuxName}
+                    terminalTarget={terminalTarget}
                     startFullscreen={startFullscreen}
                     variant={terminalVariant}
                     appearance="dark"

--- a/packages/web/src/components/terminal/useXtermTerminal.ts
+++ b/packages/web/src/components/terminal/useXtermTerminal.ts
@@ -12,6 +12,7 @@ import type { Terminal as TerminalType } from "@xterm/xterm";
 import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
 
 import { useMux } from "@/hooks/useMux";
+import type { TerminalTarget } from "@/lib/mux-protocol";
 import { attachTouchScroll } from "@/lib/terminal-touch-scroll";
 
 import { registerClipboardHandlers } from "./terminal-clipboard";
@@ -23,8 +24,8 @@ export interface UseXtermTerminalOptions {
   variant: TerminalVariant;
   fontSize: number;
   autoFocus: boolean;
-  /** Actual tmux session name. When provided, the terminal server uses it directly instead of resolving from sessionId. */
-  tmuxName?: string;
+  /** Runtime-specific terminal attachment target. */
+  terminalTarget?: TerminalTarget;
 }
 
 export interface UseXtermTerminalResult {
@@ -48,7 +49,7 @@ export function useXtermTerminal(
   sessionId: string,
   options: UseXtermTerminalOptions,
 ): UseXtermTerminalResult {
-  const { appearance, variant, fontSize, autoFocus, tmuxName } = options;
+  const { appearance, variant, fontSize, autoFocus, terminalTarget } = options;
   const { resolvedTheme } = useTheme();
   const terminalThemes = useMemo(() => buildTerminalThemes(variant), [variant]);
   const {
@@ -234,7 +235,7 @@ export function useXtermTerminal(
         // hazard if subscribeTerminal ever fires synchronously.
         let programmaticScroll = false;
 
-        openTerminal(sessionId, tmuxName);
+        openTerminal(sessionId, terminalTarget);
 
         unsubscribe = subscribeTerminal(sessionId, (data) => {
           if (selectionActive) {
@@ -320,7 +321,7 @@ export function useXtermTerminal(
   }, [
     appearance,
     sessionId,
-    tmuxName,
+    terminalTarget,
     variant,
     resolvedTheme,
     terminalThemes,

--- a/packages/web/src/lib/mux-protocol.ts
+++ b/packages/web/src/lib/mux-protocol.ts
@@ -2,10 +2,14 @@ import type { AttentionLevel } from "./types";
 
 // ── Client → Server ──
 
+export type TerminalTarget =
+  | { runtime: "tmux"; sessionName?: string }
+  | { runtime: "zellij"; sessionName: string };
+
 export type ClientMessage =
   | { ch: "terminal"; id: string; type: "data"; data: string }
   | { ch: "terminal"; id: string; type: "resize"; cols: number; rows: number }
-  | { ch: "terminal"; id: string; type: "open"; tmuxName?: string }
+  | { ch: "terminal"; id: string; type: "open"; tmuxName?: string; target?: TerminalTarget }
   | { ch: "terminal"; id: string; type: "close" }
   | { ch: "system"; type: "ping" }
   | { ch: "subscribe"; topics: ("sessions")[] };

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -188,6 +188,7 @@ export function sessionToDashboard(session: Session): DashboardSession {
           state: normalizeDashboardPRState(session.lifecycle.pr.state),
         }
       : null,
+    runtimeHandle: session.runtimeHandle,
     metadata: session.metadata,
     agentReportAudit: [],
   });

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -34,6 +34,7 @@ import {
 
 // Static plugin imports — webpack needs these to be string literals
 import pluginRuntimeTmux from "@aoagents/ao-plugin-runtime-tmux";
+import pluginRuntimeZellij from "@aoagents/ao-plugin-runtime-zellij";
 import pluginAgentClaudeCode from "@aoagents/ao-plugin-agent-claude-code";
 import pluginAgentCodex from "@aoagents/ao-plugin-agent-codex";
 import pluginAgentCursor from "@aoagents/ao-plugin-agent-cursor";
@@ -104,6 +105,7 @@ async function initServices(): Promise<Services> {
 
   // Register plugins explicitly (webpack can't handle dynamic import() in core)
   registry.register(pluginRuntimeTmux);
+  registry.register(pluginRuntimeZellij);
   registry.register(pluginAgentClaudeCode);
   registry.register(pluginAgentCodex);
   registry.register(pluginAgentCursor);

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -24,6 +24,7 @@ export type {
   CanonicalRuntimeState,
   CanonicalRuntimeReason,
   DashboardAttentionZoneMode,
+  RuntimeHandle,
 } from "@aoagents/ao-core/types";
 
 import {
@@ -48,6 +49,7 @@ import {
   type CanonicalRuntimeState,
   type CanonicalRuntimeReason,
   type DashboardAttentionZoneMode,
+  type RuntimeHandle,
 } from "@aoagents/ao-core/types";
 import type { AgentReportedState } from "@aoagents/ao-core";
 
@@ -112,6 +114,7 @@ export interface DashboardSession {
   createdAt: string;
   lastActivityAt: string;
   pr: DashboardPR | null;
+  runtimeHandle?: RuntimeHandle | null;
   metadata: Record<string, string>;
   agentReportAudit?: DashboardAgentReportAuditEntry[];
   attentionLevel?: AttentionLevel;

--- a/packages/web/src/providers/MuxProvider.tsx
+++ b/packages/web/src/providers/MuxProvider.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import React, { useEffect, useRef, useState, useMemo, useCallback, type ReactNode } from "react";
-import type { ClientMessage, ServerMessage, SessionPatch } from "@/lib/mux-protocol";
+import type { ClientMessage, ServerMessage, SessionPatch, TerminalTarget } from "@/lib/mux-protocol";
 
 interface MuxContextValue {
   subscribeTerminal: (id: string, callback: (data: string) => void) => () => void;
   writeTerminal: (id: string, data: string) => void;
-  openTerminal: (id: string, tmuxName?: string) => void;
+  openTerminal: (id: string, target?: TerminalTarget) => void;
   closeTerminal: (id: string) => void;
   resizeTerminal: (id: string, cols: number, rows: number) => void;
   status: "connecting" | "connected" | "reconnecting" | "disconnected";
@@ -71,7 +71,7 @@ function buildMuxWsUrl(runtimeConfig: { directTerminalPort?: string; proxyWsPath
 export function MuxProvider({ children }: { children: ReactNode }) {
   const wsRef = useRef<WebSocket | null>(null);
   const subscribersRef = useRef(new Map<string, Set<(data: string) => void>>());
-  const openedTerminalsRef = useRef(new Map<string, string | undefined>());
+  const openedTerminalsRef = useRef(new Map<string, TerminalTarget | undefined>());
   const [status, setStatus] = useState<"connecting" | "connected" | "reconnecting" | "disconnected">(
     "connecting",
   );
@@ -105,12 +105,12 @@ export function MuxProvider({ children }: { children: ReactNode }) {
         reconnectAttempt.current = 0;
 
         // Re-open previously opened terminals
-        for (const [terminalId, tmuxName] of openedTerminalsRef.current) {
+        for (const [terminalId, target] of openedTerminalsRef.current) {
           const openMsg: ClientMessage = {
             ch: "terminal",
             id: terminalId,
             type: "open",
-            ...(tmuxName && { tmuxName }),
+            ...(target && { target }),
           };
           ws.send(JSON.stringify(openMsg));
         }
@@ -137,7 +137,7 @@ export function MuxProvider({ children }: { children: ReactNode }) {
                 }
               }
             } else if (msg.type === "opened") {
-              // Terminal opened successfully — preserve existing tmuxName
+              // Terminal opened successfully — preserve existing target
               if (!openedTerminalsRef.current.has(msg.id)) {
                 openedTerminalsRef.current.set(msg.id, undefined);
               }
@@ -272,14 +272,14 @@ export function MuxProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const openTerminal = useCallback((id: string, tmuxName?: string) => {
-    openedTerminalsRef.current.set(id, tmuxName);
+  const openTerminal = useCallback((id: string, target?: TerminalTarget) => {
+    openedTerminalsRef.current.set(id, target);
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       const msg: ClientMessage = {
         ch: "terminal",
         id,
         type: "open",
-        ...(tmuxName && { tmuxName }),
+        ...(target && { target }),
       };
       wsRef.current.send(JSON.stringify(msg));
     }

--- a/packages/web/src/providers/__tests__/MuxProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/MuxProvider.test.tsx
@@ -481,6 +481,53 @@ describe("MuxProvider terminal operations", () => {
     })).toBe(true);
   });
 
+  it("openTerminal sends runtime target when provided", async () => {
+    const { result, ws } = await setupConnected();
+    act(() =>
+      result.current.openTerminal("session-abc", { runtime: "zellij", sessionName: "session-abc" }),
+    );
+    const openMessage = ws.sentMessages
+      .map((m) => JSON.parse(m) as Record<string, unknown>)
+      .find((p) => p.ch === "terminal" && p.type === "open" && p.id === "session-abc");
+
+    expect(openMessage).toMatchObject({
+      target: { runtime: "zellij", sessionName: "session-abc" },
+    });
+  });
+
+  it("re-opens runtime targets on reconnect", async () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useMux(), { wrapper });
+      await flushInit();
+
+      const ws1 = MockWebSocket.instances[0];
+      act(() => ws1.simulateOpen());
+      act(() =>
+        result.current.openTerminal("session-abc", {
+          runtime: "zellij",
+          sessionName: "session-abc",
+        }),
+      );
+      act(() => ws1.simulateClose());
+      act(() => vi.advanceTimersByTime(1100));
+      await flushInit();
+
+      const ws2 = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+      act(() => ws2.simulateOpen());
+
+      const openMessage = ws2.sentMessages
+        .map((m) => JSON.parse(m) as Record<string, unknown>)
+        .find((p) => p.ch === "terminal" && p.type === "open" && p.id === "session-abc");
+
+      expect(openMessage).toMatchObject({
+        target: { runtime: "zellij", sessionName: "session-abc" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("closeTerminal sends close message", async () => {
     const { result, ws } = await setupConnected();
     act(() => result.current.openTerminal("session-abc"));

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -41,6 +41,10 @@ export default defineConfig({
         replacement: resolve(__dirname, "../plugins/runtime-tmux/src/index.ts"),
       },
       {
+        find: "@aoagents/ao-plugin-runtime-zellij",
+        replacement: resolve(__dirname, "../plugins/runtime-zellij/src/index.ts"),
+      },
+      {
         find: "@aoagents/ao-plugin-agent-claude-code",
         replacement: resolve(__dirname, "../plugins/agent-claude-code/src/index.ts"),
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@aoagents/ao-plugin-runtime-tmux':
         specifier: workspace:*
         version: link:../plugins/runtime-tmux
+      '@aoagents/ao-plugin-runtime-zellij':
+        specifier: workspace:*
+        version: link:../plugins/runtime-zellij
       '@aoagents/ao-plugin-scm-github':
         specifier: workspace:*
         version: link:../plugins/scm-github
@@ -207,6 +210,9 @@ importers:
       '@aoagents/ao-plugin-runtime-tmux':
         specifier: workspace:*
         version: link:../plugins/runtime-tmux
+      '@aoagents/ao-plugin-runtime-zellij':
+        specifier: workspace:*
+        version: link:../plugins/runtime-zellij
       '@aoagents/ao-plugin-tracker-linear':
         specifier: workspace:*
         version: link:../plugins/tracker-linear
@@ -465,6 +471,22 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/plugins/runtime-zellij:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/plugins/scm-github:
     dependencies:
       '@aoagents/ao-core':
@@ -632,6 +654,9 @@ importers:
       '@aoagents/ao-plugin-runtime-tmux':
         specifier: workspace:*
         version: link:../plugins/runtime-tmux
+      '@aoagents/ao-plugin-runtime-zellij':
+        specifier: workspace:*
+        version: link:../plugins/runtime-zellij
       '@aoagents/ao-plugin-scm-github':
         specifier: workspace:*
         version: link:../plugins/scm-github

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -384,7 +384,7 @@
         "runtime": {
           "type": "string",
           "default": "tmux",
-          "description": "Default runtime plugin name."
+          "description": "Default runtime plugin name. Built-ins: tmux, zellij, process."
         },
         "agent": {
           "type": "string",


### PR DESCRIPTION
## Summary
- add a built-in `@aoagents/ao-plugin-runtime-zellij` runtime plugin
- register Zellij in core, CLI, web, docs, schema, changesets, and lockfile
- add unit and integration coverage, including long AO session ID mapping for Zellij's session-name limit

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @aoagents/ao-core build`
- `pnpm --filter @aoagents/ao-plugin-runtime-zellij test`
- `pnpm --filter @aoagents/ao-plugin-runtime-zellij typecheck`
- `pnpm --filter @aoagents/ao-plugin-runtime-zellij build`
- `pnpm --filter @aoagents/ao-core test -- plugin-registry.test.ts`
- `pnpm --filter @aoagents/ao-web test -- services.test.ts`
- `pnpm --filter @aoagents/ao-integration-tests test -- runtime-zellij.integration.test.ts`
- `pnpm --filter '@aoagents/ao-plugin-*' build`
- `pnpm --filter @aoagents/ao-cli typecheck`
- `pnpm --filter @aoagents/ao-web typecheck`
- `pnpm --filter @aoagents/ao-integration-tests typecheck`
- `pnpm --filter @aoagents/ao-cli build`
- `pnpm --filter @aoagents/ao-web build`
- `ao doctor`