### PR TITLE
fix(web): refresh dashboard after project delete

### DIFF
--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -262,9 +262,8 @@ function ProjectSidebarInner({
       setProjectMenuOpenId(null);
       if (activeProjectId === project.id) {
         router.push("/");
-      } else if ("refresh" in router && typeof router.refresh === "function") {
-        router.refresh();
       }
+      router.refresh();
       onMobileClose?.();
     } catch (error) {
       window.alert(error instanceof Error ? error.message : "Failed to remove project.");

--- a/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
@@ -225,6 +225,37 @@ describe("ProjectSidebar", () => {
     });
   });
 
+  it("refreshes after removing the active project before redirecting home", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => true),
+    );
+
+    render(
+      <ProjectSidebar
+        projects={projects}
+        sessions={[]}
+        activeProjectId="project-2"
+        activeSessionId={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Project actions for Project Two/i }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Remove project" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/projects/project-2", { method: "DELETE" });
+      expect(mockPush).toHaveBeenCalledWith("/");
+      expect(mockRefresh).toHaveBeenCalled();
+      expect(screen.queryByRole("button", { name: /^Project Two 0$/ })).not.toBeInTheDocument();
+    });
+  });
+
   it("shows non-done worker sessions for the expanded active project", () => {
     render(
       <ProjectSidebar

--- a/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
@@ -225,7 +225,7 @@ describe("ProjectSidebar", () => {
     });
   });
 
-  it("refreshes after removing the active project before redirecting home", async () => {
+  it("redirects home and refreshes after removing the active project", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ ok: true }),


### PR DESCRIPTION
## Summary
- call `router.refresh()` after a successful project DELETE so the server-rendered dashboard data is reloaded immediately
- keep the existing redirect for deleting the active project, but always refresh afterward so the removed project does not reappear on remount/SSE refresh
- add a regression test covering active-project removal and the refresh call

## Linked issue
- https://github.com/ComposioHQ/agent-orchestrator/issues/1530

## Validation
- `pnpm --filter @aoagents/ao-web test -- src/components/__tests__/ProjectSidebar.test.tsx`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` *(fails in unchanged `packages/core` on upstream main: `agent-report.test.ts`, `file-lock.test.ts`, `lifecycle-manager.test.ts`)*
