### PR TITLE
feat(cli): add --preview-prompt to ao spawn

### DIFF
--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -4,23 +4,28 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { type Session, type SessionManager, getProjectBaseDir } from "@composio/ao-core";
 
-const { mockExec, mockConfigRef, mockSessionManager, mockEnsureLifecycleWorker } = vi.hoisted(
-  () => ({
-    mockExec: vi.fn(),
-    mockConfigRef: { current: null as Record<string, unknown> | null },
-    mockSessionManager: {
-      list: vi.fn(),
-      kill: vi.fn(),
-      cleanup: vi.fn(),
-      get: vi.fn(),
-      spawn: vi.fn(),
-      spawnOrchestrator: vi.fn(),
-      send: vi.fn(),
-      claimPR: vi.fn(),
-    },
-    mockEnsureLifecycleWorker: vi.fn(),
-  }),
-);
+const {
+  mockExec,
+  mockConfigRef,
+  mockSessionManager,
+  mockEnsureLifecycleWorker,
+  mockDecompose,
+} = vi.hoisted(() => ({
+  mockExec: vi.fn(),
+  mockConfigRef: { current: null as Record<string, unknown> | null },
+  mockSessionManager: {
+    list: vi.fn(),
+    kill: vi.fn(),
+    cleanup: vi.fn(),
+    get: vi.fn(),
+    spawn: vi.fn(),
+    spawnOrchestrator: vi.fn(),
+    send: vi.fn(),
+    claimPR: vi.fn(),
+  },
+  mockEnsureLifecycleWorker: vi.fn(),
+  mockDecompose: vi.fn(),
+}));
 
 vi.mock("../../src/lib/shell.js", () => ({
   tmux: vi.fn(),
@@ -48,6 +53,7 @@ vi.mock("@composio/ao-core", async (importOriginal) => {
   return {
     ...actual,
     loadConfig: () => mockConfigRef.current,
+    decompose: (...args: Parameters<typeof actual.decompose>) => mockDecompose(...args),
   };
 });
 
@@ -117,6 +123,7 @@ beforeEach(() => {
   mockSessionManager.claimPR.mockReset();
   mockExec.mockReset();
   mockEnsureLifecycleWorker.mockReset();
+  mockDecompose.mockReset();
   mockEnsureLifecycleWorker.mockResolvedValue({
     running: true,
     started: true,
@@ -362,6 +369,98 @@ describe("spawn command", () => {
     });
   });
 
+  it("prints a prompt preview without creating a session", async () => {
+    const projects = (mockConfigRef.current as Record<string, unknown>).projects as Record<
+      string,
+      Record<string, unknown>
+    >;
+    projects["my-app"].agentRules = "Always run tests before pushing.";
+
+    await program.parseAsync(["node", "test", "spawn", "INT-42", "--preview-prompt"]);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("SPAWN PROMPT PREVIEW");
+    expect(output).toContain("Work on issue: INT-42");
+    expect(output).toContain("## Project Rules");
+    expect(output).toContain("Always run tests before pushing.");
+    expect(mockEnsureLifecycleWorker).not.toHaveBeenCalled();
+    expect(mockSessionManager.spawn).not.toHaveBeenCalled();
+  });
+
+  it("notes that tracker issue details are omitted in preview mode", async () => {
+    const projects = (mockConfigRef.current as Record<string, unknown>).projects as Record<
+      string,
+      Record<string, unknown>
+    >;
+    projects["my-app"].tracker = { plugin: "github" };
+
+    await program.parseAsync(["node", "test", "spawn", "INT-42", "--preview-prompt"]);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("tracker issue details are omitted in preview mode");
+    expect(output).not.toContain("## Issue Details");
+    expect(mockSessionManager.spawn).not.toHaveBeenCalled();
+  });
+
+  it("previews decomposed prompts with lineage and sibling context", async () => {
+    mockDecompose.mockResolvedValue({
+      id: "plan-1",
+      rootTask: "INT-42",
+      maxDepth: 3,
+      phase: "review",
+      createdAt: "2026-04-09T00:00:00.000Z",
+      tree: {
+        id: "1",
+        depth: 0,
+        description: "INT-42",
+        kind: "composite",
+        status: "ready",
+        lineage: [],
+        children: [
+          {
+            id: "1.1",
+            depth: 1,
+            description: "Build CLI flag",
+            kind: "atomic",
+            status: "ready",
+            lineage: ["INT-42"],
+            children: [],
+          },
+          {
+            id: "1.2",
+            depth: 1,
+            description: "Add tests",
+            kind: "atomic",
+            status: "ready",
+            lineage: ["INT-42"],
+            children: [],
+          },
+        ],
+      },
+    });
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "spawn",
+      "INT-42",
+      "--decompose",
+      "--preview-prompt",
+    ]);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("Subtask 1/2: Build CLI flag");
+    expect(output).toContain("Subtask 2/2: Add tests");
+    expect(output).toContain("## Task Hierarchy");
+    expect(output).toContain("## Parallel Work");
+    expect(mockDecompose).toHaveBeenCalledWith(
+      "INT-42",
+      expect.objectContaining({ maxDepth: 3 }),
+    );
+    expect(mockEnsureLifecycleWorker).not.toHaveBeenCalled();
+    expect(mockSessionManager.spawn).not.toHaveBeenCalled();
+  });
+
   it("warns and exits when two positional args given (old syntax)", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -497,6 +596,19 @@ describe("spawn command", () => {
     expect(errors).toContain("--assign-on-github requires --claim-pr");
     expect(mockSessionManager.spawn).not.toHaveBeenCalled();
     expect(mockSessionManager.claimPR).not.toHaveBeenCalled();
+  });
+
+  it("rejects incompatible flags when previewing a prompt", async () => {
+    await expect(
+      program.parseAsync(["node", "test", "spawn", "--preview-prompt", "--claim-pr", "123"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const errors = vi
+      .mocked(console.error)
+      .mock.calls.map((c) => String(c[0]))
+      .join("\n");
+    expect(errors).toContain("--preview-prompt does not create a session");
+    expect(mockSessionManager.spawn).not.toHaveBeenCalled();
   });
 
   it("reports claim failures after creating the session", async () => {

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -9,6 +9,7 @@ import {
   getSiblings,
   formatPlanTree,
   TERMINAL_STATUSES,
+  buildPrompt,
   type OrchestratorConfig,
   type DecomposerConfig,
   DEFAULT_DECOMPOSER_CONFIG,
@@ -166,6 +167,116 @@ async function spawnSession(
   }
 }
 
+function buildSpawnPromptPreview(
+  config: OrchestratorConfig,
+  projectId: string,
+  issueId?: string,
+  lineage?: string[],
+  siblings?: string[],
+): string {
+  const project = config.projects[projectId];
+  if (!project) {
+    throw new Error(`Unknown project: ${projectId}`);
+  }
+
+  return buildPrompt({
+    project,
+    projectId,
+    issueId,
+    lineage,
+    siblings,
+  });
+}
+
+function printSpawnPromptPreviewHeader(
+  projectId: string,
+  issueId?: string,
+  decomposeEnabled?: boolean,
+): void {
+  console.log(banner("SPAWN PROMPT PREVIEW"));
+  console.log();
+  console.log(`  Project:   ${chalk.bold(projectId)}`);
+  console.log(`  Issue:     ${issueId ? chalk.bold(issueId) : chalk.dim("(none)")}`);
+  console.log(`  Decompose: ${decomposeEnabled ? chalk.bold("yes") : chalk.dim("no")}`);
+  console.log();
+}
+
+function printTrackerPreviewNote(config: OrchestratorConfig, projectId: string, issueId?: string): void {
+  const project = config.projects[projectId];
+  if (!issueId || !project?.tracker) {
+    return;
+  }
+
+  console.log(
+    chalk.yellow(
+      "Note: tracker issue details are omitted in preview mode because fetching them may require a network call.",
+    ),
+  );
+  console.log();
+}
+
+async function previewSpawnPrompt(
+  config: OrchestratorConfig,
+  projectId: string,
+  issueId: string | undefined,
+  options: { decompose?: boolean; maxDepth?: string },
+): Promise<void> {
+  printSpawnPromptPreviewHeader(projectId, issueId, options.decompose && Boolean(issueId));
+  printTrackerPreviewNote(config, projectId, issueId);
+
+  if (options.decompose && issueId) {
+    const project = config.projects[projectId];
+    if (!project) {
+      throw new Error(`Unknown project: ${projectId}`);
+    }
+
+    const decompConfig: DecomposerConfig = {
+      ...DEFAULT_DECOMPOSER_CONFIG,
+      ...(project.decomposer ?? {}),
+      maxDepth: options.maxDepth
+        ? parseInt(options.maxDepth, 10)
+        : (project.decomposer?.maxDepth ?? 3),
+    };
+
+    const spinner = ora("Decomposing task...").start();
+    const plan = await decompose(issueId, decompConfig);
+    const leaves = getLeaves(plan.tree);
+    spinner.succeed(`Decomposed into ${chalk.bold(String(leaves.length))} subtasks`);
+
+    console.log();
+    console.log(chalk.dim(formatPlanTree(plan.tree)));
+    console.log();
+
+    if (leaves.length <= 1) {
+      console.log(chalk.yellow("Task is atomic — previewing direct spawn prompt."));
+      console.log();
+      console.log(buildSpawnPromptPreview(config, projectId, issueId));
+      console.log();
+      return;
+    }
+
+    for (const [index, leaf] of leaves.entries()) {
+      const siblings = getSiblings(plan.tree, leaf.id);
+      console.log(
+        chalk.bold(`Subtask ${index + 1}/${leaves.length}: ${leaf.description}`),
+      );
+      console.log();
+      console.log(buildSpawnPromptPreview(config, projectId, issueId, leaf.lineage, siblings));
+      console.log();
+
+      if (index < leaves.length - 1) {
+        console.log(chalk.dim("─".repeat(80)));
+        console.log();
+      }
+    }
+
+    return;
+  }
+
+  console.log(buildSpawnPromptPreview(config, projectId, issueId));
+  console.log();
+}
+
 export function registerSpawn(program: Command): void {
   program
     .command("spawn")
@@ -177,6 +288,7 @@ export function registerSpawn(program: Command): void {
     .option("--claim-pr <pr>", "Immediately claim an existing PR for the spawned session")
     .option("--assign-on-github", "Assign the claimed PR to the authenticated GitHub user")
     .option("--decompose", "Decompose issue into subtasks before spawning")
+    .option("--preview-prompt", "Print the composed prompt without creating a session")
     .option("--max-depth <n>", "Max decomposition depth (default: 3)")
     .action(
       async (
@@ -188,6 +300,7 @@ export function registerSpawn(program: Command): void {
           claimPr?: string;
           assignOnGithub?: boolean;
           decompose?: boolean;
+          previewPrompt?: boolean;
           maxDepth?: string;
         },
       ) => {
@@ -231,12 +344,26 @@ export function registerSpawn(program: Command): void {
           process.exit(1);
         }
 
+        if (opts.previewPrompt && (opts.open || opts.claimPr || opts.assignOnGithub)) {
+          console.error(
+            chalk.red(
+              "--preview-prompt does not create a session, so it cannot be combined with --open, --claim-pr, or --assign-on-github.",
+            ),
+          );
+          process.exit(1);
+        }
+
         const claimOptions: SpawnClaimOptions = {
           claimPr: opts.claimPr,
           assignOnGithub: opts.assignOnGithub,
         };
 
         try {
+          if (opts.previewPrompt) {
+            await previewSpawnPrompt(config, projectId, issueId, opts);
+            return;
+          }
+
           await runSpawnPreflight(config, projectId, claimOptions);
           await ensureLifecycleWorker(config, projectId);
 


### PR DESCRIPTION
## Summary
- add a `--preview-prompt` flag to `ao spawn` that prints the composed prompt without creating a session
- reuse `buildPrompt()` so the preview matches real spawn behavior, including optional decomposition lineage/sibling context
- document preview-mode tracker omission in output and reject incompatible flags that require a real session

## Testing
- `pnpm build`
- `pnpm --filter @composio/ao-cli test -- __tests__/commands/spawn.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` *(currently blocked by unrelated existing failure in `packages/core/src/__tests__/plugin-registry.test.ts > loadBuiltins > silently skips unavailable packages` timing out)*

Upstream issue: https://github.com/ComposioHQ/agent-orchestrator/issues/1077
