### PR TITLE
refactor(core): consolidate PREnrichmentData and BatchObserver declarations

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -839,6 +839,8 @@ export interface PREnrichmentData {
   isBehind?: boolean;
   /** List of blockers preventing merge */
   blockers?: string[];
+  /** Individual CI check results (populated from batch enrichment when available) */
+  ciChecks?: CICheck[];
 }
 
 /**
@@ -1007,60 +1009,6 @@ export interface MergeReadiness {
   blockers: string[];
 }
 
-/**
- * Batch enrichment data returned by SCM plugins.
- * Contains all the information the orchestrator needs for status detection.
- */
-export interface PREnrichmentData {
-  /** Current PR state */
-  state: PRState;
-  /** Overall CI status */
-  ciStatus: CIStatus;
-  /** Review decision */
-  reviewDecision: ReviewDecision;
-  /** Whether the PR is mergeable based on CI, reviews, and merge state */
-  mergeable: boolean;
-  /** PR title */
-  title?: string;
-  /** Number of additions */
-  additions?: number;
-  /** Number of deletions */
-  deletions?: number;
-  /** Whether PR is a draft */
-  isDraft?: boolean;
-  /** Whether PR has merge conflicts */
-  hasConflicts?: boolean;
-  /** Whether PR is behind base branch */
-  isBehind?: boolean;
-  /** List of blockers preventing merge */
-  blockers?: string[];
-  /** Individual CI check results (populated from batch enrichment when available) */
-  ciChecks?: CICheck[];
-}
-
-/**
- * Observer for GraphQL batch PR enrichment operations.
- * Used by SCM plugins to report batch success/failure to the observability system.
- */
-export interface BatchObserver {
-  /** Record a successful batch enrichment */
-  recordSuccess(data: {
-    batchIndex: number;
-    totalBatches: number;
-    prCount: number;
-    durationMs: number;
-  }): void;
-  /** Record a failed batch enrichment */
-  recordFailure(data: {
-    batchIndex: number;
-    totalBatches: number;
-    prCount: number;
-    error: string;
-    durationMs: number;
-  }): void;
-  /** Log a message at a specific level */
-  log(level: ObservabilityLevel, message: string): void;
-}
 // =============================================================================
 // NOTIFIER — Plugin Slot 6 (PRIMARY INTERFACE)
 // =============================================================================


### PR DESCRIPTION
## Summary
- consolidate `PREnrichmentData` into a single declaration in `packages/core/src/types.ts`
- keep the existing `ciChecks` field on the unified interface instead of relying on declaration merging
- remove the duplicate `BatchObserver` declaration so its optional `reportPRListUnchangedRepos` hook remains in one place

## Context
- Upstream issue: https://github.com/ComposioHQ/agent-orchestrator/issues/1413

## Validation
- `pnpm --filter @aoagents/ao-core build`
- `pnpm --filter @aoagents/ao-core typecheck`
- `pnpm --filter @aoagents/ao-plugin-scm-github typecheck`
- `pnpm --filter @aoagents/ao-plugin-scm-github test`
- `pnpm lint` ✅ (warnings only, no new issues from this change)
- `pnpm typecheck` ⚠️ fails in unrelated packages (`packages/plugins/notifier-slack`, `packages/plugins/scm-github`) with existing `@aoagents/ao-core` module resolution errors
- `pnpm test` ⚠️ fails in existing unrelated core tests (`agent-report.test.ts`, `lifecycle-manager.test.ts`, `orchestrator-prompt.dist.test.ts`)
- `pnpm build` / `pnpm --filter @aoagents/ao-web build` ⚠️ web build reached Next.js trace collection after compiling successfully but did not finish cleanly within this session; no issue tied to this scoped type cleanup was surfaced before interruption
