### PR TITLE
fix: prevent long sidebar session titles from overlapping status

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -4476,8 +4476,13 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 }
 
 /* Session label */
-.project-sidebar__sess-label {
+.project-sidebar__sess-content {
   flex: 1;
+  min-width: 0;
+}
+
+.project-sidebar__sess-label {
+  display: block;
   font-size: 11.5px;
   color: var(--color-text-secondary);
   min-width: 0;
@@ -4496,7 +4501,8 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   display: flex;
   align-items: center;
   gap: 4px;
-  margin-top: -4px;
+  margin-top: 3px;
+  min-width: 0;
 }
 
 .project-sidebar__sess-id {
@@ -4517,13 +4523,6 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   color: var(--color-text-muted);
   flex-shrink: 0;
   white-space: nowrap;
-}
-
-/* Inline status (compact variant — name + status on one line) */
-.project-sidebar__sess-status--inline {
-  font-size: 10px;
-  margin-left: 6px;
-  text-transform: lowercase;
 }
 
 /* Sidebar settings popover */

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -631,7 +631,7 @@ function ProjectSidebarInner({
                           aria-label={`Open ${title}`}
                         >
                           <SessionDot level={level} />
-                          <div className="flex-1 min-w-0">
+                          <div className="project-sidebar__sess-content">
                             <span
                               className={cn(
                                 "project-sidebar__sess-label",
@@ -640,20 +640,15 @@ function ProjectSidebarInner({
                             >
                               {title}
                             </span>
-                            {showSessionId ? (
-                              <div className="project-sidebar__sess-meta">
+                            <div className="project-sidebar__sess-meta">
+                              {showSessionId ? (
                                 <span className="project-sidebar__sess-id">{session.id}</span>
-                                <span className="project-sidebar__sess-status">
-                                  {LEVEL_LABELS[level]}
-                                </span>
-                              </div>
-                            ) : null}
+                              ) : null}
+                              <span className="project-sidebar__sess-status">
+                                {LEVEL_LABELS[level]}
+                              </span>
+                            </div>
                           </div>
-                          {!showSessionId ? (
-                            <span className="project-sidebar__sess-status project-sidebar__sess-status--inline">
-                              {LEVEL_LABELS[level]}
-                            </span>
-                          ) : null}
                         </a>
                       );
                     })

--- a/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
@@ -256,6 +256,37 @@ describe("ProjectSidebar", () => {
     expect(screen.queryByRole("link", { name: "Open feat/test" })).not.toBeInTheDocument();
   });
 
+  it("renders long session titles without sharing a row with the status label", () => {
+    const longSessionTitle =
+      "Investigate why unusually long session titles in the sidebar collide with the status badge";
+
+    render(
+      <ProjectSidebar
+        projects={projects}
+        sessions={[
+          makeSession({
+            id: "worker-1",
+            projectId: "project-1",
+            summary: longSessionTitle,
+            branch: null,
+            status: "working",
+            activity: "active",
+          }),
+        ]}
+        activeProjectId="project-1"
+        activeSessionId="worker-1"
+      />,
+    );
+
+    const sessionLink = screen.getByRole("link", { name: `Open ${longSessionTitle}` });
+    expect(sessionLink.querySelector(".project-sidebar__sess-content")).not.toBeNull();
+    expect(sessionLink.querySelector(".project-sidebar__sess-meta")).not.toBeNull();
+    expect(sessionLink.querySelector(".project-sidebar__sess-status")?.textContent).toBe(
+      "working",
+    );
+    expect(sessionLink.querySelector(".project-sidebar__sess-status--inline")).toBeNull();
+  });
+
   it("keeps killed sessions visible when they still need attention", () => {
     const lastActivityAt = new Date().toISOString();
 


### PR DESCRIPTION
## Summary
- keep sidebar session titles in their own content column so long names no longer collide with the status pill
- move the status/id metadata onto a dedicated secondary row in the project sidebar
- add a regression test covering long sidebar session titles

## Issue
- Fixes upstream issue #1303
- Upstream issue: https://github.com/ComposioHQ/agent-orchestrator/issues/1303

## Validation
- `pnpm build` ✅
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (warnings only, no errors)
- `pnpm --filter @composio/ao-web exec vitest run src/components/__tests__/ProjectSidebar.test.tsx` ✅
- `pnpm test` ⚠️ blocked by existing unrelated timeout in `packages/core/src/__tests__/plugin-registry.test.ts` (`loadBuiltins > silently skips unavailable packages`)
- `pnpm --filter @composio/ao-web test` ⚠️ blocked by existing unrelated timeout in `packages/web/src/app/dev/terminal-test/page.test.tsx` (`renders the terminal comparison and documentation content`)