### PR TITLE
test(cli): add ao spawn --prompt coverage

### DIFF
--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -490,6 +490,121 @@ describe("spawn command", () => {
     });
   });
 
+  it("passes --prompt without an issue ID", async () => {
+    const fakeSession: Session = {
+      id: "app-2",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: null,
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-app-2", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync(["node", "test", "spawn", "--prompt", "Fix the flaky tests"]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: undefined,
+      agent: undefined,
+      prompt: "Fix the flaky tests",
+    });
+  });
+
+  it("passes --prompt together with an issue ID", async () => {
+    const fakeSession: Session = {
+      id: "app-3",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: "feat/INT-44",
+      issueId: "INT-44",
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-app-3", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "spawn",
+      "INT-44",
+      "--prompt",
+      "Continue from the latest CI failure",
+    ]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: "INT-44",
+      agent: undefined,
+      prompt: "Continue from the latest CI failure",
+    });
+  });
+
+  it("sanitizes --prompt by stripping newlines and trimming whitespace", async () => {
+    const fakeSession: Session = {
+      id: "app-4",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: null,
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-app-4", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "spawn",
+      "--prompt",
+      "  Fix the flaky test\nand update snapshots  ",
+    ]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: undefined,
+      agent: undefined,
+      prompt: "Fix the flaky test and update snapshots",
+    });
+  });
+
+  it("rejects --prompt values longer than 4096 characters", async () => {
+    const tooLongPrompt = "x".repeat(4097);
+
+    await expect(
+      program.parseAsync(["node", "test", "spawn", "--prompt", tooLongPrompt]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const errors = vi
+      .mocked(console.error)
+      .mock.calls.map((c) => String(c[0]))
+      .join("\n");
+    expect(errors).toContain("Prompt must be at most 4096 characters");
+    expect(mockSessionManager.spawn).not.toHaveBeenCalled();
+  });
+
   it("shows a single optional issue positional in help", () => {
     const spawnCommand = program.commands.find((command) => command.name() === "spawn");
     const help = spawnCommand?.helpInformation() ?? "";

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -579,14 +579,44 @@ describe("spawn command", () => {
       "test",
       "spawn",
       "--prompt",
-      "  Fix the flaky test\nand update snapshots  ",
+      "  Fix the flaky test\r\nand update snapshots\rnow  ",
     ]);
 
     expect(mockSessionManager.spawn).toHaveBeenCalledWith({
       projectId: "my-app",
       issueId: undefined,
       agent: undefined,
-      prompt: "Fix the flaky test and update snapshots",
+      prompt: "Fix the flaky test  and update snapshots now",
+    });
+  });
+
+  it("accepts --prompt values up to 4096 characters", async () => {
+    const fakeSession: Session = {
+      id: "app-5",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: null,
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-app-5", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    const maxLengthPrompt = "x".repeat(4096);
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync(["node", "test", "spawn", "--prompt", maxLengthPrompt]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: undefined,
+      agent: undefined,
+      prompt: maxLengthPrompt,
     });
   });
 


### PR DESCRIPTION
## Summary
- add CLI coverage for `ao spawn --prompt` without an issue id
- add coverage for `--prompt` used alongside an issue id
- add sanitization and 4096-character guard coverage

## Validation
- `pnpm --filter @aoagents/ao-cli test` ✅
- `pnpm build` ✅
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (warnings only, no new warnings introduced)
- `pnpm test` ⚠️ blocked by pre-existing unrelated failures in `packages/core`:
  - `src/__tests__/agent-report.test.ts`
  - `src/__tests__/lifecycle-manager.test.ts`
  - `src/__tests__/orchestrator-prompt.dist.test.ts`

Upstream issue: https://github.com/ComposioHQ/agent-orchestrator/issues/1124