### PR TITLE
fix(web): stabilize terminal reconnects

### DIFF
--- a/packages/web/server/__tests__/mux-terminal-manager.test.ts
+++ b/packages/web/server/__tests__/mux-terminal-manager.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface MockPty {
+  onData: ReturnType<typeof vi.fn>;
+  onExit: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+  exit?: (event: { exitCode: number }) => void;
+}
+
+describe("TerminalManager", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+    vi.doUnmock("node-pty");
+    vi.doUnmock("node:child_process");
+  });
+
+  it("keeps the PTY alive across brief subscriber gaps", async () => {
+    vi.useFakeTimers();
+
+    const ptys: MockPty[] = [];
+    vi.doMock("node:child_process", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:child_process")>();
+      return {
+        ...actual,
+        spawn: vi.fn(() => ({ on: vi.fn() })),
+        execFileSync: vi.fn(() => Buffer.from("")),
+      };
+    });
+    const ptySpawn = vi.fn(() => {
+      const pty: MockPty = {
+        onData: vi.fn(),
+        onExit: vi.fn((callback: (event: { exitCode: number }) => void) => {
+          pty.exit = callback;
+        }),
+        write: vi.fn(),
+        resize: vi.fn(),
+        kill: vi.fn(() => pty.exit?.({ exitCode: 0 })),
+      };
+      ptys.push(pty);
+      return pty;
+    });
+    vi.doMock("node-pty", () => ({ spawn: ptySpawn }));
+
+    const { TerminalManager } = await import("../mux-websocket");
+    const manager = new TerminalManager("/usr/bin/true");
+
+    const firstUnsubscribe = manager.subscribe(
+      "session-abc",
+      vi.fn(),
+      undefined,
+      "tmux-session-abc",
+    );
+    expect(ptySpawn).toHaveBeenCalledTimes(1);
+
+    firstUnsubscribe();
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(ptys[0]?.kill).not.toHaveBeenCalled();
+
+    const secondUnsubscribe = manager.subscribe(
+      "session-abc",
+      vi.fn(),
+      undefined,
+      "tmux-session-abc",
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(ptySpawn).toHaveBeenCalledTimes(1);
+    expect(ptys[0]?.kill).not.toHaveBeenCalled();
+
+    secondUnsubscribe();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(ptys[0]?.kill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -225,16 +225,18 @@ interface ManagedTerminal {
   buffer: string[];
   bufferBytes: number;
   reattachAttempts: number;
+  idleCleanupTimer: ReturnType<typeof setTimeout> | null;
 }
 
 const RING_BUFFER_MAX = 50 * 1024; // 50KB max per terminal
 const MAX_REATTACH_ATTEMPTS = 3;
+const TERMINAL_IDLE_CLEANUP_MS = 5_000;
 
 /**
  * TerminalManager manages PTY processes independently of WebSocket connections.
  * A single manager instance is shared across all mux connections.
  */
-class TerminalManager {
+export class TerminalManager {
   private terminals = new Map<string, ManagedTerminal>();
   private TMUX: string;
 
@@ -271,8 +273,14 @@ class TerminalManager {
         buffer: [],
         bufferBytes: 0,
         reattachAttempts: 0,
+        idleCleanupTimer: null,
       };
       this.terminals.set(id, terminal);
+    }
+
+    if (terminal.idleCleanupTimer) {
+      clearTimeout(terminal.idleCleanupTimer);
+      terminal.idleCleanupTimer = null;
     }
 
     // If PTY is already attached, we're done
@@ -400,9 +408,14 @@ class TerminalManager {
    * Automatically opens the terminal if needed.
    * @param onExit - called when the PTY exits and cannot be re-attached
    */
-  subscribe(id: string, callback: (data: string) => void, onExit?: (exitCode: number) => void): () => void {
+  subscribe(
+    id: string,
+    callback: (data: string) => void,
+    onExit?: (exitCode: number) => void,
+    tmuxName?: string,
+  ): () => void {
     // Ensure terminal is open
-    this.open(id);
+    this.open(id, tmuxName);
     const terminal = this.terminals.get(id);
     if (!terminal) {
       throw new Error(`Failed to open terminal: ${id}`);
@@ -416,13 +429,19 @@ class TerminalManager {
     return () => {
       terminal.subscribers.delete(callback);
       if (onExit) terminal.exitCallbacks.delete(onExit);
-      // Kill PTY and clean up when the last subscriber leaves
+      // Give React remounts and WebSocket reconnects a brief window to
+      // re-subscribe without tearing down the underlying attach process.
       if (terminal.subscribers.size === 0) {
-        if (terminal.pty) {
-          terminal.pty.kill();
-          terminal.pty = null;
-        }
-        this.terminals.delete(id);
+        if (terminal.idleCleanupTimer) return;
+        terminal.idleCleanupTimer = setTimeout(() => {
+          terminal.idleCleanupTimer = null;
+          if (terminal.subscribers.size > 0) return;
+          if (terminal.pty) {
+            terminal.pty.kill();
+            terminal.pty = null;
+          }
+          this.terminals.delete(id);
+        }, TERMINAL_IDLE_CLEANUP_MS);
       }
     };
   }
@@ -536,11 +555,17 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
                     }
                   },
                   (exitCode) => {
-                    const exitedMsg: ServerMessage = { ch: "terminal", id, type: "exited", code: exitCode };
+                    const exitedMsg: ServerMessage = {
+                      ch: "terminal",
+                      id,
+                      type: "exited",
+                      code: exitCode,
+                    };
                     if (ws.readyState === WebSocket.OPEN) {
                       ws.send(JSON.stringify(exitedMsg));
                     }
                   },
+                  "tmuxName" in msg ? msg.tmuxName : undefined,
                 );
                 subscriptions.set(id, unsub);
               }

--- a/packages/web/src/__tests__/project-detail-route.test.ts
+++ b/packages/web/src/__tests__/project-detail-route.test.ts
@@ -7,6 +7,7 @@ import {
   getProjectDir,
   loadGlobalConfig,
   registerProjectInGlobalConfig,
+  saveGlobalConfig,
 } from "@aoagents/ao-core";
 
 const invalidatePortfolioServicesCache = vi.fn();
@@ -169,6 +170,33 @@ describe("/api/projects/[id]", () => {
         path: repoDir,
         agent: "codex",
         runtime: "tmux",
+      }),
+    });
+  });
+
+  it("GET includes effective defaults for settings placeholders", async () => {
+    const repoDir = path.join(tempRoot, "demo-defaults");
+    mkdirSync(repoDir, { recursive: true });
+    const effectiveId = registerProjectInGlobalConfig("demo", "Demo", repoDir);
+    const globalConfig = loadGlobalConfig(configPath);
+    if (!globalConfig) throw new Error("Expected global config");
+    globalConfig.defaults.agent = "codex";
+    globalConfig.defaults.runtime = "process";
+    saveGlobalConfig(globalConfig, configPath);
+
+    const { GET } = await import("@/app/api/projects/[id]/route");
+    const response = await GET(makeRequest("GET", undefined, effectiveId), {
+      params: Promise.resolve({ id: effectiveId }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      project: expect.objectContaining({
+        id: effectiveId,
+        defaults: {
+          agent: "codex",
+          runtime: "process",
+        },
       }),
     });
   });

--- a/packages/web/src/app/api/projects/[id]/route.ts
+++ b/packages/web/src/app/api/projects/[id]/route.ts
@@ -128,6 +128,10 @@ export async function GET(
           tracker: state.project?.tracker,
           scm: state.project?.scm,
           reactions: state.project?.reactions,
+          defaults: {
+            agent: state.config.defaults.agent,
+            runtime: state.config.defaults.runtime,
+          },
         },
       },
       { status: 200 },

--- a/packages/web/src/app/projects/[projectId]/settings/page.test.tsx
+++ b/packages/web/src/app/projects/[projectId]/settings/page.test.tsx
@@ -32,6 +32,7 @@ describe("ProjectSettingsPage", () => {
     hoisted.getProjectRouteDataMock.mockResolvedValue({
       projectId: "docs",
       degradedProject: null,
+      defaults: { agent: "codex", runtime: "tmux" },
       projects: [{ id: "docs", name: "Docs" }],
       project: {
         name: "Docs",
@@ -62,6 +63,7 @@ describe("ProjectSettingsPage", () => {
     hoisted.getProjectRouteDataMock.mockResolvedValue({
       projectId: "broken",
       project: null,
+      defaults: { agent: "claude-code", runtime: "tmux" },
       projects: [{ id: "broken", name: "Broken" }],
       degradedProject: {
         projectId: "broken",

--- a/packages/web/src/app/projects/[projectId]/settings/page.tsx
+++ b/packages/web/src/app/projects/[projectId]/settings/page.tsx
@@ -69,6 +69,12 @@ export default async function ProjectSettingsPage(props: {
             trackerPlugin: project.tracker?.plugin ?? "",
             scmPlugin: project.scm?.plugin ?? "",
             reactions: JSON.stringify(project.reactions ?? {}, null, 2),
+            defaults: {
+              agent: routeData.defaults.agent,
+              runtime: routeData.defaults.runtime,
+              trackerPlugin: project.tracker?.plugin,
+              scmPlugin: project.scm?.plugin,
+            },
             identity: {
               projectId,
               path: project.path,

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -83,6 +83,10 @@ export function DirectTerminal({
       params.delete("fullscreen");
     }
     const newUrl = params.toString() ? `${pathname}?${params.toString()}` : pathname;
+    const currentUrl = searchParams.toString()
+      ? `${pathname}?${searchParams.toString()}`
+      : pathname;
+    if (newUrl === currentUrl) return;
     router.replace(newUrl, { scroll: false });
   }, [fullscreen, pathname, router, searchParams]);
 

--- a/packages/web/src/components/ProjectSettingsForm.tsx
+++ b/packages/web/src/components/ProjectSettingsForm.tsx
@@ -15,6 +15,12 @@ interface ProjectSettingsFormProps {
     trackerPlugin: string;
     scmPlugin: string;
     reactions: string;
+    defaults?: {
+      agent?: string;
+      runtime?: string;
+      trackerPlugin?: string;
+      scmPlugin?: string;
+    };
     identity: {
       projectId: string;
       path: string;
@@ -123,28 +129,28 @@ function ProjectSettingsFormInner({ projectId, initialValues }: ProjectSettingsF
             label="Agent"
             value={agent}
             onChange={setAgent}
-            placeholder="claude-code"
+            placeholder={initialValues.defaults?.agent ?? "claude-code"}
           />
           <EditableField
             id="runtime"
             label="Runtime"
             value={runtime}
             onChange={setRuntime}
-            placeholder="tmux"
+            placeholder={initialValues.defaults?.runtime ?? "tmux"}
           />
           <EditableField
             id="tracker-plugin"
             label="Tracker plugin"
             value={trackerPlugin}
             onChange={setTrackerPlugin}
-            placeholder="github"
+            placeholder={initialValues.defaults?.trackerPlugin ?? "github"}
           />
           <EditableField
             id="scm-plugin"
             label="SCM plugin"
             value={scmPlugin}
             onChange={setScmPlugin}
-            placeholder="github"
+            placeholder={initialValues.defaults?.scmPlugin ?? "github"}
           />
         </div>
 

--- a/packages/web/src/components/ProjectSettingsModal.tsx
+++ b/packages/web/src/components/ProjectSettingsModal.tsx
@@ -21,6 +21,10 @@ interface ProjectSettingsResponse {
     tracker?: { plugin?: string };
     scm?: { plugin?: string };
     reactions?: Record<string, unknown>;
+    defaults?: {
+      agent?: string;
+      runtime?: string;
+    };
   };
   error?: string;
   degraded?: boolean;
@@ -96,6 +100,12 @@ export function ProjectSettingsModal({ open, projectId, onClose }: ProjectSettin
       trackerPlugin: project.tracker?.plugin ?? "",
       scmPlugin: project.scm?.plugin ?? "",
       reactions: JSON.stringify(project.reactions ?? {}, null, 2),
+      defaults: {
+        agent: project.defaults?.agent,
+        runtime: project.defaults?.runtime,
+        trackerPlugin: project.tracker?.plugin,
+        scmPlugin: project.scm?.plugin,
+      },
       identity: {
         projectId,
         path: project.path,

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -145,6 +145,16 @@ describe("DirectTerminal render", () => {
     expect(screen.getByText("XDA")).toHaveStyle({ color: "var(--color-accent)" });
   });
 
+  it("does not replace the current URL when fullscreen state already matches", async () => {
+    render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Connected")).toBeInTheDocument(),
+    );
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
   it("keeps restart and fullscreen actions available in chromeless mode", async () => {
     render(
       <DirectTerminal

--- a/packages/web/src/components/__tests__/ProjectSettingsForm.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSettingsForm.test.tsx
@@ -70,6 +70,38 @@ describe("ProjectSettingsForm", () => {
     });
   });
 
+  it("uses effective defaults as behavior placeholders", () => {
+    render(
+      <ProjectSettingsForm
+        projectId="docs"
+        initialValues={{
+          agent: "",
+          runtime: "",
+          trackerPlugin: "",
+          scmPlugin: "",
+          reactions: "{}",
+          defaults: {
+            agent: "codex",
+            runtime: "process",
+            trackerPlugin: "linear",
+            scmPlugin: "gitlab",
+          },
+          identity: {
+            projectId: "docs",
+            path: "/tmp/docs",
+            repo: "org/repo",
+            defaultBranch: "main",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Agent")).toHaveAttribute("placeholder", "codex");
+    expect(screen.getByLabelText("Runtime")).toHaveAttribute("placeholder", "process");
+    expect(screen.getByLabelText("Tracker plugin")).toHaveAttribute("placeholder", "linear");
+    expect(screen.getByLabelText("SCM plugin")).toHaveAttribute("placeholder", "gitlab");
+  });
+
   it("shows an inline error for a 400 without losing form state", async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: false,

--- a/packages/web/src/lib/project-route-data.ts
+++ b/packages/web/src/lib/project-route-data.ts
@@ -9,6 +9,10 @@ export interface ProjectRouteData {
   projectId: string;
   project: ProjectConfig | null;
   degradedProject: DegradedProjectEntry | null;
+  defaults: {
+    agent?: string;
+    runtime?: string;
+  };
   projects: ProjectInfo[];
 }
 
@@ -27,6 +31,10 @@ export const getProjectRouteData = cache(async function getProjectRouteData(
     projectId,
     project,
     degradedProject,
+    defaults: {
+      agent: config.defaults.agent,
+      runtime: config.defaults.runtime,
+    },
     projects: getAllProjects(),
   };
 });


### PR DESCRIPTION
## Summary

- keep mux terminal PTYs alive for a short idle grace window so fast React remounts or WebSocket reconnects do not kill and immediately respawn the attach process
- avoid replacing the current dashboard terminal URL when fullscreen state already matches the query string
- expose effective project defaults to the settings UI and use them as behavior placeholders instead of hardcoded `claude-code` / `tmux`

## Verification

- `pnpm --filter @aoagents/ao-web test -- MuxProvider.test.tsx DirectTerminal.render.test.tsx ProjectSettingsForm.test.tsx project-detail-route.test.ts mux-websocket.test.ts mux-terminal-manager.test.ts`
- `pnpm --filter @aoagents/ao-web typecheck`
- `pnpm --filter @aoagents/ao-web build`
- live mux smoke with a temporary tmux session:
  - first quick close/reopen produced `first_exit_count=0`
  - final idle cleanup produced `final_exit_count=1`
