### PR TITLE
feat: add tokens skills session tab

### DIFF
--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -269,6 +269,9 @@ export function writeMetadata(
   if (metadata.summary) data["summary"] = metadata.summary;
   if (metadata.project) data["project"] = metadata.project;
   if (metadata.agent) data["agent"] = metadata.agent;
+  if (metadata.model) data["model"] = metadata.model;
+  if (metadata.permissions) data["permissions"] = metadata.permissions;
+  if (metadata.subagent) data["subagent"] = metadata.subagent;
   if (metadata.createdAt) data["createdAt"] = metadata.createdAt;
   if (metadata.runtimeHandle) data["runtimeHandle"] = metadata.runtimeHandle;
   if (metadata.lifecycle) data["lifecycle"] = metadata.lifecycle;

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1357,6 +1357,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         ...(reusedOpenCodeSessionId ? { opencodeSessionId: reusedOpenCodeSessionId } : {}),
         ...(spawnConfig.prompt ? { userPrompt: spawnConfig.prompt } : {}),
         ...(displayName ? { displayName } : {}),
+        ...(selection.model ? { model: selection.model } : {}),
+        ...(selection.permissions ? { permissions: selection.permissions } : {}),
+        ...(agentLaunchConfig.subagent ? { subagent: agentLaunchConfig.subagent } : {}),
       },
     };
 
@@ -1379,6 +1382,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         issue: spawnConfig.issueId,
         project: spawnConfig.projectId,
         agent: selection.agentName, // Persist agent name for lifecycle manager
+        model: selection.model,
+        permissions: selection.permissions,
+        subagent: agentLaunchConfig.subagent,
         createdAt: createdAt.toISOString(),
         runtimeHandle: handle,
         opencodeSessionId: reusedOpenCodeSessionId,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1661,6 +1661,9 @@ export interface SessionMetadata {
   summary?: string;
   project?: string;
   agent?: string; // Agent plugin name (e.g. "codex", "claude-code") — persisted for lifecycle
+  model?: string;
+  permissions?: AgentPermissionMode;
+  subagent?: string;
   createdAt?: string;
   runtimeHandle?: RuntimeHandle;
   restoredAt?: string;

--- a/packages/web/src/__tests__/helpers.ts
+++ b/packages/web/src/__tests__/helpers.ts
@@ -207,6 +207,8 @@ export function makeSession(overrides: Partial<DashboardSession> = {}): Dashboar
     displayName: null,
     summary: "Test session",
     summaryIsFallback: false,
+    agentSessionId: null,
+    agentCost: null,
     createdAt: new Date().toISOString(),
     lastActivityAt: new Date().toISOString(),
     pr: null,

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -2016,6 +2016,134 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
     var(--color-bg-base);
 }
 
+.session-detail-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 42px;
+  padding: 7px 10px 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-surface);
+}
+
+.session-detail-tab {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 12px;
+  border-bottom: 2px solid transparent;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.session-detail-tab:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-hover);
+}
+
+.session-detail-tab[aria-selected="true"] {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+}
+
+.session-detail-info-panel {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 20px;
+  color: var(--color-text-primary);
+}
+
+.session-detail-info-section {
+  max-width: 960px;
+  border-top: 1px solid var(--color-border-default);
+  padding: 18px 0 24px;
+}
+
+.session-detail-info-section:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.session-detail-info-section__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.session-detail-info-section__header h2 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.session-detail-info-section__header span {
+  color: var(--color-text-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.session-detail-token-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.session-detail-metric-block {
+  min-width: 0;
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-surface);
+  padding: 12px;
+}
+
+.session-detail-metric-block span,
+.session-detail-skill-list dt {
+  display: block;
+  color: var(--color-text-muted);
+  font-size: 11px;
+}
+
+.session-detail-metric-block strong {
+  display: block;
+  margin-top: 6px;
+  color: var(--color-text-primary);
+  font-size: 18px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.session-detail-skill-list {
+  display: grid;
+  max-width: 720px;
+  margin: 0;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.session-detail-skill-list__row {
+  display: grid;
+  grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
+  gap: 14px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding: 11px 0;
+}
+
+.session-detail-skill-list dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.session-detail-info-empty {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 12px;
+}
+
 .session-page-header {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -5372,6 +5500,19 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 @media (max-width: 640px) {
   .dashboard-title {
     font-size: 19px;
+  }
+
+  .session-detail-info-panel {
+    padding: 14px;
+  }
+
+  .session-detail-token-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .session-detail-skill-list__row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 4px;
   }
 
   .kanban-column {

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -25,6 +25,8 @@ import { sessionActivityMeta } from "./session-detail-utils";
 
 export type { OrchestratorZones } from "./SessionDetailHeader";
 
+type SessionDetailTab = "agent" | "tokens-skills";
+
 const DirectTerminal = dynamic(
   () => import("./DirectTerminal").then((m) => ({ default: m.DirectTerminal })),
   {
@@ -67,6 +69,7 @@ export function SessionDetail({
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [showTerminal, setShowTerminal] = useState(false);
+  const [activeTab, setActiveTab] = useState<SessionDetailTab>("agent");
   const pr = session.pr;
   const terminalEnded = TERMINAL_STATUSES.has(session.status);
   const isRestorable = terminalEnded && !NON_RESTORABLE_STATUSES.has(session.status);
@@ -195,8 +198,31 @@ export function SessionDetail({
 
           <div className="dashboard-main dashboard-main--desktop">
             <main className="session-detail-page flex-1 min-h-0 flex flex-col bg-[var(--color-bg-base)]">
+              <div className="session-detail-tabs" role="tablist" aria-label="세션 상세 탭">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={activeTab === "agent"}
+                  className="session-detail-tab"
+                  onClick={() => setActiveTab("agent")}
+                >
+                  에이전트
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={activeTab === "tokens-skills"}
+                  className="session-detail-tab"
+                  onClick={() => setActiveTab("tokens-skills")}
+                >
+                  토큰·스킬
+                </button>
+              </div>
+
               <div className="flex-1 min-h-0 flex flex-col">
-                {!showTerminal ? (
+                {activeTab === "tokens-skills" ? (
+                  <TokensSkillsPanel session={session} />
+                ) : !showTerminal ? (
                   <div className="session-detail-terminal-placeholder h-full" />
                 ) : terminalEnded ? (
                   <SessionEndedSummary
@@ -236,5 +262,77 @@ export function SessionDetail({
         />
       </div>
     </SidebarContext.Provider>
+  );
+}
+
+function formatTokenCount(value: number): string {
+  return new Intl.NumberFormat("ko-KR").format(value);
+}
+
+function formatUsd(value: number): string {
+  return new Intl.NumberFormat("ko-KR", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: value < 1 ? 4 : 2,
+  }).format(value);
+}
+
+function TokensSkillsPanel({ session }: { session: DashboardSession }) {
+  const cost = session.agentCost;
+  const totalTokens = cost ? cost.inputTokens + cost.outputTokens : null;
+  const skillRows = [
+    { label: "에이전트", value: session.metadata["agent"] },
+    { label: "모델", value: session.metadata["model"] },
+    { label: "권한 모드", value: session.metadata["permissions"] },
+    { label: "서브에이전트", value: session.metadata["subagent"] },
+    { label: "내부 세션", value: session.agentSessionId },
+  ].filter((row): row is { label: string; value: string } => Boolean(row.value));
+
+  return (
+    <div className="session-detail-info-panel">
+      <section className="session-detail-info-section" aria-labelledby="session-token-title">
+        <div className="session-detail-info-section__header">
+          <h2 id="session-token-title">토큰 사용량</h2>
+          {cost ? <span>{formatUsd(cost.estimatedCostUsd)}</span> : null}
+        </div>
+        {cost && totalTokens !== null ? (
+          <div className="session-detail-token-grid">
+            <MetricBlock label="입력 토큰" value={formatTokenCount(cost.inputTokens)} />
+            <MetricBlock label="출력 토큰" value={formatTokenCount(cost.outputTokens)} />
+            <MetricBlock label="전체 토큰" value={formatTokenCount(totalTokens)} />
+            <MetricBlock label="예상 비용" value={formatUsd(cost.estimatedCostUsd)} />
+          </div>
+        ) : (
+          <p className="session-detail-info-empty">이 세션에서 수집된 토큰 데이터가 없습니다.</p>
+        )}
+      </section>
+
+      <section className="session-detail-info-section" aria-labelledby="session-skills-title">
+        <div className="session-detail-info-section__header">
+          <h2 id="session-skills-title">스킬 구성</h2>
+        </div>
+        {skillRows.length > 0 ? (
+          <dl className="session-detail-skill-list">
+            {skillRows.map((row) => (
+              <div key={row.label} className="session-detail-skill-list__row">
+                <dt>{row.label}</dt>
+                <dd>{row.value}</dd>
+              </div>
+            ))}
+          </dl>
+        ) : (
+          <p className="session-detail-info-empty">이 세션에 기록된 스킬 정보가 없습니다.</p>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function MetricBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="session-detail-metric-block">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
   );
 }

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -145,6 +145,41 @@ describe("SessionDetail desktop layout", () => {
     expect(screen.getByText("The empty state text needs to be shorter.")).toBeInTheDocument();
   });
 
+  it("shows token and skill details in their dedicated tab", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "worker-tokens",
+          projectId: "my-app",
+          agentSessionId: "codex-session-1",
+          agentCost: {
+            inputTokens: 1200,
+            outputTokens: 340,
+            estimatedCostUsd: 0.0123,
+          },
+          metadata: {
+            agent: "codex",
+            model: "gpt-5.4",
+            permissions: "auto-edit",
+            subagent: "reviewer",
+          },
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "토큰·스킬" }));
+
+    expect(screen.getByRole("heading", { name: "토큰 사용량" })).toBeInTheDocument();
+    expect(screen.getByText("1,200")).toBeInTheDocument();
+    expect(screen.getByText("340")).toBeInTheDocument();
+    expect(screen.getByText("1,540")).toBeInTheDocument();
+    expect(screen.getByText("codex")).toBeInTheDocument();
+    expect(screen.getByText("gpt-5.4")).toBeInTheDocument();
+    expect(screen.getByText("auto-edit")).toBeInTheDocument();
+    expect(screen.getByText("reviewer")).toBeInTheDocument();
+    expect(screen.getByText("codex-session-1")).toBeInTheDocument();
+  });
+
   it("sends unresolved comments back to the agent and shows sent state", async () => {
     vi.useFakeTimers();
 

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   sessionToDashboard,
   resolveProject,
+  enrichSessionIssue,
   enrichSessionPR,
   readPREnrichmentFromMetadata,
   enrichSessionAgentSummary,

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -180,6 +180,8 @@ export function sessionToDashboard(session: Session): DashboardSession {
     displayName: session.metadata["displayName"] ?? null,
     summary,
     summaryIsFallback: agentSummary ? (session.agentInfo?.summaryIsFallback ?? false) : false,
+    agentSessionId: session.agentInfo?.agentSessionId ?? null,
+    agentCost: session.agentInfo?.cost ?? null,
     createdAt: session.createdAt.toISOString(),
     lastActivityAt: session.lastActivityAt.toISOString(),
     pr: session.pr

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -109,12 +109,20 @@ export interface DashboardSession {
   summary: string | null;
   /** True when the summary is a low-quality fallback (e.g. truncated spawn prompt) */
   summaryIsFallback: boolean;
+  agentSessionId: string | null;
+  agentCost: DashboardAgentCost | null;
   createdAt: string;
   lastActivityAt: string;
   pr: DashboardPR | null;
   metadata: Record<string, string>;
   agentReportAudit?: DashboardAgentReportAuditEntry[];
   attentionLevel?: AttentionLevel;
+}
+
+export interface DashboardAgentCost {
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
 }
 
 export interface DashboardAgentReportAuditSnapshot {


### PR DESCRIPTION
## 변경 사항

- 세션 상세 화면에 `토큰·스킬` 전용 탭을 추가했습니다.
- Claude/Codex 에이전트에서 이미 수집 중인 토큰/비용 정보를 웹 직렬화 결과에 포함했습니다.
- 새 세션 생성 시 에이전트 모델, 권한 모드, 서브에이전트 구성을 메타데이터에 보존해 스킬 구성 탭에서 확인할 수 있게 했습니다.
- 관련 테스트에서 누락된 serializer import를 보완했습니다.

## 이유

에이전트 탭은 세션 흐름과 터미널 중심으로 유지하고, 토큰/스킬 상세는 별도 탭에서 다루도록 분리하기 위해서입니다.

## 검증

- `pnpm install`
- `pnpm build`
- `pnpm --filter @aoagents/ao-web typecheck`
- `pnpm --filter @aoagents/ao-web test -- serialize.test.ts SessionDetail.desktop.test.tsx`

## 이슈

Refs: tokens-skills-tab
