### PR TITLE
fix: reopen terminal after mux reconnect

### DIFF
--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -158,7 +158,7 @@ describe("DirectTerminal render", () => {
   it("renders the shared accent chrome for orchestrator terminals", async () => {
     render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
 
-    await waitFor(() => expect(screen.getByText("Connected")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Connected")).toBeInTheDocument());
 
     expect(screen.getByText("ao-orchestrator")).toHaveStyle({ color: "var(--color-accent)" });
     expect(screen.getByText("XDA")).toHaveStyle({ color: "var(--color-accent)" });
@@ -173,16 +173,18 @@ describe("DirectTerminal render", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getByRole("button", { name: "Restart OpenCode session" })).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Restart OpenCode session" })).toBeInTheDocument(),
+    );
 
-    expect(screen.getByRole("button", { name: "fullscreen" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "fullscreen" })).toBeInTheDocument();
     expect(screen.queryByText("XDA")).toBeNull();
   });
 
   it("switches the terminal shell between inline and fullscreen positioning", async () => {
     const { container } = render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
 
-    await waitFor(() => expect(screen.getByRole("button", { name: "fullscreen" })).toBeTruthy());
+    await waitFor(() => expect(screen.getByRole("button", { name: "fullscreen" })).toBeInTheDocument());
 
     const terminalShell = container.firstElementChild;
     expect(terminalShell).not.toBeNull();
@@ -191,15 +193,25 @@ describe("DirectTerminal render", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "fullscreen" }));
 
-    expect(screen.getByRole("button", { name: "exit fullscreen" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "exit fullscreen" })).toBeInTheDocument();
     expect(terminalShell).toHaveClass("fixed", "inset-0");
     expect(terminalShell).not.toHaveClass("relative");
 
     fireEvent.click(screen.getByRole("button", { name: "exit fullscreen" }));
 
-    expect(screen.getByRole("button", { name: "fullscreen" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "fullscreen" })).toBeInTheDocument();
     expect(terminalShell).toHaveClass("relative");
     expect(terminalShell).not.toHaveClass("fixed");
+  });
+
+  it("does not double-open on the initial connecting-to-connected transition", async () => {
+    muxStatus = "connecting";
+    const { rerender } = render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
+
+    muxStatus = "connected";
+    rerender(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
+
+    await waitFor(() => expect(openTerminalMock).toHaveBeenCalledTimes(1));
   });
 
   it("re-opens the terminal when mux reconnects", async () => {

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -3,7 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DirectTerminal } from "../DirectTerminal";
 
 const replaceMock = vi.fn();
+const subscribeTerminalMock = vi.fn(() => vi.fn());
+const writeTerminalMock = vi.fn();
+const openTerminalMock = vi.fn();
+const closeTerminalMock = vi.fn();
+const resizeTerminalMock = vi.fn();
 let searchParams = new URLSearchParams();
+let muxStatus: "connecting" | "connected" | "reconnecting" | "disconnected" = "connected";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: replaceMock }),
@@ -47,10 +53,18 @@ class MockTerminal {
   onData() {
     return { dispose() {} };
   }
+  onScroll() {
+    return { dispose() {} };
+  }
 }
 
 class MockFitAddon {
   fit() {}
+}
+
+class MockResizeObserver {
+  observe() {}
+  disconnect() {}
 }
 
 function MockWebLinksAddon() {
@@ -90,12 +104,12 @@ vi.mock("@xterm/addon-web-links", () => ({
 
 vi.mock("@/hooks/useMux", () => ({
   useMux: () => ({
-    subscribeTerminal: vi.fn(() => vi.fn()),
-    writeTerminal: vi.fn(),
-    openTerminal: vi.fn(),
-    closeTerminal: vi.fn(),
-    resizeTerminal: vi.fn(),
-    status: "connected",
+    subscribeTerminal: subscribeTerminalMock,
+    writeTerminal: writeTerminalMock,
+    openTerminal: openTerminalMock,
+    closeTerminal: closeTerminalMock,
+    resizeTerminal: resizeTerminalMock,
+    status: muxStatus,
     sessions: [],
     terminals: [],
   }),
@@ -104,7 +118,13 @@ vi.mock("@/hooks/useMux", () => ({
 describe("DirectTerminal render", () => {
   beforeEach(() => {
     searchParams = new URLSearchParams();
+    muxStatus = "connected";
     replaceMock.mockReset();
+    subscribeTerminalMock.mockClear();
+    writeTerminalMock.mockClear();
+    openTerminalMock.mockClear();
+    closeTerminalMock.mockClear();
+    resizeTerminalMock.mockClear();
     MockWebSocket.instances = [];
     Object.defineProperty(document, "fonts", {
       configurable: true,
@@ -118,6 +138,7 @@ describe("DirectTerminal render", () => {
       },
     });
     vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({
@@ -137,9 +158,7 @@ describe("DirectTerminal render", () => {
   it("renders the shared accent chrome for orchestrator terminals", async () => {
     render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
 
-    await waitFor(() =>
-      expect(screen.getByText("Connected")).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText("Connected")).toBeTruthy());
 
     expect(screen.getByText("ao-orchestrator")).toHaveStyle({ color: "var(--color-accent)" });
     expect(screen.getByText("XDA")).toHaveStyle({ color: "var(--color-accent)" });
@@ -154,20 +173,16 @@ describe("DirectTerminal render", () => {
       />,
     );
 
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Restart OpenCode session" })).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByRole("button", { name: "Restart OpenCode session" })).toBeTruthy());
 
-    expect(screen.getByRole("button", { name: "fullscreen" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "fullscreen" })).toBeTruthy();
     expect(screen.queryByText("XDA")).toBeNull();
   });
 
   it("switches the terminal shell between inline and fullscreen positioning", async () => {
     const { container } = render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
 
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "fullscreen" })).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByRole("button", { name: "fullscreen" })).toBeTruthy());
 
     const terminalShell = container.firstElementChild;
     expect(terminalShell).not.toBeNull();
@@ -176,14 +191,28 @@ describe("DirectTerminal render", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "fullscreen" }));
 
-    expect(screen.getByRole("button", { name: "exit fullscreen" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "exit fullscreen" })).toBeTruthy();
     expect(terminalShell).toHaveClass("fixed", "inset-0");
     expect(terminalShell).not.toHaveClass("relative");
 
     fireEvent.click(screen.getByRole("button", { name: "exit fullscreen" }));
 
-    expect(screen.getByRole("button", { name: "fullscreen" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "fullscreen" })).toBeTruthy();
     expect(terminalShell).toHaveClass("relative");
     expect(terminalShell).not.toHaveClass("fixed");
+  });
+
+  it("re-opens the terminal when mux reconnects", async () => {
+    const { rerender } = render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
+
+    await waitFor(() => expect(openTerminalMock).toHaveBeenCalledTimes(1));
+
+    muxStatus = "reconnecting";
+    rerender(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
+
+    muxStatus = "connected";
+    rerender(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
+
+    await waitFor(() => expect(openTerminalMock).toHaveBeenCalledTimes(2));
   });
 });

--- a/packages/web/src/components/terminal/useXtermTerminal.ts
+++ b/packages/web/src/components/terminal/useXtermTerminal.ts
@@ -65,6 +65,7 @@ export function useXtermTerminal(
   const [error, setError] = useState<string | null>(null);
   const followOutputRef = useRef(true);
   const [followOutput, setFollowOutput] = useState(true);
+  const previousMuxStatusRef = useRef(muxStatus);
 
   useEffect(() => {
     if (!terminalRef.current) return;
@@ -334,13 +335,21 @@ export function useXtermTerminal(
   // Re-send terminal dimensions on every reconnect so the server-side PTY
   // matches the client's xterm.js size (new PTYs spawn at 80×24 default).
   useEffect(() => {
+    const previousStatus = previousMuxStatusRef.current;
+    previousMuxStatusRef.current = muxStatus;
+
     if (muxStatus !== "connected") return;
     const fit = fitAddon.current;
     const terminal = terminalInstance.current;
     if (!fit || !terminal) return;
+
+    if (previousStatus !== "connected") {
+      openTerminal(sessionId, tmuxName);
+    }
+
     fit.fit();
     resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
-  }, [muxStatus, sessionId, resizeTerminalMux]);
+  }, [muxStatus, sessionId, tmuxName, resizeTerminalMux, openTerminal]);
 
   // Live theme switching without terminal recreation
   useEffect(() => {

--- a/packages/web/src/components/terminal/useXtermTerminal.ts
+++ b/packages/web/src/components/terminal/useXtermTerminal.ts
@@ -66,6 +66,7 @@ export function useXtermTerminal(
   const followOutputRef = useRef(true);
   const [followOutput, setFollowOutput] = useState(true);
   const previousMuxStatusRef = useRef(muxStatus);
+  const hasRequestedInitialOpenRef = useRef(false);
 
   useEffect(() => {
     if (!terminalRef.current) return;
@@ -235,6 +236,7 @@ export function useXtermTerminal(
         // hazard if subscribeTerminal ever fires synchronously.
         let programmaticScroll = false;
 
+        hasRequestedInitialOpenRef.current = true;
         openTerminal(sessionId, tmuxName);
 
         unsubscribe = subscribeTerminal(sessionId, (data) => {
@@ -343,7 +345,7 @@ export function useXtermTerminal(
     const terminal = terminalInstance.current;
     if (!fit || !terminal) return;
 
-    if (previousStatus !== "connected") {
+    if (previousStatus !== "connected" && hasRequestedInitialOpenRef.current) {
       openTerminal(sessionId, tmuxName);
     }
 


### PR DESCRIPTION
## Summary
- replay `openTerminal()` when mux transitions back to `connected`
- keep the resize replay on reconnect so restored PTYs reattach and resize correctly
- add reconnect regression coverage for `DirectTerminal`

## Testing
- `pnpm test -- src/components/__tests__/DirectTerminal.render.test.tsx`

Closes #1564
