### PR TITLE
fix(core): preserve manual kill lifecycle reason

### DIFF
--- a/packages/core/src/__tests__/session-manager/lifecycle.test.ts
+++ b/packages/core/src/__tests__/session-manager/lifecycle.test.ts
@@ -13,6 +13,7 @@ import {
   updateMetadata,
 } from "../../metadata.js";
 import { getProjectSessionsDir, getProjectWorktreesDir } from "../../paths.js";
+import { parseCanonicalLifecycle } from "../../lifecycle-state.js";
 import type {
   OrchestratorConfig,
   PluginRegistry,
@@ -66,6 +67,48 @@ describe("kill", () => {
     const meta = readMetadataRaw(sessionsDir, "app-1");
     expect(meta).not.toBeNull();
     expect(meta!["status"]).toMatch(/killed|terminated/);
+  });
+
+  it("persists manually_killed before runtime teardown can race with list reconciliation", async () => {
+    const managedWorktree = join(getProjectWorktreesDir("my-app"), "app-1");
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: managedWorktree,
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: makeHandle("rt-1"),
+    });
+
+    let sm: ReturnType<typeof createSessionManager>;
+    let reasonObservedDuringDestroy: string | undefined;
+    const racingRuntime: Runtime = {
+      ...mockRuntime,
+      isAlive: vi.fn().mockResolvedValue(false),
+      destroy: vi.fn().mockImplementation(async () => {
+        await sm.list();
+        const meta = readMetadataRaw(sessionsDir, "app-1");
+        reasonObservedDuringDestroy = meta
+          ? parseCanonicalLifecycle(meta).session.reason
+          : undefined;
+      }),
+    };
+    const registryWithRacingRuntime: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return racingRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    sm = createSessionManager({ config, registry: registryWithRacingRuntime });
+    await sm.kill("app-1");
+
+    expect(reasonObservedDuringDestroy).toBe("manually_killed");
+    const meta = readMetadataRaw(sessionsDir, "app-1");
+    expect(meta).not.toBeNull();
+    expect(parseCanonicalLifecycle(meta!).session.reason).toBe("manually_killed");
   });
 
   it("does not destroy workspace paths outside managed roots", async () => {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -2043,6 +2043,28 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const killReason: LifecycleKillReason = options?.reason ?? "manually_killed";
     const cleanupAgent = resolveSelectionForSession(project, sessionId, raw).agentName;
 
+    const runtimeReason =
+      killReason === "pr_merged"
+        ? "pr_merged_cleanup"
+        : killReason === "auto_cleanup"
+          ? "auto_cleanup"
+          : "manual_kill_requested";
+    const terminatedLifecycle = buildUpdatedLifecycle(sessionId, raw, (next) => {
+      next.session.state = "terminated";
+      next.session.reason = killReason;
+      next.session.terminatedAt = new Date().toISOString();
+      next.session.lastTransitionAt = next.session.terminatedAt;
+      next.runtime.state = raw["runtimeHandle"] || raw["tmuxName"] ? "missing" : "exited";
+      next.runtime.reason = runtimeReason;
+      next.runtime.lastObservedAt = new Date().toISOString();
+    });
+
+    // Persist the user/business terminal reason before tearing down the runtime.
+    // Otherwise a concurrent list() can observe the dead runtime and relabel the
+    // session as runtime_lost before this kill path writes its final state.
+    updateMetadata(sessionsDir, sessionId, lifecycleMetadataUpdates(raw, terminatedLifecycle));
+    invalidateCache();
+
     // Destroy runtime — prefer handle.runtimeName to find the correct plugin
     if (raw["runtimeHandle"]) {
       const handle = safeJsonParse<RuntimeHandle>(raw["runtimeHandle"]);
@@ -2095,28 +2117,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     }
 
-    const runtimeReason =
-      killReason === "pr_merged"
-        ? "pr_merged_cleanup"
-        : killReason === "auto_cleanup"
-          ? "auto_cleanup"
-          : "manual_kill_requested";
-    const terminatedLifecycle = buildUpdatedLifecycle(sessionId, raw, (next) => {
-      next.session.state = "terminated";
-      next.session.reason = killReason;
-      next.session.terminatedAt = new Date().toISOString();
-      next.session.lastTransitionAt = next.session.terminatedAt;
-      next.runtime.state = raw["runtimeHandle"] || raw["tmuxName"] ? "missing" : "exited";
-      next.runtime.reason = runtimeReason;
-      next.runtime.lastObservedAt = new Date().toISOString();
-    });
-    updateMetadata(sessionsDir, sessionId, {
-      ...lifecycleMetadataUpdates(raw, terminatedLifecycle),
-      ...(didPurgeOpenCodeSession && {
+    if (didPurgeOpenCodeSession) {
+      updateMetadata(sessionsDir, sessionId, {
         opencodeSessionId: "",
         opencodeCleanedAt: new Date().toISOString(),
-      }),
-    });
+      });
+    }
 
     invalidateCache();
     return { cleaned: true, alreadyTerminated: false };

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -2054,9 +2054,6 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       next.session.reason = killReason;
       next.session.terminatedAt = new Date().toISOString();
       next.session.lastTransitionAt = next.session.terminatedAt;
-      next.runtime.state = raw["runtimeHandle"] || raw["tmuxName"] ? "missing" : "exited";
-      next.runtime.reason = runtimeReason;
-      next.runtime.lastObservedAt = new Date().toISOString();
     });
 
     // Persist the user/business terminal reason before tearing down the runtime.
@@ -2116,6 +2113,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         }
       }
     }
+
+    const postTeardownLifecycle = buildUpdatedLifecycle(sessionId, raw, (next) => {
+      next.session = { ...terminatedLifecycle.session };
+      next.runtime.state = raw["runtimeHandle"] || raw["tmuxName"] ? "missing" : "exited";
+      next.runtime.reason = runtimeReason;
+      next.runtime.lastObservedAt = new Date().toISOString();
+    });
+    updateMetadata(sessionsDir, sessionId, lifecycleMetadataUpdates(raw, postTeardownLifecycle));
 
     if (didPurgeOpenCodeSession) {
       updateMetadata(sessionsDir, sessionId, {


### PR DESCRIPTION
## Summary
- persist the terminated lifecycle reason before runtime/workspace teardown in kill()
- keep optional OpenCode cleanup metadata as a follow-up update after teardown
- add a regression test where list() runs during runtime destroy and must still observe manually_killed

Fixes #1569.

## Verification
- pnpm --filter @aoagents/ao-core test -- src/__tests__/session-manager/lifecycle.test.ts
- pre-commit gitleaks scan passed