### PR TITLE
fix: align update checks with install method

### DIFF
--- a/packages/cli/__tests__/commands/update.test.ts
+++ b/packages/cli/__tests__/commands/update.test.ts
@@ -5,9 +5,7 @@ import { Command } from "commander";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const {
-  mockRunRepoScript,
-} = vi.hoisted(() => ({
+const { mockRunRepoScript } = vi.hoisted(() => ({
   mockRunRepoScript: vi.fn(),
 }));
 
@@ -45,6 +43,7 @@ vi.mock("../../src/lib/update-check.js", () => ({
   invalidateCache: () => mockInvalidateCache(),
   getCurrentVersion: () => mockGetCurrentVersion(),
   getUpdateCommand: (...args: unknown[]) => mockGetUpdateCommand(...args),
+  isVersionOutdated: (current: string, latest: string) => current !== latest,
 }));
 
 const { mockPromptConfirm } = vi.hoisted(() => ({
@@ -56,8 +55,9 @@ vi.mock("../../src/lib/prompts.js", () => ({
 }));
 
 // Mock child_process.spawn for npm install tests
-const { mockSpawn } = vi.hoisted(() => ({
+const { mockSpawn, mockSpawnSync } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
+  mockSpawnSync: vi.fn(),
 }));
 
 vi.mock("node:child_process", async () => {
@@ -65,10 +65,11 @@ vi.mock("node:child_process", async () => {
   return {
     ...actual,
     spawn: (...args: unknown[]) => mockSpawn(...args),
+    spawnSync: (...args: unknown[]) => mockSpawnSync(...args),
   };
 });
 
-import { registerUpdate } from "../../src/commands/update.js";
+import { parseAoVersionOutput, registerUpdate } from "../../src/commands/update.js";
 import { EventEmitter } from "node:events";
 
 function makeNpmUpdateInfo(overrides = {}) {
@@ -102,11 +103,15 @@ describe("update command", () => {
     mockRunRepoScript.mockResolvedValue(0);
     mockDetectInstallMethod.mockReturnValue("git");
     mockCheckForUpdate.mockReset();
-    mockCheckForUpdate.mockResolvedValue(makeNpmUpdateInfo({ installMethod: "git", recommendedCommand: "ao update" }));
+    mockCheckForUpdate.mockResolvedValue(
+      makeNpmUpdateInfo({ installMethod: "git", recommendedCommand: "ao update" }),
+    );
     mockInvalidateCache.mockReset();
     mockPromptConfirm.mockReset();
     mockPromptConfirm.mockResolvedValue(false);
     mockSpawn.mockReset();
+    mockSpawnSync.mockReset();
+    mockSpawnSync.mockReturnValue({ status: 0, stdout: "0.3.0\n", stderr: "" });
     origStdinTTY = process.stdin.isTTY;
     origStdoutTTY = process.stdout.isTTY;
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -187,9 +192,9 @@ describe("update command", () => {
         new Error("Script not found: ao-update.sh. Expected at: /tmp/ao-update.sh"),
       );
 
-      await expect(
-        program.parseAsync(["node", "test", "update"]),
-      ).rejects.toThrow("process.exit(1)");
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow(
+        "process.exit(1)",
+      );
 
       expect(mockSpawn).not.toHaveBeenCalled();
       expect(mockCheckForUpdate).not.toHaveBeenCalled();
@@ -234,7 +239,9 @@ describe("update command", () => {
     });
 
     it("prints already up to date when not outdated", async () => {
-      mockCheckForUpdate.mockResolvedValue(makeNpmUpdateInfo({ isOutdated: false, latestVersion: "0.2.2", currentVersion: "0.2.2" }));
+      mockCheckForUpdate.mockResolvedValue(
+        makeNpmUpdateInfo({ isOutdated: false, latestVersion: "0.2.2", currentVersion: "0.2.2" }),
+      );
 
       const logSpy = vi.mocked(console.log);
       await program.parseAsync(["node", "test", "update"]);
@@ -246,9 +253,9 @@ describe("update command", () => {
         makeNpmUpdateInfo({ latestVersion: null, isOutdated: false }),
       );
 
-      await expect(
-        program.parseAsync(["node", "test", "update"]),
-      ).rejects.toThrow("process.exit(1)");
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow(
+        "process.exit(1)",
+      );
       expect(vi.mocked(console.error)).toHaveBeenCalledWith(
         expect.stringContaining("Could not reach npm registry"),
       );
@@ -289,8 +296,56 @@ describe("update command", () => {
 
       await program.parseAsync(["node", "test", "update"]);
 
-      expect(mockSpawn).toHaveBeenCalledWith("npm", expect.arrayContaining(["install"]), expect.anything());
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "npm",
+        expect.arrayContaining(["install"]),
+        expect.anything(),
+      );
       expect(mockInvalidateCache).toHaveBeenCalled();
+    });
+
+    it("accepts prefixed ao --version output when verifying npm updates", async () => {
+      Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+      Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+      mockPromptConfirm.mockResolvedValue(true);
+      mockSpawn.mockReturnValue(createMockChild(0));
+      mockSpawnSync.mockReturnValue({ status: 0, stdout: "ao version 0.3.0\n", stderr: "" });
+
+      await program.parseAsync(["node", "test", "update"]);
+
+      expect(mockInvalidateCache).toHaveBeenCalled();
+    });
+
+    it("uses a shell for runnable ao verification on Windows only", async () => {
+      Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+      Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+      mockPromptConfirm.mockResolvedValue(true);
+      mockSpawn.mockReturnValue(createMockChild(0));
+
+      await program.parseAsync(["node", "test", "update"]);
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        "ao",
+        ["--version"],
+        expect.objectContaining({ shell: process.platform === "win32" }),
+      );
+    });
+
+    it("exits non-zero when npm update leaves the runnable ao binary stale", async () => {
+      Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+      Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+      mockPromptConfirm.mockResolvedValue(true);
+      mockSpawn.mockReturnValue(createMockChild(0));
+      mockSpawnSync.mockReturnValue({ status: 0, stdout: "0.2.2\n", stderr: "" });
+
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow(
+        "process.exit(1)",
+      );
+
+      expect(mockInvalidateCache).not.toHaveBeenCalled();
+      expect(vi.mocked(console.error)).toHaveBeenCalledWith(
+        expect.stringContaining("runnable `ao` in PATH"),
+      );
     });
 
     it("exits non-zero when npm install fails", async () => {
@@ -299,9 +354,9 @@ describe("update command", () => {
       mockPromptConfirm.mockResolvedValue(true);
       mockSpawn.mockReturnValue(createMockChild(1));
 
-      await expect(
-        program.parseAsync(["node", "test", "update"]),
-      ).rejects.toThrow("process.exit(1)");
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow(
+        "process.exit(1)",
+      );
       expect(mockInvalidateCache).not.toHaveBeenCalled();
     });
 
@@ -327,9 +382,9 @@ describe("update command", () => {
       mockPromptConfirm.mockResolvedValue(true);
       mockSpawn.mockReturnValue(createMockChild(null, "SIGTERM"));
 
-      await expect(
-        program.parseAsync(["node", "test", "update"]),
-      ).rejects.toThrow("process.exit(1)");
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow(
+        "process.exit(1)",
+      );
 
       expect(vi.mocked(console.error)).not.toHaveBeenCalledWith(
         expect.stringContaining("exited with code null"),
@@ -346,9 +401,7 @@ describe("update command", () => {
       mockSpawn.mockReturnValue(child);
       setTimeout(() => child.emit("error", new Error("ENOENT: npm not found")), 0);
 
-      await expect(
-        program.parseAsync(["node", "test", "update"]),
-      ).rejects.toThrow("ENOENT");
+      await expect(program.parseAsync(["node", "test", "update"])).rejects.toThrow("ENOENT");
     });
 
     it("does nothing when user declines prompt", async () => {
@@ -378,7 +431,9 @@ describe("update command", () => {
 
       await program.parseAsync(["node", "test", "update"]);
 
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Could not detect install method"));
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not detect install method"),
+      );
       expect(mockRunRepoScript).not.toHaveBeenCalled();
     });
 
@@ -406,5 +461,15 @@ describe("update command", () => {
       await program.parseAsync(["node", "test", "update"]);
       expect(mockGetUpdateCommand).toHaveBeenCalledWith("npm-global");
     });
+  });
+});
+
+describe("parseAoVersionOutput", () => {
+  it("parses bare semver output", () => {
+    expect(parseAoVersionOutput("0.3.0\n")).toBe("0.3.0");
+  });
+
+  it("parses prefixed ao version output", () => {
+    expect(parseAoVersionOutput("ao version 0.3.0\n")).toBe("0.3.0");
   });
 });

--- a/packages/cli/__tests__/lib/update-check.test.ts
+++ b/packages/cli/__tests__/lib/update-check.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
 
 // ---------------------------------------------------------------------------
 // Mocks — hoisted so they're available before module import
@@ -12,6 +13,18 @@ const { mockExistsSync, mockReadFileSync, mockWriteFileSync, mockUnlinkSync, moc
     mockUnlinkSync: vi.fn(),
     mockMkdirSync: vi.fn(),
   }));
+
+const { mockSpawn } = vi.hoisted(() => ({
+  mockSpawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual("node:child_process");
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => mockSpawn(...args),
+  };
+});
 
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual("node:fs");
@@ -45,6 +58,7 @@ import {
   getCacheDir,
   readCachedUpdateInfo,
   fetchLatestVersion,
+  fetchLatestGitBranchVersion,
   invalidateCache,
   writeCache,
   checkForUpdate,
@@ -61,6 +75,7 @@ describe("update-check", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mockExistsSync.mockReturnValue(false);
+    mockSpawn.mockReset();
   });
 
   afterEach(() => {
@@ -127,39 +142,51 @@ describe("update-check", () => {
   describe("classifyInstallPath", () => {
     it("returns 'npm-global' for /usr/local/lib/node_modules path", () => {
       expect(
-        classifyInstallPath("/usr/local/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/usr/local/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("npm-global");
     });
 
     it("returns 'npm-global' for nvm global path", () => {
       expect(
-        classifyInstallPath("/home/user/.nvm/versions/node/v20.0.0/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/.nvm/versions/node/v20.0.0/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("npm-global");
     });
 
     it("returns 'npm-global' for Windows global path", () => {
       expect(
-        classifyInstallPath("C:\\Users\\test\\AppData\\Roaming\\npm\\lib\\node_modules\\@aoagents\\ao-cli\\dist\\lib\\update-check.js"),
+        classifyInstallPath(
+          "C:\\Users\\test\\AppData\\Roaming\\npm\\lib\\node_modules\\@aoagents\\ao-cli\\dist\\lib\\update-check.js",
+        ),
       ).toBe("npm-global");
     });
 
     it("returns 'pnpm-global' for pnpm global store path", () => {
       expect(
-        classifyInstallPath("/home/user/.local/share/pnpm/global/5/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/.local/share/pnpm/global/5/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("pnpm-global");
     });
 
     it("returns 'unknown' for local pnpm node_modules/.pnpm (not global)", () => {
       mockExistsSync.mockReturnValue(false);
       expect(
-        classifyInstallPath("/home/user/my-project/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/my-project/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("unknown");
     });
 
     it("returns 'unknown' for local project node_modules (npx)", () => {
       mockExistsSync.mockReturnValue(false);
       expect(
-        classifyInstallPath("/home/user/my-project/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/my-project/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("unknown");
     });
 
@@ -189,9 +216,7 @@ describe("update-check", () => {
 
     it("returns 'unknown' when .git does not exist at the resolved repo root", () => {
       mockExistsSync.mockReturnValue(false);
-      expect(
-        classifyInstallPath("/tmp/random/path/update-check.ts"),
-      ).toBe("unknown");
+      expect(classifyInstallPath("/tmp/random/path/update-check.ts")).toBe("unknown");
     });
   });
 
@@ -293,6 +318,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: now,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
 
@@ -309,6 +335,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: old,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       expect(readCachedUpdateInfo()).toBeNull();
@@ -322,6 +349,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: recent,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       expect(readCachedUpdateInfo()).not.toBeNull();
@@ -337,6 +365,33 @@ describe("update-check", () => {
         }),
       );
       expect(readCachedUpdateInfo()).toBeNull();
+    });
+
+    it("returns null when cache was written for a different install method", () => {
+      const now = new Date().toISOString();
+      const currentVersion = getCurrentVersion();
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          latestVersion: "0.3.0",
+          checkedAt: now,
+          currentVersionAtCheck: currentVersion,
+          installMethod: "npm-global",
+        }),
+      );
+      expect(readCachedUpdateInfo("git")).toBeNull();
+    });
+
+    it("returns null when cache is missing install method", () => {
+      const now = new Date().toISOString();
+      const currentVersion = getCurrentVersion();
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          latestVersion: "0.3.0",
+          checkedAt: now,
+          currentVersionAtCheck: currentVersion,
+        }),
+      );
+      expect(readCachedUpdateInfo("git")).toBeNull();
     });
 
     it("returns null on invalid JSON", () => {
@@ -375,7 +430,9 @@ describe("update-check", () => {
         currentVersionAtCheck: "0.2.2",
       });
 
-      expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining("ao"), { recursive: true });
+      expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining("ao"), {
+        recursive: true,
+      });
       expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
       const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
       expect(written.latestVersion).toBe("0.3.0");
@@ -486,6 +543,85 @@ describe("update-check", () => {
     });
   });
 
+  describe("fetchLatestGitBranchVersion", () => {
+    function mockGitProcess(code: number, stdout = "") {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter & { setEncoding: (encoding: BufferEncoding) => void };
+        kill: () => void;
+      };
+      child.stdout = new EventEmitter() as EventEmitter & {
+        setEncoding: (encoding: BufferEncoding) => void;
+      };
+      child.stdout.setEncoding = vi.fn();
+      child.kill = vi.fn();
+
+      setImmediate(() => {
+        if (stdout) {
+          child.stdout.emit("data", stdout);
+        }
+        child.emit("exit", code);
+      });
+
+      return child;
+    }
+
+    it("fetches the configured branch and reads its package version from the remote-tracking ref", async () => {
+      mockExistsSync.mockImplementation((path: string) => path.endsWith(".git"));
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: "@aoagents/ao" }));
+      mockSpawn.mockImplementation((_cmd: string, args: string[]) => {
+        if (args.join(" ") === "remote get-url upstream") {
+          return mockGitProcess(1);
+        }
+        if (args.join(" ") === "remote get-url origin") {
+          return mockGitProcess(0, "https://github.com/ComposioHQ/agent-orchestrator.git\n");
+        }
+        if (args.join(" ") === "fetch origin main") {
+          return mockGitProcess(0);
+        }
+        if (args.join(" ") === "show origin/main:packages/ao/package.json") {
+          return mockGitProcess(0, JSON.stringify({ version: "0.3.0" }));
+        }
+        return mockGitProcess(1);
+      });
+
+      await expect(fetchLatestGitBranchVersion()).resolves.toBe("0.3.0");
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "git",
+        ["fetch", "origin", "main"],
+        expect.objectContaining({ stdio: ["ignore", "pipe", "ignore"] }),
+      );
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "git",
+        ["show", "origin/main:packages/ao/package.json"],
+        expect.anything(),
+      );
+    });
+
+    it("does not read a stale ref when fetch fails", async () => {
+      mockExistsSync.mockImplementation((path: string) => path.endsWith(".git"));
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: "@aoagents/ao" }));
+      mockSpawn.mockImplementation((_cmd: string, args: string[]) => {
+        if (args.join(" ") === "remote get-url upstream") {
+          return mockGitProcess(1);
+        }
+        if (args.join(" ") === "remote get-url origin") {
+          return mockGitProcess(0, "https://github.com/ComposioHQ/agent-orchestrator.git\n");
+        }
+        if (args.join(" ") === "fetch origin main") {
+          return mockGitProcess(1);
+        }
+        throw new Error(`unexpected git command: ${args.join(" ")}`);
+      });
+
+      await expect(fetchLatestGitBranchVersion()).resolves.toBeNull();
+      expect(mockSpawn).not.toHaveBeenCalledWith(
+        "git",
+        ["show", "origin/main:packages/ao/package.json"],
+        expect.anything(),
+      );
+    });
+  });
+
   // -----------------------------------------------------------------------
   // invalidateCache
   // -----------------------------------------------------------------------
@@ -518,6 +654,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: now,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       mockExistsSync.mockReturnValue(false);
@@ -536,6 +673,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: now,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       mockExistsSync.mockReturnValue(false);
@@ -580,6 +718,7 @@ describe("update-check", () => {
       const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
       expect(written.latestVersion).toBe("0.3.0");
       expect(written.currentVersionAtCheck).toBe(getCurrentVersion());
+      expect(written.installMethod).toBeDefined();
     });
 
     it("does NOT write cache when fetch fails", async () => {
@@ -682,6 +821,7 @@ describe("update-check", () => {
           latestVersion: "99.0.0",
           checkedAt: new Date().toISOString(),
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
 
@@ -701,6 +841,7 @@ describe("update-check", () => {
           latestVersion: currentVersion,
           checkedAt: new Date().toISOString(),
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       maybeShowUpdateNotice();

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import type { Command } from "commander";
 import chalk from "chalk";
 import { runRepoScript } from "../lib/script-runner.js";
@@ -8,6 +8,7 @@ import {
   getCurrentVersion,
   getUpdateCommand,
   invalidateCache,
+  isVersionOutdated,
 } from "../lib/update-check.js";
 import { promptConfirm } from "../lib/prompts.js";
 
@@ -23,37 +24,33 @@ export function registerUpdate(program: Command): void {
     .option("--skip-smoke", "Skip smoke tests after rebuilding (git installs only)")
     .option("--smoke-only", "Run smoke tests without fetching or rebuilding (git installs only)")
     .option("--check", "Print version info as JSON without upgrading")
-    .action(
-      async (opts: { skipSmoke?: boolean; smokeOnly?: boolean; check?: boolean }) => {
-        if (opts.skipSmoke && opts.smokeOnly) {
-          console.error(
-            "`ao update` does not allow `--skip-smoke` together with `--smoke-only`.",
-          );
-          process.exit(1);
-        }
+    .action(async (opts: { skipSmoke?: boolean; smokeOnly?: boolean; check?: boolean }) => {
+      if (opts.skipSmoke && opts.smokeOnly) {
+        console.error("`ao update` does not allow `--skip-smoke` together with `--smoke-only`.");
+        process.exit(1);
+      }
 
-        // --check: print JSON and exit
-        if (opts.check) {
-          await handleCheck();
-          return;
-        }
+      // --check: print JSON and exit
+      if (opts.check) {
+        await handleCheck();
+        return;
+      }
 
-        const method = detectInstallMethod();
+      const method = detectInstallMethod();
 
-        switch (method) {
-          case "git":
-            await handleGitUpdate(opts);
-            break;
-          case "npm-global":
-          case "pnpm-global":
-            await handleNpmUpdate(opts);
-            break;
-          case "unknown":
-            await handleUnknownUpdate();
-            break;
-        }
-      },
-    );
+      switch (method) {
+        case "git":
+          await handleGitUpdate(opts);
+          break;
+        case "npm-global":
+        case "pnpm-global":
+          await handleNpmUpdate(opts);
+          break;
+        case "unknown":
+          await handleUnknownUpdate();
+          break;
+      }
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -69,10 +66,7 @@ async function handleCheck(): Promise<void> {
 // git install
 // ---------------------------------------------------------------------------
 
-async function handleGitUpdate(opts: {
-  skipSmoke?: boolean;
-  smokeOnly?: boolean;
-}): Promise<void> {
+async function handleGitUpdate(opts: { skipSmoke?: boolean; smokeOnly?: boolean }): Promise<void> {
   const args: string[] = [];
   if (opts.skipSmoke) args.push("--skip-smoke");
   if (opts.smokeOnly) args.push("--smoke-only");
@@ -84,10 +78,7 @@ async function handleGitUpdate(opts: {
     }
     invalidateCache();
   } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message.includes("Script not found: ao-update.sh")
-    ) {
+    if (error instanceof Error && error.message.includes("Script not found: ao-update.sh")) {
       console.error(
         chalk.red(
           "ao-update.sh is missing from the bundled assets. " +
@@ -107,10 +98,7 @@ async function handleGitUpdate(opts: {
 // npm-global install
 // ---------------------------------------------------------------------------
 
-async function handleNpmUpdate(opts: {
-  skipSmoke?: boolean;
-  smokeOnly?: boolean;
-}): Promise<void> {
+async function handleNpmUpdate(opts: { skipSmoke?: boolean; smokeOnly?: boolean }): Promise<void> {
   if (opts.skipSmoke || opts.smokeOnly) {
     console.log(
       chalk.yellow("--skip-smoke and --smoke-only only apply to git source installs. Ignoring."),
@@ -147,6 +135,21 @@ async function handleNpmUpdate(opts: {
 
   const exitCode = await runNpmInstall(command);
   if (exitCode === 0) {
+    const verified = verifyRunnableAoVersion(info.latestVersion);
+    if (!verified) {
+      console.error(
+        chalk.red(
+          "\nUpdate command completed, but the runnable `ao` in PATH still does not report the latest version.",
+        ),
+      );
+      console.error(
+        chalk.yellow(
+          "Check your PATH, shell hash cache, or package manager global bin directory, then rerun `ao --version`.",
+        ),
+      );
+      process.exit(1);
+    }
+
     invalidateCache();
     console.log(chalk.green("\nUpdate complete."));
   } else {
@@ -156,8 +159,12 @@ async function handleNpmUpdate(opts: {
 
 function runNpmInstall(command: string): Promise<number> {
   const [cmd, ...args] = command.split(" ");
+  if (!cmd) {
+    return Promise.resolve(1);
+  }
+
   return new Promise<number>((resolveExit, reject) => {
-    const child = spawn(cmd!, args, { stdio: "inherit" });
+    const child = spawn(cmd, args, { stdio: "inherit" });
     child.on("error", reject);
     child.on("exit", (code, signal) => {
       if (signal) {
@@ -171,6 +178,30 @@ function runNpmInstall(command: string): Promise<number> {
       resolveExit(code ?? 1);
     });
   });
+}
+
+export function parseAoVersionOutput(output: string): string | null {
+  const match = output.match(/\b(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/);
+  return match?.[1] ?? null;
+}
+
+function verifyRunnableAoVersion(expectedVersion: string): boolean {
+  const result = spawnSync("ao", ["--version"], {
+    encoding: "utf-8",
+    shell: process.platform === "win32",
+    timeout: 3000,
+  });
+
+  if (result.status !== 0 || result.error) {
+    return false;
+  }
+
+  const actualVersion = parseAoVersionOutput(`${result.stdout}\n${result.stderr}`);
+  if (!actualVersion) {
+    return false;
+  }
+
+  return actualVersion === expectedVersion || !isVersionOutdated(actualVersion, expectedVersion);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -7,6 +7,7 @@
  *   - `ao doctor` (version freshness check)
  */
 
+import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
@@ -33,6 +34,7 @@ interface CacheData {
   latestVersion: string;
   checkedAt: string;
   currentVersionAtCheck: string;
+  installMethod?: InstallMethod;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,16 +97,14 @@ export function classifyInstallPath(resolvedPath: string): InstallMethod {
     // Note: /.pnpm/ alone is NOT a global signal — pnpm creates node_modules/.pnpm/
     // for local installs too. Only pnpm/global paths indicate a global install.
     const isPnpmGlobal =
-      resolvedPath.includes("/pnpm/global/") ||
-      resolvedPath.includes("\\pnpm\\global\\");
+      resolvedPath.includes("/pnpm/global/") || resolvedPath.includes("\\pnpm\\global\\");
 
     if (isPnpmGlobal) {
       return "pnpm-global";
     }
 
     const isNpmGlobal =
-      resolvedPath.includes("/lib/node_modules/") ||
-      resolvedPath.includes("\\lib\\node_modules\\");
+      resolvedPath.includes("/lib/node_modules/") || resolvedPath.includes("\\lib\\node_modules\\");
 
     if (isNpmGlobal) {
       return "npm-global";
@@ -180,7 +180,7 @@ function getCachePath(): string {
 }
 
 /** Read cached update info. Returns null if missing, expired, corrupt, or version-mismatched. */
-export function readCachedUpdateInfo(): CacheData | null {
+export function readCachedUpdateInfo(installMethod = detectInstallMethod()): CacheData | null {
   try {
     const raw = readFileSync(getCachePath(), "utf-8");
     const data = JSON.parse(raw) as CacheData;
@@ -190,6 +190,13 @@ export function readCachedUpdateInfo(): CacheData | null {
     // Cache is stale if user upgraded since the check
     const currentVersion = getCurrentVersion();
     if (data.currentVersionAtCheck && data.currentVersionAtCheck !== currentVersion) {
+      return null;
+    }
+
+    // Cache entries are install-method specific: git/source installs compare
+    // against the update branch, while global package installs compare against
+    // the npm registry. Never reuse one method's answer for another method.
+    if (!data.installMethod || data.installMethod !== installMethod) {
       return null;
     }
 
@@ -241,6 +248,91 @@ export async function fetchLatestVersion(): Promise<string | null> {
 }
 
 // ---------------------------------------------------------------------------
+// Git branch fetch
+// ---------------------------------------------------------------------------
+
+function getSourceRepoRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../../../../");
+}
+
+function gitOutput(args: string[], cwd: string): Promise<string | null> {
+  return new Promise((resolveOutput) => {
+    const child = spawn("git", args, {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+
+    let stdout = "";
+    let settled = false;
+
+    const finish = (output: string | null): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      resolveOutput(output);
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill();
+      finish(null);
+    }, FETCH_TIMEOUT_MS);
+
+    child.stdout.setEncoding("utf-8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.on("error", () => finish(null));
+    child.on("exit", (code) => finish(code === 0 ? stdout.trim() : null));
+  });
+}
+
+async function hasGitRemote(repoRoot: string, remote: string): Promise<boolean> {
+  return (await gitOutput(["remote", "get-url", remote], repoRoot)) !== null;
+}
+
+async function resolveUpdateRemote(repoRoot: string): Promise<string> {
+  return (await hasGitRemote(repoRoot, "upstream")) ? "upstream" : "origin";
+}
+
+async function readPackageVersionFromGitRef(repoRoot: string, ref: string): Promise<string | null> {
+  const raw = await gitOutput(["show", `${ref}:packages/ao/package.json`], repoRoot);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    return typeof parsed.version === "string" ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch the version from the same git branch that `ao update` pulls.
+ *
+ * Important: only read the remote-tracking ref after a successful fetch. This
+ * avoids using stale FETCH_HEAD or stale refs when the network fetch fails.
+ */
+export async function fetchLatestGitBranchVersion(): Promise<string | null> {
+  const repoRoot = getSourceRepoRoot();
+  if (!isAgentOrchestratorRepoRoot(repoRoot)) {
+    return null;
+  }
+
+  const remote = await resolveUpdateRemote(repoRoot);
+  const branch = process.env["AO_UPDATE_BRANCH"] || "main";
+  const fetchResult = await gitOutput(["fetch", remote, branch], repoRoot);
+  if (fetchResult === null) {
+    return null;
+  }
+
+  return readPackageVersionFromGitRef(repoRoot, `${remote}/${branch}`);
+}
+
+// ---------------------------------------------------------------------------
 // Orchestrator
 // ---------------------------------------------------------------------------
 
@@ -252,7 +344,7 @@ export async function checkForUpdate(opts?: { force?: boolean }): Promise<Update
 
   // Try cache first (unless forced)
   if (!opts?.force) {
-    const cached = readCachedUpdateInfo();
+    const cached = readCachedUpdateInfo(installMethod);
     if (cached) {
       return {
         currentVersion,
@@ -265,8 +357,9 @@ export async function checkForUpdate(opts?: { force?: boolean }): Promise<Update
     }
   }
 
-  // Fetch from registry
-  const latestVersion = await fetchLatestVersion();
+  // Fetch from the source that matches the install/update method.
+  const latestVersion =
+    installMethod === "git" ? await fetchLatestGitBranchVersion() : await fetchLatestVersion();
   const now = new Date().toISOString();
 
   if (latestVersion) {
@@ -274,6 +367,7 @@ export async function checkForUpdate(opts?: { force?: boolean }): Promise<Update
       latestVersion,
       checkedAt: now,
       currentVersionAtCheck: currentVersion,
+      installMethod,
     });
   }
 


### PR DESCRIPTION
## Summary
- Compare source/git installs against the git branch that `ao update` fetches instead of npm latest
- Store install method with update-check cache entries and ignore legacy/cross-method cache data
- Verify the runnable `ao` in PATH reports the updated version after npm/pnpm global updates, including prefixed version output

Closes #1540

## Testing
- `env -u NODE_ENV pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @aoagents/ao-cli test -- __tests__/lib/update-check.test.ts __tests__/commands/update.test.ts`

Note: `pnpm test` currently fails outside this change: with `NODE_ENV=development`, cli start stop tests exit at `src/commands/start.ts:2535`; with `NODE_ENV` unset after build, core plugin integration cannot import `/dist/atomic-write.js` from built dist.
