### PR TITLE
Add YouTrack support

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "@aoagents/ao-plugin-terminal-web": "workspace:*",
     "@aoagents/ao-plugin-tracker-github": "workspace:*",
     "@aoagents/ao-plugin-tracker-linear": "workspace:*",
+    "@aoagents/ao-plugin-tracker-youtrack": "workspace:*",
     "@aoagents/ao-plugin-workspace-clone": "workspace:*",
     "@aoagents/ao-plugin-workspace-worktree": "workspace:*",
     "@aoagents/ao-web": "workspace:*",

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -52,6 +52,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "tracker", name: "github", pkg: "@aoagents/ao-plugin-tracker-github" },
   { slot: "tracker", name: "linear", pkg: "@aoagents/ao-plugin-tracker-linear" },
   { slot: "tracker", name: "gitlab", pkg: "@aoagents/ao-plugin-tracker-gitlab" },
+  { slot: "tracker", name: "youtrack", pkg: "@aoagents/ao-plugin-tracker-youtrack" },
   // SCM
   { slot: "scm", name: "github", pkg: "@aoagents/ao-plugin-scm-github" },
   { slot: "scm", name: "gitlab", pkg: "@aoagents/ao-plugin-scm-gitlab" },

--- a/packages/plugins/tracker-youtrack/package.json
+++ b/packages/plugins/tracker-youtrack/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@aoagents/ao-plugin-tracker-youtrack",
+  "version": "0.1.0",
+  "description": "Tracker plugin: JetBrains YouTrack",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/tracker-youtrack"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/tracker-youtrack/src/index.test.ts
+++ b/packages/plugins/tracker-youtrack/src/index.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }));
+
+import pluginDefault, { create, manifest } from "./index.js";
+import type { ProjectConfig } from "@aoagents/ao-core";
+
+const project: ProjectConfig = {
+  name: "test",
+  repo: "acme/app",
+  path: "/tmp/repo",
+  defaultBranch: "main",
+  sessionPrefix: "test",
+  tracker: { plugin: "youtrack", projectId: "PROJ" },
+};
+
+const sampleIssue = {
+  id: "2-123",
+  idReadable: "PROJ-123",
+  summary: "Fix login bug",
+  description: "Users cannot log in with SSO.",
+  resolved: null,
+  tags: [{ id: "9-1", name: "agent:backlog" }],
+  customFields: [
+    {
+      name: "State",
+      $type: "StateIssueCustomField",
+      value: { name: "In Progress", $type: "StateBundleElement" },
+    },
+    {
+      name: "Priority",
+      $type: "SingleEnumIssueCustomField",
+      value: { name: "Major", $type: "EnumBundleElement" },
+    },
+    {
+      name: "Assignee",
+      $type: "SingleUserIssueCustomField",
+      value: { name: "Alice Smith", login: "alice", $type: "User" },
+    },
+    {
+      name: "Type",
+      $type: "SingleEnumIssueCustomField",
+      value: { name: "Bug", $type: "EnumBundleElement" },
+    },
+  ],
+};
+
+function mockFetchOk(data: unknown) {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+function mockFetchError(status: number, body = "Error") {
+  fetchMock.mockResolvedValueOnce({
+    ok: false,
+    status,
+    text: () => Promise.resolve(body),
+  });
+}
+
+describe("tracker-youtrack plugin", () => {
+  let tracker: ReturnType<typeof create>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("YOUTRACK_HOST", "https://mycompany.youtrack.cloud");
+    vi.stubEnv("YOUTRACK_TOKEN", "test-token");
+    tracker = create();
+  });
+
+  describe("manifest", () => {
+    it("has correct metadata", () => {
+      expect(manifest.name).toBe("youtrack");
+      expect(manifest.slot).toBe("tracker");
+      expect(manifest.version).toBe("0.1.0");
+    });
+  });
+
+  describe("default export", () => {
+    it("is a valid PluginModule", () => {
+      expect(pluginDefault.manifest.name).toBe("youtrack");
+      expect(typeof pluginDefault.create).toBe("function");
+    });
+  });
+
+  describe("create()", () => {
+    it("returns a Tracker with correct name", () => {
+      expect(tracker.name).toBe("youtrack");
+    });
+  });
+
+  describe("getIssue", () => {
+    it("returns Issue with correct fields", async () => {
+      mockFetchOk(sampleIssue);
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.id).toBe("PROJ-123");
+      expect(issue.title).toBe("Fix login bug");
+      expect(issue.description).toBe("Users cannot log in with SSO.");
+      expect(issue.state).toBe("in_progress");
+      expect(issue.labels).toEqual(["agent:backlog"]);
+      expect(issue.assignee).toBe("alice");
+      expect(issue.priority).toBe(2); // Major
+    });
+
+    it("maps resolved issue to closed", async () => {
+      mockFetchOk({ ...sampleIssue, resolved: 1700000000000 });
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.state).toBe("closed");
+    });
+
+    it("maps Done state to closed", async () => {
+      mockFetchOk({
+        ...sampleIssue,
+        customFields: [
+          {
+            name: "State",
+            $type: "StateIssueCustomField",
+            value: { name: "Done", $type: "StateBundleElement" },
+          },
+        ],
+      });
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.state).toBe("closed");
+    });
+
+    it("maps unresolved issue with no state to open", async () => {
+      mockFetchOk({
+        ...sampleIssue,
+        customFields: [],
+      });
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.state).toBe("open");
+    });
+
+    it("maps Critical priority to 1", async () => {
+      mockFetchOk({
+        ...sampleIssue,
+        customFields: [
+          ...sampleIssue.customFields.filter((f) => f.name !== "Priority"),
+          {
+            name: "Priority",
+            $type: "SingleEnumIssueCustomField",
+            value: { name: "Critical", $type: "EnumBundleElement" },
+          },
+        ],
+      });
+      const issue = await tracker.getIssue("PROJ-123", project);
+      expect(issue.priority).toBe(1);
+    });
+
+    it("throws on API error", async () => {
+      mockFetchError(404, "Not found");
+      await expect(tracker.getIssue("PROJ-999", project)).rejects.toThrow("404");
+    });
+  });
+
+  describe("isCompleted", () => {
+    it("returns true when resolved is not null", async () => {
+      mockFetchOk({ id: "2-123", resolved: 1700000000000, customFields: [] });
+      expect(await tracker.isCompleted("PROJ-123", project)).toBe(true);
+    });
+
+    it("returns false when resolved is null", async () => {
+      mockFetchOk({ id: "2-123", resolved: null, customFields: [] });
+      expect(await tracker.isCompleted("PROJ-123", project)).toBe(false);
+    });
+  });
+
+  describe("issueUrl", () => {
+    it("generates correct URL", () => {
+      expect(tracker.issueUrl("PROJ-123", project)).toBe(
+        "https://mycompany.youtrack.cloud/issue/PROJ-123",
+      );
+    });
+  });
+
+  describe("issueLabel", () => {
+    it("extracts issue ID from YouTrack URL", () => {
+      expect(
+        tracker.issueLabel(
+          "https://mycompany.youtrack.cloud/issue/PROJ-123",
+          project,
+        ),
+      ).toBe("PROJ-123");
+    });
+
+    it("returns full URL when pattern does not match", () => {
+      const url = "https://example.com/something";
+      expect(tracker.issueLabel(url, project)).toBe(url);
+    });
+  });
+
+  describe("branchName", () => {
+    it("generates correct branch name", () => {
+      expect(tracker.branchName("PROJ-123", project)).toBe("feat/PROJ-123");
+    });
+  });
+
+  describe("generatePrompt", () => {
+    it("includes title, description, tags, and priority", async () => {
+      mockFetchOk(sampleIssue);
+      const prompt = await tracker.generatePrompt("PROJ-123", project);
+      expect(prompt).toContain("Fix login bug");
+      expect(prompt).toContain("Users cannot log in with SSO.");
+      expect(prompt).toContain("Tags: agent:backlog");
+      expect(prompt).toContain("Major");
+    });
+  });
+
+  describe("listIssues", () => {
+    it("returns mapped issues", async () => {
+      mockFetchOk([sampleIssue]);
+      const issues = await tracker.listIssues!({}, project);
+      expect(issues).toHaveLength(1);
+      expect(issues[0].id).toBe("PROJ-123");
+    });
+
+    it("filters by closed state", async () => {
+      mockFetchOk([]);
+      await tracker.listIssues!({ state: "closed" }, project);
+      const url = fetchMock.mock.calls[0][0];
+      expect(url).toContain("Resolved");
+    });
+
+    it("filters by open state", async () => {
+      mockFetchOk([]);
+      await tracker.listIssues!({ state: "open" }, project);
+      const url = fetchMock.mock.calls[0][0];
+      expect(url).toContain("-Resolved");
+    });
+
+    it("filters by labels via tag query syntax", async () => {
+      mockFetchOk([]);
+      await tracker.listIssues!(
+        { state: "open", labels: ["agent:backlog"] },
+        project,
+      );
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(decodeURIComponent(url)).toContain("tag: {agent:backlog}");
+    });
+
+    it("returns empty labels when issue has no tags", async () => {
+      mockFetchOk([{ ...sampleIssue, tags: [] }]);
+      const issues = await tracker.listIssues!({}, project);
+      expect(issues[0].labels).toEqual([]);
+    });
+  });
+
+  describe("updateIssue", () => {
+    it("updates state to closed via command API", async () => {
+      mockFetchOk({}); // execute command
+      await tracker.updateIssue!("PROJ-123", { state: "closed" }, project);
+      const url = fetchMock.mock.calls[0][0];
+      expect(url).toContain("/api/commands");
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.query).toBe("State Resolved");
+      expect(body.issues).toEqual([{ idReadable: "PROJ-123" }]);
+    });
+
+    it("updates state to in_progress via command API", async () => {
+      mockFetchOk({}); // execute command
+      await tracker.updateIssue!("PROJ-123", { state: "in_progress" }, project);
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.query).toBe("State In Progress");
+    });
+
+    it("adds a comment", async () => {
+      mockFetchOk({}); // POST comment
+      await tracker.updateIssue!("PROJ-123", { comment: "Working on it" }, project);
+      const url = fetchMock.mock.calls[0][0];
+      expect(url).toContain("/comments");
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.text).toBe("Working on it");
+    });
+
+    it("adds tags via unquoted tag commands", async () => {
+      mockFetchOk({});
+      await tracker.updateIssue!(
+        "PROJ-123",
+        { labels: ["agent:in-progress"] },
+        project,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.query).toBe("tag agent:in-progress");
+    });
+
+    it("removes tags via remove-tag commands", async () => {
+      mockFetchOk({});
+      await tracker.updateIssue!(
+        "PROJ-123",
+        { removeLabels: ["agent:backlog"] },
+        project,
+      );
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.query).toBe("remove tag agent:backlog");
+    });
+
+    it("supports adding and removing tags in a single update", async () => {
+      mockFetchOk({}); // tag add
+      mockFetchOk({}); // tag remove
+      await tracker.updateIssue!(
+        "PROJ-123",
+        {
+          labels: ["agent:in-progress"],
+          removeLabels: ["agent:backlog"],
+        },
+        project,
+      );
+      const body1 = JSON.parse(fetchMock.mock.calls[0][1].body);
+      const body2 = JSON.parse(fetchMock.mock.calls[1][1].body);
+      expect(body1.query).toBe("tag agent:in-progress");
+      expect(body2.query).toBe("remove tag agent:backlog");
+    });
+  });
+
+  describe("createIssue", () => {
+    it("creates an issue", async () => {
+      // First: resolve project
+      mockFetchOk([{ id: "proj-internal", shortName: "PROJ", name: "Project" }]);
+      // Second: create issue
+      mockFetchOk(sampleIssue);
+      const issue = await tracker.createIssue!(
+        { title: "New bug", description: "Desc" },
+        project,
+      );
+      expect(issue.id).toBe("PROJ-123");
+    });
+
+    it("throws when projectId is not in config", async () => {
+      const badProject = {
+        ...project,
+        tracker: { plugin: "youtrack" },
+      } as ProjectConfig;
+      await expect(
+        tracker.createIssue!({ title: "New" }, badProject),
+      ).rejects.toThrow("projectId");
+    });
+
+    it("throws when project is not found in YouTrack", async () => {
+      mockFetchOk([]); // no projects found
+      await expect(
+        tracker.createIssue!({ title: "New" }, project),
+      ).rejects.toThrow("not found");
+    });
+
+    it("applies labels as separate tag commands after creation", async () => {
+      mockFetchOk([{ id: "proj-internal", shortName: "PROJ", name: "Project" }]);
+      mockFetchOk(sampleIssue);
+      mockFetchOk({}); // tag command
+      await tracker.createIssue!(
+        { title: "New", description: "", labels: ["agent:backlog"] },
+        project,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      const body = JSON.parse(fetchMock.mock.calls[2][1].body);
+      expect(body.query).toBe("tag agent:backlog");
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws when YOUTRACK_TOKEN is missing", async () => {
+      vi.stubEnv("YOUTRACK_TOKEN", "");
+      await expect(tracker.getIssue("PROJ-123", project)).rejects.toThrow(
+        "YOUTRACK_TOKEN",
+      );
+    });
+
+    it("throws when YOUTRACK_HOST is missing", async () => {
+      vi.stubEnv("YOUTRACK_HOST", "");
+      const noHostProject = {
+        ...project,
+        tracker: { plugin: "youtrack", projectId: "PROJ" },
+      } as ProjectConfig;
+      await expect(tracker.getIssue("PROJ-123", noHostProject)).rejects.toThrow(
+        "YOUTRACK_HOST",
+      );
+    });
+  });
+});

--- a/packages/plugins/tracker-youtrack/src/index.test.ts
+++ b/packages/plugins/tracker-youtrack/src/index.test.ts
@@ -92,6 +92,25 @@ describe("tracker-youtrack plugin", () => {
     it("returns a Tracker with correct name", () => {
       expect(tracker.name).toBe("youtrack");
     });
+
+    it("captures plugin config for host and token", async () => {
+      vi.stubEnv("YOUTRACK_HOST", "");
+      vi.stubEnv("YOUTRACK_TOKEN", "");
+      const configuredTracker = create({
+        host: "https://configured.youtrack.cloud/",
+        token: "configured-token",
+      });
+
+      mockFetchOk(sampleIssue);
+      await configuredTracker.getIssue("PROJ-123", project);
+
+      expect(fetchMock.mock.calls[0][0]).toContain(
+        "https://configured.youtrack.cloud/api/issues/PROJ-123",
+      );
+      expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe(
+        "Bearer configured-token",
+      );
+    });
   });
 
   describe("getIssue", () => {
@@ -224,14 +243,14 @@ describe("tracker-youtrack plugin", () => {
       mockFetchOk([]);
       await tracker.listIssues!({ state: "closed" }, project);
       const url = fetchMock.mock.calls[0][0];
-      expect(url).toContain("Resolved");
+      expect(decodeURIComponent(url)).toContain("#Resolved");
     });
 
     it("filters by open state", async () => {
       mockFetchOk([]);
       await tracker.listIssues!({ state: "open" }, project);
       const url = fetchMock.mock.calls[0][0];
-      expect(url).toContain("-Resolved");
+      expect(decodeURIComponent(url)).toContain("#Unresolved");
     });
 
     it("filters by labels via tag query syntax", async () => {
@@ -366,18 +385,20 @@ describe("tracker-youtrack plugin", () => {
   describe("error handling", () => {
     it("throws when YOUTRACK_TOKEN is missing", async () => {
       vi.stubEnv("YOUTRACK_TOKEN", "");
-      await expect(tracker.getIssue("PROJ-123", project)).rejects.toThrow(
+      const trackerWithoutToken = create();
+      await expect(trackerWithoutToken.getIssue("PROJ-123", project)).rejects.toThrow(
         "YOUTRACK_TOKEN",
       );
     });
 
     it("throws when YOUTRACK_HOST is missing", async () => {
       vi.stubEnv("YOUTRACK_HOST", "");
+      const trackerWithoutHost = create();
       const noHostProject = {
         ...project,
         tracker: { plugin: "youtrack", projectId: "PROJ" },
       } as ProjectConfig;
-      await expect(tracker.getIssue("PROJ-123", noHostProject)).rejects.toThrow(
+      await expect(trackerWithoutHost.getIssue("PROJ-123", noHostProject)).rejects.toThrow(
         "YOUTRACK_HOST",
       );
     });

--- a/packages/plugins/tracker-youtrack/src/index.ts
+++ b/packages/plugins/tracker-youtrack/src/index.ts
@@ -1,0 +1,504 @@
+/**
+ * tracker-youtrack plugin — JetBrains YouTrack as an issue tracker.
+ *
+ * Uses the YouTrack REST API via fetch().
+ * Auth: YOUTRACK_TOKEN env var (Bearer token).
+ * Requires YOUTRACK_HOST env var (e.g. https://mycompany.youtrack.cloud).
+ */
+
+import type {
+  PluginModule,
+  Tracker,
+  Issue,
+  IssueFilters,
+  IssueUpdate,
+  CreateIssueInput,
+  ProjectConfig,
+} from "@aoagents/ao-core";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Auth helpers
+// ---------------------------------------------------------------------------
+
+function getHost(project: ProjectConfig): string {
+  const fromConfig = project.tracker?.["host"] as string | undefined;
+  const fromEnv = process.env["YOUTRACK_HOST"];
+  const host = fromConfig ?? fromEnv;
+  if (!host) {
+    throw new Error(
+      "YouTrack host is required: set YOUTRACK_HOST env var or tracker.host in project config",
+    );
+  }
+  // Strip trailing slash
+  return host.replace(/\/+$/, "");
+}
+
+function getToken(): string {
+  const token = process.env["YOUTRACK_TOKEN"];
+  if (!token) {
+    throw new Error(
+      "YOUTRACK_TOKEN environment variable is required for the YouTrack tracker plugin",
+    );
+  }
+  return token;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch helper
+// ---------------------------------------------------------------------------
+
+async function youtrackFetch<T>(
+  host: string,
+  path: string,
+  options: { method?: string; body?: Record<string, unknown> } = {},
+): Promise<T> {
+  const url = `${host}/api${path}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const fetchOptions: RequestInit = {
+      method: options.method ?? "GET",
+      signal: controller.signal,
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${getToken()}`,
+      },
+    };
+
+    if (options.body) {
+      fetchOptions.headers = {
+        ...fetchOptions.headers,
+        "Content-Type": "application/json",
+      };
+      fetchOptions.body = JSON.stringify(options.body);
+    }
+
+    const response = await fetch(url, fetchOptions);
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `YouTrack API returned HTTP ${response.status}: ${text.slice(0, 200)}`,
+      );
+    }
+
+    const data: unknown = await response.json();
+    return data as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Run a YouTrack command against a single issue.
+ *
+ */
+async function executeCommand(
+  host: string,
+  identifier: string,
+  query: string,
+): Promise<void> {
+  await youtrackFetch(host, `/commands`, {
+    method: "POST",
+    body: { query, issues: [{ idReadable: identifier }] },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// YouTrack API types
+// ---------------------------------------------------------------------------
+
+interface YouTrackIssue {
+  id: string;
+  idReadable: string;
+  summary: string;
+  description: string | null;
+  resolved: number | null;
+  tags?: Array<{ id: string; name: string }>;
+  customFields: YouTrackCustomField[];
+}
+
+interface YouTrackCustomField {
+  name: string;
+  $type: string;
+  value: YouTrackFieldValue | YouTrackFieldValue[] | null;
+}
+
+interface YouTrackFieldValue {
+  name?: string;
+  login?: string;
+  $type?: string;
+  [key: string]: unknown;
+}
+
+interface YouTrackProject {
+  id: string;
+  shortName: string;
+  name: string;
+}
+
+// ---------------------------------------------------------------------------
+// State mapping
+// ---------------------------------------------------------------------------
+
+/** Extract a custom field value by name from an issue */
+function getCustomFieldValue(
+  issue: YouTrackIssue,
+  fieldName: string,
+): YouTrackFieldValue | null {
+  const field = issue.customFields.find((f) => f.name === fieldName);
+  if (!field || !field.value) return null;
+  if (Array.isArray(field.value)) return field.value[0] ?? null;
+  return field.value;
+}
+
+function mapYouTrackState(issue: YouTrackIssue): Issue["state"] {
+  if (issue.resolved !== null) return "closed";
+  const stateValue = getCustomFieldValue(issue, "State");
+  if (!stateValue?.name) return "open";
+
+  const name = stateValue.name.toLowerCase();
+  if (
+    name.includes("done") ||
+    name.includes("fixed") ||
+    name.includes("closed") ||
+    name.includes("complete") ||
+    name.includes("verified") ||
+    name.includes("resolved")
+  ) {
+    return "closed";
+  }
+  if (
+    name.includes("in progress") ||
+    name.includes("open") ||
+    name.includes("in review") ||
+    name.includes("testing")
+  ) {
+    return "in_progress";
+  }
+  return "open";
+}
+
+function mapYouTrackPriority(issue: YouTrackIssue): number | undefined {
+  const priorityValue = getCustomFieldValue(issue, "Priority");
+  if (!priorityValue?.name) return undefined;
+
+  const name = priorityValue.name.toLowerCase();
+  if (name.includes("critical") || name.includes("show-stopper")) return 1;
+  if (name.includes("major") || name.includes("high")) return 2;
+  if (name.includes("normal") || name.includes("medium")) return 3;
+  if (name.includes("minor") || name.includes("low")) return 4;
+  return undefined;
+}
+
+function getAssignee(issue: YouTrackIssue): string | undefined {
+  const assigneeValue = getCustomFieldValue(issue, "Assignee");
+  return assigneeValue?.login ?? assigneeValue?.name ?? undefined;
+}
+
+function getLabels(issue: YouTrackIssue): string[] {
+  return (issue.tags ?? [])
+    .map((t) => t.name)
+    .filter((name): name is string => typeof name === "string" && name.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Issue fields query param
+// ---------------------------------------------------------------------------
+
+const ISSUE_FIELDS =
+  "id,idReadable,summary,description,resolved,tags(id,name),customFields(name,$type,value(name,login,$type))";
+
+// ---------------------------------------------------------------------------
+// Tracker implementation
+// ---------------------------------------------------------------------------
+
+function createYouTrackTracker(): Tracker {
+  return {
+    name: "youtrack",
+
+    async getIssue(identifier: string, project: ProjectConfig): Promise<Issue> {
+      const host = getHost(project);
+      const issue = await youtrackFetch<YouTrackIssue>(
+        host,
+        `/issues/${identifier}?fields=${ISSUE_FIELDS}`,
+      );
+
+      return {
+        id: issue.idReadable,
+        title: issue.summary,
+        description: issue.description ?? "",
+        url: `${host}/issue/${issue.idReadable}`,
+        state: mapYouTrackState(issue),
+        labels: getLabels(issue),
+        assignee: getAssignee(issue),
+        priority: mapYouTrackPriority(issue),
+      };
+    },
+
+    async isCompleted(identifier: string, project: ProjectConfig): Promise<boolean> {
+      const host = getHost(project);
+      const issue = await youtrackFetch<YouTrackIssue>(
+        host,
+        `/issues/${identifier}?fields=id,resolved,customFields(name,$type,value(name,$type))`,
+      );
+      return issue.resolved !== null;
+    },
+
+    issueUrl(identifier: string, project: ProjectConfig): string {
+      const host = getHost(project);
+      return `${host}/issue/${identifier}`;
+    },
+
+    issueLabel(url: string, _project: ProjectConfig): string {
+      // Extract issue ID from YouTrack URL
+      // Example: https://mycompany.youtrack.cloud/issue/PROJ-123 -> PROJ-123
+      const match = url.match(/\/issue\/([A-Za-z]+-\d+)/);
+      return match ? match[1] : url;
+    },
+
+    branchName(identifier: string, _project: ProjectConfig): string {
+      return `feat/${identifier}`;
+    },
+
+    async generatePrompt(identifier: string, project: ProjectConfig): Promise<string> {
+      const issue = await this.getIssue(identifier, project);
+      const lines = [
+        `You are working on YouTrack issue ${issue.id}: ${issue.title}`,
+        `Issue URL: ${issue.url}`,
+        "",
+      ];
+
+      if (issue.labels.length > 0) {
+        lines.push(`Tags: ${issue.labels.join(", ")}`);
+      }
+
+      if (issue.priority !== undefined) {
+        const priorityNames: Record<number, string> = {
+          1: "Critical",
+          2: "Major",
+          3: "Normal",
+          4: "Minor",
+        };
+        lines.push(`Priority: ${priorityNames[issue.priority] ?? String(issue.priority)}`);
+      }
+
+      if (issue.description) {
+        lines.push("## Description", "", issue.description);
+      }
+
+      lines.push(
+        "",
+        "Please implement the changes described in this issue. When done, commit and push your changes.",
+      );
+
+      return lines.join("\n");
+    },
+
+    async listIssues(filters: IssueFilters, project: ProjectConfig): Promise<Issue[]> {
+      const host = getHost(project);
+      const projectShortName = project.tracker?.["projectId"] as string | undefined;
+
+      // Build YouTrack query string
+      const queryParts: string[] = [];
+
+      if (projectShortName) {
+        queryParts.push(`project: {${projectShortName}}`);
+      }
+
+      if (filters.state === "closed") {
+        queryParts.push("State: {Resolved}");
+      } else if (filters.state === "open") {
+        queryParts.push("State: -Resolved");
+      }
+      // "all" = no state filter
+
+      if (filters.assignee) {
+        queryParts.push(`Assignee: {${filters.assignee}}`);
+      }
+
+      if (filters.labels && filters.labels.length > 0) {
+        for (const label of filters.labels) {
+          queryParts.push(`tag: {${label}}`);
+        }
+      }
+
+      const query = queryParts.join(" ");
+      const limit = filters.limit ?? 30;
+
+      const url = `/issues?fields=${ISSUE_FIELDS}&$top=${limit}&query=${encodeURIComponent(query)}`;
+      const issues = await youtrackFetch<YouTrackIssue[]>(host, url);
+
+      return issues.map((issue) => ({
+        id: issue.idReadable,
+        title: issue.summary,
+        description: issue.description ?? "",
+        url: `${host}/issue/${issue.idReadable}`,
+        state: mapYouTrackState(issue),
+        labels: getLabels(issue),
+        assignee: getAssignee(issue),
+        priority: mapYouTrackPriority(issue),
+      }));
+    },
+
+    async updateIssue(
+      identifier: string,
+      update: IssueUpdate,
+      project: ProjectConfig,
+    ): Promise<void> {
+      const host = getHost(project);
+
+      // Handle state change using command API
+      if (update.state) {
+        let command: string;
+        if (update.state === "closed") {
+          command = "State Resolved";
+        } else if (update.state === "in_progress") {
+          command = "State In Progress";
+        } else {
+          command = "State Open";
+        }
+
+        await executeCommand(host, identifier, command);
+      }
+
+      // Handle assignee
+      if (update.assignee) {
+        await executeCommand(host, identifier, `Assignee ${update.assignee}`);
+      }
+
+      // Handle labels — map to YouTrack tags via the command API.
+      // Tag names must NOT be wrapped in quotes: the /api/commands parser
+      // treats double quotes as literal characters in the tag name and would
+      // create a brand-new tag like `"agent:backlog"` instead of resolving the
+      // existing one. Each tag is a separate command call so that one failing
+      // command does not abort the rest.
+      if (update.labels && update.labels.length > 0) {
+        for (const label of update.labels) {
+          await executeCommand(host, identifier, `tag ${label}`);
+        }
+      }
+
+      if (update.removeLabels && update.removeLabels.length > 0) {
+        for (const label of update.removeLabels) {
+          await executeCommand(host, identifier, `remove tag ${label}`);
+        }
+      }
+
+      // Handle comment
+      if (update.comment) {
+        await youtrackFetch(host, `/issues/${identifier}/comments`, {
+          method: "POST",
+          body: { text: update.comment },
+        });
+      }
+    },
+
+    async createIssue(input: CreateIssueInput, project: ProjectConfig): Promise<Issue> {
+      const host = getHost(project);
+      const projectId = project.tracker?.["projectId"] as string | undefined;
+      if (!projectId) {
+        throw new Error(
+          "YouTrack tracker requires 'projectId' in project tracker config",
+        );
+      }
+
+      // Resolve project internal ID
+      const projects = await youtrackFetch<YouTrackProject[]>(
+        host,
+        `/admin/projects?fields=id,shortName,name&query=${encodeURIComponent(projectId)}`,
+      );
+      const targetProject = projects.find((p) => p.shortName === projectId);
+      if (!targetProject) {
+        throw new Error(`YouTrack project "${projectId}" not found`);
+      }
+
+      const body: Record<string, unknown> = {
+        summary: input.title,
+        description: input.description ?? "",
+        project: { id: targetProject.id },
+      };
+
+      const created = await youtrackFetch<YouTrackIssue>(host, `/issues?fields=${ISSUE_FIELDS}`, {
+        method: "POST",
+        body,
+      });
+
+      // Apply assignee and priority via a single chained command (single-token values
+      // chain safely with spaces).
+      const commands: string[] = [];
+      if (input.assignee) {
+        commands.push(`Assignee ${input.assignee}`);
+      }
+      if (input.priority !== undefined) {
+        const priorityNames: Record<number, string> = {
+          1: "Critical",
+          2: "Major",
+          3: "Normal",
+          4: "Minor",
+        };
+        const priorityName = priorityNames[input.priority];
+        if (priorityName) {
+          commands.push(`Priority ${priorityName}`);
+        }
+      }
+
+      if (commands.length > 0) {
+        try {
+          await executeCommand(host, created.idReadable, commands.join(" "));
+        } catch {
+          // Commands are best-effort; creation already succeeded
+        }
+      }
+
+      // Tags must be applied as separate command calls — chaining multiple
+      // `tag` commands in one query confuses the parser. Names go unquoted
+      // (see updateIssue() comment for why).
+      if (input.labels && input.labels.length > 0) {
+        for (const label of input.labels) {
+          try {
+            await executeCommand(host, created.idReadable, `tag ${label}`);
+          } catch {
+            // Best-effort
+          }
+        }
+      }
+
+      return {
+        id: created.idReadable,
+        title: created.summary,
+        description: created.description ?? "",
+        url: `${host}/issue/${created.idReadable}`,
+        state: mapYouTrackState(created),
+        labels: getLabels(created),
+        assignee: input.assignee,
+        priority: input.priority,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin module export
+// ---------------------------------------------------------------------------
+
+export const manifest = {
+  name: "youtrack",
+  slot: "tracker" as const,
+  description: "Tracker plugin: JetBrains YouTrack",
+  version: "0.1.0",
+};
+
+export function create(): Tracker {
+  return createYouTrackTracker();
+}
+
+export default { manifest, create } satisfies PluginModule<Tracker>;

--- a/packages/plugins/tracker-youtrack/src/index.ts
+++ b/packages/plugins/tracker-youtrack/src/index.ts
@@ -23,24 +23,32 @@ import type {
 const REQUEST_TIMEOUT_MS = 30_000;
 
 // ---------------------------------------------------------------------------
-// Auth helpers
+// Config helpers
 // ---------------------------------------------------------------------------
 
-function getHost(project: ProjectConfig): string {
-  const fromConfig = project.tracker?.["host"] as string | undefined;
-  const fromEnv = process.env["YOUTRACK_HOST"];
-  const host = fromConfig ?? fromEnv;
+function configString(
+  config: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = config?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function normalizeHost(host: string | undefined): string | undefined {
+  return host?.replace(/\/+$/, "");
+}
+
+function resolveHost(project: ProjectConfig, defaultHost: string | undefined): string {
+  const host = normalizeHost((project.tracker?.["host"] as string | undefined) ?? defaultHost);
   if (!host) {
     throw new Error(
       "YouTrack host is required: set YOUTRACK_HOST env var or tracker.host in project config",
     );
   }
-  // Strip trailing slash
-  return host.replace(/\/+$/, "");
+  return host;
 }
 
-function getToken(): string {
-  const token = process.env["YOUTRACK_TOKEN"];
+function requireToken(token: string | undefined): string {
   if (!token) {
     throw new Error(
       "YOUTRACK_TOKEN environment variable is required for the YouTrack tracker plugin",
@@ -55,6 +63,7 @@ function getToken(): string {
 
 async function youtrackFetch<T>(
   host: string,
+  token: string,
   path: string,
   options: { method?: string; body?: Record<string, unknown> } = {},
 ): Promise<T> {
@@ -69,7 +78,7 @@ async function youtrackFetch<T>(
       signal: controller.signal,
       headers: {
         Accept: "application/json",
-        Authorization: `Bearer ${getToken()}`,
+        Authorization: `Bearer ${token}`,
       },
     };
 
@@ -103,10 +112,11 @@ async function youtrackFetch<T>(
  */
 async function executeCommand(
   host: string,
+  token: string,
   identifier: string,
   query: string,
 ): Promise<void> {
-  await youtrackFetch(host, `/commands`, {
+  await youtrackFetch(host, token, `/commands`, {
     method: "POST",
     body: { query, issues: [{ idReadable: identifier }] },
   });
@@ -221,14 +231,18 @@ const ISSUE_FIELDS =
 // Tracker implementation
 // ---------------------------------------------------------------------------
 
-function createYouTrackTracker(): Tracker {
+function createYouTrackTracker(config?: Record<string, unknown>): Tracker {
+  const defaultHost = normalizeHost(configString(config, "host") ?? process.env["YOUTRACK_HOST"]);
+  const token = configString(config, "token") ?? process.env["YOUTRACK_TOKEN"];
+
   return {
     name: "youtrack",
 
     async getIssue(identifier: string, project: ProjectConfig): Promise<Issue> {
-      const host = getHost(project);
+      const host = resolveHost(project, defaultHost);
       const issue = await youtrackFetch<YouTrackIssue>(
         host,
+        requireToken(token),
         `/issues/${identifier}?fields=${ISSUE_FIELDS}`,
       );
 
@@ -245,16 +259,17 @@ function createYouTrackTracker(): Tracker {
     },
 
     async isCompleted(identifier: string, project: ProjectConfig): Promise<boolean> {
-      const host = getHost(project);
+      const host = resolveHost(project, defaultHost);
       const issue = await youtrackFetch<YouTrackIssue>(
         host,
+        requireToken(token),
         `/issues/${identifier}?fields=id,resolved,customFields(name,$type,value(name,$type))`,
       );
       return issue.resolved !== null;
     },
 
     issueUrl(identifier: string, project: ProjectConfig): string {
-      const host = getHost(project);
+      const host = resolveHost(project, defaultHost);
       return `${host}/issue/${identifier}`;
     },
 
@@ -304,7 +319,7 @@ function createYouTrackTracker(): Tracker {
     },
 
     async listIssues(filters: IssueFilters, project: ProjectConfig): Promise<Issue[]> {
-      const host = getHost(project);
+      const host = resolveHost(project, defaultHost);
       const projectShortName = project.tracker?.["projectId"] as string | undefined;
 
       // Build YouTrack query string
@@ -315,9 +330,9 @@ function createYouTrackTracker(): Tracker {
       }
 
       if (filters.state === "closed") {
-        queryParts.push("State: {Resolved}");
+        queryParts.push("#Resolved");
       } else if (filters.state === "open") {
-        queryParts.push("State: -Resolved");
+        queryParts.push("#Unresolved");
       }
       // "all" = no state filter
 
@@ -335,7 +350,7 @@ function createYouTrackTracker(): Tracker {
       const limit = filters.limit ?? 30;
 
       const url = `/issues?fields=${ISSUE_FIELDS}&$top=${limit}&query=${encodeURIComponent(query)}`;
-      const issues = await youtrackFetch<YouTrackIssue[]>(host, url);
+      const issues = await youtrackFetch<YouTrackIssue[]>(host, requireToken(token), url);
 
       return issues.map((issue) => ({
         id: issue.idReadable,
@@ -354,7 +369,8 @@ function createYouTrackTracker(): Tracker {
       update: IssueUpdate,
       project: ProjectConfig,
     ): Promise<void> {
-      const host = getHost(project);
+      const host = resolveHost(project, defaultHost);
+      const authToken = requireToken(token);
 
       // Handle state change using command API
       if (update.state) {
@@ -367,12 +383,12 @@ function createYouTrackTracker(): Tracker {
           command = "State Open";
         }
 
-        await executeCommand(host, identifier, command);
+        await executeCommand(host, authToken, identifier, command);
       }
 
       // Handle assignee
       if (update.assignee) {
-        await executeCommand(host, identifier, `Assignee ${update.assignee}`);
+        await executeCommand(host, authToken, identifier, `Assignee ${update.assignee}`);
       }
 
       // Handle labels — map to YouTrack tags via the command API.
@@ -383,19 +399,19 @@ function createYouTrackTracker(): Tracker {
       // command does not abort the rest.
       if (update.labels && update.labels.length > 0) {
         for (const label of update.labels) {
-          await executeCommand(host, identifier, `tag ${label}`);
+          await executeCommand(host, authToken, identifier, `tag ${label}`);
         }
       }
 
       if (update.removeLabels && update.removeLabels.length > 0) {
         for (const label of update.removeLabels) {
-          await executeCommand(host, identifier, `remove tag ${label}`);
+          await executeCommand(host, authToken, identifier, `remove tag ${label}`);
         }
       }
 
       // Handle comment
       if (update.comment) {
-        await youtrackFetch(host, `/issues/${identifier}/comments`, {
+        await youtrackFetch(host, authToken, `/issues/${identifier}/comments`, {
           method: "POST",
           body: { text: update.comment },
         });
@@ -403,7 +419,8 @@ function createYouTrackTracker(): Tracker {
     },
 
     async createIssue(input: CreateIssueInput, project: ProjectConfig): Promise<Issue> {
-      const host = getHost(project);
+      const host = resolveHost(project, defaultHost);
+      const authToken = requireToken(token);
       const projectId = project.tracker?.["projectId"] as string | undefined;
       if (!projectId) {
         throw new Error(
@@ -414,6 +431,7 @@ function createYouTrackTracker(): Tracker {
       // Resolve project internal ID
       const projects = await youtrackFetch<YouTrackProject[]>(
         host,
+        authToken,
         `/admin/projects?fields=id,shortName,name&query=${encodeURIComponent(projectId)}`,
       );
       const targetProject = projects.find((p) => p.shortName === projectId);
@@ -427,10 +445,15 @@ function createYouTrackTracker(): Tracker {
         project: { id: targetProject.id },
       };
 
-      const created = await youtrackFetch<YouTrackIssue>(host, `/issues?fields=${ISSUE_FIELDS}`, {
-        method: "POST",
-        body,
-      });
+      const created = await youtrackFetch<YouTrackIssue>(
+        host,
+        authToken,
+        `/issues?fields=${ISSUE_FIELDS}`,
+        {
+          method: "POST",
+          body,
+        },
+      );
 
       // Apply assignee and priority via a single chained command (single-token values
       // chain safely with spaces).
@@ -453,9 +476,12 @@ function createYouTrackTracker(): Tracker {
 
       if (commands.length > 0) {
         try {
-          await executeCommand(host, created.idReadable, commands.join(" "));
-        } catch {
-          // Commands are best-effort; creation already succeeded
+          await executeCommand(host, authToken, created.idReadable, commands.join(" "));
+        } catch (error) {
+          console.warn(
+            `[youtrack] Failed to apply post-create fields to ${created.idReadable}:`,
+            error,
+          );
         }
       }
 
@@ -465,9 +491,12 @@ function createYouTrackTracker(): Tracker {
       if (input.labels && input.labels.length > 0) {
         for (const label of input.labels) {
           try {
-            await executeCommand(host, created.idReadable, `tag ${label}`);
-          } catch {
-            // Best-effort
+            await executeCommand(host, authToken, created.idReadable, `tag ${label}`);
+          } catch (error) {
+            console.warn(
+              `[youtrack] Failed to apply tag "${label}" to ${created.idReadable}:`,
+              error,
+            );
           }
         }
       }
@@ -497,8 +526,8 @@ export const manifest = {
   version: "0.1.0",
 };
 
-export function create(): Tracker {
-  return createYouTrackTracker();
+export function create(config?: Record<string, unknown>): Tracker {
+  return createYouTrackTracker(config);
 }
 
 export default { manifest, create } satisfies PluginModule<Tracker>;

--- a/packages/plugins/tracker-youtrack/tsconfig.json
+++ b/packages/plugins/tracker-youtrack/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -37,6 +37,7 @@
     "@aoagents/ao-plugin-scm-github": "workspace:*",
     "@aoagents/ao-plugin-tracker-github": "workspace:*",
     "@aoagents/ao-plugin-tracker-linear": "workspace:*",
+    "@aoagents/ao-plugin-tracker-youtrack": "workspace:*",
     "@aoagents/ao-plugin-workspace-worktree": "workspace:*",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -42,6 +42,7 @@ import pluginWorkspaceWorktree from "@aoagents/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@aoagents/ao-plugin-scm-github";
 import pluginTrackerGithub from "@aoagents/ao-plugin-tracker-github";
 import pluginTrackerLinear from "@aoagents/ao-plugin-tracker-linear";
+import pluginTrackerYouTrack from "@aoagents/ao-plugin-tracker-youtrack";
 
 export interface Services {
   config: LoadedConfig;
@@ -112,6 +113,7 @@ async function initServices(): Promise<Services> {
   registry.register(pluginScmGithub);
   registry.register(pluginTrackerGithub);
   registry.register(pluginTrackerLinear);
+  registry.register(pluginTrackerYouTrack);
 
   const sessionManager = createSessionManager({ config, registry });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@aoagents/ao-plugin-tracker-linear':
         specifier: workspace:*
         version: link:../plugins/tracker-linear
+      '@aoagents/ao-plugin-tracker-youtrack':
+        specifier: workspace:*
+        version: link:../plugins/tracker-youtrack
       '@aoagents/ao-plugin-workspace-clone':
         specifier: workspace:*
         version: link:../plugins/workspace-clone
@@ -580,6 +583,22 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/plugins/tracker-youtrack:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/plugins/workspace-clone:
     dependencies:
       '@aoagents/ao-core':
@@ -641,6 +660,9 @@ importers:
       '@aoagents/ao-plugin-tracker-linear':
         specifier: workspace:*
         version: link:../plugins/tracker-linear
+      '@aoagents/ao-plugin-tracker-youtrack':
+        specifier: workspace:*
+        version: link:../plugins/tracker-youtrack
       '@aoagents/ao-plugin-workspace-worktree':
         specifier: workspace:*
         version: link:../plugins/workspace-worktree


### PR DESCRIPTION
**Description**
Adds a built-in YouTrack tracker plugin so AO can work with JetBrains YouTrack issues alongside GitHub, GitLab, and Linear.

**What Changed**

- Added @aoagents/ao-plugin-tracker-youtrack.
- Supports YouTrack issue lookup, completion checks, issue URLs, branch names, prompt generation, issue listing, updates, comments, and issue creation.
- Maps YouTrack states, priorities, assignees, and tags into AO’s common tracker model.
- Uses YouTrack REST API with YOUTRACK_TOKEN and either YOUTRACK_HOST or tracker.host.
- Supports backlog-style tag filtering with `agent:backlog`.
- Registers the YouTrack tracker as a built-in plugin in core and wires it into the web dashboard.
- Adds package dependencies for CLI/web usage.
- Adds unit coverage for tracker behavior, filtering, updates, creation, and error handling.

**Testing**

- `pnpm --filter @aoagents/ao-plugin-tracker-youtrack test`
- `pnpm --filter @aoagents/ao-plugin-tracker-youtrack typecheck`