### PR TITLE
feat: add pi.dev agent plugin

### DIFF
--- a/.changeset/agent-pi-plugin.md
+++ b/.changeset/agent-pi-plugin.md
@@ -1,0 +1,7 @@
+---
+"@aoagents/ao-plugin-agent-pi": minor
+"@aoagents/ao-cli": minor
+"@aoagents/ao-core": patch
+---
+
+Add pi.dev agent plugin (`@aoagents/ao-plugin-agent-pi`). Pi sessions can now be spawned per worktree alongside the existing claude-code, codex, aider, and opencode peers. Reads native pi JSONL at `~/.pi/agent/sessions/` for activity state and uses pi's per-message `usage.cost.total` for cost tracking. Wires the plugin into the CLI registry, auto-detection, and the core BUILTIN_PLUGINS list.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
+    "@aoagents/ao-plugin-agent-pi": "workspace:*",
     "@aoagents/ao-plugin-notifier-composio": "workspace:*",
     "@aoagents/ao-plugin-notifier-desktop": "workspace:*",
     "@aoagents/ao-plugin-notifier-discord": "workspace:*",

--- a/packages/cli/src/lib/detect-agent.ts
+++ b/packages/cli/src/lib/detect-agent.ts
@@ -21,6 +21,7 @@ const AGENT_PLUGINS: Array<{ name: string; pkg: string }> = [
   { name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
   { name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { name: "pi", pkg: "@aoagents/ao-plugin-agent-pi" },
 ];
 
 /**

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -5,6 +5,7 @@ import aiderPlugin from "@aoagents/ao-plugin-agent-aider";
 import cursorPlugin from "@aoagents/ao-plugin-agent-cursor";
 import kimicodePlugin from "@aoagents/ao-plugin-agent-kimicode";
 import opencodePlugin from "@aoagents/ao-plugin-agent-opencode";
+import piPlugin from "@aoagents/ao-plugin-agent-pi";
 import githubSCMPlugin from "@aoagents/ao-plugin-scm-github";
 
 const agentPlugins: Record<string, { create(): Agent }> = {
@@ -14,6 +15,7 @@ const agentPlugins: Record<string, { create(): Agent }> = {
   cursor: cursorPlugin,
   kimicode: kimicodePlugin,
   opencode: opencodePlugin,
+  pi: piPlugin,
 };
 
 const scmPlugins: Record<string, { create(): SCM }> = {

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -46,6 +46,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { slot: "agent", name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
   { slot: "agent", name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { slot: "agent", name: "pi", pkg: "@aoagents/ao-plugin-agent-pi" },
   // Workspaces
   { slot: "workspace", name: "worktree", pkg: "@aoagents/ao-plugin-workspace-worktree" },
   { slot: "workspace", name: "clone", pkg: "@aoagents/ao-plugin-workspace-clone" },

--- a/packages/plugins/agent-pi/package.json
+++ b/packages/plugins/agent-pi/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@aoagents/ao-plugin-agent-pi",
+  "version": "0.1.0",
+  "description": "Agent plugin: pi.dev coding agent",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-pi"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-pi/src/index.test.ts
+++ b/packages/plugins/agent-pi/src/index.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createActivitySignal,
+  type Session,
+  type RuntimeHandle,
+  type AgentLaunchConfig,
+} from "@aoagents/ao-core";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const {
+  mockExecFileAsync,
+  mockReaddir,
+  mockStat,
+  mockCreateReadStream,
+  mockHomedir,
+  mockReadLastJsonlEntry,
+  mockReadLastActivityEntry,
+} = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(),
+  mockReaddir: vi.fn(),
+  mockStat: vi.fn(),
+  mockCreateReadStream: vi.fn(),
+  mockHomedir: vi.fn(() => "/mock/home"),
+  mockReadLastJsonlEntry: vi.fn(),
+  mockReadLastActivityEntry: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => {
+  const fn = Object.assign((..._args: unknown[]) => {}, {
+    [Symbol.for("nodejs.util.promisify.custom")]: mockExecFileAsync,
+  });
+  return { execFile: fn, execFileSync: vi.fn() };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readdir: mockReaddir,
+  stat: mockStat,
+}));
+
+vi.mock("node:fs", () => ({
+  createReadStream: mockCreateReadStream,
+}));
+
+vi.mock("node:os", () => ({
+  homedir: mockHomedir,
+}));
+
+vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    readLastJsonlEntry: mockReadLastJsonlEntry,
+    readLastActivityEntry: mockReadLastActivityEntry,
+  };
+});
+
+import { Readable } from "node:stream";
+import {
+  create,
+  manifest,
+  default as defaultExport,
+  _resetSessionFileCache,
+} from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "test-1",
+    projectId: "test-project",
+    status: "working",
+    activity: "active",
+    activitySignal: createActivitySignal("valid", {
+      activity: "active",
+      timestamp: new Date(),
+      source: "native",
+    }),
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/workspace/test",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeTmuxHandle(id = "test-session"): RuntimeHandle {
+  return { id, runtimeName: "tmux", data: {} };
+}
+
+function makeProcessHandle(pid?: number | string): RuntimeHandle {
+  return { id: "proc-1", runtimeName: "process", data: pid !== undefined ? { pid } : {} };
+}
+
+function makeLaunchConfig(overrides: Partial<AgentLaunchConfig> = {}): AgentLaunchConfig {
+  return {
+    sessionId: "sess-1",
+    projectConfig: {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/repo",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+    },
+    ...overrides,
+  };
+}
+
+function mockTmuxWithProcess(processName: string, found = true) {
+  mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === "tmux" && args[0] === "list-panes") {
+      return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+    }
+    if (cmd === "ps") {
+      const line = found ? `  789 ttys003  ${processName}` : "  789 ttys003  bash";
+      return Promise.resolve({
+        stdout: `  PID TT       ARGS\n${line}\n`,
+        stderr: "",
+      });
+    }
+    return Promise.reject(new Error(`Unexpected: ${cmd} ${args.join(" ")}`));
+  });
+}
+
+function makeContentStream(content: string): Readable {
+  return Readable.from(Buffer.from(content, "utf-8"));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetSessionFileCache();
+  mockHomedir.mockReturnValue("/mock/home");
+  // Default: no session subdirs, no JSONL entries
+  mockReaddir.mockResolvedValue([]);
+  mockStat.mockRejectedValue(new Error("ENOENT"));
+  mockCreateReadStream.mockReturnValue(makeContentStream(""));
+  mockReadLastJsonlEntry.mockResolvedValue(null);
+  mockReadLastActivityEntry.mockResolvedValue(null);
+});
+
+// =========================================================================
+// Manifest & Exports
+// =========================================================================
+describe("plugin manifest & exports", () => {
+  it("has correct manifest", () => {
+    expect(manifest).toEqual({
+      name: "pi",
+      slot: "agent",
+      description: "Agent plugin: pi.dev coding agent",
+      version: "0.1.0",
+      displayName: "Pi",
+    });
+  });
+
+  it("create() returns agent with correct name and processName", () => {
+    const agent = create();
+    expect(agent.name).toBe("pi");
+    expect(agent.processName).toBe("pi");
+    expect(agent.promptDelivery).toBe("post-launch");
+  });
+
+  it("default export is a valid PluginModule", () => {
+    expect(defaultExport.manifest).toBe(manifest);
+    expect(typeof defaultExport.create).toBe("function");
+    expect(typeof defaultExport.detect).toBe("function");
+  });
+});
+
+// =========================================================================
+// getLaunchCommand
+// =========================================================================
+describe("getLaunchCommand", () => {
+  const agent = create();
+
+  it("returns shell-escaped pi binary", () => {
+    expect(agent.getLaunchCommand(makeLaunchConfig())).toBe("'pi'");
+  });
+
+  it("ignores prompt — pi gets it via post-launch sendMessage", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "Fix bug" }));
+    expect(cmd).toBe("'pi'");
+  });
+});
+
+// =========================================================================
+// getEnvironment
+// =========================================================================
+describe("getEnvironment", () => {
+  const agent = create();
+
+  it("sets AO_SESSION_ID", () => {
+    const env = agent.getEnvironment(makeLaunchConfig({ sessionId: "abc" }));
+    expect(env["AO_SESSION_ID"]).toBe("abc");
+  });
+
+  it("sets AO_ISSUE_ID when provided", () => {
+    const env = agent.getEnvironment(makeLaunchConfig({ sessionId: "abc", issueId: "ISSUE-1" }));
+    expect(env["AO_ISSUE_ID"]).toBe("ISSUE-1");
+  });
+
+  it("omits AO_ISSUE_ID when not provided", () => {
+    const env = agent.getEnvironment(makeLaunchConfig({ sessionId: "abc" }));
+    expect(env["AO_ISSUE_ID"]).toBeUndefined();
+  });
+});
+
+// =========================================================================
+// detectActivity
+// =========================================================================
+describe("detectActivity", () => {
+  const agent = create();
+
+  it("returns idle on empty output", () => {
+    expect(agent.detectActivity("")).toBe("idle");
+  });
+
+  it("returns idle on prompt char", () => {
+    expect(agent.detectActivity("> ")).toBe("idle");
+  });
+
+  it("returns waiting_input on (y)es/(n)o", () => {
+    expect(agent.detectActivity("Apply this change?\n(Y)es / (N)o")).toBe("waiting_input");
+  });
+
+  it("returns waiting_input on approval prompt", () => {
+    expect(agent.detectActivity("approval required: write /etc/hosts")).toBe("waiting_input");
+  });
+
+  it("returns blocked on auth error", () => {
+    expect(agent.detectActivity("authentication failed: invalid api key")).toBe("blocked");
+  });
+
+  it("returns active by default", () => {
+    expect(agent.detectActivity("Thinking...")).toBe("active");
+  });
+});
+
+// =========================================================================
+// isProcessRunning
+// =========================================================================
+describe("isProcessRunning", () => {
+  const agent = create();
+
+  it("returns true when tmux pane runs pi", async () => {
+    mockTmuxWithProcess("pi");
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("returns true when tmux pane runs .pi (npm dot-prefixed)", async () => {
+    mockTmuxWithProcess("/usr/local/bin/.pi --foo");
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("returns false when no matching process in tmux pane", async () => {
+    mockTmuxWithProcess("pi", false);
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns true for live PID via process runtime", async () => {
+    const realKill = process.kill;
+    const killSpy = vi.spyOn(process, "kill").mockImplementation((_pid: number, _sig?: NodeJS.Signals | number) => true);
+    try {
+      expect(await agent.isProcessRunning(makeProcessHandle(1234))).toBe(true);
+    } finally {
+      killSpy.mockRestore();
+      void realKill;
+    }
+  });
+
+  it("returns false for dead PID via process runtime", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    try {
+      expect(await agent.isProcessRunning(makeProcessHandle(1234))).toBe(false);
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+});
+
+// =========================================================================
+// getActivityState — the 7 required scenarios
+// =========================================================================
+describe("getActivityState", () => {
+  const agent = create();
+
+  it("1. returns exited when process is not running", async () => {
+    mockTmuxWithProcess("pi", false);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeTmuxHandle() }),
+    );
+    expect(state?.state).toBe("exited");
+  });
+
+  it("2. returns waiting_input from AO activity JSONL", async () => {
+    mockTmuxWithProcess("pi");
+    const now = new Date();
+    mockReadLastActivityEntry.mockResolvedValue({
+      entry: { state: "waiting_input", ts: now.toISOString() },
+      modifiedAt: now,
+    });
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeTmuxHandle() }),
+    );
+    expect(state?.state).toBe("waiting_input");
+  });
+
+  it("3. returns blocked from AO activity JSONL", async () => {
+    mockTmuxWithProcess("pi");
+    const now = new Date();
+    mockReadLastActivityEntry.mockResolvedValue({
+      entry: { state: "blocked", ts: now.toISOString() },
+      modifiedAt: now,
+    });
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeTmuxHandle() }),
+    );
+    expect(state?.state).toBe("blocked");
+  });
+
+  it("4. returns active from native pi JSONL when entry is fresh", async () => {
+    mockTmuxWithProcess("pi");
+    // Make findPiSessionFile resolve to a path: simulate matching subdir
+    mockReaddir.mockImplementation(async (path: string) => {
+      if (path === "/mock/home/.pi/agent/sessions/-workspace-test") {
+        return ["12345_abc.jsonl"] as unknown as string[];
+      }
+      return [] as unknown as string[];
+    });
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+    const fresh = new Date();
+    mockReadLastJsonlEntry.mockResolvedValue({
+      modifiedAt: fresh,
+      lastType: "agent_message",
+    });
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeTmuxHandle() }),
+    );
+    expect(state?.state).toBe("active");
+  });
+
+  it("5. returns idle from native pi JSONL when entry is old", async () => {
+    mockTmuxWithProcess("pi");
+    mockReaddir.mockImplementation(async (path: string) => {
+      if (path === "/mock/home/.pi/agent/sessions/-workspace-test") {
+        return ["12345_abc.jsonl"] as unknown as string[];
+      }
+      return [] as unknown as string[];
+    });
+    mockStat.mockResolvedValue({ mtimeMs: Date.now() - 10 * 60_000, mtime: new Date() });
+    const old = new Date(Date.now() - 10 * 60_000); // 10min old
+    mockReadLastJsonlEntry.mockResolvedValue({
+      modifiedAt: old,
+      lastType: "agent_message",
+    });
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeTmuxHandle() }),
+    );
+    expect(state?.state).toBe("idle");
+  });
+
+  it("6. returns ready from native pi JSONL when entry is mid-aged", async () => {
+    mockTmuxWithProcess("pi");
+    mockReaddir.mockImplementation(async (path: string) => {
+      if (path === "/mock/home/.pi/agent/sessions/-workspace-test") {
+        return ["12345_abc.jsonl"] as unknown as string[];
+      }
+      return [] as unknown as string[];
+    });
+    mockStat.mockResolvedValue({ mtimeMs: Date.now() - 90_000, mtime: new Date() });
+    const mid = new Date(Date.now() - 90_000); // 90s old
+    mockReadLastJsonlEntry.mockResolvedValue({
+      modifiedAt: mid,
+      lastType: "agent_message",
+    });
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeTmuxHandle() }),
+    );
+    expect(state?.state).toBe("ready");
+  });
+
+  it("7. returns null when no signal at all (no JSONL, no activity log)", async () => {
+    mockTmuxWithProcess("pi");
+    // readdir returns nothing; readLastJsonlEntry/readLastActivityEntry return null
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeTmuxHandle() }),
+    );
+    expect(state).toBeNull();
+  });
+});

--- a/packages/plugins/agent-pi/src/index.ts
+++ b/packages/plugins/agent-pi/src/index.ts
@@ -1,0 +1,567 @@
+import {
+  DEFAULT_READY_THRESHOLD_MS,
+  DEFAULT_ACTIVE_WINDOW_MS,
+  shellEscape,
+  readLastJsonlEntry,
+  readLastActivityEntry,
+  checkActivityLogState,
+  getActivityFallbackState,
+  recordTerminalActivity,
+  type Agent,
+  type AgentLaunchConfig,
+  type AgentSessionInfo,
+  type ActivityState,
+  type ActivityDetection,
+  type CostEstimate,
+  type PluginModule,
+  type ProjectConfig,
+  type RuntimeHandle,
+  type Session,
+  type WorkspaceHooksConfig,
+} from "@aoagents/ao-core";
+import { execFile, execFileSync } from "node:child_process";
+import { createReadStream } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { createInterface } from "node:readline";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// =============================================================================
+// Plugin Manifest
+// =============================================================================
+
+export const manifest = {
+  name: "pi",
+  slot: "agent" as const,
+  description: "Agent plugin: pi.dev coding agent",
+  version: "0.1.0",
+  displayName: "Pi",
+};
+
+// =============================================================================
+// Pi Session JSONL Parsing
+//
+// Pi stores sessions at:
+//   ~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl
+//
+// Encoding: forward slashes in the workspace path are replaced with hyphens.
+// Per the docs, the directory name appears as `--<path>--` — interpreted here
+// as: encoded path with `/` -> `-`, but real-world encodings vary, so we
+// fall back to scanning all session subdirs and matching the JSONL header.
+// =============================================================================
+
+const PI_SESSIONS_DIR = join(homedir(), ".pi", "agent", "sessions");
+
+interface PiUsageCost {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  total?: number;
+}
+
+interface PiUsage {
+  cost?: PiUsageCost;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+interface PiJsonlLine {
+  type?: string;
+  id?: string;
+  parentId?: string | null;
+  timestamp?: string;
+  role?: string;
+  cwd?: string;
+  workspacePath?: string;
+  model?: string;
+  thinkingLevel?: string;
+  usage?: PiUsage;
+  errorMessage?: string;
+  stopReason?: string;
+  content?: unknown;
+}
+
+/** Encode a workspace path to pi's session-dir naming convention. */
+function encodeWorkspaceDirName(workspacePath: string): string {
+  // /Users/foo/bar -> -Users-foo-bar
+  return workspacePath.replace(/\//g, "-");
+}
+
+async function listSessionSubdirs(): Promise<string[]> {
+  try {
+    const entries = await readdir(PI_SESSIONS_DIR, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  } catch {
+    return [];
+  }
+}
+
+async function listJsonlFiles(dir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir);
+    return entries.filter((f) => f.endsWith(".jsonl")).map((f) => join(dir, f));
+  } catch {
+    return [];
+  }
+}
+
+async function readFirstJsonlLine(filePath: string): Promise<PiJsonlLine | null> {
+  try {
+    const rl = createInterface({
+      input: createReadStream(filePath, { encoding: "utf-8" }),
+      crlfDelay: Infinity,
+    });
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const parsed: unknown = JSON.parse(trimmed);
+        rl.close();
+        if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+          return parsed as PiJsonlLine;
+        }
+      } catch {
+        // Skip malformed line, return null after first attempt
+      }
+      rl.close();
+      return null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find the most recent pi session JSONL file for the given workspace.
+ *
+ * Strategy:
+ * 1. Compute the expected encoded subdir name and look there directly.
+ * 2. Fall back to scanning all session subdirs and parsing each JSONL header
+ *    looking for one whose `cwd`/`workspacePath` matches.
+ *
+ * Returns the path of the most recently modified matching file, or null.
+ */
+async function findPiSessionFile(workspacePath: string): Promise<string | null> {
+  const candidates: string[] = [];
+
+  // Strategy 1: direct lookup by encoded name
+  const encoded = encodeWorkspaceDirName(workspacePath);
+  const directDir = join(PI_SESSIONS_DIR, encoded);
+  const directFiles = await listJsonlFiles(directDir);
+  candidates.push(...directFiles);
+
+  // Strategy 2: scan all subdirs, match via header cwd
+  if (candidates.length === 0) {
+    const subdirs = await listSessionSubdirs();
+    for (const sub of subdirs) {
+      const dir = join(PI_SESSIONS_DIR, sub);
+      const files = await listJsonlFiles(dir);
+      for (const f of files) {
+        const header = await readFirstJsonlLine(f);
+        if (!header) continue;
+        if (header.cwd === workspacePath || header.workspacePath === workspacePath) {
+          candidates.push(f);
+          break;
+        }
+      }
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  let best: { path: string; mtime: number } | null = null;
+  for (const p of candidates) {
+    try {
+      const s = await stat(p);
+      if (!best || s.mtimeMs > best.mtime) {
+        best = { path: p, mtime: s.mtimeMs };
+      }
+    } catch {
+      // skip
+    }
+  }
+  return best?.path ?? null;
+}
+
+interface PiSessionData {
+  sessionId: string | null;
+  model: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalCost: number;
+}
+
+/** Stream the pi JSONL session file and aggregate session-level data. */
+async function streamPiSessionData(filePath: string): Promise<PiSessionData | null> {
+  try {
+    const data: PiSessionData = {
+      sessionId: null,
+      model: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      totalCost: 0,
+    };
+    const rl = createInterface({
+      input: createReadStream(filePath, { encoding: "utf-8" }),
+      crlfDelay: Infinity,
+    });
+
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let entry: PiJsonlLine;
+      try {
+        const parsed: unknown = JSON.parse(trimmed);
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) continue;
+        entry = parsed as PiJsonlLine;
+      } catch {
+        continue;
+      }
+
+      if (!data.sessionId && typeof entry.id === "string" && (!entry.type || entry.type === "session")) {
+        // Header line: only top-level entry without parentId carries the session id.
+        if (entry.parentId === null || entry.parentId === undefined) {
+          data.sessionId = entry.id;
+        }
+      }
+
+      if (typeof entry.model === "string" && entry.model) {
+        data.model = entry.model;
+      }
+
+      const usage = entry.usage;
+      if (usage) {
+        if (typeof usage.cost?.total === "number") data.totalCost += usage.cost.total;
+        if (typeof usage.inputTokens === "number") data.inputTokens += usage.inputTokens;
+        if (typeof usage.outputTokens === "number") data.outputTokens += usage.outputTokens;
+        if (typeof usage.cacheReadTokens === "number") data.cacheReadTokens += usage.cacheReadTokens;
+        if (typeof usage.cacheWriteTokens === "number")
+          data.cacheWriteTokens += usage.cacheWriteTokens;
+      }
+    }
+
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+// =============================================================================
+// Binary Resolution
+// =============================================================================
+
+export async function resolvePiBinary(): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("which", ["pi"], { timeout: 10_000 });
+    const resolved = stdout.trim();
+    if (resolved) return resolved;
+  } catch {
+    // not found via which
+  }
+
+  const home = homedir();
+  const candidates = [
+    "/usr/local/bin/pi",
+    "/opt/homebrew/bin/pi",
+    join(home, ".npm", "bin", "pi"),
+    join(home, ".npm-global", "bin", "pi"),
+  ];
+  for (const c of candidates) {
+    try {
+      await stat(c);
+      return c;
+    } catch {
+      // skip
+    }
+  }
+  return "pi";
+}
+
+// =============================================================================
+// Session-file cache (avoids redundant scans inside one refresh cycle)
+// =============================================================================
+
+const SESSION_FILE_CACHE_TTL_MS = 30_000;
+const sessionFileCache = new Map<string, { path: string | null; expiry: number }>();
+
+async function findPiSessionFileCached(workspacePath: string): Promise<string | null> {
+  const cached = sessionFileCache.get(workspacePath);
+  if (cached && Date.now() < cached.expiry) return cached.path;
+  const result = await findPiSessionFile(workspacePath);
+  sessionFileCache.set(workspacePath, {
+    path: result,
+    expiry: Date.now() + SESSION_FILE_CACHE_TTL_MS,
+  });
+  return result;
+}
+
+// =============================================================================
+// Agent Implementation
+// =============================================================================
+
+function createPiAgent(): Agent {
+  let resolvedBinary: string | null = null;
+  let resolvingBinary: Promise<string> | null = null;
+
+  return {
+    name: "pi",
+    processName: "pi",
+
+    // Pi exits immediately when invoked with `-p`; keep agent interactive in
+    // tmux and inject the prompt via runtime.sendMessage after launch.
+    promptDelivery: "post-launch",
+
+    getLaunchCommand(_config: AgentLaunchConfig): string {
+      const binary = resolvedBinary ?? "pi";
+      // Pi has no documented flags for permissions / model overrides — both
+      // are managed inside pi via /login and slash commands. Keep it simple
+      // and let the user configure pi the usual way.
+      return shellEscape(binary);
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      const env: Record<string, string> = {};
+      env["AO_SESSION_ID"] = config.sessionId;
+      if (config.issueId) env["AO_ISSUE_ID"] = config.issueId;
+      // PATH and GH_PATH are injected by session-manager.
+      // ANTHROPIC_API_KEY is expected to be set in the user's shell — pi
+      // reads it natively. We don't override it here.
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      if (!terminalOutput.trim()) return "idle";
+
+      const lines = terminalOutput.trim().split("\n");
+      const lastLine = lines[lines.length - 1]?.trim() ?? "";
+      const tail = lines.slice(-6).join("\n");
+
+      // Pi's interactive prompt: typically "> " when waiting for user input.
+      if (/^[>$#]\s*$/.test(lastLine)) return "idle";
+
+      // Permission/approval prompts (best-effort patterns — verify with real
+      // pi output and tighten as needed).
+      if (/\(y\)es.*\(n\)o/i.test(tail)) return "waiting_input";
+      if (/approval required/i.test(tail)) return "waiting_input";
+      if (/Allow .+\?/i.test(tail)) return "waiting_input";
+      if (/Do you want to proceed\?/i.test(tail)) return "waiting_input";
+
+      // Errors
+      if (/^error:/im.test(tail)) return "blocked";
+      if (/authentication failed/i.test(tail)) return "blocked";
+
+      return "active";
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
+      const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
+      const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
+
+      // 1. Process check
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (!running) return { state: "exited", timestamp: exitedAt };
+
+      if (!session.workspacePath) return null;
+
+      // 2. AO activity JSONL — only source of waiting_input/blocked since pi's
+      //    native JSONL has no dedicated permission_request type.
+      const activityResult = await readLastActivityEntry(session.workspacePath);
+      const activityState = checkActivityLogState(activityResult);
+      if (activityState) return activityState;
+
+      // 3. Native pi JSONL — use timestamp of last entry for active/ready/idle.
+      const sessionFile = await findPiSessionFileCached(session.workspacePath);
+      if (sessionFile) {
+        const entry = await readLastJsonlEntry(sessionFile);
+        if (entry) {
+          const ageMs = Date.now() - entry.modifiedAt.getTime();
+          const timestamp = entry.modifiedAt;
+          if (ageMs <= activeWindowMs) return { state: "active", timestamp };
+          if (ageMs <= threshold) return { state: "ready", timestamp };
+          return { state: "idle", timestamp };
+        }
+
+        // Fallback to file mtime if line parsing failed.
+        try {
+          const s = await stat(sessionFile);
+          const ageMs = Date.now() - s.mtimeMs;
+          if (ageMs <= activeWindowMs) return { state: "active", timestamp: s.mtime };
+          if (ageMs <= threshold) return { state: "ready", timestamp: s.mtime };
+          return { state: "idle", timestamp: s.mtime };
+        } catch {
+          // continue to fallback
+        }
+      }
+
+      // 4. Last-resort: AO activity entry with age-based decay
+      const fallback = getActivityFallbackState(activityResult, activeWindowMs, threshold);
+      if (fallback) return fallback;
+
+      return null;
+    },
+
+    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
+      if (!session.workspacePath) return;
+      await recordTerminalActivity(session.workspacePath, terminalOutput, (output) =>
+        this.detectActivity(output),
+      );
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      try {
+        if (handle.runtimeName === "tmux" && handle.id) {
+          const { stdout: ttyOut } = await execFileAsync(
+            "tmux",
+            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+            { timeout: 30_000 },
+          );
+          const ttys = ttyOut
+            .trim()
+            .split("\n")
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (ttys.length === 0) return false;
+
+          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
+            timeout: 30_000,
+          });
+          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
+          // Match `pi` or `.pi` (some npm globals install with dot prefix),
+          // possibly via node wrapper (e.g. "node /path/to/pi").
+          const processRe = /(?:^|\/)\.?pi(?:\s|$)/;
+          for (const line of psOut.split("\n")) {
+            const cols = line.trimStart().split(/\s+/);
+            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+            const args = cols.slice(2).join(" ");
+            if (processRe.test(args)) return true;
+          }
+          return false;
+        }
+
+        const rawPid = handle.data["pid"];
+        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+        if (Number.isFinite(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+            return true;
+          } catch (err: unknown) {
+            if (err instanceof Error && "code" in err && err.code === "EPERM") return true;
+            return false;
+          }
+        }
+        return false;
+      } catch {
+        return false;
+      }
+    },
+
+    async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {
+      if (!session.workspacePath) return null;
+      const sessionFile = await findPiSessionFileCached(session.workspacePath);
+      if (!sessionFile) return null;
+
+      const data = await streamPiSessionData(sessionFile);
+      if (!data) return null;
+
+      const agentSessionId = data.sessionId ?? basename(sessionFile, ".jsonl");
+
+      let cost: CostEstimate | undefined;
+      const totalInputTokens = data.inputTokens + data.cacheReadTokens + data.cacheWriteTokens;
+      if (data.totalCost > 0 || totalInputTokens > 0 || data.outputTokens > 0) {
+        cost = {
+          inputTokens: totalInputTokens,
+          outputTokens: data.outputTokens,
+          // Pi reports cost.total directly — prefer it over our own estimate.
+          estimatedCostUsd: data.totalCost,
+        };
+      }
+
+      return {
+        summary: data.model ? `Pi session (${data.model})` : null,
+        summaryIsFallback: true,
+        agentSessionId,
+        metadata: {
+          ...(data.sessionId ? { piSessionId: data.sessionId } : {}),
+          ...(data.model ? { piModel: data.model } : {}),
+        },
+        cost,
+      };
+    },
+
+    async getRestoreCommand(session: Session, _project: ProjectConfig): Promise<string | null> {
+      let sessionId = session.metadata?.["piSessionId"]?.trim();
+      if (!sessionId) {
+        if (!session.workspacePath) return null;
+        const sessionFile = await findPiSessionFileCached(session.workspacePath);
+        if (!sessionFile) return null;
+        const data = await streamPiSessionData(sessionFile);
+        if (!data?.sessionId) return null;
+        sessionId = data.sessionId;
+      }
+
+      const binary = resolvedBinary ?? "pi";
+      // pi --session <id> resumes a specific session.
+      return `${shellEscape(binary)} --session ${shellEscape(sessionId)}`;
+    },
+
+    async setupWorkspaceHooks(
+      _workspacePath: string,
+      _config: WorkspaceHooksConfig,
+    ): Promise<void> {
+      // PATH wrappers (~/.ao/bin) are installed by session-manager for all
+      // agents. Pi reads project AGENTS.md natively, but .ao/AGENTS.md lives
+      // under .ao/ which pi does not auto-discover — that's acceptable for v1.
+    },
+
+    async postLaunchSetup(_session: Session): Promise<void> {
+      if (!resolvedBinary) {
+        if (!resolvingBinary) resolvingBinary = resolvePiBinary();
+        try {
+          resolvedBinary = await resolvingBinary;
+        } finally {
+          resolvingBinary = null;
+        }
+      }
+    },
+  };
+}
+
+// =============================================================================
+// Plugin Export
+// =============================================================================
+
+export function create(): Agent {
+  return createPiAgent();
+}
+
+export function detect(): boolean {
+  try {
+    execFileSync("pi", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** @internal Reset the session-file cache. Exported for tests only. */
+export function _resetSessionFileCache(): void {
+  sessionFileCache.clear();
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-pi/tsconfig.json
+++ b/packages/plugins/agent-pi/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@aoagents/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
+      '@aoagents/ao-plugin-agent-pi':
+        specifier: workspace:*
+        version: link:../plugins/agent-pi
       '@aoagents/ao-plugin-notifier-composio':
         specifier: workspace:*
         version: link:../plugins/notifier-composio
@@ -342,6 +345,22 @@ importers:
         version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/plugins/agent-opencode:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/plugins/agent-pi:
     dependencies:
       '@aoagents/ao-core':
         specifier: workspace:*
@@ -4082,6 +4101,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -5742,13 +5762,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -7748,7 +7768,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -7766,7 +7786,7 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       vite-node: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## Summary

Adds `@aoagents/ao-plugin-agent-pi` — a new agent plugin for the [pi.dev coding agent](https://pi.dev). Pi sessions are spawned per worktree like any other agent slot, peer with `claude-code`, `codex`, `aider`, `opencode`.

## What changed

- **New package** `packages/plugins/agent-pi/` implementing the `Agent` interface
  - Resolves the `pi` binary via `which` + npm/Homebrew fallbacks
  - Reads pi's native JSONL at `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl` with a subdir-scan fallback that matches the session header `cwd` field
  - Aggregates cost from per-message `usage.cost.total` (pi reports cost natively, no estimation needed)
  - `promptDelivery: post-launch` — `pi -p` exits immediately, so prompts go via `runtime.sendMessage` after the interactive process is up
- **Wired into the registry**:
  - `packages/cli/package.json` — workspace dep
  - `packages/cli/src/lib/plugins.ts` — CLI registry
  - `packages/cli/src/lib/detect-agent.ts` — auto-detection
  - `packages/core/src/plugin-registry.ts` — `BUILTIN_PLUGINS`

## Activity detection

Follows the contract documented in CLAUDE.md (\`getActivityState\` cascade):

1. Process check first → \`exited\`
2. AO activity JSONL handles \`waiting_input\`/\`blocked\` (pi has no dedicated permission_request type in its native JSONL, so terminal-derived state is the source for actionable states)
3. Native pi JSONL timestamps drive \`active\`/\`ready\`/\`idle\`
4. File-mtime fallback when entry parsing fails
5. \`getActivityFallbackState\` as last resort

## Tests

26 cases in \`src/index.test.ts\` covering:

- Manifest, exports, default plugin module shape
- \`getLaunchCommand\` with and without prompt
- \`getEnvironment\` (\`AO_SESSION_ID\`, \`AO_ISSUE_ID\`)
- \`detectActivity\` for idle / waiting_input / blocked / active patterns
- \`isProcessRunning\` for tmux + process runtimes, including the npm dot-prefix case (\`.pi\`)
- All 7 required \`getActivityState\` scenarios from CLAUDE.md

## Test plan

- [x] \`pnpm --filter @aoagents/ao-plugin-agent-pi typecheck\`
- [x] \`pnpm --filter @aoagents/ao-plugin-agent-pi build\`
- [x] \`pnpm --filter @aoagents/ao-plugin-agent-pi test\` → 26/26
- [x] \`pnpm --filter @aoagents/ao-cli typecheck\`
- [x] \`pnpm --filter @aoagents/ao-core typecheck\`
- [x] \`pnpm build\` (full monorepo)
- [x] \`pnpm lint\` (0 errors, pre-existing warnings only)
- [x] Runtime sanity check: \`detect()\` returns \`true\` with pi installed, \`getAgentByName('pi')\` resolves correctly

Pre-existing failures in \`packages/cli/__tests__/commands/start.test.ts\` (8 failures in \`stop command\` and \`Ctrl+C handling\` suites) reproduce on \`upstream/main\` without these changes — unrelated to this PR.

## Notes for review

A few things that need real-world validation with pi running and would be good to verify in review:

1. **Session dir encoding** — implemented as \`/foo/bar → -foo-bar\`. The doc pattern \`~/.pi/agent/sessions/--<path>--/...\` is ambiguous; the subdir-scan fallback covers other encodings by matching the JSONL header \`cwd\`. Confirm with \`ls ~/.pi/agent/sessions/\` after a real session.
2. **\`detectActivity\` patterns** — used generic regexes (\`(y)es/(n)o\`, \`approval required\`, \`Allow X?\`, \`Do you want to proceed?\`). These should be tightened against real pi terminal output for permission prompts.
3. **JSONL header field** — assumed \`cwd\`/\`workspacePath\` is in the header. Pi's session-format docs document \`id\` and entry types but did not explicitly confirm the cwd field name.

Happy to iterate on any of the above.