### PR TITLE
feat(spawn): surface prompt-delivery progress via onProgress callback

### DIFF
--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -172,10 +172,12 @@ describe("spawn command", () => {
     // Single arg = issue; project is auto-detected (only one project in config)
     await program.parseAsync(["node", "test", "spawn", "INT-100"]);
 
-    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
-      projectId: "my-app",
-      issueId: "INT-100",
-    });
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "my-app",
+        issueId: "INT-100",
+      }),
+    );
 
     const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(output).toContain("app-7");
@@ -202,10 +204,12 @@ describe("spawn command", () => {
 
     await program.parseAsync(["node", "test", "spawn", "42"]);
 
-    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
-      projectId: "my-app",
-      issueId: "42",
-    });
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "my-app",
+        issueId: "42",
+      }),
+    );
   });
 
   it("auto-detects the project from a nested cwd in multi-project configs", async () => {
@@ -250,10 +254,12 @@ describe("spawn command", () => {
 
     await program.parseAsync(["node", "test", "spawn", "INT-42"]);
 
-    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
-      projectId: "backend",
-      issueId: "INT-42",
-    });
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "backend",
+        issueId: "INT-42",
+      }),
+    );
   });
 
   it("routes a <projectId>/<issue> identifier to the prefixed project", async () => {
@@ -306,10 +312,12 @@ describe("spawn command", () => {
 
     await program.parseAsync(["node", "test", "spawn", "x402-identity/1"]);
 
-    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
-      projectId: "x402-identity",
-      issueId: "1",
-    });
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "x402-identity",
+        issueId: "1",
+      }),
+    );
   });
 
   it("routes via sessionPrefix when that matches instead of project id", async () => {
@@ -358,10 +366,12 @@ describe("spawn command", () => {
 
     await program.parseAsync(["node", "test", "spawn", "xid/7"]);
 
-    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
-      projectId: "x402-identity",
-      issueId: "7",
-    });
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "x402-identity",
+        issueId: "7",
+      }),
+    );
   });
 
   it("leaves the issueId untouched when the prefix is not a configured project", async () => {
@@ -384,10 +394,12 @@ describe("spawn command", () => {
 
     await program.parseAsync(["node", "test", "spawn", "some-org/42"]);
 
-    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
-      projectId: "my-app",
-      issueId: "some-org/42",
-    });
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "my-app",
+        issueId: "some-org/42",
+      }),
+    );
   });
 
   it("spawns without issueId when none provided", async () => {
@@ -412,10 +424,12 @@ describe("spawn command", () => {
     // No args: project auto-detected, no issue
     await program.parseAsync(["node", "test", "spawn"]);
 
-    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
-      projectId: "my-app",
-      issueId: undefined,
-    });
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "my-app",
+        issueId: undefined,
+      }),
+    );
   });
 
   it("shows dashboard URL instead of raw tmux attach", async () => {
@@ -466,11 +480,13 @@ describe("spawn command", () => {
 
     await program.parseAsync(["node", "test", "spawn", "--agent", "codex"]);
 
-    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
-      projectId: "my-app",
-      issueId: undefined,
-      agent: "codex",
-    });
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "my-app",
+        issueId: undefined,
+        agent: "codex",
+      }),
+    );
   });
 
   it("passes --agent flag with issue ID", async () => {
@@ -494,11 +510,13 @@ describe("spawn command", () => {
 
     await program.parseAsync(["node", "test", "spawn", "INT-42", "--agent", "codex"]);
 
-    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
-      projectId: "my-app",
-      issueId: "INT-42",
-      agent: "codex",
-    });
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "my-app",
+        issueId: "INT-42",
+        agent: "codex",
+      }),
+    );
   });
 
   it("shows a single optional issue positional in help", () => {
@@ -570,11 +588,13 @@ describe("spawn command", () => {
 
     await program.parseAsync(["node", "test", "spawn", "--claim-pr", "123"]);
 
-    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
-      projectId: "my-app",
-      issueId: undefined,
-      agent: undefined,
-    });
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "my-app",
+        issueId: undefined,
+        agent: undefined,
+      }),
+    );
     expect(mockSessionManager.claimPR).toHaveBeenCalledWith("app-1", "123", {
       assignOnGithub: undefined,
     });

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -221,6 +221,9 @@ async function spawnSession(
       issueId,
       agent,
       prompt: sanitizedPrompt,
+      onProgress: (text) => {
+        spinner.text = text;
+      },
     });
 
     let claimedPrUrl: string | null = null;

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1258,6 +1258,75 @@ describe("spawn", () => {
     vi.useRealTimers();
   }, 30_000);
 
+  it("invokes onProgress before each post-launch prompt-delivery attempt", async () => {
+    vi.useFakeTimers();
+    const failingRuntime: Runtime = {
+      ...mockRuntime,
+      sendMessage: vi.fn().mockRejectedValue(new Error("tmux send failed")),
+    };
+    const postLaunchAgent = {
+      ...mockAgent,
+      promptDelivery: "post-launch" as const,
+    };
+    const registryWithFailingSend: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return failingRuntime;
+        if (slot === "agent") return postLaunchAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    const onProgress = vi.fn();
+    const sm = createSessionManager({ config, registry: registryWithFailingSend });
+    const spawnPromise = sm.spawn({
+      projectId: "my-app",
+      prompt: "Fix the bug",
+      onProgress,
+    });
+    await vi.advanceTimersByTimeAsync(18_000);
+    await spawnPromise;
+
+    expect(onProgress).toHaveBeenCalledWith("Delivering prompt (attempt 1/3)");
+    expect(onProgress).toHaveBeenCalledWith("Delivering prompt (attempt 2/3)");
+    expect(onProgress).toHaveBeenCalledWith("Delivering prompt (attempt 3/3)");
+    vi.useRealTimers();
+  }, 30_000);
+
+  it("does not throw when onProgress callback throws", async () => {
+    vi.useFakeTimers();
+    const postLaunchAgent = {
+      ...mockAgent,
+      promptDelivery: "post-launch" as const,
+    };
+    const registryWithPostLaunch: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return postLaunchAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    const onProgress = vi.fn().mockImplementation(() => {
+      throw new Error("spinner blew up");
+    });
+    const sm = createSessionManager({ config, registry: registryWithPostLaunch });
+    const spawnPromise = sm.spawn({
+      projectId: "my-app",
+      prompt: "Fix the bug",
+      onProgress,
+    });
+    await vi.advanceTimersByTimeAsync(3_000);
+    const session = await spawnPromise;
+
+    expect(session.id).toBe("app-1");
+    expect(mockRuntime.sendMessage).toHaveBeenCalled();
+    vi.useRealTimers();
+  }, 20_000);
+
   it("waits before sending post-launch prompt", async () => {
     vi.useFakeTimers();
     const postLaunchAgent = {

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1288,9 +1288,10 @@ describe("spawn", () => {
     await vi.advanceTimersByTimeAsync(18_000);
     await spawnPromise;
 
-    expect(onProgress).toHaveBeenCalledWith("Delivering prompt (attempt 1/3)");
-    expect(onProgress).toHaveBeenCalledWith("Delivering prompt (attempt 2/3)");
-    expect(onProgress).toHaveBeenCalledWith("Delivering prompt (attempt 3/3)");
+    expect(onProgress).toHaveBeenCalledTimes(3);
+    expect(onProgress).toHaveBeenNthCalledWith(1, "Waiting to deliver prompt (attempt 1/3)");
+    expect(onProgress).toHaveBeenNthCalledWith(2, "Waiting to deliver prompt (attempt 2/3)");
+    expect(onProgress).toHaveBeenNthCalledWith(3, "Waiting to deliver prompt (attempt 3/3)");
     vi.useRealTimers();
   }, 30_000);
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -184,6 +184,18 @@ function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function reportProgress(
+  onProgress: ((text: string) => void) | undefined,
+  text: string,
+): void {
+  if (!onProgress) return;
+  try {
+    onProgress(text);
+  } catch {
+    // Progress reporting must never break spawn.
+  }
+}
+
 /** Get the next session number for a project. */
 function getNextSessionNumber(existingSessions: string[], prefix: string): number {
   let max = 0;
@@ -1426,6 +1438,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           try {
             // Wait for agent to start and be ready for input
             // Use exponential backoff: 3s, 6s, 9s between attempts
+            reportProgress(
+              spawnConfig.onProgress,
+              `Delivering prompt (attempt ${attempt}/${maxRetries})`,
+            );
             await new Promise((resolve) => setTimeout(resolve, baseDelayMs * attempt));
             await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
             promptDelivered = true;

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1440,7 +1440,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
             // Use exponential backoff: 3s, 6s, 9s between attempts
             reportProgress(
               spawnConfig.onProgress,
-              `Delivering prompt (attempt ${attempt}/${maxRetries})`,
+              `Waiting to deliver prompt (attempt ${attempt}/${maxRetries})`,
             );
             await new Promise((resolve) => setTimeout(resolve, baseDelayMs * attempt));
             await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -368,6 +368,13 @@ export interface SessionSpawnConfig {
   agent?: string;
   /** Override the OpenCode subagent for this session (e.g. "sisyphus", "oracle") */
   subagent?: string;
+  /**
+   * Optional progress reporter. Called with short status strings during
+   * long-running phases (e.g. post-launch prompt delivery, which can wait
+   * up to ~18s across retries). The CLI uses this to update its spinner
+   * text. Errors thrown by the callback are swallowed.
+   */
+  onProgress?: (text: string) => void;
 }
 
 /** Config for creating an orchestrator session */


### PR DESCRIPTION
## Summary

Post-launch prompt delivery (Claude Code, OpenCode-interactive, etc.) retries up to 3× with 3s/6s/9s exponential backoff — up to **18s of silent \"Spawning session via core\"** spinner text. The user has no idea what's happening.

This PR adds an optional `onProgress: (text: string) => void` to `SessionSpawnConfig`. The CLI passes a callback that updates spinner text, so the user sees `"Delivering prompt (attempt 2/3)"` instead of a frozen spinner.

## Changes

- **`packages/core/src/types.ts`**: add optional `onProgress` to `SessionSpawnConfig`. Optional → fully backwards-compatible.
- **`packages/core/src/session-manager.ts`**: small `reportProgress` helper (try/catch-wrapped so a throwing callback can never break spawn) + one call inside the prompt-delivery retry loop.
- **`packages/cli/src/commands/spawn.ts`**: pass `(text) => { spinner.text = text; }`.
- **Tests**: progress fires once per attempt; a throwing `onProgress` does not break spawn.

Net diff: +95 LOC (10 functional + 16 helper/doc + 69 tests).

## Test plan

- [x] `pnpm --filter @aoagents/ao-core test -- spawn` — 105 pass, 2 new
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (only pre-existing warnings)
- [ ] Manual: `ao spawn` against a Claude Code project, observe spinner text changes during the 3s wait

## Notes

- API is opt-in. Existing call sites (e.g. `ao spawn group` batch mode) don't need to pass it; they don't have a spinner anyway.
- Group-mode `sm.spawn` calls don't pass a `prompt`, so the post-launch loop doesn't fire — no callback needed there.
- The reporter try/catches the callback because UX should never crash core. Same posture as `recordActivityEvent` errors elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)