### PR TITLE
chore: release 0.4.1

### DIFF
--- a/packages/ao/CHANGELOG.md
+++ b/packages/ao/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aoagents/ao
 
+## 0.4.1
+
+### Patch Changes
+
+- @aoagents/ao-cli@0.4.1
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/ao/package.json
+++ b/packages/ao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Orchestrate parallel AI coding agents — global CLI wrapper",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-cli
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-web@0.4.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI for agent-orchestrator — the `ao` command",
   "license": "MIT",
   "type": "module",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @aoagents/ao-web
 
+## 0.4.1
+
+### Patch Changes
+
+- Fix blank-terminal regression in dashboard session detail views.
+
+  The mux WebSocket server was using non-exact tmux targets when calling
+  `set-option` and `attach-session`, so tmux's prefix matching could
+  attach a PTY to the wrong session (e.g. `ao-1` resolving against
+  `ao-15`). Pass `=${tmuxSessionId}` so tmux requires an exact match.
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-web",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Web dashboard for agent-orchestrator",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

Patch release for the dashboard direct-terminal regression fixed in #1608 (merged as `d0fde88f`).

- `@aoagents/ao-web`: **0.4.0 → 0.4.1**
- `@aoagents/ao-cli`: **0.4.0 → 0.4.1** (transitive — depends on web)
- `@aoagents/ao`: **0.4.0 → 0.4.1** (transitive — depends on cli)
- All other linked packages stay at 0.4.0 — no pending changesets touch them.

## Why now

So users running `ao update` pull a build that includes the exact-match tmux targeting fix. Without bumping, the published `@aoagents/ao` keeps shipping the broken `mux-websocket.ts`.

## Publishing

Merge this, then run `pnpm release` (= `pnpm -r build && changeset publish`) from a clean checkout of `main` with npm auth. There's no automated release workflow in `.github/workflows/` — publishing is manual.

## Test plan

- [x] `pnpm build` — clean
- [x] `changeset version` consumed `.changeset/fix-direct-terminal-attach.md` and bumped only the affected packages
- [ ] After merge: verify `pnpm release` publishes 0.4.1 to npm
- [ ] After publish: `npm install -g @aoagents/ao` resolves to 0.4.1 and `ao --version` reports it

🤖 Generated with [Claude Code](https://claude.com/claude-code)