### PR TITLE
fix(workspace-worktree): auto-recover from orphaned worktrees on spawn

### DIFF
--- a/.changeset/fix-orphan-worktree-recovery.md
+++ b/.changeset/fix-orphan-worktree-recovery.md
@@ -1,0 +1,18 @@
+---
+"@aoagents/ao-plugin-workspace-worktree": patch
+---
+
+Auto-recover from orphaned worktrees on session spawn.
+
+Previously, if a prior `ao start` was killed before it could clean up — by Ctrl-C, kill -9, system sleep, or any error during setup — the orchestrator worktree would stay registered with git even after its directory was removed. Every subsequent `ao start` for that project then failed with:
+
+```
+fatal: 'orchestrator/<name>' is already checked out at '/path/that/no/longer/exists'
+```
+
+Two fixes in `workspace.create()`:
+
+1. Always run `git worktree prune` at the start. This clears registry entries pointing to paths git no longer sees on disk.
+2. After prune, look up which worktree (if any) currently owns the target branch. If it's at the path we'd create anyway, reuse it instead of failing — this is the common orchestrator-restart case. If the branch is checked out at a different path, throw a clear error that names the offending path so users know exactly what to remove.
+
+Closes the long-standing "spawn failure leaves orphaned worktrees, re-spawn fails" issue.

--- a/packages/ao/CHANGELOG.md
+++ b/packages/ao/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aoagents/ao
 
+## 0.4.1
+
+### Patch Changes
+
+- @aoagents/ao-cli@0.4.1
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/ao/package.json
+++ b/packages/ao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Orchestrate parallel AI coding agents — global CLI wrapper",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-cli
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-web@0.4.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI for agent-orchestrator — the `ao` command",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-worktree/src/__tests__/index.test.ts
+++ b/packages/plugins/workspace-worktree/src/__tests__/index.test.ts
@@ -69,6 +69,16 @@ function mockOriginRemote(fetchSucceeds = true) {
   }
 }
 
+/**
+ * Default startup mocks for create(): no stale registrations, no worktree
+ * owns the target branch. Use when you want the test to exercise the
+ * normal create-new-worktree path.
+ */
+function mockNoOrphan() {
+  mockGitSuccess(""); // git worktree prune
+  mockGitSuccess(""); // git worktree list --porcelain (findWorktreeForBranch — no match)
+}
+
 function makeProject(overrides?: Partial<ProjectConfig>): ProjectConfig {
   return {
     name: "test-project",
@@ -115,6 +125,7 @@ describe("create() factory", () => {
   it("uses ~/.worktrees as default base dir", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitSuccess(""); // worktree add
@@ -127,6 +138,7 @@ describe("create() factory", () => {
   it("uses custom worktreeDir from config", async () => {
     const ws = create({ worktreeDir: "/custom/worktrees" });
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitSuccess(""); // worktree add
@@ -139,6 +151,7 @@ describe("create() factory", () => {
   it("expands tilde in custom worktreeDir", async () => {
     const ws = create({ worktreeDir: "~/custom-path" });
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitSuccess(""); // worktree add
@@ -151,6 +164,7 @@ describe("create() factory", () => {
   it("uses per-call worktreeDir override instead of plugin default", async () => {
     const ws = create(); // default: ~/.worktrees
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitSuccess(""); // worktree add
@@ -166,6 +180,7 @@ describe("create() factory", () => {
   it("per-call worktreeDir overrides plugin-level worktreeDir", async () => {
     const ws = create({ worktreeDir: "/old/worktrees" });
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitSuccess(""); // worktree add
@@ -182,30 +197,27 @@ describe("workspace.create()", () => {
   it("calls git fetch and git worktree add with correct args", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitSuccess(""); // worktree add
 
     await ws.create(makeCreateConfig());
 
-    // First call: git remote get-url origin
     expect(mockExecFileAsync).toHaveBeenCalledWith("git", ["remote", "get-url", "origin"], {
       cwd: "/repo/path",
     });
 
-    // Second call: git fetch origin --quiet
     expect(mockExecFileAsync).toHaveBeenCalledWith("git", ["fetch", "origin", "--quiet"], {
       cwd: "/repo/path",
     });
 
-    // Third call: git rev-parse --verify --quiet origin/main
     expect(mockExecFileAsync).toHaveBeenCalledWith(
       "git",
       ["rev-parse", "--verify", "--quiet", "origin/main"],
       { cwd: "/repo/path" },
     );
 
-    // Fourth call: git worktree add -b <branch> <path> <baseRef>
     expect(mockExecFileAsync).toHaveBeenCalledWith(
       "git",
       [
@@ -223,6 +235,7 @@ describe("workspace.create()", () => {
   it("creates the project worktree directory", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitSuccess(""); // worktree add
@@ -237,9 +250,10 @@ describe("workspace.create()", () => {
   it("removes a stale unregistered worktree directory before creating a new worktree", async () => {
     const ws = create();
 
-    mockExistsSync.mockReturnValueOnce(true);
     mockGitSuccess(""); // git worktree prune
-    mockGitSuccess("worktree /repo/path\nHEAD deadbeef\nbranch refs/heads/main"); // git worktree list --porcelain
+    mockGitSuccess("worktree /repo/path\nHEAD deadbeef\nbranch refs/heads/main"); // findWorktreeForBranch — no match
+    mockExistsSync.mockReturnValueOnce(true); // existsSync(worktreePath) inside clearStaleWorktreePath
+    mockGitSuccess("worktree /repo/path\nHEAD deadbeef\nbranch refs/heads/main"); // isRegisteredWorktree — no match
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitSuccess(""); // worktree add
@@ -258,14 +272,79 @@ describe("workspace.create()", () => {
     );
   });
 
-  it("throws a useful error when the existing worktree path is still registered with git", async () => {
+  it("reuses an existing worktree when it already owns the target branch at the expected path", async () => {
+    // Recovery from a prior `ao start` killed before cleanup: the worktree
+    // is still registered with git AT the path we'd create for this session.
+    // Adopt it instead of failing, so subsequent starts don't get stuck on
+    // "branch already checked out".
     const ws = create();
 
-    mockExistsSync.mockReturnValueOnce(true);
     mockGitSuccess(""); // git worktree prune
     mockGitSuccess(
       "worktree /mock-home/.worktrees/myproject/session-1\nHEAD deadbeef\nbranch refs/heads/feat/TEST-1",
-    ); // git worktree list --porcelain
+    ); // findWorktreeForBranch — matches our target path
+
+    const info = await ws.create(makeCreateConfig());
+
+    expect(info).toEqual({
+      path: "/mock-home/.worktrees/myproject/session-1",
+      branch: "feat/TEST-1",
+      sessionId: "session-1",
+      projectId: "myproject",
+    });
+    // No additional git calls — we did not try to create or check out anything.
+    expect(mockExecFileAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a clear error when the target branch is checked out at a different path", async () => {
+    const ws = create();
+
+    mockGitSuccess(""); // git worktree prune
+    mockGitSuccess(
+      "worktree /some/other/path\nHEAD deadbeef\nbranch refs/heads/feat/TEST-1",
+    ); // findWorktreeForBranch — owned elsewhere
+
+    await expect(ws.create(makeCreateConfig())).rejects.toThrow(
+      'Branch "feat/TEST-1" is already checked out at "/some/other/path".',
+    );
+  });
+
+  it("recovers when git's worktree registry points to a path that no longer exists", async () => {
+    // This is the actual user-facing failure mode: a previous spawn left a
+    // worktree registration pointing to a directory that has since been
+    // wiped. Without `git worktree prune` at the top of create(), the next
+    // `git worktree add -b` reports "branch already exists" and we never
+    // recover. With prune, the dead registration is cleared first.
+    const ws = create();
+
+    mockGitSuccess(""); // git worktree prune (clears the dead registration)
+    mockGitSuccess(""); // findWorktreeForBranch — empty after prune
+    mockOriginRemote();
+    mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
+    mockGitSuccess(""); // worktree add succeeds
+
+    const info = await ws.create(makeCreateConfig());
+
+    expect(info.path).toBe("/mock-home/.worktrees/myproject/session-1");
+    expect(mockExecFileAsync).toHaveBeenNthCalledWith(
+      1,
+      "git",
+      ["worktree", "prune"],
+      { cwd: "/repo/path" },
+    );
+  });
+
+  it("throws a useful error when the existing worktree path is still registered with git", async () => {
+    const ws = create();
+
+    mockGitSuccess(""); // git worktree prune
+    mockGitSuccess(
+      "worktree /mock-home/.worktrees/myproject/session-1\nHEAD deadbeef\nbranch refs/heads/some-other-branch",
+    ); // findWorktreeForBranch — owned by a different branch
+    mockExistsSync.mockReturnValueOnce(true);
+    mockGitSuccess(
+      "worktree /mock-home/.worktrees/myproject/session-1\nHEAD deadbeef\nbranch refs/heads/some-other-branch",
+    ); // isRegisteredWorktree — registered
 
     await expect(ws.create(makeCreateConfig())).rejects.toThrow(
       'Worktree path "/mock-home/.worktrees/myproject/session-1" already exists and is still registered with git',
@@ -275,6 +354,7 @@ describe("workspace.create()", () => {
   it("continues when fetch fails (offline)", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockOriginRemote(false);
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitSuccess(""); // worktree add succeeds
@@ -287,6 +367,7 @@ describe("workspace.create()", () => {
   it("uses refs/heads/<defaultBranch> when origin is missing", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockGitError("fatal: not a git repository"); // git remote get-url origin fails
     mockGitSuccess(""); // git rev-parse --verify --quiet refs/heads/main
     mockGitSuccess(""); // worktree add succeeds
@@ -316,6 +397,7 @@ describe("workspace.create()", () => {
   it("throws when neither origin nor the local default branch can be resolved", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockGitError("fatal: not a git repository"); // git remote get-url origin fails
     mockGitError("fatal: invalid reference"); // git rev-parse --verify --quiet refs/heads/main
 
@@ -327,6 +409,7 @@ describe("workspace.create()", () => {
   it("handles branch already exists by adding worktree then checking out", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitError("already exists"); // worktree add -b fails
@@ -353,6 +436,7 @@ describe("workspace.create()", () => {
   it("handles existing branch with local default-branch fallback when origin is missing", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockGitError("fatal: not a git repository"); // git remote get-url origin fails
     mockGitSuccess(""); // git rev-parse --verify --quiet refs/heads/main
     mockGitError("already exists"); // worktree add -b fails
@@ -377,6 +461,7 @@ describe("workspace.create()", () => {
   it("cleans up worktree on checkout failure", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitError("already exists"); // worktree add -b fails
@@ -399,6 +484,7 @@ describe("workspace.create()", () => {
   it("still throws on checkout failure even if cleanup fails", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitError("already exists"); // worktree add -b fails
@@ -414,6 +500,7 @@ describe("workspace.create()", () => {
   it("throws for non-already-exists worktree add errors", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitError("fatal: invalid reference"); // worktree add fails with other error
@@ -458,6 +545,7 @@ describe("workspace.create()", () => {
   it("returns correct WorkspaceInfo", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitSuccess(""); // worktree add
@@ -475,6 +563,7 @@ describe("workspace.create()", () => {
   it("expands tilde in project path", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockOriginRemote();
     mockGitSuccess(""); // git rev-parse --verify --quiet origin/main
     mockGitSuccess(""); // worktree add
@@ -494,6 +583,7 @@ describe("workspace.create()", () => {
   it("uses the local default branch when origin remote is missing", async () => {
     const ws = create();
 
+    mockNoOrphan();
     mockGitError("fatal: not a git repository"); // git remote get-url origin fails
     mockGitSuccess(""); // git rev-parse --verify --quiet refs/heads/main
     mockGitSuccess(""); // worktree add

--- a/packages/plugins/workspace-worktree/src/index.ts
+++ b/packages/plugins/workspace-worktree/src/index.ts
@@ -81,14 +81,37 @@ async function isRegisteredWorktree(repoPath: string, worktreePath: string): Pro
   }
 }
 
+/**
+ * Find the worktree (if any) that currently owns `branch` according to git.
+ * Returns the worktree's filesystem path, or null when the branch is not
+ * checked out in any worktree.
+ */
+async function findWorktreeForBranch(
+  repoPath: string,
+  branch: string,
+): Promise<string | null> {
+  let output: string;
+  try {
+    output = await git(repoPath, "worktree", "list", "--porcelain");
+  } catch {
+    return null;
+  }
+  const wantRef = `refs/heads/${branch}`;
+  let currentPath: string | null = null;
+  for (const line of output.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      currentPath = line.slice("worktree ".length);
+    } else if (line.startsWith("branch ") && line.slice("branch ".length) === wantRef) {
+      return currentPath;
+    } else if (line === "") {
+      currentPath = null;
+    }
+  }
+  return null;
+}
+
 async function clearStaleWorktreePath(repoPath: string, worktreePath: string): Promise<void> {
   if (!existsSync(worktreePath)) return;
-
-  try {
-    await git(repoPath, "worktree", "prune");
-  } catch {
-    // Best-effort prune before checking whether the path is still registered.
-  }
 
   if (await isRegisteredWorktree(repoPath, worktreePath)) {
     throw new Error(
@@ -136,6 +159,35 @@ export function create(config?: Record<string, unknown>): Workspace {
       const worktreePath = join(projectWorktreeDir, cfg.sessionId);
 
       mkdirSync(projectWorktreeDir, { recursive: true });
+
+      // Clean up registry entries pointing to paths git no longer sees on
+      // disk. Without this, a worktree dir wiped by some prior cleanup keeps
+      // its git-side registration, and the branch it owned looks "in use".
+      try {
+        await git(repoPath, "worktree", "prune");
+      } catch {
+        // best-effort
+      }
+
+      // If a live worktree already owns this branch, reuse it. Recovers from
+      // a previous spawn that was killed before it could clean up — without
+      // this, every subsequent ao start hits "branch already checked out".
+      const branchOwner = await findWorktreeForBranch(repoPath, cfg.branch);
+      if (branchOwner === worktreePath) {
+        return {
+          path: worktreePath,
+          branch: cfg.branch,
+          sessionId: cfg.sessionId,
+          projectId: cfg.projectId,
+        };
+      }
+      if (branchOwner) {
+        throw new Error(
+          `Branch "${cfg.branch}" is already checked out at "${branchOwner}". ` +
+            `Remove that worktree (\`git worktree remove ${branchOwner}\`) before retrying.`,
+        );
+      }
+
       await clearStaleWorktreePath(repoPath, worktreePath);
 
       const hasOrigin = await hasOriginRemote(repoPath);

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @aoagents/ao-web
 
+## 0.4.1
+
+### Patch Changes
+
+- Fix blank-terminal regression in dashboard session detail views.
+
+  The mux WebSocket server was using non-exact tmux targets when calling
+  `set-option` and `attach-session`, so tmux's prefix matching could
+  attach a PTY to the wrong session (e.g. `ao-1` resolving against
+  `ao-15`). Pass `=${tmuxSessionId}` so tmux requires an exact match.
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-web",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Web dashboard for agent-orchestrator",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

Closes the long-standing UX bug where a single ungraceful `ao start` exit poisons a project until the user manually `git worktree remove`s the orphan.

**Before:** if `ao start` was killed during setup (Ctrl-C, kill -9, sleep, error), the orchestrator worktree stayed registered with git. Every subsequent `ao start` for that project failed with:

```
fatal: 'orchestrator/<name>' is already checked out at '/some/path'
```

…even when that path had already been wiped from disk. No recovery path other than `cd <repo> && git worktree remove …`.

**After:** two changes to `workspace.create()`:

1. Always run `git worktree prune` at the top. Clears registry entries pointing to paths git no longer sees on disk. Previously this only ran inside `clearStaleWorktreePath`, which early-returned when the path was already gone — exactly the case where prune was needed.
2. After prune, look up which worktree owns the target branch. If at the path we'd create → **reuse** it (the common orchestrator-restart case). If at a different path → throw a **clear** error naming the conflict.

## Why

This caused real user pain — surfaced while debugging a separate dashboard issue. A user had a previous `ao start` for `mercury` that left an orphan; every subsequent start hit the same `'already checked out at /that/path'` error. The recovery (`git worktree remove`) is one command, but unless you happen to know what worktrees are or that `ao` uses them, the error is opaque.

## Test plan

- [x] `pnpm --filter @aoagents/ao-plugin-workspace-worktree test` — 53/53 passing
- [x] `pnpm --filter @aoagents/ao-plugin-workspace-worktree typecheck` — clean
- [x] `pnpm typecheck` (full repo) — clean
- New tests added:
  - reuses an existing worktree when it already owns the target branch at the expected path
  - throws a clear error when the target branch is checked out at a different path
  - recovers when git's worktree registry points to a path that no longer exists (the actual user-facing failure)
- Existing tests updated to mock the new `prune` + `list --porcelain` calls via a `mockNoOrphan()` helper.

## Changeset

Patch bump for `@aoagents/ao-plugin-workspace-worktree`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)