### PR TITLE
fix(core): recover from stale empty orchestrator reservation file

### DIFF
--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, readFileSync, existsSync } from "node:fs";
+import { mkdirSync, readFileSync, existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { createSessionManager } from "../../session-manager.js";
 import { validateConfig } from "../../config.js";
@@ -12,6 +12,7 @@ import {
   writeMetadata,
   readMetadata,
   readMetadataRaw,
+  reserveSessionId,
 } from "../../metadata.js";
 import { getProjectWorktreesDir } from "../../paths.js";
 import type {
@@ -1718,6 +1719,43 @@ describe("spawn", () => {
         'canonical orchestrator session is terminal with status "done"',
       );
       expect(mockWorkspace.create).not.toHaveBeenCalled();
+    });
+
+    it("ensureOrchestrator recovers from stale empty reservation file", async () => {
+      // Simulate a previous crashed/killed `ao start` that reserved the
+      // orchestrator session ID (empty file) but never wrote metadata.
+      reserveSessionId(sessionsDir, "app-orchestrator");
+
+      // Verify the pre-condition: file exists but readMetadataRaw returns null.
+      expect(readMetadataRaw(sessionsDir, "app-orchestrator")).toBeNull();
+      expect(existsSync(join(sessionsDir, "app-orchestrator.json"))).toBe(true);
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      // ensureOrchestrator should clean up the stale file and succeed.
+      const session = await sm.ensureOrchestrator({ projectId: "my-app" });
+
+      expect(session.id).toBe("app-orchestrator");
+      expect(session.status).toBe("working");
+      expect(mockWorkspace.create).toHaveBeenCalledTimes(1);
+
+      // Verify the metadata file now has valid content.
+      const meta = readMetadataRaw(sessionsDir, "app-orchestrator");
+      expect(meta?.["role"]).toBe("orchestrator");
+    });
+
+    it("ensureOrchestrator recovers from stale corrupt reservation file", async () => {
+      // Simulate a corrupt metadata file (not empty, but not valid JSON either).
+      writeFileSync(join(sessionsDir, "app-orchestrator.json"), "corrupt");
+
+      expect(readMetadataRaw(sessionsDir, "app-orchestrator")).toBeNull();
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const session = await sm.ensureOrchestrator({ projectId: "my-app" });
+
+      expect(session.id).toBe("app-orchestrator");
+      expect(session.status).toBe("working");
+      expect(mockWorkspace.create).toHaveBeenCalledTimes(1);
     });
 
     it("cleans up reserved metadata on workspace creation failure", async () => {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1837,18 +1837,17 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     }
 
     // Check for a stale reservation file: `get()` returned null (no valid
-    // metadata) but the file exists on disk from a previous crashed/killed
-    // run. `reserveSessionId` will see this as occupied and throw. Clean up
-    // now to avoid a confusing error and a 20s concurrent-orchestrator wait.
+    // metadata) but the file may exist on disk from a previous crashed/killed
+    // run. `reserveSessionId` will see it as occupied and throw. Unconditionally
+    // attempt cleanup — if the file doesn't exist this is a no-op, and if it
+    // does but a concurrent process just wrote valid metadata, the O_EXCL in
+    // reserveSessionId protects it (deleteMetadata won't remove a file that
+    // was re-created after our stat).
     const sessionsDir = getProjectSessionsDir(orchestratorConfig.projectId);
-    if (readMetadataRaw(sessionsDir, sessionId) === null) {
-      // No valid metadata — but the file might still exist (empty or corrupt).
-      // Try a best-effort cleanup so `reserveSessionId` succeeds.
-      try {
-        deleteMetadata(sessionsDir, sessionId);
-      } catch {
-        /* best effort — file may not exist, that's fine */
-      }
+    try {
+      deleteMetadata(sessionsDir, sessionId);
+    } catch {
+      /* best effort — file may not exist, that's fine */
     }
 
     try {
@@ -1870,7 +1869,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         /* best effort */
       }
 
-      return await spawnOrchestrator(orchestratorConfig);
+      try {
+        return await spawnOrchestrator(orchestratorConfig);
+      } catch (retryErr) {
+        // Third attempt failed — surface original error with retry context
+        // rather than the raw "already exists" message.
+        throw new Error(
+          `Orchestrator session "${sessionId}" could not be created after retry. ` +
+            `Another process may be creating it concurrently. Original error: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`,
+        );
+      }
     }
   }
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1877,6 +1877,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         throw new Error(
           `Orchestrator session "${sessionId}" could not be created after retry. ` +
             `Another process may be creating it concurrently. Original error: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`,
+          { cause: retryErr },
         );
       }
     }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1836,6 +1836,21 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       );
     }
 
+    // Check for a stale reservation file: `get()` returned null (no valid
+    // metadata) but the file exists on disk from a previous crashed/killed
+    // run. `reserveSessionId` will see this as occupied and throw. Clean up
+    // now to avoid a confusing error and a 20s concurrent-orchestrator wait.
+    const sessionsDir = getProjectSessionsDir(orchestratorConfig.projectId);
+    if (readMetadataRaw(sessionsDir, sessionId) === null) {
+      // No valid metadata — but the file might still exist (empty or corrupt).
+      // Try a best-effort cleanup so `reserveSessionId` succeeds.
+      try {
+        deleteMetadata(sessionsDir, sessionId);
+      } catch {
+        /* best effort — file may not exist, that's fine */
+      }
+    }
+
     try {
       return await spawnOrchestrator(orchestratorConfig);
     } catch (err) {
@@ -1843,9 +1858,19 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         throw err;
       }
 
+      // Reservation still failed after cleanup — check for a concurrent
+      // orchestrator that won the race between our cleanup and spawn.
       const concurrent = await waitForConcurrentOrchestrator(sessionId);
       if (concurrent) return concurrent;
-      throw err;
+
+      // Stale file was recreated during the race — one more cleanup attempt.
+      try {
+        deleteMetadata(sessionsDir, sessionId);
+      } catch {
+        /* best effort */
+      }
+
+      return await spawnOrchestrator(orchestratorConfig);
     }
   }
 


### PR DESCRIPTION
## Problem

`ao start` fails with `"Orchestrator session already exists"` after a previous run crashes/is killed before writing orchestrator metadata. The empty reservation file left on disk causes a mismatch: `readMetadataRaw()` returns `null` (treats empty as absent) while `reserveSessionId()` sees the file as occupied.

See #1661 for full root cause analysis.

## Fix

Two-layer recovery in `ensureOrchestratorInternal()`:

1. **Proactive cleanup (fast path):** After `get()` returns null, unconditionally attempt `deleteMetadata` to remove any stale reservation file before calling `spawnOrchestrator()`. This avoids both the confusing error and the 20-second concurrent-orchestrator poll.

2. **Catch-block retry (race path):** If a concurrent process recreates the file between cleanup and spawn, catch the reservation error, wait for concurrent orchestrator, and if none found, clean up + retry once with a descriptive error on final failure.

## Testing

Two new test cases in `spawn.test.ts`:
- **Empty reservation file:** Uses `reserveSessionId()` to create the exact same stale empty file that a crashed `ao start` leaves behind. Verifies `ensureOrchestrator()` succeeds and writes valid metadata.
- **Corrupt reservation file:** Writes garbage content. Verifies the same recovery path.

Both tests pass without the 20s concurrent-orchestrator timeout thanks to the proactive cleanup.

---

## Manual review scripts

The reviewer scripts are maintained in this gist instead of inline in the PR body:

- [reproduce-stale-reservation.sh](https://gist.github.com/yyovil/15245c49916defbe10e7507780fa0e7a#file-reproduce-stale-reservation-sh) — run on `main` before the fix.
- [verify-stale-reservation-fix.sh](https://gist.github.com/yyovil/15245c49916defbe10e7507780fa0e7a#file-verify-stale-reservation-fix-sh) — run on this fix branch.

Notes:
- The scripts use the current AO metadata layout: `~/.agent-orchestrator/projects/<project-id>/sessions/<session-prefix>-orchestrator.json`.
- Both scripts accept optional arguments: `<project-id> [session-prefix]`. If `session-prefix` is omitted, it defaults to `project-id`.

Closes #1661
