### PR TITLE
feat(pipeline): v1.1b — pipeline triggers + concurrency policy

### DIFF
--- a/packages/cli/src/lib/create-session-manager.ts
+++ b/packages/cli/src/lib/create-session-manager.ts
@@ -17,6 +17,7 @@ import {
   type LifecycleManager,
 } from "@aoagents/ao-core";
 import { importPluginModuleFromSource } from "./plugin-store.js";
+import { createPipelineAutoTrigger } from "./pipeline-auto-trigger.js";
 
 const registryPromises = new Map<string, Promise<PluginRegistry>>();
 
@@ -71,5 +72,12 @@ export async function getLifecycleManager(
 ): Promise<LifecycleManager> {
   const registry = await getPluginRegistry(config);
   const sessionManager = createSessionManager({ config, registry });
-  return createLifecycleManager({ config, registry, sessionManager, projectId });
+  const pipelineAutoTrigger = createPipelineAutoTrigger({ config, registry, projectId });
+  return createLifecycleManager({
+    config,
+    registry,
+    sessionManager,
+    projectId,
+    pipelineAutoTrigger,
+  });
 }

--- a/packages/cli/src/lib/pipeline-auto-trigger.ts
+++ b/packages/cli/src/lib/pipeline-auto-trigger.ts
@@ -58,14 +58,37 @@ export function createPipelineAutoTrigger(opts: {
   const { config, registry, projectId } = opts;
   return async () => {
     const projectIds = projectId ? [projectId] : Object.keys(config.projects ?? {});
+
+    // Process each project and collect failures. We never abort early so a
+    // bad SCM plugin in one project can't starve auto-triggers in others —
+    // but if any project failed, re-throw so the lifecycle-manager catch
+    // records `pipeline_auto_trigger=failure`. Without this re-throw,
+    // operators have no visibility into a persistently broken auto-trigger.
+    const failures: Array<{ projectId: string; error: unknown }> = [];
     for (const pid of projectIds) {
       try {
         await runProjectAutoTrigger(config, registry, pid);
-      } catch {
-        // Per-project failures must not abort other projects in the loop.
-        // The wrapping try/catch in lifecycle-manager.pollAll surfaces the
-        // failure to observability if all projects fail in aggregate.
+      } catch (error) {
+        failures.push({ projectId: pid, error });
       }
+    }
+
+    if (failures.length > 0) {
+      const summary = failures
+        .map(({ projectId: pid, error }) => {
+          const msg = error instanceof Error ? error.message : String(error);
+          return `${pid}: ${msg}`;
+        })
+        .join("; ");
+      const aggregate = new Error(
+        `pipeline auto-trigger failed for ${failures.length}/${projectIds.length} project(s): ${summary}`,
+      );
+      // Preserve the first error's stack via `cause` so observability has
+      // something useful to log. Aggregating all of them via AggregateError
+      // would be more correct, but our observer.recordOperation only
+      // surfaces a single `reason` string.
+      (aggregate as Error & { cause?: unknown }).cause = failures[0].error;
+      throw aggregate;
     }
   };
 }

--- a/packages/cli/src/lib/pipeline-auto-trigger.ts
+++ b/packages/cli/src/lib/pipeline-auto-trigger.ts
@@ -1,0 +1,152 @@
+/**
+ * CLI-side wiring for the pipeline auto-trigger pass.
+ *
+ * Builds the `pipelineAutoTrigger` callback that `createLifecycleManager`
+ * calls once per poll cycle. Per project, this:
+ *
+ *  1. Loads the pipeline store and persisted last-checked state.
+ *  2. Resolves the SCM plugin from project config.
+ *  3. Iterates configured pipelines, drives `runAutoTriggerPass` against the
+ *     raw `triggerRun` / `cancelRun` adapters in `pipeline-service`.
+ *  4. Persists the new state.
+ *
+ * Why `triggerRun` and not `engine.startRun` (yet)? The PipelineEngine isn't
+ * instantiated inside the lifecycle manager today (v0.4 wiring is the next
+ * sub-task). Using `triggerRun` here keeps the CLI mutation path consistent
+ * with `ao pipeline run` — runs land in the store via the same reducer, and
+ * the auto-trigger pass becomes a "headless ao pipeline run" until a real
+ * engine takes over.
+ *
+ * Concurrency policy applies *per pipeline* per the v1.1b spec — any
+ * non-terminal run on the same pipelineName counts as "active" regardless
+ * of which PR triggered it. SessionId encoding (`pipeline.<name>.pr-<n>`)
+ * still scopes loops per PR for trace clarity, but the policy decision
+ * looks across all of a pipeline's loops.
+ */
+
+import {
+  asRunId,
+  autoTriggerStatePath,
+  createPipelineStore,
+  getProjectPipelinesDir,
+  readAutoTriggerState,
+  runAutoTriggerPass,
+  writeAutoTriggerState,
+  type AutoTriggerDispatchInput,
+  type OrchestratorConfig,
+  type Pipeline,
+  type PluginRegistry,
+  type SCM,
+} from "@aoagents/ao-core";
+
+import {
+  cancelRun as cancelRunInStore,
+  hydrateEngineState,
+  listConfiguredPipelines,
+  resolveConfiguredPipeline,
+  triggerRun,
+  LoopAlreadyActiveError,
+} from "./pipeline-service.js";
+
+/** Build the lifecycle-manager hook for one or all projects. */
+export function createPipelineAutoTrigger(opts: {
+  config: OrchestratorConfig;
+  registry: PluginRegistry;
+  /** When set, only this project is processed; else all configured projects. */
+  projectId?: string;
+}): () => Promise<void> {
+  const { config, registry, projectId } = opts;
+  return async () => {
+    const projectIds = projectId ? [projectId] : Object.keys(config.projects ?? {});
+    for (const pid of projectIds) {
+      try {
+        await runProjectAutoTrigger(config, registry, pid);
+      } catch {
+        // Per-project failures must not abort other projects in the loop.
+        // The wrapping try/catch in lifecycle-manager.pollAll surfaces the
+        // failure to observability if all projects fail in aggregate.
+      }
+    }
+  };
+}
+
+async function runProjectAutoTrigger(
+  config: OrchestratorConfig,
+  registry: PluginRegistry,
+  projectId: string,
+): Promise<void> {
+  const project = config.projects?.[projectId];
+  if (!project) return;
+
+  const scmPluginName = project.scm?.plugin;
+  if (!scmPluginName) return;
+  const scm = registry.get<SCM>("scm", scmPluginName);
+  if (!scm) return;
+
+  const summaries = listConfiguredPipelines(config, projectId);
+  const pipelines: Pipeline[] = [];
+  for (const summary of summaries) {
+    try {
+      pipelines.push(resolveConfiguredPipeline(config, projectId, summary.pipelineId));
+    } catch {
+      // Misconfigured pipeline — config-load already surfaced these.
+    }
+  }
+  if (pipelines.length === 0) return;
+
+  const pipelinesDir = getProjectPipelinesDir(projectId);
+  const store = createPipelineStore(pipelinesDir);
+  const statePath = autoTriggerStatePath(pipelinesDir);
+  const prevState = await readAutoTriggerState(statePath);
+
+  const sessionIdFor = (pipelineName: string, prNumber: number): string =>
+    `pipeline.${pipelineName}.pr-${prNumber}`;
+
+  const isActiveRunForPipeline = (pipelineName: string): boolean => {
+    const engineState = hydrateEngineState(store);
+    for (const runId of Object.values(engineState.currentRunByLoop)) {
+      const run = engineState.runs[runId];
+      if (run && run.pipelineName === pipelineName) return true;
+    }
+    return false;
+  };
+
+  const cancelActiveRunsForPipeline = async (pipelineName: string): Promise<void> => {
+    const engineState = hydrateEngineState(store);
+    for (const runId of Object.values(engineState.currentRunByLoop)) {
+      const run = engineState.runs[runId];
+      if (run && run.pipelineName === pipelineName) {
+        try {
+          cancelRunInStore(store, asRunId(runId));
+        } catch {
+          // Run may have just terminated; cancel is a no-op then.
+        }
+      }
+    }
+  };
+
+  const startRunFor = async (input: AutoTriggerDispatchInput): Promise<void> => {
+    const pipeline = pipelines.find((p) => p.name === input.pipelineName);
+    if (!pipeline) return;
+    const sessionId = sessionIdFor(input.pipelineName, input.prNumber);
+    try {
+      triggerRun(store, registry, pipeline, {
+        sessionId,
+        headSha: `auto:${input.triggerEventType}:pr-${input.prNumber}`,
+      });
+    } catch (err) {
+      if (err instanceof LoopAlreadyActiveError) return;
+      throw err;
+    }
+  };
+
+  const result = await runAutoTriggerPass(prevState, {
+    scm,
+    pipelines,
+    isActiveRun: isActiveRunForPipeline,
+    startRun: startRunFor,
+    cancelActiveRun: cancelActiveRunsForPipeline,
+  });
+
+  await writeAutoTriggerState(statePath, result.state);
+}

--- a/packages/core/src/__tests__/pipeline-config-triggers.test.ts
+++ b/packages/core/src/__tests__/pipeline-config-triggers.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Config-schema coverage for `Pipeline.triggers` + `Pipeline.concurrency`.
+ *
+ * The trigger evaluator + concurrency decisions are tested in
+ * `pipeline-triggers.test.ts`. This file just locks in the YAML surface so
+ * accidental schema regressions surface at PR review.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ConfiguredPipelineSchema,
+  configuredPipelineToRuntime,
+} from "../pipeline/index.js";
+
+const minimalStage = {
+  name: "review",
+  trigger: { on: ["pr.opened"] },
+  executor: { kind: "agent" as const, plugin: "codex", mode: "review" as const },
+  task: { prompt: "review" },
+};
+
+describe("ConfiguredPipelineSchema — triggers", () => {
+  it("accepts a pipeline with no triggers (manual-only)", () => {
+    const result = ConfiguredPipelineSchema.safeParse({ stages: [minimalStage] });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts the four trigger event types", () => {
+    for (const on of ["pr_opened", "pr_push", "pr_review_requested", "manual"]) {
+      const result = ConfiguredPipelineSchema.safeParse({
+        stages: [minimalStage],
+        triggers: [{ on }],
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects unknown trigger event types", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [minimalStage],
+      triggers: [{ on: "pr_closed" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts all filter combinations", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [minimalStage],
+      triggers: [
+        {
+          on: "pr_push",
+          branches: ["main", "release/*"],
+          files: ["src/**", "packages/**"],
+          labels: ["needs-review"],
+          excludeDrafts: true,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("ConfiguredPipelineSchema — concurrency", () => {
+  it("accepts the three policies", () => {
+    for (const concurrency of ["cancel_in_progress", "skip", "queue"]) {
+      const result = ConfiguredPipelineSchema.safeParse({
+        stages: [minimalStage],
+        concurrency,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects an unknown policy", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [minimalStage],
+      concurrency: "kill_all",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("configuredPipelineToRuntime — triggers + concurrency", () => {
+  it("forwards triggers and concurrency into runtime Pipeline", () => {
+    const parsed = ConfiguredPipelineSchema.parse({
+      stages: [minimalStage],
+      triggers: [{ on: "pr_push", files: ["src/**"], excludeDrafts: true }],
+      concurrency: "skip",
+    });
+    const runtime = configuredPipelineToRuntime("review", parsed);
+    expect(runtime.triggers).toEqual([
+      { on: "pr_push", files: ["src/**"], excludeDrafts: true },
+    ]);
+    expect(runtime.concurrency).toBe("skip");
+  });
+
+  it("omits triggers/concurrency when not specified", () => {
+    const parsed = ConfiguredPipelineSchema.parse({ stages: [minimalStage] });
+    const runtime = configuredPipelineToRuntime("review", parsed);
+    expect(runtime.triggers).toBeUndefined();
+    expect(runtime.concurrency).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/pipeline-triggers.test.ts
+++ b/packages/core/src/__tests__/pipeline-triggers.test.ts
@@ -1,0 +1,568 @@
+/**
+ * Trigger evaluation + concurrency policy + auto-trigger pass tests.
+ *
+ * Three layers, in order of widening scope:
+ *  1. Pure glob + filter evaluation (`evaluateTrigger`)
+ *  2. Concurrency decision (`decideConcurrencyAction`)
+ *  3. End-to-end pass (`runAutoTriggerPass`) with fake SCM + dispatcher,
+ *     covering: dispatch, cancel_then_start, skip, queue, drain, and the
+ *     last-checked timestamp advance.
+ */
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  anyValueMatchesAnyGlob,
+  asPipelineId,
+  decideConcurrencyAction,
+  evaluateTrigger,
+  matchesAnyGlob,
+  runAutoTriggerPass,
+  readAutoTriggerState,
+  writeAutoTriggerState,
+  type AutoTriggerState,
+  type ConcurrencyPolicy,
+  type Pipeline,
+  type PipelineTrigger,
+} from "../pipeline/index.js";
+import type { SCM, PREvent } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function trigger(overrides: Partial<PipelineTrigger> = {}): PipelineTrigger {
+  return { on: "pr_opened", ...overrides };
+}
+
+function makeEvent(overrides: Partial<PREvent> = {}): PREvent {
+  return {
+    type: "pr_opened",
+    prNumber: 1,
+    baseBranch: "main",
+    headBranch: "feature/x",
+    labels: [],
+    changedFiles: [],
+    isDraft: false,
+    occurredAt: new Date("2026-05-06T10:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makePipeline(overrides: Partial<Pipeline> = {}): Pipeline {
+  return {
+    id: asPipelineId("review"),
+    name: "review",
+    stages: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Glob matching
+// ---------------------------------------------------------------------------
+
+describe("matchesAnyGlob", () => {
+  it("returns true when patterns is undefined or empty (filter not set)", () => {
+    expect(matchesAnyGlob(undefined, "anything")).toBe(true);
+    expect(matchesAnyGlob([], "anything")).toBe(true);
+  });
+
+  it("matches exact strings", () => {
+    expect(matchesAnyGlob(["main"], "main")).toBe(true);
+    expect(matchesAnyGlob(["main"], "develop")).toBe(false);
+  });
+
+  it("supports * single-segment wildcard", () => {
+    expect(matchesAnyGlob(["release/*"], "release/1.2.3")).toBe(true);
+    expect(matchesAnyGlob(["release/*"], "release/feature/x")).toBe(false);
+  });
+
+  it("supports ** any-segment wildcard", () => {
+    expect(matchesAnyGlob(["src/**"], "src/foo/bar.ts")).toBe(true);
+    expect(matchesAnyGlob(["src/**"], "src/foo.ts")).toBe(true);
+    expect(matchesAnyGlob(["src/**"], "lib/foo.ts")).toBe(false);
+  });
+
+  it("escapes regex metacharacters in literal segments", () => {
+    expect(matchesAnyGlob(["a.b"], "axb")).toBe(false); // dot is literal
+    expect(matchesAnyGlob(["a.b"], "a.b")).toBe(true);
+  });
+});
+
+describe("anyValueMatchesAnyGlob", () => {
+  it("returns true when patterns is undefined (filter not set)", () => {
+    expect(anyValueMatchesAnyGlob(undefined, [])).toBe(true);
+    expect(anyValueMatchesAnyGlob(undefined, ["anything"])).toBe(true);
+  });
+
+  it("returns false when patterns is set but values is empty", () => {
+    expect(anyValueMatchesAnyGlob(["src/**"], [])).toBe(false);
+  });
+
+  it("returns true if any value matches any pattern", () => {
+    expect(
+      anyValueMatchesAnyGlob(
+        ["src/**", "packages/**"],
+        ["docs/intro.md", "src/foo.ts"],
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false if no value matches any pattern", () => {
+    expect(
+      anyValueMatchesAnyGlob(
+        ["src/**", "packages/**"],
+        ["docs/intro.md", "README.md"],
+      ),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateTrigger
+// ---------------------------------------------------------------------------
+
+describe("evaluateTrigger", () => {
+  it("fires on event-type match with no filters", () => {
+    expect(
+      evaluateTrigger({ trigger: trigger({ on: "pr_opened" }), event: makeEvent() }),
+    ).toBe(true);
+  });
+
+  it("does not fire when event type differs from trigger.on", () => {
+    expect(
+      evaluateTrigger({
+        trigger: trigger({ on: "pr_push" }),
+        event: makeEvent({ type: "pr_opened" }),
+      }),
+    ).toBe(false);
+  });
+
+  it("never fires for manual triggers", () => {
+    expect(
+      evaluateTrigger({
+        trigger: trigger({ on: "manual" }),
+        event: makeEvent({ type: "pr_opened" }),
+      }),
+    ).toBe(false);
+  });
+
+  it("respects branches filter", () => {
+    expect(
+      evaluateTrigger({
+        trigger: trigger({ branches: ["main", "develop"] }),
+        event: makeEvent({ baseBranch: "main" }),
+      }),
+    ).toBe(true);
+    expect(
+      evaluateTrigger({
+        trigger: trigger({ branches: ["main"] }),
+        event: makeEvent({ baseBranch: "feature" }),
+      }),
+    ).toBe(false);
+  });
+
+  it("respects files filter (any-match across changed files)", () => {
+    expect(
+      evaluateTrigger({
+        trigger: trigger({ on: "pr_push", files: ["src/**"] }),
+        event: makeEvent({ type: "pr_push", changedFiles: ["docs/x.md", "src/y.ts"] }),
+      }),
+    ).toBe(true);
+    expect(
+      evaluateTrigger({
+        trigger: trigger({ on: "pr_push", files: ["src/**"] }),
+        event: makeEvent({ type: "pr_push", changedFiles: ["docs/x.md"] }),
+      }),
+    ).toBe(false);
+  });
+
+  it("respects labels filter", () => {
+    expect(
+      evaluateTrigger({
+        trigger: trigger({ labels: ["needs-review"] }),
+        event: makeEvent({ labels: ["bug", "needs-review"] }),
+      }),
+    ).toBe(true);
+    expect(
+      evaluateTrigger({
+        trigger: trigger({ labels: ["needs-review"] }),
+        event: makeEvent({ labels: ["bug"] }),
+      }),
+    ).toBe(false);
+  });
+
+  it("respects excludeDrafts", () => {
+    expect(
+      evaluateTrigger({
+        trigger: trigger({ excludeDrafts: true }),
+        event: makeEvent({ isDraft: true }),
+      }),
+    ).toBe(false);
+    expect(
+      evaluateTrigger({
+        trigger: trigger({ excludeDrafts: true }),
+        event: makeEvent({ isDraft: false }),
+      }),
+    ).toBe(true);
+    // Default: drafts are allowed.
+    expect(
+      evaluateTrigger({ trigger: trigger(), event: makeEvent({ isDraft: true }) }),
+    ).toBe(true);
+  });
+
+  it("conjoins all filters", () => {
+    const t = trigger({
+      branches: ["main"],
+      files: ["src/**"],
+      labels: ["ci-ok"],
+      excludeDrafts: true,
+    });
+    expect(
+      evaluateTrigger({
+        trigger: t,
+        event: makeEvent({
+          baseBranch: "main",
+          changedFiles: ["src/x.ts"],
+          labels: ["ci-ok"],
+          isDraft: false,
+        }),
+      }),
+    ).toBe(true);
+    // Any one mismatch breaks the conjunction.
+    expect(
+      evaluateTrigger({
+        trigger: t,
+        event: makeEvent({
+          baseBranch: "main",
+          changedFiles: ["src/x.ts"],
+          labels: ["ci-ok"],
+          isDraft: true,
+        }),
+      }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decideConcurrencyAction
+// ---------------------------------------------------------------------------
+
+describe("decideConcurrencyAction", () => {
+  const policies: ConcurrencyPolicy[] = ["cancel_in_progress", "skip", "queue"];
+
+  it.each(policies)("starts immediately when no active run (policy=%s)", (policy) => {
+    expect(decideConcurrencyAction({ policy, hasActiveRun: false })).toBe("start");
+  });
+
+  it("returns cancel_then_start for cancel_in_progress with active run", () => {
+    expect(
+      decideConcurrencyAction({ policy: "cancel_in_progress", hasActiveRun: true }),
+    ).toBe("cancel_then_start");
+  });
+
+  it("returns skip for skip policy with active run", () => {
+    expect(decideConcurrencyAction({ policy: "skip", hasActiveRun: true })).toBe(
+      "skip",
+    );
+  });
+
+  it("returns queue for queue policy with active run", () => {
+    expect(decideConcurrencyAction({ policy: "queue", hasActiveRun: true })).toBe(
+      "queue",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runAutoTriggerPass — end-to-end with fake SCM + dispatcher
+// ---------------------------------------------------------------------------
+
+function fakeScm(events: PREvent[]): SCM {
+  return {
+    name: "fake",
+    detectPR: async () => null,
+    getPRState: async () => "open",
+    mergePR: async () => undefined,
+    closePR: async () => undefined,
+    getCIChecks: async () => [],
+    getCISummary: async () => "none",
+    getReviews: async () => [],
+    getReviewDecision: async () => "none",
+    getPendingComments: async () => [],
+    getMergeability: async () => ({
+      mergeable: false,
+      ciPassing: false,
+      approved: false,
+      noConflicts: true,
+      blockers: [],
+    }),
+    async getRecentPREvents() {
+      return events;
+    },
+  };
+}
+
+function emptyState(at = new Date(0)): AutoTriggerState {
+  return { lastCheckedAt: at.toISOString(), queued: [] };
+}
+
+describe("runAutoTriggerPass", () => {
+  it("dispatches when a trigger matches and no run is active", async () => {
+    const events = [makeEvent({ type: "pr_opened", prNumber: 7 })];
+    const startRun = vi.fn();
+    const cancelActiveRun = vi.fn();
+    const pipeline = makePipeline({
+      triggers: [trigger({ on: "pr_opened", branches: ["main"] })],
+    });
+
+    const result = await runAutoTriggerPass(emptyState(), {
+      scm: fakeScm(events),
+      pipelines: [pipeline],
+      isActiveRun: () => false,
+      startRun,
+      cancelActiveRun,
+      now: () => new Date("2026-05-06T11:00:00Z"),
+    });
+
+    expect(startRun.mock.calls).toHaveLength(1);
+    expect(cancelActiveRun.mock.calls).toHaveLength(0);
+    expect(result.dispatched).toBe(1);
+    expect(result.state.lastCheckedAt).toBe("2026-05-06T11:00:00.000Z");
+  });
+
+  it("cancels active run and starts new one under cancel_in_progress", async () => {
+    const events = [makeEvent({ type: "pr_push", prNumber: 9 })];
+    const startRun = vi.fn();
+    const cancelActiveRun = vi.fn();
+    const pipeline = makePipeline({
+      concurrency: "cancel_in_progress",
+      triggers: [trigger({ on: "pr_push" })],
+    });
+
+    const result = await runAutoTriggerPass(emptyState(), {
+      scm: fakeScm(events),
+      pipelines: [pipeline],
+      isActiveRun: () => true,
+      startRun,
+      cancelActiveRun,
+    });
+
+    expect(cancelActiveRun.mock.calls).toEqual([["review"]]);
+    expect(startRun.mock.calls).toHaveLength(1);
+    expect(result.dispatched).toBe(1);
+  });
+
+  it("skips trigger silently under skip policy when run is active", async () => {
+    const events = [makeEvent({ type: "pr_push", prNumber: 9 })];
+    const startRun = vi.fn();
+    const cancelActiveRun = vi.fn();
+    const pipeline = makePipeline({
+      concurrency: "skip",
+      triggers: [trigger({ on: "pr_push" })],
+    });
+
+    const result = await runAutoTriggerPass(emptyState(), {
+      scm: fakeScm(events),
+      pipelines: [pipeline],
+      isActiveRun: () => true,
+      startRun,
+      cancelActiveRun,
+    });
+
+    expect(startRun.mock.calls).toHaveLength(0);
+    expect(cancelActiveRun.mock.calls).toHaveLength(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("queues trigger and drains it on a later pass when run becomes idle", async () => {
+    const startRun = vi.fn();
+    const cancelActiveRun = vi.fn();
+    const pipeline = makePipeline({
+      concurrency: "queue",
+      triggers: [trigger({ on: "pr_push" })],
+    });
+
+    let active = true;
+    // First pass: run is active → queue.
+    const events = [makeEvent({ type: "pr_push", prNumber: 11 })];
+    const pass1 = await runAutoTriggerPass(emptyState(), {
+      scm: fakeScm(events),
+      pipelines: [pipeline],
+      isActiveRun: () => active,
+      startRun,
+      cancelActiveRun,
+      now: () => new Date("2026-05-06T11:00:00Z"),
+    });
+    expect(pass1.queued).toBe(1);
+    expect(pass1.dispatched).toBe(0);
+    expect(pass1.state.queued).toHaveLength(1);
+
+    // Second pass: no new events, run now idle → drain the queue.
+    active = false;
+    const pass2 = await runAutoTriggerPass(pass1.state, {
+      scm: fakeScm([]),
+      pipelines: [pipeline],
+      isActiveRun: () => active,
+      startRun,
+      cancelActiveRun,
+      now: () => new Date("2026-05-06T11:05:00Z"),
+    });
+    expect(pass2.drained).toBe(1);
+    expect(startRun.mock.calls).toHaveLength(1);
+    expect(pass2.state.queued).toHaveLength(0);
+  });
+
+  it("ages out queued entries past queueMaxAgeMs", async () => {
+    const startRun = vi.fn();
+    const pipeline = makePipeline({
+      concurrency: "queue",
+      triggers: [trigger({ on: "pr_push" })],
+    });
+
+    const seedState: AutoTriggerState = {
+      lastCheckedAt: "2026-05-05T10:00:00.000Z",
+      queued: [
+        {
+          pipelineName: "review",
+          prNumber: 33,
+          queuedAt: "2026-05-05T10:00:00.000Z", // 24h+ old
+          triggerEventType: "pr_push",
+        },
+      ],
+    };
+
+    const result = await runAutoTriggerPass(seedState, {
+      scm: fakeScm([]),
+      pipelines: [pipeline],
+      isActiveRun: () => false,
+      startRun,
+      cancelActiveRun: vi.fn(),
+      now: () => new Date("2026-05-06T11:00:00Z"), // 25h later
+      queueMaxAgeMs: 24 * 60 * 60 * 1000,
+    });
+
+    expect(result.drained).toBe(0);
+    expect(startRun.mock.calls).toHaveLength(0);
+    expect(result.state.queued).toHaveLength(0);
+  });
+
+  it("advances lastCheckedAt even when SCM has no getRecentPREvents", async () => {
+    const startRun = vi.fn();
+    const cancelActiveRun = vi.fn();
+    const pipeline = makePipeline({
+      triggers: [trigger({ on: "pr_opened" })],
+    });
+    const scm: SCM = {
+      name: "fake-no-events",
+      detectPR: async () => null,
+      getPRState: async () => "open",
+      mergePR: async () => undefined,
+      closePR: async () => undefined,
+      getCIChecks: async () => [],
+      getCISummary: async () => "none",
+      getReviews: async () => [],
+      getReviewDecision: async () => "none",
+      getPendingComments: async () => [],
+      getMergeability: async () => ({
+      mergeable: false,
+      ciPassing: false,
+      approved: false,
+      noConflicts: true,
+      blockers: [],
+    }),
+    };
+
+    const result = await runAutoTriggerPass(emptyState(), {
+      scm,
+      pipelines: [pipeline],
+      isActiveRun: () => false,
+      startRun,
+      cancelActiveRun,
+      now: () => new Date("2026-05-06T11:00:00Z"),
+    });
+
+    expect(startRun.mock.calls).toHaveLength(0);
+    expect(result.state.lastCheckedAt).toBe("2026-05-06T11:00:00.000Z");
+  });
+
+  it("never fires manual triggers from PR events", async () => {
+    const events = [makeEvent({ type: "pr_opened", prNumber: 1 })];
+    const startRun = vi.fn();
+    const pipeline = makePipeline({
+      triggers: [trigger({ on: "manual" })],
+    });
+
+    const result = await runAutoTriggerPass(emptyState(), {
+      scm: fakeScm(events),
+      pipelines: [pipeline],
+      isActiveRun: () => false,
+      startRun,
+      cancelActiveRun: vi.fn(),
+    });
+
+    expect(result.dispatched).toBe(0);
+    expect(startRun.mock.calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence (last-checked timestamp survives restarts)
+// ---------------------------------------------------------------------------
+
+describe("readAutoTriggerState / writeAutoTriggerState", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), "ao-trigger-state-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it("returns empty state when file is missing", async () => {
+    const state = await readAutoTriggerState(join(tmp, "missing.json"));
+    expect(state.queued).toEqual([]);
+    expect(new Date(state.lastCheckedAt).getTime()).toBe(0);
+  });
+
+  it("round-trips a state through write+read", async () => {
+    const path = join(tmp, "auto-trigger-state.json");
+    const stateOut: AutoTriggerState = {
+      lastCheckedAt: "2026-05-06T11:00:00.000Z",
+      queued: [
+        {
+          pipelineName: "review",
+          prNumber: 42,
+          queuedAt: "2026-05-06T10:59:00.000Z",
+          triggerEventType: "pr_push",
+        },
+      ],
+    };
+    await writeAutoTriggerState(path, stateOut);
+    const stateIn = await readAutoTriggerState(path);
+    expect(stateIn).toEqual(stateOut);
+
+    const raw = await readFile(path, "utf8");
+    expect(JSON.parse(raw)).toEqual(stateOut);
+  });
+
+  it("recovers gracefully from corrupt JSON", async () => {
+    const path = join(tmp, "corrupt.json");
+    await writeAutoTriggerState(path, {
+      lastCheckedAt: "ignored",
+      queued: [],
+    });
+    // Stomp the file with junk.
+    await import("node:fs/promises").then((fs) =>
+      fs.writeFile(path, "not json", "utf8"),
+    );
+    const state = await readAutoTriggerState(path);
+    expect(state.queued).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/pipeline-triggers.test.ts
+++ b/packages/core/src/__tests__/pipeline-triggers.test.ts
@@ -87,6 +87,14 @@ describe("matchesAnyGlob", () => {
     expect(matchesAnyGlob(["src/**"], "lib/foo.ts")).toBe(false);
   });
 
+  it("matches root-level files with **\\/X (GitHub Actions semantics)", () => {
+    // **\/*.ts must match both `config.ts` (root) and `src/foo.ts` (nested)
+    expect(matchesAnyGlob(["**/*.ts"], "config.ts")).toBe(true);
+    expect(matchesAnyGlob(["**/*.ts"], "src/foo.ts")).toBe(true);
+    expect(matchesAnyGlob(["**/*.ts"], "src/nested/foo.ts")).toBe(true);
+    expect(matchesAnyGlob(["**/*.ts"], "config.js")).toBe(false);
+  });
+
   it("escapes regex metacharacters in literal segments", () => {
     expect(matchesAnyGlob(["a.b"], "axb")).toBe(false); // dot is literal
     expect(matchesAnyGlob(["a.b"], "a.b")).toBe(true);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -410,6 +410,19 @@ export {
   ConfiguredPipelineSchema,
   PipelinesConfigSchema,
   configuredPipelineToRuntime,
+  // v1.1b: trigger evaluation + auto-trigger pass
+  evaluateTrigger,
+  decideConcurrencyAction,
+  matchesAnyGlob,
+  anyValueMatchesAnyGlob,
+  triggerEventForPREvent,
+  runAutoTriggerPass,
+  readAutoTriggerState,
+  writeAutoTriggerState,
+  autoTriggerStatePath,
+  makeInitialAutoTriggerState,
+  EMPTY_AUTO_TRIGGER_STATE,
+  DEFAULT_QUEUE_MAX_AGE_MS,
 } from "./pipeline/index.js";
 
 export type {
@@ -470,6 +483,19 @@ export type {
   StartRunInput,
   ConfiguredPipeline,
   PipelinesConfig,
+  // v1.1b: trigger types
+  PipelineTrigger,
+  PipelineTriggerEvent,
+  ConcurrencyPolicy,
+  ConcurrencyAction,
+  ConcurrencyDecisionContext,
+  TriggerEvaluationContext,
+  AutoTriggerState,
+  AutoTriggerPassDeps,
+  AutoTriggerPassResult,
+  AutoTriggerActionLog,
+  DispatchInput as AutoTriggerDispatchInput,
+  QueuedTrigger,
 } from "./pipeline/index.js";
 
 // Activity event logging — structured diagnostic event trail

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -459,6 +459,16 @@ export interface LifecycleManagerDeps {
   sessionManager: OpenCodeSessionManager;
   /** When set, only poll sessions belonging to this project. */
   projectId?: string;
+  /**
+   * Optional hook driving Pipeline.triggers auto-firing. Invoked once per
+   * `pollAll` cycle (after session checks). Failures are observed and
+   * swallowed — auto-triggers never block session polling.
+   *
+   * The hook is intentionally opaque to the lifecycle manager: it owns its
+   * own SCM access, store, and persisted last-checked timestamp. See
+   * `runAutoTriggerPass` in `pipeline/auto-trigger.ts` for the building blocks.
+   */
+  pipelineAutoTrigger?: () => Promise<void>;
 }
 
 /** Track attempt counts for reactions per session. */
@@ -472,7 +482,13 @@ interface ReactionTracker {
 
 /** Create a LifecycleManager instance. */
 export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleManager {
-  const { config, registry, sessionManager, projectId: scopedProjectId } = deps;
+  const {
+    config,
+    registry,
+    sessionManager,
+    projectId: scopedProjectId,
+    pipelineAutoTrigger,
+  } = deps;
   const observer = createProjectObserver(config, "lifecycle-manager");
 
   const states = new Map<SessionId, SessionStatus>();
@@ -2452,6 +2468,26 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       // Persist batch enrichment data to session metadata files so the
       // web dashboard can read it without calling GitHub API.
       persistPREnrichmentToMetadata(sessionsToCheck);
+
+      // Pipeline auto-trigger pass — fires Pipeline.triggers based on
+      // SCM events since last checked. Isolated try/catch so a misconfigured
+      // SCM plugin or a transient outage never breaks session polling.
+      if (pipelineAutoTrigger) {
+        try {
+          await pipelineAutoTrigger();
+        } catch (err) {
+          observer.recordOperation({
+            metric: "pipeline_auto_trigger",
+            operation: "pipeline.auto_trigger",
+            outcome: "failure",
+            correlationId,
+            projectId: scopedProjectId,
+            durationMs: Date.now() - startedAt,
+            reason: err instanceof Error ? err.message : String(err),
+            level: "warn",
+          });
+        }
+      }
 
       // Prune stale entries from states, reactionTrackers, and lastReviewBacklogCheckAt
       // for sessions that no longer appear in the session list (e.g., after kill/cleanup)

--- a/packages/core/src/observability.ts
+++ b/packages/core/src/observability.ts
@@ -24,6 +24,7 @@ export type ObservabilityMetricName =
   | "graphql_batch"
   | "kill"
   | "lifecycle_poll"
+  | "pipeline_auto_trigger"
   | "restore"
   | "send"
   | "spawn"

--- a/packages/core/src/pipeline/auto-trigger.ts
+++ b/packages/core/src/pipeline/auto-trigger.ts
@@ -1,0 +1,330 @@
+/**
+ * Auto-trigger orchestrator — drives `Pipeline.triggers` from polled SCM
+ * events and applies the configured concurrency policy.
+ *
+ * Pure I/O coordination on top of the pure `triggers.ts` decision functions:
+ *
+ *   1. Fetch events since the last-checked timestamp (via SCM.getRecentPREvents).
+ *   2. For each pipeline configured on the project, evaluate every trigger
+ *      against every event. Earliest matching event wins per (pipeline, event).
+ *   3. Apply the concurrency policy (`isActiveRun(pipelineName)` is supplied
+ *      by the caller — we don't reach into the engine state directly).
+ *   4. For `start` / `cancel_then_start`, call `startRun(pipelineName, opts)`.
+ *      For `cancel_then_start`, also call `cancelActiveRun(pipelineName)`
+ *      first. For `queue`, persist a queue entry; for `skip`, drop silently.
+ *   5. Drain the persisted queue: any queued entry whose pipeline now has
+ *      no active run is dispatched.
+ *   6. Persist `lastCheckedAt = now` (and the updated queue).
+ *
+ * State persistence: a single JSON file per project at
+ * `{getProjectPipelinesDir(projectId)}/auto-trigger-state.json`. Persisting
+ * `lastCheckedAt` is the load-bearing requirement — without it, a restart
+ * re-fires every event in the SCM event window. The queue lives in the same
+ * file so a process restart recovers in-flight queued triggers, but the
+ * format is deliberately small (no migrations machinery yet).
+ *
+ * Dependency injection: this module never imports `engine.ts` directly. The
+ * caller wires `startRun` / `cancelActiveRun` / `isActiveRun` callbacks so
+ * the lifecycle-manager can either dispatch through a real PipelineEngine
+ * (when v0.4 lifecycle wiring lands) or through the CLI's `triggerRun`
+ * adapter (today). Decoupling here means the auto-trigger pass is unit
+ * testable without the engine and survives the engine wiring rework.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { PREvent, SCM } from "../types.js";
+import {
+  decideConcurrencyAction,
+  evaluateTrigger,
+  type ConcurrencyAction,
+} from "./triggers.js";
+import {
+  DEFAULT_CONCURRENCY_POLICY,
+  type ConcurrencyPolicy,
+  type Pipeline,
+  type PipelineTrigger,
+} from "./types.js";
+
+/**
+ * Persisted state for one project. Kept intentionally tiny; if more state
+ * shows up here, take a beat and decide whether it should live in the
+ * pipeline store instead.
+ */
+export interface AutoTriggerState {
+  /** ISO timestamp of the last poll. Used as `since` for `getRecentPREvents`. */
+  lastCheckedAt: string;
+  /**
+   * Triggers held over by the `queue` policy. Drained on the next pass when
+   * the target pipeline's loop is idle.
+   */
+  queued: QueuedTrigger[];
+}
+
+export interface QueuedTrigger {
+  pipelineName: string;
+  prNumber: number;
+  /** ISO. Drop entries older than `queueMaxAgeMs` to bound the queue. */
+  queuedAt: string;
+  /** Carried for observability. The dispatcher only needs `prNumber`. */
+  triggerEventType: PREvent["type"];
+}
+
+export const DEFAULT_QUEUE_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h
+
+export const EMPTY_AUTO_TRIGGER_STATE: AutoTriggerState = {
+  lastCheckedAt: new Date(0).toISOString(),
+  queued: [],
+};
+
+// ============================================================================
+// State persistence
+// ============================================================================
+
+/**
+ * Read the per-project auto-trigger state from `path`. Missing file yields
+ * `EMPTY_AUTO_TRIGGER_STATE`; corrupt JSON yields the same and is logged
+ * by the caller (we don't want a bad state file to block trigger evaluation
+ * forever — a fresh `lastCheckedAt = epoch` is recoverable, just noisy).
+ */
+export async function readAutoTriggerState(path: string): Promise<AutoTriggerState> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { ...EMPTY_AUTO_TRIGGER_STATE };
+    }
+    throw err;
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<AutoTriggerState>;
+    return {
+      lastCheckedAt:
+        typeof parsed.lastCheckedAt === "string"
+          ? parsed.lastCheckedAt
+          : EMPTY_AUTO_TRIGGER_STATE.lastCheckedAt,
+      queued: Array.isArray(parsed.queued) ? parsed.queued : [],
+    };
+  } catch {
+    return { ...EMPTY_AUTO_TRIGGER_STATE };
+  }
+}
+
+export async function writeAutoTriggerState(
+  path: string,
+  state: AutoTriggerState,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2), "utf8");
+}
+
+// ============================================================================
+// Pass orchestration
+// ============================================================================
+
+export interface DispatchInput {
+  pipelineName: string;
+  prNumber: number;
+  triggerEventType: PREvent["type"] | "manual_queue_drain";
+}
+
+export interface AutoTriggerPassDeps {
+  /** SCM plugin instance for the project. May lack `getRecentPREvents`. */
+  scm: SCM;
+  /** Pipelines configured on the project. */
+  pipelines: Pipeline[];
+  /** True if a non-terminal run is currently in-flight for this pipeline. */
+  isActiveRun(pipelineName: string): boolean;
+  /** Start a run. The caller resolves `pipelineName` to a Pipeline internally. */
+  startRun(input: DispatchInput): Promise<void> | void;
+  /** Cancel the active run for a pipeline (no-op when there isn't one). */
+  cancelActiveRun(pipelineName: string): Promise<void> | void;
+  /** Override clock for tests. */
+  now?: () => Date;
+  /** Drop queued entries older than this. Defaults to `DEFAULT_QUEUE_MAX_AGE_MS`. */
+  queueMaxAgeMs?: number;
+  /** Per-action observability hook. */
+  onAction?: (action: AutoTriggerActionLog) => void;
+}
+
+export interface AutoTriggerActionLog {
+  action: ConcurrencyAction | "drain";
+  pipelineName: string;
+  prNumber: number;
+  trigger: PipelineTrigger;
+  /** When `action === "drain"`, the original event type carried in the queue. */
+  drainedFromEventType?: PREvent["type"];
+}
+
+export interface AutoTriggerPassResult {
+  /** Updated state, suitable for `writeAutoTriggerState`. */
+  state: AutoTriggerState;
+  /** Number of dispatches that called `startRun`. */
+  dispatched: number;
+  /** Number of trigger evaluations that decided `skip`. */
+  skipped: number;
+  /** Number of trigger evaluations that pushed to the queue. */
+  queued: number;
+  /** Number of queued entries dispatched in the drain phase. */
+  drained: number;
+}
+
+/**
+ * Run one auto-trigger pass. Returns the new state — the caller persists it.
+ * Tests pass the previous state directly; the lifecycle-manager wraps this
+ * with `readAutoTriggerState` / `writeAutoTriggerState`.
+ */
+export async function runAutoTriggerPass(
+  prevState: AutoTriggerState,
+  deps: AutoTriggerPassDeps,
+): Promise<AutoTriggerPassResult> {
+  const now = deps.now?.() ?? new Date();
+  const queueMaxAgeMs = deps.queueMaxAgeMs ?? DEFAULT_QUEUE_MAX_AGE_MS;
+  const since = new Date(prevState.lastCheckedAt);
+
+  let dispatched = 0;
+  let skipped = 0;
+  let queuedCount = 0;
+  let drained = 0;
+
+  // Mutable working copy of the queue. Newly enqueued entries land here;
+  // drained entries are removed.
+  const workingQueue: QueuedTrigger[] = [...prevState.queued];
+
+  // ---- Phase 1: ingest fresh events ----
+
+  // Plugins without getRecentPREvents short-circuit to a no-op pass — but
+  // we still drain the queue and advance `lastCheckedAt`. Without advancing,
+  // a transient SCM outage would leave us re-fetching the same window
+  // forever once the plugin starts implementing the method.
+  const events: PREvent[] = deps.scm.getRecentPREvents
+    ? await deps.scm.getRecentPREvents(since)
+    : [];
+
+  // Sort events by occurredAt ascending so cancel_in_progress ordering is
+  // deterministic when multiple events match the same pipeline in one pass.
+  events.sort((a, b) => a.occurredAt.getTime() - b.occurredAt.getTime());
+
+  for (const event of events) {
+    for (const pipeline of deps.pipelines) {
+      const matchedTrigger = findMatchingTrigger(pipeline, event);
+      if (!matchedTrigger) continue;
+
+      const policy = pipeline.concurrency ?? DEFAULT_CONCURRENCY_POLICY;
+      const hasActiveRun = deps.isActiveRun(pipeline.name);
+      const action = decideConcurrencyAction({ policy, hasActiveRun });
+
+      deps.onAction?.({
+        action,
+        pipelineName: pipeline.name,
+        prNumber: event.prNumber,
+        trigger: matchedTrigger,
+      });
+
+      switch (action) {
+        case "start":
+          await deps.startRun({
+            pipelineName: pipeline.name,
+            prNumber: event.prNumber,
+            triggerEventType: event.type,
+          });
+          dispatched++;
+          break;
+
+        case "cancel_then_start":
+          await deps.cancelActiveRun(pipeline.name);
+          await deps.startRun({
+            pipelineName: pipeline.name,
+            prNumber: event.prNumber,
+            triggerEventType: event.type,
+          });
+          dispatched++;
+          break;
+
+        case "skip":
+          skipped++;
+          break;
+
+        case "queue":
+          workingQueue.push({
+            pipelineName: pipeline.name,
+            prNumber: event.prNumber,
+            queuedAt: now.toISOString(),
+            triggerEventType: event.type,
+          });
+          queuedCount++;
+          break;
+      }
+    }
+  }
+
+  // ---- Phase 2: age out + drain queue ----
+
+  const stillFresh = workingQueue.filter((q) => {
+    const ageMs = now.getTime() - new Date(q.queuedAt).getTime();
+    return ageMs <= queueMaxAgeMs;
+  });
+
+  const remainingQueue: QueuedTrigger[] = [];
+  for (const entry of stillFresh) {
+    if (deps.isActiveRun(entry.pipelineName)) {
+      remainingQueue.push(entry);
+      continue;
+    }
+    deps.onAction?.({
+      action: "drain",
+      pipelineName: entry.pipelineName,
+      prNumber: entry.prNumber,
+      // Synthetic trigger record for observability — the queue intentionally
+      // doesn't store the original `PipelineTrigger` because by drain time
+      // its filter context is irrelevant.
+      trigger: { on: entry.triggerEventType },
+      drainedFromEventType: entry.triggerEventType,
+    });
+    await deps.startRun({
+      pipelineName: entry.pipelineName,
+      prNumber: entry.prNumber,
+      triggerEventType: entry.triggerEventType,
+    });
+    drained++;
+  }
+
+  // ---- Phase 3: build new state ----
+
+  const nextState: AutoTriggerState = {
+    lastCheckedAt: now.toISOString(),
+    queued: remainingQueue,
+  };
+
+  return { state: nextState, dispatched, skipped, queued: queuedCount, drained };
+}
+
+/**
+ * Return the first trigger on `pipeline` that matches `event`. We pick the
+ * first match (declaration order) so operators can put their narrower
+ * triggers first — same-event with different filters resolves to the most
+ * specific configured trigger.
+ */
+function findMatchingTrigger(pipeline: Pipeline, event: PREvent): PipelineTrigger | null {
+  for (const trigger of pipeline.triggers ?? []) {
+    if (evaluateTrigger({ trigger, event })) return trigger;
+  }
+  return null;
+}
+
+/** For tests: build a fresh state pinned to a specific timestamp. */
+export function makeInitialAutoTriggerState(at: Date): AutoTriggerState {
+  return { lastCheckedAt: at.toISOString(), queued: [] };
+}
+
+/** Resolve the per-project state file path (caller-controlled root dir). */
+export function autoTriggerStatePath(pipelinesDir: string): string {
+  return `${pipelinesDir}/auto-trigger-state.json`;
+}
+
+// Re-export for convenience — the policy default is consumed both by the
+// pass and by callers that need to surface the effective policy in UIs.
+export { DEFAULT_CONCURRENCY_POLICY } from "./types.js";
+export type { ConcurrencyPolicy };

--- a/packages/core/src/pipeline/auto-trigger.ts
+++ b/packages/core/src/pipeline/auto-trigger.ts
@@ -127,7 +127,7 @@ export async function writeAutoTriggerState(
 export interface DispatchInput {
   pipelineName: string;
   prNumber: number;
-  triggerEventType: PREvent["type"] | "manual_queue_drain";
+  triggerEventType: PREvent["type"];
 }
 
 export interface AutoTriggerPassDeps {

--- a/packages/core/src/pipeline/config-schema.ts
+++ b/packages/core/src/pipeline/config-schema.ts
@@ -15,7 +15,9 @@ import { z } from "zod";
 import { findFirstStageCycle } from "./dag.js";
 import {
   asPipelineId,
+  type ConcurrencyPolicy,
   type Pipeline,
+  type PipelineTrigger,
   type Stage,
   type StageExecutor,
   type StageRoutePredicate,
@@ -75,6 +77,23 @@ const StageRoutesSchema = z.object({
   when: StageRoutePredicateSchema,
 });
 
+const PipelineTriggerEventSchema = z.enum([
+  "pr_opened",
+  "pr_push",
+  "pr_review_requested",
+  "manual",
+]);
+
+const PipelineTriggerSchema = z.object({
+  on: PipelineTriggerEventSchema,
+  branches: z.array(z.string().min(1)).optional(),
+  files: z.array(z.string().min(1)).optional(),
+  labels: z.array(z.string().min(1)).optional(),
+  excludeDrafts: z.boolean().optional(),
+});
+
+const ConcurrencyPolicySchema = z.enum(["cancel_in_progress", "skip", "queue"]);
+
 const StageSchema = z.object({
   name: z.string().min(1),
   trigger: StageTriggerSchema,
@@ -108,6 +127,8 @@ export const ConfiguredPipelineSchema = z
     name: z.string().min(1).optional(),
     stages: z.array(StageSchema).min(1),
     maxConcurrentStages: z.number().int().positive().optional(),
+    triggers: z.array(PipelineTriggerSchema).optional(),
+    concurrency: ConcurrencyPolicySchema.optional(),
   })
   .superRefine((pipeline, ctx) => {
     const stageNames = new Set(pipeline.stages.map((s) => s.name));
@@ -231,12 +252,26 @@ export function configuredPipelineToRuntime(key: string, configured: ConfiguredP
     };
   });
 
+  const triggers: PipelineTrigger[] | undefined = configured.triggers
+    ? configured.triggers.map((t) => ({
+        on: t.on,
+        ...(t.branches !== undefined ? { branches: [...t.branches] } : {}),
+        ...(t.files !== undefined ? { files: [...t.files] } : {}),
+        ...(t.labels !== undefined ? { labels: [...t.labels] } : {}),
+        ...(t.excludeDrafts !== undefined ? { excludeDrafts: t.excludeDrafts } : {}),
+      }))
+    : undefined;
+
   return {
     id: asPipelineId(key),
     name: configured.name ?? key,
     stages,
     ...(configured.maxConcurrentStages !== undefined
       ? { maxConcurrentStages: configured.maxConcurrentStages }
+      : {}),
+    ...(triggers !== undefined ? { triggers } : {}),
+    ...(configured.concurrency !== undefined
+      ? { concurrency: configured.concurrency as ConcurrencyPolicy }
       : {}),
   };
 }

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -55,3 +55,30 @@ export {
   type ConfiguredPipeline,
   type PipelinesConfig,
 } from "./config-schema.js";
+
+export {
+  evaluateTrigger,
+  decideConcurrencyAction,
+  matchesAnyGlob,
+  anyValueMatchesAnyGlob,
+  triggerEventForPREvent,
+  type ConcurrencyAction,
+  type ConcurrencyDecisionContext,
+  type TriggerEvaluationContext,
+} from "./triggers.js";
+
+export {
+  runAutoTriggerPass,
+  readAutoTriggerState,
+  writeAutoTriggerState,
+  autoTriggerStatePath,
+  makeInitialAutoTriggerState,
+  EMPTY_AUTO_TRIGGER_STATE,
+  DEFAULT_QUEUE_MAX_AGE_MS,
+  type AutoTriggerState,
+  type AutoTriggerPassDeps,
+  type AutoTriggerPassResult,
+  type AutoTriggerActionLog,
+  type DispatchInput,
+  type QueuedTrigger,
+} from "./auto-trigger.js";

--- a/packages/core/src/pipeline/triggers.ts
+++ b/packages/core/src/pipeline/triggers.ts
@@ -1,0 +1,170 @@
+/**
+ * Pure trigger evaluation + concurrency policy decisions.
+ *
+ * Two responsibilities, both deterministic and side-effect-free so the
+ * lifecycle-manager integration tests can assert on the decision tier
+ * without standing up a real SCM/store.
+ *
+ *   evaluateTrigger(trigger, event)         → boolean
+ *   decideConcurrencyAction(policy, active) → ConcurrencyAction
+ *
+ * Glob support is intentionally minimal: `*` matches a single path segment,
+ * `**` matches any number of segments (including zero). Branch globs use
+ * the same matcher because branch names like `release/*` are common and
+ * GitHub-style ref-name matching is otherwise just exact-string equality.
+ * No bracket character classes, no extglob — anything richer should land
+ * in the v1.3 predicate DSL, not here.
+ */
+
+import type { PREvent } from "../types.js";
+import type {
+  ConcurrencyPolicy,
+  PipelineTrigger,
+  PipelineTriggerEvent,
+} from "./types.js";
+
+// ============================================================================
+// Glob matching
+// ============================================================================
+
+/**
+ * Convert a single glob pattern to an anchored RegExp.
+ *
+ * Rules:
+ *  - `**` matches any number of path segments (including zero).
+ *  - `*` matches anything except `/`.
+ *  - All other regex metacharacters are escaped.
+ *
+ * Patterns are matched against the full string, so `src/**` only matches
+ * paths under `src/` (not `src` itself). To match the leading directory,
+ * use `src` or `src/**` together — see tests for the explicit semantics.
+ */
+function compileGlob(pattern: string): RegExp {
+  let re = "";
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i];
+    if (c === "*") {
+      if (pattern[i + 1] === "*") {
+        re += ".*";
+        i++;
+      } else {
+        re += "[^/]*";
+      }
+    } else if (/[.+?^${}()|[\]\\]/.test(c)) {
+      re += "\\" + c;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+/**
+ * Returns true if `value` matches any of `patterns`. An empty/missing
+ * pattern list matches every value (filter is "not set").
+ */
+export function matchesAnyGlob(patterns: string[] | undefined, value: string): boolean {
+  if (!patterns || patterns.length === 0) return true;
+  return patterns.some((p) => compileGlob(p).test(value));
+}
+
+/**
+ * Returns true if any value in `values` matches any pattern in `patterns`.
+ * An empty pattern list matches everything (filter is "not set"); an empty
+ * values list with non-empty patterns matches nothing (e.g. files filter
+ * set but no changed files reported).
+ */
+export function anyValueMatchesAnyGlob(
+  patterns: string[] | undefined,
+  values: string[],
+): boolean {
+  if (!patterns || patterns.length === 0) return true;
+  if (values.length === 0) return false;
+  const compiled = patterns.map(compileGlob);
+  return values.some((v) => compiled.some((re) => re.test(v)));
+}
+
+// ============================================================================
+// Event-type ↔ trigger-type compatibility
+// ============================================================================
+
+/** Map a `PREvent.type` to the `PipelineTriggerEvent` that fires for it. */
+export function triggerEventForPREvent(prEventType: PREvent["type"]): PipelineTriggerEvent {
+  // Same string identifiers — kept as a function so the boundary stays
+  // explicit and a future divergence (e.g. mapping a `pr_synchronized`
+  // SCM event to `pr_push`) has a single place to update.
+  return prEventType;
+}
+
+// ============================================================================
+// Trigger evaluation
+// ============================================================================
+
+export interface TriggerEvaluationContext {
+  trigger: PipelineTrigger;
+  event: PREvent;
+}
+
+/**
+ * Returns true if `trigger` should fire for `event`.
+ *
+ * - `manual` triggers never fire automatically (they're invoked by
+ *   `ao pipeline run`). This function returns `false` for them so callers
+ *   don't need a separate skip check.
+ * - All filter fields are conjoined: branches AND files AND labels AND
+ *   excludeDrafts must all match. Within a single filter (e.g. `files`),
+ *   any match is sufficient (disjunctive within a list, conjunctive across
+ *   filters).
+ */
+export function evaluateTrigger({ trigger, event }: TriggerEvaluationContext): boolean {
+  if (trigger.on === "manual") return false;
+  if (trigger.on !== triggerEventForPREvent(event.type)) return false;
+
+  if (trigger.excludeDrafts === true && event.isDraft) return false;
+
+  if (!matchesAnyGlob(trigger.branches, event.baseBranch)) return false;
+  if (!anyValueMatchesAnyGlob(trigger.files, event.changedFiles)) return false;
+  if (!anyValueMatchesAnyGlob(trigger.labels, event.labels)) return false;
+
+  return true;
+}
+
+// ============================================================================
+// Concurrency policy
+// ============================================================================
+
+/**
+ * The action the dispatcher should take given a trigger match and the
+ * current state of the pipeline's loop.
+ *
+ *  - `start`              — no active run; just dispatch.
+ *  - `cancel_then_start`  — active run exists; cancel it then dispatch.
+ *  - `skip`               — active run exists; drop the trigger silently.
+ *  - `queue`              — active run exists; remember and dispatch later.
+ */
+export type ConcurrencyAction = "start" | "cancel_then_start" | "skip" | "queue";
+
+export interface ConcurrencyDecisionContext {
+  policy: ConcurrencyPolicy;
+  /** True if a non-terminal run already exists for this pipeline+session loop. */
+  hasActiveRun: boolean;
+}
+
+/**
+ * Decide what to do for a trigger that just matched, given an active-run
+ * state and a configured policy. Pure; no I/O.
+ */
+export function decideConcurrencyAction({
+  policy,
+  hasActiveRun,
+}: ConcurrencyDecisionContext): ConcurrencyAction {
+  if (!hasActiveRun) return "start";
+  switch (policy) {
+    case "cancel_in_progress":
+      return "cancel_then_start";
+    case "skip":
+      return "skip";
+    case "queue":
+      return "queue";
+  }
+}

--- a/packages/core/src/pipeline/triggers.ts
+++ b/packages/core/src/pipeline/triggers.ts
@@ -30,26 +30,33 @@ import type {
 /**
  * Convert a single glob pattern to an anchored RegExp.
  *
- * Rules:
- *  - `**` matches any number of path segments (including zero).
+ * Rules (matching GitHub Actions glob semantics):
+ *  - `**` matches any number of path segments (including zero). When
+ *    written as `**\/X` it collapses the separator too, so `**\/*.ts`
+ *    matches both `config.ts` (zero segments) and `src/foo.ts`.
  *  - `*` matches anything except `/`.
  *  - All other regex metacharacters are escaped.
  *
- * Patterns are matched against the full string, so `src/**` only matches
- * paths under `src/` (not `src` itself). To match the leading directory,
- * use `src` or `src/**` together — see tests for the explicit semantics.
+ * Patterns are matched against the full string. `src/**` matches paths
+ * strictly under `src/` (not `src` itself); use `src` or `src/**` together
+ * if you need both.
  */
 function compileGlob(pattern: string): RegExp {
   let re = "";
   for (let i = 0; i < pattern.length; i++) {
     const c = pattern[i];
-    if (c === "*") {
-      if (pattern[i + 1] === "*") {
+    if (c === "*" && pattern[i + 1] === "*") {
+      // `**/` collapses the separator so root-level paths match.
+      // `**` not followed by `/` is just any-character (including `/`).
+      if (pattern[i + 2] === "/") {
+        re += "(?:.*/)?";
+        i += 2;
+      } else {
         re += ".*";
         i++;
-      } else {
-        re += "[^/]*";
       }
+    } else if (c === "*") {
+      re += "[^/]*";
     } else if (/[.+?^${}()|[\]\\]/.test(c)) {
       re += "\\" + c;
     } else {

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -141,12 +141,58 @@ export interface Stage {
   routes?: StageRoutes;
 }
 
+/**
+ * Pipeline-level trigger event. Distinct from `StageTriggerEvent` (the per-stage
+ * "when can this stage run within a run" gate) — `PipelineTriggerEvent` controls
+ * "when does a *new run* of the whole pipeline get fired".
+ */
+export type PipelineTriggerEvent = "pr_opened" | "pr_push" | "pr_review_requested" | "manual";
+
+/**
+ * One trigger entry under `Pipeline.triggers`. All filter fields are optional;
+ * when set they narrow the firing condition. A trigger fires only when its
+ * `on` event type matches and every set filter matches.
+ *
+ * `manual` triggers ignore filters — they only fire from `ao pipeline run`.
+ * `manual` is always available regardless of whether it appears in the list.
+ */
+export interface PipelineTrigger {
+  on: PipelineTriggerEvent;
+  /** Glob-match against PR base branch. Empty/missing = match any. */
+  branches?: string[];
+  /** Only fire if the diff touches any of these path globs. Missing = match any. */
+  files?: string[];
+  /** Only fire if the PR has any of these labels. Missing = match any. */
+  labels?: string[];
+  /** Skip draft PRs when true. Default false. */
+  excludeDrafts?: boolean;
+}
+
+/**
+ * What happens when a trigger fires while a run is already in progress for
+ * the same pipeline.
+ *
+ *  - `cancel_in_progress` (default) — kill the active run, start fresh.
+ *  - `skip` — silently ignore the new trigger.
+ *  - `queue` — wait for the active run to terminate, then start.
+ */
+export type ConcurrencyPolicy = "cancel_in_progress" | "skip" | "queue";
+
+export const DEFAULT_CONCURRENCY_POLICY: ConcurrencyPolicy = "cancel_in_progress";
+
 export interface Pipeline {
   id: PipelineId;
   name: string;
   stages: Stage[];
   /** Default 1 in v0; engine enforces serial execution when unset. */
   maxConcurrentStages?: number;
+  /**
+   * Auto-firing triggers for this pipeline. Empty or missing = manual only.
+   * Unrelated to `Stage.trigger`, which controls intra-run stage gating.
+   */
+  triggers?: PipelineTrigger[];
+  /** Concurrency policy when a trigger fires while a run is active. */
+  concurrency?: ConcurrencyPolicy;
 }
 
 // ============================================================================

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -815,6 +815,19 @@ export interface SCM {
   getMergeability(pr: PRInfo): Promise<MergeReadiness>;
 
   /**
+   * Return PR-related events that occurred since `since`.
+   *
+   * Used by the lifecycle manager to drive auto-firing pipeline triggers
+   * (`pr_opened` / `pr_push` / `pr_review_requested`). The implementation
+   * is expected to filter to repos owned by the project on the caller's
+   * behalf — callers will not pass repo context here in v1.1b.
+   *
+   * Optional. SCM plugins that don't implement this method short-circuit
+   * the trigger evaluation pass to a no-op (auto-triggers won't fire).
+   */
+  getRecentPREvents?(since: Date): Promise<PREvent[]>;
+
+  /**
    * Batch fetch PR data for multiple PRs in a single GraphQL query.
    * Used by the orchestrator to poll all active sessions efficiently.
    *
@@ -947,6 +960,31 @@ export interface SCMWebhookEvent {
   sha?: string;
   timestamp?: Date;
   data: Record<string, unknown>;
+}
+
+// --- PR Event Polling (for pipeline auto-triggers) ---
+
+/**
+ * Minimal PR event shape consumed by `Pipeline.triggers` evaluation.
+ *
+ * Distinct from `SCMWebhookEvent`, which is push-based and covers a wider
+ * surface (issue comments, generic webhook actions). `PREvent` is the
+ * pull-based, narrowly-typed view that the lifecycle manager polls when
+ * webhooks aren't configured. Plugins that already process webhooks may
+ * synthesize `PREvent`s from a buffered ingest queue instead of re-querying.
+ */
+export type PREventType = "pr_opened" | "pr_push" | "pr_review_requested";
+
+export interface PREvent {
+  type: PREventType;
+  prNumber: number;
+  baseBranch: string;
+  headBranch: string;
+  labels: string[];
+  /** Paths the diff touches at the SHA the event refers to. Empty if unknown. */
+  changedFiles: string[];
+  isDraft: boolean;
+  occurredAt: Date;
 }
 
 // --- CI Types ---


### PR DESCRIPTION
Closes #1663.

## Summary

- Adds `Pipeline.triggers[]` config: `pr_opened`, `pr_push`, `pr_review_requested`, `manual` with `branches` / `files` / `labels` / `excludeDrafts` filters.
- Adds `Pipeline.concurrency` policy: `cancel_in_progress` (default) / `skip` / `queue`.
- Adds optional `SCM.getRecentPREvents(since)` + the `PREvent` type.
- Wires a per-poll auto-trigger pass into `lifecycle-manager.pollAll`.
- Persists `{pipelinesDir}/auto-trigger-state.json` (last-checked timestamp + queued triggers) so restarts don't re-fire the SCM event window.
- 50+ Vitest cases for glob matching, filter conjunction, concurrency decisions, end-to-end pass behaviour (start/cancel/skip/queue/drain), queue aging, and last-checked persistence.

## Architecture notes

- **Pure decisions vs I/O.** `pipeline/triggers.ts` is pure (`evaluateTrigger`, `decideConcurrencyAction`). `pipeline/auto-trigger.ts` orchestrates persistence + dispatching but takes `startRun` / `cancelActiveRun` / `isActiveRun` as injected callbacks.
- **No engine coupling yet.** The PipelineEngine isn't instantiated inside lifecycle-manager today (v0.4 wiring is the next sub-task). The CLI-side wiring drives the pass through the existing `triggerRun` / `cancelRun` adapters in `pipeline-service`. When the engine moves into lifecycle-manager, the auto-trigger pass swaps `startRun` to call `engine.startRun` — no changes to the trigger logic itself.
- **Concurrency scope.** Policy applies *per pipeline* (per the v1.1b spec) — any non-terminal run on the same `pipelineName` counts as active regardless of which PR fired it. SessionIds are encoded as `pipeline.<name>.pr-<n>` so loops are per-PR for trace clarity even though the policy looks across loops.
- **Manual triggers always work.** `evaluateTrigger` returns `false` for `on: "manual"` so they never fire from PR events; `ao pipeline run` continues to work via `triggerRun` regardless of the trigger list (acceptance criterion).
- **No new deps.** Glob matching is hand-rolled (`*` single-segment, `**` any-segment) — keeps `@aoagents/ao-core` dependency-free.

## Files

- `packages/core/src/pipeline/types.ts` — `PipelineTrigger`, `PipelineTriggerEvent`, `ConcurrencyPolicy`, `DEFAULT_CONCURRENCY_POLICY`. Adds `triggers?` and `concurrency?` to `Pipeline`.
- `packages/core/src/pipeline/config-schema.ts` — Zod schema for the new fields. Runtime conversion preserves arrays via spread.
- `packages/core/src/pipeline/triggers.ts` — pure decision module (new).
- `packages/core/src/pipeline/auto-trigger.ts` — pass orchestrator + state persistence (new).
- `packages/core/src/types.ts` — `PREvent`, `PREventType`, `SCM.getRecentPREvents`.
- `packages/core/src/lifecycle-manager.ts` — `pipelineAutoTrigger` dep + invocation in `pollAll` (try/catch isolated; observability metric `pipeline_auto_trigger`).
- `packages/cli/src/lib/pipeline-auto-trigger.ts` — CLI wiring: per-project SCM resolve, store-backed `isActiveRun`, dispatch via `triggerRun` (new).
- `packages/cli/src/lib/create-session-manager.ts` — wires the auto-trigger into `getLifecycleManager`.

## Test plan

- [x] `pnpm --filter @aoagents/ao-core test` — 1207 pass (33 new in `pipeline-triggers.test.ts`, 8 new in `pipeline-config-triggers.test.ts`)
- [x] `pnpm --filter @aoagents/ao-cli test` — 644 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm exec eslint` on touched files — clean (only pre-existing warnings in unrelated files)
- [ ] Manual: configure a pipeline with `pr_opened` trigger + `branches: [main]`, verify it fires when a PR opens against main
- [ ] Manual: stop / start `ao` mid-pass, confirm `auto-trigger-state.json` persists `lastCheckedAt`
- [ ] Manual: configure `concurrency: cancel_in_progress`, push twice in quick succession, verify the first run is cancelled