### PR TITLE
fix: suppress notifier plugin warnings from CLI output

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -56,7 +56,8 @@ interface PluginReference {
 }
 
 async function loadPluginRegistry(config: OrchestratorConfig): Promise<PluginRegistry> {
-  const registry = createPluginRegistry();
+  // Doctor should show notifier warnings — they're diagnostic info
+  const registry = createPluginRegistry({ suppressNotifierWarnings: false });
   await registry.loadFromConfig(config, importPluginModuleFromSource);
   return registry;
 }

--- a/packages/cli/src/commands/plugin.ts
+++ b/packages/cli/src/commands/plugin.ts
@@ -233,18 +233,12 @@ async function verifyPluginDescriptor(
     name: imported.manifest.name,
   };
 
-  const registry = createPluginRegistry();
+  const registry = createPluginRegistry({ suppressNotifierWarnings: true });
   const tempConfig: OrchestratorConfig = {
     ...config,
     plugins: upsertInstalledPlugin(config.plugins ?? [], normalizedDescriptor),
   };
-  const originalWarn = console.warn;
-  console.warn = () => {};
-  try {
-    await registry.loadFromConfig(tempConfig, importPluginModuleFromSource);
-  } finally {
-    console.warn = originalWarn;
-  }
+  await registry.loadFromConfig(tempConfig, importPluginModuleFromSource);
 
   const registered = registry.get(imported.manifest.slot, imported.manifest.name);
   if (!registered) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export { isPortfolioEnabled } from "./feature-flags.js";
 // Plugin registry
 export {
   createPluginRegistry,
+  type CreatePluginRegistryOptions,
   isPluginModule,
   normalizeImportedPluginModule,
   resolveLocalPluginEntrypoint,

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -382,7 +382,19 @@ function resolvePluginSpecifier(
   }
 }
 
-export function createPluginRegistry(): PluginRegistry {
+export interface CreatePluginRegistryOptions {
+  /**
+   * When true, suppress console.warn emitted by notifier plugins during
+   * their create() initialization. Defaults to true — warnings are only
+   * shown when running `ao doctor`.
+   */
+  suppressNotifierWarnings?: boolean;
+}
+
+export function createPluginRegistry(
+  options: CreatePluginRegistryOptions = {},
+): PluginRegistry {
+  const { suppressNotifierWarnings = true } = options;
   const plugins: PluginMap = new Map();
 
   function registerInstance(
@@ -394,6 +406,22 @@ export function createPluginRegistry(): PluginRegistry {
     plugins.set(makeKey(slot, name), { manifest, instance });
   }
 
+  /**
+   * Run a function with console.warn temporarily silenced.
+   * Used to suppress noisy notifier misconfiguration warnings that
+   * should only appear during `ao doctor` diagnostics.
+   */
+  function withSuppressedWarn<T>(fn: () => T): T {
+    if (!suppressNotifierWarnings) return fn();
+    const original = console.warn;
+    console.warn = () => {};
+    try {
+      return fn();
+    } finally {
+      console.warn = original;
+    }
+  }
+
   function registerNotifier(
     plugin: PluginModule,
     config: OrchestratorConfig,
@@ -403,12 +431,13 @@ export function createPluginRegistry(): PluginRegistry {
     const registrations = collectNotifierRegistrations(manifest.name, config, isExternalLoad);
 
     if (registrations.length === 0) {
-      registerInstance(manifest.slot, manifest.name, manifest, plugin.create(undefined));
+      const instance = withSuppressedWarn(() => plugin.create(undefined));
+      registerInstance(manifest.slot, manifest.name, manifest, instance);
       return;
     }
 
     for (const [index, registration] of registrations.entries()) {
-      const instance = plugin.create(registration.config);
+      const instance = withSuppressedWarn(() => plugin.create(registration.config));
       registerInstance(manifest.slot, registration.registrationName, manifest, instance);
 
       if (index === 0 && registration.registrationName !== manifest.name) {


### PR DESCRIPTION
## Problem

Notifier plugins (`notifier-discord`, `notifier-slack`, `notifier-openclaw`, `notifier-webhook`, `notifier-composio`, `notifier-desktop`) emit unconditional `console.warn()` during their `create()` initialization when config is missing (no webhook URL, no token, unsupported OS).

Since `getPluginRegistry()` is called by almost every CLI command, these warnings spam the terminal on **every invocation** — even commands that have nothing to do with notifications.

### Affected commands (all of these trigger the spam)
`ao status`, `ao session ls`, `ao session show`, `ao session kill`, `ao session restore`, `ao session claim-pr`, `ao session detail`, `ao session cleanup`, `ao spawn`, `ao send`, `ao start`, `ao stop`, `ao review-check`, `ao report`, `ao verify`, `ao plugin list`, `ao plugin install`

### Example spam on every `ao status` run
```
[notifier-slack] No webhookUrl configured — notifications will be no-ops
[notifier-discord] No webhookUrl configured. Set it in agent-orchestrator.yaml...
[notifier-webhook] No url configured — notifications will be no-ops
[notifier-openclaw] No token configured. Set OPENCLAW_HOOKS_TOKEN env var...
[notifier-composio] No composioApiKey or COMPOSIO_API_KEY configured — notifications will be no-ops
[notifier-desktop] Desktop notifications not supported on linux
```

## Fix

Add `suppressNotifierWarnings` option (default: `true`) to `createPluginRegistry()`. When enabled, `console.warn` is temporarily silenced during notifier plugin `create()` calls via a `withSuppressedWarn()` wrapper.

Only `ao doctor` disables suppression (`suppressNotifierWarnings: false`), so warnings appear where they belong — during diagnostics.

### Files changed
- **`packages/core/src/plugin-registry.ts`** — Added `CreatePluginRegistryOptions` interface and `withSuppressedWarn()` helper. All `registerNotifier()` calls now route through it.
- **`packages/core/src/index.ts`** — Export `CreatePluginRegistryOptions` type.
- **`packages/cli/src/commands/doctor.ts`** — Creates registry with `suppressNotifierWarnings: false`.
- **`packages/cli/src/commands/plugin.ts`** — Removes manual `console.warn` suppression hack, uses the new option instead.

### Tests
- `plugin-registry.test.ts`: 37/37 pass ✅
- `doctor.test.ts`: 10/10 pass ✅
- `plugin.test.ts`: 6/6 pass ✅
- Full `pnpm build`: clean ✅

Closes #1681