### PR TITLE
fix(setup): pin public npm registry in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 access=public
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

- Pins `registry=https://registry.npmjs.org/` in the project `.npmrc` so a fresh source install works regardless of the user's global npm/pnpm registry config.
- Fixes `ERR_PNPM_FETCH_404` from `scripts/setup.sh` when the user has a private mirror (AWS CodeArtifact, Artifactory, Verdaccio, GitHub Packages, etc.) configured in `~/.npmrc` that doesn't proxy public packages.
- Closes #1694.

## Why

pnpm merges project `.npmrc` over `~/.npmrc`, so without an explicit `registry=` line in our repo, install resolves through whatever mirror the user's machine is pointed at. On corporate setups where IT/onboarding has run something like `aws codeartifact login --tool npm`, public packages we depend on (`@clack/core`, etc.) 404 immediately and setup dies before downloading anything. Pinning npmjs.org in the project file scopes the override to this repo only — it does not affect any of the user's other projects, and anyone who genuinely wants to install through a mirror can override locally.

## Test plan

- [ ] On a machine with `~/.npmrc` set to a private mirror that does not proxy npmjs.org, `git clone` + `bash scripts/setup.sh` completes without `ERR_PNPM_FETCH_404`.
- [ ] On a clean machine (no global registry override), `pnpm install` still works as before.
- [ ] Inside the repo, `pnpm config get registry` reports `https://registry.npmjs.org/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)