### PR TITLE
docs: add AO agent plugin builder skill

### DIFF
--- a/skills/ao-agent-plugin-builder/SKILL.md
+++ b/skills/ao-agent-plugin-builder/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: ao-agent-plugin-builder
+description: Build new Agent Orchestrator agent plugin packages in this repository. Use when Codex needs to add support for a coding-agent CLI (for example Amp, GitHub Copilot, Gemini, Qwen Code, Auggie, Goose, Kiro, Cline), choose the closest existing `packages/plugins/agent-*` template, wire AO registry/CLI/web surfaces, implement launch/activity/session behavior, and validate the plugin without mass-scaffolding unrelated agents.
+---
+
+# AO Agent Plugin Builder
+
+Use this skill to add one AO `agent` plugin at a time by copying the closest implemented agent pattern and proving it with tests. Do not implement multiple target agents in one pass unless the user explicitly asks.
+
+## Source-truth files to inspect first
+
+Always ground the work in the current checkout before editing:
+
+- Agent examples: `packages/plugins/agent-{aider,claude-code,codex,cursor,kimicode,opencode}/`
+- Interface: `packages/core/src/types.ts` (`Agent`, `AgentLaunchConfig`, `AgentSessionInfo`, `ActivityState`)
+- Built-ins: `packages/core/src/plugin-registry.ts`
+- CLI detection/install UX: `packages/cli/src/lib/detect-agent.ts`, `packages/cli/src/commands/start.ts`
+- CLI package deps: `packages/cli/package.json`
+- Dashboard static registration: `packages/web/src/lib/services.ts`
+- Marketplace catalog: `packages/cli/src/assets/plugin-registry.json` when the plugin should be installer-visible
+- Scaffold support: `packages/cli/src/lib/plugin-scaffold.ts` and `ao plugin create --help`
+- Architecture docs: `CLAUDE.md`, `docs/DEVELOPMENT.md`, `docs/PLUGIN_SPEC.md`
+
+If you do not know what a target agent CLI flag does, run that CLI's `--help` or docs lookup before using the flag.
+
+## Workflow
+
+1. **Classify the target agent.** Identify binary name, install command, interactive vs one-shot mode, prompt flag, model flag, permission/approval flags, workspace/cwd flag, resume/session support, and native session logs. Prefer real `--help` output over catalog names.
+2. **Choose names.** Use `packages/plugins/agent-{slug}` for the directory, `@aoagents/ao-plugin-agent-{slug}` for the package, `manifest.name = "{slug}"`, `manifest.slot = "agent" as const`, and a human `displayName`.
+3. **Choose the closest template.** Read `references/patterns.md` for the template matrix. Default to `agent-kimicode` or `agent-cursor` for a normal interactive terminal CLI; use `agent-claude-code`, `agent-codex`, or `agent-opencode` only when the target matches their native-hook/session-log/session-list behavior.
+4. **Create the package surgically.** Copy the chosen `packages/plugins/agent-*` package, then rename only what must change. Use `ao plugin create` only as a generic external-plugin scaffold reference; built-in repo plugins need the established monorepo package shape.
+5. **Implement the full `Agent` contract.** Cover launch command, environment, process liveness, activity detection, session info, workspace hooks, optional pre/post launch setup, optional restore, and optional preflight. Use `shellEscape()` for command args and shared activity/workspace helpers from `@aoagents/ao-core`.
+6. **Wire AO surfaces.** Update built-in registry, CLI dependencies/detection/install prompt when appropriate, dashboard static imports/registration, marketplace catalog if installer-visible, package docs/changelog/changeset only if the package change needs release metadata.
+7. **Test the plugin behavior.** Unit-test manifest, `detect()`, launch command quoting/flags, activity states, liveness, session info, hooks, restore/preflight paths, and all fallback behavior. Mock external CLIs and filesystem state.
+8. **Validate wiring.** Run this skill's helper script plus repo checks:
+   ```bash
+   python3 skills/ao-agent-plugin-builder/scripts/check_agent_plugin_wiring.py {slug}
+   pnpm --filter @aoagents/ao-plugin-agent-{slug} typecheck
+   pnpm --filter @aoagents/ao-plugin-agent-{slug} test
+   pnpm --filter @aoagents/ao-core test -- plugin-registry
+   pnpm --filter @aoagents/ao-cli test -- detect-agent plugin
+   ```
+
+## Bundled references
+
+- `references/patterns.md` — current implemented-agent patterns, template selection, wiring facts, and repo-specific pitfalls.
+- `references/checklist.md` — implementation checklist from target CLI research through validation.
+- `references/amp-example.md` — worked first-target recommendation for Amp, including what to verify before coding.
+- `scripts/check_agent_plugin_wiring.py` — deterministic smoke checker for built-in agent package wiring.
+
+## Repo-specific guardrails
+
+- Keep the PR to one agent plugin plus directly required wiring/tests/docs. Do not add every catalog agent.
+- Do not change the `Agent` interface unless the target cannot be represented by existing optional methods; that is a separate architecture task.
+- Do not parse huge native logs by slurping whole files; stream or tail bounded bytes.
+- Do not rely only on terminal text when the target exposes native JSONL/SQLite/session APIs.
+- Do not add cross-plugin imports. Agent plugins communicate through core `Session` data and shared core utilities only.

--- a/skills/ao-agent-plugin-builder/agents/openai.yaml
+++ b/skills/ao-agent-plugin-builder/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AO Agent Plugin Builder"
+  short_description: "Build AO agent plugins from repo patterns"
+  default_prompt: "Use this skill to add one AO agent plugin by copying the closest existing agent package pattern, wiring registry/CLI/web surfaces, testing activity/session behavior, and validating the diff."

--- a/skills/ao-agent-plugin-builder/references/amp-example.md
+++ b/skills/ao-agent-plugin-builder/references/amp-example.md
@@ -1,0 +1,51 @@
+# Worked First-Target Recommendation: Amp
+
+Amp is a good first target after this skill lands because it is likely to exercise the normal "new coding-agent CLI" path without requiring the special Claude/Codex/OpenCode-native integrations up front. Treat this as a recommendation, not a substitute for CLI research.
+
+## Before coding Amp support
+
+Verify these facts from the real Amp CLI/docs in the implementation session:
+
+1. Binary name and vendor-identifying `--help`/`--version` output.
+2. Interactive launch command that keeps the session alive.
+3. Prompt-delivery mechanism and whether any prompt flag causes one-shot exit.
+4. Model flag, if any.
+5. Approval/permission flags, if any.
+6. Workdir/cwd flag, if any.
+7. Resume/session ID support, if any.
+8. Native logs/session store, if any.
+9. Safe install command for `ao start` install prompt, if any.
+
+Do not assume these from another CLI. If a flag is unclear, inspect help output before using it.
+
+## Likely template choice
+
+Start from `agent-kimicode` if Amp has:
+
+- a dedicated binary (`amp` or similar),
+- interactive prompt delivery,
+- optional model/approval flags,
+- a native session store or cwd-derived session files,
+- no need for post-launch prompt delivery.
+
+Start from `agent-cursor` instead if Amp has no useful native session store yet and activity/session info must initially be terminal-derived.
+
+Use `agent-claude-code` only if Amp's prompt flag exits one-shot and AO must send the prompt after launch. Use `agent-codex` or `agent-opencode` only if Amp exposes comparable native JSONL/session-list semantics.
+
+## Expected Amp PR shape
+
+A minimal first Amp PR should usually touch:
+
+- `packages/plugins/agent-amp/package.json`
+- `packages/plugins/agent-amp/tsconfig.json`
+- `packages/plugins/agent-amp/src/index.ts`
+- `packages/plugins/agent-amp/src/index.test.ts`
+- `packages/cli/package.json`
+- `packages/core/src/plugin-registry.ts`
+- `packages/cli/src/lib/detect-agent.ts`
+- `packages/cli/src/commands/start.ts` only if install command is verified
+- `packages/web/src/lib/services.ts`
+- `packages/cli/src/assets/plugin-registry.json` only if marketplace-visible
+- tests/docs/changeset as justified by the actual diff
+
+Do not scaffold Amp plus Gemini/Qwen/Copilot/etc. in the same PR.

--- a/skills/ao-agent-plugin-builder/references/checklist.md
+++ b/skills/ao-agent-plugin-builder/references/checklist.md
@@ -1,0 +1,97 @@
+# AO Agent Plugin Implementation Checklist
+
+Use this checklist for each new agent plugin. Keep it scoped to one target CLI.
+
+## 1. Target CLI research
+
+- [ ] Record target name, binary name, expected global install command, and vendor.
+- [ ] Run or inspect `--help` for launch, prompt, model, permission/approval, cwd/workdir, resume/session, and JSON/log flags.
+- [ ] Determine whether initial prompt delivery is inline or post-launch. Inline is default; use `promptDelivery: "post-launch"` when inline flags cause one-shot exit.
+- [ ] Find native activity/session data, if any: JSONL, SQLite, config dir, session list, title, summary, token/cost, timestamps.
+- [ ] Identify terminal prompts that should be `waiting_input` and hard agent errors that should be `blocked`.
+
+## 2. Naming and package setup
+
+- [ ] Choose lowercase hyphen slug: `{slug}`.
+- [ ] Create `packages/plugins/agent-{slug}` by copying the closest existing agent plugin.
+- [ ] Set package name to `@aoagents/ao-plugin-agent-{slug}`.
+- [ ] Set `manifest.name` to `{slug}`, `manifest.slot` to `"agent" as const`, and `displayName` to the human product name.
+- [ ] Keep `tsconfig.json` aligned with existing agent packages.
+- [ ] Keep package scripts: `build`, `typecheck`, `test`, `clean`.
+
+## 3. Launch command
+
+- [ ] Start with the verified binary name.
+- [ ] Map `config.permissions` through `normalizeAgentPermissionMode()` to the target's real approval flag, if any.
+- [ ] Map `config.model` to the target's real model flag.
+- [ ] Prefer `config.systemPromptFile` for long system prompts. Only inline `config.systemPrompt` when the target supports it safely.
+- [ ] Pass `config.prompt` through the target's verified prompt mechanism, or rely on post-launch delivery.
+- [ ] Use `config.workspacePath ?? config.projectConfig.path` when the CLI needs an explicit cwd/workdir.
+- [ ] Escape every shell argument with `shellEscape()`.
+
+## 4. Environment and hooks
+
+- [ ] Return `AO_SESSION_ID` and optional `AO_ISSUE_ID` from `getEnvironment()`.
+- [ ] Add target-specific env vars only when verified.
+- [ ] Implement `setupWorkspaceHooks()`. Use `setupPathWrapperWorkspace(workspacePath)` for PATH-wrapper agents unless native hooks are required.
+- [ ] Add `preLaunchSetup()` if matching native session files requires a before-start baseline.
+- [ ] Add `postLaunchSetup()` only for real after-start work.
+
+## 5. Activity and process state
+
+- [ ] Implement `detectActivity()` as a pure function. Check waiting-input patterns before idle prompts.
+- [ ] Implement `recordActivity()` with `recordTerminalActivity()` if terminal prompts/errors are needed by `getActivityState()`.
+- [ ] Implement `getActivityState()` with process liveness first, then actionable AO activity JSONL, then native activity signal, then decay/fallback.
+- [ ] Implement `isProcessRunning()` for tmux TTY and PID handles. Avoid global process-name checks.
+- [ ] Use bounded reads/streams for native logs.
+
+## 6. Session info and restore
+
+- [ ] Return `{ summary, summaryIsFallback?, agentSessionId, metadata?, cost? }` from `getSessionInfo()`.
+- [ ] Persist native session IDs through `metadata` when useful for restore.
+- [ ] Implement `getRestoreCommand()` if the target can resume a known session.
+- [ ] Return `null` for missing native data; throw only for unexpected failures that should surface.
+
+## 7. Wiring
+
+- [ ] Add dependency in `packages/cli/package.json`.
+- [ ] Add built-in entry in `packages/core/src/plugin-registry.ts`.
+- [ ] Add CLI detection entry in `packages/cli/src/lib/detect-agent.ts`.
+- [ ] Add `AGENT_INSTALL_OPTIONS` entry in `packages/cli/src/commands/start.ts` only when the install command is known and safe.
+- [ ] Add static import and `registry.register(...)` in `packages/web/src/lib/services.ts`.
+- [ ] Add marketplace entry in `packages/cli/src/assets/plugin-registry.json` only when `ao plugin search/install` should show it.
+- [ ] Update user-facing supported-agent docs only when they contain an explicit list.
+- [ ] Add a changeset if the package/wiring change needs release metadata.
+
+## 8. Tests
+
+- [ ] Unit-test manifest and `create()` shape.
+- [ ] Unit-test launch command for permissions/model/prompt/system-prompt/workdir/session/resume flags.
+- [ ] Unit-test `detect()` success/failure without requiring the real CLI.
+- [ ] Unit-test `detectActivity()` for idle, active, waiting_input, and blocked patterns.
+- [ ] Unit-test `getActivityState()` decay and fallback behavior.
+- [ ] Unit-test `isProcessRunning()` tmux and PID paths.
+- [ ] Unit-test `getSessionInfo()` native parsing and missing-data returns.
+- [ ] Unit-test hooks/preflight/restore when implemented.
+- [ ] Add or update core/CLI tests if registry/detection behavior changes.
+
+## 9. Validation commands
+
+Run the tightest checks first:
+
+```bash
+python3 skills/ao-agent-plugin-builder/scripts/check_agent_plugin_wiring.py {slug}
+pnpm --filter @aoagents/ao-plugin-agent-{slug} typecheck
+pnpm --filter @aoagents/ao-plugin-agent-{slug} test
+pnpm --filter @aoagents/ao-plugin-agent-{slug} build
+```
+
+Then validate affected central packages:
+
+```bash
+pnpm --filter @aoagents/ao-core test -- plugin-registry
+pnpm --filter @aoagents/ao-cli test -- detect-agent plugin
+pnpm --filter @aoagents/ao-web typecheck
+```
+
+If package dependencies or lockfile changed, run `pnpm install --lockfile-only` or the repo's expected install workflow before final validation.

--- a/skills/ao-agent-plugin-builder/references/patterns.md
+++ b/skills/ao-agent-plugin-builder/references/patterns.md
@@ -1,0 +1,146 @@
+# AO Agent Plugin Patterns
+
+Use this reference after opening the real current files. It captures the patterns found in this repo, but code truth wins when files drift.
+
+## Implemented agent plugins
+
+| Plugin | Package | Binary/process | Best template when target CLI... | Notable pattern |
+|---|---|---|---|---|
+| `agent-cursor` | `@aoagents/ao-plugin-agent-cursor` | `agent` | Is a simple interactive terminal CLI with prompt/model/permission flags and no proven native log API | Smallest terminal-derived implementation; careful `detect()` to avoid false positives for a generic binary name. |
+| `agent-kimicode` | `@aoagents/ao-plugin-agent-kimicode` | `kimi` | Needs explicit workdir, PATH wrappers, terminal-derived waiting/error states, and native session-file matching | Most modern general template; uses `workspacePath`, `setupPathWrapperWorkspace`, bounded JSONL scan, pre-launch baseline, and session discovery helper. |
+| `agent-aider` | `@aoagents/ao-plugin-agent-aider` | `aider` | Has chat history files and auto-commit behavior | Uses `.aider.chat.history.md` mtime plus recent commits as activity/session summary fallback. |
+| `agent-codex` | `@aoagents/ao-plugin-agent-codex` | `codex` | Has native JSONL sessions under a home-dir store and supports resume/cost parsing | Native JSONL parser, bounded session matching, restore command, model/permission mapping. |
+| `agent-claude-code` | `@aoagents/ao-plugin-agent-claude-code` | `claude` | Needs post-launch prompt delivery or agent-native hook configuration | `promptDelivery: "post-launch"`, native `.claude/settings.json` PostToolUse hooks, JSONL summary/cost parsing. |
+| `agent-opencode` | `@aoagents/ao-plugin-agent-opencode` | `opencode` | Requires creating/discovering a named session then resuming it | Uses `opencode run --format json`, title `AO:{sessionId}`, shared OpenCode cache/helpers from core. |
+
+Default recommendation for new catalog CLIs: start from `agent-kimicode` if the CLI has a dedicated binary and supports interactive prompt delivery; start from `agent-cursor` if there is no native session store yet and the launch command is straightforward.
+
+## Monorepo package shape
+
+Built-in agent plugins live at:
+
+```text
+packages/plugins/agent-{slug}/
+├── package.json
+├── tsconfig.json
+└── src/
+    ├── index.ts
+    └── index.test.ts
+```
+
+Use the existing `package.json` shape:
+
+- `name`: `@aoagents/ao-plugin-agent-{slug}`
+- `version`: match repo release flow for current packages when copying
+- `type`: `module`
+- `main`: `dist/index.js`
+- `types`: `dist/index.d.ts`
+- `exports["."].import`: `./dist/index.js`
+- `files`: `["dist"]`
+- scripts: `build`, `typecheck`, `test`, `clean`
+- dependency: `@aoagents/ao-core: "workspace:*"`
+- dev dependencies: `@types/node`, `typescript`, `vitest`
+
+Use the existing `tsconfig.json` shape:
+
+```json
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}
+```
+
+`pnpm-workspace.yaml` already includes `packages/plugins/*`; do not edit it for a normal new plugin.
+
+## Required `src/index.ts` shape
+
+Every built-in agent package exports:
+
+```ts
+export const manifest = {
+  name: "{slug}",
+  slot: "agent" as const,
+  description: "Agent plugin: ...",
+  version: "0.1.0",
+  displayName: "...",
+};
+
+export function create(): Agent { ... }
+export function detect(): boolean { ... }
+export default { manifest, create, detect } satisfies PluginModule<Agent>;
+```
+
+The returned `Agent` must include:
+
+- `name` and `processName`
+- `getLaunchCommand(config)`
+- `getEnvironment(config)` with `AO_SESSION_ID` and optional `AO_ISSUE_ID`; the current session manager injects `PATH: buildAgentPath(...)`, `GH_PATH`, `AO_SESSION`, `AO_DATA_DIR`, `AO_PROJECT_ID`, and `AO_CONFIG_PATH` around this environment
+- `detectActivity(output)` even when native activity is preferred
+- `getActivityState(session, readyThresholdMs?)`
+- `isProcessRunning(handle)`
+- `getSessionInfo(session)`
+- `setupWorkspaceHooks(...)` even if it only delegates to shared PATH wrappers or intentionally no-ops because session-manager handles wrappers
+
+Optional but common:
+
+- `promptDelivery: "post-launch"` when inline prompt flags trigger one-shot exit
+- `preLaunchSetup(workspacePath)` for baseline snapshots before the CLI writes session files
+- `postLaunchSetup(session)` for after-start config or binary resolution
+- `getRestoreCommand(session, project)` when native resume exists
+- `recordActivity(session, terminalOutput)` when native logs do not cover waiting/blocked states
+- `preflight(context)` for actionable prerequisite errors before spawn
+
+## Activity-state pattern
+
+Good `getActivityState()` implementations use this order:
+
+1. Check runtime/process liveness first. Return `exited` if dead.
+2. Prefer fresh actionable AO activity JSONL (`readLastActivityEntry` + `checkActivityLogState`) for `waiting_input`/`blocked` when terminal classification is the only source.
+3. Read the best native signal: JSONL mtime, session list updated time, SQLite row timestamp, chat-history mtime, etc.
+4. Decay by `DEFAULT_ACTIVE_WINDOW_MS` and `DEFAULT_READY_THRESHOLD_MS`: active -> ready -> idle.
+5. Use `getActivityFallbackState()` only as a last resort.
+
+Implement `recordActivity()` with `recordTerminalActivity()` when relying on terminal-derived prompts/errors. Do not mark compiler/test output as `blocked` unless the target agent exposes a reliable unrecoverable error signal; terminal text alone often contains expected failures while the agent is still working.
+
+## Process liveness pattern
+
+For tmux handles, inspect the pane TTY and then `ps -eo pid,tty,args` for the target process. For process runtime handles, use `process.kill(pid, 0)` and treat `EPERM` as running. Avoid plain `pgrep {binary}` because it can match another user's unrelated session.
+
+## Hook and metadata pattern
+
+AO dashboard PR tracking depends on metadata updates when agents run `git` and `gh` commands.
+
+- Claude Code uses native PostToolUse hooks in `.claude/settings.json`.
+- Most other agents rely on shared PATH wrappers from `@aoagents/ao-core` (`setupPathWrapperWorkspace`, `buildAgentPath`, `PREFERRED_GH_PATH`).
+- Current `session-manager.ts` also calls `setupPathWrapperWorkspace()` for non-Claude agents, but plugins still keep `setupWorkspaceHooks()` because older paths and docs expect the method.
+
+Do not write secrets into generated hook/config files. `.ao/AGENTS.md` and wrapper state are AO-owned workspace artifacts.
+
+## Built-in wiring surfaces
+
+For a built-in agent plugin, update all relevant surfaces:
+
+1. `packages/core/src/plugin-registry.ts` — add `{ slot: "agent", name: "{slug}", pkg: "@aoagents/ao-plugin-agent-{slug}" }`.
+2. `packages/cli/package.json` — add a workspace dependency.
+3. `packages/cli/src/lib/detect-agent.ts` — add to `AGENT_PLUGINS` so `ao start` can detect it.
+4. `packages/cli/src/commands/start.ts` — add an install option only when there is a safe, known global install command.
+5. `packages/web/src/lib/services.ts` — static import and `registry.register(...)`; Next.js cannot rely on core dynamic import for built-ins.
+6. `packages/cli/src/assets/plugin-registry.json` — add only if the plugin should appear in `ao plugin search/install` as a registry-backed package.
+7. Tests/docs — update docs/examples only when user-facing supported-agent lists would otherwise be stale.
+
+## Scaffold support in this repo
+
+`ao plugin create` and `packages/cli/src/lib/plugin-scaffold.ts` generate a generic plugin package with placeholder implementation, `README.md`, and external config examples. That is useful for local/external plugins, but built-in agent packages in this repo should be copied from `packages/plugins/agent-*` because they need the full `Agent` implementation, package metadata, tests, and monorepo wiring.
+
+## Common repo-specific mistakes
+
+- Copying generic scaffold output and leaving a placeholder `create()` object instead of a real `Agent`.
+- Updating `plugin-registry.ts` but forgetting `detect-agent.ts` or `web/src/lib/services.ts`.
+- Assuming `-p`, `--prompt`, or `--print` behavior from another CLI. Verify target CLI help; some flags exit after one shot.
+- Passing `projectConfig.path` when the target needs the isolated worktree cwd. Prefer `config.workspacePath ?? config.projectConfig.path`.
+- Omitting `shellEscape()` for prompt/model/system-prompt/workdir/session args.
+- Reading a whole JSONL/session file to get one summary or timestamp.
+- Matching a generic binary name without checking vendor/help output (`agent`, `code`, `cli`, etc.).
+- Adding all catalog agents at once. Keep one plugin per PR unless asked otherwise.

--- a/skills/ao-agent-plugin-builder/scripts/check_agent_plugin_wiring.py
+++ b/skills/ao-agent-plugin-builder/scripts/check_agent_plugin_wiring.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Check built-in AO agent plugin wiring for one slug.
+
+Run from the repository root:
+  python3 skills/ao-agent-plugin-builder/scripts/check_agent_plugin_wiring.py kimicode
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def slug_to_import_name(slug: str) -> str:
+    parts = re.split(r"[^a-zA-Z0-9]+", slug)
+    return "pluginAgent" + "".join(part.capitalize() for part in parts if part)
+
+
+class Checker:
+    def __init__(self, root: Path, slug: str, package_name: str) -> None:
+        self.root = root
+        self.slug = slug
+        self.package_name = package_name
+        self.failures: list[str] = []
+        self.warnings: list[str] = []
+
+    def path(self, rel: str) -> Path:
+        return self.root / rel
+
+    def read(self, rel: str) -> str:
+        return self.path(rel).read_text(encoding="utf-8")
+
+    def require(self, condition: bool, message: str) -> None:
+        if condition:
+            print(f"PASS {message}")
+        else:
+            print(f"FAIL {message}")
+            self.failures.append(message)
+
+    def warn_if_missing(self, condition: bool, message: str) -> None:
+        if condition:
+            print(f"PASS {message}")
+        else:
+            print(f"WARN {message}")
+            self.warnings.append(message)
+
+    def check_package(self) -> None:
+        base = self.path(f"packages/plugins/agent-{self.slug}")
+        self.require(base.is_dir(), f"packages/plugins/agent-{self.slug}/ exists")
+        package_json_path = base / "package.json"
+        self.require(package_json_path.is_file(), "package.json exists")
+        if package_json_path.is_file():
+            data = json.loads(package_json_path.read_text(encoding="utf-8"))
+            self.require(data.get("name") == self.package_name, f"package name is {self.package_name}")
+            self.require(data.get("type") == "module", "package is ESM")
+            self.require(data.get("main") == "dist/index.js", "main points at dist/index.js")
+            self.require(data.get("types") == "dist/index.d.ts", "types points at dist/index.d.ts")
+            scripts = data.get("scripts", {})
+            for script in ("build", "typecheck", "test", "clean"):
+                self.require(script in scripts, f"package script '{script}' exists")
+            deps = data.get("dependencies", {})
+            self.require(
+                deps.get("@aoagents/ao-core") == "workspace:*",
+                "depends on @aoagents/ao-core workspace:*",
+            )
+        tsconfig_path = base / "tsconfig.json"
+        self.require(tsconfig_path.is_file(), "tsconfig.json exists")
+        if tsconfig_path.is_file():
+            tsconfig = json.loads(tsconfig_path.read_text(encoding="utf-8"))
+            self.require(
+                tsconfig.get("extends") == "../../../tsconfig.node.json",
+                "tsconfig extends ../../../tsconfig.node.json",
+            )
+        self.require((base / "src" / "index.ts").is_file(), "src/index.ts exists")
+        self.require((base / "src" / "index.test.ts").is_file(), "src/index.test.ts exists")
+
+    def check_index(self) -> None:
+        rel = f"packages/plugins/agent-{self.slug}/src/index.ts"
+        path = self.path(rel)
+        if not path.is_file():
+            return
+        text = path.read_text(encoding="utf-8")
+        self.require(f'name: "{self.slug}"' in text, "manifest.name matches slug")
+        self.require('slot: "agent" as const' in text, "manifest.slot is agent")
+        self.require("type Agent" in text or ", Agent" in text, "imports Agent type")
+        self.require("type PluginModule" in text or ", PluginModule" in text, "imports PluginModule type")
+        self.require("getLaunchCommand(" in text, "implements getLaunchCommand")
+        self.require("getEnvironment(" in text, "implements getEnvironment")
+        self.require("detectActivity(" in text, "implements detectActivity")
+        self.require("getActivityState(" in text, "implements getActivityState")
+        self.require("isProcessRunning(" in text, "implements isProcessRunning")
+        self.require("getSessionInfo(" in text, "implements getSessionInfo")
+        self.require("export function create" in text, "exports create()")
+        self.require("export function detect" in text, "exports detect()")
+        self.require("satisfies PluginModule<Agent>" in text, "default export satisfies PluginModule<Agent>")
+        self.require("shellEscape" in text, "uses shellEscape for launch args")
+
+    def check_central_wiring(self) -> None:
+        cli_package = json.loads(self.read("packages/cli/package.json"))
+        deps = cli_package.get("dependencies", {})
+        self.require(deps.get(self.package_name) == "workspace:*", "packages/cli/package.json has workspace dependency")
+
+        registry = self.read("packages/core/src/plugin-registry.ts")
+        registry_pattern = (
+            rf'\{{\s*slot:\s*"agent",\s*name:\s*"{re.escape(self.slug)}",'
+            rf'\s*pkg:\s*"{re.escape(self.package_name)}"\s*\}}'
+        )
+        self.require(re.search(registry_pattern, registry) is not None, "core BUILTIN_PLUGINS includes agent")
+
+        detect_agent = self.read("packages/cli/src/lib/detect-agent.ts")
+        detect_pattern = (
+            rf'\{{\s*name:\s*"{re.escape(self.slug)}",'
+            rf'\s*pkg:\s*"{re.escape(self.package_name)}"\s*\}}'
+        )
+        self.require(re.search(detect_pattern, detect_agent) is not None, "CLI AGENT_PLUGINS includes agent")
+
+        services = self.read("packages/web/src/lib/services.ts")
+        import_name = slug_to_import_name(self.slug)
+        self.require(self.package_name in services, "web services statically import package")
+        self.require(f"registry.register({import_name})" in services, f"web services register {import_name}")
+
+        marketplace = self.read("packages/cli/src/assets/plugin-registry.json")
+        self.warn_if_missing(
+            self.package_name in marketplace,
+            "marketplace catalog includes package when installer-visible",
+        )
+
+        start_ts = self.read("packages/cli/src/commands/start.ts")
+        self.warn_if_missing(
+            f'id: "{self.slug}"' in start_ts,
+            "ao start install options include agent when install command is known",
+        )
+
+    def run(self) -> int:
+        self.check_package()
+        self.check_index()
+        self.check_central_wiring()
+        print()
+        print(f"Summary: {len(self.failures)} failure(s), {len(self.warnings)} warning(s)")
+        if self.failures:
+            return 1
+        return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check built-in AO agent plugin wiring for one slug.",
+    )
+    parser.add_argument("slug", help="agent slug, e.g. kimicode or amp")
+    parser.add_argument(
+        "--package-name",
+        help="expected package name (default: @aoagents/ao-plugin-agent-{slug})",
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="repository root (default: current directory)",
+    )
+    args = parser.parse_args()
+
+    slug = args.slug.strip().lower()
+    if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", slug):
+        print("slug must be lowercase hyphen-case", file=sys.stderr)
+        return 2
+
+    root = Path(args.root).resolve()
+    package_name = args.package_name or f"@aoagents/ao-plugin-agent-{slug}"
+    return Checker(root, slug, package_name).run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a repo-local `ao-agent-plugin-builder` skill for building new AO agent plugins from existing `packages/plugins/agent-*` patterns
- document template selection across aider/claude-code/codex/cursor/kimicode/opencode, wiring surfaces, implementation checklist, and Amp as a suggested first target
- include a helper script to smoke-check built-in agent package wiring across package, core registry, CLI detection, web services, and optional marketplace/install entries

## Validation
- `python3 /Users/tanishqpalandurkar/.claude/plugins/marketplaces/claude-plugins-official/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py skills/ao-agent-plugin-builder`
- `git diff --check`
- `python3 -m py_compile skills/ao-agent-plugin-builder/scripts/check_agent_plugin_wiring.py`
- `python3 skills/ao-agent-plugin-builder/scripts/check_agent_plugin_wiring.py kimicode`
- `python3 skills/ao-agent-plugin-builder/scripts/check_agent_plugin_wiring.py cursor` (expected warnings for optional marketplace/install entries)

## Suggested first target
Amp, after verifying its real CLI help/docs for prompt, model, approval, workdir, resume, and session-log behavior.
