### PR TITLE
fix(core): read legacy key=value metadata in .json session files

### DIFF
--- a/packages/core/src/__tests__/metadata.test.ts
+++ b/packages/core/src/__tests__/metadata.test.ts
@@ -687,6 +687,43 @@ describe("legacy key=value metadata in .json files", () => {
     expect(readMetadata(dataDir, "empty-kv")).toBeNull();
   });
 
+  it("readMetadata returns null for comment-only/blank key=value file (exercises fallback path)", () => {
+    writeFileSync(join(dataDir, "blank-kv.json"), "# comment\n\n  \n", "utf-8");
+    expect(readMetadata(dataDir, "blank-kv")).toBeNull();
+  });
+
+  it("mutateMetadata round-trips legacy key=value content into JSON", () => {
+    writeFileSync(
+      join(dataDir, "rt-legacy.json"),
+      [
+        "codexThreadId=019df929-1773-7720-b07d-08e3cb9851fb",
+        "codexModel=gpt-5.4",
+        "status=working",
+        'runtimeHandle={"id":"ao-orchestrator","runtimeName":"tmux","data":{"createdAt":1778013362949,"workspacePath":"/Users/test"}}',
+        "tmuxName=ao-orchestrator",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    // mutateMetadata should read the legacy format and rewrite as JSON
+    mutateMetadata(dataDir, "rt-legacy", (existing) => {
+      return { ...existing, status: "idle" };
+    });
+
+    // Verify the file is now valid JSON and all fields are preserved
+    const meta = readMetadata(dataDir, "rt-legacy");
+    expect(meta).not.toBeNull();
+    expect(meta!.tmuxName).toBe("ao-orchestrator");
+    expect(meta!.runtimeHandle).toBeDefined();
+    expect(meta!.runtimeHandle?.id).toBe("ao-orchestrator");
+    expect(meta!.runtimeHandle?.runtimeName).toBe("tmux");
+    expect(meta!.status).toBe("idle");
+
+    // Verify the underlying file is now valid JSON (not key=value)
+    const raw = readFileSync(join(dataDir, "rt-legacy.json"), "utf-8");
+    expect(() => JSON.parse(raw)).not.toThrow();
+  });
+
   it("readMetadata still returns null for corrupt JSON that starts with {", () => {
     writeFileSync(join(dataDir, "corrupt-kv.json"), "{this is not valid json", "utf-8");
     expect(readMetadata(dataDir, "corrupt-kv")).toBeNull();

--- a/packages/core/src/__tests__/metadata.test.ts
+++ b/packages/core/src/__tests__/metadata.test.ts
@@ -638,3 +638,57 @@ describe("corrupt JSON handling", () => {
     expect(meta!.status).toBe("working");
   });
 });
+
+describe("legacy key=value metadata in .json files", () => {
+  it("readMetadata parses key=value content from a .json file", () => {
+    writeFileSync(
+      join(dataDir, "ao-orchestrator.json"),
+      [
+        "codexThreadId=019df929-1773-7720-b07d-08e3cb9851fb",
+        "codexModel=gpt-5.4",
+        "status=working",
+        'runtimeHandle={"id":"ao-orchestrator","runtimeName":"tmux","data":{"createdAt":1778013362949,"workspacePath":"/Users/test"}}',
+        "tmuxName=ao-orchestrator",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const meta = readMetadata(dataDir, "ao-orchestrator");
+    expect(meta).not.toBeNull();
+    expect(meta!.tmuxName).toBe("ao-orchestrator");
+    expect(meta!.runtimeHandle).toBeDefined();
+    expect(meta!.runtimeHandle?.id).toBe("ao-orchestrator");
+    expect(meta!.runtimeHandle?.runtimeName).toBe("tmux");
+    expect(meta!.status).toBe("working");
+  });
+
+  it("readMetadataRaw parses key=value content from a .json file", () => {
+    writeFileSync(
+      join(dataDir, "ao-orchestrator-raw.json"),
+      [
+        "codexThreadId=019df929-1773-7720-b07d-08e3cb9851fb",
+        "codexModel=gpt-5.4",
+        "status=working",
+        'runtimeHandle={"id":"ao-orchestrator","runtimeName":"tmux","data":{"createdAt":1778013362949}}',
+        "tmuxName=ao-orchestrator",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const raw = readMetadataRaw(dataDir, "ao-orchestrator-raw");
+    expect(raw).not.toBeNull();
+    expect(raw!["codexThreadId"]).toBe("019df929-1773-7720-b07d-08e3cb9851fb");
+    expect(raw!["tmuxName"]).toBe("ao-orchestrator");
+    expect(raw!["status"]).toBe("working");
+  });
+
+  it("readMetadata still returns null for empty key=value file", () => {
+    writeFileSync(join(dataDir, "empty-kv.json"), "", "utf-8");
+    expect(readMetadata(dataDir, "empty-kv")).toBeNull();
+  });
+
+  it("readMetadata still returns null for corrupt JSON that starts with {", () => {
+    writeFileSync(join(dataDir, "corrupt-kv.json"), "{this is not valid json", "utf-8");
+    expect(readMetadata(dataDir, "corrupt-kv")).toBeNull();
+  });
+});

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -46,7 +46,7 @@ function serializeMetadata(data: Record<string, unknown>): string {
 
 /** Parse metadata file content. Returns null on invalid content.
  *  Supports JSON format (current) and legacy key=value format.
- *  If content starts with '{' but fails JSON parse, it's corrupt — return null.
+ *  If content starts with '{' or '[' but fails JSON parse, it's corrupt — return null.
  *  Otherwise, fall back to key=value parsing for legacy metadata files.
  */
 function parseMetadataContent(content: string): Record<string, unknown> | null {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -35,6 +35,7 @@ import { assertValidSessionIdComponent, SESSION_ID_COMPONENT_PATTERN } from "./u
 import { flattenToStringRecord } from "./utils/metadata-flatten.js";
 import { validateStatus } from "./utils/validation.js";
 import { withFileLockSync } from "./file-lock.js";
+import { parseKeyValueContent } from "./key-value.js";
 
 const JSON_EXTENSION = ".json";
 
@@ -43,14 +44,29 @@ function serializeMetadata(data: Record<string, unknown>): string {
   return JSON.stringify(data, null, 2) + "\n";
 }
 
-/** Parse JSON metadata file content. Returns null on invalid JSON. */
+/** Parse metadata file content. Returns null on invalid content.
+ *  Supports JSON format (current) and legacy key=value format.
+ *  If content starts with '{' but fails JSON parse, it's corrupt — return null.
+ *  Otherwise, fall back to key=value parsing for legacy metadata files.
+ */
 function parseMetadataContent(content: string): Record<string, unknown> | null {
+  // Try JSON first — this is the current format.
   try {
     const parsed = JSON.parse(content);
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
     return parsed as Record<string, unknown>;
   } catch {
-    return null;
+    // JSON parse failed.  If the content looks like it was intended to be JSON
+    // (starts with '{' or '['), treat it as corrupt rather than falling through
+    // to the key=value parser.
+    const firstChar = content.trim()[0];
+    if (firstChar === "{" || firstChar === "[") return null;
+
+    // Fall back to legacy key=value format (pre-V2 metadata files that were
+    // stored with a .json extension).
+    const kv = parseKeyValueContent(content);
+    if (Object.keys(kv).length === 0) return null;
+    return kv as Record<string, unknown>;
   }
 }
 


### PR DESCRIPTION
## Problem

`ao start` fails when a valid canonical orchestrator session is alive but its `.json` metadata file contains legacy `key=value` format instead of JSON. `parseMetadataContent()` in `metadata.ts` only attempts `JSON.parse()` and returns `null` on non-JSON content, while `reserveSessionId()` sees the file as existing — creating a self-contradictory state that blocks recovery.

Fixes #1720

## Fix

Modified `parseMetadataContent()` to fall back to `parseKeyValueContent()` (an existing helper used elsewhere in the codebase for legacy formats) when:
1. `JSON.parse()` fails, AND
2. The content does NOT start with `{` or `[` (preserving corrupt-JSON behavior)

This is the smallest change that resolves the issue — only `packages/core/src/metadata.ts` is modified (plus tests).

## Key design choices

- **JSON-first**: valid JSON is always preferred; the fallback only triggers on parse failure
- **Corrupt JSON preserved**: content starting with `{` or `[` that fails to parse is still treated as corrupt (not silently parsed as key=value)
- **Empty content returns null**: an empty file still returns `null` (matches existing `reserveSessionId` sentinel)
- **No destructive behavior**: legacy metadata files are read, not deleted — a subsequent `writeMetadata`/`updateMetadata` call will rewrite in JSON format

## Tests added

4 new tests in `packages/core/src/__tests__/metadata.test.ts`:
- `readMetadata` parses key=value content from a `.json` file (with `runtimeHandle`, `tmuxName`, `status`)
- `readMetadataRaw` parses key=value content from a `.json` file
- Returns `null` for empty key=value file
- Returns `null` for corrupt JSON that starts with `{`

## Validation

- `pnpm --filter @aoagents/ao-core test -- metadata` — 47/47 passed
- `pnpm --filter @aoagents/ao-core typecheck` — clean