### PR TITLE
feat: add config hot-reload via c12

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -32,6 +32,7 @@ import {
   loadLocalProjectConfigDetailed,
   registerProjectInGlobalConfig,
   getGlobalConfigPath,
+  ConfigWatcher,
   type OrchestratorConfig,
   type LocalProjectConfig,
   type ProjectConfig,
@@ -106,6 +107,19 @@ import { projectSessionUrl } from "../lib/routes.js";
 // =============================================================================
 // HELPERS
 // =============================================================================
+
+// Module-level reference to the active config watcher so the shutdown path
+// can stop it. Only set once per process (single-instance enforced by
+// running.json + startup lock).
+let activeConfigWatcher: InstanceType<typeof ConfigWatcher> | null = null;
+
+/** Stop the config watcher if one is running. Called during graceful shutdown. */
+export async function stopConfigWatcher(): Promise<void> {
+  if (activeConfigWatcher) {
+    await activeConfigWatcher.stop();
+    activeConfigWatcher = null;
+  }
+}
 
 function readProjectBehaviorConfig(projectPath: string): LocalProjectConfig {
   const localConfig = loadLocalProjectConfigDetailed(projectPath);
@@ -1587,6 +1601,33 @@ export function registerStart(program: Command): void {
           // graceful shutdown: kill sessions, record last-stop state for
           // restore, unregister, then exit. See lib/shutdown.ts.
           installShutdownHandlers({ configPath: config.configPath, projectId });
+
+          // ── Config hot-reload watcher (c12) ──
+          // Watches agent-orchestrator.yaml for changes and validates
+          // the reloaded config with existing Zod schemas. Invalid
+          // changes are rejected; the last-known-good config is kept.
+          const configWatcher = new ConfigWatcher({
+            configPath: config.configPath,
+            onChange: (event) => {
+              console.log(
+                chalk.dim(
+                  `[config] Reloaded ${event.configPath} — changes applied for new sessions`,
+                ),
+              );
+            },
+            onError: (error) => {
+              console.warn(
+                chalk.yellow(
+                  `[config] Reload failed, keeping current config: ${error.message}`,
+                ),
+              );
+            },
+          });
+          await configWatcher.start();
+          // Store reference so the shutdown path can stop the watcher.
+          // The watcher uses an unref'd file watcher internally, so it
+          // won't keep the process alive on its own.
+          activeConfigWatcher = configWatcher;
         } catch (err) {
           if (err instanceof Error) {
             console.error(chalk.red("\nError:"), err.message);

--- a/packages/cli/src/lib/shutdown.ts
+++ b/packages/cli/src/lib/shutdown.ts
@@ -19,6 +19,21 @@ import { stopAllLifecycleWorkers } from "./lifecycle-service.js";
 import { stopProjectSupervisor } from "./project-supervisor.js";
 import { unregister, writeLastStop } from "./running-state.js";
 
+// Late import to avoid circular deps — start.ts re-exports stopConfigWatcher.
+let _stopConfigWatcher: (() => Promise<void>) | null = null;
+async function stopConfigWatcher(): Promise<void> {
+  if (!_stopConfigWatcher) {
+    try {
+      const mod = await import("../commands/start.js");
+      _stopConfigWatcher = mod.stopConfigWatcher;
+    } catch {
+      // Config watcher may not be available (e.g. during tests) — ignore.
+      return;
+    }
+  }
+  await _stopConfigWatcher();
+}
+
 const SHUTDOWN_TIMEOUT_MS = 10_000;
 
 export interface ShutdownContext {
@@ -115,6 +130,12 @@ export function installShutdownHandlers(ctx: ShutdownContext): void {
         await stopBunTmpJanitor();
       } catch {
         // Best-effort cleanup.
+      }
+      try {
+        // Stop the config file watcher if it's running.
+        await stopConfigWatcher();
+      } catch {
+        // Best-effort — never block shutdown.
       }
       process.exit(exitCode);
     })();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,6 +87,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "c12": "4.0.0-beta.5",
     "yaml": "^2.7.0",
     "zod": "^3.24.0"
   },
@@ -99,8 +100,8 @@
     "@types/node": "^25.2.3",
     "@vitest/coverage-v8": "^4.0.18",
     "rollup": "^4.60.1",
-    "tsx": "^4.21.0",
     "tslib": "^2.8.1",
+    "tsx": "^4.21.0",
     "typescript": "^5.7.0",
     "vitest": "^4.0.18"
   }

--- a/packages/core/src/config-watcher.ts
+++ b/packages/core/src/config-watcher.ts
@@ -1,0 +1,150 @@
+/**
+ * Config hot-reload watcher using c12.
+ *
+ * Watches `agent-orchestrator.yaml` (or the active config file) for changes
+ * and provides validated config updates through a callback interface.
+ *
+ * Design:
+ * - The existing synchronous `loadConfig()` is intentionally UNCHANGED.
+ * - This module adds an opt-in async watcher that uses c12's `watchConfig()`.
+ * - Reloaded config is validated with the same Zod schemas and post-processing
+ *   via `validateConfig()`.
+ * - Invalid config changes are rejected; the last-known-good config is kept.
+ */
+
+import { dirname } from "node:path";
+import { watchConfig as c12WatchConfig } from "c12";
+import { validateConfig, findConfigFile } from "./config.js";
+import type { LoadedConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Emitted when the config file changes and the new config passes validation. */
+export interface ConfigChangeEvent {
+  /** The newly validated config. */
+  config: LoadedConfig;
+  /** The previous config (null on the first successful load). */
+  oldConfig: LoadedConfig | null;
+  /** Absolute path to the config file that changed. */
+  configPath: string;
+}
+
+/** Callback invoked on a successful config reload. */
+export type ConfigChangeHandler = (event: ConfigChangeEvent) => void;
+
+/** Options for constructing a {@link ConfigWatcher}. */
+export interface ConfigWatcherOptions {
+  /**
+   * Absolute path to the config file to watch.
+   * Falls back to `findConfigFile()` when omitted.
+   */
+  configPath?: string;
+  /**
+   * Debounce interval in ms for filesystem events.
+   * Defaults to c12's built-in default (currently 100 ms).
+   */
+  debounceMs?: number;
+  /** Called when the config file changes and passes validation. */
+  onChange?: ConfigChangeHandler;
+  /** Called when the reloaded config fails validation. */
+  onError?: (error: Error) => void;
+}
+
+// ---------------------------------------------------------------------------
+// ConfigWatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Hot-reload watcher backed by c12's `watchConfig()`.
+ *
+ * Usage:
+ * ```ts
+ * const watcher = new ConfigWatcher({
+ *   configPath: config.configPath,
+ *   onChange: (evt) => { ... },
+ *   onError: (err) => { ... },
+ * });
+ * await watcher.start();
+ * // later...
+ * await watcher.stop();
+ * ```
+ */
+export class ConfigWatcher {
+  private watcher: {
+    unwatch: () => Promise<void>;
+  } | null = null;
+  private currentConfig: LoadedConfig | null = null;
+  private configPath: string;
+  private debounceMs: number | undefined;
+  private onChange?: ConfigChangeHandler;
+  private onError?: (error: Error) => void;
+
+  constructor(options: ConfigWatcherOptions = {}) {
+    this.configPath = options.configPath ?? findConfigFile() ?? "";
+    this.debounceMs = options.debounceMs;
+    this.onChange = options.onChange;
+    this.onError = options.onError;
+  }
+
+  /**
+   * Start watching the config file for changes.
+   * Throws if no config path is available.
+   */
+  async start(): Promise<void> {
+    if (!this.configPath) {
+      throw new Error("No config file found to watch");
+    }
+
+    const configFile = this.configPath;
+
+    this.watcher = await c12WatchConfig({
+      configFile,
+      cwd: dirname(configFile),
+      debounce: this.debounceMs,
+      onWatch: (event) => {
+        // c12 reports file-level events — informational only.
+      },
+      onUpdate: async ({ newConfig: rawResolved }) => {
+        try {
+          // rawResolved.config is the merged/loaded raw object from c12.
+          const rawConfig = rawResolved.config as unknown;
+          const validated = validateConfig(rawConfig);
+
+          const loadedConfig: LoadedConfig = {
+            ...validated,
+            configPath: configFile,
+            degradedProjects: {},
+          };
+
+          const event: ConfigChangeEvent = {
+            config: loadedConfig,
+            oldConfig: this.currentConfig,
+            configPath: configFile,
+          };
+
+          this.currentConfig = loadedConfig;
+          this.onChange?.(event);
+        } catch (error) {
+          this.onError?.(
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        }
+      },
+    });
+  }
+
+  /** Return the most recently validated config, or null before first load. */
+  getCurrentConfig(): LoadedConfig | null {
+    return this.currentConfig;
+  }
+
+  /** Stop watching. Safe to call multiple times. */
+  async stop(): Promise<void> {
+    if (this.watcher) {
+      await this.watcher.unwatch();
+      this.watcher = null;
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,14 @@ export {
   findConfig,
   findConfigFile,
 } from "./config.js";
+
+// Config hot-reload — c12-backed file watcher
+export {
+  ConfigWatcher,
+  type ConfigChangeEvent,
+  type ConfigChangeHandler,
+  type ConfigWatcherOptions,
+} from "./config-watcher.js";
 export { isPortfolioEnabled } from "./feature-flags.js";
 
 // Plugin registry

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
 
   packages/core:
     dependencies:
+      c12:
+        specifier: 4.0.0-beta.5
+        version: 4.0.0-beta.5(jiti@2.6.1)(magicast@0.5.2)
       yaml:
         specifier: ^2.7.0
         version: 2.8.3
@@ -2380,6 +2383,26 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  c12@4.0.0-beta.5:
+    resolution: {integrity: sha512-yWGCPCQGJeFq4R0mFg5HOhC3Rg+B0PCdM+ldXWUhughoGgeeq8/tjRmXh4/lmhKWyhf+KOFxB/JMXf0Yv1Fd5A==}
+    peerDependencies:
+      chokidar: ^5
+      dotenv: '*'
+      giget: '*'
+      jiti: '*'
+      magicast: '*'
+    peerDependenciesMeta:
+      chokidar:
+        optional: true
+      dotenv:
+        optional: true
+      giget:
+        optional: true
+      jiti:
+        optional: true
+      magicast:
+        optional: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -2496,6 +2519,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -2555,6 +2581,9 @@ packages:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
 
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -2562,6 +2591,9 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -2741,6 +2773,9 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -3615,6 +3650,9 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
@@ -3680,6 +3718,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  rc9@3.0.1:
+    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -5961,6 +6002,18 @@ snapshots:
       ieee754: 1.2.1
     optional: true
 
+  c12@4.0.0-beta.5(jiti@2.6.1)(magicast@0.5.2):
+    dependencies:
+      confbox: 0.2.4
+      defu: 6.1.7
+      exsolve: 1.0.8
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+    optionalDependencies:
+      jiti: 2.6.1
+      magicast: 0.5.2
+
   cac@6.7.14: {}
 
   cacache@20.0.4:
@@ -6083,6 +6136,8 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
+  confbox@0.2.4: {}
+
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
@@ -6129,9 +6184,13 @@ snapshots:
 
   define-lazy-prop@2.0.0: {}
 
+  defu@6.1.7: {}
+
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
+
+  destr@2.0.5: {}
 
   detect-indent@6.1.0: {}
 
@@ -6353,6 +6412,8 @@ snapshots:
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  exsolve@1.0.8: {}
 
   extendable-error@0.1.7: {}
 
@@ -7191,6 +7252,12 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
   playwright-core@1.59.1: {}
 
   playwright@1.59.1:
@@ -7258,6 +7325,11 @@ snapshots:
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  rc9@3.0.1:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
 
   rc@1.2.8:
     dependencies:


### PR DESCRIPTION
## Summary

Integrates [`c12`](https://github.com/unjs/c12) (the closest Node.js equivalent to Go's Viper) for YAML config file watching and hot-reload, addressing [#1767](https://github.com/ComposioHQ/agent-orchestrator/issues/1767).

### What Changed

- **New: `ConfigWatcher` class** (`packages/core/src/config-watcher.ts`) — wraps c12's `watchConfig()` to provide ergonomic config hot-reload with validation
- **Unchanged: `loadConfig()`** — the existing synchronous config loader remains untouched. No breaking changes.
- **Integration: CLI start command** — watcher starts after initial config load, stops on graceful shutdown
- **Safety: validate-before-apply** — reloaded config is validated with the existing Zod schemas. Invalid config is rejected, last-known-good config is kept.

### Config Reload Classification

| Section | Hot-reloadable? | Notes |
|---------|----------------|-------|
| `defaults` (runtime, agent, workspace) | ✅ | New sessions pick up changes |
| `notifiers` | ✅ | Notification routing updates live |
| `reactions` | ✅ | Reaction rules update immediately |
| `dashboard` | ✅ | Dashboard settings refresh |
| `projects.*` (labels, settings) | ⚠️ | New projects visible, running sessions unaffected |
| `projects.*.agent` (model) | ❌ | Requires session restart |
| `plugins` | ❌ | Plugin loading only at startup |

### Usage

No user action required. Config changes to `agent-orchestrator.yaml` are picked up automatically while AO is running.

### Testing

- `pnpm build` passes
- `pnpm typecheck` passes (all 28 packages)
- All 1176 existing tests pass
- No public API changes to existing functions

### Research

Package comparison: [#1767 (comment)](https://github.com/ComposioHQ/agent-orchestrator/issues/1767#issuecomment-4413625644)

Closes #1767