### PR TITLE
feat(doctor): check node-pty spawn-helper exec bit + auto-fix

### DIFF
--- a/packages/cli/__tests__/scripts/doctor-script.test.ts
+++ b/packages/cli/__tests__/scripts/doctor-script.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  statSync,
   symlinkSync,
   utimesSync,
   writeFileSync,
@@ -250,6 +251,150 @@ exit 0`,
     expect(result.stdout).toContain("FIXED");
     expect(repairedLauncherIsExecutable).toBe(true);
     expect(npmCommands).toContain("link --force");
+  });
+
+  it("warns about a non-executable node-pty spawn-helper", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-spawn-helper-warn-"));
+    const fakeRepo = createHealthyRepo(tempRoot);
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    createHealthyPath(binDir);
+
+    const helperDir = join(
+      fakeRepo,
+      "node_modules",
+      "node-pty",
+      "prebuilds",
+      `${process.platform}-${process.arch}`,
+    );
+    mkdirSync(helperDir, { recursive: true });
+    const helperPath = join(helperDir, "spawn-helper");
+    writeFileSync(helperPath, "#!/bin/sh\nexit 0\n");
+    chmodSync(helperPath, 0o644);
+
+    const configPath = join(tempRoot, "agent-orchestrator.yaml");
+    const dataDir = join(tempRoot, "data");
+    const worktreeDir = join(tempRoot, "worktrees");
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(worktreeDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      [`dataDir: ${dataDir}`, `worktreeDir: ${worktreeDir}`, "projects: {}"].join("\n"),
+    );
+
+    const result = spawnSync("bash", [scriptPath], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:/bin:/usr/bin`,
+        AO_REPO_ROOT: fakeRepo,
+        AO_CONFIG_PATH: configPath,
+      },
+      encoding: "utf8",
+    });
+
+    const helperModeAfter = statSync(helperPath).mode & 0o777;
+    rmSync(tempRoot, { recursive: true, force: true });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("WARN");
+    expect(result.stdout).toContain("spawn-helper is not executable");
+    expect(result.stdout).toContain(helperPath);
+    expect(helperModeAfter).toBe(0o644);
+  });
+
+  it("repairs a non-executable node-pty spawn-helper in --fix mode", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-spawn-helper-fix-"));
+    const fakeRepo = createHealthyRepo(tempRoot);
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    createHealthyPath(binDir);
+
+    const helperDir = join(
+      fakeRepo,
+      "node_modules",
+      "node-pty",
+      "prebuilds",
+      `${process.platform}-${process.arch}`,
+    );
+    mkdirSync(helperDir, { recursive: true });
+    const helperPath = join(helperDir, "spawn-helper");
+    writeFileSync(helperPath, "#!/bin/sh\nexit 0\n");
+    chmodSync(helperPath, 0o644);
+
+    const configPath = join(tempRoot, "agent-orchestrator.yaml");
+    const dataDir = join(tempRoot, "data");
+    const worktreeDir = join(tempRoot, "worktrees");
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(worktreeDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      [`dataDir: ${dataDir}`, `worktreeDir: ${worktreeDir}`, "projects: {}"].join("\n"),
+    );
+
+    const result = spawnSync("bash", [scriptPath, "--fix"], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:/bin:/usr/bin`,
+        AO_REPO_ROOT: fakeRepo,
+        AO_CONFIG_PATH: configPath,
+      },
+      encoding: "utf8",
+    });
+
+    const helperModeAfter = statSync(helperPath).mode & 0o777;
+    rmSync(tempRoot, { recursive: true, force: true });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("FIXED");
+    expect(result.stdout).toContain("spawn-helper made executable");
+    expect(helperModeAfter & 0o111).not.toBe(0);
+  });
+
+  it("passes when node-pty spawn-helper is already executable", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "ao-doctor-spawn-helper-pass-"));
+    const fakeRepo = createHealthyRepo(tempRoot);
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    createHealthyPath(binDir);
+
+    const helperDir = join(
+      fakeRepo,
+      "node_modules",
+      "node-pty",
+      "prebuilds",
+      `${process.platform}-${process.arch}`,
+    );
+    mkdirSync(helperDir, { recursive: true });
+    const helperPath = join(helperDir, "spawn-helper");
+    writeFileSync(helperPath, "#!/bin/sh\nexit 0\n");
+    chmodSync(helperPath, 0o755);
+
+    const configPath = join(tempRoot, "agent-orchestrator.yaml");
+    const dataDir = join(tempRoot, "data");
+    const worktreeDir = join(tempRoot, "worktrees");
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(worktreeDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      [`dataDir: ${dataDir}`, `worktreeDir: ${worktreeDir}`, "projects: {}"].join("\n"),
+    );
+
+    const result = spawnSync("bash", [scriptPath], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:/bin:/usr/bin`,
+        AO_REPO_ROOT: fakeRepo,
+        AO_CONFIG_PATH: configPath,
+      },
+      encoding: "utf8",
+    });
+
+    rmSync(tempRoot, { recursive: true, force: true });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("spawn-helper is executable");
+    expect(result.stdout).not.toContain("WARN node-pty");
+    expect(result.stdout).not.toContain("FAIL node-pty");
   });
 
   it("reports a healthy packaged install without source-checkout failures", () => {

--- a/packages/cli/src/assets/scripts/ao-doctor.sh
+++ b/packages/cli/src/assets/scripts/ao-doctor.sh
@@ -318,6 +318,69 @@ check_install_layout() {
   fi
 }
 
+find_package_up() {
+  local dir="$1"
+  shift
+  local rel
+  rel="$(IFS=/; printf '%s' "$*")"
+  while true; do
+    if [ -e "$dir/node_modules/$rel" ]; then
+      printf '%s' "$dir/node_modules/$rel"
+      return 0
+    fi
+    local parent
+    parent="$(dirname "$dir")"
+    if [ "$parent" = "$dir" ]; then
+      return 1
+    fi
+    dir="$parent"
+  done
+}
+
+check_node_pty_spawn_helper() {
+  case "$(uname -s 2>/dev/null)" in
+    Linux|Darwin) ;;
+    *) return ;;
+  esac
+
+  local node_pty_dir
+  node_pty_dir="$(find_package_up "$REPO_ROOT" "node-pty" 2>/dev/null || true)"
+  if [ -z "$node_pty_dir" ] || [ ! -d "$node_pty_dir" ]; then
+    return
+  fi
+
+  local platform arch uname_machine
+  platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  uname_machine="$(uname -m)"
+  case "$uname_machine" in
+    x86_64|amd64) arch="x64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    i386|i486|i586|i686) arch="ia32" ;;
+    *) arch="$uname_machine" ;;
+  esac
+
+  local helper="$node_pty_dir/prebuilds/${platform}-${arch}/spawn-helper"
+  if [ ! -f "$helper" ]; then
+    return
+  fi
+
+  if [ -x "$helper" ]; then
+    pass "node-pty spawn-helper is executable ($helper)"
+    return
+  fi
+
+  if [ "$FIX_MODE" = true ]; then
+    if chmod 0755 "$helper" 2>/dev/null; then
+      fixed "node-pty spawn-helper made executable: $helper"
+      return
+    fi
+    fail "Could not chmod node-pty spawn-helper at $helper. Fix: chmod 0755 $helper"
+    return
+  fi
+
+  warn "node-pty spawn-helper is not executable ($helper). Web dashboard terminals will fail with 'posix_spawnp failed' errors. Fix: rerun ao doctor --fix or chmod 0755 $helper. Upstream: microsoft/node-pty#919"
+}
+
 check_runtime_sanity() {
   if [ "$SCRIPT_LAYOUT" = "package-install" ]; then
     if [ ! -f "$REPO_ROOT/dist/index.js" ]; then
@@ -410,6 +473,7 @@ check_config_dirs
 check_stale_temp_files
 check_install_layout
 check_runtime_sanity
+check_node_pty_spawn_helper
 
 printf '\nResults: %s PASS, %s WARN, %s FAIL, %s FIXED\n' "$PASS_COUNT" "$WARN_COUNT" "$FAIL_COUNT" "$FIX_COUNT"
 


### PR DESCRIPTION
## Summary

Adds an `ao doctor` check + `--fix` auto-remediation for the long-standing **node-pty `spawn-helper` missing exec bit** issue (`posix_spawnp failed`). Closes part of #1770.

This is the "Option D" pairing from #1770 — a discoverable, auditable, idempotent fix that lives where users already look when something seems off, and that survives every install-policy variant (Socket Firewall, pnpm 10's default `--ignore-scripts`, manual `npm config set ignore-scripts true`, Renovate / Dependabot bots, etc.) where the existing postinstall remediation in #638 / #1086 is silently skipped.

## What changed

**`packages/cli/src/assets/scripts/ao-doctor.sh`**

- New `find_package_up()` helper — bash mirror of `findPackageUp()` from `packages/ao/bin/postinstall.js`, walks up `node_modules/<pkg>` directories from `REPO_ROOT`. Same algorithm so the doctor inspects the same `node-pty` copy the postinstall would have repaired.
- New `check_node_pty_spawn_helper()` — locates `prebuilds/<platform>-<arch>/spawn-helper`, then:
  - **PASS** when executable.
  - **WARN** with remediation hint when not executable and `--fix` is not set. Mentions both `ao doctor --fix` and the manual `chmod 0755 <path>`, plus a pointer to upstream microsoft/node-pty#919.
  - **FIXED** when not executable and `--fix` is set — `chmod 0755` and report. Falls through to **FAIL** if chmod itself fails (read-only filesystem, permission denied, etc.).
  - Silent skip on Windows (uses ConPTY, no spawn-helper binary), when `node-pty` is not installed (e.g. configurations that disable the web surface), or when no prebuild exists for the current platform-arch (separate concern, tracked in #489).
- Wired into the call list after `check_runtime_sanity`, so all install-layout sanity is verified first.

**`packages/cli/__tests__/scripts/doctor-script.test.ts`**

Three new tests using the existing fake-repo / fake-PATH harness:

- `warns about a non-executable node-pty spawn-helper` — sets up a 0o644 helper, runs without `--fix`, expects WARN, and verifies the file is still 0o644 afterwards (no silent mutation).
- `repairs a non-executable node-pty spawn-helper in --fix mode` — same setup, runs with `--fix`, expects FIXED, and verifies the file now has the exec bit set.
- `passes when node-pty spawn-helper is already executable` — sets up a 0o755 helper, expects PASS and asserts no WARN/FAIL on the node-pty line.

## Why a runtime check, not just an upgraded postinstall

Both PR #638 (chmod) and PR #1086 (`node-gyp rebuild` fallback) live in `packages/ao/bin/postinstall.js`. Postinstall scripts increasingly fail closed in 2026:

- **pnpm 10+** — `--ignore-scripts` is the default
- **Socket Firewall (`sfw npm`)** — forces `ignore-scripts=true` to neutralize supply-chain attack vectors
- **`npm config set ignore-scripts true`** — common in shared dev orgs and CI
- **`npm install --ignore-scripts`** — recommended in security guides
- **Dependabot / Renovate** — run with scripts disabled by default

In any of these, AO's existing remediation never runs and users hit a blank dashboard terminal panel with no in-product error (the `posix_spawnp failed` message is only visible in browser DevTools). A doctor check is the natural next layer because:

1. **Users already run `ao doctor` when something is wrong** — discoverable.
2. **`FIXED` is auditable** — the chmod is reported, not silent.
3. **Reuses existing infrastructure** — the `pass`/`warn`/`fail`/`fixed` reporters and the `--fix` flag in the bash script work out of the box.
4. **Strictly additive** — runs after install-layout checks, doesn't touch hot paths.

This is complementary to (not a replacement for) the existing postinstall — when scripts run, the postinstall fixes things proactively; when they don't, the doctor diagnoses + fixes on demand.

## Test plan

```bash
# Unit tests (added)
pnpm --filter @aoagents/ao-cli exec vitest run __tests__/scripts/doctor-script.test.ts

# Manual: simulate the user-facing failure
INSTALL=$(npm root -g)/@aoagents/ao
HELPER=$(find $INSTALL -path '*node-pty/prebuilds/darwin-arm64/spawn-helper' -print -quit)
chmod -x "$HELPER"
ao doctor                # expect: WARN node-pty spawn-helper is not executable (...)
ao doctor --fix          # expect: FIXED node-pty spawn-helper made executable: ...
ls -la "$HELPER"         # confirm exec bit set
```

Tested locally on macOS arm64 / Node 24.15.0 / `pnpm install --frozen-lockfile && pnpm build`. All 7 tests in `doctor-script.test.ts` pass (4 existing + 3 new).

## Related

- Closes part of #1770 (Option D)
- Complements #638 (postinstall chmod), #1086 (node-gyp rebuild fallback)
- Upstream context: microsoft/node-pty#850 (closed, original report), microsoft/node-pty#858 + microsoft/node-pty#866 (merged fixes), **microsoft/node-pty#919 (open)** — release-management ask for a 1.1.1 patch that backports the fix to the `latest` dist-tag
