### PR TITLE
fix(worktree): resolve Git executable outside PATH

### DIFF
--- a/packages/core/src/__tests__/platform.test.ts
+++ b/packages/core/src/__tests__/platform.test.ts
@@ -1,4 +1,48 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getGitExecutable, isWindows } from "../platform.js";
+
+describe("platform executable resolution", () => {
+  let tempRoot: string;
+  let originalPath: string | undefined;
+  let originalPathExt: string | undefined;
+
+  beforeEach(() => {
+    tempRoot = join(
+      tmpdir(),
+      `ao-platform-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    mkdirSync(tempRoot, { recursive: true });
+    originalPath = process.env["PATH"];
+    originalPathExt = process.env["PATHEXT"];
+  });
+
+  afterEach(() => {
+    if (originalPath === undefined) delete process.env["PATH"];
+    else process.env["PATH"] = originalPath;
+
+    if (originalPathExt === undefined) delete process.env["PATHEXT"];
+    else process.env["PATHEXT"] = originalPathExt;
+
+    rmSync(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  });
+
+  it("resolves git from PATH before falling back to bare git", () => {
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+
+    const executableName = isWindows() ? "git.EXE" : "git";
+    const executablePath = join(binDir, executableName);
+    writeFileSync(executablePath, "");
+
+    process.env["PATH"] = binDir;
+    process.env["PATHEXT"] = ".EXE";
+
+    expect(getGitExecutable()).toBe(executablePath);
+  });
+});
 
 describe("platform adapter", () => {
   const originalPlatform = process.platform;

--- a/packages/core/src/__tests__/platform.test.ts
+++ b/packages/core/src/__tests__/platform.test.ts
@@ -1,15 +1,17 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getGitExecutable, isWindows } from "../platform.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetGitExecutableCache, getGitExecutable, isWindows } from "../platform.js";
 
 describe("platform executable resolution", () => {
   let tempRoot: string;
   let originalPath: string | undefined;
   let originalPathExt: string | undefined;
+  const originalPlatform = process.platform;
 
   beforeEach(() => {
+    _resetGitExecutableCache();
     tempRoot = join(
       tmpdir(),
       `ao-platform-${Date.now()}-${Math.random().toString(16).slice(2)}`,
@@ -20,6 +22,11 @@ describe("platform executable resolution", () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    _resetGitExecutableCache();
+    vi.doUnmock("node:fs");
+    vi.resetModules();
+
     if (originalPath === undefined) delete process.env["PATH"];
     else process.env["PATH"] = originalPath;
 
@@ -41,6 +48,45 @@ describe("platform executable resolution", () => {
     process.env["PATHEXT"] = ".EXE";
 
     expect(getGitExecutable()).toBe(executablePath);
+  });
+
+  async function loadPlatformWithMockedFs(platform: NodeJS.Platform, existingPaths: Set<string>) {
+    Object.defineProperty(process, "platform", { value: platform });
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (path: string) => existingPaths.has(path),
+      };
+    });
+    return import("../platform.js");
+  }
+
+  it("falls back to standard Windows Git install paths", async () => {
+    process.env["PATH"] = "";
+    const gitPath = "C:\\Program Files\\Git\\cmd\\git.exe";
+
+    const mod = await loadPlatformWithMockedFs("win32", new Set([gitPath]));
+
+    expect(mod.getGitExecutable()).toBe(gitPath);
+  });
+
+  it("falls back to Homebrew Git on macOS", async () => {
+    process.env["PATH"] = "";
+    const gitPath = "/opt/homebrew/bin/git";
+
+    const mod = await loadPlatformWithMockedFs("darwin", new Set([gitPath]));
+
+    expect(mod.getGitExecutable()).toBe(gitPath);
+  });
+
+  it("falls back to bare git when PATH and standard install paths miss", async () => {
+    process.env["PATH"] = "";
+
+    const mod = await loadPlatformWithMockedFs("linux", new Set());
+
+    expect(mod.getGitExecutable()).toBe("git");
   });
 });
 

--- a/packages/core/src/__tests__/platform.test.ts
+++ b/packages/core/src/__tests__/platform.test.ts
@@ -54,9 +54,9 @@ describe("platform executable resolution", () => {
     Object.defineProperty(process, "platform", { value: platform });
     vi.resetModules();
     vi.doMock("node:fs", async () => {
-      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      const actual = await vi.importActual("node:fs");
       return {
-        ...actual,
+        ...(actual as Record<string, unknown>),
         existsSync: (path: string) => existingPaths.has(path),
       };
     });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -278,6 +278,7 @@ export {
   isMac,
   getDefaultRuntime,
   getShell,
+  getGitExecutable,
   killProcessTree,
   findPidByPort,
   getEnvDefaults,

--- a/packages/core/src/platform.ts
+++ b/packages/core/src/platform.ts
@@ -53,28 +53,54 @@ function inferShellArgsFlag(cmd: string): (command: string) => string[] {
   return (c) => ["-Command", c];
 }
 
+function pathDelimiterForCurrentPlatform(): string {
+  return isWindows() ? ";" : ":";
+}
+
+function executableExtensions(): string[] {
+  if (!isWindows()) return [""];
+  return [...(process.env["PATHEXT"]?.split(";").filter(Boolean) ?? [".COM", ".EXE", ".BAT", ".CMD"]), ""];
+}
+
 /**
- * Walk PATH looking for an executable. Windows-only: only ever called from
- * resolveWindowsShell. Hard-coded `;` separator and `\` path join regardless
- * of host OS so unit tests that simulate Windows on a Linux CI runner produce
- * canonical Windows paths.
+ * Walk PATH looking for an executable. Uses platform-specific delimiters and
+ * separators so tests can simulate Windows path lookup on any host OS.
  */
 function findOnPath(name: string): string | null {
-  const exts = process.env["PATHEXT"]?.split(";").filter(Boolean) ?? [
-    ".COM",
-    ".EXE",
-    ".BAT",
-    ".CMD",
-  ];
-  const dirs = (process.env["PATH"] ?? "").split(";").filter(Boolean);
+  const dirs = (process.env["PATH"] ?? "").split(pathDelimiterForCurrentPlatform()).filter(Boolean);
   for (const dir of dirs) {
     const base = dir.endsWith("\\") || dir.endsWith("/") ? dir.slice(0, -1) : dir;
-    for (const ext of [...exts, ""]) {
-      const candidate = `${base}\\${name}${ext}`;
+    for (const ext of executableExtensions()) {
+      const candidate = isWindows() ? `${base}\\${name}${ext}` : `${base}/${name}${ext}`;
       if (existsSync(candidate)) return candidate;
     }
   }
   return null;
+}
+
+/**
+ * Resolve Git for child_process.execFile callers.
+ *
+ * Most callers should work with bare "git", but GUI-launched Windows shells can
+ * have Node on PATH without Git. Falling back to standard install paths keeps
+ * worktree setup from failing with a raw ENOENT when Git is installed.
+ */
+export function getGitExecutable(): string {
+  const pathGit = findOnPath("git");
+  if (pathGit) return pathGit;
+
+  const candidates = isWindows()
+    ? [
+        "C:\\Program Files\\Git\\cmd\\git.exe",
+        "C:\\Program Files\\Git\\bin\\git.exe",
+        "C:\\Program Files (x86)\\Git\\cmd\\git.exe",
+        "C:\\Program Files (x86)\\Git\\bin\\git.exe",
+      ]
+    : isMac()
+      ? ["/usr/bin/git", "/opt/homebrew/bin/git", "/usr/local/bin/git"]
+      : ["/usr/bin/git", "/usr/local/bin/git"];
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? "git";
 }
 
 function resolveWindowsShell(): ShellInfo {

--- a/packages/core/src/platform.ts
+++ b/packages/core/src/platform.ts
@@ -32,6 +32,7 @@ interface ShellInfo {
 }
 
 let cachedShell: ShellInfo | null = null;
+let cachedGitExecutable: string | null = null;
 
 /**
  * Infer the command-string flag for a given shell from its basename.
@@ -86,8 +87,10 @@ function findOnPath(name: string): string | null {
  * worktree setup from failing with a raw ENOENT when Git is installed.
  */
 export function getGitExecutable(): string {
+  if (cachedGitExecutable) return cachedGitExecutable;
+
   const pathGit = findOnPath("git");
-  if (pathGit) return pathGit;
+  if (pathGit) return (cachedGitExecutable = pathGit);
 
   const candidates = isWindows()
     ? [
@@ -100,7 +103,14 @@ export function getGitExecutable(): string {
       ? ["/usr/bin/git", "/opt/homebrew/bin/git", "/usr/local/bin/git"]
       : ["/usr/bin/git", "/usr/local/bin/git"];
 
-  return candidates.find((candidate) => existsSync(candidate)) ?? "git";
+  return (cachedGitExecutable = candidates.find((candidate) => existsSync(candidate)) ?? "git");
+}
+
+/** Reset cached git executable (for testing)
+ * @internal
+ */
+export function _resetGitExecutableCache(): void {
+  cachedGitExecutable = null;
 }
 
 function resolveWindowsShell(): ShellInfo {

--- a/packages/plugins/workspace-worktree/src/__tests__/index.test.ts
+++ b/packages/plugins/workspace-worktree/src/__tests__/index.test.ts
@@ -25,6 +25,7 @@ vi.mock("node:fs", () => ({
 }));
 
 vi.mock("@aoagents/ao-core", () => ({
+  getGitExecutable: vi.fn(() => "git"),
   getShell: vi.fn(() => ({ cmd: "sh", args: (c: string) => ["-c", c] })),
   isWindows: vi.fn(() => false),
 }));

--- a/packages/plugins/workspace-worktree/src/index.ts
+++ b/packages/plugins/workspace-worktree/src/index.ts
@@ -14,6 +14,7 @@ import {
 import { join, resolve, basename, dirname, sep } from "node:path";
 import { homedir } from "node:os";
 import {
+  getGitExecutable,
   getShell,
   isWindows,
   type PluginModule,
@@ -37,12 +38,27 @@ export const manifest = {
 
 /** Run a git command in a given directory */
 async function git(cwd: string, ...args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, {
-    cwd,
-    windowsHide: true,
-    timeout: GIT_TIMEOUT,
-  });
-  return stdout.trimEnd();
+  const gitExecutable = getGitExecutable();
+  try {
+    const { stdout } = await execFileAsync(gitExecutable, args, {
+      cwd,
+      windowsHide: true,
+      timeout: GIT_TIMEOUT,
+    });
+    return stdout.trimEnd();
+  } catch (err) {
+    const code =
+      typeof err === "object" && err !== null && "code" in err
+        ? String((err as { code?: unknown }).code)
+        : undefined;
+    if (code === "ENOENT") {
+      throw new Error(
+        `Git executable not found while setting up the worktree. Install Git or add it to PATH. Tried: ${gitExecutable}`,
+        { cause: err },
+      );
+    }
+    throw err;
+  }
 }
 
 /**
@@ -525,7 +541,7 @@ export function create(config?: Record<string, unknown>): Workspace {
     async exists(workspacePath: string): Promise<boolean> {
       if (!existsSync(workspacePath)) return false;
       try {
-        await execFileAsync("git", ["rev-parse", "--is-inside-work-tree"], {
+        await execFileAsync(getGitExecutable(), ["rev-parse", "--is-inside-work-tree"], {
           cwd: workspacePath,
           timeout: GIT_TIMEOUT,
           windowsHide: true,


### PR DESCRIPTION
## Summary
- Resolve Git via the shared platform layer before worktree operations.
- Fall back to common Git install locations on Windows, macOS, and Linux when PATH is degraded.
- Surface a clearer worktree setup error when Git is truly unavailable.

closes https://github.com/ComposioHQ/agent-orchestrator/issues/1777

## Test plan
- `pnpm --filter @aoagents/ao-core test -- src/__tests__/platform.test.ts`
- `pnpm --filter @aoagents/ao-core typecheck && pnpm --filter @aoagents/ao-core build && pnpm --filter @aoagents/ao-plugin-workspace-worktree typecheck && pnpm --filter @aoagents/ao-plugin-workspace-worktree build`
- Reduced-PATH repro: `getGitExecutable()` resolves `C:\Program Files\Git\cmd\git.exe` and `workspaceExists=true`