### PR TITLE
fix(web): guard backlog polling and verification labels

### DIFF
--- a/packages/web/src/__tests__/services.test.ts
+++ b/packages/web/src/__tests__/services.test.ts
@@ -370,6 +370,56 @@ describe("pollBacklog", () => {
     expect(mockUpdateIssue).toHaveBeenCalledTimes(2);
   });
 
+  it("deduplicates active backlog issues per project", async () => {
+    mockLoadConfig.mockReturnValue({
+      configPath: "/tmp/agent-orchestrator.yaml",
+      port: 3000,
+      readyThresholdMs: 300_000,
+      defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+      projects: {
+        "test-project": {
+          path: "/tmp/test-project",
+          tracker: { plugin: "github" },
+          backlog: { label: "agent:backlog", maxConcurrent: 5 },
+        },
+        "other-project": {
+          path: "/tmp/other-project",
+          tracker: { plugin: "github" },
+          backlog: { label: "agent:backlog", maxConcurrent: 5 },
+        },
+      },
+      notifiers: {},
+      notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+      reactions: {},
+    });
+    mockListSessions.mockResolvedValue([
+      {
+        id: "other-1",
+        projectId: "other-project",
+        issueId: "123",
+        status: "working",
+        lifecycle: { pr: { state: "none" } },
+      },
+    ]);
+    mockListIssues.mockImplementation((_query, project) =>
+      project.path === "/tmp/test-project" ? [backlogIssue("123")] : [],
+    );
+    configureBacklogRegistry();
+
+    const { pollBacklog } = await import("../lib/services");
+    await pollBacklog();
+
+    expect(mockSpawn).toHaveBeenCalledWith({
+      projectId: "test-project",
+      issueId: "123",
+    });
+    expect(mockUpdateIssue).toHaveBeenCalledWith(
+      "123",
+      expect.objectContaining({ removeLabels: ["agent:backlog"] }),
+      expect.objectContaining({ path: "/tmp/test-project" }),
+    );
+  });
+
   it("releases transient issue claims when a spawn fails", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     mockListIssues.mockResolvedValue([backlogIssue("123")]);

--- a/packages/web/src/__tests__/services.test.ts
+++ b/packages/web/src/__tests__/services.test.ts
@@ -7,6 +7,7 @@ const {
   mockRegister,
   mockCreateSessionManager,
   mockRegistry,
+  mockIsOrchestratorSession,
   tmuxPlugin,
   claudePlugin,
   codexPlugin,
@@ -26,6 +27,7 @@ const {
   }
   const mockRegister = vi.fn();
   const mockCreateSessionManager = vi.fn();
+  const mockIsOrchestratorSession = vi.fn();
   const mockRegistry = {
     register: mockRegister,
     get: vi.fn(),
@@ -41,6 +43,7 @@ const {
     mockRegister,
     mockCreateSessionManager,
     mockRegistry,
+    mockIsOrchestratorSession,
     tmuxPlugin: { manifest: { name: "tmux" } },
     claudePlugin: { manifest: { name: "claude-code" } },
     codexPlugin: { manifest: { name: "codex" } },
@@ -64,7 +67,15 @@ vi.mock("@aoagents/ao-core", () => ({
     getStates: vi.fn(),
     check: vi.fn(),
   }),
-  TERMINAL_STATUSES: new Set(["merged", "killed"]) as ReadonlySet<string>,
+  isOrchestratorSession: mockIsOrchestratorSession,
+  TERMINAL_STATUSES: new Set([
+    "merged",
+    "killed",
+    "terminated",
+    "done",
+    "cleanup",
+    "errored",
+  ]) as ReadonlySet<string>,
 }));
 
 vi.mock("@aoagents/ao-plugin-runtime-tmux", () => ({ default: tmuxPlugin }));
@@ -76,11 +87,36 @@ vi.mock("@aoagents/ao-plugin-scm-github", () => ({ default: scmPlugin }));
 vi.mock("@aoagents/ao-plugin-tracker-github", () => ({ default: trackerGithubPlugin }));
 vi.mock("@aoagents/ao-plugin-tracker-linear", () => ({ default: trackerLinearPlugin }));
 
+type ServicesGlobal = typeof globalThis & {
+  _aoServices?: unknown;
+  _aoServicesInit?: unknown;
+  _aoBacklogStarted?: boolean;
+  _aoBacklogTimer?: ReturnType<typeof setInterval>;
+  _aoBacklogPollInFlight?: Promise<void>;
+  _aoBacklogClaimingIssues?: Set<string>;
+};
+
+function clearServiceGlobals(): void {
+  const globalForServices = globalThis as ServicesGlobal;
+  if (globalForServices._aoBacklogTimer) {
+    clearInterval(globalForServices._aoBacklogTimer);
+  }
+  delete globalForServices._aoServices;
+  delete globalForServices._aoServicesInit;
+  delete globalForServices._aoBacklogStarted;
+  delete globalForServices._aoBacklogTimer;
+  delete globalForServices._aoBacklogPollInFlight;
+  delete globalForServices._aoBacklogClaimingIssues;
+}
+
 describe("services", () => {
   beforeEach(() => {
     vi.resetModules();
     mockRegister.mockClear();
+    mockRegistry.get.mockReset();
     mockCreateSessionManager.mockReset();
+    mockIsOrchestratorSession.mockReset();
+    mockIsOrchestratorSession.mockReturnValue(false);
     mockLoadConfig.mockReset();
     mockGetGlobalConfigPath.mockReset();
     mockGetGlobalConfigPath.mockReturnValue("/tmp/global-config.yaml");
@@ -95,13 +131,11 @@ describe("services", () => {
       reactions: {},
     });
     mockCreateSessionManager.mockReturnValue({});
-    delete (globalThis as typeof globalThis & { _aoServices?: unknown })._aoServices;
-    delete (globalThis as typeof globalThis & { _aoServicesInit?: unknown })._aoServicesInit;
+    clearServiceGlobals();
   });
 
   afterEach(() => {
-    delete (globalThis as typeof globalThis & { _aoServices?: unknown })._aoServices;
-    delete (globalThis as typeof globalThis & { _aoServicesInit?: unknown })._aoServicesInit;
+    clearServiceGlobals();
   });
 
   it("registers the OpenCode agent plugin with web services", async () => {
@@ -169,16 +203,66 @@ describe("services", () => {
 describe("pollBacklog", () => {
   const mockUpdateIssue = vi.fn();
   const mockListIssues = vi.fn();
+  const mockListReopenedIssues = vi.fn();
+  const mockListSessions = vi.fn();
   const mockSpawn = vi.fn();
+
+  function backlogIssue(id: string) {
+    return {
+      id,
+      title: `Test Issue ${id}`,
+      description: "Test description",
+      url: `https://github.com/test/test/issues/${id}`,
+      state: "open",
+      labels: ["agent:backlog"],
+    };
+  }
+
+  function configureBacklogRegistry(): void {
+    mockRegistry.get.mockImplementation((slot: string) => {
+      if (slot === "tracker") {
+        return {
+          name: "github",
+          listIssues: vi.fn((query, project) => {
+            if (query?.labels?.includes("agent:done")) {
+              return mockListReopenedIssues(query, project);
+            }
+            return mockListIssues(query, project);
+          }),
+          updateIssue: mockUpdateIssue,
+        };
+      }
+      if (slot === "agent") {
+        return { name: "claude-code" };
+      }
+      if (slot === "runtime") {
+        return { name: "tmux" };
+      }
+      if (slot === "workspace") {
+        return { name: "worktree" };
+      }
+      return null;
+    });
+  }
 
   beforeEach(async () => {
     vi.resetModules();
     mockRegister.mockClear();
+    mockRegistry.get.mockReset();
     mockCreateSessionManager.mockReset();
+    mockIsOrchestratorSession.mockReset();
+    mockIsOrchestratorSession.mockReturnValue(false);
     mockLoadConfig.mockReset();
     mockUpdateIssue.mockClear();
     mockListIssues.mockClear();
+    mockListReopenedIssues.mockClear();
+    mockListSessions.mockClear();
     mockSpawn.mockClear();
+    mockListSessions.mockResolvedValue([]);
+    mockListIssues.mockResolvedValue([]);
+    mockListReopenedIssues.mockResolvedValue([]);
+    mockUpdateIssue.mockResolvedValue(undefined);
+    mockSpawn.mockResolvedValue(undefined);
 
     mockLoadConfig.mockReturnValue({
       configPath: "/tmp/agent-orchestrator.yaml",
@@ -199,49 +283,19 @@ describe("pollBacklog", () => {
 
     mockCreateSessionManager.mockReturnValue({
       spawn: mockSpawn,
-      list: vi.fn().mockResolvedValue([]),
+      list: mockListSessions,
     });
 
-    delete (globalThis as typeof globalThis & { _aoServices?: unknown })._aoServices;
-    delete (globalThis as typeof globalThis & { _aoServicesInit?: unknown })._aoServicesInit;
+    clearServiceGlobals();
   });
 
   afterEach(() => {
-    delete (globalThis as typeof globalThis & { _aoServices?: unknown })._aoServices;
-    delete (globalThis as typeof globalThis & { _aoServicesInit?: unknown })._aoServicesInit;
+    clearServiceGlobals();
   });
 
   it("removes agent:backlog label when claiming an issue", async () => {
-    mockListIssues.mockResolvedValue([
-      {
-        id: "123",
-        title: "Test Issue",
-        description: "Test description",
-        url: "https://github.com/test/test/issues/123",
-        state: "open",
-        labels: ["agent:backlog"],
-      },
-    ]);
-
-    mockRegistry.get.mockImplementation((slot: string) => {
-      if (slot === "tracker") {
-        return {
-          name: "github",
-          listIssues: mockListIssues,
-          updateIssue: mockUpdateIssue,
-        };
-      }
-      if (slot === "agent") {
-        return { name: "claude-code" };
-      }
-      if (slot === "runtime") {
-        return { name: "tmux" };
-      }
-      if (slot === "workspace") {
-        return { name: "worktree" };
-      }
-      return null;
-    });
+    mockListIssues.mockResolvedValue([backlogIssue("123")]);
+    configureBacklogRegistry();
 
     const { pollBacklog } = await import("../lib/services");
     await pollBacklog();
@@ -255,5 +309,84 @@ describe("pollBacklog", () => {
       },
       expect.objectContaining({ tracker: { plugin: "github" } }),
     );
+  });
+
+  it("deduplicates concurrent backlog polls", async () => {
+    mockListIssues.mockResolvedValue([backlogIssue("123")]);
+    mockSpawn.mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 10)));
+    configureBacklogRegistry();
+
+    const { pollBacklog } = await import("../lib/services");
+    await Promise.all([pollBacklog(), pollBacklog()]);
+
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(mockUpdateIssue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not spawn more sessions than available capacity", async () => {
+    mockListSessions.mockResolvedValue([
+      {
+        id: "s1",
+        projectId: "test-project",
+        issueId: "900",
+        status: "working",
+        lifecycle: { pr: { state: "none" } },
+      },
+      {
+        id: "s2",
+        projectId: "test-project",
+        issueId: "901",
+        status: "ci_failed",
+        lifecycle: { pr: { state: "none" } },
+      },
+      {
+        id: "s3",
+        projectId: "test-project",
+        issueId: "902",
+        status: "mergeable",
+        lifecycle: { pr: { state: "none" } },
+      },
+    ]);
+    mockListIssues.mockResolvedValue([
+      backlogIssue("100"),
+      backlogIssue("101"),
+      backlogIssue("102"),
+    ]);
+    configureBacklogRegistry();
+
+    const { pollBacklog } = await import("../lib/services");
+    await pollBacklog();
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockSpawn).toHaveBeenNthCalledWith(1, {
+      projectId: "test-project",
+      issueId: "100",
+    });
+    expect(mockSpawn).toHaveBeenNthCalledWith(2, {
+      projectId: "test-project",
+      issueId: "101",
+    });
+    expect(mockUpdateIssue).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases transient issue claims when a spawn fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockListIssues.mockResolvedValue([backlogIssue("123")]);
+    mockSpawn
+      .mockRejectedValueOnce(new Error("worktree already exists"))
+      .mockResolvedValueOnce(undefined);
+    configureBacklogRegistry();
+
+    try {
+      const { pollBacklog } = await import("../lib/services");
+      await pollBacklog();
+      await pollBacklog();
+
+      expect(mockSpawn).toHaveBeenCalledTimes(2);
+      expect(mockUpdateIssue).toHaveBeenCalledTimes(1);
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/packages/web/src/app/api/setup-labels/route.test.ts
+++ b/packages/web/src/app/api/setup-labels/route.test.ts
@@ -40,8 +40,16 @@ describe("POST /api/setup-labels", () => {
 
   it("creates verification lifecycle labels", async () => {
     const response = await POST();
+    const body = await response.json();
 
     expect(response.status).toBe(200);
+    expect(body.results).toEqual(
+      expect.arrayContaining([
+        { repo: "acme/app", label: "merged-unverified", status: "created" },
+        { repo: "acme/app", label: "verified", status: "created" },
+        { repo: "acme/app", label: "verification-failed", status: "created" },
+      ]),
+    );
     for (const [name, color, description] of [
       ["merged-unverified", "F59E0B", "PR merged; awaiting verification"],
       ["verified", "16A34A", "Work verified after staging check"],
@@ -65,5 +73,31 @@ describe("POST /api/setup-labels", () => {
         expect.any(Function),
       );
     }
+  });
+
+  it("records label creation failures as existing labels", async () => {
+    execFileMock.mockImplementationOnce(
+      (
+        _cmd: string,
+        _args: string[],
+        _options: { timeout: number },
+        callback: (error: Error | null, stdout?: string, stderr?: string) => void,
+      ) => callback(new Error("label already exists"), "", ""),
+    );
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.results[0]).toEqual({
+      repo: "acme/app",
+      label: "agent:backlog",
+      status: "exists",
+    });
+    expect(body.results).toEqual(
+      expect.arrayContaining([
+        { repo: "acme/app", label: "merged-unverified", status: "created" },
+      ]),
+    );
   });
 });

--- a/packages/web/src/app/api/setup-labels/route.test.ts
+++ b/packages/web/src/app/api/setup-labels/route.test.ts
@@ -75,14 +75,17 @@ describe("POST /api/setup-labels", () => {
     }
   });
 
-  it("records label creation failures as existing labels", async () => {
+  it("records already-existing labels as existing labels", async () => {
+    const existsError = Object.assign(new Error("label already exists"), {
+      stderr: "label already exists",
+    });
     execFileMock.mockImplementationOnce(
       (
         _cmd: string,
         _args: string[],
         _options: { timeout: number },
         callback: (error: Error | null, stdout?: string, stderr?: string) => void,
-      ) => callback(new Error("label already exists"), "", ""),
+      ) => callback(existsError, "", existsError.stderr),
     );
 
     const response = await POST();
@@ -95,9 +98,35 @@ describe("POST /api/setup-labels", () => {
       status: "exists",
     });
     expect(body.results).toEqual(
-      expect.arrayContaining([
-        { repo: "acme/app", label: "merged-unverified", status: "created" },
-      ]),
+      expect.arrayContaining([{ repo: "acme/app", label: "merged-unverified", status: "created" }]),
+    );
+  });
+
+  it("reports non-idempotent label creation failures", async () => {
+    const authError = Object.assign(new Error("authentication failed"), {
+      stderr: "authentication failed",
+    });
+    execFileMock.mockImplementationOnce(
+      (
+        _cmd: string,
+        _args: string[],
+        _options: { timeout: number },
+        callback: (error: Error | null, stdout?: string, stderr?: string) => void,
+      ) => callback(authError, "", authError.stderr),
+    );
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(response.status).toBe(207);
+    expect(body.results[0]).toEqual({
+      repo: "acme/app",
+      label: "agent:backlog",
+      status: "failed",
+      error: "authentication failed",
+    });
+    expect(body.results).toEqual(
+      expect.arrayContaining([{ repo: "acme/app", label: "merged-unverified", status: "created" }]),
     );
   });
 });

--- a/packages/web/src/app/api/setup-labels/route.test.ts
+++ b/packages/web/src/app/api/setup-labels/route.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const execFileMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      _cmd: string,
+      _args: string[],
+      _options: { timeout: number },
+      callback: (error: Error | null, stdout?: string, stderr?: string) => void,
+    ) => callback(null, "", ""),
+  ),
+);
+
+const getServicesMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    config: {
+      projects: {
+        app: { repo: "acme/app" },
+      },
+    },
+  })),
+);
+
+vi.mock("node:child_process", () => ({
+  default: { execFile: execFileMock },
+  execFile: execFileMock,
+}));
+
+vi.mock("@/lib/services", () => ({
+  getServices: getServicesMock,
+}));
+
+import { POST } from "./route";
+
+describe("POST /api/setup-labels", () => {
+  beforeEach(() => {
+    execFileMock.mockClear();
+    getServicesMock.mockClear();
+  });
+
+  it("creates verification lifecycle labels", async () => {
+    const response = await POST();
+
+    expect(response.status).toBe(200);
+    for (const [name, color, description] of [
+      ["merged-unverified", "F59E0B", "PR merged; awaiting verification"],
+      ["verified", "16A34A", "Work verified after staging check"],
+      ["verification-failed", "DC2626", "Verification failed; needs follow-up"],
+    ]) {
+      expect(execFileMock).toHaveBeenCalledWith(
+        "gh",
+        expect.arrayContaining([
+          "label",
+          "create",
+          name,
+          "--repo",
+          "acme/app",
+          "--color",
+          color,
+          "--description",
+          description,
+          "--force",
+        ]),
+        { timeout: 10_000 },
+        expect.any(Function),
+      );
+    }
+  });
+});

--- a/packages/web/src/app/api/setup-labels/route.ts
+++ b/packages/web/src/app/api/setup-labels/route.ts
@@ -12,6 +12,9 @@ const LABELS = [
   { name: "agent:in-progress", color: "7C3AED", description: "Agent is working on this" },
   { name: "agent:blocked", color: "DC2626", description: "Agent is blocked" },
   { name: "agent:done", color: "16A34A", description: "Agent completed this" },
+  { name: "merged-unverified", color: "F59E0B", description: "PR merged; awaiting verification" },
+  { name: "verified", color: "16A34A", description: "Work verified after staging check" },
+  { name: "verification-failed", color: "DC2626", description: "Verification failed; needs follow-up" },
 ];
 
 /**

--- a/packages/web/src/app/api/setup-labels/route.ts
+++ b/packages/web/src/app/api/setup-labels/route.ts
@@ -14,8 +14,32 @@ const LABELS = [
   { name: "agent:done", color: "16A34A", description: "Agent completed this" },
   { name: "merged-unverified", color: "F59E0B", description: "PR merged; awaiting verification" },
   { name: "verified", color: "16A34A", description: "Work verified after staging check" },
-  { name: "verification-failed", color: "DC2626", description: "Verification failed; needs follow-up" },
+  {
+    name: "verification-failed",
+    color: "DC2626",
+    description: "Verification failed; needs follow-up",
+  },
 ];
+
+type SetupLabelResult = {
+  repo: string;
+  label: string;
+  status: "created" | "exists" | "failed";
+  error?: string;
+};
+
+function commandErrorMessage(error: unknown): string {
+  if (typeof error === "object" && error !== null) {
+    const stderr = "stderr" in error ? (error as { stderr?: unknown }).stderr : undefined;
+    if (typeof stderr === "string" && stderr.trim()) return stderr.trim();
+    if (error instanceof Error) return error.message;
+  }
+  return String(error);
+}
+
+function isExistingLabelError(error: unknown): boolean {
+  return commandErrorMessage(error).toLowerCase().includes("already exists");
+}
 
 /**
  * POST /api/setup-labels — Create agent labels on all configured repos.
@@ -24,28 +48,48 @@ const LABELS = [
 export async function POST() {
   try {
     const { config } = await getServices();
-    const results: Array<{ repo: string; label: string; status: string }> = [];
+    const results: SetupLabelResult[] = [];
+    let hasFailures = false;
 
     for (const project of Object.values(config.projects)) {
       if (!project.repo) continue;
 
       for (const label of LABELS) {
         try {
-          await execFileAsync("gh", [
-            "label", "create", label.name,
-            "--repo", project.repo,
-            "--color", label.color,
-            "--description", label.description,
-            "--force",
-          ], { timeout: 10_000 });
+          await execFileAsync(
+            "gh",
+            [
+              "label",
+              "create",
+              label.name,
+              "--repo",
+              project.repo,
+              "--color",
+              label.color,
+              "--description",
+              label.description,
+              "--force",
+            ],
+            { timeout: 10_000 },
+          );
           results.push({ repo: project.repo, label: label.name, status: "created" });
-        } catch {
-          results.push({ repo: project.repo, label: label.name, status: "exists" });
+        } catch (error) {
+          if (isExistingLabelError(error)) {
+            results.push({ repo: project.repo, label: label.name, status: "exists" });
+            continue;
+          }
+          hasFailures = true;
+          results.push({
+            repo: project.repo,
+            label: label.name,
+            status: "failed",
+            error: commandErrorMessage(error),
+          });
         }
       }
     }
 
-    return NextResponse.json({ results });
+    return NextResponse.json({ results }, { status: hasFailures ? 207 : 200 });
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Failed to setup labels" },

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -181,6 +181,10 @@ function getBacklogClaimingIssues(): Set<string> {
   return globalForBacklog._aoBacklogClaimingIssues;
 }
 
+function backlogIssueKey(projectId: string, issueId: string): string {
+  return `${projectId}:${issueId.toLowerCase()}`;
+}
+
 // Track which issues we've already processed to avoid repeated API calls
 const processedIssues = new Set<string>();
 
@@ -316,7 +320,9 @@ async function pollBacklogOnce(): Promise<void> {
     );
     const activeIssueIds = new Set(
       workerSessions
-        .map((session) => session.issueId?.toLowerCase())
+        .map((session) =>
+          session.issueId ? backlogIssueKey(session.projectId, session.issueId) : null,
+        )
         .filter((issueId): issueId is string => Boolean(issueId)),
     );
     const claimingIssueIds = getBacklogClaimingIssues();
@@ -345,7 +351,7 @@ async function pollBacklogOnce(): Promise<void> {
       for (const issue of backlogIssues) {
         if (availableSlots <= 0) break;
 
-        const issueKey = issue.id.toLowerCase();
+        const issueKey = backlogIssueKey(projectId, issue.id);
 
         // Skip if already being worked on or claimed by an in-flight spawn.
         if (activeIssueIds.has(issueKey) || claimingIssueIds.has(issueKey)) continue;

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -160,6 +160,8 @@ const MAX_CONCURRENT_AGENTS = 5; // Max active agent sessions across all project
 const globalForBacklog = globalThis as typeof globalThis & {
   _aoBacklogStarted?: boolean;
   _aoBacklogTimer?: ReturnType<typeof setInterval>;
+  _aoBacklogPollInFlight?: Promise<void>;
+  _aoBacklogClaimingIssues?: Set<string>;
 };
 
 /** Start the backlog auto-claim loop. Idempotent — safe to call multiple times. */
@@ -170,6 +172,13 @@ export function startBacklogPoller(): void {
   // Run immediately, then on interval
   void pollBacklog();
   globalForBacklog._aoBacklogTimer = setInterval(() => void pollBacklog(), BACKLOG_POLL_INTERVAL);
+}
+
+function getBacklogClaimingIssues(): Set<string> {
+  if (!globalForBacklog._aoBacklogClaimingIssues) {
+    globalForBacklog._aoBacklogClaimingIssues = new Set();
+  }
+  return globalForBacklog._aoBacklogClaimingIssues;
 }
 
 // Track which issues we've already processed to avoid repeated API calls
@@ -267,7 +276,22 @@ async function relabelReopenedIssues(
   }
 }
 
-export async function pollBacklog(): Promise<void> {
+export function pollBacklog(): Promise<void> {
+  if (globalForBacklog._aoBacklogPollInFlight) {
+    return globalForBacklog._aoBacklogPollInFlight;
+  }
+
+  const pollPromise = pollBacklogOnce().finally(() => {
+    if (globalForBacklog._aoBacklogPollInFlight === pollPromise) {
+      globalForBacklog._aoBacklogPollInFlight = undefined;
+    }
+  });
+
+  globalForBacklog._aoBacklogPollInFlight = pollPromise;
+  return pollPromise;
+}
+
+async function pollBacklogOnce(): Promise<void> {
   try {
     const { config, registry, sessionManager } = await getServices();
 
@@ -295,6 +319,7 @@ export async function pollBacklog(): Promise<void> {
         .map((session) => session.issueId?.toLowerCase())
         .filter((issueId): issueId is string => Boolean(issueId)),
     );
+    const claimingIssueIds = getBacklogClaimingIssues();
 
     // Auto-scaling: respect max concurrent agents
     let availableSlots = MAX_CONCURRENT_AGENTS - workerSessions.length;
@@ -320,14 +345,17 @@ export async function pollBacklog(): Promise<void> {
       for (const issue of backlogIssues) {
         if (availableSlots <= 0) break;
 
-        // Skip if already being worked on
-        if (activeIssueIds.has(issue.id.toLowerCase())) continue;
+        const issueKey = issue.id.toLowerCase();
 
+        // Skip if already being worked on or claimed by an in-flight spawn.
+        if (activeIssueIds.has(issueKey) || claimingIssueIds.has(issueKey)) continue;
+
+        claimingIssueIds.add(issueKey);
         try {
           await sessionManager.spawn({ projectId, issueId: issue.id });
           availableSlots--;
 
-          activeIssueIds.add(issue.id.toLowerCase());
+          activeIssueIds.add(issueKey);
 
           // Mark as claimed on the tracker
           if (tracker.updateIssue) {
@@ -343,6 +371,8 @@ export async function pollBacklog(): Promise<void> {
           }
         } catch (err) {
           console.error(`[backlog] Failed to spawn session for issue ${issue.id}:`, err);
+        } finally {
+          claimingIssueIds.delete(issueKey);
         }
       }
     }


### PR DESCRIPTION
## Summary
- serialize backlog polling in the dashboard process so reentrant polls cannot overspawn agents
- release transient backlog claims after failed spawns
- include verification workflow labels in the setup-labels route and coverage

## Testing
- `pnpm --filter @aoagents/ao-web test -- src/__tests__/services.test.ts src/app/api/setup-labels/route.test.ts`
- `pnpm --filter @aoagents/ao-web typecheck`
- `git diff --check`
