### PR TITLE
fix(web): polish dashboard accessibility and scoped state

### DIFF
--- a/packages/plugins/tracker-linear/src/index.ts
+++ b/packages/plugins/tracker-linear/src/index.ts
@@ -137,7 +137,7 @@ function createComposioTransport(apiKey: string, entityId: string): GraphQLTrans
     if (!clientPromise) {
       clientPromise = (async () => {
         try {
-          const { Composio } = await import("@composio/core");
+          const { Composio } = await import(/* webpackIgnore: true */ "@composio/core");
           const client = new Composio({ apiKey });
           return client.tools;
         } catch (err: unknown) {

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -6,10 +6,18 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const homeDir = os.homedir().replace(/\\/g, "/");
+// Next does not expose a public helper for extending the default
+// htmlLimitedBots list. Keep the default Next 15 crawler coverage here and add
+// only narrow audit UAs, avoiding private next/dist imports in runtime config.
+const nextDefaultHtmlLimitedBotsSource = String.raw`[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight`;
+const htmlLimitedBots = new RegExp(
+  `${nextDefaultHtmlLimitedBotsSource}|Lighthouse|PageSpeed`,
+  "i",
+);
 const nextConfig = {
-  // Keep metadata in the initial HTML for Lighthouse-style audits. The local
-  // DevTools Lighthouse runner presents as Chrome, so include Chrome here.
-  htmlLimitedBots: /Chrome|Chromium|Lighthouse|PageSpeed/i,
+  // Preserve Next's crawler list and add narrow audit UAs without matching
+  // ordinary Chrome/Chromium browser traffic.
+  htmlLimitedBots,
   outputFileTracingRoot: path.join(__dirname, "../.."),
   transpilePackages: [
     "@aoagents/ao-core",

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -7,6 +7,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /** @type {import('next').NextConfig} */
 const homeDir = os.homedir().replace(/\\/g, "/");
 const nextConfig = {
+  // Keep metadata in the initial HTML for Lighthouse-style audits. The local
+  // DevTools Lighthouse runner presents as Chrome, so include Chrome here.
+  htmlLimitedBots: /Chrome|Chromium|Lighthouse|PageSpeed/i,
   outputFileTracingRoot: path.join(__dirname, "../.."),
   transpilePackages: [
     "@aoagents/ao-core",

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1351,6 +1351,23 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   text-decoration: underline;
 }
 
+.topbar-pr-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  color: var(--color-accent);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.topbar-pr-pill:hover {
+  text-decoration: underline;
+}
+
 /* Danger button variant (kill) */
 .dashboard-app-btn--danger {
   color: var(--color-status-error);
@@ -4529,6 +4546,21 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   white-space: nowrap;
 }
 
+.project-sidebar__sess-pr {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 4px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-primary);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  line-height: 1.2;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 /* Inline status (compact variant — name + status on one line) */
 .project-sidebar__sess-status--inline {
   font-size: 10px;
@@ -7619,6 +7651,10 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
     font-size: 9px;
     padding: 1px 5px;
     max-width: 90px;
+  }
+  .topbar-session-pills .topbar-pr-pill {
+    font-size: 9px;
+    padding: 1px 5px;
   }
   .topbar-session-pills .topbar-zone-pill {
     font-size: 9px;

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -5068,8 +5068,8 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   gap: 8px;
   width: 100%;
   min-width: 0;
-  height: calc(100vh - 240px);
-  height: calc(100dvh - 240px);
+  min-height: 0;
+  height: 100%;
   overflow-x: auto;
   padding-bottom: 8px;
 }

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -200,8 +200,8 @@
   /* Text — cream, not blue-white */
   --color-text-primary: #f0ece8;
   --color-text-secondary: #a8a29e;
-  --color-text-tertiary: #78716c;
-  --color-text-muted: #57534e;
+  --color-text-tertiary: #96908b;
+  --color-text-muted: #8f8984;
   --color-text-inverse: #121110;
 
   /* Interactive accent — warm periwinkle */
@@ -223,17 +223,17 @@
   --color-status-attention: #e2a336;
   --color-status-idle: #44403c;
   --color-status-done: #44403c;
-  --color-status-error: #ef4444;
+  --color-status-error: #f87171;
   --color-status-merge: #22c55e;
   --color-ci-pass: #22c55e;
-  --color-ci-fail: #ef4444;
+  --color-ci-fail: #f87171;
 
   /* Semantic aliases */
   --color-accent-blue: #60a5fa;
   --color-accent-green: #22c55e;
   --color-accent-yellow: #eab308;
   --color-accent-orange: #ff9d57;
-  --color-accent-red: #ef4444;
+  --color-accent-red: #f87171;
   --color-accent-violet: #a78bfa;
   --color-accent-purple: #a78bfa;
 
@@ -309,8 +309,8 @@
   --color-column-header: transparent;
 
   /* Alert colors — warm-tinted */
-  --color-alert-ci: #ef4444;
-  --color-alert-ci-bg: rgba(239, 68, 68, 0.08);
+  --color-alert-ci: #f87171;
+  --color-alert-ci-bg: rgba(248, 113, 113, 0.08);
   --color-alert-ci-unknown: #e2a336;
   --color-alert-review: #60a5fa;
   --color-alert-review-bg: rgba(96, 165, 250, 0.08);
@@ -358,9 +358,9 @@
   --z-base: 0;
   --z-raised: 10;
   --z-nav: 100;
-  --z-modal: 200;
   --z-bottom-nav: 250;
   --z-overlay: 300;
+  --z-modal: 360;
   --z-toast: 400;
   --z-connection-bar: 500;
 
@@ -4062,7 +4062,7 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 .project-settings-modal-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  z-index: var(--z-modal);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -7688,3 +7688,112 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 .topbar-zone-pill--working { background: color-mix(in srgb, var(--color-accent-blue)      12%, transparent); color: var(--color-accent-blue); }
 .topbar-zone-pill--pending { background: color-mix(in srgb, var(--color-status-attention) 12%, transparent); color: var(--color-status-attention); }
 .topbar-zone-pill--done    { background: color-mix(in srgb, var(--color-text-tertiary)    14%, transparent); color: var(--color-text-tertiary); }
+
+/* ── Accessibility polish from UX audit ─────────────────────────────── */
+.dark .project-sidebar__sect-label,
+.dark .project-sidebar__sess-status,
+.dark .project-sidebar__sess-pr,
+.dark .project-sidebar__proj-badge {
+  color: var(--color-text-secondary);
+}
+
+.dark .dashboard-main__subtitle,
+.dark .kanban-column__title,
+.dark .kanban-column__count,
+.dark .card__id,
+.dark .card__branch,
+.dark .card__meta-sep,
+.dark .card__diff-size,
+.dark .session-card__secondary,
+.dark .card__status,
+.dark .done-bar__toggle,
+.dark .done-bar__label,
+.dark .done-bar__count,
+.dark .dashboard-stat-card__meta {
+  color: var(--color-text-secondary);
+}
+
+.dark .alert-row__notified {
+  opacity: 1;
+}
+
+.dark .alert-row__action {
+  opacity: 1;
+}
+
+.dark .terminal .xterm-dim {
+  color: #8b8b96 !important;
+}
+
+.kanban-column-body {
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
+}
+
+.kanban-column::after {
+  content: "";
+  display: block;
+  height: 10px;
+  margin-top: -10px;
+  pointer-events: none;
+  background: linear-gradient(to bottom, transparent, var(--color-column-bg));
+}
+
+@media (max-width: 767px) {
+  .dashboard-app-sidebar-toggle,
+  .dashboard-app-btn,
+  .project-sidebar__add-btn,
+  .project-sidebar__footer-btn,
+  .project-sidebar__theme-toggle,
+  .project-sidebar__proj-action,
+  .project-sidebar__proj-toggle,
+  .project-sidebar__sess-row,
+  .project-sidebar__collapsed-icon,
+  .project-sidebar__collapsed-session-btn,
+  .add-project-modal__iconbtn,
+  .add-project-modal__toolbtn {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .project-sidebar__sess-row {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+
+  .project-sidebar__proj-toggle {
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+}
+
+@media (max-width: 640px) {
+  .add-project-modal-backdrop,
+  .project-settings-modal-backdrop {
+    align-items: center;
+    justify-content: center;
+    padding: 12px;
+  }
+
+  .add-project-modal,
+  .project-settings-modal {
+    width: calc(100vw - 24px);
+    max-height: calc(100dvh - 24px);
+  }
+
+  .add-project-modal {
+    height: min(680px, calc(100dvh - 24px));
+  }
+
+  .project-settings-modal {
+    height: auto;
+  }
+
+  .project-settings-modal__header {
+    padding: 14px 16px;
+  }
+
+  .project-settings-modal__title {
+    font-size: 18px;
+  }
+}

--- a/packages/web/src/app/layout.test.ts
+++ b/packages/web/src/app/layout.test.ts
@@ -14,10 +14,10 @@ describe("app layout metadata", () => {
     ]);
   });
 
-  it("builds metadata with the project-aware title and apple web app settings", async () => {
-    const { generateMetadata } = await import("./layout");
+  it("exports metadata with the project-aware title and apple web app settings", async () => {
+    const { metadata } = await import("./layout");
 
-    await expect(generateMetadata()).resolves.toMatchObject({
+    expect(metadata).toMatchObject({
       title: {
         template: "%s | Agent Orchestrator",
         default: "ao | Agent Orchestrator",

--- a/packages/web/src/app/layout.test.ts
+++ b/packages/web/src/app/layout.test.ts
@@ -14,10 +14,10 @@ describe("app layout metadata", () => {
     ]);
   });
 
-  it("exports metadata with the project-aware title and apple web app settings", async () => {
-    const { metadata } = await import("./layout");
+  it("generates metadata with the project-aware title and apple web app settings", async () => {
+    const { generateMetadata } = await import("./layout");
 
-    expect(metadata).toMatchObject({
+    await expect(generateMetadata()).resolves.toMatchObject({
       title: {
         template: "%s | Agent Orchestrator",
         default: "ao | Agent Orchestrator",

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -15,7 +15,7 @@ export const viewport: Viewport = {
   ],
 };
 
-export async function generateMetadata(): Promise<Metadata> {
+function createMetadata(): Metadata {
   const projectName = getProjectName();
   return {
     title: {
@@ -30,6 +30,8 @@ export async function generateMetadata(): Promise<Metadata> {
     },
   };
 }
+
+export const metadata: Metadata = createMetadata();
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -15,7 +15,7 @@ export const viewport: Viewport = {
   ],
 };
 
-function createMetadata(): Metadata {
+export async function generateMetadata(): Promise<Metadata> {
   const projectName = getProjectName();
   return {
     title: {
@@ -30,8 +30,6 @@ function createMetadata(): Metadata {
     },
   };
 }
-
-export const metadata: Metadata = createMetadata();
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/packages/web/src/app/orchestrators/page.tsx
+++ b/packages/web/src/app/orchestrators/page.tsx
@@ -20,7 +20,10 @@ export async function generateMetadata(props: {
       projectName = project.name;
     }
   }
-  return { title: { absolute: `ao | ${projectName} - Orchestrator` } };
+  return {
+    title: { absolute: `ao | ${projectName} - Orchestrator` },
+    description: `Open or resume the AO orchestrator session for ${projectName}.`,
+  };
 }
 
 export default async function OrchestratorsRoute(props: {
@@ -39,6 +42,12 @@ export default async function OrchestratorsRoute(props: {
           <p className="mt-2 text-[var(--color-text-secondary)]">
             No project specified. Please provide a project parameter.
           </p>
+          <a
+            href="/"
+            className="mt-4 inline-flex border border-[var(--color-border-default)] px-4 py-2 text-sm font-medium text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated-hover)] hover:text-[var(--color-text-primary)] hover:no-underline"
+          >
+            Back to dashboard
+          </a>
         </div>
       </div>
     );

--- a/packages/web/src/app/page.test.tsx
+++ b/packages/web/src/app/page.test.tsx
@@ -1,33 +1,17 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
-  getProjectRouteDataMock: vi.fn(),
   getDashboardPageDataMock: vi.fn(),
+  getDashboardProjectNameMock: vi.fn(),
+  resolveDashboardProjectFilterMock: vi.fn(),
   dashboardPropsMock: vi.fn(),
-}));
-
-vi.mock("next/link", () => ({
-  default: ({
-    children,
-    ...props
-  }: React.PropsWithChildren<React.AnchorHTMLAttributes<HTMLAnchorElement>>) => (
-    <a {...props}>{children}</a>
-  ),
-}));
-
-vi.mock("next/navigation", () => ({
-  notFound: vi.fn(() => {
-    throw new Error("NEXT_NOT_FOUND");
-  }),
-}));
-
-vi.mock("@/lib/project-route-data", () => ({
-  getProjectRouteData: hoisted.getProjectRouteDataMock,
 }));
 
 vi.mock("@/lib/dashboard-page-data", () => ({
   getDashboardPageData: hoisted.getDashboardPageDataMock,
+  getDashboardProjectName: hoisted.getDashboardProjectNameMock,
+  resolveDashboardProjectFilter: hoisted.resolveDashboardProjectFilterMock,
 }));
 
 vi.mock("@/components/Dashboard", () => ({
@@ -37,42 +21,15 @@ vi.mock("@/components/Dashboard", () => ({
   },
 }));
 
-import ProjectPage from "./page";
+import Home from "./page";
 
-describe("ProjectPage", () => {
+describe("Home dashboard route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("renders degraded project state when the project is degraded", async () => {
-    hoisted.getProjectRouteDataMock.mockResolvedValue({
-      projectId: "broken",
-      project: null,
-      projects: [{ id: "broken", name: "Broken" }],
-      degradedProject: {
-        projectId: "broken",
-        path: "/tmp/broken",
-        resolveError: "Local config failed validation",
-      },
-    });
-
-    render(await ProjectPage({ params: Promise.resolve({ projectId: "broken" }) }));
-
-    expect(screen.getByText("This project's config failed to load")).toBeInTheDocument();
-    expect(screen.getByText("Local config failed validation")).toBeInTheDocument();
-    expect(screen.queryByTestId("dashboard")).not.toBeInTheDocument();
-  });
-
-  it("passes all-project sessions to the dashboard while keeping the selected project context", async () => {
-    hoisted.getProjectRouteDataMock.mockResolvedValue({
-      projectId: "nebula",
-      project: { id: "nebula", name: "Nebula" },
-      projects: [
-        { id: "nebula", name: "Nebula" },
-        { id: "other", name: "Other" },
-      ],
-      degradedProject: null,
-    });
+  it("keeps the selected project context but seeds Dashboard with all-project sidebar data", async () => {
+    hoisted.resolveDashboardProjectFilterMock.mockReturnValue("nebula");
     const selectedProjectData = {
       sessions: [{ id: "neb-1" }],
       orchestrators: [{ id: "orch-neb", projectId: "nebula" }],
@@ -98,8 +55,9 @@ describe("ProjectPage", () => {
       project === "all" ? allProjectData : selectedProjectData,
     );
 
-    render(await ProjectPage({ params: Promise.resolve({ projectId: "nebula" }) }));
+    render(await Home({ searchParams: Promise.resolve({ project: "nebula" }) }));
 
+    expect(hoisted.resolveDashboardProjectFilterMock).toHaveBeenCalledWith("nebula");
     expect(hoisted.getDashboardPageDataMock).toHaveBeenCalledWith("nebula");
     expect(hoisted.getDashboardPageDataMock).toHaveBeenCalledWith("all");
     expect(hoisted.dashboardPropsMock).toHaveBeenCalledWith(

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -23,20 +23,18 @@ export async function generateMetadata(props: {
 export default async function Home(props: { searchParams: Promise<{ project?: string }> }) {
   const searchParams = await props.searchParams;
   const projectFilter = resolveDashboardProjectFilter(searchParams.project);
-  const pageData = await getDashboardPageData(projectFilter);
-  const sidebarData = pageData.selectedProjectId
-    ? await getDashboardPageData("all")
-    : pageData;
+  const pageData = await getDashboardPageData("all");
+  const selectedProjectId = projectFilter === "all" ? undefined : projectFilter;
 
   return (
     <Dashboard
-      initialSessions={sidebarData.sessions}
-      projectId={pageData.selectedProjectId}
-      projectName={pageData.projectName}
+      initialSessions={pageData.sessions}
+      projectId={selectedProjectId}
+      projectName={getDashboardProjectName(projectFilter)}
       projects={pageData.projects}
-      orchestrators={sidebarData.orchestrators}
+      orchestrators={pageData.orchestrators}
       attentionZones={pageData.attentionZones}
-      dashboardLoadError={pageData.dashboardLoadError ?? sidebarData.dashboardLoadError}
+      dashboardLoadError={pageData.dashboardLoadError}
     />
   );
 }

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -14,23 +14,29 @@ export async function generateMetadata(props: {
   const searchParams = await props.searchParams;
   const projectFilter = resolveDashboardProjectFilter(searchParams.project);
   const projectName = getDashboardProjectName(projectFilter);
-  return { title: { absolute: `ao | ${projectName}` } };
+  return {
+    title: { absolute: `ao | ${projectName}` },
+    description: `Live AO dashboard for ${projectName} agent sessions, pull requests, and merge status.`,
+  };
 }
 
 export default async function Home(props: { searchParams: Promise<{ project?: string }> }) {
   const searchParams = await props.searchParams;
   const projectFilter = resolveDashboardProjectFilter(searchParams.project);
   const pageData = await getDashboardPageData(projectFilter);
+  const sidebarData = pageData.selectedProjectId
+    ? await getDashboardPageData("all")
+    : pageData;
 
   return (
     <Dashboard
-      initialSessions={pageData.sessions}
+      initialSessions={sidebarData.sessions}
       projectId={pageData.selectedProjectId}
       projectName={pageData.projectName}
       projects={pageData.projects}
-      orchestrators={pageData.orchestrators}
+      orchestrators={sidebarData.orchestrators}
       attentionZones={pageData.attentionZones}
-      dashboardLoadError={pageData.dashboardLoadError}
+      dashboardLoadError={pageData.dashboardLoadError ?? sidebarData.dashboardLoadError}
     />
   );
 }

--- a/packages/web/src/app/projects/[projectId]/page.test.tsx
+++ b/packages/web/src/app/projects/[projectId]/page.test.tsx
@@ -65,49 +65,40 @@ describe("ProjectPage", () => {
 
   it("passes all-project sessions to the dashboard while keeping the selected project context", async () => {
     hoisted.getProjectRouteDataMock.mockResolvedValue({
-      projectId: "nebula",
-      project: { id: "nebula", name: "Nebula" },
+      projectId: "alpha",
+      project: { id: "alpha", name: "Alpha" },
       projects: [
-        { id: "nebula", name: "Nebula" },
-        { id: "other", name: "Other" },
+        { id: "alpha", name: "Alpha" },
+        { id: "beta", name: "Beta" },
       ],
       degradedProject: null,
     });
-    const selectedProjectData = {
-      sessions: [{ id: "neb-1" }],
-      orchestrators: [{ id: "orch-neb", projectId: "nebula" }],
-      projectName: "Nebula",
-      projects: [
-        { id: "nebula", name: "Nebula" },
-        { id: "other", name: "Other" },
-      ],
-      selectedProjectId: "nebula",
-      attentionZones: "simple",
-    };
     const allProjectData = {
-      ...selectedProjectData,
-      sessions: [{ id: "neb-1" }, { id: "other-1" }],
+      sessions: [{ id: "alpha-1" }, { id: "beta-1" }],
       orchestrators: [
-        { id: "orch-neb", projectId: "nebula" },
-        { id: "orch-other", projectId: "other" },
+        { id: "orch-alpha", projectId: "alpha" },
+        { id: "orch-beta", projectId: "beta" },
+      ],
+      projects: [
+        { id: "alpha", name: "Alpha" },
+        { id: "beta", name: "Beta" },
       ],
       projectName: "All Projects",
       selectedProjectId: undefined,
+      attentionZones: "simple",
     };
-    hoisted.getDashboardPageDataMock.mockImplementation(async (project?: string) =>
-      project === "all" ? allProjectData : selectedProjectData,
-    );
+    hoisted.getDashboardPageDataMock.mockResolvedValue(allProjectData);
 
-    render(await ProjectPage({ params: Promise.resolve({ projectId: "nebula" }) }));
+    render(await ProjectPage({ params: Promise.resolve({ projectId: "alpha" }) }));
 
-    expect(hoisted.getDashboardPageDataMock).toHaveBeenCalledWith("nebula");
+    expect(hoisted.getDashboardPageDataMock).toHaveBeenCalledTimes(1);
     expect(hoisted.getDashboardPageDataMock).toHaveBeenCalledWith("all");
     expect(hoisted.dashboardPropsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         initialSessions: allProjectData.sessions,
         orchestrators: allProjectData.orchestrators,
-        projectId: "nebula",
-        projectName: "Nebula",
+        projectId: "alpha",
+        projectName: "Alpha",
       }),
     );
   });

--- a/packages/web/src/app/projects/[projectId]/page.tsx
+++ b/packages/web/src/app/projects/[projectId]/page.tsx
@@ -19,9 +19,7 @@ export async function generateMetadata(props: {
   };
 }
 
-export default async function ProjectPage(props: {
-  params: Promise<{ projectId: string }>;
-}) {
+export default async function ProjectPage(props: { params: Promise<{ projectId: string }> }) {
   const { projectId } = await props.params;
   const routeData = await getProjectRouteData(projectId);
 
@@ -39,19 +37,19 @@ export default async function ProjectPage(props: {
     );
   }
 
-  const pageData = await getDashboardPageData(projectId);
-  const sidebarData = await getDashboardPageData("all");
+  const pageData = await getDashboardPageData("all");
+  const projectName = routeData.project?.name ?? routeData.projectId;
 
   return (
     <div className="min-h-screen bg-[var(--color-bg-canvas)]">
       <Dashboard
-        initialSessions={sidebarData.sessions}
-        projectId={pageData.selectedProjectId}
-        projectName={pageData.projectName}
+        initialSessions={pageData.sessions}
+        projectId={routeData.projectId}
+        projectName={projectName}
         projects={pageData.projects}
-        orchestrators={sidebarData.orchestrators}
+        orchestrators={pageData.orchestrators}
         attentionZones={pageData.attentionZones}
-        dashboardLoadError={pageData.dashboardLoadError ?? sidebarData.dashboardLoadError}
+        dashboardLoadError={pageData.dashboardLoadError}
       />
     </div>
   );

--- a/packages/web/src/app/projects/[projectId]/page.tsx
+++ b/packages/web/src/app/projects/[projectId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Dashboard } from "@/components/Dashboard";
 import { DegradedProjectState } from "@/components/DegradedProjectState";
@@ -5,6 +6,18 @@ import { getDashboardPageData } from "@/lib/dashboard-page-data";
 import { getProjectRouteData } from "@/lib/project-route-data";
 
 export const dynamic = "force-dynamic";
+
+export async function generateMetadata(props: {
+  params: Promise<{ projectId: string }>;
+}): Promise<Metadata> {
+  const { projectId } = await props.params;
+  const routeData = await getProjectRouteData(projectId);
+  const projectName = routeData?.project?.name ?? routeData?.projectId ?? projectId;
+  return {
+    title: { absolute: `ao | ${projectName}` },
+    description: `Live AO dashboard for ${projectName} agent sessions, pull requests, and merge status.`,
+  };
+}
 
 export default async function ProjectPage(props: {
   params: Promise<{ projectId: string }>;
@@ -27,16 +40,18 @@ export default async function ProjectPage(props: {
   }
 
   const pageData = await getDashboardPageData(projectId);
+  const sidebarData = await getDashboardPageData("all");
 
   return (
     <div className="min-h-screen bg-[var(--color-bg-canvas)]">
       <Dashboard
-        initialSessions={pageData.sessions}
+        initialSessions={sidebarData.sessions}
         projectId={pageData.selectedProjectId}
         projectName={pageData.projectName}
         projects={pageData.projects}
-        orchestrators={pageData.orchestrators}
+        orchestrators={sidebarData.orchestrators}
         attentionZones={pageData.attentionZones}
+        dashboardLoadError={pageData.dashboardLoadError ?? sidebarData.dashboardLoadError}
       />
     </div>
   );

--- a/packages/web/src/app/projects/[projectId]/settings/page.tsx
+++ b/packages/web/src/app/projects/[projectId]/settings/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { DegradedProjectState } from "@/components/DegradedProjectState";
@@ -5,6 +6,18 @@ import { ProjectSettingsForm } from "@/components/ProjectSettingsForm";
 import { getProjectRouteData } from "@/lib/project-route-data";
 
 export const dynamic = "force-dynamic";
+
+export async function generateMetadata(props: {
+  params: Promise<{ projectId: string }>;
+}): Promise<Metadata> {
+  const { projectId } = await props.params;
+  const routeData = await getProjectRouteData(projectId);
+  const projectName = routeData?.project?.name ?? routeData?.projectId ?? projectId;
+  return {
+    title: { absolute: `ao | ${projectName} Settings` },
+    description: `Behavior settings for the ${projectName} AO project.`,
+  };
+}
 
 export default async function ProjectSettingsPage(props: {
   params: Promise<{ projectId: string }>;

--- a/packages/web/src/app/prs/page.test.tsx
+++ b/packages/web/src/app/prs/page.test.tsx
@@ -5,7 +5,7 @@ const hoisted = vi.hoisted(() => ({
   getDashboardPageDataMock: vi.fn(),
   getDashboardProjectNameMock: vi.fn(),
   resolveDashboardProjectFilterMock: vi.fn(),
-  dashboardPropsMock: vi.fn(),
+  pullRequestsPagePropsMock: vi.fn(),
 }));
 
 vi.mock("@/lib/dashboard-page-data", () => ({
@@ -14,21 +14,21 @@ vi.mock("@/lib/dashboard-page-data", () => ({
   resolveDashboardProjectFilter: hoisted.resolveDashboardProjectFilterMock,
 }));
 
-vi.mock("@/components/Dashboard", () => ({
-  Dashboard: (props: Record<string, unknown>) => {
-    hoisted.dashboardPropsMock(props);
-    return <div data-testid="dashboard" />;
+vi.mock("@/components/PullRequestsPage", () => ({
+  PullRequestsPage: (props: Record<string, unknown>) => {
+    hoisted.pullRequestsPagePropsMock(props);
+    return <div data-testid="pull-requests-page" />;
   },
 }));
 
-import Home from "./page";
+import PullRequestsRoute from "./page";
 
-describe("Home dashboard route", () => {
+describe("PullRequestsRoute", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("keeps the selected project context but seeds Dashboard with all-project sidebar data", async () => {
+  it("loads all sessions once and keeps the selected project context for client filtering", async () => {
     hoisted.resolveDashboardProjectFilterMock.mockReturnValue("alpha");
     hoisted.getDashboardProjectNameMock.mockReturnValue("Alpha");
     const allProjectData = {
@@ -47,13 +47,13 @@ describe("Home dashboard route", () => {
     };
     hoisted.getDashboardPageDataMock.mockResolvedValue(allProjectData);
 
-    render(await Home({ searchParams: Promise.resolve({ project: "alpha" }) }));
+    render(await PullRequestsRoute({ searchParams: Promise.resolve({ project: "alpha" }) }));
 
     expect(hoisted.resolveDashboardProjectFilterMock).toHaveBeenCalledWith("alpha");
     expect(hoisted.getDashboardPageDataMock).toHaveBeenCalledTimes(1);
     expect(hoisted.getDashboardPageDataMock).toHaveBeenCalledWith("all");
     expect(hoisted.getDashboardProjectNameMock).toHaveBeenCalledWith("alpha");
-    expect(hoisted.dashboardPropsMock).toHaveBeenCalledWith(
+    expect(hoisted.pullRequestsPagePropsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         initialSessions: allProjectData.sessions,
         orchestrators: allProjectData.orchestrators,

--- a/packages/web/src/app/prs/page.tsx
+++ b/packages/web/src/app/prs/page.tsx
@@ -14,7 +14,10 @@ export async function generateMetadata(props: {
   const searchParams = await props.searchParams;
   const projectFilter = resolveDashboardProjectFilter(searchParams.project);
   const projectName = getDashboardProjectName(projectFilter);
-  return { title: { absolute: `ao | ${projectName} PRs` } };
+  return {
+    title: { absolute: `ao | ${projectName} PRs` },
+    description: `Pull requests opened by AO agents for ${projectName}.`,
+  };
 }
 
 export default async function PullRequestsRoute(props: {
@@ -23,14 +26,17 @@ export default async function PullRequestsRoute(props: {
   const searchParams = await props.searchParams;
   const projectFilter = resolveDashboardProjectFilter(searchParams.project);
   const pageData = await getDashboardPageData(projectFilter);
+  const sidebarData = pageData.selectedProjectId
+    ? await getDashboardPageData("all")
+    : pageData;
 
   return (
     <PullRequestsPage
-      initialSessions={pageData.sessions}
+      initialSessions={sidebarData.sessions}
       projectId={pageData.selectedProjectId}
       projectName={pageData.projectName}
       projects={pageData.projects}
-      orchestrators={pageData.orchestrators}
+      orchestrators={sidebarData.orchestrators}
       attentionZones={pageData.attentionZones}
     />
   );

--- a/packages/web/src/app/prs/page.tsx
+++ b/packages/web/src/app/prs/page.tsx
@@ -25,18 +25,16 @@ export default async function PullRequestsRoute(props: {
 }) {
   const searchParams = await props.searchParams;
   const projectFilter = resolveDashboardProjectFilter(searchParams.project);
-  const pageData = await getDashboardPageData(projectFilter);
-  const sidebarData = pageData.selectedProjectId
-    ? await getDashboardPageData("all")
-    : pageData;
+  const pageData = await getDashboardPageData("all");
+  const selectedProjectId = projectFilter === "all" ? undefined : projectFilter;
 
   return (
     <PullRequestsPage
-      initialSessions={sidebarData.sessions}
-      projectId={pageData.selectedProjectId}
-      projectName={pageData.projectName}
+      initialSessions={pageData.sessions}
+      projectId={selectedProjectId}
+      projectName={getDashboardProjectName(projectFilter)}
       projects={pageData.projects}
-      orchestrators={sidebarData.orchestrators}
+      orchestrators={pageData.orchestrators}
       attentionZones={pageData.attentionZones}
     />
   );

--- a/packages/web/src/components/AddProjectModal.tsx
+++ b/packages/web/src/components/AddProjectModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type PointerEvent, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
@@ -39,6 +39,7 @@ interface AddProjectModalProps {
 export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
   const router = useRouter();
   const modalRef = useRef<HTMLDivElement>(null);
+  const backdropPointerStartedRef = useRef(false);
   const [submitting, setSubmitting] = useState(false);
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [networkError, setNetworkError] = useState<string | null>(null);
@@ -254,6 +255,26 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
 
   if (!open || typeof document === "undefined") return null;
 
+  const handleBackdropPointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    backdropPointerStartedRef.current = event.target === event.currentTarget;
+  };
+
+  const handleBackdropPointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    const releaseTarget = document.elementFromPoint(event.clientX, event.clientY);
+    const shouldClose = backdropPointerStartedRef.current && releaseTarget === event.currentTarget;
+    backdropPointerStartedRef.current = false;
+    if (shouldClose) onClose();
+  };
+
+  const handleBackdropPointerCancel = () => {
+    backdropPointerStartedRef.current = false;
+  };
+
+  const handleDialogPointerEvent = (event: PointerEvent<HTMLDivElement>) => {
+    backdropPointerStartedRef.current = false;
+    event.stopPropagation();
+  };
+
   const navigateHistory = (nextIndex: number) => {
     if (nextIndex < 0 || nextIndex >= browseHistory.length) return;
     setBrowseHistoryIndex(nextIndex);
@@ -282,7 +303,12 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
   ) : null;
 
   return createPortal(
-    <div className="add-project-modal-backdrop" onClick={onClose}>
+    <div
+      className="add-project-modal-backdrop"
+      onPointerDown={handleBackdropPointerDown}
+      onPointerUp={handleBackdropPointerUp}
+      onPointerCancel={handleBackdropPointerCancel}
+    >
       <div
         ref={modalRef}
         role="dialog"
@@ -290,6 +316,9 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
         aria-label="Add project"
         className="add-project-modal"
         tabIndex={-1}
+        onPointerDown={handleDialogPointerEvent}
+        onPointerUp={handleDialogPointerEvent}
+        onPointerCancel={handleDialogPointerEvent}
         onClick={(event) => event.stopPropagation()}
       >
         <div className="add-project-modal__titlebar">

--- a/packages/web/src/components/AddProjectModal.tsx
+++ b/packages/web/src/components/AddProjectModal.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 import {
   ArrowUpIcon,
   ChevronLeftIcon,
@@ -50,6 +52,7 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
   const [browseError, setBrowseError] = useState<string | null>(null);
   const [projectIdInput, setProjectIdInput] = useState("");
   const [projectNameInput, setProjectNameInput] = useState("");
+  useFocusTrap(open, modalRef);
 
   const browse = async (
     path: string,
@@ -120,7 +123,6 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     setSelectedBrowsePath(initialPath);
     setProjectIdInput("");
     setProjectNameInput("");
-    modalRef.current?.focus();
     void browse(initialPath, { mode: "replace", selectedPath: initialPath });
   }, [open]);
 
@@ -250,7 +252,7 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     }
   };
 
-  if (!open) return null;
+  if (!open || typeof document === "undefined") return null;
 
   const navigateHistory = (nextIndex: number) => {
     if (nextIndex < 0 || nextIndex >= browseHistory.length) return;
@@ -279,9 +281,17 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     <div className="add-project-modal__notice add-project-modal__notice--error">{networkError}</div>
   ) : null;
 
-  return (
-    <div className="add-project-modal-backdrop">
-      <div ref={modalRef} role="dialog" aria-modal="true" aria-label="Add project" className="add-project-modal" tabIndex={-1}>
+  return createPortal(
+    <div className="add-project-modal-backdrop" onClick={onClose}>
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Add project"
+        className="add-project-modal"
+        tabIndex={-1}
+        onClick={(event) => event.stopPropagation()}
+      >
         <div className="add-project-modal__titlebar">
           <h2 className="add-project-modal__windowtitle">add project</h2>
           <button type="button" aria-label="Close" onClick={onClose} className="add-project-modal__iconbtn">×</button>
@@ -369,6 +379,7 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/packages/web/src/components/AddProjectModal.tsx
+++ b/packages/web/src/components/AddProjectModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type PointerEvent, useEffect, useMemo, useRef, useState } from "react";
+import { type KeyboardEvent as ReactKeyboardEvent, type PointerEvent, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
@@ -275,6 +275,13 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     event.stopPropagation();
   };
 
+  const handleDialogKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Escape") return;
+    event.preventDefault();
+    event.stopPropagation();
+    onClose();
+  };
+
   const navigateHistory = (nextIndex: number) => {
     if (nextIndex < 0 || nextIndex >= browseHistory.length) return;
     setBrowseHistoryIndex(nextIndex);
@@ -319,6 +326,7 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
         onPointerDown={handleDialogPointerEvent}
         onPointerUp={handleDialogPointerEvent}
         onPointerCancel={handleDialogPointerEvent}
+        onKeyDown={handleDialogKeyDown}
         onClick={(event) => event.stopPropagation()}
       >
         <div className="add-project-modal__titlebar">

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/lib/types";
 import { AttentionZone } from "./AttentionZone";
 import { DynamicFavicon, countNeedingAttention } from "./DynamicFavicon";
-import { useSessionEvents } from "@/hooks/useSessionEvents";
+import { useSessionEvents, type AttentionMap } from "@/hooks/useSessionEvents";
 import { useMuxOptional } from "@/providers/MuxProvider";
 import { ProjectSidebar } from "./ProjectSidebar";
 import type { ProjectInfo } from "@/lib/project-name";
@@ -25,6 +25,7 @@ import { ConnectionBar } from "./ConnectionBar";
 import { CopyDebugBundleButton } from "./CopyDebugBundleButton";
 import { SidebarContext } from "./workspace/SidebarContext";
 import { projectDashboardPath, projectSessionPath } from "@/lib/routes";
+import { filterProjectSessions } from "@/lib/project-utils";
 
 interface DashboardProps {
   initialSessions: DashboardSession[];
@@ -168,10 +169,23 @@ function DashboardInner({
     attentionZones,
   });
 
+  const projectMap = useMemo(
+    () =>
+      Object.fromEntries(
+        projects.map((project) => [project.id, { sessionPrefix: project.sessionPrefix }]),
+      ),
+    [projects],
+  );
   const projectSessions = useMemo(() => {
-    if (!projectId) return sessions;
-    return sessions.filter((s) => s.projectId === projectId);
-  }, [sessions, projectId]);
+    return filterProjectSessions(sessions, projectId, projectMap);
+  }, [sessions, projectId, projectMap]);
+  const pageAttentionLevels = useMemo<AttentionMap>(() => {
+    if (!projectId) return attentionLevels;
+    const visibleIds = new Set(projectSessions.map((session) => session.id));
+    return Object.fromEntries(
+      Object.entries(attentionLevels).filter(([sessionId]) => visibleIds.has(sessionId)),
+    ) as AttentionMap;
+  }, [attentionLevels, projectId, projectSessions]);
   const connectionStatus: "connected" | "reconnecting" | "disconnected" =
     mux?.status === "disconnected" ? "disconnected"
     : mux?.status === "connected" ? "connected"
@@ -235,10 +249,10 @@ function DashboardInner({
 
   // Update document title with live attention counts
   useEffect(() => {
-    const needsAttention = countNeedingAttention(attentionLevels);
+    const needsAttention = countNeedingAttention(pageAttentionLevels);
     const label = projectName ?? "ao";
     document.title = needsAttention > 0 ? `${label} (${needsAttention} need attention)` : label;
-  }, [attentionLevels, projectName]);
+  }, [pageAttentionLevels, projectName]);
 
   useEffect(() => {
     setMobileMenuOpen(false);
@@ -478,6 +492,13 @@ function DashboardInner({
       : (projectName ?? (allProjectsView ? "All projects" : "Dashboard"));
   const showHeaderProjectLabel = !allProjectsView && headerProjectLabel.trim().length > 0;
 
+  const mobileSidebarHiddenProps =
+    isMobile && !mobileMenuOpen
+      ? ({ "aria-hidden": true, inert: true } as React.HTMLAttributes<HTMLDivElement> & {
+          inert: boolean;
+        })
+      : {};
+
   const handleToggleSidebar = () => {
     if (typeof window !== "undefined" && window.innerWidth < 768) {
       setMobileMenuOpen((current) => !current);
@@ -597,6 +618,7 @@ function DashboardInner({
           >
             <div
               className={`sidebar-wrapper${mobileMenuOpen ? " sidebar-wrapper--mobile-open" : ""}`}
+              {...mobileSidebarHiddenProps}
             >
               <ProjectSidebar
                 projects={projects}
@@ -614,7 +636,7 @@ function DashboardInner({
             )}
 
             <main className="dashboard-main dashboard-main--desktop">
-              <DynamicFavicon attentionLevels={attentionLevels} projectName={projectName} />
+              <DynamicFavicon attentionLevels={pageAttentionLevels} projectName={projectName} />
               <div className="dashboard-main__subhead">
                 <h1 className="dashboard-main__title">Dashboard</h1>
                 <p className="dashboard-main__subtitle">

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -482,8 +482,8 @@ function DashboardInner({
   ) : null;
 
   const anyRateLimited = useMemo(
-    () => sessions.some((session) => session.pr && isPRRateLimited(session.pr)),
-    [sessions],
+    () => projectSessions.some((session) => session.pr && isPRRateLimited(session.pr)),
+    [projectSessions],
   );
   const normalizedProjectName = projectName?.trim().toLowerCase();
   const headerProjectLabel =

--- a/packages/web/src/components/ProjectSettingsForm.tsx
+++ b/packages/web/src/components/ProjectSettingsForm.tsx
@@ -32,9 +32,23 @@ function ProjectSettingsFormInner({ projectId, initialValues }: ProjectSettingsF
   const [trackerPlugin, setTrackerPlugin] = useState(initialValues.trackerPlugin);
   const [scmPlugin, setScmPlugin] = useState(initialValues.scmPlugin);
   const [reactions, setReactions] = useState(initialValues.reactions);
+  const [baseline, setBaseline] = useState(() => ({
+    agent: initialValues.agent,
+    runtime: initialValues.runtime,
+    trackerPlugin: initialValues.trackerPlugin,
+    scmPlugin: initialValues.scmPlugin,
+    reactions: initialValues.reactions,
+  }));
   const [submitting, setSubmitting] = useState(false);
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [networkError, setNetworkError] = useState<string | null>(null);
+
+  const hasChanges =
+    agent !== baseline.agent ||
+    runtime !== baseline.runtime ||
+    trackerPlugin !== baseline.trackerPlugin ||
+    scmPlugin !== baseline.scmPlugin ||
+    reactions !== baseline.reactions;
 
   const behaviorPayload = useMemo(
     () => ({
@@ -85,6 +99,7 @@ function ProjectSettingsFormInner({ projectId, initialValues }: ProjectSettingsF
         return;
       }
 
+      setBaseline({ agent, runtime, trackerPlugin, scmPlugin, reactions });
       showToast("Project settings updated.", "success");
       router.refresh();
     } catch {
@@ -110,7 +125,7 @@ function ProjectSettingsFormInner({ projectId, initialValues }: ProjectSettingsF
           <button
             type="button"
             onClick={() => void submit()}
-            disabled={submitting}
+            disabled={submitting || !hasChanges}
             className="project-settings-form__save"
           >
             {submitting ? "Saving..." : "Save changes"}

--- a/packages/web/src/components/ProjectSettingsModal.tsx
+++ b/packages/web/src/components/ProjectSettingsModal.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { ProjectSettingsForm } from "@/components/ProjectSettingsForm";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 
 interface ProjectSettingsModalProps {
   open: boolean;
@@ -31,11 +33,7 @@ export function ProjectSettingsModal({ open, projectId, onClose }: ProjectSettin
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [project, setProject] = useState<ProjectSettingsResponse["project"] | null>(null);
-
-  useEffect(() => {
-    if (!open || !projectId) return;
-    modalRef.current?.focus();
-  }, [open, projectId]);
+  useFocusTrap(Boolean(open && projectId), modalRef);
 
   useEffect(() => {
     if (!open) return;
@@ -105,9 +103,9 @@ export function ProjectSettingsModal({ open, projectId, onClose }: ProjectSettin
     };
   }, [project, projectId]);
 
-  if (!open || !projectId) return null;
+  if (!open || !projectId || typeof document === "undefined") return null;
 
-  return (
+  return createPortal(
     <div className="project-settings-modal-backdrop" onClick={onClose}>
       <div
         ref={modalRef}
@@ -145,6 +143,7 @@ export function ProjectSettingsModal({ open, projectId, onClose }: ProjectSettin
           ) : null}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/packages/web/src/components/ProjectSettingsModal.tsx
+++ b/packages/web/src/components/ProjectSettingsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type PointerEvent, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { ProjectSettingsForm } from "@/components/ProjectSettingsForm";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
@@ -30,6 +30,7 @@ interface ProjectSettingsResponse {
 
 export function ProjectSettingsModal({ open, projectId, onClose }: ProjectSettingsModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
+  const backdropPointerStartedRef = useRef(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [project, setProject] = useState<ProjectSettingsResponse["project"] | null>(null);
@@ -105,8 +106,33 @@ export function ProjectSettingsModal({ open, projectId, onClose }: ProjectSettin
 
   if (!open || !projectId || typeof document === "undefined") return null;
 
+  const handleBackdropPointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    backdropPointerStartedRef.current = event.target === event.currentTarget;
+  };
+
+  const handleBackdropPointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    const releaseTarget = document.elementFromPoint(event.clientX, event.clientY);
+    const shouldClose = backdropPointerStartedRef.current && releaseTarget === event.currentTarget;
+    backdropPointerStartedRef.current = false;
+    if (shouldClose) onClose();
+  };
+
+  const handleBackdropPointerCancel = () => {
+    backdropPointerStartedRef.current = false;
+  };
+
+  const handleDialogPointerEvent = (event: PointerEvent<HTMLDivElement>) => {
+    backdropPointerStartedRef.current = false;
+    event.stopPropagation();
+  };
+
   return createPortal(
-    <div className="project-settings-modal-backdrop" onClick={onClose}>
+    <div
+      className="project-settings-modal-backdrop"
+      onPointerDown={handleBackdropPointerDown}
+      onPointerUp={handleBackdropPointerUp}
+      onPointerCancel={handleBackdropPointerCancel}
+    >
       <div
         ref={modalRef}
         role="dialog"
@@ -114,6 +140,9 @@ export function ProjectSettingsModal({ open, projectId, onClose }: ProjectSettin
         aria-label="Project settings"
         className="project-settings-modal"
         tabIndex={-1}
+        onPointerDown={handleDialogPointerEvent}
+        onPointerUp={handleDialogPointerEvent}
+        onPointerCancel={handleDialogPointerEvent}
         onClick={(event) => event.stopPropagation()}
       >
         <div className="project-settings-modal__header">

--- a/packages/web/src/components/ProjectSettingsModal.tsx
+++ b/packages/web/src/components/ProjectSettingsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type PointerEvent, useEffect, useMemo, useRef, useState } from "react";
+import { type KeyboardEvent as ReactKeyboardEvent, type PointerEvent, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { ProjectSettingsForm } from "@/components/ProjectSettingsForm";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
@@ -126,6 +126,13 @@ export function ProjectSettingsModal({ open, projectId, onClose }: ProjectSettin
     event.stopPropagation();
   };
 
+  const handleDialogKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Escape") return;
+    event.preventDefault();
+    event.stopPropagation();
+    onClose();
+  };
+
   return createPortal(
     <div
       className="project-settings-modal-backdrop"
@@ -143,6 +150,7 @@ export function ProjectSettingsModal({ open, projectId, onClose }: ProjectSettin
         onPointerDown={handleDialogPointerEvent}
         onPointerUp={handleDialogPointerEvent}
         onPointerCancel={handleDialogPointerEvent}
+        onKeyDown={handleDialogKeyDown}
         onClick={(event) => event.stopPropagation()}
       >
         <div className="project-settings-modal__header">

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -404,8 +404,8 @@ function ProjectSidebarInner({
                       isActive && "project-sidebar__collapsed-session-btn--active",
                     )}
                     data-level={level}
-                    title={rawTitle}
-                    aria-label={rawTitle}
+                    title={`${rawTitle} · ${LEVEL_LABELS[level]}`}
+                    aria-label={`${rawTitle}, ${LEVEL_LABELS[level]}`}
                   >
                     <span className="project-sidebar__session-abbr-first">{abbr[0]}</span>
                     <span className="project-sidebar__session-abbr-rest">{abbr.slice(1)}</span>
@@ -708,7 +708,6 @@ function ProjectSidebarInner({
                       const level = getAttentionLevel(session);
                       const isSessionActive = activeSessionId === session.id;
                       const title = session.branch ?? getSessionTitle(session);
-                      const prLabel = session.pr ? `, PR #${session.pr.number}` : "";
                       const sessionHref = projectSessionPath(project.id, session.id);
                       return (
                         <a
@@ -724,7 +723,6 @@ function ProjectSidebarInner({
                             isSessionActive && "project-sidebar__sess-row--active",
                           )}
                           aria-current={isSessionActive ? "page" : undefined}
-                          aria-label={`Open ${title}${prLabel}`}
                         >
                           <SessionDot level={level} />
                           <div className="flex-1 min-w-0">

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -708,6 +708,7 @@ function ProjectSidebarInner({
                       const level = getAttentionLevel(session);
                       const isSessionActive = activeSessionId === session.id;
                       const title = session.branch ?? getSessionTitle(session);
+                      const prLabel = session.pr ? `, PR #${session.pr.number}` : "";
                       const sessionHref = projectSessionPath(project.id, session.id);
                       return (
                         <a
@@ -723,7 +724,7 @@ function ProjectSidebarInner({
                             isSessionActive && "project-sidebar__sess-row--active",
                           )}
                           aria-current={isSessionActive ? "page" : undefined}
-                          aria-label={`Open ${title}`}
+                          aria-label={`Open ${title}${prLabel}`}
                         >
                           <SessionDot level={level} />
                           <div className="flex-1 min-w-0">
@@ -744,6 +745,9 @@ function ProjectSidebarInner({
                               </div>
                             ) : null}
                           </div>
+                          {session.pr ? (
+                            <span className="project-sidebar__sess-pr">#{session.pr.number}</span>
+                          ) : null}
                           {!showSessionId ? (
                             <span className="project-sidebar__sess-status project-sidebar__sess-status--inline">
                               {LEVEL_LABELS[level]}

--- a/packages/web/src/components/PullRequestsPage.tsx
+++ b/packages/web/src/components/PullRequestsPage.tsx
@@ -10,7 +10,7 @@ import {
   type DashboardAttentionZoneMode,
   getAttentionLevel,
 } from "@/lib/types";
-import { useSessionEvents } from "@/hooks/useSessionEvents";
+import { useSessionEvents, type AttentionMap } from "@/hooks/useSessionEvents";
 import { useMuxOptional } from "@/providers/MuxProvider";
 import { ProjectSidebar } from "./ProjectSidebar";
 import { ThemeToggle } from "./ThemeToggle";
@@ -18,7 +18,7 @@ import { DynamicFavicon } from "./DynamicFavicon";
 import { PRCard, PRTableRow } from "./PRStatus";
 import { MobileBottomNav } from "./MobileBottomNav";
 import type { ProjectInfo } from "@/lib/project-name";
-import { getProjectScopedHref } from "@/lib/project-utils";
+import { filterProjectSessions, getProjectScopedHref } from "@/lib/project-utils";
 import { projectDashboardPath, projectSessionPath } from "@/lib/routes";
 
 interface PullRequestsPageProps {
@@ -65,7 +65,6 @@ export function PullRequestsPage({
   }, [initialSessions, attentionZones]);
   const { sessions, attentionLevels } = useSessionEvents({
     initialSessions,
-    project: projectId,
     muxSessions: mux?.status === "connected" ? mux.sessions : undefined,
     initialAttentionLevels,
     attentionZones,
@@ -84,13 +83,30 @@ export function PullRequestsPage({
     [orchestratorLinks, projectId],
   );
   const [prFilter, setPrFilter] = useState<PRFilterValue>("all");
+  const projectMap = useMemo(
+    () =>
+      Object.fromEntries(
+        projects.map((project) => [project.id, { sessionPrefix: project.sessionPrefix }]),
+      ),
+    [projects],
+  );
+  const projectSessions = useMemo(() => {
+    return filterProjectSessions(sessions, projectId, projectMap);
+  }, [projectId, projectMap, sessions]);
+  const pageAttentionLevels = useMemo<AttentionMap>(() => {
+    if (!projectId) return attentionLevels;
+    const visibleIds = new Set(projectSessions.map((session) => session.id));
+    return Object.fromEntries(
+      Object.entries(attentionLevels).filter(([sessionId]) => visibleIds.has(sessionId)),
+    ) as AttentionMap;
+  }, [attentionLevels, projectId, projectSessions]);
 
   const allPRs = useMemo(() => {
-    return sessions
+    return projectSessions
       .filter((session): session is DashboardSession & { pr: DashboardPR } => !!session.pr)
       .map((session) => session.pr)
       .sort((a, b) => b.number - a.number);
-  }, [sessions]);
+  }, [projectSessions]);
 
   const openPRs = useMemo(() => allPRs.filter((pr) => pr.state === "open"), [allPRs]);
   const mergedPRs = useMemo(() => allPRs.filter((pr) => pr.state === "merged"), [allPRs]);
@@ -101,6 +117,12 @@ export function PullRequestsPage({
     ? projectSessionPath(currentProjectOrchestrator.projectId, currentProjectOrchestrator.id)
     : null;
   const activeMobilePRs = prFilter === "open" ? openPRs : prFilter === "merged" ? mergedPRs : prFilter === "closed" ? closedPRs : allPRs;
+  const mobileSidebarHiddenProps =
+    isMobile && !mobileMenuOpen
+      ? ({ "aria-hidden": true, inert: true } as React.HTMLAttributes<HTMLDivElement> & {
+          inert: boolean;
+        })
+      : {};
 
   useEffect(() => {
     setMobileMenuOpen(false);
@@ -111,7 +133,10 @@ export function PullRequestsPage({
         className={`dashboard-shell flex h-screen${!isMobile && sidebarCollapsed ? " dashboard-shell--sidebar-collapsed" : ""}`}
       >
       {showSidebar ? (
-        <div className={`sidebar-wrapper${mobileMenuOpen ? " sidebar-wrapper--mobile-open" : ""}`}>
+        <div
+          className={`sidebar-wrapper${mobileMenuOpen ? " sidebar-wrapper--mobile-open" : ""}`}
+          {...mobileSidebarHiddenProps}
+        >
           <ProjectSidebar
             projects={projects}
             sessions={sessions}
@@ -128,7 +153,7 @@ export function PullRequestsPage({
         <div className="sidebar-mobile-backdrop" onClick={() => setMobileMenuOpen(false)} />
       )}
       <div className="dashboard-main flex-1 overflow-y-auto px-4 py-4 md:px-7 md:py-6">
-        <DynamicFavicon attentionLevels={attentionLevels} projectName={projectName ? `${projectName} PRs` : "Pull Requests"} />
+        <DynamicFavicon attentionLevels={pageAttentionLevels} projectName={projectName ? `${projectName} PRs` : "Pull Requests"} />
         {isMobile ? (
           <section className="mobile-pr-page-header">
             <div className="mobile-pr-page-header__top">

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -8,7 +8,7 @@ import dynamic from "next/dynamic";
 import { getSessionTitle } from "@/lib/format";
 import type { ProjectInfo } from "@/lib/project-name";
 import { SidebarContext } from "./workspace/SidebarContext";
-import { projectDashboardPath, projectSessionPath } from "@/lib/routes";
+import { projectDashboardPath, projectPullRequestsPath, projectSessionPath } from "@/lib/routes";
 
 import { ProjectSidebar, type ProjectSidebarOrchestrator } from "./ProjectSidebar";
 import { MobileBottomNav } from "./MobileBottomNav";
@@ -83,6 +83,13 @@ export function SessionDetail({
     ? `/exit\nopencode --session ${opencodeSessionId}\n`
     : undefined;
   const dashboardHref = session.projectId ? projectDashboardPath(session.projectId) : "/";
+  const prsHref = session.projectId ? projectPullRequestsPath(session.projectId) : "/prs";
+  const mobileSidebarHiddenProps =
+    isMobile && !mobileSidebarOpen
+      ? ({ "aria-hidden": true, inert: true } as React.HTMLAttributes<HTMLDivElement> & {
+          inert: boolean;
+        })
+      : {};
 
   const handleKill = useCallback(async () => {
     try {
@@ -166,6 +173,7 @@ export function SessionDetail({
               className={`sidebar-wrapper${
                 mobileSidebarOpen ? " sidebar-wrapper--mobile-open" : ""
               }`}
+              {...mobileSidebarHiddenProps}
             >
               <ProjectSidebar
                 projects={projects}
@@ -187,7 +195,10 @@ export function SessionDetail({
           )}
 
           <div className="dashboard-main dashboard-main--desktop">
-            <main className="session-detail-page flex-1 min-h-0 flex flex-col bg-[var(--color-bg-base)]">
+            <main
+              className="session-detail-page flex-1 min-h-0 flex flex-col bg-[var(--color-bg-base)]"
+              aria-label={`${headline} terminal session`}
+            >
               <div className="flex-1 min-h-0 flex flex-col">
                 {!showTerminal ? (
                   <div className="session-detail-terminal-placeholder h-full" />
@@ -220,9 +231,7 @@ export function SessionDetail({
           ariaLabel="Session navigation"
           activeTab={isOrchestrator ? "orchestrator" : undefined}
           dashboardHref={dashboardHref}
-          prsHref={
-            session.projectId ? `/?project=${encodeURIComponent(session.projectId)}&tab=prs` : "/"
-          }
+          prsHref={prsHref}
           showOrchestrator={!!orchestratorHref}
           orchestratorHref={orchestratorHref}
         />

--- a/packages/web/src/components/SessionDetailHeader.tsx
+++ b/packages/web/src/components/SessionDetailHeader.tsx
@@ -274,6 +274,7 @@ export function SessionDetailHeader({
             type="button"
             className="dashboard-app-btn dashboard-app-btn--restore"
             onClick={onRestore}
+            aria-label={`Restore ${session.id}`}
           >
             <svg
               className="topbar-action-icon"
@@ -294,6 +295,7 @@ export function SessionDetailHeader({
             type="button"
             className="dashboard-app-btn dashboard-app-btn--danger"
             onClick={onKill}
+            aria-label={`Terminate ${session.id}`}
           >
             <svg
               className="h-3.5 w-3.5"

--- a/packages/web/src/components/SessionDetailHeader.tsx
+++ b/packages/web/src/components/SessionDetailHeader.tsx
@@ -191,6 +191,12 @@ export function SessionDetailHeader({
               <span className="topbar-branch-pill">{session.branch}</span>
             )
           ) : null}
+          {pr ? (
+            <a href={pr.url} target="_blank" rel="noopener noreferrer" className="topbar-pr-pill">
+              PR #{pr.number}
+              <span aria-hidden="true">↗</span>
+            </a>
+          ) : null}
           {isOrchestrator && orchestratorZones ? (
             <OrchestratorZonePills zones={orchestratorZones} />
           ) : null}
@@ -221,7 +227,7 @@ export function SessionDetailHeader({
                 setPrPopoverOpen((value) => !value);
               }}
               aria-expanded={prPopoverOpen}
-              aria-label={`PR #${pr.number}`}
+              aria-label={`PR details for #${pr.number}`}
             >
               <span
                 className={cn(
@@ -234,7 +240,7 @@ export function SessionDetailHeader({
                       : "topbar-pr-dot--amber",
                 )}
               />
-              PR #{pr.number}
+              <span className="topbar-btn-label">Details</span>
               <svg
                 width="10"
                 height="10"

--- a/packages/web/src/components/__tests__/AddProjectModal.test.tsx
+++ b/packages/web/src/components/__tests__/AddProjectModal.test.tsx
@@ -80,6 +80,41 @@ describe("AddProjectModal", () => {
     expect(screen.getByRole("button", { name: /^add project$/i })).toBeDisabled();
   });
 
+  it("does not close when a pointer drag starts inside and ends on the backdrop", async () => {
+    const onClose = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ entries: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AddProjectModal open onClose={onClose} />);
+
+    const dialog = await screen.findByRole("dialog", { name: /add project/i });
+    const backdrop = dialog.parentElement;
+    if (!backdrop) throw new Error("Expected modal backdrop");
+    const elementFromPoint = vi.fn<(x: number, y: number) => Element | null>();
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: elementFromPoint,
+    });
+
+    elementFromPoint.mockReturnValue(backdrop);
+    fireEvent.pointerDown(dialog);
+    fireEvent.pointerUp(backdrop);
+    expect(onClose).not.toHaveBeenCalled();
+
+    elementFromPoint.mockReturnValue(dialog);
+    fireEvent.pointerDown(backdrop);
+    fireEvent.pointerUp(backdrop, { clientX: 24, clientY: 24 });
+    expect(onClose).not.toHaveBeenCalled();
+
+    elementFromPoint.mockReturnValue(backdrop);
+    fireEvent.pointerDown(backdrop);
+    fireEvent.pointerUp(backdrop, { clientX: 4, clientY: 4 });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("offers opening the existing project or using a suffixed project ID when the server returns 409", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/web/src/components/__tests__/AddProjectModal.test.tsx
+++ b/packages/web/src/components/__tests__/AddProjectModal.test.tsx
@@ -115,6 +115,23 @@ describe("AddProjectModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("closes when Escape is pressed inside the dialog", async () => {
+    const onClose = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ entries: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AddProjectModal open onClose={onClose} />);
+
+    fireEvent.keyDown(await screen.findByRole("dialog", { name: /add project/i }), {
+      key: "Escape",
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("offers opening the existing project or using a suffixed project ID when the server returns 409", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/web/src/components/__tests__/Dashboard.mobile.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.mobile.test.tsx
@@ -181,6 +181,44 @@ describe("Dashboard unified layout (mobile viewport)", () => {
     expect(screen.queryByText(/GitHub API rate limited/i)).not.toBeInTheDocument();
   });
 
+  it("keeps the rate limit banner scoped to the selected project", () => {
+    render(
+      <Dashboard
+        projectId="alpha"
+        projectName="Alpha"
+        projects={[
+          { id: "alpha", name: "Alpha" },
+          { id: "beta", name: "Beta" },
+        ]}
+        initialSessions={[
+          makeSession({
+            id: "alpha-1",
+            projectId: "alpha",
+            status: "working",
+            pr: makePR({ number: 210 }),
+          }),
+          makeSession({
+            id: "beta-1",
+            projectId: "beta",
+            status: "reviewing",
+            pr: makePR({
+              number: 211,
+              mergeability: {
+                mergeable: false,
+                ciPassing: false,
+                approved: false,
+                noConflicts: true,
+                blockers: ["API rate limited or unavailable"],
+              },
+            }),
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText(/GitHub API rate limited/i)).not.toBeInTheDocument();
+  });
+
   it("opens the done bar and restores completed sessions", async () => {
     vi.setSystemTime(new Date("2026-04-11T11:07:00.000Z"));
 

--- a/packages/web/src/components/__tests__/ProjectSettingsForm.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSettingsForm.test.tsx
@@ -41,6 +41,7 @@ describe("ProjectSettingsForm", () => {
 
     expect(screen.getByDisplayValue("/tmp/docs")).toBeDisabled();
     expect(screen.getByDisplayValue("org/repo")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
 
     fireEvent.change(screen.getByLabelText("Agent"), { target: { value: "claude-code" } });
     fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
@@ -67,6 +68,7 @@ describe("ProjectSettingsForm", () => {
     await waitFor(() => {
       expect(refreshMock).toHaveBeenCalled();
       expect(screen.getByText("Project settings updated.")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
     });
   });
 

--- a/packages/web/src/components/__tests__/ProjectSettingsModal.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSettingsModal.test.tsx
@@ -52,4 +52,16 @@ describe("ProjectSettingsModal", () => {
     fireEvent.pointerUp(backdrop, { clientX: 4, clientY: 4 });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("closes when Escape is pressed inside the dialog", async () => {
+    const onClose = vi.fn();
+
+    render(<ProjectSettingsModal open projectId="alpha" onClose={onClose} />);
+
+    fireEvent.keyDown(await screen.findByRole("dialog", { name: /project settings/i }), {
+      key: "Escape",
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/web/src/components/__tests__/ProjectSettingsModal.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSettingsModal.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectSettingsModal } from "@/components/ProjectSettingsModal";
+
+vi.mock("@/components/ProjectSettingsForm", () => ({
+  ProjectSettingsForm: () => <form aria-label="Project settings form" />,
+}));
+
+describe("ProjectSettingsModal", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        project: {
+          id: "alpha",
+          name: "Alpha",
+          path: "/tmp/alpha",
+          tracker: {},
+          scm: {},
+        },
+      }),
+    } as Response);
+  });
+
+  it("does not close when a pointer drag starts inside and ends on the backdrop", async () => {
+    const onClose = vi.fn();
+
+    render(<ProjectSettingsModal open projectId="alpha" onClose={onClose} />);
+
+    const dialog = await screen.findByRole("dialog", { name: /project settings/i });
+    const backdrop = dialog.parentElement;
+    if (!backdrop) throw new Error("Expected settings modal backdrop");
+    const elementFromPoint = vi.fn<(x: number, y: number) => Element | null>();
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: elementFromPoint,
+    });
+
+    elementFromPoint.mockReturnValue(backdrop);
+    fireEvent.pointerDown(dialog);
+    fireEvent.pointerUp(backdrop);
+    expect(onClose).not.toHaveBeenCalled();
+
+    elementFromPoint.mockReturnValue(dialog);
+    fireEvent.pointerDown(backdrop);
+    fireEvent.pointerUp(backdrop, { clientX: 24, clientY: 24 });
+    expect(onClose).not.toHaveBeenCalled();
+
+    elementFromPoint.mockReturnValue(backdrop);
+    fireEvent.pointerDown(backdrop);
+    fireEvent.pointerUp(backdrop, { clientX: 4, clientY: 4 });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
@@ -297,6 +297,7 @@ describe("ProjectSidebar", () => {
             branch: null,
             status: "needs_input",
             activity: "waiting_input",
+            pr: makePR({ number: 42, title: "Review API changes" }),
           }),
           makeSession({
             id: "worker-2",
@@ -312,7 +313,10 @@ describe("ProjectSidebar", () => {
     );
 
     // Session rows are now anchors (support ctrl/cmd-click to open in new tab)
-    expect(screen.getByRole("link", { name: "Open Review API changes" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open Review API changes, PR #42" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("#42")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Open feat/test" })).not.toBeInTheDocument();
   });
 
@@ -399,7 +403,7 @@ describe("ProjectSidebar", () => {
 
     expect(screen.getByRole("button", { name: /^Project One 1$/ })).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Open Runtime missing but needs review" }),
+      screen.getByRole("link", { name: "Open Runtime missing but needs review, PR #100" }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Open Actually finished" })).not.toBeInTheDocument();
   });

--- a/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
@@ -314,7 +314,7 @@ describe("ProjectSidebar", () => {
 
     // Session rows are now anchors (support ctrl/cmd-click to open in new tab)
     expect(
-      screen.getByRole("link", { name: "Open Review API changes, PR #42" }),
+      screen.getByRole("link", { name: /Review API changes.*#42.*(respond|review|merge|working)/ }),
     ).toBeInTheDocument();
     expect(screen.getByText("#42")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Open feat/test" })).not.toBeInTheDocument();
@@ -403,7 +403,9 @@ describe("ProjectSidebar", () => {
 
     expect(screen.getByRole("button", { name: /^Project One 1$/ })).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Open Runtime missing but needs review, PR #100" }),
+      screen.getByRole("link", {
+        name: /Runtime missing but needs review.*#100.*(respond|review|merge|working)/,
+      }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Open Actually finished" })).not.toBeInTheDocument();
   });
@@ -437,7 +439,7 @@ describe("ProjectSidebar", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("link", { name: "Open Implement sidebar polish" }));
+    fireEvent.click(screen.getByRole("link", { name: /Implement sidebar polish.*working/ }));
 
     expect(mockPush).toHaveBeenCalledWith("/projects/project-1/sessions/worker-2");
   });

--- a/packages/web/src/components/__tests__/PullRequestsPage.test.tsx
+++ b/packages/web/src/components/__tests__/PullRequestsPage.test.tsx
@@ -141,6 +141,40 @@ describe("PullRequestsPage", () => {
     expect(screen.getByText("Closed PR")).toBeInTheDocument();
   });
 
+
+  it("keeps the sidebar portfolio counts while filtering PRs to the selected project", () => {
+    mockDesktopViewport();
+
+    render(
+      <PullRequestsPage
+        initialSessions={[
+          makeSession({
+            id: "my-app-pr",
+            projectId: "my-app",
+            status: "approved",
+            pr: makePR({ number: 634, title: "Scoped project PR" }),
+          }),
+          makeSession({
+            id: "docs-pr",
+            projectId: "docs",
+            status: "approved",
+            pr: makePR({ number: 777, title: "Docs PR should stay out" }),
+          }),
+        ]}
+        projectId="my-app"
+        projectName="My App"
+        projects={[
+          { id: "my-app", name: "My App", path: "/tmp/my-app" },
+          { id: "docs", name: "Docs", path: "/tmp/docs" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /^Docs 1$/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "#634" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "#777" })).not.toBeInTheDocument();
+  });
+
   it("shows the empty desktop state when there are no pull requests", () => {
     mockDesktopViewport();
 

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -215,7 +215,7 @@ describe("SessionDetail desktop layout", () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Restore terminal" })).not.toBeInTheDocument();
     expect(
-      within(screen.getByRole("banner")).getByRole("button", { name: "Restore" }),
+      within(screen.getByRole("banner")).getByRole("button", { name: "Restore worker-ended" }),
     ).toBeInTheDocument();
     expect(
       within(screen.getByRole("banner")).queryByRole("link", { name: "Orchestrator" }),
@@ -252,11 +252,15 @@ describe("SessionDetail desktop layout", () => {
       />,
     );
 
-    expect(within(screen.getByRole("banner")).getByRole("button", { name: "Restore" })).toHaveClass(
-      "dashboard-app-btn--restore",
-    );
     expect(
-      within(screen.getByRole("banner")).queryByRole("button", { name: "Kill" }),
+      within(screen.getByRole("banner")).getByRole("button", {
+        name: "Restore my-app-orchestrator",
+      }),
+    ).toHaveClass("dashboard-app-btn--restore");
+    expect(
+      within(screen.getByRole("banner")).queryByRole("button", {
+        name: "Terminate my-app-orchestrator",
+      }),
     ).not.toBeInTheDocument();
   });
 
@@ -274,7 +278,7 @@ describe("SessionDetail desktop layout", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+    fireEvent.click(screen.getByRole("button", { name: "Restore worker-restore" }));
 
     await act(async () => {});
 
@@ -371,7 +375,7 @@ describe("SessionDetail desktop layout", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Kill" }));
+      fireEvent.click(screen.getByRole("button", { name: "Terminate worker-kill" }));
     });
 
     expect(global.fetch).toHaveBeenCalledWith("/api/sessions/worker-kill/kill", { method: "POST" });
@@ -391,7 +395,7 @@ describe("SessionDetail desktop layout", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Kill" }));
+      fireEvent.click(screen.getByRole("button", { name: "Terminate worker-kill-dashboard" }));
     });
 
     expect(routerPushMock).toHaveBeenCalledWith("/projects/my-app");

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -128,13 +128,15 @@ describe("SessionDetail desktop layout", () => {
       "href",
       "https://github.com/acme/app/tree/feat/desktop-detail",
     );
-    // PR button is anchored to the PR URL (ctrl-click opens on GitHub, plain click toggles popover)
-    const prButton = screen.getByRole("link", { name: "PR #310" });
-    expect(prButton).toHaveAttribute("href", "https://github.com/acme/app/pull/100");
+    // Related PR is visible as a direct link in the topbar pills.
+    expect(screen.getByRole("link", { name: "PR #310" })).toHaveAttribute(
+      "href",
+      "https://github.com/acme/app/pull/100",
+    );
 
-    // PR details (blockers, file count, unresolved comments) now live inside a
-    // popover anchored to the PR button. Click to open it before asserting contents.
-    fireEvent.click(prButton);
+    // PR details (blockers, file count, unresolved comments) stay available from
+    // a compact popover trigger.
+    fireEvent.click(screen.getByRole("link", { name: "PR details for #310" }));
 
     expect(screen.getByText("3 files")).toBeInTheDocument();
     expect(screen.getByText("Draft")).toBeInTheDocument();
@@ -169,8 +171,8 @@ describe("SessionDetail desktop layout", () => {
       />,
     );
 
-    // Open the PR popover (button is now a link with aria-label "PR #311")
-    fireEvent.click(screen.getByRole("link", { name: "PR #311" }));
+    // Open the PR popover from the compact details trigger.
+    fireEvent.click(screen.getByRole("link", { name: "PR details for #311" }));
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Ask Agent to Fix" }));

--- a/packages/web/src/components/__tests__/SessionDetail.mobile.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.mobile.test.tsx
@@ -102,6 +102,21 @@ describe("SessionDetail unified layout (mobile viewport)", () => {
     expect(screen.getAllByRole("link", { name: /PR #88/i }).length).toBeGreaterThan(0);
   });
 
+
+  it("links the mobile PR tab to the PR route for the session project", () => {
+    render(
+      <SessionDetail
+        session={makeSession({ id: "worker-pr-nav", projectId: "my-app" })}
+        projectOrchestratorId={null}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "PRs" })).toHaveAttribute(
+      "href",
+      "/prs?project=my-app",
+    );
+  });
+
   it("renders the session detail shell for active sessions", () => {
     render(
       <SessionDetail

--- a/packages/web/src/components/terminal/useXtermTerminal.ts
+++ b/packages/web/src/components/terminal/useXtermTerminal.ts
@@ -103,7 +103,7 @@ export function useXtermTerminal(
           theme: activeTheme,
           // Light mode needs an explicit contrast floor because agent UIs often emit
           // dim/faint ANSI sequences that become unreadable on a near-white background.
-          minimumContrastRatio: isDark ? 1 : 7,
+          minimumContrastRatio: isDark ? 4.5 : 7,
           // scrollback disabled — tmux provides scrollback/copy-mode, and leaving
           // this > 0 makes FitAddon subtract DEFAULT_SCROLL_BAR_WIDTH (14px) from
           // the available width, causing right-side clipping when the actual
@@ -395,7 +395,7 @@ export function useXtermTerminal(
     if (!terminal) return;
     const isDark = appearance === "dark" || resolvedTheme !== "light";
     terminal.options.theme = isDark ? terminalThemes.dark : terminalThemes.light;
-    terminal.options.minimumContrastRatio = isDark ? 1 : 7;
+    terminal.options.minimumContrastRatio = isDark ? 4.5 : 7;
   }, [appearance, resolvedTheme, terminalThemes]);
 
   // Font size change — mutate in place and persist, then resize the PTY so

--- a/packages/web/src/components/terminal/useXtermTerminal.ts
+++ b/packages/web/src/components/terminal/useXtermTerminal.ts
@@ -166,10 +166,10 @@ export function useXtermTerminal(
         };
         // Feature-detect addEventListener — jsdom's document.fonts mock lacks it.
         const fontsFace = typeof document !== "undefined" ? document.fonts : undefined;
-        const fontsListenerAttached =
-          !!fontsFace && typeof fontsFace.addEventListener === "function";
-        if (fontsListenerAttached) {
-          fontsFace!.addEventListener("loadingdone", handleFontsLoadingDone);
+        let fontsListenerAttached = false;
+        if (fontsFace && typeof fontsFace.addEventListener === "function") {
+          fontsFace.addEventListener("loadingdone", handleFontsLoadingDone);
+          fontsListenerAttached = true;
         }
 
         // Touch scroll on mobile — disables follow-output while user scrolls.

--- a/packages/web/src/hooks/__tests__/useFocusTrap.test.tsx
+++ b/packages/web/src/hooks/__tests__/useFocusTrap.test.tsx
@@ -1,0 +1,34 @@
+import { useRef } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
+
+function FocusTrapFixture() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(true, containerRef);
+
+  return (
+    <div ref={containerRef} role="dialog" tabIndex={-1}>
+      <button type="button">First visible</button>
+      <button type="button">Last visible</button>
+      <button type="button" style={{ display: "none" }}>
+        Hidden tail
+      </button>
+    </div>
+  );
+}
+
+describe("useFocusTrap", () => {
+  it("skips hidden focusable elements when wrapping focus", () => {
+    render(<FocusTrapFixture />);
+
+    const first = screen.getByRole("button", { name: /first visible/i });
+    const last = screen.getByRole("button", { name: /last visible/i });
+    expect(first).toHaveFocus();
+
+    last.focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    expect(first).toHaveFocus();
+  });
+});

--- a/packages/web/src/hooks/useFocusTrap.ts
+++ b/packages/web/src/hooks/useFocusTrap.ts
@@ -13,8 +13,24 @@ const FOCUSABLE_SELECTOR = [
 
 function getFocusableElements(container: HTMLElement): HTMLElement[] {
   return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
-    (element) => element.tabIndex !== -1 && !element.hasAttribute("disabled"),
+    (element) =>
+      element.tabIndex !== -1 && !element.hasAttribute("disabled") && !isHiddenFromFocus(element),
   );
+}
+
+function isHiddenFromFocus(element: HTMLElement): boolean {
+  for (let current: HTMLElement | null = element; current; current = current.parentElement) {
+    if (current.hidden || current.getAttribute("aria-hidden") === "true") return true;
+    const style = window.getComputedStyle(current);
+    if (
+      style.display === "none" ||
+      style.visibility === "hidden" ||
+      style.visibility === "collapse"
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function useFocusTrap(active: boolean, containerRef: RefObject<HTMLElement | null>) {

--- a/packages/web/src/hooks/useFocusTrap.ts
+++ b/packages/web/src/hooks/useFocusTrap.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (element) => element.tabIndex !== -1 && !element.hasAttribute("disabled"),
+  );
+}
+
+export function useFocusTrap(active: boolean, containerRef: RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const previousFocus =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    const firstFocusable = getFocusableElements(container)[0] ?? container;
+    firstFocusable.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") return;
+      const currentContainer = containerRef.current;
+      if (!currentContainer) return;
+
+      const focusable = getFocusableElements(currentContainer);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        currentContainer.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const activeElement = document.activeElement;
+
+      if (!currentContainer.contains(activeElement)) {
+        event.preventDefault();
+        first.focus();
+        return;
+      }
+
+      if (event.shiftKey && activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+      if (previousFocus && document.contains(previousFocus)) {
+        previousFocus.focus();
+      }
+    };
+  }, [active, containerRef]);
+}

--- a/packages/web/src/lib/__tests__/next-config.test.ts
+++ b/packages/web/src/lib/__tests__/next-config.test.ts
@@ -1,6 +1,12 @@
 import { readFileSync } from "fs";
+import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
 import nextConfig from "../../../next.config.js";
+
+const require = createRequire(import.meta.url);
+const { HTML_LIMITED_BOT_UA_RE_STRING } = require("next/dist/shared/lib/router/utils/is-bot") as {
+  HTML_LIMITED_BOT_UA_RE_STRING: string;
+};
 
 describe("next config htmlLimitedBots", () => {
   const htmlLimitedBots = nextConfig.htmlLimitedBots as RegExp;
@@ -23,5 +29,9 @@ describe("next config htmlLimitedBots", () => {
     const source = readFileSync("next.config.js", "utf8");
 
     expect(source).not.toContain("next/dist/");
+  });
+
+  it("fails loudly when Next changes its default HTML-limited bot list", () => {
+    expect(htmlLimitedBots.source).toContain(HTML_LIMITED_BOT_UA_RE_STRING);
   });
 });

--- a/packages/web/src/lib/__tests__/next-config.test.ts
+++ b/packages/web/src/lib/__tests__/next-config.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "fs";
+import { describe, expect, it } from "vitest";
+import nextConfig from "../../../next.config.js";
+
+describe("next config htmlLimitedBots", () => {
+  const htmlLimitedBots = nextConfig.htmlLimitedBots as RegExp;
+
+  it("preserves Next's crawler list without matching normal Chrome traffic", () => {
+    expect(htmlLimitedBots.test("Slackbot-LinkExpanding 1.0")).toBe(true);
+    expect(htmlLimitedBots.test("facebookexternalhit/1.1")).toBe(true);
+    expect(htmlLimitedBots.test("Mozilla/5.0 AppleWebKit/537.36 Chrome/120.0 Safari/537.36")).toBe(
+      false,
+    );
+  });
+
+  it("keeps audit user agents HTML-limited", () => {
+    expect(htmlLimitedBots.test("Chrome-Lighthouse")).toBe(true);
+    expect(htmlLimitedBots.test("PageSpeed Insights")).toBe(true);
+    expect(htmlLimitedBots.test("Mozilla/5.0 Lighthouse")).toBe(true);
+  });
+
+  it("does not depend on private Next internals at config evaluation time", () => {
+    const source = readFileSync("next.config.js", "utf8");
+
+    expect(source).not.toContain("next/dist/");
+  });
+});

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -9,3 +9,7 @@ export function projectSessionPath(projectId: string, sessionId: string): string
 export function projectSessionHashPath(projectId: string, sessionId: string, hash: string): string {
   return `${projectSessionPath(projectId, sessionId)}${hash}`;
 }
+
+export function projectPullRequestsPath(projectId: string): string {
+  return `/prs?project=${encodeURIComponent(projectId)}`;
+}


### PR DESCRIPTION
## Summary
- surface related PR context in session navigation/header areas
- improve dashboard accessibility, modal focus/backdrop behavior, contrast, touch targets, and available board height
- preserve all-project sidebar hydration while scoping selected-project route state and alerts correctly
- keep selected dashboard views lean and avoid private Next internals for metadata/bot handling

## Testing
- `pnpm --filter @aoagents/ao-web test -- src/app/layout.test.ts src/app/page.test.tsx src/app/projects/[projectId]/page.test.tsx src/app/prs/page.test.tsx src/components/__tests__/AddProjectModal.test.tsx src/components/__tests__/Dashboard.mobile.test.tsx src/components/__tests__/ProjectSettingsForm.test.tsx src/components/__tests__/ProjectSettingsModal.test.tsx src/components/__tests__/ProjectSidebar.test.tsx src/components/__tests__/PullRequestsPage.test.tsx src/components/__tests__/SessionDetail.desktop.test.tsx src/components/__tests__/SessionDetail.mobile.test.tsx src/lib/__tests__/next-config.test.ts`
- `pnpm --filter @aoagents/ao-plugin-tracker-linear test`
- `pnpm --filter @aoagents/ao-web typecheck`
- `pnpm --filter @aoagents/ao-plugin-tracker-linear typecheck`
- `pnpm --filter @aoagents/ao-web build`
- `git diff --check`
