### PR TITLE
fix(cli): ao start --interactive crashes on flat local config

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1538,13 +1538,17 @@ export function registerStart(program: Command): void {
               writeProjectBehaviorConfig(project.path, nextLocalConfig);
               console.log(chalk.dim(`  ✓ Saved to ${project.path}/agent-orchestrator.yaml\n`));
             } else {
-              const rawYaml = readFileSync(config.configPath, "utf-8");
-              const rawConfig = yamlParse(rawYaml);
-              const proj = rawConfig.projects[projectId];
-              proj.orchestrator = { ...(proj.orchestrator ?? {}), agent: orchestratorAgent };
-              proj.worker = { ...(proj.worker ?? {}), agent: workerAgent };
-              writeFileSync(config.configPath, configToYaml(rawConfig as Record<string, unknown>));
-              console.log(chalk.dim(`  ✓ Saved to ${config.configPath}\n`));
+              const nextLocalConfig = readProjectBehaviorConfig(project.path);
+              nextLocalConfig.orchestrator = {
+                ...(nextLocalConfig.orchestrator ?? {}),
+                agent: orchestratorAgent,
+              };
+              nextLocalConfig.worker = {
+                ...(nextLocalConfig.worker ?? {}),
+                agent: workerAgent,
+              };
+              writeProjectBehaviorConfig(project.path, nextLocalConfig);
+              console.log(chalk.dim(`  ✓ Saved to ${project.path}/agent-orchestrator.yaml\n`));
             }
             config = loadConfig(config.configPath);
             project = config.projects[projectId];


### PR DESCRIPTION
## Summary

`ao start --interactive` crashes with `Cannot read properties of undefined` when the project uses a flat (non-wrapped) local `agent-orchestrator.yaml`.

**Root cause:** The `else` branch (non-canonical config path) reads raw YAML and assumes `rawConfig.projects[projectId]` exists. Flat configs have no `projects:` key, so this is `undefined[projectId]` → crash.

**Fix:** Replace the raw YAML manipulation in the `else` branch with the same `readProjectBehaviorConfig`/`writeProjectBehaviorConfig` helpers that the `if` branch already uses. These helpers correctly handle both flat and wrapped config shapes via `loadLocalProjectConfigDetailed`.

Fixes #1791

## Test

1. Create a flat `agent-orchestrator.yaml` (no `projects:` key):
   ```yaml
   agent: claude-code
   repo: https://github.com/example/my-repo
   ```
2. Run `ao start --interactive`
3. Select orchestrator and worker agents
4. **Before:** `Cannot read properties of undefined`
5. **After:** Agent selections saved, `ao start` proceeds normally

Also verify wrapped configs still work — the `readProjectBehaviorConfig`/`writeProjectBehaviorConfig` pair handles both shapes transparently.