### PR TITLE
fix(core): track actual PR repo in batch enrichment for multi-repo projects (#1477)

### DIFF
--- a/packages/core/src/__tests__/plugin-integration.test.ts
+++ b/packages/core/src/__tests__/plugin-integration.test.ts
@@ -624,5 +624,44 @@ describe("plugin integration", () => {
       const states = lm.getStates();
       expect(states.get("app-1")).toBe("changes_requested");
     });
+    it("populatePREnrichmentCache includes actual PR repo when it differs from configured repo", async () => {
+      const submodulePR = makePR({
+        number: 99,
+        url: "https://github.com/acme/sub-module/pull/99",
+        title: "feat: fix in submodule",
+        owner: "acme",
+        repo: "sub-module",
+        branch: "feat/issue-99",
+        baseBranch: "main",
+      });
+      seedSession({ status: "pr_open", pr: submodulePR });
+      const scmPlugin = registry.get("scm", "github") as ReturnType<typeof scmGithub.create>;
+      const originalBatch = scmPlugin.enrichSessionsPRBatch;
+      let capturedRepos: string[] = [];
+      scmPlugin.enrichSessionsPRBatch = vi.fn().mockImplementation(
+        (_prs, _observer, repos) => {
+          capturedRepos = repos ?? [];
+          return Promise.resolve(
+            new Map([[`${submodulePR.owner}/${submodulePR.repo}#${submodulePR.number}`, {
+              state: "open", ciStatus: "passing", reviewDecision: "approved", mergeable: true,
+            }]]),
+          );
+        },
+      );
+      const mockSM: OpenCodeSessionManager = {
+        ...sm,
+        list: vi.fn().mockResolvedValue([makeSession({ status: "pr_open", pr: submodulePR })]),
+        get: vi.fn().mockResolvedValue(makeSession({ status: "pr_open", pr: submodulePR })),
+        kill: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue(undefined),
+        claimPR: vi.fn(),
+        spawnOrchestrator: vi.fn(),
+      };
+      const lm = createLifecycleManager({ config, registry, sessionManager: mockSM });
+      await lm.check("app-1");
+      scmPlugin.enrichSessionsPRBatch = originalBatch;
+      expect(capturedRepos).toContain("acme/sub-module");
+      expect(capturedRepos).toContain("acme/app");
+    });
   });
 });

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -530,7 +530,15 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         reposByPlugin.set(pluginKey, new Set());
       }
       reposByPlugin.get(pluginKey)!.add(project.repo);
-
+      //Option : also track the actual PR repo of ot differs from the configured repo.
+      // This handles multi repo projects (eg: git submodules) where an agent creates
+      // a PR on a different repo than the one configured in agent-orchestrator.yaml
+      if (session.pr) {
+        const actualPRRepo = `${session.pr.owner}/${session.pr.repo}`;
+        if (actualPRRepo !== project.repo) {
+          reposByPlugin.get(pluginKey)!.add(actualPRRepo);
+        }
+      }
       if (!session.pr) continue;
 
       const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -530,16 +530,16 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         reposByPlugin.set(pluginKey, new Set());
       }
       reposByPlugin.get(pluginKey)!.add(project.repo);
-      //Option : also track the actual PR repo of ot differs from the configured repo.
+      // Also track the actual PR repo if it differs from the configured repo.
       // This handles multi repo projects (eg: git submodules) where an agent creates
       // a PR on a different repo than the one configured in agent-orchestrator.yaml
-      if (session.pr) {
+      if (!session.pr) continue;
         const actualPRRepo = `${session.pr.owner}/${session.pr.repo}`;
         if (actualPRRepo !== project.repo) {
           reposByPlugin.get(pluginKey)!.add(actualPRRepo);
         }
-      }
-      if (!session.pr) continue;
+      
+      
 
       const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
       if (seenPRKeys.has(prKey)) continue;


### PR DESCRIPTION
## Problem

When a project uses git submodules or spans multiple repos, the lifecycle 
manager only polls the configured `repo` field in `agent-orchestrator.yaml`. 
If an agent creates a PR on a different repo (e.g. a submodule), the lifecycle 
manager skips it entirely — never polling CI status, review decisions, or merge 
state. The session gets stuck in `working/idle` forever.

## Root Cause

In `populatePREnrichmentCache()`, only `project.repo` was added to 
`reposByPlugin`. PRs on any other repo were excluded from batch enrichment.

## Fix 

Also add the actual PR repo (`session.pr.owner/session.pr.repo`) to 
`reposByPlugin` when it differs from `project.repo`. This ensures Guard 1 
runs for the actual PR repo and batch enrichment fetches CI status, review 
decisions, and merge state correctly.

No config changes required — works automatically using data already stored 
in session metadata.

## Testing

Added a test: `populatePREnrichmentCache includes actual PR repo when it 
differs from configured repo` — verifies both the configured repo and actual 
PR repo are passed to `enrichSessionsPRBatch`.

## Backwards Compatible

Existing single-repo projects are unaffected — the configured repo match still 
runs first. The actual PR repo is only added as an additional entry when it 
differs from `project.repo`.

Fixes #1477