### PR TITLE
fix(cli): use pnpm -r build in ao-update.sh to prevent half-built workspace

### DIFF
--- a/packages/cli/src/assets/scripts/ao-update.sh
+++ b/packages/cli/src/assets/scripts/ao-update.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+trap 'printf '\''ERROR: Update incomplete. Run: pnpm -r build && ao update --skip-smoke\'' >&2; exit 1' ERR
+
 SKIP_SMOKE=false
 SMOKE_ONLY=false
 TARGET_BRANCH="${AO_UPDATE_BRANCH:-main}"
@@ -190,9 +192,7 @@ if [ "$SMOKE_ONLY" = false ]; then
     run_cmd pnpm --filter @aoagents/ao-cli clean
     run_cmd pnpm --filter @aoagents/ao-web clean
 
-    run_cmd pnpm --filter @aoagents/ao-core build
-    run_cmd pnpm --filter @aoagents/ao-cli build
-    run_cmd pnpm --filter @aoagents/ao-web build
+    run_cmd pnpm -r build
 
     printf '\nRefreshing ao launcher...\n'
     (


### PR DESCRIPTION
## Summary

Fixes [#1800](https://github.com/ComposioHQ/agent-orchestrator/issues/1800)

`ao-update.sh` was running filtered builds (`--filter @aoagents/ao-core/cli/web`) which skip plugin packages. The CLI imports 6+ agent plugins directly — if any plugin's `dist/` is missing after `git pull`, `tsc` fails, `set -e` aborts the script, and the workspace is left half-built.

**Changes:**
1. Replace 3 filtered `build` commands with `pnpm -r build` — pnpm's topological sort handles ordering correctly and builds all workspace packages including plugins
2. Add `ERR` trap that prints a clear "update incomplete" message with recovery instructions instead of silent abort

**Before:**
```bash
run_cmd pnpm --filter @aoagents/ao-core build
run_cmd pnpm --filter @aoagents/ao-cli build
run_cmd pnpm --filter @aoagents/ao-web build
```

**After:**
```bash
run_cmd pnpm -r build
```

The filtered `clean` commands are kept (harmless, only touch 3 packages).

## Test

1. Delete a plugin's `dist/`: `rm -rf packages/plugins/agent-kimicode/dist`
2. Run `bash packages/cli/src/assets/scripts/ao-update.sh`
3. Before fix: script aborts silently at CLI build
4. After fix: all packages build successfully, or clear error message if something else fails

## Impact

Users hitting this when new plugins are added to main will no longer get a broken workspace after `ao update`.