### PR TITLE
feat(cli): prevent idle sleep on Linux via systemd-inhibit

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -49,6 +49,8 @@ Every helper you need to write Windows-safe code. **Memorise the imports — the
 ```ts
 import {
   isWindows,
+  isMac,
+  isLinux,
   getDefaultRuntime,
   getShell,
   killProcessTree,
@@ -60,6 +62,8 @@ import {
 | Symbol | Purpose | Notes |
 |--------|---------|-------|
 | `isWindows(): boolean` | The canonical OS check. **Always use this** instead of `process.platform === "win32"`. | Constant-time. Trivially mockable in tests. |
+| `isMac(): boolean` | The canonical macOS check. Use instead of `process.platform === "darwin"`. | Same shape as `isWindows()`. |
+| `isLinux(): boolean` | The canonical Linux check. Use instead of `process.platform === "linux"`. | Same shape as `isWindows()`. |
 | `getDefaultRuntime(): "tmux" \| "process"` | Returns `"process"` on Windows, `"tmux"` elsewhere. Used by `ao start` / startup-preflight to default runtime selection. | Don't hardcode `"tmux"`. |
 | `getShell(): { cmd, args(command) }` | Resolves the shell for non-interactive command execution. POSIX → `/bin/sh -c`. Windows → priority order: `AO_SHELL` env override → `pwsh` → `powershell.exe` (absolute path, robust to degraded PATH) → `powershell` → `cmd.exe`. Cached. | Use this whenever you need to run *any* shellish string. Don't assume bash. |
 | `killProcessTree(pid, signal?)` | Kills a process and its descendants. Windows → `taskkill /T /F /PID <pid>`. POSIX → `process.kill(-pid, signal)` with direct-PID fallback. Guards `pid > 0`. | **Never write `process.kill(-pid, …)` directly.** Negative PIDs are POSIX-only. |

--- a/packages/cli/__tests__/lib/prevent-sleep.test.ts
+++ b/packages/cli/__tests__/lib/prevent-sleep.test.ts
@@ -3,9 +3,13 @@ import type { ChildProcess } from "node:child_process";
 
 const mockSpawn = vi.hoisted(() => vi.fn());
 
-vi.mock("node:child_process", () => ({
-  spawn: mockSpawn,
-}));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: mockSpawn,
+  };
+});
 
 import { preventIdleSleep } from "../../src/lib/prevent-sleep.js";
 
@@ -159,16 +163,103 @@ describe("preventIdleSleep", () => {
     });
   });
 
-  describe("on non-macOS platforms", () => {
-    it("returns null on Linux", () => {
+  describe("on Linux", () => {
+    beforeEach(() => {
       setPlatform("linux");
+    });
+
+    it("spawns systemd-inhibit with --what=idle --mode=block and a pid watchdog", () => {
+      const mockChild = {
+        pid: 9999,
+        unref: vi.fn(),
+        on: vi.fn(),
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      const handle = preventIdleSleep(12345);
+
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+      const [cmd, args, opts] = mockSpawn.mock.calls[0]!;
+      expect(cmd).toBe("systemd-inhibit");
+      expect(args).toEqual([
+        "--what=idle",
+        "--who=Agent Orchestrator",
+        "--why=Active agent session running",
+        "--mode=block",
+        "sh",
+        "-c",
+        "while kill -0 12345 2>/dev/null; do sleep 5; done",
+      ]);
+      expect(opts).toEqual({ stdio: "ignore", detached: true });
+      expect(mockChild.unref).toHaveBeenCalled();
+      expect(handle).not.toBeNull();
+    });
+
+    it("defaults to current process pid", () => {
+      const mockChild = {
+        pid: 9999,
+        unref: vi.fn(),
+        on: vi.fn(),
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      preventIdleSleep();
+
+      const args = mockSpawn.mock.calls[0]![1] as string[];
+      expect(args[args.length - 1]).toBe(
+        `while kill -0 ${process.pid} 2>/dev/null; do sleep 5; done`,
+      );
+    });
+
+    it("release function kills the systemd-inhibit process", () => {
+      const mockChild = {
+        pid: 9999,
+        unref: vi.fn(),
+        on: vi.fn(),
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      const handle = preventIdleSleep();
+      handle?.release();
+
+      expect(mockChild.kill).toHaveBeenCalled();
+    });
+
+    it("returns null when systemd-inhibit is missing (no pid)", () => {
+      const mockChild = {
+        pid: undefined,
+        unref: vi.fn(),
+        on: vi.fn(),
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
 
       const handle = preventIdleSleep();
 
       expect(handle).toBeNull();
-      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(mockChild.unref).not.toHaveBeenCalled();
     });
 
+    it("registers async error handler for ENOENT on non-systemd systems", () => {
+      const onMock = vi.fn();
+      const mockChild = {
+        pid: 9999,
+        unref: vi.fn(),
+        on: onMock,
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      preventIdleSleep();
+
+      expect(onMock).toHaveBeenCalledWith("error", expect.any(Function));
+    });
+  });
+
+  describe("on unsupported platforms", () => {
     it("returns null on Windows", () => {
       setPlatform("win32");
 

--- a/packages/cli/__tests__/lib/prevent-sleep.test.ts
+++ b/packages/cli/__tests__/lib/prevent-sleep.test.ts
@@ -163,6 +163,27 @@ describe("preventIdleSleep", () => {
       expect(handle).toBeNull();
       expect(mockChild.unref).not.toHaveBeenCalled();
     });
+
+    it("swallows async ENOENT error when caffeinate is missing (pid undefined)", async () => {
+      // Real EventEmitter so emit("error") goes through Node's listener machinery.
+      // Without a registered listener, this would propagate as an uncaught
+      // exception and crash AO on stripped macOS images / containers without
+      // caffeinate.
+      const emitter = new EventEmitter();
+      const mockChild = Object.assign(emitter, {
+        pid: undefined,
+        unref: vi.fn(),
+        kill: vi.fn(),
+      }) as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      const handle = preventIdleSleep();
+
+      expect(handle).toBeNull();
+      // The error listener must be attached BEFORE the pid check so the
+      // async ENOENT that fires after we return is swallowed.
+      expect(() => emitter.emit("error", new Error("spawn ENOENT"))).not.toThrow();
+    });
   });
 
   describe("on Linux", () => {

--- a/packages/cli/__tests__/lib/prevent-sleep.test.ts
+++ b/packages/cli/__tests__/lib/prevent-sleep.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
 import type { ChildProcess } from "node:child_process";
 
 const mockSpawn = vi.hoisted(() => vi.fn());
@@ -291,6 +292,26 @@ describe("preventIdleSleep", () => {
       preventIdleSleep();
 
       expect(onMock).toHaveBeenCalledWith("error", expect.any(Function));
+    });
+
+    it("swallows async ENOENT error when systemd-inhibit is missing (pid undefined)", async () => {
+      // Real EventEmitter so emit("error") goes through Node's listener machinery.
+      // Without a registered listener, this would propagate as an uncaught
+      // exception and crash AO on hosts where systemd-inhibit is absent.
+      const emitter = new EventEmitter();
+      const mockChild = Object.assign(emitter, {
+        pid: undefined,
+        unref: vi.fn(),
+        kill: vi.fn(),
+      }) as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      const handle = preventIdleSleep();
+
+      expect(handle).toBeNull();
+      // The error listener must be attached BEFORE the pid check so the
+      // async ENOENT that fires after we return is swallowed.
+      expect(() => emitter.emit("error", new Error("spawn ENOENT"))).not.toThrow();
     });
   });
 

--- a/packages/cli/__tests__/lib/prevent-sleep.test.ts
+++ b/packages/cli/__tests__/lib/prevent-sleep.test.ts
@@ -213,7 +213,7 @@ describe("preventIdleSleep", () => {
       );
     });
 
-    it("release function kills the systemd-inhibit process", () => {
+    it("release function group-kills systemd-inhibit and its sh watchdog", () => {
       const mockChild = {
         pid: 9999,
         unref: vi.fn(),
@@ -221,11 +221,35 @@ describe("preventIdleSleep", () => {
         kill: vi.fn(),
       } as unknown as ChildProcess;
       mockSpawn.mockReturnValue(mockChild);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
       const handle = preventIdleSleep();
       handle?.release();
 
+      // Negative PID targets the whole process group so the sh watchdog dies
+      // alongside systemd-inhibit, instead of lingering up to 5s as an orphan.
+      expect(processKillSpy).toHaveBeenCalledWith(-9999, "SIGTERM");
+      expect(mockChild.kill).not.toHaveBeenCalled();
+      processKillSpy.mockRestore();
+    });
+
+    it("release falls back to child.kill() if group-kill throws", () => {
+      const mockChild = {
+        pid: 9999,
+        unref: vi.fn(),
+        on: vi.fn(),
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+        throw new Error("ESRCH");
+      });
+
+      const handle = preventIdleSleep();
+      expect(() => handle?.release()).not.toThrow();
+
       expect(mockChild.kill).toHaveBeenCalled();
+      processKillSpy.mockRestore();
     });
 
     it("returns null when systemd-inhibit is missing (no pid)", () => {

--- a/packages/cli/__tests__/lib/prevent-sleep.test.ts
+++ b/packages/cli/__tests__/lib/prevent-sleep.test.ts
@@ -212,7 +212,7 @@ describe("preventIdleSleep", () => {
         "--mode=block",
         "sh",
         "-c",
-        "while kill -0 12345 2>/dev/null; do sleep 5; done",
+        "while kill -0 '12345' 2>/dev/null; do sleep 5; done",
       ]);
       expect(opts).toEqual({ stdio: "ignore", detached: true });
       expect(mockChild.unref).toHaveBeenCalled();
@@ -232,7 +232,7 @@ describe("preventIdleSleep", () => {
 
       const args = mockSpawn.mock.calls[0]![1] as string[];
       expect(args[args.length - 1]).toBe(
-        `while kill -0 ${process.pid} 2>/dev/null; do sleep 5; done`,
+        `while kill -0 '${process.pid}' 2>/dev/null; do sleep 5; done`,
       );
     });
 

--- a/packages/cli/__tests__/lib/prevent-sleep.test.ts
+++ b/packages/cli/__tests__/lib/prevent-sleep.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "node:events";
 import type { ChildProcess } from "node:child_process";
+import type * as ChildProcessModule from "node:child_process";
 
 const mockSpawn = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:child_process")>();
+  const actual = await importOriginal<typeof ChildProcessModule>();
   return {
     ...actual,
     spawn: mockSpawn,

--- a/packages/cli/__tests__/lib/prevent-sleep.test.ts
+++ b/packages/cli/__tests__/lib/prevent-sleep.test.ts
@@ -226,14 +226,14 @@ describe("preventIdleSleep", () => {
       const handle = preventIdleSleep();
       handle?.release();
 
-      // Negative PID targets the whole process group so the sh watchdog dies
-      // alongside systemd-inhibit, instead of lingering up to 5s as an orphan.
+      // killProcessTree signals the negative PID so the whole group dies in
+      // one shot — the sh watchdog can't linger up to 5s as an orphan.
       expect(processKillSpy).toHaveBeenCalledWith(-9999, "SIGTERM");
       expect(mockChild.kill).not.toHaveBeenCalled();
       processKillSpy.mockRestore();
     });
 
-    it("release falls back to child.kill() if group-kill throws", () => {
+    it("release falls back to direct-PID kill if group-kill throws", async () => {
       const mockChild = {
         pid: 9999,
         unref: vi.fn(),
@@ -241,14 +241,25 @@ describe("preventIdleSleep", () => {
         kill: vi.fn(),
       } as unknown as ChildProcess;
       mockSpawn.mockReturnValue(mockChild);
-      const processKillSpy = vi.spyOn(process, "kill").mockImplementation(() => {
-        throw new Error("ESRCH");
-      });
+      // killProcessTree's POSIX path tries process.kill(-pid) first, then
+      // falls back to process.kill(pid) if the group-kill throws. Throw only
+      // for the negative-PID call so we can assert the fallback is exercised.
+      const processKillSpy = vi
+        .spyOn(process, "kill")
+        .mockImplementation((pid: number) => {
+          if (pid < 0) throw new Error("ESRCH");
+          return true;
+        });
 
       const handle = preventIdleSleep();
       expect(() => handle?.release()).not.toThrow();
+      // release() is fire-and-forget around an async helper; flush the
+      // microtask queue so the inner try/catch runs before we assert.
+      await Promise.resolve();
 
-      expect(mockChild.kill).toHaveBeenCalled();
+      expect(processKillSpy).toHaveBeenCalledWith(-9999, "SIGTERM");
+      expect(processKillSpy).toHaveBeenCalledWith(9999, "SIGTERM");
+      expect(mockChild.kill).not.toHaveBeenCalled();
       processKillSpy.mockRestore();
     });
 

--- a/packages/cli/src/lib/prevent-sleep.ts
+++ b/packages/cli/src/lib/prevent-sleep.ts
@@ -99,18 +99,22 @@ function preventIdleSleepLinux(targetPid: number): SleepPreventionHandle | null 
     { stdio: "ignore", detached: true },
   );
 
-  // Synchronous spawn failure (binary missing entirely). The async `error`
-  // event handles the more common ENOENT-from-execvp case below.
+  // Attach the error listener BEFORE the pid check. Node emits `error`
+  // asynchronously when execvp fails (ENOENT — no systemd-inhibit on PATH,
+  // WSL1, some containers, Alpine without elogind); without a listener that
+  // becomes an unhandled error and crashes AO. The pid-undefined branch
+  // below still needs the listener attached because the async `error` event
+  // fires after this function returns.
+  child.on("error", () => {
+    // Non-systemd environment. Nothing to release; silently ignore.
+  });
+
   if (child.pid === undefined) {
     return null;
   }
 
   const inhibitPid = child.pid;
   child.unref();
-  child.on("error", () => {
-    // Non-systemd environment (no systemd-inhibit on PATH — WSL1, some
-    // containers, Alpine without elogind). Nothing to release; silently ignore.
-  });
 
   return {
     release: () => {

--- a/packages/cli/src/lib/prevent-sleep.ts
+++ b/packages/cli/src/lib/prevent-sleep.ts
@@ -1,16 +1,24 @@
 /**
- * Idle sleep prevention for macOS.
+ * Idle sleep prevention.
  *
- * Spawns `caffeinate -i -w <pid>` to hold an idle-sleep prevention assertion
- * for the duration of the AO process. The assertion is automatically released
- * when the watched process exits (cleanly, on crash, or via kill -9).
+ * macOS: spawns `caffeinate -i -w <pid>` to hold an idle-sleep prevention
+ * assertion for the lifetime of the watched process. caffeinate releases the
+ * assertion automatically when that pid exits.
  *
- * No-op on non-macOS platforms.
+ * Linux: spawns `systemd-inhibit --what=idle --mode=block ...` wrapping a
+ * tiny shell watchdog that polls the watched pid every 5s and exits when the
+ * process is gone — releasing the inhibitor lock the same way `-w <pid>`
+ * does on macOS. No-op on non-systemd systems (containers without
+ * systemd-inhibit, WSL1, etc.) — the async spawn `error` event is swallowed.
+ *
+ * No-op on Windows and other unsupported platforms.
  *
  * @see https://github.com/ComposioHQ/agent-orchestrator/issues/1072
+ * @see https://github.com/ComposioHQ/agent-orchestrator/issues/1799
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
+import { isLinux, isMac } from "@aoagents/ao-core";
 
 export interface SleepPreventionHandle {
   /** Release the sleep prevention assertion early (optional — auto-releases on process exit) */
@@ -18,50 +26,89 @@ export interface SleepPreventionHandle {
 }
 
 /**
- * Prevent macOS idle sleep for the lifetime of a process.
+ * Prevent idle sleep for the lifetime of a process.
  *
- * @param pid - The process ID to watch. When this process exits, the assertion is released.
- *              Defaults to the current process.
- * @returns A handle to release the assertion early, or null if not on macOS.
- *
- * @example
- * ```ts
- * // Prevent sleep for the current process
- * const handle = preventIdleSleep();
- *
- * // Prevent sleep while a child process runs
- * const child = spawn("node", ["server.js"]);
- * const handle = preventIdleSleep(child.pid);
- * ```
+ * @param pid - The process ID to watch. When this process exits, the assertion
+ *              is released. Defaults to the current process.
+ * @returns A handle to release the assertion early, or null if the current
+ *          platform is unsupported or the underlying binary is unavailable.
  */
 export function preventIdleSleep(pid?: number): SleepPreventionHandle | null {
-  // Only supported on macOS
-  if (process.platform !== "darwin") {
-    return null;
-  }
-
   const targetPid = pid ?? process.pid;
 
-  // Spawn caffeinate:
-  // -i: Create an assertion to prevent idle sleep (works on battery)
-  // -w <pid>: Wait for the specified process to exit, then release the assertion
+  if (isMac()) {
+    return preventIdleSleepMac(targetPid);
+  }
+  if (isLinux()) {
+    return preventIdleSleepLinux(targetPid);
+  }
+  return null;
+}
+
+function preventIdleSleepMac(targetPid: number): SleepPreventionHandle | null {
+  // -i: prevent idle sleep (works on battery)
+  // -w <pid>: release the assertion when <pid> exits
   const child: ChildProcess = spawn("caffeinate", ["-i", "-w", String(targetPid)], {
     stdio: "ignore",
     detached: true,
   });
 
-  // Check if spawn succeeded — child.pid is undefined if spawn failed synchronously
-  // (e.g., ENOENT when caffeinate doesn't exist)
+  // child.pid is undefined when spawn fails synchronously (e.g., ENOENT on old
+  // macOS versions where caffeinate is missing).
   if (child.pid === undefined) {
     return null;
   }
 
-  // Don't keep the Node event loop alive for this child
   child.unref();
-
-  // Handle spawn errors silently — caffeinate might not exist on old macOS versions
   child.on("error", () => {
     // caffeinate not available — silently ignore
+  });
+
+  return {
+    release: () => {
+      try {
+        child.kill();
+      } catch {
+        // Already dead or not killable — ignore
+      }
+    },
+  };
+}
+
+function preventIdleSleepLinux(targetPid: number): SleepPreventionHandle | null {
+  // systemd-inhibit holds the lock for as long as its child process is alive.
+  // We give it a pid-polling watchdog so the lock auto-releases when AO dies
+  // (mirroring caffeinate's `-w <pid>` behaviour). 5s poll interval is well
+  // under any reasonable idle-suspend timeout.
+  //
+  //   --what=idle      only blocks idle auto-suspend (not lid-close / manual)
+  //   --mode=block     actually prevents the action (vs `delay`)
+  //   --who / --why    human-readable strings shown by `systemd-inhibit --list`
+  const watchdog = `while kill -0 ${targetPid} 2>/dev/null; do sleep 5; done`;
+  const child: ChildProcess = spawn(
+    "systemd-inhibit",
+    [
+      "--what=idle",
+      "--who=Agent Orchestrator",
+      "--why=Active agent session running",
+      "--mode=block",
+      "sh",
+      "-c",
+      watchdog,
+    ],
+    { stdio: "ignore", detached: true },
+  );
+
+  // Synchronous spawn failure (binary missing entirely). The async `error`
+  // event handles the more common ENOENT-from-execvp case below.
+  if (child.pid === undefined) {
+    return null;
+  }
+
+  child.unref();
+  child.on("error", () => {
+    // Non-systemd environment (no systemd-inhibit on PATH — WSL1, some
+    // containers, Alpine without elogind). Nothing to release; silently ignore.
   });
 
   return {

--- a/packages/cli/src/lib/prevent-sleep.ts
+++ b/packages/cli/src/lib/prevent-sleep.ts
@@ -53,6 +53,16 @@ function preventIdleSleepMac(targetPid: number): SleepPreventionHandle | null {
     detached: true,
   });
 
+  // Attach the error listener BEFORE the pid check. Node emits `error`
+  // asynchronously when execvp fails (ENOENT — caffeinate missing on stripped
+  // macOS images or containers); without a listener that becomes an unhandled
+  // exception and crashes AO. The pid-undefined branch below still needs the
+  // listener attached because the async `error` event fires after this
+  // function returns.
+  child.on("error", () => {
+    // caffeinate not available — silently ignore
+  });
+
   // child.pid is undefined when spawn fails synchronously (e.g., ENOENT on old
   // macOS versions where caffeinate is missing).
   if (child.pid === undefined) {
@@ -60,9 +70,6 @@ function preventIdleSleepMac(targetPid: number): SleepPreventionHandle | null {
   }
 
   child.unref();
-  child.on("error", () => {
-    // caffeinate not available — silently ignore
-  });
 
   return {
     release: () => {

--- a/packages/cli/src/lib/prevent-sleep.ts
+++ b/packages/cli/src/lib/prevent-sleep.ts
@@ -105,6 +105,7 @@ function preventIdleSleepLinux(targetPid: number): SleepPreventionHandle | null 
     return null;
   }
 
+  const inhibitPid = child.pid;
   child.unref();
   child.on("error", () => {
     // Non-systemd environment (no systemd-inhibit on PATH — WSL1, some
@@ -113,10 +114,19 @@ function preventIdleSleepLinux(targetPid: number): SleepPreventionHandle | null 
 
   return {
     release: () => {
+      // detached: true put systemd-inhibit in its own process group, with the
+      // `sh -c watchdog` as a child of that group. A direct child.kill() would
+      // only signal systemd-inhibit, leaving the sh watchdog to linger as an
+      // orphan until its next 5s poll. Negative-pid signals the whole group so
+      // both die immediately. Linux-only branch, so PGID semantics are safe.
       try {
-        child.kill();
+        process.kill(-inhibitPid, "SIGTERM");
       } catch {
-        // Already dead or not killable — ignore
+        try {
+          child.kill();
+        } catch {
+          // Already dead or not killable — ignore
+        }
       }
     },
   };

--- a/packages/cli/src/lib/prevent-sleep.ts
+++ b/packages/cli/src/lib/prevent-sleep.ts
@@ -18,7 +18,7 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { isLinux, isMac } from "@aoagents/ao-core";
+import { isLinux, isMac, killProcessTree } from "@aoagents/ao-core";
 
 export interface SleepPreventionHandle {
   /** Release the sleep prevention assertion early (optional — auto-releases on process exit) */
@@ -114,20 +114,14 @@ function preventIdleSleepLinux(targetPid: number): SleepPreventionHandle | null 
 
   return {
     release: () => {
-      // detached: true put systemd-inhibit in its own process group, with the
-      // `sh -c watchdog` as a child of that group. A direct child.kill() would
-      // only signal systemd-inhibit, leaving the sh watchdog to linger as an
-      // orphan until its next 5s poll. Negative-pid signals the whole group so
-      // both die immediately. Linux-only branch, so PGID semantics are safe.
-      try {
-        process.kill(-inhibitPid, "SIGTERM");
-      } catch {
-        try {
-          child.kill();
-        } catch {
-          // Already dead or not killable — ignore
-        }
-      }
+      // detached: true put systemd-inhibit in its own process group with the
+      // `sh -c watchdog` as a group member. killProcessTree signals the
+      // negative PID so the whole group dies in one shot (no orphan watchdog
+      // lingering up to 5s); it also handles the direct-PID fallback if the
+      // group-kill EPERMs. CROSS_PLATFORM.md mandates this helper for any
+      // process-tree teardown. Fire-and-forget — kernel signal delivery is
+      // async anyway and release() is sync.
+      void killProcessTree(inhibitPid);
     },
   };
 }

--- a/packages/cli/src/lib/prevent-sleep.ts
+++ b/packages/cli/src/lib/prevent-sleep.ts
@@ -18,7 +18,7 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { isLinux, isMac, killProcessTree } from "@aoagents/ao-core";
+import { isLinux, isMac, killProcessTree, shellEscape } from "@aoagents/ao-core";
 
 export interface SleepPreventionHandle {
   /** Release the sleep prevention assertion early (optional — auto-releases on process exit) */
@@ -91,7 +91,7 @@ function preventIdleSleepLinux(targetPid: number): SleepPreventionHandle | null 
   //   --what=idle      only blocks idle auto-suspend (not lid-close / manual)
   //   --mode=block     actually prevents the action (vs `delay`)
   //   --who / --why    human-readable strings shown by `systemd-inhibit --list`
-  const watchdog = `while kill -0 ${targetPid} 2>/dev/null; do sleep 5; done`;
+  const watchdog = `while kill -0 ${shellEscape(String(targetPid))} 2>/dev/null; do sleep 5; done`;
   const child: ChildProcess = spawn(
     "systemd-inhibit",
     [

--- a/packages/cli/src/lib/startup-preflight.ts
+++ b/packages/cli/src/lib/startup-preflight.ts
@@ -297,13 +297,13 @@ export async function runtimePreflight(config: OrchestratorConfig): Promise<void
   warnAboutLegacyStorage();
   await warnAboutOpenClawStatus(config);
 
-  // Prevent macOS idle sleep while AO is running (if enabled in config).
-  // Uses caffeinate -i -w <pid> to hold an assertion tied to this process
-  // lifetime. No-op on non-macOS platforms.
+  // Prevent idle sleep while AO is running (if enabled in config).
+  // macOS: caffeinate -i -w <pid>. Linux: systemd-inhibit --what=idle.
+  // No-op on Windows and on systems without the underlying binary.
   if (config.power?.preventIdleSleep !== false) {
     const sleepHandle = preventIdleSleep();
     if (sleepHandle) {
-      console.log(chalk.dim("  Preventing macOS idle sleep while AO is running"));
+      console.log(chalk.dim("  Preventing idle sleep while AO is running"));
     }
   }
 

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -1191,9 +1191,11 @@ describe("Config Validation - Power Config", () => {
       },
     });
 
-    // Default is true on darwin, false elsewhere
+    // Default is true on darwin and linux, false elsewhere
     expect(config.power).toBeDefined();
-    expect(config.power!.preventIdleSleep).toBe(process.platform === "darwin");
+    expect(config.power!.preventIdleSleep).toBe(
+      process.platform === "darwin" || process.platform === "linux",
+    );
   });
 
   it("accepts explicit power.preventIdleSleep: true", () => {

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from "vitest";
 import { validateConfig } from "../config.js";
+import { isLinux, isMac } from "../platform.js";
 
 describe("Config Validation - Project Uniqueness", () => {
   it("accepts projects that share a basename when projectIds differ", () => {
@@ -1193,9 +1194,7 @@ describe("Config Validation - Power Config", () => {
 
     // Default is true on darwin and linux, false elsewhere
     expect(config.power).toBeDefined();
-    expect(config.power!.preventIdleSleep).toBe(
-      process.platform === "darwin" || process.platform === "linux",
-    );
+    expect(config.power!.preventIdleSleep).toBe(isMac() || isLinux());
   });
 
   it("accepts explicit power.preventIdleSleep: true", () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -25,7 +25,7 @@ import {
   type OrchestratorConfig,
 } from "./types.js";
 import { generateSessionPrefix } from "./paths.js";
-import { getDefaultRuntime } from "./platform.js";
+import { getDefaultRuntime, isMac, isLinux } from "./platform.js";
 import {
   getGlobalConfigPath,
   isCanonicalGlobalConfigPath,
@@ -307,11 +307,12 @@ const InstalledPluginConfigSchema = z
 const PowerConfigSchema = z
   .object({
     /**
-     * Prevent macOS idle sleep while AO is running.
-     * Uses `caffeinate -i -w <pid>` to hold an assertion.
-     * Defaults to true on macOS, no-op on other platforms.
+     * Prevent idle sleep while AO is running.
+     * macOS: `caffeinate -i -w <pid>`.
+     * Linux: `systemd-inhibit --what=idle --mode=block` with a pid watchdog.
+     * Defaults to true on macOS and Linux, no-op on other platforms.
      */
-    preventIdleSleep: z.boolean().default(process.platform === "darwin"),
+    preventIdleSleep: z.boolean().default(isMac() || isLinux()),
   })
   .default({});
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -276,6 +276,7 @@ export {
 export {
   isWindows,
   isMac,
+  isLinux,
   getDefaultRuntime,
   getShell,
   killProcessTree,

--- a/packages/core/src/platform.ts
+++ b/packages/core/src/platform.ts
@@ -20,6 +20,10 @@ export function isMac(): boolean {
   return process.platform === "darwin";
 }
 
+export function isLinux(): boolean {
+  return process.platform === "linux";
+}
+
 export function getDefaultRuntime(): "tmux" | "process" {
   return isWindows() ? "process" : "tmux";
 }


### PR DESCRIPTION
Closes #1799.

## Summary
- Extends idle-sleep prevention (previously macOS-only via `caffeinate`) to Linux using `systemd-inhibit --what=idle --mode=block` with a pid-poll watchdog that auto-releases the lock when AO exits — mirroring caffeinate's `-w <pid>` semantics.
- Non-systemd environments (containers without systemd-inhibit, WSL1, Alpine without elogind) silently no-op via the async spawn `error` handler — no crashes.
- Adds `isLinux()` to `packages/core/src/platform.ts` (and re-exports from `@aoagents/ao-core`) so callers avoid inline `process.platform` checks per the cross-platform golden rule.
- `power.preventIdleSleep` config default now resolves to `true` on macOS **and** Linux (false elsewhere). Existing macOS behavior is unchanged behaviorally.
- Startup-preflight log message is now platform-neutral.

## Test plan
- [x] `pnpm --filter @aoagents/ao-core typecheck`
- [x] `pnpm --filter @aoagents/ao-cli typecheck`
- [x] `pnpm --filter @aoagents/ao-cli test __tests__/lib/prevent-sleep.test.ts` — 13/13 (Linux + macOS + Windows branches all covered)
- [x] `pnpm --filter @aoagents/ao-core test config-validation` — 60/60
- [x] `pnpm build` clean
- [x] Smoke test on a real Ubuntu host: confirm `systemd-inhibit --list` shows the AO entry while `ao start` is running and disappears after `ao stop` / Ctrl+C

🤖 Generated with [Claude Code](https://claude.com/claude-code)