### PR TITLE
feat: add mistral agent plugin

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,6 +17,7 @@
       "@aoagents/ao-plugin-agent-opencode",
       "@aoagents/ao-plugin-agent-cursor",
       "@aoagents/ao-plugin-agent-kimicode",
+      "@aoagents/ao-plugin-agent-mistral",
       "@aoagents/ao-plugin-workspace-worktree",
       "@aoagents/ao-plugin-workspace-clone",
       "@aoagents/ao-plugin-tracker-github",

--- a/.changeset/mistral-agent-plugin.md
+++ b/.changeset/mistral-agent-plugin.md
@@ -1,0 +1,6 @@
+---
+"@aoagents/ao-cli": minor
+"@aoagents/ao-plugin-agent-mistral": minor
+---
+
+Add the Mistral Vibe CLI agent plugin.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-grok": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",
+    "@aoagents/ao-plugin-agent-mistral": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
     "@aoagents/ao-plugin-notifier-composio": "workspace:*",
     "@aoagents/ao-plugin-notifier-dashboard": "workspace:*",

--- a/packages/cli/src/assets/plugin-registry.json
+++ b/packages/cli/src/assets/plugin-registry.json
@@ -32,6 +32,14 @@
     "latestVersion": "0.1.0"
   },
   {
+    "id": "agent-mistral",
+    "package": "@aoagents/ao-plugin-agent-mistral",
+    "slot": "agent",
+    "description": "Agent plugin: Mistral Vibe CLI",
+    "source": "registry",
+    "latestVersion": "0.7.0"
+  },
+  {
     "id": "notifier-openclaw",
     "package": "@aoagents/ao-plugin-notifier-openclaw",
     "slot": "notifier",

--- a/packages/cli/src/lib/detect-agent.ts
+++ b/packages/cli/src/lib/detect-agent.ts
@@ -22,6 +22,7 @@ const AGENT_PLUGINS: Array<{ name: string; pkg: string }> = [
   { name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
   { name: "grok", pkg: "@aoagents/ao-plugin-agent-grok" },
   { name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { name: "mistral", pkg: "@aoagents/ao-plugin-agent-mistral" },
 ];
 
 /**

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -6,6 +6,7 @@ import cursorPlugin from "@aoagents/ao-plugin-agent-cursor";
 import kimicodePlugin from "@aoagents/ao-plugin-agent-kimicode";
 import grokPlugin from "@aoagents/ao-plugin-agent-grok";
 import opencodePlugin from "@aoagents/ao-plugin-agent-opencode";
+import mistralPlugin from "@aoagents/ao-plugin-agent-mistral";
 import githubSCMPlugin from "@aoagents/ao-plugin-scm-github";
 
 const agentPlugins: Record<string, { create(): Agent }> = {
@@ -16,6 +17,7 @@ const agentPlugins: Record<string, { create(): Agent }> = {
   kimicode: kimicodePlugin,
   grok: grokPlugin,
   opencode: opencodePlugin,
+  mistral: mistralPlugin,
 };
 
 const scmPlugins: Record<string, { create(): SCM }> = {

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -48,6 +48,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
   { slot: "agent", name: "grok", pkg: "@aoagents/ao-plugin-agent-grok" },
   { slot: "agent", name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { slot: "agent", name: "mistral", pkg: "@aoagents/ao-plugin-agent-mistral" },
   // Workspaces
   { slot: "workspace", name: "worktree", pkg: "@aoagents/ao-plugin-workspace-worktree" },
   { slot: "workspace", name: "clone", pkg: "@aoagents/ao-plugin-workspace-clone" },

--- a/packages/plugins/agent-mistral/package.json
+++ b/packages/plugins/agent-mistral/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@aoagents/ao-plugin-agent-mistral",
+  "version": "0.7.0",
+  "description": "Agent plugin: Mistral Vibe CLI",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-mistral"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*",
+    "which": "^6.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "@types/which": "^3.0.4",
+    "@vitest/coverage-v8": "^4.0.18",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/plugins/agent-mistral/src/index.test.ts
+++ b/packages/plugins/agent-mistral/src/index.test.ts
@@ -1,0 +1,354 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectConfig, RuntimeHandle, Session } from "@aoagents/ao-core";
+import which from "which";
+import { execFileSync } from "node:child_process";
+import type * as ChildProcess from "node:child_process";
+import plugin, { create, detect, manifest } from "./index.js";
+
+vi.mock("which", () => ({
+  default: {
+    sync: vi.fn(),
+  },
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof ChildProcess>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  };
+});
+
+const mockedWhichSync = vi.mocked(which.sync);
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+function projectConfig(path: string): ProjectConfig {
+  return {
+    path,
+    sessionPrefix: "app",
+  } as ProjectConfig;
+}
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "app-1",
+    projectId: "app",
+    status: "working",
+    activity: "active",
+    activitySignal: { state: "valid", activity: "active", source: "runtime" },
+    lifecycle: {} as Session["lifecycle"],
+    branch: "main",
+    issueId: null,
+    pr: null,
+    workspacePath: null,
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    lastActivityAt: new Date("2026-01-01T00:00:00.000Z"),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function processHandle(pid = 1234): RuntimeHandle {
+  return { id: "app-1", runtimeName: "process", data: { pid } };
+}
+
+function tmuxHandle(): RuntimeHandle {
+  return { id: "app-1", runtimeName: "tmux", data: {} };
+}
+
+describe("agent-mistral plugin", () => {
+  let tmp: string;
+  const previousPath = process.env["PATH"];
+  const previousGhPath = process.env["GH_PATH"];
+  const previousVibeHome = process.env["VIBE_HOME"];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "ao-mistral-test-"));
+    vi.clearAllMocks();
+    process.env["PATH"] = "/usr/bin:/bin";
+    process.env["GH_PATH"] = "/opt/homebrew/bin/gh";
+    delete process.env["VIBE_HOME"];
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    if (previousPath === undefined) delete process.env["PATH"];
+    else process.env["PATH"] = previousPath;
+    if (previousGhPath === undefined) delete process.env["GH_PATH"];
+    else process.env["GH_PATH"] = previousGhPath;
+    if (previousVibeHome === undefined) delete process.env["VIBE_HOME"];
+    else process.env["VIBE_HOME"] = previousVibeHome;
+    vi.restoreAllMocks();
+  });
+
+  it("exports the manifest and default plugin shape", () => {
+    expect(manifest).toMatchObject({
+      name: "mistral",
+      slot: "agent",
+      description: "Agent plugin: Mistral Vibe CLI",
+      displayName: "Mistral Vibe",
+    });
+    expect(plugin.manifest).toBe(manifest);
+    expect(plugin.create).toBe(create);
+    expect(plugin.detect).toBe(detect);
+  });
+
+  it("creates a Forge-style agent descriptor", () => {
+    const agent = create();
+    expect(agent.name).toBe("mistral");
+    expect(agent.processName).toBe("vibe");
+    expect(agent.promptDelivery).toBe("post-launch");
+  });
+
+  it("detects the vibe executable with which.sync", () => {
+    mockedWhichSync.mockReturnValue("/usr/local/bin/vibe");
+    expect(detect()).toBe(true);
+    expect(mockedWhichSync).toHaveBeenCalledWith("vibe");
+  });
+
+  it("returns false when vibe detection throws", () => {
+    mockedWhichSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(detect()).toBe(false);
+  });
+
+  it("builds a fresh interactive launch command", () => {
+    const agent = create();
+    const command = agent.getLaunchCommand({
+      sessionId: "app-1",
+      projectConfig: projectConfig("/repo/root"),
+      workspacePath: "/tmp/work tree",
+      prompt: "do not inline me",
+    });
+    expect(command).toBe("vibe --workdir '/tmp/work tree' --trust");
+    expect(command).not.toContain("do not inline me");
+    expect(command).not.toContain("--prompt");
+  });
+
+  it("maps AO permission modes to documented Vibe agents", () => {
+    const agent = create();
+    expect(
+      agent.getLaunchCommand({
+        sessionId: "app-1",
+        projectConfig: projectConfig("/repo"),
+        permissions: "permissionless",
+      }),
+    ).toContain("--agent 'auto-approve'");
+    expect(
+      agent.getLaunchCommand({
+        sessionId: "app-1",
+        projectConfig: projectConfig("/repo"),
+        permissions: "auto-edit",
+      }),
+    ).toContain("--agent 'accept-edits'");
+  });
+
+  it("returns AO and Vibe automation environment", () => {
+    const agent = create();
+    const env = agent.getEnvironment({
+      sessionId: "app-1",
+      projectConfig: projectConfig("/repo"),
+      model: "devstral-small-2507",
+    });
+    expect(env.AO_SESSION_ID).toBe("app-1");
+    expect(env.AO_SESSION_NAME).toBe("app-1");
+    expect(env.PATH).toContain("/usr/bin");
+    expect(env.GH_PATH).toBe("/opt/homebrew/bin/gh");
+    expect(env.VIBE_ACTIVE_MODEL).toBe("devstral-small-2507");
+    expect(env.VIBE_ENABLE_AUTO_UPDATE).toBe("false");
+    expect(env.VIBE_ENABLE_UPDATE_CHECKS).toBe("false");
+    expect(env.VIBE_ENABLE_NOTIFICATIONS).toBe("false");
+  });
+
+  it("checks process-handle liveness with signal 0", async () => {
+    const agent = create();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    await expect(agent.isProcessRunning(processHandle(4321))).resolves.toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(4321, 0);
+  });
+
+  it("treats EPERM from signal 0 as process-running", async () => {
+    const agent = create();
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      const err = new Error("denied") as NodeJS.ErrnoException;
+      err.code = "EPERM";
+      throw err;
+    });
+    await expect(agent.isProcessRunning(processHandle(4321))).resolves.toBe(true);
+  });
+
+  it("returns false for dead process handles", async () => {
+    const agent = create();
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      const err = new Error("missing") as NodeJS.ErrnoException;
+      err.code = "ESRCH";
+      throw err;
+    });
+    await expect(agent.isProcessRunning(processHandle(4321))).resolves.toBe(false);
+  });
+
+  it("checks tmux pane TTYs for the vibe process", async () => {
+    const agent = create();
+    mockedExecFileSync
+      .mockReturnValueOnce("/dev/ttys001\n")
+      .mockReturnValueOnce("/opt/homebrew/bin/vibe --workdir /repo\n");
+    await expect(agent.isProcessRunning(tmuxHandle())).resolves.toBe(true);
+    expect(mockedExecFileSync).toHaveBeenNthCalledWith(
+      1,
+      "tmux",
+      ["list-panes", "-t", "app-1", "-F", "#{pane_tty}"],
+      expect.objectContaining({ encoding: "utf-8" }),
+    );
+    expect(mockedExecFileSync).toHaveBeenNthCalledWith(
+      2,
+      "ps",
+      ["-o", "command=", "-t", "ttys001"],
+      expect.objectContaining({ encoding: "utf-8" }),
+    );
+  });
+
+  it("returns false when tmux has no vibe process", async () => {
+    const agent = create();
+    mockedExecFileSync.mockReturnValueOnce("/dev/ttys001\n").mockReturnValueOnce("zsh\n");
+    await expect(agent.isProcessRunning(tmuxHandle())).resolves.toBe(false);
+  });
+
+  it("records idle, active, waiting-input, and blocked terminal activity", async () => {
+    const agent = create();
+    const s = session({ workspacePath: tmp });
+
+    await agent.recordActivity?.(s, "");
+    await agent.recordActivity?.(s, "Thinking about the plan");
+    await agent.recordActivity?.(s, "Do you trust this working directory? (y/n)");
+    await agent.recordActivity?.(s, "Traceback (most recent call last): boom");
+
+    const log = readFileSync(join(tmp, ".ao", "activity.jsonl"), "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { state: string; trigger?: string });
+    expect(log.map((entry) => entry.state)).toEqual(["idle", "active", "waiting_input", "blocked"]);
+    expect(log[2].trigger).toContain("Do you trust");
+    expect(log[3].trigger).toContain("Traceback");
+  });
+
+  it("does not record activity without a workspace path", async () => {
+    const agent = create();
+    await agent.recordActivity?.(session({ workspacePath: null }), "Thinking");
+    expect(() => readFileSync(join(tmp, ".ao", "activity.jsonl"), "utf-8")).toThrow();
+  });
+
+  it("reports exited activity without a runtime handle", async () => {
+    const agent = create();
+    const result = await agent.getActivityState(
+      session({ workspacePath: tmp, runtimeHandle: null }),
+    );
+    expect(result?.state).toBe("exited");
+  });
+
+  it("reports exited activity when the runtime process is gone", async () => {
+    const agent = create();
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      const err = new Error("missing") as NodeJS.ErrnoException;
+      err.code = "ESRCH";
+      throw err;
+    });
+    const result = await agent.getActivityState(
+      session({ workspacePath: tmp, runtimeHandle: processHandle(2222) }),
+    );
+    expect(result?.state).toBe("exited");
+  });
+
+  it("prefers actionable activity-log state", async () => {
+    const agent = create();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    await agent.recordActivity?.(
+      session({ workspacePath: tmp }),
+      "Enter your API key to continue?",
+    );
+    const result = await agent.getActivityState(
+      session({ workspacePath: tmp, runtimeHandle: processHandle(2222) }),
+    );
+    expect(result?.state).toBe("waiting_input");
+  });
+
+  it("falls back to stale idle from the activity log", async () => {
+    const agent = create();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    mkdirSync(join(tmp, ".ao"), { recursive: true });
+    writeFileSync(
+      join(tmp, ".ao", "activity.jsonl"),
+      JSON.stringify({
+        ts: "2026-01-01T00:00:00.000Z",
+        state: "active",
+        source: "terminal",
+      }) + "\n",
+    );
+    const result = await agent.getActivityState(
+      session({ workspacePath: tmp, runtimeHandle: processHandle(2222) }),
+      1,
+    );
+    expect(result?.state).toBe("idle");
+  });
+
+  it("returns null when activity is unavailable", async () => {
+    const agent = create();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    const result = await agent.getActivityState(
+      session({ workspacePath: tmp, runtimeHandle: processHandle(2222) }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("extracts session info from Vibe session metadata", async () => {
+    const agent = create();
+    process.env["VIBE_HOME"] = join(tmp, "vibe-home");
+    const logDir = join(process.env["VIBE_HOME"], "logs", "session", "session_20260513_deadbeef");
+    mkdirSync(logDir, { recursive: true });
+    writeFileSync(
+      join(logDir, "meta.json"),
+      JSON.stringify({
+        session_id: "deadbeef-0000-0000-0000-123456789abc",
+        title: "Refactor parser",
+        environment: { working_directory: tmp },
+      }),
+    );
+
+    const info = await agent.getSessionInfo(session({ workspacePath: tmp }));
+    expect(info).toEqual({
+      summary: "Refactor parser",
+      agentSessionId: "deadbeef-0000-0000-0000-123456789abc",
+      metadata: { mistralSessionId: "deadbeef-0000-0000-0000-123456789abc" },
+    });
+  });
+
+  it("returns null when Vibe metadata is unavailable", async () => {
+    const agent = create();
+    process.env["VIBE_HOME"] = join(tmp, "missing-vibe-home");
+    await expect(agent.getSessionInfo(session({ workspacePath: tmp }))).resolves.toBeNull();
+  });
+
+  it("builds a restore command when a Mistral session id was persisted", async () => {
+    const agent = create();
+    const command = await agent.getRestoreCommand?.(
+      session({ workspacePath: "/tmp/work tree", metadata: { mistralSessionId: "abc123" } }),
+      projectConfig("/repo/root"),
+    );
+    expect(command).toBe("vibe --workdir '/tmp/work tree' --trust --resume 'abc123'");
+  });
+
+  it("does not fake restore when no Mistral session id is known", async () => {
+    const agent = create();
+    await expect(
+      agent.getRestoreCommand?.(
+        session({ workspacePath: "/tmp/work tree" }),
+        projectConfig("/repo/root"),
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/plugins/agent-mistral/src/index.test.ts
+++ b/packages/plugins/agent-mistral/src/index.test.ts
@@ -65,6 +65,7 @@ describe("agent-mistral plugin", () => {
   let tmp: string;
   const previousPath = process.env["PATH"];
   const previousGhPath = process.env["GH_PATH"];
+  const previousHome = process.env["HOME"];
   const previousVibeHome = process.env["VIBE_HOME"];
 
   beforeEach(() => {
@@ -81,6 +82,8 @@ describe("agent-mistral plugin", () => {
     else process.env["PATH"] = previousPath;
     if (previousGhPath === undefined) delete process.env["GH_PATH"];
     else process.env["GH_PATH"] = previousGhPath;
+    if (previousHome === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = previousHome;
     if (previousVibeHome === undefined) delete process.env["VIBE_HOME"];
     else process.env["VIBE_HOME"] = previousVibeHome;
     vi.restoreAllMocks();
@@ -102,7 +105,7 @@ describe("agent-mistral plugin", () => {
     const agent = create();
     expect(agent.name).toBe("mistral");
     expect(agent.processName).toBe("vibe");
-    expect(agent.promptDelivery).toBe("post-launch");
+    expect(agent.promptDelivery).toBe("inline");
   });
 
   it("detects the vibe executable with which.sync", () => {
@@ -124,10 +127,26 @@ describe("agent-mistral plugin", () => {
       sessionId: "app-1",
       projectConfig: projectConfig("/repo/root"),
       workspacePath: "/tmp/work tree",
-      prompt: "do not inline me",
+      prompt: "summarize the branch",
     });
-    expect(command).toBe("vibe --workdir '/tmp/work tree' --trust");
-    expect(command).not.toContain("do not inline me");
+    expect(command).toBe("vibe --workdir '/tmp/work tree' --trust 'summarize the branch'");
+    expect(command).not.toContain("--prompt");
+  });
+
+  it("combines system prompt files with the task prompt for Vibe's positional prompt", () => {
+    const agent = create();
+    const systemPromptFile = join(tmp, "system.md");
+    writeFileSync(systemPromptFile, "System rules", "utf-8");
+
+    const command = agent.getLaunchCommand({
+      sessionId: "app-1",
+      projectConfig: projectConfig("/repo/root"),
+      workspacePath: "/tmp/work tree",
+      systemPromptFile,
+      prompt: "print READY",
+    });
+
+    expect(command).toBe("vibe --workdir '/tmp/work tree' --trust 'System rules\n\nprint READY'");
     expect(command).not.toContain("--prompt");
   });
 
@@ -325,6 +344,27 @@ describe("agent-mistral plugin", () => {
       agentSessionId: "deadbeef-0000-0000-0000-123456789abc",
       metadata: { mistralSessionId: "deadbeef-0000-0000-0000-123456789abc" },
     });
+  });
+
+  it("matches Vibe metadata workspace paths that start with a home-directory tilde", async () => {
+    const agent = create();
+    process.env["HOME"] = tmp;
+    process.env["VIBE_HOME"] = join(tmp, "vibe-home");
+    const workspacePath = join(tmp, "project");
+    mkdirSync(workspacePath, { recursive: true });
+    const logDir = join(process.env["VIBE_HOME"], "logs", "session", "session_20260513_homepath");
+    mkdirSync(logDir, { recursive: true });
+    writeFileSync(
+      join(logDir, "meta.json"),
+      JSON.stringify({
+        session_id: "homepath-0000-0000-0000-123456789abc",
+        title: "Home path session",
+        environment: { working_directory: "~/project" },
+      }),
+    );
+
+    const info = await agent.getSessionInfo(session({ workspacePath }));
+    expect(info?.agentSessionId).toBe("homepath-0000-0000-0000-123456789abc");
   });
 
   it("returns null when Vibe metadata is unavailable", async () => {

--- a/packages/plugins/agent-mistral/src/index.ts
+++ b/packages/plugins/agent-mistral/src/index.ts
@@ -1,0 +1,339 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { createRequire } from "node:module";
+import {
+  type ActivityDetection,
+  type ActivityState,
+  type Agent,
+  type AgentLaunchConfig,
+  type AgentSessionInfo,
+  type PluginModule,
+  type ProjectConfig,
+  type RuntimeHandle,
+  type Session,
+  type WorkspaceHooksConfig,
+  buildAgentPath,
+  checkActivityLogState,
+  getActivityFallbackState,
+  readLastActivityEntry,
+  recordTerminalActivity,
+  setupPathWrapperWorkspace,
+  shellEscape,
+} from "@aoagents/ao-core";
+import which from "which";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as { name: string; version: string };
+
+const PACKAGE_PREFIX = "@aoagents/ao-plugin-agent-";
+const VIBE_EXECUTABLE = "vibe";
+const COMMAND_TIMEOUT_MS = 2_000;
+const ACTIVE_WINDOW_MS = 30_000;
+const MAX_METADATA_BYTES = 64 * 1024;
+
+type MistralAgent = Agent & { promptDelivery: "post-launch" };
+
+function pluginNameFromPackageName(packageName: string): string {
+  return packageName.startsWith(PACKAGE_PREFIX)
+    ? packageName.slice(PACKAGE_PREFIX.length)
+    : packageName;
+}
+
+const pluginName = pluginNameFromPackageName(packageJson.name);
+
+export const manifest = {
+  name: pluginName,
+  slot: "agent" as const,
+  description: "Agent plugin: Mistral Vibe CLI",
+  version: packageJson.version,
+  displayName: "Mistral Vibe",
+};
+
+export function detect(): boolean {
+  try {
+    return Boolean(which.sync(VIBE_EXECUTABLE));
+  } catch {
+    return false;
+  }
+}
+
+function workspacePathFor(config: AgentLaunchConfig): string {
+  return config.workspacePath ?? config.projectConfig.path;
+}
+
+function permissionAgentFlag(permissions: AgentLaunchConfig["permissions"]): string | null {
+  if (permissions === "permissionless" || permissions === "skip") return "auto-approve";
+  if (permissions === "auto-edit") return "accept-edits";
+  return null;
+}
+
+function buildLaunchCommand(config: AgentLaunchConfig): string {
+  const args = [VIBE_EXECUTABLE, "--workdir", shellEscape(workspacePathFor(config)), "--trust"];
+  const agent = permissionAgentFlag(config.permissions);
+  if (agent) args.push("--agent", shellEscape(agent));
+  return args.join(" ");
+}
+
+function getConfiguredVibeHome(): string {
+  const configured = process.env["VIBE_HOME"];
+  return configured ? resolve(configured) : join(homedir(), ".vibe");
+}
+
+function getVibeSessionLogDir(): string {
+  return join(getConfiguredVibeHome(), "logs", "session");
+}
+
+function normalizePathForCompare(path: string): string {
+  return resolve(path);
+}
+
+interface VibeMetadata {
+  session_id?: unknown;
+  title?: unknown;
+  environment?: unknown;
+}
+
+function readJsonFileBounded(path: string): unknown {
+  const stat = statSync(path);
+  if (!stat.isFile() || stat.size > MAX_METADATA_BYTES) return null;
+  return JSON.parse(readFileSync(path, "utf-8")) as unknown;
+}
+
+function findLatestVibeMetadata(workspacePath: string): VibeMetadata | null {
+  const sessionLogDir = getVibeSessionLogDir();
+  if (!existsSync(sessionLogDir)) return null;
+
+  const expectedWorkingDirectory = normalizePathForCompare(workspacePath);
+  let latest: { metadata: VibeMetadata; mtimeMs: number } | null = null;
+
+  for (const entry of readdirSync(sessionLogDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith("session_")) continue;
+    const metadataPath = join(sessionLogDir, entry.name, "meta.json");
+    try {
+      const parsed = readJsonFileBounded(metadataPath);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) continue;
+      const metadata = parsed as VibeMetadata;
+      if (typeof metadata.session_id !== "string") continue;
+      const environment = metadata.environment;
+      if (typeof environment !== "object" || environment === null || Array.isArray(environment)) {
+        continue;
+      }
+      const workingDirectory = (environment as Record<string, unknown>)["working_directory"];
+      if (typeof workingDirectory !== "string") continue;
+      if (normalizePathForCompare(workingDirectory) !== expectedWorkingDirectory) continue;
+
+      const mtimeMs = statSync(metadataPath).mtimeMs;
+      if (!latest || mtimeMs > latest.mtimeMs) latest = { metadata, mtimeMs };
+    } catch {
+      continue;
+    }
+  }
+
+  return latest?.metadata ?? null;
+}
+
+function getStoredMistralSessionId(session: Session): string | null {
+  return session.metadata["mistralSessionId"] ?? session.agentInfo?.agentSessionId ?? null;
+}
+
+function matchesProcessName(output: string): boolean {
+  return output
+    .split("\n")
+    .some(
+      (line) =>
+        /(^|[\s/])vibe([\s/]|$)/.test(line.trim()) || basename(line.trim()) === VIBE_EXECUTABLE,
+    );
+}
+
+function isTmuxProcessRunning(handle: RuntimeHandle): boolean {
+  try {
+    const ttyOutput = execFileSync("tmux", ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"], {
+      encoding: "utf-8",
+      timeout: COMMAND_TIMEOUT_MS,
+    });
+    const ttys = ttyOutput
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+    for (const tty of ttys) {
+      const psTty = tty.startsWith("/dev/") ? tty.slice("/dev/".length) : tty;
+      try {
+        const psOutput = execFileSync("ps", ["-o", "command=", "-t", psTty], {
+          encoding: "utf-8",
+          timeout: COMMAND_TIMEOUT_MS,
+        });
+        if (matchesProcessName(psOutput)) return true;
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function isPidRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function classifyTerminalOutput(output: string): ActivityState {
+  const trimmed = output.trim();
+  if (!trimmed) return "idle";
+
+  const lower = trimmed.toLowerCase();
+
+  if (
+    lower.includes("traceback (most recent call last)") ||
+    lower.includes("session logging is disabled") ||
+    lower.includes("failed to load session") ||
+    lower.includes("failed to persist session") ||
+    lower.includes("no previous sessions found") ||
+    /\bsession ['"].*['"] not found\b/i.test(trimmed)
+  ) {
+    return "blocked";
+  }
+
+  if (
+    lower.includes("enter your api key") ||
+    lower.includes("trust the working directory") ||
+    lower.includes("do you trust") ||
+    lower.includes("awaiting approval") ||
+    lower.includes("asking a question") ||
+    lower.includes("approve") ||
+    /\((y\/n|yes\/no)\)/i.test(trimmed) ||
+    /\?\s*$/.test(trimmed)
+  ) {
+    return "waiting_input";
+  }
+
+  if (
+    lower.includes("thinking") ||
+    lower.includes("running") ||
+    lower.includes("executing") ||
+    lower.includes("working") ||
+    lower.includes("analyzing") ||
+    lower.includes("reading") ||
+    lower.includes("writing") ||
+    lower.includes("applying")
+  ) {
+    return "active";
+  }
+
+  if (/^>\s*$/m.test(trimmed) || lower.includes("start interacting with the agent")) {
+    return "ready";
+  }
+
+  return "idle";
+}
+
+export function create(): MistralAgent {
+  const agent: MistralAgent = {
+    name: pluginName,
+    processName: VIBE_EXECUTABLE,
+    promptDelivery: "post-launch",
+
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      return buildLaunchCommand(config);
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      return {
+        PATH: buildAgentPath(process.env["PATH"]),
+        AO_SESSION_ID: config.sessionId,
+        AO_SESSION_NAME: config.sessionId,
+        VIBE_ENABLE_AUTO_UPDATE: "false",
+        VIBE_ENABLE_UPDATE_CHECKS: "false",
+        VIBE_ENABLE_NOTIFICATIONS: "false",
+        VIBE_DISABLE_WELCOME_BANNER_ANIMATION: "true",
+        ...(config.model ? { VIBE_ACTIVE_MODEL: config.model } : {}),
+        ...(process.env["GH_PATH"] ? { GH_PATH: process.env["GH_PATH"] } : {}),
+      };
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      return classifyTerminalOutput(terminalOutput);
+    },
+
+    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
+      if (!session.workspacePath) return;
+      await recordTerminalActivity(session.workspacePath, terminalOutput, classifyTerminalOutput);
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs = 300_000,
+    ): Promise<ActivityDetection | null> {
+      if (!session.runtimeHandle) return { state: "exited", timestamp: new Date() };
+      if (!(await agent.isProcessRunning(session.runtimeHandle))) {
+        return { state: "exited", timestamp: new Date() };
+      }
+      if (!session.workspacePath) return null;
+
+      const lastActivity = await readLastActivityEntry(session.workspacePath);
+      const activityLogState = checkActivityLogState(lastActivity);
+      if (activityLogState) return activityLogState;
+
+      return getActivityFallbackState(lastActivity, ACTIVE_WINDOW_MS, readyThresholdMs);
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      if (handle.runtimeName === "tmux") return isTmuxProcessRunning(handle);
+      const pid = handle.data["pid"];
+      return typeof pid === "number" && pid > 0 ? isPidRunning(pid) : false;
+    },
+
+    async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {
+      if (!session.workspacePath) return null;
+      const metadata = findLatestVibeMetadata(session.workspacePath);
+      if (!metadata || typeof metadata.session_id !== "string") return null;
+      const summary =
+        typeof metadata.title === "string" && metadata.title.length > 0 ? metadata.title : null;
+      return {
+        summary,
+        agentSessionId: metadata.session_id,
+        metadata: { mistralSessionId: metadata.session_id },
+      };
+    },
+
+    async getRestoreCommand(session: Session, project: ProjectConfig): Promise<string | null> {
+      const mistralSessionId = getStoredMistralSessionId(session);
+      if (!mistralSessionId) return null;
+      const workspacePath = session.workspacePath ?? project.path;
+      return [
+        VIBE_EXECUTABLE,
+        "--workdir",
+        shellEscape(workspacePath),
+        "--trust",
+        "--resume",
+        shellEscape(mistralSessionId),
+      ].join(" ");
+    },
+
+    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+      await setupPathWrapperWorkspace(workspacePath);
+    },
+
+    async postLaunchSetup(session: Session): Promise<void> {
+      if (!session.workspacePath) return;
+      await setupPathWrapperWorkspace(session.workspacePath);
+    },
+  };
+
+  return agent;
+}
+
+const plugin: PluginModule<Agent> = {
+  manifest,
+  create,
+  detect,
+};
+
+export default plugin;

--- a/packages/plugins/agent-mistral/src/index.ts
+++ b/packages/plugins/agent-mistral/src/index.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { createRequire } from "node:module";
@@ -17,10 +17,12 @@ import {
   buildAgentPath,
   checkActivityLogState,
   getActivityFallbackState,
+  getEnvDefaults,
   readLastActivityEntry,
   recordTerminalActivity,
   setupPathWrapperWorkspace,
   shellEscape,
+  isWindows,
 } from "@aoagents/ao-core";
 import which from "which";
 
@@ -33,7 +35,7 @@ const COMMAND_TIMEOUT_MS = 2_000;
 const ACTIVE_WINDOW_MS = 30_000;
 const MAX_METADATA_BYTES = 64 * 1024;
 
-type MistralAgent = Agent & { promptDelivery: "post-launch" };
+type MistralAgent = Agent & { promptDelivery: "inline" };
 
 function pluginNameFromPackageName(packageName: string): string {
   return packageName.startsWith(PACKAGE_PREFIX)
@@ -69,11 +71,36 @@ function permissionAgentFlag(permissions: AgentLaunchConfig["permissions"]): str
   return null;
 }
 
-function buildLaunchCommand(config: AgentLaunchConfig): string {
-  const args = [VIBE_EXECUTABLE, "--workdir", shellEscape(workspacePathFor(config)), "--trust"];
-  const agent = permissionAgentFlag(config.permissions);
+function buildBaseVibeCommandArgs(
+  workspacePath: string,
+  permissions: AgentLaunchConfig["permissions"],
+): string[] {
+  const args = [VIBE_EXECUTABLE, "--workdir", shellEscape(workspacePath), "--trust"];
+  const agent = permissionAgentFlag(permissions);
   if (agent) args.push("--agent", shellEscape(agent));
+  return args;
+}
+
+function buildLaunchCommand(config: AgentLaunchConfig): string {
+  const args = buildBaseVibeCommandArgs(workspacePathFor(config), config.permissions);
+  const prompt = buildInitialPrompt(config);
+  if (prompt) args.push(shellEscape(prompt));
   return args.join(" ");
+}
+
+function buildInitialPrompt(config: AgentLaunchConfig): string | null {
+  const taskPrompt = typeof config.prompt === "string" ? config.prompt : "";
+  if (taskPrompt.length === 0) return null;
+
+  if (config.systemPromptFile) {
+    return `${readFileSync(config.systemPromptFile, "utf-8")}\n\n${taskPrompt}`;
+  }
+
+  if (config.systemPrompt) {
+    return `${config.systemPrompt}\n\n${taskPrompt}`;
+  }
+
+  return taskPrompt;
 }
 
 function getConfiguredVibeHome(): string {
@@ -86,7 +113,14 @@ function getVibeSessionLogDir(): string {
 }
 
 function normalizePathForCompare(path: string): string {
-  return resolve(path);
+  const expanded = path.replace(/^~/, getEnvDefaults().HOME ?? "");
+  let canonical = resolve(expanded);
+  try {
+    canonical = realpathSync(canonical);
+  } catch {
+    // Compare the resolved literal path when the filesystem entry is gone.
+  }
+  return isWindows() ? canonical.toLowerCase() : canonical;
 }
 
 interface VibeMetadata {
@@ -238,7 +272,7 @@ export function create(): MistralAgent {
   const agent: MistralAgent = {
     name: pluginName,
     processName: VIBE_EXECUTABLE,
-    promptDelivery: "post-launch",
+    promptDelivery: "inline",
 
     getLaunchCommand(config: AgentLaunchConfig): string {
       return buildLaunchCommand(config);
@@ -308,10 +342,7 @@ export function create(): MistralAgent {
       if (!mistralSessionId) return null;
       const workspacePath = session.workspacePath ?? project.path;
       return [
-        VIBE_EXECUTABLE,
-        "--workdir",
-        shellEscape(workspacePath),
-        "--trust",
+        ...buildBaseVibeCommandArgs(workspacePath, project.agentConfig?.permissions),
         "--resume",
         shellEscape(mistralSessionId),
       ].join(" ");

--- a/packages/plugins/agent-mistral/tsconfig.json
+++ b/packages/plugins/agent-mistral/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@aoagents/ao-plugin-agent-kimicode':
         specifier: workspace:*
         version: link:../plugins/agent-kimicode
+      '@aoagents/ao-plugin-agent-mistral':
+        specifier: workspace:*
+        version: link:../plugins/agent-mistral
       '@aoagents/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
@@ -379,6 +382,31 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/plugins/agent-mistral:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+      which:
+        specifier: ^6.0.1
+        version: 6.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.1.4(vitest@4.1.4)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/plugins/agent-opencode:
     dependencies:


### PR DESCRIPTION
## Summary
- Add `@aoagents/ao-plugin-agent-mistral` for the Mistral Vibe CLI (`vibe`) using the Forge-style plugin contract.
- Register the plugin in CLI agent detection, direct plugin resolution, the plugin registry asset, linked changeset config, and workspace lockfile.
- Add focused tests for manifest/default export shape, detection, launch/restore commands, env, liveness, terminal activity logging, activity state fallback, and Vibe session metadata extraction.

## Verified command surface
- Verified with `uvx --from mistral-vibe vibe --help` and `uvx --from mistral-vibe vibe --version` (`vibe 2.9.6`).
- Used documented `vibe --workdir`, `--trust`, `--agent`, and `--resume SESSION_ID` flags.

## Unsupported / best-effort capabilities
- No separate Vibe stats/cost command was found or used; `getSessionInfo()` only returns summary/session id from local Vibe `meta.json` when available.
- Restore is only emitted after AO has persisted a real `mistralSessionId`; otherwise it returns `null` and AO falls back to fresh launch.

## Tests
- `pnpm exec eslint packages/plugins/agent-mistral/src/index.ts packages/plugins/agent-mistral/src/index.test.ts packages/cli/src/lib/plugins.ts packages/cli/src/lib/detect-agent.ts`
- `pnpm --filter @aoagents/ao-plugin-agent-mistral typecheck`
- `pnpm --filter @aoagents/ao-plugin-agent-mistral build`
- `pnpm --filter @aoagents/ao-plugin-agent-mistral test`
- `pnpm --filter @aoagents/ao-cli typecheck`
- `pnpm --filter @aoagents/ao-cli build`
- `pnpm changeset status --since origin/main` (with PATH cleaned to avoid the local AO git wrapper recursion)