### PR TITLE
fix(web): add localStorage mock for Node 25 compatibility in vitest setup

### DIFF
--- a/packages/web/src/__tests__/setup.ts
+++ b/packages/web/src/__tests__/setup.ts
@@ -2,6 +2,31 @@ import { cleanup } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { afterEach, expect } from "vitest";
 
+// Node.js 25 exposes a native localStorage stub via --localstorage-file that
+// omits .clear() / .key() / .length. Replace it with a complete in-memory
+// implementation so tests that call window.localStorage.clear() work on any
+// Node version. Harmless on Node <= 22 where jsdom already provides this.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => {
+      store[k] = String(v);
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      store = {};
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+})();
+Object.defineProperty(window, "localStorage", { value: localStorageMock, writable: true });
+
 expect.extend(matchers);
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
Fixes #1840

## What

Node.js 25 introduces a native \`localStorage\` global (via \`--localstorage-file\`) that shadows jsdom's implementation. When no file path is configured (the vitest default), Node 25 installs a stub that exposes \`getItem\`/\`setItem\`/\`removeItem\` but omits \`clear()\`, \`key()\`, and \`length\`. This makes all 8 tests in \`UpdateBanner.test.tsx\` fail with:

\`\`\`
TypeError: window.localStorage.clear is not a function
\`\`\`

Node 25 also emits the warning \`'--localstorage-file' was provided without a valid path\`, confirming the native stub is active.

## Fix

Add a complete in-memory \`localStorage\` implementation to \`packages/web/src/__tests__/setup.ts\` that unconditionally replaces \`window.localStorage\` before any test runs. The mock is spec-compliant (implements \`getItem\`, \`setItem\`, \`removeItem\`, \`clear\`, \`key\`, and \`length\`). It is harmless on Node \<= 22 where jsdom already provides a correct implementation.

## Test plan

\`pnpm --filter @aoagents/ao-web test\` passes all 74 test files (903 tests) on Node 25.8.0 after this change. \`UpdateBanner.test.tsx\` passes all 8 tests.