### PR TITLE
fix(cli): deduplicate enrichment and cache tmux probes in ao status

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -124,13 +124,21 @@ async function gatherSessionInfo(
     lastActivity = activityTs ? formatAge(activityTs) : "-";
   }
 
-  // Get agent's auto-generated summary via introspection
+  // Get agent's auto-generated summary — reuse enriched agentInfo when
+  // available to avoid a redundant getSessionInfo() call per session (#1850).
+  // session.agentInfo is populated by enrichSessionWithRuntimeState during
+  // sm.list() above.  Only fall back to a live probe if enrichment was skipped
+  // or returned null (e.g. terminal sessions).
   let claudeSummary: string | null = null;
-  try {
-    const introspection = await agent.getSessionInfo(session);
-    claudeSummary = introspection?.summary ?? null;
-  } catch {
-    // Summary extraction failed — not critical
+  if (session.agentInfo?.summary !== undefined && session.agentInfo?.summary !== null) {
+    claudeSummary = session.agentInfo.summary;
+  } else {
+    try {
+      const introspection = await agent.getSessionInfo(session);
+      claudeSummary = introspection?.summary ?? null;
+    } catch {
+      // Summary extraction failed — not critical
+    }
   }
 
   // Use activity from session (already enriched by sessionManager.list())

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1016,12 +1016,57 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
    */
   const TERMINAL_SESSION_STATUSES = new Set(["killed", "done", "merged", "terminated", "cleanup"]);
 
+  /**
+   * Kill an orphaned tmux session whose agent process has exited.
+   * This prevents the tmux-vs-status count discrepancy reported in #1850.
+   */
+  async function killOrphanedTmuxSession(tmuxSessionId: string): Promise<void> {
+    await execFileAsync("tmux", ["kill-session", "-t", tmuxSessionId], {
+      timeout: 5_000,
+    }).catch(() => {
+      // Session may have already been destroyed — ignore.
+    });
+  }
+
   async function enrichSessionWithRuntimeState(
     session: Session,
     plugins: ReturnType<typeof resolvePlugins>,
     handleFromMetadata: boolean,
     sessionsDir: string,
   ): Promise<void> {
+    // ── Fast-path: skip expensive enrichment for terminal sessions (#1850) ──
+    // Sessions that are already done/killed/merged/etc. are hidden from the
+    // default `ao status` output (status.ts:377-382), so running isAlive(),
+    // getActivityState(), and getSessionInfo() on them is wasted work that
+    // adds seconds per session.  We only check for orphaned tmux sessions.
+    const isTerminal = TERMINAL_SESSION_STATUSES.has(session.status);
+    if (isTerminal) {
+      // Clean up orphaned tmux sessions (Fix #4 from #1850):
+      // For terminal sessions, the agent has exited. If the tmux session is
+      // still alive, it's an orphan — kill it to match `tmux ls` output.
+      if (
+        handleFromMetadata &&
+        session.runtimeHandle &&
+        session.runtimeHandle.runtimeName === "tmux" &&
+        plugins.runtime
+      ) {
+        try {
+          const alive = await plugins.runtime.isAlive(session.runtimeHandle);
+          if (alive) {
+            // Agent exited but tmux session still lingers — kill it.
+            try {
+              await killOrphanedTmuxSession(session.runtimeHandle.id);
+            } catch {
+              // Best-effort; tmux kill-session may fail if race with user.
+            }
+          }
+        } catch {
+          // isAlive probe failed — skip cleanup.
+        }
+      }
+      return; // Skip getActivityState + getSessionInfo for terminal sessions
+    }
+
     // Check runtime liveness first — for all statuses except "spawning".
     // Skip spawning sessions because tmux may not be fully initialized yet,
     // and a false-negative from isAlive() would permanently mark the session

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -627,15 +627,18 @@ let psCache: {
 const PS_CACHE_TTL_MS = 5_000;
 
 /**
- * TTL cache for `tmux list-panes` output. Same rationale as psCache:
- * listing N sessions would call `tmux list-panes` N times, each with a
- * 30s timeout. Coalesce into a single call per TTL window (#1850).
+ * TTL cache for `tmux list-panes -a` output, indexed by session name.
+ * Same rationale as psCache: listing N sessions would call `tmux list-panes`
+ * N times, each with a 30s timeout. We batch into a single `list-panes -a`
+ * call per TTL window that fetches ALL sessions at once, then split the
+ * output into per-session TTY lists (#1850).
  */
-type TmuxPaneResult = string | null;
 let tmuxPaneCache: {
-  results: Map<string, TmuxPaneResult>;
+  /** Per-session TTY output (same format as `tmux list-panes -F #{pane_tty}`) */
+  results: Map<string, string>;
   timestamp: number;
-  promise?: Promise<void>;
+  /** In-flight promise so concurrent callers share the batch call */
+  promise: Promise<void>;
 } | null = null;
 const TMUX_PANE_CACHE_TTL_MS = 5_000;
 
@@ -645,41 +648,47 @@ export function resetTmuxPaneCache(): void {
 }
 
 /**
- * Fetch and cache `tmux list-panes` for a specific session handle.
- * The cache batches concurrent requests within the TTL window.
+ * Fetch ALL tmux panes in one call (`tmux list-panes -a`) and cache the
+ * results indexed by session name.  Concurrent requests within the TTL
+ * window share the same batch call.
  */
-async function getCachedTmuxPanes(handleId: string): Promise<TmuxPaneResult> {
+async function getCachedTmuxPanes(handleId: string): Promise<string | null> {
   if (isWindows()) return null;
 
   const now = Date.now();
+
+  // Return cached result if still fresh
   if (tmuxPaneCache && now - tmuxPaneCache.timestamp < TMUX_PANE_CACHE_TTL_MS) {
-    // Cache hit — return cached result for this handleId, or wait for
-    // in-flight batch to complete.
-    if (tmuxPaneCache.promise) await tmuxPaneCache.promise;
+    await tmuxPaneCache.promise;
     return tmuxPaneCache.results.get(handleId) ?? null;
   }
 
-  // Start a fresh cache entry. Individual lookups are done sequentially
-  // so each handle gets its own result in the map.
-  const results = new Map<string, TmuxPaneResult>();
-  const promise = (async () => {
-    // No-op: results are populated on-demand below.
-  })();
+  // Start a batch fetch of all sessions' panes
+  const results = new Map<string, string>();
+  const promise = execFileAsync("tmux", [
+    "list-panes",
+    "-a",
+    "-F",
+    "#{session_name}\t#{pane_tty}",
+  ], { timeout: 30_000 })
+    .then(({ stdout }) => {
+      for (const line of stdout.trim().split("\n")) {
+        const tabIdx = line.indexOf("\t");
+        if (tabIdx === -1) continue;
+        const sessionName = line.slice(0, tabIdx);
+        const paneTty = line.slice(tabIdx + 1);
+        // Append to existing entry (multi-pane sessions)
+        const existing = results.get(sessionName);
+        results.set(sessionName, existing ? existing + "\n" + paneTty : paneTty);
+      }
+    })
+    .catch(() => {
+      // tmux not running or no sessions — results stays empty
+    });
 
-  tmuxPaneCache = { results, timestamp: now, promise: Promise.resolve() };
-
-  try {
-    const { stdout } = await execFileAsync(
-      "tmux",
-      ["list-panes", "-t", handleId, "-F", "#{pane_tty}"],
-      { timeout: 30_000 },
-    );
-    tmuxPaneCache.results.set(handleId, stdout);
-    return stdout;
-  } catch {
-    tmuxPaneCache.results.set(handleId, null);
-    return null;
-  }
+  tmuxPaneCache = { results, timestamp: now, promise };
+  await promise;
+  return results.get(handleId) ?? null;
 }
 
 /** Reset the ps cache. Exported for testing only. */

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -626,6 +626,62 @@ let psCache: {
 } | null = null;
 const PS_CACHE_TTL_MS = 5_000;
 
+/**
+ * TTL cache for `tmux list-panes` output. Same rationale as psCache:
+ * listing N sessions would call `tmux list-panes` N times, each with a
+ * 30s timeout. Coalesce into a single call per TTL window (#1850).
+ */
+type TmuxPaneResult = string | null;
+let tmuxPaneCache: {
+  results: Map<string, TmuxPaneResult>;
+  timestamp: number;
+  promise?: Promise<void>;
+} | null = null;
+const TMUX_PANE_CACHE_TTL_MS = 5_000;
+
+/** Reset the tmux pane cache. Exported for testing only. */
+export function resetTmuxPaneCache(): void {
+  tmuxPaneCache = null;
+}
+
+/**
+ * Fetch and cache `tmux list-panes` for a specific session handle.
+ * The cache batches concurrent requests within the TTL window.
+ */
+async function getCachedTmuxPanes(handleId: string): Promise<TmuxPaneResult> {
+  if (isWindows()) return null;
+
+  const now = Date.now();
+  if (tmuxPaneCache && now - tmuxPaneCache.timestamp < TMUX_PANE_CACHE_TTL_MS) {
+    // Cache hit — return cached result for this handleId, or wait for
+    // in-flight batch to complete.
+    if (tmuxPaneCache.promise) await tmuxPaneCache.promise;
+    return tmuxPaneCache.results.get(handleId) ?? null;
+  }
+
+  // Start a fresh cache entry. Individual lookups are done sequentially
+  // so each handle gets its own result in the map.
+  const results = new Map<string, TmuxPaneResult>();
+  const promise = (async () => {
+    // No-op: results are populated on-demand below.
+  })();
+
+  tmuxPaneCache = { results, timestamp: now, promise: Promise.resolve() };
+
+  try {
+    const { stdout } = await execFileAsync(
+      "tmux",
+      ["list-panes", "-t", handleId, "-F", "#{pane_tty}"],
+      { timeout: 30_000 },
+    );
+    tmuxPaneCache.results.set(handleId, stdout);
+    return stdout;
+  } catch {
+    tmuxPaneCache.results.set(handleId, null);
+    return null;
+  }
+}
+
 /** Reset the ps cache. Exported for testing only. */
 export function resetPsCache(): void {
   psCache = null;
@@ -679,11 +735,8 @@ async function findClaudeProcess(
     // For tmux runtime, get the pane TTY and find claude on it
     if (handle.runtimeName === "tmux" && handle.id) {
       if (isWindows()) return null;
-      const { stdout: ttyOut } = await execFileAsync(
-        "tmux",
-        ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
-        { timeout: 30_000 },
-      );
+      const ttyOut = await getCachedTmuxPanes(handle.id);
+      if (!ttyOut) return null;
       // Iterate all pane TTYs (multi-pane sessions) — succeed on any match
       const ttys = ttyOut
         .trim()


### PR DESCRIPTION
## Summary

Fixes [#1850](https://github.com/ComposioHQ/agent-orchestrator/issues/1850) — `ao status` is slow and reports inconsistent session counts vs `tmux ls`.

Four fixes targeting the highest-impact, lowest-risk improvements:

### 1. Skip enrichment for terminal sessions (`session-manager.ts`)
Sessions already in a terminal state (`killed`/`done`/`merged`/`terminated`/`cleanup`) are hidden from the default `ao status` output. Previously, every such session still ran the full `isAlive()` → `getActivityState()` → `getSessionInfo()` pipeline, adding seconds per session. Now we skip straight to a lightweight orphan check.

### 2. Deduplicate `getSessionInfo` call (`status.ts`)
`enrichSessionWithRuntimeState` already stores the result of `agent.getSessionInfo(session)` in `session.agentInfo`. But `gatherSessionInfo` was calling `agent.getSessionInfo(session)` again to get the summary. Now we reuse the cached `session.agentInfo.summary` and only fall back to a live probe when the cached value is null.

### 3. Cache `tmux list-panes` results (`agent-claude-code/index.ts`)
The `tmux list-panes` call in `findClaudeProcess` had no caching (30s timeout per call), unlike the `ps` call which has a 5s TTL cache. Added the same 5s TTL caching pattern for `tmux list-panes`, so N sessions share results within a cache window.

### 4. Kill orphaned tmux sessions (`session-manager.ts`)
When a session is terminal and the tmux session is still alive (agent exited but tmux lingers), we now kill the tmux session. This prevents the `tmux ls` vs `ao status` count discrepancy.

## Test Plan
- [x] `pnpm typecheck` passes for `core`, `cli`, and `agent-claude-code`
- [ ] Manual: `ao status` with 10+ sessions — verify speedup
- [ ] Manual: `tmux ls` matches session count after running `ao status`