### PR TITLE
feat: add Continue CLI agent plugin

### DIFF
--- a/.changeset/calm-cn-agents.md
+++ b/.changeset/calm-cn-agents.md
@@ -1,0 +1,8 @@
+---
+"@aoagents/ao-plugin-agent-cn": minor
+"@aoagents/ao-core": patch
+"@aoagents/ao-cli": patch
+"@aoagents/ao-web": patch
+---
+
+Add a built-in Continue CLI (`cn`) agent plugin and wire post-launch prompt delivery for interactive agent startup.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "@aoagents/ao-notifier-macos": "workspace:*",
     "@aoagents/ao-plugin-agent-aider": "workspace:*",
     "@aoagents/ao-plugin-agent-claude-code": "workspace:*",
+    "@aoagents/ao-plugin-agent-cn": "workspace:*",
     "@aoagents/ao-plugin-agent-codex": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",

--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -29,7 +29,7 @@ observability:
 
 defaults:
   runtime: tmux               # tmux | process
-  agent: claude-code          # claude-code | aider | codex | cursor | kimicode | opencode
+  agent: claude-code          # claude-code | aider | cn | codex | cursor | kimicode | opencode
   workspace: worktree         # worktree | clone
   notifiers:
     - desktop                 # desktop | discord | slack | webhook | composio | openclaw
@@ -182,7 +182,7 @@ notificationRouting:
 
 # ── Available plugins ───────────────────────────────────────────────
 #
-# Agent:     claude-code, aider, codex, cursor, kimicode, opencode
+# Agent:     claude-code, aider, cn, codex, cursor, kimicode, opencode
 # Runtime:   tmux, process
 # Workspace: worktree, clone
 # SCM:       github, gitlab

--- a/packages/cli/src/lib/detect-agent.ts
+++ b/packages/cli/src/lib/detect-agent.ts
@@ -17,6 +17,7 @@ export interface DetectedAgent {
 const AGENT_PLUGINS: Array<{ name: string; pkg: string }> = [
   { name: "claude-code", pkg: "@aoagents/ao-plugin-agent-claude-code" },
   { name: "aider", pkg: "@aoagents/ao-plugin-agent-aider" },
+  { name: "cn", pkg: "@aoagents/ao-plugin-agent-cn" },
   { name: "codex", pkg: "@aoagents/ao-plugin-agent-codex" },
   { name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -2,6 +2,7 @@ import type { Agent, OrchestratorConfig, PluginRegistry, SCM } from "@aoagents/a
 import claudeCodePlugin from "@aoagents/ao-plugin-agent-claude-code";
 import codexPlugin from "@aoagents/ao-plugin-agent-codex";
 import aiderPlugin from "@aoagents/ao-plugin-agent-aider";
+import cnPlugin from "@aoagents/ao-plugin-agent-cn";
 import cursorPlugin from "@aoagents/ao-plugin-agent-cursor";
 import kimicodePlugin from "@aoagents/ao-plugin-agent-kimicode";
 import opencodePlugin from "@aoagents/ao-plugin-agent-opencode";
@@ -11,6 +12,7 @@ const agentPlugins: Record<string, { create(): Agent }> = {
   "claude-code": claudeCodePlugin,
   codex: codexPlugin,
   aider: aiderPlugin,
+  cn: cnPlugin,
   cursor: cursorPlugin,
   kimicode: kimicodePlugin,
   opencode: opencodePlugin,

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1128,15 +1128,23 @@ describe("spawn", () => {
       }),
     };
 
-    const sm = createSessionManager({ config, registry: registryWithPostLaunch });
+    const sm = createSessionManager({
+      config,
+      registry: registryWithPostLaunch,
+      postLaunchPromptDelayMs: 0,
+    });
     const session = await sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
 
     expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({ id: "rt-1" }),
       expect.stringContaining("Fix the bug"),
     );
+    const deliveredPrompt = vi.mocked(mockRuntime.sendMessage).mock.calls[0]?.[1] as string;
+    expect(deliveredPrompt).toContain("Agent Orchestrator");
+    expect(deliveredPrompt).toContain("Session Lifecycle");
+    expect(deliveredPrompt).toContain("Fix the bug");
     expect(session.metadata["promptDelivered"]).toBe("true");
-  }, 10_000);
+  });
 
   it("writes worker system prompt to file and passes only explicit task prompt to agent", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1113,6 +1113,31 @@ describe("spawn", () => {
     expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("sends prompt post-launch when agent requests interactive prompt delivery", async () => {
+    const postLaunchAgent: Agent = {
+      ...mockAgent,
+      promptDelivery: "post-launch",
+    };
+    const registryWithPostLaunch: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return postLaunchAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    const sm = createSessionManager({ config, registry: registryWithPostLaunch });
+    const session = await sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
+
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "rt-1" }),
+      expect.stringContaining("Fix the bug"),
+    );
+    expect(session.metadata["promptDelivered"]).toBe("true");
+  }, 10_000);
+
   it("writes worker system prompt to file and passes only explicit task prompt to agent", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -44,6 +44,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "claude-code", pkg: "@aoagents/ao-plugin-agent-claude-code" },
   { slot: "agent", name: "codex", pkg: "@aoagents/ao-plugin-agent-codex" },
   { slot: "agent", name: "aider", pkg: "@aoagents/ao-plugin-agent-aider" },
+  { slot: "agent", name: "cn", pkg: "@aoagents/ao-plugin-agent-cn" },
   { slot: "agent", name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { slot: "agent", name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
   { slot: "agent", name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -11,7 +11,15 @@
  * Reference: scripts/claude-ao-session, scripts/send-to-session
  */
 
-import { statSync, existsSync, writeFileSync, mkdirSync, utimesSync, unlinkSync } from "node:fs";
+import {
+  statSync,
+  existsSync,
+  writeFileSync,
+  mkdirSync,
+  utimesSync,
+  unlinkSync,
+  readFileSync,
+} from "node:fs";
 import { recordActivityEvent } from "./activity-events.js";
 import { execFile } from "node:child_process";
 import { basename, join, resolve } from "node:path";
@@ -300,17 +308,31 @@ async function deliverPostLaunchPrompt(options: {
   runtime: Runtime;
   handle: RuntimeHandle;
   prompt: string | undefined;
+  systemPromptFile?: string;
   sessionId: SessionId;
+  baseDelayMs?: number;
 }): Promise<boolean | null> {
-  if (options.agent.promptDelivery !== "post-launch" || !options.prompt) {
+  if (options.agent.promptDelivery !== "post-launch") {
     return null;
   }
 
+  const promptParts: string[] = [];
+  if (options.systemPromptFile) {
+    promptParts.push(readFileSync(options.systemPromptFile, "utf8").trim());
+  }
+  if (options.prompt?.trim()) {
+    promptParts.push(options.prompt.trim());
+  }
+
+  const prompt = promptParts.filter(Boolean).join("\n\n---\n\n");
+  if (!prompt) return null;
+
+  const baseDelayMs = options.baseDelayMs ?? POST_LAUNCH_PROMPT_BASE_DELAY_MS;
   let lastError: Error | undefined;
   for (let attempt = 1; attempt <= POST_LAUNCH_PROMPT_ATTEMPTS; attempt++) {
     try {
-      await sleep(POST_LAUNCH_PROMPT_BASE_DELAY_MS * attempt);
-      await options.runtime.sendMessage(options.handle, options.prompt);
+      await sleep(baseDelayMs * attempt);
+      await options.runtime.sendMessage(options.handle, prompt);
       return true;
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
@@ -405,6 +427,7 @@ function metadataToSession(
 export interface SessionManagerDeps {
   config: OrchestratorConfig;
   registry: PluginRegistry;
+  postLaunchPromptDelayMs?: number;
 }
 
 /** Create a SessionManager instance. */
@@ -1557,7 +1580,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         runtime: plugins.runtime,
         handle,
         prompt: agentLaunchConfig.prompt,
+        systemPromptFile: agentLaunchConfig.systemPromptFile,
         sessionId,
+        baseDelayMs: deps.postLaunchPromptDelayMs,
       });
       if (promptDelivered !== null) {
         session.metadata["promptDelivered"] = String(promptDelivered);
@@ -2042,8 +2067,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         agent: plugins.agent,
         runtime: plugins.runtime,
         handle,
-        prompt: orchestratorConfig.systemPrompt,
+        prompt: undefined,
+        systemPromptFile,
         sessionId,
+        baseDelayMs: deps.postLaunchPromptDelayMs,
       });
       if (promptDelivered !== null) {
         session.metadata["promptDelivered"] = String(promptDelivered);

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -288,9 +288,43 @@ const SEND_BOOTSTRAP_READY_TIMEOUT_MS = 20_000;
 const SEND_BOOTSTRAP_STABLE_POLLS = 2;
 const ENSURE_ORCHESTRATOR_CONFLICT_WAIT_MS = 20_000;
 const ENSURE_ORCHESTRATOR_CONFLICT_POLL_MS = 250;
+const POST_LAUNCH_PROMPT_ATTEMPTS = 3;
+const POST_LAUNCH_PROMPT_BASE_DELAY_MS = 3_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function deliverPostLaunchPrompt(options: {
+  agent: Agent;
+  runtime: Runtime;
+  handle: RuntimeHandle;
+  prompt: string | undefined;
+  sessionId: SessionId;
+}): Promise<boolean | null> {
+  if (options.agent.promptDelivery !== "post-launch" || !options.prompt) {
+    return null;
+  }
+
+  let lastError: Error | undefined;
+  for (let attempt = 1; attempt <= POST_LAUNCH_PROMPT_ATTEMPTS; attempt++) {
+    try {
+      await sleep(POST_LAUNCH_PROMPT_BASE_DELAY_MS * attempt);
+      await options.runtime.sendMessage(options.handle, options.prompt);
+      return true;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      console.error(
+        `[session-manager] Prompt delivery attempt ${attempt}/${POST_LAUNCH_PROMPT_ATTEMPTS} failed for ${options.sessionId}: ${lastError.message}`,
+      );
+    }
+  }
+
+  console.error(
+    `[session-manager] Failed to deliver prompt to session ${options.sessionId}. ` +
+      `User can retry with 'ao send'. Last error: ${lastError?.message}`,
+  );
+  return false;
 }
 
 async function isAgentProcessNotDefinitelyMissing(
@@ -1518,6 +1552,17 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         }
       }
 
+      const promptDelivered = await deliverPostLaunchPrompt({
+        agent: plugins.agent,
+        runtime: plugins.runtime,
+        handle,
+        prompt: agentLaunchConfig.prompt,
+        sessionId,
+      });
+      if (promptDelivered !== null) {
+        session.metadata["promptDelivered"] = String(promptDelivered);
+      }
+
       if (Object.keys(session.metadata || {}).length > 0) {
         updateMetadata(sessionsDir, sessionId, session.metadata);
       }
@@ -1527,8 +1572,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       // final form. Dismiss the stack so nothing below can trigger a rollback.
       cleanupStack.dismiss();
 
-      // Prompt is delivered inline via the agent's launch command (positional argument).
-      // No post-launch polling needed — the prompt is part of process invocation.
+      // Prompt delivery has completed (inline via launch command, or post-launch
+      // via runtime.sendMessage for agents that require interactive startup).
       recordActivityEvent({
         projectId: spawnConfig.projectId,
         sessionId,
@@ -1991,6 +2036,17 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         if (discovered) {
           session.metadata["opencodeSessionId"] = discovered;
         }
+      }
+
+      const promptDelivered = await deliverPostLaunchPrompt({
+        agent: plugins.agent,
+        runtime: plugins.runtime,
+        handle,
+        prompt: orchestratorConfig.systemPrompt,
+        sessionId,
+      });
+      if (promptDelivered !== null) {
+        session.metadata["promptDelivered"] = String(promptDelivered);
       }
 
       if (Object.keys(session.metadata || {}).length > 0) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -475,6 +475,14 @@ export interface Agent {
   /** Process name to look for (e.g. "claude", "codex", "aider") */
   readonly processName: string;
 
+  /**
+   * How the initial prompt should be delivered to the agent.
+   * - "inline" (default): prompt is included in the launch command.
+   * - "post-launch": prompt is sent via runtime.sendMessage() after the agent starts,
+   *   keeping the agent in interactive mode.
+   */
+  readonly promptDelivery?: "inline" | "post-launch";
+
   /** Get the shell command to launch this agent */
   getLaunchCommand(config: AgentLaunchConfig): string;
 

--- a/packages/plugins/agent-cn/package.json
+++ b/packages/plugins/agent-cn/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@aoagents/ao-plugin-agent-cn",
+  "version": "0.1.0",
+  "description": "Agent plugin: Continue CLI",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-cn"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*",
+    "which": "^6.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "@types/which": "^3.0.4",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-cn/src/index.test.ts
+++ b/packages/plugins/agent-cn/src/index.test.ts
@@ -318,12 +318,33 @@ describe("recordActivity", () => {
     expect(classify?.("Would you like to continue?\n> Continue (tab)")).toBe("waiting_input");
   });
 
+  it("ignores stale tool permission prompts when later output is active", async () => {
+    await agent.recordActivity?.(makeSession(), "Would you like to continue?\nBuilding package");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Would you like to continue?\nBuilding package")).toBe("active");
+  });
+
   it("classifies auth failures as blocked", async () => {
     await agent.recordActivity?.(makeSession(), "Not authenticated. Please run 'cn login' first.");
     const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
       | ((output: string) => string)
       | undefined;
     expect(classify?.("Not authenticated. Please run 'cn login' first.")).toBe("blocked");
+  });
+
+  it("ignores stale auth failures when later output is active", async () => {
+    await agent.recordActivity?.(
+      makeSession(),
+      "Not authenticated. Please run 'cn login' first.\nRetrying request",
+    );
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Not authenticated. Please run 'cn login' first.\nRetrying request")).toBe(
+      "active",
+    );
   });
 
   it("classifies ordinary output as active", async () => {

--- a/packages/plugins/agent-cn/src/index.test.ts
+++ b/packages/plugins/agent-cn/src/index.test.ts
@@ -21,13 +21,11 @@ const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
 const {
   mockReadLastActivityEntry,
   mockRecordTerminalActivity,
-  mockSetupPathWrapperWorkspace,
   mockExecFileAsync,
   mockWhichSync,
 } = vi.hoisted(() => ({
   mockReadLastActivityEntry: vi.fn().mockResolvedValue(null),
   mockRecordTerminalActivity: vi.fn().mockResolvedValue(undefined),
-  mockSetupPathWrapperWorkspace: vi.fn().mockResolvedValue(undefined),
   mockExecFileAsync: vi.fn(),
   mockWhichSync: vi.fn(),
 }));
@@ -38,7 +36,6 @@ vi.mock("@aoagents/ao-core", async (importOriginal) => {
     ...actual,
     readLastActivityEntry: mockReadLastActivityEntry,
     recordTerminalActivity: mockRecordTerminalActivity,
-    setupPathWrapperWorkspace: mockSetupPathWrapperWorkspace,
   };
 });
 
@@ -223,8 +220,8 @@ describe("getEnvironment", () => {
     const env = agent.getEnvironment(makeLaunchConfig());
     expect(env["AO_SESSION_ID"]).toBe("sess-1");
     expect(env["AO_ISSUE_ID"]).toBeUndefined();
-    expect(env["PATH"]).toContain(".ao");
-    expect(env["GH_PATH"]).toBeTruthy();
+    expect(env["PATH"]).toBeUndefined();
+    expect(env["GH_PATH"]).toBeUndefined();
     expect(env["CONTINUE_CLI_ENABLE_TELEMETRY"]).toBe("0");
     expect(env["CONTINUE_METRICS_ENABLED"]).toBe("0");
     expect(env["CONTINUE_ALLOW_ANONYMOUS_TELEMETRY"]).toBe("0");
@@ -337,6 +334,14 @@ describe("recordActivity", () => {
     expect(classify?.("Thinking about your request")).toBe("active");
   });
 
+  it("keeps normal progress lines that mention errors active", async () => {
+    await agent.recordActivity?.(makeSession(), "Fixing error in authentication module");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Fixing error in authentication module")).toBe("active");
+  });
+
   it("skips recording when workspacePath is missing", async () => {
     await agent.recordActivity?.(makeSession({ workspacePath: null }), "still running");
     expect(mockRecordTerminalActivity).not.toHaveBeenCalled();
@@ -414,19 +419,5 @@ describe("session and restore", () => {
       },
     );
     expect(cmd).toBeNull();
-  });
-});
-
-describe("workspace hooks", () => {
-  const agent = create();
-
-  it("sets up path wrappers for workspace hooks", async () => {
-    await agent.setupWorkspaceHooks?.("/workspace/test", { dataDir: "/tmp/sessions" });
-    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
-  });
-
-  it("sets up path wrappers after launch when workspacePath exists", async () => {
-    await agent.postLaunchSetup?.(makeSession({ workspacePath: "/workspace/test" }));
-    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
   });
 });

--- a/packages/plugins/agent-cn/src/index.test.ts
+++ b/packages/plugins/agent-cn/src/index.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  PROCESS_PROBE_INDETERMINATE,
+  type AgentLaunchConfig,
+  type RuntimeHandle,
+  type Session,
+} from "@aoagents/ao-core";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as {
+  name: string;
+  version: string;
+  description: string;
+};
+const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
+const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
+  ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)
+  : packageJson.name;
+
+const {
+  mockReadLastActivityEntry,
+  mockRecordTerminalActivity,
+  mockSetupPathWrapperWorkspace,
+  mockExecFileAsync,
+  mockWhichSync,
+} = vi.hoisted(() => ({
+  mockReadLastActivityEntry: vi.fn().mockResolvedValue(null),
+  mockRecordTerminalActivity: vi.fn().mockResolvedValue(undefined),
+  mockSetupPathWrapperWorkspace: vi.fn().mockResolvedValue(undefined),
+  mockExecFileAsync: vi.fn(),
+  mockWhichSync: vi.fn(),
+}));
+
+vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    readLastActivityEntry: mockReadLastActivityEntry,
+    recordTerminalActivity: mockRecordTerminalActivity,
+    setupPathWrapperWorkspace: mockSetupPathWrapperWorkspace,
+  };
+});
+
+vi.mock("which", () => ({
+  default: {
+    sync: mockWhichSync,
+  },
+  sync: mockWhichSync,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: (...args: unknown[]) => {
+    const callback = args[args.length - 1];
+    const result = mockExecFileAsync(...args.slice(0, -1));
+    if (typeof callback === "function" && result && typeof result.then === "function") {
+      result.then(
+        (value: { stdout: string; stderr: string }) => callback(null, value),
+        (err: Error) => callback(err),
+      );
+    }
+  },
+}));
+
+import { create, detect, manifest, default as defaultExport } from "./index.js";
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "test-1",
+    projectId: "test-project",
+    status: "working",
+    activity: "active",
+    activitySignal: {
+      state: "valid",
+      activity: "active",
+      source: "runtime",
+      timestamp: new Date(),
+    },
+    lifecycle: {} as Session["lifecycle"],
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/workspace/test",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeTmuxHandle(id = "test-session"): RuntimeHandle {
+  return { id, runtimeName: "tmux", data: {} };
+}
+
+function makeProcessHandle(pid?: number | string): RuntimeHandle {
+  return { id: "proc-1", runtimeName: "process", data: pid !== undefined ? { pid } : {} };
+}
+
+function makeLaunchConfig(overrides: Partial<AgentLaunchConfig> = {}): AgentLaunchConfig {
+  return {
+    sessionId: "sess-1",
+    projectConfig: {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/repo",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+      agentConfig: {
+        model: "provider/gpt-4o-mini",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeActivityResult(
+  state: "active" | "ready" | "idle" | "waiting_input" | "blocked",
+  ts: Date,
+): {
+  entry: {
+    state: "active" | "ready" | "idle" | "waiting_input" | "blocked";
+    ts: string;
+    source: string;
+  };
+  modifiedAt: Date;
+} {
+  return {
+    entry: {
+      state,
+      ts: ts.toISOString(),
+      source: "terminal",
+    },
+    modifiedAt: ts,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWhichSync.mockReset();
+  mockExecFileAsync.mockReset();
+});
+
+describe("manifest", () => {
+  it("has correct Continue CLI manifest", () => {
+    expect(manifest).toEqual({
+      name: pluginName,
+      slot: "agent",
+      description: packageJson.description,
+      version: packageJson.version,
+      displayName: "Continue CLI",
+    });
+  });
+});
+
+describe("create", () => {
+  it("uses cn as process name and post-launch prompt mode", () => {
+    const agent = create();
+    expect(agent.name).toBe(pluginName);
+    expect(agent.processName).toBe(pluginName);
+    expect(agent.promptDelivery).toBe("post-launch");
+  });
+
+  it("exports plugin module shape", () => {
+    expect(defaultExport.manifest).toBe(manifest);
+    expect(typeof defaultExport.create).toBe("function");
+  });
+});
+
+describe("detect", () => {
+  it("returns true when which resolves", () => {
+    mockWhichSync.mockReturnValue("/usr/local/bin/cn");
+    expect(detect()).toBe(true);
+  });
+
+  it("returns false when which fails", () => {
+    mockWhichSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(detect()).toBe(false);
+  });
+});
+
+describe("getLaunchCommand", () => {
+  const agent = create();
+
+  it("uses interactive launch without session metadata", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig());
+    expect(cmd).toBe("cn");
+  });
+
+  it("still launches fresh when session metadata is present", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        projectConfig: {
+          ...makeLaunchConfig().projectConfig,
+          agentConfig: { continueSessionId: "2dbd6c3b-89bf-4fa1-b5dd-d5a84859befa" },
+        },
+      }),
+    );
+    expect(cmd).toBe("cn");
+  });
+
+  it("does not include prompt flags in launch command", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        prompt: "Do work",
+        systemPrompt: "You are helpful",
+        systemPromptFile: "/tmp/prompt.md",
+      }),
+    );
+    expect(cmd).toBe("cn");
+    expect(cmd).not.toContain("-p");
+    expect(cmd).not.toContain("--prompt");
+  });
+});
+
+describe("getEnvironment", () => {
+  const agent = create();
+
+  it("writes AO session keys and Continue CLI flags", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["AO_SESSION_ID"]).toBe("sess-1");
+    expect(env["AO_ISSUE_ID"]).toBeUndefined();
+    expect(env["PATH"]).toContain(".ao");
+    expect(env["GH_PATH"]).toBeTruthy();
+    expect(env["CONTINUE_CLI_ENABLE_TELEMETRY"]).toBe("0");
+    expect(env["CONTINUE_METRICS_ENABLED"]).toBe("0");
+    expect(env["CONTINUE_ALLOW_ANONYMOUS_TELEMETRY"]).toBe("0");
+  });
+
+  it("includes AO_ISSUE_ID when provided", () => {
+    const env = agent.getEnvironment(makeLaunchConfig({ issueId: "INT-42" }));
+    expect(env["AO_ISSUE_ID"]).toBe("INT-42");
+  });
+});
+
+describe("isProcessRunning", () => {
+  const agent = create();
+
+  it("returns true when cn is on tmux pane", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") {
+        return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      }
+      if (cmd === "ps") {
+        return Promise.resolve({
+          stdout: `  PID TT       ARGS\n  789 ttys003  cn\n`,
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("returns false when tmux process is missing", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      if (cmd === "ps") {
+        return Promise.resolve({ stdout: "  PID TT      ARGS\n  789 ttys003  bash\n", stderr: "" });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns indeterminate when tmux probing fails", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("tmux failed"));
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(PROCESS_PROBE_INDETERMINATE);
+  });
+
+  it("returns true when process handle pid is alive", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(123, 0);
+    killSpy.mockRestore();
+  });
+
+  it("treats EPERM as a live process", async () => {
+    const err = Object.assign(new Error("EPERM"), { code: "EPERM" });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw err;
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
+    killSpy.mockRestore();
+  });
+
+  it("returns false when process handle pid is dead", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(false);
+    killSpy.mockRestore();
+  });
+});
+
+describe("recordActivity", () => {
+  const agent = create();
+
+  it("classifies idle terminal output when recording activity", async () => {
+    await agent.recordActivity?.(makeSession(), "Continue\nEnter text...");
+    expect(mockRecordTerminalActivity).toHaveBeenCalledWith(
+      "/workspace/test",
+      "Continue\nEnter text...",
+      expect.any(Function),
+    );
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Continue\nEnter text...")).toBe("idle");
+  });
+
+  it("classifies tool permission prompts as waiting_input", async () => {
+    await agent.recordActivity?.(makeSession(), "Would you like to continue?\n> Continue (tab)");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Would you like to continue?\n> Continue (tab)")).toBe("waiting_input");
+  });
+
+  it("classifies auth failures as blocked", async () => {
+    await agent.recordActivity?.(makeSession(), "Not authenticated. Please run 'cn login' first.");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Not authenticated. Please run 'cn login' first.")).toBe("blocked");
+  });
+
+  it("classifies ordinary output as active", async () => {
+    await agent.recordActivity?.(makeSession(), "Thinking about your request");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Thinking about your request")).toBe("active");
+  });
+
+  it("skips recording when workspacePath is missing", async () => {
+    await agent.recordActivity?.(makeSession({ workspacePath: null }), "still running");
+    expect(mockRecordTerminalActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe("getActivityState", () => {
+  const agent = create();
+
+  it("falls back to exited when runtime handle is missing", async () => {
+    const state = await agent.getActivityState(makeSession({ runtimeHandle: null }));
+    expect(state).toMatchObject({ state: "exited" });
+  });
+
+  it("returns null when liveness probing is indeterminate", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("tmux failed"));
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeTmuxHandle(), metadata: {} }),
+    );
+    expect(state).toBeNull();
+  });
+
+  it("uses activity JSONL state", async () => {
+    const activityAt = new Date();
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("waiting_input", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("waiting_input");
+    expect(state?.timestamp?.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("decays stale fallback state to idle", async () => {
+    const activityAt = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("active", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("idle");
+    expect(state?.timestamp?.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("returns null when no activity data is available", async () => {
+    mockReadLastActivityEntry.mockResolvedValue(null);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state).toBeNull();
+    killSpy.mockRestore();
+  });
+});
+
+describe("session and restore", () => {
+  const agent = create();
+
+  it("does not expose session info without a stable current Continue session id source", async () => {
+    await expect(agent.getSessionInfo(makeSession())).resolves.toBeNull();
+  });
+
+  it("does not build a restore command from AO metadata", async () => {
+    const cmd = await agent.getRestoreCommand?.(
+      makeSession({ metadata: { continueSessionId: "abc" } }),
+      {
+        name: "my-project",
+        repo: "owner/repo",
+        path: "/workspace/repo",
+        defaultBranch: "main",
+        sessionPrefix: "my",
+        agentConfig: {},
+      },
+    );
+    expect(cmd).toBeNull();
+  });
+});
+
+describe("workspace hooks", () => {
+  const agent = create();
+
+  it("sets up path wrappers for workspace hooks", async () => {
+    await agent.setupWorkspaceHooks?.("/workspace/test", { dataDir: "/tmp/sessions" });
+    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
+  });
+
+  it("sets up path wrappers after launch when workspacePath exists", async () => {
+    await agent.postLaunchSetup?.(makeSession({ workspacePath: "/workspace/test" }));
+    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
+  });
+});

--- a/packages/plugins/agent-cn/src/index.test.ts
+++ b/packages/plugins/agent-cn/src/index.test.ts
@@ -152,11 +152,11 @@ describe("manifest", () => {
 });
 
 describe("create", () => {
-  it("uses cn as process name and post-launch prompt mode", () => {
+  it("uses cn as process name and inline prompt mode", () => {
     const agent = create();
     expect(agent.name).toBe(pluginName);
     expect(agent.processName).toBe(pluginName);
-    expect(agent.promptDelivery).toBe("post-launch");
+    expect(agent.promptDelivery).toBeUndefined();
   });
 
   it("exports plugin module shape", () => {
@@ -199,7 +199,7 @@ describe("getLaunchCommand", () => {
     expect(cmd).toBe("cn");
   });
 
-  it("does not include prompt flags in launch command", () => {
+  it("passes the system prompt file and task prompt to Continue CLI on launch", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({
         prompt: "Do work",
@@ -207,9 +207,17 @@ describe("getLaunchCommand", () => {
         systemPromptFile: "/tmp/prompt.md",
       }),
     );
-    expect(cmd).toBe("cn");
-    expect(cmd).not.toContain("-p");
-    expect(cmd).not.toContain("--prompt");
+    expect(cmd).toBe("cn --prompt '/tmp/prompt.md' 'Do work'");
+  });
+
+  it("shell-escapes prompt arguments", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        prompt: "fix it's broken",
+        systemPromptFile: "/tmp/prompt with spaces.md",
+      }),
+    );
+    expect(cmd).toBe("cn --prompt '/tmp/prompt with spaces.md' 'fix it'\\''s broken'");
   });
 });
 

--- a/packages/plugins/agent-cn/src/index.test.ts
+++ b/packages/plugins/agent-cn/src/index.test.ts
@@ -294,6 +294,30 @@ describe("isProcessRunning", () => {
   });
 });
 
+describe("detectActivity", () => {
+  const agent = create();
+
+  it("classifies the current Continue permission prompt as waiting_input", () => {
+    expect(agent.detectActivity("Would you like to continue?\n> Continue (tab)")).toBe(
+      "waiting_input",
+    );
+  });
+
+  it("ignores stale permission prompts when latest output is active", () => {
+    expect(agent.detectActivity("Would you like to continue?\nBuilding package")).toBe("active");
+  });
+
+  it("ignores stale auth prompts when latest output is active", () => {
+    expect(
+      agent.detectActivity("Not authenticated. Please run 'cn login' first.\nBuilding package"),
+    ).toBe("active");
+  });
+
+  it("ignores stale error lines when latest output is active", () => {
+    expect(agent.detectActivity("Error: request failed\nBuilding package")).toBe("active");
+  });
+});
+
 describe("recordActivity", () => {
   const agent = create();
 

--- a/packages/plugins/agent-cn/src/index.ts
+++ b/packages/plugins/agent-cn/src/index.ts
@@ -46,16 +46,23 @@ function classifyCnTerminalOutput(terminalOutput: string): ActivityState {
 
   const lines = normalizedOutput.split("\n").map((line) => line.trim());
   const lastLine = lines[lines.length - 1] ?? "";
+  const nonEmptyLines = lines.filter(Boolean);
   const lastNonEmptyLine = [...lines].reverse().find(Boolean) ?? "";
+  const recentOutput = nonEmptyLines.slice(-3).join("\n");
 
   if (/^[>$#]\s*$/.test(lastLine)) return "idle";
   if (/Enter text\.\.\./i.test(lastNonEmptyLine)) return "idle";
-  if (/Would you like to continue\?/i.test(normalizedOutput)) return "waiting_input";
-  if (/Press enter to continue/i.test(normalizedOutput)) return "waiting_input";
-  if (/Press Enter for default/i.test(normalizedOutput)) return "waiting_input";
-  if (/Enter your .*API key/i.test(normalizedOutput)) return "waiting_input";
   if (
-    /Not authenticated|Please run ['"]?cn login|Authentication required/i.test(normalizedOutput)
+    /Would you like to continue\?/i.test(lastNonEmptyLine) ||
+    (/Would you like to continue\?/i.test(recentOutput) && /^>\s*\S/.test(lastNonEmptyLine))
+  ) {
+    return "waiting_input";
+  }
+  if (/Press enter to continue/i.test(lastNonEmptyLine)) return "waiting_input";
+  if (/Press Enter for default/i.test(lastNonEmptyLine)) return "waiting_input";
+  if (/Enter your .*API key/i.test(lastNonEmptyLine)) return "waiting_input";
+  if (
+    /Not authenticated|Please run ['"]?cn login|Authentication required/i.test(lastNonEmptyLine)
   ) {
     return "blocked";
   }

--- a/packages/plugins/agent-cn/src/index.ts
+++ b/packages/plugins/agent-cn/src/index.ts
@@ -7,6 +7,7 @@ import {
   isWindows,
   readLastActivityEntry,
   recordTerminalActivity,
+  shellEscape,
   type ActivityDetection,
   type ActivityState,
   type Agent,
@@ -88,10 +89,17 @@ function createCnAgent(): Agent {
   return {
     name: pluginName,
     processName: pluginName,
-    promptDelivery: "post-launch",
 
-    getLaunchCommand(_config: AgentLaunchConfig): string {
-      return "cn";
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      const args: string[] = [];
+      if (config.systemPromptFile) {
+        args.push("--prompt", shellEscape(config.systemPromptFile));
+      }
+      if (config.prompt) {
+        args.push(shellEscape(config.prompt));
+      }
+
+      return args.length > 0 ? `cn ${args.join(" ")}` : "cn";
     },
 
     getEnvironment(config: AgentLaunchConfig): Record<string, string> {

--- a/packages/plugins/agent-cn/src/index.ts
+++ b/packages/plugins/agent-cn/src/index.ts
@@ -1,0 +1,227 @@
+import {
+  DEFAULT_ACTIVE_WINDOW_MS,
+  DEFAULT_READY_THRESHOLD_MS,
+  PROCESS_PROBE_INDETERMINATE,
+  PREFERRED_GH_PATH,
+  buildAgentPath,
+  checkActivityLogState,
+  getActivityFallbackState,
+  isWindows,
+  readLastActivityEntry,
+  recordTerminalActivity,
+  setupPathWrapperWorkspace,
+  type ActivityDetection,
+  type ActivityState,
+  type Agent,
+  type AgentLaunchConfig,
+  type AgentSessionInfo,
+  type PluginModule,
+  type ProcessProbeResult,
+  type ProjectConfig,
+  type RuntimeHandle,
+  type Session,
+  type WorkspaceHooksConfig,
+} from "@aoagents/ao-core";
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import { promisify } from "node:util";
+import which from "which";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as {
+  name: string;
+  version: string;
+  description: string;
+};
+const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
+const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
+  ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)
+  : packageJson.name;
+
+const execFileAsync = promisify(execFile);
+const ANSI_ESCAPE_RE = new RegExp(
+  `${String.fromCharCode(27)}(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~])`,
+  "g",
+);
+
+function classifyCnTerminalOutput(terminalOutput: string): ActivityState {
+  const normalizedOutput = terminalOutput.replaceAll(ANSI_ESCAPE_RE, "").trim();
+  if (!normalizedOutput) return "idle";
+
+  const lines = normalizedOutput.split("\n").map((line) => line.trim());
+  const lastLine = lines[lines.length - 1] ?? "";
+  const lastNonEmptyLine = [...lines].reverse().find(Boolean) ?? "";
+
+  if (/^[>$#]\s*$/.test(lastLine)) return "idle";
+  if (/Enter text\.\.\./i.test(lastNonEmptyLine)) return "idle";
+  if (/Would you like to continue\?/i.test(normalizedOutput)) return "waiting_input";
+  if (/Press enter to continue/i.test(normalizedOutput)) return "waiting_input";
+  if (/Press Enter for default/i.test(normalizedOutput)) return "waiting_input";
+  if (/Enter your .*API key/i.test(normalizedOutput)) return "waiting_input";
+  if (
+    /Not authenticated|Please run ['"]?cn login|Authentication required/i.test(normalizedOutput)
+  ) {
+    return "blocked";
+  }
+  if (/error|failed|exception/i.test(lastLine)) return "blocked";
+
+  return "active";
+}
+
+export const manifest = {
+  name: pluginName,
+  slot: "agent" as const,
+  description: packageJson.description,
+  version: packageJson.version,
+  displayName: "Continue CLI",
+};
+
+function createCnAgent(): Agent {
+  return {
+    name: pluginName,
+    processName: pluginName,
+    promptDelivery: "post-launch",
+
+    getLaunchCommand(_config: AgentLaunchConfig): string {
+      return "cn";
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      const env: Record<string, string> = {};
+      env["AO_SESSION_ID"] = config.sessionId;
+      if (config.issueId) {
+        env["AO_ISSUE_ID"] = config.issueId;
+      }
+
+      env["PATH"] = buildAgentPath(process.env["PATH"]);
+      env["GH_PATH"] = PREFERRED_GH_PATH;
+      env["CONTINUE_CLI_ENABLE_TELEMETRY"] = "0";
+      env["CONTINUE_METRICS_ENABLED"] = "0";
+      env["CONTINUE_ALLOW_ANONYMOUS_TELEMETRY"] = "0";
+
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      return classifyCnTerminalOutput(terminalOutput);
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
+      const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
+      const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
+
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (running === PROCESS_PROBE_INDETERMINATE) return null;
+      if (!running) return { state: "exited", timestamp: exitedAt };
+
+      let activityResult: Awaited<ReturnType<typeof readLastActivityEntry>> = null;
+      if (session.workspacePath) {
+        activityResult = await readLastActivityEntry(session.workspacePath);
+        const activityState = checkActivityLogState(activityResult);
+        if (activityState) return activityState;
+      }
+
+      const fallback = getActivityFallbackState(activityResult, activeWindowMs, threshold);
+      if (fallback) return fallback;
+
+      return null;
+    },
+
+    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
+      if (!session.workspacePath) return;
+      await recordTerminalActivity(session.workspacePath, terminalOutput, (output: string) =>
+        classifyCnTerminalOutput(output),
+      );
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
+      try {
+        if (handle.runtimeName === "tmux" && handle.id) {
+          if (isWindows()) return PROCESS_PROBE_INDETERMINATE;
+
+          const { stdout: ttyOut } = await execFileAsync(
+            "tmux",
+            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+            { timeout: 30_000 },
+          );
+          const ttys = ttyOut
+            .trim()
+            .split("\n")
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (ttys.length === 0) return false;
+
+          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
+            timeout: 30_000,
+          });
+          if (!psOut) return PROCESS_PROBE_INDETERMINATE;
+
+          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
+          const processRe = /(?:^|\/)(?:cn|cn\.js)(?:\s|$)/;
+          for (const line of psOut.split("\n")) {
+            const cols = line.trimStart().split(/\s+/);
+            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+            const args = cols.slice(2).join(" ");
+            if (processRe.test(args)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        const rawPid = handle.data["pid"];
+        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+        if (Number.isFinite(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+            return true;
+          } catch (err: unknown) {
+            if (err instanceof Error && (err as NodeJS.ErrnoException).code === "EPERM") {
+              return true;
+            }
+            return false;
+          }
+        }
+        return false;
+      } catch {
+        return PROCESS_PROBE_INDETERMINATE;
+      }
+    },
+
+    async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {
+      return null;
+    },
+
+    async getRestoreCommand(_session: Session, _project: ProjectConfig): Promise<string | null> {
+      return null;
+    },
+
+    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+      await setupPathWrapperWorkspace(workspacePath);
+    },
+
+    async postLaunchSetup(session: Session): Promise<void> {
+      if (!session.workspacePath) return;
+      await setupPathWrapperWorkspace(session.workspacePath);
+    },
+  };
+}
+
+export function create(): Agent {
+  return createCnAgent();
+}
+
+export function detect(): boolean {
+  try {
+    return Boolean(which.sync("cn"));
+  } catch {
+    return false;
+  }
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-cn/src/index.ts
+++ b/packages/plugins/agent-cn/src/index.ts
@@ -2,14 +2,11 @@ import {
   DEFAULT_ACTIVE_WINDOW_MS,
   DEFAULT_READY_THRESHOLD_MS,
   PROCESS_PROBE_INDETERMINATE,
-  PREFERRED_GH_PATH,
-  buildAgentPath,
   checkActivityLogState,
   getActivityFallbackState,
   isWindows,
   readLastActivityEntry,
   recordTerminalActivity,
-  setupPathWrapperWorkspace,
   type ActivityDetection,
   type ActivityState,
   type Agent,
@@ -20,7 +17,6 @@ import {
   type ProjectConfig,
   type RuntimeHandle,
   type Session,
-  type WorkspaceHooksConfig,
 } from "@aoagents/ao-core";
 import { execFile } from "node:child_process";
 import { createRequire } from "node:module";
@@ -63,7 +59,7 @@ function classifyCnTerminalOutput(terminalOutput: string): ActivityState {
   ) {
     return "blocked";
   }
-  if (/error|failed|exception/i.test(lastLine)) return "blocked";
+  if (/^\s*(error|failed|exception)\b/i.test(lastLine)) return "blocked";
 
   return "active";
 }
@@ -93,8 +89,6 @@ function createCnAgent(): Agent {
         env["AO_ISSUE_ID"] = config.issueId;
       }
 
-      env["PATH"] = buildAgentPath(process.env["PATH"]);
-      env["GH_PATH"] = PREFERRED_GH_PATH;
       env["CONTINUE_CLI_ENABLE_TELEMETRY"] = "0";
       env["CONTINUE_METRICS_ENABLED"] = "0";
       env["CONTINUE_ALLOW_ANONYMOUS_TELEMETRY"] = "0";
@@ -201,14 +195,6 @@ function createCnAgent(): Agent {
       return null;
     },
 
-    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
-      await setupPathWrapperWorkspace(workspacePath);
-    },
-
-    async postLaunchSetup(session: Session): Promise<void> {
-      if (!session.workspacePath) return;
-      await setupPathWrapperWorkspace(session.workspacePath);
-    },
   };
 }
 

--- a/packages/plugins/agent-cn/src/index.ts
+++ b/packages/plugins/agent-cn/src/index.ts
@@ -47,26 +47,31 @@ function classifyCnTerminalOutput(terminalOutput: string): ActivityState {
   const lines = normalizedOutput.split("\n").map((line) => line.trim());
   const lastLine = lines[lines.length - 1] ?? "";
   const nonEmptyLines = lines.filter(Boolean);
-  const lastNonEmptyLine = [...lines].reverse().find(Boolean) ?? "";
-  const recentOutput = nonEmptyLines.slice(-3).join("\n");
+  const lastNonEmptyLine = nonEmptyLines[nonEmptyLines.length - 1] ?? "";
+  const previousNonEmptyLine = nonEmptyLines[nonEmptyLines.length - 2] ?? "";
+  const lastLineIsBarePrompt = /^[>$#]\s*$/.test(lastLine);
+  const latestRelevantLine = lastLineIsBarePrompt ? previousNonEmptyLine : lastNonEmptyLine;
+  const latestRelevantText =
+    /^>\s*\S/.test(latestRelevantLine) && /Would you like to continue\?/i.test(previousNonEmptyLine)
+      ? `${previousNonEmptyLine}\n${latestRelevantLine}`
+      : latestRelevantLine;
 
-  if (/^[>$#]\s*$/.test(lastLine)) return "idle";
-  if (/Enter text\.\.\./i.test(lastNonEmptyLine)) return "idle";
+  if (!latestRelevantLine) return "idle";
+  if (/Enter text\.\.\./i.test(latestRelevantLine)) return "idle";
   if (
-    /Would you like to continue\?/i.test(lastNonEmptyLine) ||
-    (/Would you like to continue\?/i.test(recentOutput) && /^>\s*\S/.test(lastNonEmptyLine))
+    /Would you like to continue\?/i.test(latestRelevantText) ||
+    /Press enter to continue/i.test(latestRelevantText) ||
+    /Press Enter for default/i.test(latestRelevantText) ||
+    /Enter your .*API key/i.test(latestRelevantText)
   ) {
     return "waiting_input";
   }
-  if (/Press enter to continue/i.test(lastNonEmptyLine)) return "waiting_input";
-  if (/Press Enter for default/i.test(lastNonEmptyLine)) return "waiting_input";
-  if (/Enter your .*API key/i.test(lastNonEmptyLine)) return "waiting_input";
   if (
-    /Not authenticated|Please run ['"]?cn login|Authentication required/i.test(lastNonEmptyLine)
+    /Not authenticated|Please run ['"]?cn login|Authentication required/i.test(latestRelevantText)
   ) {
     return "blocked";
   }
-  if (/^\s*(error|failed|exception)\b/i.test(lastLine)) return "blocked";
+  if (/^\s*(error|failed|exception)\b/i.test(latestRelevantLine)) return "blocked";
 
   return "active";
 }

--- a/packages/plugins/agent-cn/tsconfig.json
+++ b/packages/plugins/agent-cn/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@aoagents/ao-core": "workspace:*",
     "@aoagents/ao-plugin-agent-claude-code": "workspace:*",
+    "@aoagents/ao-plugin-agent-cn": "workspace:*",
     "@aoagents/ao-plugin-agent-codex": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -37,6 +37,7 @@ import pluginRuntimeTmux from "@aoagents/ao-plugin-runtime-tmux";
 import pluginRuntimeProcess from "@aoagents/ao-plugin-runtime-process";
 import pluginAgentClaudeCode from "@aoagents/ao-plugin-agent-claude-code";
 import pluginAgentCodex from "@aoagents/ao-plugin-agent-codex";
+import pluginAgentCn from "@aoagents/ao-plugin-agent-cn";
 import pluginAgentCursor from "@aoagents/ao-plugin-agent-cursor";
 import pluginAgentKimicode from "@aoagents/ao-plugin-agent-kimicode";
 import pluginAgentOpencode from "@aoagents/ao-plugin-agent-opencode";
@@ -109,6 +110,7 @@ async function initServices(): Promise<Services> {
   registry.register(pluginRuntimeProcess);
   registry.register(pluginAgentClaudeCode);
   registry.register(pluginAgentCodex);
+  registry.register(pluginAgentCn);
   registry.register(pluginAgentCursor);
   registry.register(pluginAgentKimicode);
   registry.register(pluginAgentOpencode);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       '@aoagents/ao-plugin-agent-claude-code':
         specifier: workspace:*
         version: link:../plugins/agent-claude-code
+      '@aoagents/ao-plugin-agent-cn':
+        specifier: workspace:*
+        version: link:../plugins/agent-cn
       '@aoagents/ao-plugin-agent-codex':
         specifier: workspace:*
         version: link:../plugins/agent-codex
@@ -300,6 +303,28 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/plugins/agent-cn:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+      which:
+        specifier: ^6.0.1
+        version: 6.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -682,6 +707,9 @@ importers:
       '@aoagents/ao-plugin-agent-claude-code':
         specifier: workspace:*
         version: link:../plugins/agent-claude-code
+      '@aoagents/ao-plugin-agent-cn':
+        specifier: workspace:*
+        version: link:../plugins/agent-cn
       '@aoagents/ao-plugin-agent-codex':
         specifier: workspace:*
         version: link:../plugins/agent-codex
@@ -1974,6 +2002,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/which@3.0.4':
+    resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
+
+  '@types/wrap-ansi@3.0.0':
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -5076,6 +5110,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/which@3.0.4': {}
+
+  '@types/wrap-ansi@3.0.0': {}
 
   '@types/ws@8.18.1':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `@aoagents/ao-plugin-agent-cn` for Continue CLI (`cn`) using the Forge-derived plugin shape.
- Wire `cn` into built-in agent registration for core, CLI detection, and web services.
- Add optional `Agent.promptDelivery` support so interactive CLIs can receive the initial AO prompt after launch instead of via one-shot prompt flags.

## Continue CLI command surface checked
- Package: `@continuedev/cli` 1.5.45 (`npm view @continuedev/cli ...`).
- Executable/detection: `cn`; plugin detection uses `which.sync("cn")`.
- Fresh launch: `cn` starts interactive TUI by default; `-p/--print` is headless/exit mode, so the plugin uses post-launch prompt delivery and does not pass prompt flags.
- Session listing/metadata: `cn ls --json` exposes session IDs/titles/workspace metadata.
- Resume support: `cn --resume` resumes the most recent session only; `cn --fork <sessionId>` forks history into a new session. There is no clean documented command to resume a specific current AO-owned session ID, so this plugin leaves `getSessionInfo()` and `getRestoreCommand()` unsupported/null.
- Waiting-input prompts observed from CLI source/help include tool permission (`Would you like to continue?`), interrupted state (`Press enter to continue`), quiz/default prompts, API-key/free-trial prompts, and auth-required messages.

## Validation
- `corepack pnpm --filter @aoagents/ao-core build`
- `corepack pnpm --filter @aoagents/ao-core exec vitest run src/__tests__/session-manager/spawn.test.ts`
- `corepack pnpm --filter @aoagents/ao-plugin-agent-cn test`
- `corepack pnpm --filter @aoagents/ao-plugin-agent-cn typecheck`
- `corepack pnpm --filter @aoagents/ao-plugin-agent-cn build`
- `corepack pnpm --filter @aoagents/ao-core typecheck`
- `corepack pnpm --filter @aoagents/ao-cli typecheck`
- `corepack pnpm --filter @aoagents/ao-web typecheck`
- `git diff --check`
