### PR TITLE
feat: add Cline agent plugin

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "@aoagents/ao-notifier-macos": "workspace:*",
     "@aoagents/ao-plugin-agent-aider": "workspace:*",
     "@aoagents/ao-plugin-agent-claude-code": "workspace:*",
+    "@aoagents/ao-plugin-agent-cline": "workspace:*",
     "@aoagents/ao-plugin-agent-codex": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",

--- a/packages/cli/src/lib/detect-agent.ts
+++ b/packages/cli/src/lib/detect-agent.ts
@@ -18,6 +18,7 @@ const AGENT_PLUGINS: Array<{ name: string; pkg: string }> = [
   { name: "claude-code", pkg: "@aoagents/ao-plugin-agent-claude-code" },
   { name: "aider", pkg: "@aoagents/ao-plugin-agent-aider" },
   { name: "codex", pkg: "@aoagents/ao-plugin-agent-codex" },
+  { name: "cline", pkg: "@aoagents/ao-plugin-agent-cline" },
   { name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
   { name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -1,6 +1,7 @@
 import type { Agent, OrchestratorConfig, PluginRegistry, SCM } from "@aoagents/ao-core";
 import claudeCodePlugin from "@aoagents/ao-plugin-agent-claude-code";
 import codexPlugin from "@aoagents/ao-plugin-agent-codex";
+import clinePlugin from "@aoagents/ao-plugin-agent-cline";
 import aiderPlugin from "@aoagents/ao-plugin-agent-aider";
 import cursorPlugin from "@aoagents/ao-plugin-agent-cursor";
 import kimicodePlugin from "@aoagents/ao-plugin-agent-kimicode";
@@ -10,6 +11,7 @@ import githubSCMPlugin from "@aoagents/ao-plugin-scm-github";
 const agentPlugins: Record<string, { create(): Agent }> = {
   "claude-code": claudeCodePlugin,
   codex: codexPlugin,
+  cline: clinePlugin,
   aider: aiderPlugin,
   cursor: cursorPlugin,
   kimicode: kimicodePlugin,

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1113,6 +1113,58 @@ describe("spawn", () => {
     expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("delivers system and task prompts after launch for post-launch agents", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(
+      ((handler: (...args: unknown[]) => void, _timeout?: number, ...args: unknown[]) => {
+        handler(...args);
+        return 0 as unknown as NodeJS.Timeout;
+      }) as typeof setTimeout,
+    );
+    try {
+      mockAgent.promptDelivery = "post-launch";
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      const session = await sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
+
+      const launchConfig = vi.mocked(mockAgent.getLaunchCommand).mock.calls[0]?.[0];
+      expect(launchConfig?.systemPromptFile).toBeTruthy();
+      const systemPrompt = readFileSync(launchConfig!.systemPromptFile!, "utf-8").trim();
+      const deliveredPrompt = vi.mocked(mockRuntime.sendMessage).mock.calls[0]?.[1];
+
+      expect(mockRuntime.sendMessage).toHaveBeenCalledTimes(1);
+      expect(mockRuntime.sendMessage).toHaveBeenCalledWith(makeHandle("rt-1"), expect.any(String));
+      expect(deliveredPrompt).toContain("Session Lifecycle");
+      expect(deliveredPrompt).toContain("Fix the bug");
+      expect(deliveredPrompt).toContain(systemPrompt);
+      expect(readMetadataRaw(sessionsDir, session.id)?.promptDelivered).toBe("true");
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  it("retries post-launch prompt delivery before marking it delivered", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(
+      ((handler: (...args: unknown[]) => void, _timeout?: number, ...args: unknown[]) => {
+        handler(...args);
+        return 0 as unknown as NodeJS.Timeout;
+      }) as typeof setTimeout,
+    );
+    try {
+      mockAgent.promptDelivery = "post-launch";
+      vi.mocked(mockRuntime.sendMessage)
+        .mockRejectedValueOnce(new Error("not ready"))
+        .mockResolvedValueOnce(undefined);
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      const session = await sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
+
+      expect(mockRuntime.sendMessage).toHaveBeenCalledTimes(2);
+      expect(readMetadataRaw(sessionsDir, session.id)?.promptDelivered).toBe("true");
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
   it("writes worker system prompt to file and passes only explicit task prompt to agent", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1121,8 +1121,20 @@ describe("spawn", () => {
       }) as typeof setTimeout,
     );
     try {
-      mockAgent.promptDelivery = "post-launch";
-      const sm = createSessionManager({ config, registry: mockRegistry });
+      const postLaunchAgent: typeof mockAgent = {
+        ...mockAgent,
+        promptDelivery: "post-launch",
+      };
+      const registryWithPostLaunch: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return postLaunchAgent;
+          if (slot === "workspace") return mockWorkspace;
+          return null;
+        }),
+      };
+      const sm = createSessionManager({ config, registry: registryWithPostLaunch });
 
       const session = await sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
 
@@ -1150,11 +1162,23 @@ describe("spawn", () => {
       }) as typeof setTimeout,
     );
     try {
-      mockAgent.promptDelivery = "post-launch";
+      const postLaunchAgent: typeof mockAgent = {
+        ...mockAgent,
+        promptDelivery: "post-launch",
+      };
+      const registryWithPostLaunch: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return postLaunchAgent;
+          if (slot === "workspace") return mockWorkspace;
+          return null;
+        }),
+      };
       vi.mocked(mockRuntime.sendMessage)
         .mockRejectedValueOnce(new Error("not ready"))
         .mockResolvedValueOnce(undefined);
-      const sm = createSessionManager({ config, registry: mockRegistry });
+      const sm = createSessionManager({ config, registry: registryWithPostLaunch });
 
       const session = await sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
 

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -43,6 +43,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   // Agents
   { slot: "agent", name: "claude-code", pkg: "@aoagents/ao-plugin-agent-claude-code" },
   { slot: "agent", name: "codex", pkg: "@aoagents/ao-plugin-agent-codex" },
+  { slot: "agent", name: "cline", pkg: "@aoagents/ao-plugin-agent-cline" },
   { slot: "agent", name: "aider", pkg: "@aoagents/ao-plugin-agent-aider" },
   { slot: "agent", name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { slot: "agent", name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -11,7 +11,7 @@
  * Reference: scripts/claude-ao-session, scripts/send-to-session
  */
 
-import { statSync, existsSync, writeFileSync, mkdirSync, utimesSync, unlinkSync } from "node:fs";
+import { statSync, existsSync, readFileSync, writeFileSync, mkdirSync, utimesSync, unlinkSync } from "node:fs";
 import { recordActivityEvent } from "./activity-events.js";
 import { execFile } from "node:child_process";
 import { basename, join, resolve } from "node:path";
@@ -40,6 +40,7 @@ import {
   type ProjectConfig,
   type Runtime,
   type Agent,
+  type AgentLaunchConfig,
   type Workspace,
   type WorkspaceCreateConfig,
   type Tracker,
@@ -291,6 +292,78 @@ const ENSURE_ORCHESTRATOR_CONFLICT_POLL_MS = 250;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const POST_LAUNCH_PROMPT_STARTUP_GRACE_MS = 2_000;
+const POST_LAUNCH_PROMPT_RETRY_DELAYS_MS = [1_000, 2_000] as const;
+
+function buildPostLaunchPrompt(config: AgentLaunchConfig): string | null {
+  const promptParts: string[] = [];
+
+  if (config.systemPromptFile) {
+    try {
+      const systemPrompt = readFileSync(config.systemPromptFile, "utf-8").trim();
+      if (systemPrompt) promptParts.push(systemPrompt);
+    } catch {
+      // If the file is unexpectedly unavailable, still deliver the task prompt below.
+    }
+  } else if (config.systemPrompt?.trim()) {
+    promptParts.push(config.systemPrompt.trim());
+  }
+
+  if (config.prompt?.trim()) {
+    promptParts.push(config.prompt.trim());
+  }
+
+  return promptParts.length > 0 ? promptParts.join("\n\n") : null;
+}
+
+async function deliverPostLaunchPrompt(input: {
+  agent: Agent;
+  runtime: Runtime;
+  handle: RuntimeHandle;
+  session: Session;
+  sessionsDir: string;
+  launchConfig: AgentLaunchConfig;
+}): Promise<void> {
+  if (input.agent.promptDelivery !== "post-launch") return;
+
+  const message = buildPostLaunchPrompt(input.launchConfig);
+  if (!message) return;
+
+  const maxAttempts = POST_LAUNCH_PROMPT_RETRY_DELAYS_MS.length + 1;
+  let promptDelivered = false;
+  let lastError: Error | undefined;
+
+  await sleep(POST_LAUNCH_PROMPT_STARTUP_GRACE_MS);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await input.runtime.sendMessage(input.handle, message);
+      promptDelivered = true;
+      break;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      console.error(
+        `[session-manager] Prompt delivery attempt ${attempt}/${maxAttempts} failed: ${lastError.message}`,
+      );
+
+      const retryDelay = POST_LAUNCH_PROMPT_RETRY_DELAYS_MS[attempt - 1];
+      if (retryDelay !== undefined) {
+        await sleep(retryDelay);
+      }
+    }
+  }
+
+  if (!promptDelivered) {
+    console.error(
+      `[session-manager] Failed to deliver prompt to session ${input.session.id} after ${maxAttempts} attempts. ` +
+        `User can retry with 'ao send'. Last error: ${lastError?.message}`,
+    );
+  }
+
+  input.session.metadata["promptDelivered"] = String(promptDelivered);
+  updateMetadata(input.sessionsDir, input.session.id, input.session.metadata);
 }
 
 async function isAgentProcessNotDefinitelyMissing(
@@ -1527,38 +1600,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       // final form. Dismiss the stack so nothing below can trigger a rollback.
       cleanupStack.dismiss();
 
-      // Send initial prompts post-launch for agents that must stay interactive.
-      // Prompt delivery failure should not destroy the session; users can retry with `ao send`.
-      if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt) {
-        const maxRetries = 3;
-        const baseDelayMs = 3_000;
-        let promptDelivered = false;
-        let lastError: Error | undefined;
-
-        for (let attempt = 1; attempt <= maxRetries; attempt++) {
-          try {
-            await sleep(baseDelayMs * attempt);
-            await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
-            promptDelivered = true;
-            break;
-          } catch (err) {
-            lastError = err instanceof Error ? err : new Error(String(err));
-            console.error(
-              `[session-manager] Prompt delivery attempt ${attempt}/${maxRetries} failed: ${lastError.message}`,
-            );
-          }
-        }
-
-        if (!promptDelivered) {
-          console.error(
-            `[session-manager] Failed to deliver prompt to session ${sessionId} after ${maxRetries} attempts. ` +
-              `User can retry with 'ao send'. Last error: ${lastError?.message}`,
-          );
-        }
-
-        session.metadata["promptDelivered"] = String(promptDelivered);
-        updateMetadata(sessionsDir, sessionId, session.metadata);
-      }
+      await deliverPostLaunchPrompt({
+        agent: plugins.agent,
+        runtime: plugins.runtime,
+        handle,
+        session,
+        sessionsDir,
+        launchConfig: agentLaunchConfig,
+      });
 
       recordActivityEvent({
         projectId: spawnConfig.projectId,
@@ -2051,6 +2100,15 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       await cleanupWorktreeAndMetadata(systemPromptFile);
       throw err;
     }
+
+    await deliverPostLaunchPrompt({
+      agent: plugins.agent,
+      runtime: plugins.runtime,
+      handle,
+      session,
+      sessionsDir,
+      launchConfig: agentLaunchConfig,
+    });
 
     recordActivityEvent({
       projectId: orchestratorConfig.projectId,

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1527,8 +1527,39 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       // final form. Dismiss the stack so nothing below can trigger a rollback.
       cleanupStack.dismiss();
 
-      // Prompt is delivered inline via the agent's launch command (positional argument).
-      // No post-launch polling needed — the prompt is part of process invocation.
+      // Send initial prompts post-launch for agents that must stay interactive.
+      // Prompt delivery failure should not destroy the session; users can retry with `ao send`.
+      if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt) {
+        const maxRetries = 3;
+        const baseDelayMs = 3_000;
+        let promptDelivered = false;
+        let lastError: Error | undefined;
+
+        for (let attempt = 1; attempt <= maxRetries; attempt++) {
+          try {
+            await sleep(baseDelayMs * attempt);
+            await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
+            promptDelivered = true;
+            break;
+          } catch (err) {
+            lastError = err instanceof Error ? err : new Error(String(err));
+            console.error(
+              `[session-manager] Prompt delivery attempt ${attempt}/${maxRetries} failed: ${lastError.message}`,
+            );
+          }
+        }
+
+        if (!promptDelivered) {
+          console.error(
+            `[session-manager] Failed to deliver prompt to session ${sessionId} after ${maxRetries} attempts. ` +
+              `User can retry with 'ao send'. Last error: ${lastError?.message}`,
+          );
+        }
+
+        session.metadata["promptDelivered"] = String(promptDelivered);
+        updateMetadata(sessionsDir, sessionId, session.metadata);
+      }
+
       recordActivityEvent({
         projectId: spawnConfig.projectId,
         sessionId,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -475,6 +475,14 @@ export interface Agent {
   /** Process name to look for (e.g. "claude", "codex", "aider") */
   readonly processName: string;
 
+  /**
+   * How the initial prompt should be delivered to the agent.
+   * - "inline" (default): prompt is included in the launch command.
+   * - "post-launch": prompt is sent via runtime.sendMessage() after the agent starts,
+   *   keeping the agent in interactive mode.
+   */
+  readonly promptDelivery?: "inline" | "post-launch";
+
   /** Get the shell command to launch this agent */
   getLaunchCommand(config: AgentLaunchConfig): string;
 

--- a/packages/plugins/agent-cline/package.json
+++ b/packages/plugins/agent-cline/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@aoagents/ao-plugin-agent-cline",
+  "version": "0.1.0",
+  "description": "Agent plugin: Cline",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-cline"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*",
+    "which": "^6.0.1"
+  },
+  "devDependencies": {
+    "@types/which": "^3.0.4",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-cline/src/index.test.ts
+++ b/packages/plugins/agent-cline/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
+  PROCESS_PROBE_INDETERMINATE,
   createActivitySignal,
   type Session,
   type RuntimeHandle,
@@ -221,12 +222,12 @@ describe("getLaunchCommand", () => {
 describe("getEnvironment", () => {
   const agent = create();
 
-  it("writes AO session keys and PATH wrappers", () => {
+  it("writes AO session keys without overriding centralized PATH settings", () => {
     const env = agent.getEnvironment(makeLaunchConfig());
     expect(env["AO_SESSION_ID"]).toBe("sess-1");
     expect(env["AO_ISSUE_ID"]).toBeUndefined();
-    expect(env["PATH"]).toContain(".ao/bin");
-    expect(env["GH_PATH"]).toBeTruthy();
+    expect(env["PATH"]).toBeUndefined();
+    expect(env["GH_PATH"]).toBeUndefined();
   });
 
   it("includes AO_ISSUE_ID when provided", () => {
@@ -253,6 +254,18 @@ describe("isProcessRunning", () => {
     });
 
     expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+    expect(mockExecFileAsync).toHaveBeenNthCalledWith(
+      1,
+      "tmux",
+      ["list-panes", "-t", "=test-session", "-F", "#{pane_tty}"],
+      expect.objectContaining({ windowsHide: true }),
+    );
+    expect(mockExecFileAsync).toHaveBeenNthCalledWith(
+      2,
+      "ps",
+      ["-eo", "pid,tty,args"],
+      expect.objectContaining({ windowsHide: true }),
+    );
   });
 
   it("returns false when tmux process is missing", async () => {
@@ -264,6 +277,16 @@ describe("isProcessRunning", () => {
       return Promise.reject(new Error("unexpected"));
     });
     expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns indeterminate when tmux probing fails", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("tmux unavailable"));
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(PROCESS_PROBE_INDETERMINATE);
+  });
+
+  it("returns indeterminate when tmux returns no panes", async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: "\n", stderr: "" });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(PROCESS_PROBE_INDETERMINATE);
   });
 
   it("returns true when process handle pid is alive", async () => {
@@ -286,6 +309,14 @@ describe("isProcessRunning", () => {
       throw Object.assign(new Error("no such process"), { code: "ESRCH" });
     });
     expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(false);
+    killSpy.mockRestore();
+  });
+
+  it("returns indeterminate when process probing fails unexpectedly", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("invalid signal"), { code: "EINVAL" });
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(PROCESS_PROBE_INDETERMINATE);
     killSpy.mockRestore();
   });
 });
@@ -338,6 +369,15 @@ describe("recordActivity", () => {
     expect(classify?.("Task completed")).toBe("ready");
   });
 
+  it("does not classify generic done or complete text as ready", async () => {
+    await agent.recordActivity?.(makeSession(), "tests done: 3/5");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("tests done: 3/5")).toBe("active");
+    expect(classify?.("implementation almost complete")).toBe("active");
+  });
+
   it("skips recording when workspacePath is missing", async () => {
     await agent.recordActivity?.(makeSession({ workspacePath: null }), "still running");
     expect(mockRecordTerminalActivity).not.toHaveBeenCalled();
@@ -361,6 +401,12 @@ describe("getActivityState", () => {
     );
     expect(state).toMatchObject({ state: "exited" });
     killSpy.mockRestore();
+  });
+
+  it("returns null when process probing is indeterminate", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("tmux unavailable"));
+    const state = await agent.getActivityState(makeSession({ runtimeHandle: makeTmuxHandle() }));
+    expect(state).toBeNull();
   });
 
   it("falls back to activity JSONL state", async () => {

--- a/packages/plugins/agent-cline/src/index.test.ts
+++ b/packages/plugins/agent-cline/src/index.test.ts
@@ -1,0 +1,521 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createActivitySignal,
+  type Session,
+  type RuntimeHandle,
+  type AgentLaunchConfig,
+} from "@aoagents/ao-core";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as {
+  name: string;
+  version: string;
+  description: string;
+};
+const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
+const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
+  ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)
+  : packageJson.name;
+
+const {
+  mockReadLastActivityEntry,
+  mockRecordTerminalActivity,
+  mockSetupPathWrapperWorkspace,
+  mockExecFileAsync,
+  mockWhichSync,
+} = vi.hoisted(() => ({
+  mockReadLastActivityEntry: vi.fn().mockResolvedValue(null),
+  mockRecordTerminalActivity: vi.fn().mockResolvedValue(undefined),
+  mockSetupPathWrapperWorkspace: vi.fn().mockResolvedValue(undefined),
+  mockExecFileAsync: vi.fn(),
+  mockWhichSync: vi.fn(),
+}));
+
+vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    readLastActivityEntry: mockReadLastActivityEntry,
+    recordTerminalActivity: mockRecordTerminalActivity,
+    setupPathWrapperWorkspace: mockSetupPathWrapperWorkspace,
+  };
+});
+
+vi.mock("which", () => ({
+  default: {
+    sync: mockWhichSync,
+  },
+  sync: mockWhichSync,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: (...args: unknown[]) => {
+    const callback = args[args.length - 1];
+    const result = mockExecFileAsync(...args.slice(0, -1));
+    if (typeof callback === "function" && result && typeof result.then === "function") {
+      result.then(
+        (value: { stdout: string; stderr: string }) => callback(null, value),
+        (err: Error) => callback(err),
+      );
+    }
+  },
+  execFileSync: vi.fn(),
+}));
+
+import { create, detect, manifest, default as defaultExport } from "./index.js";
+
+const VALID_CLINE_SESSION_ID = "cline-session-123";
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "test-1",
+    projectId: "test-project",
+    status: "working",
+    activity: "active",
+    activitySignal: createActivitySignal("valid", {
+      activity: "active",
+      timestamp: new Date(),
+      source: "native",
+    }),
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/workspace/test",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeTmuxHandle(id = "test-session"): RuntimeHandle {
+  return { id, runtimeName: "tmux", data: {} };
+}
+
+function makeProcessHandle(pid?: number | string): RuntimeHandle {
+  return { id: "proc-1", runtimeName: "process", data: pid !== undefined ? { pid } : {} };
+}
+
+function makeLaunchConfig(overrides: Partial<AgentLaunchConfig> = {}): AgentLaunchConfig {
+  return {
+    sessionId: "sess-1",
+    projectConfig: {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/repo",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+      agentConfig: {
+        model: "provider/gpt-4o-mini",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeActivityResult(
+  state: "active" | "ready" | "idle" | "waiting_input" | "blocked",
+  ts: Date,
+): {
+  entry: {
+    state: "active" | "ready" | "idle" | "waiting_input" | "blocked";
+    ts: string;
+    source: string;
+  };
+  modifiedAt: Date;
+} {
+  return {
+    entry: {
+      state,
+      ts: ts.toISOString(),
+      source: "terminal",
+    },
+    modifiedAt: ts,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWhichSync.mockReset();
+  mockExecFileAsync.mockReset();
+});
+
+describe("manifest", () => {
+  it("has correct Cline manifest", () => {
+    expect(manifest).toEqual({
+      name: pluginName,
+      slot: "agent",
+      description: packageJson.description,
+      version: packageJson.version,
+      displayName: "Cline",
+    });
+  });
+});
+
+describe("create", () => {
+  it("uses cline as process name and post-launch prompt mode", () => {
+    const agent = create();
+    expect(agent.name).toBe(pluginName);
+    expect(agent.processName).toBe(pluginName);
+    expect(agent.promptDelivery).toBe("post-launch");
+  });
+
+  it("exports plugin module shape", () => {
+    expect(defaultExport.manifest).toBe(manifest);
+    expect(typeof defaultExport.create).toBe("function");
+    expect(typeof defaultExport.detect).toBe("function");
+  });
+});
+
+describe("detect", () => {
+  it("returns true when which resolves", () => {
+    mockWhichSync.mockReturnValue("/usr/local/bin/cline");
+    expect(detect()).toBe(true);
+  });
+
+  it("returns false when which fails", () => {
+    mockWhichSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(detect()).toBe(false);
+  });
+});
+
+describe("getLaunchCommand", () => {
+  const agent = create();
+
+  it("uses interactive TUI launch without a configured Cline session id", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig());
+    expect(cmd).toBe("cline --tui");
+  });
+
+  it("uses --id when a Cline session id is configured", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        projectConfig: {
+          ...makeLaunchConfig().projectConfig,
+          agentConfig: { clineSessionId: VALID_CLINE_SESSION_ID },
+        },
+      }),
+    );
+    expect(cmd).toBe(`cline --tui --id '${VALID_CLINE_SESSION_ID}'`);
+  });
+
+  it("does not include prompt flags in launch command", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        prompt: "Do work",
+        systemPrompt: "You are helpful",
+        systemPromptFile: "/tmp/prompt.md",
+      }),
+    );
+    expect(cmd).toBe("cline --tui");
+    expect(cmd).not.toContain("Do work");
+    expect(cmd).not.toContain("--system");
+  });
+});
+
+describe("getEnvironment", () => {
+  const agent = create();
+
+  it("writes AO session keys and PATH wrappers", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["AO_SESSION_ID"]).toBe("sess-1");
+    expect(env["AO_ISSUE_ID"]).toBeUndefined();
+    expect(env["PATH"]).toContain(".ao/bin");
+    expect(env["GH_PATH"]).toBeTruthy();
+  });
+
+  it("includes AO_ISSUE_ID when provided", () => {
+    const env = agent.getEnvironment(makeLaunchConfig({ issueId: "INT-42" }));
+    expect(env["AO_ISSUE_ID"]).toBe("INT-42");
+  });
+});
+
+describe("isProcessRunning", () => {
+  const agent = create();
+
+  it("returns true when cline is on tmux pane", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") {
+        return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      }
+      if (cmd === "ps") {
+        return Promise.resolve({
+          stdout: "  PID TT       ARGS\n  789 ttys003  node /usr/local/bin/cline --tui\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("returns false when tmux process is missing", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      if (cmd === "ps") {
+        return Promise.resolve({ stdout: "  PID TT      ARGS\n  789 ttys003  bash\n", stderr: "" });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns true when process handle pid is alive", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(123, 0);
+    killSpy.mockRestore();
+  });
+
+  it("treats EPERM as a running process", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
+    killSpy.mockRestore();
+  });
+
+  it("returns false when process handle pid is dead", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(false);
+    killSpy.mockRestore();
+  });
+});
+
+describe("recordActivity", () => {
+  const agent = create();
+
+  it("classifies idle terminal output when recording activity", async () => {
+    await agent.recordActivity?.(makeSession(), "Press h + Enter to show shortcuts\n> ");
+    expect(mockRecordTerminalActivity).toHaveBeenCalledWith(
+      "/workspace/test",
+      "Press h + Enter to show shortcuts\n> ",
+      expect.any(Function),
+    );
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("\u001b[32m>\u001b[0m ")).toBe("idle");
+  });
+
+  it("classifies active terminal output when recording activity", async () => {
+    await agent.recordActivity?.(makeSession(), "[read_file] package.json");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("[read_file] package.json")).toBe("active");
+  });
+
+  it("classifies waiting_input terminal output when recording activity", async () => {
+    await agent.recordActivity?.(makeSession(), 'Approve "write_to_file" {"path":"x"} [y/N] ');
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.('Approve "write_to_file" {"path":"x"} [y/N] ')).toBe("waiting_input");
+  });
+
+  it("classifies blocked terminal output when recording activity", async () => {
+    await agent.recordActivity?.(makeSession(), "error: interactive mode requires a TTY");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("error: interactive mode requires a TTY")).toBe("blocked");
+  });
+
+  it("classifies completed terminal output as ready", async () => {
+    await agent.recordActivity?.(makeSession(), "Task completed");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Task completed")).toBe("ready");
+  });
+
+  it("skips recording when workspacePath is missing", async () => {
+    await agent.recordActivity?.(makeSession({ workspacePath: null }), "still running");
+    expect(mockRecordTerminalActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe("getActivityState", () => {
+  const agent = create();
+
+  it("falls back to exited when runtime handle missing", async () => {
+    const state = await agent.getActivityState(makeSession({ runtimeHandle: null }));
+    expect(state).toMatchObject({ state: "exited" });
+  });
+
+  it("returns exited when process is no longer running", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+    });
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state).toMatchObject({ state: "exited" });
+    killSpy.mockRestore();
+  });
+
+  it("falls back to activity JSONL state", async () => {
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("waiting_input", new Date()));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("waiting_input");
+    killSpy.mockRestore();
+  });
+
+  it("returns blocked from recent activity JSONL", async () => {
+    const activityAt = new Date();
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("blocked", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("blocked");
+    expect(state?.timestamp?.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("decays JSONL fallback state to idle when the entry is stale", async () => {
+    const activityAt = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("active", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("idle");
+    expect(state?.timestamp?.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("returns null when no activity data is available", async () => {
+    mockReadLastActivityEntry.mockResolvedValue(null);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state).toBeNull();
+    killSpy.mockRestore();
+  });
+});
+
+describe("getSessionInfo", () => {
+  const agent = create();
+
+  it("returns null without a Cline session id", async () => {
+    expect(await agent.getSessionInfo(makeSession())).toBeNull();
+  });
+
+  it("uses Cline history title as the summary", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "cline" && args[0] === "history") {
+        return Promise.resolve({
+          stdout: JSON.stringify([
+            {
+              sessionId: VALID_CLINE_SESSION_ID,
+              prompt: "fallback prompt",
+              metadata: { title: "Implement dashboard fix" },
+            },
+          ]),
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+
+    const info = await agent.getSessionInfo(
+      makeSession({ metadata: { clineSessionId: VALID_CLINE_SESSION_ID } }),
+    );
+    expect(info).toMatchObject({
+      agentSessionId: VALID_CLINE_SESSION_ID,
+      summary: "Implement dashboard fix",
+      summaryIsFallback: false,
+    });
+  });
+
+  it("uses prompt as fallback summary when history has no title", async () => {
+    mockExecFileAsync.mockResolvedValue({
+      stdout: JSON.stringify([{ sessionId: VALID_CLINE_SESSION_ID, prompt: "fallback prompt" }]),
+      stderr: "",
+    });
+
+    const info = await agent.getSessionInfo(
+      makeSession({ metadata: { clineSessionId: VALID_CLINE_SESSION_ID } }),
+    );
+    expect(info).toMatchObject({
+      agentSessionId: VALID_CLINE_SESSION_ID,
+      summary: "fallback prompt",
+      summaryIsFallback: true,
+    });
+  });
+
+  it("treats Cline history lookup as unavailable when command fails", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("history unavailable"));
+    const info = await agent.getSessionInfo(
+      makeSession({ metadata: { clineSessionId: VALID_CLINE_SESSION_ID } }),
+    );
+    expect(info).toMatchObject({
+      agentSessionId: VALID_CLINE_SESSION_ID,
+      summary: null,
+    });
+  });
+});
+
+describe("getRestoreCommand", () => {
+  const agent = create();
+
+  it("builds restore command using the Cline session id only", async () => {
+    const cmd = await agent.getRestoreCommand?.(
+      makeSession({ metadata: { clineSessionId: VALID_CLINE_SESSION_ID } }),
+      {
+        name: "my-project",
+        repo: "owner/repo",
+        path: "/workspace/repo",
+        defaultBranch: "main",
+        sessionPrefix: "my",
+        agentConfig: { model: "provider/gpt-4o" },
+      },
+    );
+    expect(cmd).toBe(`cline --tui --id '${VALID_CLINE_SESSION_ID}'`);
+  });
+
+  it("returns null when no Cline session id is stored", async () => {
+    const cmd = await agent.getRestoreCommand?.(makeSession(), {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/repo",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+      agentConfig: { model: "provider/gpt-4o" },
+    });
+    expect(cmd).toBeNull();
+  });
+});
+
+describe("workspace hooks", () => {
+  const agent = create();
+
+  it("sets up PATH wrapper hooks for the workspace", async () => {
+    await agent.setupWorkspaceHooks?.("/workspace/test", { dataDir: "/tmp/data" });
+    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
+  });
+
+  it("sets up PATH wrappers after launch when workspace path exists", async () => {
+    await agent.postLaunchSetup?.(makeSession({ workspacePath: "/workspace/test" }));
+    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
+  });
+
+  it("skips post-launch setup when workspace path is absent", async () => {
+    await agent.postLaunchSetup?.(makeSession({ workspacePath: null }));
+    expect(mockSetupPathWrapperWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/agent-cline/src/index.ts
+++ b/packages/plugins/agent-cline/src/index.ts
@@ -1,14 +1,14 @@
 import {
   DEFAULT_READY_THRESHOLD_MS,
   DEFAULT_ACTIVE_WINDOW_MS,
+  PROCESS_PROBE_INDETERMINATE,
+  isWindows,
   shellEscape,
-  buildAgentPath,
   readLastActivityEntry,
   checkActivityLogState,
   getActivityFallbackState,
   recordTerminalActivity,
   setupPathWrapperWorkspace,
-  PREFERRED_GH_PATH,
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
@@ -16,6 +16,7 @@ import {
   type ActivityState,
   type PluginModule,
   type ProjectConfig,
+  type ProcessProbeResult,
   type RuntimeHandle,
   type Session,
   type WorkspaceHooksConfig,
@@ -79,8 +80,8 @@ function classifyClineTerminalOutput(terminalOutput: string): ActivityState {
   if (/press\s+h\s*\+\s*enter\s+to\s+show\s+shortcuts/i.test(lastNonEmptyLine)) return "idle";
   if (CLINE_APPROVAL_PROMPT_RE.test(lastNonEmptyLine)) return "waiting_input";
   if (CLINE_CONTINUE_PROMPT_RE.test(lastNonEmptyLine)) return "waiting_input";
-  if (/\b(task|session)\s+(completed|finished|ended)\b/i.test(lastNonEmptyLine)) return "ready";
-  if (/\b(done|complete)\b/i.test(lastNonEmptyLine)) return "ready";
+  if (/\b(?:task\s+(?:completed|finished)|session\s+ended)\b/i.test(lastNonEmptyLine))
+    return "ready";
   if (
     /\b(error|failed|exception|not authenticated|requires a tty|requires approval in a tty|denied by user)\b/i.test(
       lastNonEmptyLine,
@@ -111,6 +112,7 @@ async function readClineHistory(): Promise<ClineHistoryEntry[]> {
       {
         timeout: CLINE_COMMAND_TIMEOUT_MS,
         maxBuffer: 10 * 1024 * 1024,
+        windowsHide: true,
       },
     );
     return parseClineHistory(stdout);
@@ -162,9 +164,6 @@ function createClineAgent(): Agent {
         env["AO_ISSUE_ID"] = config.issueId;
       }
 
-      env["PATH"] = buildAgentPath(process.env["PATH"]);
-      env["GH_PATH"] = PREFERRED_GH_PATH;
-
       return env;
     },
 
@@ -182,6 +181,7 @@ function createClineAgent(): Agent {
       const exitedAt = new Date();
       if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
       const running = await this.isProcessRunning(session.runtimeHandle);
+      if (running === PROCESS_PROBE_INDETERMINATE) return null;
       if (!running) return { state: "exited", timestamp: exitedAt };
 
       let activityResult: Awaited<ReturnType<typeof readLastActivityEntry>> = null;
@@ -204,24 +204,29 @@ function createClineAgent(): Agent {
       );
     },
 
-    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
-      try {
-        if (handle.runtimeName === "tmux" && handle.id) {
+    async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
+      if (handle.runtimeName === "tmux" && handle.id) {
+        if (isWindows()) return false;
+
+        try {
           const { stdout: ttyOut } = await execFileAsync(
             "tmux",
-            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
-            { timeout: CLINE_COMMAND_TIMEOUT_MS },
+            ["list-panes", "-t", `=${handle.id}`, "-F", "#{pane_tty}"],
+            { timeout: CLINE_COMMAND_TIMEOUT_MS, windowsHide: true },
           );
           const ttys = ttyOut
             .trim()
             .split("\n")
             .map((t) => t.trim())
             .filter(Boolean);
-          if (ttys.length === 0) return false;
+          if (ttys.length === 0) return PROCESS_PROBE_INDETERMINATE;
 
           const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
             timeout: CLINE_COMMAND_TIMEOUT_MS,
+            windowsHide: true,
           });
+          if (!psOut.trim()) return PROCESS_PROBE_INDETERMINATE;
+
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
           const processRe = /(?:^|[\s/])cline(?:\s|$)/;
           for (const line of psOut.split("\n")) {
@@ -233,25 +238,28 @@ function createClineAgent(): Agent {
             }
           }
           return false;
+        } catch {
+          return PROCESS_PROBE_INDETERMINATE;
         }
+      }
 
-        const rawPid = handle.data["pid"];
-        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
-        if (Number.isFinite(pid) && pid > 0) {
-          try {
-            process.kill(pid, 0);
+      const rawPid = handle.data["pid"];
+      const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+      if (Number.isFinite(pid) && pid > 0) {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch (err: unknown) {
+          if (err instanceof Error && (err as NodeJS.ErrnoException).code === "EPERM") {
             return true;
-          } catch (err: unknown) {
-            if (err instanceof Error && (err as NodeJS.ErrnoException).code === "EPERM") {
-              return true;
-            }
+          }
+          if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ESRCH") {
             return false;
           }
+          return PROCESS_PROBE_INDETERMINATE;
         }
-        return false;
-      } catch {
-        return false;
       }
+      return false;
     },
 
     async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {

--- a/packages/plugins/agent-cline/src/index.ts
+++ b/packages/plugins/agent-cline/src/index.ts
@@ -1,0 +1,301 @@
+import {
+  DEFAULT_READY_THRESHOLD_MS,
+  DEFAULT_ACTIVE_WINDOW_MS,
+  shellEscape,
+  buildAgentPath,
+  readLastActivityEntry,
+  checkActivityLogState,
+  getActivityFallbackState,
+  recordTerminalActivity,
+  setupPathWrapperWorkspace,
+  PREFERRED_GH_PATH,
+  type Agent,
+  type AgentSessionInfo,
+  type AgentLaunchConfig,
+  type ActivityDetection,
+  type ActivityState,
+  type PluginModule,
+  type ProjectConfig,
+  type RuntimeHandle,
+  type Session,
+  type WorkspaceHooksConfig,
+} from "@aoagents/ao-core";
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import { promisify } from "node:util";
+import which from "which";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as {
+  name: string;
+  version: string;
+  description: string;
+};
+const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
+const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
+  ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)
+  : packageJson.name;
+
+const execFileAsync = promisify(execFile);
+const CLINE_COMMAND_TIMEOUT_MS = 30_000;
+const CLINE_HISTORY_LIMIT = "200";
+const ANSI_ESCAPE_RE = new RegExp(
+  `${String.fromCharCode(27)}(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~])`,
+  "g",
+);
+const CLINE_APPROVAL_PROMPT_RE = /approve\s+"?[\w.-]+"?.*\[[Yy]\/N\]\s*$/i;
+const CLINE_CONTINUE_PROMPT_RE =
+  /(?:do you want to continue|continue\?|proceed\?).*(?:\[[Yy]\/N\]|[Yy]\/N)\s*$/i;
+
+interface ClineHistoryEntry {
+  sessionId?: unknown;
+  prompt?: unknown;
+  metadata?: {
+    title?: unknown;
+  };
+}
+
+function asValidClineSessionId(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 512) return undefined;
+  if (/[\0\r\n]/.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+function getConfiguredSessionId(config: AgentLaunchConfig): string | undefined {
+  return asValidClineSessionId(config.projectConfig.agentConfig?.["clineSessionId"]);
+}
+
+function classifyClineTerminalOutput(terminalOutput: string): ActivityState {
+  const normalizedOutput = terminalOutput.replaceAll(ANSI_ESCAPE_RE, "").trim();
+  if (!normalizedOutput) return "idle";
+
+  const lines = normalizedOutput.split("\n").map((line) => line.trim());
+  const lastLine = lines[lines.length - 1] ?? "";
+  const lastNonEmptyLine = [...lines].reverse().find(Boolean) ?? "";
+
+  if (/^>\s*$/.test(lastLine)) return "idle";
+  if (/press\s+h\s*\+\s*enter\s+to\s+show\s+shortcuts/i.test(lastNonEmptyLine)) return "idle";
+  if (CLINE_APPROVAL_PROMPT_RE.test(lastNonEmptyLine)) return "waiting_input";
+  if (CLINE_CONTINUE_PROMPT_RE.test(lastNonEmptyLine)) return "waiting_input";
+  if (/\b(task|session)\s+(completed|finished|ended)\b/i.test(lastNonEmptyLine)) return "ready";
+  if (/\b(done|complete)\b/i.test(lastNonEmptyLine)) return "ready";
+  if (
+    /\b(error|failed|exception|not authenticated|requires a tty|requires approval in a tty|denied by user)\b/i.test(
+      lastNonEmptyLine,
+    )
+  ) {
+    return "blocked";
+  }
+
+  return "active";
+}
+
+function parseClineHistory(text: string): ClineHistoryEntry[] {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return Array.isArray(parsed)
+      ? (parsed.filter((entry) => entry && typeof entry === "object") as ClineHistoryEntry[])
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+async function readClineHistory(): Promise<ClineHistoryEntry[]> {
+  try {
+    const { stdout } = await execFileAsync(
+      "cline",
+      ["history", "--json", "--limit", CLINE_HISTORY_LIMIT],
+      {
+        timeout: CLINE_COMMAND_TIMEOUT_MS,
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
+    return parseClineHistory(stdout);
+  } catch {
+    return [];
+  }
+}
+
+function getHistorySummary(entry: ClineHistoryEntry): {
+  summary: string | null;
+  summaryIsFallback?: boolean;
+} {
+  const title = typeof entry.metadata?.title === "string" ? entry.metadata.title.trim() : "";
+  if (title) return { summary: title, summaryIsFallback: false };
+
+  const prompt = typeof entry.prompt === "string" ? entry.prompt.trim() : "";
+  if (prompt) return { summary: prompt.slice(0, 200), summaryIsFallback: true };
+
+  return { summary: null };
+}
+
+export const manifest = {
+  name: pluginName,
+  slot: "agent" as const,
+  description: packageJson.description,
+  version: packageJson.version,
+  displayName: "Cline",
+};
+
+function createClineAgent(): Agent {
+  return {
+    name: pluginName,
+    processName: pluginName,
+    promptDelivery: "post-launch",
+
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      const sessionId = getConfiguredSessionId(config);
+      if (!sessionId) {
+        return "cline --tui";
+      }
+      return `cline --tui --id ${shellEscape(sessionId)}`;
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      const env: Record<string, string> = {};
+      env["AO_SESSION_ID"] = config.sessionId;
+      // NOTE: AO_PROJECT_ID is the caller's responsibility (spawn.ts sets it)
+      if (config.issueId) {
+        env["AO_ISSUE_ID"] = config.issueId;
+      }
+
+      env["PATH"] = buildAgentPath(process.env["PATH"]);
+      env["GH_PATH"] = PREFERRED_GH_PATH;
+
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      return classifyClineTerminalOutput(terminalOutput);
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
+      const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
+      const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
+
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (!running) return { state: "exited", timestamp: exitedAt };
+
+      let activityResult: Awaited<ReturnType<typeof readLastActivityEntry>> = null;
+      if (session.workspacePath) {
+        activityResult = await readLastActivityEntry(session.workspacePath);
+        const activityState = checkActivityLogState(activityResult);
+        if (activityState) return activityState;
+      }
+
+      const fallback = getActivityFallbackState(activityResult, activeWindowMs, threshold);
+      if (fallback) return fallback;
+
+      return null;
+    },
+
+    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
+      if (!session.workspacePath) return;
+      await recordTerminalActivity(session.workspacePath, terminalOutput, (output: string) =>
+        classifyClineTerminalOutput(output),
+      );
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      try {
+        if (handle.runtimeName === "tmux" && handle.id) {
+          const { stdout: ttyOut } = await execFileAsync(
+            "tmux",
+            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+            { timeout: CLINE_COMMAND_TIMEOUT_MS },
+          );
+          const ttys = ttyOut
+            .trim()
+            .split("\n")
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (ttys.length === 0) return false;
+
+          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
+            timeout: CLINE_COMMAND_TIMEOUT_MS,
+          });
+          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
+          const processRe = /(?:^|[\s/])cline(?:\s|$)/;
+          for (const line of psOut.split("\n")) {
+            const cols = line.trimStart().split(/\s+/);
+            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+            const args = cols.slice(2).join(" ");
+            if (processRe.test(args)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        const rawPid = handle.data["pid"];
+        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+        if (Number.isFinite(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+            return true;
+          } catch (err: unknown) {
+            if (err instanceof Error && (err as NodeJS.ErrnoException).code === "EPERM") {
+              return true;
+            }
+            return false;
+          }
+        }
+        return false;
+      } catch {
+        return false;
+      }
+    },
+
+    async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {
+      const sessionId = asValidClineSessionId(session.metadata["clineSessionId"]);
+      if (!sessionId) return null;
+
+      const history = await readClineHistory();
+      const entry = history.find((item) => asValidClineSessionId(item.sessionId) === sessionId);
+      const { summary, summaryIsFallback } = entry ? getHistorySummary(entry) : { summary: null };
+
+      return {
+        agentSessionId: sessionId,
+        summary,
+        summaryIsFallback,
+      };
+    },
+
+    async getRestoreCommand(session: Session, _project: ProjectConfig): Promise<string | null> {
+      const sessionId = asValidClineSessionId(session.metadata["clineSessionId"]);
+      if (!sessionId) return null;
+      return `cline --tui --id ${shellEscape(sessionId)}`;
+    },
+
+    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+      await setupPathWrapperWorkspace(workspacePath);
+    },
+
+    async postLaunchSetup(session: Session): Promise<void> {
+      if (!session.workspacePath) return;
+      await setupPathWrapperWorkspace(session.workspacePath);
+    },
+  };
+}
+
+export function create(): Agent {
+  return createClineAgent();
+}
+
+export function detect(): boolean {
+  try {
+    return Boolean(which.sync("cline"));
+  } catch {
+    return false;
+  }
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-cline/tsconfig.json
+++ b/packages/plugins/agent-cline/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@aoagents/ao-core": "workspace:*",
     "@aoagents/ao-plugin-agent-claude-code": "workspace:*",
+    "@aoagents/ao-plugin-agent-cline": "workspace:*",
     "@aoagents/ao-plugin-agent-codex": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -37,6 +37,7 @@ import pluginRuntimeTmux from "@aoagents/ao-plugin-runtime-tmux";
 import pluginRuntimeProcess from "@aoagents/ao-plugin-runtime-process";
 import pluginAgentClaudeCode from "@aoagents/ao-plugin-agent-claude-code";
 import pluginAgentCodex from "@aoagents/ao-plugin-agent-codex";
+import pluginAgentCline from "@aoagents/ao-plugin-agent-cline";
 import pluginAgentCursor from "@aoagents/ao-plugin-agent-cursor";
 import pluginAgentKimicode from "@aoagents/ao-plugin-agent-kimicode";
 import pluginAgentOpencode from "@aoagents/ao-plugin-agent-opencode";
@@ -109,6 +110,7 @@ async function initServices(): Promise<Services> {
   registry.register(pluginRuntimeProcess);
   registry.register(pluginAgentClaudeCode);
   registry.register(pluginAgentCodex);
+  registry.register(pluginAgentCline);
   registry.register(pluginAgentCursor);
   registry.register(pluginAgentKimicode);
   registry.register(pluginAgentOpencode);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       '@aoagents/ao-plugin-agent-claude-code':
         specifier: workspace:*
         version: link:../plugins/agent-claude-code
+      '@aoagents/ao-plugin-agent-cline':
+        specifier: workspace:*
+        version: link:../plugins/agent-cline
       '@aoagents/ao-plugin-agent-codex':
         specifier: workspace:*
         version: link:../plugins/agent-codex
@@ -300,6 +303,28 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/plugins/agent-cline:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+      which:
+        specifier: ^6.0.1
+        version: 6.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -682,6 +707,9 @@ importers:
       '@aoagents/ao-plugin-agent-claude-code':
         specifier: workspace:*
         version: link:../plugins/agent-claude-code
+      '@aoagents/ao-plugin-agent-cline':
+        specifier: workspace:*
+        version: link:../plugins/agent-cline
       '@aoagents/ao-plugin-agent-codex':
         specifier: workspace:*
         version: link:../plugins/agent-codex
@@ -1974,6 +2002,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/which@3.0.4':
+    resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -5076,6 +5107,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/which@3.0.4': {}
 
   '@types/ws@8.18.1':
     dependencies:


### PR DESCRIPTION
## Summary
- add `@aoagents/ao-plugin-agent-cline` following the Forge-style agent plugin shape
- wire Cline into core built-ins, CLI detection/direct imports, and web service registration
- add post-launch prompt delivery support for interactive agents and focused Cline plugin tests

## Cline CLI surface verified
- executable/detection: `cline` via `which cline`
- installed help checked: `cline --version` -> `3.0.2`; `cline --help`; `cline history --help`; `cline config --help`
- launch: `cline --tui` for an interactive session; AO sends the prompt post-launch
- restore: documented `--id <session-id>` is used only when AO metadata/config already contains `clineSessionId`
- metadata: `cline history --json --limit 200` is used defensively for title/prompt summaries when `clineSessionId` is known

## Unsupported/Conservative assumptions
- No automatic live Cline session-id discovery is implemented; Cline history exposes saved `sessionId`s, but the plugin does not infer a current task id from terminal output.
- No cost/token extraction is implemented; history may contain display metadata, but there is no clean token-stat command in the verified CLI surface.
- No Cline hook integration is added; PATH wrapper setup matches Forge-style workspace behavior only.

## Validation
- `pnpm --filter @aoagents/ao-core build`
- `pnpm --filter @aoagents/ao-plugin-agent-cline test`
- `pnpm --filter @aoagents/ao-plugin-agent-cline typecheck`
- `pnpm --filter @aoagents/ao-plugin-agent-cline build`
- `pnpm --filter @aoagents/ao-cli typecheck`
- `pnpm --filter @aoagents/ao-web typecheck`
- `pnpm --filter @aoagents/ao-core test -- src/__tests__/session-manager/spawn.test.ts`
- `git diff --check`
