### PR TITLE
feat: add copilot agent plugin

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "@aoagents/ao-plugin-agent-aider": "workspace:*",
     "@aoagents/ao-plugin-agent-claude-code": "workspace:*",
     "@aoagents/ao-plugin-agent-codex": "workspace:*",
+    "@aoagents/ao-plugin-agent-copilot": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",

--- a/packages/cli/src/lib/detect-agent.ts
+++ b/packages/cli/src/lib/detect-agent.ts
@@ -21,6 +21,7 @@ const AGENT_PLUGINS: Array<{ name: string; pkg: string }> = [
   { name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
   { name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { name: "copilot", pkg: "@aoagents/ao-plugin-agent-copilot" },
 ];
 
 /**

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -5,6 +5,7 @@ import aiderPlugin from "@aoagents/ao-plugin-agent-aider";
 import cursorPlugin from "@aoagents/ao-plugin-agent-cursor";
 import kimicodePlugin from "@aoagents/ao-plugin-agent-kimicode";
 import opencodePlugin from "@aoagents/ao-plugin-agent-opencode";
+import copilotPlugin from "@aoagents/ao-plugin-agent-copilot";
 import githubSCMPlugin from "@aoagents/ao-plugin-scm-github";
 
 const agentPlugins: Record<string, { create(): Agent }> = {
@@ -14,6 +15,7 @@ const agentPlugins: Record<string, { create(): Agent }> = {
   cursor: cursorPlugin,
   kimicode: kimicodePlugin,
   opencode: opencodePlugin,
+  copilot: copilotPlugin,
 };
 
 const scmPlugins: Record<string, { create(): SCM }> = {

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1113,6 +1113,38 @@ describe("spawn", () => {
     expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("sends initial prompt after launch for post-launch prompt agents", async () => {
+    const postLaunchAgent: Agent = {
+      ...mockAgent,
+      promptDelivery: "post-launch",
+    };
+    const registryWithPostLaunchAgent: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return postLaunchAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+    const sm = createSessionManager({ config, registry: registryWithPostLaunchAgent });
+
+    await sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
+
+    expect(postLaunchAgent.getLaunchCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("Fix the bug"),
+      }),
+    );
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      makeHandle("rt-1"),
+      expect.stringContaining("Session Lifecycle"),
+    );
+    const message = vi.mocked(mockRuntime.sendMessage).mock.calls[0]?.[1];
+    expect(message).toContain("## User Request");
+    expect(message).toContain("Fix the bug");
+  });
+
   it("writes worker system prompt to file and passes only explicit task prompt to agent", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 
@@ -2091,6 +2123,33 @@ describe("spawn", () => {
           workspacePath: "/tmp/ws",
           launchCommand: "mock-agent --start",
         }),
+      );
+    });
+
+    it("sends orchestrator system prompt after launch for post-launch prompt agents", async () => {
+      const postLaunchAgent: Agent = {
+        ...mockAgent,
+        promptDelivery: "post-launch",
+      };
+      const registryWithPostLaunchAgent: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return postLaunchAgent;
+          if (slot === "workspace") return mockWorkspace;
+          return null;
+        }),
+      };
+      const sm = createSessionManager({ config, registry: registryWithPostLaunchAgent });
+
+      await sm.spawnOrchestrator({
+        projectId: "my-app",
+        systemPrompt: "Coordinate the worker sessions.",
+      });
+
+      expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+        makeHandle("rt-1"),
+        "Coordinate the worker sessions.",
       );
     });
 

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -47,6 +47,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { slot: "agent", name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
   { slot: "agent", name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { slot: "agent", name: "copilot", pkg: "@aoagents/ao-plugin-agent-copilot" },
   // Workspaces
   { slot: "workspace", name: "worktree", pkg: "@aoagents/ao-plugin-workspace-worktree" },
   { slot: "workspace", name: "clone", pkg: "@aoagents/ao-plugin-workspace-clone" },

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -279,6 +279,10 @@ function deriveDisplayName(input: { issueTitle?: string; prompt?: string }): str
   return undefined;
 }
 
+function buildPostLaunchInitialPrompt(input: { systemPrompt: string; taskPrompt: string }): string {
+  return `${input.systemPrompt.trim()}\n\n## User Request\n${input.taskPrompt.trim()}`;
+}
+
 const SEND_RESTORE_READY_TIMEOUT_MS = 5_000;
 const SEND_RESTORE_READY_POLL_MS = 500;
 const SEND_CONFIRMATION_ATTEMPTS = 6;
@@ -1504,6 +1508,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         await plugins.agent.postLaunchSetup(session);
       }
 
+      if (plugins.agent.promptDelivery === "post-launch" && taskPrompt?.trim()) {
+        await plugins.runtime.sendMessage(
+          handle,
+          buildPostLaunchInitialPrompt({ systemPrompt, taskPrompt }),
+        );
+      }
+
       if (
         plugins.agent.name === "opencode" &&
         opencodeIssueSessionStrategy === "reuse" &&
@@ -1977,6 +1988,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       if (plugins.agent.postLaunchSetup) {
         await plugins.agent.postLaunchSetup(session);
+      }
+
+      if (
+        plugins.agent.promptDelivery === "post-launch" &&
+        orchestratorConfig.systemPrompt?.trim()
+      ) {
+        await plugins.runtime.sendMessage(handle, orchestratorConfig.systemPrompt);
       }
 
       if (

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -475,6 +475,13 @@ export interface Agent {
   /** Process name to look for (e.g. "claude", "codex", "aider") */
   readonly processName: string;
 
+  /**
+   * How the initial user prompt is delivered.
+   * - inline (default): getLaunchCommand embeds the prompt in the launch command.
+   * - post-launch: runtime sends the prompt after the interactive process starts.
+   */
+  readonly promptDelivery?: "inline" | "post-launch";
+
   /** Get the shell command to launch this agent */
   getLaunchCommand(config: AgentLaunchConfig): string;
 

--- a/packages/plugins/agent-copilot/package.json
+++ b/packages/plugins/agent-copilot/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@aoagents/ao-plugin-agent-copilot",
+  "version": "0.8.0",
+  "description": "Agent plugin: GitHub Copilot CLI",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-copilot"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*",
+    "which": "^6.0.1"
+  },
+  "devDependencies": {
+    "@types/which": "^3.0.4",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-copilot/src/index.test.ts
+++ b/packages/plugins/agent-copilot/src/index.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AgentLaunchConfig, RuntimeHandle, Session } from "@aoagents/ao-core";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as {
+  name: string;
+  version: string;
+  description: string;
+};
+const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
+const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
+  ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)
+  : packageJson.name;
+
+const {
+  mockReadLastActivityEntry,
+  mockRecordTerminalActivity,
+  mockSetupPathWrapperWorkspace,
+  mockExecFileAsync,
+  mockWhichSync,
+} = vi.hoisted(() => ({
+  mockReadLastActivityEntry: vi.fn().mockResolvedValue(null),
+  mockRecordTerminalActivity: vi.fn().mockResolvedValue(undefined),
+  mockSetupPathWrapperWorkspace: vi.fn().mockResolvedValue(undefined),
+  mockExecFileAsync: vi.fn(),
+  mockWhichSync: vi.fn(),
+}));
+
+vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    readLastActivityEntry: mockReadLastActivityEntry,
+    recordTerminalActivity: mockRecordTerminalActivity,
+    setupPathWrapperWorkspace: mockSetupPathWrapperWorkspace,
+  };
+});
+
+vi.mock("which", () => ({
+  default: {
+    sync: mockWhichSync,
+  },
+  sync: mockWhichSync,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: (...args: unknown[]) => {
+    const callback = args[args.length - 1];
+    const result = mockExecFileAsync(...args.slice(0, -1));
+    if (typeof callback === "function" && result && typeof result.then === "function") {
+      result.then(
+        (value: { stdout: string; stderr: string }) => callback(null, value),
+        (err: Error) => callback(err),
+      );
+    }
+  },
+}));
+
+import { PROCESS_PROBE_INDETERMINATE } from "@aoagents/ao-core";
+import { create, detect, manifest, default as defaultExport } from "./index.js";
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "test-1",
+    projectId: "test-project",
+    status: "working",
+    activity: "active",
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/workspace/test",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeTmuxHandle(id = "test-session"): RuntimeHandle {
+  return { id, runtimeName: "tmux", data: {} };
+}
+
+function makeProcessHandle(pid?: number | string): RuntimeHandle {
+  return { id: "proc-1", runtimeName: "process", data: pid !== undefined ? { pid } : {} };
+}
+
+function makeLaunchConfig(overrides: Partial<AgentLaunchConfig> = {}): AgentLaunchConfig {
+  return {
+    sessionId: "sess-1",
+    projectConfig: {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/repo",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+      agentConfig: {
+        model: "gpt-5.4",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeActivityResult(
+  state: "active" | "ready" | "idle" | "waiting_input" | "blocked",
+  ts: Date,
+): {
+  entry: {
+    state: "active" | "ready" | "idle" | "waiting_input" | "blocked";
+    ts: string;
+    source: string;
+  };
+  modifiedAt: Date;
+} {
+  return {
+    entry: {
+      state,
+      ts: ts.toISOString(),
+      source: "terminal",
+    },
+    modifiedAt: ts,
+  };
+}
+
+function extractResumeId(command: string): string {
+  const match = command.match(/--resume='([^']+)'/);
+  if (!match?.[1]) throw new Error(`missing resume id in ${command}`);
+  return match[1];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWhichSync.mockReset();
+  mockReadLastActivityEntry.mockResolvedValue(null);
+});
+
+describe("manifest", () => {
+  it("has correct Copilot manifest", () => {
+    expect(manifest).toEqual({
+      name: pluginName,
+      slot: "agent",
+      description: packageJson.description,
+      version: packageJson.version,
+      displayName: "GitHub Copilot CLI",
+    });
+  });
+});
+
+describe("create", () => {
+  it("uses copilot as process name and post-launch prompt mode", () => {
+    const agent = create();
+    expect(agent.name).toBe(pluginName);
+    expect(agent.processName).toBe(pluginName);
+    expect(agent.promptDelivery).toBe("post-launch");
+  });
+
+  it("exports plugin module shape", () => {
+    expect(defaultExport.manifest).toBe(manifest);
+    expect(typeof defaultExport.create).toBe("function");
+    expect(typeof defaultExport.detect).toBe("function");
+  });
+});
+
+describe("detect", () => {
+  it("returns true when which resolves", () => {
+    mockWhichSync.mockReturnValue("/usr/local/bin/copilot");
+    expect(detect()).toBe(true);
+  });
+
+  it("returns false when which fails", () => {
+    mockWhichSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(detect()).toBe(false);
+  });
+});
+
+describe("getLaunchCommand", () => {
+  const agent = create();
+
+  it("uses interactive launch with a stable Copilot session id", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig());
+    expect(cmd).toMatch(/^copilot --no-auto-update --resume='[0-9a-f-]+' --model 'gpt-5\.4'$/);
+    expect(extractResumeId(cmd)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("uses launch-time model override when provided", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ model: "claude-sonnet-4.6" }));
+    expect(cmd).toContain("--model 'claude-sonnet-4.6'");
+  });
+
+  it("maps permissionless mode to Copilot all-permissions mode", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "permissionless" }));
+    expect(cmd).toContain("--allow-all");
+  });
+
+  it("uses project agentConfig permissions when launch permissions are absent", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        projectConfig: {
+          ...makeLaunchConfig().projectConfig,
+          agentConfig: { permissions: "permissionless" },
+        },
+      }),
+    );
+    expect(cmd).toContain("--allow-all");
+  });
+
+  it("maps auto-edit mode to Copilot write approval", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "auto-edit" }));
+    expect(cmd).toContain("--allow-tool=write");
+  });
+
+  it("does not include prompt flags in launch command", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        prompt: "Do work",
+        systemPrompt: "You are helpful",
+        systemPromptFile: "/tmp/prompt.md",
+      }),
+    );
+    expect(cmd).not.toContain(" -p ");
+    expect(cmd).not.toContain(" --prompt");
+    expect(cmd).not.toContain(" -i ");
+    expect(cmd).not.toContain(" --interactive");
+  });
+});
+
+describe("getEnvironment", () => {
+  const agent = create();
+
+  it("writes AO session keys and Copilot flags", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["AO_SESSION_ID"]).toBe("sess-1");
+    expect(env["AO_ISSUE_ID"]).toBeUndefined();
+    expect(env["COPILOT_AUTO_UPDATE"]).toBe("false");
+    expect(env["GH_PATH"]).toBe("/usr/local/bin/gh");
+    expect(env["PATH"]).toContain(".ao/bin");
+  });
+
+  it("includes AO_ISSUE_ID when provided", () => {
+    const env = agent.getEnvironment(makeLaunchConfig({ issueId: "INT-42" }));
+    expect(env["AO_ISSUE_ID"]).toBe("INT-42");
+  });
+});
+
+describe("isProcessRunning", () => {
+  const agent = create();
+
+  it("returns true when copilot is on tmux pane", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") {
+        return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      }
+      if (cmd === "ps") {
+        return Promise.resolve({
+          stdout: "  PID TT       ARGS\n  789 ttys003  /usr/local/bin/copilot --no-auto-update\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("returns false when tmux process is missing", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      if (cmd === "ps") {
+        return Promise.resolve({ stdout: "  PID TT      ARGS\n  789 ttys003  bash\n", stderr: "" });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns indeterminate when tmux probing fails", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("tmux timed out"));
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(PROCESS_PROBE_INDETERMINATE);
+  });
+
+  it("returns true when process handle pid is alive", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(123, 0);
+    killSpy.mockRestore();
+  });
+
+  it("treats EPERM as alive for process handles", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
+    killSpy.mockRestore();
+  });
+
+  it("returns false when process handle pid is dead", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(false);
+    killSpy.mockRestore();
+  });
+});
+
+describe("recordActivity", () => {
+  const agent = create();
+
+  it("classifies idle terminal output when recording activity", async () => {
+    await agent.recordActivity?.(makeSession(), "done\n> ");
+    expect(mockRecordTerminalActivity).toHaveBeenCalledWith(
+      "/workspace/test",
+      "done\n> ",
+      expect.any(Function),
+    );
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("done\n> ")).toBe("idle");
+  });
+
+  it("classifies active terminal output when recording activity", async () => {
+    await agent.recordActivity?.(makeSession(), "GitHub Copilot is working on your request");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("GitHub Copilot is working on your request")).toBe("active");
+  });
+
+  it("classifies folder trust prompts as waiting_input", async () => {
+    await agent.recordActivity?.(
+      makeSession(),
+      "Confirm folder trust\nDo you trust the files in this folder?\nCurrent selection: 1. Yes\n↑↓ to navigate · Enter to select",
+    );
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(
+      classify?.(
+        "Confirm folder trust\nDo you trust the files in this folder?\nCurrent selection: 1. Yes\n↑↓ to navigate · Enter to select",
+      ),
+    ).toBe("waiting_input");
+  });
+
+  it("classifies authentication failures as blocked", async () => {
+    await agent.recordActivity?.(makeSession(), "Error: not authenticated");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Error: not authenticated")).toBe("blocked");
+  });
+
+  it("skips recording when workspacePath is missing", async () => {
+    await agent.recordActivity?.(makeSession({ workspacePath: null }), "still running");
+    expect(mockRecordTerminalActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe("getActivityState", () => {
+  const agent = create();
+
+  it("falls back to exited when runtime handle missing", async () => {
+    const state = await agent.getActivityState(makeSession({ runtimeHandle: null }));
+    expect(state).toMatchObject({ state: "exited" });
+  });
+
+  it("returns null when process probe is indeterminate", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("tmux timed out"));
+    const state = await agent.getActivityState(makeSession({ runtimeHandle: makeTmuxHandle() }));
+    expect(state).toBeNull();
+  });
+
+  it("falls back to activity JSONL waiting_input state", async () => {
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("waiting_input", new Date()));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("waiting_input");
+    killSpy.mockRestore();
+  });
+
+  it("returns blocked from recent activity JSONL", async () => {
+    const activityAt = new Date();
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("blocked", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("blocked");
+    expect(state?.timestamp?.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("returns active from JSONL fallback", async () => {
+    const activityAt = new Date();
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("active", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("active");
+    expect(state?.timestamp?.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("decays JSONL fallback state to idle when the entry is stale", async () => {
+    const activityAt = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("active", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("idle");
+    expect(state?.timestamp?.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("returns null when no JSONL activity data is available", async () => {
+    mockReadLastActivityEntry.mockResolvedValue(null);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state).toBeNull();
+    killSpy.mockRestore();
+  });
+});
+
+describe("getSessionInfo", () => {
+  const agent = create();
+
+  it("returns the stable Copilot session id without summary or cost", async () => {
+    const info = await agent.getSessionInfo(makeSession({ id: "sess-1" }));
+    expect(info).toEqual({
+      agentSessionId: extractResumeId(
+        agent.getLaunchCommand(makeLaunchConfig({ sessionId: "sess-1" })),
+      ),
+      summary: null,
+    });
+  });
+});
+
+describe("getRestoreCommand", () => {
+  const agent = create();
+
+  it("builds restore command using the stable Copilot session id", async () => {
+    const session = makeSession({ id: "sess-1", issueId: "123" });
+    const project = makeLaunchConfig().projectConfig;
+    const restore = await agent.getRestoreCommand?.(session, project);
+    expect(restore).toBe(
+      agent.getLaunchCommand(makeLaunchConfig({ sessionId: "sess-1", issueId: "123" })),
+    );
+  });
+});
+
+describe("workspace hooks", () => {
+  const agent = create();
+
+  it("sets up path wrapper workspace hooks", async () => {
+    await agent.setupWorkspaceHooks?.("/workspace/test", { dataDir: "/data", sessionId: "sess-1" });
+    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
+  });
+
+  it("postLaunchSetup sets up path wrapper hooks when workspace exists", async () => {
+    await agent.postLaunchSetup?.(makeSession({ workspacePath: "/workspace/test" }));
+    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
+  });
+
+  it("postLaunchSetup skips sessions without a workspace", async () => {
+    await agent.postLaunchSetup?.(makeSession({ workspacePath: null }));
+    expect(mockSetupPathWrapperWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/agent-copilot/src/index.test.ts
+++ b/packages/plugins/agent-copilot/src/index.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { AgentLaunchConfig, RuntimeHandle, Session } from "@aoagents/ao-core";
+import {
+  PROCESS_PROBE_INDETERMINATE,
+  isWindows,
+  type AgentLaunchConfig,
+  type RuntimeHandle,
+  type Session,
+} from "@aoagents/ao-core";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
@@ -57,7 +63,6 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import { PROCESS_PROBE_INDETERMINATE, isWindows } from "@aoagents/ao-core";
 import { create, detect, manifest, default as defaultExport } from "./index.js";
 
 const itIfNotWindows = isWindows() ? it.skip : it;

--- a/packages/plugins/agent-copilot/src/index.test.ts
+++ b/packages/plugins/agent-copilot/src/index.test.ts
@@ -138,6 +138,12 @@ function extractResumeId(command: string): string {
   return match[1];
 }
 
+function extractNameId(command: string): string {
+  const match = command.match(/--name '([^']+)'/);
+  if (!match?.[1]) throw new Error(`missing name id in ${command}`);
+  return match[1];
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockWhichSync.mockReset();
@@ -157,11 +163,11 @@ describe("manifest", () => {
 });
 
 describe("create", () => {
-  it("uses copilot as process name and post-launch prompt mode", () => {
+  it("uses copilot as process name and inline prompt mode", () => {
     const agent = create();
     expect(agent.name).toBe(pluginName);
     expect(agent.processName).toBe(pluginName);
-    expect(agent.promptDelivery).toBe("post-launch");
+    expect(agent.promptDelivery).toBe("inline");
   });
 
   it("exports plugin module shape", () => {
@@ -188,10 +194,10 @@ describe("detect", () => {
 describe("getLaunchCommand", () => {
   const agent = create();
 
-  it("uses interactive launch with a stable Copilot session id", () => {
+  it("uses interactive launch with a stable Copilot session name", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig());
-    expect(cmd).toMatch(/^copilot --no-auto-update --resume='[0-9a-f-]+' --model 'gpt-5\.4'$/);
-    expect(extractResumeId(cmd)).toMatch(
+    expect(cmd).toMatch(/^copilot --no-auto-update --name '[0-9a-f-]+' --model 'gpt-5\.4'$/);
+    expect(extractNameId(cmd)).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
     );
   });
@@ -223,18 +229,23 @@ describe("getLaunchCommand", () => {
     expect(cmd).toContain("--allow-tool=write");
   });
 
-  it("does not include prompt flags in launch command", () => {
+  it("passes the initial prompt to interactive mode", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({
         prompt: "Do work",
         systemPrompt: "You are helpful",
-        systemPromptFile: "/tmp/prompt.md",
       }),
     );
     expect(cmd).not.toContain(" -p ");
     expect(cmd).not.toContain(" --prompt");
-    expect(cmd).not.toContain(" -i ");
-    expect(cmd).not.toContain(" --interactive");
+    expect(cmd).toContain("--interactive 'You are helpful\n\n## User Request\nDo work'");
+  });
+
+  it("does not pass an interactive prompt when restoring", async () => {
+    const session = makeSession({ id: "sess-1", issueId: "123" });
+    const project = makeLaunchConfig().projectConfig;
+    const restore = await agent.getRestoreCommand?.(session, project);
+    expect(restore).not.toContain("--interactive");
   });
 });
 
@@ -446,7 +457,7 @@ describe("getSessionInfo", () => {
   it("returns the stable Copilot session id without summary or cost", async () => {
     const info = await agent.getSessionInfo(makeSession({ id: "sess-1" }));
     expect(info).toEqual({
-      agentSessionId: extractResumeId(
+      agentSessionId: extractNameId(
         agent.getLaunchCommand(makeLaunchConfig({ sessionId: "sess-1" })),
       ),
       summary: null,
@@ -461,8 +472,11 @@ describe("getRestoreCommand", () => {
     const session = makeSession({ id: "sess-1", issueId: "123" });
     const project = makeLaunchConfig().projectConfig;
     const restore = await agent.getRestoreCommand?.(session, project);
-    expect(restore).toBe(
-      agent.getLaunchCommand(makeLaunchConfig({ sessionId: "sess-1", issueId: "123" })),
+    expect(restore).toMatch(
+      /^copilot --no-auto-update --resume='[0-9a-f-]+' --model 'gpt-5\.4'$/,
+    );
+    expect(extractResumeId(restore ?? "")).toBe(
+      extractNameId(agent.getLaunchCommand(makeLaunchConfig({ sessionId: "sess-1" }))),
     );
   });
 });

--- a/packages/plugins/agent-copilot/src/index.test.ts
+++ b/packages/plugins/agent-copilot/src/index.test.ts
@@ -57,8 +57,10 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import { PROCESS_PROBE_INDETERMINATE } from "@aoagents/ao-core";
+import { PROCESS_PROBE_INDETERMINATE, isWindows } from "@aoagents/ao-core";
 import { create, detect, manifest, default as defaultExport } from "./index.js";
+
+const itIfNotWindows = isWindows() ? it.skip : it;
 
 function makeSession(overrides: Partial<Session> = {}): Session {
   return {
@@ -185,7 +187,7 @@ describe("getLaunchCommand", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig());
     expect(cmd).toMatch(/^copilot --no-auto-update --resume='[0-9a-f-]+' --model 'gpt-5\.4'$/);
     expect(extractResumeId(cmd)).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      /^[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
     );
   });
 
@@ -239,8 +241,8 @@ describe("getEnvironment", () => {
     expect(env["AO_SESSION_ID"]).toBe("sess-1");
     expect(env["AO_ISSUE_ID"]).toBeUndefined();
     expect(env["COPILOT_AUTO_UPDATE"]).toBe("false");
-    expect(env["GH_PATH"]).toBe("/usr/local/bin/gh");
-    expect(env["PATH"]).toContain(".ao/bin");
+    expect(env["GH_PATH"]).toBeUndefined();
+    expect(env["PATH"]).toBeUndefined();
   });
 
   it("includes AO_ISSUE_ID when provided", () => {
@@ -252,7 +254,7 @@ describe("getEnvironment", () => {
 describe("isProcessRunning", () => {
   const agent = create();
 
-  it("returns true when copilot is on tmux pane", async () => {
+  itIfNotWindows("returns true when copilot is on tmux pane", async () => {
     mockExecFileAsync.mockImplementation((cmd: string) => {
       if (cmd === "tmux") {
         return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
@@ -269,7 +271,7 @@ describe("isProcessRunning", () => {
     expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
   });
 
-  it("returns false when tmux process is missing", async () => {
+  itIfNotWindows("returns false when tmux process is missing", async () => {
     mockExecFileAsync.mockImplementation((cmd: string) => {
       if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
       if (cmd === "ps") {
@@ -280,7 +282,7 @@ describe("isProcessRunning", () => {
     expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
   });
 
-  it("returns indeterminate when tmux probing fails", async () => {
+  itIfNotWindows("returns indeterminate when tmux probing fails", async () => {
     mockExecFileAsync.mockRejectedValue(new Error("tmux timed out"));
     expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(PROCESS_PROBE_INDETERMINATE);
   });
@@ -370,7 +372,7 @@ describe("getActivityState", () => {
     expect(state).toMatchObject({ state: "exited" });
   });
 
-  it("returns null when process probe is indeterminate", async () => {
+  itIfNotWindows("returns null when process probe is indeterminate", async () => {
     mockExecFileAsync.mockRejectedValue(new Error("tmux timed out"));
     const state = await agent.getActivityState(makeSession({ runtimeHandle: makeTmuxHandle() }));
     expect(state).toBeNull();

--- a/packages/plugins/agent-copilot/src/index.ts
+++ b/packages/plugins/agent-copilot/src/index.ts
@@ -25,6 +25,7 @@ import {
 } from "@aoagents/ao-core";
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { promisify } from "node:util";
 import which from "which";
@@ -119,10 +120,38 @@ function getConfiguredPermissionMode(config: AgentLaunchConfig): string | undefi
   return config.permissions ?? agentConfig?.permissions;
 }
 
-function buildCopilotCommand(config: AgentLaunchConfig, restoreSessionId?: string): string {
+function buildInitialPrompt(config: AgentLaunchConfig): string | null {
+  const parts: string[] = [];
+
+  if (config.systemPromptFile) {
+    try {
+      const systemPrompt = readFileSync(config.systemPromptFile, "utf-8").trim();
+      if (systemPrompt) parts.push(systemPrompt);
+    } catch {
+      // Continue with the task prompt if the system prompt file is unexpectedly unavailable.
+    }
+  } else if (config.systemPrompt?.trim()) {
+    parts.push(config.systemPrompt.trim());
+  }
+
+  if (config.prompt?.trim()) {
+    parts.push(`## User Request\n${config.prompt.trim()}`);
+  }
+
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
+function buildCopilotCommand(
+  config: AgentLaunchConfig,
+  options: { restoreSessionId?: string } = {},
+): string {
   const parts = [COPILOT_EXECUTABLE, "--no-auto-update"];
-  const copilotSessionId = restoreSessionId ?? makeCopilotSessionId(config.sessionId);
-  parts.push(`--resume=${shellEscape(copilotSessionId)}`);
+  const copilotSessionId = options.restoreSessionId ?? makeCopilotSessionId(config.sessionId);
+  if (options.restoreSessionId) {
+    parts.push(`--resume=${shellEscape(copilotSessionId)}`);
+  } else {
+    parts.push("--name", shellEscape(copilotSessionId));
+  }
 
   const model = getConfiguredModel(config);
   if (model) {
@@ -134,6 +163,13 @@ function buildCopilotCommand(config: AgentLaunchConfig, restoreSessionId?: strin
     parts.push("--allow-all");
   } else if (permissionMode === "auto-edit") {
     parts.push("--allow-tool=write");
+  }
+
+  if (!options.restoreSessionId) {
+    const initialPrompt = buildInitialPrompt(config);
+    if (initialPrompt) {
+      parts.push("--interactive", shellEscape(initialPrompt));
+    }
   }
 
   return parts.join(" ");
@@ -151,7 +187,7 @@ function createCopilotAgent(): Agent {
   return {
     name: pluginName,
     processName: pluginName,
-    promptDelivery: "post-launch",
+    promptDelivery: "inline",
 
     getLaunchCommand(config: AgentLaunchConfig): string {
       return buildCopilotCommand(config);
@@ -264,12 +300,15 @@ function createCopilotAgent(): Agent {
     },
 
     async getRestoreCommand(session: Session, project: ProjectConfig): Promise<string | null> {
-      return buildCopilotCommand({
-        sessionId: session.id,
-        projectConfig: project,
-        workspacePath: session.workspacePath ?? undefined,
-        issueId: session.issueId ?? undefined,
-      });
+      return buildCopilotCommand(
+        {
+          sessionId: session.id,
+          projectConfig: project,
+          workspacePath: session.workspacePath ?? undefined,
+          issueId: session.issueId ?? undefined,
+        },
+        { restoreSessionId: makeCopilotSessionId(session.id) },
+      );
     },
 
     async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {

--- a/packages/plugins/agent-copilot/src/index.ts
+++ b/packages/plugins/agent-copilot/src/index.ts
@@ -47,7 +47,7 @@ const COPILOT_SESSION_NAMESPACE = "ao-agent-copilot";
 const UUID_VERSION_8_CUSTOM = 0x80;
 
 const ANSI_ESCAPE_RE = new RegExp(
-  `${String.fromCharCode(27)}(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])`,
+  `${String.fromCharCode(27)}(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~])`,
   "g",
 );
 

--- a/packages/plugins/agent-copilot/src/index.ts
+++ b/packages/plugins/agent-copilot/src/index.ts
@@ -1,0 +1,301 @@
+import {
+  DEFAULT_ACTIVE_WINDOW_MS,
+  DEFAULT_READY_THRESHOLD_MS,
+  PROCESS_PROBE_INDETERMINATE,
+  PREFERRED_GH_PATH,
+  buildAgentPath,
+  checkActivityLogState,
+  getActivityFallbackState,
+  isWindows,
+  normalizeAgentPermissionMode,
+  readLastActivityEntry,
+  recordTerminalActivity,
+  setupPathWrapperWorkspace,
+  shellEscape,
+  type ActivityDetection,
+  type ActivityState,
+  type Agent,
+  type AgentLaunchConfig,
+  type AgentSessionInfo,
+  type AgentSpecificConfig,
+  type PluginModule,
+  type ProcessProbeResult,
+  type ProjectConfig,
+  type RuntimeHandle,
+  type Session,
+  type WorkspaceHooksConfig,
+} from "@aoagents/ao-core";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import { promisify } from "node:util";
+import which from "which";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as {
+  name: string;
+  version: string;
+  description: string;
+};
+const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
+const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
+  ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)
+  : packageJson.name;
+
+const execFileAsync = promisify(execFile);
+const COPILOT_EXECUTABLE = "copilot";
+const COPILOT_PROCESS_RE = /(?:^|\/)copilot(?:\s|$)/;
+const COPILOT_SESSION_NAMESPACE = "ao-agent-copilot";
+
+const ANSI_ESCAPE_RE = new RegExp(
+  `${String.fromCharCode(27)}(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])`,
+  "g",
+);
+
+function makeCopilotSessionId(sessionId: string): string {
+  const bytes = createHash("sha256")
+    .update(`${COPILOT_SESSION_NAMESPACE}:${sessionId}`)
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function classifyCopilotTerminalOutput(terminalOutput: string): ActivityState {
+  const normalizedOutput = terminalOutput.replaceAll(ANSI_ESCAPE_RE, "").trim();
+  if (!normalizedOutput) return "idle";
+
+  const lines = normalizedOutput.split("\n").map((line) => line.trim());
+  const lastLine = lines[lines.length - 1] ?? "";
+  const lastNonEmptyLine = [...lines].reverse().find(Boolean) ?? "";
+  const lowerOutput = normalizedOutput.toLowerCase();
+  const lowerLastLine = lastLine.toLowerCase();
+
+  if (/^[>$#]\s*$/.test(lastLine)) return "idle";
+  if (
+    lowerOutput.includes("confirm folder trust") ||
+    lowerOutput.includes("do you trust the files in this folder?")
+  ) {
+    return "waiting_input";
+  }
+  if (lowerOutput.includes("current selection:") && lowerOutput.includes("enter to select")) {
+    return "waiting_input";
+  }
+  if (
+    lowerOutput.includes("permission needed:") ||
+    lowerOutput.includes("path permission needed:")
+  ) {
+    return "waiting_input";
+  }
+  if (
+    /\b(run command|allow command|approve|deny)\b/i.test(lastNonEmptyLine) &&
+    /\?\s*$/.test(lastNonEmptyLine)
+  ) {
+    return "waiting_input";
+  }
+  if (
+    lowerOutput.includes("no prompt provided") ||
+    lowerOutput.includes("not authenticated") ||
+    lowerOutput.includes("authentication failed") ||
+    lowerOutput.includes("could not locate copilot cli") ||
+    lowerOutput.includes("cannot find github copilot cli") ||
+    /^error\b/i.test(lastLine) ||
+    lowerLastLine.startsWith("error:")
+  ) {
+    return "blocked";
+  }
+
+  return "active";
+}
+
+function getConfiguredModel(config: AgentLaunchConfig): string | undefined {
+  const agentConfig = config.projectConfig.agentConfig as AgentSpecificConfig | undefined;
+  return config.model ?? agentConfig?.model;
+}
+
+function getConfiguredPermissionMode(config: AgentLaunchConfig): string | undefined {
+  const agentConfig = config.projectConfig.agentConfig as AgentSpecificConfig | undefined;
+  return config.permissions ?? agentConfig?.permissions;
+}
+
+function buildCopilotCommand(config: AgentLaunchConfig, restoreSessionId?: string): string {
+  const parts = [COPILOT_EXECUTABLE, "--no-auto-update"];
+  const copilotSessionId = restoreSessionId ?? makeCopilotSessionId(config.sessionId);
+  parts.push(`--resume=${shellEscape(copilotSessionId)}`);
+
+  const model = getConfiguredModel(config);
+  if (model) {
+    parts.push("--model", shellEscape(model));
+  }
+
+  const permissionMode = normalizeAgentPermissionMode(getConfiguredPermissionMode(config));
+  if (permissionMode === "permissionless") {
+    parts.push("--allow-all");
+  } else if (permissionMode === "auto-edit") {
+    parts.push("--allow-tool=write");
+  }
+
+  return parts.join(" ");
+}
+
+export const manifest = {
+  name: pluginName,
+  slot: "agent" as const,
+  description: packageJson.description,
+  version: packageJson.version,
+  displayName: "GitHub Copilot CLI",
+};
+
+function createCopilotAgent(): Agent {
+  return {
+    name: pluginName,
+    processName: pluginName,
+    promptDelivery: "post-launch",
+
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      return buildCopilotCommand(config);
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      const env: Record<string, string> = {};
+      env["AO_SESSION_ID"] = config.sessionId;
+      if (config.issueId) {
+        env["AO_ISSUE_ID"] = config.issueId;
+      }
+
+      env["PATH"] = buildAgentPath(process.env["PATH"]);
+      env["GH_PATH"] = PREFERRED_GH_PATH;
+      env["COPILOT_AUTO_UPDATE"] = "false";
+
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      return classifyCopilotTerminalOutput(terminalOutput);
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
+      const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
+      const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
+
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (running === false) return { state: "exited", timestamp: exitedAt };
+      if (running === PROCESS_PROBE_INDETERMINATE) return null;
+
+      let activityResult: Awaited<ReturnType<typeof readLastActivityEntry>> = null;
+      if (session.workspacePath) {
+        activityResult = await readLastActivityEntry(session.workspacePath);
+        const activityState = checkActivityLogState(activityResult);
+        if (activityState) return activityState;
+      }
+
+      const fallback = getActivityFallbackState(activityResult, activeWindowMs, threshold);
+      if (fallback) return fallback;
+
+      return null;
+    },
+
+    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
+      if (!session.workspacePath) return;
+      await recordTerminalActivity(session.workspacePath, terminalOutput, (output: string) =>
+        classifyCopilotTerminalOutput(output),
+      );
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
+      try {
+        if (handle.runtimeName === "tmux" && handle.id) {
+          if (isWindows()) return PROCESS_PROBE_INDETERMINATE;
+          const { stdout: ttyOut } = await execFileAsync(
+            "tmux",
+            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+            { timeout: 30_000 },
+          );
+          const ttys = ttyOut
+            .trim()
+            .split("\n")
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (ttys.length === 0) return false;
+
+          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
+            timeout: 30_000,
+          });
+          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
+          for (const line of psOut.split("\n")) {
+            const cols = line.trimStart().split(/\s+/);
+            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+            const args = cols.slice(2).join(" ");
+            if (COPILOT_PROCESS_RE.test(args)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        const rawPid = handle.data["pid"];
+        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+        if (Number.isFinite(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+            return true;
+          } catch (err: unknown) {
+            if (err instanceof Error && (err as NodeJS.ErrnoException).code === "EPERM") {
+              return true;
+            }
+            return false;
+          }
+        }
+        return false;
+      } catch {
+        return PROCESS_PROBE_INDETERMINATE;
+      }
+    },
+
+    async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {
+      return {
+        agentSessionId: makeCopilotSessionId(session.id),
+        summary: null,
+      };
+    },
+
+    async getRestoreCommand(session: Session, project: ProjectConfig): Promise<string | null> {
+      return buildCopilotCommand({
+        sessionId: session.id,
+        projectConfig: project,
+        workspacePath: session.workspacePath ?? undefined,
+        issueId: session.issueId ?? undefined,
+      });
+    },
+
+    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+      await setupPathWrapperWorkspace(workspacePath);
+    },
+
+    async postLaunchSetup(session: Session): Promise<void> {
+      if (!session.workspacePath) return;
+      await setupPathWrapperWorkspace(session.workspacePath);
+    },
+  };
+}
+
+export function create(): Agent {
+  return createCopilotAgent();
+}
+
+export function detect(): boolean {
+  try {
+    return Boolean(which.sync(COPILOT_EXECUTABLE));
+  } catch {
+    return false;
+  }
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-copilot/src/index.ts
+++ b/packages/plugins/agent-copilot/src/index.ts
@@ -2,8 +2,6 @@ import {
   DEFAULT_ACTIVE_WINDOW_MS,
   DEFAULT_READY_THRESHOLD_MS,
   PROCESS_PROBE_INDETERMINATE,
-  PREFERRED_GH_PATH,
-  buildAgentPath,
   checkActivityLogState,
   getActivityFallbackState,
   isWindows,
@@ -46,6 +44,7 @@ const execFileAsync = promisify(execFile);
 const COPILOT_EXECUTABLE = "copilot";
 const COPILOT_PROCESS_RE = /(?:^|\/)copilot(?:\s|$)/;
 const COPILOT_SESSION_NAMESPACE = "ao-agent-copilot";
+const UUID_VERSION_8_CUSTOM = 0x80;
 
 const ANSI_ESCAPE_RE = new RegExp(
   `${String.fromCharCode(27)}(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])`,
@@ -57,7 +56,7 @@ function makeCopilotSessionId(sessionId: string): string {
     .update(`${COPILOT_SESSION_NAMESPACE}:${sessionId}`)
     .digest()
     .subarray(0, 16);
-  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[6] = (bytes[6] & 0x0f) | UUID_VERSION_8_CUSTOM;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;
   const hex = bytes.toString("hex");
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
@@ -165,8 +164,6 @@ function createCopilotAgent(): Agent {
         env["AO_ISSUE_ID"] = config.issueId;
       }
 
-      env["PATH"] = buildAgentPath(process.env["PATH"]);
-      env["GH_PATH"] = PREFERRED_GH_PATH;
       env["COPILOT_AUTO_UPDATE"] = "false";
 
       return env;
@@ -212,7 +209,7 @@ function createCopilotAgent(): Agent {
     async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
       try {
         if (handle.runtimeName === "tmux" && handle.id) {
-          if (isWindows()) return PROCESS_PROBE_INDETERMINATE;
+          if (isWindows()) return false;
           const { stdout: ttyOut } = await execFileAsync(
             "tmux",
             ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],

--- a/packages/plugins/agent-copilot/tsconfig.json
+++ b/packages/plugins/agent-copilot/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -13,6 +13,7 @@ const nextConfig = {
     "@aoagents/ao-plugin-agent-claude-code",
     "@aoagents/ao-plugin-agent-codex",
     "@aoagents/ao-plugin-agent-opencode",
+    "@aoagents/ao-plugin-agent-copilot",
     "@aoagents/ao-plugin-runtime-tmux",
     "@aoagents/ao-plugin-scm-github",
     "@aoagents/ao-plugin-tracker-github",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -46,6 +46,7 @@
     "@aoagents/ao-core": "workspace:*",
     "@aoagents/ao-plugin-agent-claude-code": "workspace:*",
     "@aoagents/ao-plugin-agent-codex": "workspace:*",
+    "@aoagents/ao-plugin-agent-copilot": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -40,6 +40,7 @@ import pluginAgentCodex from "@aoagents/ao-plugin-agent-codex";
 import pluginAgentCursor from "@aoagents/ao-plugin-agent-cursor";
 import pluginAgentKimicode from "@aoagents/ao-plugin-agent-kimicode";
 import pluginAgentOpencode from "@aoagents/ao-plugin-agent-opencode";
+import pluginAgentCopilot from "@aoagents/ao-plugin-agent-copilot";
 import pluginWorkspaceWorktree from "@aoagents/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@aoagents/ao-plugin-scm-github";
 import pluginTrackerGithub from "@aoagents/ao-plugin-tracker-github";
@@ -112,6 +113,7 @@ async function initServices(): Promise<Services> {
   registry.register(pluginAgentCursor);
   registry.register(pluginAgentKimicode);
   registry.register(pluginAgentOpencode);
+  registry.register(pluginAgentCopilot);
   registry.register(pluginWorkspaceWorktree);
   registry.register(pluginScmGithub);
   registry.register(pluginTrackerGithub);

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -53,6 +53,10 @@ export default defineConfig({
         replacement: resolve(__dirname, "../plugins/agent-opencode/src/index.ts"),
       },
       {
+        find: "@aoagents/ao-plugin-agent-copilot",
+        replacement: resolve(__dirname, "../plugins/agent-copilot/src/index.ts"),
+      },
+      {
         find: "@aoagents/ao-plugin-workspace-worktree",
         replacement: resolve(__dirname, "../plugins/workspace-worktree/src/index.ts"),
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       '@aoagents/ao-plugin-agent-codex':
         specifier: workspace:*
         version: link:../plugins/agent-codex
+      '@aoagents/ao-plugin-agent-copilot':
+        specifier: workspace:*
+        version: link:../plugins/agent-copilot
       '@aoagents/ao-plugin-agent-cursor':
         specifier: workspace:*
         version: link:../plugins/agent-cursor
@@ -316,6 +319,28 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/plugins/agent-copilot:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+      which:
+        specifier: ^6.0.1
+        version: 6.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -685,6 +710,9 @@ importers:
       '@aoagents/ao-plugin-agent-codex':
         specifier: workspace:*
         version: link:../plugins/agent-codex
+      '@aoagents/ao-plugin-agent-copilot':
+        specifier: workspace:*
+        version: link:../plugins/agent-copilot
       '@aoagents/ao-plugin-agent-cursor':
         specifier: workspace:*
         version: link:../plugins/agent-cursor
@@ -1974,6 +2002,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/which@3.0.4':
+    resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
+
+  '@types/wrap-ansi@3.0.0':
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -5076,6 +5110,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/which@3.0.4': {}
+
+  '@types/wrap-ansi@3.0.0': {}
 
   '@types/ws@8.18.1':
     dependencies:


### PR DESCRIPTION
## Summary
- add a new `@aoagents/ao-plugin-agent-copilot` built-in agent package following the Forge plugin shape
- wire Copilot into core registry, CLI direct imports/detection, web service registration, and workspace package deps
- add focused Copilot plugin tests for manifest/export shape, detection, launch/restore, env, liveness, activity recording/state, and hooks

## Copilot CLI surface verified
- executable: `copilot`
- help/version checked with `npx -y @github/copilot --help`, `npx -y @github/copilot --version`, `copilot help commands`, `copilot help environment`, `copilot help permissions`, and `copilot login --help`
- launch: interactive `copilot`; this plugin starts/resumes a deterministic UUID via documented `--resume=<uuid>` and uses post-launch prompt delivery
- restore/session: Copilot documents `--resume[=sessionId]`, `--continue`, and `--name`; the plugin uses a deterministic UUID derived from AO session id
- waiting input: observed folder trust prompt in a PTY; classifier also covers documented permission prompts and authentication/install failures
- metadata/statistics: no non-interactive metadata/statistics command found; `/usage`, `/context`, and `/session` are interactive commands, so summary/cost lookup remains unavailable

## Validation
- `pnpm --filter @aoagents/ao-core build`
- `pnpm --filter @aoagents/ao-plugin-agent-copilot test`
- `pnpm --filter @aoagents/ao-plugin-agent-copilot typecheck`
- `pnpm --filter @aoagents/ao-plugin-agent-copilot build`
- `pnpm --filter @aoagents/ao-core typecheck`
- `pnpm --filter @aoagents/ao-cli typecheck`
- `pnpm --filter @aoagents/ao-web typecheck`

## Unsupported / conservative assumptions
- Copilot CLI exposes no stable machine-readable session metadata/statistics command, so `getSessionInfo()` only returns the deterministic AO-derived Copilot session UUID and no summary/cost.
- `detect()` intentionally follows the Forge skill's which-based pattern; a VS Code Copilot shim can satisfy `which copilot` before the standalone CLI is fully installed.
- First-run folder trust remains a Copilot runtime prompt; the plugin classifies it as `waiting_input` rather than auto-trusting workspaces.
