### PR TITLE
feat: add Pi agent plugin

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
+    "@aoagents/ao-plugin-agent-pi": "workspace:*",
     "@aoagents/ao-plugin-notifier-composio": "workspace:*",
     "@aoagents/ao-plugin-notifier-dashboard": "workspace:*",
     "@aoagents/ao-plugin-notifier-desktop": "workspace:*",

--- a/packages/cli/src/lib/detect-agent.ts
+++ b/packages/cli/src/lib/detect-agent.ts
@@ -21,6 +21,7 @@ const AGENT_PLUGINS: Array<{ name: string; pkg: string }> = [
   { name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
   { name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { name: "pi", pkg: "@aoagents/ao-plugin-agent-pi" },
 ];
 
 /**

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -5,6 +5,7 @@ import aiderPlugin from "@aoagents/ao-plugin-agent-aider";
 import cursorPlugin from "@aoagents/ao-plugin-agent-cursor";
 import kimicodePlugin from "@aoagents/ao-plugin-agent-kimicode";
 import opencodePlugin from "@aoagents/ao-plugin-agent-opencode";
+import piPlugin from "@aoagents/ao-plugin-agent-pi";
 import githubSCMPlugin from "@aoagents/ao-plugin-scm-github";
 
 const agentPlugins: Record<string, { create(): Agent }> = {
@@ -14,6 +15,7 @@ const agentPlugins: Record<string, { create(): Agent }> = {
   cursor: cursorPlugin,
   kimicode: kimicodePlugin,
   opencode: opencodePlugin,
+  pi: piPlugin,
 };
 
 const scmPlugins: Record<string, { create(): SCM }> = {

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -2385,6 +2385,30 @@ describe("spawn", () => {
       expect(readFileSync(promptFile, "utf-8")).toBe("You are the orchestrator.");
     });
 
+    it("does not send orchestrator system prompt again for post-launch prompt agents", async () => {
+      const postLaunchAgent: Agent = {
+        ...mockAgent,
+        promptDelivery: "post-launch",
+      };
+      const registryWithPostLaunchAgent: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return postLaunchAgent;
+          if (slot === "workspace") return mockWorkspace;
+          return null;
+        }),
+      };
+      const sm = createSessionManager({ config, registry: registryWithPostLaunchAgent });
+
+      await sm.spawnOrchestrator({
+        projectId: "my-app",
+        systemPrompt: "You are the orchestrator.",
+      });
+
+      expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
+    });
+
     it("persists displayName derived from the orchestrator system prompt", async () => {
       const sm = createSessionManager({ config, registry: mockRegistry });
 

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -47,6 +47,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { slot: "agent", name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
   { slot: "agent", name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
+  { slot: "agent", name: "pi", pkg: "@aoagents/ao-plugin-agent-pi" },
   // Workspaces
   { slot: "workspace", name: "worktree", pkg: "@aoagents/ao-plugin-workspace-worktree" },
   { slot: "workspace", name: "clone", pkg: "@aoagents/ao-plugin-workspace-clone" },

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1504,6 +1504,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         await plugins.agent.postLaunchSetup(session);
       }
 
+      if (plugins.agent.promptDelivery === "post-launch" && taskPrompt) {
+        await plugins.runtime.sendMessage(handle, taskPrompt);
+      }
+
       if (
         plugins.agent.name === "opencode" &&
         opencodeIssueSessionStrategy === "reuse" &&

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -475,6 +475,12 @@ export interface Agent {
   /** Process name to look for (e.g. "claude", "codex", "aider") */
   readonly processName: string;
 
+  /**
+   * How AO should deliver the initial worker task prompt.
+   * Defaults to inline launch-command delivery.
+   */
+  readonly promptDelivery?: "inline" | "post-launch";
+
   /** Get the shell command to launch this agent */
   getLaunchCommand(config: AgentLaunchConfig): string;
 

--- a/packages/plugins/agent-pi/package.json
+++ b/packages/plugins/agent-pi/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@aoagents/ao-plugin-agent-pi",
+  "version": "0.1.0",
+  "description": "Agent plugin: Pi",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-pi"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*",
+    "which": "^6.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "@types/which": "^3.0.4",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-pi/src/index.test.ts
+++ b/packages/plugins/agent-pi/src/index.test.ts
@@ -441,6 +441,25 @@ describe("recordActivity", () => {
     );
   });
 
+  it("does not classify stale waiting-input prompts in scrollback as waiting_input", async () => {
+    await agent.recordActivity?.(
+      makeSession(),
+      "Press any key to continue...\nReading package.json",
+    );
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Press any key to continue...\nReading package.json")).toBe("active");
+  });
+
+  it("does not classify stale idle prompts in scrollback as idle", async () => {
+    await agent.recordActivity?.(makeSession(), "How can I help?\nReading package.json");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("How can I help?\nReading package.json")).toBe("active");
+  });
+
   it("classifies blocked terminal output", async () => {
     await agent.recordActivity?.(makeSession(), "Error: API key is missing");
     const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as

--- a/packages/plugins/agent-pi/src/index.test.ts
+++ b/packages/plugins/agent-pi/src/index.test.ts
@@ -244,11 +244,11 @@ describe("manifest", () => {
 });
 
 describe("create", () => {
-  it("uses pi as process name and post-launch prompt mode", () => {
+  it("uses pi as process name and inline prompt mode", () => {
     const agent = create();
     expect(agent.name).toBe(pluginName);
     expect(agent.processName).toBe(pluginName);
-    expect(agent.promptDelivery).toBe("post-launch");
+    expect(agent.promptDelivery).toBe("inline");
   });
 
   it("exports plugin module shape", () => {
@@ -280,7 +280,7 @@ describe("getLaunchCommand", () => {
     expect(cmd).toBe("pi --session-dir '/workspace/repo/.ao/pi-sessions/sess-1'");
   });
 
-  it("passes the AO system prompt file without inlining the task prompt", () => {
+  it("passes the AO system prompt file", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ systemPromptFile: "/tmp/system prompt.md" }),
     );
@@ -303,7 +303,7 @@ describe("getLaunchCommand", () => {
     );
   });
 
-  it("does not include prompt flags in launch command", () => {
+  it("passes the task prompt as Pi's positional initial message", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({
         prompt: "Do work",
@@ -312,7 +312,7 @@ describe("getLaunchCommand", () => {
       }),
     );
     expect(cmd).toBe(
-      "pi --session-dir '/workspace/repo/.ao/pi-sessions/sess-1' --append-system-prompt '/tmp/prompt.md'",
+      "pi --session-dir '/workspace/repo/.ao/pi-sessions/sess-1' --append-system-prompt '/tmp/prompt.md' 'Do work'",
     );
     expect(cmd).not.toContain("-p ");
     expect(cmd).not.toContain("--print");

--- a/packages/plugins/agent-pi/src/index.test.ts
+++ b/packages/plugins/agent-pi/src/index.test.ts
@@ -1,0 +1,646 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AgentLaunchConfig, RuntimeHandle, Session } from "@aoagents/ao-core";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as {
+  name: string;
+  version: string;
+  description: string;
+};
+const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
+const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
+  ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)
+  : packageJson.name;
+
+const {
+  mockReadLastActivityEntry,
+  mockRecordTerminalActivity,
+  mockSetupPathWrapperWorkspace,
+  mockExecFileAsync,
+  mockWhichSync,
+  mockIsWindows,
+} = vi.hoisted(() => ({
+  mockReadLastActivityEntry: vi.fn().mockResolvedValue(null),
+  mockRecordTerminalActivity: vi.fn().mockResolvedValue(undefined),
+  mockSetupPathWrapperWorkspace: vi.fn().mockResolvedValue(undefined),
+  mockExecFileAsync: vi.fn(),
+  mockWhichSync: vi.fn(),
+  mockIsWindows: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    readLastActivityEntry: mockReadLastActivityEntry,
+    recordTerminalActivity: mockRecordTerminalActivity,
+    setupPathWrapperWorkspace: mockSetupPathWrapperWorkspace,
+    isWindows: mockIsWindows,
+  };
+});
+
+vi.mock("which", () => ({
+  default: {
+    sync: mockWhichSync,
+  },
+  sync: mockWhichSync,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: (...args: unknown[]) => {
+    const callback = args[args.length - 1];
+    const result = mockExecFileAsync(...args.slice(0, -1));
+    if (typeof callback === "function" && result && typeof result.then === "function") {
+      result.then(
+        (value: { stdout: string; stderr: string }) => callback(null, value),
+        (err: Error) => callback(err),
+      );
+    }
+  },
+}));
+
+import { create, detect, manifest, default as defaultExport } from "./index.js";
+
+const VALID_PI_SESSION_ID = "019e29c4-125d-750d-bb67-24c58b841553";
+
+function makeLifecycle(): Session["lifecycle"] {
+  const now = new Date().toISOString();
+  return {
+    version: 2,
+    session: {
+      kind: "worker",
+      state: "working",
+      reason: "task_in_progress",
+      startedAt: now,
+      completedAt: null,
+      terminatedAt: null,
+      lastTransitionAt: now,
+    },
+    pr: {
+      state: "none",
+      reason: "not_created",
+      number: null,
+      url: null,
+      lastObservedAt: null,
+    },
+    runtime: {
+      state: "alive",
+      reason: "process_running",
+      lastObservedAt: now,
+      handle: null,
+      tmuxName: null,
+    },
+  };
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "sess-1",
+    projectId: "test-project",
+    status: "working",
+    activity: "active",
+    activitySignal: { state: "valid", activity: "active", source: "terminal" },
+    lifecycle: makeLifecycle(),
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/workspace/repo",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeLaunchConfig(overrides: Partial<AgentLaunchConfig> = {}): AgentLaunchConfig {
+  return {
+    sessionId: "sess-1",
+    workspacePath: "/workspace/repo",
+    projectConfig: {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/source",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+      agentConfig: {},
+    },
+    ...overrides,
+  };
+}
+
+function makeTmuxHandle(id = "test-session"): RuntimeHandle {
+  return { id, runtimeName: "tmux", data: {} };
+}
+
+function makeProcessHandle(pid?: number | string): RuntimeHandle {
+  return { id: "proc-1", runtimeName: "process", data: pid !== undefined ? { pid } : {} };
+}
+
+function makeActivityResult(
+  state: "active" | "ready" | "idle" | "waiting_input" | "blocked",
+  ts: Date,
+): {
+  entry: {
+    state: "active" | "ready" | "idle" | "waiting_input" | "blocked";
+    ts: string;
+    source: string;
+  };
+  modifiedAt: Date;
+} {
+  return {
+    entry: {
+      state,
+      ts: ts.toISOString(),
+      source: "terminal",
+    },
+    modifiedAt: ts,
+  };
+}
+
+async function writePiSessionFile(
+  dir: string,
+  options: {
+    id?: string;
+    userText?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    costTotal?: number;
+  } = {},
+): Promise<string> {
+  const id = options.id ?? VALID_PI_SESSION_ID;
+  const filePath = join(dir, `2026-05-15T03-52-56-157Z_${id}.jsonl`);
+  const lines = [
+    JSON.stringify({
+      type: "session",
+      version: 3,
+      id,
+      timestamp: "2026-05-15T03:52:56.157Z",
+      cwd: "/workspace/repo",
+    }),
+    JSON.stringify({
+      type: "message",
+      id: "user-1",
+      timestamp: "2026-05-15T03:52:56.196Z",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: options.userText ?? "Implement the feature" }],
+      },
+    }),
+    JSON.stringify({
+      type: "message",
+      id: "assistant-1",
+      timestamp: "2026-05-15T03:52:59.710Z",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Done" }],
+        usage: {
+          input: options.inputTokens ?? 1200,
+          output: options.outputTokens ?? 34,
+          cost: { total: options.costTotal ?? 0.0123 },
+        },
+      },
+    }),
+  ];
+  await writeFile(filePath, `${lines.join("\n")}\n`, "utf8");
+  return filePath;
+}
+
+let tempDirs: string[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWhichSync.mockReset();
+  mockExecFileAsync.mockReset();
+  mockIsWindows.mockReturnValue(false);
+});
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs = [];
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "ao-pi-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("manifest", () => {
+  it("has correct Pi manifest", () => {
+    expect(manifest).toEqual({
+      name: pluginName,
+      slot: "agent",
+      description: packageJson.description,
+      version: packageJson.version,
+      displayName: "Pi",
+    });
+  });
+});
+
+describe("create", () => {
+  it("uses pi as process name and post-launch prompt mode", () => {
+    const agent = create();
+    expect(agent.name).toBe(pluginName);
+    expect(agent.processName).toBe(pluginName);
+    expect(agent.promptDelivery).toBe("post-launch");
+  });
+
+  it("exports plugin module shape", () => {
+    expect(defaultExport.manifest).toBe(manifest);
+    expect(typeof defaultExport.create).toBe("function");
+    expect(typeof defaultExport.detect).toBe("function");
+  });
+});
+
+describe("detect", () => {
+  it("returns true when which resolves pi", () => {
+    mockWhichSync.mockReturnValue("/usr/local/bin/pi");
+    expect(detect()).toBe(true);
+  });
+
+  it("returns false when which fails", () => {
+    mockWhichSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(detect()).toBe(false);
+  });
+});
+
+describe("getLaunchCommand", () => {
+  const agent = create();
+
+  it("uses interactive launch with an AO-owned session directory", () => {
+    const cmd = agent.getLaunchCommand(makeLaunchConfig());
+    expect(cmd).toBe("pi --session-dir '/workspace/repo/.ao/pi-sessions/sess-1'");
+  });
+
+  it("passes the AO system prompt file without inlining the task prompt", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ systemPromptFile: "/tmp/system prompt.md" }),
+    );
+    expect(cmd).toBe(
+      "pi --session-dir '/workspace/repo/.ao/pi-sessions/sess-1' --append-system-prompt '/tmp/system prompt.md'",
+    );
+  });
+
+  it("uses --session when configured with Pi session metadata", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        projectConfig: {
+          ...makeLaunchConfig().projectConfig,
+          agentConfig: { piSessionId: VALID_PI_SESSION_ID },
+        },
+      }),
+    );
+    expect(cmd).toBe(
+      `pi --session-dir '/workspace/repo/.ao/pi-sessions/sess-1' --session '${VALID_PI_SESSION_ID}'`,
+    );
+  });
+
+  it("does not include prompt flags in launch command", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        prompt: "Do work",
+        systemPrompt: "You are helpful",
+        systemPromptFile: "/tmp/prompt.md",
+      }),
+    );
+    expect(cmd).toBe(
+      "pi --session-dir '/workspace/repo/.ao/pi-sessions/sess-1' --append-system-prompt '/tmp/prompt.md'",
+    );
+    expect(cmd).not.toContain("-p ");
+    expect(cmd).not.toContain("--print");
+  });
+});
+
+describe("getEnvironment", () => {
+  const agent = create();
+
+  it("writes AO session keys and Pi session-dir env", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["AO_SESSION_ID"]).toBe("sess-1");
+    expect(env["AO_ISSUE_ID"]).toBeUndefined();
+    expect(env["PI_CODING_AGENT_SESSION_DIR"]).toBe("/workspace/repo/.ao/pi-sessions/sess-1");
+    expect(env["PATH"]).toBeUndefined();
+    expect(env["GH_PATH"]).toBeUndefined();
+  });
+
+  it("includes AO_ISSUE_ID when provided", () => {
+    const env = agent.getEnvironment(makeLaunchConfig({ issueId: "42" }));
+    expect(env["AO_ISSUE_ID"]).toBe("42");
+  });
+});
+
+describe("isProcessRunning", () => {
+  const agent = create();
+
+  it("returns true when pi is on tmux pane", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      if (cmd === "ps") {
+        return Promise.resolve({
+          stdout:
+            "  PID TT       ARGS\n  789 ttys003  node /x/@earendil-works/pi-coding-agent/dist/cli.js --session-dir /tmp/pi\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("returns false when tmux process is missing", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      if (cmd === "ps")
+        return Promise.resolve({
+          stdout: "  PID TT       ARGS\n  789 ttys003  bash\n",
+          stderr: "",
+        });
+      return Promise.reject(new Error("unexpected"));
+    });
+
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns indeterminate for tmux handles on Windows", async () => {
+    mockIsWindows.mockReturnValue(true);
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe("indeterminate");
+  });
+
+  it("returns true when process handle pid is alive", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(123, 0);
+    killSpy.mockRestore();
+  });
+
+  it("treats EPERM as a running process", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      const err = new Error("EPERM") as NodeJS.ErrnoException;
+      err.code = "EPERM";
+      throw err;
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
+    killSpy.mockRestore();
+  });
+
+  it("returns false when process handle pid is dead", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(false);
+    killSpy.mockRestore();
+  });
+});
+
+describe("recordActivity", () => {
+  const agent = create();
+
+  it("classifies Pi's ready prompt as idle", async () => {
+    await agent.recordActivity?.(
+      makeSession(),
+      "How can I help?\nShare what you want to do in this repo",
+    );
+    expect(mockRecordTerminalActivity).toHaveBeenCalledWith(
+      "/workspace/repo",
+      "How can I help?\nShare what you want to do in this repo",
+      expect.any(Function),
+    );
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("How can I help?\nShare what you want to do in this repo")).toBe("idle");
+  });
+
+  it("classifies active output", async () => {
+    await agent.recordActivity?.(makeSession(), "Reading package.json");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Reading package.json")).toBe("active");
+  });
+
+  it("classifies waiting-input terminal prompts", async () => {
+    await agent.recordActivity?.(
+      makeSession(),
+      "Warning: legacy settings\nPress any key to continue...",
+    );
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Warning: legacy settings\nPress any key to continue...")).toBe(
+      "waiting_input",
+    );
+  });
+
+  it("classifies blocked terminal output", async () => {
+    await agent.recordActivity?.(makeSession(), "Error: API key is missing");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Error: API key is missing")).toBe("blocked");
+  });
+
+  it("does not classify old errors in terminal history as blocked", async () => {
+    await agent.recordActivity?.(makeSession(), "Error: old failure\nReading package.json");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Error: old failure\nReading package.json")).toBe("active");
+  });
+
+  it("skips recording when workspacePath is missing", async () => {
+    await agent.recordActivity?.(makeSession({ workspacePath: null }), "Reading package.json");
+    expect(mockRecordTerminalActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe("getActivityState", () => {
+  const agent = create();
+
+  it("returns exited when runtime handle is missing", async () => {
+    const state = await agent.getActivityState(makeSession({ runtimeHandle: null }));
+    expect(state).toMatchObject({ state: "exited" });
+  });
+
+  it("returns exited when process is not running", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state).toMatchObject({ state: "exited" });
+    killSpy.mockRestore();
+  });
+
+  it("returns waiting_input from activity JSONL", async () => {
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("waiting_input", new Date()));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("waiting_input");
+    killSpy.mockRestore();
+  });
+
+  it("returns active from JSONL fallback", async () => {
+    const activityAt = new Date();
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("active", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("active");
+    expect(state?.timestamp?.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("decays JSONL fallback state to idle when stale", async () => {
+    const activityAt = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("active", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("idle");
+    expect(state?.timestamp?.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("returns null when no reliable activity data exists", async () => {
+    mockReadLastActivityEntry.mockResolvedValue(null);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state).toBeNull();
+    killSpy.mockRestore();
+  });
+});
+
+describe("getSessionInfo", () => {
+  const agent = create();
+
+  it("returns null when no session directory is available", async () => {
+    expect(await agent.getSessionInfo(makeSession({ workspacePath: null }))).toBeNull();
+  });
+
+  it("extracts Pi session id, fallback summary, cost, and metadata", async () => {
+    const dir = await makeTempDir();
+    await writePiSessionFile(dir, {
+      userText: "Implement agent-pi plugin",
+      inputTokens: 300,
+      outputTokens: 20,
+      costTotal: 0.004,
+    });
+    const info = await agent.getSessionInfo(makeSession({ metadata: { piSessionDir: dir } }));
+
+    expect(info).toMatchObject({
+      agentSessionId: VALID_PI_SESSION_ID,
+      summary: "Implement agent-pi plugin",
+      summaryIsFallback: true,
+      metadata: {
+        piSessionId: VALID_PI_SESSION_ID,
+        piSessionDir: dir,
+      },
+      cost: {
+        inputTokens: 300,
+        outputTokens: 20,
+        estimatedCostUsd: 0.004,
+      },
+    });
+  });
+
+  it("discovers Pi session files in cwd slug subdirectories", async () => {
+    const dir = await makeTempDir();
+    const nestedDir = join(dir, "--workspace--repo--");
+    await mkdir(nestedDir);
+    await writePiSessionFile(nestedDir, { userText: "Nested Pi session" });
+
+    const info = await agent.getSessionInfo(makeSession({ metadata: { piSessionDir: dir } }));
+
+    expect(info).toMatchObject({
+      agentSessionId: VALID_PI_SESSION_ID,
+      summary: "Nested Pi session",
+      metadata: {
+        piSessionId: VALID_PI_SESSION_ID,
+        piSessionDir: dir,
+      },
+    });
+  });
+
+  it("returns null when Pi session metadata is unavailable", async () => {
+    const dir = await makeTempDir();
+    expect(await agent.getSessionInfo(makeSession({ metadata: { piSessionDir: dir } }))).toBeNull();
+  });
+});
+
+describe("getRestoreCommand", () => {
+  const agent = create();
+
+  it("builds restore command from persisted Pi session metadata", async () => {
+    const dir = await makeTempDir();
+    const cmd = await agent.getRestoreCommand?.(
+      makeSession({ metadata: { piSessionId: VALID_PI_SESSION_ID, piSessionDir: dir } }),
+      makeLaunchConfig().projectConfig,
+    );
+    expect(cmd).toBe(`pi --session-dir '${dir}' --session '${VALID_PI_SESSION_ID}'`);
+  });
+
+  it("discovers a Pi session id from the AO-owned session directory", async () => {
+    const dir = await makeTempDir();
+    await writePiSessionFile(dir);
+    const cmd = await agent.getRestoreCommand?.(
+      makeSession({ metadata: { piSessionDir: dir } }),
+      makeLaunchConfig().projectConfig,
+    );
+    expect(cmd).toBe(`pi --session-dir '${dir}' --session '${VALID_PI_SESSION_ID}'`);
+  });
+
+  it("discovers a Pi session id from nested cwd session directories", async () => {
+    const dir = await makeTempDir();
+    const nestedDir = join(dir, "--workspace--repo--");
+    await mkdir(nestedDir);
+    await writePiSessionFile(nestedDir);
+    const cmd = await agent.getRestoreCommand?.(
+      makeSession({ metadata: { piSessionDir: dir } }),
+      makeLaunchConfig().projectConfig,
+    );
+    expect(cmd).toBe(`pi --session-dir '${dir}' --session '${VALID_PI_SESSION_ID}'`);
+  });
+
+  it("returns null when no session id can be found", async () => {
+    const dir = await makeTempDir();
+    const cmd = await agent.getRestoreCommand?.(
+      makeSession({ metadata: { piSessionDir: dir } }),
+      makeLaunchConfig().projectConfig,
+    );
+    expect(cmd).toBeNull();
+  });
+});
+
+describe("workspace hooks", () => {
+  const agent = create();
+
+  it("sets up path-wrapper workspace hooks", async () => {
+    await agent.setupWorkspaceHooks?.("/workspace/repo", {
+      dataDir: "/tmp/ao",
+      sessionId: "sess-1",
+    });
+    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/repo");
+  });
+
+  it("runs path-wrapper setup after launch when workspace exists", async () => {
+    await agent.postLaunchSetup?.(makeSession({ workspacePath: "/workspace/repo" }));
+    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/repo");
+  });
+});

--- a/packages/plugins/agent-pi/src/index.ts
+++ b/packages/plugins/agent-pi/src/index.ts
@@ -133,10 +133,8 @@ function classifyPiTerminalOutput(terminalOutput: string): ActivityState {
   const lastNonEmptyLine = [...lines].reverse().find(Boolean) ?? "";
 
   if (/^[>$#]\s*$/.test(lastLine)) return "idle";
-  if (PI_IDLE_PROMPT_RE.test(normalizedOutput)) return "idle";
-  if (PI_WAITING_INPUT_RE.test(lastNonEmptyLine) || PI_WAITING_INPUT_RE.test(normalizedOutput)) {
-    return "waiting_input";
-  }
+  if (PI_IDLE_PROMPT_RE.test(lastNonEmptyLine)) return "idle";
+  if (PI_WAITING_INPUT_RE.test(lastNonEmptyLine)) return "waiting_input";
   if (PI_BLOCKED_RE.test(lastLine) || PI_BLOCKED_RE.test(lastNonEmptyLine)) return "blocked";
 
   return "active";

--- a/packages/plugins/agent-pi/src/index.ts
+++ b/packages/plugins/agent-pi/src/index.ts
@@ -113,6 +113,7 @@ function buildPiCommand(
   sessionDir: string,
   sessionId?: string | null,
   systemPromptFile?: string,
+  prompt?: string,
 ): string {
   const parts = [PI_EXECUTABLE, "--session-dir", shellEscape(sessionDir)];
   if (systemPromptFile) {
@@ -120,6 +121,9 @@ function buildPiCommand(
   }
   if (sessionId) {
     parts.push("--session", shellEscape(sessionId));
+  }
+  if (prompt) {
+    parts.push(shellEscape(prompt));
   }
   return parts.join(" ");
 }
@@ -328,13 +332,14 @@ function createPiAgent(): Agent {
   return {
     name: pluginName,
     processName: pluginName,
-    promptDelivery: "post-launch",
+    promptDelivery: "inline",
 
     getLaunchCommand(config: AgentLaunchConfig): string {
       return buildPiCommand(
         getPiSessionDir(config),
         getConfiguredPiSessionId(config),
         config.systemPromptFile,
+        config.prompt,
       );
     },
 

--- a/packages/plugins/agent-pi/src/index.ts
+++ b/packages/plugins/agent-pi/src/index.ts
@@ -1,0 +1,495 @@
+import {
+  DEFAULT_ACTIVE_WINDOW_MS,
+  DEFAULT_READY_THRESHOLD_MS,
+  PROCESS_PROBE_INDETERMINATE,
+  checkActivityLogState,
+  getActivityFallbackState,
+  isWindows,
+  readLastActivityEntry,
+  recordTerminalActivity,
+  setupPathWrapperWorkspace,
+  shellEscape,
+  type ActivityDetection,
+  type ActivityState,
+  type Agent,
+  type AgentLaunchConfig,
+  type AgentSessionInfo,
+  type CostEstimate,
+  type PluginModule,
+  type ProcessProbeResult,
+  type ProjectConfig,
+  type RuntimeHandle,
+  type Session,
+  type WorkspaceHooksConfig,
+} from "@aoagents/ao-core";
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import { open, readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import which from "which";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as {
+  name: string;
+  version: string;
+  description: string;
+};
+const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
+const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
+  ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)
+  : packageJson.name;
+
+const execFileAsync = promisify(execFile);
+const PI_EXECUTABLE = "pi";
+const PI_SESSION_ID_METADATA_KEY = "piSessionId";
+const PI_SESSION_DIR_METADATA_KEY = "piSessionDir";
+const MAX_SESSION_SCAN_BYTES = 2 * 1024 * 1024;
+const MAX_SESSION_HEAD_BYTES = 64 * 1024;
+const MAX_SESSION_SCAN_DEPTH = 4;
+const MAX_SESSION_SCAN_FILES = 200;
+const PI_SESSION_ID_RE =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+const ANSI_ESCAPE_RE = new RegExp(
+  `${String.fromCharCode(27)}(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~])`,
+  "g",
+);
+const PI_WAITING_INPUT_RE =
+  /(?:press any key to continue|delete session\?.*(?:confirm|cancel)|\bconfirm\b.*\bcancel\b)/i;
+const PI_IDLE_PROMPT_RE = /(?:how can i help\?|share what you want to do in this repo)/i;
+const PI_BLOCKED_RE =
+  /(?:\berror\b|\bfailed\b|\bexception\b|not authenticated|api key|unknown option|cannot execute)/i;
+
+type JsonObject = Record<string, unknown>;
+
+interface PiSessionFileInfo {
+  path: string;
+  modifiedAt: Date;
+  id: string;
+  summary: string | null;
+  cost?: CostEstimate;
+}
+
+function asValidPiSessionId(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return PI_SESSION_ID_RE.test(trimmed) ? trimmed : null;
+}
+
+function stringFromRecord(record: JsonObject, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function getPiSessionDir(config: AgentLaunchConfig): string {
+  return join(
+    config.workspacePath ?? config.projectConfig.path,
+    ".ao",
+    "pi-sessions",
+    config.sessionId,
+  );
+}
+
+function getPiSessionDirForSession(session: Session): string | null {
+  const fromMetadata = stringFromRecord(session.metadata ?? {}, PI_SESSION_DIR_METADATA_KEY);
+  if (fromMetadata) return fromMetadata;
+  if (!session.workspacePath) return null;
+  return join(session.workspacePath, ".ao", "pi-sessions", session.id);
+}
+
+function getConfiguredPiSessionId(config: AgentLaunchConfig): string | null {
+  return asValidPiSessionId(config.projectConfig.agentConfig?.[PI_SESSION_ID_METADATA_KEY]);
+}
+
+function getSessionPiSessionId(session: Session): string | null {
+  return (
+    asValidPiSessionId(session.metadata?.[PI_SESSION_ID_METADATA_KEY]) ??
+    asValidPiSessionId(session.agentInfo?.agentSessionId)
+  );
+}
+
+function buildPiCommand(
+  sessionDir: string,
+  sessionId?: string | null,
+  systemPromptFile?: string,
+): string {
+  const parts = [PI_EXECUTABLE, "--session-dir", shellEscape(sessionDir)];
+  if (systemPromptFile) {
+    parts.push("--append-system-prompt", shellEscape(systemPromptFile));
+  }
+  if (sessionId) {
+    parts.push("--session", shellEscape(sessionId));
+  }
+  return parts.join(" ");
+}
+
+function classifyPiTerminalOutput(terminalOutput: string): ActivityState {
+  const normalizedOutput = terminalOutput.replaceAll(ANSI_ESCAPE_RE, "").trim();
+  if (!normalizedOutput) return "idle";
+
+  const lines = normalizedOutput.split("\n").map((line) => line.trim());
+  const lastLine = lines[lines.length - 1] ?? "";
+  const lastNonEmptyLine = [...lines].reverse().find(Boolean) ?? "";
+
+  if (/^[>$#]\s*$/.test(lastLine)) return "idle";
+  if (PI_IDLE_PROMPT_RE.test(normalizedOutput)) return "idle";
+  if (PI_WAITING_INPUT_RE.test(lastNonEmptyLine) || PI_WAITING_INPUT_RE.test(normalizedOutput)) {
+    return "waiting_input";
+  }
+  if (PI_BLOCKED_RE.test(lastLine) || PI_BLOCKED_RE.test(lastNonEmptyLine)) return "blocked";
+
+  return "active";
+}
+
+function parseJsonLine(line: string): JsonObject | null {
+  try {
+    const parsed: unknown = JSON.parse(line);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as JsonObject)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractTextContent(content: unknown): string | null {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return null;
+
+  const text = content
+    .map((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) return null;
+      const record = item as JsonObject;
+      return record["type"] === "text" && typeof record["text"] === "string"
+        ? record["text"]
+        : null;
+    })
+    .filter((part): part is string => Boolean(part))
+    .join(" ")
+    .trim();
+
+  return text.length > 0 ? text : null;
+}
+
+function truncateSummary(summary: string): string {
+  const normalized = summary.replace(/\s+/g, " ").trim();
+  return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+}
+
+function parseUsageCost(usage: unknown): CostEstimate | undefined {
+  if (!usage || typeof usage !== "object" || Array.isArray(usage)) return undefined;
+  const record = usage as JsonObject;
+  const input = record["input"];
+  const output = record["output"];
+  const cost = record["cost"];
+  if (typeof input !== "number" || typeof output !== "number") return undefined;
+  if (!cost || typeof cost !== "object" || Array.isArray(cost)) return undefined;
+  const total = (cost as JsonObject)["total"];
+  if (typeof total !== "number") return undefined;
+  return {
+    inputTokens: input,
+    outputTokens: output,
+    estimatedCostUsd: total,
+  };
+}
+
+async function readSessionFileBounded(filePath: string, size: number): Promise<string> {
+  if (size <= MAX_SESSION_SCAN_BYTES) {
+    return await readFile(filePath, "utf8");
+  }
+
+  const handle = await open(filePath, "r");
+  try {
+    const headSize = Math.min(MAX_SESSION_HEAD_BYTES, size);
+    const tailSize = Math.min(MAX_SESSION_SCAN_BYTES, size);
+    const head = Buffer.alloc(headSize);
+    const tail = Buffer.alloc(tailSize);
+    await handle.read(head, 0, headSize, 0);
+    await handle.read(tail, 0, tailSize, Math.max(0, size - tailSize));
+    return `${head.toString("utf8")}\n${tail.toString("utf8")}`;
+  } finally {
+    await handle.close();
+  }
+}
+
+function parsePiSessionFile(
+  filePath: string,
+  modifiedAt: Date,
+  text: string,
+): PiSessionFileInfo | null {
+  let id: string | null = null;
+  let summary: string | null = null;
+  let cost: CostEstimate | undefined;
+
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    const entry = parseJsonLine(line);
+    if (!entry) continue;
+
+    if (entry["type"] === "session") {
+      id = asValidPiSessionId(entry["id"]) ?? id;
+      continue;
+    }
+
+    if (!summary && entry["type"] === "message") {
+      const message = entry["message"];
+      if (message && typeof message === "object" && !Array.isArray(message)) {
+        const messageRecord = message as JsonObject;
+        if (messageRecord["role"] === "user") {
+          const textContent = extractTextContent(messageRecord["content"]);
+          if (textContent) summary = truncateSummary(textContent);
+        }
+      }
+    }
+
+    if (entry["type"] === "message") {
+      const message = entry["message"];
+      if (message && typeof message === "object" && !Array.isArray(message)) {
+        const messageRecord = message as JsonObject;
+        const parsedCost = parseUsageCost(messageRecord["usage"]);
+        if (parsedCost) cost = parsedCost;
+      }
+    }
+  }
+
+  if (!id) return null;
+  return { path: filePath, modifiedAt, id, summary, ...(cost ? { cost } : {}) };
+}
+
+async function findPiSessionCandidates(
+  sessionDir: string,
+): Promise<Array<{ path: string; modifiedAt: Date; size: number }>> {
+  const candidates: Array<{ path: string; modifiedAt: Date; size: number }> = [];
+  const pending: Array<{ dir: string; depth: number }> = [{ dir: sessionDir, depth: 0 }];
+
+  while (pending.length > 0 && candidates.length < MAX_SESSION_SCAN_FILES) {
+    const current = pending.shift();
+    if (!current) break;
+
+    let entries: Array<{ name: string; isDirectory(): boolean; isFile(): boolean }>;
+    try {
+      entries = await readdir(current.dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const entryPath = join(current.dir, entry.name);
+      if (entry.isDirectory()) {
+        if (current.depth < MAX_SESSION_SCAN_DEPTH) {
+          pending.push({ dir: entryPath, depth: current.depth + 1 });
+        }
+        continue;
+      }
+
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      if (candidates.length >= MAX_SESSION_SCAN_FILES) break;
+
+      try {
+        const stats = await stat(entryPath);
+        if (!stats.isFile()) continue;
+        candidates.push({ path: entryPath, modifiedAt: stats.mtime, size: stats.size });
+      } catch {
+        // Ignore files that disappear while scanning.
+      }
+    }
+  }
+
+  return candidates;
+}
+
+async function findLatestPiSession(sessionDir: string): Promise<PiSessionFileInfo | null> {
+  const candidates = await findPiSessionCandidates(sessionDir);
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => b.modifiedAt.getTime() - a.modifiedAt.getTime());
+
+  for (const candidate of candidates) {
+    try {
+      const text = await readSessionFileBounded(candidate.path, candidate.size);
+      const parsed = parsePiSessionFile(candidate.path, candidate.modifiedAt, text);
+      if (parsed) return parsed;
+    } catch {
+      // Try the next session file.
+    }
+  }
+
+  return null;
+}
+
+export const manifest = {
+  name: pluginName,
+  slot: "agent" as const,
+  description: packageJson.description,
+  version: packageJson.version,
+  displayName: "Pi",
+};
+
+function createPiAgent(): Agent {
+  return {
+    name: pluginName,
+    processName: pluginName,
+    promptDelivery: "post-launch",
+
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      return buildPiCommand(
+        getPiSessionDir(config),
+        getConfiguredPiSessionId(config),
+        config.systemPromptFile,
+      );
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      const env: Record<string, string> = {};
+      env["AO_SESSION_ID"] = config.sessionId;
+      if (config.issueId) {
+        env["AO_ISSUE_ID"] = config.issueId;
+      }
+      env["PI_CODING_AGENT_SESSION_DIR"] = getPiSessionDir(config);
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      return classifyPiTerminalOutput(terminalOutput);
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
+      const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
+      const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
+
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (running === false) return { state: "exited", timestamp: exitedAt };
+
+      let activityResult: Awaited<ReturnType<typeof readLastActivityEntry>> = null;
+      if (session.workspacePath) {
+        activityResult = await readLastActivityEntry(session.workspacePath);
+        const activityState = checkActivityLogState(activityResult);
+        if (activityState) return activityState;
+      }
+
+      const fallback = getActivityFallbackState(activityResult, activeWindowMs, threshold);
+      if (fallback) return fallback;
+
+      return null;
+    },
+
+    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
+      if (!session.workspacePath) return;
+      await recordTerminalActivity(session.workspacePath, terminalOutput, (output: string) =>
+        classifyPiTerminalOutput(output),
+      );
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
+      try {
+        if (handle.runtimeName === "tmux" && handle.id) {
+          if (isWindows()) return PROCESS_PROBE_INDETERMINATE;
+
+          const { stdout: ttyOut } = await execFileAsync(
+            "tmux",
+            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+            { timeout: 30_000 },
+          );
+          const ttys = ttyOut
+            .trim()
+            .split("\n")
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (ttys.length === 0) return false;
+
+          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
+            timeout: 30_000,
+          });
+          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
+          const processRe =
+            /(?:^|\/)pi(?:\s|$)|@earendil-works\/pi-coding-agent|pi-coding-agent|dist\/cli\.js/;
+          for (const line of psOut.split("\n")) {
+            const cols = line.trimStart().split(/\s+/);
+            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+            const args = cols.slice(2).join(" ");
+            if (processRe.test(args)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        const rawPid = handle.data["pid"];
+        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+        if (Number.isFinite(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+            return true;
+          } catch (err: unknown) {
+            if (err instanceof Error && (err as NodeJS.ErrnoException).code === "EPERM") {
+              return true;
+            }
+            return false;
+          }
+        }
+        return false;
+      } catch {
+        return false;
+      }
+    },
+
+    async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {
+      const sessionDir = getPiSessionDirForSession(session);
+      if (!sessionDir) return null;
+
+      const latestSession = await findLatestPiSession(sessionDir);
+      if (!latestSession) return null;
+
+      return {
+        agentSessionId: latestSession.id,
+        summary: latestSession.summary,
+        summaryIsFallback: latestSession.summary ? true : undefined,
+        metadata: {
+          [PI_SESSION_ID_METADATA_KEY]: latestSession.id,
+          [PI_SESSION_DIR_METADATA_KEY]: sessionDir,
+        },
+        ...(latestSession.cost ? { cost: latestSession.cost } : {}),
+      };
+    },
+
+    async getRestoreCommand(session: Session, _project: ProjectConfig): Promise<string | null> {
+      const sessionDir = getPiSessionDirForSession(session);
+      if (!sessionDir) return null;
+
+      const sessionId =
+        getSessionPiSessionId(session) ?? (await findLatestPiSession(sessionDir))?.id ?? null;
+      if (!sessionId) return null;
+
+      return buildPiCommand(sessionDir, sessionId);
+    },
+
+    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+      await setupPathWrapperWorkspace(workspacePath);
+    },
+
+    async postLaunchSetup(session: Session): Promise<void> {
+      if (!session.workspacePath) return;
+      await setupPathWrapperWorkspace(session.workspacePath);
+    },
+  };
+}
+
+export function create(): Agent {
+  return createPiAgent();
+}
+
+export function detect(): boolean {
+  try {
+    return Boolean(which.sync(PI_EXECUTABLE));
+  } catch {
+    return false;
+  }
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-pi/tsconfig.json
+++ b/packages/plugins/agent-pi/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugins/agent-pi/tsconfig.json
+++ b/packages/plugins/agent-pi/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
 }

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -13,6 +13,7 @@ const nextConfig = {
     "@aoagents/ao-plugin-agent-claude-code",
     "@aoagents/ao-plugin-agent-codex",
     "@aoagents/ao-plugin-agent-opencode",
+    "@aoagents/ao-plugin-agent-pi",
     "@aoagents/ao-plugin-runtime-tmux",
     "@aoagents/ao-plugin-scm-github",
     "@aoagents/ao-plugin-tracker-github",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -49,6 +49,7 @@
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
+    "@aoagents/ao-plugin-agent-pi": "workspace:*",
     "@aoagents/ao-plugin-runtime-process": "workspace:*",
     "@aoagents/ao-plugin-runtime-tmux": "workspace:*",
     "@aoagents/ao-plugin-scm-github": "workspace:*",

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -40,6 +40,7 @@ import pluginAgentCodex from "@aoagents/ao-plugin-agent-codex";
 import pluginAgentCursor from "@aoagents/ao-plugin-agent-cursor";
 import pluginAgentKimicode from "@aoagents/ao-plugin-agent-kimicode";
 import pluginAgentOpencode from "@aoagents/ao-plugin-agent-opencode";
+import pluginAgentPi from "@aoagents/ao-plugin-agent-pi";
 import pluginWorkspaceWorktree from "@aoagents/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@aoagents/ao-plugin-scm-github";
 import pluginTrackerGithub from "@aoagents/ao-plugin-tracker-github";
@@ -112,6 +113,7 @@ async function initServices(): Promise<Services> {
   registry.register(pluginAgentCursor);
   registry.register(pluginAgentKimicode);
   registry.register(pluginAgentOpencode);
+  registry.register(pluginAgentPi);
   registry.register(pluginWorkspaceWorktree);
   registry.register(pluginScmGithub);
   registry.register(pluginTrackerGithub);

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -53,6 +53,10 @@ export default defineConfig({
         replacement: resolve(__dirname, "../plugins/agent-opencode/src/index.ts"),
       },
       {
+        find: "@aoagents/ao-plugin-agent-pi",
+        replacement: resolve(__dirname, "../plugins/agent-pi/src/index.ts"),
+      },
+      {
         find: "@aoagents/ao-plugin-workspace-worktree",
         replacement: resolve(__dirname, "../plugins/workspace-worktree/src/index.ts"),
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@aoagents/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
+      '@aoagents/ao-plugin-agent-pi':
+        specifier: workspace:*
+        version: link:../plugins/agent-pi
       '@aoagents/ao-plugin-notifier-composio':
         specifier: workspace:*
         version: link:../plugins/notifier-composio
@@ -364,6 +367,28 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/plugins/agent-pi:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+      which:
+        specifier: ^6.0.1
+        version: 6.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -694,6 +719,9 @@ importers:
       '@aoagents/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
+      '@aoagents/ao-plugin-agent-pi':
+        specifier: workspace:*
+        version: link:../plugins/agent-pi
       '@aoagents/ao-plugin-runtime-process':
         specifier: workspace:*
         version: link:../plugins/runtime-process
@@ -1974,6 +2002,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/which@3.0.4':
+    resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -5076,6 +5107,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/which@3.0.4': {}
 
   '@types/ws@8.18.1':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `@aoagents/ao-plugin-agent-pi` using the Forge-shaped agent plugin contract.
- Register Pi in core, CLI detection/direct imports, and web service bundling.
- Add optional `Agent.promptDelivery = "post-launch"` support so interactive CLIs can receive the initial task after launch.

## Pi CLI surface verified
- Executable/detection: `pi`, detected with `which.sync("pi")`.
- Verified local CLI version: `pi --version` => `0.74.0`.
- Verified help: `pi --help` documents interactive launch, positional messages, `--append-system-prompt`, `--session-dir`, `--session`, `--continue`, `--resume`, `--fork`, `--export`, and env vars including `PI_CODING_AGENT_SESSION_DIR`.
- Launch: `pi --session-dir <workspace>/.ao/pi-sessions/<ao-session-id> --append-system-prompt <systemPromptFile>`; AO sends the task prompt post-launch.
- Restore: `pi --session-dir <dir> --session <uuid>` only when AO has or can discover a Pi JSONL session UUID.
- Stable session id source: Pi JSONL session header (`{"type":"session","id":"..."}`) in the AO-owned session directory.
- Metadata/statistics: no separate metadata command found; plugin reads bounded Pi JSONL session data for fallback summary and usage cost when present.

## Unsupported / conservative assumptions
- No Pi machine-readable session-list/stat command is used.
- No restore is attempted without a persisted/discovered full Pi UUID.
- `--resume`, `--continue`, and `--fork` are documented but not used for AO restore because they either require interactive choice or do not target AO's known stable session id as directly as `--session`.

## Validation
- `pnpm --filter @aoagents/ao-core build`
- `pnpm --filter @aoagents/ao-plugin-agent-pi test`
- `pnpm --filter @aoagents/ao-plugin-agent-pi typecheck`
- `pnpm --filter @aoagents/ao-plugin-agent-pi build`
- `pnpm --filter @aoagents/ao-cli typecheck`
- `pnpm --filter @aoagents/ao-web typecheck`
- `git diff --check`
- Targeted eslint on changed TS files: 0 errors; existing warnings in `packages/core/src/session-manager.ts` only.
