### PR TITLE
fix(web): truncate long session names in sidebar (closes #1802)

### DIFF
--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -858,7 +858,7 @@ function ProjectSidebarInner({
                             aria-label={`Open ${title}`}
                           >
                             <SessionDot level={level} />
-                            <div className="flex-1 min-w-0">
+                            <div className="flex-1 min-w-0 overflow-hidden">
                               <span
                                 className={cn(
                                   "project-sidebar__sess-label",


### PR DESCRIPTION
## Summary
- Adds `overflow-hidden` to the inner wrapper around the session label in `ProjectSidebar.tsx` so the existing `text-overflow: ellipsis` on `.project-sidebar__sess-label` engages.
- Without an overflow-constrained parent, long branch names (e.g. `fix/googletasks-scope-qa-mismatches`) grew past their flex slot and overlapped the "working" status pill.

Closes #1802.

## Test plan
- [x] Open dashboard with a session whose branch name is long enough to overflow the sidebar slot
- [x] Verify the label truncates with an ellipsis and the status pill no longer overlaps the text
- [x] Confirm short names still render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)