### PR TITLE
feat(spawn): add --name flag to set session displayName

### DIFF
--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -203,6 +203,7 @@ async function spawnSession(
   agent?: string,
   claimOptions?: SpawnClaimOptions,
   prompt?: string,
+  displayName?: string,
 ): Promise<void> {
   const spinner = ora("Creating session").start();
 
@@ -216,11 +217,18 @@ async function spawnSession(
       throw new Error("Prompt must be at most 4096 characters");
     }
 
+    // Validate display name length
+    const sanitizedDisplayName = displayName?.trim() || undefined;
+    if (sanitizedDisplayName && sanitizedDisplayName.length > 80) {
+      throw new Error("Name must be at most 80 characters");
+    }
+
     const session = await sm.spawn({
       projectId,
       issueId,
       agent,
       prompt: sanitizedPrompt,
+      displayName: sanitizedDisplayName,
     });
 
     let claimedPrUrl: string | null = null;
@@ -280,6 +288,7 @@ export function registerSpawn(program: Command): void {
     .option("--claim-pr <pr>", "Immediately claim an existing PR for the spawned session")
     .option("--assign-on-github", "Assign the claimed PR to the authenticated GitHub user")
     .option("--prompt <text>", "Initial prompt/instructions for the agent (use instead of an issue)")
+    .option("--name <text>", "Custom display name for the session (overrides auto-derived name)")
     .action(
       async (
         issue: string | undefined,
@@ -289,6 +298,7 @@ export function registerSpawn(program: Command): void {
           claimPr?: string;
           assignOnGithub?: boolean;
           prompt?: string;
+          name?: string;
         },
         command: Command,
       ) => {
@@ -327,7 +337,7 @@ export function registerSpawn(program: Command): void {
           await runSpawnPreflight(config, projectId, claimOptions);
           await ensureAOPollingProject(projectId);
 
-          await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions, opts.prompt);
+          await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions, opts.prompt, opts.name);
         } catch (err) {
           console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
           process.exit(1);

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1372,10 +1372,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       // enrichment (which is a live tracker API call), this value is captured at
       // spawn time and persisted, so the dashboard has a good name even when the
       // tracker is unavailable or the session has no attached PR yet.
-      const displayName = deriveDisplayName({
+      // A user-supplied displayName (via --name) always takes priority.
+      const autoDisplayName = deriveDisplayName({
         issueTitle: resolvedIssue?.title,
         prompt: spawnConfig.prompt,
       });
+      const displayName = spawnConfig.displayName?.trim()
+        ? spawnConfig.displayName!.trim().slice(0, DISPLAY_NAME_MAX_LENGTH)
+        : autoDisplayName;
 
       // Write metadata and run post-launch setup
       const createdAt = new Date();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -368,6 +368,8 @@ export interface SessionSpawnConfig {
   agent?: string;
   /** Override the OpenCode subagent for this session (e.g. "sisyphus", "oracle") */
   subagent?: string;
+  /** Custom display name for the session (overrides auto-derived name) */
+  displayName?: string;
 }
 
 /** Config for creating an orchestrator session */


### PR DESCRIPTION

## Summary

Add a `--name <text>` option to `ao spawn` that sets the `displayName` metadata on the created session, overriding the auto-derived name.

Currently, session display names are derived from issue titles or prompts via `deriveDisplayName()`. This works well for issue-backed sessions but gives generic names like "olli-16" for prompt-only or unnamed sessions. The `--name` flag lets users provide a descriptive name at spawn time.

## Changes

### `packages/core/src/types.ts`
- Added `displayName?: string` to `SessionSpawnConfig` interface with JSDoc comment

### `packages/core/src/session-manager.ts`
- Modified `_spawnInner()` to use `spawnConfig.displayName` (trimmed, truncated to `DISPLAY_NAME_MAX_LENGTH`) when provided, falling back to the auto-derived `deriveDisplayName()` result

### `packages/cli/src/commands/spawn.ts`
- Added `--name <text>` CLI option with description
- Added `name` to the action handler options type
- Added `displayName` parameter to `spawnSession()` function
- Added validation: names longer than 80 characters are rejected with a clear error
- Threads `displayName` through to `sm.spawn()`

## Not included

`--name` is intentionally **not** added to `ao batch-spawn` because assigning a single name to multiple sessions is semantically ambiguous. If needed in the future, batch-spawn could support `--name-prefix` or a CSV mapping.

## Test plan

- [x] `pnpm --filter @aoagents/ao-core typecheck` passes
- [x] `pnpm build` succeeds
- [ ] Manual: `ao spawn --name "My custom session"` creates a session with `displayName: "My custom session"` in metadata
- [ ] Manual: `ao spawn --name "x"` (1 char) works
- [ ] Manual: `ao spawn --name <81+ chars>` is rejected with error
- [ ] Manual: `ao spawn` without `--name` keeps existing behavior (auto-derived name)
