### PR TITLE
fix: sanitize project IDs with dots/special chars on ao start

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -135,7 +135,12 @@ function writeProjectBehaviorConfig(projectPath: string, config: LocalProjectCon
  */
 async function registerFlatConfig(configPath: string): Promise<string | null> {
   const projectPath = resolve(dirname(configPath));
-  const projectId = basename(projectPath);
+  // Sanitize folder name so names like "llama.cpp" or "my.app"
+  // produce valid project IDs matching [a-zA-Z0-9_-]+
+  const rawBasename = basename(projectPath);
+  const projectId =
+    rawBasename.replace(/[^a-zA-Z0-9_-]/g, "-").replace(/^-+|-+$/g, "") ||
+    "project";
 
   // Read flat config fields
   const raw = readFileSync(configPath, "utf-8");
@@ -149,10 +154,7 @@ async function registerFlatConfig(configPath: string): Promise<string | null> {
     typeof parsed["defaultBranch"] === "string"
       ? parsed["defaultBranch"]
       : await detectDefaultBranch(projectPath, repo ?? null);
-  // Strip characters invalid in sessionPrefix (Zod: [a-zA-Z0-9_-]+)
-  // so folder names like "my.app" don't produce invalid prefixes.
-  const prefixInput = projectId.replace(/[^a-zA-Z0-9_-]/g, "-").replace(/^-+|-+$/g, "");
-  const prefix = generateSessionPrefix(prefixInput || projectId);
+  const prefix = generateSessionPrefix(projectId);
 
   console.log(chalk.dim(`\n  Registering project "${projectId}" in global config...\n`));
 
@@ -515,7 +517,12 @@ export async function autoCreateConfig(workingDir: string): Promise<Orchestrator
   const agentRules = generateRulesFromTemplates(projectType);
 
   // Build config with smart defaults
-  const projectId = basename(workingDir);
+  // Sanitize folder name so names like "llama.cpp" or "my.app"
+  // produce valid project IDs matching [a-zA-Z0-9_-]+
+  const rawBasename = basename(workingDir);
+  const projectId =
+    rawBasename.replace(/[^a-zA-Z0-9_-]/g, "-").replace(/^-+|-+$/g, "") ||
+    "project";
   let repo: string | undefined = env.ownerRepo ?? undefined;
   const path = workingDir;
   const defaultBranch = env.defaultBranch || "main";

--- a/packages/core/src/__tests__/paths.test.ts
+++ b/packages/core/src/__tests__/paths.test.ts
@@ -111,6 +111,13 @@ describe("generateProjectId", () => {
     expect(generateProjectId("/home/user/repos/integrator")).toBe("integrator");
     expect(generateProjectId("~/repos/agent-orchestrator")).toBe("agent-orchestrator");
   });
+
+  it("sanitizes special characters in basename", () => {
+    expect(generateProjectId("~/repos/llama.cpp")).toBe("llama-cpp");
+    expect(generateProjectId("~/repos/my.app")).toBe("my-app");
+    expect(generateProjectId("~/repos/my_app-v2.0")).toBe("my_app-v2-0");
+    expect(generateProjectId("/tmp/...")).toBe("project");
+  });
 });
 
 describe("parseTmuxNameV2", () => {

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -45,11 +45,13 @@ export function generateConfigHash(configPath: string): string {
 /**
  * Generate project ID from project path (basename of the path).
  * Example: ~/repos/integrator → "integrator"
+ * Example: ~/repos/llama.cpp → "llama-cpp"
  *
  * @deprecated New project registrations use generateExternalId() from global-config.ts.
  */
 export function generateProjectId(projectPath: string): string {
-  return basename(projectPath);
+  const raw = basename(projectPath);
+  return raw.replace(/[^a-zA-Z0-9_-]/g, "-").replace(/^-+|-+$/g, "") || "project";
 }
 
 /**


### PR DESCRIPTION
## Summary

When `ao start` auto-generates a project ID from a folder name containing dots or special characters (e.g. `llama.cpp`, `my.app`), the raw basename fails Zod validation because the project ID schema requires `[a-zA-Z0-9_-]+`.

## Root Cause

Two code paths in `start.ts` use `basename()` directly without sanitization:
1. `registerFlatConfig()` — registers existing flat configs
2. `autoCreateConfig()` — first-run config generation

Both pass the raw basename as a project key, which later fails Zod schema validation in `config.ts`.

The deprecated `generateProjectId()` in `paths.ts` had the same issue.

## Solution

Sanitize project IDs the same way session prefixes are already sanitized: replace `[^a-zA-Z0-9_-]` with `-` and strip leading/trailing dashes. If the result is empty (e.g. folder named `...`), fall back to `"project"`.

## Changes

- **`packages/cli/src/commands/start.ts`**: Sanitize `projectId` in both `registerFlatConfig()` and `autoCreateConfig()`. Remove now-redundant `prefixInput` variable since `projectId` is already sanitized.
- **`packages/core/src/paths.ts`**: Apply same sanitization to deprecated `generateProjectId()`.
- **`packages/core/src/__tests__/paths.test.ts`**: Add test coverage for sanitization of dot-containing and all-special-char basenames.

## Testing

- All existing tests pass (15/15 in paths.test.ts)
- New test covers: `llama.cpp` → `llama-cpp`, `my.app` → `my-app`, `my_app-v2.0` → `my_app-v2-0`, `...` → `project`