### PR TITLE
fix(cli): sanitize project IDs derived from folder names with dots/special chars

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -661,6 +661,11 @@ async function addProjectToConfig(
   await ensureGit("adding projects");
 
   let projectId = sanitizeProjectId(basename(resolvedPath));
+  if (!projectId) {
+    throw new Error(
+      `Cannot derive a valid project ID from path "${resolvedPath}" — folder name contains only special characters.`,
+    );
+  }
 
   // Avoid overwriting an existing project with the same directory name
   if (config.projects[projectId]) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -34,6 +34,7 @@ import {
   loadLocalProjectConfigDetailed,
   registerProjectInGlobalConfig,
   getGlobalConfigPath,
+  sanitizeProjectId,
   type OrchestratorConfig,
   type LocalProjectConfig,
   type ProjectConfig,
@@ -135,7 +136,7 @@ function writeProjectBehaviorConfig(projectPath: string, config: LocalProjectCon
  */
 async function registerFlatConfig(configPath: string): Promise<string | null> {
   const projectPath = resolve(dirname(configPath));
-  const projectId = basename(projectPath);
+  const projectId = sanitizeProjectId(basename(projectPath));
 
   // Read flat config fields
   const raw = readFileSync(configPath, "utf-8");
@@ -515,7 +516,7 @@ export async function autoCreateConfig(workingDir: string): Promise<Orchestrator
   const agentRules = generateRulesFromTemplates(projectType);
 
   // Build config with smart defaults
-  const projectId = basename(workingDir);
+  const projectId = sanitizeProjectId(basename(workingDir));
   let repo: string | undefined = env.ownerRepo ?? undefined;
   const path = workingDir;
   const defaultBranch = env.defaultBranch || "main";
@@ -659,7 +660,7 @@ async function addProjectToConfig(
 
   await ensureGit("adding projects");
 
-  let projectId = basename(resolvedPath);
+  let projectId = sanitizeProjectId(basename(resolvedPath));
 
   // Avoid overwriting an existing project with the same directory name
   if (config.projects[projectId]) {


### PR DESCRIPTION
## Summary

- Apply `sanitizeProjectId()` to all three `basename()` call sites in `ao start` that derive project IDs from folder names
- Folders like `llama.cpp` now become `llama-cpp` instead of throwing a Zod validation error
- Covers: `registerFlatConfig`, onboarding init flow, and `addProject` flow

## Reproduction

1. Create/clone a repo with dots in folder name (e.g. `llama.cpp`)
2. Run `ao start` in that directory
3. Before this fix: validation error. After: auto-sanitized to `llama-cpp`

## Test plan

- [ ] `ao start` in a folder named `my.app` succeeds (derives `my-app`)
- [ ] `ao start` in a folder named `test_repo` still works (no change)
- [ ] Existing `sanitizeProjectId` unit tests cover the transform rules

Closes #1877