### PR TITLE
fix(web): replace dead-end Update button with copyable CLI command when blocked

### DIFF
--- a/packages/web/src/components/UpdateBanner.tsx
+++ b/packages/web/src/components/UpdateBanner.tsx
@@ -119,8 +119,10 @@ export function UpdateBanner() {
           <span className="font-medium">
             Update available{channelLabel}: {info.current} → {info.latest}
           </span>
-          {phase === "blocked" && errorMessage ? (
-            <span className="text-xs text-[var(--color-status-error)]">{errorMessage}</span>
+          {phase === "blocked" ? (
+            <span className="text-xs text-[var(--color-text-secondary)]">
+              Sessions are active. Run in your terminal:
+            </span>
           ) : phase === "error" && errorMessage ? (
             <span className="text-xs text-[var(--color-status-error)]">
               {errorMessage}
@@ -135,14 +137,29 @@ export function UpdateBanner() {
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={() => void handleUpdate()}
-          disabled={phase === "starting"}
-          className="rounded-sm border border-[var(--color-accent-amber-border)] bg-[var(--color-accent-amber)] px-3 py-1 text-xs font-medium text-[var(--color-text-inverse)] hover:bg-[color-mix(in_srgb,var(--color-accent-amber)_85%,black)] disabled:cursor-wait disabled:opacity-60"
-        >
-          {phase === "starting" ? "Updating…" : "Update"}
-        </button>
+        {phase === "blocked" ? (
+          <code
+            onClick={(e) => {
+              void navigator.clipboard.writeText("ao stop && ao update && ao start");
+              const el = e.currentTarget;
+              el.textContent = "Copied!";
+              setTimeout(() => { el.textContent = "ao stop && ao update && ao start"; }, 1500);
+            }}
+            title="Click to copy"
+            className="cursor-pointer rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 font-[var(--font-mono)] text-xs text-[var(--color-text-primary)] hover:bg-[var(--color-bg-elevated-hover)]"
+          >
+            ao stop &amp;&amp; ao update &amp;&amp; ao start
+          </code>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void handleUpdate()}
+            disabled={phase === "starting"}
+            className="rounded-sm border border-[var(--color-accent-amber-border)] bg-[var(--color-accent-amber)] px-3 py-1 text-xs font-medium text-[var(--color-text-inverse)] hover:bg-[color-mix(in_srgb,var(--color-accent-amber)_85%,black)] disabled:cursor-wait disabled:opacity-60"
+          >
+            {phase === "starting" ? "Updating…" : "Update"}
+          </button>
+        )}
         <button
           type="button"
           onClick={handleDismiss}

--- a/packages/web/src/components/UpdateBanner.tsx
+++ b/packages/web/src/components/UpdateBanner.tsx
@@ -25,6 +25,7 @@ export function UpdateBanner() {
   const [phase, setPhase] = useState<Phase>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [dismissedFor, setDismissedFor] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   // Hydrate dismissal flag from localStorage on mount.
   useEffect(() => {
@@ -139,16 +140,19 @@ export function UpdateBanner() {
       <div className="flex items-center gap-2">
         {phase === "blocked" ? (
           <code
-            onClick={(e) => {
-              void navigator.clipboard.writeText("ao stop && ao update && ao start");
-              const el = e.currentTarget;
-              el.textContent = "Copied!";
-              setTimeout(() => { el.textContent = "ao stop && ao update && ao start"; }, 1500);
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") e.currentTarget.click(); }}
+            onClick={() => {
+              navigator.clipboard.writeText("ao stop && ao update && ao start").then(() => {
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+              }).catch(() => {/* clipboard unavailable */});
             }}
             title="Click to copy"
             className="cursor-pointer rounded-sm border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 font-[var(--font-mono)] text-xs text-[var(--color-text-primary)] hover:bg-[var(--color-bg-elevated-hover)]"
           >
-            ao stop &amp;&amp; ao update &amp;&amp; ao start
+            {copied ? "Copied!" : "ao stop && ao update && ao start"}
           </code>
         ) : (
           <button


### PR DESCRIPTION
## Summary

- When sessions are active and the 409 fires, replace the Update button with a click-to-copy CLI command: `ao stop && ao update && ao start`
- Changes the error text from the raw 409 message to a clear directive: "Sessions are active. Run in your terminal:"
- Click-to-copy feedback shows "Copied!" for 1.5s

## Before / After

**Before:** User clicks Update -> sees error "N sessions active. Run ao stop first" -> runs ao stop -> dashboard dies -> user stuck

**After:** User sees the blocked state -> copies the one-liner from the banner -> runs it in terminal -> AO stops, updates, and restarts cleanly

## Test plan

- [ ] Banner shows Update button when no sessions are active (unchanged)
- [ ] Banner shows CLI command when sessions are active (409 response)
- [ ] Clicking the CLI command copies to clipboard and shows "Copied!" feedback
- [ ] Dismiss button still works in blocked state
- [ ] Typecheck passes

Closes #1879