### PR TITLE
refactor(core): introduce ActivityReducer; consolidate dual getActivityState path

### DIFF
--- a/packages/core/src/__tests__/activity-reducer.test.ts
+++ b/packages/core/src/__tests__/activity-reducer.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyEvent,
+  applyLivenessTick,
+  applyProcessProbe,
+  composeActivity,
+  snapshot,
+  subscribe,
+} from "../activity-reducer.js";
+
+const sessionId = (name: string) => `activity-reducer-${name}`;
+
+describe("activity-reducer", () => {
+  it("stores waiting_input as sticky inbox", () => {
+    applyEvent(sessionId("waiting-input"), { state: "waiting_input" });
+
+    expect(snapshot(sessionId("waiting-input"))?.inbox).toBe("waiting_input");
+  });
+
+  it("keeps inbox sticky when active liveness arrives", () => {
+    const id = sessionId("sticky-active");
+    applyEvent(id, { state: "waiting_input" });
+    applyEvent(id, { state: "active" });
+
+    expect(snapshot(id)?.inbox).toBe("waiting_input");
+    expect(snapshot(id)?.liveness).toBe("active");
+  });
+
+  it("clears inbox and marks liveness exited when process probe reports dead", () => {
+    const id = sessionId("process-dead");
+    applyEvent(id, { state: "waiting_input" });
+
+    applyProcessProbe(id, false);
+
+    expect(snapshot(id)?.inbox).toBeNull();
+    expect(snapshot(id)?.liveness).toBe("exited");
+  });
+
+  it("composes activity with exited over inbox over liveness precedence", () => {
+    const inboxId = sessionId("compose-inbox");
+    applyEvent(inboxId, { state: "waiting_input" });
+    applyEvent(inboxId, { state: "active" });
+
+    expect(composeActivity(snapshot(inboxId))?.state).toBe("waiting_input");
+
+    const exitedId = sessionId("compose-exited");
+    applyEvent(exitedId, { state: "waiting_input" });
+    applyProcessProbe(exitedId, false);
+
+    expect(composeActivity(snapshot(exitedId))?.state).toBe("exited");
+
+    const liveId = sessionId("compose-liveness");
+    applyEvent(liveId, { state: "ready" });
+
+    expect(composeActivity(snapshot(liveId))?.state).toBe("ready");
+  });
+
+  it("notifies subscribers on inbox change and liveness class change", () => {
+    const id = sessionId("subscribe");
+    const listener = vi.fn();
+    const unsubscribe = subscribe(id, listener);
+
+    applyEvent(id, { state: "waiting_input" });
+    applyEvent(id, { state: "active", timestamp: new Date("2026-01-01T00:00:00.000Z") });
+    applyLivenessTick(id, new Date("2026-01-01T00:00:31.000Z"));
+
+    unsubscribe();
+
+    expect(listener).toHaveBeenCalledTimes(3);
+    expect(listener.mock.calls[0]?.[0].inbox).toBe("waiting_input");
+    expect(listener.mock.calls[1]?.[0].liveness).toBe("active");
+    expect(listener.mock.calls[2]?.[0].liveness).toBe("ready");
+  });
+});

--- a/packages/core/src/__tests__/activity-reducer.test.ts
+++ b/packages/core/src/__tests__/activity-reducer.test.ts
@@ -4,6 +4,7 @@ import {
   applyLivenessTick,
   applyProcessProbe,
   composeActivity,
+  resetActivity,
   snapshot,
   subscribe,
 } from "../activity-reducer.js";
@@ -24,6 +25,13 @@ describe("activity-reducer", () => {
 
     expect(snapshot(id)?.inbox).toBe("waiting_input");
     expect(snapshot(id)?.liveness).toBe("active");
+  });
+
+  it("returns null for live process probes before reducer state exists", () => {
+    const id = sessionId("live-no-state");
+
+    expect(applyProcessProbe(id, true)).toBeNull();
+    expect(snapshot(id)).toBeNull();
   });
 
   it("clears inbox and marks liveness exited when process probe reports dead", () => {
@@ -53,6 +61,18 @@ describe("activity-reducer", () => {
     applyEvent(liveId, { state: "ready" });
 
     expect(composeActivity(snapshot(liveId))?.state).toBe("ready");
+  });
+
+  it("drops listeners when resetting activity", () => {
+    const id = sessionId("reset-listeners");
+    const listener = vi.fn();
+    const unsubscribe = subscribe(id, listener);
+
+    resetActivity(id);
+    applyEvent(id, { state: "active" });
+    unsubscribe();
+
+    expect(listener).not.toHaveBeenCalled();
   });
 
   it("notifies subscribers on inbox change and liveness class change", () => {

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -1,15 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import {
-  readFileSync,
-  utimesSync,
-} from "node:fs";
+import { readFileSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { createSessionManager } from "../../session-manager.js";
-import {
-  writeMetadata,
-  readMetadataRaw,
-  updateMetadata,
-} from "../../metadata.js";
+import { writeMetadata, readMetadataRaw, updateMetadata } from "../../metadata.js";
 import { createInitialCanonicalLifecycle } from "../../lifecycle-state.js";
 import type {
   OrchestratorConfig,
@@ -20,8 +13,14 @@ import type {
   RuntimeHandle,
   Session,
 } from "../../types.js";
-import { setupTestContext, teardownTestContext, makeHandle, type TestContext } from "../test-utils.js";
+import {
+  setupTestContext,
+  teardownTestContext,
+  makeHandle,
+  type TestContext,
+} from "../test-utils.js";
 import { installMockOpencode, PATH_SEP } from "./opencode-helpers.js";
+import { applyEvent, resetActivity } from "../../activity-reducer.js";
 
 let ctx: TestContext;
 let tmpDir: string;
@@ -34,8 +33,21 @@ let config: OrchestratorConfig;
 let originalPath: string | undefined;
 
 beforeEach(() => {
+  resetActivity("app-1");
+  resetActivity("app-2");
+  resetActivity("app-orchestrator");
+  resetActivity("my-app-orchestrator");
   ctx = setupTestContext();
-  ({ tmpDir, sessionsDir, mockRuntime, mockAgent, mockWorkspace, mockRegistry, config, originalPath } = ctx);
+  ({
+    tmpDir,
+    sessionsDir,
+    mockRuntime,
+    mockAgent,
+    mockWorkspace,
+    mockRegistry,
+    config,
+    originalPath,
+  } = ctx);
 });
 
 afterEach(() => {
@@ -288,7 +300,10 @@ describe("list", () => {
       status: "working",
       project: "my-app",
       runtimeHandle: makeHandle("rt-1"),
+      createdAt: new Date(0).toISOString(),
     });
+
+    applyEvent("app-1", { state: "active" });
 
     const sm = createSessionManager({
       config,
@@ -296,9 +311,7 @@ describe("list", () => {
     });
     const sessions = await sm.list();
 
-    // Verify getActivityState was called
-    expect(agentWithState.getActivityState).toHaveBeenCalled();
-    // Verify activity state was set
+    expect(agentWithState.getActivityState).not.toHaveBeenCalled();
     expect(sessions[0].activity).toBe("active");
   });
 
@@ -340,8 +353,8 @@ describe("list", () => {
 
       expect(sessions).toHaveLength(1);
       expect(sessions[0].runtimeHandle?.id).toBe(expectedTmuxName);
-      expect(sessions[0].activity).toBe("active");
-      expect(selectedAgent.getActivityState).toHaveBeenCalled();
+      expect(sessions[0].activity).toBeNull();
+      expect(selectedAgent.getActivityState).not.toHaveBeenCalled();
     },
   );
 
@@ -411,9 +424,9 @@ describe("list", () => {
     const sm = createSessionManager({ config, registry: registryWithError });
     const sessions = await sm.list();
 
-    // Should keep null (absent) when getActivityState fails
+    expect(agentWithError.getActivityState).not.toHaveBeenCalled();
     expect(sessions[0].activity).toBeNull();
-    expect(sessions[0].activitySignal.state).toBe("probe_failure");
+    expect(sessions[0].activitySignal.state).toBe("unavailable");
   });
 
   it("keeps existing activity when getActivityState returns null", async () => {
@@ -441,10 +454,9 @@ describe("list", () => {
     const sm = createSessionManager({ config, registry: registryWithNull });
     const sessions = await sm.list();
 
-    // null = "I don't know" — activity stays null (absent)
-    expect(agentWithNull.getActivityState).toHaveBeenCalled();
+    expect(agentWithNull.getActivityState).not.toHaveBeenCalled();
     expect(sessions[0].activity).toBeNull();
-    expect(sessions[0].activitySignal.state).toBe("null");
+    expect(sessions[0].activitySignal.state).toBe("unavailable");
   });
 
   it("does not persist runtime_lost from list() when agent activity probe is indeterminate", async () => {
@@ -506,7 +518,10 @@ describe("list", () => {
       status: "working",
       project: "my-app",
       runtimeHandle: makeHandle("rt-1"),
+      createdAt: new Date(0).toISOString(),
     });
+
+    applyEvent("app-1", { state: "idle" });
 
     const sm = createSessionManager({ config, registry: registryWithStaleSignal });
     const sessions = await sm.list();
@@ -538,6 +553,8 @@ describe("list", () => {
       runtimeHandle: makeHandle("rt-1"),
     });
 
+    applyEvent("app-1", { state: "active", timestamp: newerTimestamp });
+
     const sm = createSessionManager({ config, registry: registryWithTimestamp });
     const sessions = await sm.list();
 
@@ -567,11 +584,15 @@ describe("list", () => {
       status: "working",
       project: "my-app",
       runtimeHandle: makeHandle("rt-1"),
+      createdAt: new Date(0).toISOString(),
     });
+
+    applyEvent("app-1", { state: "active" });
 
     const sm = createSessionManager({ config, registry: registryWithOldTimestamp });
     const sessions = await sm.list();
 
+    expect(agentWithOldTimestamp.getActivityState).not.toHaveBeenCalled();
     expect(sessions[0].activity).toBe("active");
     // lastActivityAt should NOT be downgraded to the older detection timestamp
     expect(sessions[0].lastActivityAt.getTime()).toBeGreaterThan(olderTimestamp.getTime());
@@ -618,7 +639,10 @@ describe("get", () => {
       status: "working",
       project: "my-app",
       runtimeHandle: makeHandle("rt-1"),
+      createdAt: new Date(0).toISOString(),
     });
+
+    applyEvent("app-1", { state: "idle" });
 
     const sm = createSessionManager({
       config,
@@ -626,9 +650,7 @@ describe("get", () => {
     });
     const session = await sm.get("app-1");
 
-    // Verify getActivityState was called
-    expect(agentWithState.getActivityState).toHaveBeenCalled();
-    // Verify activity state was set
+    expect(agentWithState.getActivityState).not.toHaveBeenCalled();
     expect(session!.activity).toBe("idle");
   });
 

--- a/packages/core/src/activity-reducer.ts
+++ b/packages/core/src/activity-reducer.ts
@@ -121,15 +121,13 @@ export function applyLivenessTick(sessionId: SessionId, now: Date): ActivityRedu
   return cloneState(state);
 }
 
-export function applyProcessProbe(sessionId: SessionId, alive: boolean): ActivityReducerState {
+export function applyProcessProbe(
+  sessionId: SessionId,
+  alive: boolean,
+): ActivityReducerState | null {
   const existing = reducerStates.get(sessionId);
   if (alive && !existing) {
-    return {
-      liveness: "idle",
-      inbox: null,
-      lastEventAt: new Date(),
-      source: "process-probe",
-    };
+    return null;
   }
   const state = getOrCreateState(sessionId);
   const before = cloneState(state);
@@ -158,6 +156,8 @@ export function clearInbox(
   sessionId: SessionId,
   _reason: ActivityReducerClearReason,
 ): ActivityReducerState {
+  // Kept as part of the reducer boundary so PR-D/PR-E can route explicit
+  // clear causes into activity-event logging without changing call sites.
   const state = getOrCreateState(sessionId);
   const before = cloneState(state);
   state.inbox = null;
@@ -178,6 +178,7 @@ export function composeActivity(state: ActivityReducerState | null): ActivityDet
 
 export function resetActivity(sessionId: SessionId): void {
   reducerStates.delete(sessionId);
+  listeners.delete(sessionId);
 }
 
 export function subscribe(sessionId: SessionId, listener: ActivityReducerListener): () => void {

--- a/packages/core/src/activity-reducer.ts
+++ b/packages/core/src/activity-reducer.ts
@@ -1,0 +1,196 @@
+import {
+  DEFAULT_ACTIVE_WINDOW_MS,
+  DEFAULT_READY_THRESHOLD_MS,
+  type ActivityDetection,
+  type ActivityState,
+  type SessionId,
+} from "./types.js";
+
+export type ActivityReducerLiveness = "active" | "ready" | "idle" | "exited";
+export type ActivityReducerInbox = "waiting_input" | "blocked" | null;
+export type ActivityReducerSource = "native-stream" | "native-poll" | "terminal" | "process-probe";
+
+export interface ActivityReducerState {
+  liveness: ActivityReducerLiveness;
+  inbox: ActivityReducerInbox;
+  lastEventAt: Date;
+  source: ActivityReducerSource;
+  eventTimestamp?: Date;
+}
+
+export interface ActivityReducerEvent {
+  state: ActivityState;
+  timestamp?: Date;
+  source?: ActivityReducerSource;
+}
+
+export type ActivityReducerClearReason = "resolved" | "override" | "exited";
+export type ActivityReducerListener = (state: ActivityReducerState) => void;
+
+const reducerStates = new Map<SessionId, ActivityReducerState>();
+const listeners = new Map<SessionId, Set<ActivityReducerListener>>();
+
+function cloneState(state: ActivityReducerState): ActivityReducerState {
+  return {
+    liveness: state.liveness,
+    inbox: state.inbox,
+    lastEventAt: new Date(state.lastEventAt.getTime()),
+    source: state.source,
+    eventTimestamp: state.eventTimestamp ? new Date(state.eventTimestamp.getTime()) : undefined,
+  };
+}
+
+function getOrCreateState(sessionId: SessionId, now: Date = new Date()): ActivityReducerState {
+  const existing = reducerStates.get(sessionId);
+  if (existing) return existing;
+
+  const created: ActivityReducerState = {
+    liveness: "idle",
+    inbox: null,
+    lastEventAt: now,
+    source: "process-probe",
+  };
+  reducerStates.set(sessionId, created);
+  return created;
+}
+
+function notifyIfChanged(sessionId: SessionId, before: ActivityReducerState): void {
+  const after = reducerStates.get(sessionId);
+  if (!after) return;
+
+  if (before.inbox === after.inbox && before.liveness === after.liveness) return;
+
+  const sessionListeners = listeners.get(sessionId);
+  if (!sessionListeners) return;
+
+  const eventSnapshot = cloneState(after);
+  for (const listener of sessionListeners) {
+    listener(eventSnapshot);
+  }
+}
+
+function ageLiveness(state: ActivityReducerState, now: Date): ActivityReducerLiveness {
+  if (state.liveness === "exited" || state.liveness === "idle") return state.liveness;
+
+  const ageMs = Math.max(0, now.getTime() - state.lastEventAt.getTime());
+  if (ageMs <= DEFAULT_ACTIVE_WINDOW_MS) return "active";
+  if (ageMs <= DEFAULT_READY_THRESHOLD_MS) return "ready";
+  return "idle";
+}
+
+export function snapshot(sessionId: SessionId): ActivityReducerState | null {
+  const state = reducerStates.get(sessionId);
+  return state ? cloneState(state) : null;
+}
+
+export function applyEvent(
+  sessionId: SessionId,
+  event: ActivityReducerEvent,
+): ActivityReducerState {
+  const eventAt = event.timestamp ?? new Date();
+  const state = getOrCreateState(sessionId, eventAt);
+  const before = cloneState(state);
+
+  state.lastEventAt = eventAt;
+  state.eventTimestamp = event.timestamp;
+  state.source = event.source ?? "native-poll";
+
+  if (event.state === "waiting_input" || event.state === "blocked") {
+    state.inbox = event.state;
+    if (state.liveness === "exited") {
+      state.liveness = "active";
+    }
+  } else if (event.state === "exited") {
+    state.liveness = "exited";
+    state.inbox = null;
+    state.eventTimestamp = event.timestamp;
+    state.source = event.source ?? "process-probe";
+  } else {
+    state.liveness = event.state;
+  }
+
+  notifyIfChanged(sessionId, before);
+  return cloneState(state);
+}
+
+export function applyLivenessTick(sessionId: SessionId, now: Date): ActivityReducerState {
+  const state = getOrCreateState(sessionId, now);
+  const before = cloneState(state);
+  state.liveness = ageLiveness(state, now);
+  notifyIfChanged(sessionId, before);
+  return cloneState(state);
+}
+
+export function applyProcessProbe(sessionId: SessionId, alive: boolean): ActivityReducerState {
+  const existing = reducerStates.get(sessionId);
+  if (alive && !existing) {
+    return {
+      liveness: "idle",
+      inbox: null,
+      lastEventAt: new Date(),
+      source: "process-probe",
+    };
+  }
+  const state = getOrCreateState(sessionId);
+  const before = cloneState(state);
+
+  if (alive) {
+    if (state.liveness !== "exited") {
+      return cloneState(state);
+    }
+    state.lastEventAt = new Date();
+    state.eventTimestamp = undefined;
+    state.source = "process-probe";
+    state.liveness = "idle";
+  } else {
+    state.lastEventAt = new Date();
+    state.eventTimestamp = state.lastEventAt;
+    state.source = "process-probe";
+    state.liveness = "exited";
+    state.inbox = null;
+  }
+
+  notifyIfChanged(sessionId, before);
+  return cloneState(state);
+}
+
+export function clearInbox(
+  sessionId: SessionId,
+  _reason: ActivityReducerClearReason,
+): ActivityReducerState {
+  const state = getOrCreateState(sessionId);
+  const before = cloneState(state);
+  state.inbox = null;
+  notifyIfChanged(sessionId, before);
+  return cloneState(state);
+}
+
+export function composeActivity(state: ActivityReducerState | null): ActivityDetection | null {
+  if (!state) return null;
+  if (state.liveness === "exited") {
+    return { state: "exited", timestamp: state.eventTimestamp };
+  }
+  if (state.inbox) {
+    return { state: state.inbox, timestamp: state.eventTimestamp };
+  }
+  return { state: state.liveness, timestamp: state.eventTimestamp };
+}
+
+export function resetActivity(sessionId: SessionId): void {
+  reducerStates.delete(sessionId);
+}
+
+export function subscribe(sessionId: SessionId, listener: ActivityReducerListener): () => void {
+  const sessionListeners = listeners.get(sessionId) ?? new Set<ActivityReducerListener>();
+  sessionListeners.add(listener);
+  listeners.set(sessionId, sessionListeners);
+
+  return () => {
+    const currentListeners = listeners.get(sessionId);
+    if (!currentListeners) return;
+    currentListeners.delete(listener);
+    if (currentListeners.size === 0) {
+      listeners.delete(sessionId);
+    }
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -173,6 +173,27 @@ export {
 export { resolveSpawnTarget } from "./spawn-target.js";
 export type { SpawnTarget } from "./spawn-target.js";
 
+// ActivityReducer — single-writer activity state projection
+export {
+  applyEvent,
+  applyLivenessTick,
+  applyProcessProbe,
+  clearInbox,
+  composeActivity,
+  resetActivity,
+  snapshot as snapshotActivityReducer,
+  subscribe as subscribeActivityReducer,
+} from "./activity-reducer.js";
+export type {
+  ActivityReducerClearReason,
+  ActivityReducerEvent,
+  ActivityReducerInbox,
+  ActivityReducerListener,
+  ActivityReducerLiveness,
+  ActivityReducerSource,
+  ActivityReducerState,
+} from "./activity-reducer.js";
+
 // Activity log — JSONL activity tracking for agents without native JSONL
 export {
   appendActivityEntry,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -15,6 +15,15 @@ import { readFile, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { recordActivityEvent } from "./activity-events.js";
 import {
+  applyEvent,
+  applyLivenessTick,
+  applyProcessProbe,
+  clearInbox,
+  composeActivity,
+  resetActivity,
+  snapshot as snapshotActivity,
+} from "./activity-reducer.js";
+import {
   ACTIVITY_STATE,
   SESSION_STATUS,
   TERMINAL_STATUSES,
@@ -671,7 +680,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     // When Guard 1 returned 304, the repo is in prListUnchangedRepos — no new PRs exist.
     for (const session of sessions) {
       if (!session.branch) continue;
-      if (session.metadata["prAutoDetect"] === "off" || session.metadata["prAutoDetect"] === "false") continue;
+      if (
+        session.metadata["prAutoDetect"] === "off" ||
+        session.metadata["prAutoDetect"] === "false"
+      )
+        continue;
       if (session.metadata["role"] === "orchestrator" || session.id.endsWith("-orchestrator"))
         continue;
       if (
@@ -1020,26 +1033,53 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
         const detectedActivity = await agent.getActivityState(session, config.readyThresholdMs);
         if (detectedActivity) {
-          activitySignal = classifyActivitySignal(detectedActivity, "native");
+          const reducedSnapshot = snapshotActivity(session.id);
+          if (reducedSnapshot && session.createdAt > reducedSnapshot.lastEventAt) {
+            resetActivity(session.id);
+          }
+          const hasObservedActivity = activityStateCache.has(session.id);
+          if (
+            !hasObservedActivity &&
+            detectedActivity.state !== "waiting_input" &&
+            detectedActivity.state !== "blocked"
+          ) {
+            clearInbox(session.id, "override");
+          }
+          applyEvent(session.id, {
+            state: detectedActivity.state,
+            timestamp: detectedActivity.timestamp,
+            source: "native-poll",
+          });
+          applyLivenessTick(session.id, new Date(nowIso));
+          const composedActivity =
+            composeActivity(snapshotActivity(session.id)) ?? detectedActivity;
+          const activitySignalDetection =
+            (composedActivity.state === "waiting_input" ||
+              composedActivity.state === "blocked" ||
+              composedActivity.state === "exited") &&
+            composedActivity.state !== detectedActivity.state
+              ? composedActivity
+              : detectedActivity;
+          activitySignal = classifyActivitySignal(activitySignalDetection, "native");
           activityEvidence = formatActivitySignalEvidence(activitySignal);
           lifecycle.runtime.lastObservedAt = nowIso;
           const prevActivity = activityStateCache.get(session.id);
-          activityStateCache.set(session.id, detectedActivity.state);
-          if (prevActivity !== undefined && prevActivity !== detectedActivity.state) {
+          activityStateCache.set(session.id, composedActivity.state);
+          if (prevActivity !== undefined && prevActivity !== composedActivity.state) {
             recordActivityEvent({
               projectId: session.projectId,
               sessionId: session.id,
               source: "lifecycle",
               kind: "activity.transition",
-              summary: `${prevActivity} → ${detectedActivity.state}`,
-              data: { from: prevActivity, to: detectedActivity.state },
+              summary: `${prevActivity} → ${composedActivity.state}`,
+              data: { from: prevActivity, to: composedActivity.state },
             });
           }
           if (lifecycle.runtime.state !== "missing" && lifecycle.runtime.state !== "probe_failed") {
             lifecycle.runtime.state = "alive";
             lifecycle.runtime.reason = "process_running";
           }
-          if (detectedActivity.state === "waiting_input") {
+          if (composedActivity.state === "waiting_input") {
             return commit({
               status: SESSION_STATUS.NEEDS_INPUT,
               evidence: activityEvidence,
@@ -1048,8 +1088,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
               sessionReason: "awaiting_user_input",
             });
           }
-          if (detectedActivity.state === "exited" && canProbeRuntimeIdentity) {
+          if (composedActivity.state === "exited" && canProbeRuntimeIdentity) {
             processProbe = { state: "dead", failed: false };
+            applyProcessProbe(session.id, false);
             lifecycle.runtime.state = "exited";
             lifecycle.runtime.reason = "process_missing";
           }
@@ -1068,9 +1109,24 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const terminalOutput = runtime ? await runtime.getOutput(session.runtimeHandle, 10) : "";
           if (terminalOutput) {
             const activity = agent.detectActivity(terminalOutput);
-            activitySignal = classifyActivitySignal({ state: activity }, "terminal");
+            if (
+              !activityStateCache.has(session.id) &&
+              activity !== "waiting_input" &&
+              activity !== "blocked"
+            ) {
+              clearInbox(session.id, "override");
+            }
+            applyEvent(session.id, { state: activity, source: "terminal" });
+            applyLivenessTick(session.id, new Date(nowIso));
+            const composedActivity = composeActivity(snapshotActivity(session.id)) ?? {
+              state: activity,
+            };
+            activitySignal = classifyActivitySignal(
+              composedActivity.state === activity ? { state: activity } : composedActivity,
+              "terminal",
+            );
             activityEvidence = formatActivitySignalEvidence(activitySignal);
-            if (activity === "waiting_input") {
+            if (composedActivity.state === "waiting_input") {
               return commit({
                 status: SESSION_STATUS.NEEDS_INPUT,
                 evidence: activityEvidence,
@@ -1083,6 +1139,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             try {
               const processAlive = await agent.isProcessRunning(session.runtimeHandle);
               processProbe = processProbeResultToProbeResult(processAlive);
+              if (processAlive === true || processAlive === false) {
+                applyProcessProbe(session.id, processAlive);
+              }
               if (processAlive === false) {
                 lifecycle.runtime.state = "exited";
                 lifecycle.runtime.reason = "process_missing";
@@ -1157,6 +1216,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       try {
         const processAlive = await agent.isProcessRunning(session.runtimeHandle);
         processProbe = processProbeResultToProbeResult(processAlive);
+        if (processAlive === true || processAlive === false) {
+          applyProcessProbe(session.id, processAlive);
+        }
         if (processAlive === false) {
           lifecycle.runtime.state = "exited";
           lifecycle.runtime.reason = "process_missing";
@@ -1316,16 +1378,14 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     ) {
       const mapped = mapAgentReportToLifecycle(agentReport.state);
       return commit({
-        status: deriveLegacyStatus(
-          {
-            ...lifecycle,
-            session: {
-              ...lifecycle.session,
-              state: mapped.sessionState,
-              reason: mapped.sessionReason,
-            },
+        status: deriveLegacyStatus({
+          ...lifecycle,
+          session: {
+            ...lifecycle.session,
+            state: mapped.sessionState,
+            reason: mapped.sessionReason,
           },
-        ),
+        }),
         evidence: `agent_report:${agentReport.state}`,
         detecting: { attempts: 0 },
         sessionState: mapped.sessionState,
@@ -1623,9 +1683,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     if (!project) return;
 
     const sessionsDir = getProjectSessionsDir(session.projectId);
-    const lifecycleUpdates = buildLifecycleMetadataPatch(
-      cloneLifecycle(session.lifecycle),
-    );
+    const lifecycleUpdates = buildLifecycleMetadataPatch(cloneLifecycle(session.lifecycle));
     const mergedUpdates = { ...updates, ...lifecycleUpdates };
     updateMetadata(sessionsDir, session.id, mergedUpdates);
     sessionManager.invalidateCache();
@@ -2310,9 +2368,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           activity,
           // Elapsed wall-time since cleanup was first deferred. NOT a Unix
           // timestamp — naming it `pendingSinceMs` was misleading (Greptile).
-          pendingElapsedMs: Number.isFinite(pendingSinceMs)
-            ? Date.now() - pendingSinceMs
-            : null,
+          pendingElapsedMs: Number.isFinite(pendingSinceMs) ? Date.now() - pendingSinceMs : null,
           graceMs,
         },
       });

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1090,7 +1090,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           }
           if (composedActivity.state === "exited" && canProbeRuntimeIdentity) {
             processProbe = { state: "dead", failed: false };
-            applyProcessProbe(session.id, false);
             lifecycle.runtime.state = "exited";
             lifecycle.runtime.reason = "process_missing";
           }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -13,6 +13,13 @@
 
 import { statSync, existsSync, writeFileSync, mkdirSync, utimesSync, unlinkSync } from "node:fs";
 import { recordActivityEvent } from "./activity-events.js";
+import {
+  applyProcessProbe,
+  composeActivity,
+  resetActivity,
+  snapshot as snapshotActivity,
+  subscribe as subscribeActivity,
+} from "./activity-reducer.js";
 import { execFile } from "node:child_process";
 import { basename, join, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -108,7 +115,6 @@ const OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS = 10_000;
 // windowsHide:true suppresses the conhost popup that the shell would otherwise flash.
 const EXEC_SHELL_OPTION =
   process.platform === "win32" ? ({ shell: true, windowsHide: true } as const) : ({} as const);
-
 
 function errorIncludesSessionNotFound(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -308,7 +314,10 @@ async function isAgentProcessNotDefinitelyMissing(
 }
 
 function isFixedOrchestratorReservationError(err: unknown, sessionId: string): boolean {
-  return err instanceof Error && err.message.includes(`Orchestrator session "${sessionId}" already exists`);
+  return (
+    err instanceof Error &&
+    err.message.includes(`Orchestrator session "${sessionId}" already exists`)
+  );
 }
 
 async function getTmuxForegroundCommand(sessionName: string): Promise<string | null> {
@@ -326,9 +335,7 @@ async function getTmuxForegroundCommand(sessionName: string): Promise<string | n
 }
 
 /** Parse lifecycle from raw metadata for writeMetadata (restore path). */
-function parseLifecycleFromRaw(
-  raw: Record<string, string>,
-): CanonicalSessionLifecycle | undefined {
+function parseLifecycleFromRaw(raw: Record<string, string>): CanonicalSessionLifecycle | undefined {
   const source = raw["lifecycle"] ?? raw["statePayload"];
   if (!source) return undefined;
   try {
@@ -605,7 +612,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const duplicatePRAttachments = new Map<string, ActiveSessionRecord[]>();
 
     for (const record of repaired) {
-      if (!record.raw["lifecycle"] && (!record.raw["statePayload"] || record.raw["stateVersion"] !== "2")) {
+      if (
+        !record.raw["lifecycle"] &&
+        (!record.raw["statePayload"] || record.raw["stateVersion"] !== "2")
+      ) {
         const lifecycle = cloneLifecycle(
           parseCanonicalLifecycle(record.raw, {
             sessionId: record.sessionName,
@@ -687,7 +697,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return repaired;
   }
 
-  function loadActiveSessionRecords(projectId: string, project: ProjectConfig): ActiveSessionRecord[] {
+  function loadActiveSessionRecords(
+    projectId: string,
+    project: ProjectConfig,
+  ): ActiveSessionRecord[] {
     const sessionsDir = getProjectSessionsDir(projectId);
     if (!existsSync(sessionsDir)) return [];
 
@@ -843,9 +856,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     );
     for (let attempts = 0; attempts < 10_000; attempts++) {
       const sessionId = `${project.sessionPrefix}-${num}`;
-      const tmuxName = project.path
-        ? generateSessionName(project.sessionPrefix, num)
-        : undefined;
+      const tmuxName = project.path ? generateSessionName(project.sessionPrefix, num) : undefined;
 
       if (!usedNumbers.has(num) && reserveSessionId(sessionsDir, sessionId)) {
         return { num, sessionId, tmuxName };
@@ -1093,6 +1104,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     ) {
       try {
         const alive = await plugins.runtime.isAlive(session.runtimeHandle);
+        if (alive) {
+          applyProcessProbe(session.id, true);
+        }
         if (!alive) {
           session.lifecycle.runtime.state = "missing";
           session.lifecycle.runtime.reason =
@@ -1111,6 +1125,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           if (!TERMINAL_SESSION_STATUSES.has(session.status)) {
             session.status = "killed";
           }
+          applyProcessProbe(session.id, false);
           session.activity = "exited";
           session.activitySignal = createActivitySignal("valid", {
             activity: "exited",
@@ -1131,30 +1146,29 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     }
 
-    // Detect activity independently of runtime handle and session status.
-    // Activity detection reads JSONL files on disk — it only needs workspacePath,
-    // not a runtime handle. Gating on runtimeHandle caused sessions created by
-    // external scripts (which don't store runtimeHandle) to always show "unknown".
-    // This now runs for ALL sessions, including terminal statuses, so a merged
-    // session with a live agent shows accurate activity (ready/idle/waiting_input).
+    // Lifecycle-manager is the single writer for activity probes. Session-manager
+    // only mirrors the reducer snapshot into legacy session fields for consumers.
     session.activitySignal = createActivitySignal("unavailable");
     if (plugins.agent) {
-      try {
-        const detected = await plugins.agent.getActivityState(session, config.readyThresholdMs);
-        if (detected !== null) {
-          session.activitySignal = classifyActivitySignal(detected, "native");
-          session.activity = detected.state;
+      const reducedSnapshot = snapshotActivity(session.id);
+      if (reducedSnapshot && session.createdAt > reducedSnapshot.lastEventAt) {
+        resetActivity(session.id);
+      }
+      const reducedActivity = composeActivity(snapshotActivity(session.id));
+      if (reducedActivity) {
+        session.activitySignal = classifyActivitySignal(reducedActivity, "native");
+        session.activity = reducedActivity.state;
+        if (reducedActivity.state === "exited") {
+          session.lifecycle.runtime.state = "exited";
+          session.lifecycle.runtime.reason = "process_missing";
+        } else {
           session.lifecycle.runtime.state = "alive";
           session.lifecycle.runtime.reason = "process_running";
-          session.lifecycle.runtime.lastObservedAt = new Date().toISOString();
-          if (detected.timestamp && detected.timestamp > session.lastActivityAt) {
-            session.lastActivityAt = detected.timestamp;
-          }
-        } else {
-          session.activitySignal = createActivitySignal("null", { source: "native" });
         }
-      } catch {
-        session.activitySignal = createActivitySignal("probe_failure", { source: "native" });
+        session.lifecycle.runtime.lastObservedAt = new Date().toISOString();
+        if (reducedActivity.timestamp && reducedActivity.timestamp > session.lastActivityAt) {
+          session.lastActivityAt = reducedActivity.timestamp;
+        }
       }
 
       // Enrich with agent session info (summary, cost, native restore metadata).
@@ -1844,7 +1858,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return null;
   }
 
-  async function ensureOrchestratorInternal(orchestratorConfig: OrchestratorSpawnConfig): Promise<Session> {
+  async function ensureOrchestratorInternal(
+    orchestratorConfig: OrchestratorSpawnConfig,
+  ): Promise<Session> {
     const project = config.projects[orchestratorConfig.projectId];
     if (!project) {
       throw new Error(`Unknown project: ${orchestratorConfig.projectId}`);
@@ -1870,10 +1886,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       const orchestratorSessionStrategy = normalizeOrchestratorSessionStrategy(
         project.orchestratorSessionStrategy,
       );
-      if (
-        orchestratorSessionStrategy === "delete" ||
-        orchestratorSessionStrategy === "ignore"
-      ) {
+      if (orchestratorSessionStrategy === "delete" || orchestratorSessionStrategy === "ignore") {
         await kill(sessionId, { purgeOpenCode: orchestratorSessionStrategy === "delete" });
         deleteMetadata(getProjectSessionsDir(orchestratorConfig.projectId), sessionId);
         return spawnOrchestrator(orchestratorConfig);
@@ -2402,8 +2415,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           continue;
         }
 
-        const cleanupAgent = resolveSelectionForSession(project, terminatedId, terminatedRaw).agentName;
-        const mappedOpenCodeSessionId = asValidOpenCodeSessionId(terminatedRaw["opencodeSessionId"]);
+        const cleanupAgent = resolveSelectionForSession(
+          project,
+          terminatedId,
+          terminatedRaw,
+        ).agentName;
+        const mappedOpenCodeSessionId = asValidOpenCodeSessionId(
+          terminatedRaw["opencodeSessionId"],
+        );
         if (cleanupAgent === "opencode" && terminatedRaw["opencodeCleanedAt"]) {
           pushSkipped(projectKey, terminatedId);
           continue;
@@ -2487,15 +2506,6 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         return (await runtimePlugin.getOutput(handle, SEND_CONFIRMATION_OUTPUT_LINES)) ?? "";
       } catch {
         return "";
-      }
-    };
-
-    const detectActivityFromOutput = (output: string) => {
-      if (!output) return null;
-      try {
-        return agentPlugin.detectActivity(output);
-      } catch {
-        return null;
       }
     };
 
@@ -2672,39 +2682,52 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
 
       const baselineOutput = await captureOutput(handle);
-      const baselineActivity = detectActivityFromOutput(baselineOutput) ?? session.activity;
+      const baselineActivity =
+        composeActivity(snapshotActivity(sessionId))?.state ?? session.activity;
       const baselineUpdatedAt = await getOpenCodeSessionUpdatedAt();
+      let reducerObservedDelivery = false;
+      const unsubscribe = subscribeActivity(sessionId, (state) => {
+        const activity = composeActivity(state)?.state;
+        if (
+          (baselineActivity !== "active" && activity === "active") ||
+          (baselineActivity !== "waiting_input" && activity === "waiting_input")
+        ) {
+          reducerObservedDelivery = true;
+        }
+      });
 
       await runtimePlugin.sendMessage(handle, message);
 
-      for (let attempt = 1; attempt <= SEND_CONFIRMATION_ATTEMPTS; attempt++) {
-        // Sleep before each check (including the first) so the runtime has time
-        // to reflect the message in its output.
-        await sleep(SEND_CONFIRMATION_POLL_MS);
+      try {
+        for (let attempt = 1; attempt <= SEND_CONFIRMATION_ATTEMPTS; attempt++) {
+          // Sleep before each check (including the first) so the runtime has time
+          // to reflect the message in its output.
+          await sleep(SEND_CONFIRMATION_POLL_MS);
 
-        const output = await captureOutput(handle);
-        const activity = detectActivityFromOutput(output) ?? session.activity;
-        const updatedAt = await getOpenCodeSessionUpdatedAt();
-        const delivered =
-          (baselineUpdatedAt !== undefined &&
-            updatedAt !== undefined &&
-            updatedAt > baselineUpdatedAt) ||
-          hasQueuedMessage(output) ||
-          (output.length > 0 && output !== baselineOutput) ||
-          (baselineActivity !== "active" && activity === "active") ||
-          (baselineActivity !== "waiting_input" && activity === "waiting_input");
+          const output = await captureOutput(handle);
+          const updatedAt = await getOpenCodeSessionUpdatedAt();
+          const delivered =
+            reducerObservedDelivery ||
+            (baselineUpdatedAt !== undefined &&
+              updatedAt !== undefined &&
+              updatedAt > baselineUpdatedAt) ||
+            hasQueuedMessage(output) ||
+            (output.length > 0 && output !== baselineOutput);
 
-        if (delivered) {
-          return;
+          if (delivered) {
+            return;
+          }
         }
-      }
 
-      // Message was already sent via runtimePlugin.sendMessage above — if we
-      // cannot *confirm* delivery (e.g. agent is slow to show output), treat it
-      // as a soft success rather than throwing.  Throwing here caused the caller
-      // to report failure, which prevented the dispatch-hash from updating and
-      // led to duplicate messages on the next poll cycle.
-      return;
+        // Message was already sent via runtimePlugin.sendMessage above — if we
+        // cannot *confirm* delivery (e.g. agent is slow to show output), treat it
+        // as a soft success rather than throwing.  Throwing here caused the caller
+        // to report failure, which prevented the dispatch-hash from updating and
+        // led to duplicate messages on the next poll cycle.
+        return;
+      } finally {
+        unsubscribe();
+      }
     };
 
     let prepared = await prepareSession();
@@ -2774,7 +2797,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       const samePr = otherRaw["pr"] === pr.url;
       const sameBranch =
-        otherRaw["branch"] === pr.branch && (otherRaw["prAutoDetect"] ?? "on") !== "off" && otherRaw["prAutoDetect"] !== "false";
+        otherRaw["branch"] === pr.branch &&
+        (otherRaw["prAutoDetect"] ?? "on") !== "off" &&
+        otherRaw["prAutoDetect"] !== "false";
 
       if (samePr || sameBranch) {
         conflictingSessions.add(sessionName);
@@ -2824,9 +2849,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       updateMetadata(sessionsDir, previousSessionId, {
         pr: "",
         prAutoDetect: "false",
-        ...(PR_TRACKING_STATUSES.has(previousRaw["status"] ?? "")
-          ? { status: "working" }
-          : {}),
+        ...(PR_TRACKING_STATUSES.has(previousRaw["status"] ?? "") ? { status: "working" } : {}),
         ...lifecycleMetadataUpdates(previousRaw, previousLifecycle),
       });
       invalidateCache();


### PR DESCRIPTION
## Problem

Wave 2 of #1899. The activity pipeline still had the tracking issue's "two probers, divergent writes" problem: `lifecycle-manager` and `session-manager` could both call `getActivityState`, and `ao send --wait` had a third terminal-output parser path.

Prior context: #1902 and #1903.

## Scope

- Add `packages/core/src/activity-reducer.ts` with reducer APIs:
  - `snapshot`
  - `applyEvent`
  - `applyLivenessTick`
  - `applyProcessProbe`
  - `clearInbox`
  - `composeActivity`
  - `subscribe`
- Route lifecycle activity observations and process probes through the reducer.
- Remove `session-manager`'s `getActivityState` probe; it now mirrors reducer snapshots into `session.activity` / `session.activitySignal`.
- Replace send-await's `detectActivityFromOutput` closure with reducer subscription for active / waiting-input rising edges.
- Update session-manager query tests for the new single-writer contract.

No plugin changes.

## Reducer behavior

- Splits liveness (`active` / `ready` / `idle` / `exited`) from sticky inbox (`waiting_input` / `blocked` / `null`).
- Ages liveness with the existing active/ready windows.
- Keeps inbox sticky until process death, explicit clear, or override handling.
- Composes legacy activity at the boundary with precedence: `exited > inbox > liveness`.

## Tests

- Added `activity-reducer.test.ts` for sticky inbox, liveness updates, process-death clearing, compose precedence, and subscription notifications.
- Updated session-manager query tests to assert it does not call `getActivityState` and reads reducer snapshots instead.
- Ran:
  - `pnpm build` ✅
  - `pnpm typecheck` ✅
  - `pnpm lint` ✅ (existing warnings only)
  - `pnpm --filter @aoagents/ao-core test` ✅
  - `pnpm test` ⚠️ run, but existing `@aoagents/ao-plugin-tracker-linear` tests fail because optional `@composio/core` is not installed in this checkout.

## #1899 checklist

- [x] PR-C — Introduce ActivityReducer in core; lifecycle-manager owns it; session-manager reads snapshot; two `getActivityState` call sites consolidate to one; send-await subscribes instead of running its own detect.
