### PR TITLE
Fix: Sanitize project ID derived from folder name to allow dots and special chars

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -659,7 +659,7 @@ async function addProjectToConfig(
 
   await ensureGit("adding projects");
 
-  let projectId = basename(resolvedPath);
+  let projectId = basename(resolvedPath).replace(/[^a-zA-Z0-9_-]/g, "-").replace(/^-+|-+$/g, "") || basename(resolvedPath);
 
   // Avoid overwriting an existing project with the same directory name
   if (config.projects[projectId]) {


### PR DESCRIPTION
## Fix: Sanitize project ID derived from folder name

Issue: #1877

**Problem:** When running `ao start` in a directory with dots or special characters in its name (e.g. `llama.cpp`), the project ID is set to the raw folder name which fails validation because project IDs must match `[a-zA-Z0-9_-]+`.

**Root Cause:** In `packages/cli/src/commands/start.ts`, line 662:
```ts
let projectId = basename(resolvedPath);
```
This uses the folder name directly without sanitizing invalid characters.

**Fix:** Apply the same sanitization pattern already used elsewhere in the file (line 154):
```ts
let projectId = basename(resolvedPath).replace(/[^a-zA-Z0-9_-]/g, "-").replace(/^-+|-+$/g, "") || basename(resolvedPath);
```

This replaces invalid characters with `-` and trims leading/trailing dashes, converting `llama.cpp` to `llama-cpp`.

Closes #1877
