### PR TITLE
fix(web): address post-merge Greptile feedback — mobile sidebar, dead variable, sessionStorage race

### DIFF
--- a/packages/web/src/app/projects/[projectId]/sessions/[id]/page.tsx
+++ b/packages/web/src/app/projects/[projectId]/sessions/[id]/page.tsx
@@ -114,8 +114,10 @@ export default function ProjectSessionPage() {
   const id = params.id as string;
   const expectedProjectId = typeof params.projectId === "string" ? params.projectId : undefined;
 
-  // Read optimistic session data written by sidebar navigation
-  const cachedSession = (() => {
+  // Read optimistic session data written by sidebar navigation.
+  // Lazy initialiser ensures the sessionStorage read+remove runs exactly once
+  // per mount — safe under React Strict Mode's double-invocation.
+  const [session, setSession] = useState<DashboardSession | null>(() => {
     if (typeof sessionStorage === "undefined") return null;
     try {
       const raw = sessionStorage.getItem(`ao-session-nav:${id}`);
@@ -127,15 +129,13 @@ export default function ProjectSessionPage() {
       /* ignore */
     }
     return null;
-  })();
-
-  const [session, setSession] = useState<DashboardSession | null>(cachedSession);
+  });
   const [zoneCounts, setZoneCounts] = useState<ZoneCounts | null>(null);
   const [projectOrchestratorId, setProjectOrchestratorId] = useState<string | null | undefined>(
     undefined,
   );
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
-  const [loading, setLoading] = useState(cachedSession === null);
+  const [loading, setLoading] = useState(session === null);
   const [routeError, setRouteError] = useState<Error | null>(null);
   const [sessionMissing, setSessionMissing] = useState(false);
   const [prefixByProject, setPrefixByProject] = useState<Map<string, string>>(new Map());
@@ -150,7 +150,7 @@ export default function ProjectSessionPage() {
   const sessionIsOrchestratorRef = useRef(false);
   const resolvedProjectSessionsKeyRef = useRef<string | null>(null);
   const prefixByProjectRef = useRef<Map<string, string>>(new Map());
-  const hasLoadedSessionRef = useRef(cachedSession !== null);
+  const hasLoadedSessionRef = useRef(session !== null);
   const fetchingSessionRef = useRef(false);
   const fetchingProjectSessionsRef = useRef(false);
   const sessionFetchControllerRef = useRef<AbortController | null>(null);

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -26,7 +26,6 @@ import { UpdateBanner } from "./UpdateBanner";
 import { CopyDebugBundleButton } from "./CopyDebugBundleButton";
 import { SidebarContext, useSidebarContext } from "./workspace/SidebarContext";
 import { ProjectSidebar } from "./ProjectSidebar";
-import { isOrchestratorSession } from "@aoagents/ao-core/types";
 import { projectDashboardPath, projectSessionPath } from "@/lib/routes";
 import { BottomSheet } from "./BottomSheet";
 
@@ -177,24 +176,6 @@ function DashboardInner({
     return sessions.filter((s) => s.projectId === projectId);
   }, [sessions, projectId]);
 
-  const allSessionPrefixes = useMemo(
-    () => projects.map((p) => p.sessionPrefix ?? p.id),
-    [projects],
-  );
-
-  const sidebarOrchestrators = useMemo(
-    () =>
-      sessions
-        .filter((s) =>
-          isOrchestratorSession(
-            s,
-            projects.find((p) => p.id === s.projectId)?.sessionPrefix ?? s.projectId,
-            allSessionPrefixes,
-          ),
-        )
-        .map((s) => ({ id: s.id, projectId: s.projectId })),
-    [sessions, projects, allSessionPrefixes],
-  );
   const connectionStatus: "connected" | "reconnecting" | "disconnected" =
     mux?.status === "disconnected"
       ? "disconnected"
@@ -862,7 +843,7 @@ function DashboardInner({
             <ProjectSidebar
               projects={projects}
               sessions={sessions}
-              orchestrators={sidebarOrchestrators}
+              orchestrators={activeOrchestrators}
               activeProjectId={projectId}
               activeSessionId={activeSessionId}
               loading={!liveSessionsResolved}

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -221,8 +221,13 @@ function DashboardInner({
   const isInsideLayout = parentCtx !== null;
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const prevProjectParamRef = useRef(searchParams.get("project"));
   useEffect(() => {
-    if (!isInsideLayout) setMobileSidebarOpen(false);
+    const current = searchParams.get("project");
+    if (!isInsideLayout && prevProjectParamRef.current !== current) {
+      setMobileSidebarOpen(false);
+      prevProjectParamRef.current = current;
+    }
   }, [isInsideLayout, searchParams]);
   const handleToggleSidebar = useCallback(() => {
     if (isInsideLayout && parentCtx) { parentCtx.onToggleSidebar(); return; }

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -221,6 +221,9 @@ function DashboardInner({
   const isInsideLayout = parentCtx !== null;
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  useEffect(() => {
+    if (!isInsideLayout) setMobileSidebarOpen(false);
+  }, [isInsideLayout, searchParams]);
   const handleToggleSidebar = useCallback(() => {
     if (isInsideLayout && parentCtx) { parentCtx.onToggleSidebar(); return; }
     if (isMobile) {

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -430,7 +430,7 @@ function ProjectSidebarInner({
       (sessions ?? [])
         .map(
           (s) =>
-            `${s.id}:${s.status}:${s.activity ?? ""}:${s.projectId}:${s.displayName ?? ""}:${s.displayNameUserSet ? "1" : "0"}:${s.branch ?? ""}:${s.issueTitle ?? ""}:${s.pr?.title ?? ""}:${s.summary ?? ""}`,
+            `${s.id}:${s.status}:${s.activity ?? ""}:${s.projectId}:${s.displayName ?? ""}:${s.displayNameUserSet ? "1" : "0"}:${s.branch ?? ""}:${s.issueTitle ?? ""}:${s.pr?.title ?? ""}:${s.pr?.ciStatus ?? ""}:${s.pr?.reviewDecision ?? ""}:${s.pr?.mergeability ?? ""}:${s.pr?.unresolvedThreads ?? 0}:${s.summary ?? ""}`,
         )
         .join("|"),
     [sessions],

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -276,7 +276,7 @@ function ProjectSidebarInner({
   orchestrators,
   activeProjectId,
   activeSessionId,
-  loading = false,
+  loading: _loading = false,
   error = false,
   onRetry,
   collapsed = false,
@@ -284,7 +284,6 @@ function ProjectSidebarInner({
   onMobileClose,
 }: ProjectSidebarProps) {
   const router = useRouter();
-  const _isLoading = loading || sessions === null;
 
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(
     () =>


### PR DESCRIPTION
Closes #1916

## Summary

- **Mobile sidebar auto-close regression**: Restores `useEffect` that closes the sidebar overlay when `?project=…` changes on the standalone `/` dashboard. Was dropped in the shared-layout refactor (PR #1846); `ProjectLayoutClient` handles this for `/projects/*` routes but the root dashboard had no equivalent.
- **Dead `_isLoading` variable**: Removes unused `const _isLoading = loading || sessions === null` from `ProjectSidebar` — replaced by inline `sessions === null` checks. Renames `loading` prop to `_loading` to satisfy lint.
- **`sessionStorage` Strict Mode race**: Converts the render-time IIFE (reads + removes `ao-session-nav:{id}`) to a `useState` lazy initialiser. React Strict Mode double-invokes the component in dev — the IIFE would consume the entry on the first call, returning `null` on the second, defeating the navigation-cache optimisation entirely in development.

## Test plan

- [ ] On mobile at `/`, open the sidebar then switch `?project=` — overlay should close
- [ ] Click a session from the sidebar — no loading spinner flash (cache hit works in dev)
- [ ] Typecheck, tests, build all pass
🤖 Generated with [Claude Code](https://claude.com/claude-code)