### PR TITLE
fix(agent-codex): detect codex-unwrapped processes

### DIFF
--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -447,6 +447,13 @@ describe("isProcessRunning", () => {
     expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
   });
 
+  it("returns true when Nix launches Codex as codex-unwrapped", async () => {
+    mockTmuxWithProcess(
+      "/nix/store/n6yvqvcmp1jbg031vssnp55hfzsksnm5-codex-0.131.0/bin/codex-unwrapped resume",
+    );
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
   it("returns false when codex not on tmux pane TTY", async () => {
     mockTmuxWithProcess("codex", false);
     expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -725,7 +725,7 @@ function createCodexAgent(): Agent {
           });
           if (!psOut) return PROCESS_PROBE_INDETERMINATE;
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
-          const processRe = /(?:^|\/)codex(?:\s|$)/;
+          const processRe = /(?:^|\/)codex(?:-unwrapped)?(?:\s|$)/;
           for (const line of psOut.split("\n")) {
             const cols = line.trimStart().split(/\s+/);
             if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;


### PR DESCRIPTION
Fixes #1954

## Summary
- Accept `codex-unwrapped` as a valid Codex process name in the tmux liveness probe.
- Add a regression test for Nix-launched Codex processes whose long-lived child is `/nix/store/.../bin/codex-unwrapped`.

## Test
- `pnpm --filter @aoagents/ao-plugin-agent-codex test`
- `pnpm --filter @aoagents/ao-plugin-agent-codex typecheck`
- `pnpm --filter @aoagents/ao-plugin-agent-codex build`
- `git diff --check`
