### PR TITLE
fix(cli): sanitize project IDs derived from folder names

### DIFF
--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -148,7 +148,10 @@ export function registerProjectCommand(program: Command): void {
 
       let projectId = opts.key;
       if (!projectId) {
-        projectId = basename(resolvedPath) || "project";
+        const rawId = basename(resolvedPath) || "project";
+        // Sanitize to match Zod schema [a-zA-Z0-9_-]+
+        // so paths like "/home/user/llama.cpp" produce "llama-cpp" as project ID.
+        projectId = rawId.replace(/[^a-zA-Z0-9_-]/g, "-").replace(/^-+|-+$/g, "") || rawId;
       }
 
       const effectiveId = registerProject(resolvedPath, projectId, basename(resolvedPath) || projectId);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -148,7 +148,10 @@ function writeProjectBehaviorConfig(projectPath: string, config: LocalProjectCon
  */
 async function registerFlatConfig(configPath: string): Promise<string | null> {
   const projectPath = resolve(dirname(configPath));
-  const projectId = basename(projectPath);
+  const rawProjectId = basename(projectPath);
+  // Sanitize projectId to match Zod schema [a-zA-Z0-9_-]+
+  // so folder names like "llama.cpp" become "llama-cpp".
+  const projectId = rawProjectId.replace(/[^a-zA-Z0-9_-]/g, "-").replace(/^-+|-+$/g, "") || rawProjectId;
 
   // Read flat config fields
   const raw = readFileSync(configPath, "utf-8");


### PR DESCRIPTION
## Summary

When a repository folder name contains special characters like dots (e.g. `llama.cpp`), the auto-derived project ID fails Zod validation on the next config load, throwing:

```
Error: [
  {
    "validation": "regex",
    "code": "invalid_string",
    "message": "Project ID must match [a-zA-Z0-9_-]+ (no dots, slashes, or special characters)",
    "path": [
      "projects",
      "llama.cpp"
    ]
  }
]
```

## Root Cause

`registerFlatConfig` (start.ts) and `ao project add` (project.ts) derive the project ID from the directory basename without sanitizing special characters. The Zod schema at `packages/core/src/config.ts:372` enforces `/^[a-zA-Z0-9_-]+$/` on project IDs, causing the validated config to reject entries with dots or other special characters.

## Fix

Sanitize the basename-derived project ID by replacing characters outside `[a-zA-Z0-9_-]` with hyphens, then stripping leading/trailing hyphens. Falls back to the raw name if sanitization produces an empty string.

This matches the same sanitization pattern already used for `sessionPrefix` on the next line of `registerFlatConfig`.

## Testing

- `ao start` in `~/llama.cpp` → project ID becomes `llama-cpp` instead of `llama.cpp`
- `ao project add ~/my.app.project` → project ID becomes `my-app-project`
- Folder names with only valid characters (`my-project`, `my_project`) are unchanged