### PR TITLE
fix(cli): sanitize project IDs derived from folder names

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -20,6 +20,7 @@ import {
   loadConfig,
   generateOrchestratorPrompt,
   generateSessionPrefix,
+  sanitizeProjectId,
   getOrchestratorSessionId,
   isRepoUrl,
   configToYaml,
@@ -148,7 +149,8 @@ function writeProjectBehaviorConfig(projectPath: string, config: LocalProjectCon
  */
 async function registerFlatConfig(configPath: string): Promise<string | null> {
   const projectPath = resolve(dirname(configPath));
-  const projectId = basename(projectPath);
+  let projectId = basename(projectPath);
+  projectId = sanitizeProjectId(projectId);
 
   // Read flat config fields
   const raw = readFileSync(configPath, "utf-8");
@@ -682,6 +684,7 @@ async function addProjectToConfig(
   await ensureGit("adding projects");
 
   let projectId = basename(resolvedPath);
+  projectId = sanitizeProjectId(projectId);
 
   // Avoid overwriting an existing project with the same directory name
   if (config.projects[projectId]) {


### PR DESCRIPTION
This is an independent contribution and is not affiliated with any hackathon or competition.

## Summary

When running `ao start` in a directory whose name contains dots or special characters (e.g. `llama.cpp`), the project ID derived from the folder name fails Zod validation. This change applies the existing `sanitizeProjectId()` helper to auto-generated project IDs before registration.

## Root Cause

The CLI derives the project ID from `basename(projectPath)` without sanitization. If the folder name contains characters outside `[a-zA-Z0-9_-]` (such as dots), the subsequent Zod schema validation rejects the config with a runtime error.

## Fix

Two call sites now sanitize the derived ID using the already-existing `sanitizeProjectId()` utility from `@aoagents/ao-core`:

1. `registerFlatConfig()` — project ID derived from flat config path
2. `addProjectToConfig()` — project ID derived when adding an existing repo

The helper lowercases the string, replaces invalid characters with hyphens, strips leading/trailing hyphens, and collapses consecutive hyphens. For example, `llama.cpp` becomes `llama-cpp`.

## Testing

- Existing `sanitizeProjectId` test suite covers this transformation (see `config-generator.test.ts`)
- No new logic introduced — just applying an existing, tested utility at the point of ID derivation