### PR TITLE
fix: scope dashboard notifications to the live daemon

### DIFF
--- a/packages/cli/__tests__/lib/running-state.test.ts
+++ b/packages/cli/__tests__/lib/running-state.test.ts
@@ -45,6 +45,11 @@ describe("running-state", () => {
       port: 4321,
       startedAt: new Date("2026-04-19T00:00:00.000Z").toISOString(),
       projects: ["my-app"],
+      dashboardNotificationStore: join(
+        testHome,
+        ".agent-orchestrator",
+        "dashboard-notifications.jsonl",
+      ),
     });
     expect(existsSync(stateFile)).toBe(true);
     expect(killSpy).toHaveBeenCalledWith(424242, 0);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -35,6 +35,7 @@ import {
   recordActivityEvent,
   registerProjectInGlobalConfig,
   getGlobalConfigPath,
+  getDaemonDashboardNotificationStorePath,
   type OrchestratorConfig,
   type LocalProjectConfig,
   type ProjectConfig,
@@ -815,9 +816,16 @@ async function startDashboard(
   configPath: string | null,
   terminalPort?: number,
   directTerminalPort?: number,
+  dashboardNotificationStore?: string,
   devMode?: boolean,
 ): Promise<ChildProcess> {
-  const env = await buildDashboardEnv(port, configPath, terminalPort, directTerminalPort);
+  const env = await buildDashboardEnv(
+    port,
+    configPath,
+    terminalPort,
+    directTerminalPort,
+    dashboardNotificationStore,
+  );
 
   // Detect monorepo vs npm install: the `server/` source directory only exists
   // in the monorepo. Published npm packages only have `dist-server/`.
@@ -901,6 +909,7 @@ async function runStartup(
 
   const shouldStartLifecycle = opts?.dashboard !== false || opts?.orchestrator !== false;
   let port = config.port ?? DEFAULT_PORT;
+  const dashboardNotificationStore = getDaemonDashboardNotificationStorePath();
   console.log(chalk.bold(`\nStarting orchestrator for ${chalk.cyan(project.name)}\n`));
 
   const spinner = ora();
@@ -942,6 +951,7 @@ async function runStartup(
       config.configPath,
       config.terminalPort,
       config.directTerminalPort,
+      dashboardNotificationStore,
       opts?.dev,
     );
     spinner.succeed(`Dashboard starting on ${dashboardUrl(port)}`);

--- a/packages/cli/src/lib/running-state.ts
+++ b/packages/cli/src/lib/running-state.ts
@@ -11,7 +11,11 @@ import {
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { setTimeout as sleep } from "node:timers/promises";
-import { atomicWriteFileSync, recordActivityEvent } from "@aoagents/ao-core";
+import {
+  atomicWriteFileSync,
+  getDaemonDashboardNotificationStorePath,
+  recordActivityEvent,
+} from "@aoagents/ao-core";
 
 export interface RunningState {
   pid: number;
@@ -19,6 +23,7 @@ export interface RunningState {
   port: number;
   startedAt: string;
   projects: string[];
+  dashboardNotificationStore?: string;
 }
 
 const STATE_DIR = join(homedir(), ".agent-orchestrator");
@@ -187,7 +192,11 @@ function writeState(state: RunningState | null): void {
 export async function register(entry: RunningState): Promise<void> {
   const release = await acquireLock(STATE_LOCK_FILE, 5000, "running.json lock");
   try {
-    writeState(entry);
+    writeState({
+      ...entry,
+      dashboardNotificationStore:
+        entry.dashboardNotificationStore ?? getDaemonDashboardNotificationStorePath(),
+    });
   } finally {
     release();
   }

--- a/packages/cli/src/lib/running-state.ts
+++ b/packages/cli/src/lib/running-state.ts
@@ -14,6 +14,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import {
   atomicWriteFileSync,
   getDaemonDashboardNotificationStorePath,
+  isProcessAlive,
   recordActivityEvent,
 } from "@aoagents/ao-core";
 
@@ -49,18 +50,6 @@ interface LockMetadata {
 
 function ensureDir(): void {
   mkdirSync(STATE_DIR, { recursive: true });
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error: unknown) {
-    if ((error as { code?: string }).code === "EPERM") {
-      return true;
-    }
-    return false;
-  }
 }
 
 function readLockMetadata(lockFile: string): LockMetadata | null {

--- a/packages/cli/src/lib/web-dir.ts
+++ b/packages/cli/src/lib/web-dir.ts
@@ -132,12 +132,17 @@ export async function buildDashboardEnv(
   configPath: string | null,
   terminalPort?: number,
   directTerminalPort?: number,
+  dashboardNotificationStore?: string | null,
 ): Promise<Record<string, string>> {
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
 
   // Pass config path so dashboard uses the same config as the CLI
   if (configPath) {
     env["AO_CONFIG_PATH"] = configPath;
+  }
+
+  if (dashboardNotificationStore) {
+    env["AO_DASHBOARD_NOTIFICATION_STORE"] = dashboardNotificationStore;
   }
 
   env["PORT"] = String(port);

--- a/packages/core/src/__tests__/dashboard-notifications.test.ts
+++ b/packages/core/src/__tests__/dashboard-notifications.test.ts
@@ -7,6 +7,7 @@ import { buildCIFailureNotificationData } from "../notification-data.js";
 import {
   appendDashboardNotificationRecord,
   createDashboardNotificationRecord,
+  getDaemonDashboardNotificationStorePath,
   getLiveDashboardNotificationStorePath,
   normalizeDashboardNotificationLimit,
   readDashboardNotificationsFromFile,
@@ -186,6 +187,46 @@ describe("dashboard notifications", () => {
       );
 
       expect(getLiveDashboardNotificationStorePath()).toBe(storePath);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env["HOME"];
+      } else {
+        process.env["HOME"] = originalHome;
+      }
+      if (originalUserProfile === undefined) {
+        delete process.env["USERPROFILE"];
+      } else {
+        process.env["USERPROFILE"] = originalUserProfile;
+      }
+    }
+  });
+
+  it("falls back to the daemon store for invalid live daemon store paths", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "ao-dashboard-notifications-invalid-live-"));
+    const originalHome = process.env["HOME"];
+    const originalUserProfile = process.env["USERPROFILE"];
+
+    try {
+      process.env["HOME"] = tempDir;
+      process.env["USERPROFILE"] = tempDir;
+      const stateDir = join(tempDir, ".agent-orchestrator");
+      mkdirSync(stateDir, { recursive: true });
+
+      writeFileSync(
+        join(stateDir, "running.json"),
+        JSON.stringify({
+          pid: process.pid,
+          configPath: join(tempDir, "project", "agent-orchestrator.yaml"),
+          port: 3000,
+          startedAt: "2026-05-22T00:00:00.000Z",
+          projects: ["demo"],
+          dashboardNotificationStore: "   ",
+        }),
+      );
+
+      expect(getLiveDashboardNotificationStorePath()).toBe(
+        getDaemonDashboardNotificationStorePath(),
+      );
     } finally {
       if (originalHome === undefined) {
         delete process.env["HOME"];

--- a/packages/core/src/__tests__/dashboard-notifications.test.ts
+++ b/packages/core/src/__tests__/dashboard-notifications.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
@@ -7,6 +7,7 @@ import { buildCIFailureNotificationData } from "../notification-data.js";
 import {
   appendDashboardNotificationRecord,
   createDashboardNotificationRecord,
+  getLiveDashboardNotificationStorePath,
   normalizeDashboardNotificationLimit,
   readDashboardNotificationsFromFile,
   writeDashboardNotificationsToFile,
@@ -142,5 +143,60 @@ describe("dashboard notifications", () => {
     expect(normalizeDashboardNotificationLimit(0)).toBe(1);
     expect(normalizeDashboardNotificationLimit("1000")).toBe(500);
     expect(normalizeDashboardNotificationLimit("75")).toBe(75);
+  });
+
+  it("caches the live daemon store path without trimming valid path whitespace", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "ao-dashboard-notifications-live-"));
+    const originalHome = process.env["HOME"];
+    const originalUserProfile = process.env["USERPROFILE"];
+
+    try {
+      process.env["HOME"] = tempDir;
+      process.env["USERPROFILE"] = tempDir;
+      const stateDir = join(tempDir, ".agent-orchestrator");
+      mkdirSync(stateDir, { recursive: true });
+      const runningPath = join(stateDir, "running.json");
+      const storePath = join(tempDir, " dashboard-notifications.jsonl ");
+      const updatedStorePath = join(tempDir, "updated-dashboard-notifications.jsonl");
+
+      writeFileSync(
+        runningPath,
+        JSON.stringify({
+          pid: process.pid,
+          configPath: join(tempDir, "project", "agent-orchestrator.yaml"),
+          port: 3000,
+          startedAt: "2026-05-21T00:00:00.000Z",
+          projects: ["demo"],
+          dashboardNotificationStore: storePath,
+        }),
+      );
+
+      expect(getLiveDashboardNotificationStorePath()).toBe(storePath);
+
+      writeFileSync(
+        runningPath,
+        JSON.stringify({
+          pid: process.pid,
+          configPath: join(tempDir, "project", "agent-orchestrator.yaml"),
+          port: 3000,
+          startedAt: "2026-05-21T00:00:01.000Z",
+          projects: ["demo"],
+          dashboardNotificationStore: updatedStorePath,
+        }),
+      );
+
+      expect(getLiveDashboardNotificationStorePath()).toBe(storePath);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env["HOME"];
+      } else {
+        process.env["HOME"] = originalHome;
+      }
+      if (originalUserProfile === undefined) {
+        delete process.env["USERPROFILE"];
+      } else {
+        process.env["USERPROFILE"] = originalUserProfile;
+      }
+    }
   });
 });

--- a/packages/core/src/__tests__/process-utils.test.ts
+++ b/packages/core/src/__tests__/process-utils.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isProcessAlive } from "../process-utils.js";
+
+describe("isProcessAlive", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not signal invalid pids", () => {
+    const kill = vi.spyOn(process, "kill");
+
+    expect(isProcessAlive(0)).toBe(false);
+    expect(isProcessAlive(-1)).toBe(false);
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("treats EPERM as alive", () => {
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      const error = new Error("denied") as Error & { code: string };
+      error.code = "EPERM";
+      throw error;
+    });
+
+    expect(isProcessAlive(123)).toBe(true);
+  });
+
+  it("treats missing processes as not alive", () => {
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      const error = new Error("gone") as Error & { code: string };
+      error.code = "ESRCH";
+      throw error;
+    });
+
+    expect(isProcessAlive(123)).toBe(false);
+  });
+});

--- a/packages/core/src/daemon-children.ts
+++ b/packages/core/src/daemon-children.ts
@@ -19,6 +19,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { promisify } from "node:util";
 import { atomicWriteFileSync } from "./atomic-write.js";
 import { isWindows, killProcessTree } from "./platform.js";
+import { isProcessAlive } from "./process-utils.js";
 
 const execFileAsync = promisify(execFileCb);
 const DEFAULT_GRACE_MS = 5_000;
@@ -142,16 +143,6 @@ function writeRawDaemonChildren(entries: DaemonChildEntry[]): void {
   }
   ensureStateDir();
   atomicWriteFileSync(file, JSON.stringify(entries, null, 2));
-}
-
-function isProcessAlive(pid: number): boolean {
-  if (pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err: unknown) {
-    return (err as { code?: string }).code === "EPERM";
-  }
 }
 
 async function waitForProcessesExit(pids: number[], timeoutMs: number): Promise<Set<number>> {

--- a/packages/core/src/dashboard-notifications.ts
+++ b/packages/core/src/dashboard-notifications.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import type { NotifyAction, OrchestratorEvent } from "./types.js";
 import type { NotificationDataV3 } from "./notification-data.js";
 import { atomicWriteFileSync } from "./atomic-write.js";
-import { getObservabilityBaseDir } from "./paths.js";
+import { getAoBaseDir, getObservabilityBaseDir } from "./paths.js";
 
 export const DEFAULT_DASHBOARD_NOTIFICATION_LIMIT = 50;
 export const MAX_DASHBOARD_NOTIFICATION_LIMIT = 500;
@@ -57,6 +57,44 @@ export function normalizeDashboardNotificationLimit(value: unknown): number {
 
 export function getDashboardNotificationStorePath(configPath: string): string {
   return join(getObservabilityBaseDir(configPath), "dashboard-notifications.jsonl");
+}
+
+export function getDaemonDashboardNotificationStorePath(): string {
+  return join(getAoBaseDir(), "dashboard-notifications.jsonl");
+}
+
+function getRunningStatePath(): string {
+  return join(getAoBaseDir(), "running.json");
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    return (err as { code?: string }).code === "EPERM";
+  }
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function getLiveDashboardNotificationStorePath(): string | null {
+  try {
+    const raw = readFileSync(getRunningStatePath(), "utf-8");
+    const state = JSON.parse(raw) as Record<string, unknown>;
+    const pid = state["pid"];
+    if (typeof pid !== "number" || !isProcessAlive(pid)) return null;
+
+    return (
+      nonEmptyString(state["dashboardNotificationStore"]) ??
+      getDaemonDashboardNotificationStorePath()
+    );
+  } catch {
+    return null;
+  }
 }
 
 function toJsonRecord(value: unknown): DashboardNotificationEventData {

--- a/packages/core/src/dashboard-notifications.ts
+++ b/packages/core/src/dashboard-notifications.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import type { NotifyAction, OrchestratorEvent } from "./types.js";
 import type { NotificationDataV3 } from "./notification-data.js";
 import { atomicWriteFileSync } from "./atomic-write.js";
@@ -68,8 +68,8 @@ function getRunningStatePath(): string {
   return join(getAoBaseDir(), "running.json");
 }
 
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.length > 0 ? value : null;
+export function validateDashboardNotificationStorePath(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 && isAbsolute(value) ? value : null;
 }
 
 interface LiveDashboardNotificationStoreCache {
@@ -98,7 +98,7 @@ export function getLiveDashboardNotificationStorePath(): string | null {
     if (typeof pid !== "number" || !isProcessAlive(pid)) return null;
 
     const storePath =
-      nonEmptyString(state["dashboardNotificationStore"]) ??
+      validateDashboardNotificationStorePath(state["dashboardNotificationStore"]) ??
       getDaemonDashboardNotificationStorePath();
     liveDashboardNotificationStoreCache = { runningStatePath, pid, storePath };
     return storePath;

--- a/packages/core/src/dashboard-notifications.ts
+++ b/packages/core/src/dashboard-notifications.ts
@@ -4,6 +4,7 @@ import type { NotifyAction, OrchestratorEvent } from "./types.js";
 import type { NotificationDataV3 } from "./notification-data.js";
 import { atomicWriteFileSync } from "./atomic-write.js";
 import { getAoBaseDir, getObservabilityBaseDir } from "./paths.js";
+import { isProcessAlive } from "./process-utils.js";
 
 export const DEFAULT_DASHBOARD_NOTIFICATION_LIMIT = 50;
 export const MAX_DASHBOARD_NOTIFICATION_LIMIT = 500;
@@ -67,31 +68,40 @@ function getRunningStatePath(): string {
   return join(getAoBaseDir(), "running.json");
 }
 
-function isProcessAlive(pid: number): boolean {
-  if (pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err: unknown) {
-    return (err as { code?: string }).code === "EPERM";
-  }
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+interface LiveDashboardNotificationStoreCache {
+  runningStatePath: string;
+  pid: number;
+  storePath: string;
 }
+
+let liveDashboardNotificationStoreCache: LiveDashboardNotificationStoreCache | null = null;
 
 export function getLiveDashboardNotificationStorePath(): string | null {
+  const runningStatePath = getRunningStatePath();
+  if (
+    liveDashboardNotificationStoreCache &&
+    liveDashboardNotificationStoreCache.runningStatePath === runningStatePath &&
+    isProcessAlive(liveDashboardNotificationStoreCache.pid)
+  ) {
+    return liveDashboardNotificationStoreCache.storePath;
+  }
+  liveDashboardNotificationStoreCache = null;
+
   try {
-    const raw = readFileSync(getRunningStatePath(), "utf-8");
+    const raw = readFileSync(runningStatePath, "utf-8");
     const state = JSON.parse(raw) as Record<string, unknown>;
     const pid = state["pid"];
     if (typeof pid !== "number" || !isProcessAlive(pid)) return null;
 
-    return (
+    const storePath =
       nonEmptyString(state["dashboardNotificationStore"]) ??
-      getDaemonDashboardNotificationStorePath()
-    );
+      getDaemonDashboardNotificationStorePath();
+    liveDashboardNotificationStoreCache = { runningStatePath, pid, storePath };
+    return storePath;
   } catch {
     return null;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -382,6 +382,8 @@ export {
   appendDashboardNotificationRecord,
   createDashboardNotificationRecord,
   getDashboardNotificationStorePath,
+  getDaemonDashboardNotificationStorePath,
+  getLiveDashboardNotificationStorePath,
   normalizeDashboardNotificationLimit,
   readDashboardNotifications,
   readDashboardNotificationsFromFile,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -388,6 +388,7 @@ export {
   normalizeDashboardNotificationLimit,
   readDashboardNotifications,
   readDashboardNotificationsFromFile,
+  validateDashboardNotificationStorePath,
   writeDashboardNotificationsToFile,
   type DashboardNotificationEventData,
   type DashboardNotificationRecord,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -170,6 +170,7 @@ export type { SessionManagerDeps } from "./session-manager.js";
 // Process-scoped async memoization — used by plugins to dedupe shared
 // prerequisite checks (e.g. multiple github plugins checking gh auth).
 export { memoizeAsync, _clearProcessCacheForTests } from "./process-cache.js";
+export { isProcessAlive } from "./process-utils.js";
 
 // Lifecycle manager — state machine + reaction engine
 export { createLifecycleManager } from "./lifecycle-manager.js";

--- a/packages/core/src/process-utils.ts
+++ b/packages/core/src/process-utils.ts
@@ -1,0 +1,9 @@
+export function isProcessAlive(pid: number): boolean {
+  if (pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    return (err as { code?: string }).code === "EPERM";
+  }
+}

--- a/packages/core/src/windows-pty-registry.ts
+++ b/packages/core/src/windows-pty-registry.ts
@@ -22,6 +22,7 @@ import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { atomicWriteFileSync } from "./atomic-write.js";
+import { isProcessAlive } from "./process-utils.js";
 
 export interface WindowsPtyHostEntry {
   sessionId: string;
@@ -68,15 +69,6 @@ function writeRaw(entries: WindowsPtyHostEntry[]): void {
   atomicWriteFileSync(file, JSON.stringify(entries, null, 2));
 }
 
-function isAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err: unknown) {
-    return (err as { code?: string }).code === "EPERM";
-  }
-}
-
 /**
  * Add (or replace) an entry for a freshly-spawned pty-host.
  * If a stale entry for the same `sessionId` exists, it's overwritten.
@@ -103,7 +95,7 @@ export function unregisterWindowsPtyHost(sessionId: string): void {
  */
 export function getWindowsPtyHosts(): WindowsPtyHostEntry[] {
   const all = readRaw();
-  const live = all.filter((e) => isAlive(e.ptyHostPid));
+  const live = all.filter((e) => isProcessAlive(e.ptyHostPid));
   if (live.length !== all.length) writeRaw(live);
   return live;
 }

--- a/packages/plugins/notifier-dashboard/src/index.test.ts
+++ b/packages/plugins/notifier-dashboard/src/index.test.ts
@@ -1,19 +1,23 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildSessionTransitionNotificationData,
+  getDaemonDashboardNotificationStorePath,
   getDashboardNotificationStorePath,
   readDashboardNotifications,
+  readDashboardNotificationsFromFile,
   type OrchestratorEvent,
 } from "@aoagents/ao-core";
 import { create, manifest } from "./index.js";
 
 let tempDir: string | null = null;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
 
 function makeConfigPath(): string {
-  tempDir = mkdtempSync(join(tmpdir(), "ao-dashboard-plugin-"));
+  if (!tempDir) throw new Error("tempDir not initialized");
   return join(tempDir, "agent-orchestrator.yaml");
 }
 
@@ -53,9 +57,29 @@ function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEven
   };
 }
 
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "ao-dashboard-plugin-"));
+  originalHome = process.env["HOME"];
+  originalUserProfile = process.env["USERPROFILE"];
+  process.env["HOME"] = tempDir;
+  process.env["USERPROFILE"] = tempDir;
+});
+
 afterEach(() => {
+  if (originalHome === undefined) {
+    delete process.env["HOME"];
+  } else {
+    process.env["HOME"] = originalHome;
+  }
+  if (originalUserProfile === undefined) {
+    delete process.env["USERPROFILE"];
+  } else {
+    process.env["USERPROFILE"] = originalUserProfile;
+  }
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
   tempDir = null;
+  originalHome = undefined;
+  originalUserProfile = undefined;
   vi.restoreAllMocks();
 });
 
@@ -108,13 +132,42 @@ describe("notifier-dashboard", () => {
     ]);
   });
 
+  it("persists to the live daemon dashboard store when one is registered", async () => {
+    if (!tempDir) throw new Error("tempDir not initialized");
+    const stateDir = join(tempDir, ".agent-orchestrator");
+    mkdirSync(stateDir, { recursive: true });
+    const daemonStorePath = getDaemonDashboardNotificationStorePath();
+    const configPath = join(tempDir, ".agent-orchestrator", "config.yaml");
+    writeFileSync(
+      join(stateDir, "running.json"),
+      JSON.stringify({
+        pid: process.pid,
+        configPath: join(tempDir, "project", "agent-orchestrator.yaml"),
+        port: 3000,
+        startedAt: "2026-05-21T00:00:00.000Z",
+        projects: ["demo"],
+        dashboardNotificationStore: daemonStorePath,
+      }),
+    );
+
+    const notifier = create({ configPath });
+    await notifier.notify(makeEvent({ id: "evt-live" }));
+
+    expect(
+      readDashboardNotificationsFromFile(daemonStorePath).map((record) => record.event.id),
+    ).toEqual(["evt-live"]);
+    expect(readDashboardNotifications(configPath)).toEqual([]);
+  });
+
   it("warns and no-ops when configPath is missing", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const notifier = create();
 
     await notifier.notify(makeEvent());
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("No configPath available"));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No live dashboard notification store or configPath available"),
+    );
   });
 
   it("uses the expected store path shape", () => {

--- a/packages/plugins/notifier-dashboard/src/index.ts
+++ b/packages/plugins/notifier-dashboard/src/index.ts
@@ -1,5 +1,8 @@
 import {
-  appendDashboardNotification,
+  appendDashboardNotificationRecord,
+  createDashboardNotificationRecord,
+  getDashboardNotificationStorePath,
+  getLiveDashboardNotificationStorePath,
   normalizeDashboardNotificationLimit,
   type Notifier,
   type NotifyAction,
@@ -21,20 +24,31 @@ function stringValue(value: unknown): string | undefined {
 export function create(config?: Record<string, unknown>): Notifier {
   const configPath = stringValue(config?.configPath);
   const limit = normalizeDashboardNotificationLimit(config?.limit);
-  let warnedMissingConfigPath = false;
+  let warnedMissingStore = false;
+
+  function resolveStorePath(): string | null {
+    const liveStorePath = getLiveDashboardNotificationStorePath();
+    if (liveStorePath) return liveStorePath;
+    return configPath ? getDashboardNotificationStorePath(configPath) : null;
+  }
 
   function persist(event: OrchestratorEvent, actions?: NotifyAction[]): void {
-    if (!configPath) {
-      if (!warnedMissingConfigPath) {
+    const storePath = resolveStorePath();
+    if (!storePath) {
+      if (!warnedMissingStore) {
         console.warn(
-          "[notifier-dashboard] No configPath available - dashboard notifications will be no-ops",
+          "[notifier-dashboard] No live dashboard notification store or configPath available - dashboard notifications will be no-ops",
         );
-        warnedMissingConfigPath = true;
+        warnedMissingStore = true;
       }
       return;
     }
 
-    appendDashboardNotification(configPath, event, actions, { limit });
+    appendDashboardNotificationRecord(
+      storePath,
+      createDashboardNotificationRecord(event, actions),
+      limit,
+    );
   }
 
   return {

--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "node:events";
-import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Socket } from "node:net";
 import { WebSocket } from "ws";
-import { appendDashboardNotification, isWindows, type OrchestratorEvent } from "@aoagents/ao-core";
+import {
+  appendDashboardNotification,
+  appendDashboardNotificationRecord,
+  createDashboardNotificationRecord,
+  getDaemonDashboardNotificationStorePath,
+  isWindows,
+  type OrchestratorEvent,
+} from "@aoagents/ao-core";
 import type { SessionBroadcaster as SessionBroadcasterType } from "../mux-websocket";
 
 // vi.mock factories run before module-level statements. Hoist the mock
@@ -783,10 +790,16 @@ describe("TerminalManager ui.terminal_pty_lost activity events", () => {
 describe("NotificationBroadcaster", () => {
   let tempDir: string | null = null;
   let configPath: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
 
   beforeEach(() => {
     vi.useFakeTimers();
     tempDir = mkdtempSync(join(tmpdir(), "ao-notification-broadcaster-"));
+    originalHome = process.env["HOME"];
+    originalUserProfile = process.env["USERPROFILE"];
+    process.env["HOME"] = tempDir;
+    process.env["USERPROFILE"] = tempDir;
     configPath = join(tempDir, "agent-orchestrator.yaml");
     writeFileSync(
       configPath,
@@ -804,6 +817,16 @@ describe("NotificationBroadcaster", () => {
   afterEach(() => {
     vi.clearAllTimers();
     vi.useRealTimers();
+    if (originalHome === undefined) {
+      delete process.env["HOME"];
+    } else {
+      process.env["HOME"] = originalHome;
+    }
+    if (originalUserProfile === undefined) {
+      delete process.env["USERPROFILE"];
+    } else {
+      process.env["USERPROFILE"] = originalUserProfile;
+    }
     if (tempDir) rmSync(tempDir, { recursive: true, force: true });
     tempDir = null;
   });
@@ -835,6 +858,31 @@ describe("NotificationBroadcaster", () => {
     });
   }
 
+  function writeRunningState(dashboardNotificationStore: string): void {
+    if (!tempDir) throw new Error("tempDir not initialized");
+    const stateDir = join(tempDir, ".agent-orchestrator");
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, "running.json"),
+      JSON.stringify({
+        pid: process.pid,
+        configPath,
+        port: 3000,
+        startedAt: "2026-05-21T00:00:00.000Z",
+        projects: ["demo"],
+        dashboardNotificationStore,
+      }),
+    );
+  }
+
+  function appendDaemonEvent(id: string, receivedAt: string, storePath: string): void {
+    appendDashboardNotificationRecord(
+      storePath,
+      createDashboardNotificationRecord(makeEvent(id), undefined, new Date(receivedAt)),
+      2,
+    );
+  }
+
   it("sends an immediate dashboard notification snapshot", () => {
     appendEvent("evt-1", "2026-05-13T12:00:01.000Z");
     const broadcaster = new NotificationBroadcaster(configPath);
@@ -844,6 +892,25 @@ describe("NotificationBroadcaster", () => {
 
     expect(callback).toHaveBeenCalledWith(
       [expect.objectContaining({ event: expect.objectContaining({ id: "evt-1" }) })],
+      "snapshot",
+      2,
+    );
+
+    unsubscribe();
+  });
+
+  it("reads the live daemon dashboard notification store instead of the config-scoped store", () => {
+    appendEvent("evt-config", "2026-05-13T12:00:01.000Z");
+    const daemonStorePath = getDaemonDashboardNotificationStorePath();
+    writeRunningState(daemonStorePath);
+    appendDaemonEvent("evt-daemon", "2026-05-13T12:00:02.000Z", daemonStorePath);
+    const broadcaster = new NotificationBroadcaster(configPath);
+    const callback = vi.fn();
+
+    const unsubscribe = broadcaster.subscribe(callback);
+
+    expect(callback).toHaveBeenCalledWith(
+      [expect.objectContaining({ event: expect.objectContaining({ id: "evt-daemon" }) })],
       "snapshot",
       2,
     );

--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -939,6 +939,24 @@ describe("NotificationBroadcaster", () => {
     unsubscribe();
   });
 
+  it("ignores a whitespace-only env store path", () => {
+    const daemonStorePath = getDaemonDashboardNotificationStorePath();
+    writeRunningState(daemonStorePath);
+    appendDaemonEvent("evt-daemon", "2026-05-13T12:00:02.000Z", daemonStorePath);
+    const broadcaster = new NotificationBroadcaster(configPath, "   ");
+    const callback = vi.fn();
+
+    const unsubscribe = broadcaster.subscribe(callback);
+
+    expect(callback).toHaveBeenCalledWith(
+      [expect.objectContaining({ event: expect.objectContaining({ id: "evt-daemon" }) })],
+      "snapshot",
+      2,
+    );
+
+    unsubscribe();
+  });
+
   it("does not let a new subscriber suppress appends for existing subscribers", () => {
     appendEvent("evt-1", "2026-05-13T12:00:01.000Z");
     const broadcaster = new NotificationBroadcaster(configPath);

--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -918,6 +918,27 @@ describe("NotificationBroadcaster", () => {
     unsubscribe();
   });
 
+  it("uses the daemon store passed through env without consulting later running state", () => {
+    if (!tempDir) throw new Error("tempDir not initialized");
+    const envStorePath = join(tempDir, "env-dashboard-notifications.jsonl");
+    const laterRunningStorePath = join(tempDir, "later-running-dashboard-notifications.jsonl");
+    writeRunningState(laterRunningStorePath);
+    appendDaemonEvent("evt-env", "2026-05-13T12:00:02.000Z", envStorePath);
+    appendDaemonEvent("evt-running", "2026-05-13T12:00:03.000Z", laterRunningStorePath);
+    const broadcaster = new NotificationBroadcaster(configPath, envStorePath);
+    const callback = vi.fn();
+
+    const unsubscribe = broadcaster.subscribe(callback);
+
+    expect(callback).toHaveBeenCalledWith(
+      [expect.objectContaining({ event: expect.objectContaining({ id: "evt-env" }) })],
+      "snapshot",
+      2,
+    );
+
+    unsubscribe();
+  });
+
   it("does not let a new subscriber suppress appends for existing subscribers", () => {
     appendEvent("evt-1", "2026-05-13T12:00:01.000Z");
     const broadcaster = new NotificationBroadcaster(configPath);

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_DASHBOARD_NOTIFICATION_LIMIT,
   getEnvDefaults,
   getDashboardNotificationStorePath,
+  getLiveDashboardNotificationStorePath,
   getNodePtyPrebuildsSubdir,
   isWindows,
   loadConfig,
@@ -245,7 +246,8 @@ function readDashboardLimit(configPath: string | undefined): number {
 
 /**
  * Polls the dashboard notification JSONL store and broadcasts changes to mux
- * subscribers. The store is config-scoped and survives dashboard reloads.
+ * subscribers. A live daemon's store wins over the config-scoped fallback so
+ * producers that resolved a different config still write to the visible dashboard.
  */
 export class NotificationBroadcaster {
   private subscribers = new Set<
@@ -259,11 +261,25 @@ export class NotificationBroadcaster {
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private lastRecords: DashboardNotificationRecord[] = [];
   private readonly configPath: string | undefined;
-  private readonly storePath: string | null;
+  private readonly envStorePath: string | null;
 
-  constructor(configPath = process.env["AO_CONFIG_PATH"]) {
+  constructor(
+    configPath = process.env["AO_CONFIG_PATH"],
+    envStorePath = process.env["AO_DASHBOARD_NOTIFICATION_STORE"],
+  ) {
     this.configPath = configPath;
-    this.storePath = configPath ? getDashboardNotificationStorePath(configPath) : null;
+    this.envStorePath =
+      typeof envStorePath === "string" && envStorePath.trim().length > 0
+        ? envStorePath.trim()
+        : null;
+  }
+
+  private getStorePath(): string | null {
+    return (
+      getLiveDashboardNotificationStorePath() ??
+      this.envStorePath ??
+      (this.configPath ? getDashboardNotificationStorePath(this.configPath) : null)
+    );
   }
 
   subscribe(
@@ -334,11 +350,12 @@ export class NotificationBroadcaster {
     limit: number;
   } {
     const limit = readDashboardLimit(this.configPath);
-    if (!this.storePath) return { notifications: [], error: null, limit };
+    const storePath = this.getStorePath();
+    if (!storePath) return { notifications: [], error: null, limit };
 
     try {
       return {
-        notifications: readDashboardNotificationsFromFile(this.storePath, limit),
+        notifications: readDashboardNotificationsFromFile(storePath, limit),
         error: null,
         limit,
       };

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -269,15 +269,13 @@ export class NotificationBroadcaster {
   ) {
     this.configPath = configPath;
     this.envStorePath =
-      typeof envStorePath === "string" && envStorePath.trim().length > 0
-        ? envStorePath.trim()
-        : null;
+      typeof envStorePath === "string" && envStorePath.length > 0 ? envStorePath : null;
   }
 
   private getStorePath(): string | null {
     return (
-      getLiveDashboardNotificationStorePath() ??
       this.envStorePath ??
+      getLiveDashboardNotificationStorePath() ??
       (this.configPath ? getDashboardNotificationStorePath(this.configPath) : null)
     );
   }

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -23,6 +23,7 @@ import {
   normalizeDashboardNotificationLimit,
   recordActivityEvent,
   readDashboardNotificationsFromFile,
+  validateDashboardNotificationStorePath,
   type DashboardNotificationRecord,
 } from "@aoagents/ao-core";
 import {
@@ -268,8 +269,7 @@ export class NotificationBroadcaster {
     envStorePath = process.env["AO_DASHBOARD_NOTIFICATION_STORE"],
   ) {
     this.configPath = configPath;
-    this.envStorePath =
-      typeof envStorePath === "string" && envStorePath.length > 0 ? envStorePath : null;
+    this.envStorePath = validateDashboardNotificationStorePath(envStorePath);
   }
 
   private getStorePath(): string | null {


### PR DESCRIPTION
## Summary
- add a daemon-level dashboard notification store path and persist it in running.json
- route dashboard notifier writes to the live daemon store when a daemon is running, falling back to the config-scoped store otherwise
- make the mux notification broadcaster read the live daemon store so global/local config resolution cannot split dashboard notifications

Closes #1984

## Tests
- pnpm build
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pnpm --filter @aoagents/ao-core test -- dashboard-notifications
- pnpm --filter @aoagents/ao-plugin-notifier-dashboard test
- pnpm --filter @aoagents/ao-cli test -- __tests__/lib/running-state.test.ts
- pnpm --filter @aoagents/ao-web test -- server/__tests__/mux-websocket.test.ts
- pnpm --filter @aoagents/ao-web test

## Notes
- pnpm test was run and currently fails on unrelated existing/local-environment failures: notifier-desktop integration expects osascript arguments but the macOS notifier path uses terminal-notifier, and cli path-equality canonicalizes /var to /private/var on this macOS host.