### PR TITLE
fix(core): terminate runtime-lost sessions when agent process probe is indeterminate (#2025)

### DIFF
--- a/.changeset/fix-runtime-lost-indeterminate-2025.md
+++ b/.changeset/fix-runtime-lost-indeterminate-2025.md
@@ -1,0 +1,7 @@
+---
+"@aoagents/ao-core": patch
+---
+
+fix(core): terminate runtime-lost sessions when the agent process probe is indeterminate (#2025)
+
+When a tmux session vanished, `runtime.isAlive` reported a clean dead but the agent's tmux-based `isProcessRunning` threw and was mapped to `INDETERMINATE`. The lifecycle poll short-circuited on the indeterminate probe with `skipMetadataWrite`, never reaching `resolveProbeDecision`, so the session froze forever in `detecting`/`runtime_lost` on the dashboard sidebar. The poll now treats an indeterminate agent probe as dead when the runtime is authoritatively dead (a process inside a gone tmux session cannot be alive), letting the session resolve terminal. The `#1838` false-termination protection is preserved — this only fires on an authoritative dead runtime, and the recent-liveness guard still keeps a genuinely-working agent in `detecting`.

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -729,6 +729,38 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("working");
   });
 
+  it("terminates a runtime-lost session even when the agent process probe is indeterminate (#2025)", async () => {
+    // tmux gone: runtime.isAlive returns a clean dead, but the agent's
+    // tmux-based isProcessRunning throws -> indeterminate. The authoritative
+    // dead runtime must win so the session reaches a terminal state instead of
+    // freezing in detecting forever.
+    vi.mocked(plugins.runtime.isAlive).mockResolvedValue(false);
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue(null);
+    vi.mocked(plugins.agent.detectActivity).mockReturnValue("idle");
+    vi.mocked(plugins.agent.isProcessRunning).mockResolvedValue("indeterminate");
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({
+        status: "detecting",
+        workspacePath: null,
+        metadata: {
+          lifecycleEvidence: "idle_beyond_threshold activity_signal=valid via_native activity=idle",
+          detectingAttempts: "1",
+        },
+      }),
+      metaOverrides: {
+        lifecycleEvidence: "idle_beyond_threshold activity_signal=valid via_native activity=idle",
+        detectingAttempts: "1",
+      },
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("killed");
+    const meta = readMetadataRaw(env.sessionsDir, "app-1");
+    expect(meta?.["lifecycleEvidence"]).toContain("runtime_dead process_dead");
+  });
+
   it("does not mark a session stuck from terminal-only idle evidence without a timestamp", async () => {
     config.reactions = {
       "agent-stuck": { auto: true, action: "notify", threshold: "1m" },

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -761,6 +761,28 @@ describe("check (single session)", () => {
     expect(meta?.["lifecycleEvidence"]).toContain("runtime_dead process_dead");
   });
 
+  it("keeps a session in detecting when the runtime is dead but the agent probe is indeterminate AND activity is fresh (#1838 guard at the reclassification site)", async () => {
+    // Even after reclassifying the indeterminate probe to dead, a fresh liveness
+    // signal must route through the signal_disagreement branch to detecting —
+    // never a false termination of a genuinely-working agent.
+    vi.mocked(plugins.runtime.isAlive).mockResolvedValue(false);
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({
+      state: "active",
+      timestamp: new Date(Date.now() - 5_000),
+    });
+    vi.mocked(plugins.agent.isProcessRunning).mockResolvedValue("indeterminate");
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("detecting");
+    const meta = readMetadataRaw(env.sessionsDir, "app-1");
+    expect(meta?.["lifecycleEvidence"]).toContain("signal_disagreement");
+  });
+
   it("does not mark a session stuck from terminal-only idle evidence without a timestamp", async () => {
     config.reactions = {
       "agent-stuck": { auto: true, action: "notify", threshold: "1m" },

--- a/packages/core/src/__tests__/lifecycle-status-decisions.test.ts
+++ b/packages/core/src/__tests__/lifecycle-status-decisions.test.ts
@@ -3,9 +3,11 @@ import {
   createDetectingDecision,
   hashEvidence,
   isDetectingTimedOut,
+  resolveProbeDecision,
   DETECTING_MAX_ATTEMPTS,
   DETECTING_MAX_DURATION_MS,
 } from "../lifecycle-status-decisions.js";
+import { createActivitySignal } from "../activity-signal.js";
 
 describe("hashEvidence", () => {
   it("returns a 12-character hex string", () => {
@@ -214,5 +216,80 @@ describe("createDetectingDecision", () => {
 
       expect(result.detecting.startedAt).toBe(previousStartedAt);
     });
+  });
+});
+
+describe("resolveProbeDecision", () => {
+  const noLivenessSignal = createActivitySignal("null", { source: "native" });
+  const recentLivenessSignal = createActivitySignal("valid", {
+    activity: "active",
+    timestamp: new Date(),
+    source: "native",
+  });
+
+  const baseProbeInput = {
+    currentAttempts: 0,
+    canProbeRuntimeIdentity: true,
+    activitySignal: noLivenessSignal,
+    activityEvidence: "activity_signal=null via_native",
+    idleWasBlocked: false,
+  };
+
+  it("terminates when both runtime and agent probes report dead", () => {
+    const decision = resolveProbeDecision({
+      ...baseProbeInput,
+      runtimeProbe: { state: "dead", failed: false },
+      processProbe: { state: "dead", failed: false },
+    });
+
+    expect(decision?.sessionState).toBe("terminated");
+    expect(decision?.sessionReason).toBe("runtime_lost");
+  });
+
+  it("keeps a dead runtime with a genuinely unknown process in detecting (no-agent grace)", () => {
+    // When the process state is truly unknown (e.g. no agent plugin to probe),
+    // resolveProbeDecision gives detecting grace rather than terminating. The
+    // #2025 path differs: the manager reclassifies an indeterminate agent probe
+    // to dead before this point, so it lands in the dead+dead terminal branch.
+    const decision = resolveProbeDecision({
+      ...baseProbeInput,
+      runtimeProbe: { state: "dead", failed: false },
+      processProbe: { state: "unknown", failed: false },
+    });
+
+    expect(decision?.sessionState).toBe("detecting");
+    expect(decision?.evidence).toContain("runtime_dead process_unknown");
+  });
+
+  it("stays in detecting when runtime is dead but recent activity supports liveness (preserves #1838 protection)", () => {
+    const decision = resolveProbeDecision({
+      ...baseProbeInput,
+      activitySignal: recentLivenessSignal,
+      runtimeProbe: { state: "dead", failed: false },
+      processProbe: { state: "unknown", failed: false },
+    });
+
+    expect(decision?.sessionState).toBe("detecting");
+  });
+
+  it("stays in detecting on a transient probe failure (preserves #1838 protection)", () => {
+    const decision = resolveProbeDecision({
+      ...baseProbeInput,
+      runtimeProbe: { state: "unknown", failed: true },
+      processProbe: { state: "unknown", failed: false },
+    });
+
+    expect(decision?.sessionState).toBe("detecting");
+  });
+
+  it("does not terminate a live runtime when the agent probe is indeterminate", () => {
+    const decision = resolveProbeDecision({
+      ...baseProbeInput,
+      runtimeProbe: { state: "alive", failed: false },
+      processProbe: { state: "unknown", failed: false },
+    });
+
+    // runtime alive + agent unknown is not a terminal signal; no decision here.
+    expect(decision).toBeNull();
   });
 });

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1190,6 +1190,20 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     // genuinely-working agent in `detecting`.
     const runtimeAuthoritativelyDead = runtimeProbe.state === "dead" && !runtimeProbe.failed;
     if (processProbe.indeterminate && runtimeAuthoritativelyDead) {
+      // Leave a trace: the audit trail otherwise shows the session jumping
+      // straight to terminal with no record of the intermediate reclassification.
+      recordActivityEvent({
+        projectId: session.projectId,
+        sessionId: session.id,
+        source: "agent",
+        kind: "agent.process_probe_failed",
+        level: "warn",
+        summary: `agent.isProcessRunning indeterminate for ${session.id} — reclassified dead (runtime authoritatively dead)`,
+        data: {
+          agentName,
+          reason: "probe_indeterminate_runtime_dead",
+        },
+      });
       processProbe = { state: "dead", failed: false };
     } else if (processProbe.indeterminate) {
       recordActivityEvent({

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1176,7 +1176,22 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
     }
 
-    if (processProbe.indeterminate) {
+    // An indeterminate agent process probe normally means "we couldn't tell" —
+    // hold the current state rather than risk a false termination (#1838).
+    //
+    // The exception: when the runtime probe authoritatively reports dead (e.g. a
+    // clean `tmux has-session` false), the agent process living inside that
+    // runtime cannot be alive. The agent's own probe is indeterminate precisely
+    // because it is tmux-based and threw when the session vanished. Reclassify
+    // it as dead so the poll can resolve terminal instead of freezing forever in
+    // `detecting` (#2025). #1838 protection is intact: we only do this on an
+    // authoritative dead runtime, never on a flaky/alive one. The
+    // recent-liveness guard inside resolveProbeDecision still keeps a
+    // genuinely-working agent in `detecting`.
+    const runtimeAuthoritativelyDead = runtimeProbe.state === "dead" && !runtimeProbe.failed;
+    if (processProbe.indeterminate && runtimeAuthoritativelyDead) {
+      processProbe = { state: "dead", failed: false };
+    } else if (processProbe.indeterminate) {
       recordActivityEvent({
         projectId: session.projectId,
         sessionId: session.id,


### PR DESCRIPTION
## Summary

Fixes #2025. Codex/claude worker sessions whose tmux runtime vanished got stuck **permanently** on the dashboard sidebar in `detecting / runtime_lost` ("Detecting runtime truth (runtime lost)") and never reached a terminal state.

Root cause: when a tmux session is gone, `runtime.isAlive` returns a clean `false` (authoritative dead), but the agent's tmux-based `isProcessRunning` (`tmux list-panes`) **throws** → mapped to `PROCESS_PROBE_INDETERMINATE`. The lifecycle poll short-circuited on the indeterminate probe at `lifecycle-manager.ts` with `skipMetadataWrite: true`, **never reaching `resolveProbeDecision`** — so the session froze in `detecting` forever (which `deriveLegacyStatus` maps to non-terminal `detecting`, keeping the card on the sidebar). The displayed `activity=idle` evidence was a stale fossil preserved by the skip.

## Fix

A process living inside a dead tmux session cannot be alive. When the runtime probe authoritatively reports dead, reclassify the indeterminate agent process probe as `dead`, so the poll falls through to `resolveProbeDecision` → `dead + dead` → `terminated / runtime_lost`.

- **No agent-plugin changes** — single core change in the lifecycle poll.
- **#1838 protection preserved**: this only fires on an *authoritative dead runtime* (`runtimeProbe.state === "dead" && !failed`), never on a flaky/alive one. A transient `ps`/`tmux` timeout still yields `runtimeProbe.failed` (state `unknown`) → indeterminate still short-circuits, no false termination.
- **Recent-liveness guard intact**: a dead runtime with fresh agent activity still routes to `detecting` via the existing `signal_disagreement` branch, so a genuinely-working agent whose runtime probe glitched is not killed.
- `resolveProbeDecision`'s general `dead + unknown → detecting` grace (e.g. no agent plugin to probe) is untouched.

Affects all agents — codex and claude-code share the same tmux-probe pattern.

## User-facing change

When a worker's terminal ends because its tmux session is gone (e.g. the smoke test finished, `ao stop` killed the pane, the tmux server was reaped, laptop sleep/wake) — and the session was not manually killed and has no PR:

**Before**
- The session stayed on the sidebar **forever** showing "Detecting runtime truth (runtime lost)", `Runtime: missing`, `PR: none`, and a stale `activity=idle` line.
- It never moved to a terminal/ended state on its own. The only way to clear it was to **manually kill** it. Zombie cards piled up over time (one per dead worker).

**Now**
- The session promptly resolves to a terminal **ended** state (`terminated / runtime_lost`, shown as `killed`), the same as any other finished session.
- It leaves the active list, moves to the ended/terminated grouping, and becomes eligible for normal cleanup — **no manual kill required**.
- No change for sessions you manually kill, sessions with a live runtime, or sessions whose agent is still genuinely active (a fresh activity signal still holds them in `detecting`, never falsely terminated).

## Test plan

- [x] `resolveProbeDecision` unit tests: dead+dead → terminated; dead+unknown (no agent) → detecting grace; dead+unknown+recent-liveness → detecting (#1838); transient probe failure → detecting (#1838); alive+unknown → null.
- [x] Lifecycle-manager poll regression: runtime dead + agent probe `indeterminate` + null activity → `killed` (`runtime_dead process_dead`), metadata written (not skipped).
- [x] Existing "leaves lifecycle metadata untouched when process probe is indeterminate" (runtime *alive*) still passes — #1838 guard.
- [x] Full core suite: 1329 tests pass. Full monorepo build + typecheck green. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
