### PR TITLE
fix(core): auto-terminate sessions when agent exits but runtime stays alive (closes #1933, #1966)

### DIFF
--- a/.changeset/terminate-on-agent-exit.md
+++ b/.changeset/terminate-on-agent-exit.md
@@ -1,0 +1,7 @@
+---
+"@aoagents/ao-core": patch
+---
+
+fix(core): auto-terminate sessions when the agent exits but the runtime stays alive
+
+Previously, when an agent process exited while its tmux runtime stayed alive (keep-alive shell), the lifecycle treated `runtime=alive` + `process=dead` as a signal disagreement, ran the detecting cycle, and parked the session at `stuck`/`probe_failure` indefinitely — leaving it lingering on the dashboard sidebar. When the native activity signal and the process probe both agree the agent has exited, the session now terminates directly with reason `agent_process_exited`. Closes #1933 and #1966.

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -589,7 +589,7 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("killed");
   });
 
-  it("detects killed state when getActivityState returns exited", async () => {
+  it("terminates when getActivityState returns exited even though the runtime is still alive (#1933, #1966)", async () => {
     vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "exited" });
     vi.mocked(plugins.runtime.isAlive).mockResolvedValue(true);
 
@@ -598,7 +598,7 @@ describe("check (single session)", () => {
     });
 
     await lm.check("app-1");
-    expect(lm.getStates().get("app-1")).toBe("detecting");
+    expect(lm.getStates().get("app-1")).toBe("killed");
   });
 
   it("detects killed via terminal fallback when getActivityState returns null", async () => {

--- a/packages/core/src/__tests__/lifecycle-state.test.ts
+++ b/packages/core/src/__tests__/lifecycle-state.test.ts
@@ -55,10 +55,15 @@ describe("deriveLegacyStatus", () => {
     merged.session.state = "terminated";
     merged.session.reason = "pr_merged";
 
+    const agentExited = createOpenPRLifecycle();
+    agentExited.session.state = "terminated";
+    agentExited.session.reason = "agent_process_exited";
+
     expect(deriveLegacyStatus(killed)).toBe("killed");
     expect(deriveLegacyStatus(cleanup)).toBe("cleanup");
     expect(deriveLegacyStatus(errored)).toBe("errored");
     expect(deriveLegacyStatus(merged)).toBe("cleanup");
+    expect(deriveLegacyStatus(agentExited)).toBe("killed");
   });
 
   it("keeps PR-oriented aliases for idle workers with open PRs", () => {

--- a/packages/core/src/__tests__/lifecycle-status-decisions.test.ts
+++ b/packages/core/src/__tests__/lifecycle-status-decisions.test.ts
@@ -3,9 +3,12 @@ import {
   createDetectingDecision,
   hashEvidence,
   isDetectingTimedOut,
+  resolveProbeDecision,
   DETECTING_MAX_ATTEMPTS,
   DETECTING_MAX_DURATION_MS,
 } from "../lifecycle-status-decisions.js";
+import { createActivitySignal } from "../activity-signal.js";
+import type { ActivitySignal } from "../types.js";
 
 describe("hashEvidence", () => {
   it("returns a 12-character hex string", () => {
@@ -214,5 +217,61 @@ describe("createDetectingDecision", () => {
 
       expect(result.detecting.startedAt).toBe(previousStartedAt);
     });
+  });
+});
+
+describe("resolveProbeDecision", () => {
+  const baseProbeInput = {
+    currentAttempts: 0,
+    canProbeRuntimeIdentity: true,
+    activityEvidence: "",
+    idleWasBlocked: false,
+  };
+
+  const exitedSignal: ActivitySignal = createActivitySignal("valid", {
+    activity: "exited",
+    source: "native",
+  });
+
+  it("terminates immediately when the native activity signal says the agent exited, even if the runtime is still alive", () => {
+    const result = resolveProbeDecision({
+      ...baseProbeInput,
+      runtimeProbe: { state: "alive", failed: false },
+      processProbe: { state: "dead", failed: false },
+      activitySignal: exitedSignal,
+      activityEvidence: "activity_signal=valid via_native activity=exited",
+    });
+
+    expect(result?.sessionState).toBe("terminated");
+    expect(result?.sessionReason).toBe("agent_process_exited");
+    expect(result?.status).toBe("killed");
+    // Must not route into the detecting/stuck cycle.
+    expect(result?.detecting.attempts).toBe(0);
+  });
+
+  it("does not enter signal_disagreement detecting when activity confirms the agent exited", () => {
+    const result = resolveProbeDecision({
+      ...baseProbeInput,
+      // Carries 50 prior detecting attempts — a session already parked at stuck.
+      currentAttempts: 50,
+      runtimeProbe: { state: "alive", failed: false },
+      processProbe: { state: "dead", failed: false },
+      activitySignal: exitedSignal,
+    });
+
+    expect(result?.sessionState).toBe("terminated");
+    expect(result?.evidence).not.toContain("signal_disagreement");
+  });
+
+  it("keeps treating runtime=alive process=dead as signal disagreement when the agent has NOT exited", () => {
+    const result = resolveProbeDecision({
+      ...baseProbeInput,
+      runtimeProbe: { state: "alive", failed: false },
+      processProbe: { state: "dead", failed: false },
+      activitySignal: createActivitySignal("unavailable"),
+    });
+
+    expect(result?.sessionState).toBe("detecting");
+    expect(result?.evidence).toContain("signal_disagreement");
   });
 });

--- a/packages/core/src/lifecycle-state.ts
+++ b/packages/core/src/lifecycle-state.ts
@@ -446,6 +446,7 @@ export function deriveLegacyStatus(
       switch (lifecycle.session.reason) {
         case "manually_killed":
         case "runtime_lost":
+        case "agent_process_exited":
           return "killed";
         case "auto_cleanup":
         case "pr_merged":

--- a/packages/core/src/lifecycle-status-decisions.ts
+++ b/packages/core/src/lifecycle-status-decisions.ts
@@ -300,7 +300,8 @@ export function resolveProbeDecision(input: ProbeDecisionInput): LifecycleDecisi
   if (
     input.activitySignal.state === "valid" &&
     input.activitySignal.activity === "exited" &&
-    input.processProbe.state === "dead"
+    input.processProbe.state === "dead" &&
+    !input.processProbe.failed
   ) {
     return createLifecycleDecision({
       status: SESSION_STATUS.KILLED,

--- a/packages/core/src/lifecycle-status-decisions.ts
+++ b/packages/core/src/lifecycle-status-decisions.ts
@@ -290,6 +290,27 @@ export function parseAttemptCount(raw: string | undefined): number {
 export function resolveProbeDecision(input: ProbeDecisionInput): LifecycleDecision | null {
   const recentActivitySupportsLiveness = supportsRecentLiveness(input.activitySignal);
 
+  // When the native activity signal and the process probe agree the agent has
+  // exited, the session is done — terminate it regardless of the runtime probe.
+  // The tmux keep-alive shell keeps the runtime "alive" after the agent dies,
+  // which would otherwise route this into the signal_disagreement detecting/stuck
+  // cycle and park the session at stuck forever (#1933, #1966). The
+  // processProbe=dead requirement excludes spawning sessions, whose process
+  // probe stays "unknown" until the agent has started (#1035).
+  if (
+    input.activitySignal.state === "valid" &&
+    input.activitySignal.activity === "exited" &&
+    input.processProbe.state === "dead"
+  ) {
+    return createLifecycleDecision({
+      status: SESSION_STATUS.KILLED,
+      evidence: `agent_exited runtime=${input.runtimeProbe.state} process=${input.processProbe.state} ${input.activityEvidence}`,
+      detecting: { attempts: 0 },
+      sessionState: "terminated",
+      sessionReason: "agent_process_exited",
+    });
+  }
+
   if (input.runtimeProbe.failed || input.processProbe.failed) {
     return createDetectingDecision({
       currentAttempts: input.currentAttempts,


### PR DESCRIPTION
## Summary

When an agent process exits but its tmux runtime stays alive (the keep-alive shell pattern), `resolveProbeDecision` treated `runtime=alive` + `process=dead` as a **signal disagreement**, ran the detecting cycle, and escalated the session to `stuck`/`probe_failure`. Every subsequent poll hit the same branch, so the session stayed `stuck` **forever** — lingering on the dashboard sidebar with an orange dot that no toggle could clear. Closes #1933 and #1966 (same root cause, different trigger).

## Root cause

`packages/core/src/lifecycle-status-decisions.ts` — the `runtimeProbe.state === "alive" && processProbe.state === "dead"` arm of `resolveProbeDecision` routed into `createDetectingDecision`. But when the agent's native activity signal definitively reports `exited` (and the process probe agrees), the runtime being alive is irrelevant — the agent is the source of truth. There was no path promoting `stuck` → `terminated` once all signals agreed the agent was gone.

## Fix

Add a branch at the top of `resolveProbeDecision`: when `activitySignal.state === "valid"` + `activity === "exited"` **and** `processProbe.state === "dead"`, terminate directly with reason `agent_process_exited` (mapped to legacy status `killed` in `deriveLegacyStatus`). The `processProbe=dead` requirement keeps spawning sessions safe — their process probe stays `unknown` until the agent starts (#1035), so they are never killed prematurely.

- `packages/core/src/lifecycle-status-decisions.ts` — new terminate-on-exit branch
- `packages/core/src/lifecycle-state.ts` — map `agent_process_exited` → `killed`

## Test plan

- [x] New unit tests for `resolveProbeDecision`: terminates on `activity=exited`, doesn't enter signal_disagreement, still treats `runtime=alive`/`process=dead` as disagreement when the agent has *not* exited
- [x] New `deriveLegacyStatus` test: `terminated` + `agent_process_exited` → `killed`
- [x] Updated the mislabeled existing test ("detects killed state when getActivityState returns exited" was asserting `detecting`) to expect `killed`
- [x] Verified spawning sessions are unaffected (#1035 regression test still green)
- [x] `pnpm --filter @aoagents/ao-core test` — 1326 passed
- [x] `pnpm --filter @aoagents/ao-core typecheck`, `pnpm lint` (0 errors), full `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)