### PR TITLE
fixed and added modal

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -4591,6 +4591,26 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   box-shadow: 0 24px 64px rgb(0 0 0 / 18%);
 }
 
+.project-settings-modal--confirm {
+  width: min(480px, calc(100vw - 48px));
+  max-height: none;
+}
+
+.project-settings-modal__confirm-body {
+  margin: 0;
+  padding: 0 20px 18px;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.project-settings-modal__confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 0 20px 20px;
+}
+
 .project-settings-modal__header {
   display: flex;
   align-items: flex-start;

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -13,6 +13,8 @@ import { projectDashboardPath, projectReviewPath, projectSessionPath } from "@/l
 import { ThemeToggle } from "./ThemeToggle";
 import { AddProjectModal } from "./AddProjectModal";
 import { ProjectSettingsModal } from "./ProjectSettingsModal";
+import { RemoveProjectConfirmModal } from "./RemoveProjectConfirmModal";
+import { ToastProvider, useToast } from "./Toast";
 
 /** Minimal shape needed to render an orchestrator link in the sidebar. */
 export interface ProjectSidebarOrchestrator {
@@ -110,7 +112,11 @@ export function ProjectSidebar(props: ProjectSidebarProps) {
   if (props.projects.length === 0) {
     return <ProjectSidebarEmpty collapsed={props.collapsed} />;
   }
-  return <ProjectSidebarInner {...props} />;
+  return (
+    <ToastProvider>
+      <ProjectSidebarInner {...props} />
+    </ToastProvider>
+  );
 }
 
 interface SessionRowProps {
@@ -284,6 +290,7 @@ function ProjectSidebarInner({
   onMobileClose,
 }: ProjectSidebarProps) {
   const router = useRouter();
+  const { showToast } = useToast();
   const _isLoading = loading || sessions === null;
 
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(
@@ -304,6 +311,7 @@ function ProjectSidebarInner({
   const [projectMenuOpenId, setProjectMenuOpenId] = useState<string | null>(null);
   const [projectSettingsProjectId, setProjectSettingsProjectId] = useState<string | null>(null);
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
+  const [projectPendingRemoval, setProjectPendingRemoval] = useState<ProjectInfo | null>(null);
   const [removedProjectIds, setRemovedProjectIds] = useState<Set<string>>(new Set());
   const [addProjectOpen, setAddProjectOpen] = useState(false);
   const settingsRef = useRef<HTMLDivElement>(null);
@@ -565,11 +573,19 @@ function ProjectSidebarInner({
     });
   };
 
-  const handleRemoveProject = async (project: ProjectInfo) => {
-    const confirmed = window.confirm(
-      `Remove project ${project.name} from AO? This clears its AO sessions/history and removes it from the portfolio, but keeps the repository folder on disk.`,
-    );
-    if (!confirmed) return;
+  const requestRemoveProject = (project: ProjectInfo) => {
+    setProjectMenuOpenId(null);
+    setProjectPendingRemoval(project);
+  };
+
+  const cancelRemoveProject = () => {
+    if (deletingProjectId) return;
+    setProjectPendingRemoval(null);
+  };
+
+  const confirmRemoveProject = async () => {
+    const project = projectPendingRemoval;
+    if (!project) return;
 
     setDeletingProjectId(project.id);
     try {
@@ -591,7 +607,7 @@ function ProjectSidebarInner({
         next.delete(project.id);
         return next;
       });
-      setProjectMenuOpenId(null);
+      setProjectPendingRemoval(null);
       if (activeProjectId === project.id) {
         router.push("/");
       } else if ("refresh" in router && typeof router.refresh === "function") {
@@ -599,7 +615,8 @@ function ProjectSidebarInner({
       }
       onMobileClose?.();
     } catch (error) {
-      window.alert(error instanceof Error ? error.message : "Failed to remove project.");
+      const message = error instanceof Error ? error.message : "Failed to remove project.";
+      showToast(message, "error");
     } finally {
       setDeletingProjectId(null);
     }
@@ -972,7 +989,7 @@ function ProjectSidebarInner({
                         type="button"
                         className="project-sidebar__proj-menu-item project-sidebar__proj-menu-item--danger"
                         role="menuitem"
-                        onClick={() => void handleRemoveProject(project)}
+                        onClick={() => requestRemoveProject(project)}
                         disabled={deletingProjectId === project.id}
                       >
                         {deletingProjectId === project.id ? "Removing..." : "Remove project"}
@@ -1184,6 +1201,12 @@ function ProjectSidebarInner({
         open={projectSettingsProjectId !== null}
         projectId={projectSettingsProjectId}
         onClose={() => setProjectSettingsProjectId(null)}
+      />
+      <RemoveProjectConfirmModal
+        project={projectPendingRemoval}
+        busy={projectPendingRemoval !== null && deletingProjectId === projectPendingRemoval.id}
+        onCancel={cancelRemoveProject}
+        onConfirm={() => void confirmRemoveProject()}
       />
     </aside>
   );

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -573,17 +573,17 @@ function ProjectSidebarInner({
     });
   };
 
-  const requestRemoveProject = (project: ProjectInfo) => {
+  const requestRemoveProject = useCallback((project: ProjectInfo) => {
     setProjectMenuOpenId(null);
     setProjectPendingRemoval(project);
-  };
+  }, []);
 
-  const cancelRemoveProject = () => {
+  const cancelRemoveProject = useCallback(() => {
     if (deletingProjectId) return;
     setProjectPendingRemoval(null);
-  };
+  }, [deletingProjectId]);
 
-  const confirmRemoveProject = async () => {
+  const confirmRemoveProject = useCallback(async () => {
     const project = projectPendingRemoval;
     if (!project) return;
 
@@ -620,7 +620,11 @@ function ProjectSidebarInner({
     } finally {
       setDeletingProjectId(null);
     }
-  };
+  }, [activeProjectId, onMobileClose, projectPendingRemoval, router, showToast]);
+
+  const handleConfirmRemoveProject = useCallback(() => {
+    void confirmRemoveProject();
+  }, [confirmRemoveProject]);
 
   if (collapsed) {
     return (
@@ -1206,7 +1210,7 @@ function ProjectSidebarInner({
         project={projectPendingRemoval}
         busy={projectPendingRemoval !== null && deletingProjectId === projectPendingRemoval.id}
         onCancel={cancelRemoveProject}
-        onConfirm={() => void confirmRemoveProject()}
+        onConfirm={handleConfirmRemoveProject}
       />
     </aside>
   );

--- a/packages/web/src/components/RemoveProjectConfirmModal.tsx
+++ b/packages/web/src/components/RemoveProjectConfirmModal.tsx
@@ -6,6 +6,9 @@ import type { ProjectInfo } from "@/lib/project-name";
 export const REMOVE_PROJECT_CONFIRM_MESSAGE =
   "This clears its AO sessions/history and removes it from the portfolio, but keeps the repository folder on disk.";
 
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
 interface RemoveProjectConfirmModalProps {
   project: ProjectInfo | null;
   busy: boolean;
@@ -23,19 +26,36 @@ export function RemoveProjectConfirmModal({
 
   useEffect(() => {
     if (!project) return;
-    modalRef.current?.focus();
-  }, [project]);
+    const modal = modalRef.current;
+    if (!modal) return;
 
-  useEffect(() => {
-    if (!project) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const focusable = modal.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    first.focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape" && !busy) {
         event.preventDefault();
         onCancel();
+        return;
       }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+
+      if (event.key === "Tab") {
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    modal.addEventListener("keydown", handleKeyDown);
+    return () => modal.removeEventListener("keydown", handleKeyDown);
   }, [project, busy, onCancel]);
 
   if (!project) return null;

--- a/packages/web/src/components/RemoveProjectConfirmModal.tsx
+++ b/packages/web/src/components/RemoveProjectConfirmModal.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { ProjectInfo } from "@/lib/project-name";
+
+export const REMOVE_PROJECT_CONFIRM_MESSAGE =
+  "This clears its AO sessions/history and removes it from the portfolio, but keeps the repository folder on disk.";
+
+interface RemoveProjectConfirmModalProps {
+  project: ProjectInfo | null;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function RemoveProjectConfirmModal({
+  project,
+  busy,
+  onCancel,
+  onConfirm,
+}: RemoveProjectConfirmModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!project) return;
+    modalRef.current?.focus();
+  }, [project]);
+
+  useEffect(() => {
+    if (!project) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !busy) {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [project, busy, onCancel]);
+
+  if (!project) return null;
+
+  return (
+    <div className="project-settings-modal-backdrop" onClick={busy ? undefined : onCancel}>
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="remove-project-title"
+        className="project-settings-modal project-settings-modal--confirm"
+        tabIndex={-1}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="project-settings-modal__header">
+          <div>
+            <p className="project-settings-modal__eyebrow">Remove project</p>
+            <h2 id="remove-project-title" className="project-settings-modal__title">
+              Remove {project.name}?
+            </h2>
+          </div>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onCancel}
+            disabled={busy}
+            className="project-settings-modal__close"
+          >
+            ×
+          </button>
+        </div>
+
+        <p className="project-settings-modal__confirm-body">{REMOVE_PROJECT_CONFIRM_MESSAGE}</p>
+
+        <div className="project-settings-modal__confirm-actions">
+          <button
+            type="button"
+            className="bottom-sheet__btn bottom-sheet__btn--cancel"
+            onClick={onCancel}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="bottom-sheet__btn bottom-sheet__btn--danger"
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {busy ? "Removing…" : "Remove from AO"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { ProjectSidebar } from "@/components/ProjectSidebar";
 import { makePR, makeSession } from "@/__tests__/helpers";
 
@@ -263,10 +263,6 @@ describe("ProjectSidebar", () => {
       json: async () => ({ ok: true }),
     });
     vi.stubGlobal("fetch", fetchMock);
-    vi.stubGlobal(
-      "confirm",
-      vi.fn(() => true),
-    );
 
     render(
       <ProjectSidebar
@@ -280,11 +276,64 @@ describe("ProjectSidebar", () => {
     fireEvent.click(screen.getByRole("button", { name: /Project actions for Project Two/i }));
     fireEvent.click(await screen.findByRole("menuitem", { name: "Remove project" }));
 
+    const dialog = await screen.findByRole("dialog", { name: /Remove project/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Remove from AO" }));
+
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/projects/project-2", { method: "DELETE" });
       expect(mockRefresh).toHaveBeenCalled();
       expect(screen.queryByRole("button", { name: /^Project Two 0$/ })).not.toBeInTheDocument();
     });
+  });
+
+  it("cancels remove project without calling the API", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <ProjectSidebar
+        projects={projects}
+        sessions={[]}
+        activeProjectId="project-1"
+        activeSessionId={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Project actions for Project Two/i }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Remove project" }));
+
+    const dialog = await screen.findByRole("dialog", { name: /Remove project/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("dialog", { name: /Remove project/i })).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a toast when remove project fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Cannot remove active project." }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <ProjectSidebar
+        projects={projects}
+        sessions={[]}
+        activeProjectId="project-1"
+        activeSessionId={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Project actions for Project Two/i }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Remove project" }));
+
+    const dialog = await screen.findByRole("dialog", { name: /Remove project/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Remove from AO" }));
+
+    expect(await screen.findByText("Cannot remove active project.")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith("/api/projects/project-2", { method: "DELETE" });
+    expect(screen.getByRole("button", { name: /^Project Two 0$/ })).toBeInTheDocument();
   });
 
   it("shows non-done worker sessions for the expanded active project", () => {

--- a/packages/web/src/components/__tests__/RemoveProjectConfirmModal.test.tsx
+++ b/packages/web/src/components/__tests__/RemoveProjectConfirmModal.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { RemoveProjectConfirmModal } from "../RemoveProjectConfirmModal";
+
+const project = { id: "project-1", name: "Project One", sessionPrefix: "project-1" };
+
+describe("RemoveProjectConfirmModal", () => {
+  it("traps Tab focus within the dialog", () => {
+    render(
+      <RemoveProjectConfirmModal
+        project={project}
+        busy={false}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: /Remove Project One/i });
+    const close = screen.getByRole("button", { name: "Close" });
+    const remove = screen.getByRole("button", { name: "Remove from AO" });
+
+    remove.focus();
+    fireEvent.keyDown(dialog, { key: "Tab" });
+    expect(document.activeElement).toBe(close);
+
+    close.focus();
+    fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(remove);
+  });
+
+  it("calls onCancel when Escape is pressed", () => {
+    const onCancel = vi.fn();
+    render(
+      <RemoveProjectConfirmModal
+        project={project}
+        busy={false}
+        onCancel={onCancel}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog", { name: /Remove Project One/i }), {
+      key: "Escape",
+    });
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onCancel on Escape while busy", () => {
+    const onCancel = vi.fn();
+    render(
+      <RemoveProjectConfirmModal
+        project={project}
+        busy={true}
+        onCancel={onCancel}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog", { name: /Remove Project One/i }), {
+      key: "Escape",
+    });
+
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #2052

Problem: Remove project used window.confirm and window.alert.

Solution: In-app confirm modal (RemoveProjectConfirmModal) and error toasts via `useToast`.


https://github.com/user-attachments/assets/1c1eb871-114f-4801-a252-03ca5b4f4aee

