### PR TITLE
fix(web): emit manifest link with crossorigin=use-credentials for credential-gated proxies

### DIFF
--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -34,6 +34,9 @@ export async function generateMetadata(): Promise<Metadata> {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
+      <head>
+        <link rel="manifest" href="/manifest.webmanifest" crossOrigin="use-credentials" />
+      </head>
       <body className="h-screen overflow-hidden bg-[var(--color-bg-base)] text-[var(--color-text-primary)] antialiased">
         <Providers>{children}</Providers>
         <ServiceWorkerRegistrar />
@@ -41,3 +44,4 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     </html>
   );
 }
+

--- a/packages/web/src/app/manifest.test.ts
+++ b/packages/web/src/app/manifest.test.ts
@@ -6,9 +6,9 @@ vi.mock("@/lib/project-name", () => ({
 
 describe("app manifest", () => {
   it("builds the PWA manifest with project-aware naming and icons", async () => {
-    const { default: manifest } = await import("./manifest");
+    const { buildPwaManifest } = await import("@/lib/pwa-manifest");
 
-    expect(manifest()).toMatchObject({
+    expect(buildPwaManifest()).toMatchObject({
       name: "ao | Agent Orchestrator",
       short_name: "ao",
       start_url: "/",

--- a/packages/web/src/app/manifest.webmanifest/route.ts
+++ b/packages/web/src/app/manifest.webmanifest/route.ts
@@ -1,0 +1,8 @@
+import { buildPwaManifest } from "@/lib/pwa-manifest";
+
+export function GET() {
+  const manifest = buildPwaManifest();
+  return new Response(JSON.stringify(manifest), {
+    headers: { "Content-Type": "application/manifest+json" },
+  });
+}

--- a/packages/web/src/app/manifest.webmanifest/route.ts
+++ b/packages/web/src/app/manifest.webmanifest/route.ts
@@ -3,6 +3,9 @@ import { buildPwaManifest } from "@/lib/pwa-manifest";
 export function GET() {
   const manifest = buildPwaManifest();
   return new Response(JSON.stringify(manifest), {
-    headers: { "Content-Type": "application/manifest+json" },
+    headers: {
+      "Content-Type": "application/manifest+json",
+      "Cache-Control": "public, max-age=0, must-revalidate",
+    },
   });
 }

--- a/packages/web/src/lib/pwa-manifest.ts
+++ b/packages/web/src/lib/pwa-manifest.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 import { getProjectName } from "@/lib/project-name";
 
-export default function manifest(): MetadataRoute.Manifest {
+export function buildPwaManifest(): MetadataRoute.Manifest {
   const projectName = getProjectName();
   return {
     name: `ao | ${projectName}`,


### PR DESCRIPTION
closes #2008

problem: when running the dashboard behind credential-gated reverse proxies (like cloudflare access or oauth2-proxy), same-origin manifest fetches omit credentials by default, leading to cors errors and blocking the pwa manifest from loading.

solution:

extract manifest builder as a pure function in pwa-manifest.ts
serve the manifest JSON via a route handler in manifest.webmanifest/route.ts
delete manifest.ts to stop next.js auto-emitting a link tag without crossorigin
emit the manifest link manually in layout.tsx with crossOrigin="use-credentials"