### PR TITLE
feat: implement issue spawn rejection for closed or cancelled states

### DIFF
--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -21,6 +21,7 @@ import type {
   Agent,
   Workspace,
   Tracker,
+  Issue,
 } from "../../types.js";
 import {
   setupTestContext,
@@ -1087,6 +1088,78 @@ describe("spawn", () => {
     // Should not create workspace or runtime when auth fails
     expect(mockWorkspace.create).not.toHaveBeenCalled();
     expect(mockRuntime.create).not.toHaveBeenCalled();
+  });
+
+  function registryWithTracker(mockTracker: Tracker): PluginRegistry {
+    return {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "workspace") return mockWorkspace;
+        if (slot === "tracker") return mockTracker;
+        return null;
+      }),
+    };
+  }
+
+  function baseMockTracker(issue: Partial<Issue> & Pick<Issue, "id" | "state">): Tracker {
+    return {
+      name: "mock-tracker",
+      getIssue: vi.fn().mockResolvedValue({
+        title: "Test issue",
+        description: "",
+        url: "https://example.com/issues/1",
+        labels: [],
+        ...issue,
+      }),
+      isCompleted: vi.fn().mockResolvedValue(issue.state === "closed" || issue.state === "cancelled"),
+      issueUrl: vi.fn().mockReturnValue("https://example.com/issues/1"),
+      branchName: vi.fn().mockReturnValue(`feat/${issue.id}`),
+      generatePrompt: vi.fn().mockResolvedValue("Work on issue"),
+    };
+  }
+
+  it("rejects spawn when tracker issue is closed", async () => {
+    const mockTracker = baseMockTracker({ id: "42", state: "closed" });
+    const sm = createSessionManager({
+      config,
+      registry: registryWithTracker(mockTracker),
+    });
+
+    await expect(sm.spawn({ projectId: "my-app", issueId: "42" })).rejects.toThrow(
+      /Issue 42 is closed/,
+    );
+    expect(mockWorkspace.create).not.toHaveBeenCalled();
+    expect(mockRuntime.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects spawn when tracker issue is cancelled", async () => {
+    const mockTracker = baseMockTracker({ id: "99", state: "cancelled" });
+    const sm = createSessionManager({
+      config,
+      registry: registryWithTracker(mockTracker),
+    });
+
+    await expect(sm.spawn({ projectId: "my-app", issueId: "99" })).rejects.toThrow(
+      /Issue 99 is cancelled/,
+    );
+    expect(mockWorkspace.create).not.toHaveBeenCalled();
+    expect(mockRuntime.create).not.toHaveBeenCalled();
+  });
+
+  it("allows spawn when tracker issue is in_progress", async () => {
+    const mockTracker = baseMockTracker({ id: "INT-50", state: "in_progress" });
+    const sm = createSessionManager({
+      config,
+      registry: registryWithTracker(mockTracker),
+    });
+
+    const session = await sm.spawn({ projectId: "my-app", issueId: "INT-50" });
+
+    expect(session.issueId).toBe("INT-50");
+    expect(mockWorkspace.create).toHaveBeenCalled();
+    expect(mockRuntime.create).toHaveBeenCalled();
   });
 
   it("spawns without issue tracking when no issueId provided", async () => {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -20,6 +20,7 @@ import { promisify } from "node:util";
 import {
   isIssueNotFoundError,
   isRestorable,
+  isSpawnableIssueState,
   isTerminalSession,
   NON_RESTORABLE_STATUSES,
   IssueNotSpawnableError,
@@ -1262,7 +1263,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       if (resolvedIssue) {
         const { state } = resolvedIssue;
-        if (state === "closed" || state === "cancelled") {
+        if (state && !isSpawnableIssueState(state)) {
           recordActivityEvent({
             projectId: spawnConfig.projectId,
             source: "session-manager",

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -22,6 +22,7 @@ import {
   isRestorable,
   isTerminalSession,
   NON_RESTORABLE_STATUSES,
+  IssueNotSpawnableError,
   SessionNotFoundError,
   SessionNotRestorableError,
   WorkspaceMissingError,
@@ -1256,6 +1257,26 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
             },
           });
           throw new Error(`Failed to fetch issue ${spawnConfig.issueId}: ${err}`, { cause: err });
+        }
+      }
+
+      if (resolvedIssue) {
+        const { state } = resolvedIssue;
+        if (state === "closed" || state === "cancelled") {
+          recordActivityEvent({
+            projectId: spawnConfig.projectId,
+            source: "session-manager",
+            kind: "session.spawn_rejected",
+            level: "warn",
+            summary: `spawn rejected: issue ${spawnConfig.issueId} is ${state}`,
+            data: {
+              issueId: spawnConfig.issueId,
+              issueState: state,
+              tracker: plugins.tracker.name,
+              reason: "issue_not_spawnable",
+            },
+          });
+          throw new IssueNotSpawnableError(spawnConfig.issueId, state);
         }
       }
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2003,11 +2003,10 @@ export function isIssueNotFoundError(err: unknown): boolean {
 export class IssueNotSpawnableError extends Error {
   constructor(
     public readonly issueId: string,
-    public readonly state: "closed" | "cancelled",
+    public readonly state: Exclude<Issue["state"], "open" | "in_progress">,
   ) {
-    const label = state === "cancelled" ? "cancelled" : "closed";
     super(
-      `Issue ${issueId} is ${label}. Cannot spawn a session for a closed/cancelled issue.`,
+      `Issue ${issueId} is ${state}. Cannot spawn a session for a closed/cancelled issue.`,
     );
     this.name = "IssueNotSpawnableError";
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -760,6 +760,13 @@ export interface Issue {
   branchName?: string;
 }
 
+/** Issue states that allow spawning a new worker session. */
+export function isSpawnableIssueState(
+  state: Issue["state"],
+): state is "open" | "in_progress" {
+  return state === "open" || state === "in_progress";
+}
+
 export interface IssueFilters {
   state?: "open" | "closed" | "all";
   labels?: string[];
@@ -1990,6 +1997,20 @@ export function isIssueNotFoundError(err: unknown): boolean {
     // GitHub: "invalid issue format" (ad-hoc free-text strings)
     message.includes("invalid issue format")
   );
+}
+
+/** Thrown when spawn is requested for a tracker issue that is closed or cancelled. */
+export class IssueNotSpawnableError extends Error {
+  constructor(
+    public readonly issueId: string,
+    public readonly state: "closed" | "cancelled",
+  ) {
+    const label = state === "cancelled" ? "cancelled" : "closed";
+    super(
+      `Issue ${issueId} is ${label}. Cannot spawn a session for a closed/cancelled issue.`,
+    );
+    this.name = "IssueNotSpawnableError";
+  }
 }
 
 /** Thrown when a session cannot be restored (e.g. merged, still working). */

--- a/packages/web/src/app/api/spawn/route.ts
+++ b/packages/web/src/app/api/spawn/route.ts
@@ -122,16 +122,6 @@ export async function POST(request: NextRequest) {
             : {}),
         },
       });
-      if (err instanceof IssueNotSpawnableError) {
-        recordActivityEvent({
-          projectId: typeof body.projectId === "string" ? body.projectId : "unknown",
-          source: "api",
-          kind: "api.session_spawn_rejected",
-          level: "warn",
-          summary: `session spawn rejected: ${err.message}`,
-          data: { reason: "issue_not_spawnable", issueId: err.issueId, issueState: err.state },
-        });
-      }
     }
     return jsonWithCorrelation(
       { error: err instanceof Error ? err.message : "Failed to spawn session" },

--- a/packages/web/src/app/api/spawn/route.ts
+++ b/packages/web/src/app/api/spawn/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from "next/server";
-import { recordActivityEvent } from "@aoagents/ao-core";
+import { IssueNotSpawnableError, recordActivityEvent } from "@aoagents/ao-core";
 import { validateIdentifier, validateString, validateConfiguredProject } from "@/lib/validation";
 import { getServices } from "@/lib/services";
 import { sessionToDashboard } from "@/lib/serialize";
@@ -103,6 +103,7 @@ export async function POST(request: NextRequest) {
     );
   } catch (err) {
     const { config } = await getServices().catch(() => ({ config: undefined }));
+    const statusCode = err instanceof IssueNotSpawnableError ? 409 : 500;
     if (config) {
       recordApiObservation({
         config,
@@ -111,15 +112,30 @@ export async function POST(request: NextRequest) {
         correlationId,
         startedAt,
         outcome: "failure",
-        statusCode: 500,
+        statusCode,
         projectId: typeof body.projectId === "string" ? body.projectId : undefined,
         reason: err instanceof Error ? err.message : "Failed to spawn session",
-        data: { issueId: body.issueId },
+        data: {
+          issueId: body.issueId,
+          ...(err instanceof IssueNotSpawnableError
+            ? { reason: "issue_not_spawnable", issueState: err.state }
+            : {}),
+        },
       });
+      if (err instanceof IssueNotSpawnableError) {
+        recordActivityEvent({
+          projectId: typeof body.projectId === "string" ? body.projectId : "unknown",
+          source: "api",
+          kind: "api.session_spawn_rejected",
+          level: "warn",
+          summary: `session spawn rejected: ${err.message}`,
+          data: { reason: "issue_not_spawnable", issueId: err.issueId, issueState: err.state },
+        });
+      }
     }
     return jsonWithCorrelation(
       { error: err instanceof Error ? err.message : "Failed to spawn session" },
-      { status: 500 },
+      { status: statusCode },
       correlationId,
     );
   }


### PR DESCRIPTION
## Summary

  This PR prevents AO from spawning new worker sessions for tracker issues that are already `closed` or `cancelled`.

  Previously, spawn requests could continue even when the linked tracker issue was no longer actionable. The session manager now checks
  the resolved issue state before creating a workspace or runtime, records a rejection activity event, and throws a typed
  `IssueNotSpawnableError`.

  ## Changes

  - Added `IssueNotSpawnableError` for closed/cancelled issue spawn attempts
  - Added `isSpawnableIssueState()` helper for spawn-eligible issue states
  - Updated `SessionManager.spawn()` to reject closed or cancelled tracker issues before workspace/runtime creation
  - Updated `/api/spawn` to return `409 Conflict` for non-spawnable issues instead of `500`
  - Added API/activity metadata for rejected spawn attempts
  - Added session manager tests for:
    - rejecting `closed` issues
    - rejecting `cancelled` issues
    - allowing `in_progress` issues

  ## Testing

  - Added coverage in `packages/core/src/__tests__/session-manager/spawn.test.ts`
<img width="588" height="151" alt="Screenshot 2026-05-26 at 18 01 33" src="https://github.com/user-attachments/assets/26f04e49-380d-4ce2-b473-5c3e67c7389e" />
