### PR TITLE
fix(agent-codex): launch workers with codex exec

### DIFF
--- a/.changeset/fix-codex-exec-launch.md
+++ b/.changeset/fix-codex-exec-launch.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-plugin-agent-codex": patch
+---
+
+Launch Codex worker sessions with `codex exec` so spawned AO workers run non-interactively.

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -267,7 +267,7 @@ describe("getLaunchCommand", () => {
 
   it("generates base command", () => {
     expect(agent.getLaunchCommand(makeLaunchConfig())).toBe(
-      "'codex' -c check_for_update_on_startup=false",
+      "'codex' exec -c check_for_update_on_startup=false",
     );
   });
 
@@ -317,7 +317,7 @@ describe("getLaunchCommand", () => {
       makeLaunchConfig({ permissions: "permissionless", model: "o3", prompt: "Go" }),
     );
     expect(cmd).toBe(
-      "'codex' -c check_for_update_on_startup=false --dangerously-bypass-approvals-and-sandbox --model 'o3' -c model_reasoning_effort=high -- 'Go'",
+      "'codex' exec -c check_for_update_on_startup=false --dangerously-bypass-approvals-and-sandbox --model 'o3' -c model_reasoning_effort=high -- 'Go'",
     );
   });
 
@@ -1971,7 +1971,7 @@ describe("postLaunchSetup", () => {
 
     // Before postLaunchSetup, binary is "codex"
     expect(agent.getLaunchCommand(makeLaunchConfig())).toBe(
-      "'codex' -c check_for_update_on_startup=false",
+      "'codex' exec -c check_for_update_on_startup=false",
     );
 
     // After postLaunchSetup resolves the binary
@@ -1979,7 +1979,7 @@ describe("postLaunchSetup", () => {
 
     // Now getLaunchCommand should use the resolved binary
     expect(agent.getLaunchCommand(makeLaunchConfig())).toBe(
-      "'/opt/bin/codex' -c check_for_update_on_startup=false",
+      "'/opt/bin/codex' exec -c check_for_update_on_startup=false",
     );
   });
 });

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -606,7 +606,7 @@ function createCodexAgent(): Agent {
 
     getLaunchCommand(config: AgentLaunchConfig): string {
       const binary = resolvedBinary ?? "codex";
-      const parts: string[] = [shellEscape(binary)];
+      const parts: string[] = [shellEscape(binary), "exec"];
       appendNoUpdateCheckFlag(parts);
 
       appendApprovalFlags(parts, config.permissions);


### PR DESCRIPTION
## Summary
- launch Codex worker sessions with `codex exec` so AO-created workers run non-interactively
- keep existing option handling for permissions, model, reasoning effort, config, prompt, and post-launch setup
- add a patch changeset for `@aoagents/ao-plugin-agent-codex`

Fixes #2078

## Why
The current `agent-codex` process command starts as `codex ...`, which opens the interactive Codex UI and ignores AO's prompt-driven worker contract. In local AO smoke testing this left spawned workers idle until they were marked `stuck`. The Codex CLI's non-interactive form is `codex exec <prompt>`, which is the expected mode for headless AO worker launches.

## Validation
- `corepack pnpm --filter @aoagents/ao-core build`
- `corepack pnpm --filter @aoagents/ao-plugin-agent-codex test`
- `corepack pnpm --filter @aoagents/ao-plugin-agent-codex typecheck`
- `corepack pnpm --filter @aoagents/ao-plugin-agent-codex build`

Note: `corepack pnpm install --frozen-lockfile` completed, but emitted a local Windows warning about rebuilding `node-pty` because the Visual Studio Spectre-mitigated libraries are not installed. That did not affect the Codex plugin checks above.