### PR TITLE
fix(agent-claude-code): use $CLAUDE_PROJECT_DIR for hook commands (fixes #2090)

### DIFF
--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -902,14 +902,18 @@ describe("hook setup — relative path (symlink-safe)", () => {
     return parsed.hooks.PostToolUse[0].hooks[0].command;
   }
 
-  it("setupWorkspaceHooks writes a relative hook command (not absolute)", async () => {
+  it("setupWorkspaceHooks writes a $CLAUDE_PROJECT_DIR-based hook command (not a hardcoded absolute path)", async () => {
     await agent.setupWorkspaceHooks!(
       "/Users/equinox/.worktrees/integrator/integrator-5",
       {} as WorkspaceHooksConfig,
     );
 
     const hookCommand = getWrittenHookCommand();
-    expect(hookCommand).toBe(".claude/metadata-updater.sh");
+    // $CLAUDE_PROJECT_DIR resolves to the worktree root at hook-execution time,
+    // so the command works even when a hook fires from a sub-agent (Agent/Task)
+    // whose cwd is not the worktree root — while keeping settings.json content
+    // identical across worktrees (no hardcoded path).
+    expect(hookCommand).toBe("$CLAUDE_PROJECT_DIR/.claude/metadata-updater.sh");
     expect(hookCommand).not.toMatch(/^\//);
   });
 
@@ -950,7 +954,7 @@ describe("hook setup — relative path (symlink-safe)", () => {
     expect(content1).toBe(content2);
   });
 
-  it("updates an existing absolute hook path to relative", async () => {
+  it("updates an existing absolute hook path to the $CLAUDE_PROJECT_DIR form", async () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFile.mockResolvedValue(
       JSON.stringify({
@@ -978,7 +982,7 @@ describe("hook setup — relative path (symlink-safe)", () => {
     );
 
     const hookCommand = getWrittenHookCommand();
-    expect(hookCommand).toBe(".claude/metadata-updater.sh");
+    expect(hookCommand).toBe("$CLAUDE_PROJECT_DIR/.claude/metadata-updater.sh");
   });
 
   it("still writes the script file to the correct absolute filesystem path", async () => {
@@ -1021,8 +1025,8 @@ describe("setupWorkspaceHooks — activity-updater (#1941)", () => {
   }
 
   /** Activity-updater command paths (unix vs win32) */
-  const ACTIVITY_CMD_UNIX = ".claude/activity-updater.sh";
-  const ACTIVITY_CMD_WIN = "node .claude/activity-updater.cjs";
+  const ACTIVITY_CMD_UNIX = "$CLAUDE_PROJECT_DIR/.claude/activity-updater.sh";
+  const ACTIVITY_CMD_WIN = "node $CLAUDE_PROJECT_DIR/.claude/activity-updater.cjs";
 
   /**
    * Every Claude Code hook event the script knows how to translate into an
@@ -1326,7 +1330,7 @@ describe("setupWorkspaceHooks on win32", () => {
     await agent.setupWorkspaceHooks!("C:\\\\Users\\\\dev\\\\workspace", {} as WorkspaceHooksConfig);
 
     const hookCommand = getWrittenHookCommand();
-    expect(hookCommand).toBe("node .claude/metadata-updater.cjs");
+    expect(hookCommand).toBe("node $CLAUDE_PROJECT_DIR/.claude/metadata-updater.cjs");
     expect(hookCommand).not.toContain(".sh");
   });
 

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -1009,8 +1009,8 @@ async function setupHookInWorkspace(workspacePath: string): Promise<void> {
     await writeFile(activityPath, ACTIVITY_UPDATER_SCRIPT_NODE, "utf-8");
     // .cjs forces CJS regardless of workspace package.json "type"; node
     // invocation is required on Windows because shebangs aren't honoured.
-    metadataCommand = "node .claude/metadata-updater.cjs";
-    activityCommand = "node .claude/activity-updater.cjs";
+    metadataCommand = "node $CLAUDE_PROJECT_DIR/.claude/metadata-updater.cjs";
+    activityCommand = "node $CLAUDE_PROJECT_DIR/.claude/activity-updater.cjs";
   } else {
     const metadataPath = join(claudeDir, "metadata-updater.sh");
     const activityPath = join(claudeDir, "activity-updater.sh");
@@ -1018,8 +1018,8 @@ async function setupHookInWorkspace(workspacePath: string): Promise<void> {
     await writeFile(activityPath, ACTIVITY_UPDATER_SCRIPT, "utf-8");
     await chmod(metadataPath, 0o755);
     await chmod(activityPath, 0o755);
-    metadataCommand = ".claude/metadata-updater.sh";
-    activityCommand = ".claude/activity-updater.sh";
+    metadataCommand = "$CLAUDE_PROJECT_DIR/.claude/metadata-updater.sh";
+    activityCommand = "$CLAUDE_PROJECT_DIR/.claude/activity-updater.sh";
   }
 
   let existingSettings: Record<string, unknown> = {};


### PR DESCRIPTION
## Problem

The Claude Code agent plugin registers its activity/metadata lifecycle hooks with **relative** command paths (`.claude/activity-updater.sh`, `.claude/metadata-updater.sh`) for every hook event, including `PreToolUse`/`PostToolUse`/`SubagentStart`/`SubagentStop`.

When a hook fires from a **sub-agent** (`Agent`/`Task` tool) call, the process working directory is not the worktree root, so the shell can't resolve the relative path:

```
PreToolUse:Agent hook error  ⎿ Failed with non-blocking status code: /bin/sh: 1: .claude/activity-updater.sh: not found
PostToolUse:Read hook error  ⎿ Failed with non-blocking status code: /bin/sh: 1: .claude/activity-updater.sh: not found
```

It's non-blocking, but it (a) spams the agent transcript while sub-agents run and (b) drops the `.ao/activity.jsonl` signal during sub-agent work, which can cause **false `stuck` / `probe_failure`** lifecycle detection on otherwise-healthy sessions. At the top-level agent cwd (worktree root) the relative path resolves fine — which is why it only shows up once the agent dispatches parallel `Explore`/`Task` sub-agents.

## Fix

Prefix the hook commands with `$CLAUDE_PROJECT_DIR`, which Claude Code exports for hook execution and which always points at the worktree root:

```
$CLAUDE_PROJECT_DIR/.claude/activity-updater.sh
node $CLAUDE_PROJECT_DIR/.claude/activity-updater.cjs   # windows branch
```

This resolves correctly regardless of the hook's cwd, while keeping `settings.json` content **identical across worktrees** (no hardcoded absolute path — preserving the existing "different worktree paths produce identical settings.json" guarantee). The dedup/upsert logic keys off the bare filenames (`activity-updater.sh`, …), so existing settings migrate cleanly.

Applied to both the unix (`.sh`) and windows (`.cjs`) branches.

## Tests

- Updated `index.test.ts` assertions to the new `$CLAUDE_PROJECT_DIR` contract (including the "updates an existing absolute hook path" migration test).
- `pnpm --filter @aoagents/ao-plugin-agent-claude-code typecheck` ✅
- `pnpm --filter @aoagents/ao-plugin-agent-claude-code test` → **270 passing**. The one failing test (`activity-updater.integration.test.ts`, a special-character escaping round-trip) **also fails on pristine `main`** in this environment (`/bin/sh` escaping), and is unrelated to this change — it touches neither the hook command paths nor the updater scripts.

Fixes #2090