### PR TITLE
fix(web): pass onMerge to AttentionZone in kanban view

### DIFF
--- a/.changeset/fix-kanban-merge-button.md
+++ b/.changeset/fix-kanban-merge-button.md
@@ -1,0 +1,9 @@
+---
+"@aoagents/ao-web": patch
+---
+
+fix: pass onMerge callback to AttentionZone in kanban view and parse merge error responses
+
+The merge button on kanban session cards was a no-op because `onMerge` was not passed
+to the `AttentionZone` component. The optional chain `onMerge?.()` silently did nothing.
+Also improved the error toast to show human-readable blocker messages instead of raw JSON.

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -403,7 +403,18 @@ function DashboardInner({
         if (!res.ok) {
           const text = await res.text();
           console.error(`Failed to merge PR #${prNumber}:`, text);
-          showToast(`Merge failed: ${text}`, "error");
+          let message = "Merge failed";
+          try {
+            const body = JSON.parse(text);
+            if (body.blockers?.length) {
+              message = `Merge blocked: ${body.blockers.join(", ")}`;
+            } else if (body.error) {
+              message = body.error;
+            }
+          } catch {
+            message = text || message;
+          }
+          showToast(message, "error");
           return;
         } else {
           showToast(`PR #${prNumber} merged`, "success");
@@ -721,6 +732,7 @@ function DashboardInner({
                       level={level}
                       sessions={grouped[level]}
                       onKill={handleKill}
+                      onMerge={handleMerge}
                       onRestore={handleRestore}
                       compactMobile={isMobile}
                       collapsed={isMobile && collapsedZones.has(level)}


### PR DESCRIPTION
## Summary

- Pass `onMerge={handleMerge}` to `AttentionZone` in the kanban layout — the prop was missing, making the merge button a silent no-op
- Parse JSON error responses from `/api/prs/:id/merge` so the toast shows human-readable blocker reasons instead of raw JSON

## What happened

The `handleMerge` callback was wired to `BottomSheet` (mobile preview) but never forwarded to `AttentionZone` in the desktop kanban grid. Since `SessionCard` declares `onMerge` as optional (`onMerge?.()`), clicking the merge button silently did nothing — no fetch, no error, no toast.

Additionally, when a merge *does* fail (e.g. CI blockers), the error toast dumped raw JSON like `{"error":"PR is not mergeable","blockers":["CI is failing"]}`. Now it shows `Merge blocked: CI is failing`.

## Changes

**`packages/web/src/components/Dashboard.tsx`**
1. Added `onMerge={handleMerge}` to the `AttentionZone` component in the kanban `map()` (line ~723)
2. Parse the merge API error response JSON to extract `blockers` or `error` for the toast message

## How to test

1. Start AO with a project that has an open PR in the "merge" kanban column
2. Click the "Merge PR #N" button on the kanban card
3. **Before fix:** nothing happens, no network request in DevTools
4. **After fix:** merge request fires; on success a "PR merged" toast appears; on failure a readable error toast appears (e.g. "Merge blocked: CI is failing")

Closes #TBD