### PR TITLE
feat(spawn): add --model flag for per-session model override

### DIFF
--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -202,6 +202,7 @@ async function spawnSession(
   issueId?: string,
   openTab?: boolean,
   agent?: string,
+  model?: string,
   claimOptions?: SpawnClaimOptions,
   prompt?: string,
 ): Promise<void> {
@@ -235,6 +236,7 @@ async function spawnSession(
       projectId,
       issueId,
       agent,
+      model,
       prompt: sanitizedPrompt,
     });
 
@@ -302,6 +304,7 @@ export function registerSpawn(program: Command): void {
     .allowExcessArguments()
     .option("--open", "Open session in terminal tab")
     .option("--agent <name>", "Override the agent plugin (e.g. codex, claude-code)")
+    .option("--model <name>", "Override the model for the spawned session")
     .option("--claim-pr <pr>", "Immediately claim an existing PR for the spawned session")
     .option("--assign-on-github", "Assign the claimed PR to the authenticated GitHub user")
     .option(
@@ -314,6 +317,7 @@ export function registerSpawn(program: Command): void {
         opts: {
           open?: boolean;
           agent?: string;
+          model?: string;
           claimPr?: string;
           assignOnGithub?: boolean;
           prompt?: string;
@@ -379,6 +383,7 @@ export function registerSpawn(program: Command): void {
             issueId,
             opts.open,
             opts.agent,
+            opts.model,
             claimOptions,
             opts.prompt,
           );

--- a/packages/core/src/agent-selection.ts
+++ b/packages/core/src/agent-selection.ts
@@ -60,8 +60,9 @@ export function resolveAgentSelection(params: {
   defaults: DefaultPlugins;
   persistedAgent?: string;
   spawnAgentOverride?: string;
+  spawnModelOverride?: string;
 }): ResolvedAgentSelection {
-  const { role, project, defaults, persistedAgent, spawnAgentOverride } = params;
+  const { role, project, defaults, persistedAgent, spawnAgentOverride, spawnModelOverride } = params;
   const roleProjectConfig = role === "orchestrator" ? project.orchestrator : project.worker;
   const roleDefaults = role === "orchestrator" ? defaults.orchestrator : defaults.worker;
   const sharedConfig = project.agentConfig ?? {};
@@ -87,12 +88,13 @@ export function resolveAgentSelection(params: {
   }
 
   const model =
-    role === "orchestrator"
+    spawnModelOverride ??
+    (role === "orchestrator"
       ? (roleAgentConfig.orchestratorModel ??
         roleAgentConfig.model ??
         sharedConfig.orchestratorModel ??
         sharedConfig.model)
-      : (roleAgentConfig.model ?? sharedConfig.model);
+      : (roleAgentConfig.model ?? sharedConfig.model));
 
   if (model !== undefined) {
     agentConfig.model = model;

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1273,6 +1273,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       project,
       defaults: config.defaults,
       spawnAgentOverride: spawnConfig.agent,
+      spawnModelOverride: spawnConfig.model,
     });
     const plugins = resolvePlugins(project, selection.agentName);
     if (!plugins.runtime) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -376,6 +376,7 @@ export interface SessionSpawnConfig {
   prompt?: string;
   /** Override the agent plugin for this session (e.g. "codex", "claude-code") */
   agent?: string;
+  model?: string;
   /** Override the OpenCode subagent for this session (e.g. "sisyphus", "oracle") */
   subagent?: string;
 }


### PR DESCRIPTION
 ## What & why
  
  `ao spawn` had no way to set the model for a single session — the model
  was resolved only from project/role `agentConfig.model`, so every session
  in a project shared one model. This adds a `--model <name>` flag to
  `ao spawn` that overrides the model for that one spawn.

  Resolution precedence: `--model` > role `agentConfig.model` > project
  `agentConfig.model`. The agent plugins already forward the resolved
  `config.model` to the underlying CLI as `--model`, so no plugin changes
  are needed; this PR only wires the spawn flag through to 
  `resolveAgentSelection`.
  
  ## Changes
  
  - `--model <name>` option on `ao spawn`
  - `SessionSpawnConfig.model` threaded to `resolveAgentSelection({ spawnModelOverride })`
  - `spawnModelOverride` takes precedence over role/project model in `resolveAgentSelection`

  ## Backward compatibility
  
  When `--model` is omitted, model resolution is unchanged.

  ## How to test

  ```
  ao spawn <issue> --agent claude-code --model claude-opus-4-7
  ao spawn --help   # lists the new --model flag
  ```
  
  - `pnpm build` and `pnpm typecheck` pass for core and cli
  - `ao spawn --help` shows the `--model` flag 

  ## Issue
  
  Addresses the per-session (`ao spawn --model`) part of #2116.