### PR TITLE
fix(cli): exclude terminated sessions from ao status active count with --include-terminated

### DIFF
--- a/.changeset/short-poets-smile.md
+++ b/.changeset/short-poets-smile.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-cli": patch
+---
+
+Fix `ao status --include-terminated` counting terminated sessions as active in the footer summary. The flag now only affects visibility — terminated sessions are never counted as "active sessions" or orchestrators in the summary line.

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -1287,6 +1287,68 @@ describe("status command", () => {
     expect(output).not.toContain("terminated sessions hidden");
   });
 
+  it("excludes terminated sessions from the active count in the summary by default", async () => {
+    writeFileSync(join(sessionsDir, "app-1"), "branch=feat/a\nstatus=working\n");
+    writeFileSync(join(sessionsDir, "app-2"), "branch=feat/b\nstatus=killed\n");
+    writeFileSync(join(sessionsDir, "app-3"), "branch=feat/c\nstatus=merged\n");
+
+    mockTmux.mockResolvedValue(null);
+    mockGit.mockResolvedValue(null);
+
+    await program.parseAsync(["node", "test", "status"]);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("1 active session across");
+    expect(output).toContain("2 terminated sessions hidden");
+  });
+
+  it("does not count terminated sessions as active when --include-terminated is passed", async () => {
+    writeFileSync(join(sessionsDir, "app-1"), "branch=feat/a\nstatus=working\n");
+    writeFileSync(join(sessionsDir, "app-2"), "branch=feat/b\nstatus=killed\n");
+    writeFileSync(join(sessionsDir, "app-3"), "branch=feat/c\nstatus=merged\n");
+
+    mockTmux.mockResolvedValue(null);
+    mockGit.mockResolvedValue(null);
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "status",
+      "--include-terminated",
+    ]);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    // Terminated sessions are displayed...
+    expect(output).toContain("app-2");
+    expect(output).toContain("app-3");
+    // ...but never counted as active in the summary.
+    expect(output).toContain("1 active session across");
+    expect(output).not.toContain("3 active sessions");
+  });
+
+  it("does not count terminated orchestrators in the summary when --include-terminated is passed", async () => {
+    writeFileSync(join(sessionsDir, "app-1"), "branch=feat/a\nstatus=working\n");
+    writeFileSync(
+      join(sessionsDir, "app-orchestrator"),
+      "branch=main\nstatus=killed\nrole=orchestrator\n",
+    );
+
+    mockTmux.mockResolvedValue(null);
+    mockGit.mockResolvedValue(null);
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "status",
+      "--include-terminated",
+    ]);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("1 active session across");
+    // The "· N orchestrator(s)" suffix only renders when the count is > 0.
+    expect(output).not.toContain("· 1 orchestrator");
+  });
+
   it("reports hiddenTerminatedCount in JSON output when filtering terminal sessions", async () => {
     writeFileSync(join(sessionsDir, "app-1"), "branch=feat/a\nstatus=working\n");
     writeFileSync(join(sessionsDir, "app-2"), "branch=feat/b\nstatus=merged\n");

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -533,8 +533,18 @@ export function registerStatus(program: Command): void {
           const orchestrators = sessionInfos.filter((info) => info.role === "orchestrator");
           const workers = sessionInfos.filter((info) => info.role === "worker");
 
-          totalWorkers += workers.length;
-          totalOrchestrators += orchestrators.length;
+          // Summary totals count only non-terminal sessions — --include-terminated
+          // affects visibility, never what counts as "active" in the footer.
+          // sessionInfos[i] corresponds to projectSessions[i] (parallel map above).
+          sessionInfos.forEach((info, i) => {
+            const session = projectSessions[i];
+            if (session && isTerminalSession(session)) return;
+            if (info.role === "orchestrator") {
+              totalOrchestrators++;
+            } else {
+              totalWorkers++;
+            }
+          });
 
           for (const info of sessionInfos) {
             if (opts.json) {


### PR DESCRIPTION
## What

Fixes a session-count bug in the `ao status` footer summary: with terminated sessions present, `ao status --include-terminated` counted them as active (e.g. `5 active sessions across 2 projects` when all 5 were terminated), while plain `ao status` correctly showed `0 active sessions`.

## Why

The summary totals in `packages/cli/src/commands/status.ts` counted every *displayed* session (`totalWorkers += workers.length`). Since `--include-terminated` adds terminal sessions to the displayed list, they leaked into the "active" count. The flag should only affect visibility, never what counts as active.

## How

- Summary totals (workers **and** orchestrators) now skip sessions where `isTerminalSession()` is true, pairing each `SessionInfo` with its source `Session` (the arrays are parallel by construction).
- Display behavior is unchanged: terminated sessions are still listed when the flag is passed, and the `N terminated sessions hidden` footer still appears when it isn't.

## Tests

Added three tests in `packages/cli/__tests__/commands/status.test.ts`:
1. Default (no flag): terminated sessions excluded from the active count (and hidden-footer still printed)
2. `--include-terminated`: terminated sessions are displayed but **not** counted as active
3. `--include-terminated`: terminated orchestrators don't produce a `· 1 orchestrator` suffix

Verified tests 2–3 fail without the fix and pass with it.

## Verification

- `pnpm --filter @aoagents/ao-cli typecheck` ✅
- `eslint` on changed files ✅
- `pnpm --filter @aoagents/ao-cli test`: 907 passed, 1 failed — the failure (`canonicalCompareKey > expands ~ to HOME` in `path-equality.test.ts`) is pre-existing and environment-specific (macOS `/tmp` → `/private/tmp` symlink); it fails identically on a clean tree without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)