### PR TITLE
fix(core): exempt orchestrator sessions from idle-beyond-threshold stuck transition

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -857,6 +857,69 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("stuck");
   });
 
+  it("does not mark orchestrator sessions stuck when idle exceeds agent-stuck threshold", async () => {
+    config.reactions = {
+      "agent-stuck": { auto: true, action: "notify", threshold: "1m", priority: "urgent" },
+    };
+
+    const notifier = createMockNotifier();
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      notifier,
+    });
+
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({
+      state: "idle",
+      timestamp: new Date(Date.now() - 120_000),
+    });
+
+    const session = makeSession({ status: "working", metadata: { agent: "mock-agent" } });
+    session.lifecycle.session.kind = "orchestrator";
+
+    const lm = setupCheck("app-1", {
+      session,
+      metaOverrides: { agent: "mock-agent" },
+      registry,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("working");
+    expect(notifier.notify).not.toHaveBeenCalled();
+  });
+
+  it("still marks worker sessions stuck and fires the agent-stuck reaction when idle exceeds threshold", async () => {
+    config.reactions = {
+      "agent-stuck": { auto: true, action: "notify", threshold: "1m", priority: "urgent" },
+    };
+
+    const notifier = createMockNotifier();
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      notifier,
+    });
+
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({
+      state: "idle",
+      timestamp: new Date(Date.now() - 120_000),
+    });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working", metadata: { agent: "mock-agent" } }),
+      metaOverrides: { agent: "mock-agent" },
+      registry,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("stuck");
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reaction.triggered" }),
+    );
+  });
+
   it("still auto-detects PR before marking idle sessions as stuck", async () => {
     config.reactions = {
       "agent-stuck": { auto: true, action: "notify", threshold: "1m" },

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1521,9 +1521,14 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       });
     }
 
+    // Orchestrator sessions are human-driven and idle by design while waiting
+    // for user input — never escalate them to stuck via idle decay. Same
+    // authoritative `lifecycle.session.kind` check as the agent-report branch
+    // above (string-matching role/id suffixes misses numbered orchestrator IDs).
     if (
       detectedIdleTimestamp &&
       hasPositiveIdleEvidence(activitySignal) &&
+      lifecycle.session.kind !== "orchestrator" &&
       isIdleBeyondThreshold(session, detectedIdleTimestamp)
     ) {
       return commit({


### PR DESCRIPTION
## What

Fixes a false-positive `agent-stuck` notification for orchestrator sessions. The idle-beyond-threshold stuck transition in `determineStatus` (`lifecycle-manager.ts`) did not exempt orchestrator sessions, so after the default 10m agent-stuck threshold a human-driven orchestrator — idle by design while waiting for user input — was flagged `stuck`, emitting `session.stuck` and firing the default agent-stuck reaction (URGENT desktop notification).

## Why

The agent-report branch immediately above this block already skips orchestrators via `lifecycle.session.kind !== "orchestrator"`, and its comment states `lifecycle.session.kind` is the authoritative source (string-matching role/id suffixes misses numbered orchestrator IDs like `${prefix}-orchestrator-1`). This PR applies the same exemption to the idle-beyond-threshold stuck transition so orchestrator sessions never transition to `stuck` via idle decay.

## Invariants preserved (per lifecycle-manager.ts guidance)

- **Runtime death**: probed and resolved earlier via `resolveProbeDecision` — unaffected.
- **Activity `waiting_input`/`blocked`**: short-circuit earlier in the cascade — unaffected.
- **SCM ground truth** (PR merged/closed, CI, reviews): handled earlier — unaffected.
- **Worker stuck detection**: unchanged; the exemption only applies when `lifecycle.session.kind === "orchestrator"`. An exempted orchestrator falls through to the existing default branches and keeps its current status (no transition → no event).

## Tests

- `does not mark orchestrator sessions stuck when idle exceeds agent-stuck threshold` — orchestrator session idle 2m past a 1m threshold stays `working` and emits no notification.
- `still marks worker sessions stuck and fires the agent-stuck reaction when idle exceeds threshold` — identical setup with worker kind transitions to `stuck` and fires the agent-stuck notify reaction (proves the no-notification assertion above is non-vacuous).

## Verification

- `pnpm --filter @aoagents/ao-core typecheck` ✅
- `pnpm --filter @aoagents/ao-core test` ✅ 1346 passed (74 files)
- ESLint on changed files ✅ 0 errors (2 pre-existing warnings untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)