### PR TITLE
feat(tracker-github): derive conventional <type>/<issue>-<slug> branch names

### DIFF
--- a/packages/plugins/tracker-github/src/index.ts
+++ b/packages/plugins/tracker-github/src/index.ts
@@ -151,6 +151,39 @@ function issueCacheKey(repo: string, identifier: string): string {
   return `${repo}#${identifier.replace(/^#/, "")}`;
 }
 
+/** Map a GitHub issue's labels to a conventional-commit branch type. */
+export function branchTypeFromLabels(labels: string[]): string {
+  const lower = labels.map((l) => l.toLowerCase());
+  if (lower.includes("bug")) return "fix";
+  if (lower.some((l) => l === "documentation" || l === "docs")) return "docs";
+  if (lower.includes("chore")) return "chore";
+  if (lower.some((l) => l === "refactor" || l === "refactoring")) return "refactor";
+  return "feat";
+}
+
+/** Build a short, git-safe slug from an issue title (max ~6 words). */
+export function slugFromTitle(title: string): string {
+  const slug = title
+    .toLowerCase()
+    // drop a leading conventional-commit prefix if the title already has one
+    .replace(/^\s*(feat|fix|docs|chore|refactor|test|perf|style|build|ci)(\([^)]*\))?!?:\s*/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .split("-")
+    .filter(Boolean)
+    .slice(0, 6)
+    .join("-");
+  return slug || "change";
+}
+
+/**
+ * Derive a conventional `<type>/<issue>-<slug>` branch name from an issue,
+ * e.g. `feat/27-property-detail-page`. Type is inferred from the issue labels.
+ */
+export function deriveBranchName(issue: Pick<Issue, "id" | "title" | "labels">): string {
+  return `${branchTypeFromLabels(issue.labels)}/${issue.id}-${slugFromTitle(issue.title)}`;
+}
+
 function createGitHubTracker(): Tracker {
   const issueCache = new Map<string, CachedIssue>();
   const inflight = new Map<string, Promise<Issue>>();
@@ -217,6 +250,7 @@ function createGitHubTracker(): Tracker {
           labels: data.labels.map((l) => l.name),
           assignee: data.assignees[0]?.login,
         };
+        issue.branchName = deriveBranchName(issue);
 
         writeCachedIssue(repo, identifier, issue);
         return issue;

--- a/packages/plugins/tracker-github/test/index.test.ts
+++ b/packages/plugins/tracker-github/test/index.test.ts
@@ -12,7 +12,7 @@ vi.mock("node:child_process", () => {
   return { execFile };
 });
 
-import { create, manifest } from "../src/index.js";
+import { create, manifest, deriveBranchName } from "../src/index.js";
 import {
   _clearProcessCacheForTests,
   type PreflightContext,
@@ -96,6 +96,7 @@ describe("tracker-github plugin", () => {
         state: "open",
         labels: ["bug", "priority-high"],
         assignee: "alice",
+        branchName: "fix/123-fix-login-bug",
       });
     });
 
@@ -310,6 +311,40 @@ describe("tracker-github plugin", () => {
 
     it("strips # prefix", () => {
       expect(tracker.branchName("#42", project)).toBe("feat/issue-42");
+    });
+  });
+
+  // ---- deriveBranchName (type/issue-slug from labels + title) -------------
+
+  describe("deriveBranchName", () => {
+    it("defaults to feat with a title slug", () => {
+      expect(
+        deriveBranchName({ id: "27", title: "Property detail page", labels: ["enhancement"] }),
+      ).toBe("feat/27-property-detail-page");
+    });
+
+    it("maps the bug label to fix", () => {
+      expect(deriveBranchName({ id: "8", title: "Map crash on load", labels: ["bug"] })).toBe(
+        "fix/8-map-crash-on-load",
+      );
+    });
+
+    it("maps documentation to docs", () => {
+      expect(
+        deriveBranchName({ id: "30", title: "Update README", labels: ["documentation"] }),
+      ).toBe("docs/30-update-readme");
+    });
+
+    it("strips a leading conventional-commit prefix from the title", () => {
+      expect(deriveBranchName({ id: "5", title: "feat: Add login flow", labels: [] })).toBe(
+        "feat/5-add-login-flow",
+      );
+    });
+
+    it("falls back to a 'change' slug when the title has no word chars", () => {
+      expect(deriveBranchName({ id: "9", title: "!!!", labels: ["chore"] })).toBe(
+        "chore/9-change",
+      );
     });
   });
 


### PR DESCRIPTION
## What
`tracker-github` currently hardcodes every branch to `feat/issue-N`. This derives a conventional-commit prefix from the issue's primary label and adds a slug from the title:

| label | prefix |
|---|---|
| `bug` | `fix` |
| `documentation` / `docs` | `docs` |
| `chore` | `chore` |
| `refactor` | `refactor` |
| default (e.g. `enhancement`) | `feat` |

Examples: `feat/27-property-detail-page`, `fix/8-map-crash-on-load`, `docs/30-update-readme`.

## How
- Adds `deriveBranchName(issue)` and sets `Issue.branchName` in `getIssue()`, so it flows through the existing session-manager precedence (`Issue.branchName` preferred over `tracker.branchName()` when git-safe).
- The sync `branchName()` fallback (`feat/issue-N`) is unchanged — behaviour is preserved when no issue/labels are available.
- Slug is lowercase, hyphenated, ≤6 words, and strips a leading conventional-commit prefix already present in the title.
- Unit tests added for the label→type mapping and slugging.

## Note
This changes the default branch-name shape for label-bearing issues. Happy to gate it behind a config flag if you'd prefer it opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)