### PR TITLE
feat(core): allow orchestrator permissions to be configurable via config

### DIFF
--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1923,19 +1923,21 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     }
 
     // Get agent launch config — uses systemPromptFile, no issue/tracker interaction.
-    // Orchestrator ALWAYS gets permissionless mode — it must run ao CLI commands autonomously.
+    // Orchestrator defaults to permissionless mode to run ao CLI commands autonomously,
+    // but can be overridden via orchestrator.agentConfig.permissions in config.
+    const orchestratorPermissions = selection.permissions ?? ("permissionless" as const);
     const agentLaunchConfig = {
       sessionId,
       projectConfig: {
         ...project,
         agentConfig: {
           ...selection.agentConfig,
-          permissions: "permissionless" as const,
+          permissions: orchestratorPermissions,
           ...(reusableOpenCodeSessionId ? { opencodeSessionId: reusableOpenCodeSessionId } : {}),
         },
       },
       workspacePath,
-      permissions: "permissionless" as const,
+      permissions: orchestratorPermissions,
       model: selection.model,
       systemPromptFile,
       subagent: selection.subagent,
@@ -3540,11 +3542,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     // 7. Get launch command — try restore command first, fall back to fresh launch
     let launchCommand: string;
+    const orchestratorRestorePermissions = selection.role === "orchestrator"
+      ? (selection.permissions ?? ("permissionless" as const))
+      : undefined;
     const projectConfigForLaunch: ProjectConfig = {
       ...project,
       agentConfig: {
         ...selection.agentConfig,
-        ...(selection.role === "orchestrator" ? { permissions: "permissionless" as const } : {}),
+        ...(orchestratorRestorePermissions ? { permissions: orchestratorRestorePermissions } : {}),
         ...(session.metadata?.opencodeSessionId
           ? { opencodeSessionId: session.metadata.opencodeSessionId }
           : {}),
@@ -3571,7 +3576,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       projectConfig: projectConfigForLaunch,
       workspacePath,
       issueId: session.issueId ?? undefined,
-      permissions: selection.role === "orchestrator" ? "permissionless" : selection.permissions,
+      permissions: selection.role === "orchestrator"
+        ? (selection.permissions ?? ("permissionless" as const))
+        : selection.permissions,
       model: selection.model,
       subagent: selection.subagent,
       ...(orchestratorSystemPromptFile && { systemPromptFile: orchestratorSystemPromptFile }),


### PR DESCRIPTION
## Problem
Orchestrator sessions had hardcoded `permissions: "permissionless"` across three code paths (spawn, restore, and resume). This was not configurable and prevented users from enabling permission prompts for orchestrator agents.

## Solution
- Extract orchestrator permissions from `selection.permissions` (which respects the config) instead of hardcoding to "permissionless"
- Preserve backward compatibility by falling back to "permissionless" if `orchestrator.agentConfig.permissions` is not explicitly configured
- Applied consistently across all three orchestrator launch paths:
  1. Fresh orchestrator spawn (_spawnOrchestratorInner)
  2. Orchestrator restore via projectConfigForLaunch
  3. Orchestrator resume via agentLaunchConfig permissions field

## Config Usage
Users can now configure orchestrator permissions in agent-orchestrator.yaml:

  orchestrator:
    agentConfig:
      permissions: default        # or "auto-edit", "suggest", etc.

If not specified, defaults to "permissionless" (original behavior).

## Testing Plan

1. **Config loading verification:**
   - Load a config with `orchestrator.agentConfig.permissions: default`
   - Verify loadConfig() returns the correct permissions
   - Verify loadConfig() falls back to "permissionless" when not configured

2. **Fresh orchestrator spawn:**
   - Run `ao start` with orchestrator permissions set to "default"
   - Verify the launch command does NOT contain `--dangerously-skip-permissions`
   - Run `ao start` without orchestrator config
   - Verify fallback to "permissionless" (flag IS present)

3. **Orchestrator resume/restore:**
   - Kill and restore an existing orchestrator session with default permissions
   - Verify it launches with correct permissions (no flag for "default")
   - Test with different permission modes: permissionless, default, auto-edit, suggest

4. **Backward compatibility:**
   - Existing configs without orchestrator.agentConfig.permissions must still work
   - Verify they get "permissionless" by default (original behavior preserved)

5. **Integration tests:**
   - Run: `pnpm test:integration`
   - Verify no regressions in session spawn/restore logic