### PR TITLE
test: smoke tests for worktree adoption + --attach-session (Step 0 TDD)

### DIFF
--- a/packages/integration-tests/src/__tests__/project-add-worktree.smoke.test.ts
+++ b/packages/integration-tests/src/__tests__/project-add-worktree.smoke.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Smoke tests for worktree canonicalization on `ao project add`.
+ *
+ * Status: SKIPPED — Step 0 TDD. Unblock in PR 2 (worktree adoption).
+ *
+ * These tests ARE THE SPEC. The assertions define exactly what PR 2 must satisfy.
+ * When all tests pass without the .skip, the feature is correctly implemented.
+ *
+ * Feature:
+ *   When `ao project add <path>` is given a git worktree path (not the main repo),
+ *   AO should detect this and:
+ *     1. Register the PARENT (main) repo as the project in the global config
+ *     2. Create a session metadata file that adopts the worktree directory
+ *     3. Set adoptedWorkspace='true' in the session metadata so AO knows it does
+ *        not own the directory lifecycle (it will not delete it on kill)
+ */
+
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  getProjectSessionsDir,
+  listMetadata,
+  readMetadataRaw,
+  registerProjectInGlobalConfig,
+} from "@aoagents/ao-core";
+
+// ─── Stubs for APIs to be created in PR 2 ────────────────────────────────────
+//
+// registerProjectWithWorktreeDetection(worktreePath, opts) will be exported from
+// @aoagents/ao-core once PR 2 lands. It must:
+//   1. Detect the supplied path is a git worktree via
+//        `git -C <path> rev-parse --git-common-dir`  (not equal to .git → it's a worktree)
+//   2. Resolve the main (parent) repo path via
+//        `git -C <path> worktree list --porcelain` (first entry is the main worktree)
+//   3. Register the parent repo via registerProjectInGlobalConfig (idempotent)
+//   4. Allocate the next available session ID under the project's session prefix
+//   5. Write a session metadata file:
+//        { worktree: <wtPath>, branch: <wt-branch>, status: 'spawning', adoptedWorkspace: 'true' }
+//   6. Return { projectId: <parentProjectId>, sessionId: <new-session-id> }
+//
+// Delete this stub and replace with:
+//   import { registerProjectWithWorktreeDetection } from "@aoagents/ao-core";
+function registerProjectWithWorktreeDetection(
+  _worktreePath: string,
+  _opts: { globalConfigPath?: string } = {},
+): { projectId: string; sessionId: string } {
+  throw new Error("not yet implemented — unblock in PR 2");
+}
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout.trimEnd();
+}
+
+describe.skip("worktree canonicalization [TODO: unblock in PR 2]", () => {
+  let tmpDir: string;
+  let mainRepoDir: string;
+  let worktreeDir: string;
+  let globalConfigPath: string;
+  let originalHome: string | undefined;
+
+  beforeAll(async () => {
+    const raw = await mkdtemp(join(tmpdir(), "ao-wt-canonicalize-"));
+    tmpDir = raw;
+    mainRepoDir = join(tmpDir, "main-repo");
+    worktreeDir = join(tmpDir, "worktrees", "feat-x");
+
+    mkdirSync(mainRepoDir, { recursive: true });
+    mkdirSync(join(tmpDir, "worktrees"), { recursive: true });
+
+    // Set up a real git repo so worktree detection can query `git worktree list`
+    await git(mainRepoDir, "init", "-b", "main");
+    await git(mainRepoDir, "config", "user.email", "test@test.com");
+    await git(mainRepoDir, "config", "user.name", "Test");
+    await writeFile(join(mainRepoDir, "README.md"), "# Test Repo\n");
+    await git(mainRepoDir, "add", ".");
+    await git(mainRepoDir, "commit", "-m", "initial commit");
+
+    // Create a real git worktree on branch feat/x
+    await git(mainRepoDir, "worktree", "add", worktreeDir, "-b", "feat/x");
+
+    // Redirect HOME so getAoBaseDir / getProjectSessionsDir resolve under tmpDir,
+    // preventing test writes from polluting the real ~/.agent-orchestrator
+    originalHome = process.env["HOME"];
+    process.env["HOME"] = tmpDir;
+
+    // Redirect global config to a temp file so we can inspect and clean it up
+    globalConfigPath = join(tmpDir, "ao-global-config.yaml");
+    process.env["AO_GLOBAL_CONFIG"] = globalConfigPath;
+  }, 30_000);
+
+  afterAll(async () => {
+    if (originalHome !== undefined) process.env["HOME"] = originalHome;
+    else delete process.env["HOME"];
+    delete process.env["AO_GLOBAL_CONFIG"];
+    if (tmpDir) await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }, 30_000);
+
+  // ─── CLI path ───────────────────────────────────────────────────────────────
+  // registerProjectWithWorktreeDetection is the core function that `ao project add`
+  // will call when it detects the supplied path is a git worktree.
+
+  it("registers the parent repo — not the worktree — as the project in the global config", () => {
+    const result = registerProjectWithWorktreeDetection(worktreeDir, { globalConfigPath });
+
+    expect(result.projectId).toBeTruthy();
+
+    // The global config must record the PARENT repo path, not the worktree path
+    const globalConfig = readFileSync(globalConfigPath, "utf-8");
+    expect(globalConfig).toContain(mainRepoDir);
+    expect(globalConfig).not.toContain(worktreeDir);
+  });
+
+  it("creates session metadata with worktree path, correct branch, and adoptedWorkspace='true'", () => {
+    const result = registerProjectWithWorktreeDetection(worktreeDir, { globalConfigPath });
+
+    const sessionsDir = getProjectSessionsDir(result.projectId);
+    const raw = readMetadataRaw(sessionsDir, result.sessionId);
+
+    expect(raw).not.toBeNull();
+    // The session's worktree field points to the adopted directory, not the parent repo
+    expect(raw!["worktree"]).toBe(worktreeDir);
+    // Branch is the actual git branch of the worktree (feat/x), not main
+    expect(raw!["branch"]).toBe("feat/x");
+    // adoptedWorkspace='true' means AO will NOT delete this directory on session kill
+    expect(raw!["adoptedWorkspace"]).toBe("true");
+  });
+
+  // ─── Web API path ────────────────────────────────────────────────────────────
+  // POST /api/projects must apply the same worktree canonicalization as the CLI.
+  //
+  // TODO: to unblock this test:
+  //   1. Add @aoagents/ao-web to integration-tests dependencies in package.json
+  //   2. Replace the postHandler stub below with:
+  //        import type { NextRequest } from "next/server";
+  //        const { POST } = await import("@aoagents/ao-web/src/app/api/projects/route.js");
+  //        const response = await POST(req as NextRequest);
+
+  it("POST /api/projects with a worktree path returns 201 with projectId + sessionId and writes matching disk state", async () => {
+    // Stub representing the to-be-updated POST handler behavior.
+    // The real handler will detect the worktree, canonicalize, and return sessionId.
+    const postHandler = async (
+      _req: Request,
+    ): Promise<{ status: number; body: { ok: boolean; projectId: string; sessionId: string } }> => {
+      throw new Error("not yet implemented — unblock in PR 2");
+    };
+
+    const response = await postHandler(
+      new Request("http://localhost/api/projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: worktreeDir }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.projectId).toBeTruthy();
+    expect(response.body.sessionId).toBeTruthy();
+
+    // Disk state must match the CLI path: same metadata written by both entry points
+    const sessionsDir = getProjectSessionsDir(response.body.projectId);
+    const raw = readMetadataRaw(sessionsDir, response.body.sessionId);
+    expect(raw!["worktree"]).toBe(worktreeDir);
+    expect(raw!["adoptedWorkspace"]).toBe("true");
+  });
+
+  // ─── Regression: plain project add must NOT create a session ─────────────────
+  // Adding a main repo (not a worktree) must register the project but must not
+  // create any session metadata files — behaviour unchanged from today.
+
+  it("ao project add <main-repo> registers as project without creating any sessions", () => {
+    const projectId = registerProjectInGlobalConfig(
+      "main-repo-regression",
+      "main-repo-regression",
+      mainRepoDir,
+      { defaultBranch: "main" },
+      globalConfigPath,
+    );
+
+    const sessionsDir = getProjectSessionsDir(projectId);
+    const sessions = existsSync(sessionsDir) ? listMetadata(sessionsDir) : [];
+    // A plain project registration creates zero sessions
+    expect(sessions).toHaveLength(0);
+  });
+
+  // ─── Idempotency: same worktree twice → one project, two sessions ─────────────
+  // Calling the registration twice for the same worktree must not duplicate the
+  // project entry but must create a fresh adopted session each time.
+
+  it("adding the same worktree twice creates one project entry and accumulates sessions", () => {
+    const result1 = registerProjectWithWorktreeDetection(worktreeDir, { globalConfigPath });
+    const result2 = registerProjectWithWorktreeDetection(worktreeDir, { globalConfigPath });
+
+    // Both calls resolve to the same parent project
+    expect(result2.projectId).toBe(result1.projectId);
+    // Each call allocates a new, distinct session ID
+    expect(result2.sessionId).not.toBe(result1.sessionId);
+
+    // Both session metadata files are present on disk
+    const sessionsDir = getProjectSessionsDir(result1.projectId);
+    const sessions = listMetadata(sessionsDir);
+    expect(sessions).toContain(result1.sessionId);
+    expect(sessions).toContain(result2.sessionId);
+  });
+});

--- a/packages/integration-tests/src/__tests__/spawn-attach-session.smoke.test.ts
+++ b/packages/integration-tests/src/__tests__/spawn-attach-session.smoke.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Smoke tests for `ao spawn --attach-session <id>`.
+ *
+ * Status: SKIPPED — Step 0 TDD. Unblock in PR 1 (attach-session spawn flag).
+ *
+ * These tests ARE THE SPEC. The assertions define exactly what PR 1 must satisfy.
+ * When all tests pass without the .skip, the feature is correctly implemented.
+ *
+ * Feature:
+ *   `ao spawn --attach-session <id>` adopts an existing AO session's worktree
+ *   instead of creating a new one. It seeds the new session with the old session's
+ *   agent resume keys so the agent can continue the conversation.
+ *
+ * Contract:
+ *   - The new session's metadata.worktree == source session's metadata.worktree
+ *   - The new session's metadata.adoptedWorkspace == 'true'
+ *   - All resume keys from the source session (claudeSessionUuid, codexThreadId, …)
+ *     are copied to the new session so the agent can restore prior context
+ *   - Killing the new session must NOT delete the worktree directory (adoptedWorkspace)
+ *   - --attach-session and --claim-pr are mutually exclusive (validation error)
+ */
+
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  getProjectSessionsDir,
+  readMetadataRaw,
+  writeMetadata,
+  type SessionMetadata,
+} from "@aoagents/ao-core";
+
+// ─── Stubs for APIs to be created / extended in PR 1 ─────────────────────────
+//
+// SessionSpawnConfig will gain an `attachSessionId?: string` field in PR 1.
+// SpawnAttachConfig below is a local stand-in until that field is added.
+// Delete this interface and replace with the updated SessionSpawnConfig import.
+interface SpawnAttachConfig {
+  projectId: string;
+  /** ID of the existing AO session whose worktree to adopt. */
+  attachSessionId: string;
+  /** Mutually exclusive with attachSessionId — using both must be a validation error. */
+  claimPr?: number;
+}
+
+// spawnWithAttach represents the session-manager.spawn() path after PR 1.
+// When implemented, it should:
+//   1. Validate that attachSessionId and claimPr are not both set (throw if so)
+//   2. Read source session metadata to obtain worktreePath and resume keys
+//   3. Allocate a new session ID under the project's session prefix
+//   4. Write metadata: { worktree: <src.worktree>, adoptedWorkspace: 'true',
+//        branch: <src.branch>, claudeSessionUuid: <src.claudeSessionUuid>, … }
+//   5. Return the new session object (without starting the agent process — that is
+//        the job of the lifecycle manager, which is not started in these tests)
+//
+// Delete this stub and replace with:
+//   import { createSessionManager } from "@aoagents/ao-core";
+//   const sessionManager = createSessionManager({ config, registry });
+//   const session = await sessionManager.spawn({ projectId, attachSessionId });
+async function spawnWithAttach(
+  _config: SpawnAttachConfig,
+  _opts: { sessionsDir: string },
+): Promise<{ sessionId: string }> {
+  throw new Error("not yet implemented — unblock in PR 1");
+}
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout.trimEnd();
+}
+
+describe.skip("spawn --attach-session [TODO: unblock in PR 1]", () => {
+  const projectId = "attach-session-test";
+  let tmpDir: string;
+  let mainRepoDir: string;
+  let worktreeDir: string;
+  let sessionsDir: string;
+  let originalHome: string | undefined;
+
+  // Source session that will be "attached to" in all tests
+  const sourceSessionId = "ao-1";
+  const sourceWorktreePath = ""; // set in beforeAll after tmpDir is known
+
+  beforeAll(async () => {
+    const raw = await mkdtemp(join(tmpdir(), "ao-attach-session-"));
+    tmpDir = raw;
+    mainRepoDir = join(tmpDir, "main-repo");
+    worktreeDir = join(tmpDir, "worktrees", "session-wt");
+
+    mkdirSync(mainRepoDir, { recursive: true });
+    mkdirSync(join(tmpDir, "worktrees"), { recursive: true });
+
+    // Set up a real git repo and worktree so that worktree-path assertions are
+    // verifiable against real filesystem state
+    await git(mainRepoDir, "init", "-b", "main");
+    await git(mainRepoDir, "config", "user.email", "test@test.com");
+    await git(mainRepoDir, "config", "user.name", "Test");
+    await writeFile(join(mainRepoDir, "README.md"), "# Test\n");
+    await git(mainRepoDir, "add", ".");
+    await git(mainRepoDir, "commit", "-m", "initial commit");
+    await git(mainRepoDir, "worktree", "add", worktreeDir, "-b", "session/ao-1");
+
+    // Redirect HOME so session storage goes to tmpDir, not real ~/.agent-orchestrator
+    originalHome = process.env["HOME"];
+    process.env["HOME"] = tmpDir;
+
+    sessionsDir = getProjectSessionsDir(projectId);
+    mkdirSync(sessionsDir, { recursive: true });
+
+    // Write metadata for the source session (as if ao had already spawned it)
+    const sourceMetadata: SessionMetadata = {
+      worktree: worktreeDir,
+      branch: "session/ao-1",
+      status: "idle",
+      project: projectId,
+      claudeSessionUuid: "claude-uuid-abc123",
+      codexThreadId: undefined,
+      createdAt: new Date().toISOString(),
+    };
+    writeMetadata(sessionsDir, sourceSessionId, sourceMetadata);
+  }, 30_000);
+
+  afterAll(async () => {
+    if (originalHome !== undefined) process.env["HOME"] = originalHome;
+    else delete process.env["HOME"];
+    if (tmpDir) await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }, 30_000);
+
+  // ─── Basic attach: new session adopts source session's worktree ─────────────
+
+  it("creates a new session that adopts the source session's worktree directory", async () => {
+    const result = await spawnWithAttach(
+      { projectId, attachSessionId: sourceSessionId },
+      { sessionsDir },
+    );
+
+    expect(result.sessionId).toBeTruthy();
+    expect(result.sessionId).not.toBe(sourceSessionId); // must be a fresh ID
+
+    const raw = readMetadataRaw(sessionsDir, result.sessionId);
+    expect(raw).not.toBeNull();
+    // Worktree path is inherited from the source session
+    expect(raw!["worktree"]).toBe(worktreeDir);
+    // adoptedWorkspace flag: AO will NOT delete this directory on kill
+    expect(raw!["adoptedWorkspace"]).toBe("true");
+    // Branch is copied from the source session
+    expect(raw!["branch"]).toBe("session/ao-1");
+  });
+
+  // ─── Resume key seeding: agent keys propagate from source to new session ────
+
+  it("seeds the new session with the source session's claudeSessionUuid so the agent can resume", async () => {
+    const result = await spawnWithAttach(
+      { projectId, attachSessionId: sourceSessionId },
+      { sessionsDir },
+    );
+
+    const raw = readMetadataRaw(sessionsDir, result.sessionId);
+    expect(raw).not.toBeNull();
+    // claudeSessionUuid present in source → must be copied to new session
+    expect(raw!["claudeSessionUuid"]).toBe("claude-uuid-abc123");
+  });
+
+  it("omits resume keys that are absent in the source session (no phantom keys written)", async () => {
+    const result = await spawnWithAttach(
+      { projectId, attachSessionId: sourceSessionId },
+      { sessionsDir },
+    );
+
+    const raw = readMetadataRaw(sessionsDir, result.sessionId);
+    // codexThreadId was undefined in source — new session must not invent a value
+    expect(raw!["codexThreadId"]).toBeUndefined();
+  });
+
+  // ─── Kill safety: adopted worktree survives session termination ─────────────
+
+  it("killing the adopted session does not delete the worktree directory", async () => {
+    const result = await spawnWithAttach(
+      { projectId, attachSessionId: sourceSessionId },
+      { sessionsDir },
+    );
+
+    // Simulate kill: the session manager's kill() path checks adoptedWorkspace
+    // and skips workspace.destroy() when it is 'true'. We verify the directory
+    // still exists after the kill hook would have run.
+    //
+    // TODO: replace the comment below with the actual kill call once PR 1 lands:
+    //   await sessionManager.kill(result.sessionId, "manually_killed");
+    //
+    // For now, assert the precondition that makes kill-safety work:
+    const raw = readMetadataRaw(sessionsDir, result.sessionId);
+    expect(raw!["adoptedWorkspace"]).toBe("true");
+    expect(existsSync(worktreeDir)).toBe(true); // worktree must still exist
+  });
+
+  // ─── Mutual exclusion: --attach-session + --claim-pr must be rejected ───────
+  // Attaching to an existing worktree and claiming a PR imply conflicting
+  // workspace setups: attach-session adopts an existing dir, claim-pr checks out
+  // a new one. Allowing both would silently overwrite the adopted worktree.
+
+  it("spawn with both attachSessionId and claimPr throws a validation error", async () => {
+    await expect(
+      spawnWithAttach(
+        { projectId, attachSessionId: sourceSessionId, claimPr: 42 },
+        { sessionsDir },
+      ),
+    ).rejects.toThrow(/attach-session.*claim-pr|mutually exclusive/i);
+  });
+});

--- a/packages/integration-tests/vitest.config.ts
+++ b/packages/integration-tests/vitest.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
     testTimeout: 120_000,
     hookTimeout: 60_000,
     pool: "forks",
-    include: ["src/**/*.integration.test.ts"],
+    include: ["src/**/*.integration.test.ts", "src/**/*.smoke.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary

- **project-add-worktree.smoke.test.ts** spec for ao project add worktree-path canonicalization: when the path is a git worktree, AO registers the parent repo as the project and creates a session with adoptedWorkspace=true. Covers CLI path, Web API path, regression (main repo add creates no sessions), and idempotency.
- **spawn-attach-session.smoke.test.ts** spec for ao spawn --attach-session id: adopts an existing session worktree, seeds agent resume keys (claudeSessionUuid, etc.) from the source session, preserves the worktree on kill, and is mutually exclusive with --claim-pr.
- **vitest.config.ts** extended to pick up *.smoke.test.ts files alongside *.integration.test.ts.

All tests use describe.skip with TODO comments pointing to the implementation PRs (PR 1: attach-session, PR 2: worktree canonicalization).

## Test plan
- [ ] Both describe blocks are skipped (show down-arrow in vitest output, no failures)
- [ ] pnpm typecheck passes with no errors
- [ ] pnpm test:integration exits without error (skipped tests are not failures)

Generated with Claude Code