### PR TITLE
fix(web): ship public/ assets in the published ao-web package

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,8 @@
     ".next/*.json",
     ".next/BUILD_ID",
     "dist-server",
-    "next.config.js"
+    "next.config.js",
+    "public"
   ],
   "scripts": {
     "dev": "concurrently \"npm:dev:next\" \"npm:dev:direct-terminal\"",


### PR DESCRIPTION
Closes #2123

## Problem
`packages/web/public/` is committed in source, but `public/` is missing from the `files` allowlist in `packages/web/package.json`. As a result, npm strips `public/` from the published `@aoagents/ao-web` tarball, so `public/mascot.png` (and other public assets) never ship. At runtime the dashboard logs:

```
⨯ The requested resource isn't a valid image for /mascot.png received null
```

and the `AppMark` brand mark renders as a broken image.

## Fix
Add `"public"` to the `files` array so the committed static assets are included in the published package.

## Verification
`npm pack --dry-run` in `packages/web` **before** the change does not list any `public/` files; **after** the change it includes them:

```
public/mascot.png
public/offline.html
public/sw.js
```

No code/runtime changes — packaging metadata only.