### PR TITLE
fix(sidebar): make project row hover icons clickable and non-overlapping

### DIFF
--- a/packages/web/src/app/mc-sidebar.css
+++ b/packages/web/src/app/mc-sidebar.css
@@ -140,10 +140,11 @@
 }
 
 /* On hover the action icons reveal over the right slot — reserve room so the
-   project name re-truncates (ellipsis) instead of running under the icons. */
+   project name re-truncates (ellipsis) instead of running under the icons.
+   3 icons × 24px + 2 gaps × 1px + 6px right offset = 80px; pad a bit more. */
 .project-sidebar__proj-row:hover .project-sidebar__proj-toggle,
 .project-sidebar__proj-row:focus-within .project-sidebar__proj-toggle {
-  padding-right: 78px;
+  padding-right: 84px;
 }
 
 .project-sidebar__proj-toggle:hover {
@@ -191,6 +192,7 @@
 .project-sidebar__proj-row:hover .project-sidebar__proj-count,
 .project-sidebar__proj-row:focus-within .project-sidebar__proj-count {
   opacity: 0;
+  pointer-events: none;
 }
 
 /* ── Per-project action icons — out of flow, revealed on hover ────────── */
@@ -205,6 +207,10 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+  /* z-index ensures icons paint above sibling session rows that come later
+     in the DOM and have position: relative (which would otherwise stack on
+     top and intercept hover/click events over the action icons). */
+  z-index: 10;
 }
 
 .project-sidebar__proj-row:hover .project-sidebar__proj-actions,


### PR DESCRIPTION
## Summary

Fixes three bugs with the project row hover action icons (dashboard, orchestrator, kebab menu) in the sidebar.

**Reported by @aditi** in #bug-triaging: *"the 3 icons on the session show up while hovering but can't click on it. also they appear only for the second session not the first"*

### Bug 1 — Icons overlap text
`padding-right: 78px` on hover was insufficient for 3 icons (24px × 3) + 2 gaps (1px × 2) + 6px right offset = 80px needed. The project name text ran under the icons.

**Fix:** Bumped to `84px`.

### Bug 2 — Icons not clickable
The session count badge (`.proj-count`) faded to `opacity: 0` on hover but kept `pointer-events: auto`. The invisible count span sat on top of the action icons and intercepted clicks.

**Fix:** Added `pointer-events: none` to the count on hover.

### Bug 3 — Icons only work on the second project row
The absolute-positioned actions container (`.proj-actions`) had no `z-index`. Session rows below it in the DOM have `position: relative` (creating stacking contexts that paint on top). When the first project is expanded with sessions underneath, those session rows' stacking context covered the project row's action icons, intercepting hover/click events.

**Fix:** Added `z-index: 10` to `.project-sidebar__proj-actions`.

## Test Plan
- [x] `pnpm --filter @aoagents/ao-web typecheck` — passes
- [x] `pnpm --filter @aoagents/ao-web build` — passes
- [ ] Visual: hover a project row with expanded sessions — all 3 icons visible, clickable, not overlapping text
- [ ] Visual: hover a project row without expanded sessions — all 3 icons visible, clickable
- [ ] Visual: icons appear on ALL project rows, not just the second one

## Changed Files
- `packages/web/src/app/mc-sidebar.css` — 3 CSS fixes (8 insertions, 2 deletions)
