### PR TITLE
ci(gitleaks): allowlist historical false-positive commits from rewrite graft

### DIFF
--- a/.github/.gitleaks.toml
+++ b/.github/.gitleaks.toml
@@ -1,0 +1,191 @@
+title = "gitleaks config"
+
+[[rules]]
+    description = "AWS Access Key"
+    regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+    tags = ["key", "AWS"]
+
+[[rules]]
+    description = "AWS Secret Key"
+    regex = '''(?i)aws(.{0,20})?(?-i)['\"][0-9a-zA-Z\/+]{40}['\"]'''
+    tags = ["key", "AWS"]
+
+[[rules]]
+    description = "AWS MWS key"
+    regex = '''amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'''
+    tags = ["key", "AWS", "MWS"]
+
+[[rules]]
+    description = "Facebook Secret Key"
+    regex = '''(?i)(facebook|fb)(.{0,20})?(?-i)['\"][0-9a-f]{32}['\"]'''
+    tags = ["key", "Facebook"]
+
+[[rules]]
+    description = "Facebook Client ID"
+    regex = '''(?i)(facebook|fb)(.{0,20})?['\"][0-9]{13,17}['\"]'''
+    tags = ["key", "Facebook"]
+
+[[rules]]
+    description = "Twitter Secret Key"
+    regex = '''(?i)twitter(.{0,20})?[0-9a-z]{35,44}'''
+    tags = ["key", "Twitter"]
+
+[[rules]]
+    description = "Twitter Client ID"
+    regex = '''(?i)twitter(.{0,20})?[0-9a-z]{18,25}'''
+    tags = ["client", "Twitter"]
+
+[[rules]]
+    description = "Github Personal Access Token"
+    regex = '''ghp_[0-9a-zA-Z]{36}'''
+    tags = ["key", "Github"]
+[[rules]]
+    description = "Github OAuth Access Token"
+    regex = '''gho_[0-9a-zA-Z]{36}'''
+    tags = ["key", "Github"]
+[[rules]]
+    description = "Github App Token"
+    regex = '''(ghu|ghs)_[0-9a-zA-Z]{36}'''
+    tags = ["key", "Github"]
+[[rules]]
+    description = "Github Refresh Token"
+    regex = '''ghr_[0-9a-zA-Z]{76}'''
+    tags = ["key", "Github"]
+
+[[rules]]
+    description = "LinkedIn Client ID"
+    regex = '''(?i)linkedin(.{0,20})?(?-i)[0-9a-z]{12}'''
+    tags = ["client", "LinkedIn"]
+
+[[rules]]
+    description = "LinkedIn Secret Key"
+    regex = '''(?i)linkedin(.{0,20})?[0-9a-z]{16}'''
+    tags = ["secret", "LinkedIn"]
+
+[[rules]]
+    description = "Slack"
+    regex = '''xox[baprs]-([0-9a-zA-Z]{10,48})?'''
+    tags = ["key", "Slack"]
+
+[[rules]]
+    description = "Asymmetric Private Key"
+    regex = '''-----BEGIN ((EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY( BLOCK)?-----'''
+    tags = ["key", "AsymmetricPrivateKey"]
+
+[[rules]]
+    description = "Google API key"
+    regex = '''AIza[0-9A-Za-z\\-_]{35}'''
+    tags = ["key", "Google"]
+
+[[rules]]
+    description = "Google (GCP) Service Account"
+    regex = '''"type": "service_account"'''
+    tags = ["key", "Google"]
+
+[[rules]]
+    description = "Heroku API key"
+    regex = '''(?i)heroku(.{0,20})?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'''
+    tags = ["key", "Heroku"]
+
+[[rules]]
+    description = "MailChimp API key"
+    regex = '''(?i)(mailchimp|mc)(.{0,20})?[0-9a-f]{32}-us[0-9]{1,2}'''
+    tags = ["key", "Mailchimp"]
+
+[[rules]]
+    description = "Mailgun API key"
+    regex = '''((?i)(mailgun|mg)(.{0,20})?)?key-[0-9a-z]{32}'''
+    tags = ["key", "Mailgun"]
+
+[[rules]]
+    description = "PayPal Braintree access token"
+    regex = '''access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}'''
+    tags = ["key", "Paypal"]
+
+[[rules]]
+    description = "Picatic API key"
+    regex = '''sk_live_[0-9a-z]{32}'''
+    tags = ["key", "Picatic"]
+
+[[rules]]
+    description = "SendGrid API Key"
+    regex = '''SG\.[\w_]{16,32}\.[\w_]{16,64}'''
+    tags = ["key", "SendGrid"]
+
+[[rules]]
+    description = "Slack Webhook"
+    regex = '''https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8,12}/[a-zA-Z0-9_]{24}'''
+    tags = ["key", "slack"]
+
+[[rules]]
+    description = "Stripe API key"
+    regex = '''(?i)stripe(.{0,20})?[sr]k_live_[0-9a-zA-Z]{24}'''
+    tags = ["key", "Stripe"]
+
+[[rules]]
+    description = "Square access token"
+    regex = '''sq0atp-[0-9A-Za-z\-_]{22}'''
+    tags = ["key", "square"]
+
+[[rules]]
+    description = "Square OAuth secret"
+    regex = '''sq0csp-[0-9A-Za-z\\-_]{43}'''
+    tags = ["key", "square"]
+
+[[rules]]
+    description = "Twilio API key"
+    regex = '''(?i)twilio(.{0,20})?SK[0-9a-f]{32}'''
+    tags = ["key", "twilio"]
+
+[[rules]]
+    description = "Dynatrace ttoken"
+    regex = '''dt0[a-zA-Z]{1}[0-9]{2}\.[A-Z0-9]{24}\.[A-Z0-9]{64}'''
+    tags = ["key", "Dynatrace"]
+
+[[rules]]
+    description = "Shopify shared secret"
+    regex = '''shpss_[a-fA-F0-9]{32}'''
+    tags = ["key", "Shopify"]
+
+[[rules]]
+    description = "Shopify access token"
+    regex = '''shpat_[a-fA-F0-9]{32}'''
+    tags = ["key", "Shopify"]
+
+[[rules]]
+    description = "Shopify custom app access token"
+    regex = '''shpca_[a-fA-F0-9]{32}'''
+    tags = ["key", "Shopify"]
+
+[[rules]]
+    description = "Shopify private app access token"
+    regex = '''shppa_[a-fA-F0-9]{32}'''
+    tags = ["key", "Shopify"]
+
+[[rules]]
+    description = "PyPI upload token"
+    regex = '''pypi-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
+    tags = ["key", "pypi"]
+
+[allowlist]
+    description = "Allowlisted files"
+    files = ['''^\.?gitleaks.toml$''',
+    '''(.*?)(png|jpg|gif|doc|docx|pdf|bin|xls|pyc|zip)$''',
+    '''(go.mod|go.sum)$''']
+    # Historical false positives from the ReverbCode rewrite graft (#2166).
+    # All offenders are example secret-patterns in security docs and
+    # secret-redaction test fixtures, living in files already deleted from
+    # the tree. The push-event scan walks full history, so these commits are
+    # allowlisted to keep `main` green without weakening detection on new code.
+    commits = [
+        "15ad44633a34151e81737183e6f35889a38ffbcb",
+        "1efa966296178deaf161853f5bc1abf595e22223",
+        "560dea0d188dbc5bec70b39ca4c72cfce0303413",
+        "66005c05c50404635c3c2481cf6c5e855b86a801",
+        "7ba759991e4a19e79b594b618a92c0674b977121",
+        "9144c0ec06a733bc11a45a78f21231eadc29e2eb",
+        "957e14999f0ea583325b2759060216a01e3d4461",
+        "cb2fc088a83b394fc128235f4106bbfc88d8ede8",
+        "f56338cbabd2185cab706ae09e1471b0bd9b7b43",
+        "fc7d76ad54d6a7350de0fca298a1294ce8a1f3a2",
+    ]


### PR DESCRIPTION
## Problem

The `gitleaks` job fails on **every push to `main`** and will keep failing indefinitely.

`gitleaks-action@v1.6.0` (gitleaks **v7.4.0**) scans differently per event:

```sh
# push  → no commit filter, scans ENTIRE git history
gitleaks --path=$GITHUB_WORKSPACE --verbose --redact
# pull_request → only the PR's own commits
gitleaks ... --commits-file=commit_list.txt
```

The ReverbCode rewrite graft (#2166) brought 279 commits of prior history. **10** of them trip **42** findings, all false positives:

- Example secret-patterns in security docs (`SECURITY.md`, `docs/DEVELOPMENT.md`, `docs/SECURITY-AUDIT-SUMMARY.md`) describing what tokens look like (`xoxb-*`, `-----BEGIN ... PRIVATE KEY-----`, etc.).
- Secret-redaction **test fixtures** in `packages/core/src/activity-events.ts` + tests (secret-shaped strings used to assert the sanitizer strips them).

All offending files are **already deleted** from the tree. That's why PRs are green (they only scan their own diff) while pushes to `main` re-scan full history and fail.

## Fix

Add `.github/.gitleaks.toml` (the path `gitleaks-action` already points `--config-path` at) containing the **full gitleaks v7.4.0 default ruleset** plus a `commits` allowlist for the 10 historical commits. The default rules must be included verbatim because gitleaks v7 *replaces* its built-in config when a config file is supplied; detection on new code is otherwise unchanged.

Allowlisting by commit SHA is precise and forward-safe: the offending files are gone, so no new code is exempted.

## Verification

Ran the exact CI binary (gitleaks v7.4.0) over full history:

| | result | exit |
|---|---|---|
| without config | `leaks found: 42` | 1 |
| with this config | `No leaks found` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)