### PR TITLE
fix(web): split pending board idle sessions

### DIFF
--- a/packages/web/src/__tests__/components.test.tsx
+++ b/packages/web/src/__tests__/components.test.tsx
@@ -549,7 +549,7 @@ describe("AttentionZone", () => {
     const cases: Array<[string, string]> = [
       ["review", "Review"],
       ["pending", "In review"],
-      ["working", "Working"],
+      ["working", "Pending"],
       ["done", "Done"],
     ];
     for (const [level, expectedLabel] of cases) {
@@ -557,7 +557,7 @@ describe("AttentionZone", () => {
         <AttentionZone level={level as "review" | "pending" | "working" | "done"} sessions={[]} />,
       );
       expect(screen.getByText(expectedLabel)).toBeInTheDocument();
-      expect(screen.getByText("0")).toBeInTheDocument();
+      expect(screen.getAllByText("0").length).toBeGreaterThan(0);
       unmount();
     }
   });
@@ -573,7 +573,7 @@ describe("AttentionZone", () => {
     const sessions = [makeSession({ id: "s1" })];
     render(<AttentionZone level="working" sessions={sessions} />);
     // working is defaultCollapsed: false (Kanban always shows), so sessions visible.
-    // "Working" appears as both the column header and the card's StatusBadge.
+    expect(screen.getByText("Pending")).toBeInTheDocument();
     expect(screen.getAllByText("Working").length).toBeGreaterThan(0);
   });
 

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -6010,6 +6010,50 @@ body:not(.is-resizing-x) .sidebar-wrapper {
   gap: 5px;
 }
 
+.kanban-column-body > .kanban-column__pending-sections {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 6px;
+  min-height: 100%;
+}
+
+.kanban-column__pending-section {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.kanban-column__pending-section + .kanban-column__pending-section {
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: 6px;
+}
+
+.kanban-column__subheader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 20px;
+  padding: 0 4px;
+}
+
+.kanban-column__subheader-title {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.kanban-column__subheader-count {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.6;
+  color: var(--color-text-muted);
+}
+
 .kanban-column-body::-webkit-scrollbar {
   width: 4px;
 }

--- a/packages/web/src/app/projects/[projectId]/loading.test.tsx
+++ b/packages/web/src/app/projects/[projectId]/loading.test.tsx
@@ -10,6 +10,6 @@ describe("ProjectRouteLoading", () => {
     expect(screen.getByText("Loading project…")).toBeInTheDocument();
     // Sidebar is owned by ProjectLayoutClient — no duplicate skeleton sidebar here
     expect(screen.queryByText("Projects")).not.toBeInTheDocument();
-    expect(screen.getByText("Working")).toBeInTheDocument();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/projects/[projectId]/loading.tsx
+++ b/packages/web/src/app/projects/[projectId]/loading.tsx
@@ -32,7 +32,7 @@ export default function ProjectRouteLoading() {
         <main className="dashboard-main flex flex-col flex-1 min-h-0 overflow-hidden">
           <div className="board-wrapper" aria-hidden="true">
             <div className="kanban-ghost">
-              {["Working", "Pending", "Review", "Respond", "Merge"].map((label) => (
+              {["Pending", "Needs you", "In review", "Ready to merge"].map((label) => (
                 <div key={label} className="kanban-ghost__col">
                   <div className="kanban-ghost__head">{label}</div>
                 </div>

--- a/packages/web/src/components/AttentionZone.tsx
+++ b/packages/web/src/components/AttentionZone.tsx
@@ -52,7 +52,7 @@ const zoneConfig: Record<
     emptyMessage: "Nothing blocked.",
   },
   working: {
-    label: "Working",
+    label: "Pending",
     emptyMessage: "No agents running.",
   },
   done: {
@@ -172,7 +172,14 @@ function AttentionZoneView({
       </div>
 
       <div className="kanban-column-body">
-        {sessions.length > 0 ? (
+        {level === "working" ? (
+          <PendingColumnSections
+            sessions={sessions}
+            onKill={onKill}
+            onMerge={onMerge}
+            onRestore={onRestore}
+          />
+        ) : sessions.length > 0 ? (
           <div className="kanban-column__stack">
             {sessions.map((session) => (
               <SessionCard
@@ -187,6 +194,76 @@ function AttentionZoneView({
         ) : null}
       </div>
     </div>
+  );
+}
+
+function PendingColumnSections({
+  sessions,
+  onKill,
+  onMerge,
+  onRestore,
+}: {
+  sessions: DashboardSession[];
+  onKill?: (sessionId: string) => void;
+  onMerge?: (prNumber: number, owner?: string, repo?: string) => void;
+  onRestore?: (sessionId: string) => void;
+}) {
+  const workingSessions = sessions.filter((session) => session.activity !== "idle");
+  const idleSessions = sessions.filter((session) => session.activity === "idle");
+
+  return (
+    <div className="kanban-column__pending-sections">
+      <PendingColumnSection
+        title="Working"
+        sessions={workingSessions}
+        onKill={onKill}
+        onMerge={onMerge}
+        onRestore={onRestore}
+      />
+      <PendingColumnSection
+        title="Idle"
+        sessions={idleSessions}
+        onKill={onKill}
+        onMerge={onMerge}
+        onRestore={onRestore}
+      />
+    </div>
+  );
+}
+
+function PendingColumnSection({
+  title,
+  sessions,
+  onKill,
+  onMerge,
+  onRestore,
+}: {
+  title: "Working" | "Idle";
+  sessions: DashboardSession[];
+  onKill?: (sessionId: string) => void;
+  onMerge?: (prNumber: number, owner?: string, repo?: string) => void;
+  onRestore?: (sessionId: string) => void;
+}) {
+  return (
+    <section className="kanban-column__pending-section" aria-label={`${title} sessions`}>
+      <div className="kanban-column__subheader">
+        <span className="kanban-column__subheader-title">{title}</span>
+        <span className="kanban-column__subheader-count">{sessions.length}</span>
+      </div>
+      {sessions.length > 0 ? (
+        <div className="kanban-column__stack">
+          {sessions.map((session) => (
+            <SessionCard
+              key={session.id}
+              session={session}
+              onKill={onKill}
+              onMerge={onMerge}
+              onRestore={onRestore}
+            />
+          ))}
+        </div>
+      ) : null}
+    </section>
   );
 }
 
@@ -290,7 +367,7 @@ export function getActionChipLabel(session: DashboardSession): string {
   if (session.status === "ci_failed") return "ci failed";
   if (session.status === "changes_requested") return "changes";
   // Review-class: PR signals — aggregate across all PRs
-  const prs = session.prs.length > 0 ? session.prs : (session.pr ? [session.pr] : []);
+  const prs = session.prs.length > 0 ? session.prs : session.pr ? [session.pr] : [];
   if (prs.some((p) => p.ciStatus === "failing")) return "ci failed";
   if (prs.some((p) => p.reviewDecision === "changes_requested")) return "changes";
   if (prs.some((p) => !p.mergeability.noConflicts)) return "conflicts";
@@ -306,7 +383,7 @@ function SessionStateChip({
 }) {
   let label = zoneConfig[level].label.toLowerCase();
 
-  const prs = session.prs.length > 0 ? session.prs : (session.pr ? [session.pr] : []);
+  const prs = session.prs.length > 0 ? session.prs : session.pr ? [session.pr] : [];
   if (level === "merge" && prs.length > 0 && prs.every((p) => isPRMergeReady(p))) {
     label = "ready";
   } else if (level === "action") {

--- a/packages/web/src/components/Skeleton.tsx
+++ b/packages/web/src/components/Skeleton.tsx
@@ -8,7 +8,7 @@ interface EmptyStateProps {
   spawnDisabled?: boolean;
 }
 
-const KANBAN_GHOST_COLUMNS = ["Working", "Needs you", "In review", "Ready to merge"] as const;
+const KANBAN_GHOST_COLUMNS = ["Pending", "Needs you", "In review", "Ready to merge"] as const;
 
 export function EmptyState({
   message,
@@ -90,7 +90,8 @@ export function EmptyState({
             <>
               <p className="empty-state__headline">Ready to orchestrate</p>
               <p className="empty-state__hint">
-                Open the main orchestrator to start a session and fan out parallel agents across your codebase.
+                Open the main orchestrator to start a session and fan out parallel agents across
+                your codebase.
               </p>
               {orchestratorHref ? (
                 <a href={orchestratorHref} className="empty-state__cta">

--- a/packages/web/src/components/__tests__/Dashboard.kanbanLayout.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.kanbanLayout.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { Dashboard } from "@/components/Dashboard";
 import { makePR, makeSession } from "@/__tests__/helpers";
 
@@ -42,7 +42,38 @@ describe("Dashboard kanban layout", () => {
     const titles = Array.from(document.querySelectorAll(".kanban-column__title")).map(
       (el) => el.textContent,
     );
-    expect(titles).toEqual(["Working", "Needs you", "In review", "Ready to merge"]);
+    expect(titles).toEqual(["Pending", "Needs you", "In review", "Ready to merge"]);
+  });
+
+  it("splits the pending column into working and idle sessions", () => {
+    render(
+      <Dashboard
+        initialSessions={[
+          makeSession({
+            id: "working-1",
+            activity: "active",
+            issueLabel: "ACTIVE-1",
+          }),
+          makeSession({
+            id: "idle-1",
+            activity: "idle",
+            issueLabel: "IDLE-1",
+          }),
+        ]}
+      />,
+    );
+
+    const pendingColumn = document.querySelector('.kanban-column[data-level="working"]');
+    expect(pendingColumn).toBeTruthy();
+    const pendingScope = within(pendingColumn as HTMLElement);
+
+    expect(pendingScope.getByText("Pending")).toBeInTheDocument();
+    const workingSection = pendingColumn?.querySelector('[aria-label="Working sessions"]');
+    const idleSection = pendingColumn?.querySelector('[aria-label="Idle sessions"]');
+    expect(workingSection).toBeTruthy();
+    expect(idleSection).toBeTruthy();
+    expect(within(workingSection as HTMLElement).getByText("working-1")).toBeInTheDocument();
+    expect(within(idleSection as HTMLElement).getByText("idle-1")).toBeInTheDocument();
   });
 
   it("uses five board columns in detailed attention mode", () => {


### PR DESCRIPTION
## Summary
- rename the first board column from Working to Pending while keeping the existing four-column layout
- split that Pending column into Working and Idle sections using session activity, with a simple divider and no nested card chrome
- update loading skeleton labels and tests for the new board shape

## Checks
- pnpm --filter @aoagents/ao-web test -- Dashboard.kanbanLayout.test.tsx components.test.tsx loading.test.tsx
- pnpm --filter @aoagents/ao-web typecheck
- pnpm exec prettier --check packages/web/src/components/AttentionZone.tsx packages/web/src/app/globals.css packages/web/src/components/__tests__/Dashboard.kanbanLayout.test.tsx packages/web/src/__tests__/components.test.tsx packages/web/src/components/Skeleton.tsx packages/web/src/app/projects/[projectId]/loading.tsx packages/web/src/app/projects/[projectId]/loading.test.tsx