### PR TITLE
fix: deep-link PR attention actions

### DIFF
--- a/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
@@ -73,6 +73,48 @@ function respondWithProjectAndPRs() {
 	});
 }
 
+function respondWithAttentionPR() {
+	getMock.mockImplementation(async (url: string) => {
+		if (url === "/api/v1/projects") {
+			return { data: { projects: [{ id: "proj-1", name: "my-app", path: "/repo/my-app" }] }, error: undefined };
+		}
+		if (url === "/api/v1/sessions/sess-1/pr") {
+			return { data: { sessionId: "sess-1", prs: [] }, error: undefined };
+		}
+		if (url === "/api/v1/sessions") {
+			return {
+				data: {
+					sessions: [
+						{
+							id: "sess-1",
+							projectId: "proj-1",
+							displayName: "fix the bug",
+							harness: "claude-code",
+							status: "changes_requested",
+							isTerminated: false,
+							updatedAt: "2026-06-10T16:15:04Z",
+							prs: [
+								{
+									number: 278,
+									state: "open",
+									url: "https://github.com/aoagents/ReverbCode/pull/278",
+									ci: "passing",
+									review: "changes_requested",
+									mergeability: "conflicting",
+									reviewComments: true,
+									updatedAt: "2026-06-10T16:15:04Z",
+								},
+							],
+						},
+					],
+				},
+				error: undefined,
+			};
+		}
+		throw new Error(`unexpected GET ${url}`);
+	});
+}
+
 function renderWithProviders(node: ReactNode) {
 	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	render(<QueryClientProvider client={queryClient}>{node}</QueryClientProvider>);
@@ -91,6 +133,20 @@ describe("PR hydration for a normal project (#251)", () => {
 		expect(await screen.findByText("PR #278 · open")).toBeInTheDocument();
 		expect(screen.getByText("PR #279 · draft")).toBeInTheDocument();
 		expect(screen.queryByText("no PR yet")).not.toBeInTheDocument();
+	});
+
+	it("links Board attention states to comments and merge conflict targets", async () => {
+		respondWithAttentionPR();
+		renderWithProviders(<SessionsBoard />);
+
+		expect(await screen.findByRole("link", { name: "comments" })).toHaveAttribute(
+			"href",
+			"https://github.com/aoagents/ReverbCode/pull/278/files",
+		);
+		expect(screen.getByRole("link", { name: "conflicts" })).toHaveAttribute(
+			"href",
+			"https://github.com/aoagents/ReverbCode/pull/278/conflicts",
+		);
 	});
 
 	it("lists every session PR on the PR page instead of being empty", async () => {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -15,7 +15,7 @@ import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { formatTimeCompact } from "../lib/format-time";
 import { useSessionScmSummary, type SessionPRSummary } from "../hooks/useSessionScmSummary";
-import { prStatusRows, sessionPRDisplaySummaries, type PRDisplayTone } from "../lib/pr-display";
+import { prBrowserUrl, prStatusRows, sessionPRDisplaySummaries, type PRDisplayTone } from "../lib/pr-display";
 import type { SessionStatus, WorkspaceSession } from "../types/workspace";
 import { sortedPRs, workerDisplayStatus } from "../types/workspace";
 import { BrowserPanelView } from "./BrowserPanel";
@@ -219,7 +219,7 @@ function PRSummaryCard({ pr }: { pr: SessionPRSummary }) {
 					{pr.state}
 				</Badge>
 				<a
-					href={pr.htmlUrl || pr.url}
+					href={prBrowserUrl(pr)}
 					target="_blank"
 					rel="noopener noreferrer"
 					className="ml-auto inline-flex items-center gap-0.5 text-[11px] font-medium text-accent hover:underline"

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type KeyboardEvent } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { Plus } from "lucide-react";
@@ -263,11 +263,22 @@ function SessionCard({ session, onOpen }: { session: WorkspaceSession; onOpen: (
 	const branch = session.branch || "";
 	const showBranch = branch !== "" && !sameLabel(branch, session.title) && !sameLabel(branch, session.id);
 	const prSummaries = sessionPRDisplaySummaries(session, useSessionScmSummary(session.id).data);
+	const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+		if (event.target !== event.currentTarget) {
+			return;
+		}
+		if (event.key === "Enter" || event.key === " ") {
+			event.preventDefault();
+			onOpen();
+		}
+	};
 	return (
-		<button
+		<div
 			className="w-full rounded-[7px] border border-border bg-surface text-left transition-colors hover:border-border-strong"
 			onClick={onOpen}
-			type="button"
+			onKeyDown={handleKeyDown}
+			role="button"
+			tabIndex={0}
 		>
 			<div className="flex items-center gap-2 px-[13px] pb-[9px] pt-3">
 				<span className={cn("inline-flex items-center gap-1.5 text-[11px] font-medium", badge.className)}>
@@ -303,7 +314,7 @@ function SessionCard({ session, onOpen }: { session: WorkspaceSession; onOpen: (
 					"no PR yet"
 				)}
 			</div>
-		</button>
+		</div>
 	);
 }
 
@@ -316,7 +327,7 @@ function BoardPRSummary({ className, pr }: { className?: string; pr: SessionPRSu
 			</span>
 			{diffSummary ? <span className="truncate">{diffSummary}</span> : null}
 			<PRStatusStrip pr={pr} />
-			<PRAttentionPanel className="mt-1.5 pt-1.5" interactiveLinks={false} maxItems={2} pr={pr} />
+			<PRAttentionPanel className="mt-1.5 pt-1.5" maxItems={2} pr={pr} />
 		</div>
 	);
 }

--- a/frontend/src/renderer/lib/pr-display.test.ts
+++ b/frontend/src/renderer/lib/pr-display.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SessionPRSummary } from "../hooks/useSessionScmSummary";
-import { prAttentionItems, prDiffSummary, prStatusRows } from "./pr-display";
+import { prAttentionItems, prBrowserUrl, prDiffSummary, prStatusRows } from "./pr-display";
 
 const summary = (overrides: Partial<SessionPRSummary> = {}): SessionPRSummary => ({
 	url: "https://github.com/acme/repo/pull/7",
@@ -56,6 +56,19 @@ describe("prDiffSummary", () => {
 	});
 });
 
+describe("prBrowserUrl", () => {
+	it("normalizes issue-shaped GitHub PR URLs to the pull request page", () => {
+		expect(
+			prBrowserUrl(
+				summary({
+					url: "https://github.com/acme/repo/issues/7",
+					htmlUrl: "https://github.com/acme/repo/issues/7",
+				}),
+			),
+		).toBe("https://github.com/acme/repo/pull/7");
+	});
+});
+
 describe("prAttentionItems", () => {
 	it("returns no attention for clean open PRs", () => {
 		expect(prAttentionItems(summary())).toEqual([]);
@@ -97,6 +110,44 @@ describe("prAttentionItems", () => {
 		expect(items.find((item) => item.kind === "review_changes_requested")?.links[0]).toMatchObject({
 			label: "alice +5",
 			href: "https://github.com/acme/repo/pull/7#discussion_r1",
+		});
+	});
+
+	it("links requested changes to the PR comments surface when comment URLs are missing", () => {
+		const items = prAttentionItems(
+			summary({
+				url: "https://github.com/acme/repo/issues/7",
+				htmlUrl: "https://github.com/acme/repo/issues/7",
+				review: {
+					decision: "changes_requested",
+					hasUnresolvedHumanComments: false,
+					unresolvedBy: [],
+				},
+			}),
+		);
+
+		expect(items.find((item) => item.kind === "review_changes_requested")?.links[0]).toMatchObject({
+			label: "comments",
+			href: "https://github.com/acme/repo/pull/7/files",
+		});
+	});
+
+	it("links merge conflicts to GitHub's conflict resolution page", () => {
+		const items = prAttentionItems(
+			summary({
+				url: "https://github.com/acme/repo/issues/7",
+				htmlUrl: "https://github.com/acme/repo/issues/7",
+				mergeability: {
+					state: "conflicting",
+					reasons: [],
+					prUrl: "https://github.com/acme/repo/issues/7",
+				},
+			}),
+		);
+
+		expect(items.find((item) => item.kind === "merge_conflict")?.links[0]).toMatchObject({
+			label: "conflicts",
+			href: "https://github.com/acme/repo/pull/7/conflicts",
 		});
 	});
 

--- a/frontend/src/renderer/lib/pr-display.ts
+++ b/frontend/src/renderer/lib/pr-display.ts
@@ -188,7 +188,8 @@ export function prAttentionItems(pr: SessionPRSummary): PRAttentionItem[] {
 			kind: "review_changes_requested",
 			title: "Address requested changes",
 			summary: links.length === 0 ? "Requested changes still active" : undefined,
-			links: links.length > 0 ? links : [{ label: "comments", href: reviewCommentsUrl(pr), title: "Open review comments" }],
+			links:
+				links.length > 0 ? links : [{ label: "comments", href: reviewCommentsUrl(pr), title: "Open review comments" }],
 			overflowLabel: overflowLabel(pr.review.unresolvedBy.length, 3, "reviewer"),
 			tone: "warning",
 		});
@@ -335,7 +336,8 @@ function mergeAttention(
 	fallback: string,
 	tone: PRDisplayTone,
 ): PRAttentionItem {
-	const href = kind === "merge_conflict" ? mergeConflictUrl(pr) : pr.mergeability.prUrl || pr.htmlUrl || pr.url || undefined;
+	const href =
+		kind === "merge_conflict" ? mergeConflictUrl(pr) : pr.mergeability.prUrl || pr.htmlUrl || pr.url || undefined;
 	const fileLinks = (pr.mergeability.conflictFiles ?? []).slice(0, 3).map((file) => ({
 		label: file.path,
 		href: file.url || href,

--- a/frontend/src/renderer/lib/pr-display.ts
+++ b/frontend/src/renderer/lib/pr-display.ts
@@ -46,6 +46,10 @@ export function comparePRDisplaySummaries(a: SessionPRSummary, b: SessionPRSumma
 	return prStateRank[a.state] - prStateRank[b.state] || a.number - b.number;
 }
 
+export function prBrowserUrl(pr: SessionPRSummary): string {
+	return prBaseUrl(pr) ?? pr.htmlUrl ?? pr.url;
+}
+
 export function sessionPRDisplaySummaries(
 	session: WorkspaceSession,
 	summaries: SessionPRSummary[] = [],
@@ -177,14 +181,14 @@ export function prAttentionItems(pr: SessionPRSummary): PRAttentionItem[] {
 		const reviewers = pr.review.unresolvedBy.slice(0, 3);
 		const links = reviewers.map((reviewer) => ({
 			label: reviewerLabel(reviewer),
-			href: reviewer.links.find((link) => link.url)?.url || undefined,
+			href: reviewer.links.find((link) => link.url)?.url || reviewCommentsUrl(pr),
 			title: `${reviewer.count} unresolved ${pluralize("comment", reviewer.count)}`,
 		}));
 		items.push({
 			kind: "review_changes_requested",
 			title: "Address requested changes",
 			summary: links.length === 0 ? "Requested changes still active" : undefined,
-			links,
+			links: links.length > 0 ? links : [{ label: "comments", href: reviewCommentsUrl(pr), title: "Open review comments" }],
 			overflowLabel: overflowLabel(pr.review.unresolvedBy.length, 3, "reviewer"),
 			tone: "warning",
 		});
@@ -331,18 +335,22 @@ function mergeAttention(
 	fallback: string,
 	tone: PRDisplayTone,
 ): PRAttentionItem {
+	const href = kind === "merge_conflict" ? mergeConflictUrl(pr) : pr.mergeability.prUrl || pr.htmlUrl || pr.url || undefined;
 	const fileLinks = (pr.mergeability.conflictFiles ?? []).slice(0, 3).map((file) => ({
 		label: file.path,
-		href: file.url || pr.mergeability.prUrl || undefined,
+		href: file.url || href,
+		title: kind === "merge_conflict" ? "Open merge conflicts" : undefined,
 	}));
 	const reasonLinks =
-		fileLinks.length > 0
+		fileLinks.length > 0 || kind === "merge_conflict"
 			? []
 			: pr.mergeability.reasons.slice(0, 3).map((reason) => ({
 					label: mergeReasonLabel(reason),
-					href: pr.mergeability.prUrl || undefined,
+					href,
 				}));
-	const links = fileLinks.length > 0 ? fileLinks : reasonLinks;
+	const fallbackLink =
+		kind === "merge_conflict" && href ? [{ label: "conflicts", href, title: "Open merge conflicts" }] : [];
+	const links = fileLinks.length > 0 ? fileLinks : reasonLinks.length > 0 ? reasonLinks : fallbackLink;
 	return {
 		kind,
 		title,
@@ -354,6 +362,43 @@ function mergeAttention(
 				: overflowLabel(pr.mergeability.reasons.length, 3, "reason"),
 		tone,
 	};
+}
+
+function reviewCommentsUrl(pr: SessionPRSummary): string | undefined {
+	return prSubpageUrl(pr, "files") ?? prBrowserUrl(pr);
+}
+
+function mergeConflictUrl(pr: SessionPRSummary): string | undefined {
+	return prSubpageUrl(pr, "conflicts") ?? pr.mergeability.prUrl ?? prBrowserUrl(pr);
+}
+
+function prBaseUrl(pr: SessionPRSummary): string | undefined {
+	return prURL(pr);
+}
+
+function prSubpageUrl(pr: SessionPRSummary, subpage: "conflicts" | "files"): string | undefined {
+	const base = prURL(pr);
+	return base ? `${base}/${subpage}` : undefined;
+}
+
+function prURL(pr: SessionPRSummary): string | undefined {
+	const raw = pr.htmlUrl || pr.mergeability.prUrl || pr.url;
+	if (!raw) {
+		return undefined;
+	}
+	try {
+		const url = new URL(raw);
+		const match = url.pathname.match(/^(\/[^/]+\/[^/]+)\/(?:pull|issues)\/(\d+)(?:\/.*)?$/);
+		if (!match) {
+			return undefined;
+		}
+		url.pathname = `${match[1]}/pull/${match[2]}`;
+		url.search = "";
+		url.hash = "";
+		return url.toString();
+	} catch {
+		return undefined;
+	}
 }
 
 function reviewerLabel(reviewer: SessionPRSummary["review"]["unresolvedBy"][number]): string {


### PR DESCRIPTION
## Summary

- normalize GitHub issue-shaped PR URLs to `/pull/{number}` before rendering PR links
- deep-link requested-change attention to review comments/files when no direct discussion URL is available
- deep-link merge-conflict attention to GitHub's `/conflicts` page
- make dashboard session cards allow nested attention links to be clicked directly

Fixes #2198

## Tests

- `npm run test -- pr-display.test.ts pr-hydration.test.tsx`
- `npm run typecheck`
