### PR TITLE
fix: split pending kanban idle sessions

### DIFF
--- a/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
 // Drives the real useWorkspaceQuery + real Board / PR-page consumers end to end
@@ -25,47 +25,49 @@ import { PullRequestsPage } from "../../components/PullRequestsPage";
 
 // One ordinary project with one worker session that has multiple PRs.
 function respondWithProjectAndPRs() {
+	respondWithSessions([
+		{
+			id: "sess-1",
+			projectId: "proj-1",
+			displayName: "fix the bug",
+			harness: "claude-code",
+			status: "pr_open",
+			isTerminated: false,
+			updatedAt: "2026-06-10T16:15:04Z",
+			prs: [
+				{
+					number: 278,
+					state: "open",
+					url: "https://github.com/aoagents/ReverbCode/pull/278",
+					ci: "passing",
+					review: "approved",
+					mergeability: "clean",
+					reviewComments: false,
+					updatedAt: "2026-06-10T16:15:04Z",
+				},
+				{
+					number: 279,
+					state: "draft",
+					url: "https://github.com/aoagents/ReverbCode/pull/279",
+					ci: "pending",
+					review: "pending",
+					mergeability: "unknown",
+					reviewComments: false,
+					updatedAt: "2026-06-10T16:20:04Z",
+				},
+			],
+		},
+	]);
+}
+
+function respondWithSessions(sessions: Array<Record<string, unknown>>) {
 	getMock.mockImplementation(async (url: string) => {
 		if (url === "/api/v1/projects") {
 			return { data: { projects: [{ id: "proj-1", name: "my-app", path: "/repo/my-app" }] }, error: undefined };
 		}
 		if (url === "/api/v1/sessions") {
 			return {
-				data: {
-					sessions: [
-						{
-							id: "sess-1",
-							projectId: "proj-1",
-							displayName: "fix the bug",
-							harness: "claude-code",
-							status: "pr_open",
-							isTerminated: false,
-							updatedAt: "2026-06-10T16:15:04Z",
-							prs: [
-								{
-									number: 278,
-									state: "open",
-									url: "https://github.com/aoagents/ReverbCode/pull/278",
-									ci: "passing",
-									review: "approved",
-									mergeability: "clean",
-									reviewComments: false,
-									updatedAt: "2026-06-10T16:15:04Z",
-								},
-								{
-									number: 279,
-									state: "draft",
-									url: "https://github.com/aoagents/ReverbCode/pull/279",
-									ci: "pending",
-									review: "pending",
-									mergeability: "unknown",
-									reviewComments: false,
-									updatedAt: "2026-06-10T16:20:04Z",
-								},
-							],
-						},
-					],
-				},
+				data: { sessions },
 				error: undefined,
 			};
 		}
@@ -84,6 +86,10 @@ beforeEach(() => {
 	respondWithProjectAndPRs();
 });
 
+afterEach(() => {
+	cleanup();
+});
+
 describe("PR hydration for a normal project (#251)", () => {
 	it("renders every session PR on the Board card instead of 'no PR yet'", async () => {
 		renderWithProviders(<SessionsBoard />);
@@ -100,5 +106,45 @@ describe("PR hydration for a normal project (#251)", () => {
 		expect(screen.getByText("#279")).toBeInTheDocument();
 		expect(screen.queryByText("No open pull requests.")).not.toBeInTheDocument();
 		expect(screen.getAllByText("fix the bug")).toHaveLength(2);
+	});
+
+	it("keeps four board columns and splits pending work into working and idle sections", async () => {
+		respondWithSessions([
+			{
+				id: "active-1",
+				projectId: "proj-1",
+				displayName: "active worker",
+				harness: "codex",
+				status: "working",
+				isTerminated: false,
+				updatedAt: "2026-06-10T16:15:04Z",
+				prs: [],
+			},
+			{
+				id: "idle-1",
+				projectId: "proj-1",
+				displayName: "idle worker",
+				harness: "codex",
+				status: "idle",
+				isTerminated: false,
+				updatedAt: "2026-06-10T16:16:04Z",
+				prs: [],
+			},
+		]);
+
+		renderWithProviders(<SessionsBoard />);
+
+		expect(await screen.findByText("active worker")).toBeInTheDocument();
+		expect(await screen.findByText("idle worker")).toBeInTheDocument();
+		expect(screen.getByText("Pending")).toBeInTheDocument();
+		expect(screen.getByText("Needs you")).toBeInTheDocument();
+		expect(screen.getByText("In review")).toBeInTheDocument();
+		expect(screen.getByText("Ready to merge")).toBeInTheDocument();
+
+		const workingSection = screen.getByLabelText("Working sessions");
+		const idleSection = screen.getByLabelText("Idle sessions");
+		expect(within(workingSection).getByText("active worker")).toBeInTheDocument();
+		expect(within(idleSection).getByText("idle worker")).toBeInTheDocument();
+		expect(within(idleSection).getAllByText("Idle").length).toBeGreaterThan(0);
 	});
 });

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -337,22 +337,19 @@ function activityDetail(status: SessionStatus): string | null {
 	}
 }
 
-const STATUS_PILL: Record<
-	ReturnType<typeof workerDisplayStatus> | "idle",
-	{ label: string; tone: string; breathe: boolean }
-> = {
+const STATUS_PILL: Record<ReturnType<typeof workerDisplayStatus>, { label: string; tone: string; breathe: boolean }> = {
 	working: { label: "Working", tone: "var(--orange)", breathe: true },
+	idle: { label: "Idle", tone: "var(--fg-muted)", breathe: false },
 	needs_you: { label: "Input needed", tone: "var(--amber)", breathe: false },
 	ci_failed: { label: "CI failed", tone: "var(--red)", breathe: false },
 	no_signal: { label: "No signal", tone: "var(--fg-muted)", breathe: false },
 	mergeable: { label: "Ready", tone: "var(--green)", breathe: false },
 	done: { label: "Done", tone: "var(--fg-muted)", breathe: false },
 	unknown: { label: "Unknown", tone: "var(--fg-muted)", breathe: false },
-	idle: { label: "Idle", tone: "var(--fg-muted)", breathe: false },
 };
 
 function InspectorStatusPill({ session }: { session: WorkspaceSession }) {
-	const key = session.status === "idle" ? "idle" : workerDisplayStatus(session);
+	const key = workerDisplayStatus(session);
 	const { label, tone, breathe } = STATUS_PILL[key];
 	return (
 		<span

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -32,7 +32,7 @@ type Column = {
 const COLUMNS: Column[] = [
 	{
 		level: "working",
-		label: "Working",
+		label: "Pending",
 		glow: "color-mix(in srgb, var(--orange) 7%, transparent)",
 		dot: "var(--orange)",
 		dotGlow: true,
@@ -248,12 +248,63 @@ function ZoneColumn({
 				<span className="ml-auto font-mono text-[11px] leading-none text-passive">{sessions.length}</span>
 			</div>
 			<div className="min-h-0 flex-1 overflow-y-auto px-[11px] pb-3">
+				{col.level === "working" ? (
+					<PendingColumnSections sessions={sessions} onOpen={onOpen} />
+				) : (
+					<div className="flex flex-col gap-2.5">
+						{sessions.map((session) => (
+							<SessionCard key={session.id} session={session} onOpen={() => onOpen(session)} />
+						))}
+					</div>
+				)}
+			</div>
+		</section>
+	);
+}
+
+function PendingColumnSections({
+	sessions,
+	onOpen,
+}: {
+	sessions: WorkspaceSession[];
+	onOpen: (s: WorkspaceSession) => void;
+}) {
+	const workingSessions = sessions.filter((session) => session.status !== "idle");
+	const idleSessions = sessions.filter((session) => session.status === "idle");
+
+	return (
+		<div className="grid min-h-full grid-rows-[minmax(0,1fr)_auto] gap-2">
+			<PendingColumnSection onOpen={onOpen} sessions={workingSessions} title="Working" />
+			<PendingColumnSection onOpen={onOpen} sessions={idleSessions} title="Idle" />
+		</div>
+	);
+}
+
+function PendingColumnSection({
+	title,
+	sessions,
+	onOpen,
+}: {
+	title: "Working" | "Idle";
+	sessions: WorkspaceSession[];
+	onOpen: (s: WorkspaceSession) => void;
+}) {
+	return (
+		<section
+			aria-label={`${title} sessions`}
+			className="flex min-h-0 flex-col gap-2 border-t border-border pt-2 first:border-t-0 first:pt-0"
+		>
+			<div className="flex min-h-5 items-center gap-2 px-1">
+				<span className="font-mono text-[10px] font-medium uppercase tracking-[0.05em] text-passive">{title}</span>
+				<span className="ml-auto font-mono text-[10px] leading-none text-passive">{sessions.length}</span>
+			</div>
+			{sessions.length > 0 && (
 				<div className="flex flex-col gap-2.5">
 					{sessions.map((session) => (
 						<SessionCard key={session.id} session={session} onOpen={() => onOpen(session)} />
 					))}
 				</div>
-			</div>
+			)}
 		</section>
 	);
 }
@@ -365,6 +416,8 @@ function sessionBadge(session: WorkspaceSession): { label: string; className: st
 			return { label: "Merged", className: "text-passive" };
 		case "terminated":
 			return { label: "Terminated", className: "text-passive" };
+		case "idle":
+			return { label: "Idle", className: "text-passive" };
 		default:
 			return { label: "Working", className: "text-working" };
 	}

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -29,6 +29,7 @@ const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperti
 // Tones are theme vars so the pill tracks the light/dark status palettes.
 const STATUS_PILL: Record<WorkerDisplayStatus, { label: string; tone: string; breathe: boolean }> = {
 	working: { label: "Working", tone: "var(--orange)", breathe: true },
+	idle: { label: "Idle", tone: "var(--fg-muted)", breathe: false },
 	needs_you: { label: "Needs input", tone: "var(--amber)", breathe: false },
 	ci_failed: { label: "CI failed", tone: "var(--red)", breathe: false },
 	no_signal: { label: "No signal", tone: "var(--fg-muted)", breathe: false },

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -107,7 +107,8 @@ function SessionDot({ session }: { session: WorkspaceSession }) {
 			aria-hidden="true"
 			className={cn(
 				"mt-px h-1.5 w-1.5 shrink-0 rounded-full",
-				zone === "working" && "animate-status-pulse bg-working",
+				zone === "working" && session.status !== "idle" && "animate-status-pulse bg-working",
+				session.status === "idle" && "bg-passive",
 				zone === "action" && (session.status === "ci_failed" ? "bg-error" : "bg-warning"),
 				zone === "pending" && "bg-passive",
 				zone === "merge" && "bg-success",

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -82,7 +82,7 @@ describe("workerDisplayStatus", () => {
 		["terminated", "done"],
 		["unknown", "unknown"],
 		["working", "working"],
-		["idle", "working"],
+		["idle", "idle"],
 	] as const)("maps %s to %s", (status, expected) => {
 		expect(workerDisplayStatus(sessionWith({ status }))).toBe(expected);
 	});
@@ -153,6 +153,7 @@ describe("workerStatusPulses", () => {
 	it("pulses only for working and needs_you", () => {
 		expect(workerStatusPulses("working")).toBe(true);
 		expect(workerStatusPulses("needs_you")).toBe(true);
+		expect(workerStatusPulses("idle")).toBe(false);
 		expect(workerStatusPulses("mergeable")).toBe(false);
 		expect(workerStatusPulses("no_signal")).toBe(false);
 		expect(workerStatusPulses("done")).toBe(false);

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -135,6 +135,7 @@ export type WorkspaceSession = {
 /** Glanceable worker status. Maps 1:1 to the accent colors in DESIGN.md. */
 export type WorkerDisplayStatus =
 	| "working"
+	| "idle"
 	| "needs_you"
 	| "mergeable"
 	| "ci_failed"
@@ -159,6 +160,8 @@ export function workerDisplayStatus(session: WorkspaceSession): WorkerDisplaySta
 		case "merged":
 		case "terminated":
 			return "done";
+		case "idle":
+			return "idle";
 		case "unknown":
 			return "unknown";
 		default:
@@ -228,6 +231,7 @@ export function sessionNeedsAttention(session: WorkspaceSession): boolean {
 
 export const workerStatusLabel: Record<WorkerDisplayStatus, string> = {
 	working: "working",
+	idle: "idle",
 	needs_you: "needs you",
 	mergeable: "mergeable",
 	ci_failed: "ci failed",
@@ -257,7 +261,7 @@ export const attentionZoneLabel: Record<AttentionZone, string> = {
 	merge: "Ready to merge",
 	action: "Needs you",
 	pending: "Pending",
-	working: "Working",
+	working: "Pending",
 	done: "Done",
 };
 


### PR DESCRIPTION
## Summary
- rename the first Kanban column to Pending
- split pending sessions into Working and Idle sections
- show Idle as its own card badge and cover the behavior in the PR hydration integration test

## What this fixes
Idle sessions were mixed into the active working list, making the Pending column look noisier and hiding which sessions were actually waiting.

## Verification
- npm test -- src/renderer/__tests__/integration/pr-hydration.test.tsx
- go test ./...