### PR TITLE
feat: pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+## Description
+
+Brief description of the changes in this PR.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Related Issues
+
+Fixes #(issue number)
+
+## Changes Made
+
+- Change 1
+- Change 2
+- Change 3
+
+## Testing
+
+Describe the tests you ran to verify your changes:
+
+- [ ] Unit tests pass (`cd core && pytest tests/`)
+- [ ] Lint passes (`cd core && ruff check .`)
+- [ ] Manual testing performed
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+
+## Screenshots (if applicable)
+
+Add screenshots to demonstrate UI changes.


### PR DESCRIPTION
## Problem Statement

Currently the repository does not provide a default pull request template. This makes PR descriptions less consistent and can leave reviewers without important context such as the type of change, related issue, changes made, testing performed, checklist confirmation, or screenshots for UI changes.

resolves #2211

## Proposed Solution

Add a GitHub pull request template at `.github/PULL_REQUEST_TEMPLATE.md`, .

The template should include sections for:

- Description
- Type of Change
- Related Issues
- Changes Made
- Testing
- Checklist
- Screenshots, if applicable

## Alternatives Considered

Contributors can manually write PR descriptions, but this often leads to missing details and extra reviewer follow-up. A shared template keeps the review process faster and more consistent.

## Additional Context

Reference template example:

[PULL_REQUEST_TEMPLATE.md](https://github.com/user-attachments/files/27063867/PULL_REQUEST_TEMPLATE.md)

## Implementation Ideas

Create:

```text
.github/PULL_REQUEST_TEMPLATE.md
