### PR TITLE
fix(cli): treat run-file removal as stopped in `ao stop` (#2214)

### DIFF
--- a/backend/internal/cli/stop.go
+++ b/backend/internal/cli/stop.go
@@ -125,11 +125,19 @@ func (c *commandContext) waitForStopped(ctx context.Context, pid int, runFilePat
 			return daemonStatus{State: stateStopped, RunFile: runFilePath, DataDir: dataDir}, nil
 		}
 		if info == nil {
-			// The daemon removes running.json before the process necessarily exits.
-			// Keep waiting so Windows releases inherited handles such as daemon.log
-			// before tests or callers clean up the data directory.
+			// The run-file is the daemon's own liveness marker; it removes it as
+			// it shuts down, before the OS process has necessarily exited. Once
+			// the marker is gone the daemon has committed to stopping, so treat
+			// that as stopped.
+			//
+			// We still poll for full process exit as a best effort so Windows
+			// releases inherited handles such as daemon.log before callers clean
+			// up the data directory, but exceeding the timeout is NOT an error:
+			// with no desktop client connected the daemon can drain its
+			// background workers slower than the stop timeout, and failing here
+			// made `ao stop` spuriously report failure (issue #2214).
 			if !c.deps.Now().Before(deadline) {
-				return daemonStatus{}, fmt.Errorf("daemon pid %d removed run-file but did not exit within %s", pid, timeout)
+				return daemonStatus{State: stateStopped, RunFile: runFilePath, DataDir: dataDir}, nil
 			}
 			c.deps.Sleep(100 * time.Millisecond)
 			continue

--- a/backend/internal/cli/stop_test.go
+++ b/backend/internal/cli/stop_test.go
@@ -118,3 +118,28 @@ func TestWaitForStoppedWaitsAfterRunFileRemovedUntilProcessExits(t *testing.T) {
 		t.Fatalf("process checks = %d, want at least 3", aliveChecks)
 	}
 }
+
+// TestWaitForStoppedReportsStoppedWhenRunFileGoneButProcessLingers covers
+// issue #2214: once the daemon has removed its run-file (its liveness marker)
+// the stop is committed, so if the process is still draining background workers
+// past the timeout, waitForStopped must report stopped rather than erroring.
+func TestWaitForStoppedReportsStoppedWhenRunFileGoneButProcessLingers(t *testing.T) {
+	dir := t.TempDir()
+	runFile := filepath.Join(dir, "running.json") // never written: run-file already gone
+
+	const stoppedPID = 1111
+	now := time.Unix(200, 0).UTC()
+	c := &commandContext{deps: Deps{
+		ProcessAlive: func(int) bool { return true }, // process never exits
+		Now:          func() time.Time { return now },
+		Sleep:        func(d time.Duration) { now = now.Add(d) },
+	}.withDefaults()}
+
+	st, err := c.waitForStopped(context.Background(), stoppedPID, runFile, dir, time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if st.State != stateStopped {
+		t.Fatalf("state = %q, want stopped", st.State)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2214. `ao stop` -> `waitForStopped` removed the daemon's run-file and then *additionally* waited for the daemon process to fully exit, erroring with `daemon pid <N> removed run-file but did not exit within 10s` when the process lingered past the stop timeout. This is the `TestE2E_Lifecycle` failure described in the issue.

The run-file is the daemon's **own liveness marker**. Once the daemon has removed it, the daemon has committed to stopping. When no desktop/supervisor client is connected (as in the e2e harness, and on a user's machine with no running app), the daemon can drain its background workers slower than the 10s stop timeout, so insisting on process-exit made `ao stop` spuriously report failure even though shutdown was already underway.

## Change

In `waitForStopped`, when the run-file is gone (`info == nil`) we now treat the daemon as **stopped**. We still poll for full process exit as a best effort (so Windows releases inherited handles such as `daemon.log` before callers clean up the data dir), but exceeding the grace is no longer an error: it returns `stopped` instead.

This is suggested direction #1 from the issue and also fixes the user-facing `ao stop` UX on a machine with no connected desktop client.

## Tests

- New unit test `TestWaitForStoppedReportsStoppedWhenRunFileGoneButProcessLingers`: run-file gone + process never exits before deadline -> reports `stopped`, no error.
- Existing `waitForStopped` unit tests still pass (concurrent-start guard, own-run-file removal, wait-until-process-exits).
- `go test -tags e2e -run TestE2E_Lifecycle` passes; full `./internal/cli/...` suite (151 tests) passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)