### PR TITLE
ci(release): build darwin-x64 on macos-13 for Intel Mac ao start

### DIFF
--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, macos-13, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -82,13 +82,14 @@ jobs:
       # to the space-free names `ao start` fetches and upload to the v<version>
       # release the publish step just created, with --clobber (so re-runs replace).
       #
-      # Arch-coverage note: each runner only builds its host arch, so macos-latest
-      # (Apple silicon) produces darwin-arm64 only. The darwin-x64 alias needs an
-      # Intel macOS runner (e.g. macos-13) and is NOT produced here (gap, spec §8).
+      # Arch-coverage note: each runner only builds its host arch. macos-latest
+      # (Apple silicon) produces darwin-arm64; macos-13 (Intel x64) produces
+      # darwin-x64. Both macOS runners run this step (see the `if` below), so the
+      # arm64 and x64 stable aliases are now both built (spec §8).
       # The Linux stable name is undecided (spec §11.3), so we build the deb/rpm
       # but intentionally upload no Linux alias yet.
       - name: Upload stable asset aliases (macOS)
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos')
         shell: bash
         run: |
           # electron-forge publisher-github creates the release as v<package.json


### PR DESCRIPTION
## Problem

The desktop release workflow only builds on `macos-latest`, which is GitHub's Apple-Silicon (arm64) runner. Because each runner only packages its host arch, the `darwin-x64` stable alias `agent-orchestrator-darwin-x64.zip` is never produced. As a result, `ao start` on Intel Macs 404s when it fetches that constant `releases/latest/download/agent-orchestrator-darwin-x64.zip` URL.

## Fix

- Add `macos-13` (GitHub's Intel x64 runner) to the job matrix `os: [...]`.
- Broaden the "Upload stable asset aliases (macOS)" step's condition from `if: matrix.os == 'macos-latest'` to `if: startsWith(matrix.os, 'macos')` so it runs on both macOS runners. The step already derives the arch via `uname -m` (`arm64` -> arm64 alias, `x86_64` -> x64 alias) and globs `out/make/zip/darwin/*/*.zip`, so the Intel runner now emits and uploads the x64 alias with no other changes.
- Update the now-stale comment that noted the darwin-x64 gap to reflect that both arm64 and x64 aliases are now built.

No changes to the Windows or Linux steps.

## Verification

No real CI run is available. Validated the workflow YAML parses cleanly and confirmed the matrix now lists `macos-13` and the macOS alias step's `if` (`startsWith(matrix.os, 'macos')`) matches both `macos-latest` and `macos-13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)