### PR TITLE
feat(spawn): add per-session --model override with durable persistence

### DIFF
--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -82,6 +82,13 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 		cmd = append(cmd, "-c", "developer_instructions="+codexTOMLConfigString(cfg.SystemPrompt))
 	}
 
+	// Per-session model override (set by `ao spawn --model` or project worker
+	// config). Must precede the `--` prompt separator so codex parses it as a
+	// flag, not a positional prompt arg.
+	if model := strings.TrimSpace(cfg.Config.Model); model != "" {
+		cmd = append(cmd, "--model", model)
+	}
+
 	if cfg.Prompt != "" {
 		cmd = append(cmd, "--", cfg.Prompt)
 	}

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -581,3 +581,47 @@ func TestDoctorLaunchProbesMirrorLaunchFlags(t *testing.T) {
 		}
 	}
 }
+
+func TestGetLaunchCommandAppliesModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "codex"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "gpt-5.5-codex"},
+		Prompt: "do the thing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsSubsequence(cmd, []string{"--model", "gpt-5.5-codex"}) {
+		t.Fatalf("command %#v missing --model flag", cmd)
+	}
+	// --model must precede the `--` prompt separator, else codex parses it as a
+	// positional prompt arg instead of a flag.
+	modelIdx, dashIdx := -1, -1
+	for i, a := range cmd {
+		if a == "--model" && modelIdx == -1 {
+			modelIdx = i
+		}
+		if a == "--" && dashIdx == -1 {
+			dashIdx = i
+		}
+	}
+	if modelIdx == -1 {
+		t.Fatalf("--model not found in %#v", cmd)
+	}
+	if dashIdx != -1 && modelIdx > dashIdx {
+		t.Fatalf("--model (%d) must precede prompt separator -- (%d): %#v", modelIdx, dashIdx, cmd)
+	}
+}
+
+func TestGetLaunchCommandNoModelByDefault(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "codex"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range cmd {
+		if a == "--model" {
+			t.Fatalf("unexpected --model in %#v when no model configured", cmd)
+		}
+	}
+}

--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -20,6 +20,7 @@ type spawnOptions struct {
 	issue      string
 	claimPR    string
 	noTakeover bool
+	model      string
 }
 
 // spawnRequest mirrors the daemon's SpawnSessionRequest body for
@@ -30,6 +31,7 @@ type spawnRequest struct {
 	Harness   string `json:"harness,omitempty"`
 	Branch    string `json:"branch,omitempty"`
 	Prompt    string `json:"prompt,omitempty"`
+	Model     string `json:"model,omitempty"`
 }
 
 type spawnResult struct {
@@ -72,6 +74,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 				Harness:   opts.harness,
 				Branch:    opts.branch,
 				Prompt:    opts.prompt,
+				Model:     opts.model,
 			}
 			var res spawnResult
 			if err := ctx.postJSON(cmd.Context(), "sessions", req, &res); err != nil {
@@ -125,6 +128,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 	f.StringVar(&opts.branch, "branch", "", "Branch for the session worktree (default: ao/<session-id>/root)")
 	f.StringVar(&opts.prompt, "prompt", "", "Initial prompt for the agent")
 	f.StringVar(&opts.issue, "issue", "", "Issue id to associate with the session")
+	f.StringVar(&opts.model, "model", "", "Override the model for this session only (per-spawn; overrides project worker.agentConfig.model)")
 	f.StringVar(&opts.claimPR, "claim-pr", "", "Immediately claim an existing PR for the spawned session")
 	f.BoolVar(&opts.noTakeover, "no-takeover", false, "Refuse if another active session owns the claimed PR (requires --claim-pr)")
 	return cmd

--- a/backend/internal/domain/session.go
+++ b/backend/internal/domain/session.go
@@ -38,6 +38,10 @@ type SessionMetadata struct {
 	// even when PreviewURL is unchanged. The desktop browser panel keys
 	// navigation on it so a repeated `ao preview <same-url>` still refreshes.
 	PreviewRevision int64 `json:"previewRevision,omitempty"`
+	// Model is the agent model this session launched with (from `ao spawn --model`
+	// or resolved project/role config), persisted so a restart restores the same
+	// model. Empty means fall back to the resolved project/role config on restore.
+	Model string `json:"model,omitempty"`
 }
 
 // SessionRecord is the persistence shape. It intentionally stores only durable

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2458,6 +2458,8 @@ components:
           - worker
           - orchestrator
           type: string
+        model:
+          type: string
         projectId:
           type: string
         prompt:

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -146,6 +146,7 @@ type SpawnSessionRequest struct {
 	Harness   domain.AgentHarness `json:"harness,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,kiro,kilocode,vibe,pi,autohand"`
 	Branch    string              `json:"branch,omitempty"`
 	Prompt    string              `json:"prompt,omitempty" maxLength:"4096"`
+	Model     string              `json:"model,omitempty"`
 }
 
 // SessionResponse is the { session } body shared by session create/get.

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -123,7 +123,7 @@ func (c *SessionsController) spawn(w http.ResponseWriter, r *http.Request) {
 	if in.Kind == "" {
 		in.Kind = domain.KindWorker
 	}
-	sess, err := c.Svc.Spawn(r.Context(), ports.SpawnConfig{ProjectID: in.ProjectID, IssueID: in.IssueID, Kind: in.Kind, Harness: in.Harness, Branch: in.Branch, Prompt: in.Prompt})
+	sess, err := c.Svc.Spawn(r.Context(), ports.SpawnConfig{ProjectID: in.ProjectID, IssueID: in.IssueID, Kind: in.Kind, Harness: in.Harness, Branch: in.Branch, Prompt: in.Prompt, Model: in.Model})
 	if err != nil {
 		envelope.WriteError(w, r, err)
 		return

--- a/backend/internal/ports/session.go
+++ b/backend/internal/ports/session.go
@@ -18,4 +18,7 @@ type SpawnConfig struct {
 	Harness   domain.AgentHarness
 	Branch    string
 	Prompt    string
+	// Model, when set, overrides the resolved agent config's model for this
+	// session only (per-spawn override of project/role worker.agentConfig.model).
+	Model string
 }

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -253,6 +253,10 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: %w", id, err)
 	}
 	agentConfig := effectiveAgentConfig(cfg.Kind, project.Config)
+	// Per-spawn --model override takes precedence over project/role config.
+	if cfg.Model != "" {
+		agentConfig.Model = cfg.Model
+	}
 	argv, err := agent.GetLaunchCommand(ctx, ports.LaunchConfig{
 		SessionID:     string(id),
 		WorkspacePath: ws.Path,
@@ -288,7 +292,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: runtime: %w", id, err)
 	}
 
-	metadata := domain.SessionMetadata{Branch: ws.Branch, WorkspacePath: ws.Path, RuntimeHandleID: handle.ID, Prompt: prompt}
+	metadata := domain.SessionMetadata{Branch: ws.Branch, WorkspacePath: ws.Path, RuntimeHandleID: handle.ID, Prompt: prompt, Model: agentConfig.Model}
 	if err := m.lcm.MarkSpawned(ctx, id, metadata); err != nil {
 		_ = m.runtime.Destroy(ctx, handle)
 		_ = m.workspace.Destroy(ctx, ws)
@@ -521,7 +525,13 @@ func (m *Manager) Restore(ctx context.Context, id domain.SessionID) (domain.Sess
 	}
 	// Restore re-applies the project's resolved agent config so a configured
 	// model/permissions carry across a restore, matching fresh spawn.
-	argv, err := restoreArgv(ctx, agent, id, ws.Path, meta, systemPrompt, effectiveAgentConfig(rec.Kind, project.Config), rec.Kind)
+	restoreConfig := effectiveAgentConfig(rec.Kind, project.Config)
+	// Prefer the model the session originally launched with (persisted at spawn)
+	// over a possibly-changed project config, so a restart is faithful.
+	if meta.Model != "" {
+		restoreConfig.Model = meta.Model
+	}
+	argv, err := restoreArgv(ctx, agent, id, ws.Path, meta, systemPrompt, restoreConfig, rec.Kind)
 	if err != nil {
 		return domain.SessionRecord{}, fmt.Errorf("restore %s: %w", id, err)
 	}

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -1764,3 +1764,46 @@ func TestReconcileReap_TerminatedAndDeadTmuxLeftAlone(t *testing.T) {
 		t.Fatalf("Destroy calls = %d, want 0", rt.destroyed)
 	}
 }
+
+func TestSpawn_PerSpawnModelOverridesConfig(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: domain.ProjectConfig{
+		AgentConfig: domain.AgentConfig{Model: "base-model"},
+		Worker:      domain.RoleOverride{Harness: domain.HarnessCodex, AgentConfig: domain.AgentConfig{Model: "worker-model"}},
+	}}
+	agent := &recordingAgent{}
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{}
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{Runtime: rt, Agents: singleAgent{agent: agent}, Workspace: ws, Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LookPath: lookPath})
+
+	rec, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, Model: "spawn-model"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Per-spawn --model wins over both base config and the worker role override.
+	if agent.lastConfig.Model != "spawn-model" {
+		t.Fatalf("launch model = %q, want per-spawn spawn-model", agent.lastConfig.Model)
+	}
+	// And it is persisted on the record so a restart restores the same model.
+	if rec.Metadata.Model != "spawn-model" {
+		t.Fatalf("persisted model = %q, want spawn-model", rec.Metadata.Model)
+	}
+}
+
+func TestSpawn_NoModelFallsBackToConfig(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: domain.ProjectConfig{
+		AgentConfig: domain.AgentConfig{Model: "base-model"},
+	}}
+	agent := &recordingAgent{}
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{Runtime: &fakeRuntime{}, Agents: singleAgent{agent: agent}, Workspace: &fakeWorkspace{}, Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LookPath: lookPath})
+
+	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, Harness: domain.HarnessCodex}); err != nil {
+		t.Fatal(err)
+	}
+	if agent.lastConfig.Model != "base-model" {
+		t.Fatalf("launch model = %q, want fallback base-model", agent.lastConfig.Model)
+	}
+}

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -170,6 +170,7 @@ type Session struct {
 	FirstSignalAt   sql.NullTime
 	PreviewURL      string
 	PreviewRevision int64
+	Model           string
 }
 
 type SessionWorktree struct {

--- a/backend/internal/storage/sqlite/gen/sessions.sql.go
+++ b/backend/internal/storage/sqlite/gen/sessions.sql.go
@@ -16,7 +16,7 @@ import (
 const getSession = `-- name: GetSession :one
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision, model
 FROM sessions WHERE id = ?
 `
 
@@ -44,6 +44,7 @@ func (q *Queries) GetSession(ctx context.Context, id domain.SessionID) (Session,
 		&i.FirstSignalAt,
 		&i.PreviewURL,
 		&i.PreviewRevision,
+		&i.Model,
 	)
 	return i, err
 }
@@ -53,8 +54,8 @@ INSERT INTO sessions (
     id, project_id, num, issue_id, kind, harness, display_name,
     activity_state, activity_last_at, first_signal_at, is_terminated,
     branch, workspace_path, runtime_handle_id, agent_session_id, prompt,
-    preview_url, preview_revision, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    preview_url, preview_revision, model, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type InsertSessionParams struct {
@@ -76,6 +77,7 @@ type InsertSessionParams struct {
 	Prompt          string
 	PreviewURL      string
 	PreviewRevision int64
+	Model           string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
@@ -100,6 +102,7 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) er
 		arg.Prompt,
 		arg.PreviewURL,
 		arg.PreviewRevision,
+		arg.Model,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)
@@ -109,7 +112,7 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) er
 const listAllSessions = `-- name: ListAllSessions :many
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision, model
 FROM sessions ORDER BY project_id, num
 `
 
@@ -143,6 +146,7 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]Session, error) {
 			&i.FirstSignalAt,
 			&i.PreviewURL,
 			&i.PreviewRevision,
+			&i.Model,
 		); err != nil {
 			return nil, err
 		}
@@ -160,7 +164,7 @@ func (q *Queries) ListAllSessions(ctx context.Context) ([]Session, error) {
 const listSessionsByProject = `-- name: ListSessionsByProject :many
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision, model
 FROM sessions WHERE project_id = ? ORDER BY num
 `
 
@@ -194,6 +198,7 @@ func (q *Queries) ListSessionsByProject(ctx context.Context, projectID domain.Pr
 			&i.FirstSignalAt,
 			&i.PreviewURL,
 			&i.PreviewRevision,
+			&i.Model,
 		); err != nil {
 			return nil, err
 		}
@@ -287,7 +292,7 @@ UPDATE sessions SET
     issue_id = ?, kind = ?, harness = ?, display_name = ?,
     activity_state = ?, activity_last_at = ?, first_signal_at = ?, is_terminated = ?,
     branch = ?, workspace_path = ?, runtime_handle_id = ?, agent_session_id = ?, prompt = ?,
-    preview_url = ?, preview_revision = ?, updated_at = ?
+    preview_url = ?, preview_revision = ?, model = ?, updated_at = ?
 WHERE id = ?
 `
 
@@ -307,6 +312,7 @@ type UpdateSessionParams struct {
 	Prompt          string
 	PreviewURL      string
 	PreviewRevision int64
+	Model           string
 	UpdatedAt       time.Time
 	ID              domain.SessionID
 }
@@ -328,6 +334,7 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) er
 		arg.Prompt,
 		arg.PreviewURL,
 		arg.PreviewRevision,
+		arg.Model,
 		arg.UpdatedAt,
 		arg.ID,
 	)

--- a/backend/internal/storage/sqlite/migrations/0020_add_session_model.sql
+++ b/backend/internal/storage/sqlite/migrations/0020_add_session_model.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- model is the agent model this session launched with, captured at spawn time
+-- (from `ao spawn --model` or the resolved project/role worker.agentConfig.model).
+-- It is durable so a daemon restart restores the session on the SAME model
+-- rather than re-resolving from project config, which may have since changed.
+-- Defaulting to '' keeps existing rows valid without backfill; '' means "use the
+-- resolved project/role config model" on restore (unchanged legacy behaviour).
+-- +goose StatementBegin
+ALTER TABLE sessions ADD COLUMN model TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE sessions DROP COLUMN model;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/sessions.sql
+++ b/backend/internal/storage/sqlite/queries/sessions.sql
@@ -6,33 +6,33 @@ INSERT INTO sessions (
     id, project_id, num, issue_id, kind, harness, display_name,
     activity_state, activity_last_at, first_signal_at, is_terminated,
     branch, workspace_path, runtime_handle_id, agent_session_id, prompt,
-    preview_url, preview_revision, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    preview_url, preview_revision, model, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: UpdateSession :exec
 UPDATE sessions SET
     issue_id = ?, kind = ?, harness = ?, display_name = ?,
     activity_state = ?, activity_last_at = ?, first_signal_at = ?, is_terminated = ?,
     branch = ?, workspace_path = ?, runtime_handle_id = ?, agent_session_id = ?, prompt = ?,
-    preview_url = ?, preview_revision = ?, updated_at = ?
+    preview_url = ?, preview_revision = ?, model = ?, updated_at = ?
 WHERE id = ?;
 
 -- name: GetSession :one
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision, model
 FROM sessions WHERE id = ?;
 
 -- name: ListSessionsByProject :many
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision, model
 FROM sessions WHERE project_id = ? ORDER BY num;
 
 -- name: ListAllSessions :many
 SELECT id, project_id, num, issue_id, kind, harness,
     activity_state, activity_last_at, is_terminated, branch, workspace_path,
-    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision
+    runtime_handle_id, agent_session_id, prompt, created_at, updated_at, display_name, first_signal_at, preview_url, preview_revision, model
 FROM sessions ORDER BY project_id, num;
 
 

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -208,6 +208,7 @@ func rowToRecord(row gen.Session) domain.SessionRecord {
 			Prompt:          row.Prompt,
 			PreviewURL:      row.PreviewURL,
 			PreviewRevision: row.PreviewRevision,
+			Model:           row.Model,
 		},
 		CreatedAt: row.CreatedAt,
 		UpdatedAt: row.UpdatedAt,
@@ -235,6 +236,7 @@ func recordToInsert(rec domain.SessionRecord, num int64) gen.InsertSessionParams
 		Prompt:          rec.Metadata.Prompt,
 		PreviewURL:      rec.Metadata.PreviewURL,
 		PreviewRevision: rec.Metadata.PreviewRevision,
+		Model:           rec.Metadata.Model,
 		CreatedAt:       rec.CreatedAt,
 		UpdatedAt:       rec.UpdatedAt,
 	}
@@ -259,6 +261,7 @@ func recordToUpdate(rec domain.SessionRecord) gen.UpdateSessionParams {
 		Prompt:          rec.Metadata.Prompt,
 		PreviewURL:      rec.Metadata.PreviewURL,
 		PreviewRevision: rec.Metadata.PreviewRevision,
+		Model:           rec.Metadata.Model,
 		UpdatedAt:       rec.UpdatedAt,
 	}
 }

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -821,3 +821,39 @@ func TestUpsertSessionWorktreeEmptyStateDefaultsToActive(t *testing.T) {
 		t.Fatalf("State = %q, want %q", got.State, "active")
 	}
 }
+
+func TestSessionModelPersists(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	rec := sampleRecord("mer")
+	rec.Metadata.Model = "claude-opus-4-8"
+	created, err := s.CreateSession(ctx, rec)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	got, ok, err := s.GetSession(ctx, created.ID)
+	if err != nil || !ok {
+		t.Fatalf("get session: ok=%v err=%v", ok, err)
+	}
+	if got.Metadata.Model != "claude-opus-4-8" {
+		t.Fatalf("model not persisted across reload: got %q want %q", got.Metadata.Model, "claude-opus-4-8")
+	}
+}
+
+func TestSessionModelEmptyByDefault(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	created, err := s.CreateSession(ctx, sampleRecord("mer"))
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	got, _, err := s.GetSession(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if got.Metadata.Model != "" {
+		t.Fatalf("expected empty model, got %q", got.Metadata.Model)
+	}
+}


### PR DESCRIPTION
`ao spawn --model <model>` overrides the agent model for a single session, taking precedence over the project/role worker.agentConfig.model. The value is threaded CLI -> POST /sessions -> SpawnConfig -> session manager, which applies it on top of effectiveAgentConfig (base <- role <- per-spawn) so the claude-code adapter (and the codex adapter, updated here) emit `--model`.

Persisted on the session record (new `model` column, migration 0020) and re-applied on restore, so a daemon restart restores the session on the same model instead of re-resolving from project config -- matching how branch / prompt / workspace already survive restarts.

Tests: codex adapter flag emission (+ ordering before the prompt separator); sqlite persistence round-trip; manager spawn override + config fallback.