### PR TITLE
fix: prioritize PR status over waiting input

### DIFF
--- a/backend/internal/service/session/status.go
+++ b/backend/internal/service/session/status.go
@@ -32,16 +32,16 @@ func deriveStatus(rec domain.SessionRecord, prs []domain.PRFacts, now time.Time,
 		return domain.StatusTerminated
 	}
 
-	if rec.Activity.State == domain.ActivityWaitingInput {
-		return domain.StatusNeedsInput
-	}
-
 	open := openPRs(prs)
 	if len(open) > 0 {
 		return aggregatePRStatus(open)
 	}
 	if anyMerged(prs) {
 		return domain.StatusMerged
+	}
+
+	if rec.Activity.State == domain.ActivityWaitingInput {
+		return domain.StatusNeedsInput
 	}
 
 	if rec.Activity.State == domain.ActivityActive {

--- a/backend/internal/service/session/status_test.go
+++ b/backend/internal/service/session/status_test.go
@@ -41,7 +41,9 @@ func TestServiceDerivesStatusFromSessionFactsAndPR(t *testing.T) {
 	}{
 		{"terminated", statusRec(domain.ActivityExited, true), nil, false, domain.StatusTerminated},
 		{"merged-pr", statusRec(domain.ActivityIdle, true), statusPR(domain.PRFacts{Merged: true}), false, domain.StatusMerged},
-		{"needs-input", statusRec(domain.ActivityWaitingInput, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusNeedsInput},
+		{"waiting-input-with-open-pr", statusRec(domain.ActivityWaitingInput, false), statusPR(domain.PRFacts{}), false, domain.StatusPROpen},
+		{"waiting-input-with-failing-pr", statusRec(domain.ActivityWaitingInput, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusCIFailed},
+		{"waiting-input-without-pr", statusRec(domain.ActivityWaitingInput, false), nil, false, domain.StatusNeedsInput},
 		{"ci-failed", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusCIFailed},
 		{"draft", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{Draft: true}), false, domain.StatusDraft},
 		{"changes-requested", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{Review: domain.ReviewChangesRequest}), false, domain.StatusChangesRequested},

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -426,17 +426,18 @@ The `service.Session` computes display status from durable facts using this prec
 ```mermaid
 flowchart TD
     CheckTerm{is_terminated?}
-    CheckTerm -->|Yes| PRMerged{PR merged?}
-    CheckTerm -->|No| CheckWait{activity_state<br/>== waiting_input?}
+    CheckTerm -->|Yes| TermPRMerged{PR merged?}
+    CheckTerm -->|No| CheckOpenPR{Has open PR facts?}
 
-    PRMerged -->|Yes| Merged[merged]
-    PRMerged -->|No| Terminated[terminated]
+    TermPRMerged -->|Yes| Merged[merged]
+    TermPRMerged -->|No| Terminated[terminated]
 
+    CheckOpenPR -->|Yes| PRPipeline[PR Pipeline Check]
+    CheckOpenPR -->|No| LivePRMerged{PR merged?}
+    LivePRMerged -->|Yes| Merged
+    LivePRMerged -->|No| CheckWait{activity_state<br/>== waiting_input?}
     CheckWait -->|Yes| NeedsInput[needs_input]
-    CheckWait -->|No| CheckPR{Has PR facts?}
-
-    CheckPR -->|Yes| PRPipeline[PR Pipeline Check]
-    CheckPR -->|No| CheckActive{activity_state<br/>== active?}
+    CheckWait -->|No| CheckActive{activity_state<br/>== active?}
 
     PRPipeline --> PRState{PR State}
     PRState -->|ci failed| CIFailed[ci_failed]


### PR DESCRIPTION
## Summary

Prioritize PR-derived session statuses over a sticky `waiting_input` activity state so workers that have opened PRs show the actionable PR pipeline state instead of remaining pinned to `needs_input`.

## Root Cause

`deriveStatus` returned `needs_input` before evaluating PR facts. If a worker's last persisted activity signal was `waiting_input`, newer PR facts such as an open PR or failing CI could not affect the display status.

## Changes

- Evaluate open and merged PR facts before falling back to `waiting_input` for live sessions.
- Update status derivation tests for `waiting_input` combined with open, failing, and absent PR facts.
- Refresh the architecture status precedence diagram to match the read model.

## Testing

- `git diff --check`
- `GOTOOLCHAIN=auto GOSUMDB=sum.golang.org go test ./internal/service/session`
- Attempted `GOTOOLCHAIN=auto GOSUMDB=sum.golang.org go test ./...`; it hit unrelated local terminal/runtime failures in `backend/internal/adapters/runtime/tmux` (`no server running on /tmp/tmux-1000/default`) and `backend/internal/terminal` (fish-shell parsing during an attachment integration test). The changed session package passed.

Fixes AgentWrapper/agent-orchestrator#2174
