### PR TITLE
[codex] fix empty project repo error

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -33,14 +33,15 @@ var (
 // and errors.Is works because the adapter wraps the ports sentinel.
 var ErrPreservedConflict = ports.ErrPreservedConflict
 
-// ErrBranchCheckedOutElsewhere and ErrBranchNotFetched are adapter-local aliases
-// of the port-level sentinels: they preserve the gitworktree-prefixed message
-// while letting the service layer match on ports.ErrWorkspaceBranchCheckedOutElsewhere
-// / ports.ErrWorkspaceBranchNotFetched without importing this package. Tests
-// inside the adapter use these names; callers outside use the port sentinels.
+// ErrBranchCheckedOutElsewhere, ErrBranchNotFetched, and ErrRepoUnborn are
+// adapter-local aliases of the port-level sentinels: they preserve the
+// gitworktree-prefixed message while letting the service layer match on ports
+// sentinels without importing this package. Tests inside the adapter use these
+// names; callers outside use the port sentinels.
 var (
 	ErrBranchCheckedOutElsewhere = ports.ErrWorkspaceBranchCheckedOutElsewhere
 	ErrBranchNotFetched          = ports.ErrWorkspaceBranchNotFetched
+	ErrRepoUnborn                = ports.ErrWorkspaceRepoUnborn
 	ErrBranchInvalid             = ports.ErrWorkspaceBranchInvalid
 )
 
@@ -497,6 +498,13 @@ func (w *Workspace) addWorktree(ctx context.Context, repo, path, branch, baseBra
 	baseRef, err := w.resolveBaseRef(ctx, repo, branch, baseBranch)
 	if err != nil {
 		if errors.Is(err, errNoBaseRef) {
+			hasCommit, headErr := w.repoHasCommit(ctx, repo)
+			if headErr != nil {
+				return headErr
+			}
+			if !hasCommit {
+				return fmt.Errorf("%w: %q has no commits yet", ErrRepoUnborn, repo)
+			}
 			return fmt.Errorf("%w: %q has no local head, no remote, and no tag — run `git fetch` then retry", ErrBranchNotFetched, branch)
 		}
 		return err
@@ -547,6 +555,18 @@ func (w *Workspace) resolveBaseRef(ctx context.Context, repo, branch, baseBranch
 		return tagRef, nil
 	}
 	return "", fmt.Errorf("%w for branch %q (tried %s, %s)", errNoBaseRef, branch, strings.Join(candidates, ", "), tagRef)
+}
+
+func (w *Workspace) repoHasCommit(ctx context.Context, repo string) (bool, error) {
+	_, err := w.run(ctx, w.binary, revParseHeadArgs(repo)...)
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 128 {
+		return false, nil
+	}
+	return false, fmt.Errorf("gitworktree: verify repo HEAD: %w", err)
 }
 
 func (w *Workspace) refExists(ctx context.Context, repo, ref string) (bool, error) {

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -457,6 +457,8 @@ func TestAddWorktreeReportsBranchNotFetched(t *testing.T) {
 			return nil, nil
 		case strings.Contains(joined, "worktree list --porcelain"):
 			return nil, nil
+		case strings.Contains(joined, "rev-parse --verify HEAD"):
+			return []byte("commit"), nil
 		case strings.Contains(joined, "rev-parse"):
 			return nil, commandError{args: args, err: exitOne}
 		default:
@@ -467,6 +469,43 @@ func TestAddWorktreeReportsBranchNotFetched(t *testing.T) {
 	_, err = ws.Create(context.Background(), ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess", Branch: "feature/missing"})
 	if !errors.Is(err, ports.ErrWorkspaceBranchNotFetched) {
 		t.Fatalf("err = %v, want ports.ErrWorkspaceBranchNotFetched", err)
+	}
+}
+
+func TestAddWorktreeReportsUnbornRepository(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	exitOne := func() error {
+		cmd := exec.Command("sh", "-c", "exit 1")
+		return cmd.Run()
+	}()
+	exit128 := func() error {
+		cmd := exec.Command("sh", "-c", "exit 128")
+		return cmd.Run()
+	}()
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "check-ref-format"):
+			return nil, nil
+		case strings.Contains(joined, "worktree list --porcelain"):
+			return nil, nil
+		case strings.Contains(joined, "rev-parse --verify HEAD"):
+			return nil, commandError{args: args, err: exit128}
+		case strings.Contains(joined, "rev-parse"):
+			return nil, commandError{args: args, err: exitOne}
+		default:
+			t.Fatalf("unexpected git invocation: %v", args)
+			return nil, nil
+		}
+	}
+	_, err = ws.Create(context.Background(), ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess", Branch: "feature/unborn"})
+	if !errors.Is(err, ports.ErrWorkspaceRepoUnborn) {
+		t.Fatalf("err = %v, want ports.ErrWorkspaceRepoUnborn", err)
 	}
 }
 

--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -206,6 +206,10 @@ func TestProjectsAPI_AddValidationAndConflicts(t *testing.T) {
 	repoB := gitRepo(t, "repo-b")
 
 	notRepo := t.TempDir()
+	unbornRepo := filepath.Join(t.TempDir(), "unborn")
+	if out, err := exec.Command("git", "init", "-b", "main", unbornRepo).CombinedOutput(); err != nil {
+		t.Fatalf("git init unborn fixture: %v\n%s", err, out)
+	}
 
 	cases := []struct {
 		name, body, wantCode string
@@ -218,6 +222,8 @@ func TestProjectsAPI_AddValidationAndConflicts(t *testing.T) {
 		{name: "missing path", body: `{}`, wantStatus: 400, wantCode: "PATH_REQUIRED"},
 
 		{name: "not git", body: `{"path":` + quote(notRepo) + `}`, wantStatus: 400, wantCode: "NOT_A_GIT_REPO"},
+
+		{name: "unborn git repo", body: `{"path":` + quote(unbornRepo) + `}`, wantStatus: 400, wantCode: "PROJECT_UNBORN"},
 	}
 
 	for _, tc := range cases {
@@ -513,6 +519,15 @@ func gitRepo(t *testing.T, name string) string {
 
 		t.Fatalf("git init fixture: %v\n%s", err, out)
 
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write readme fixture: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", dir, "add", "README.md").CombinedOutput(); err != nil {
+		t.Fatalf("git add fixture: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", dir, "-c", "user.email=ao@example.com", "-c", "user.name=AO Test", "commit", "-m", "initial").CombinedOutput(); err != nil {
+		t.Fatalf("git commit fixture: %v\n%s", err, out)
 	}
 
 	return dir

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -151,6 +151,9 @@ var (
 	// ErrWorkspaceBranchNotFetched reports the requested branch exists nowhere
 	// reachable (no local head, no remote-tracking branch, no tag).
 	ErrWorkspaceBranchNotFetched = errors.New("workspace: branch is not fetched")
+	// ErrWorkspaceRepoUnborn reports the source repository has no commits, so
+	// git has no commit object to use as a worktree base.
+	ErrWorkspaceRepoUnborn = errors.New("workspace: repository has no commits")
 	// ErrWorkspaceBranchInvalid reports the requested branch name is not a valid
 	// git ref (rejected by `git check-ref-format`).
 	ErrWorkspaceBranchInvalid = errors.New("workspace: invalid branch name")

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -209,6 +209,12 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 	if !isGitRepo(path) {
 		return Project{}, apierr.Invalid("NOT_A_GIT_REPO", "Repository path must point to a git repository", nil)
 	}
+	if _, err := gitOutput(ctx, path, "rev-parse", "--verify", "HEAD"); err != nil {
+		return Project{}, apierr.Invalid("PROJECT_UNBORN", "This repository has no commits yet. Create an initial commit before adding it to AO.", map[string]any{
+			"path":         path,
+			"suggestedFix": "Add and commit a file, or run `git commit --allow-empty -m \"initial commit\"`, then add the project again.",
+		})
+	}
 	// Record the repo's actual checked-out branch as the project default so
 	// session worktrees base off a branch that exists. Without this a repo on
 	// `master` (or any non-`main` default) falls back to DefaultBranchName and

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -38,6 +38,7 @@ func gitRepo(t *testing.T) string {
 	if out, err := exec.Command("git", "init", "-b", "main", dir).CombinedOutput(); err != nil {
 		t.Fatalf("git unavailable: %v (%s)", err, out)
 	}
+	commitTestFile(t, dir)
 	return dir
 }
 
@@ -49,7 +50,21 @@ func gitRepoOnBranch(t *testing.T, branch string) string {
 	if out, err := exec.Command("git", "init", "-b", branch, dir).CombinedOutput(); err != nil {
 		t.Fatalf("git unavailable: %v (%s)", err, out)
 	}
+	commitTestFile(t, dir)
 	return dir
+}
+
+func commitTestFile(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", dir, "add", "README.md").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", dir, "-c", "user.email=ao@example.com", "-c", "user.name=AO Test", "commit", "-m", "initial").CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v (%s)", err, out)
+	}
 }
 
 // gitRepoWithOriginHead creates a repo whose remote default (origin/HEAD) points
@@ -440,6 +455,13 @@ func TestManager_AddValidationAndConflicts(t *testing.T) {
 
 	_, err = m.Add(ctx, project.AddInput{Path: t.TempDir()}) // exists but not a git repo
 	wantCode(t, err, "NOT_A_GIT_REPO")
+
+	unbornRepo := t.TempDir()
+	if out, err := exec.Command("git", "init", "-b", "main", unbornRepo).CombinedOutput(); err != nil {
+		t.Fatalf("git init unborn repo: %v (%s)", err, out)
+	}
+	_, err = m.Add(ctx, project.AddInput{Path: unbornRepo})
+	wantCode(t, err, "PROJECT_UNBORN")
 
 	// An embedded ".." passes the id pattern but would yield an invalid git
 	// branch (ao/a..b-1) at spawn time; reject it up front as a clear 400.

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -476,6 +476,8 @@ func toAPIError(err error) error {
 		return apierr.Conflict("BRANCH_CHECKED_OUT_ELSEWHERE", err.Error(), nil)
 	case errors.Is(err, ports.ErrWorkspaceBranchNotFetched):
 		return apierr.Invalid("BRANCH_NOT_FETCHED", err.Error(), nil)
+	case errors.Is(err, ports.ErrWorkspaceRepoUnborn):
+		return apierr.Invalid("PROJECT_UNBORN", "This repository has no commits yet. Create an initial commit before starting an AO session.", nil)
 	case errors.Is(err, ports.ErrWorkspaceBranchInvalid):
 		return apierr.Invalid("INVALID_BRANCH", err.Error(), nil)
 	case errors.Is(err, ports.ErrAgentBinaryNotFound):

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -526,6 +526,7 @@ func TestToAPIErrorMapsWorkspaceBranchSentinels(t *testing.T) {
 	}{
 		{"checked out elsewhere", fmt.Errorf("spawn mer-1: workspace: %w: \"x\" is checked out at \"/tmp\"", ports.ErrWorkspaceBranchCheckedOutElsewhere), apierr.KindConflict, "BRANCH_CHECKED_OUT_ELSEWHERE"},
 		{"not fetched", fmt.Errorf("spawn mer-1: workspace: %w: \"x\" has no local head", ports.ErrWorkspaceBranchNotFetched), apierr.KindInvalid, "BRANCH_NOT_FETCHED"},
+		{"unborn repo", fmt.Errorf("spawn mer-1: workspace: %w: \"/repo\" has no commits yet", ports.ErrWorkspaceRepoUnborn), apierr.KindInvalid, "PROJECT_UNBORN"},
 		{"invalid branch", fmt.Errorf("spawn mer-1: workspace: %w: \"bad!!\" (exit 1)", ports.ErrWorkspaceBranchInvalid), apierr.KindInvalid, "INVALID_BRANCH"},
 		{"agent binary not found", fmt.Errorf("spawn mer-1: %w", ports.ErrAgentBinaryNotFound), apierr.KindInvalid, "AGENT_BINARY_NOT_FOUND"},
 		{"unknown harness", fmt.Errorf("spawn: %w: %q", sessionmanager.ErrUnknownHarness, "bogus"), apierr.KindInvalid, "UNKNOWN_HARNESS"},


### PR DESCRIPTION
## Summary

- reject single-repo projects with no commits using a clear `PROJECT_UNBORN` API error
- add a defensive workspace sentinel so already-registered unborn repos do not surface as `BRANCH_NOT_FETCHED`
- update project, HTTP controller, session error mapping, and git worktree tests

## Root Cause

Freshly initialized repositories have an unborn `HEAD`: Git can report a branch name, but there is no commit object to use as a worktree base. AO let those repos register, then session spawn collapsed the missing base into the existing branch-not-fetched error, which incorrectly told users to run `git fetch`.

## Testing

- `go test ./internal/service/project ./internal/adapters/workspace/gitworktree ./internal/service/session ./internal/httpd/controllers`
- `go test ./internal/httpd/...`
- `git diff --check`

Full `go test ./...` was attempted; changed areas passed, but unrelated tmux/terminal integration tests failed in this environment with tmux target/session errors.

Fixes AgentWrapper/agent-orchestrator#2196