### PR TITLE
feat: Global Settings (migration + update channel) + ao start download progress

### DIFF
--- a/backend/internal/adapters/runtime/ptyexec/spawn_windows.go
+++ b/backend/internal/adapters/runtime/ptyexec/spawn_windows.go
@@ -8,8 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	winpty "github.com/aymanbagabas/go-pty"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 // detachGrace mirrors the Unix value: how long Close waits for the attach

--- a/backend/internal/cli/start.go
+++ b/backend/internal/cli/start.go
@@ -298,7 +298,7 @@ func (c *commandContext) fetchAppDarwin(ctx context.Context, w io.Writer) (strin
 // untested on real Windows hardware (this build host is macOS). If the installed
 // exe isn't where electron-builder's defaults put it, this surfaces as a clear
 // "not found" error rather than silently launching the wrong thing.
-func (c *commandContext) fetchAppWindows(ctx context.Context) (string, error) {
+func (c *commandContext) fetchAppWindows(ctx context.Context, w io.Writer) (string, error) {
 	asset, err := assetName()
 	if err != nil {
 		return "", err
@@ -318,10 +318,13 @@ func (c *commandContext) fetchAppWindows(ctx context.Context) (string, error) {
 	}
 
 	installerPath := filepath.Join(staging, asset)
-	if err := c.download(ctx, url, installerPath); err != nil {
+	if err := c.download(ctx, w, url, asset, installerPath); err != nil {
 		return "", fmt.Errorf("download %s: %w", url, err)
 	}
 
+	// The `/S` installer runs with no UI and no output; announce it so the wait
+	// after the download reads as progress, not a hang.
+	_, _ = fmt.Fprintln(w, "Installing...")
 	// NSIS silent install (`/S`) to the default per-user location. The installer
 	// is configured oneClick:false/perMachine:false, so `/S` installs without UI
 	// under %LOCALAPPDATA% for the current user.
@@ -343,7 +346,7 @@ func (c *commandContext) fetchAppWindows(ctx context.Context) (string, error) {
 // fetchAppLinux downloads the self-contained AppImage to a stable path under
 // ~/.ao, makes it executable, and returns it. There is no install step (spec
 // §6.3). Re-runs resolve the existing file via knownAppLocations and skip fetch.
-func (c *commandContext) fetchAppLinux(ctx context.Context) (string, error) {
+func (c *commandContext) fetchAppLinux(ctx context.Context, w io.Writer) (string, error) {
 	asset, err := assetName()
 	if err != nil {
 		return "", err
@@ -357,9 +360,12 @@ func (c *commandContext) fetchAppLinux(ctx context.Context) (string, error) {
 	// Download to a temp name in the same dir, then rename for atomicity so a
 	// killed download never leaves a half-written executable at the stable path.
 	tmpPath := appPath + ".part"
-	if err := c.download(ctx, url, tmpPath); err != nil {
+	if err := c.download(ctx, w, url, asset, tmpPath); err != nil {
 		return "", fmt.Errorf("download %s: %w", url, err)
 	}
+	// chmod+rename is near-instant, but a one-line marker keeps the post-download
+	// step from looking silent and matches the other platforms.
+	_, _ = fmt.Fprintln(w, "Installing...")
 	// An AppImage is a self-contained executable; it must be 0755 to launch.
 	if err := os.Chmod(tmpPath, 0o755); err != nil { //nolint:gosec // G302: AppImage must be executable
 		return "", fmt.Errorf("chmod AppImage: %w", err)
@@ -373,8 +379,13 @@ func (c *commandContext) fetchAppLinux(ctx context.Context) (string, error) {
 	return appPath, nil
 }
 
-// download streams url to dst using the injected HTTP client.
-func (c *commandContext) download(ctx context.Context, url, dst string) error {
+// download streams url to dst using the injected HTTP client, reporting progress
+// to w. asset is the human-facing filename used in the announce line. A silent
+// hundreds-of-MB fetch reads as a hang, so we print a start line (with the size
+// from Content-Length when present) and then progress: a live carriage-return
+// percentage when w is an interactive terminal, or a plain start+done pair when
+// it is not (CI, pipes, redirected output).
+func (c *commandContext) download(ctx context.Context, w io.Writer, url, asset, dst string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return err
@@ -394,15 +405,93 @@ func (c *commandContext) download(ctx context.Context, url, dst string) error {
 		return fmt.Errorf("unexpected status %s", resp.Status)
 	}
 
+	// Content-Length is -1 when the server omits the header; total<=0 means the
+	// percentage is unknown and we report transferred bytes instead.
+	total := resp.ContentLength
+	if total > 0 {
+		_, _ = fmt.Fprintf(w, "Downloading Agent Orchestrator (%s, ~%s) from %s...\n", asset, humanBytes(total), releaseRepo)
+	} else {
+		_, _ = fmt.Fprintf(w, "Downloading Agent Orchestrator (%s) from %s...\n", asset, releaseRepo)
+	}
+
 	f, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = f.Close() }()
-	if _, err := io.Copy(f, resp.Body); err != nil {
+
+	pw := &progressWriter{w: w, total: total, tty: writerIsInteractive(w)}
+	if _, err := io.Copy(f, io.TeeReader(resp.Body, pw)); err != nil {
 		return err
 	}
+	pw.done()
 	return f.Close()
+}
+
+// progressWriter counts bytes copied through it and renders download progress to
+// w. On an interactive terminal it overwrites a single line with a carriage
+// return; otherwise it stays quiet during the copy and prints one "Done" line at
+// the end, so logs and pipes never fill with \r spam or per-chunk noise.
+type progressWriter struct {
+	w       io.Writer
+	total   int64 // bytes; <=0 when Content-Length was absent
+	tty     bool
+	written int64
+}
+
+func (p *progressWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	p.written += int64(n)
+	if p.tty {
+		if p.total > 0 {
+			pct := p.written * 100 / p.total
+			_, _ = fmt.Fprintf(p.w, "\r  %d%% (%s / %s)", pct, humanBytes(p.written), humanBytes(p.total))
+		} else {
+			_, _ = fmt.Fprintf(p.w, "\r  %s", humanBytes(p.written))
+		}
+	}
+	return n, nil
+}
+
+// done emits the terminal progress line. On a TTY it closes the live line with a
+// newline; off a TTY it prints the single completion line.
+func (p *progressWriter) done() {
+	if p.tty {
+		_, _ = fmt.Fprintln(p.w)
+		return
+	}
+	_, _ = fmt.Fprintf(p.w, "Downloaded %s.\n", humanBytes(p.written))
+}
+
+// writerIsInteractive reports whether w is an interactive terminal, mirroring
+// stdinIsInteractive: only a real *os.File backed by a character device counts,
+// so a bytes.Buffer or pipe is treated as non-interactive.
+func writerIsInteractive(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+// humanBytes formats a byte count with a binary-unit suffix (KiB, MiB, ...),
+// e.g. 314572800 -> "300.0 MiB". A tiny hand-rolled formatter avoids promoting
+// the already-indirect go-humanize dependency to a direct one for one string.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
 }
 
 // assetName maps the current GOOS/GOARCH to the stable release asset name the

--- a/backend/internal/cli/start.go
+++ b/backend/internal/cli/start.go
@@ -87,7 +87,9 @@ func (c *commandContext) runStart(ctx context.Context, cmd *cobra.Command, opts 
 
 	var err error
 	if appPath == "" {
-		appPath, err = c.fetchApp(ctx)
+		// Progress for the fetch path goes to stderr so stdout stays pure JSON
+		// under --json. The resolve-and-launch fast path above stays quiet.
+		appPath, err = c.fetchApp(ctx, cmd.ErrOrStderr())
 		if err != nil {
 			return err
 		}
@@ -233,14 +235,14 @@ func isUsableBundle(p string) bool {
 // the resolved bundle path (spec §6.3). macOS unpacks a signed zip into staging,
 // Windows runs the NSIS installer silently, and Linux drops a chmod'd AppImage at
 // a stable path.
-func (c *commandContext) fetchApp(ctx context.Context) (string, error) {
+func (c *commandContext) fetchApp(ctx context.Context, w io.Writer) (string, error) {
 	switch runtime.GOOS {
 	case "darwin":
-		return c.fetchAppDarwin(ctx)
+		return c.fetchAppDarwin(ctx, w)
 	case "windows":
-		return c.fetchAppWindows(ctx)
+		return c.fetchAppWindows(ctx, w)
 	case "linux":
-		return c.fetchAppLinux(ctx)
+		return c.fetchAppLinux(ctx, w)
 	default:
 		return "", fmt.Errorf("ao start: fetch not supported on %s", runtime.GOOS)
 	}
@@ -248,7 +250,7 @@ func (c *commandContext) fetchApp(ctx context.Context) (string, error) {
 
 // fetchAppDarwin downloads the latest macOS release zip and unpacks it into a
 // staging dir under ~/.ao/staging, returning the .app bundle path (spec §6.3).
-func (c *commandContext) fetchAppDarwin(ctx context.Context) (string, error) {
+func (c *commandContext) fetchAppDarwin(ctx context.Context, w io.Writer) (string, error) {
 	asset, err := assetName()
 	if err != nil {
 		return "", err
@@ -270,10 +272,13 @@ func (c *commandContext) fetchAppDarwin(ctx context.Context) (string, error) {
 	}
 
 	zipPath := filepath.Join(staging, asset)
-	if err := c.download(ctx, url, zipPath); err != nil {
+	if err := c.download(ctx, w, url, asset, zipPath); err != nil {
 		return "", fmt.Errorf("download %s: %w", url, err)
 	}
 
+	// The unpack step is silent and can take seconds on a large bundle; announce
+	// it so a quiet `ao start` doesn't look hung after the download finishes.
+	_, _ = fmt.Fprintln(w, "Unpacking...")
 	// ditto preserves the .app code signature; plain unzip corrupts it (spec §6.3).
 	if out, err := c.deps.CommandOutput(ctx, "ditto", "-x", "-k", zipPath, staging); err != nil {
 		return "", fmt.Errorf("ditto unpack: %w: %s", err, out)

--- a/backend/internal/cli/start_test.go
+++ b/backend/internal/cli/start_test.go
@@ -1,14 +1,17 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -317,7 +320,7 @@ func TestDownload_IgnoresShortClientTimeout(t *testing.T) {
 	}.withDefaults()}
 
 	dst := filepath.Join(t.TempDir(), "out.zip")
-	if err := c.download(context.Background(), srv.URL, dst); err != nil {
+	if err := c.download(context.Background(), io.Discard, srv.URL, "out.zip", dst); err != nil {
 		t.Fatalf("download failed (short client timeout leaked into large-asset path?): %v", err)
 	}
 	got, err := os.ReadFile(dst)
@@ -326,6 +329,104 @@ func TestDownload_IgnoresShortClientTimeout(t *testing.T) {
 	}
 	if string(got) != body {
 		t.Fatalf("downloaded %q, want %q", got, body)
+	}
+}
+
+// TestDownload_NonTTYProgress proves a non-interactive writer (a bytes.Buffer is
+// not an *os.File, so it's non-TTY) gets a plain start line plus a final done
+// line and NO carriage returns, while the bytes still land on disk correctly.
+func TestDownload_NonTTYProgress(t *testing.T) {
+	const body = "release-zip-bytes-payload"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body)) // net/http sets Content-Length for a known body
+	}))
+	t.Cleanup(srv.Close)
+
+	orig := releaseRepo
+	releaseRepo = "owner/repo"
+	t.Cleanup(func() { releaseRepo = orig })
+
+	c := &commandContext{deps: Deps{}.withDefaults()}
+	dst := filepath.Join(t.TempDir(), "out.zip")
+
+	var buf bytes.Buffer
+	if err := c.download(context.Background(), &buf, srv.URL, "agent-orchestrator.zip", dst); err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+
+	// Bytes on disk are intact.
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != body {
+		t.Fatalf("downloaded %q, want %q", got, body)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "\r") {
+		t.Fatalf("non-TTY progress must not emit carriage returns, got %q", out)
+	}
+	// Start line: asset name, size, and repo are all present.
+	if !strings.Contains(out, "Downloading Agent Orchestrator (agent-orchestrator.zip, ") {
+		t.Fatalf("missing start line in %q", out)
+	}
+	if !strings.Contains(out, "from owner/repo...") {
+		t.Fatalf("start line missing repo in %q", out)
+	}
+	// Done line is present (the only per-copy line off a TTY).
+	if !strings.Contains(out, "Downloaded ") {
+		t.Fatalf("missing done line in %q", out)
+	}
+}
+
+// TestDownload_NoContentLengthOmitsSize proves the start line drops the size
+// segment when the server omits Content-Length, and still reports transferred
+// bytes on the done line.
+func TestDownload_NoContentLengthOmitsSize(t *testing.T) {
+	const body = "streamed-bytes"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Chunked transfer (no Content-Length): flush so the header omits length.
+		w.Header().Set("Transfer-Encoding", "chunked")
+		_, _ = w.Write([]byte(body))
+		if fl, ok := w.(http.Flusher); ok {
+			fl.Flush()
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &commandContext{deps: Deps{}.withDefaults()}
+	dst := filepath.Join(t.TempDir(), "out.bin")
+
+	var buf bytes.Buffer
+	if err := c.download(context.Background(), &buf, srv.URL, "asset.bin", dst); err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+	out := buf.String()
+	// No "~<size>)" segment when Content-Length is absent.
+	if strings.Contains(out, "~") {
+		t.Fatalf("size segment should be omitted without Content-Length, got %q", out)
+	}
+	if !strings.Contains(out, "Downloading Agent Orchestrator (asset.bin) from") {
+		t.Fatalf("unexpected start line in %q", out)
+	}
+	if !strings.Contains(out, "Downloaded ") {
+		t.Fatalf("missing done line in %q", out)
+	}
+}
+
+func TestHumanBytes(t *testing.T) {
+	cases := map[int64]string{
+		0:         "0 B",
+		512:       "512 B",
+		1024:      "1.0 KiB",
+		1536:      "1.5 KiB",
+		314572800: "300.0 MiB",
+	}
+	for n, want := range cases {
+		if got := humanBytes(n); got != want {
+			t.Errorf("humanBytes(%d) = %q, want %q", n, got, want)
+		}
 	}
 }
 

--- a/backend/internal/legacyimport/config.go
+++ b/backend/internal/legacyimport/config.go
@@ -21,11 +21,11 @@ type legacyConfig struct {
 // represent are typed; the rest are captured as raw nodes purely so the importer
 // can report them as dropped (issue #247 §4).
 type legacyProjectConfig struct {
-	Path          string             `yaml:"path"`
-	Name          string             `yaml:"name"`
+	Path string `yaml:"path"`
+	Name string `yaml:"name"`
 	// Repo is captured as a raw YAML node but never consumed; the origin URL is
 	// re-resolved from the repo path at import time.
-	Repo *yaml.Node `yaml:"repo"`
+	Repo          *yaml.Node         `yaml:"repo"`
 	DefaultBranch string             `yaml:"defaultBranch"`
 	SessionPrefix string             `yaml:"sessionPrefix"`
 	Env           map[string]string  `yaml:"env"`

--- a/backend/internal/legacyimport/project_test.go
+++ b/backend/internal/legacyimport/project_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	yaml "gopkg.in/yaml.v3"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
 // nonNilNode returns a non-nil *yaml.Node for struct fields that are captured

--- a/backend/internal/service/importer/importer_test.go
+++ b/backend/internal/service/importer/importer_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
-type fakeStore struct{ projects map[string]domain.ProjectRecord }
+type fakeStore struct {
+	projects map[string]domain.ProjectRecord
+}
 
 func newFakeStore() *fakeStore { return &fakeStore{projects: map[string]domain.ProjectRecord{}} }
 func (f *fakeStore) GetProject(_ context.Context, id string) (domain.ProjectRecord, bool, error) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -11,8 +11,20 @@ import {
 	WebContentsView,
 	type OpenDialogOptions,
 } from "electron";
-import { startAutoUpdates, ensureUpdatePrefs } from "./main/auto-updater";
-import { readUpdateSettings, writeUpdateSettings, type UpdateSettings } from "./main/update-settings";
+import {
+	startAutoUpdates,
+	ensureUpdatePrefs,
+	checkForUpdatesNow,
+	downloadUpdateNow,
+	quitAndInstallUpdate,
+	getUpdateStatus,
+} from "./main/auto-updater";
+import {
+	readUpdateSettings,
+	writeUpdateSettings,
+	type UpdateSettings,
+	type UpdateStatus,
+} from "./main/update-settings";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
@@ -816,6 +828,19 @@ ipcMain.handle("updateSettings:set", async (_event, settings: UpdateSettings) =>
 	const runFile = runFilePath();
 	if (!runFile) return;
 	await writeUpdateSettings(path.dirname(runFile), settings);
+});
+
+ipcMain.handle("updates:getStatus", (): UpdateStatus => getUpdateStatus());
+ipcMain.handle("updates:check", async () => {
+	const runFile = runFilePath();
+	if (!runFile) return;
+	await checkForUpdatesNow(path.dirname(runFile));
+});
+ipcMain.handle("updates:download", async () => {
+	await downloadUpdateNow();
+});
+ipcMain.handle("updates:install", () => {
+	quitAndInstallUpdate();
 });
 
 ipcMain.handle("notifications:show", (_event, notification: { id: string; title: string; body?: string }) => {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -12,6 +12,7 @@ import {
 	type OpenDialogOptions,
 } from "electron";
 import { startAutoUpdates, ensureUpdatePrefs } from "./main/auto-updater";
+import { readUpdateSettings, writeUpdateSettings, type UpdateSettings } from "./main/update-settings";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
@@ -804,6 +805,17 @@ ipcMain.handle("appState:setMigration", async (_event, migration: MigrationState
 	const runFile = runFilePath();
 	if (!runFile) return;
 	await updateMigration({ stateDir: path.dirname(runFile), migration, now: () => new Date() });
+});
+
+ipcMain.handle("updateSettings:get", async (): Promise<UpdateSettings> => {
+	const runFile = runFilePath();
+	if (!runFile) return { enabled: false, channel: "latest", nightlyAck: false };
+	return readUpdateSettings(path.dirname(runFile));
+});
+ipcMain.handle("updateSettings:set", async (_event, settings: UpdateSettings) => {
+	const runFile = runFilePath();
+	if (!runFile) return;
+	await writeUpdateSettings(path.dirname(runFile), settings);
 });
 
 ipcMain.handle("notifications:show", (_event, notification: { id: string; title: string; body?: string }) => {

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1,8 +1,14 @@
 import { autoUpdater } from "electron-updater";
-import { dialog } from "electron";
+import { app, BrowserWindow, dialog } from "electron";
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { readUpdateSettings, writeUpdateSettings, UPDATE_SETTINGS_FILE_NAME } from "./update-settings";
+import {
+	readUpdateSettings,
+	writeUpdateSettings,
+	UPDATE_SETTINGS_FILE_NAME,
+	type UpdateChannel,
+	type UpdateStatus,
+} from "./update-settings";
 
 // Default release repo, mirroring backend cli.releaseRepo. Override via env for
 // fork test builds (AO_RELEASE_REPO=owner/repo).
@@ -15,6 +21,50 @@ function repo(): { owner: string; name: string } {
 	return { owner: defOwner, name: defName };
 }
 
+// configureFeed points electron-updater at the GitHub Releases feed for the
+// chosen channel. Shared by the launch auto-check and the manual Settings flow.
+function configureFeed(channel: UpdateChannel): void {
+	const { owner, name } = repo();
+	autoUpdater.setFeedURL({ provider: "github", owner, repo: name });
+	autoUpdater.channel = channel; // "latest" | "nightly"
+	autoUpdater.allowDowngrade = true; // permits a nightly -> stable channel switch
+}
+
+let lastStatus: UpdateStatus = { state: "idle" };
+let eventsWired = false;
+
+// broadcast pushes the latest update status to every renderer window so the
+// Global Settings Updates section can reflect check/download progress live.
+function broadcast(status: UpdateStatus): void {
+	lastStatus = status;
+	for (const win of BrowserWindow.getAllWindows()) {
+		if (!win.isDestroyed()) win.webContents.send("updates:status", status);
+	}
+}
+
+// wireUpdaterEvents registers electron-updater listeners once and forwards each
+// to the renderer as an UpdateStatus. Idempotent: safe to call on every entry
+// point (launch auto-check and manual check).
+function wireUpdaterEvents(): void {
+	if (eventsWired) return;
+	eventsWired = true;
+	autoUpdater.on("checking-for-update", () => broadcast({ state: "checking" }));
+	autoUpdater.on("update-available", (info) => broadcast({ state: "available", version: info?.version }));
+	autoUpdater.on("update-not-available", () => broadcast({ state: "not-available" }));
+	autoUpdater.on("download-progress", (p) =>
+		broadcast({ state: "downloading", percent: Math.max(0, Math.min(100, Math.round(p?.percent ?? 0))) }),
+	);
+	autoUpdater.on("update-downloaded", (info) => broadcast({ state: "downloaded", version: info?.version }));
+	autoUpdater.on("error", (err) => {
+		// Never crash on update failure (offline, unsigned macOS, etc.).
+		broadcast({ state: "error", message: err?.message ?? String(err) });
+	});
+}
+
+export function getUpdateStatus(): UpdateStatus {
+	return lastStatus;
+}
+
 // startAutoUpdates configures electron-updater from the user's ~/.ao settings.
 // It is a thin shell: all policy (channel, opt-in) comes from update-settings.
 // Caller guards on app.isPackaged.
@@ -22,23 +72,60 @@ export async function startAutoUpdates(stateDir: string): Promise<void> {
 	const settings = await readUpdateSettings(stateDir);
 	if (!settings.enabled) return;
 
-	const { owner, name } = repo();
-	autoUpdater.setFeedURL({ provider: "github", owner, repo: name });
-	autoUpdater.channel = settings.channel; // "latest" | "nightly"
-	autoUpdater.allowDowngrade = true; // permits a nightly -> stable channel switch
+	wireUpdaterEvents();
+	configureFeed(settings.channel);
 	autoUpdater.autoDownload = true;
 	autoUpdater.autoInstallOnAppQuit = true;
-
-	autoUpdater.on("error", (err) => {
-		// Never crash on update failure (offline, unsigned macOS, etc.).
-		console.error("auto-update error:", err?.message ?? err);
-	});
 
 	try {
 		await autoUpdater.checkForUpdates();
 	} catch (err) {
 		console.error("auto-update check failed:", err);
 	}
+}
+
+// checkForUpdatesNow runs a manual update check regardless of the auto-update
+// opt-in, so a user who never enabled auto-updates can still pull the latest
+// build from Settings. It does NOT auto-download — the user clicks Update — and
+// reports progress via the broadcast status. Updates only work in the packaged,
+// signed app; in dev electron-updater has no feed, so surface that plainly.
+export async function checkForUpdatesNow(stateDir: string): Promise<void> {
+	wireUpdaterEvents();
+	if (!app.isPackaged) {
+		broadcast({ state: "unsupported", message: "Updates are only available in the installed app." });
+		return;
+	}
+	const settings = await readUpdateSettings(stateDir);
+	configureFeed(settings.channel);
+	autoUpdater.autoDownload = false;
+	autoUpdater.autoInstallOnAppQuit = true;
+	broadcast({ state: "checking" });
+	try {
+		await autoUpdater.checkForUpdates();
+	} catch (err) {
+		broadcast({ state: "error", message: (err as Error)?.message ?? "Update check failed" });
+	}
+}
+
+// downloadUpdateNow starts downloading the update found by checkForUpdatesNow.
+export async function downloadUpdateNow(): Promise<void> {
+	wireUpdaterEvents();
+	if (!app.isPackaged) {
+		broadcast({ state: "unsupported", message: "Updates are only available in the installed app." });
+		return;
+	}
+	try {
+		await autoUpdater.downloadUpdate();
+	} catch (err) {
+		broadcast({ state: "error", message: (err as Error)?.message ?? "Download failed" });
+	}
+}
+
+// quitAndInstallUpdate installs a downloaded update and relaunches. isSilent
+// false keeps the installer UI on Windows; isForceRunAfter relaunches the app.
+export function quitAndInstallUpdate(): void {
+	if (!app.isPackaged) return;
+	autoUpdater.quitAndInstall(false, true);
 }
 
 // ensureUpdatePrefs prompts once (first run, before any settings file exists)

--- a/frontend/src/main/update-settings.ts
+++ b/frontend/src/main/update-settings.ts
@@ -12,14 +12,7 @@ export interface UpdateSettings {
 // Live state of a manual update check/download, streamed to the renderer so the
 // Global Settings "Check for updates" / "Update" buttons can reflect progress.
 export type UpdateState =
-	| "idle"
-	| "checking"
-	| "available"
-	| "not-available"
-	| "downloading"
-	| "downloaded"
-	| "error"
-	| "unsupported";
+	"idle" | "checking" | "available" | "not-available" | "downloading" | "downloaded" | "error" | "unsupported";
 
 export interface UpdateStatus {
 	state: UpdateState;

--- a/frontend/src/main/update-settings.ts
+++ b/frontend/src/main/update-settings.ts
@@ -9,6 +9,25 @@ export interface UpdateSettings {
 	nightlyAck: boolean;
 }
 
+// Live state of a manual update check/download, streamed to the renderer so the
+// Global Settings "Check for updates" / "Update" buttons can reflect progress.
+export type UpdateState =
+	| "idle"
+	| "checking"
+	| "available"
+	| "not-available"
+	| "downloading"
+	| "downloaded"
+	| "error"
+	| "unsupported";
+
+export interface UpdateStatus {
+	state: UpdateState;
+	version?: string;
+	percent?: number;
+	message?: string;
+}
+
 /** File holding the user's auto-update preferences under the ~/.ao state dir. */
 export const UPDATE_SETTINGS_FILE_NAME = "update-settings.json";
 

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -3,7 +3,7 @@ import type { BrowserNavState, BrowserRect } from "./main/browser-view-host";
 import type { DaemonStatus } from "./shared/daemon-status";
 import type { TelemetryBootstrap } from "./shared/telemetry";
 import type { MigrationState } from "./main/app-state";
-import type { UpdateSettings } from "./main/update-settings";
+import type { UpdateSettings, UpdateStatus } from "./main/update-settings";
 
 export type BrowserBoundsInput = {
 	viewId: string;
@@ -78,6 +78,19 @@ const api = {
 	updateSettings: {
 		get: () => ipcRenderer.invoke("updateSettings:get") as Promise<UpdateSettings>,
 		set: (settings: UpdateSettings) => ipcRenderer.invoke("updateSettings:set", settings) as Promise<void>,
+	},
+	updates: {
+		getStatus: () => ipcRenderer.invoke("updates:getStatus") as Promise<UpdateStatus>,
+		check: () => ipcRenderer.invoke("updates:check") as Promise<void>,
+		download: () => ipcRenderer.invoke("updates:download") as Promise<void>,
+		install: () => ipcRenderer.invoke("updates:install") as Promise<void>,
+		onStatus: (listener: (status: UpdateStatus) => void) => {
+			const wrapped = (_event: Electron.IpcRendererEvent, status: UpdateStatus) => listener(status);
+			ipcRenderer.on("updates:status", wrapped);
+			return () => {
+				ipcRenderer.off("updates:status", wrapped);
+			};
+		},
 	},
 };
 

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -3,6 +3,7 @@ import type { BrowserNavState, BrowserRect } from "./main/browser-view-host";
 import type { DaemonStatus } from "./shared/daemon-status";
 import type { TelemetryBootstrap } from "./shared/telemetry";
 import type { MigrationState } from "./main/app-state";
+import type { UpdateSettings } from "./main/update-settings";
 
 export type BrowserBoundsInput = {
 	viewId: string;
@@ -73,6 +74,10 @@ const api = {
 		getMigration: () => ipcRenderer.invoke("appState:getMigration") as Promise<MigrationState>,
 		setMigration: (migration: MigrationState) =>
 			ipcRenderer.invoke("appState:setMigration", migration) as Promise<void>,
+	},
+	updateSettings: {
+		get: () => ipcRenderer.invoke("updateSettings:get") as Promise<UpdateSettings>,
+		set: (settings: UpdateSettings) => ipcRenderer.invoke("updateSettings:set", settings) as Promise<void>,
 	},
 };
 

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -1,0 +1,111 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GlobalSettingsForm } from "./GlobalSettingsForm";
+
+const { getMock, postMock, getMigration, setMigration, getUpdate, setUpdate } = vi.hoisted(() => ({
+	getMock: vi.fn(),
+	postMock: vi.fn(),
+	getMigration: vi.fn(),
+	setMigration: vi.fn(),
+	getUpdate: vi.fn(),
+	setUpdate: vi.fn(),
+}));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: { GET: getMock, POST: postMock },
+	apiErrorMessage: (e: unknown, fb = "Request failed") =>
+		e instanceof Error ? e.message : ((e as { message?: string })?.message ?? fb),
+}));
+vi.mock("../lib/bridge", () => ({
+	aoBridge: {
+		appState: { getMigration, setMigration },
+		updateSettings: { get: getUpdate, set: setUpdate },
+	},
+}));
+
+function renderForm() {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	render(
+		<QueryClientProvider client={qc}>
+			<GlobalSettingsForm />
+		</QueryClientProvider>,
+	);
+	return qc;
+}
+
+beforeEach(() => {
+	for (const m of [getMock, postMock, getMigration, setMigration, getUpdate, setUpdate]) m.mockReset();
+	getMigration.mockResolvedValue({ status: "pending" });
+	getMock.mockResolvedValue({ data: { available: true, legacyRoot: "/home/u/.agent-orchestrator" }, error: undefined });
+	postMock.mockResolvedValue({ data: { report: { projectsImported: 2, projectsSkipped: 1 } }, error: undefined });
+	setMigration.mockResolvedValue(undefined);
+	getUpdate.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false });
+	setUpdate.mockResolvedValue(undefined);
+});
+
+describe("GlobalSettingsForm", () => {
+	it("renders the Updates and Migration sections", async () => {
+		renderForm();
+		expect(await screen.findByText("Updates")).toBeInTheDocument();
+		expect(screen.getByText("Migration")).toBeInTheDocument();
+	});
+
+	it("shows the nightly warning and saves the loaded channel", async () => {
+		getUpdate.mockResolvedValue({ enabled: true, channel: "nightly", nightlyAck: true });
+		renderForm();
+		expect(await screen.findByText(/Nightly builds are cut every day/i)).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+		await waitFor(() =>
+			expect(setUpdate).toHaveBeenCalledWith(expect.objectContaining({ channel: "nightly", enabled: true })),
+		);
+	});
+
+	it("hides the nightly warning on the stable channel", async () => {
+		renderForm();
+		await screen.findByText("Updates");
+		expect(screen.queryByText(/Nightly builds are cut every day/i)).not.toBeInTheDocument();
+	});
+
+	it("shows migration status and the available legacy root", async () => {
+		renderForm();
+		expect(await screen.findByText("Not migrated yet")).toBeInTheDocument();
+		expect(await screen.findByText("/home/u/.agent-orchestrator")).toBeInTheDocument();
+	});
+
+	it("Run migration imports and marks completed", async () => {
+		renderForm();
+		const btn = await screen.findByRole("button", { name: "Run migration" });
+		await userEvent.click(btn);
+		await waitFor(() => expect(postMock).toHaveBeenCalledWith("/api/v1/import"));
+		expect(setMigration).toHaveBeenCalledWith(expect.objectContaining({ status: "completed" }));
+		expect(await screen.findByText("Migration complete.")).toBeInTheDocument();
+	});
+
+	it("lets a declined user re-run the migration", async () => {
+		getMigration.mockResolvedValue({ status: "declined", lastAttemptAt: "2026-06-01T00:00:00.000Z" });
+		renderForm();
+		expect(await screen.findByText("Declined")).toBeInTheDocument();
+		const btn = await screen.findByRole("button", { name: "Run migration" });
+		expect(btn).toBeEnabled();
+		await userEvent.click(btn);
+		await waitFor(() => expect(postMock).toHaveBeenCalledWith("/api/v1/import"));
+	});
+
+	it("disables Run when no legacy install is available", async () => {
+		getMock.mockResolvedValue({ data: { available: false, legacyRoot: "" }, error: undefined });
+		renderForm();
+		expect(await screen.findByText("None found")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Run migration" })).toBeDisabled();
+	});
+
+	it("a failed import surfaces the error and marks failed", async () => {
+		postMock.mockResolvedValue({ data: undefined, error: { message: "disk full" } });
+		renderForm();
+		const btn = await screen.findByRole("button", { name: "Run migration" });
+		await userEvent.click(btn);
+		expect(await screen.findByText(/disk full/i)).toBeInTheDocument();
+		expect(setMigration).toHaveBeenCalledWith(expect.objectContaining({ status: "failed", error: "disk full" }));
+	});
+});

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -1,16 +1,33 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GlobalSettingsForm } from "./GlobalSettingsForm";
 
-const { getMock, postMock, getMigration, setMigration, getUpdate, setUpdate } = vi.hoisted(() => ({
+const {
+	getMock,
+	postMock,
+	getMigration,
+	setMigration,
+	getUpdate,
+	setUpdate,
+	updGetStatus,
+	updCheck,
+	updDownload,
+	updInstall,
+	updOnStatus,
+} = vi.hoisted(() => ({
 	getMock: vi.fn(),
 	postMock: vi.fn(),
 	getMigration: vi.fn(),
 	setMigration: vi.fn(),
 	getUpdate: vi.fn(),
 	setUpdate: vi.fn(),
+	updGetStatus: vi.fn(),
+	updCheck: vi.fn(),
+	updDownload: vi.fn(),
+	updInstall: vi.fn(),
+	updOnStatus: vi.fn(),
 }));
 
 vi.mock("../lib/api-client", () => ({
@@ -22,6 +39,13 @@ vi.mock("../lib/bridge", () => ({
 	aoBridge: {
 		appState: { getMigration, setMigration },
 		updateSettings: { get: getUpdate, set: setUpdate },
+		updates: {
+			getStatus: updGetStatus,
+			check: updCheck,
+			download: updDownload,
+			install: updInstall,
+			onStatus: updOnStatus,
+		},
 	},
 }));
 
@@ -43,6 +67,11 @@ beforeEach(() => {
 	setMigration.mockResolvedValue(undefined);
 	getUpdate.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false });
 	setUpdate.mockResolvedValue(undefined);
+	updGetStatus.mockResolvedValue({ state: "idle" });
+	updCheck.mockResolvedValue(undefined);
+	updDownload.mockResolvedValue(undefined);
+	updInstall.mockResolvedValue(undefined);
+	updOnStatus.mockReturnValue(() => undefined);
 });
 
 describe("GlobalSettingsForm", () => {
@@ -98,6 +127,41 @@ describe("GlobalSettingsForm", () => {
 		renderForm();
 		expect(await screen.findByText("None found")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Run migration" })).toBeDisabled();
+	});
+
+	it("Check for updates triggers a manual check", async () => {
+		renderForm();
+		const btn = await screen.findByRole("button", { name: "Check for updates" });
+		await userEvent.click(btn);
+		expect(updCheck).toHaveBeenCalled();
+	});
+
+	it("offers an Update button when an update is available and downloads it", async () => {
+		let emit: (s: { state: string; version?: string }) => void = () => undefined;
+		updOnStatus.mockImplementation((cb: (s: unknown) => void) => {
+			emit = cb as typeof emit;
+			return () => undefined;
+		});
+		renderForm();
+		await screen.findByRole("button", { name: "Check for updates" });
+		act(() => emit({ state: "available", version: "1.2.3" }));
+		const updateBtn = await screen.findByRole("button", { name: "Update to v1.2.3" });
+		await userEvent.click(updateBtn);
+		expect(updDownload).toHaveBeenCalled();
+	});
+
+	it("offers Restart & install once downloaded and installs it", async () => {
+		let emit: (s: { state: string; version?: string }) => void = () => undefined;
+		updOnStatus.mockImplementation((cb: (s: unknown) => void) => {
+			emit = cb as typeof emit;
+			return () => undefined;
+		});
+		renderForm();
+		await screen.findByRole("button", { name: "Check for updates" });
+		act(() => emit({ state: "downloaded", version: "1.2.3" }));
+		const installBtn = await screen.findByRole("button", { name: /Restart & install/ });
+		await userEvent.click(installBtn);
+		expect(updInstall).toHaveBeenCalled();
 	});
 
 	it("a failed import surfaces the error and marks failed", async () => {

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -16,6 +16,7 @@ const {
 	updDownload,
 	updInstall,
 	updOnStatus,
+	getVersion,
 } = vi.hoisted(() => ({
 	getMock: vi.fn(),
 	postMock: vi.fn(),
@@ -28,6 +29,7 @@ const {
 	updDownload: vi.fn(),
 	updInstall: vi.fn(),
 	updOnStatus: vi.fn(),
+	getVersion: vi.fn(),
 }));
 
 vi.mock("../lib/api-client", () => ({
@@ -37,6 +39,7 @@ vi.mock("../lib/api-client", () => ({
 }));
 vi.mock("../lib/bridge", () => ({
 	aoBridge: {
+		app: { getVersion },
 		appState: { getMigration, setMigration },
 		updateSettings: { get: getUpdate, set: setUpdate },
 		updates: {
@@ -72,6 +75,7 @@ beforeEach(() => {
 	updDownload.mockResolvedValue(undefined);
 	updInstall.mockResolvedValue(undefined);
 	updOnStatus.mockReturnValue(() => undefined);
+	getVersion.mockResolvedValue("1.4.0");
 });
 
 describe("GlobalSettingsForm", () => {
@@ -127,6 +131,11 @@ describe("GlobalSettingsForm", () => {
 		renderForm();
 		expect(await screen.findByText("None found")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Run migration" })).toBeDisabled();
+	});
+
+	it("shows the current app version", async () => {
+		renderForm();
+		expect(await screen.findByText("v1.4.0")).toBeInTheDocument();
 	});
 
 	it("Check for updates triggers a manual check", async () => {

--- a/frontend/src/renderer/components/GlobalSettingsForm.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.tsx
@@ -1,12 +1,20 @@
 import { DashboardSubhead } from "./DashboardSubhead";
+import { MigrationSection } from "./MigrationSection";
+import { UpdatesSection } from "./UpdatesSection";
 
-// App-wide settings, shown from the sidebar when no project is selected. The
-// body is intentionally empty for now; it will be filled in incrementally.
+// App-wide settings, shown from the sidebar when no project is selected. Each
+// section is a self-contained card: Updates (auto-update channel, #2207) and
+// Migration (re-run the legacy-AO import, #2205).
 export function GlobalSettingsForm() {
 	return (
 		<div className="flex h-full min-h-0 flex-col bg-background text-foreground">
 			<DashboardSubhead title="Global settings" subtitle="Settings that apply across all projects" />
-			<div className="min-h-0 flex-1 overflow-y-auto p-[18px]" />
+			<div className="min-h-0 flex-1 overflow-y-auto p-[18px]">
+				<div className="mx-auto flex max-w-2xl flex-col gap-4">
+					<UpdatesSection />
+					<MigrationSection />
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/frontend/src/renderer/components/MigrationSection.tsx
+++ b/frontend/src/renderer/components/MigrationSection.tsx
@@ -1,0 +1,185 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { aoBridge } from "../lib/bridge";
+import { migrationOfferQueryKey } from "../hooks/useMigrationOffer";
+import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import type { MigrationState, MigrationStatus } from "../../main/app-state";
+import { Button } from "./ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+
+export const migrationSettingsQueryKey = ["migration-settings"] as const;
+
+interface MigrationView {
+	migration: MigrationState;
+	available: boolean;
+	legacyRoot: string;
+}
+
+// fetchMigrationSettings reads the persisted decision (app marker) and asks the
+// daemon whether legacy data is present. Unlike useMigrationOffer it never
+// short-circuits on a terminal status: Settings always shows the full state so a
+// user who declined or already completed can re-run. A 501/unreachable daemon
+// resolves to "not available", never an error.
+async function fetchMigrationSettings(): Promise<MigrationView> {
+	const migration = await aoBridge.appState.getMigration();
+	const { data, error } = await apiClient.GET("/api/v1/import");
+	return {
+		migration,
+		available: !error && (data?.available ?? false),
+		legacyRoot: data?.legacyRoot ?? "",
+	};
+}
+
+const STATUS_LABEL: Record<MigrationStatus, string> = {
+	pending: "Not migrated yet",
+	completed: "Completed",
+	declined: "Declined",
+	failed: "Last attempt failed",
+};
+
+function statusClass(status: MigrationStatus): string {
+	switch (status) {
+		case "completed":
+			return "text-success";
+		case "failed":
+			return "text-error";
+		default:
+			return "text-muted-foreground";
+	}
+}
+
+function formatTime(iso?: string): string {
+	if (!iso) return "";
+	const d = new Date(iso);
+	return Number.isNaN(d.getTime()) ? "" : d.toLocaleString();
+}
+
+// MigrationSection is a drop-in Settings card for re-running the legacy-AO
+// import. It reads the persisted migration decision + the daemon's availability,
+// shows the last report/error, and exposes a Run / Re-run button that calls the
+// idempotent POST /api/v1/import (safe even when completed/declined/failed).
+// Issue #2205.
+export function MigrationSection() {
+	const queryClient = useQueryClient();
+	const query = useQuery({
+		queryKey: migrationSettingsQueryKey,
+		queryFn: fetchMigrationSettings,
+	});
+
+	const run = useMutation({
+		mutationFn: async () => {
+			const nowIso = () => new Date().toISOString();
+			const { data, error } = await apiClient.POST("/api/v1/import");
+			if (error) {
+				const msg = apiErrorMessage(error);
+				await aoBridge.appState.setMigration({ status: "failed", lastAttemptAt: nowIso(), error: msg });
+				throw new Error(msg);
+			}
+			const report = data?.report;
+			await aoBridge.appState.setMigration({
+				status: "completed",
+				lastAttemptAt: nowIso(),
+				completedAt: nowIso(),
+				report: report
+					? { projectsImported: report.projectsImported, projectsSkipped: report.projectsSkipped }
+					: undefined,
+			});
+		},
+		onSettled: () => {
+			void queryClient.invalidateQueries({ queryKey: migrationSettingsQueryKey });
+			void queryClient.invalidateQueries({ queryKey: migrationOfferQueryKey });
+			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+		},
+	});
+
+	const migration = query.data?.migration ?? { status: "pending" as MigrationStatus };
+	const available = query.data?.available ?? false;
+	const legacyRoot = query.data?.legacyRoot ?? "";
+	const report = migration.report;
+	const completed = migration.status === "completed";
+	const buttonLabel = run.isPending
+		? "Running…"
+		: completed
+			? "Re-run migration"
+			: migration.status === "failed"
+				? "Retry migration"
+				: "Run migration";
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="text-[13px]">Migration</CardTitle>
+			</CardHeader>
+			<CardContent className="flex flex-col gap-4">
+				<p className="text-[12px] leading-5 text-muted-foreground">
+					Import projects and orchestrator sessions from an earlier Agent Orchestrator install. Your old files are
+					never modified, and this is safe to run more than once.
+				</p>
+
+				<div className="flex flex-col gap-2 text-[12px]">
+					<Row label="Status">
+						<span className={statusClass(migration.status)}>{STATUS_LABEL[migration.status]}</span>
+					</Row>
+					{formatTime(migration.completedAt || migration.lastAttemptAt) && (
+						<Row label={completed ? "Completed" : "Last attempt"}>
+							<span className="text-foreground">{formatTime(migration.completedAt || migration.lastAttemptAt)}</span>
+						</Row>
+					)}
+					{report && (
+						<Row label="Last report">
+							<span className="text-foreground">
+								{report.projectsImported} imported, {report.projectsSkipped} already present
+							</span>
+						</Row>
+					)}
+					<Row label="Legacy install">
+						{query.isLoading ? (
+							<span className="text-passive">Checking…</span>
+						) : available ? (
+							<span className="font-mono text-[11px] text-foreground">{legacyRoot || "found"}</span>
+						) : (
+							<span className="text-passive">None found</span>
+						)}
+					</Row>
+				</div>
+
+				{migration.status === "failed" && migration.error && (
+					<p className="text-[12px] leading-5 text-error">
+						{migration.error}. Your legacy projects are untouched (nothing is ever deleted).
+					</p>
+				)}
+				{run.isError && (
+					<p className="text-[12px] leading-5 text-error">
+						{run.error instanceof Error ? run.error.message : "Migration failed."}
+					</p>
+				)}
+				{run.isSuccess && !run.isPending && <p className="text-[12px] leading-5 text-success">Migration complete.</p>}
+
+				<div className="flex items-center gap-3">
+					<Button
+						type="button"
+						variant="primary"
+						onClick={() => run.mutate()}
+						disabled={run.isPending || (!available && !completed)}
+					>
+						{run.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+						{buttonLabel}
+					</Button>
+					{!available && !query.isLoading && (
+						<span className="text-[12px] text-passive">Nothing to import from a legacy install.</span>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+	return (
+		<div className="flex items-center gap-3">
+			<span className="w-28 shrink-0 text-passive">{label}</span>
+			<span className="min-w-0 flex-1 truncate">{children}</span>
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/MigrationSection.tsx
+++ b/frontend/src/renderer/components/MigrationSection.tsx
@@ -113,8 +113,8 @@ export function MigrationSection() {
 			</CardHeader>
 			<CardContent className="flex flex-col gap-4">
 				<p className="text-[12px] leading-5 text-muted-foreground">
-					Import projects and orchestrator sessions from an earlier Agent Orchestrator install. Your old files are
-					never modified, and this is safe to run more than once.
+					Import projects and orchestrator sessions from an earlier Agent Orchestrator install. Your old files are never
+					modified, and this is safe to run more than once.
 				</p>
 
 				<div className="flex flex-col gap-2 text-[12px]">

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -6,14 +6,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Sidebar } from "./Sidebar";
 import type { WorkspaceSummary } from "../types/workspace";
 
-const { navigateMock } = vi.hoisted(() => ({ navigateMock: vi.fn() }));
+const { navigateMock, mockParams } = vi.hoisted(() => ({
+	navigateMock: vi.fn(),
+	mockParams: { projectId: undefined as string | undefined },
+}));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@tanstack/react-router")>();
 	return {
 		...actual,
 		useNavigate: () => navigateMock,
-		useParams: () => ({}),
+		useParams: () => mockParams,
 		useRouterState: ({ select }: { select: (state: { location: { pathname: string } }) => unknown }) =>
 			select({ location: { pathname: "/" } }),
 	};
@@ -61,6 +64,7 @@ async function chooseOption(trigger: HTMLElement, optionName: string) {
 
 beforeEach(() => {
 	navigateMock.mockReset();
+	mockParams.projectId = undefined;
 	vi.spyOn(window, "confirm").mockReturnValue(true);
 	vi.spyOn(window, "alert").mockImplementation(() => undefined);
 });
@@ -140,6 +144,18 @@ describe("Sidebar", () => {
 		renderSidebar();
 
 		await user.click(screen.getAllByLabelText("Settings")[0]);
+		await user.click(await screen.findByRole("menuitem", { name: "Global settings" }));
+
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/settings" });
+	});
+
+	it("shows both project and global settings in the footer menu when a project is selected", async () => {
+		mockParams.projectId = "proj-1";
+		const user = userEvent.setup();
+		renderSidebar();
+
+		await user.click(screen.getAllByLabelText("Settings")[0]);
+		expect(await screen.findByRole("menuitem", { name: "Project settings" })).toBeInTheDocument();
 		await user.click(await screen.findByRole("menuitem", { name: "Global settings" }));
 
 		expect(navigateMock).toHaveBeenCalledWith({ to: "/settings" });

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -286,17 +286,16 @@ export function Sidebar({
 								<DropdownMenuShortcut>⌘K</DropdownMenuShortcut>
 							</DropdownMenuItem>
 							<DropdownMenuSeparator />
-							{selection.activeProjectId ? (
+							{selection.activeProjectId && (
 								<DropdownMenuItem onSelect={() => selection.goSettings(selection.activeProjectId!)}>
 									<Settings aria-hidden="true" />
 									Project settings
 								</DropdownMenuItem>
-							) : (
-								<DropdownMenuItem onSelect={selection.goGlobalSettings}>
-									<Settings aria-hidden="true" />
-									Global settings
-								</DropdownMenuItem>
 							)}
+							<DropdownMenuItem onSelect={selection.goGlobalSettings}>
+								<Settings aria-hidden="true" />
+								Global settings
+							</DropdownMenuItem>
 						</DropdownMenuContent>
 					</DropdownMenu>
 					<Tooltip>
@@ -347,17 +346,16 @@ export function Sidebar({
 								<DropdownMenuShortcut>⌘K</DropdownMenuShortcut>
 							</DropdownMenuItem>
 							<DropdownMenuSeparator />
-							{selection.activeProjectId ? (
+							{selection.activeProjectId && (
 								<DropdownMenuItem onSelect={() => selection.goSettings(selection.activeProjectId!)}>
 									<Settings aria-hidden="true" />
 									Project settings
 								</DropdownMenuItem>
-							) : (
-								<DropdownMenuItem onSelect={selection.goGlobalSettings}>
-									<Settings aria-hidden="true" />
-									Global settings
-								</DropdownMenuItem>
 							)}
+							<DropdownMenuItem onSelect={selection.goGlobalSettings}>
+								<Settings aria-hidden="true" />
+								Global settings
+							</DropdownMenuItem>
 						</DropdownMenuContent>
 					</DropdownMenu>
 					{!isMac && (

--- a/frontend/src/renderer/components/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/UpdatesSection.tsx
@@ -1,0 +1,124 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { aoBridge } from "../lib/bridge";
+import type { UpdateChannel, UpdateSettings } from "../../main/update-settings";
+import { Button } from "./ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Label } from "./ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+
+export const updateSettingsQueryKey = ["update-settings"] as const;
+
+const CHANNEL_OPTIONS: { value: UpdateChannel; label: string }[] = [
+	{ value: "latest", label: "Stable (latest release)" },
+	{ value: "nightly", label: "Nightly (pre-release)" },
+];
+
+// UpdatesSection is the Global Settings card for the desktop auto-update channel
+// (issue #2207). It reads/writes ~/.ao/update-settings.json via the main process
+// (the same file auto-updater.ts consumes), letting a user pick Stable vs Nightly.
+// Changes apply on the next launch / update check.
+export function UpdatesSection() {
+	const queryClient = useQueryClient();
+	const query = useQuery({
+		queryKey: updateSettingsQueryKey,
+		queryFn: () => aoBridge.updateSettings.get(),
+	});
+
+	const [form, setForm] = useState<UpdateSettings>({ enabled: false, channel: "latest", nightlyAck: false });
+	const [savedAt, setSavedAt] = useState<number | null>(null);
+
+	// Seed the form once settings load (and on refetch). Keying off the loaded
+	// value keeps local edits responsive without a controlled-from-query loop.
+	useEffect(() => {
+		if (query.data) setForm(query.data);
+	}, [query.data]);
+
+	const save = useMutation({
+		mutationFn: async (next: UpdateSettings) => {
+			await aoBridge.updateSettings.set(next);
+		},
+		onSuccess: () => {
+			setSavedAt(Date.now());
+			void queryClient.invalidateQueries({ queryKey: updateSettingsQueryKey });
+		},
+	});
+
+	const setEnabled = (enabled: boolean) => {
+		setSavedAt(null);
+		setForm((f) => ({ ...f, enabled }));
+	};
+	const setChannel = (channel: UpdateChannel) => {
+		setSavedAt(null);
+		// Selecting Nightly in Settings is itself the acknowledgement of the
+		// instability warning shown below; Stable clears it.
+		setForm((f) => ({ ...f, channel, nightlyAck: channel === "nightly" }));
+	};
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="text-[13px]">Updates</CardTitle>
+			</CardHeader>
+			<CardContent className="flex flex-col gap-4">
+				<div className="flex flex-col gap-1.5">
+					<Label htmlFor="updatesEnabled" className="text-[12px] text-muted-foreground">
+						Automatic updates
+					</Label>
+					<EnabledSelect id="updatesEnabled" value={form.enabled} onChange={setEnabled} />
+				</div>
+
+				<div className="flex flex-col gap-1.5">
+					<Label htmlFor="updateChannel" className="text-[12px] text-muted-foreground">
+						Update channel
+					</Label>
+					<Select value={form.channel} onValueChange={(v) => setChannel(v as UpdateChannel)} disabled={!form.enabled}>
+						<SelectTrigger id="updateChannel" className="h-8 w-full text-[13px]">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{CHANNEL_OPTIONS.map((opt) => (
+								<SelectItem key={opt.value} value={opt.value}>
+									{opt.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				{form.channel === "nightly" && form.enabled && (
+					<p className="text-[12px] leading-5 text-warning">
+						Nightly builds are cut every day and can be unstable or lose data. Only use Nightly if you are comfortable
+						with that.
+					</p>
+				)}
+
+				<div className="flex items-center gap-3">
+					<Button type="button" variant="primary" onClick={() => save.mutate(form)} disabled={save.isPending}>
+						{save.isPending ? "Saving…" : "Save changes"}
+					</Button>
+					{save.isError && (
+						<span className="text-[12px] text-error">
+							{save.error instanceof Error ? save.error.message : "Save failed"}
+						</span>
+					)}
+					{savedAt && !save.isPending && !save.isError && <span className="text-[12px] text-success">Saved.</span>}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+function EnabledSelect({ id, value, onChange }: { id: string; value: boolean; onChange: (value: boolean) => void }) {
+	return (
+		<Select value={value ? "on" : "off"} onValueChange={(v) => onChange(v === "on")}>
+			<SelectTrigger id={id} className="h-8 w-full text-[13px]">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value="on">Enabled</SelectItem>
+				<SelectItem value="off">Disabled</SelectItem>
+			</SelectContent>
+		</Select>
+	);
+}

--- a/frontend/src/renderer/components/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/UpdatesSection.tsx
@@ -117,6 +117,7 @@ export function UpdatesSection() {
 // updates are off, so users who never opted in can still pull the latest build.
 function UpdateActions() {
 	const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
+	const version = useQuery({ queryKey: ["app-version"], queryFn: () => aoBridge.app.getVersion() });
 
 	useEffect(() => {
 		let live = true;
@@ -135,7 +136,11 @@ function UpdateActions() {
 	const busy = checking || downloading;
 
 	return (
-		<div className="flex flex-col gap-2 border-t border-border pt-4">
+		<div className="flex flex-col gap-3 border-t border-border pt-4">
+			<div className="flex items-center gap-2 text-[12px]">
+				<span className="text-passive">Current version</span>
+				<span className="font-mono text-[11px] text-foreground">{version.data ? `v${version.data}` : "…"}</span>
+			</div>
 			<div className="flex items-center gap-3">
 				<Button type="button" variant="outline" onClick={() => void aoBridge.updates.check()} disabled={busy}>
 					{checking && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/frontend/src/renderer/components/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/UpdatesSection.tsx
@@ -1,7 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
 import { aoBridge } from "../lib/bridge";
-import type { UpdateChannel, UpdateSettings } from "../../main/update-settings";
+import type { UpdateChannel, UpdateSettings, UpdateStatus } from "../../main/update-settings";
 import { Button } from "./ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Label } from "./ui/label";
@@ -104,9 +105,83 @@ export function UpdatesSection() {
 					)}
 					{savedAt && !save.isPending && !save.isError && <span className="text-[12px] text-success">Saved.</span>}
 				</div>
+
+				<UpdateActions />
 			</CardContent>
 		</Card>
 	);
+}
+
+// UpdateActions is the on-demand update control: a Check for updates button plus
+// an Update button that downloads then installs. It works even when automatic
+// updates are off, so users who never opted in can still pull the latest build.
+function UpdateActions() {
+	const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
+
+	useEffect(() => {
+		let live = true;
+		void aoBridge.updates.getStatus().then((s) => {
+			if (live) setStatus(s);
+		});
+		const off = aoBridge.updates.onStatus(setStatus);
+		return () => {
+			live = false;
+			off?.();
+		};
+	}, []);
+
+	const checking = status.state === "checking";
+	const downloading = status.state === "downloading";
+	const busy = checking || downloading;
+
+	return (
+		<div className="flex flex-col gap-2 border-t border-border pt-4">
+			<div className="flex items-center gap-3">
+				<Button type="button" variant="outline" onClick={() => void aoBridge.updates.check()} disabled={busy}>
+					{checking && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+					Check for updates
+				</Button>
+
+				{status.state === "available" && (
+					<Button type="button" variant="primary" onClick={() => void aoBridge.updates.download()}>
+						Update to {status.version ? `v${status.version}` : "latest"}
+					</Button>
+				)}
+				{status.state === "downloaded" && (
+					<Button type="button" variant="primary" onClick={() => void aoBridge.updates.install()}>
+						Restart &amp; install
+					</Button>
+				)}
+
+				<UpdateStatusLine status={status} />
+			</div>
+		</div>
+	);
+}
+
+function UpdateStatusLine({ status }: { status: UpdateStatus }) {
+	switch (status.state) {
+		case "checking":
+			return <span className="text-[12px] text-muted-foreground">Checking for updates…</span>;
+		case "available":
+			return (
+				<span className="text-[12px] text-muted-foreground">
+					Update available{status.version ? ` (v${status.version})` : ""}.
+				</span>
+			);
+		case "downloading":
+			return <span className="text-[12px] text-muted-foreground">Downloading… {status.percent ?? 0}%</span>;
+		case "downloaded":
+			return <span className="text-[12px] text-success">Downloaded. Restart to finish updating.</span>;
+		case "not-available":
+			return <span className="text-[12px] text-muted-foreground">You're on the latest version.</span>;
+		case "unsupported":
+			return <span className="text-[12px] text-passive">{status.message ?? "Updates need the installed app."}</span>;
+		case "error":
+			return <span className="text-[12px] text-error">{status.message ?? "Update failed."}</span>;
+		default:
+			return null;
+	}
 }
 
 function EnabledSelect({ id, value, onChange }: { id: string; value: boolean; onChange: (value: boolean) => void }) {

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -122,6 +122,60 @@ describe("useBrowserView", () => {
 		);
 	});
 
+	it("re-measures after a layout transition settles, catching a position-only shift", async () => {
+		// A ResizeObserver fires on size changes only; entering pop-out / opening the
+		// inspector moves the slot to a new x without resizing it, so the transition
+		// itself must drive a settle re-measure or the native overlay keeps stale
+		// (spilled) bounds. This is the regression behind the preview covering the
+		// terminal until an unrelated window resize fixed it.
+		vi.useFakeTimers();
+		try {
+			const bridge = setupBridge();
+			const slot = createSlot();
+			const { result, rerender } = renderHook(
+				({ poppedOut }) => useBrowserView({ sessionId: "sess-1", active: true, poppedOut }),
+				{ initialProps: { poppedOut: false } },
+			);
+			// ensure() resolves on a microtask; flush it without advancing timers.
+			await act(async () => {
+				await Promise.resolve();
+			});
+			act(() => result.current.slotRef(slot));
+			// Flush the mount measure (immediate frame + settle timer).
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+			expect(bridge.setBounds).toHaveBeenCalled();
+
+			// Pop-out transition: the immediate frame captures the still-animating
+			// geometry; the final position only lands once the panel has settled.
+			act(() => rerender({ poppedOut: true }));
+			await act(async () => {
+				vi.advanceTimersByTime(20);
+			});
+			bridge.setBounds.mockClear();
+			slot.getBoundingClientRect = vi.fn(() => ({
+				x: 240,
+				y: 34,
+				width: 320,
+				height: 240,
+				top: 34,
+				right: 560,
+				bottom: 274,
+				left: 240,
+				toJSON: () => ({}),
+			}));
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+			expect(bridge.setBounds).toHaveBeenCalledWith(
+				expect.objectContaining({ rect: expect.objectContaining({ x: 240, width: 320 }) }),
+			);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("hides the native view when inactive and on unmount without destroying session state", async () => {
 		const bridge = setupBridge();
 		const slot = createSlot();

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -77,6 +77,7 @@ export function useBrowserView({
 	const viewIdRef = useRef("");
 	const activeRef = useRef(active);
 	const frameRef = useRef<number | null>(null);
+	const settleTimerRef = useRef<number | null>(null);
 	const observerRef = useRef<ResizeObserver | null>(null);
 	const previewTriggerRef = useRef<{ revision: number | null; target: string } | null>(null);
 
@@ -123,6 +124,23 @@ export function useBrowserView({
 			: window.setTimeout(() => measureAndSend(), 16);
 	}, [measureAndSend]);
 
+	// A ResizeObserver only fires on size changes, so a position-only layout shift
+	// leaves the native overlay at stale bounds: entering/leaving pop-out moves the
+	// slot into a different panel, and opening the inspector (what `ao preview`
+	// does) reflows the slot's x without changing the observed node's box size.
+	// Neither fires the observer, so the view visibly spills over the sidebar/
+	// terminal until an unrelated window resize re-measures it. Re-measure now and
+	// again once the panel transition has settled (~240ms) so the final geometry
+	// always wins.
+	const scheduleSettleMeasure = useCallback(() => {
+		scheduleMeasure();
+		if (settleTimerRef.current !== null) window.clearTimeout(settleTimerRef.current);
+		settleTimerRef.current = window.setTimeout(() => {
+			settleTimerRef.current = null;
+			measureAndSend();
+		}, 280);
+	}, [measureAndSend, scheduleMeasure]);
+
 	const slotRef = useCallback(
 		(node: HTMLDivElement | null) => {
 			observerRef.current?.disconnect();
@@ -151,7 +169,7 @@ export function useBrowserView({
 			viewIdRef.current = state.viewId;
 			setViewId(state.viewId);
 			setNavState(state);
-			scheduleMeasure();
+			scheduleSettleMeasure();
 		});
 		return () => {
 			disposed = true;
@@ -161,7 +179,7 @@ export function useBrowserView({
 			}
 			viewIdRef.current = "";
 		};
-	}, [scheduleMeasure, sendHiddenBounds, sessionId]);
+	}, [scheduleSettleMeasure, sendHiddenBounds, sessionId]);
 
 	useEffect(() => {
 		return window.ao?.browser.onNavState((state) => {
@@ -172,11 +190,11 @@ export function useBrowserView({
 
 	useEffect(() => {
 		if (active) {
-			scheduleMeasure();
+			scheduleSettleMeasure();
 		} else {
 			sendHiddenBounds();
 		}
-	}, [active, poppedOut, scheduleMeasure, sendHiddenBounds]);
+	}, [active, poppedOut, scheduleSettleMeasure, sendHiddenBounds]);
 
 	useEffect(() => {
 		const handle = () => scheduleMeasure();
@@ -187,6 +205,7 @@ export function useBrowserView({
 			window.removeEventListener("scroll", handle, true);
 			observerRef.current?.disconnect();
 			cancelScheduledMeasure();
+			if (settleTimerRef.current !== null) window.clearTimeout(settleTimerRef.current);
 		};
 	}, [cancelScheduledMeasure, scheduleMeasure]);
 

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -100,4 +100,11 @@ export const aoBridge: AoBridge =
 			get: async () => ({ enabled: false, channel: "latest", nightlyAck: false }),
 			set: async () => undefined,
 		},
+		updates: {
+			getStatus: async () => ({ state: "idle" }),
+			check: async () => undefined,
+			download: async () => undefined,
+			install: async () => undefined,
+			onStatus: () => () => undefined,
+		},
 	} satisfies AoBridge);

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -96,4 +96,8 @@ export const aoBridge: AoBridge =
 			getMigration: async () => ({ status: "pending" }),
 			setMigration: async () => undefined,
 		},
+		updateSettings: {
+			get: async () => ({ enabled: false, channel: "latest", nightlyAck: false }),
+			set: async () => undefined,
+		},
 	} satisfies AoBridge);

--- a/frontend/src/renderer/routeTree.gen.ts
+++ b/frontend/src/renderer/routeTree.gen.ts
@@ -8,204 +8,209 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as ShellRouteImport } from "./routes/_shell";
-import { Route as ShellIndexRouteImport } from "./routes/_shell.index";
-import { Route as ShellSettingsRouteImport } from "./routes/_shell.settings";
-import { Route as ShellPrsRouteImport } from "./routes/_shell.prs";
-import { Route as ShellSessionsSessionIdRouteImport } from "./routes/_shell.sessions.$sessionId";
-import { Route as ShellProjectsProjectIdRouteImport } from "./routes/_shell.projects.$projectId";
-import { Route as ShellProjectsProjectIdSettingsRouteImport } from "./routes/_shell.projects.$projectId_.settings";
-import { Route as ShellProjectsProjectIdSessionsSessionIdRouteImport } from "./routes/_shell.projects.$projectId_.sessions.$sessionId";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as ShellRouteImport } from './routes/_shell'
+import { Route as ShellIndexRouteImport } from './routes/_shell.index'
+import { Route as ShellSettingsRouteImport } from './routes/_shell.settings'
+import { Route as ShellPrsRouteImport } from './routes/_shell.prs'
+import { Route as ShellSessionsSessionIdRouteImport } from './routes/_shell.sessions.$sessionId'
+import { Route as ShellProjectsProjectIdRouteImport } from './routes/_shell.projects.$projectId'
+import { Route as ShellProjectsProjectIdSettingsRouteImport } from './routes/_shell.projects.$projectId_.settings'
+import { Route as ShellProjectsProjectIdSessionsSessionIdRouteImport } from './routes/_shell.projects.$projectId_.sessions.$sessionId'
 
 const ShellRoute = ShellRouteImport.update({
-	id: "/_shell",
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/_shell',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ShellIndexRoute = ShellIndexRouteImport.update({
-	id: "/",
-	path: "/",
-	getParentRoute: () => ShellRoute,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => ShellRoute,
+} as any)
 const ShellSettingsRoute = ShellSettingsRouteImport.update({
-	id: "/settings",
-	path: "/settings",
-	getParentRoute: () => ShellRoute,
-} as any);
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => ShellRoute,
+} as any)
 const ShellPrsRoute = ShellPrsRouteImport.update({
-	id: "/prs",
-	path: "/prs",
-	getParentRoute: () => ShellRoute,
-} as any);
+  id: '/prs',
+  path: '/prs',
+  getParentRoute: () => ShellRoute,
+} as any)
 const ShellSessionsSessionIdRoute = ShellSessionsSessionIdRouteImport.update({
-	id: "/sessions/$sessionId",
-	path: "/sessions/$sessionId",
-	getParentRoute: () => ShellRoute,
-} as any);
+  id: '/sessions/$sessionId',
+  path: '/sessions/$sessionId',
+  getParentRoute: () => ShellRoute,
+} as any)
 const ShellProjectsProjectIdRoute = ShellProjectsProjectIdRouteImport.update({
-	id: "/projects/$projectId",
-	path: "/projects/$projectId",
-	getParentRoute: () => ShellRoute,
-} as any);
-const ShellProjectsProjectIdSettingsRoute = ShellProjectsProjectIdSettingsRouteImport.update({
-	id: "/projects/$projectId_/settings",
-	path: "/projects/$projectId/settings",
-	getParentRoute: () => ShellRoute,
-} as any);
-const ShellProjectsProjectIdSessionsSessionIdRoute = ShellProjectsProjectIdSessionsSessionIdRouteImport.update({
-	id: "/projects/$projectId_/sessions/$sessionId",
-	path: "/projects/$projectId/sessions/$sessionId",
-	getParentRoute: () => ShellRoute,
-} as any);
+  id: '/projects/$projectId',
+  path: '/projects/$projectId',
+  getParentRoute: () => ShellRoute,
+} as any)
+const ShellProjectsProjectIdSettingsRoute =
+  ShellProjectsProjectIdSettingsRouteImport.update({
+    id: '/projects/$projectId_/settings',
+    path: '/projects/$projectId/settings',
+    getParentRoute: () => ShellRoute,
+  } as any)
+const ShellProjectsProjectIdSessionsSessionIdRoute =
+  ShellProjectsProjectIdSessionsSessionIdRouteImport.update({
+    id: '/projects/$projectId_/sessions/$sessionId',
+    path: '/projects/$projectId/sessions/$sessionId',
+    getParentRoute: () => ShellRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
-	"/": typeof ShellIndexRoute;
-	"/prs": typeof ShellPrsRoute;
-	"/settings": typeof ShellSettingsRoute;
-	"/projects/$projectId": typeof ShellProjectsProjectIdRoute;
-	"/sessions/$sessionId": typeof ShellSessionsSessionIdRoute;
-	"/projects/$projectId/settings": typeof ShellProjectsProjectIdSettingsRoute;
-	"/projects/$projectId/sessions/$sessionId": typeof ShellProjectsProjectIdSessionsSessionIdRoute;
+  '/': typeof ShellIndexRoute
+  '/prs': typeof ShellPrsRoute
+  '/settings': typeof ShellSettingsRoute
+  '/projects/$projectId': typeof ShellProjectsProjectIdRoute
+  '/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
+  '/projects/$projectId/settings': typeof ShellProjectsProjectIdSettingsRoute
+  '/projects/$projectId/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
 }
 export interface FileRoutesByTo {
-	"/prs": typeof ShellPrsRoute;
-	"/settings": typeof ShellSettingsRoute;
-	"/": typeof ShellIndexRoute;
-	"/projects/$projectId": typeof ShellProjectsProjectIdRoute;
-	"/sessions/$sessionId": typeof ShellSessionsSessionIdRoute;
-	"/projects/$projectId/settings": typeof ShellProjectsProjectIdSettingsRoute;
-	"/projects/$projectId/sessions/$sessionId": typeof ShellProjectsProjectIdSessionsSessionIdRoute;
+  '/prs': typeof ShellPrsRoute
+  '/settings': typeof ShellSettingsRoute
+  '/': typeof ShellIndexRoute
+  '/projects/$projectId': typeof ShellProjectsProjectIdRoute
+  '/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
+  '/projects/$projectId/settings': typeof ShellProjectsProjectIdSettingsRoute
+  '/projects/$projectId/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport;
-	"/_shell": typeof ShellRouteWithChildren;
-	"/_shell/prs": typeof ShellPrsRoute;
-	"/_shell/settings": typeof ShellSettingsRoute;
-	"/_shell/": typeof ShellIndexRoute;
-	"/_shell/projects/$projectId": typeof ShellProjectsProjectIdRoute;
-	"/_shell/sessions/$sessionId": typeof ShellSessionsSessionIdRoute;
-	"/_shell/projects/$projectId_/settings": typeof ShellProjectsProjectIdSettingsRoute;
-	"/_shell/projects/$projectId_/sessions/$sessionId": typeof ShellProjectsProjectIdSessionsSessionIdRoute;
+  __root__: typeof rootRouteImport
+  '/_shell': typeof ShellRouteWithChildren
+  '/_shell/prs': typeof ShellPrsRoute
+  '/_shell/settings': typeof ShellSettingsRoute
+  '/_shell/': typeof ShellIndexRoute
+  '/_shell/projects/$projectId': typeof ShellProjectsProjectIdRoute
+  '/_shell/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
+  '/_shell/projects/$projectId_/settings': typeof ShellProjectsProjectIdSettingsRoute
+  '/_shell/projects/$projectId_/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath;
-	fullPaths:
-		| "/"
-		| "/prs"
-		| "/settings"
-		| "/projects/$projectId"
-		| "/sessions/$sessionId"
-		| "/projects/$projectId/settings"
-		| "/projects/$projectId/sessions/$sessionId";
-	fileRoutesByTo: FileRoutesByTo;
-	to:
-		| "/prs"
-		| "/settings"
-		| "/"
-		| "/projects/$projectId"
-		| "/sessions/$sessionId"
-		| "/projects/$projectId/settings"
-		| "/projects/$projectId/sessions/$sessionId";
-	id:
-		| "__root__"
-		| "/_shell"
-		| "/_shell/prs"
-		| "/_shell/settings"
-		| "/_shell/"
-		| "/_shell/projects/$projectId"
-		| "/_shell/sessions/$sessionId"
-		| "/_shell/projects/$projectId_/settings"
-		| "/_shell/projects/$projectId_/sessions/$sessionId";
-	fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/prs'
+    | '/settings'
+    | '/projects/$projectId'
+    | '/sessions/$sessionId'
+    | '/projects/$projectId/settings'
+    | '/projects/$projectId/sessions/$sessionId'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/prs'
+    | '/settings'
+    | '/'
+    | '/projects/$projectId'
+    | '/sessions/$sessionId'
+    | '/projects/$projectId/settings'
+    | '/projects/$projectId/sessions/$sessionId'
+  id:
+    | '__root__'
+    | '/_shell'
+    | '/_shell/prs'
+    | '/_shell/settings'
+    | '/_shell/'
+    | '/_shell/projects/$projectId'
+    | '/_shell/sessions/$sessionId'
+    | '/_shell/projects/$projectId_/settings'
+    | '/_shell/projects/$projectId_/sessions/$sessionId'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	ShellRoute: typeof ShellRouteWithChildren;
+  ShellRoute: typeof ShellRouteWithChildren
 }
 
-declare module "@tanstack/react-router" {
-	interface FileRoutesByPath {
-		"/_shell": {
-			id: "/_shell";
-			path: "";
-			fullPath: "/";
-			preLoaderRoute: typeof ShellRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		"/_shell/": {
-			id: "/_shell/";
-			path: "/";
-			fullPath: "/";
-			preLoaderRoute: typeof ShellIndexRouteImport;
-			parentRoute: typeof ShellRoute;
-		};
-		"/_shell/settings": {
-			id: "/_shell/settings";
-			path: "/settings";
-			fullPath: "/settings";
-			preLoaderRoute: typeof ShellSettingsRouteImport;
-			parentRoute: typeof ShellRoute;
-		};
-		"/_shell/prs": {
-			id: "/_shell/prs";
-			path: "/prs";
-			fullPath: "/prs";
-			preLoaderRoute: typeof ShellPrsRouteImport;
-			parentRoute: typeof ShellRoute;
-		};
-		"/_shell/sessions/$sessionId": {
-			id: "/_shell/sessions/$sessionId";
-			path: "/sessions/$sessionId";
-			fullPath: "/sessions/$sessionId";
-			preLoaderRoute: typeof ShellSessionsSessionIdRouteImport;
-			parentRoute: typeof ShellRoute;
-		};
-		"/_shell/projects/$projectId": {
-			id: "/_shell/projects/$projectId";
-			path: "/projects/$projectId";
-			fullPath: "/projects/$projectId";
-			preLoaderRoute: typeof ShellProjectsProjectIdRouteImport;
-			parentRoute: typeof ShellRoute;
-		};
-		"/_shell/projects/$projectId_/settings": {
-			id: "/_shell/projects/$projectId_/settings";
-			path: "/projects/$projectId/settings";
-			fullPath: "/projects/$projectId/settings";
-			preLoaderRoute: typeof ShellProjectsProjectIdSettingsRouteImport;
-			parentRoute: typeof ShellRoute;
-		};
-		"/_shell/projects/$projectId_/sessions/$sessionId": {
-			id: "/_shell/projects/$projectId_/sessions/$sessionId";
-			path: "/projects/$projectId/sessions/$sessionId";
-			fullPath: "/projects/$projectId/sessions/$sessionId";
-			preLoaderRoute: typeof ShellProjectsProjectIdSessionsSessionIdRouteImport;
-			parentRoute: typeof ShellRoute;
-		};
-	}
+declare module '@tanstack/react-router' {
+  interface FileRoutesByPath {
+    '/_shell': {
+      id: '/_shell'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof ShellRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_shell/': {
+      id: '/_shell/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof ShellIndexRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/settings': {
+      id: '/_shell/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof ShellSettingsRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/prs': {
+      id: '/_shell/prs'
+      path: '/prs'
+      fullPath: '/prs'
+      preLoaderRoute: typeof ShellPrsRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/sessions/$sessionId': {
+      id: '/_shell/sessions/$sessionId'
+      path: '/sessions/$sessionId'
+      fullPath: '/sessions/$sessionId'
+      preLoaderRoute: typeof ShellSessionsSessionIdRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/projects/$projectId': {
+      id: '/_shell/projects/$projectId'
+      path: '/projects/$projectId'
+      fullPath: '/projects/$projectId'
+      preLoaderRoute: typeof ShellProjectsProjectIdRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/projects/$projectId_/settings': {
+      id: '/_shell/projects/$projectId_/settings'
+      path: '/projects/$projectId/settings'
+      fullPath: '/projects/$projectId/settings'
+      preLoaderRoute: typeof ShellProjectsProjectIdSettingsRouteImport
+      parentRoute: typeof ShellRoute
+    }
+    '/_shell/projects/$projectId_/sessions/$sessionId': {
+      id: '/_shell/projects/$projectId_/sessions/$sessionId'
+      path: '/projects/$projectId/sessions/$sessionId'
+      fullPath: '/projects/$projectId/sessions/$sessionId'
+      preLoaderRoute: typeof ShellProjectsProjectIdSessionsSessionIdRouteImport
+      parentRoute: typeof ShellRoute
+    }
+  }
 }
 
 interface ShellRouteChildren {
-	ShellPrsRoute: typeof ShellPrsRoute;
-	ShellSettingsRoute: typeof ShellSettingsRoute;
-	ShellIndexRoute: typeof ShellIndexRoute;
-	ShellProjectsProjectIdRoute: typeof ShellProjectsProjectIdRoute;
-	ShellSessionsSessionIdRoute: typeof ShellSessionsSessionIdRoute;
-	ShellProjectsProjectIdSettingsRoute: typeof ShellProjectsProjectIdSettingsRoute;
-	ShellProjectsProjectIdSessionsSessionIdRoute: typeof ShellProjectsProjectIdSessionsSessionIdRoute;
+  ShellPrsRoute: typeof ShellPrsRoute
+  ShellSettingsRoute: typeof ShellSettingsRoute
+  ShellIndexRoute: typeof ShellIndexRoute
+  ShellProjectsProjectIdRoute: typeof ShellProjectsProjectIdRoute
+  ShellSessionsSessionIdRoute: typeof ShellSessionsSessionIdRoute
+  ShellProjectsProjectIdSettingsRoute: typeof ShellProjectsProjectIdSettingsRoute
+  ShellProjectsProjectIdSessionsSessionIdRoute: typeof ShellProjectsProjectIdSessionsSessionIdRoute
 }
 
 const ShellRouteChildren: ShellRouteChildren = {
-	ShellPrsRoute: ShellPrsRoute,
-	ShellSettingsRoute: ShellSettingsRoute,
-	ShellIndexRoute: ShellIndexRoute,
-	ShellProjectsProjectIdRoute: ShellProjectsProjectIdRoute,
-	ShellSessionsSessionIdRoute: ShellSessionsSessionIdRoute,
-	ShellProjectsProjectIdSettingsRoute: ShellProjectsProjectIdSettingsRoute,
-	ShellProjectsProjectIdSessionsSessionIdRoute: ShellProjectsProjectIdSessionsSessionIdRoute,
-};
+  ShellPrsRoute: ShellPrsRoute,
+  ShellSettingsRoute: ShellSettingsRoute,
+  ShellIndexRoute: ShellIndexRoute,
+  ShellProjectsProjectIdRoute: ShellProjectsProjectIdRoute,
+  ShellSessionsSessionIdRoute: ShellSessionsSessionIdRoute,
+  ShellProjectsProjectIdSettingsRoute: ShellProjectsProjectIdSettingsRoute,
+  ShellProjectsProjectIdSessionsSessionIdRoute:
+    ShellProjectsProjectIdSessionsSessionIdRoute,
+}
 
-const ShellRouteWithChildren = ShellRoute._addFileChildren(ShellRouteChildren);
+const ShellRouteWithChildren = ShellRoute._addFileChildren(ShellRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
-	ShellRoute: ShellRouteWithChildren,
-};
-export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>();
+  ShellRoute: ShellRouteWithChildren,
+}
+export const routeTree = rootRouteImport
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/frontend/src/renderer/routeTree.gen.ts
+++ b/frontend/src/renderer/routeTree.gen.ts
@@ -8,209 +8,204 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as ShellRouteImport } from './routes/_shell'
-import { Route as ShellIndexRouteImport } from './routes/_shell.index'
-import { Route as ShellSettingsRouteImport } from './routes/_shell.settings'
-import { Route as ShellPrsRouteImport } from './routes/_shell.prs'
-import { Route as ShellSessionsSessionIdRouteImport } from './routes/_shell.sessions.$sessionId'
-import { Route as ShellProjectsProjectIdRouteImport } from './routes/_shell.projects.$projectId'
-import { Route as ShellProjectsProjectIdSettingsRouteImport } from './routes/_shell.projects.$projectId_.settings'
-import { Route as ShellProjectsProjectIdSessionsSessionIdRouteImport } from './routes/_shell.projects.$projectId_.sessions.$sessionId'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as ShellRouteImport } from "./routes/_shell";
+import { Route as ShellIndexRouteImport } from "./routes/_shell.index";
+import { Route as ShellSettingsRouteImport } from "./routes/_shell.settings";
+import { Route as ShellPrsRouteImport } from "./routes/_shell.prs";
+import { Route as ShellSessionsSessionIdRouteImport } from "./routes/_shell.sessions.$sessionId";
+import { Route as ShellProjectsProjectIdRouteImport } from "./routes/_shell.projects.$projectId";
+import { Route as ShellProjectsProjectIdSettingsRouteImport } from "./routes/_shell.projects.$projectId_.settings";
+import { Route as ShellProjectsProjectIdSessionsSessionIdRouteImport } from "./routes/_shell.projects.$projectId_.sessions.$sessionId";
 
 const ShellRoute = ShellRouteImport.update({
-  id: '/_shell',
-  getParentRoute: () => rootRouteImport,
-} as any)
+	id: "/_shell",
+	getParentRoute: () => rootRouteImport,
+} as any);
 const ShellIndexRoute = ShellIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => ShellRoute,
-} as any)
+	id: "/",
+	path: "/",
+	getParentRoute: () => ShellRoute,
+} as any);
 const ShellSettingsRoute = ShellSettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => ShellRoute,
-} as any)
+	id: "/settings",
+	path: "/settings",
+	getParentRoute: () => ShellRoute,
+} as any);
 const ShellPrsRoute = ShellPrsRouteImport.update({
-  id: '/prs',
-  path: '/prs',
-  getParentRoute: () => ShellRoute,
-} as any)
+	id: "/prs",
+	path: "/prs",
+	getParentRoute: () => ShellRoute,
+} as any);
 const ShellSessionsSessionIdRoute = ShellSessionsSessionIdRouteImport.update({
-  id: '/sessions/$sessionId',
-  path: '/sessions/$sessionId',
-  getParentRoute: () => ShellRoute,
-} as any)
+	id: "/sessions/$sessionId",
+	path: "/sessions/$sessionId",
+	getParentRoute: () => ShellRoute,
+} as any);
 const ShellProjectsProjectIdRoute = ShellProjectsProjectIdRouteImport.update({
-  id: '/projects/$projectId',
-  path: '/projects/$projectId',
-  getParentRoute: () => ShellRoute,
-} as any)
-const ShellProjectsProjectIdSettingsRoute =
-  ShellProjectsProjectIdSettingsRouteImport.update({
-    id: '/projects/$projectId_/settings',
-    path: '/projects/$projectId/settings',
-    getParentRoute: () => ShellRoute,
-  } as any)
-const ShellProjectsProjectIdSessionsSessionIdRoute =
-  ShellProjectsProjectIdSessionsSessionIdRouteImport.update({
-    id: '/projects/$projectId_/sessions/$sessionId',
-    path: '/projects/$projectId/sessions/$sessionId',
-    getParentRoute: () => ShellRoute,
-  } as any)
+	id: "/projects/$projectId",
+	path: "/projects/$projectId",
+	getParentRoute: () => ShellRoute,
+} as any);
+const ShellProjectsProjectIdSettingsRoute = ShellProjectsProjectIdSettingsRouteImport.update({
+	id: "/projects/$projectId_/settings",
+	path: "/projects/$projectId/settings",
+	getParentRoute: () => ShellRoute,
+} as any);
+const ShellProjectsProjectIdSessionsSessionIdRoute = ShellProjectsProjectIdSessionsSessionIdRouteImport.update({
+	id: "/projects/$projectId_/sessions/$sessionId",
+	path: "/projects/$projectId/sessions/$sessionId",
+	getParentRoute: () => ShellRoute,
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof ShellIndexRoute
-  '/prs': typeof ShellPrsRoute
-  '/settings': typeof ShellSettingsRoute
-  '/projects/$projectId': typeof ShellProjectsProjectIdRoute
-  '/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
-  '/projects/$projectId/settings': typeof ShellProjectsProjectIdSettingsRoute
-  '/projects/$projectId/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
+	"/": typeof ShellIndexRoute;
+	"/prs": typeof ShellPrsRoute;
+	"/settings": typeof ShellSettingsRoute;
+	"/projects/$projectId": typeof ShellProjectsProjectIdRoute;
+	"/sessions/$sessionId": typeof ShellSessionsSessionIdRoute;
+	"/projects/$projectId/settings": typeof ShellProjectsProjectIdSettingsRoute;
+	"/projects/$projectId/sessions/$sessionId": typeof ShellProjectsProjectIdSessionsSessionIdRoute;
 }
 export interface FileRoutesByTo {
-  '/prs': typeof ShellPrsRoute
-  '/settings': typeof ShellSettingsRoute
-  '/': typeof ShellIndexRoute
-  '/projects/$projectId': typeof ShellProjectsProjectIdRoute
-  '/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
-  '/projects/$projectId/settings': typeof ShellProjectsProjectIdSettingsRoute
-  '/projects/$projectId/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
+	"/prs": typeof ShellPrsRoute;
+	"/settings": typeof ShellSettingsRoute;
+	"/": typeof ShellIndexRoute;
+	"/projects/$projectId": typeof ShellProjectsProjectIdRoute;
+	"/sessions/$sessionId": typeof ShellSessionsSessionIdRoute;
+	"/projects/$projectId/settings": typeof ShellProjectsProjectIdSettingsRoute;
+	"/projects/$projectId/sessions/$sessionId": typeof ShellProjectsProjectIdSessionsSessionIdRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/_shell': typeof ShellRouteWithChildren
-  '/_shell/prs': typeof ShellPrsRoute
-  '/_shell/settings': typeof ShellSettingsRoute
-  '/_shell/': typeof ShellIndexRoute
-  '/_shell/projects/$projectId': typeof ShellProjectsProjectIdRoute
-  '/_shell/sessions/$sessionId': typeof ShellSessionsSessionIdRoute
-  '/_shell/projects/$projectId_/settings': typeof ShellProjectsProjectIdSettingsRoute
-  '/_shell/projects/$projectId_/sessions/$sessionId': typeof ShellProjectsProjectIdSessionsSessionIdRoute
+	__root__: typeof rootRouteImport;
+	"/_shell": typeof ShellRouteWithChildren;
+	"/_shell/prs": typeof ShellPrsRoute;
+	"/_shell/settings": typeof ShellSettingsRoute;
+	"/_shell/": typeof ShellIndexRoute;
+	"/_shell/projects/$projectId": typeof ShellProjectsProjectIdRoute;
+	"/_shell/sessions/$sessionId": typeof ShellSessionsSessionIdRoute;
+	"/_shell/projects/$projectId_/settings": typeof ShellProjectsProjectIdSettingsRoute;
+	"/_shell/projects/$projectId_/sessions/$sessionId": typeof ShellProjectsProjectIdSessionsSessionIdRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/prs'
-    | '/settings'
-    | '/projects/$projectId'
-    | '/sessions/$sessionId'
-    | '/projects/$projectId/settings'
-    | '/projects/$projectId/sessions/$sessionId'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/prs'
-    | '/settings'
-    | '/'
-    | '/projects/$projectId'
-    | '/sessions/$sessionId'
-    | '/projects/$projectId/settings'
-    | '/projects/$projectId/sessions/$sessionId'
-  id:
-    | '__root__'
-    | '/_shell'
-    | '/_shell/prs'
-    | '/_shell/settings'
-    | '/_shell/'
-    | '/_shell/projects/$projectId'
-    | '/_shell/sessions/$sessionId'
-    | '/_shell/projects/$projectId_/settings'
-    | '/_shell/projects/$projectId_/sessions/$sessionId'
-  fileRoutesById: FileRoutesById
+	fileRoutesByFullPath: FileRoutesByFullPath;
+	fullPaths:
+		| "/"
+		| "/prs"
+		| "/settings"
+		| "/projects/$projectId"
+		| "/sessions/$sessionId"
+		| "/projects/$projectId/settings"
+		| "/projects/$projectId/sessions/$sessionId";
+	fileRoutesByTo: FileRoutesByTo;
+	to:
+		| "/prs"
+		| "/settings"
+		| "/"
+		| "/projects/$projectId"
+		| "/sessions/$sessionId"
+		| "/projects/$projectId/settings"
+		| "/projects/$projectId/sessions/$sessionId";
+	id:
+		| "__root__"
+		| "/_shell"
+		| "/_shell/prs"
+		| "/_shell/settings"
+		| "/_shell/"
+		| "/_shell/projects/$projectId"
+		| "/_shell/sessions/$sessionId"
+		| "/_shell/projects/$projectId_/settings"
+		| "/_shell/projects/$projectId_/sessions/$sessionId";
+	fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  ShellRoute: typeof ShellRouteWithChildren
+	ShellRoute: typeof ShellRouteWithChildren;
 }
 
-declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {
-    '/_shell': {
-      id: '/_shell'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof ShellRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_shell/': {
-      id: '/_shell/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof ShellIndexRouteImport
-      parentRoute: typeof ShellRoute
-    }
-    '/_shell/settings': {
-      id: '/_shell/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof ShellSettingsRouteImport
-      parentRoute: typeof ShellRoute
-    }
-    '/_shell/prs': {
-      id: '/_shell/prs'
-      path: '/prs'
-      fullPath: '/prs'
-      preLoaderRoute: typeof ShellPrsRouteImport
-      parentRoute: typeof ShellRoute
-    }
-    '/_shell/sessions/$sessionId': {
-      id: '/_shell/sessions/$sessionId'
-      path: '/sessions/$sessionId'
-      fullPath: '/sessions/$sessionId'
-      preLoaderRoute: typeof ShellSessionsSessionIdRouteImport
-      parentRoute: typeof ShellRoute
-    }
-    '/_shell/projects/$projectId': {
-      id: '/_shell/projects/$projectId'
-      path: '/projects/$projectId'
-      fullPath: '/projects/$projectId'
-      preLoaderRoute: typeof ShellProjectsProjectIdRouteImport
-      parentRoute: typeof ShellRoute
-    }
-    '/_shell/projects/$projectId_/settings': {
-      id: '/_shell/projects/$projectId_/settings'
-      path: '/projects/$projectId/settings'
-      fullPath: '/projects/$projectId/settings'
-      preLoaderRoute: typeof ShellProjectsProjectIdSettingsRouteImport
-      parentRoute: typeof ShellRoute
-    }
-    '/_shell/projects/$projectId_/sessions/$sessionId': {
-      id: '/_shell/projects/$projectId_/sessions/$sessionId'
-      path: '/projects/$projectId/sessions/$sessionId'
-      fullPath: '/projects/$projectId/sessions/$sessionId'
-      preLoaderRoute: typeof ShellProjectsProjectIdSessionsSessionIdRouteImport
-      parentRoute: typeof ShellRoute
-    }
-  }
+declare module "@tanstack/react-router" {
+	interface FileRoutesByPath {
+		"/_shell": {
+			id: "/_shell";
+			path: "";
+			fullPath: "/";
+			preLoaderRoute: typeof ShellRouteImport;
+			parentRoute: typeof rootRouteImport;
+		};
+		"/_shell/": {
+			id: "/_shell/";
+			path: "/";
+			fullPath: "/";
+			preLoaderRoute: typeof ShellIndexRouteImport;
+			parentRoute: typeof ShellRoute;
+		};
+		"/_shell/settings": {
+			id: "/_shell/settings";
+			path: "/settings";
+			fullPath: "/settings";
+			preLoaderRoute: typeof ShellSettingsRouteImport;
+			parentRoute: typeof ShellRoute;
+		};
+		"/_shell/prs": {
+			id: "/_shell/prs";
+			path: "/prs";
+			fullPath: "/prs";
+			preLoaderRoute: typeof ShellPrsRouteImport;
+			parentRoute: typeof ShellRoute;
+		};
+		"/_shell/sessions/$sessionId": {
+			id: "/_shell/sessions/$sessionId";
+			path: "/sessions/$sessionId";
+			fullPath: "/sessions/$sessionId";
+			preLoaderRoute: typeof ShellSessionsSessionIdRouteImport;
+			parentRoute: typeof ShellRoute;
+		};
+		"/_shell/projects/$projectId": {
+			id: "/_shell/projects/$projectId";
+			path: "/projects/$projectId";
+			fullPath: "/projects/$projectId";
+			preLoaderRoute: typeof ShellProjectsProjectIdRouteImport;
+			parentRoute: typeof ShellRoute;
+		};
+		"/_shell/projects/$projectId_/settings": {
+			id: "/_shell/projects/$projectId_/settings";
+			path: "/projects/$projectId/settings";
+			fullPath: "/projects/$projectId/settings";
+			preLoaderRoute: typeof ShellProjectsProjectIdSettingsRouteImport;
+			parentRoute: typeof ShellRoute;
+		};
+		"/_shell/projects/$projectId_/sessions/$sessionId": {
+			id: "/_shell/projects/$projectId_/sessions/$sessionId";
+			path: "/projects/$projectId/sessions/$sessionId";
+			fullPath: "/projects/$projectId/sessions/$sessionId";
+			preLoaderRoute: typeof ShellProjectsProjectIdSessionsSessionIdRouteImport;
+			parentRoute: typeof ShellRoute;
+		};
+	}
 }
 
 interface ShellRouteChildren {
-  ShellPrsRoute: typeof ShellPrsRoute
-  ShellSettingsRoute: typeof ShellSettingsRoute
-  ShellIndexRoute: typeof ShellIndexRoute
-  ShellProjectsProjectIdRoute: typeof ShellProjectsProjectIdRoute
-  ShellSessionsSessionIdRoute: typeof ShellSessionsSessionIdRoute
-  ShellProjectsProjectIdSettingsRoute: typeof ShellProjectsProjectIdSettingsRoute
-  ShellProjectsProjectIdSessionsSessionIdRoute: typeof ShellProjectsProjectIdSessionsSessionIdRoute
+	ShellPrsRoute: typeof ShellPrsRoute;
+	ShellSettingsRoute: typeof ShellSettingsRoute;
+	ShellIndexRoute: typeof ShellIndexRoute;
+	ShellProjectsProjectIdRoute: typeof ShellProjectsProjectIdRoute;
+	ShellSessionsSessionIdRoute: typeof ShellSessionsSessionIdRoute;
+	ShellProjectsProjectIdSettingsRoute: typeof ShellProjectsProjectIdSettingsRoute;
+	ShellProjectsProjectIdSessionsSessionIdRoute: typeof ShellProjectsProjectIdSessionsSessionIdRoute;
 }
 
 const ShellRouteChildren: ShellRouteChildren = {
-  ShellPrsRoute: ShellPrsRoute,
-  ShellSettingsRoute: ShellSettingsRoute,
-  ShellIndexRoute: ShellIndexRoute,
-  ShellProjectsProjectIdRoute: ShellProjectsProjectIdRoute,
-  ShellSessionsSessionIdRoute: ShellSessionsSessionIdRoute,
-  ShellProjectsProjectIdSettingsRoute: ShellProjectsProjectIdSettingsRoute,
-  ShellProjectsProjectIdSessionsSessionIdRoute:
-    ShellProjectsProjectIdSessionsSessionIdRoute,
-}
+	ShellPrsRoute: ShellPrsRoute,
+	ShellSettingsRoute: ShellSettingsRoute,
+	ShellIndexRoute: ShellIndexRoute,
+	ShellProjectsProjectIdRoute: ShellProjectsProjectIdRoute,
+	ShellSessionsSessionIdRoute: ShellSessionsSessionIdRoute,
+	ShellProjectsProjectIdSettingsRoute: ShellProjectsProjectIdSettingsRoute,
+	ShellProjectsProjectIdSessionsSessionIdRoute: ShellProjectsProjectIdSessionsSessionIdRoute,
+};
 
-const ShellRouteWithChildren = ShellRoute._addFileChildren(ShellRouteChildren)
+const ShellRouteWithChildren = ShellRoute._addFileChildren(ShellRouteChildren);
 
 const rootRouteChildren: RootRouteChildren = {
-  ShellRoute: ShellRouteWithChildren,
-}
-export const routeTree = rootRouteImport
-  ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+	ShellRoute: ShellRouteWithChildren,
+};
+export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>();

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -141,5 +141,9 @@ if (typeof window !== "undefined") {
 			getMigration: async () => ({ status: "pending" }),
 			setMigration: async () => undefined,
 		},
+		updateSettings: {
+			get: async () => ({ enabled: false, channel: "latest", nightlyAck: false }),
+			set: async () => undefined,
+		},
 	};
 } // end if (typeof window !== "undefined")

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -145,5 +145,12 @@ if (typeof window !== "undefined") {
 			get: async () => ({ enabled: false, channel: "latest", nightlyAck: false }),
 			set: async () => undefined,
 		},
+		updates: {
+			getStatus: async () => ({ state: "idle" }),
+			check: async () => undefined,
+			download: async () => undefined,
+			install: async () => undefined,
+			onStatus: () => () => undefined,
+		},
 	};
 } // end if (typeof window !== "undefined")


### PR DESCRIPTION
## What

Three related Global Settings / `ao start` follow-ups. They share the global Settings surface, so they ship together.

### #2205 — Global Settings Migration section
The page scaffold (`_shell.settings` + sidebar entry) and the migration plumbing (app-state `migration` marker, `appState:get/setMigration` IPC, `GET/POST /api/v1/import`) already landed in #2218 / #2219. This adds the missing piece: a drop-in **`MigrationSection`** card in the (previously blank) Settings page that
- reads the persisted decision + the daemon's legacy-data availability (never short-circuits on a terminal status, unlike the launch popup),
- shows status, last attempt/completed time, last report (`N imported, N already present`) or error, and the legacy install path,
- exposes a **Run / Re-run migration** button hitting the idempotent `POST /api/v1/import` (safe when `completed`/`declined`/`failed`), so a user who chose **Don't Migrate** can redo it.

### #2207 — Update channel selector (latest vs nightly)
The auto-update infra (`update-settings.json` `{enabled, channel, nightlyAck}`, `auto-updater.ts` reading the channel) landed in #2220/#2226 but had no UI. This adds:
- `updateSettings:get/set` IPC over the existing `~/.ao/update-settings.json` writer (no new state location),
- an **`UpdatesSection`** card to pick automatic-updates on/off and **Stable (latest)** vs **Nightly (pre-release)**, with the nightly instability warning. Selecting Nightly records `nightlyAck`. The choice persists to `~/.ao` and the existing auto-updater consumes it on the next launch / update check.

### #2234 — `ao start` download + install progress
`download()` streamed a hundreds-of-MB asset with zero output, then ran a silent install, so a slow fetch looked like a hang. Now (fetch path only; the resolve-and-launch fast path stays quiet):
- a start line `Downloading Agent Orchestrator (<asset>, ~NN MiB) from <repo>...` (size from `Content-Length` when present),
- a TTY-aware progress reader (`io.TeeReader` + a hand-rolled counting `io.Writer`): live `\r` percentage on a terminal, plain start + `Downloaded NN MiB.` lines off a TTY (CI/pipes, no `\r` spam),
- an `Unpacking...` / `Installing...` line before the otherwise-silent post-download step.

All output goes to **stderr**, so `--json` stdout stays pure. No new dependency (TTY detection mirrors the existing `stdinIsInteractive`).

## Test
- `frontend`: `npm run typecheck` clean; `vitest run` 353 passed (incl. new `GlobalSettingsForm.test.tsx`, 8 cases); renderer vite build OK.
- `backend`: `go build ./...`, `go test ./internal/cli/...` (161 passed, incl. new download-progress tests), `go vet`, `gofmt` clean.
- Previewed the Settings page via `ao preview`.

## Notes
- **No changeset added:** the rewrite repo has no changeset tooling (no `.changeset/`, nothing in `package.json`/CI); recent feature PRs (#2218/#2219/#2220) added none. Versioning happens via `frontend-release.yml`, so a changeset would be dead tooling here. Flagging in case the intent was to introduce changesets.
- The channel change takes effect on the next launch / update check (the auto-updater reads settings at startup); it does not force an immediate re-check.

Closes #2205
Closes #2207
Closes #2234
