### PR TITLE
docs: add dogfood marker to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 <h1 align="center">Agent Orchestrator</h1>
 
+> Dogfooding Agent Orchestrator on this repo.
+
 <p align="center"><strong>The orchestration layer for parallel AI coding agents</strong></p>
 
 <p align="center">


### PR DESCRIPTION
Closes #1

Adds a single dogfood marker line just under the main title in `README.md`:

> Dogfooding Agent Orchestrator (private) on this repo.

This is an end-to-end loop check on the private repo. Docs-only change.