### PR TITLE
fix(ci): decouple macos-13 Intel runner from publish-feed (#2237)

### DIFF
--- a/.github/workflows/frontend-nightly.yml
+++ b/.github/workflows/frontend-nightly.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-13, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -92,6 +92,70 @@ jobs:
           AO_RELEASE_PRERELEASE: "true"
           # macOS signing + notarization env is exported by the "macOS signing
           # setup" step above via $GITHUB_ENV; the cert is in the keychain.
+
+  # Dedicated Intel (darwin-x64) nightly build leg, decoupled from the release
+  # matrix so the scarce macos-13 runner does not block publish-feed. Mirrors
+  # the release job's macOS steps exactly. publish-feed stays needs: release
+  # only (three fast legs); the x64 feed entry appears if this job finishes
+  # first, but the feed is not gated on it.
+  release-intel:
+    needs: guard
+    if: needs.guard.outputs.should_build == 'true'
+    runs-on: macos-13
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - run: npm ci
+      - name: Stamp nightly version
+        shell: bash
+        env:
+          NIGHTLY_VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          node -e "const v=process.env.NIGHTLY_VERSION.split('+')[0]; const fs=require('fs'); const p=require('./package.json'); p.version=v; fs.writeFileSync('./package.json', JSON.stringify(p,null,'\t')+'\n');"
+      - name: macOS signing setup
+        uses: ./.github/actions/macos-signing-setup
+        with:
+          csc-link: ${{ secrets.CSC_LINK }}
+          csc-key-password: ${{ secrets.CSC_KEY_PASSWORD }}
+          apple-api-key-base64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          apple-api-key-id: ${{ secrets.APPLE_API_KEY_ID }}
+          apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
+          apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      - name: Publish
+        run: npm run publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AO_RELEASE_REPO: ${{ github.repository }}
+          AO_RELEASE_PRERELEASE: "true"
+      - name: Upload stable asset aliases (macOS)
+        shell: bash
+        run: |
+          tag="v$(node -p "require('./package.json').version")"
+          arch="$(uname -m)"
+          case "$arch" in
+            arm64) alias_name="agent-orchestrator-darwin-arm64.zip" ;;
+            x86_64) alias_name="agent-orchestrator-darwin-x64.zip" ;;
+            *) echo "unsupported macOS arch: $arch" >&2; exit 1 ;;
+          esac
+          src="$(ls out/make/zip/darwin/*/*.zip | head -n1)"
+          if [ -z "$src" ]; then echo "no macOS zip found under out/make/zip/darwin" >&2; exit 1; fi
+          cp "$src" "$alias_name"
+          gh release upload "$tag" "$alias_name" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Generate the nightly electron-updater feed from the versioned prerelease
   # assets. The nightly version is only stamped in-memory on the build runners,

--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-13, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -145,6 +145,61 @@ jobs:
           # AppImage (electron-builder) output: out/make/<productName>-<version>.AppImage
           src="$(ls out/make/*.AppImage | head -n1)"
           if [ -z "$src" ]; then echo "no AppImage found under out/make" >&2; exit 1; fi
+          cp "$src" "$alias_name"
+          gh release upload "$tag" "$alias_name" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Dedicated Intel (darwin-x64) build leg, decoupled from the release matrix so
+  # the scarce macos-13 runner does not block publish-feed. publish-feed needs
+  # only the three fast legs (release); this job uploads the x64 installer and
+  # stable alias independently. feed.mjs includes the x64 entry if this job
+  # finishes before publish-feed, but the feed is not gated on it.
+  release-intel:
+    runs-on: macos-13
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - run: npm ci
+      - name: macOS signing setup
+        uses: ./.github/actions/macos-signing-setup
+        with:
+          csc-link: ${{ secrets.CSC_LINK }}
+          csc-key-password: ${{ secrets.CSC_KEY_PASSWORD }}
+          apple-api-key-base64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          apple-api-key-id: ${{ secrets.APPLE_API_KEY_ID }}
+          apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
+          apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      - name: Publish
+        run: npm run publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AO_RELEASE_REPO: ${{ github.repository }}
+      - name: Upload stable asset aliases (macOS)
+        shell: bash
+        run: |
+          tag="v$(node -p "require('./package.json').version")"
+          arch="$(uname -m)"
+          case "$arch" in
+            arm64) alias_name="agent-orchestrator-darwin-arm64.zip" ;;
+            x86_64) alias_name="agent-orchestrator-darwin-x64.zip" ;;
+            *) echo "unsupported macOS arch: $arch" >&2; exit 1 ;;
+          esac
+          src="$(ls out/make/zip/darwin/*/*.zip | head -n1)"
+          if [ -z "$src" ]; then echo "no macOS zip found under out/make/zip/darwin" >&2; exit 1; fi
           cp "$src" "$alias_name"
           gh release upload "$tag" "$alias_name" --clobber
         env:


### PR DESCRIPTION
## What / why

Closes #2237. The `publish-feed` job declared `needs: release`, which waits for **every** leg of the build matrix including the scarce GitHub `macos-13` (Intel) runner. When that runner queues for hours, the entire electron-updater feed (`latest*.yml` + `.blockmap`) is blocked from publishing even though win/linux/mac-arm built successfully. Observed on the fork `v0.10.4` run: `macos-13` queued 1.5h+, `publish-feed` never started, no feed shipped.

## Change

Both `frontend-release.yml` and `frontend-nightly.yml`:

- **Remove `macos-13` from the `release` matrix** -> `[macos-latest, windows-latest, ubuntu-latest]`.
- **Add a non-blocking `release-intel` job** on `macos-13` that mirrors a macOS build leg (checkout, node 20, go, `macos-signing-setup`, `npm run publish`, the darwin-x64 stable-alias upload). In the nightly workflow it also carries `needs: guard`, `if: should_build`, the nightly version stamp, and `AO_RELEASE_PRERELEASE: "true"`.
- **`publish-feed` stays `needs: release`** (now satisfied by the three fast legs), so the feed publishes as soon as they finish.

The Intel installer + the `darwin-x64` alias still build and upload (for `ao start` and direct download). `feed.mjs` already generates the mac feed from whatever versioned mac zips are present, so `latest-mac.yml` is arm64-first and includes the x64 entry when `release-intel` happens to finish before `publish-feed`.

## Tradeoff

When the Intel runner lags, `latest-mac.yml` ships arm64-only until the next run, so Intel-mac users do not auto-update until the x64 entry lands. That is the accepted tradeoff in #2237 (option 1): the alternative is the entire feed blocked indefinitely on every release. The Intel installer itself is never blocked.

## Note

The macOS build steps are intentionally duplicated between `release` and `release-intel` (GitHub Actions cannot share a leg across a matrix boundary). Keep them in sync.

## Validation

- Both workflows parse (js-yaml load).
- Structural review: `macos-13` is out of both matrices, `release-intel` is a top-level job mirroring the macOS leg, `publish-feed` is unchanged and still `needs: release`. The rest is only verifiable on a real CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
