### PR TITLE
chore: restore gofmt/goimports formatting (unbreak Go CI)

### DIFF
--- a/backend/internal/legacyimport/config.go
+++ b/backend/internal/legacyimport/config.go
@@ -21,11 +21,11 @@ type legacyConfig struct {
 // represent are typed; the rest are captured as raw nodes purely so the importer
 // can report them as dropped (issue #247 §4).
 type legacyProjectConfig struct {
-	Path          string             `yaml:"path"`
-	Name          string             `yaml:"name"`
+	Path string `yaml:"path"`
+	Name string `yaml:"name"`
 	// Repo is captured as a raw YAML node but never consumed; the origin URL is
 	// re-resolved from the repo path at import time.
-	Repo *yaml.Node `yaml:"repo"`
+	Repo          *yaml.Node         `yaml:"repo"`
 	DefaultBranch string             `yaml:"defaultBranch"`
 	SessionPrefix string             `yaml:"sessionPrefix"`
 	Env           map[string]string  `yaml:"env"`

--- a/backend/internal/legacyimport/project_test.go
+++ b/backend/internal/legacyimport/project_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	yaml "gopkg.in/yaml.v3"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
 // nonNilNode returns a non-nil *yaml.Node for struct fields that are captured

--- a/backend/internal/service/importer/importer_test.go
+++ b/backend/internal/service/importer/importer_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
-type fakeStore struct{ projects map[string]domain.ProjectRecord }
+type fakeStore struct {
+	projects map[string]domain.ProjectRecord
+}
 
 func newFakeStore() *fakeStore { return &fakeStore{projects: map[string]domain.ProjectRecord{}} }
 func (f *fakeStore) GetProject(_ context.Context, id string) (domain.ProjectRecord, bool, error) {


### PR DESCRIPTION
## What

Restores gofmt/goimports formatting on three files so the **Go** workflow passes again.

## Why

`main` has been red on the Go workflow since #2219. That PR changed `legacyProjectConfig.Repo` from `string` to `*yaml.Node` and added a doc comment, which split the struct's gofmt alignment blocks, but it was merged without re-running the formatter. As a result, on `main` today:

- the `build-test` job fails at **Check formatting** (`gofmt -l .`)
- the `lint` job fails at **golangci-lint** (goimports)

Affected files:
- `internal/legacyimport/config.go` — struct field alignment
- `internal/legacyimport/project_test.go` — local import grouping (goimports `local-prefixes`)
- `internal/service/importer/importer_test.go` — struct expansion

## How

Ran `golangci-lint fmt` (gofmt + goimports with the repo's configured `local-prefixes`). **Formatting only, no behavior change.**

## Verification
- `gofmt -l` clean on the touched files
- `golangci-lint run` → 0 issues
- `go build ./...`, `go vet ./...`, and `go test` on the touched packages all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)