### PR TITLE
fix(import): surface legacy store parse errors instead of swallowing them

### DIFF
--- a/backend/internal/cli/import.go
+++ b/backend/internal/cli/import.go
@@ -63,7 +63,11 @@ func (c *commandContext) runImport(cmd *cobra.Command, opts importOptions) error
 	if root == "" {
 		root = legacyimport.DefaultLegacyRootDir()
 	}
-	if !legacyimport.HasLegacyData(root) {
+	has, err := legacyimport.HasLegacyData(root)
+	if err != nil {
+		return fmt.Errorf("read legacy store at %s: %w", root, err)
+	}
+	if !has {
 		_, err := fmt.Fprintf(cmd.OutOrStdout(), "No legacy AO projects found at %s. Nothing to import.\n", root)
 		return err
 	}

--- a/backend/internal/legacyimport/config.go
+++ b/backend/internal/legacyimport/config.go
@@ -21,11 +21,11 @@ type legacyConfig struct {
 // represent are typed; the rest are captured as raw nodes purely so the importer
 // can report them as dropped (issue #247 §4).
 type legacyProjectConfig struct {
-	Path          string             `yaml:"path"`
-	Name          string             `yaml:"name"`
+	Path string `yaml:"path"`
+	Name string `yaml:"name"`
 	// Repo is captured as a raw YAML node but never consumed; the origin URL is
 	// re-resolved from the repo path at import time.
-	Repo *yaml.Node `yaml:"repo"`
+	Repo          *yaml.Node         `yaml:"repo"`
 	DefaultBranch string             `yaml:"defaultBranch"`
 	SessionPrefix string             `yaml:"sessionPrefix"`
 	Env           map[string]string  `yaml:"env"`

--- a/backend/internal/legacyimport/importer.go
+++ b/backend/internal/legacyimport/importer.go
@@ -44,15 +44,20 @@ type Report struct {
 
 // HasLegacyData reports whether root holds an importable legacy store: a
 // config.yaml with at least one project. Used for the first-boot opt-in check.
-func HasLegacyData(root string) bool {
+//
+// A missing store is (false, nil); a store that exists but fails to parse
+// returns the parse error so callers can distinguish "nothing to import" from
+// "the store is there but unreadable" instead of silently reporting the latter
+// as the former (issue #2186).
+func HasLegacyData(root string) (bool, error) {
 	if root == "" {
-		return false
+		return false, nil
 	}
 	cfg, err := loadLegacyConfig(root)
 	if err != nil {
-		return false
+		return false, err
 	}
-	return len(cfg.Projects) > 0
+	return len(cfg.Projects) > 0, nil
 }
 
 // rewriteProjectID gates the rewrite project-id charset (validateProjectID,

--- a/backend/internal/legacyimport/importer_test.go
+++ b/backend/internal/legacyimport/importer_test.go
@@ -119,11 +119,74 @@ func TestRun_NoLegacyData(t *testing.T) {
 
 func TestHasLegacyData(t *testing.T) {
 	root := writeLegacyRoot(t)
-	if !HasLegacyData(root) {
+	has, err := HasLegacyData(root)
+	if err != nil {
+		t.Fatalf("HasLegacyData: %v", err)
+	}
+	if !has {
 		t.Fatal("HasLegacyData = false, want true")
 	}
-	if HasLegacyData(filepath.Join(t.TempDir(), "nope")) {
+
+	missing, err := HasLegacyData(filepath.Join(t.TempDir(), "nope"))
+	if err != nil {
+		t.Fatalf("HasLegacyData(missing) errored: %v", err)
+	}
+	if missing {
 		t.Fatal("HasLegacyData = true for missing root")
+	}
+}
+
+// TestHasLegacyData_ParseErrorSurfaced guards #2186 bug 2: a legacy store that
+// exists but fails to parse must return the error, not a silent (false, nil)
+// that the CLI would render as "No legacy AO projects found".
+func TestHasLegacyData_ParseErrorSurfaced(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-orchestrator")
+	mustMkdir(t, root)
+	// An unterminated quote is a YAML syntax error (not a tolerated TypeError).
+	mustWrite(t, filepath.Join(root, "config.yaml"), `projects:
+  alpha:
+    path: "/repos/alpha
+`)
+	has, err := HasLegacyData(root)
+	if err == nil {
+		t.Fatal("HasLegacyData on a malformed config returned nil error; want the parse error surfaced")
+	}
+	if has {
+		t.Fatal("HasLegacyData = true for an unparseable config")
+	}
+}
+
+// TestRun_ObjectFormRepo guards #2186 bug 1: a legacy config.yaml whose `repo:`
+// is a mapping (the shape `ao project add` writes) must still decode and import.
+// When `repo` was typed as a string, yaml.Unmarshal failed and the whole store
+// silently imported zero projects.
+func TestRun_ObjectFormRepo(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-orchestrator")
+	mustMkdir(t, filepath.Join(root, "projects", "tg_content_factory", "sessions"))
+	mustWrite(t, filepath.Join(root, "config.yaml"), `projects:
+  tg_content_factory:
+    projectId: tg_content_factory
+    path: /repos/tg_content_factory
+    repo:
+      owner: axisrow
+      name: tg_content_factory
+      platform: github
+      originUrl: https://github.com/axisrow/tg_content_factory
+    defaultBranch: develop
+    source: ao-project-add
+`)
+	store := newFakeStore()
+	rep, err := Run(context.Background(), store, runOpts(root))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if rep.ProjectsImported != 1 {
+		t.Fatalf("projectsImported = %d, want 1 (object-form repo must decode)", rep.ProjectsImported)
+	}
+	// A non-default branch is carried into the rewrite config, proving sibling
+	// fields decode correctly alongside the object-form repo mapping.
+	if got := store.projects["tg_content_factory"].Config.DefaultBranch; got != "develop" {
+		t.Fatalf("defaultBranch = %q, want develop", got)
 	}
 }
 

--- a/backend/internal/legacyimport/project_test.go
+++ b/backend/internal/legacyimport/project_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	yaml "gopkg.in/yaml.v3"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
 // nonNilNode returns a non-nil *yaml.Node for struct fields that are captured

--- a/backend/internal/service/importer/importer.go
+++ b/backend/internal/service/importer/importer.go
@@ -57,7 +57,11 @@ func New(deps Deps) *Manager {
 // Status reports availability only: legacy data present at the root. It never
 // errors on a missing legacy store; that is simply "not available".
 func (m *Manager) Status(_ context.Context) (Status, error) {
-	return Status{Available: legacyimport.HasLegacyData(m.root), LegacyRoot: m.root}, nil
+	// Per the contract above, a missing or unreadable legacy store is simply
+	// "not available"; the parse error is intentionally not surfaced here (the
+	// `ao import` CLI is the path that reports it — issue #2186).
+	has, _ := legacyimport.HasLegacyData(m.root)
+	return Status{Available: has, LegacyRoot: m.root}, nil
 }
 
 // Run executes the import through the daemon's store. Idempotent: the engine

--- a/backend/internal/service/importer/importer_test.go
+++ b/backend/internal/service/importer/importer_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
-type fakeStore struct{ projects map[string]domain.ProjectRecord }
+type fakeStore struct {
+	projects map[string]domain.ProjectRecord
+}
 
 func newFakeStore() *fakeStore { return &fakeStore{projects: map[string]domain.ProjectRecord{}} }
 func (f *fakeStore) GetProject(_ context.Context, id string) (domain.ProjectRecord, bool, error) {


### PR DESCRIPTION
Closes #2186.

## Background

`ao import` reported **"No legacy AO projects found"** for a legacy store that actually contained projects but failed to parse, because `HasLegacyData` collapsed every error (including a YAML parse failure) into a bare `false`. A user with a valid store was told there was nothing to import, with no hint of the underlying schema drift.

The issue described two bugs:
1. **`repo:` typed as `string`** while the legacy schema (what `ao project add` writes) stores it as a mapping → `yaml.Unmarshal` fails.
2. **The parse error was swallowed**, surfacing as the misleading "nothing to import".

**Bug 1 already landed** in #2219 (which changed `Repo` to `*yaml.Node` and made `loadLegacyConfig` tolerate type errors), but with **no regression test** and **no reference to this issue**, so #2186 stayed open. This PR adds the missing regression test and fixes the still-open Bug 2.

## Changes

- `HasLegacyData` now returns `(bool, error)`: a missing store is `(false, nil)`; a store that exists but fails to parse returns the parse error so callers can distinguish "nothing to import" from "the store is unreadable".
- `ao import` surfaces that error instead of printing the misleading message.
- The import **service** `Status` keeps its documented "never errors on a missing/unreadable store" contract (the CLI is the diagnostic path).

## Tests
- `TestRun_ObjectFormRepo` — regression guard for the object-form `repo:` mapping (Bug 1).
- `TestHasLegacyData_ParseErrorSurfaced` — covers the new error path (Bug 2).

## Note
Stacked on #2245 (the gofmt fix that unbreaks the Go CI). Until that merges this PR shows that commit too; the substantive change here is the single `fix(import): …` commit. Rebasing onto `main` after #2245 lands will collapse it to one commit.

## Verification
- `go test ./internal/legacyimport/... ./internal/cli/... ./internal/service/importer/...` pass
- `golangci-lint v2.12.2 run` → 0 issues; `gofmt -l` clean; `go build ./...` + `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)