### PR TITLE
  fix: surface conflicting PRs

### DIFF
--- a/backend/internal/domain/notification.go
+++ b/backend/internal/domain/notification.go
@@ -13,6 +13,8 @@ const (
 	NotificationNeedsInput NotificationType = "needs_input"
 	// NotificationReadyToMerge means a PR has no known merge blockers.
 	NotificationReadyToMerge NotificationType = "ready_to_merge"
+	// NotificationPRConflicting means a tracked PR has merge conflicts.
+	NotificationPRConflicting NotificationType = "pr_conflicting"
 	// NotificationPRMerged means a tracked PR was merged.
 	NotificationPRMerged NotificationType = "pr_merged"
 	// NotificationPRClosedUnmerged means a tracked PR closed without merging.
@@ -22,7 +24,7 @@ const (
 // Valid reports whether t is one of the v1 notification kinds.
 func (t NotificationType) Valid() bool {
 	switch t {
-	case NotificationNeedsInput, NotificationReadyToMerge, NotificationPRMerged, NotificationPRClosedUnmerged:
+	case NotificationNeedsInput, NotificationReadyToMerge, NotificationPRConflicting, NotificationPRMerged, NotificationPRClosedUnmerged:
 		return true
 	default:
 		return false

--- a/backend/internal/domain/session.go
+++ b/backend/internal/domain/session.go
@@ -67,7 +67,7 @@ type SessionRecord struct {
 // plus the derived display Status.
 type Session struct {
 	SessionRecord
-	Status           SessionStatus `json:"status" enum:"working,pr_open,draft,ci_failed,review_pending,changes_requested,approved,mergeable,merged,needs_input,idle,terminated,no_signal"`
+	Status           SessionStatus `json:"status" enum:"working,pr_open,draft,ci_failed,conflicting,review_pending,changes_requested,approved,mergeable,merged,needs_input,idle,terminated,no_signal"`
 	TerminalHandleID string        `json:"terminalHandleId,omitempty"`
 	// PRs are the session's attributed pull requests (one session can own many).
 	// They feed status derivation and are surfaced on the API read model. Not

--- a/backend/internal/domain/status.go
+++ b/backend/internal/domain/status.go
@@ -10,6 +10,7 @@ const (
 	StatusPROpen           SessionStatus = "pr_open"
 	StatusDraft            SessionStatus = "draft"
 	StatusCIFailed         SessionStatus = "ci_failed"
+	StatusConflicting      SessionStatus = "conflicting"
 	StatusReviewPending    SessionStatus = "review_pending"
 	StatusChangesRequested SessionStatus = "changes_requested"
 	StatusApproved         SessionStatus = "approved"

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -1586,6 +1586,7 @@ components:
           - pr_open
           - draft
           - ci_failed
+          - conflicting
           - review_pending
           - changes_requested
           - approved
@@ -1813,6 +1814,7 @@ components:
           enum:
           - needs_input
           - ready_to_merge
+          - pr_conflicting
           - pr_merged
           - pr_closed_unmerged
           type: string

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -458,7 +458,7 @@ type NotificationResponse struct {
 	SessionID string             `json:"sessionId"`
 	ProjectID string             `json:"projectId"`
 	PRURL     string             `json:"prUrl"`
-	Type      string             `json:"type" enum:"needs_input,ready_to_merge,pr_merged,pr_closed_unmerged"`
+	Type      string             `json:"type" enum:"needs_input,ready_to_merge,pr_conflicting,pr_merged,pr_closed_unmerged"`
 	Title     string             `json:"title"`
 	Body      string             `json:"body"`
 	Status    string             `json:"status" enum:"unread,read"`

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -800,6 +800,21 @@ func TestPRObservation_RetriesAfterMessengerFailure(t *testing.T) {
 	}
 }
 
+func TestPRObservation_MergeConflictNudgesWhileWaitingInput(t *testing.T) {
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", Activity: domain.Activity{State: domain.ActivityWaitingInput}}
+	o := ports.PRObservation{Fetched: true, URL: "pr1", Mergeability: domain.MergeConflicting}
+	if err := m.ApplyPRObservation(ctx, "mer-1", o); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("waiting-input conflict should nudge once, got %v", msg.msgs)
+	}
+	if !strings.Contains(msg.msgs[0], "merge conflicts") {
+		t.Fatalf("nudge should mention merge conflicts, got %q", msg.msgs[0])
+	}
+}
+
 func TestActivity_FirstSignalStampsReceipt(t *testing.T) {
 	m, st, _ := newManager()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: time.Now()}}
@@ -920,6 +935,11 @@ func TestSCMObservation_Notifications(t *testing.T) {
 			want: domain.NotificationReadyToMerge,
 		},
 		{
+			name: "conflicting",
+			obs:  ports.SCMObservation{Fetched: true, PR: ports.SCMPRObservation{URL: "https://github.com/o/r/pull/4", Number: 4, Title: "checkout"}, Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeConflicting)}},
+			want: domain.NotificationPRConflicting,
+		},
+		{
 			name: "merged",
 			obs:  ports.SCMObservation{Fetched: true, PR: ports.SCMPRObservation{URL: "https://github.com/o/r/pull/2", Number: 2, Merged: true}},
 			want: domain.NotificationPRMerged,
@@ -945,6 +965,51 @@ func TestSCMObservation_Notifications(t *testing.T) {
 				t.Fatalf("intent = %+v, want type %s", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestSCMObservation_ConflictingNotSuppressedWhileWaitingInput(t *testing.T) {
+	st := newFakeStore()
+	sink := &fakeNotificationSink{}
+	m := New(st, nil, WithNotificationSink(sink))
+	rec := working("mer-1")
+	rec.Activity.State = domain.ActivityWaitingInput
+	st.sessions["mer-1"] = rec
+	obs := ports.SCMObservation{
+		Fetched:      true,
+		PR:           ports.SCMPRObservation{URL: "https://github.com/o/r/pull/1", Number: 1},
+		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeConflicting)},
+	}
+	if err := m.ApplySCMObservation(ctx, "mer-1", obs); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.intents) != 1 {
+		t.Fatalf("intents = %d, want 1", len(sink.intents))
+	}
+	if got := sink.intents[0]; got.Type != domain.NotificationPRConflicting {
+		t.Fatalf("intent = %+v, want conflicting", got)
+	}
+}
+
+func TestSCMObservation_ConflictingNotificationSurvivesNudgeFailure(t *testing.T) {
+	st := newFakeStore()
+	msg := &fakeMessenger{err: errors.New("pane unavailable")}
+	sink := &fakeNotificationSink{}
+	m := New(st, msg, WithNotificationSink(sink))
+	st.sessions["mer-1"] = working("mer-1")
+	obs := ports.SCMObservation{
+		Fetched:      true,
+		PR:           ports.SCMPRObservation{URL: "https://github.com/o/r/pull/1", Number: 1},
+		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeConflicting)},
+	}
+	if err := m.ApplySCMObservation(ctx, "mer-1", obs); err == nil {
+		t.Fatal("want nudge delivery error returned")
+	}
+	if len(sink.intents) != 1 {
+		t.Fatalf("conflict notification should survive nudge failure, got %+v", sink.intents)
+	}
+	if got := sink.intents[0]; got.Type != domain.NotificationPRConflicting {
+		t.Fatalf("intent = %+v, want conflicting", got)
 	}
 }
 

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -91,7 +91,11 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 	if err != nil || !ok {
 		return err
 	}
-	if rec.IsTerminated || rec.Activity.State == domain.ActivityWaitingInput {
+	if rec.IsTerminated {
+		return nil
+	}
+	waitingInput := rec.Activity.State == domain.ActivityWaitingInput
+	if waitingInput && o.Mergeability != domain.MergeConflicting {
 		return nil
 	}
 	if o.CI == domain.CIFailing {
@@ -223,15 +227,20 @@ func (m *Manager) ApplySCMObservation(ctx context.Context, id domain.SessionID, 
 	if !o.Fetched {
 		return nil
 	}
-	if err := m.ApplyPRObservation(ctx, id, scmToPRObservation(o)); err != nil {
-		return err
+	prErr := m.ApplyPRObservation(ctx, id, scmToPRObservation(o))
+	if prErr != nil && domain.Mergeability(o.Mergeability.State) != domain.MergeConflicting {
+		return prErr
+	}
+	if prErr != nil {
+		slog.Default().Warn("lifecycle: merge-conflict nudge failed; still emitting user notification",
+			"session", id, "pr", firstSCMNonEmpty(o.PR.URL, o.PR.HTMLURL), "err", prErr)
 	}
 	intent, err := m.notificationIntentForCurrentSCM(ctx, id, o)
 	if err != nil {
 		return err
 	}
 	m.emitNotification(ctx, intent)
-	return nil
+	return prErr
 }
 
 func (m *Manager) notificationIntentForCurrentSCM(ctx context.Context, id domain.SessionID, o ports.SCMObservation) (*ports.NotificationIntent, error) {
@@ -270,6 +279,10 @@ func (m *Manager) notificationIntentForSCM(rec domain.SessionRecord, o ports.SCM
 	}
 	if o.PR.Closed {
 		base.Type = domain.NotificationPRClosedUnmerged
+		return &base
+	}
+	if !rec.IsTerminated && domain.Mergeability(o.Mergeability.State) == domain.MergeConflicting {
+		base.Type = domain.NotificationPRConflicting
 		return &base
 	}
 	if rec.IsTerminated || rec.Activity.State == domain.ActivityWaitingInput || !scmObservationIsReadyToMerge(o) {

--- a/backend/internal/notify/enrich.go
+++ b/backend/internal/notify/enrich.go
@@ -36,6 +36,8 @@ func titleForIntent(intent Intent) string {
 		return fmt.Sprintf("%s needs input", sessionLabel(intent))
 	case domain.NotificationReadyToMerge:
 		return fmt.Sprintf("%s is ready to merge", prLabel(intent))
+	case domain.NotificationPRConflicting:
+		return fmt.Sprintf("%s has merge conflicts", prLabel(intent))
 	case domain.NotificationPRMerged:
 		return fmt.Sprintf("%s was merged", prLabel(intent))
 	case domain.NotificationPRClosedUnmerged:
@@ -54,6 +56,11 @@ func bodyForIntent(intent Intent) string {
 			return fmt.Sprintf("%s has no known blocking CI or review feedback.", s)
 		}
 		return "The pull request has no known blocking CI or review feedback."
+	case domain.NotificationPRConflicting:
+		if s := sessionLabel(intent); s != "session" {
+			return fmt.Sprintf("%s needs a rebase before this pull request can merge.", s)
+		}
+		return "The pull request needs a rebase before it can merge."
 	case domain.NotificationPRMerged:
 		if title := strings.TrimSpace(intent.PRTitle); title != "" {
 			return fmt.Sprintf("%s was merged.", title)

--- a/backend/internal/notify/manager_test.go
+++ b/backend/internal/notify/manager_test.go
@@ -78,6 +78,34 @@ func TestManagerNotifyRejectsUnknownType(t *testing.T) {
 	}
 }
 
+func TestManagerNotifyEnrichesPRConflicting(t *testing.T) {
+	st := &fakeStore{}
+	now := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	mgr := New(Deps{Store: st, Clock: func() time.Time { return now }, NewID: func() string { return "ntf_1" }})
+
+	err := mgr.Notify(context.Background(), Intent{
+		Type:               domain.NotificationPRConflicting,
+		SessionID:          "mer-1",
+		ProjectID:          "mer",
+		SessionDisplayName: "checkout-flow",
+		PRURL:              "https://github.com/o/r/pull/1",
+		PRNumber:           1,
+	})
+	if err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if len(st.rows) != 1 {
+		t.Fatalf("stored rows = %d, want 1", len(st.rows))
+	}
+	got := st.rows[0]
+	if got.Type != domain.NotificationPRConflicting || got.Title != "PR #1 has merge conflicts" {
+		t.Fatalf("stored notification = %+v", got)
+	}
+	if got.Body != "checkout-flow needs a rebase before this pull request can merge." {
+		t.Fatalf("body = %q", got.Body)
+	}
+}
+
 func TestHubProjectFilter(t *testing.T) {
 	hub := NewHub()
 	ch, unsub := hub.Subscribe("mer")

--- a/backend/internal/service/session/status.go
+++ b/backend/internal/service/session/status.go
@@ -32,16 +32,23 @@ func deriveStatus(rec domain.SessionRecord, prs []domain.PRFacts, now time.Time,
 		return domain.StatusTerminated
 	}
 
-	if rec.Activity.State == domain.ActivityWaitingInput {
-		return domain.StatusNeedsInput
-	}
-
 	open := openPRs(prs)
 	if len(open) > 0 {
-		return aggregatePRStatus(open)
+		status := aggregatePRStatus(open)
+		if status == domain.StatusConflicting {
+			return status
+		}
+		if rec.Activity.State == domain.ActivityWaitingInput {
+			return domain.StatusNeedsInput
+		}
+		return status
 	}
 	if anyMerged(prs) {
 		return domain.StatusMerged
+	}
+
+	if rec.Activity.State == domain.ActivityWaitingInput {
+		return domain.StatusNeedsInput
 	}
 
 	if rec.Activity.State == domain.ActivityActive {
@@ -81,10 +88,11 @@ func anyMerged(prs []domain.PRFacts) bool {
 // A stacked child blocked by an open parent cannot merge yet, so its readiness
 // signals (mergeable/approved/review-pending/open) are not actionable for the
 // session and are suppressed. Its problem signals are still actionable: failing
-// CI, draft state, and requested-changes/unresolved-comments must stay visible
-// so a broken child is not hidden behind the stack. If no PR contributes any
-// signal (a degenerate stack with no visible root), it falls back to aggregating
-// the raw status across all open PRs so the session never goes dark.
+// CI, merge conflicts, draft state, and requested-changes/unresolved-comments
+// must stay visible so a broken child is not hidden behind the stack. If no PR
+// contributes any signal (a degenerate stack with no visible root), it falls
+// back to aggregating the raw status across all open PRs so the session never
+// goes dark.
 func aggregatePRStatus(open []domain.PRFacts) domain.SessionStatus {
 	stacks := buildStacks(open)
 	candidates := make([]domain.SessionStatus, 0, len(open))
@@ -114,7 +122,7 @@ func aggregatePRStatus(open []domain.PRFacts) domain.SessionStatus {
 // inability to merge until its parent does.
 func isActionableChildSignal(s domain.SessionStatus) bool {
 	switch s {
-	case domain.StatusCIFailed, domain.StatusDraft, domain.StatusChangesRequested:
+	case domain.StatusCIFailed, domain.StatusConflicting, domain.StatusDraft, domain.StatusChangesRequested:
 		return true
 	default:
 		return false
@@ -128,20 +136,22 @@ func statusSeverity(s domain.SessionStatus) int {
 	switch s {
 	case domain.StatusCIFailed:
 		return 0
-	case domain.StatusChangesRequested:
+	case domain.StatusConflicting:
 		return 1
-	case domain.StatusDraft:
+	case domain.StatusChangesRequested:
 		return 2
-	case domain.StatusReviewPending:
+	case domain.StatusDraft:
 		return 3
-	case domain.StatusPROpen:
+	case domain.StatusReviewPending:
 		return 4
-	case domain.StatusApproved:
+	case domain.StatusPROpen:
 		return 5
-	case domain.StatusMergeable:
+	case domain.StatusApproved:
 		return 6
-	default:
+	case domain.StatusMergeable:
 		return 7
+	default:
+		return 8
 	}
 }
 
@@ -149,6 +159,8 @@ func prPipelineStatus(pr domain.PRFacts) domain.SessionStatus {
 	switch {
 	case pr.CI == domain.CIFailing:
 		return domain.StatusCIFailed
+	case pr.Mergeability == domain.MergeConflicting:
+		return domain.StatusConflicting
 	case pr.Draft:
 		return domain.StatusDraft
 	case pr.Review == domain.ReviewChangesRequest || pr.ReviewComments:

--- a/backend/internal/service/session/status_test.go
+++ b/backend/internal/service/session/status_test.go
@@ -42,7 +42,9 @@ func TestServiceDerivesStatusFromSessionFactsAndPR(t *testing.T) {
 		{"terminated", statusRec(domain.ActivityExited, true), nil, false, domain.StatusTerminated},
 		{"merged-pr", statusRec(domain.ActivityIdle, true), statusPR(domain.PRFacts{Merged: true}), false, domain.StatusMerged},
 		{"needs-input", statusRec(domain.ActivityWaitingInput, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusNeedsInput},
+		{"waiting-input-conflicting-pr", statusRec(domain.ActivityWaitingInput, false), statusPR(domain.PRFacts{Mergeability: domain.MergeConflicting}), false, domain.StatusConflicting},
 		{"ci-failed", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusCIFailed},
+		{"conflicting", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{Review: domain.ReviewApproved, CI: domain.CIPassing, Mergeability: domain.MergeConflicting}), false, domain.StatusConflicting},
 		{"draft", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{Draft: true}), false, domain.StatusDraft},
 		{"changes-requested", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{Review: domain.ReviewChangesRequest}), false, domain.StatusChangesRequested},
 		{"mergeable", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{Mergeability: domain.MergeMergeable}), false, domain.StatusMergeable},
@@ -96,6 +98,7 @@ func TestAggregateStackedChildSignals(t *testing.T) {
 		want domain.SessionStatus
 	}{
 		{"blocked-child-ci-failing-surfaces", []domain.PRFacts{parent, child(domain.PRFacts{CI: domain.CIFailing})}, domain.StatusCIFailed},
+		{"blocked-child-conflicting-surfaces", []domain.PRFacts{parent, child(domain.PRFacts{Mergeability: domain.MergeConflicting})}, domain.StatusConflicting},
 		{"blocked-child-draft-surfaces", []domain.PRFacts{parent, child(domain.PRFacts{Draft: true})}, domain.StatusDraft},
 		{"blocked-child-changes-requested-surfaces", []domain.PRFacts{parent, child(domain.PRFacts{Review: domain.ReviewChangesRequest})}, domain.StatusChangesRequested},
 		{"blocked-child-unresolved-comments-surfaces", []domain.PRFacts{parent, child(domain.PRFacts{ReviewComments: true})}, domain.StatusChangesRequested},

--- a/backend/internal/storage/sqlite/migrations/0020_notification_conflicting.sql
+++ b/backend/internal/storage/sqlite/migrations/0020_notification_conflicting.sql
@@ -1,0 +1,116 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE notifications_new (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    pr_url TEXT NOT NULL DEFAULT '',
+    type TEXT NOT NULL CHECK (
+        type IN (
+            'needs_input',
+            'ready_to_merge',
+            'pr_conflicting',
+            'pr_merged',
+            'pr_closed_unmerged'
+        )
+    ),
+    title TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'unread' CHECK (status IN ('read', 'unread')),
+    created_at TIMESTAMP NOT NULL
+);
+
+INSERT INTO notifications_new (
+    id,
+    session_id,
+    project_id,
+    pr_url,
+    type,
+    title,
+    body,
+    status,
+    created_at
+)
+SELECT
+    id,
+    session_id,
+    project_id,
+    pr_url,
+    type,
+    title,
+    body,
+    status,
+    created_at
+FROM notifications;
+
+DROP INDEX IF EXISTS idx_notifications_unread_dedupe;
+DROP INDEX IF EXISTS idx_notifications_status;
+DROP TABLE notifications;
+ALTER TABLE notifications_new RENAME TO notifications;
+
+CREATE INDEX idx_notifications_status
+    ON notifications(status, created_at DESC);
+
+CREATE UNIQUE INDEX idx_notifications_unread_dedupe
+    ON notifications(session_id, type, pr_url)
+    WHERE status = 'unread';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DELETE FROM notifications WHERE type = 'pr_conflicting';
+
+CREATE TABLE notifications_old (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    pr_url TEXT NOT NULL DEFAULT '',
+    type TEXT NOT NULL CHECK (
+        type IN (
+            'needs_input',
+            'ready_to_merge',
+            'pr_merged',
+            'pr_closed_unmerged'
+        )
+    ),
+    title TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'unread' CHECK (status IN ('read', 'unread')),
+    created_at TIMESTAMP NOT NULL
+);
+
+INSERT INTO notifications_old (
+    id,
+    session_id,
+    project_id,
+    pr_url,
+    type,
+    title,
+    body,
+    status,
+    created_at
+)
+SELECT
+    id,
+    session_id,
+    project_id,
+    pr_url,
+    type,
+    title,
+    body,
+    status,
+    created_at
+FROM notifications;
+
+DROP INDEX IF EXISTS idx_notifications_unread_dedupe;
+DROP INDEX IF EXISTS idx_notifications_status;
+DROP TABLE notifications;
+ALTER TABLE notifications_old RENAME TO notifications;
+
+CREATE INDEX idx_notifications_status
+    ON notifications(status, created_at DESC);
+
+CREATE UNIQUE INDEX idx_notifications_unread_dedupe
+    ON notifications(session_id, type, pr_url)
+    WHERE status = 'unread';
+-- +goose StatementEnd

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -549,7 +549,7 @@ export interface components {
             projectId: string;
             prs: components["schemas"]["SessionPRFacts"][];
             /** @enum {string} */
-            status: "working" | "pr_open" | "draft" | "ci_failed" | "review_pending" | "changes_requested" | "approved" | "mergeable" | "merged" | "needs_input" | "idle" | "terminated" | "no_signal";
+            status: "working" | "pr_open" | "draft" | "ci_failed" | "conflicting" | "review_pending" | "changes_requested" | "approved" | "mergeable" | "merged" | "needs_input" | "idle" | "terminated" | "no_signal";
             terminalHandleId?: string;
             /** Format: date-time */
             updatedAt: string;
@@ -635,7 +635,7 @@ export interface components {
             target: components["schemas"]["NotificationTarget"];
             title: string;
             /** @enum {string} */
-            type: "needs_input" | "ready_to_merge" | "pr_merged" | "pr_closed_unmerged";
+            type: "needs_input" | "ready_to_merge" | "pr_conflicting" | "pr_merged" | "pr_closed_unmerged";
         };
         NotificationTarget: {
             /** @enum {string} */

--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -29,6 +29,18 @@ const notifications: NotificationDTO[] = [
 		createdAt: "2026-06-16T11:00:00Z",
 		target: { kind: "session", sessionId: "sess-2" },
 	},
+	{
+		id: "ntf_3",
+		sessionId: "sess-3",
+		projectId: "proj-1",
+		prUrl: "https://github.com/o/r/pull/3",
+		type: "pr_conflicting",
+		title: "PR #3 has merge conflicts",
+		body: "",
+		status: "unread",
+		createdAt: "2026-06-16T12:00:00Z",
+		target: { kind: "session", sessionId: "sess-3" },
+	},
 ];
 
 vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
@@ -57,9 +69,9 @@ describe("NotificationCenter", () => {
 	it("renders a filled bell with a text-only yellow unread count", () => {
 		renderNotificationCenter();
 
-		const trigger = screen.getByRole("button", { name: "2 unread notifications" });
+		const trigger = screen.getByRole("button", { name: "3 unread notifications" });
 		const bell = trigger.querySelector("svg");
-		const count = screen.getByText("2");
+		const count = screen.getByText("3");
 
 		expect(bell).toHaveClass("fill-current");
 		expect(count).toHaveClass("text-[11px]");

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -159,6 +159,7 @@ function NotificationItem({
 					"mt-0.5 grid h-6 w-6 place-items-center rounded-md border",
 					notification.type === "needs_input" && "border-warning/40 text-warning",
 					notification.type === "ready_to_merge" && "border-success/40 text-success",
+					notification.type === "pr_conflicting" && "border-error/40 text-error",
 					notification.type === "pr_merged" && "border-accent-dim text-accent",
 					notification.type === "pr_closed_unmerged" && "border-error/40 text-error",
 				)}
@@ -205,6 +206,8 @@ function notificationIcon(type: string) {
 			return CircleAlert;
 		case "ready_to_merge":
 			return GitPullRequest;
+		case "pr_conflicting":
+			return CircleAlert;
 		case "pr_merged":
 			return GitMerge;
 		case "pr_closed_unmerged":

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -344,6 +344,7 @@ const STATUS_PILL: Record<
 	working: { label: "Working", tone: "var(--orange)", breathe: true },
 	needs_you: { label: "Input needed", tone: "var(--amber)", breathe: false },
 	ci_failed: { label: "CI failed", tone: "var(--red)", breathe: false },
+	conflicting: { label: "Conflicts", tone: "var(--red)", breathe: false },
 	no_signal: { label: "No signal", tone: "var(--fg-muted)", breathe: false },
 	mergeable: { label: "Ready", tone: "var(--green)", breathe: false },
 	done: { label: "Done", tone: "var(--fg-muted)", breathe: false },

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -349,6 +349,8 @@ function sessionBadge(session: WorkspaceSession): { label: string; className: st
 			return { label: "No signal", className: "text-passive" };
 		case "ci_failed":
 			return { label: "CI failed", className: "text-error" };
+		case "conflicting":
+			return { label: "Conflicts", className: "text-error" };
 		case "changes_requested":
 			return { label: "Changes requested", className: "text-warning" };
 		case "review_pending":

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -31,6 +31,7 @@ const STATUS_PILL: Record<WorkerDisplayStatus, { label: string; tone: string; br
 	working: { label: "Working", tone: "var(--orange)", breathe: true },
 	needs_you: { label: "Needs input", tone: "var(--amber)", breathe: false },
 	ci_failed: { label: "CI failed", tone: "var(--red)", breathe: false },
+	conflicting: { label: "Conflicts", tone: "var(--red)", breathe: false },
 	no_signal: { label: "No signal", tone: "var(--fg-muted)", breathe: false },
 	mergeable: { label: "Ready", tone: "var(--green)", breathe: false },
 	done: { label: "Done", tone: "var(--fg-muted)", breathe: false },

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -75,6 +75,7 @@ describe("workerDisplayStatus", () => {
 		["changes_requested", "needs_you"],
 		["review_pending", "needs_you"],
 		["ci_failed", "ci_failed"],
+		["conflicting", "conflicting"],
 		["no_signal", "no_signal"],
 		["approved", "mergeable"],
 		["mergeable", "mergeable"],
@@ -132,7 +133,7 @@ describe("findProjectOrchestrator", () => {
 });
 
 describe("sessionNeedsAttention", () => {
-	it.each(["needs_input", "no_signal", "changes_requested", "review_pending", "ci_failed"] as const)(
+	it.each(["needs_input", "no_signal", "changes_requested", "review_pending", "ci_failed", "conflicting"] as const)(
 		"is true for %s",
 		(status) => {
 			expect(sessionNeedsAttention(sessionWith({ status }))).toBe(true);
@@ -154,6 +155,7 @@ describe("workerStatusPulses", () => {
 		expect(workerStatusPulses("working")).toBe(true);
 		expect(workerStatusPulses("needs_you")).toBe(true);
 		expect(workerStatusPulses("mergeable")).toBe(false);
+		expect(workerStatusPulses("conflicting")).toBe(false);
 		expect(workerStatusPulses("no_signal")).toBe(false);
 		expect(workerStatusPulses("done")).toBe(false);
 		expect(workerStatusPulses("unknown")).toBe(false);
@@ -213,6 +215,7 @@ describe("attentionZone", () => {
 		["needs_input", "action"],
 		["no_signal", "action"],
 		["ci_failed", "action"],
+		["conflicting", "action"],
 		["changes_requested", "action"],
 		["review_pending", "pending"],
 		["pr_open", "pending"],

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -3,6 +3,7 @@ export type SessionStatus =
 	| "pr_open"
 	| "draft"
 	| "ci_failed"
+	| "conflicting"
 	| "review_pending"
 	| "changes_requested"
 	| "approved"
@@ -19,6 +20,7 @@ const sessionStatuses = new Set<SessionStatus>([
 	"pr_open",
 	"draft",
 	"ci_failed",
+	"conflicting",
 	"review_pending",
 	"changes_requested",
 	"approved",
@@ -134,7 +136,7 @@ export type WorkspaceSession = {
 
 /** Glanceable worker status. Maps 1:1 to the accent colors in DESIGN.md. */
 export type WorkerDisplayStatus =
-	"working" | "needs_you" | "mergeable" | "ci_failed" | "no_signal" | "done" | "unknown";
+	"working" | "needs_you" | "mergeable" | "ci_failed" | "conflicting" | "no_signal" | "done" | "unknown";
 
 export function workerDisplayStatus(session: WorkspaceSession): WorkerDisplayStatus {
 	if (session.displayStatus) return session.displayStatus;
@@ -145,6 +147,8 @@ export function workerDisplayStatus(session: WorkspaceSession): WorkerDisplaySta
 			return "needs_you";
 		case "ci_failed":
 			return "ci_failed";
+		case "conflicting":
+			return "conflicting";
 		case "no_signal":
 			return "no_signal";
 		case "approved":
@@ -215,6 +219,7 @@ export function sessionNeedsAttention(session: WorkspaceSession): boolean {
 		session.status === "needs_input" ||
 		session.status === "no_signal" ||
 		session.status === "changes_requested" ||
+		session.status === "conflicting" ||
 		session.status === "review_pending" ||
 		session.status === "ci_failed"
 	);
@@ -225,6 +230,7 @@ export const workerStatusLabel: Record<WorkerDisplayStatus, string> = {
 	needs_you: "needs you",
 	mergeable: "mergeable",
 	ci_failed: "ci failed",
+	conflicting: "conflicting",
 	no_signal: "no signal",
 	done: "done",
 	unknown: "unknown",
@@ -270,6 +276,7 @@ export function attentionZone(session: WorkspaceSession): AttentionZone {
 		case "needs_input":
 		case "no_signal":
 		case "ci_failed":
+		case "conflicting":
 		case "changes_requested":
 			return "action";
 		// Waiting on an external reviewer / CI — nothing to do right now.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,5 @@
 	},
 	"devDependencies": {
 		"openapi-typescript": "7.4.4"
-	},
-	"packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
 	},
 	"devDependencies": {
 		"openapi-typescript": "7.4.4"
-	}
+	},
+	"packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215"
 }


### PR DESCRIPTION
## Summary

  - add a derived `conflicting` session status for open PRs with merge conflicts
  - allow merge-conflict nudges even when the session is `waiting_input`
  - add `pr_conflicting` notifications so conflicts reach the user even if the agent is paused
  - show conflicting sessions in the frontend as Needs you / Conflicts instead of Ready to merge
  - regenerate OpenAPI and frontend API schema for the new enum values

  ## Notes

  This intentionally keeps the change scoped to merge conflicts. The broader behavior where `waiting_input` can mask other PR-derived statuses is related to #290 and should be handled separately.

  A new SQLite migration is included because notification `type` has a CHECK constraint and existing migrations should not be edited.
  
fix for #2173   

  ## Test

  - `go test ./internal/service/session ./internal/lifecycle ./internal/notify`
  - `go test ./internal/httpd/...`
  - `npm run frontend:typecheck`
  - `cd frontend && npm exec vitest run src/renderer/types/workspace.test.ts src/renderer/components/NotificationCenter.test.tsx`