### PR TITLE
chore(release): stamp desktop app version 0.10.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "agent-orchestrator",
 	"productName": "Agent Orchestrator",
-	"version": "0.0.0",
+	"version": "0.10.0",
 	"private": true,
 	"description": "Electron + TypeScript frontend for the agent-orchestrator rewrite",
 	"author": "Agent Orchestrator",


### PR DESCRIPTION
Stamps `frontend/package.json` to `0.10.0` for the prod desktop release.

The stable release workflow reads the app version from `frontend/package.json` (it does not stamp from the git tag, unlike the nightly workflow), so the `desktop-v0.10.0` cut needs this committed at the tagged commit. Without it the app ships as `0.0.0` and the stable update channel never advances.

Merge after #2244 (the `app-update.yml` fix + `macos-15-intel` leg). Then `desktop-v0.10.0` is cut on main HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)