### PR TITLE
ci(release): gate signed release on the release environment

### DIFF
--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -41,6 +41,11 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    # Gates the signed release behind the `release` environment's required
+    # reviewers: any write-access user can push a desktop-v* tag, but only
+    # designated approvers can let the build that consumes the signing secrets
+    # proceed. Configure reviewers in repo Settings > Environments > release.
+    environment: release
     permissions:
       contents: write
     defaults:
@@ -157,6 +162,7 @@ jobs:
   # finishes before publish-feed, but the feed is not gated on it.
   release-intel:
     runs-on: macos-13
+    environment: release # same approval gate as the matrix release job
     permissions:
       contents: write
     defaults:


### PR DESCRIPTION
## Why
The Desktop release workflow triggers on any `desktop-v*` tag push (or `workflow_dispatch`) and consumes the repo-level macOS signing secrets. There is no tag protection and no environment gate, so **any of the ~10 write-access collaborators can cut a fully signed, notarized production build** to ~7.6k users. Now that live Developer ID + notarization secrets are configured on this repo, that surface should be closed.

## What
Adds `environment: release` to the `release` and `release-intel` jobs so the build that uses the signing secrets cannot run until a **required reviewer approves** the deployment to the `release` environment.

## Required to take effect (admin)
This PR is inert until an admin configures the `release` environment (Settings > Environments > release) with **required reviewers**. Until then, behavior is unchanged (no worse than today). Recommended companion control: a tag ruleset restricting who can create `desktop-v*` tags.

## Note for whoever merges second
This touches the `release-intel` job, which #2244 also edits (`macos-13` -> `macos-15-intel`). If #2244 merges first, resolve the trivial conflict by keeping both `runs-on: macos-15-intel` and `environment: release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)