### PR TITLE
fix(orchestrator): teach status commands and ao --help fallback

### DIFF
--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1016,6 +1016,10 @@ Spawn worker sessions for implementation with:
 Message workers with `+"`ao send`"+`, for example:
 `+"`ao send --session <worker-session-id> --message \"<your message>\"`"+`
 
+Check on workers with `+"`ao session ls`"+` and `+"`ao session get <worker-session-id>`"+`.
+
+If you're unsure which command to use, run `+"`ao --help`"+` before guessing.
+
 Use workers for focused implementation tasks, track their progress, synthesize their results, and only step into implementation directly for true emergencies or small coordination fixes.`, project, project)
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -807,6 +807,9 @@ func TestSpawnOrchestrator_UsesCoordinatorPrompt(t *testing.T) {
 		"You are the human-facing coordinator for project mer",
 		`ao spawn --project mer --prompt "<clear worker task>"`,
 		"`ao send`",
+		"`ao session ls`",
+		"`ao session get <worker-session-id>`",
+		"run `ao --help` before guessing",
 		"avoid doing implementation yourself unless it is necessary",
 	} {
 		if !strings.Contains(systemPrompt, want) {


### PR DESCRIPTION
Point orchestrator sessions at ao session ls/get instead of guessing invalid commands like ao list or ao status --session.

Fixes #2197