### PR TITLE
UI : use React.Memo position for SelectContent to prevent scroll reset

### DIFF
--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -132,7 +132,7 @@ export function RequiredAgentField({
 				<SelectTrigger id={id} className="h-8 w-full text-[13px]" aria-invalid={invalid || undefined}>
 					<SelectValue placeholder={placeholder} />
 				</SelectTrigger>
-				<SelectContent>
+				<SelectContent position="popper">
 					{AGENT_OPTIONS.map((agent) => (
 						<SelectItem key={agent} value={agent}>
 							{agent}

--- a/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
+++ b/frontend/src/renderer/components/CreateProjectAgentSheet.tsx
@@ -1,6 +1,6 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { AGENT_OPTIONS } from "../lib/agent-options";
 import { Button } from "./ui/button";
 import { Label } from "./ui/label";
@@ -108,7 +108,7 @@ export function CreateProjectAgentSheet({
 	);
 }
 
-export function RequiredAgentField({
+export const RequiredAgentField = memo(function RequiredAgentField({
 	id,
 	invalid = false,
 	label,
@@ -132,7 +132,7 @@ export function RequiredAgentField({
 				<SelectTrigger id={id} className="h-8 w-full text-[13px]" aria-invalid={invalid || undefined}>
 					<SelectValue placeholder={placeholder} />
 				</SelectTrigger>
-				<SelectContent position="popper">
+				<SelectContent>
 					{AGENT_OPTIONS.map((agent) => (
 						<SelectItem key={agent} value={agent}>
 							{agent}
@@ -142,4 +142,4 @@ export function RequiredAgentField({
 			</Select>
 		</div>
 	);
-}
+});

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -251,7 +251,7 @@ function PermissionModeSelect({
 			<SelectTrigger id={id} className="h-8 w-full text-[13px]">
 				<SelectValue />
 			</SelectTrigger>
-			<SelectContent>
+			<SelectContent position="popper">
 				<SelectItem value="__default__">Project default</SelectItem>
 				{PERMISSION_MODE_OPTIONS.map((opt) => (
 					<SelectItem key={opt.value} value={opt.value}>
@@ -269,7 +269,7 @@ function ReviewerSelect({ id, value, onChange }: { id: string; value: string; on
 			<SelectTrigger id={id} className="h-8 w-full text-[13px]">
 				<SelectValue />
 			</SelectTrigger>
-			<SelectContent>
+			<SelectContent position="popper">
 				<SelectItem value="__default__">Project default</SelectItem>
 				{REVIEWER_OPTIONS.map((reviewer) => (
 					<SelectItem key={reviewer} value={reviewer}>

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -251,7 +251,7 @@ function PermissionModeSelect({
 			<SelectTrigger id={id} className="h-8 w-full text-[13px]">
 				<SelectValue />
 			</SelectTrigger>
-			<SelectContent position="popper">
+			<SelectContent>
 				<SelectItem value="__default__">Project default</SelectItem>
 				{PERMISSION_MODE_OPTIONS.map((opt) => (
 					<SelectItem key={opt.value} value={opt.value}>
@@ -269,7 +269,7 @@ function ReviewerSelect({ id, value, onChange }: { id: string; value: string; on
 			<SelectTrigger id={id} className="h-8 w-full text-[13px]">
 				<SelectValue />
 			</SelectTrigger>
-			<SelectContent position="popper">
+			<SelectContent>
 				<SelectItem value="__default__">Project default</SelectItem>
 				{REVIEWER_OPTIONS.map((reviewer) => (
 					<SelectItem key={reviewer} value={reviewer}>


### PR DESCRIPTION
Issue

https://github.com/user-attachments/assets/f4eed2d6-4e3d-4882-9757-e939bf5182dc

 ### Bug Description:

  While trying to scroll down to see the complete list of worker and orchestrator agents in the dropdown, the list would automatically snap back to the top every few seconds, causing a bad user
  experience.

 ### Cause & Fix:

  This issue occurred because the Radix UI  <Select>  component uses an  item-aligned  positioning strategy by default. Whenever the UI received live background updates (like workspace status
  broadcasts), the parent component re-rendered. This caused the dropdown to recalculate its alignment and reset the scroll position to the top.

### After the fix


wrapped the  RequiredAgentField  component with  React.memo . This ensures the dropdown component isolates itself from unrelated parent re-renders caused by background SSE events. The component now only re-renders when the actual agent selection changes, preserving the user's scroll position while maintaining the correct native alignment.
