### PR TITLE
fix: restart reviewer after stale running supersession

### DIFF
--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -17,6 +17,8 @@ type Launcher interface {
 	// Spawn launches a fresh reviewer and returns the runtime handle id of the
 	// live pane (stable per worker, reused across passes).
 	Spawn(ctx context.Context, spec LaunchSpec) (handleID string, err error)
+	// Destroy tears down an existing reviewer pane before a hard restart.
+	Destroy(ctx context.Context, handleID string) error
 	// Notify asks an already-running reviewer pane to review a new commit.
 	Notify(ctx context.Context, handleID string, spec LaunchSpec) error
 	// Alive reports whether a reviewer pane is still running.
@@ -33,11 +35,12 @@ type LaunchSpec struct {
 	TargetSHA     string
 }
 
-// reviewerRuntime is the runtime surface the launcher needs: create a pane,
-// inject a message into a running pane, and probe liveness. The tmux runtime
-// satisfies it.
+// reviewerRuntime is the runtime surface the launcher needs: create or destroy
+// a pane, inject a message into a running pane, and probe liveness. The tmux
+// runtime satisfies it.
 type reviewerRuntime interface {
 	Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error)
+	Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 	IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error)
 	SendMessage(ctx context.Context, handle ports.RuntimeHandle, message string) error
 }
@@ -138,6 +141,13 @@ func (l *agentLauncher) Notify(ctx context.Context, handleID string, spec Launch
 		return fmt.Errorf("notify reviewer: %w", err)
 	}
 	return nil
+}
+
+func (l *agentLauncher) Destroy(ctx context.Context, handleID string) error {
+	if handleID == "" {
+		return nil
+	}
+	return l.runtime.Destroy(ctx, ports.RuntimeHandle{ID: handleID})
 }
 
 func (l *agentLauncher) Alive(ctx context.Context, handleID string) (bool, error) {

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -48,6 +48,7 @@ type fakeRuntime struct {
 	sentMsg   string
 	sentTo    string
 	alive     bool
+	destroyed string
 }
 
 func (f *fakeRuntime) Create(_ context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
@@ -56,6 +57,10 @@ func (f *fakeRuntime) Create(_ context.Context, cfg ports.RuntimeConfig) (ports.
 }
 func (f *fakeRuntime) IsAlive(_ context.Context, _ ports.RuntimeHandle) (bool, error) {
 	return f.alive, nil
+}
+func (f *fakeRuntime) Destroy(_ context.Context, handle ports.RuntimeHandle) error {
+	f.destroyed = handle.ID
+	return nil
 }
 func (f *fakeRuntime) SendMessage(_ context.Context, handle ports.RuntimeHandle, msg string) error {
 	f.sentTo = handle.ID
@@ -123,6 +128,18 @@ func TestLauncherNotifySendsMessageToHandle(t *testing.T) {
 	}
 	if rt.sentTo != "review-mer-1" || !strings.Contains(rt.sentMsg, "run-1") {
 		t.Fatalf("sent to %q msg %q", rt.sentTo, rt.sentMsg)
+	}
+}
+
+func TestLauncherDestroyTearsDownHandle(t *testing.T) {
+	rt := &fakeRuntime{}
+	l := NewLauncher(fakeReviewerResolver{ok: true}, rt)
+
+	if err := l.Destroy(context.Background(), "review-mer-1"); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if rt.destroyed != "review-mer-1" {
+		t.Fatalf("destroyed handle = %q", rt.destroyed)
 	}
 }
 

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -207,7 +207,8 @@ func (e *Engine) Trigger(ctx stdctx.Context, workerID domain.SessionID) (Trigger
 			}
 		}
 	}
-	if _, err := e.store.SupersedeStaleRunningReviewRuns(ctx, workerID, targetSHA, "superseded by a review trigger for a newer commit"); err != nil {
+	staleRunning, err := e.store.SupersedeStaleRunningReviewRuns(ctx, workerID, targetSHA, "superseded by a review trigger for a newer commit")
+	if err != nil {
 		return TriggerResult{}, err
 	}
 
@@ -268,10 +269,16 @@ func (e *Engine) Trigger(ctx stdctx.Context, workerID domain.SessionID) (Trigger
 			return TriggerResult{}, failRun(err)
 		}
 		if alive {
-			if err := e.launcher.Notify(ctx, review.ReviewerHandleID, spec); err != nil {
-				return TriggerResult{}, failRun(fmt.Errorf("notify reviewer: %w", err))
+			if staleRunning > 0 {
+				if err := e.launcher.Destroy(ctx, review.ReviewerHandleID); err != nil {
+					return TriggerResult{}, failRun(fmt.Errorf("destroy reviewer: %w", err))
+				}
+			} else {
+				if err := e.launcher.Notify(ctx, review.ReviewerHandleID, spec); err != nil {
+					return TriggerResult{}, failRun(fmt.Errorf("notify reviewer: %w", err))
+				}
+				handleID = review.ReviewerHandleID
 			}
-			handleID = review.ReviewerHandleID
 		}
 	}
 	if handleID == "" {

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -127,15 +127,19 @@ func (f fakeProjects) GetProject(_ context.Context, id string) (domain.ProjectRe
 }
 
 type fakeLauncher struct {
-	handle     string
-	alive      bool
-	spawnErr   error
-	notifyErr  error
-	spawned    bool
-	spawnCount int
-	notified   bool
-	gotSpec    LaunchSpec
-	gotHandle  string
+	handle          string
+	alive           bool
+	spawnErr        error
+	notifyErr       error
+	destroyErr      error
+	spawned         bool
+	spawnCount      int
+	notified        bool
+	destroyed       bool
+	destroyCount    int
+	gotSpec         LaunchSpec
+	gotHandle       string
+	destroyedHandle string
 }
 
 func (f *fakeLauncher) Spawn(_ context.Context, spec LaunchSpec) (string, error) {
@@ -152,6 +156,12 @@ func (f *fakeLauncher) Notify(_ context.Context, handleID string, spec LaunchSpe
 	f.gotHandle = handleID
 	f.gotSpec = spec
 	return f.notifyErr
+}
+func (f *fakeLauncher) Destroy(_ context.Context, handleID string) error {
+	f.destroyed = true
+	f.destroyCount++
+	f.destroyedHandle = handleID
+	return f.destroyErr
 }
 func (f *fakeLauncher) Alive(_ context.Context, _ string) (bool, error) {
 	return f.alive || f.spawned, nil
@@ -285,7 +295,7 @@ func TestTriggerIsIdempotentForSameCommit(t *testing.T) {
 	if res.Created || res.Run.ID != "run-1" || res.ReviewerHandleID != "review-mer-1" {
 		t.Fatalf("expected reuse of existing run: %+v", res)
 	}
-	if launcher.spawned || launcher.notified {
+	if launcher.spawned || launcher.notified || launcher.destroyed {
 		t.Fatalf("should not launch for an already-reviewed commit: %+v", launcher)
 	}
 	if len(store.runs) != 1 {
@@ -308,7 +318,7 @@ func TestTriggerReusesRunningRowWithNoVerdict(t *testing.T) {
 	if res.Created || res.Run.ID != "run-1" {
 		t.Fatalf("expected reuse of the running review for the same commit: %+v", res)
 	}
-	if launcher.spawned || launcher.notified {
+	if launcher.spawned || launcher.notified || launcher.destroyed {
 		t.Fatalf("running same-commit review should not relaunch: %+v", launcher)
 	}
 	if got := store.runs[0]; got.Status != domain.ReviewRunRunning {
@@ -331,7 +341,7 @@ func TestTriggerSupersedesNonRunningRowWithNoVerdict(t *testing.T) {
 	if !res.Created {
 		t.Fatalf("expected a fresh pass when prior non-running row has no verdict: %+v", res)
 	}
-	if !launcher.notified || launcher.spawned {
+	if !launcher.notified || launcher.spawned || launcher.destroyed {
 		t.Fatalf("expected notify on live reviewer pane, not spawn: %+v", launcher)
 	}
 	if stale := store.runs[0]; stale.ID != "run-1" || stale.Status != domain.ReviewRunFailed {
@@ -351,7 +361,7 @@ func TestTriggerNotifiesLiveReviewerOnNewCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Trigger: %v", err)
 	}
-	if !launcher.notified || launcher.spawned {
+	if !launcher.notified || launcher.spawned || launcher.destroyed {
 		t.Fatalf("expected notify on live reviewer: %+v", launcher)
 	}
 	if launcher.gotHandle != "review-mer-1" {
@@ -380,8 +390,62 @@ func TestTriggerSupersedesOlderRunningRunOnNewCommit(t *testing.T) {
 	if old := store.runs[0]; old.ID != "run-old" || old.Status != domain.ReviewRunFailed {
 		t.Fatalf("expected older running run to be failed, got %+v", old)
 	}
-	if !launcher.notified || launcher.spawned {
-		t.Fatalf("expected live reviewer pane reused for new commit: %+v", launcher)
+	if !launcher.destroyed || launcher.destroyedHandle != "review-mer-1" || !launcher.spawned || launcher.notified {
+		t.Fatalf("expected stale live reviewer pane destroyed and respawned: %+v", launcher)
+	}
+}
+
+func TestTriggerDestroyFailureAfterStaleRunningRunFailsNewRun(t *testing.T) {
+	destroyErr := errors.New("tmux kill failed")
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		runs:   []domain.ReviewRun{{ID: "run-old", SessionID: "mer-1", TargetSHA: "sha0", Status: domain.ReviewRunRunning}},
+	}
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-1", destroyErr: destroyErr}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	if _, err := eng.Trigger(context.Background(), "mer-1"); !errors.Is(err, destroyErr) {
+		t.Fatalf("err = %v, want destroyErr", err)
+	}
+	if old := store.runs[0]; old.ID != "run-old" || old.Status != domain.ReviewRunFailed {
+		t.Fatalf("expected older running run to be failed, got %+v", old)
+	}
+	if len(store.runs) != 2 {
+		t.Fatalf("expected newly inserted run, got %+v", store.runs)
+	}
+	if newRun := store.runs[1]; newRun.TargetSHA != "sha1" || newRun.Status != domain.ReviewRunFailed || !strings.Contains(newRun.Body, "destroy reviewer") {
+		t.Fatalf("expected new run failed with destroy error, got %+v", newRun)
+	}
+	if !launcher.destroyed || launcher.spawned || launcher.notified {
+		t.Fatalf("expected destroy only, got %+v", launcher)
+	}
+}
+
+func TestTriggerMultipleStaleRunningRunsDestroyAndSpawnOnce(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		runs: []domain.ReviewRun{
+			{ID: "run-old-1", SessionID: "mer-1", TargetSHA: "sha0", Status: domain.ReviewRunRunning},
+			{ID: "run-old-2", SessionID: "mer-1", TargetSHA: "sha00", Status: domain.ReviewRunRunning},
+		},
+	}
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if !res.Created || res.Run.TargetSHA != "sha1" {
+		t.Fatalf("expected new run for new commit, got %+v", res)
+	}
+	for i := 0; i < 2; i++ {
+		if store.runs[i].Status != domain.ReviewRunFailed {
+			t.Fatalf("stale run %d not failed: %+v", i, store.runs[i])
+		}
+	}
+	if launcher.destroyCount != 1 || launcher.spawnCount != 1 || launcher.notified {
+		t.Fatalf("expected one destroy and one spawn, got %+v", launcher)
 	}
 }
 

--- a/backend/internal/service/review/review_test.go
+++ b/backend/internal/service/review/review_test.go
@@ -129,3 +129,18 @@ func TestSubmitCompletedRetryRejectsDifferentRecordedFields(t *testing.T) {
 		})
 	}
 }
+
+func TestSubmitRejectsFailedRun(t *testing.T) {
+	st := &fakeStore{ok: true, run: domain.ReviewRun{
+		ID: "run-1", SessionID: "mer-1", Status: domain.ReviewRunFailed,
+	}}
+	reducer := &fakeReducer{outcome: lifecycle.ReviewDeliverySent}
+	svc := New(nil, st, WithLifecycleReducer(reducer))
+
+	if _, err := svc.Submit(context.Background(), "mer-1", "run-1", domain.VerdictApproved, "", "987"); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("err = %v, want ErrInvalid", err)
+	}
+	if st.updateCalls != 0 || st.markCalls != 0 || reducer.calls != 0 {
+		t.Fatalf("failed run should not update or deliver: update=%d mark=%d reducer=%d", st.updateCalls, st.markCalls, reducer.calls)
+	}
+}


### PR DESCRIPTION
  ## Summary
  - Restart the shared reviewer terminal when stale running review runs are superseded by a newer PR head
  - Add `Destroy` to the internal review launcher boundary and wire it to the runtime
  - Keep same-head idempotency and completed-prior-run notify behavior unchanged

  Closes #2171

  ## Tests
  - `env GOCACHE=/private/tmp/ao-go-cache go test ./internal/review ./internal/service/review ./internal/storage/sqlite/store`
  - `npm run lint`