### PR TITLE
fix(update): nightly channel never resolves (missing allowPrerelease)

### DIFF
--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -17,6 +17,11 @@ import {
 // checkForUpdates.
 function configureFeed(channel: UpdateChannel): void {
 	autoUpdater.channel = channel; // "latest" | "nightly"
+	// Nightly builds ship as GitHub *prereleases*. With allowPrerelease false
+	// (the default) electron-updater only inspects the latest NON-prerelease
+	// release and looks for nightly-mac.yml there, which 404s. Enable prerelease
+	// scanning on the nightly channel only; stable must never pull prereleases.
+	autoUpdater.allowPrerelease = channel === "nightly";
 	autoUpdater.allowDowngrade = true; // permits a nightly -> stable channel switch
 }
 


### PR DESCRIPTION
## Problem
On the **nightly** channel the app 404s:
`Cannot find nightly-mac.yml in the latest release artifacts (.../releases/download/v0.10.0/nightly-mac.yml)`

Nightly builds publish as GitHub **prereleases**, but `configureFeed` set `autoUpdater.channel` and `allowDowngrade` and **never set `allowPrerelease`**. With `allowPrerelease` at its default `false`, electron-updater only inspects the latest **non-prerelease** release (`v0.10.0`) and looks for `nightly-mac.yml` there → 404. So the nightly channel never resolved, even with a valid nightly published.

## Fix
```ts
autoUpdater.allowPrerelease = channel === "nightly";
```
Nightly scans prereleases (finds the `*-nightly-*` feed); stable stays on non-prereleases only.

## Note
Ships in the next desktop release. The currently-installed `v0.10.0` can't self-heal on nightly (that's the bug), users on nightly should switch to Stable once to pick up the build that contains this fix, then nightly works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)