### PR TITLE
ci: retry transient macOS sign/notary flakes in the publish step

### DIFF
--- a/.github/workflows/frontend-nightly.yml
+++ b/.github/workflows/frontend-nightly.yml
@@ -85,7 +85,16 @@ jobs:
           apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
           apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
       - name: Publish
-        run: npm run publish
+        run: |
+          # Retry transient macOS sign/notary flakes (Apple notary -1009,
+          # osx-sign keychain races) so the build self-heals instead of failing.
+          for i in 1 2 3; do
+            if npm run publish; then exit 0; fi
+            echo "::warning::publish attempt $i/3 failed (likely a transient macOS sign/notary flake)"
+            [ "$i" -lt 3 ] && sleep 30
+          done
+          echo "::error::publish failed after 3 attempts" >&2
+          exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AO_RELEASE_REPO: ${{ github.repository }}
@@ -135,7 +144,16 @@ jobs:
           apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
           apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
       - name: Publish
-        run: npm run publish
+        run: |
+          # Retry transient macOS sign/notary flakes (Apple notary -1009,
+          # osx-sign keychain races) so the build self-heals instead of failing.
+          for i in 1 2 3; do
+            if npm run publish; then exit 0; fi
+            echo "::warning::publish attempt $i/3 failed (likely a transient macOS sign/notary flake)"
+            [ "$i" -lt 3 ] && sleep 30
+          done
+          echo "::error::publish failed after 3 attempts" >&2
+          exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AO_RELEASE_REPO: ${{ github.repository }}

--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -76,7 +76,16 @@ jobs:
           apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
           apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
       - name: Publish
-        run: npm run publish
+        run: |
+          # Retry transient macOS sign/notary flakes (Apple notary -1009,
+          # osx-sign keychain races) so the build self-heals instead of failing.
+          for i in 1 2 3; do
+            if npm run publish; then exit 0; fi
+            echo "::warning::publish attempt $i/3 failed (likely a transient macOS sign/notary flake)"
+            [ "$i" -lt 3 ] && sleep 30
+          done
+          echo "::error::publish failed after 3 attempts" >&2
+          exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AO_RELEASE_REPO: ${{ github.repository }}
@@ -191,7 +200,16 @@ jobs:
           apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
           apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
       - name: Publish
-        run: npm run publish
+        run: |
+          # Retry transient macOS sign/notary flakes (Apple notary -1009,
+          # osx-sign keychain races) so the build self-heals instead of failing.
+          for i in 1 2 3; do
+            if npm run publish; then exit 0; fi
+            echo "::warning::publish attempt $i/3 failed (likely a transient macOS sign/notary flake)"
+            [ "$i" -lt 3 ] && sleep 30
+          done
+          echo "::error::publish failed after 3 attempts" >&2
+          exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AO_RELEASE_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Why
Releases fail intermittently on **transient** macOS issues that hit **either** macOS leg, not just Intel:
- Apple notary `-1009 "connection appears to be offline"` , observed on **`macos-latest` (arm64)** in the stable `v0.10.0` run (attempt 1: `release (macos-latest)` failed, `release-intel` succeeded).
- `osx-sign` keychain race → `code object is not signed at all` , observed on **`macos-15-intel`** in the nightly run.

Both pass on a manual re-run. The flakiness is general (Apple/runner), so decoupling only the Intel leg (#2264) doesn't fix it , an arm64 flake still fails `needs: release` and skips the feed.

## Fix
Wrap `npm run publish` in a 3× retry with 30s backoff across all four publish steps (release + release-intel, in both release and nightly workflows). Transient sign/notary failures self-heal in-place. The Intel leg stays coupled, so the x64 feed entry remains guaranteed.

Supersedes #2264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)