### PR TITLE
fix(ci): Windows publish shell + fresh-install smoke check (#2267)

### DIFF
--- a/.github/workflows/frontend-nightly.yml
+++ b/.github/workflows/frontend-nightly.yml
@@ -85,6 +85,7 @@ jobs:
           apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
           apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
       - name: Publish
+        shell: bash
         run: |
           # Retry transient macOS sign/notary flakes (Apple notary -1009,
           # osx-sign keychain races) so the build self-heals instead of failing.
@@ -144,6 +145,7 @@ jobs:
           apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
           apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
       - name: Publish
+        shell: bash
         run: |
           # Retry transient macOS sign/notary flakes (Apple notary -1009,
           # osx-sign keychain races) so the build self-heals instead of failing.

--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -76,6 +76,7 @@ jobs:
           apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
           apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
       - name: Publish
+        shell: bash
         run: |
           # Retry transient macOS sign/notary flakes (Apple notary -1009,
           # osx-sign keychain races) so the build self-heals instead of failing.
@@ -200,6 +201,7 @@ jobs:
           apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
           apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
       - name: Publish
+        shell: bash
         run: |
           # Retry transient macOS sign/notary flakes (Apple notary -1009,
           # osx-sign keychain races) so the build self-heals instead of failing.

--- a/test/cli/Dockerfile
+++ b/test/cli/Dockerfile
@@ -18,7 +18,13 @@ RUN cd backend && go mod download
 
 COPY backend ./backend
 # Pure-Go SQLite (modernc) builds fine with CGO disabled -> a static binary.
-RUN cd backend && CGO_ENABLED=0 go build -trimpath -o /out/ao ./cmd/ao
+# Build against a release repo with NO published assets so `ao start` reaches the
+# fetch path and fails cleanly (404) on a fresh box. The real AgentWrapper repo
+# now publishes a linux-x64 AppImage, so an unpinned binary would download it and
+# exit 0, defeating the fresh-install assertion below. See install-check.sh.
+RUN cd backend && CGO_ENABLED=0 go build -trimpath \
+      -ldflags "-X github.com/aoagents/agent-orchestrator/backend/internal/cli.releaseRepo=AgentWrapper/ao-fresh-install-fixture" \
+      -o /out/ao ./cmd/ao
 
 # ---- stage 2: a clean machine with NO Go toolchain, just like an end user ----
 FROM debian:bookworm-slim AS run

--- a/test/cli/install-check.sh
+++ b/test/cli/install-check.sh
@@ -22,12 +22,13 @@ echo "ao binary : $(command -v "$AO_BIN")"
 
 # `ao start` is now the desktop-app launcher: it resolves an installed app or
 # fetches the release, then opens it (it no longer runs a daemon). On a fresh
-# container there is no installed app, so start reaches the fetch path. With no
-# published asset for this platform it must exit non-zero with a clear `ao
-# start:` error (an unreachable/404 download on amd64, or an unsupported-arch
-# error on arm64), never a panic or a silent success. The full launcher
-# behaviour is covered by the Go e2e suite; this only proves the fresh-box path
-# is sane on whatever arch the runner uses.
+# container there is no installed app, so start reaches the fetch path. The smoke
+# binary is built against a release repo with no published assets (see
+# Dockerfile), so the fetch deterministically 404s and start must exit non-zero
+# with a clear `ao start:` error (an unreachable/404 download on amd64, or an
+# unsupported-arch error on arm64), never a panic or a silent success. The full
+# launcher behaviour is covered by the Go e2e suite; this only proves the
+# fresh-box path is sane on whatever arch the runner uses.
 if err="$("$AO_BIN" start 2>&1)"; then
   fail "start unexpectedly succeeded on a fresh machine with no installed app"
 fi


### PR DESCRIPTION
Two CI fixes.

## 1. Windows publish fails to parse (regression from #2266)

The 3x publish retry added in #2266 is bash (`for i in 1 2 3; do ... done`), but the `release` matrix Publish step had no explicit `shell:`. On `windows-latest` the default shell is PowerShell, so the step failed deterministically:

```
ParserError: Missing opening '(' after keyword 'for'.
```

Every Windows publish (stable and nightly) breaks; this is what failed the v0.10.1 cut. macOS/Ubuntu passed only because their default shell is already bash. Fix: pin `shell: bash` on all four Publish steps (release + release-intel + nightly + nightly-intel). Git Bash ships on `windows-latest`.

Verified green end to end on a fork run of the full Desktop release workflow: all legs including `release (windows-latest)` succeeded and published the Windows `.exe` plus the `latest*.yml` feed.

## 2. Fresh-install smoke check is red on main (#2267)

The container check asserts `ao start` fails cleanly on a fresh box "with no published asset". Now that AgentWrapper publishes a `linux-x64.AppImage`, the unpinned smoke binary downloads it and exits 0, tripping the assertion. Fix: build the smoke binary against a release repo with no assets, so the fetch path deterministically 404s and `start` exits non-zero with a clear error, preserving the test's intent without depending on what the real repo publishes.

Fixes #2267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)