### PR TITLE
fix(conpty): avoid integer overflow in payload size validation

### DIFF
--- a/backend/internal/adapters/runtime/conpty/proto.go
+++ b/backend/internal/adapters/runtime/conpty/proto.go
@@ -8,7 +8,7 @@ package conpty
 import (
 	"encoding/binary"
 	"fmt"
-	"math"
+	// "math"
 )
 
 // Message type constants. Values must match pty-host.ts MSG_* constants exactly.
@@ -46,16 +46,28 @@ type GetOutputReq struct {
 // EncodeMessage encodes a single frame into the binary protocol format.
 // It allocates a fresh slice of exactly 5+len(payload) bytes.
 // Returns an error if the payload exceeds the 4-byte length field capacity.
+const maxPayloadSize = ^uint32(0)
+
 func EncodeMessage(msgType byte, payload []byte) ([]byte, error) {
 	n := len(payload)
-	if n > math.MaxUint32 {
-		return nil, fmt.Errorf("conpty: payload too large (%d bytes, max %d)", n, math.MaxUint32)
+
+	if uint64(n) > uint64(maxPayloadSize) {
+		return nil, fmt.Errorf(
+			"conpty: payload too large (%d bytes, max %d)",
+			n,
+			uint64(maxPayloadSize),
+		)
 	}
-	payloadLen := uint32(n) // safe: n <= math.MaxUint32 checked above
+
+	payloadLen := uint32(n)
+
 	frame := make([]byte, 5+n)
 	frame[0] = msgType
+
 	binary.BigEndian.PutUint32(frame[1:5], payloadLen)
+
 	copy(frame[5:], payload)
+
 	return frame, nil
 }
 


### PR DESCRIPTION
## Summary

Fixes a Windows build failure in `EncodeMessage` caused by comparing `len(payload)` with `math.MaxUint32`.

`len()` returns an `int`, and on Windows this comparison can trigger an integer overflow compilation error due to implicit type conversion.

This change replaces the comparison with explicit `uint64` conversions and removes the now-unused `math` import.

## Changes

* Added a typed `maxPayloadSize` constant using `^uint32(0)`
* Replaced the payload size comparison with explicit `uint64` conversion
* Removed the unused `math` import
* Preserved existing protocol behavior and validation logic

## Why this fix

The previous implementation relied on implicit type handling between `int` and `math.MaxUint32`, which caused platform-dependent compilation issues on Windows.

Using explicit `uint64` comparison avoids architecture-specific integer overflow behavior while keeping the original bounds check intact.

## Verification

Tested successfully on:

* Windows 11
* Go 1.25

Build command used:

```bash
go build ./cmd/ao/main.go
```
