### PR TITLE
fix(frontend): canonicalize daemon identity paths

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -50,6 +50,7 @@ import { createBrowserViewHost, type BrowserViewHost } from "./main/browser-view
 import { connectSupervisor, type SupervisorLinkHandle } from "./main/supervisor-link";
 import { shouldLinkOnAttach } from "./main/daemon-owner";
 import { readMigrationState, updateMigration, writeAppStateMarker, type MigrationState } from "./main/app-state";
+import { pathInside, samePath } from "./shared/path-identity";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -338,21 +339,6 @@ function daemonEnv(): NodeJS.ProcessEnv {
 		return { ...process.env, ...telemetryOverrides(), ...ownerTag };
 	}
 	return buildDaemonEnv(process.env, cachedShellEnv, { ...telemetryOverrides(), ...ownerTag });
-}
-
-function pathKey(value: string): string {
-	const resolved = path.resolve(value);
-	return process.platform === "win32" ? resolved.toLowerCase() : resolved;
-}
-
-function samePath(a: string, b: string): boolean {
-	return pathKey(a) === pathKey(b);
-}
-
-function pathInside(child: string, parent: string): boolean {
-	const childKey = pathKey(child);
-	const parentKey = pathKey(parent);
-	return childKey === parentKey || childKey.startsWith(parentKey + path.sep);
 }
 
 function processAlive(pid: number): boolean {

--- a/frontend/src/shared/path-identity.test.ts
+++ b/frontend/src/shared/path-identity.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { pathInside, samePath } from "./path-identity";
+
+const tempDirs: string[] = [];
+
+function tempDir() {
+	const dir = mkdtempSync(path.join(os.tmpdir(), "ao-path-identity-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("path identity", () => {
+	it("matches paths that resolve to the same real directory", () => {
+		const dir = tempDir();
+		const real = realpathSync.native(dir);
+		expect(samePath(path.join(real, "."), real)).toBe(true);
+	});
+
+	it("treats Windows paths as case-insensitive", () => {
+		expect(samePath("C:\\Users\\me\\AO\\backend", "c:\\users\\me\\ao\\backend", "win32")).toBe(true);
+	});
+
+	it("uses realpath canonical casing on macOS case-insensitive volumes", () => {
+		if (process.platform !== "darwin") return;
+
+		const current = realpathSync.native(process.cwd());
+		const lowerCased = current.toLowerCase();
+		try {
+			if (realpathSync.native(lowerCased) !== current) return;
+		} catch {
+			return;
+		}
+
+		expect(samePath(lowerCased, current, "darwin")).toBe(true);
+	});
+
+	it("detects non-existent children after canonicalization", () => {
+		const dir = tempDir();
+		const child = path.join(dir, "nested", "future");
+
+		expect(pathInside(child, dir)).toBe(true);
+		expect(pathInside(dir, child)).toBe(false);
+	});
+
+	it("does not confuse sibling path prefixes with children", () => {
+		const dir = tempDir();
+		expect(pathInside(`${dir}-other`, dir)).toBe(false);
+	});
+});

--- a/frontend/src/shared/path-identity.ts
+++ b/frontend/src/shared/path-identity.ts
@@ -1,0 +1,40 @@
+import { existsSync, realpathSync } from "node:fs";
+import path from "node:path";
+
+type Platform = NodeJS.Platform;
+
+function canonicalPath(value: string): string {
+	const resolved = path.resolve(value);
+	try {
+		return realpathSync.native(resolved);
+	} catch {
+		let current = resolved;
+		const missingParts: string[] = [];
+		while (!existsSync(current)) {
+			const parent = path.dirname(current);
+			if (parent === current) return resolved;
+			missingParts.unshift(path.basename(current));
+			current = parent;
+		}
+		try {
+			return path.join(realpathSync.native(current), ...missingParts);
+		} catch {
+			return resolved;
+		}
+	}
+}
+
+export function pathIdentityKey(value: string, platform: Platform = process.platform): string {
+	const canonical = canonicalPath(value);
+	return platform === "win32" ? canonical.toLowerCase() : canonical;
+}
+
+export function samePath(a: string, b: string, platform: Platform = process.platform): boolean {
+	return pathIdentityKey(a, platform) === pathIdentityKey(b, platform);
+}
+
+export function pathInside(child: string, parent: string, platform: Platform = process.platform): boolean {
+	const childKey = pathIdentityKey(child, platform);
+	const parentKey = pathIdentityKey(parent, platform);
+	return childKey === parentKey || childKey.startsWith(parentKey + path.sep);
+}


### PR DESCRIPTION
## Summary

The desktop app now recognizes equivalent checkout paths on macOS instead of showing an empty dashboard when the daemon reports different path casing. Filesystem-backed canonicalization still rejects genuinely different checkouts and preserves Windows case-insensitive identity behavior.

Closes #2279.

This ports [aoagents/ReverbCode#415](https://github.com/aoagents/ReverbCode/pull/415) onto the current supervisor implementation without carrying unrelated changes.

## Validation

- Focused path identity and daemon attachment tests: 35 passed.
- Full frontend suite: 41 files, 375 tests passed.
- `npm run typecheck`
- `npm run package`
- Formatting and `git diff --check`

## Post-Deploy Monitoring & Validation

After the next desktop build, launch the app and daemon from path spellings that differ only by macOS casing. Healthy behavior is a ready daemon and populated board with no wrong-checkout identity message. A false match between genuinely different checkouts is the rollback trigger; the focused boundary tests cover that distinction.
