### PR TITLE
fix(frontend): restore verification commands

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,10 +4,6 @@ name: Frontend
 # because no workflow executed it (vitest only auto-loads vite.config.ts /
 # vitest.config.ts, and the repo had neither until #171) — this job is the
 # guard against that happening again.
-#
-# Typecheck is intentionally NOT run here yet: forge.config.ts and
-# update-electron-app carry pre-existing type errors. Add `npm run typecheck`
-# once those are fixed.
 
 on:
   push:
@@ -36,6 +32,9 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
 
       - name: Run vitest suite
         run: npx vitest run

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
 	},
 	"scripts": {
 		"build:daemon": "node ./scripts/build-daemon.mjs",
+		"build": "npm run build:daemon && electron-forge package",
 		"dev": "electron-forge start",
 		"dev:web": "VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts",
 		"prepackage": "npm run build:daemon",


### PR DESCRIPTION
## Summary

Frontend contributors can now run the documented `npm run build` command on a clean checkout, and pull requests regain the TypeScript gate that the workflow still described as broken even though current `main` typechecks successfully.

Closes #2281.

This updates [aoagents/ReverbCode#419](https://github.com/aoagents/ReverbCode/pull/419) for the canonical repository: the obsolete Forge typing workaround is intentionally omitted.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test -- --run` (40 files, 370 tests)
- Prettier and `git diff --check`

## Post-Deploy Monitoring & Validation

Watch the first frontend pull-request workflow after merge. Healthy signals are a successful Typecheck step followed by Vitest, and successful desktop packaging from `npm run build`. Any cross-platform typecheck failure or packaging regression is the rollback trigger.
