### PR TITLE
 fix(docs): resolve MDX parsing error in installation tabs

### DIFF
--- a/frontend/src/landing/content/docs/installation.mdx
+++ b/frontend/src/landing/content/docs/installation.mdx
@@ -44,12 +44,29 @@ If you plan to use GitLab or Linear, install and authenticate their CLIs or cred
 ## Install AO
 
 <Tabs items={["npm", "pnpm", "yarn", "from source"]}>
-	<Tab value="npm">```bash npm install -g @aoagents/ao ```</Tab>
-	<Tab value="pnpm">```bash pnpm add -g @aoagents/ao ```</Tab>
-	<Tab value="yarn">```bash yarn global add @aoagents/ao ```</Tab>
+	<Tab value="npm">
+		```bash
+		npm install -g @aoagents/ao
+		```
+	</Tab>
+	<Tab value="pnpm">
+		```bash
+		pnpm add -g @aoagents/ao
+		```
+	</Tab>
+	<Tab value="yarn">
+		```bash
+		yarn global add @aoagents/ao
+		```
+	</Tab>
 	<Tab value="from source">
-		```bash git clone https://github.com/ComposioHQ/agent-orchestrator cd agent-orchestrator pnpm install pnpm build
-		pnpm --filter @aoagents/ao link --global ```
+		```bash
+		git clone https://github.com/ComposioHQ/agent-orchestrator
+		cd agent-orchestrator
+		pnpm install
+		pnpm build
+		pnpm --filter @aoagents/ao link --global
+		```
 	</Tab>
 </Tabs>
 


### PR DESCRIPTION


## Description
This PR fixes a critical MDX compilation error (Expected a closing tag for <Tab>) that causes a 500 server error on the Installation documentation page.

## Root Cause:
The bug was inadvertently introduced in commit 598205165. The bash commands inside the "from source" <Tab> component were placed on a single line. This formatting caused the underlying Markdown parser to misinterpret the closing backticks (```), which subsequently swallowed the closing JSX </Tab> tag and broke the page build. Additionally, the bash commands were chained with spaces instead of newlines or && operators, causing terminal execution failures.

## Changes Made:

Reformatted the MDX code blocks across all tabs so that the opening and closing code fences (```) are placed on their own distinct lines, satisfying the strict MDX parser requirements.

Separated the chained bash commands (cd, pnpm install, pnpm build, etc.) in the "from source" tab onto individual lines to ensure they execute sequentially and correctly in the user's terminal.

## Testing:

Verified locally that the docs page now compiles successfully without the Fast Refresh/Webpack serialization errors.