### PR TITLE
fix: show latest reviewer verdict after PR updates

### DIFF
--- a/backend/internal/review/planner.go
+++ b/backend/internal/review/planner.go
@@ -36,7 +36,8 @@ type PRReviewState struct {
 // review runs. It is pure so the trigger path and API list path share exactly
 // the same eligibility/status rules.
 func Plan(prs []domain.PullRequest, runs []domain.ReviewRun) []PRReviewState {
-	latest := latestRunsByPRAndSHA(runs)
+	latestForHead := latestRunsByPRAndSHA(runs)
+	latestForPR := latestRunsByPR(runs)
 	reviews := make([]PRReviewState, 0, len(prs))
 	for _, pr := range prs {
 		review := PRReviewState{
@@ -48,13 +49,13 @@ func Plan(prs []domain.PullRequest, runs []domain.ReviewRun) []PRReviewState {
 		}
 		if pr.URL == "" || pr.HeadSHA == "" || pr.Draft || pr.Merged || pr.Closed {
 			review.Status = ReviewStateIneligible
-			if run, ok := latest[review.PRURL+"\x00"+review.TargetSHA]; ok {
+			if run, ok := latestForPR[review.PRURL]; ok {
 				review.LatestRun = &run
 			}
 			reviews = append(reviews, review)
 			continue
 		}
-		if run, ok := latest[review.PRURL+"\x00"+review.TargetSHA]; ok {
+		if run, ok := latestForHead[review.PRURL+"\x00"+review.TargetSHA]; ok {
 			review.LatestRun = &run
 			switch {
 			case run.Status == domain.ReviewRunRunning:
@@ -68,6 +69,8 @@ func Plan(prs []domain.PullRequest, runs []domain.ReviewRun) []PRReviewState {
 			default:
 				review.Status = ReviewStateNeedsReview
 			}
+		} else if run, ok := latestForPR[review.PRURL]; ok {
+			review.LatestRun = &run
 		}
 		reviews = append(reviews, review)
 	}
@@ -78,6 +81,19 @@ func Plan(prs []domain.PullRequest, runs []domain.ReviewRun) []PRReviewState {
 		return reviews[i].PRURL < reviews[j].PRURL
 	})
 	return reviews
+}
+
+func latestRunsByPR(runs []domain.ReviewRun) map[string]domain.ReviewRun {
+	latest := make(map[string]domain.ReviewRun)
+	for _, run := range runs {
+		if run.PRURL == "" {
+			continue
+		}
+		if existing, ok := latest[run.PRURL]; !ok || run.CreatedAt.After(existing.CreatedAt) {
+			latest[run.PRURL] = run
+		}
+	}
+	return latest
 }
 
 func latestRunsByPRAndSHA(runs []domain.ReviewRun) map[string]domain.ReviewRun {

--- a/backend/internal/review/planner_test.go
+++ b/backend/internal/review/planner_test.go
@@ -48,6 +48,23 @@ func TestPlanStatuses(t *testing.T) {
 	}
 }
 
+func TestPlanKeepsLatestRunForPRWhenHeadChanges(t *testing.T) {
+	runs := []domain.ReviewRun{
+		{ID: "older", PRURL: "pr1", TargetSHA: "sha0", Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved, CreatedAt: time.Unix(1, 0).UTC()},
+		{ID: "latest", PRURL: "pr1", TargetSHA: "sha1", Status: domain.ReviewRunDelivered, Verdict: domain.VerdictChangesRequested, CreatedAt: time.Unix(2, 0).UTC()},
+	}
+	got := Plan([]domain.PullRequest{planPR("pr1", 1, "sha2")}, runs)
+	if len(got) != 1 {
+		t.Fatalf("review states = %d, want 1", len(got))
+	}
+	if got[0].Status != ReviewStateNeedsReview {
+		t.Fatalf("status = %s, want %s", got[0].Status, ReviewStateNeedsReview)
+	}
+	if got[0].LatestRun == nil || got[0].LatestRun.ID != "latest" {
+		t.Fatalf("latest run = %+v, want latest", got[0].LatestRun)
+	}
+}
+
 func planPR(url string, n int, sha string) domain.PullRequest {
 	return domain.PullRequest{URL: url, Number: n, HeadSHA: sha}
 }

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -582,8 +582,13 @@ function sessionReviewVerdict(reviewStates: PRReviewState[]): {
 	if (reviewStates.some((reviewState) => reviewState.latestRun?.verdict === "changes_requested")) {
 		return { label: "Changes requested", tone: "danger" };
 	}
-	const reviewsWithVerdicts = reviewStates.filter((reviewState) => reviewState.status !== "ineligible" && reviewState.latestRun?.verdict);
-	if (reviewsWithVerdicts.length > 0 && reviewsWithVerdicts.every((reviewState) => reviewState.latestRun?.verdict === "approved")) {
+	const reviewsWithVerdicts = reviewStates.filter(
+		(reviewState) => reviewState.status !== "ineligible" && reviewState.latestRun?.verdict,
+	);
+	if (
+		reviewsWithVerdicts.length > 0 &&
+		reviewsWithVerdicts.every((reviewState) => reviewState.latestRun?.verdict === "approved")
+	) {
 		return { label: "Approved", tone: "success" };
 	}
 	if (reviewStates.some((reviewState) => reviewState.status === "changes_requested")) {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -579,6 +579,13 @@ function sessionReviewVerdict(reviewStates: PRReviewState[]): {
 	if (reviewStates.some((reviewState) => reviewState.latestRun?.status === "failed")) {
 		return { label: "Failed", tone: "danger" };
 	}
+	if (reviewStates.some((reviewState) => reviewState.latestRun?.verdict === "changes_requested")) {
+		return { label: "Changes requested", tone: "danger" };
+	}
+	const reviewsWithVerdicts = reviewStates.filter((reviewState) => reviewState.status !== "ineligible" && reviewState.latestRun?.verdict);
+	if (reviewsWithVerdicts.length > 0 && reviewsWithVerdicts.every((reviewState) => reviewState.latestRun?.verdict === "approved")) {
+		return { label: "Approved", tone: "success" };
+	}
 	if (reviewStates.some((reviewState) => reviewState.status === "changes_requested")) {
 		return { label: "Changes requested", tone: "danger" };
 	}
@@ -595,6 +602,12 @@ function reviewVerdict(reviewState: PRReviewState): {
 } {
 	if (reviewState.latestRun?.status === "failed") {
 		return { label: "Failed", tone: "danger" };
+	}
+	if (reviewState.latestRun?.verdict === "changes_requested") {
+		return { label: "Changes requested", tone: "danger" };
+	}
+	if (reviewState.latestRun?.verdict === "approved") {
+		return { label: "Approved", tone: "success" };
 	}
 	switch (reviewState.status) {
 		case "running":


### PR DESCRIPTION
Fixes #2300.

## Before
- Review state was selected only by the current PR head SHA.
- If a reviewer completed `changes_requested` on `sha-old` and the worker pushed `sha-new`, the planner found no run for `sha-new`.
- The Reviews tab row became `needs_review`, but had no `latestRun` attached for display.
- The visible row verdict and top badge could fall back to `Not run`, even though the latest actual review verdict was `changes_requested` or `approved`.
- The `Run review` button was available, which was correct.

## After
- The planner still marks the PR as `needs_review` when the head SHA changes, so the button stays available.
- It also attaches the newest review run for that PR as `latestRun`, even if that run was for a previous SHA.
- The Reviews tab now prefers `latestRun.verdict` when choosing the visible label.
- After `changes_requested` on `sha-old` and a push to `sha-new`, the row and top badge still show `Changes requested`.
- The user can still click `Run review` to send the next review request for `sha-new`.

## Reviewer trigger behavior
- No auto-triggering is added.
- Existing trigger flow already sends a message to a live reviewer terminal via `Notify`/`SendMessage`.
- If the reviewer pane is not alive, it spawns a new reviewer with the review prompt in the launch command.

## Tests
- `npm run lint`
- `npm run frontend:typecheck`
- `cd backend && go test ./internal/review ./internal/httpd/...`
