### PR TITLE
fix(session): keep killed sessions dead across restart (clear stale restore marker)

### DIFF
--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -96,6 +96,8 @@ type Store interface {
 	// presence of any row is the marker; preserved_ref may be empty for clean
 	// worktrees.
 	ListSessionWorktrees(ctx context.Context, id domain.SessionID) ([]domain.SessionWorktreeRecord, error)
+	// DeleteSessionWorktrees clears the "shutdown-saved" restore marker.
+	DeleteSessionWorktrees(ctx context.Context, id domain.SessionID) error
 }
 
 // Manager coordinates internal session spawn, restore, kill, and cleanup over
@@ -446,6 +448,12 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	// when the runtime/workspace handle is missing.
 	if err := m.lcm.MarkTerminated(ctx, id); err != nil {
 		return false, fmt.Errorf("kill %s: %w", id, err)
+	}
+
+	// Clear the restore marker so the next boot's RestoreAll cannot resurrect a
+	// killed session (#2319). Best-effort: teardown below still matters.
+	if err := m.store.DeleteSessionWorktrees(ctx, id); err != nil {
+		m.logger.Warn("kill: delete restore marker failed", "sessionID", id, "error", err)
 	}
 
 	// Only tear down what exists. A session may have lost its handle after a
@@ -840,6 +848,12 @@ func (m *Manager) RestoreAll(ctx context.Context) error {
 			} else {
 				m.logger.Error("restore-all: relaunch failed", "sessionID", rec.ID, "error", err)
 			}
+		}
+
+		// One-shot: drop the consumed marker so it never outlives one restart
+		// (#2319). A still-live session re-acquires it at the next quit.
+		if err := m.store.DeleteSessionWorktrees(ctx, rec.ID); err != nil {
+			m.logger.Warn("restore-all: delete restore marker failed", "sessionID", rec.ID, "error", err)
 		}
 	}
 	return nil

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -113,6 +113,10 @@ func (f *fakeStore) UpsertSessionWorktree(_ context.Context, row domain.SessionW
 func (f *fakeStore) ListSessionWorktrees(_ context.Context, id domain.SessionID) ([]domain.SessionWorktreeRecord, error) {
 	return f.worktrees[id], nil
 }
+func (f *fakeStore) DeleteSessionWorktrees(_ context.Context, id domain.SessionID) error {
+	delete(f.worktrees, id)
+	return nil
+}
 
 type fakeLCM struct {
 	store     *fakeStore
@@ -568,6 +572,29 @@ func TestKill_OtherWorkspaceErrorStillFails(t *testing.T) {
 	ws.destroyErr = errors.New("disk on fire")
 	if _, err := m.Kill(ctx, "mer-1"); err == nil || !strings.Contains(err.Error(), "disk on fire") {
 		t.Fatalf("kill err = %v, want workspace error surfaced", err)
+	}
+}
+
+// TestKill_DeletesRestoreMarker covers issue #2319 (a): a user kill is explicit
+// terminal intent and must delete the session_worktrees "shutdown-saved" marker.
+// A session that carried a marker (e.g. it survived a prior reopen cycle) and is
+// then killed must not keep that marker, or the next boot's RestoreAll would
+// resurrect it.
+func TestKill_DeletesRestoreMarker(t *testing.T) {
+	m, st, _, _ := newManager()
+	st.sessions["mer-1"] = mkLive("mer-1")
+	// The session carries a leftover shutdown-saved marker from a prior cycle.
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{SessionID: "mer-1", RepoName: "__root__"}}
+
+	if _, err := m.Kill(ctx, "mer-1"); err != nil {
+		t.Fatalf("kill err = %v", err)
+	}
+	rows, err := st.ListSessionWorktrees(ctx, "mer-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("kill must delete the restore marker, got %d rows", len(rows))
 	}
 }
 func TestRestore_ReopensTerminal(t *testing.T) {
@@ -1575,6 +1602,81 @@ func TestRestoreAll_SkipsSessionsKilledBeforeShutdown(t *testing.T) {
 	}
 	if !st.sessions["mer-1"].IsTerminated {
 		t.Error("user-killed session must remain terminated")
+	}
+}
+
+// TestRestoreAll_DeletesMarkerAfterRelaunch covers issue #2319 (b): the
+// shutdown-saved marker is one-shot. After RestoreAll relaunches a session, its
+// session_worktrees marker is deleted, so a second RestoreAll (with no fresh
+// marker) does NOT relaunch it again.
+func TestRestoreAll_DeletesMarkerAfterRelaunch(t *testing.T) {
+	m, st, rt, _ := newLifecycleManager()
+
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:           "mer-1",
+		ProjectID:    "mer",
+		Kind:         domain.KindWorker,
+		Harness:      domain.HarnessClaudeCode,
+		IsTerminated: true,
+		Metadata:     domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1/root", AgentSessionID: "agent-w"},
+		Activity:     domain.Activity{State: domain.ActivityExited},
+	}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{SessionID: "mer-1", RepoName: "__root__"}}
+
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("RestoreAll err = %v", err)
+	}
+	if rt.created != 1 {
+		t.Fatalf("first RestoreAll must relaunch once, runtime.Create called %d times", rt.created)
+	}
+	rows, err := st.ListSessionWorktrees(ctx, "mer-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("RestoreAll must delete the one-shot marker, got %d rows", len(rows))
+	}
+}
+
+// TestRestoreAll_KilledSessionNotResurrectedOnSecondBoot covers issue #2319 (c),
+// the killed-session-resurrection scenario. A terminated session WITH a marker
+// is relaunched exactly once; on a second RestoreAll (no new marker) it stays
+// terminated and is not relaunched again.
+func TestRestoreAll_KilledSessionNotResurrectedOnSecondBoot(t *testing.T) {
+	m, st, rt, _ := newLifecycleManager()
+
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:           "mer-1",
+		ProjectID:    "mer",
+		Kind:         domain.KindWorker,
+		Harness:      domain.HarnessClaudeCode,
+		IsTerminated: true,
+		Metadata:     domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1/root", AgentSessionID: "agent-w"},
+		Activity:     domain.Activity{State: domain.ActivityExited},
+	}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{SessionID: "mer-1", RepoName: "__root__"}}
+
+	// First boot: marker present, session relaunches once.
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("first RestoreAll err = %v", err)
+	}
+	if rt.created != 1 {
+		t.Fatalf("first RestoreAll must relaunch once, runtime.Create called %d times", rt.created)
+	}
+
+	// Simulate the user killing the relaunched session before the next quit, so
+	// it has no fresh marker, then a second boot.
+	if _, err := m.Kill(ctx, "mer-1"); err != nil {
+		t.Fatalf("kill err = %v", err)
+	}
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("second RestoreAll err = %v", err)
+	}
+	if rt.created != 1 {
+		t.Fatalf("killed session must NOT be resurrected on second boot, runtime.Create total = %d, want 1", rt.created)
+	}
+	if !st.sessions["mer-1"].IsTerminated {
+		t.Error("killed session must remain terminated after second RestoreAll")
 	}
 }
 


### PR DESCRIPTION
## What

Killed sessions reappear as alive after a Cmd+Q quit + reopen. This fixes the stale-restore-marker lifecycle so a killed session stays dead across restart, while remaining manually restorable on demand.

Fixes #2319.

## Root cause

The boot-time `RestoreAll` auto-relaunches any terminated session that still has a `session_worktrees` row (the "shutdown-saved" marker). That marker was write-only: nothing ever deleted it. `Kill` left it in place, and `RestoreAll` never consumed it. So a session that survived one reopen cycle (which gave it a marker via `reconcileLive`) and was then killed still carried the marker, and the next boot resurrected it. On relaunch `MarkSpawned` clears `is_terminated`, so it shows up alive.

`DeleteSessionWorktrees` already existed on the store but was never called in production.

## Fix

1. Add `DeleteSessionWorktrees` to the Manager `Store` interface (concrete store already implements it).
2. `Kill` deletes the restore marker after `MarkTerminated` (best-effort, logged on failure). A user kill is explicit terminal intent and must not leave a resurrection marker.
3. `RestoreAll` deletes the marker after consuming it, making it one-shot so it never outlives a single restart. A still-live session re-acquires a fresh marker via `reconcileLive`/`saveAndTeardownOne` at the next quit.

Manual restore (`POST /sessions/{id}/restore`) is untouched and marker-independent, so a killed session stays restorable on demand, just not auto-resurrected on boot.

## Tests

- `TestKill_DeletesRestoreMarker`: after Kill, the marker is gone.
- `TestRestoreAll_DeletesMarkerAfterRelaunch`: marker is one-shot.
- `TestRestoreAll_KilledSessionNotResurrectedOnSecondBoot`: a killed session relaunches at most once and stays terminated on the second boot.

All three failed before the fix for the right reason. `go build ./...`, `go vet ./...`, and `go test ./internal/session_manager/... ./internal/lifecycle/... ./internal/storage/...` (173 tests) all pass.

## Note for existing installs

Existing DBs may carry `session_worktrees` rows on already-killed sessions (time-bombs). A one-time cleanup `DELETE FROM session_worktrees WHERE session_id IN (SELECT id FROM sessions WHERE is_terminated=1)` defuses them; not included here since it is environment state, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
