### PR TITLE
feat: combine workspace backend lifecycle and SCM repo discovery

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -253,153 +253,13 @@ func (w *Workspace) DestroyWorkspaceProject(ctx context.Context, info ports.Work
 	return firstErr
 }
 
-// DestroyWorkspaceProjectWorktree removes one repo worktree from a workspace
-// project using that repo's canonical path. It preserves the same dirty-worktree
-// refusal contract as Destroy.
-func (w *Workspace) DestroyWorkspaceProjectWorktree(ctx context.Context, info ports.WorkspaceRepoInfo) error {
-	if info.RepoPath == "" {
-		return fmt.Errorf("gitworktree: missing repo path for worktree %q", info.Path)
-	}
-	if info.Path == "" {
-		return fmt.Errorf("%w: empty path", ErrUnsafePath)
-	}
-	repo, err := physicalAbs(info.RepoPath)
-	if err != nil {
-		return fmt.Errorf("gitworktree: repo path: %w", err)
-	}
-	path, err := w.validateManagedPath(info.Path)
-	if err != nil {
-		return err
-	}
-	_, removeErr := w.run(ctx, w.binary, worktreeRemoveArgs(repo, path)...)
-	if _, err := w.run(ctx, w.binary, worktreePruneArgs(repo)...); err != nil {
-		return fmt.Errorf("gitworktree: worktree prune: %w", err)
-	}
-	records, err := w.listRecords(ctx, repo)
-	if err != nil {
-		return err
-	}
-	if _, ok := findWorktree(records, path); ok {
-		if removeErr != nil {
-			dirty, statusErr := w.isDirty(ctx, path)
-			if statusErr == nil && dirty {
-				return fmt.Errorf("gitworktree: refusing to remove %q: %w (worktree remove: %w)", path, ports.ErrWorkspaceDirty, removeErr)
-			}
-			if statusErr != nil {
-				return fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune (worktree remove: %w; dirty probe: %w)", path, removeErr, statusErr)
-			}
-			return fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune (worktree remove: %w)", path, removeErr)
-		}
-		return fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune", path)
-	}
-	if err := os.RemoveAll(path); err != nil {
-		return fmt.Errorf("gitworktree: remove unregistered path %q: %w", path, err)
-	}
-	return nil
-}
-
-// ForceDestroyWorkspaceProjectWorktree force-removes one repo worktree after
-// its work has been preserved.
-func (w *Workspace) ForceDestroyWorkspaceProjectWorktree(ctx context.Context, info ports.WorkspaceRepoInfo) error {
-	if info.RepoPath == "" {
-		return fmt.Errorf("gitworktree: missing repo path for worktree %q", info.Path)
-	}
-	if info.Path == "" {
-		return fmt.Errorf("%w: empty path", ErrUnsafePath)
-	}
-	repo, err := physicalAbs(info.RepoPath)
-	if err != nil {
-		return fmt.Errorf("gitworktree: repo path: %w", err)
-	}
-	path, err := w.validateManagedPath(info.Path)
-	if err != nil {
-		return err
-	}
-	return w.forceDestroyPath(ctx, repo, path)
-}
-
-// RestoreWorkspaceProjectWorktree re-attaches one repo worktree for a workspace
-// project using the repo path captured from project registration.
-func (w *Workspace) RestoreWorkspaceProjectWorktree(ctx context.Context, info ports.WorkspaceRepoInfo) (ports.WorkspaceRepoInfo, error) {
-	if info.RepoPath == "" {
-		return ports.WorkspaceRepoInfo{}, fmt.Errorf("gitworktree: missing repo path for worktree %q", info.Path)
-	}
-	if info.Path == "" {
-		return ports.WorkspaceRepoInfo{}, fmt.Errorf("%w: empty path", ErrUnsafePath)
-	}
-	if info.Branch == "" {
-		return ports.WorkspaceRepoInfo{}, errors.New("gitworktree: branch is required")
-	}
-	repo, err := physicalAbs(info.RepoPath)
-	if err != nil {
-		return ports.WorkspaceRepoInfo{}, fmt.Errorf("gitworktree: repo path: %w", err)
-	}
-	path, err := w.validateManagedPath(info.Path)
-	if err != nil {
-		return ports.WorkspaceRepoInfo{}, err
-	}
-	records, err := w.listRecords(ctx, repo)
-	if err != nil {
-		return ports.WorkspaceRepoInfo{}, err
-	}
-	out := info
-	if rec, ok := findWorktree(records, path); ok {
-		if rec.Branch != "" {
-			out.Branch = rec.Branch
-		}
-		out.Path = path
-		out.RepoPath = repo
-		return out, nil
-	}
-	if nonEmpty, err := pathExistsNonEmpty(path); err != nil {
-		return ports.WorkspaceRepoInfo{}, err
-	} else if nonEmpty {
-		if _, err := moveStrayPathAside(path); err != nil {
-			return ports.WorkspaceRepoInfo{}, err
-		}
-	}
-	if err := w.validateBranch(ctx, repo, info.Branch); err != nil {
-		return ports.WorkspaceRepoInfo{}, err
-	}
-	if err := w.addWorktree(ctx, repo, path, info.Branch, ""); err != nil {
-		return ports.WorkspaceRepoInfo{}, err
-	}
-	out.Path = path
-	out.RepoPath = repo
-	return out, nil
-}
-
-// StashWorkspaceProjectWorktree captures uncommitted work for one workspace
-// project repo worktree.
-func (w *Workspace) StashWorkspaceProjectWorktree(ctx context.Context, info ports.WorkspaceRepoInfo) (string, error) {
-	return w.StashUncommitted(ctx, workspaceInfoFromRepoInfo(info))
-}
-
-// ApplyWorkspaceProjectPreserved replays a preserve ref into one workspace
-// project repo worktree.
-func (w *Workspace) ApplyWorkspaceProjectPreserved(ctx context.Context, info ports.WorkspaceRepoInfo, ref string) error {
-	return w.ApplyPreserved(ctx, workspaceInfoFromRepoInfo(info), ref)
-}
-
-func workspaceInfoFromRepoInfo(info ports.WorkspaceRepoInfo) ports.WorkspaceInfo {
-	return ports.WorkspaceInfo{
-		Path:      info.Path,
-		Branch:    info.Branch,
-		SessionID: info.SessionID,
-		ProjectID: info.ProjectID,
-	}
-}
-
 // Destroy removes the session's worktree and prunes it from the repo, refusing
 // (rather than force-deleting) if git still has the path registered afterwards.
 func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error {
-	if info.ProjectID == "" {
-		return errors.New("gitworktree: project id is required")
-	}
 	if info.Path == "" {
 		return fmt.Errorf("%w: empty path", ErrUnsafePath)
 	}
-	repo, err := w.repoPath(info.ProjectID)
+	repo, err := w.repoPathForInfo(info)
 	if err != nil {
 		return err
 	}
@@ -448,13 +308,10 @@ func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error
 // discards agent work. For interactive teardown (ao session kill, ao cleanup)
 // use Destroy, which refuses dirty worktrees via ErrWorkspaceDirty.
 func (w *Workspace) ForceDestroy(ctx context.Context, info ports.WorkspaceInfo) error {
-	if info.ProjectID == "" {
-		return errors.New("gitworktree: project id is required")
-	}
 	if info.Path == "" {
 		return fmt.Errorf("%w: empty path", ErrUnsafePath)
 	}
-	repo, err := w.repoPath(info.ProjectID)
+	repo, err := w.repoPathForInfo(info)
 	if err != nil {
 		return err
 	}
@@ -664,11 +521,11 @@ func (w *Workspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (por
 	if err := validateConfig(cfg); err != nil {
 		return ports.WorkspaceInfo{}, err
 	}
-	repo, err := w.repoPath(cfg.ProjectID)
+	repo, err := w.repoPathForConfig(cfg)
 	if err != nil {
 		return ports.WorkspaceInfo{}, err
 	}
-	path, err := w.managedPath(cfg)
+	path, err := w.restorePath(cfg)
 	if err != nil {
 		return ports.WorkspaceInfo{}, err
 	}
@@ -681,12 +538,17 @@ func (w *Workspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (por
 		if branch == "" {
 			branch = cfg.Branch
 		}
-		return ports.WorkspaceInfo{Path: path, Branch: branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID}, nil
+		return ports.WorkspaceInfo{Path: path, Branch: branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID, RepoPath: repo}, nil
 	}
 	if nonEmpty, err := pathExistsNonEmpty(path); err != nil {
 		return ports.WorkspaceInfo{}, err
 	} else if nonEmpty {
-		return ports.WorkspaceInfo{}, fmt.Errorf("gitworktree: refusing to restore %q: path exists and is not a registered worktree", path)
+		if cfg.Path == "" {
+			return ports.WorkspaceInfo{}, fmt.Errorf("gitworktree: refusing to restore %q: path exists and is not a registered worktree", path)
+		}
+		if _, err := moveStrayPathAside(path); err != nil {
+			return ports.WorkspaceInfo{}, err
+		}
 	}
 	if err := w.validateBranch(ctx, repo, cfg.Branch); err != nil {
 		return ports.WorkspaceInfo{}, err
@@ -694,7 +556,7 @@ func (w *Workspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (por
 	if err := w.addWorktree(ctx, repo, path, cfg.Branch, cfg.BaseBranch); err != nil {
 		return ports.WorkspaceInfo{}, err
 	}
-	return ports.WorkspaceInfo{Path: path, Branch: cfg.Branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID}, nil
+	return ports.WorkspaceInfo{Path: path, Branch: cfg.Branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID, RepoPath: repo}, nil
 }
 
 func (w *Workspace) existingWorktree(ctx context.Context, repo, path string, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, bool, error) {
@@ -935,6 +797,31 @@ func (w *Workspace) repoPath(project domain.ProjectID) (string, error) {
 	return abs, nil
 }
 
+func (w *Workspace) repoPathForInfo(info ports.WorkspaceInfo) (string, error) {
+	if info.RepoPath != "" {
+		repo, err := physicalAbs(info.RepoPath)
+		if err != nil {
+			return "", fmt.Errorf("gitworktree: repo path: %w", err)
+		}
+		return repo, nil
+	}
+	if info.ProjectID == "" {
+		return "", errors.New("gitworktree: project id is required")
+	}
+	return w.repoPath(info.ProjectID)
+}
+
+func (w *Workspace) repoPathForConfig(cfg ports.WorkspaceConfig) (string, error) {
+	if cfg.RepoPath != "" {
+		repo, err := physicalAbs(cfg.RepoPath)
+		if err != nil {
+			return "", fmt.Errorf("gitworktree: repo path: %w", err)
+		}
+		return repo, nil
+	}
+	return w.repoPath(cfg.ProjectID)
+}
+
 func physicalAbs(path string) (string, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
@@ -1040,6 +927,13 @@ func (w *Workspace) managedPath(cfg ports.WorkspaceConfig) (string, error) {
 		path = filepath.Join(w.managedRoot, string(cfg.ProjectID), string(cfg.SessionID))
 	}
 	return w.validateManagedPath(path)
+}
+
+func (w *Workspace) restorePath(cfg ports.WorkspaceConfig) (string, error) {
+	if cfg.Path != "" {
+		return w.validateManagedPath(cfg.Path)
+	}
+	return w.managedPath(cfg)
 }
 
 // resolvedSessionPrefix returns cfg.SessionPrefix when set, otherwise the first

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -84,6 +84,7 @@ type Workspace struct {
 type commandRunner func(ctx context.Context, binary string, args ...string) ([]byte, error)
 
 var _ ports.Workspace = (*Workspace)(nil)
+var _ ports.WorkspaceProject = (*Workspace)(nil)
 
 // New builds a gitworktree Workspace, validating that ManagedRoot and
 // RepoResolver are set and resolving the root to an absolute, symlink-free path.
@@ -141,6 +142,115 @@ func (w *Workspace) Create(ctx context.Context, cfg ports.WorkspaceConfig) (port
 		return ports.WorkspaceInfo{}, err
 	}
 	return ports.WorkspaceInfo{Path: path, Branch: cfg.Branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID}, nil
+}
+
+// CreateWorkspaceProject materialises a root-as-repo workspace session: the
+// parent repo worktree is created at the session root, then each registered
+// child repo is created at its relative path inside that root. All repos share
+// one branch name; if the requested branch already exists in any repo, one
+// suffixed branch that is free in every repo is selected and used everywhere.
+func (w *Workspace) CreateWorkspaceProject(ctx context.Context, cfg ports.WorkspaceProjectConfig) (ports.WorkspaceProjectInfo, error) {
+	if err := validateWorkspaceProjectConfig(cfg); err != nil {
+		return ports.WorkspaceProjectInfo{}, err
+	}
+	rootRepo, err := physicalAbs(cfg.RootRepoPath)
+	if err != nil {
+		return ports.WorkspaceProjectInfo{}, fmt.Errorf("gitworktree: root repo path: %w", err)
+	}
+	rootPath, err := w.managedPath(ports.WorkspaceConfig{
+		ProjectID:     cfg.ProjectID,
+		SessionID:     cfg.SessionID,
+		Kind:          cfg.Kind,
+		SessionPrefix: cfg.SessionPrefix,
+		Branch:        firstNonEmpty(cfg.Branch, defaultSessionBranchName(cfg.SessionID)),
+	})
+	if err != nil {
+		return ports.WorkspaceProjectInfo{}, err
+	}
+	repos := make([]workspaceProjectRepo, 0, len(cfg.Repos)+1)
+	repos = append(repos, workspaceProjectRepo{
+		name:       domain.RootWorkspaceRepoName,
+		repoPath:   rootRepo,
+		outputPath: rootPath,
+		baseBranch: cfg.BaseBranch,
+	})
+	for _, child := range cfg.Repos {
+		repoPath, err := physicalAbs(child.RepoPath)
+		if err != nil {
+			return ports.WorkspaceProjectInfo{}, fmt.Errorf("gitworktree: child repo %q path: %w", child.Name, err)
+		}
+		rel, err := cleanRelativePath(child.RelativePath)
+		if err != nil {
+			return ports.WorkspaceProjectInfo{}, fmt.Errorf("gitworktree: child repo %q: %w", child.Name, err)
+		}
+		outPath, err := w.validateManagedPath(filepath.Join(rootPath, filepath.FromSlash(rel)))
+		if err != nil {
+			return ports.WorkspaceProjectInfo{}, fmt.Errorf("gitworktree: child repo %q path: %w", child.Name, err)
+		}
+		repos = append(repos, workspaceProjectRepo{
+			name:         child.Name,
+			relativePath: rel,
+			repoPath:     repoPath,
+			outputPath:   outPath,
+			baseBranch:   firstNonEmpty(child.BaseBranch, cfg.BaseBranch),
+		})
+	}
+	branch, err := w.workspaceProjectBranch(ctx, repos, firstNonEmpty(cfg.Branch, defaultSessionBranchName(cfg.SessionID)))
+	if err != nil {
+		return ports.WorkspaceProjectInfo{}, err
+	}
+	created := make([]workspaceProjectRepo, 0, len(repos))
+	out := ports.WorkspaceProjectInfo{Worktrees: make([]ports.WorkspaceRepoInfo, 0, len(repos))}
+	for _, repo := range repos {
+		baseSHA, err := w.createWorkspaceProjectRepo(ctx, repo, branch)
+		if err != nil {
+			for i := len(created) - 1; i >= 0; i-- {
+				_ = w.forceDestroyPath(ctx, created[i].repoPath, created[i].outputPath)
+			}
+			return ports.WorkspaceProjectInfo{}, err
+		}
+		created = append(created, repo)
+		info := ports.WorkspaceRepoInfo{
+			RepoName:     repo.name,
+			RepoPath:     repo.repoPath,
+			Path:         repo.outputPath,
+			Branch:       branch,
+			BaseSHA:      baseSHA,
+			SessionID:    cfg.SessionID,
+			ProjectID:    cfg.ProjectID,
+			RelativePath: repo.relativePath,
+		}
+		out.Worktrees = append(out.Worktrees, info)
+		if repo.name == domain.RootWorkspaceRepoName {
+			out.Root = ports.WorkspaceInfo{Path: repo.outputPath, Branch: branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID}
+		}
+	}
+	return out, nil
+}
+
+// DestroyWorkspaceProject removes every worktree in a workspace project,
+// children first and the parent/root last. It uses the same force path as spawn
+// rollback because normal interactive cleanup still goes through Destroy and
+// the full dirty-preserve matrix is implemented separately.
+func (w *Workspace) DestroyWorkspaceProject(ctx context.Context, info ports.WorkspaceProjectInfo) error {
+	var firstErr error
+	for i := len(info.Worktrees) - 1; i >= 0; i-- {
+		wt := info.Worktrees[i]
+		if wt.Path == "" {
+			continue
+		}
+		repoPath := wt.RepoPath
+		if repoPath == "" {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("gitworktree: missing repo path for worktree %q", wt.Path)
+			}
+			continue
+		}
+		if err := w.forceDestroyPath(ctx, repoPath, wt.Path); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // Destroy removes the session's worktree and prunes it from the repo, refusing
@@ -507,6 +617,95 @@ func (w *Workspace) addWorktree(ctx context.Context, repo, path, branch, baseBra
 	return nil
 }
 
+type workspaceProjectRepo struct {
+	name         string
+	relativePath string
+	repoPath     string
+	outputPath   string
+	baseBranch   string
+}
+
+func (w *Workspace) workspaceProjectBranch(ctx context.Context, repos []workspaceProjectRepo, requested string) (string, error) {
+	branch := strings.TrimSpace(requested)
+	if branch == "" {
+		return "", errors.New("gitworktree: branch is required")
+	}
+	for i := 0; i < 100; i++ {
+		candidate := branch
+		if i > 0 {
+			candidate = fmt.Sprintf("%s-%d", branch, i+1)
+		}
+		free, err := w.workspaceProjectBranchFree(ctx, repos, candidate)
+		if err != nil {
+			return "", err
+		}
+		if free {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("gitworktree: could not find free workspace branch for %q", branch)
+}
+
+func (w *Workspace) workspaceProjectBranchFree(ctx context.Context, repos []workspaceProjectRepo, branch string) (bool, error) {
+	for _, repo := range repos {
+		if err := w.validateBranch(ctx, repo.repoPath, branch); err != nil {
+			return false, err
+		}
+		exists, err := w.refExists(ctx, repo.repoPath, "refs/heads/"+branch)
+		if err != nil {
+			return false, err
+		}
+		if exists {
+			return false, nil
+		}
+		records, err := w.listRecords(ctx, repo.repoPath)
+		if err != nil {
+			return false, err
+		}
+		if conflict, ok := findWorktreeByBranch(records, branch); ok && filepath.Clean(conflict.Path) != filepath.Clean(repo.outputPath) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (w *Workspace) createWorkspaceProjectRepo(ctx context.Context, repo workspaceProjectRepo, branch string) (string, error) {
+	baseRef, err := w.resolveBaseRef(ctx, repo.repoPath, branch, repo.baseBranch)
+	if err != nil {
+		if errors.Is(err, errNoBaseRef) {
+			return "", fmt.Errorf("%w: %q has no local head, no remote, and no tag — run `git fetch` then retry", ErrBranchNotFetched, branch)
+		}
+		return "", err
+	}
+	baseSHA, err := w.revParse(ctx, repo.repoPath, baseRef)
+	if err != nil {
+		return "", err
+	}
+	if _, err := w.run(ctx, w.binary, worktreeAddNewBranchArgs(repo.repoPath, branch, repo.outputPath, baseRef)...); err != nil {
+		return "", fmt.Errorf("gitworktree: workspace repo %q worktree add branch %q from %q: %w", repo.name, branch, baseRef, err)
+	}
+	return baseSHA, nil
+}
+
+func (w *Workspace) forceDestroyPath(ctx context.Context, repo, path string) error {
+	_, _ = w.run(ctx, w.binary, worktreeForceRemoveArgs(repo, path)...)
+	if _, err := w.run(ctx, w.binary, worktreePruneArgs(repo)...); err != nil {
+		return fmt.Errorf("gitworktree: worktree prune: %w", err)
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("gitworktree: force remove path %q: %w", path, err)
+	}
+	return nil
+}
+
+func (w *Workspace) revParse(ctx context.Context, repo, ref string) (string, error) {
+	out, err := w.run(ctx, w.binary, "-C", repo, "rev-parse", "--verify", ref)
+	if err != nil {
+		return "", fmt.Errorf("gitworktree: rev-parse %q: %w", ref, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 func (w *Workspace) validateBranch(ctx context.Context, repo, branch string) error {
 	if _, err := w.run(ctx, w.binary, checkRefFormatBranchArgs(repo, branch)...); err != nil {
 		return fmt.Errorf("%w: %q (%w)", ErrBranchInvalid, branch, err)
@@ -649,6 +848,37 @@ func validateConfig(cfg ports.WorkspaceConfig) error {
 	return nil
 }
 
+func validateWorkspaceProjectConfig(cfg ports.WorkspaceProjectConfig) error {
+	if err := validateConfig(ports.WorkspaceConfig{
+		ProjectID:     cfg.ProjectID,
+		SessionID:     cfg.SessionID,
+		Kind:          cfg.Kind,
+		SessionPrefix: cfg.SessionPrefix,
+		Branch:        firstNonEmpty(cfg.Branch, defaultSessionBranchName(cfg.SessionID)),
+		BaseBranch:    cfg.BaseBranch,
+	}); err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.RootRepoPath) == "" {
+		return errors.New("gitworktree: root repo path is required")
+	}
+	for _, repo := range cfg.Repos {
+		if strings.TrimSpace(repo.Name) == "" {
+			return errors.New("gitworktree: child repo name is required")
+		}
+		if err := validatePathComponent("child repo name", repo.Name); err != nil {
+			return err
+		}
+		if strings.TrimSpace(repo.RepoPath) == "" {
+			return fmt.Errorf("gitworktree: child repo %q path is required", repo.Name)
+		}
+		if _, err := cleanRelativePath(repo.RelativePath); err != nil {
+			return fmt.Errorf("gitworktree: child repo %q: %w", repo.Name, err)
+		}
+	}
+	return nil
+}
+
 // validatePathComponent rejects id values that could escape the managed root
 // once joined into a path. filepath.Join cleans `..` before validateManagedPath
 // runs, so a session id of "../other" would otherwise resolve back inside
@@ -686,6 +916,34 @@ func resolvedSessionPrefix(cfg ports.WorkspaceConfig) string {
 		return id
 	}
 	return id[:12]
+}
+
+func defaultSessionBranchName(id domain.SessionID) string {
+	return "ao/" + string(id)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func cleanRelativePath(path string) (string, error) {
+	rel := filepath.ToSlash(strings.TrimSpace(path))
+	if rel == "" {
+		return "", errors.New("relative path is required")
+	}
+	if strings.HasPrefix(rel, "/") {
+		return "", fmt.Errorf("%w: relative path %q must not be absolute", ErrUnsafePath, path)
+	}
+	clean := filepath.ToSlash(filepath.Clean(filepath.FromSlash(rel)))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("%w: relative path %q escapes the workspace root", ErrUnsafePath, path)
+	}
+	return clean, nil
 }
 
 func (w *Workspace) validateManagedPath(path string) (string, error) {

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -253,6 +253,143 @@ func (w *Workspace) DestroyWorkspaceProject(ctx context.Context, info ports.Work
 	return firstErr
 }
 
+// DestroyWorkspaceProjectWorktree removes one repo worktree from a workspace
+// project using that repo's canonical path. It preserves the same dirty-worktree
+// refusal contract as Destroy.
+func (w *Workspace) DestroyWorkspaceProjectWorktree(ctx context.Context, info ports.WorkspaceRepoInfo) error {
+	if info.RepoPath == "" {
+		return fmt.Errorf("gitworktree: missing repo path for worktree %q", info.Path)
+	}
+	if info.Path == "" {
+		return fmt.Errorf("%w: empty path", ErrUnsafePath)
+	}
+	repo, err := physicalAbs(info.RepoPath)
+	if err != nil {
+		return fmt.Errorf("gitworktree: repo path: %w", err)
+	}
+	path, err := w.validateManagedPath(info.Path)
+	if err != nil {
+		return err
+	}
+	_, removeErr := w.run(ctx, w.binary, worktreeRemoveArgs(repo, path)...)
+	if _, err := w.run(ctx, w.binary, worktreePruneArgs(repo)...); err != nil {
+		return fmt.Errorf("gitworktree: worktree prune: %w", err)
+	}
+	records, err := w.listRecords(ctx, repo)
+	if err != nil {
+		return err
+	}
+	if _, ok := findWorktree(records, path); ok {
+		if removeErr != nil {
+			dirty, statusErr := w.isDirty(ctx, path)
+			if statusErr == nil && dirty {
+				return fmt.Errorf("gitworktree: refusing to remove %q: %w (worktree remove: %w)", path, ports.ErrWorkspaceDirty, removeErr)
+			}
+			if statusErr != nil {
+				return fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune (worktree remove: %w; dirty probe: %w)", path, removeErr, statusErr)
+			}
+			return fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune (worktree remove: %w)", path, removeErr)
+		}
+		return fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune", path)
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("gitworktree: remove unregistered path %q: %w", path, err)
+	}
+	return nil
+}
+
+// ForceDestroyWorkspaceProjectWorktree force-removes one repo worktree after
+// its work has been preserved.
+func (w *Workspace) ForceDestroyWorkspaceProjectWorktree(ctx context.Context, info ports.WorkspaceRepoInfo) error {
+	if info.RepoPath == "" {
+		return fmt.Errorf("gitworktree: missing repo path for worktree %q", info.Path)
+	}
+	if info.Path == "" {
+		return fmt.Errorf("%w: empty path", ErrUnsafePath)
+	}
+	repo, err := physicalAbs(info.RepoPath)
+	if err != nil {
+		return fmt.Errorf("gitworktree: repo path: %w", err)
+	}
+	path, err := w.validateManagedPath(info.Path)
+	if err != nil {
+		return err
+	}
+	return w.forceDestroyPath(ctx, repo, path)
+}
+
+// RestoreWorkspaceProjectWorktree re-attaches one repo worktree for a workspace
+// project using the repo path captured from project registration.
+func (w *Workspace) RestoreWorkspaceProjectWorktree(ctx context.Context, info ports.WorkspaceRepoInfo) (ports.WorkspaceRepoInfo, error) {
+	if info.RepoPath == "" {
+		return ports.WorkspaceRepoInfo{}, fmt.Errorf("gitworktree: missing repo path for worktree %q", info.Path)
+	}
+	if info.Path == "" {
+		return ports.WorkspaceRepoInfo{}, fmt.Errorf("%w: empty path", ErrUnsafePath)
+	}
+	if info.Branch == "" {
+		return ports.WorkspaceRepoInfo{}, errors.New("gitworktree: branch is required")
+	}
+	repo, err := physicalAbs(info.RepoPath)
+	if err != nil {
+		return ports.WorkspaceRepoInfo{}, fmt.Errorf("gitworktree: repo path: %w", err)
+	}
+	path, err := w.validateManagedPath(info.Path)
+	if err != nil {
+		return ports.WorkspaceRepoInfo{}, err
+	}
+	records, err := w.listRecords(ctx, repo)
+	if err != nil {
+		return ports.WorkspaceRepoInfo{}, err
+	}
+	out := info
+	if rec, ok := findWorktree(records, path); ok {
+		if rec.Branch != "" {
+			out.Branch = rec.Branch
+		}
+		out.Path = path
+		out.RepoPath = repo
+		return out, nil
+	}
+	if nonEmpty, err := pathExistsNonEmpty(path); err != nil {
+		return ports.WorkspaceRepoInfo{}, err
+	} else if nonEmpty {
+		if _, err := moveStrayPathAside(path); err != nil {
+			return ports.WorkspaceRepoInfo{}, err
+		}
+	}
+	if err := w.validateBranch(ctx, repo, info.Branch); err != nil {
+		return ports.WorkspaceRepoInfo{}, err
+	}
+	if err := w.addWorktree(ctx, repo, path, info.Branch, ""); err != nil {
+		return ports.WorkspaceRepoInfo{}, err
+	}
+	out.Path = path
+	out.RepoPath = repo
+	return out, nil
+}
+
+// StashWorkspaceProjectWorktree captures uncommitted work for one workspace
+// project repo worktree.
+func (w *Workspace) StashWorkspaceProjectWorktree(ctx context.Context, info ports.WorkspaceRepoInfo) (string, error) {
+	return w.StashUncommitted(ctx, workspaceInfoFromRepoInfo(info))
+}
+
+// ApplyWorkspaceProjectPreserved replays a preserve ref into one workspace
+// project repo worktree.
+func (w *Workspace) ApplyWorkspaceProjectPreserved(ctx context.Context, info ports.WorkspaceRepoInfo, ref string) error {
+	return w.ApplyPreserved(ctx, workspaceInfoFromRepoInfo(info), ref)
+}
+
+func workspaceInfoFromRepoInfo(info ports.WorkspaceRepoInfo) ports.WorkspaceInfo {
+	return ports.WorkspaceInfo{
+		Path:      info.Path,
+		Branch:    info.Branch,
+		SessionID: info.SessionID,
+		ProjectID: info.ProjectID,
+	}
+}
+
 // Destroy removes the session's worktree and prunes it from the repo, refusing
 // (rather than force-deleting) if git still has the path registered afterwards.
 func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error {
@@ -1008,6 +1145,25 @@ func pathExistsNonEmpty(path string) (bool, error) {
 		return false, nil
 	}
 	return false, fmt.Errorf("gitworktree: inspect path %q: %w", path, err)
+}
+
+func moveStrayPathAside(path string) (string, error) {
+	for i := 0; i < 100; i++ {
+		candidate := path + ".stray"
+		if i > 0 {
+			candidate = fmt.Sprintf("%s.stray-%d", path, i+1)
+		}
+		if _, err := os.Lstat(candidate); err == nil {
+			continue
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("gitworktree: inspect stray destination %q: %w", candidate, err)
+		}
+		if err := os.Rename(path, candidate); err != nil {
+			return "", fmt.Errorf("gitworktree: move stray path %q aside to %q: %w", path, candidate, err)
+		}
+		return candidate, nil
+	}
+	return "", fmt.Errorf("gitworktree: move stray path %q aside: no available destination", path)
 }
 
 func runCommand(ctx context.Context, binary string, args ...string) ([]byte, error) {

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -282,7 +282,7 @@ func TestRestoreRefusesNonEmptyUnregisteredPath(t *testing.T) {
 	}
 }
 
-func TestRestoreWorkspaceProjectWorktreeMovesStrayPathAside(t *testing.T) {
+func TestRestoreWithRepoPathMovesStrayPathAside(t *testing.T) {
 	root := t.TempDir()
 	repo := t.TempDir()
 	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
@@ -317,16 +317,15 @@ func TestRestoreWorkspaceProjectWorktreeMovesStrayPathAside(t *testing.T) {
 		}
 	}
 
-	info, err := ws.RestoreWorkspaceProjectWorktree(context.Background(), ports.WorkspaceRepoInfo{
-		RepoName:  "api",
+	info, err := ws.Restore(context.Background(), ports.WorkspaceConfig{
+		ProjectID: "proj",
+		SessionID: "proj-1",
+		Branch:    "ao/proj-1",
 		RepoPath:  repo,
 		Path:      path,
-		Branch:    "ao/proj-1",
-		SessionID: "proj-1",
-		ProjectID: "proj",
 	})
 	if err != nil {
-		t.Fatalf("RestoreWorkspaceProjectWorktree: %v", err)
+		t.Fatalf("Restore: %v", err)
 	}
 	if info.Path != path || addPath != path {
 		t.Fatalf("restored path=%q addPath=%q, want %q", info.Path, addPath, path)

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -282,6 +282,63 @@ func TestRestoreRefusesNonEmptyUnregisteredPath(t *testing.T) {
 	}
 }
 
+func TestRestoreWorkspaceProjectWorktreeMovesStrayPathAside(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "sess", "api")
+	if err := mkdirFile(path, "keep.txt"); err != nil {
+		t.Fatalf("seed path: %v", err)
+	}
+	var addPath string
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "worktree list --porcelain"):
+			return []byte("worktree " + repo + "\nbranch refs/heads/main\n"), nil
+		case strings.Contains(joined, "check-ref-format"):
+			return nil, nil
+		case strings.Contains(joined, "rev-parse"):
+			return []byte("commit"), nil
+		case strings.Contains(joined, "worktree add"):
+			if len(args) >= 2 {
+				addPath = args[len(args)-2]
+			}
+			if addPath == "" {
+				t.Fatalf("could not find worktree add path in args: %v", args)
+			}
+			return nil, nil
+		default:
+			t.Fatalf("unexpected git invocation: %v", args)
+			return nil, nil
+		}
+	}
+
+	info, err := ws.RestoreWorkspaceProjectWorktree(context.Background(), ports.WorkspaceRepoInfo{
+		RepoName:  "api",
+		RepoPath:  repo,
+		Path:      path,
+		Branch:    "ao/proj-1",
+		SessionID: "proj-1",
+		ProjectID: "proj",
+	})
+	if err != nil {
+		t.Fatalf("RestoreWorkspaceProjectWorktree: %v", err)
+	}
+	if info.Path != path || addPath != path {
+		t.Fatalf("restored path=%q addPath=%q, want %q", info.Path, addPath, path)
+	}
+	if _, err := os.Stat(filepath.Join(path+".stray", "keep.txt")); err != nil {
+		t.Fatalf("stray path was not preserved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(path, "keep.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("original path still has stray file: %v", err)
+	}
+}
+
 func TestDestroyRefusesStillRegisteredPathAndPreservesDirectory(t *testing.T) {
 	root := t.TempDir()
 	repo := t.TempDir()

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -174,6 +174,60 @@ func TestOrchestratorManagedPath(t *testing.T) {
 	})
 }
 
+func TestCreateWorkspaceProjectOrchestratorCreatesRootAndChildWorktrees(t *testing.T) {
+	root := t.TempDir()
+	parentRepo := gitRepoWithInitialCommit(t, filepath.Join(t.TempDir(), "workspace-root"), "main")
+	childRepo := gitRepoWithInitialCommit(t, filepath.Join(t.TempDir(), "api"), "main")
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": parentRepo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	info, err := ws.CreateWorkspaceProject(context.Background(), ports.WorkspaceProjectConfig{
+		ProjectID:     "proj",
+		SessionID:     "proj-1",
+		Kind:          domain.KindOrchestrator,
+		SessionPrefix: "proj",
+		Branch:        "ao/proj-1",
+		RootRepoPath:  parentRepo,
+		BaseBranch:    "main",
+		Repos: []ports.WorkspaceProjectRepoConfig{{
+			Name:         "api",
+			RelativePath: "api",
+			RepoPath:     childRepo,
+			BaseBranch:   "main",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspaceProject: %v", err)
+	}
+	wantRoot := filepath.Join(ws.managedRoot, "proj", "orchestrator", "proj-orchestrator")
+	wantChild := filepath.Join(wantRoot, "api")
+	wantChildRepo, err := physicalAbs(childRepo)
+	if err != nil {
+		t.Fatalf("child physical path: %v", err)
+	}
+	if info.Root.Path != wantRoot || info.Root.Branch != "ao/proj-1" {
+		t.Fatalf("root = %#v, want path %q branch ao/proj-1", info.Root, wantRoot)
+	}
+	if len(info.Worktrees) != 2 {
+		t.Fatalf("worktrees = %d, want root and api: %#v", len(info.Worktrees), info.Worktrees)
+	}
+	if info.Worktrees[1].Path != wantChild || info.Worktrees[1].RepoPath != wantChildRepo {
+		t.Fatalf("child worktree = %#v, want path %q repo %q", info.Worktrees[1], wantChild, wantChildRepo)
+	}
+	if out, err := exec.Command("git", "-C", parentRepo, "worktree", "list", "--porcelain").CombinedOutput(); err != nil {
+		t.Fatalf("root worktree list: %v (%s)", err, out)
+	} else if !strings.Contains(string(out), wantRoot) {
+		t.Fatalf("root worktree list missing %q:\n%s", wantRoot, out)
+	}
+	if out, err := exec.Command("git", "-C", childRepo, "worktree", "list", "--porcelain").CombinedOutput(); err != nil {
+		t.Fatalf("child worktree list: %v (%s)", err, out)
+	} else if !strings.Contains(string(out), wantChild) {
+		t.Fatalf("child worktree list missing %q:\n%s", wantChild, out)
+	}
+}
+
 func TestCreateReusesRegisteredWorktreeAtExpectedPath(t *testing.T) {
 	root := t.TempDir()
 	repo := t.TempDir()
@@ -531,4 +585,27 @@ func mkdirFile(dir, name string) error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(dir, name), []byte("data"), 0o644)
+}
+
+func gitRepoWithInitialCommit(t *testing.T, dir, branch string) string {
+	t.Helper()
+	if out, err := exec.Command("git", "init", "-b", branch, dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", dir, "config", "user.email", "ao@example.com").CombinedOutput(); err != nil {
+		t.Fatalf("git config email: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", dir, "config", "user.name", "AO Test").CombinedOutput(); err != nil {
+		t.Fatalf("git config name: %v (%s)", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", dir, "add", "README.md").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v (%s)", err, out)
+	}
+	if out, err := exec.Command("git", "-C", dir, "commit", "-m", "initial").CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v (%s)", err, out)
+	}
+	return dir
 }

--- a/backend/internal/domain/project.go
+++ b/backend/internal/domain/project.go
@@ -44,6 +44,7 @@ type WorkspaceRepoRecord struct {
 	Name          string
 	RelativePath  string
 	RepoOriginURL string
+	DefaultBranch string
 	RegisteredAt  time.Time
 }
 

--- a/backend/internal/domain/project.go
+++ b/backend/internal/domain/project.go
@@ -56,10 +56,8 @@ type SessionWorktreeRecord struct {
 	BaseSHA      string
 	WorktreePath string
 	PreservedRef string
-	// ponytail: State mirrors session_worktrees.state, an enum that is unused
-	// multi-repo scaffolding. The save/restore lifecycle reads and writes only
-	// PreservedRef and row presence; State is never set by any live code path
-	// and always resolves to the column default ('active' on insert). Wire it
-	// when multi-repo worktree lifecycle states actually ship.
+	// State mirrors session_worktrees.state. Workspace project lifecycle code
+	// uses it to distinguish live rows from shutdown-saved removed rows and
+	// rows that could not be removed cleanly.
 	State string
 }

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2560,6 +2560,8 @@ components:
       type: object
     WorkspaceRepo:
       properties:
+        defaultBranch:
+          type: string
         name:
           type: string
         relativePath:
@@ -2570,6 +2572,7 @@ components:
       - name
       - relativePath
       - repo
+      - defaultBranch
       type: object
 tags:
 - description: Project registry, configuration, and lifecycle administration

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -51,6 +51,7 @@ type Store interface {
 	ListAllSessions(ctx context.Context) ([]domain.SessionRecord, error)
 	GetProject(ctx context.Context, id string) (domain.ProjectRecord, bool, error)
 	UpsertProject(ctx context.Context, row domain.ProjectRecord) error
+	ListWorkspaceRepos(ctx context.Context, projectID string) ([]domain.WorkspaceRepoRecord, error)
 	ListPRsBySession(ctx context.Context, sessionID domain.SessionID) ([]domain.PullRequest, error)
 	ListChecks(ctx context.Context, prURL string) ([]domain.PullRequestCheck, error)
 	WriteSCMObservation(ctx context.Context, pr domain.PullRequest, checks []domain.PullRequestCheck, reviews []domain.PullRequestReview, threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment, reviewMode ports.ReviewWriteMode) error
@@ -454,17 +455,27 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 			projects[sess.ProjectID] = p
 			proj = p
 		}
-		repo, ok := o.provider.ParseRepository(proj.RepoOriginURL)
-		if !ok {
-			o.logger.Debug("scm observer: project has no supported SCM origin", "project", proj.ID, "origin", proj.RepoOriginURL)
+		repos, err := o.projectSCMRepos(ctx, proj)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(repos) == 0 {
+			o.logger.Debug("scm observer: project has no supported SCM origins", "project", proj.ID)
 			continue
 		}
-		sessionRepos = append(sessionRepos, sessionRepo{session: sess, repo: repo, branch: branch})
+		for _, repo := range repos {
+			sessionRepos = append(sessionRepos, sessionRepo{session: sess, repo: repo, branch: branch})
+		}
 		prs, err := o.store.ListPRsBySession(ctx, sess.ID)
 		if err != nil {
 			return nil, nil, err
 		}
 		for _, pr := range openTrackedPRs(prs) {
+			repo, ok := repoForTrackedPR(pr, repos)
+			if !ok {
+				o.logger.Warn("scm observer: tracked PR repo no longer belongs to project", "session", sess.ID, "pr", pr.URL, "repo", pr.Repo)
+				continue
+			}
 			key := prKey(repo, pr.Number)
 			if existing, ok := out[key]; ok {
 				o.logger.Warn("scm observer: duplicate tracked PR ownership skipped", "pr", key, "kept_session", existing.session.ID, "skipped_session", sess.ID)
@@ -474,6 +485,62 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 		}
 	}
 	return out, sessionRepos, nil
+}
+
+func (o *Observer) projectSCMRepos(ctx context.Context, proj domain.ProjectRecord) ([]ports.SCMRepo, error) {
+	repos := make([]ports.SCMRepo, 0, 1)
+	seen := map[string]bool{}
+	addRepo := func(origin, label string) {
+		if strings.TrimSpace(origin) == "" {
+			return
+		}
+		repo, ok := o.provider.ParseRepository(origin)
+		if !ok {
+			o.logger.Debug("scm observer: unsupported SCM origin", "project", proj.ID, "repo", label, "origin", origin)
+			return
+		}
+		key := prKey(repo, 0)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		repos = append(repos, repo)
+	}
+
+	addRepo(proj.RepoOriginURL, domain.RootWorkspaceRepoName)
+	if proj.Kind.WithDefault() != domain.ProjectKindWorkspace {
+		return repos, nil
+	}
+	childRepos, err := o.store.ListWorkspaceRepos(ctx, proj.ID)
+	if err != nil {
+		return nil, err
+	}
+	for _, child := range childRepos {
+		addRepo(child.RepoOriginURL, child.Name)
+	}
+	return repos, nil
+}
+
+func repoForTrackedPR(pr domain.PullRequest, repos []ports.SCMRepo) (ports.SCMRepo, bool) {
+	if pr.Provider != "" || pr.Host != "" || pr.Repo != "" {
+		for _, repo := range repos {
+			if strings.EqualFold(pr.Provider, repo.Provider) &&
+				strings.EqualFold(pr.Host, repo.Host) &&
+				strings.EqualFold(pr.Repo, repoFullName(repo)) {
+				return repo, true
+			}
+		}
+		return ports.SCMRepo{}, false
+	}
+	if len(repos) == 1 {
+		return repos[0], true
+	}
+	for _, repo := range repos {
+		if strings.EqualFold(repo.Repo, repos[0].Repo) {
+			return repo, true
+		}
+	}
+	return repos[0], len(repos) > 0
 }
 
 func openTrackedPRs(prs []domain.PullRequest) []domain.PullRequest {

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -21,16 +21,20 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-var testRepo = ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "o", Name: "r", Repo: "o/r"}
+var (
+	testRepo    = ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "o", Name: "r", Repo: "o/r"}
+	testAPIRepo = ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "o", Name: "api", Repo: "o/api"}
+)
 
 type fakeStore struct {
 	mu sync.Mutex
 
-	sessions []domain.SessionRecord
-	projects map[string]domain.ProjectRecord
-	prs      map[domain.SessionID][]domain.PullRequest
-	checks   map[string][]domain.PullRequestCheck
-	writeErr error
+	sessions       []domain.SessionRecord
+	projects       map[string]domain.ProjectRecord
+	workspaceRepos map[string][]domain.WorkspaceRepoRecord
+	prs            map[domain.SessionID][]domain.PullRequest
+	checks         map[string][]domain.PullRequestCheck
+	writeErr       error
 
 	writes []fakeWrite
 
@@ -81,6 +85,12 @@ func (s *fakeStore) UpsertProject(_ context.Context, row domain.ProjectRecord) e
 	}
 	s.projects[row.ID] = row
 	return nil
+}
+
+func (s *fakeStore) ListWorkspaceRepos(_ context.Context, projectID string) ([]domain.WorkspaceRepoRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]domain.WorkspaceRepoRecord(nil), s.workspaceRepos[projectID]...), nil
 }
 
 func (s *fakeStore) ListPRsBySession(_ context.Context, id domain.SessionID) ([]domain.PullRequest, error) {
@@ -139,7 +149,16 @@ func (p *fakeProvider) SCMCredentialsAvailable(context.Context) (bool, error) {
 }
 
 func (p *fakeProvider) ParseRepository(remote string) (ports.SCMRepo, bool) {
-	return testRepo, remote != ""
+	if remote == "" {
+		return ports.SCMRepo{}, false
+	}
+	if strings.Contains(remote, "o/api") {
+		return ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "o", Name: "api", Repo: "o/api"}, true
+	}
+	if strings.Contains(remote, "o/web") {
+		return ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "o", Name: "web", Repo: "o/web"}, true
+	}
+	return testRepo, true
 }
 func (p *fakeProvider) RepoPRListGuard(_ context.Context, repo ports.SCMRepo, _ string) (ports.SCMGuardResult, error) {
 	p.mu.Lock()
@@ -509,6 +528,64 @@ func TestPoll_DiscoversSiblingUnderRootSessionNamespace(t *testing.T) {
 	}
 	if got := store.writes[0].pr.SourceBranch; got != "ao/p-1/fix" {
 		t.Fatalf("source branch = %q, want ao/p-1/fix", got)
+	}
+	if got := store.writes[0].pr.SessionID; got != "p-1" {
+		t.Fatalf("session id = %q, want p-1", got)
+	}
+	if len(lc.observed) != 1 {
+		t.Fatalf("lifecycle observations = %d, want 1", len(lc.observed))
+	}
+}
+
+func TestPoll_DiscoversWorkspaceChildRepoPR(t *testing.T) {
+	store := testStoreWithSession()
+	store.sessions[0].Metadata.Branch = "ao/p-1/root"
+	store.projects["p"] = domain.ProjectRecord{
+		ID:            "p",
+		RepoOriginURL: "https://github.com/o/r.git",
+		Kind:          domain.ProjectKindWorkspace,
+	}
+	store.workspaceRepos = map[string][]domain.WorkspaceRepoRecord{
+		"p": {{ProjectID: "p", Name: "api", RelativePath: "api", RepoOriginURL: "https://github.com/o/api.git"}},
+	}
+	prObs := testObs(12)
+	prObs.Repo = "o/api"
+	prObs.PR.URL = "https://github.com/o/api/pull/12"
+	prObs.PR.HTMLURL = "https://github.com/o/api/pull/12"
+	prObs.PR.Number = 12
+	prObs.PR.SourceBranch = "ao/p-1/api-billing"
+	prObs.PR.TargetBranch = "main"
+	prObs.PR.HeadSHA = "api-sha"
+	prObs.CI.HeadSHA = "api-sha"
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{
+			prKey(testRepo, 0):    {ETag: "root-v2"},
+			prKey(testAPIRepo, 0): {ETag: "api-v2"},
+		},
+		openPRs: map[string][]ports.SCMPRObservation{
+			prKey(testAPIRepo, 0): {
+				{URL: "https://github.com/o/api/pull/12", Number: 12, SourceBranch: "ao/p-1/api-billing", HeadRepo: "o/api", TargetBranch: "main", HeadSHA: "api-sha"},
+			},
+		},
+		observations: map[string]ports.SCMObservation{prKey(testAPIRepo, 12): prObs},
+	}
+	lc := &fakeLifecycle{}
+	obs := newTestObserver(store, provider, lc, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.fetchBatches) != 1 || len(provider.fetchBatches[0]) != 1 {
+		t.Fatalf("child repo PR not refreshed: %#v", provider.fetchBatches)
+	}
+	ref := provider.fetchBatches[0][0]
+	if ref.Repo.Repo != "o/api" || ref.Number != 12 {
+		t.Fatalf("fetched ref = %#v, want o/api#12", ref)
+	}
+	if len(store.writes) == 0 {
+		t.Fatal("expected child repo PR write")
+	}
+	if got := store.writes[0].pr.Repo; got != "o/api" {
+		t.Fatalf("persisted repo = %q, want o/api", got)
 	}
 	if got := store.writes[0].pr.SessionID; got != "p-1" {
 		t.Fatalf("session id = %q, want p-1", got)

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -148,11 +148,6 @@ type Workspace interface {
 type WorkspaceProject interface {
 	CreateWorkspaceProject(ctx context.Context, cfg WorkspaceProjectConfig) (WorkspaceProjectInfo, error)
 	DestroyWorkspaceProject(ctx context.Context, info WorkspaceProjectInfo) error
-	DestroyWorkspaceProjectWorktree(ctx context.Context, info WorkspaceRepoInfo) error
-	ForceDestroyWorkspaceProjectWorktree(ctx context.Context, info WorkspaceRepoInfo) error
-	RestoreWorkspaceProjectWorktree(ctx context.Context, info WorkspaceRepoInfo) (WorkspaceRepoInfo, error)
-	StashWorkspaceProjectWorktree(ctx context.Context, info WorkspaceRepoInfo) (ref string, err error)
-	ApplyWorkspaceProjectPreserved(ctx context.Context, info WorkspaceRepoInfo, ref string) error
 }
 
 // Workspace-level sentinels surfaced through Create/Restore/Destroy so callers
@@ -195,6 +190,10 @@ type WorkspaceConfig struct {
 	// BaseBranch is the per-project default branch new session branches are
 	// created from. Empty falls back to the workspace adapter's own default.
 	BaseBranch string
+	// RepoPath optionally overrides ProjectID-based repo resolution.
+	RepoPath string
+	// Path optionally supplies an existing managed worktree path for restore.
+	Path string
 }
 
 // WorkspaceInfo describes a created workspace — where it lives and its branch.
@@ -203,6 +202,10 @@ type WorkspaceInfo struct {
 	Branch    string
 	SessionID domain.SessionID
 	ProjectID domain.ProjectID
+	// RepoPath optionally overrides ProjectID-based repo resolution. It is used
+	// when the normal workspace lifecycle primitives operate on one child repo
+	// inside a workspace project.
+	RepoPath string
 }
 
 // WorkspaceProjectConfig describes a multi-repo workspace session. RootRepoPath

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -213,6 +213,8 @@ type WorkspaceProjectConfig struct {
 	Repos         []WorkspaceProjectRepoConfig
 }
 
+// WorkspaceProjectRepoConfig describes one registered child repo in a
+// workspace project session.
 type WorkspaceProjectRepoConfig struct {
 	Name         string
 	RelativePath string
@@ -227,6 +229,8 @@ type WorkspaceProjectInfo struct {
 	Worktrees []WorkspaceRepoInfo
 }
 
+// WorkspaceRepoInfo describes one materialized repo worktree in a workspace
+// project session.
 type WorkspaceRepoInfo struct {
 	RepoName     string
 	RepoPath     string

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -141,6 +141,15 @@ type Workspace interface {
 	ApplyPreserved(ctx context.Context, info WorkspaceInfo, ref string) error
 }
 
+// WorkspaceProject is an optional extension for projects composed from a
+// root-as-repo parent plus child repositories. It materialises the parent
+// worktree at the session root and each child repo at its registered relative
+// path inside that root.
+type WorkspaceProject interface {
+	CreateWorkspaceProject(ctx context.Context, cfg WorkspaceProjectConfig) (WorkspaceProjectInfo, error)
+	DestroyWorkspaceProject(ctx context.Context, info WorkspaceProjectInfo) error
+}
+
 // Workspace-level sentinels surfaced through Create/Restore/Destroy so callers
 // can map them to typed errors rather than collapsing every adapter failure
 // into an opaque 500. Adapters wrap these via fmt.Errorf("...: %w", sentinel).
@@ -189,4 +198,42 @@ type WorkspaceInfo struct {
 	Branch    string
 	SessionID domain.SessionID
 	ProjectID domain.ProjectID
+}
+
+// WorkspaceProjectConfig describes a multi-repo workspace session. RootRepoPath
+// and child RepoPath values are absolute paths to the canonical repositories.
+type WorkspaceProjectConfig struct {
+	ProjectID     domain.ProjectID
+	SessionID     domain.SessionID
+	Kind          domain.SessionKind
+	SessionPrefix string
+	Branch        string
+	RootRepoPath  string
+	BaseBranch    string
+	Repos         []WorkspaceProjectRepoConfig
+}
+
+type WorkspaceProjectRepoConfig struct {
+	Name         string
+	RelativePath string
+	RepoPath     string
+	BaseBranch   string
+}
+
+// WorkspaceProjectInfo returns the root worktree plus every child worktree.
+// Worktrees are ordered root first, then children in creation order.
+type WorkspaceProjectInfo struct {
+	Root      WorkspaceInfo
+	Worktrees []WorkspaceRepoInfo
+}
+
+type WorkspaceRepoInfo struct {
+	RepoName     string
+	RepoPath     string
+	Path         string
+	Branch       string
+	BaseSHA      string
+	SessionID    domain.SessionID
+	ProjectID    domain.ProjectID
+	RelativePath string
 }

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -148,6 +148,11 @@ type Workspace interface {
 type WorkspaceProject interface {
 	CreateWorkspaceProject(ctx context.Context, cfg WorkspaceProjectConfig) (WorkspaceProjectInfo, error)
 	DestroyWorkspaceProject(ctx context.Context, info WorkspaceProjectInfo) error
+	DestroyWorkspaceProjectWorktree(ctx context.Context, info WorkspaceRepoInfo) error
+	ForceDestroyWorkspaceProjectWorktree(ctx context.Context, info WorkspaceRepoInfo) error
+	RestoreWorkspaceProjectWorktree(ctx context.Context, info WorkspaceRepoInfo) (WorkspaceRepoInfo, error)
+	StashWorkspaceProjectWorktree(ctx context.Context, info WorkspaceRepoInfo) (ref string, err error)
+	ApplyWorkspaceProjectPreserved(ctx context.Context, info WorkspaceRepoInfo, ref string) error
 }
 
 // Workspace-level sentinels surfaced through Create/Restore/Destroy so callers

--- a/backend/internal/processalive/process_unix.go
+++ b/backend/internal/processalive/process_unix.go
@@ -5,16 +5,32 @@
 package processalive
 
 import (
+	"bytes"
 	"errors"
+	"os/exec"
+	"strconv"
 	"syscall"
 )
 
-// Alive reports whether pid exists. EPERM counts as alive: the process exists
-// even if the current user cannot signal it.
+// Alive reports whether pid maps to a running process. EPERM counts as alive:
+// the process exists even if the current user cannot signal it. Zombies are
+// treated as not alive because the executable has already exited; only its
+// parent has not reaped the process table entry yet.
 func Alive(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
 	err := syscall.Kill(pid, 0)
-	return err == nil || errors.Is(err, syscall.EPERM)
+	if err != nil && !errors.Is(err, syscall.EPERM) {
+		return false
+	}
+	return !isZombie(pid)
+}
+
+func isZombie(pid int) bool {
+	out, err := exec.Command("ps", "-o", "stat=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return false
+	}
+	return bytes.HasPrefix(bytes.TrimSpace(out), []byte("Z"))
 }

--- a/backend/internal/processalive/process_unix_test.go
+++ b/backend/internal/processalive/process_unix_test.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package processalive
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestAliveReportsZombieAsDead(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	defer func() { _ = cmd.Wait() }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if isZombie(cmd.Process.Pid) {
+			if Alive(cmd.Process.Pid) {
+				t.Fatal("Alive returned true for zombie process")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("child did not become a zombie before timeout")
+}

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -196,6 +196,11 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 		if err != nil {
 			return Project{}, err
 		}
+		if row.Config.DefaultBranch == "" {
+			if branch := resolveDefaultBranch(path); branch != "" && branch != domain.DefaultBranchName {
+				row.Config.DefaultBranch = branch
+			}
+		}
 		row.Kind = domain.ProjectKindWorkspace
 		row.RepoOriginURL = resolveGitOriginURL(path)
 		if err := m.store.UpsertWorkspaceProject(ctx, row, repos); err != nil {

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -634,6 +634,30 @@ func TestManager_AddWorkspaceDetectsChildDefaultBranches(t *testing.T) {
 	}
 }
 
+func TestManager_AddWorkspaceDetectsParentDefaultBranch(t *testing.T) {
+	configureCommitter(t)
+	ctx := context.Background()
+	m := newManager(t)
+	parent := t.TempDir()
+	gitRepoWithCommitOnBranch(t, parent, "master")
+	gitRepoWithCommit(t, filepath.Join(parent, "api"))
+
+	proj, err := m.Add(ctx, project.AddInput{Path: parent, ProjectID: ptr("ws"), AsWorkspace: true})
+	if err != nil {
+		t.Fatalf("Add workspace: %v", err)
+	}
+	if proj.DefaultBranch != "master" {
+		t.Fatalf("workspace parent default branch = %q, want master", proj.DefaultBranch)
+	}
+	got, err := m.Get(ctx, "ws")
+	if err != nil {
+		t.Fatalf("Get workspace: %v", err)
+	}
+	if got.Project == nil || got.Project.DefaultBranch != "master" {
+		t.Fatalf("stored workspace default branch = %#v, want master", got.Project)
+	}
+}
+
 func TestManager_AddWorkspaceRejectsUncommittedChild(t *testing.T) {
 	configureCommitter(t)
 	ctx := context.Background()

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -530,7 +530,12 @@ func configureCommitter(t *testing.T) {
 
 func gitRepoWithCommit(t *testing.T, dir string) string {
 	t.Helper()
-	if out, err := exec.Command("git", "init", "-b", "main", dir).CombinedOutput(); err != nil {
+	return gitRepoWithCommitOnBranch(t, dir, "main")
+}
+
+func gitRepoWithCommitOnBranch(t *testing.T, dir, branch string) string {
+	t.Helper()
+	if out, err := exec.Command("git", "init", "-b", branch, dir).CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v (%s)", err, out)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
@@ -566,6 +571,11 @@ func TestManager_AddWorkspaceInitializesPlainParent(t *testing.T) {
 	if len(proj.WorkspaceRepos) != 2 || proj.WorkspaceRepos[0].Name != "api" || proj.WorkspaceRepos[1].Name != "cli" {
 		t.Fatalf("WorkspaceRepos = %#v", proj.WorkspaceRepos)
 	}
+	for _, repo := range proj.WorkspaceRepos {
+		if repo.DefaultBranch != "main" {
+			t.Fatalf("repo %s default branch = %q, want main", repo.Name, repo.DefaultBranch)
+		}
+	}
 	ignored, err := os.ReadFile(filepath.Join(parent, ".gitignore"))
 	if err != nil {
 		t.Fatal(err)
@@ -592,6 +602,35 @@ func TestManager_AddWorkspaceInitializesPlainParent(t *testing.T) {
 	}
 	if got.Project == nil || got.Project.Kind != domain.ProjectKindWorkspace || len(got.Project.WorkspaceRepos) != 2 {
 		t.Fatalf("Get = %#v", got)
+	}
+}
+
+func TestManager_AddWorkspaceDetectsChildDefaultBranches(t *testing.T) {
+	configureCommitter(t)
+	ctx := context.Background()
+	m := newManager(t)
+	parent := t.TempDir()
+	gitRepoWithCommitOnBranch(t, filepath.Join(parent, "api"), "master")
+	gitRepoWithCommitOnBranch(t, filepath.Join(parent, "cli"), "develop")
+
+	proj, err := m.Add(ctx, project.AddInput{Path: parent, ProjectID: ptr("ws"), AsWorkspace: true})
+	if err != nil {
+		t.Fatalf("Add workspace: %v", err)
+	}
+	want := map[string]string{"api": "master", "cli": "develop"}
+	for _, repo := range proj.WorkspaceRepos {
+		if repo.DefaultBranch != want[repo.Name] {
+			t.Fatalf("repo %s default branch = %q, want %q", repo.Name, repo.DefaultBranch, want[repo.Name])
+		}
+	}
+	got, err := m.Get(ctx, "ws")
+	if err != nil {
+		t.Fatalf("Get workspace: %v", err)
+	}
+	for _, repo := range got.Project.WorkspaceRepos {
+		if repo.DefaultBranch != want[repo.Name] {
+			t.Fatalf("stored repo %s default branch = %q, want %q", repo.Name, repo.DefaultBranch, want[repo.Name])
+		}
 	}
 }
 

--- a/backend/internal/service/project/types.go
+++ b/backend/internal/service/project/types.go
@@ -36,7 +36,8 @@ type Degraded struct {
 
 // WorkspaceRepo is the project-detail read shape for a registered child repo.
 type WorkspaceRepo struct {
-	Name         string `json:"name"`
-	RelativePath string `json:"relativePath"`
-	Repo         string `json:"repo"`
+	Name          string `json:"name"`
+	RelativePath  string `json:"relativePath"`
+	Repo          string `json:"repo"`
+	DefaultBranch string `json:"defaultBranch"`
 }

--- a/backend/internal/service/project/workspace_registration.go
+++ b/backend/internal/service/project/workspace_registration.go
@@ -176,6 +176,7 @@ func detectWorkspaceChildren(ctx context.Context, parent string, projectID domai
 			Name:          name,
 			RelativePath:  filepath.ToSlash(name),
 			RepoOriginURL: resolveGitOriginURL(child),
+			DefaultBranch: resolveDefaultBranch(child),
 			RegisteredAt:  registeredAt,
 		})
 	}
@@ -206,8 +207,7 @@ func validateWorkspaceChild(ctx context.Context, child string) error {
 			"suggestedFix": "Run `git init -b main`, add the initial files, and create the first commit before registering the workspace.",
 		})
 	}
-	branch, err := gitOutput(ctx, child, "symbolic-ref", "--quiet", "--short", "HEAD")
-	if err != nil || strings.TrimSpace(branch) == "" {
+	if branch := resolveDefaultBranch(child); branch == "" {
 		return apierr.Invalid("WORKSPACE_CHILD_DEFAULT_BRANCH_UNKNOWN", "Workspace child repositories must have an identifiable default branch", map[string]any{
 			"path":         child,
 			"suggestedFix": "Check out the repository's default branch (for example `main`) and retry.",
@@ -352,7 +352,16 @@ func guardNoGitlinks(ctx context.Context, repo string) error {
 func workspaceReposFromRecords(records []domain.WorkspaceRepoRecord) []WorkspaceRepo {
 	out := make([]WorkspaceRepo, 0, len(records))
 	for _, rec := range records {
-		out = append(out, WorkspaceRepo{Name: rec.Name, RelativePath: rec.RelativePath, Repo: rec.RepoOriginURL})
+		defaultBranch := rec.DefaultBranch
+		if defaultBranch == "" {
+			defaultBranch = domain.DefaultBranchName
+		}
+		out = append(out, WorkspaceRepo{
+			Name:          rec.Name,
+			RelativePath:  rec.RelativePath,
+			Repo:          rec.RepoOriginURL,
+			DefaultBranch: defaultBranch,
+		})
 	}
 	return out
 }

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1027,12 +1027,8 @@ func (m *Manager) sessionWorktreeRowsToRepoInfos(ctx context.Context, project do
 }
 
 func (m *Manager) saveAndTeardownWorkspaceProject(ctx context.Context, rec domain.SessionRecord, rows []ports.WorkspaceRepoInfo, destroyRuntime bool) error {
-	adapter, ok := m.workspace.(ports.WorkspaceProject)
-	if !ok {
-		return errors.New("workspace project lifecycle is not supported by workspace adapter")
-	}
 	for _, row := range rows {
-		ref, err := adapter.StashWorkspaceProjectWorktree(ctx, row)
+		ref, err := m.workspace.StashUncommitted(ctx, workspaceInfoFromRepoInfo(row))
 		if err != nil {
 			return fmt.Errorf("save %s repo %s: stash: %w", rec.ID, row.RepoName, err)
 		}
@@ -1058,7 +1054,7 @@ func (m *Manager) saveAndTeardownWorkspaceProject(ctx context.Context, rec domai
 		}
 	}
 	for i := len(rows) - 1; i >= 0; i-- {
-		if err := adapter.ForceDestroyWorkspaceProjectWorktree(ctx, rows[i]); err != nil {
+		if err := m.workspace.ForceDestroy(ctx, workspaceInfoFromRepoInfo(rows[i])); err != nil {
 			m.logger.Warn("save-teardown-all: force destroy failed", "sessionID", rec.ID, "repo", rows[i].RepoName, "error", err)
 		}
 	}
@@ -1066,23 +1062,20 @@ func (m *Manager) saveAndTeardownWorkspaceProject(ctx context.Context, rec domai
 }
 
 func (m *Manager) destroyWorkspaceProjectRows(ctx context.Context, rows []ports.WorkspaceRepoInfo, preserveDirty bool) (bool, error) {
-	adapter, ok := m.workspace.(ports.WorkspaceProject)
-	if !ok {
-		return false, errors.New("workspace project lifecycle is not supported by workspace adapter")
-	}
 	cleaned := false
 	var firstErr error
 	for i := len(rows) - 1; i >= 0; i-- {
 		if rows[i].Path == "" {
 			continue
 		}
-		if err := adapter.DestroyWorkspaceProjectWorktree(ctx, rows[i]); err != nil {
+		info := workspaceInfoFromRepoInfo(rows[i])
+		if err := m.workspace.Destroy(ctx, info); err != nil {
 			preservedRef := ""
 			if errors.Is(err, ports.ErrWorkspaceDirty) {
 				if !preserveDirty {
 					return cleaned, err
 				}
-				ref, preserveErr := adapter.StashWorkspaceProjectWorktree(ctx, rows[i])
+				ref, preserveErr := m.workspace.StashUncommitted(ctx, info)
 				if preserveErr == nil {
 					preservedRef = ref
 					if stateErr := m.upsertWorkspaceProjectRowState(ctx, rows[i], "unavailable", ref); stateErr != nil {
@@ -1090,7 +1083,7 @@ func (m *Manager) destroyWorkspaceProjectRows(ctx context.Context, rows []ports.
 					}
 				}
 				if preserveErr == nil {
-					forceErr := adapter.ForceDestroyWorkspaceProjectWorktree(ctx, rows[i])
+					forceErr := m.workspace.ForceDestroy(ctx, info)
 					if forceErr == nil {
 						cleaned = true
 						continue
@@ -1129,18 +1122,22 @@ func (m *Manager) upsertWorkspaceProjectRowState(ctx context.Context, row ports.
 }
 
 func (m *Manager) restoreWorkspaceProjectRows(ctx context.Context, rows []ports.WorkspaceRepoInfo) (ports.WorkspaceRepoInfo, error) {
-	adapter, ok := m.workspace.(ports.WorkspaceProject)
-	if !ok {
-		return ports.WorkspaceRepoInfo{}, errors.New("workspace project lifecycle is not supported by workspace adapter")
-	}
 	var root ports.WorkspaceRepoInfo
 	for _, row := range rows {
-		restored, err := adapter.RestoreWorkspaceProjectWorktree(ctx, row)
+		restored, err := m.workspace.Restore(ctx, ports.WorkspaceConfig{
+			ProjectID: row.ProjectID,
+			SessionID: row.SessionID,
+			Branch:    row.Branch,
+			RepoPath:  row.RepoPath,
+			Path:      row.Path,
+		})
 		if err != nil {
 			return ports.WorkspaceRepoInfo{}, fmt.Errorf("repo %s: %w", row.RepoName, err)
 		}
-		if restored.RepoName == domain.RootWorkspaceRepoName {
-			root = restored
+		row.Path = restored.Path
+		row.Branch = restored.Branch
+		if row.RepoName == domain.RootWorkspaceRepoName {
+			root = row
 		}
 	}
 	if root.Path == "" {
@@ -1150,10 +1147,6 @@ func (m *Manager) restoreWorkspaceProjectRows(ctx context.Context, rows []ports.
 }
 
 func (m *Manager) applyWorkspaceProjectPreserved(ctx context.Context, rows []ports.WorkspaceRepoInfo) {
-	adapter, ok := m.workspace.(ports.WorkspaceProject)
-	if !ok {
-		return
-	}
 	for _, row := range rows {
 		var preserveRef string
 		sessionRows, err := m.store.ListSessionWorktrees(ctx, row.SessionID)
@@ -1170,7 +1163,7 @@ func (m *Manager) applyWorkspaceProjectPreserved(ctx context.Context, rows []por
 		if preserveRef == "" {
 			continue
 		}
-		if applyErr := adapter.ApplyWorkspaceProjectPreserved(ctx, row, preserveRef); applyErr != nil {
+		if applyErr := m.workspace.ApplyPreserved(ctx, workspaceInfoFromRepoInfo(row), preserveRef); applyErr != nil {
 			if errors.Is(applyErr, ports.ErrPreservedConflict) {
 				m.logger.Warn("restore-all: apply preserved produced conflicts; agent relaunched with conflict markers in place",
 					"sessionID", row.SessionID, "repo", row.RepoName, "ref", preserveRef, "error", applyErr)
@@ -1670,6 +1663,7 @@ func workspaceInfoFromRepoInfo(info ports.WorkspaceRepoInfo) ports.WorkspaceInfo
 		Branch:    info.Branch,
 		SessionID: info.SessionID,
 		ProjectID: info.ProjectID,
+		RepoPath:  info.RepoPath,
 	}
 }
 

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -526,7 +526,18 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 		}
 	}
 	freed := false
-	if ws.Path != "" {
+	if rows, ok, rowErr := m.workspaceProjectRows(ctx, rec); rowErr != nil {
+		return false, fmt.Errorf("kill %s: workspace rows: %w", id, rowErr)
+	} else if ok {
+		cleaned, err := m.destroyWorkspaceProjectRows(ctx, rows)
+		if err != nil {
+			if errors.Is(err, ports.ErrWorkspaceDirty) {
+				return false, nil
+			}
+			return false, fmt.Errorf("kill %s: workspace: %w", id, err)
+		}
+		freed = cleaned
+	} else if ws.Path != "" {
 		if err := m.workspace.Destroy(ctx, ws); err != nil {
 			if errors.Is(err, ports.ErrWorkspaceDirty) {
 				return false, nil
@@ -649,7 +660,7 @@ func (m *Manager) SaveAndTeardownAll(ctx context.Context) error {
 		if rec.Metadata.WorkspacePath == "" || rec.Metadata.Branch == "" {
 			continue
 		}
-		if err := m.saveAndTeardownOne(ctx, rec); err != nil {
+		if err := m.saveAndTeardownOne(ctx, rec, true); err != nil {
 			m.logger.Error("save-teardown-all: session failed, skipping", "sessionID", rec.ID, "error", err)
 		}
 	}
@@ -660,10 +671,15 @@ func (m *Manager) SaveAndTeardownAll(ctx context.Context) error {
 // session. The DB write (UpsertSessionWorktree) is committed before
 // ForceDestroy; if either capture or the DB write fails, ForceDestroy is
 // not called.
-func (m *Manager) saveAndTeardownOne(ctx context.Context, rec domain.SessionRecord) error {
-	ws := workspaceInfo(rec)
+func (m *Manager) saveAndTeardownOne(ctx context.Context, rec domain.SessionRecord, destroyRuntime bool) error {
+	if rows, ok, err := m.workspaceProjectRows(ctx, rec); err != nil {
+		return fmt.Errorf("save %s: workspace rows: %w", rec.ID, err)
+	} else if ok {
+		return m.saveAndTeardownWorkspaceProject(ctx, rec, rows, destroyRuntime)
+	}
 
 	// 1. Capture uncommitted work (ref may be "" for clean worktrees).
+	ws := workspaceInfo(rec)
 	ref, err := m.workspace.StashUncommitted(ctx, ws)
 	if err != nil {
 		return fmt.Errorf("save %s: stash: %w", rec.ID, err)
@@ -678,6 +694,7 @@ func (m *Manager) saveAndTeardownOne(ctx context.Context, rec domain.SessionReco
 		Branch:       rec.Metadata.Branch,
 		WorktreePath: rec.Metadata.WorkspacePath,
 		PreservedRef: ref,
+		State:        "removed",
 	}
 	if err := m.store.UpsertSessionWorktree(ctx, row); err != nil {
 		return fmt.Errorf("save %s: upsert worktree row: %w", rec.ID, err)
@@ -690,7 +707,7 @@ func (m *Manager) saveAndTeardownOne(ctx context.Context, rec domain.SessionReco
 
 	// 4. Runtime teardown (best-effort; same pattern as Kill).
 	handle := runtimeHandle(rec.Metadata)
-	if handle.ID != "" {
+	if destroyRuntime && handle.ID != "" {
 		if err := m.runtime.Destroy(ctx, handle); err != nil {
 			m.logger.Warn("save-teardown-all: runtime destroy failed", "sessionID", rec.ID, "error", err)
 		}
@@ -732,38 +749,11 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 			return nil // adopt: the session survived the crash.
 		}
 	}
-	// Runtime is gone: capture uncommitted work first.
-	ws := workspaceInfo(rec)
-	ref, err := m.workspace.StashUncommitted(ctx, ws)
-	if err != nil {
-		// Could not capture work: do NOT write a restore marker or tear down the
-		// worktree (that would risk losing un-preserved work). Mark terminated so
-		// a dead session is not left looking live; the worktree stays put.
-		m.logger.Warn("reconcile: stash uncommitted failed; terminating without restore marker", "sessionID", rec.ID, "error", err)
+	if err := m.saveAndTeardownOne(ctx, rec, false); err != nil {
+		m.logger.Warn("reconcile: save-and-teardown failed; terminating without restore marker", "sessionID", rec.ID, "error", err)
 		if mErr := m.lcm.MarkTerminated(ctx, rec.ID); mErr != nil {
 			return fmt.Errorf("reconcile %s: mark terminated: %w", rec.ID, mErr)
 		}
-		return nil
-	}
-	// Work captured. Record the shutdown-saved marker BEFORE tearing down the
-	// worktree, mirroring saveAndTeardownOne, so RestoreAll relaunches it.
-	row := domain.SessionWorktreeRecord{
-		SessionID:    rec.ID,
-		RepoName:     domain.RootWorkspaceRepoName,
-		Branch:       rec.Metadata.Branch,
-		WorktreePath: rec.Metadata.WorkspacePath,
-		PreservedRef: ref,
-	}
-	if err := m.store.UpsertSessionWorktree(ctx, row); err != nil {
-		return fmt.Errorf("reconcile %s: upsert worktree marker: %w", rec.ID, err)
-	}
-	if err := m.lcm.MarkTerminated(ctx, rec.ID); err != nil {
-		return fmt.Errorf("reconcile %s: mark terminated: %w", rec.ID, err)
-	}
-	// Remove the worktree (work is captured in the ref): RestoreAll re-creates it
-	// clean and replays the ref. The dead runtime needs no Destroy.
-	if err := m.workspace.ForceDestroy(ctx, ws); err != nil {
-		m.logger.Warn("reconcile: force destroy failed after marker", "sessionID", rec.ID, "error", err)
 	}
 	return nil
 }
@@ -858,14 +848,9 @@ func (m *Manager) RestoreAll(ctx context.Context) error {
 			// No marker: this session was killed by the user before shutdown.
 			continue
 		}
-
-		// Collect the preserve ref (may be "" for clean worktrees).
-		var preserveRef string
-		for _, r := range rows {
-			if r.PreservedRef != "" {
-				preserveRef = r.PreservedRef
-				break
-			}
+		rows = restorableWorktreeRows(rows)
+		if len(rows) == 0 {
+			continue
 		}
 
 		// Step 1: ensure the worktree exists. workspace.Restore re-creates it
@@ -875,28 +860,64 @@ func (m *Manager) RestoreAll(ctx context.Context) error {
 			m.logger.Error("restore-all: load project failed", "sessionID", rec.ID, "error", err)
 			continue
 		}
-		ws, err := m.workspace.Restore(ctx, ports.WorkspaceConfig{
-			ProjectID:     rec.ProjectID,
-			SessionID:     rec.ID,
-			Kind:          rec.Kind,
-			SessionPrefix: sessionPrefix(project),
-			Branch:        rec.Metadata.Branch,
-		})
-		if err != nil {
-			m.logger.Error("restore-all: workspace restore failed", "sessionID", rec.ID, "error", err)
+		var ws ports.WorkspaceInfo
+		if project.Kind.WithDefault() == domain.ProjectKindWorkspace && len(rows) > 1 {
+			projectRows, rowErr := m.sessionWorktreeRowsToRepoInfos(ctx, project, rec, rows)
+			if rowErr != nil {
+				m.logger.Error("restore-all: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
+				continue
+			}
+			root, restoreErr := m.restoreWorkspaceProjectRows(ctx, projectRows)
+			if restoreErr != nil {
+				m.logger.Error("restore-all: workspace project restore failed", "sessionID", rec.ID, "error", restoreErr)
+				continue
+			}
+			ws = workspaceInfoFromRepoInfo(root)
+		} else {
+			var restoreErr error
+			ws, restoreErr = m.workspace.Restore(ctx, ports.WorkspaceConfig{
+				ProjectID:     rec.ProjectID,
+				SessionID:     rec.ID,
+				Kind:          rec.Kind,
+				SessionPrefix: sessionPrefix(project),
+				Branch:        rec.Metadata.Branch,
+			})
+			if restoreErr != nil {
+				m.logger.Error("restore-all: workspace restore failed", "sessionID", rec.ID, "error", restoreErr)
+				continue
+			}
+		}
+		if ws.Path == "" {
+			m.logger.Error("restore-all: workspace restore failed", "sessionID", rec.ID, "error", "empty restored root path")
 			continue
 		}
 
 		// Step 2: replay preserve ref when one was recorded.
-		if preserveRef != "" {
-			if applyErr := m.workspace.ApplyPreserved(ctx, ws, preserveRef); applyErr != nil {
-				if errors.Is(applyErr, ports.ErrPreservedConflict) {
-					m.logger.Warn("restore-all: apply preserved produced conflicts; agent relaunched with conflict markers in place",
-						"sessionID", rec.ID, "ref", preserveRef, "error", applyErr)
-				} else {
-					m.logger.Error("restore-all: apply preserved failed", "sessionID", rec.ID, "error", applyErr)
+		if project.Kind.WithDefault() == domain.ProjectKindWorkspace && len(rows) > 1 {
+			projectRows, rowErr := m.sessionWorktreeRowsToRepoInfos(ctx, project, rec, rows)
+			if rowErr != nil {
+				m.logger.Error("restore-all: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
+				continue
+			}
+			m.applyWorkspaceProjectPreserved(ctx, projectRows)
+		} else {
+			var preserveRef string
+			for _, r := range rows {
+				if r.PreservedRef != "" {
+					preserveRef = r.PreservedRef
+					break
 				}
-				// Continue: always relaunch even on conflict (never delete the ref here).
+			}
+			if preserveRef != "" {
+				if applyErr := m.workspace.ApplyPreserved(ctx, ws, preserveRef); applyErr != nil {
+					if errors.Is(applyErr, ports.ErrPreservedConflict) {
+						m.logger.Warn("restore-all: apply preserved produced conflicts; agent relaunched with conflict markers in place",
+							"sessionID", rec.ID, "ref", preserveRef, "error", applyErr)
+					} else {
+						m.logger.Error("restore-all: apply preserved failed", "sessionID", rec.ID, "error", applyErr)
+					}
+					// Continue: always relaunch even on conflict (never delete the ref here).
+				}
 			}
 		}
 
@@ -910,6 +931,10 @@ func (m *Manager) RestoreAll(ctx context.Context) error {
 			} else {
 				m.logger.Error("restore-all: relaunch failed", "sessionID", rec.ID, "error", err)
 			}
+			continue
+		}
+		if err := m.markSessionWorktreesActive(ctx, rows); err != nil {
+			m.logger.Warn("restore-all: marking worktrees active failed", "sessionID", rec.ID, "error", err)
 		}
 
 		// One-shot: drop the consumed marker so it never outlives one restart
@@ -919,6 +944,232 @@ func (m *Manager) RestoreAll(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func restorableWorktreeRows(rows []domain.SessionWorktreeRecord) []domain.SessionWorktreeRecord {
+	out := make([]domain.SessionWorktreeRecord, 0, len(rows))
+	for _, row := range rows {
+		if row.State == "removed" {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func (m *Manager) markSessionWorktreesActive(ctx context.Context, rows []domain.SessionWorktreeRecord) error {
+	for _, row := range rows {
+		row.State = "active"
+		row.PreservedRef = ""
+		if err := m.store.UpsertSessionWorktree(ctx, row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Manager) workspaceProjectRows(ctx context.Context, rec domain.SessionRecord) ([]ports.WorkspaceRepoInfo, bool, error) {
+	rows, err := m.store.ListSessionWorktrees(ctx, rec.ID)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(rows) <= 1 {
+		return nil, false, nil
+	}
+	project, err := m.loadProject(ctx, rec.ProjectID)
+	if err != nil {
+		return nil, false, err
+	}
+	if project.Kind.WithDefault() != domain.ProjectKindWorkspace {
+		return nil, false, nil
+	}
+	infos, err := m.sessionWorktreeRowsToRepoInfos(ctx, project, rec, rows)
+	if err != nil {
+		return nil, false, err
+	}
+	return infos, true, nil
+}
+
+func (m *Manager) sessionWorktreeRowsToRepoInfos(ctx context.Context, project domain.ProjectRecord, rec domain.SessionRecord, rows []domain.SessionWorktreeRecord) ([]ports.WorkspaceRepoInfo, error) {
+	childRepos, err := m.store.ListWorkspaceRepos(ctx, project.ID)
+	if err != nil {
+		return nil, err
+	}
+	repoPaths := map[string]string{domain.RootWorkspaceRepoName: project.Path}
+	relPaths := map[string]string{}
+	for _, repo := range childRepos {
+		repoPaths[repo.Name] = filepath.Join(project.Path, filepath.FromSlash(repo.RelativePath))
+		relPaths[repo.Name] = repo.RelativePath
+	}
+	out := make([]ports.WorkspaceRepoInfo, 0, len(rows))
+	for _, row := range rows {
+		repoPath := repoPaths[row.RepoName]
+		if repoPath == "" {
+			return nil, fmt.Errorf("repo %q is not registered for workspace project %s", row.RepoName, project.ID)
+		}
+		out = append(out, ports.WorkspaceRepoInfo{
+			RepoName:     row.RepoName,
+			RepoPath:     repoPath,
+			Path:         row.WorktreePath,
+			Branch:       firstNonEmptyString(row.Branch, rec.Metadata.Branch),
+			BaseSHA:      row.BaseSHA,
+			SessionID:    rec.ID,
+			ProjectID:    rec.ProjectID,
+			RelativePath: relPaths[row.RepoName],
+		})
+	}
+	return out, nil
+}
+
+func (m *Manager) saveAndTeardownWorkspaceProject(ctx context.Context, rec domain.SessionRecord, rows []ports.WorkspaceRepoInfo, destroyRuntime bool) error {
+	adapter, ok := m.workspace.(ports.WorkspaceProject)
+	if !ok {
+		return errors.New("workspace project lifecycle is not supported by workspace adapter")
+	}
+	for _, row := range rows {
+		ref, err := adapter.StashWorkspaceProjectWorktree(ctx, row)
+		if err != nil {
+			return fmt.Errorf("save %s repo %s: stash: %w", rec.ID, row.RepoName, err)
+		}
+		if err := m.store.UpsertSessionWorktree(ctx, domain.SessionWorktreeRecord{
+			SessionID:    rec.ID,
+			RepoName:     row.RepoName,
+			Branch:       row.Branch,
+			BaseSHA:      row.BaseSHA,
+			WorktreePath: row.Path,
+			PreservedRef: ref,
+			State:        "removed",
+		}); err != nil {
+			return fmt.Errorf("save %s repo %s: upsert worktree row: %w", rec.ID, row.RepoName, err)
+		}
+	}
+	if err := m.lcm.MarkTerminated(ctx, rec.ID); err != nil {
+		return fmt.Errorf("save %s: mark terminated: %w", rec.ID, err)
+	}
+	handle := runtimeHandle(rec.Metadata)
+	if destroyRuntime && handle.ID != "" {
+		if err := m.runtime.Destroy(ctx, handle); err != nil {
+			m.logger.Warn("save-teardown-all: runtime destroy failed", "sessionID", rec.ID, "error", err)
+		}
+	}
+	for i := len(rows) - 1; i >= 0; i-- {
+		if err := adapter.ForceDestroyWorkspaceProjectWorktree(ctx, rows[i]); err != nil {
+			m.logger.Warn("save-teardown-all: force destroy failed", "sessionID", rec.ID, "repo", rows[i].RepoName, "error", err)
+		}
+	}
+	return nil
+}
+
+func (m *Manager) destroyWorkspaceProjectRows(ctx context.Context, rows []ports.WorkspaceRepoInfo) (bool, error) {
+	adapter, ok := m.workspace.(ports.WorkspaceProject)
+	if !ok {
+		return false, errors.New("workspace project lifecycle is not supported by workspace adapter")
+	}
+	cleaned := false
+	var firstErr error
+	for i := len(rows) - 1; i >= 0; i-- {
+		if rows[i].Path == "" {
+			continue
+		}
+		if err := adapter.DestroyWorkspaceProjectWorktree(ctx, rows[i]); err != nil {
+			preservedRef := ""
+			if errors.Is(err, ports.ErrWorkspaceDirty) {
+				ref, preserveErr := adapter.StashWorkspaceProjectWorktree(ctx, rows[i])
+				if preserveErr == nil {
+					preservedRef = ref
+					if stateErr := m.upsertWorkspaceProjectRowState(ctx, rows[i], "unavailable", ref); stateErr != nil {
+						preserveErr = stateErr
+					}
+				}
+				if preserveErr == nil {
+					forceErr := adapter.ForceDestroyWorkspaceProjectWorktree(ctx, rows[i])
+					if forceErr == nil {
+						cleaned = true
+						continue
+					}
+					err = forceErr
+				} else {
+					err = preserveErr
+				}
+			}
+			if stateErr := m.upsertWorkspaceProjectRowState(ctx, rows[i], "retry_remove", preservedRef); stateErr != nil && firstErr == nil {
+				firstErr = stateErr
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if err := m.upsertWorkspaceProjectRowState(ctx, rows[i], "unavailable", ""); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		cleaned = true
+	}
+	return cleaned, firstErr
+}
+
+func (m *Manager) upsertWorkspaceProjectRowState(ctx context.Context, row ports.WorkspaceRepoInfo, state, preservedRef string) error {
+	return m.store.UpsertSessionWorktree(ctx, domain.SessionWorktreeRecord{
+		SessionID:    row.SessionID,
+		RepoName:     row.RepoName,
+		Branch:       row.Branch,
+		BaseSHA:      row.BaseSHA,
+		WorktreePath: row.Path,
+		PreservedRef: preservedRef,
+		State:        state,
+	})
+}
+
+func (m *Manager) restoreWorkspaceProjectRows(ctx context.Context, rows []ports.WorkspaceRepoInfo) (ports.WorkspaceRepoInfo, error) {
+	adapter, ok := m.workspace.(ports.WorkspaceProject)
+	if !ok {
+		return ports.WorkspaceRepoInfo{}, errors.New("workspace project lifecycle is not supported by workspace adapter")
+	}
+	var root ports.WorkspaceRepoInfo
+	for _, row := range rows {
+		restored, err := adapter.RestoreWorkspaceProjectWorktree(ctx, row)
+		if err != nil {
+			return ports.WorkspaceRepoInfo{}, fmt.Errorf("repo %s: %w", row.RepoName, err)
+		}
+		if restored.RepoName == domain.RootWorkspaceRepoName {
+			root = restored
+		}
+	}
+	if root.Path == "" {
+		return ports.WorkspaceRepoInfo{}, errors.New("workspace project root worktree row missing")
+	}
+	return root, nil
+}
+
+func (m *Manager) applyWorkspaceProjectPreserved(ctx context.Context, rows []ports.WorkspaceRepoInfo) {
+	adapter, ok := m.workspace.(ports.WorkspaceProject)
+	if !ok {
+		return
+	}
+	for _, row := range rows {
+		var preserveRef string
+		sessionRows, err := m.store.ListSessionWorktrees(ctx, row.SessionID)
+		if err != nil {
+			m.logger.Error("restore-all: list worktrees failed", "sessionID", row.SessionID, "error", err)
+			continue
+		}
+		for _, sessionRow := range sessionRows {
+			if sessionRow.RepoName == row.RepoName {
+				preserveRef = sessionRow.PreservedRef
+				break
+			}
+		}
+		if preserveRef == "" {
+			continue
+		}
+		if applyErr := adapter.ApplyWorkspaceProjectPreserved(ctx, row, preserveRef); applyErr != nil {
+			if errors.Is(applyErr, ports.ErrPreservedConflict) {
+				m.logger.Warn("restore-all: apply preserved produced conflicts; agent relaunched with conflict markers in place",
+					"sessionID", row.SessionID, "repo", row.RepoName, "ref", preserveRef, "error", applyErr)
+			} else {
+				m.logger.Error("restore-all: apply preserved failed", "sessionID", row.SessionID, "repo", row.RepoName, "error", applyErr)
+			}
+		}
+	}
 }
 
 // Send delivers a message to a running session's agent via the messenger.
@@ -962,7 +1213,19 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 		if h := runtimeHandle(rec.Metadata); h.ID != "" {
 			_ = m.runtime.Destroy(ctx, h) // best effort; usually already gone
 		}
-		if err := m.workspace.Destroy(ctx, ws); err != nil {
+		if rows, ok, rowErr := m.workspaceProjectRows(ctx, rec); rowErr != nil {
+			m.logger.Warn("cleanup: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
+			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: "workspace teardown failed"})
+			continue
+		} else if ok {
+			if _, err := m.destroyWorkspaceProjectRows(ctx, rows); err != nil {
+				if !errors.Is(err, ports.ErrWorkspaceDirty) {
+					m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
+				}
+				result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(err)})
+				continue
+			}
+		} else if err := m.workspace.Destroy(ctx, ws); err != nil {
 			if !errors.Is(err, ports.ErrWorkspaceDirty) {
 				// The public reason stays a fixed string (the raw error carries
 				// internal filesystem paths); the full cause lands here.
@@ -1390,4 +1653,22 @@ func workspaceInfo(rec domain.SessionRecord) ports.WorkspaceInfo {
 		SessionID: rec.ID,
 		ProjectID: rec.ProjectID,
 	}
+}
+
+func workspaceInfoFromRepoInfo(info ports.WorkspaceRepoInfo) ports.WorkspaceInfo {
+	return ports.WorkspaceInfo{
+		Path:      info.Path,
+		Branch:    info.Branch,
+		SessionID: info.SessionID,
+		ProjectID: info.ProjectID,
+	}
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -512,12 +512,6 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 		return false, fmt.Errorf("kill %s: %w", id, err)
 	}
 
-	// Clear the restore marker so the next boot's RestoreAll cannot resurrect a
-	// killed session (#2319). Best-effort: teardown below still matters.
-	if err := m.store.DeleteSessionWorktrees(ctx, id); err != nil {
-		m.logger.Warn("kill: delete restore marker failed", "sessionID", id, "error", err)
-	}
-
 	// Only tear down what exists. A session may have lost its handle after a
 	// crash or never acquired one if spawn failed partway.
 	if handle.ID != "" {
@@ -545,6 +539,13 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 			return false, fmt.Errorf("kill %s: workspace: %w", id, err)
 		}
 		freed = true
+	}
+	// Clear the restore marker so the next boot's RestoreAll cannot resurrect a
+	// killed session (#2319). For workspace projects this must happen after
+	// teardown reads the rows; dirty-preserved rows return above and are left as
+	// non-restorable inventory.
+	if err := m.store.DeleteSessionWorktrees(ctx, id); err != nil {
+		m.logger.Warn("kill: delete restore marker failed", "sessionID", id, "error", err)
 	}
 	return freed, nil
 }

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -77,6 +77,7 @@ type Store interface {
 	// GetProject loads a project row so spawn can resolve its per-project agent
 	// config into the launch command. ok=false means the project is unknown.
 	GetProject(ctx context.Context, id string) (domain.ProjectRecord, bool, error)
+	ListWorkspaceRepos(ctx context.Context, projectID string) ([]domain.WorkspaceRepoRecord, error)
 	CreateSession(ctx context.Context, rec domain.SessionRecord) (domain.SessionRecord, error)
 	GetSession(ctx context.Context, id domain.SessionID) (domain.SessionRecord, bool, error)
 	ListSessions(ctx context.Context, project domain.ProjectID) ([]domain.SessionRecord, error)
@@ -221,16 +222,9 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 
 	branch := cfg.Branch
 	if branch == "" {
-		branch = defaultSessionBranch(id, cfg.Kind, sessionPrefix(project))
+		branch = defaultSpawnBranch(id, cfg.Kind, sessionPrefix(project), project.Kind.WithDefault())
 	}
-	ws, err := m.workspace.Create(ctx, ports.WorkspaceConfig{
-		ProjectID:     cfg.ProjectID,
-		SessionID:     id,
-		Kind:          cfg.Kind,
-		SessionPrefix: sessionPrefix(project),
-		Branch:        branch,
-		BaseBranch:    project.Config.WithDefaults().DefaultBranch,
-	})
+	ws, workspaceProject, err := m.createSessionWorkspace(ctx, project, cfg, id, branch)
 	if err != nil {
 		// Nothing observable exists yet — no worktree, no runtime — so the seed
 		// row is deleted outright instead of accumulating as a terminated orphan
@@ -242,19 +236,19 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	// Per-project workspace provisioning: symlink shared files, then run any
 	// post-create commands (e.g. `pnpm install`) before the agent launches.
 	if err := m.provisionWorkspace(ctx, project, ws.Path); err != nil {
-		_ = m.workspace.Destroy(ctx, ws)
+		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
 		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: provision: %w", id, err)
 	}
 
 	agent, ok := m.agents.Agent(cfg.Harness)
 	if !ok {
-		_ = m.workspace.Destroy(ctx, ws)
+		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
 		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: no agent adapter for harness %q", id, cfg.Harness)
 	}
 	if err := m.prepareWorkspace(ctx, agent, id, ws.Path); err != nil {
-		_ = m.workspace.Destroy(ctx, ws)
+		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
 		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: %w", id, err)
 	}
@@ -269,7 +263,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		Permissions:   agentConfig.Permissions,
 	})
 	if err != nil {
-		_ = m.workspace.Destroy(ctx, ws)
+		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
 		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: launch command: %w", id, err)
 	}
@@ -278,7 +272,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	// tmux happily creates a session+pane around a missing command, so an
 	// unresolved binary would leak through as a "live" session that never ran.
 	if err := m.validateAgentBinary(argv); err != nil {
-		_ = m.workspace.Destroy(ctx, ws)
+		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
 		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: %w", id, err)
 	}
@@ -289,7 +283,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		Env:           m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, project.Config.Env),
 	})
 	if err != nil {
-		_ = m.workspace.Destroy(ctx, ws)
+		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
 		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: runtime: %w", id, err)
 	}
@@ -297,7 +291,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	metadata := domain.SessionMetadata{Branch: ws.Branch, WorkspacePath: ws.Path, RuntimeHandleID: handle.ID, Prompt: prompt}
 	if err := m.lcm.MarkSpawned(ctx, id, metadata); err != nil {
 		_ = m.runtime.Destroy(ctx, handle)
-		_ = m.workspace.Destroy(ctx, ws)
+		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
 		m.markSpawnFailedTerminated(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: completed: %w", id, err)
 	}
@@ -318,6 +312,74 @@ func (m *Manager) loadProject(ctx context.Context, projectID domain.ProjectID) (
 		return domain.ProjectRecord{}, nil
 	}
 	return row, nil
+}
+
+func (m *Manager) createSessionWorkspace(ctx context.Context, project domain.ProjectRecord, cfg ports.SpawnConfig, id domain.SessionID, branch string) (ports.WorkspaceInfo, *ports.WorkspaceProjectInfo, error) {
+	if project.Kind.WithDefault() != domain.ProjectKindWorkspace {
+		ws, err := m.workspace.Create(ctx, ports.WorkspaceConfig{
+			ProjectID:     cfg.ProjectID,
+			SessionID:     id,
+			Kind:          cfg.Kind,
+			SessionPrefix: sessionPrefix(project),
+			Branch:        branch,
+			BaseBranch:    project.Config.WithDefaults().DefaultBranch,
+		})
+		return ws, nil, err
+	}
+	workspaceProject, ok := m.workspace.(ports.WorkspaceProject)
+	if !ok {
+		return ports.WorkspaceInfo{}, nil, errors.New("workspace project materialization is not supported by workspace adapter")
+	}
+	repos, err := m.store.ListWorkspaceRepos(ctx, project.ID)
+	if err != nil {
+		return ports.WorkspaceInfo{}, nil, err
+	}
+	childRepos := make([]ports.WorkspaceProjectRepoConfig, 0, len(repos))
+	for _, repo := range repos {
+		childRepos = append(childRepos, ports.WorkspaceProjectRepoConfig{
+			Name:         repo.Name,
+			RelativePath: repo.RelativePath,
+			RepoPath:     filepath.Join(project.Path, filepath.FromSlash(repo.RelativePath)),
+			BaseBranch:   project.Config.WithDefaults().DefaultBranch,
+		})
+	}
+	info, err := workspaceProject.CreateWorkspaceProject(ctx, ports.WorkspaceProjectConfig{
+		ProjectID:     cfg.ProjectID,
+		SessionID:     id,
+		Kind:          cfg.Kind,
+		SessionPrefix: sessionPrefix(project),
+		Branch:        branch,
+		RootRepoPath:  project.Path,
+		BaseBranch:    project.Config.WithDefaults().DefaultBranch,
+		Repos:         childRepos,
+	})
+	if err != nil {
+		return ports.WorkspaceInfo{}, nil, err
+	}
+	for _, wt := range info.Worktrees {
+		if err := m.store.UpsertSessionWorktree(ctx, domain.SessionWorktreeRecord{
+			SessionID:    id,
+			RepoName:     wt.RepoName,
+			Branch:       wt.Branch,
+			BaseSHA:      wt.BaseSHA,
+			WorktreePath: wt.Path,
+			State:        "active",
+		}); err != nil {
+			_ = workspaceProject.DestroyWorkspaceProject(ctx, info)
+			return ports.WorkspaceInfo{}, nil, fmt.Errorf("record workspace worktree %q: %w", wt.RepoName, err)
+		}
+	}
+	return info.Root, &info, nil
+}
+
+func (m *Manager) destroySpawnWorkspace(ctx context.Context, ws ports.WorkspaceInfo, workspaceProject *ports.WorkspaceProjectInfo) {
+	if workspaceProject != nil {
+		if adapter, ok := m.workspace.(ports.WorkspaceProject); ok {
+			_ = adapter.DestroyWorkspaceProject(ctx, *workspaceProject)
+			return
+		}
+	}
+	_ = m.workspace.Destroy(ctx, ws)
 }
 
 // effectiveHarness resolves the harness for a spawn: an explicit harness wins;
@@ -956,6 +1018,13 @@ func defaultSessionBranch(id domain.SessionID, kind domain.SessionKind, prefix s
 	// branch under a session namespace so sibling PR branches such as
 	// ao/<session>/<topic> remain valid Git refs.
 	return "ao/" + string(id) + "/root"
+}
+
+func defaultSpawnBranch(id domain.SessionID, kind domain.SessionKind, prefix string, projectKind domain.ProjectKind) string {
+	if projectKind == domain.ProjectKindWorkspace {
+		return "ao/" + string(id)
+	}
+	return defaultSessionBranch(id, kind, prefix)
 }
 
 func buildPrompt(cfg ports.SpawnConfig) string {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -529,7 +529,7 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	if rows, ok, rowErr := m.workspaceProjectRows(ctx, rec); rowErr != nil {
 		return false, fmt.Errorf("kill %s: workspace rows: %w", id, rowErr)
 	} else if ok {
-		cleaned, err := m.destroyWorkspaceProjectRows(ctx, rows)
+		cleaned, err := m.destroyWorkspaceProjectRows(ctx, rows, false)
 		if err != nil {
 			if errors.Is(err, ports.ErrWorkspaceDirty) {
 				return false, nil
@@ -1004,7 +1004,12 @@ func (m *Manager) sessionWorktreeRowsToRepoInfos(ctx context.Context, project do
 	for _, row := range rows {
 		repoPath := repoPaths[row.RepoName]
 		if repoPath == "" {
-			return nil, fmt.Errorf("repo %q is not registered for workspace project %s", row.RepoName, project.ID)
+			m.logger.WarnContext(ctx, "session worktree row references unregistered workspace repo",
+				"sessionID", rec.ID,
+				"projectID", project.ID,
+				"repo", row.RepoName,
+			)
+			continue
 		}
 		out = append(out, ports.WorkspaceRepoInfo{
 			RepoName:     row.RepoName,
@@ -1059,7 +1064,7 @@ func (m *Manager) saveAndTeardownWorkspaceProject(ctx context.Context, rec domai
 	return nil
 }
 
-func (m *Manager) destroyWorkspaceProjectRows(ctx context.Context, rows []ports.WorkspaceRepoInfo) (bool, error) {
+func (m *Manager) destroyWorkspaceProjectRows(ctx context.Context, rows []ports.WorkspaceRepoInfo, preserveDirty bool) (bool, error) {
 	adapter, ok := m.workspace.(ports.WorkspaceProject)
 	if !ok {
 		return false, errors.New("workspace project lifecycle is not supported by workspace adapter")
@@ -1073,6 +1078,9 @@ func (m *Manager) destroyWorkspaceProjectRows(ctx context.Context, rows []ports.
 		if err := adapter.DestroyWorkspaceProjectWorktree(ctx, rows[i]); err != nil {
 			preservedRef := ""
 			if errors.Is(err, ports.ErrWorkspaceDirty) {
+				if !preserveDirty {
+					return cleaned, err
+				}
 				ref, preserveErr := adapter.StashWorkspaceProjectWorktree(ctx, rows[i])
 				if preserveErr == nil {
 					preservedRef = ref
@@ -1218,7 +1226,7 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: "workspace teardown failed"})
 			continue
 		} else if ok {
-			if _, err := m.destroyWorkspaceProjectRows(ctx, rows); err != nil {
+			if _, err := m.destroyWorkspaceProjectRows(ctx, rows, true); err != nil {
 				if !errors.Is(err, ports.ErrWorkspaceDirty) {
 					m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
 				}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -340,7 +340,7 @@ func (m *Manager) createSessionWorkspace(ctx context.Context, project domain.Pro
 			Name:         repo.Name,
 			RelativePath: repo.RelativePath,
 			RepoPath:     filepath.Join(project.Path, filepath.FromSlash(repo.RelativePath)),
-			BaseBranch:   project.Config.WithDefaults().DefaultBranch,
+			BaseBranch:   firstNonEmptyString(repo.DefaultBranch, project.Config.WithDefaults().DefaultBranch),
 		})
 	}
 	info, err := workspaceProject.CreateWorkspaceProject(ctx, ports.WorkspaceProjectConfig{

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -333,7 +333,14 @@ func (w *fakeWorkspace) CreateWorkspaceProject(_ context.Context, cfg ports.Work
 	}
 	return out, nil
 }
-func (w *fakeWorkspace) Destroy(context.Context, ports.WorkspaceInfo) error {
+func (w *fakeWorkspace) Destroy(_ context.Context, info ports.WorkspaceInfo) error {
+	if info.RepoPath != "" {
+		entry := "Destroy:" + fakeWorkspaceRepoName(info)
+		w.calls = append(w.calls, entry)
+		if w.sharedLog != nil {
+			*w.sharedLog = append(*w.sharedLog, entry)
+		}
+	}
 	w.destroyed++
 	return w.destroyErr
 }
@@ -341,51 +348,23 @@ func (w *fakeWorkspace) DestroyWorkspaceProject(context.Context, ports.Workspace
 	w.projectDestroyed++
 	return w.destroyErr
 }
-func (w *fakeWorkspace) DestroyWorkspaceProjectWorktree(_ context.Context, info ports.WorkspaceRepoInfo) error {
-	entry := "DestroyWorkspaceProjectWorktree:" + info.RepoName
-	w.calls = append(w.calls, entry)
-	if w.sharedLog != nil {
-		*w.sharedLog = append(*w.sharedLog, entry)
-	}
-	return w.destroyErr
-}
-func (w *fakeWorkspace) ForceDestroyWorkspaceProjectWorktree(_ context.Context, info ports.WorkspaceRepoInfo) error {
-	entry := "ForceDestroyWorkspaceProjectWorktree:" + info.RepoName
-	w.calls = append(w.calls, entry)
-	if w.sharedLog != nil {
-		*w.sharedLog = append(*w.sharedLog, entry)
-	}
-	return w.forceDestroyErr
-}
-func (w *fakeWorkspace) RestoreWorkspaceProjectWorktree(_ context.Context, info ports.WorkspaceRepoInfo) (ports.WorkspaceRepoInfo, error) {
-	entry := "RestoreWorkspaceProjectWorktree:" + info.RepoName
-	w.calls = append(w.calls, entry)
-	return info, nil
-}
-func (w *fakeWorkspace) StashWorkspaceProjectWorktree(_ context.Context, info ports.WorkspaceRepoInfo) (string, error) {
-	w.stashCalls++
-	entry := "StashWorkspaceProjectWorktree:" + info.RepoName
-	w.calls = append(w.calls, entry)
-	if w.sharedLog != nil {
-		*w.sharedLog = append(*w.sharedLog, entry)
-	}
-	if w.stashErr != nil {
-		return "", w.stashErr
-	}
-	if w.stashRef == "" {
-		return "", nil
-	}
-	return w.stashRef + "/" + info.RepoName, nil
-}
-func (w *fakeWorkspace) ApplyWorkspaceProjectPreserved(_ context.Context, info ports.WorkspaceRepoInfo, ref string) error {
-	w.calls = append(w.calls, "ApplyWorkspaceProjectPreserved:"+info.RepoName+":"+ref)
-	return w.applyErr
-}
 func (w *fakeWorkspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
+	if cfg.RepoPath != "" {
+		entry := "Restore:" + fakeWorkspaceRepoName(ports.WorkspaceInfo{
+			Path:      cfg.Path,
+			SessionID: cfg.SessionID,
+			RepoPath:  cfg.RepoPath,
+		})
+		w.calls = append(w.calls, entry)
+		return ports.WorkspaceInfo{Path: cfg.Path, Branch: cfg.Branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID, RepoPath: cfg.RepoPath}, nil
+	}
 	return w.Create(ctx, cfg)
 }
 func (w *fakeWorkspace) ForceDestroy(_ context.Context, info ports.WorkspaceInfo) error {
 	entry := "ForceDestroy:" + string(info.SessionID)
+	if info.RepoPath != "" {
+		entry = "ForceDestroy:" + fakeWorkspaceRepoName(info)
+	}
 	w.calls = append(w.calls, entry)
 	if w.sharedLog != nil {
 		*w.sharedLog = append(*w.sharedLog, entry)
@@ -395,15 +374,32 @@ func (w *fakeWorkspace) ForceDestroy(_ context.Context, info ports.WorkspaceInfo
 func (w *fakeWorkspace) StashUncommitted(_ context.Context, info ports.WorkspaceInfo) (string, error) {
 	w.stashCalls++
 	entry := "StashUncommitted:" + string(info.SessionID)
+	if info.RepoPath != "" {
+		entry = "StashUncommitted:" + fakeWorkspaceRepoName(info)
+	}
 	w.calls = append(w.calls, entry)
 	if w.sharedLog != nil {
 		*w.sharedLog = append(*w.sharedLog, entry)
 	}
-	return w.stashRef, w.stashErr
+	if w.stashErr != nil || w.stashRef == "" || info.RepoPath == "" {
+		return w.stashRef, w.stashErr
+	}
+	return w.stashRef + "/" + fakeWorkspaceRepoName(info), nil
 }
 func (w *fakeWorkspace) ApplyPreserved(_ context.Context, info ports.WorkspaceInfo, ref string) error {
-	w.calls = append(w.calls, "ApplyPreserved:"+string(info.SessionID))
+	entry := "ApplyPreserved:" + string(info.SessionID)
+	if info.RepoPath != "" {
+		entry = "ApplyPreserved:" + fakeWorkspaceRepoName(info) + ":" + ref
+	}
+	w.calls = append(w.calls, entry)
 	return w.applyErr
+}
+
+func fakeWorkspaceRepoName(info ports.WorkspaceInfo) string {
+	if filepath.Base(info.Path) == string(info.SessionID) {
+		return domain.RootWorkspaceRepoName
+	}
+	return filepath.Base(info.Path)
 }
 
 type fakeMessenger struct{ msgs []string }
@@ -842,7 +838,7 @@ func TestKill_WorkspaceProjectDestroysChildrenBeforeRoot(t *testing.T) {
 	if rt.destroyed != 1 {
 		t.Fatalf("runtime destroy calls = %d, want 1", rt.destroyed)
 	}
-	want := []string{"DestroyWorkspaceProjectWorktree:api", "DestroyWorkspaceProjectWorktree:__root__"}
+	want := []string{"Destroy:api", "Destroy:__root__"}
 	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("destroy order = %v, want %v", got, want)
 	}
@@ -868,7 +864,7 @@ func TestKill_WorkspaceProjectSkipsUnregisteredChildRows(t *testing.T) {
 	if err != nil || !freed {
 		t.Fatalf("freed=%v err=%v", freed, err)
 	}
-	want := []string{"DestroyWorkspaceProjectWorktree:api", "DestroyWorkspaceProjectWorktree:__root__"}
+	want := []string{"Destroy:api", "Destroy:__root__"}
 	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("destroy calls = %v, want %v", got, want)
 	}
@@ -898,7 +894,7 @@ func TestKill_WorkspaceProjectDirtyRowRefusesRemoval(t *testing.T) {
 	if freed {
 		t.Fatal("freed = true, want false for preserved workspace project")
 	}
-	want := []string{"DestroyWorkspaceProjectWorktree:api"}
+	want := []string{"Destroy:api"}
 	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("calls = %v, want %v", got, want)
 	}
@@ -1021,7 +1017,7 @@ func TestCleanup_WorkspaceProjectDestroysChildrenBeforeRoot(t *testing.T) {
 	if len(res.Cleaned) != 1 || res.Cleaned[0] != "mer-1" {
 		t.Fatalf("cleaned = %v, want mer-1", res.Cleaned)
 	}
-	want := []string{"DestroyWorkspaceProjectWorktree:api", "DestroyWorkspaceProjectWorktree:__root__"}
+	want := []string{"Destroy:api", "Destroy:__root__"}
 	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("destroy order = %v, want %v", got, want)
 	}
@@ -1956,7 +1952,7 @@ func TestSaveAndTeardownAll_WorkspaceProjectPreservesEachRepoAndRemovesChildrenF
 	if refs[domain.RootWorkspaceRepoName] != "refs/ao/preserved/mer-1/__root__" || refs["api"] != "refs/ao/preserved/mer-1/api" {
 		t.Fatalf("preserved refs = %v", refs)
 	}
-	wantSuffix := []string{"ForceDestroyWorkspaceProjectWorktree:api", "ForceDestroyWorkspaceProjectWorktree:__root__"}
+	wantSuffix := []string{"ForceDestroy:api", "ForceDestroy:__root__"}
 	gotSuffix := ws.calls[len(ws.calls)-2:]
 	if strings.Join(gotSuffix, ",") != strings.Join(wantSuffix, ",") {
 		t.Fatalf("force destroy suffix = %v, want %v; all calls %v", gotSuffix, wantSuffix, ws.calls)
@@ -2238,13 +2234,13 @@ func TestRestoreAll_WorkspaceProjectRestoresAndAppliesEachRepo(t *testing.T) {
 	if err := m.RestoreAll(ctx); err != nil {
 		t.Fatalf("RestoreAll err = %v", err)
 	}
-	wantPrefix := []string{"RestoreWorkspaceProjectWorktree:__root__", "RestoreWorkspaceProjectWorktree:api"}
+	wantPrefix := []string{"Restore:__root__", "Restore:api"}
 	if got := ws.calls[:2]; strings.Join(got, ",") != strings.Join(wantPrefix, ",") {
 		t.Fatalf("restore prefix = %v, want %v; all calls %v", got, wantPrefix, ws.calls)
 	}
 	applied := strings.Join(ws.calls, ",")
-	if !strings.Contains(applied, "ApplyWorkspaceProjectPreserved:__root__:refs/ao/preserved/mer-1") ||
-		!strings.Contains(applied, "ApplyWorkspaceProjectPreserved:api:refs/ao/preserved/mer-1") {
+	if !strings.Contains(applied, "ApplyPreserved:__root__:refs/ao/preserved/mer-1") ||
+		!strings.Contains(applied, "ApplyPreserved:api:refs/ao/preserved/mer-1") {
 		t.Fatalf("apply calls missing, got %v", ws.calls)
 	}
 	if rt.created != 1 {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -696,8 +696,8 @@ func TestSpawn_WorkspaceProjectRollsBackAllWorktreesOnRuntimeFailure(t *testing.
 	if ws.destroyed != 0 {
 		t.Fatalf("single-workspace destroy calls = %d, want 0", ws.destroyed)
 	}
-	if !st.sessions["mer-1"].IsTerminated {
-		t.Fatal("orphaned spawn should be terminated")
+	if _, present := st.sessions["mer-1"]; present {
+		t.Fatal("seed row should be deleted after runtime creation failure")
 	}
 }
 
@@ -800,7 +800,7 @@ func TestKill_DeletesRestoreMarker(t *testing.T) {
 	m, st, _, _ := newManager()
 	st.sessions["mer-1"] = mkLive("mer-1")
 	// The session carries a leftover shutdown-saved marker from a prior cycle.
-	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{SessionID: "mer-1", RepoName: "__root__"}}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{SessionID: "mer-1", RepoName: "__root__", State: "removed"}}
 
 	if _, err := m.Kill(ctx, "mer-1"); err != nil {
 		t.Fatalf("kill err = %v", err)
@@ -2048,7 +2048,7 @@ func TestRestoreAll_DeletesMarkerAfterRelaunch(t *testing.T) {
 		Metadata:     domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1/root", AgentSessionID: "agent-w"},
 		Activity:     domain.Activity{State: domain.ActivityExited},
 	}
-	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{SessionID: "mer-1", RepoName: "__root__"}}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{SessionID: "mer-1", RepoName: "__root__", State: "removed"}}
 
 	if err := m.RestoreAll(ctx); err != nil {
 		t.Fatalf("RestoreAll err = %v", err)
@@ -2081,7 +2081,7 @@ func TestRestoreAll_KilledSessionNotResurrectedOnSecondBoot(t *testing.T) {
 		Metadata:     domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1/root", AgentSessionID: "agent-w"},
 		Activity:     domain.Activity{State: domain.ActivityExited},
 	}
-	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{SessionID: "mer-1", RepoName: "__root__"}}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{SessionID: "mer-1", RepoName: "__root__", State: "removed"}}
 
 	// First boot: marker present, session relaunches once.
 	if err := m.RestoreAll(ctx); err != nil {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -341,6 +341,46 @@ func (w *fakeWorkspace) DestroyWorkspaceProject(context.Context, ports.Workspace
 	w.projectDestroyed++
 	return w.destroyErr
 }
+func (w *fakeWorkspace) DestroyWorkspaceProjectWorktree(_ context.Context, info ports.WorkspaceRepoInfo) error {
+	entry := "DestroyWorkspaceProjectWorktree:" + info.RepoName
+	w.calls = append(w.calls, entry)
+	if w.sharedLog != nil {
+		*w.sharedLog = append(*w.sharedLog, entry)
+	}
+	return w.destroyErr
+}
+func (w *fakeWorkspace) ForceDestroyWorkspaceProjectWorktree(_ context.Context, info ports.WorkspaceRepoInfo) error {
+	entry := "ForceDestroyWorkspaceProjectWorktree:" + info.RepoName
+	w.calls = append(w.calls, entry)
+	if w.sharedLog != nil {
+		*w.sharedLog = append(*w.sharedLog, entry)
+	}
+	return w.forceDestroyErr
+}
+func (w *fakeWorkspace) RestoreWorkspaceProjectWorktree(_ context.Context, info ports.WorkspaceRepoInfo) (ports.WorkspaceRepoInfo, error) {
+	entry := "RestoreWorkspaceProjectWorktree:" + info.RepoName
+	w.calls = append(w.calls, entry)
+	return info, nil
+}
+func (w *fakeWorkspace) StashWorkspaceProjectWorktree(_ context.Context, info ports.WorkspaceRepoInfo) (string, error) {
+	w.stashCalls++
+	entry := "StashWorkspaceProjectWorktree:" + info.RepoName
+	w.calls = append(w.calls, entry)
+	if w.sharedLog != nil {
+		*w.sharedLog = append(*w.sharedLog, entry)
+	}
+	if w.stashErr != nil {
+		return "", w.stashErr
+	}
+	if w.stashRef == "" {
+		return "", nil
+	}
+	return w.stashRef + "/" + info.RepoName, nil
+}
+func (w *fakeWorkspace) ApplyWorkspaceProjectPreserved(_ context.Context, info ports.WorkspaceRepoInfo, ref string) error {
+	w.calls = append(w.calls, "ApplyWorkspaceProjectPreserved:"+info.RepoName+":"+ref)
+	return w.applyErr
+}
 func (w *fakeWorkspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
 	return w.Create(ctx, cfg)
 }
@@ -773,6 +813,80 @@ func TestKill_DeletesRestoreMarker(t *testing.T) {
 		t.Fatalf("kill must delete the restore marker, got %d rows", len(rows))
 	}
 }
+
+func TestKill_WorkspaceProjectDestroysChildrenBeforeRoot(t *testing.T) {
+	m, st, rt, ws := newManager()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", RuntimeHandleID: "h1"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api"},
+	}
+
+	freed, err := m.Kill(ctx, "mer-1")
+	if err != nil || !freed {
+		t.Fatalf("freed=%v err=%v", freed, err)
+	}
+	if rt.destroyed != 1 {
+		t.Fatalf("runtime destroy calls = %d, want 1", rt.destroyed)
+	}
+	want := []string{"DestroyWorkspaceProjectWorktree:api", "DestroyWorkspaceProjectWorktree:__root__"}
+	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("destroy order = %v, want %v", got, want)
+	}
+}
+
+func TestKill_WorkspaceProjectDirtyRowsArePreservedAndForceRemoved(t *testing.T) {
+	m, st, _, ws := newManager()
+	ws.destroyErr = fmt.Errorf("dirty: %w", ports.ErrWorkspaceDirty)
+	ws.stashRef = "refs/ao/preserved/mer-1"
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", RuntimeHandleID: "h1"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api"},
+	}
+
+	freed, err := m.Kill(ctx, "mer-1")
+	if err != nil || !freed {
+		t.Fatalf("freed=%v err=%v, want dirty rows preserved and removed", freed, err)
+	}
+	want := []string{
+		"DestroyWorkspaceProjectWorktree:api",
+		"StashWorkspaceProjectWorktree:api",
+		"ForceDestroyWorkspaceProjectWorktree:api",
+		"DestroyWorkspaceProjectWorktree:__root__",
+		"StashWorkspaceProjectWorktree:__root__",
+		"ForceDestroyWorkspaceProjectWorktree:__root__",
+	}
+	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("calls = %v, want %v", got, want)
+	}
+	refs := map[string]string{}
+	states := map[string]string{}
+	for _, row := range st.worktrees["mer-1"] {
+		refs[row.RepoName] = row.PreservedRef
+		states[row.RepoName] = row.State
+	}
+	if refs["api"] != "refs/ao/preserved/mer-1/api" || refs[domain.RootWorkspaceRepoName] != "refs/ao/preserved/mer-1/__root__" {
+		t.Fatalf("preserved refs = %v", refs)
+	}
+	if states["api"] != "unavailable" || states[domain.RootWorkspaceRepoName] != "unavailable" {
+		t.Fatalf("states = %v, want unavailable rows so RestoreAll does not resurrect killed session", states)
+	}
+}
 func TestRestore_ReopensTerminal(t *testing.T) {
 	m, st, rt, _ := newManager()
 	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", AgentSessionID: "agent-x"})
@@ -863,6 +977,87 @@ func TestCleanup_ReportsSkippedWorkspaces(t *testing.T) {
 	}
 	if strings.Contains(res.Skipped[0].Reason, "disk on fire") {
 		t.Fatalf("raw internal error leaked into public reason: %q", res.Skipped[0].Reason)
+	}
+}
+
+func TestCleanup_WorkspaceProjectDestroysChildrenBeforeRoot(t *testing.T) {
+	m, st, _, ws := newManager()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1"})
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api"},
+	}
+
+	res, err := m.Cleanup(ctx, "mer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Cleaned) != 1 || res.Cleaned[0] != "mer-1" {
+		t.Fatalf("cleaned = %v, want mer-1", res.Cleaned)
+	}
+	want := []string{"DestroyWorkspaceProjectWorktree:api", "DestroyWorkspaceProjectWorktree:__root__"}
+	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("destroy order = %v, want %v", got, want)
+	}
+}
+
+func TestCleanup_WorkspaceProjectMarksRetryRemoveAfterTeardownFailure(t *testing.T) {
+	m, st, _, ws := newManager()
+	ws.destroyErr = errors.New("locked")
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1"})
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api"},
+	}
+
+	res, err := m.Cleanup(ctx, "mer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Cleaned) != 0 || len(res.Skipped) != 1 {
+		t.Fatalf("cleanup result = %+v, want one skipped session", res)
+	}
+	states := map[string]string{}
+	for _, row := range st.worktrees["mer-1"] {
+		states[row.RepoName] = row.State
+	}
+	if states["api"] != "retry_remove" || states[domain.RootWorkspaceRepoName] != "retry_remove" {
+		t.Fatalf("states = %v, want retry_remove rows", states)
+	}
+}
+
+func TestCleanup_WorkspaceProjectRetryRemoveKeepsPreservedRef(t *testing.T) {
+	m, st, _, ws := newManager()
+	ws.destroyErr = fmt.Errorf("dirty: %w", ports.ErrWorkspaceDirty)
+	ws.forceDestroyErr = errors.New("still locked")
+	ws.stashRef = "refs/ao/preserved/mer-1"
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1"})
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api"},
+	}
+
+	res, err := m.Cleanup(ctx, "mer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Skipped) != 1 {
+		t.Fatalf("cleanup result = %+v, want one skipped session", res)
+	}
+	refs := map[string]string{}
+	states := map[string]string{}
+	for _, row := range st.worktrees["mer-1"] {
+		refs[row.RepoName] = row.PreservedRef
+		states[row.RepoName] = row.State
+	}
+	if states["api"] != "retry_remove" || refs["api"] != "refs/ao/preserved/mer-1/api" {
+		t.Fatalf("api state/ref = %q/%q, want retry_remove with preserved ref", states["api"], refs["api"])
 	}
 }
 
@@ -1706,6 +1901,44 @@ func TestSaveAndTeardownAll_NoKindFilter(t *testing.T) {
 	}
 }
 
+func TestSaveAndTeardownAll_WorkspaceProjectPreservesEachRepoAndRemovesChildrenFirst(t *testing.T) {
+	m, st, _, ws := newLifecycleManager()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	ws.stashRef = "refs/ao/preserved/mer-1"
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Kind:      domain.KindWorker,
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", RuntimeHandleID: "h1"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1", BaseSHA: "root-base"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api", BaseSHA: "api-base"},
+	}
+
+	if err := m.SaveAndTeardownAll(ctx); err != nil {
+		t.Fatalf("SaveAndTeardownAll err = %v", err)
+	}
+	rows := st.worktrees["mer-1"]
+	if len(rows) != 2 {
+		t.Fatalf("worktree rows = %v, want 2", rows)
+	}
+	refs := map[string]string{}
+	for _, row := range rows {
+		refs[row.RepoName] = row.PreservedRef
+	}
+	if refs[domain.RootWorkspaceRepoName] != "refs/ao/preserved/mer-1/__root__" || refs["api"] != "refs/ao/preserved/mer-1/api" {
+		t.Fatalf("preserved refs = %v", refs)
+	}
+	wantSuffix := []string{"ForceDestroyWorkspaceProjectWorktree:api", "ForceDestroyWorkspaceProjectWorktree:__root__"}
+	gotSuffix := ws.calls[len(ws.calls)-2:]
+	if strings.Join(gotSuffix, ",") != strings.Join(wantSuffix, ",") {
+		t.Fatalf("force destroy suffix = %v, want %v; all calls %v", gotSuffix, wantSuffix, ws.calls)
+	}
+}
+
 // TestRestoreAll_RestoresBothWorkerAndOrchestrator verifies (b): RestoreAll
 // restores both a worker and an orchestrator session saved by SaveAndTeardownAll.
 func TestRestoreAll_RestoresBothWorkerAndOrchestrator(t *testing.T) {
@@ -1732,8 +1965,8 @@ func TestRestoreAll_RestoresBothWorkerAndOrchestrator(t *testing.T) {
 		Activity:     domain.Activity{State: domain.ActivityExited},
 	}
 	// Write the shutdown-saved marker rows.
-	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{SessionID: "mer-1", RepoName: "__root__", PreservedRef: ""}}
-	st.worktrees["mer-2"] = []domain.SessionWorktreeRecord{{SessionID: "mer-2", RepoName: "__root__", PreservedRef: ""}}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{{SessionID: "mer-1", RepoName: "__root__", PreservedRef: "", State: "removed"}}
+	st.worktrees["mer-2"] = []domain.SessionWorktreeRecord{{SessionID: "mer-2", RepoName: "__root__", PreservedRef: "", State: "removed"}}
 
 	if err := m.RestoreAll(ctx); err != nil {
 		t.Fatalf("RestoreAll err = %v", err)
@@ -1856,6 +2089,32 @@ func TestRestoreAll_KilledSessionNotResurrectedOnSecondBoot(t *testing.T) {
 	}
 }
 
+func TestRestoreAll_SkipsActiveWorkspaceProjectRowsFromUserKilledSession(t *testing.T) {
+	m, st, rt, _ := newLifecycleManager()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:           "mer-1",
+		ProjectID:    "mer",
+		Kind:         domain.KindWorker,
+		Harness:      domain.HarnessClaudeCode,
+		IsTerminated: true,
+		Metadata:     domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", Prompt: "do it"},
+		Activity:     domain.Activity{State: domain.ActivityExited},
+	}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1", State: "active"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api", State: "active"},
+	}
+
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("RestoreAll err = %v", err)
+	}
+	if rt.created != 0 {
+		t.Fatalf("active inventory rows must not resurrect user-killed sessions, runtime.Create called %d times", rt.created)
+	}
+}
+
 // TestRestoreAll_AppliesPreservedRef: when the session_worktrees row has a
 // non-empty preserved_ref, RestoreAll calls ApplyPreserved after workspace
 // restore but before relaunching.
@@ -1872,7 +2131,7 @@ func TestRestoreAll_AppliesPreservedRef(t *testing.T) {
 		Activity:     domain.Activity{State: domain.ActivityExited},
 	}
 	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
-		{SessionID: "mer-1", RepoName: "__root__", PreservedRef: "refs/ao/preserved/mer-1"},
+		{SessionID: "mer-1", RepoName: "__root__", PreservedRef: "refs/ao/preserved/mer-1", State: "removed"},
 	}
 
 	if err := m.RestoreAll(ctx); err != nil {
@@ -1923,7 +2182,7 @@ func TestRestoreAll_ConflictLogsAndContinues(t *testing.T) {
 		Activity:     domain.Activity{State: domain.ActivityExited},
 	}
 	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
-		{SessionID: "mer-1", RepoName: "__root__", PreservedRef: "refs/ao/preserved/mer-1"},
+		{SessionID: "mer-1", RepoName: "__root__", PreservedRef: "refs/ao/preserved/mer-1", State: "removed"},
 	}
 
 	if err := m.RestoreAll(ctx); err != nil {
@@ -1931,6 +2190,41 @@ func TestRestoreAll_ConflictLogsAndContinues(t *testing.T) {
 	}
 	if rt.created != 1 {
 		t.Fatalf("session must still relaunch after conflict, runtime.Create called %d times", rt.created)
+	}
+}
+
+func TestRestoreAll_WorkspaceProjectRestoresAndAppliesEachRepo(t *testing.T) {
+	m, st, rt, ws := newLifecycleManager()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:           "mer-1",
+		ProjectID:    "mer",
+		Kind:         domain.KindWorker,
+		Harness:      domain.HarnessClaudeCode,
+		IsTerminated: true,
+		Metadata:     domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", AgentSessionID: "agent-w"},
+		Activity:     domain.Activity{State: domain.ActivityExited},
+	}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1", PreservedRef: "refs/ao/preserved/mer-1", State: "removed"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api", PreservedRef: "refs/ao/preserved/mer-1", State: "removed"},
+	}
+
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("RestoreAll err = %v", err)
+	}
+	wantPrefix := []string{"RestoreWorkspaceProjectWorktree:__root__", "RestoreWorkspaceProjectWorktree:api"}
+	if got := ws.calls[:2]; strings.Join(got, ",") != strings.Join(wantPrefix, ",") {
+		t.Fatalf("restore prefix = %v, want %v; all calls %v", got, wantPrefix, ws.calls)
+	}
+	applied := strings.Join(ws.calls, ",")
+	if !strings.Contains(applied, "ApplyWorkspaceProjectPreserved:__root__:refs/ao/preserved/mer-1") ||
+		!strings.Contains(applied, "ApplyWorkspaceProjectPreserved:api:refs/ao/preserved/mer-1") {
+		t.Fatalf("apply calls missing, got %v", ws.calls)
+	}
+	if rt.created != 1 {
+		t.Fatalf("runtime.Create calls = %d, want 1", rt.created)
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -20,11 +20,13 @@ import (
 var ctx = context.Background()
 
 type fakeStore struct {
-	sessions  map[domain.SessionID]domain.SessionRecord
-	pr        map[domain.SessionID]domain.PRFacts
-	projects  map[string]domain.ProjectRecord
-	num       int
-	deleteErr error
+	sessions      map[domain.SessionID]domain.SessionRecord
+	pr            map[domain.SessionID]domain.PRFacts
+	projects      map[string]domain.ProjectRecord
+	workspaceRepo map[string][]domain.WorkspaceRepoRecord
+	num           int
+	deleteErr     error
+	upsertWTErr   error
 	// worktrees maps session ID to its saved worktree rows (shutdown-saved marker).
 	worktrees map[domain.SessionID][]domain.SessionWorktreeRecord
 	// sharedLog, when non-nil, receives an ordered call entry for each
@@ -34,15 +36,19 @@ type fakeStore struct {
 
 func newFakeStore() *fakeStore {
 	return &fakeStore{
-		sessions:  map[domain.SessionID]domain.SessionRecord{},
-		pr:        map[domain.SessionID]domain.PRFacts{},
-		projects:  map[string]domain.ProjectRecord{},
-		worktrees: map[domain.SessionID][]domain.SessionWorktreeRecord{},
+		sessions:      map[domain.SessionID]domain.SessionRecord{},
+		pr:            map[domain.SessionID]domain.PRFacts{},
+		projects:      map[string]domain.ProjectRecord{},
+		workspaceRepo: map[string][]domain.WorkspaceRepoRecord{},
+		worktrees:     map[domain.SessionID][]domain.SessionWorktreeRecord{},
 	}
 }
 func (f *fakeStore) GetProject(_ context.Context, id string) (domain.ProjectRecord, bool, error) {
 	r, ok := f.projects[id]
 	return r, ok, nil
+}
+func (f *fakeStore) ListWorkspaceRepos(_ context.Context, projectID string) ([]domain.WorkspaceRepoRecord, error) {
+	return f.workspaceRepo[projectID], nil
 }
 func (f *fakeStore) CreateSession(_ context.Context, rec domain.SessionRecord) (domain.SessionRecord, error) {
 	f.num++
@@ -96,6 +102,9 @@ func (f *fakeStore) GetDisplayPRFactsForSession(_ context.Context, id domain.Ses
 	return domain.PRFacts{}, false, nil
 }
 func (f *fakeStore) UpsertSessionWorktree(_ context.Context, row domain.SessionWorktreeRecord) error {
+	if f.upsertWTErr != nil {
+		return f.upsertWTErr
+	}
 	if f.sharedLog != nil {
 		*f.sharedLog = append(*f.sharedLog, "UpsertSessionWorktree:"+string(row.SessionID))
 	}
@@ -248,10 +257,14 @@ type missingAgents struct{}
 func (missingAgents) Agent(domain.AgentHarness) (ports.Agent, bool) { return nil, false }
 
 type fakeWorkspace struct {
-	createErr  error
-	destroyErr error
-	destroyed  int
-	lastCfg    ports.WorkspaceConfig
+	createErr         error
+	destroyErr        error
+	destroyed         int
+	lastCfg           ports.WorkspaceConfig
+	projectErr        error
+	projectDestroyed  int
+	lastProjectCfg    ports.WorkspaceProjectConfig
+	projectCreateInfo ports.WorkspaceProjectInfo
 	// path, when set, is returned as the workspace path so provisioning tests
 	// can point at a real temp directory.
 	path string
@@ -280,8 +293,52 @@ func (w *fakeWorkspace) Create(_ context.Context, cfg ports.WorkspaceConfig) (po
 	}
 	return ports.WorkspaceInfo{Path: path, Branch: cfg.Branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID}, nil
 }
+func (w *fakeWorkspace) CreateWorkspaceProject(_ context.Context, cfg ports.WorkspaceProjectConfig) (ports.WorkspaceProjectInfo, error) {
+	if w.projectErr != nil {
+		return ports.WorkspaceProjectInfo{}, w.projectErr
+	}
+	w.lastProjectCfg = cfg
+	if len(w.projectCreateInfo.Worktrees) > 0 {
+		return w.projectCreateInfo, nil
+	}
+	rootPath := w.path
+	if rootPath == "" {
+		rootPath = "/ws/" + string(cfg.SessionID)
+	}
+	branch := cfg.Branch
+	root := ports.WorkspaceInfo{Path: rootPath, Branch: branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID}
+	out := ports.WorkspaceProjectInfo{
+		Root: root,
+		Worktrees: []ports.WorkspaceRepoInfo{{
+			RepoName:  domain.RootWorkspaceRepoName,
+			RepoPath:  cfg.RootRepoPath,
+			Path:      rootPath,
+			Branch:    branch,
+			BaseSHA:   "root-base",
+			SessionID: cfg.SessionID,
+			ProjectID: cfg.ProjectID,
+		}},
+	}
+	for _, repo := range cfg.Repos {
+		out.Worktrees = append(out.Worktrees, ports.WorkspaceRepoInfo{
+			RepoName:     repo.Name,
+			RepoPath:     repo.RepoPath,
+			Path:         filepath.Join(rootPath, filepath.FromSlash(repo.RelativePath)),
+			Branch:       branch,
+			BaseSHA:      repo.Name + "-base",
+			SessionID:    cfg.SessionID,
+			ProjectID:    cfg.ProjectID,
+			RelativePath: repo.RelativePath,
+		})
+	}
+	return out, nil
+}
 func (w *fakeWorkspace) Destroy(context.Context, ports.WorkspaceInfo) error {
 	w.destroyed++
+	return w.destroyErr
+}
+func (w *fakeWorkspace) DestroyWorkspaceProject(context.Context, ports.WorkspaceProjectInfo) error {
+	w.projectDestroyed++
 	return w.destroyErr
 }
 func (w *fakeWorkspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
@@ -509,6 +566,125 @@ func TestSpawn_ParksRowTerminatedWhenSeedDeleteFails(t *testing.T) {
 		t.Fatal("row must fall back to terminated when the seed delete fails")
 	}
 }
+
+func TestSpawn_WorkspaceProjectRecordsRootAndChildWorktrees(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{
+		ID:     "mer",
+		Path:   "/repo/mer",
+		Kind:   domain.ProjectKindWorkspace,
+		Config: testRoleAgents(),
+	}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{
+		{Name: "api", RelativePath: "services/api"},
+		{Name: "web", RelativePath: "apps/web"},
+	}
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{path: "/managed/mer-1"}
+	m := New(Deps{
+		Runtime: rt, Agents: fakeAgents{}, Workspace: ws, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+		LookPath: func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	rec, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Metadata.WorkspacePath != "/managed/mer-1" {
+		t.Fatalf("workspace path = %q, want root worktree path", rec.Metadata.WorkspacePath)
+	}
+	if rec.Metadata.Branch != "ao/mer-1" {
+		t.Fatalf("workspace branch = %q, want ao/mer-1", rec.Metadata.Branch)
+	}
+	if got := ws.lastProjectCfg.RootRepoPath; got != "/repo/mer" {
+		t.Fatalf("root repo path = %q, want /repo/mer", got)
+	}
+	if len(ws.lastProjectCfg.Repos) != 2 {
+		t.Fatalf("child repo configs = %d, want 2", len(ws.lastProjectCfg.Repos))
+	}
+	if got := ws.lastProjectCfg.Repos[0].RepoPath; got != "/repo/mer/services/api" {
+		t.Fatalf("api repo path = %q, want /repo/mer/services/api", got)
+	}
+	if got := ws.lastProjectCfg.Repos[1].RepoPath; got != "/repo/mer/apps/web" {
+		t.Fatalf("web repo path = %q, want /repo/mer/apps/web", got)
+	}
+	rows := st.worktrees["mer-1"]
+	if len(rows) != 3 {
+		t.Fatalf("session worktree rows = %d, want 3: %#v", len(rows), rows)
+	}
+	want := map[string]string{
+		domain.RootWorkspaceRepoName: "/managed/mer-1",
+		"api":                        "/managed/mer-1/services/api",
+		"web":                        "/managed/mer-1/apps/web",
+	}
+	for _, row := range rows {
+		if row.Branch != rec.Metadata.Branch {
+			t.Fatalf("row %s branch = %q, want %q", row.RepoName, row.Branch, rec.Metadata.Branch)
+		}
+		if want[row.RepoName] != row.WorktreePath {
+			t.Fatalf("row %s path = %q, want %q", row.RepoName, row.WorktreePath, want[row.RepoName])
+		}
+		if row.BaseSHA == "" {
+			t.Fatalf("row %s missing base sha", row.RepoName)
+		}
+	}
+	if rt.created != 1 {
+		t.Fatal("runtime should be created")
+	}
+	if ws.destroyed != 0 || ws.projectDestroyed != 0 {
+		t.Fatal("successful spawn should not destroy workspaces")
+	}
+}
+
+func TestSpawn_WorkspaceProjectRollsBackAllWorktreesOnRuntimeFailure(t *testing.T) {
+	m, st, _, ws := newManager()
+	st.projects["mer"] = domain.ProjectRecord{
+		ID:     "mer",
+		Path:   "/repo/mer",
+		Kind:   domain.ProjectKindWorkspace,
+		Config: testRoleAgents(),
+	}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	m.runtime = &fakeRuntime{createErr: errors.New("boom")}
+	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err == nil {
+		t.Fatal("expected failure")
+	}
+	if ws.projectDestroyed != 1 {
+		t.Fatalf("workspace project destroy calls = %d, want 1", ws.projectDestroyed)
+	}
+	if ws.destroyed != 0 {
+		t.Fatalf("single-workspace destroy calls = %d, want 0", ws.destroyed)
+	}
+	if !st.sessions["mer-1"].IsTerminated {
+		t.Fatal("orphaned spawn should be terminated")
+	}
+}
+
+func TestSpawn_WorkspaceProjectRollsBackWhenWorktreeRowsFail(t *testing.T) {
+	m, st, rt, ws := newManager()
+	st.projects["mer"] = domain.ProjectRecord{
+		ID:     "mer",
+		Path:   "/repo/mer",
+		Kind:   domain.ProjectKindWorkspace,
+		Config: testRoleAgents(),
+	}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	st.upsertWTErr = errors.New("db locked")
+	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err == nil || !strings.Contains(err.Error(), "record workspace worktree") {
+		t.Fatalf("err = %v, want worktree row failure", err)
+	}
+	if ws.projectDestroyed != 1 {
+		t.Fatalf("workspace project destroy calls = %d, want 1", ws.projectDestroyed)
+	}
+	if _, present := st.sessions["mer-1"]; present {
+		t.Fatal("seed row should be deleted after workspace row failure")
+	}
+	if rt.created != 0 {
+		t.Fatal("runtime.Create must not run when worktree row recording fails")
+	}
+}
+
 func TestKill_TearsDownRuntimeAndWorkspace(t *testing.T) {
 	m, st, rt, ws := newManager()
 	st.sessions["mer-1"] = mkLive("mer-1")

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -616,8 +616,8 @@ func TestSpawn_WorkspaceProjectRecordsRootAndChildWorktrees(t *testing.T) {
 		Config: testRoleAgents(),
 	}
 	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{
-		{Name: "api", RelativePath: "services/api"},
-		{Name: "web", RelativePath: "apps/web"},
+		{Name: "api", RelativePath: "services/api", DefaultBranch: "master"},
+		{Name: "web", RelativePath: "apps/web", DefaultBranch: "develop"},
 	}
 	rt := &fakeRuntime{}
 	ws := &fakeWorkspace{path: "/managed/mer-1"}
@@ -648,6 +648,12 @@ func TestSpawn_WorkspaceProjectRecordsRootAndChildWorktrees(t *testing.T) {
 	}
 	if got := ws.lastProjectCfg.Repos[1].RepoPath; got != "/repo/mer/apps/web" {
 		t.Fatalf("web repo path = %q, want /repo/mer/apps/web", got)
+	}
+	if got := ws.lastProjectCfg.Repos[0].BaseBranch; got != "master" {
+		t.Fatalf("api base branch = %q, want master", got)
+	}
+	if got := ws.lastProjectCfg.Repos[1].BaseBranch; got != "develop" {
+		t.Fatalf("web base branch = %q, want develop", got)
 	}
 	rows := st.worktrees["mer-1"]
 	if len(rows) != 3 {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -679,6 +679,45 @@ func TestSpawn_WorkspaceProjectRecordsRootAndChildWorktrees(t *testing.T) {
 	}
 }
 
+func TestSpawn_WorkspaceProjectOrchestratorUsesOrchestratorPath(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{
+		ID:     "mer",
+		Path:   "/repo/mer",
+		Kind:   domain.ProjectKindWorkspace,
+		Config: testRoleAgents(),
+	}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api", DefaultBranch: "main"}}
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{path: "/managed/mer/orchestrator/mer-orchestrator"}
+	m := New(Deps{
+		Runtime: rt, Agents: fakeAgents{}, Workspace: ws, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+		LookPath: func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	rec, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindOrchestrator})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Kind != domain.KindOrchestrator {
+		t.Fatalf("kind = %q, want orchestrator", rec.Kind)
+	}
+	if rec.Metadata.WorkspacePath != "/managed/mer/orchestrator/mer-orchestrator" {
+		t.Fatalf("workspace path = %q", rec.Metadata.WorkspacePath)
+	}
+	if ws.lastProjectCfg.Kind != domain.KindOrchestrator {
+		t.Fatalf("workspace project kind = %q, want orchestrator", ws.lastProjectCfg.Kind)
+	}
+	if ws.lastProjectCfg.Branch != "ao/mer-1" {
+		t.Fatalf("workspace project branch = %q, want ao/mer-1", ws.lastProjectCfg.Branch)
+	}
+	rows := st.worktrees["mer-1"]
+	if len(rows) != 2 {
+		t.Fatalf("session worktree rows = %d, want root and api: %#v", len(rows), rows)
+	}
+}
+
 func TestSpawn_WorkspaceProjectRollsBackAllWorktreesOnRuntimeFailure(t *testing.T) {
 	m, st, _, ws := newManager()
 	st.projects["mer"] = domain.ProjectRecord{

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -842,7 +842,33 @@ func TestKill_WorkspaceProjectDestroysChildrenBeforeRoot(t *testing.T) {
 	}
 }
 
-func TestKill_WorkspaceProjectDirtyRowsArePreservedAndForceRemoved(t *testing.T) {
+func TestKill_WorkspaceProjectSkipsUnregisteredChildRows(t *testing.T) {
+	m, st, _, ws := newManager()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", RuntimeHandleID: "h1"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1"},
+		{SessionID: "mer-1", RepoName: "old-api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/old-api"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api"},
+	}
+
+	freed, err := m.Kill(ctx, "mer-1")
+	if err != nil || !freed {
+		t.Fatalf("freed=%v err=%v", freed, err)
+	}
+	want := []string{"DestroyWorkspaceProjectWorktree:api", "DestroyWorkspaceProjectWorktree:__root__"}
+	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("destroy calls = %v, want %v", got, want)
+	}
+}
+
+func TestKill_WorkspaceProjectDirtyRowRefusesRemoval(t *testing.T) {
 	m, st, _, ws := newManager()
 	ws.destroyErr = fmt.Errorf("dirty: %w", ports.ErrWorkspaceDirty)
 	ws.stashRef = "refs/ao/preserved/mer-1"
@@ -860,31 +886,23 @@ func TestKill_WorkspaceProjectDirtyRowsArePreservedAndForceRemoved(t *testing.T)
 	}
 
 	freed, err := m.Kill(ctx, "mer-1")
-	if err != nil || !freed {
-		t.Fatalf("freed=%v err=%v, want dirty rows preserved and removed", freed, err)
+	if err != nil {
+		t.Fatalf("kill dirty workspace project err = %v, want nil", err)
 	}
-	want := []string{
-		"DestroyWorkspaceProjectWorktree:api",
-		"StashWorkspaceProjectWorktree:api",
-		"ForceDestroyWorkspaceProjectWorktree:api",
-		"DestroyWorkspaceProjectWorktree:__root__",
-		"StashWorkspaceProjectWorktree:__root__",
-		"ForceDestroyWorkspaceProjectWorktree:__root__",
+	if freed {
+		t.Fatal("freed = true, want false for preserved workspace project")
 	}
+	want := []string{"DestroyWorkspaceProjectWorktree:api"}
 	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("calls = %v, want %v", got, want)
 	}
-	refs := map[string]string{}
-	states := map[string]string{}
+	if !st.sessions["mer-1"].IsTerminated {
+		t.Fatal("session should be terminated")
+	}
 	for _, row := range st.worktrees["mer-1"] {
-		refs[row.RepoName] = row.PreservedRef
-		states[row.RepoName] = row.State
-	}
-	if refs["api"] != "refs/ao/preserved/mer-1/api" || refs[domain.RootWorkspaceRepoName] != "refs/ao/preserved/mer-1/__root__" {
-		t.Fatalf("preserved refs = %v", refs)
-	}
-	if states["api"] != "unavailable" || states[domain.RootWorkspaceRepoName] != "unavailable" {
-		t.Fatalf("states = %v, want unavailable rows so RestoreAll does not resurrect killed session", states)
+		if row.PreservedRef != "" || row.State != "" {
+			t.Fatalf("dirty kill should not mutate worktree row %+v", row)
+		}
 	}
 }
 func TestRestore_ReopensTerminal(t *testing.T) {

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -210,5 +210,6 @@ type WorkspaceRepo struct {
 	Name          string
 	RelativePath  string
 	RepoOriginURL string
+	DefaultBranch string
 	RegisteredAt  time.Time
 }

--- a/backend/internal/storage/sqlite/gen/workspace.sql.go
+++ b/backend/internal/storage/sqlite/gen/workspace.sql.go
@@ -95,7 +95,7 @@ func (q *Queries) ListSessionWorktrees(ctx context.Context, sessionID domain.Ses
 }
 
 const listWorkspaceRepos = `-- name: ListWorkspaceRepos :many
-SELECT project_id, name, relative_path, repo_origin_url, registered_at
+SELECT project_id, name, relative_path, repo_origin_url, default_branch, registered_at
 FROM workspace_repos
 WHERE project_id = ?
 ORDER BY name
@@ -115,6 +115,7 @@ func (q *Queries) ListWorkspaceRepos(ctx context.Context, projectID domain.Proje
 			&i.Name,
 			&i.RelativePath,
 			&i.RepoOriginURL,
+			&i.DefaultBranch,
 			&i.RegisteredAt,
 		); err != nil {
 			return nil, err
@@ -165,11 +166,12 @@ func (q *Queries) UpsertSessionWorktree(ctx context.Context, arg UpsertSessionWo
 }
 
 const upsertWorkspaceRepo = `-- name: UpsertWorkspaceRepo :exec
-INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, registered_at)
-VALUES (?, ?, ?, ?, ?)
+INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, default_branch, registered_at)
+VALUES (?, ?, ?, ?, ?, ?)
 ON CONFLICT (project_id, name) DO UPDATE SET
     relative_path = excluded.relative_path,
     repo_origin_url = excluded.repo_origin_url,
+    default_branch = excluded.default_branch,
     registered_at = excluded.registered_at
 `
 
@@ -178,6 +180,7 @@ type UpsertWorkspaceRepoParams struct {
 	Name          string
 	RelativePath  string
 	RepoOriginURL string
+	DefaultBranch string
 	RegisteredAt  time.Time
 }
 
@@ -187,6 +190,7 @@ func (q *Queries) UpsertWorkspaceRepo(ctx context.Context, arg UpsertWorkspaceRe
 		arg.Name,
 		arg.RelativePath,
 		arg.RepoOriginURL,
+		arg.DefaultBranch,
 		arg.RegisteredAt,
 	)
 	return err

--- a/backend/internal/storage/sqlite/migrations/0009_workspace_projects.sql
+++ b/backend/internal/storage/sqlite/migrations/0009_workspace_projects.sql
@@ -8,6 +8,7 @@ CREATE TABLE workspace_repos (
     name            TEXT NOT NULL,
     relative_path   TEXT NOT NULL,
     repo_origin_url TEXT NOT NULL DEFAULT '',
+    default_branch  TEXT NOT NULL DEFAULT 'main',
     registered_at   TIMESTAMP NOT NULL,
     PRIMARY KEY (project_id, name),
     UNIQUE (project_id, relative_path)

--- a/backend/internal/storage/sqlite/queries/workspace.sql
+++ b/backend/internal/storage/sqlite/queries/workspace.sql
@@ -2,15 +2,16 @@
 DELETE FROM workspace_repos WHERE project_id = ?;
 
 -- name: UpsertWorkspaceRepo :exec
-INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, registered_at)
-VALUES (?, ?, ?, ?, ?)
+INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, default_branch, registered_at)
+VALUES (?, ?, ?, ?, ?, ?)
 ON CONFLICT (project_id, name) DO UPDATE SET
     relative_path = excluded.relative_path,
     repo_origin_url = excluded.repo_origin_url,
+    default_branch = excluded.default_branch,
     registered_at = excluded.registered_at;
 
 -- name: ListWorkspaceRepos :many
-SELECT project_id, name, relative_path, repo_origin_url, registered_at
+SELECT project_id, name, relative_path, repo_origin_url, default_branch, registered_at
 FROM workspace_repos
 WHERE project_id = ?
 ORDER BY name;

--- a/backend/internal/storage/sqlite/store/project_store.go
+++ b/backend/internal/storage/sqlite/store/project_store.go
@@ -45,6 +45,7 @@ func (s *Store) UpsertWorkspaceProject(ctx context.Context, r domain.ProjectReco
 				Name:          repo.Name,
 				RelativePath:  repo.RelativePath,
 				RepoOriginURL: repo.RepoOriginURL,
+				DefaultBranch: repo.DefaultBranch,
 				RegisteredAt:  repo.RegisteredAt,
 			}); err != nil {
 				return err
@@ -67,6 +68,7 @@ func (s *Store) ListWorkspaceRepos(ctx context.Context, projectID string) ([]dom
 			Name:          row.Name,
 			RelativePath:  row.RelativePath,
 			RepoOriginURL: row.RepoOriginURL,
+			DefaultBranch: row.DefaultBranch,
 			RegisteredAt:  row.RegisteredAt,
 		})
 	}

--- a/backend/internal/storage/sqlite/store/session_worktree_store.go
+++ b/backend/internal/storage/sqlite/store/session_worktree_store.go
@@ -14,12 +14,9 @@ import (
 func (s *Store) UpsertSessionWorktree(ctx context.Context, row domain.SessionWorktreeRecord) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	// ponytail: session_worktrees.state is unused multi-repo scaffolding; no
-	// live code path sets domain.SessionWorktreeRecord.State, so it arrives
-	// here as "". The generated upsert includes state in the INSERT column list
-	// and the CHECK constraint rejects "". Default to 'active' (the column
-	// default) so the row stays valid without touching the schema or gen code.
-	// Wire a real value when multi-repo worktree lifecycle states ship.
+	// An empty state means the caller is creating or updating a live worktree
+	// row. Lifecycle paths set explicit states such as removed, unavailable, or
+	// retry_remove.
 	state := row.State
 	if state == "" {
 		state = "active"
@@ -75,8 +72,6 @@ func sessionWorktreeFromGen(row gen.SessionWorktree) domain.SessionWorktreeRecor
 		BaseSHA:      row.BaseSha,
 		WorktreePath: row.WorktreePath,
 		PreservedRef: row.PreservedRef,
-		// ponytail: state is read back from the DB but no caller uses it;
-		// it is unused multi-repo scaffolding (see UpsertSessionWorktree above).
-		State: row.State,
+		State:        row.State,
 	}
 }

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -916,6 +916,7 @@ export interface components {
             reviews: components["schemas"]["PRReviewState"][];
         };
         WorkspaceRepo: {
+            defaultBranch: string;
             name: string;
             relativePath: string;
             repo: string;


### PR DESCRIPTION
## Summary
- combines backend workspace project session materialization from #2224
- combines workspace project lifecycle teardown from #2243
- adds SCM observer support for workspace child repositories so session branches/PRs from nested workspace repos are discovered and tracked
- keeps workspace session worktree rows available until teardown has inspected them, while still clearing restore markers after clean kill

## Validation
- cd backend && go test ./internal/observe/scm ./internal/session_manager ./internal/adapters/workspace/gitworktree ./internal/storage/sqlite/store
- cd backend && go test ./...
