### PR TITLE
Fix/2329 workspace default branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ session-events.jsonl.*
 # Local tooling (not for the team)
 .codegraph/
 .cursor/
+.worktrees/
 
 # OS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ session-events.jsonl.*
 # Local tooling (not for the team)
 .codegraph/
 .cursor/
-.worktrees/
 
 # OS
 .DS_Store

--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -68,9 +68,10 @@ type projectDetails struct {
 }
 
 type workspaceRepoDetails struct {
-	Name         string `json:"name"`
-	RelativePath string `json:"relativePath"`
-	Repo         string `json:"repo"`
+	Name          string `json:"name"`
+	RelativePath  string `json:"relativePath"`
+	Repo          string `json:"repo"`
+	DefaultBranch string `json:"defaultBranch"`
 }
 
 // agentConfig mirrors the daemon's typed domain.AgentConfig for the CLI client.

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -137,6 +137,26 @@ func TestProjectGet_JSON(t *testing.T) {
 	}
 }
 
+func TestProjectGetWorkspace_JSONIncludesChildDefaultBranch(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := projectServer(t, http.StatusOK, `{"status":"ok","project":{"id":"ws","name":"Workspace","kind":"workspace","path":"/repo/ws","workspaceRepos":[{"name":"api","relativePath":"api","repo":"git@example.com:api.git","defaultBranch":"develop"}]}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "get", "ws", "--json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var got projectGetResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode json output: %v\nout=%s", err, out)
+	}
+	if len(got.Project.WorkspaceRepos) != 1 || got.Project.WorkspaceRepos[0].DefaultBranch != "develop" {
+		t.Fatalf("workspace repos = %#v, want child default branch develop", got.Project.WorkspaceRepos)
+	}
+}
+
 func TestProjectGet_MissingArg(t *testing.T) {
 	setConfigEnv(t)
 	_, _, err := executeCLI(t, Deps{}, "project", "get")

--- a/backend/internal/domain/project.go
+++ b/backend/internal/domain/project.go
@@ -44,6 +44,7 @@ type WorkspaceRepoRecord struct {
 	Name          string
 	RelativePath  string
 	RepoOriginURL string
+	DefaultBranch string
 	RegisteredAt  time.Time
 }
 

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2560,6 +2560,8 @@ components:
       type: object
     WorkspaceRepo:
       properties:
+        defaultBranch:
+          type: string
         name:
           type: string
         relativePath:
@@ -2570,6 +2572,7 @@ components:
       - name
       - relativePath
       - repo
+      - defaultBranch
       type: object
 tags:
 - description: Project registry, configuration, and lifecycle administration

--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -48,6 +48,47 @@ func (emptyGetManager) Get(context.Context, domain.ProjectID) (projectsvc.GetRes
 
 }
 
+type workspaceGetManager struct{ projectsvc.Manager }
+
+func (workspaceGetManager) Get(context.Context, domain.ProjectID) (projectsvc.GetResult, error) {
+	return projectsvc.GetResult{Status: "ok", Project: &projectsvc.Project{
+		ID:   "ws",
+		Name: "Workspace",
+		Kind: domain.ProjectKindWorkspace,
+		WorkspaceRepos: []projectsvc.WorkspaceRepo{{
+			Name:          "api",
+			RelativePath:  "api",
+			Repo:          "git@example.com:api.git",
+			DefaultBranch: "develop",
+		}},
+	}}, nil
+}
+
+func TestProjectsAPI_GetWorkspaceIncludesChildDefaultBranch(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{
+		Projects: workspaceGetManager{},
+	}, httpd.ControlDeps{}))
+	t.Cleanup(srv.Close)
+
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/projects/ws", "")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", status, body)
+	}
+	assertJSON(t, headers)
+	var got struct {
+		Project struct {
+			WorkspaceRepos []struct {
+				DefaultBranch string `json:"defaultBranch"`
+			} `json:"workspaceRepos"`
+		} `json:"project"`
+	}
+	mustJSON(t, body, &got)
+	if len(got.Project.WorkspaceRepos) != 1 || got.Project.WorkspaceRepos[0].DefaultBranch != "develop" {
+		t.Fatalf("workspace repos = %#v, want child default branch develop", got.Project.WorkspaceRepos)
+	}
+}
+
 // TestProjectsAPI_GetEmptyResultIs500 locks the fix for the discriminated-union
 
 // invariant: a degenerate GetResult must surface as a parseable 500 envelope,

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -595,6 +595,36 @@ func TestManager_AddWorkspaceInitializesPlainParent(t *testing.T) {
 	}
 }
 
+func TestManager_AddWorkspaceDetectsChildDefaultBranch(t *testing.T) {
+	configureCommitter(t)
+	ctx := context.Background()
+	m := newManager(t)
+	parent := t.TempDir()
+	child := gitRepoWithCommit(t, filepath.Join(parent, "api"))
+	for _, args := range [][]string{
+		{"branch", "-m", "develop"},
+		{"update-ref", "refs/remotes/origin/develop", "HEAD"},
+		{"symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop"},
+		{"switch", "-c", "feature"},
+	} {
+		if out, err := exec.Command("git", append([]string{"-C", child}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+
+	proj, err := m.Add(ctx, project.AddInput{Path: parent, ProjectID: ptr("ws"), AsWorkspace: true})
+	if err != nil {
+		t.Fatalf("Add workspace: %v", err)
+	}
+	if len(proj.WorkspaceRepos) != 1 || proj.WorkspaceRepos[0].DefaultBranch != "develop" {
+		t.Fatalf("WorkspaceRepos = %#v, want child default develop", proj.WorkspaceRepos)
+	}
+	got, err := m.Get(ctx, "ws")
+	if err != nil || got.Project == nil || got.Project.WorkspaceRepos[0].DefaultBranch != "develop" {
+		t.Fatalf("Get workspace = %#v, err=%v", got, err)
+	}
+}
+
 func TestManager_AddWorkspaceRejectsUncommittedChild(t *testing.T) {
 	configureCommitter(t)
 	ctx := context.Background()

--- a/backend/internal/service/project/types.go
+++ b/backend/internal/service/project/types.go
@@ -36,7 +36,8 @@ type Degraded struct {
 
 // WorkspaceRepo is the project-detail read shape for a registered child repo.
 type WorkspaceRepo struct {
-	Name         string `json:"name"`
-	RelativePath string `json:"relativePath"`
-	Repo         string `json:"repo"`
+	Name          string `json:"name"`
+	RelativePath  string `json:"relativePath"`
+	Repo          string `json:"repo"`
+	DefaultBranch string `json:"defaultBranch"`
 }

--- a/backend/internal/service/project/workspace_registration.go
+++ b/backend/internal/service/project/workspace_registration.go
@@ -176,6 +176,7 @@ func detectWorkspaceChildren(ctx context.Context, parent string, projectID domai
 			Name:          name,
 			RelativePath:  filepath.ToSlash(name),
 			RepoOriginURL: resolveGitOriginURL(child),
+			DefaultBranch: resolveDefaultBranch(child),
 			RegisteredAt:  registeredAt,
 		})
 	}
@@ -352,7 +353,12 @@ func guardNoGitlinks(ctx context.Context, repo string) error {
 func workspaceReposFromRecords(records []domain.WorkspaceRepoRecord) []WorkspaceRepo {
 	out := make([]WorkspaceRepo, 0, len(records))
 	for _, rec := range records {
-		out = append(out, WorkspaceRepo{Name: rec.Name, RelativePath: rec.RelativePath, Repo: rec.RepoOriginURL})
+		out = append(out, WorkspaceRepo{
+			Name:          rec.Name,
+			RelativePath:  rec.RelativePath,
+			Repo:          rec.RepoOriginURL,
+			DefaultBranch: rec.DefaultBranch,
+		})
 	}
 	return out
 }

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -211,4 +211,5 @@ type WorkspaceRepo struct {
 	RelativePath  string
 	RepoOriginURL string
 	RegisteredAt  time.Time
+	DefaultBranch string
 }

--- a/backend/internal/storage/sqlite/gen/workspace.sql.go
+++ b/backend/internal/storage/sqlite/gen/workspace.sql.go
@@ -95,26 +95,36 @@ func (q *Queries) ListSessionWorktrees(ctx context.Context, sessionID domain.Ses
 }
 
 const listWorkspaceRepos = `-- name: ListWorkspaceRepos :many
-SELECT project_id, name, relative_path, repo_origin_url, registered_at
+SELECT project_id, name, relative_path, repo_origin_url, default_branch, registered_at
 FROM workspace_repos
 WHERE project_id = ?
 ORDER BY name
 `
 
-func (q *Queries) ListWorkspaceRepos(ctx context.Context, projectID domain.ProjectID) ([]WorkspaceRepo, error) {
+type ListWorkspaceReposRow struct {
+	ProjectID     domain.ProjectID
+	Name          string
+	RelativePath  string
+	RepoOriginURL string
+	DefaultBranch string
+	RegisteredAt  time.Time
+}
+
+func (q *Queries) ListWorkspaceRepos(ctx context.Context, projectID domain.ProjectID) ([]ListWorkspaceReposRow, error) {
 	rows, err := q.db.QueryContext(ctx, listWorkspaceRepos, projectID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []WorkspaceRepo{}
+	items := []ListWorkspaceReposRow{}
 	for rows.Next() {
-		var i WorkspaceRepo
+		var i ListWorkspaceReposRow
 		if err := rows.Scan(
 			&i.ProjectID,
 			&i.Name,
 			&i.RelativePath,
 			&i.RepoOriginURL,
+			&i.DefaultBranch,
 			&i.RegisteredAt,
 		); err != nil {
 			return nil, err
@@ -165,11 +175,12 @@ func (q *Queries) UpsertSessionWorktree(ctx context.Context, arg UpsertSessionWo
 }
 
 const upsertWorkspaceRepo = `-- name: UpsertWorkspaceRepo :exec
-INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, registered_at)
-VALUES (?, ?, ?, ?, ?)
+INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, default_branch, registered_at)
+VALUES (?, ?, ?, ?, ?, ?)
 ON CONFLICT (project_id, name) DO UPDATE SET
     relative_path = excluded.relative_path,
     repo_origin_url = excluded.repo_origin_url,
+    default_branch = excluded.default_branch,
     registered_at = excluded.registered_at
 `
 
@@ -178,6 +189,7 @@ type UpsertWorkspaceRepoParams struct {
 	Name          string
 	RelativePath  string
 	RepoOriginURL string
+	DefaultBranch string
 	RegisteredAt  time.Time
 }
 
@@ -187,6 +199,7 @@ func (q *Queries) UpsertWorkspaceRepo(ctx context.Context, arg UpsertWorkspaceRe
 		arg.Name,
 		arg.RelativePath,
 		arg.RepoOriginURL,
+		arg.DefaultBranch,
 		arg.RegisteredAt,
 	)
 	return err

--- a/backend/internal/storage/sqlite/migrations/0022_workspace_repo_default_branch.sql
+++ b/backend/internal/storage/sqlite/migrations/0022_workspace_repo_default_branch.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE workspace_repos ADD COLUMN default_branch TEXT NOT NULL DEFAULT 'main';
+
+-- +goose Down
+ALTER TABLE workspace_repos DROP COLUMN default_branch;

--- a/backend/internal/storage/sqlite/queries/workspace.sql
+++ b/backend/internal/storage/sqlite/queries/workspace.sql
@@ -2,15 +2,16 @@
 DELETE FROM workspace_repos WHERE project_id = ?;
 
 -- name: UpsertWorkspaceRepo :exec
-INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, registered_at)
-VALUES (?, ?, ?, ?, ?)
+INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, default_branch, registered_at)
+VALUES (?, ?, ?, ?, ?, ?)
 ON CONFLICT (project_id, name) DO UPDATE SET
     relative_path = excluded.relative_path,
     repo_origin_url = excluded.repo_origin_url,
+    default_branch = excluded.default_branch,
     registered_at = excluded.registered_at;
 
 -- name: ListWorkspaceRepos :many
-SELECT project_id, name, relative_path, repo_origin_url, registered_at
+SELECT project_id, name, relative_path, repo_origin_url, default_branch, registered_at
 FROM workspace_repos
 WHERE project_id = ?
 ORDER BY name;

--- a/backend/internal/storage/sqlite/store/project_store.go
+++ b/backend/internal/storage/sqlite/store/project_store.go
@@ -45,6 +45,7 @@ func (s *Store) UpsertWorkspaceProject(ctx context.Context, r domain.ProjectReco
 				Name:          repo.Name,
 				RelativePath:  repo.RelativePath,
 				RepoOriginURL: repo.RepoOriginURL,
+				DefaultBranch: repo.DefaultBranch,
 				RegisteredAt:  repo.RegisteredAt,
 			}); err != nil {
 				return err
@@ -67,6 +68,7 @@ func (s *Store) ListWorkspaceRepos(ctx context.Context, projectID string) ([]dom
 			Name:          row.Name,
 			RelativePath:  row.RelativePath,
 			RepoOriginURL: row.RepoOriginURL,
+			DefaultBranch: row.DefaultBranch,
 			RegisteredAt:  row.RegisteredAt,
 		})
 	}

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -743,6 +743,36 @@ func TestConcurrentSessionCreateAssignsUniqueNums(t *testing.T) {
 	}
 }
 
+func TestWorkspaceReposRoundTripDefaultBranch(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	project := domain.ProjectRecord{
+		ID:           "ws",
+		Path:         t.TempDir(),
+		DisplayName:  "ws",
+		RegisteredAt: time.Now(),
+		Kind:         domain.ProjectKindWorkspace,
+	}
+	want := domain.WorkspaceRepoRecord{
+		ProjectID:     "ws",
+		Name:          "api",
+		RelativePath:  "api",
+		RepoOriginURL: "https://github.com/acme/api.git",
+		DefaultBranch: "develop",
+		RegisteredAt:  time.Now(),
+	}
+	if err := s.UpsertWorkspaceProject(ctx, project, []domain.WorkspaceRepoRecord{want}); err != nil {
+		t.Fatalf("upsert workspace project: %v", err)
+	}
+	got, err := s.ListWorkspaceRepos(ctx, "ws")
+	if err != nil {
+		t.Fatalf("list workspace repos: %v", err)
+	}
+	if len(got) != 1 || got[0].DefaultBranch != "develop" {
+		t.Fatalf("workspace repos = %#v, want default branch develop", got)
+	}
+}
+
 func TestSessionWorktreesRoundTrip(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/docs/superpowers/plans/2026-07-02-workspace-child-default-branch.md
+++ b/docs/superpowers/plans/2026-07-02-workspace-child-default-branch.md
@@ -1,0 +1,275 @@
+# Workspace Child Default Branch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect, persist, and expose the default branch of every direct child repository registered in a workspace project.
+
+**Architecture:** Extend the existing `workspace_repos` relational record with a required `default_branch` column and carry it through domain, sqlc, store, service, API, and CLI DTO boundaries. Registration reuses `resolveDefaultBranch`, whose remote-first behavior prevents an active feature branch from being mistaken for the repository default.
+
+**Tech Stack:** Go 1.x, SQLite/goose migrations, sqlc, code-first OpenAPI generation, TypeScript generated API schema.
+
+---
+
+### Task 1: Persist workspace child default branches
+
+**Files:**
+- Create: `backend/internal/storage/sqlite/migrations/0022_workspace_repo_default_branch.sql`
+- Modify: `backend/internal/storage/sqlite/queries/workspace.sql`
+- Modify: `backend/internal/domain/project.go`
+- Modify: `backend/internal/storage/sqlite/store/project_store.go`
+- Test: `backend/internal/storage/sqlite/store/store_test.go`
+- Generate: `backend/internal/storage/sqlite/gen/models.go`
+- Generate: `backend/internal/storage/sqlite/gen/workspace.sql.go`
+
+- [ ] **Step 1: Write the failing storage round-trip test**
+
+Add a test that upserts a workspace project with one child and verifies the branch survives `ListWorkspaceRepos`:
+
+```go
+func TestWorkspaceReposRoundTripDefaultBranch(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	project := domain.ProjectRecord{
+		ID: "ws", Path: t.TempDir(), DisplayName: "ws",
+		RegisteredAt: time.Now(), Kind: domain.ProjectKindWorkspace,
+	}
+	want := domain.WorkspaceRepoRecord{
+		ProjectID: "ws", Name: "api", RelativePath: "api",
+		RepoOriginURL: "https://github.com/acme/api.git",
+		DefaultBranch: "develop", RegisteredAt: time.Now(),
+	}
+	if err := s.UpsertWorkspaceProject(ctx, project, []domain.WorkspaceRepoRecord{want}); err != nil {
+		t.Fatalf("upsert workspace project: %v", err)
+	}
+	got, err := s.ListWorkspaceRepos(ctx, "ws")
+	if err != nil {
+		t.Fatalf("list workspace repos: %v", err)
+	}
+	if len(got) != 1 || got[0].DefaultBranch != "develop" {
+		t.Fatalf("workspace repos = %#v, want default branch develop", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run: `cd backend && go test ./internal/storage/sqlite/store -run TestWorkspaceReposRoundTripDefaultBranch -count=1`
+
+Expected: compilation fails because `WorkspaceRepoRecord.DefaultBranch` does not exist.
+
+- [ ] **Step 3: Add the migration, domain field, and query columns**
+
+Create the additive migration:
+
+```sql
+-- +goose Up
+ALTER TABLE workspace_repos ADD COLUMN default_branch TEXT NOT NULL DEFAULT 'main';
+
+-- +goose Down
+ALTER TABLE workspace_repos DROP COLUMN default_branch;
+```
+
+Add to `WorkspaceRepoRecord`:
+
+```go
+DefaultBranch string
+```
+
+Update `UpsertWorkspaceRepo` to insert and update `default_branch`, and update `ListWorkspaceRepos` to select it:
+
+```sql
+INSERT INTO workspace_repos (project_id, name, relative_path, repo_origin_url, default_branch, registered_at)
+VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT (project_id, name) DO UPDATE SET
+    relative_path = excluded.relative_path,
+    repo_origin_url = excluded.repo_origin_url,
+    default_branch = excluded.default_branch,
+    registered_at = excluded.registered_at;
+
+SELECT project_id, name, relative_path, repo_origin_url, default_branch, registered_at
+FROM workspace_repos
+WHERE project_id = ?
+ORDER BY name;
+```
+
+- [ ] **Step 4: Regenerate sqlc and wire store mappings**
+
+Run: `npm run sqlc`
+
+Expected: exit 0; generated `WorkspaceRepo` and `UpsertWorkspaceRepoParams` include `DefaultBranch`.
+
+Pass `repo.DefaultBranch` into `gen.UpsertWorkspaceRepoParams`, and copy `row.DefaultBranch` into the returned `domain.WorkspaceRepoRecord`.
+
+- [ ] **Step 5: Run the storage test to verify GREEN**
+
+Run: `cd backend && go test ./internal/storage/sqlite/store -run TestWorkspaceReposRoundTripDefaultBranch -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the persistence slice**
+
+```bash
+git add backend/internal/domain/project.go backend/internal/storage/sqlite/migrations/0022_workspace_repo_default_branch.sql backend/internal/storage/sqlite/queries/workspace.sql backend/internal/storage/sqlite/gen backend/internal/storage/sqlite/store/project_store.go backend/internal/storage/sqlite/store/store_test.go
+git commit -m "feat: persist workspace repo default branches"
+```
+
+### Task 2: Detect child defaults during registration
+
+**Files:**
+- Modify: `backend/internal/service/project/workspace_registration.go`
+- Test: `backend/internal/service/project/service_test.go`
+
+- [ ] **Step 1: Write a failing remote-first registration test**
+
+Add a workspace test that creates a child repository on `develop`, creates `refs/remotes/origin/HEAD -> origin/develop`, checks out `feature`, registers the workspace, and asserts both Add and Get report `develop`:
+
+```go
+func TestManager_AddWorkspaceDetectsChildDefaultBranch(t *testing.T) {
+	configureCommitter(t)
+	ctx := context.Background()
+	m := newManager(t)
+	parent := t.TempDir()
+	child := gitRepoWithCommit(t, filepath.Join(parent, "api"))
+	for _, args := range [][]string{
+		{"branch", "-m", "develop"},
+		{"update-ref", "refs/remotes/origin/develop", "HEAD"},
+		{"symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop"},
+		{"switch", "-c", "feature"},
+	} {
+		if out, err := exec.Command("git", append([]string{"-C", child}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	proj, err := m.Add(ctx, project.AddInput{Path: parent, ProjectID: ptr("ws"), AsWorkspace: true})
+	if err != nil {
+		t.Fatalf("Add workspace: %v", err)
+	}
+	if len(proj.WorkspaceRepos) != 1 || proj.WorkspaceRepos[0].DefaultBranch != "develop" {
+		t.Fatalf("WorkspaceRepos = %#v, want child default develop", proj.WorkspaceRepos)
+	}
+	got, err := m.Get(ctx, "ws")
+	if err != nil || got.Project == nil || got.Project.WorkspaceRepos[0].DefaultBranch != "develop" {
+		t.Fatalf("Get workspace = %#v, err=%v", got, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run: `cd backend && go test ./internal/service/project -run TestManager_AddWorkspaceDetectsChildDefaultBranch -count=1`
+
+Expected: compilation fails because service `WorkspaceRepo.DefaultBranch` does not exist.
+
+- [ ] **Step 3: Add minimal detection and service mapping**
+
+Add the API-facing field:
+
+```go
+type WorkspaceRepo struct {
+	Name          string `json:"name"`
+	RelativePath  string `json:"relativePath"`
+	Repo          string `json:"repo"`
+	DefaultBranch string `json:"defaultBranch"`
+}
+```
+
+While constructing each child record, set:
+
+```go
+DefaultBranch: resolveDefaultBranch(child),
+```
+
+Map it in `workspaceReposFromRecords`:
+
+```go
+DefaultBranch: rec.DefaultBranch,
+```
+
+- [ ] **Step 4: Run project tests to verify GREEN**
+
+Run: `cd backend && go test ./internal/service/project -run 'TestManager_AddWorkspace' -count=1`
+
+Expected: PASS, including the remote-first regression test.
+
+- [ ] **Step 5: Commit the registration slice**
+
+```bash
+git add backend/internal/service/project/types.go backend/internal/service/project/workspace_registration.go backend/internal/service/project/service_test.go
+git commit -m "feat: detect workspace repo default branches"
+```
+
+### Task 3: Expose the field through generated and mirrored API contracts
+
+**Files:**
+- Modify: `backend/internal/cli/project.go`
+- Test: `backend/internal/httpd/controllers/projects_test.go`
+- Test: `backend/internal/cli/project_test.go`
+- Generate: `backend/internal/httpd/apispec/openapi.yaml`
+- Generate: `frontend/src/api/schema.ts`
+
+- [ ] **Step 1: Add failing HTTP and CLI decoding assertions**
+
+Extend the workspace project HTTP test's response DTO with:
+
+```go
+type workspaceRepoBody struct {
+	Name          string `json:"name"`
+	RelativePath  string `json:"relativePath"`
+	Repo          string `json:"repo"`
+	DefaultBranch string `json:"defaultBranch"`
+}
+```
+
+Decode `workspaceRepos` and assert the registered child returns `main`. Extend the nearest CLI project-detail JSON fixture with `"defaultBranch":"develop"`, add `DefaultBranch` to `workspaceRepoDetails`, and assert it decodes as `develop`.
+
+- [ ] **Step 2: Run contract tests to verify RED**
+
+Run: `cd backend && go test ./internal/httpd/controllers ./internal/cli -run 'Workspace|ProjectShow' -count=1`
+
+Expected: the CLI assertion fails because its mirrored DTO drops `defaultBranch`; API schema drift remains until regeneration.
+
+- [ ] **Step 3: Add the CLI mirrored DTO field**
+
+```go
+type workspaceRepoDetails struct {
+	Name          string `json:"name"`
+	RelativePath  string `json:"relativePath"`
+	Repo          string `json:"repo"`
+	DefaultBranch string `json:"defaultBranch"`
+}
+```
+
+Keep the existing human-readable project output stable; the field is available to JSON consumers and future lifecycle/UI code.
+
+- [ ] **Step 4: Regenerate API artifacts**
+
+Run: `npm run api`
+
+Expected: exit 0; `WorkspaceRepo.defaultBranch` appears as required in `openapi.yaml` and `frontend/src/api/schema.ts`.
+
+- [ ] **Step 5: Run targeted contract verification**
+
+Run: `cd backend && go test ./internal/httpd/... ./internal/cli ./internal/service/project ./internal/storage/sqlite/store -count=1`
+
+Expected: PASS.
+
+Run: `npm run frontend:typecheck`
+
+Expected: exit 0.
+
+- [ ] **Step 6: Run repository-level verification**
+
+Run: `npm run lint`
+
+Expected: backend tests pass and golangci-lint reports no findings.
+
+Run: `git diff --check`
+
+Expected: no output and exit 0.
+
+- [ ] **Step 7: Commit generated contracts and final tests**
+
+```bash
+git add backend/internal/cli/project.go backend/internal/cli/project_test.go backend/internal/httpd/controllers/projects_test.go backend/internal/httpd/apispec/openapi.yaml frontend/src/api/schema.ts
+git commit -m "feat: expose workspace repo default branches"
+```

--- a/docs/superpowers/specs/2026-07-02-workspace-child-default-branch-design.md
+++ b/docs/superpowers/specs/2026-07-02-workspace-child-default-branch-design.md
@@ -1,0 +1,36 @@
+# Workspace Child Default Branch Design
+
+## Scope
+
+Issue #2329 requires each direct child repository registered under a workspace project to retain its own default branch. This change detects that branch during workspace registration, persists it with the child repository record, and exposes it through the existing project-detail API and CLI DTOs.
+
+Child worktree materialization is not present on `main`. The later workspace lifecycle change will consume this persisted value when selecting each child worktree's base branch; this change does not introduce or alter lifecycle behavior.
+
+## Data model
+
+Add a non-null `default_branch` column to `workspace_repos` in a new SQLite migration. Existing rows receive `main`, matching the current system fallback and avoiding nullable handling. Add `DefaultBranch` to `domain.WorkspaceRepoRecord` and carry it through sqlc queries and store mappings.
+
+## Registration and reads
+
+When `detectWorkspaceChildren` accepts a child repository, it resolves the default branch with the existing `resolveDefaultBranch` helper. That helper prefers `origin/HEAD` and falls back to the checked-out branch, avoiding accidental persistence of a feature branch when remote default metadata is available.
+
+The child validation already rejects repositories whose branch cannot be identified. The detected branch is therefore stored as a non-empty value. `workspaceReposFromRecords` exposes it as `defaultBranch` in each workspace repository object. The CLI's mirrored response DTO carries the same field; current human-readable output remains unchanged unless an established nearby format makes displaying it necessary.
+
+## Generated contracts
+
+The service DTO is the code-first API source used by the controller schema generator. Regenerate and commit the OpenAPI document and frontend TypeScript schema after adding the field. Regenerate sqlc output from the migration and query changes; generated files are never edited manually.
+
+## Testing
+
+Use test-driven development for each behavior:
+
+- A workspace child whose remote default differs from its checked-out feature branch is registered with the remote default.
+- The workspace repository store round-trips `default_branch`.
+- Project detail serialization includes each child repository's `defaultBranch`.
+- Existing migration, project-service, controller, and CLI contract tests continue to pass.
+
+Run targeted tests first, then the relevant backend suite, API drift checks, and frontend typecheck required by the changed generated contract.
+
+## Compatibility and boundaries
+
+The migration is additive and does not modify merged migrations. Existing workspace rows default to `main`. No workspace import validation, SCM observation, session teardown, or worktree lifecycle behavior changes are included.

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -916,6 +916,7 @@ export interface components {
             reviews: components["schemas"]["PRReviewState"][];
         };
         WorkspaceRepo: {
+            defaultBranch: string;
             name: string;
             relativePath: string;
             repo: string;


### PR DESCRIPTION
 Closes #2329

  ## Summary

  - Detect each workspace child repository’s default branch during registration, preferring `origin/HEAD` over the checked-out branch.
  - Persist it in a new additive `workspace_repos.default_branch` migration.
  - Expose `defaultBranch` through the project API, CLI DTO, OpenAPI specification, and frontend types.
  - Add regression coverage for persistence, detection, and API/CLI responses.

  ## Scope

  Child worktree materialization is not present on `main`. This PR stores the branch metadata for that lifecycle path to consume later.

  Workspace import validation, SCM observation, and session cleanup behavior remain unchanged.

  ## Validation

  - `go test ./internal/httpd/controllers ./internal/httpd/apispec ./internal/httpd/apispec/specgen ./internal/cli ./internal/service/project ./
  internal/storage/sqlite/store -count=1`
  - `npm run frontend:typecheck`
  - `npm run api