### PR TITLE
ci(prettier): make Prettier workflow check-only (no auto-commit)

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,11 +1,10 @@
 name: Prettier
 
-# Auto-formats the codebase on every push and commits the result back.
-# Formatting is a CI concern — developers never need to run Prettier locally
-# and formatted output never shows up as local uncommitted changes.
-#
-# GitHub Actions does not re-trigger workflows on commits made with GITHUB_TOKEN,
-# so there is no feedback loop risk.
+# Check-only: reports formatting issues without modifying the branch.
+# The job fails (and annotates unformatted files) when `prettier --check`
+# finds files that are not formatted, but it never writes, commits, or
+# pushes anything back to the PR. Developers run `npx prettier@3 --write .`
+# locally to fix the reported files.
 
 on:
   push:
@@ -18,21 +17,9 @@ jobs:
   format:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Format with Prettier
-        run: npx --yes prettier@3 --write .
-
-      - name: Commit formatted files
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git diff --quiet && exit 0
-          git add -A
-          git commit -m "chore: format with prettier [skip ci]"
-          git push
+      - name: Check formatting with Prettier
+        run: npx --yes prettier@3 --check .


### PR DESCRIPTION
## What

Changes the Prettier CI workflow from **auto-formatting and pushing commits back** to the PR branch into a **check-only** job.

## Why

The previous `prettier.yml` ran `prettier --write .` and then committed and force-pushed the formatted result to the contributor's branch (using `contents: write` and `GITHUB_TOKEN`). That silently mutates PR contents. This flips it to report-only: it annotates and fails on unformatted files but never writes, commits, or pushes anything.

## Changes

- `prettier --write .` → `prettier --check .` (fails + annotates unformatted files, no modification).
- Removed the "Commit formatted files" step (git config / add / commit / push).
- Narrowed workflow `permissions` from `contents: write` to `contents: read`.
- Dropped the now-unneeded `ref`/`token` inputs on `actions/checkout`.
- Updated the header comment to describe the check-only behavior and how to fix locally (`npx prettier@3 --write .`).

Prettier itself and the formatting rules (`.prettierrc`) are unchanged. Only the write-back behavior is removed.

## Verification

- Workflow YAML validated with `js-yaml`.
- Confirmed `npx prettier@3 --check .` exits non-zero and lists unformatted files without modifying them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)