### PR TITLE
feat(updater): restart-to-update sidebar row with per-channel escalation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "agent-orchestrator",
-	"version": "0.10.0",
+	"version": "0.10.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "agent-orchestrator",
-			"version": "0.10.0",
+			"version": "0.10.3",
 			"license": "MIT",
 			"dependencies": {
 				"@radix-ui/react-dialog": "^1.1.16",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
 				"react": "^19.2.7",
 				"react-dom": "^19.2.7",
 				"react-resizable-panels": "^4.11.2",
+				"semver": "^7.8.5",
 				"tailwind-merge": "^3.6.0",
 				"zustand": "^5.0.14"
 			},
@@ -53,6 +54,7 @@
 				"@testing-library/user-event": "^14.6.1",
 				"@types/react": "^19.2.17",
 				"@types/react-dom": "^19.2.3",
+				"@types/semver": "^7.7.1",
 				"@vitejs/plugin-react": "^6.0.2",
 				"app-builder-lib": "^26.15.3",
 				"electron": "^33.0.0",
@@ -183,6 +185,16 @@
 				"url": "https://opencollective.com/babel"
 			}
 		},
+		"node_modules/@babel/core/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/@babel/generator": {
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
@@ -225,6 +237,16 @@
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
@@ -678,19 +700,6 @@
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/@electron-forge/cli/node_modules/semver": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@electron-forge/core": {
 			"version": "7.11.2",
 			"resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.11.2.tgz",
@@ -890,19 +899,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@electron-forge/core-utils/node_modules/semver": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			},
 			"engines": {
 				"node": ">=10"
@@ -1119,19 +1115,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@electron-forge/core/node_modules/semver": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			},
 			"engines": {
 				"node": ">=10"
@@ -1611,19 +1594,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@electron-forge/shared-types/node_modules/semver": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@electron-forge/shared-types/node_modules/tar": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -1698,19 +1668,6 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/@electron-forge/template-base/node_modules/semver": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@electron-forge/template-base/node_modules/universalify": {
@@ -2089,6 +2046,16 @@
 				"global-agent": "^3.0.0"
 			}
 		},
+		"node_modules/@electron/get/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/@electron/node-gyp": {
 			"version": "10.2.0-electron.1",
 			"resolved": "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
@@ -2263,19 +2230,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
-		"node_modules/@electron/node-gyp/node_modules/semver": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@electron/node-gyp/node_modules/tar": {
@@ -2595,19 +2549,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/jet2jet"
-			}
-		},
-		"node_modules/@electron/packager/node_modules/semver": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@electron/rebuild": {
@@ -3401,19 +3342,6 @@
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
-		"node_modules/@npmcli/fs/node_modules/semver": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@npmcli/move-file": {
@@ -6605,6 +6533,13 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/semver": {
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -9045,19 +8980,6 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
-		"node_modules/electron-installer-common/node_modules/semver": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-			"license": "ISC",
-			"optional": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/electron-installer-common/node_modules/universalify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -10547,20 +10469,6 @@
 			},
 			"engines": {
 				"node": ">=10.0"
-			}
-		},
-		"node_modules/global-agent/node_modules/semver": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/global-dirs": {
@@ -12515,19 +12423,6 @@
 				"node": ">=22.12.0"
 			}
 		},
-		"node_modules/node-abi/node_modules/semver": {
-			"version": "7.8.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/node-api-version": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
@@ -12536,19 +12431,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
-			}
-		},
-		"node_modules/node-api-version/node_modules/semver": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-			"integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/node-fetch": {
@@ -12630,19 +12512,6 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=20"
-			}
-		},
-		"node_modules/node-gyp/node_modules/semver": {
-			"version": "7.8.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/node-gyp/node_modules/undici": {
@@ -14197,13 +14066,15 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/semver-compare": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
 		"@testing-library/user-event": "^14.6.1",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
+		"@types/semver": "^7.7.1",
 		"@vitejs/plugin-react": "^6.0.2",
 		"app-builder-lib": "^26.15.3",
 		"electron": "^33.0.0",
@@ -79,6 +80,7 @@
 		"react": "^19.2.7",
 		"react-dom": "^19.2.7",
 		"react-resizable-panels": "^4.11.2",
+		"semver": "^7.8.5",
 		"tailwind-merge": "^3.6.0",
 		"zustand": "^5.0.14"
 	},

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -35,6 +35,7 @@ let eventsWired = false;
 // captured from whichever entry point wired the events (both receive it).
 let stagedVersion: string | undefined;
 let stagedAtMs: number | undefined;
+let stagedEscalated = false;
 let escalationTimer: ReturnType<typeof setInterval> | undefined;
 let escalationStateDir: string | undefined;
 
@@ -96,28 +97,42 @@ async function fetchNightlyImportant(owner: string, repo: string, version: strin
 	}
 }
 
+// stagedDownloadedStatus rebuilds the enriched downloaded status from module
+// state, so transient check states can restore the row without recomputing.
+function stagedDownloadedStatus(): UpdateStatus {
+	return { state: "downloaded", version: stagedVersion, stagedAt: stagedAtMs, escalated: stagedEscalated };
+}
+
 // runEscalationCheck re-reads settings and feeds, then rebroadcasts the
-// downloaded status with a fresh escalated flag. It only runs while the last
-// status is still "downloaded" (clears the timer otherwise) and never
-// broadcasts an error state: every failure degrades to escalated staying put.
+// downloaded status with a fresh escalated flag. The timer is keyed on a build
+// being staged (stagedAtMs set), NOT on lastStatus: a manual re-check flips
+// lastStatus through checking/available while the build stays staged, and that
+// must not kill the loop. Never broadcasts an error state: every failure
+// degrades to escalated staying put.
 async function runEscalationCheck(): Promise<void> {
-	if (stagedVersion === undefined || stagedAtMs === undefined || escalationStateDir === undefined) return;
-	if (lastStatus.state !== "downloaded") {
+	if (stagedAtMs === undefined) {
 		stopEscalationTimer();
 		return;
 	}
+	if (escalationStateDir === undefined) return;
+	// A newer build is being pulled; let its progress own the status stream.
+	if (lastStatus.state === "downloading") return;
 	try {
 		const settings = await readUpdateSettings(escalationStateDir);
 		let important = false;
 		let latestStableVersion: string | undefined;
 		const coords = await readAppUpdateYml();
 		if (coords && settings.channel === "nightly") {
+			// stagedVersion is only needed by the important-flag fetch; the
+			// latest-channel 48h rule (and the behind-stable check) work without it.
 			[latestStableVersion, important] = await Promise.all([
 				fetchLatestStableVersion(coords.owner, coords.repo),
-				fetchNightlyImportant(coords.owner, coords.repo, stagedVersion),
+				stagedVersion !== undefined
+					? fetchNightlyImportant(coords.owner, coords.repo, stagedVersion)
+					: Promise.resolve(false),
 			]);
 		}
-		const escalated = evaluateEscalation({
+		stagedEscalated = evaluateEscalation({
 			channel: settings.channel,
 			stagedAt: stagedAtMs,
 			now: Date.now(),
@@ -125,7 +140,7 @@ async function runEscalationCheck(): Promise<void> {
 			runningVersion: app.getVersion(),
 			latestStableVersion,
 		});
-		broadcast({ state: "downloaded", version: stagedVersion, stagedAt: stagedAtMs, escalated });
+		broadcast(stagedDownloadedStatus());
 	} catch (err) {
 		console.debug("escalation check skipped:", err);
 	}
@@ -144,16 +159,34 @@ function stopEscalationTimer(): void {
 function wireUpdaterEvents(): void {
 	if (eventsWired) return;
 	eventsWired = true;
+	// With a build staged, "checking" briefly hides the sidebar restart row; that
+	// is acceptable and self-healing: the available / not-available handlers below
+	// restore the enriched downloaded status right after.
 	autoUpdater.on("checking-for-update", () => broadcast({ state: "checking" }));
-	autoUpdater.on("update-available", (info) => broadcast({ state: "available", version: info?.version }));
-	autoUpdater.on("update-not-available", () => broadcast({ state: "not-available" }));
+	autoUpdater.on("update-available", (info) => {
+		// A manual re-check reports the already-staged build as merely "available"
+		// (autoDownload is off on that path). It is still in cache and installs on
+		// quit, so keep the richer downloaded status instead of hiding the row.
+		if (stagedAtMs !== undefined && info?.version === stagedVersion) {
+			broadcast(stagedDownloadedStatus());
+			return;
+		}
+		broadcast({ state: "available", version: info?.version });
+	});
+	autoUpdater.on("update-not-available", () => {
+		broadcast({ state: "not-available" });
+		// The staged build outlives a "nothing newer" answer (e.g. after a channel
+		// switch); follow up so the restart row returns.
+		if (stagedAtMs !== undefined) broadcast(stagedDownloadedStatus());
+	});
 	autoUpdater.on("download-progress", (p) =>
 		broadcast({ state: "downloading", percent: Math.max(0, Math.min(100, Math.round(p?.percent ?? 0))) }),
 	);
 	autoUpdater.on("update-downloaded", (info) => {
 		stagedVersion = info?.version;
 		stagedAtMs = Date.now();
-		broadcast({ state: "downloaded", version: stagedVersion, stagedAt: stagedAtMs, escalated: false });
+		stagedEscalated = false;
+		broadcast(stagedDownloadedStatus());
 		// Evaluate now (nightly can escalate immediately), then every 30 minutes
 		// while the update sits uninstalled. unref so the timer never holds the
 		// process open on quit.

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -1,6 +1,7 @@
 import { autoUpdater } from "electron-updater";
 import { app, BrowserWindow, dialog } from "electron";
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import {
 	readUpdateSettings,
@@ -9,6 +10,7 @@ import {
 	type UpdateChannel,
 	type UpdateStatus,
 } from "./update-settings";
+import { evaluateEscalation } from "./escalation-evaluator";
 
 // configureFeed sets the update channel on electron-updater. The repo/owner
 // are loaded automatically from app-update.yml (written by forge.config.ts's
@@ -28,12 +30,111 @@ function configureFeed(channel: UpdateChannel): void {
 let lastStatus: UpdateStatus = { state: "idle" };
 let eventsWired = false;
 
+// Staged-update tracking for the escalation evaluator: set on update-downloaded,
+// re-evaluated every 30 minutes while the update sits uninstalled. stateDir is
+// captured from whichever entry point wired the events (both receive it).
+let stagedVersion: string | undefined;
+let stagedAtMs: number | undefined;
+let escalationTimer: ReturnType<typeof setInterval> | undefined;
+let escalationStateDir: string | undefined;
+
 // broadcast pushes the latest update status to every renderer window so the
 // Global Settings Updates section can reflect check/download progress live.
 function broadcast(status: UpdateStatus): void {
 	lastStatus = status;
 	for (const win of BrowserWindow.getAllWindows()) {
 		if (!win.isDestroyed()) win.webContents.send("updates:status", status);
+	}
+}
+
+// --- Read-only release-feed helpers (packaged app only; every failure is silent).
+// These regex-parse flat keys out of electron-builder yml files on purpose: no
+// yaml dependency, and a parse miss just means "no info", never an error state
+// (see issue #2270 for why this path must not broadcast errors).
+
+/** Owner/repo from the bundled app-update.yml; undefined in dev or on any failure. */
+async function readAppUpdateYml(): Promise<{ owner: string; repo: string } | undefined> {
+	if (!app.isPackaged) return undefined;
+	try {
+		const yml = await readFile(path.join(process.resourcesPath, "app-update.yml"), "utf8");
+		const owner = /^owner:\s*(.+)$/m.exec(yml)?.[1]?.trim();
+		const repo = /^repo:\s*(.+)$/m.exec(yml)?.[1]?.trim();
+		return owner && repo ? { owner, repo } : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Platform suffix matching the feed.mjs naming convention. */
+function platformSuffix(): string {
+	if (process.platform === "darwin") return "-mac";
+	if (process.platform === "linux") return "-linux";
+	return "";
+}
+
+/** Latest stable version via GitHub's /releases/latest redirect; undefined on any failure. */
+async function fetchLatestStableVersion(owner: string, repo: string): Promise<string | undefined> {
+	const url = `https://github.com/${owner}/${repo}/releases/latest/download/latest${platformSuffix()}.yml`;
+	try {
+		const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
+		if (!res.ok) return undefined;
+		return /^version:\s*(.+)$/m.exec(await res.text())?.[1]?.trim() || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** important flag on the staged nightly's release yml; false when absent, 404, or any failure. */
+async function fetchNightlyImportant(owner: string, repo: string, version: string): Promise<boolean> {
+	const url = `https://github.com/${owner}/${repo}/releases/download/v${version}/nightly${platformSuffix()}.yml`;
+	try {
+		const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
+		if (!res.ok) return false;
+		return /^important:\s*true\s*$/m.test(await res.text());
+	} catch {
+		return false;
+	}
+}
+
+// runEscalationCheck re-reads settings and feeds, then rebroadcasts the
+// downloaded status with a fresh escalated flag. It only runs while the last
+// status is still "downloaded" (clears the timer otherwise) and never
+// broadcasts an error state: every failure degrades to escalated staying put.
+async function runEscalationCheck(): Promise<void> {
+	if (stagedVersion === undefined || stagedAtMs === undefined || escalationStateDir === undefined) return;
+	if (lastStatus.state !== "downloaded") {
+		stopEscalationTimer();
+		return;
+	}
+	try {
+		const settings = await readUpdateSettings(escalationStateDir);
+		let important = false;
+		let latestStableVersion: string | undefined;
+		const coords = await readAppUpdateYml();
+		if (coords && settings.channel === "nightly") {
+			[latestStableVersion, important] = await Promise.all([
+				fetchLatestStableVersion(coords.owner, coords.repo),
+				fetchNightlyImportant(coords.owner, coords.repo, stagedVersion),
+			]);
+		}
+		const escalated = evaluateEscalation({
+			channel: settings.channel,
+			stagedAt: stagedAtMs,
+			now: Date.now(),
+			important,
+			runningVersion: app.getVersion(),
+			latestStableVersion,
+		});
+		broadcast({ state: "downloaded", version: stagedVersion, stagedAt: stagedAtMs, escalated });
+	} catch (err) {
+		console.debug("escalation check skipped:", err);
+	}
+}
+
+function stopEscalationTimer(): void {
+	if (escalationTimer !== undefined) {
+		clearInterval(escalationTimer);
+		escalationTimer = undefined;
 	}
 }
 
@@ -49,7 +150,18 @@ function wireUpdaterEvents(): void {
 	autoUpdater.on("download-progress", (p) =>
 		broadcast({ state: "downloading", percent: Math.max(0, Math.min(100, Math.round(p?.percent ?? 0))) }),
 	);
-	autoUpdater.on("update-downloaded", (info) => broadcast({ state: "downloaded", version: info?.version }));
+	autoUpdater.on("update-downloaded", (info) => {
+		stagedVersion = info?.version;
+		stagedAtMs = Date.now();
+		broadcast({ state: "downloaded", version: stagedVersion, stagedAt: stagedAtMs, escalated: false });
+		// Evaluate now (nightly can escalate immediately), then every 30 minutes
+		// while the update sits uninstalled. unref so the timer never holds the
+		// process open on quit.
+		void runEscalationCheck();
+		stopEscalationTimer();
+		escalationTimer = setInterval(() => void runEscalationCheck(), 30 * 60 * 1000);
+		escalationTimer.unref?.();
+	});
 	autoUpdater.on("error", (err) => {
 		// Never crash on update failure (offline, unsigned macOS, etc.).
 		broadcast({ state: "error", message: err?.message ?? String(err) });
@@ -67,6 +179,7 @@ export async function startAutoUpdates(stateDir: string): Promise<void> {
 	const settings = await readUpdateSettings(stateDir);
 	if (!settings.enabled) return;
 
+	escalationStateDir = stateDir;
 	wireUpdaterEvents();
 	configureFeed(settings.channel);
 	autoUpdater.autoDownload = true;
@@ -85,6 +198,7 @@ export async function startAutoUpdates(stateDir: string): Promise<void> {
 // reports progress via the broadcast status. Updates only work in the packaged,
 // signed app; in dev electron-updater has no feed, so surface that plainly.
 export async function checkForUpdatesNow(stateDir: string): Promise<void> {
+	escalationStateDir = stateDir;
 	wireUpdaterEvents();
 	if (!app.isPackaged) {
 		broadcast({ state: "unsupported", message: "Updates are only available in the installed app." });

--- a/frontend/src/main/escalation-evaluator.test.ts
+++ b/frontend/src/main/escalation-evaluator.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { evaluateEscalation } from "./escalation-evaluator";
+
+const H48 = 48 * 60 * 60 * 1000;
+const now = Date.now();
+
+describe("evaluateEscalation - latest channel", () => {
+	it("not escalated under 48h", () => {
+		expect(
+			evaluateEscalation({
+				channel: "latest",
+				stagedAt: now - H48 + 1000,
+				now,
+				important: false,
+				runningVersion: "0.10.4",
+				latestStableVersion: "0.10.5",
+			}),
+		).toBe(false);
+	});
+
+	it("escalated at exactly 48h", () => {
+		expect(
+			evaluateEscalation({
+				channel: "latest",
+				stagedAt: now - H48,
+				now,
+				important: false,
+				runningVersion: "0.10.4",
+				latestStableVersion: "0.10.5",
+			}),
+		).toBe(true);
+	});
+
+	it("escalated over 48h even without stable version info", () => {
+		expect(
+			evaluateEscalation({
+				channel: "latest",
+				stagedAt: now - H48 - 1,
+				now,
+				important: false,
+				runningVersion: "0.10.4",
+				latestStableVersion: undefined,
+			}),
+		).toBe(true);
+	});
+});
+
+describe("evaluateEscalation - nightly channel", () => {
+	it("escalated when the important flag is set", () => {
+		expect(
+			evaluateEscalation({
+				channel: "nightly",
+				stagedAt: now,
+				now,
+				important: true,
+				runningVersion: "0.10.4-nightly.202607031330",
+				latestStableVersion: undefined,
+			}),
+		).toBe(true);
+	});
+
+	it("escalated when running nightly is behind stable of the same base", () => {
+		// 0.10.4-nightly.x is a pre-release of 0.10.4, so it is behind stable 0.10.4.
+		expect(
+			evaluateEscalation({
+				channel: "nightly",
+				stagedAt: now,
+				now,
+				important: false,
+				runningVersion: "0.10.4-nightly.202607031330",
+				latestStableVersion: "0.10.4",
+			}),
+		).toBe(true);
+	});
+
+	it("not escalated when nightly is ahead of stable", () => {
+		expect(
+			evaluateEscalation({
+				channel: "nightly",
+				stagedAt: now,
+				now,
+				important: false,
+				runningVersion: "0.10.4-nightly.202607031330",
+				latestStableVersion: "0.10.3",
+			}),
+		).toBe(false);
+	});
+
+	it("not escalated when stable version info is missing", () => {
+		expect(
+			evaluateEscalation({
+				channel: "nightly",
+				stagedAt: now - H48 * 10,
+				now,
+				important: false,
+				runningVersion: "0.10.4-nightly.202607031330",
+				latestStableVersion: undefined,
+			}),
+		).toBe(false);
+	});
+
+	it("not escalated on unparseable version strings", () => {
+		expect(
+			evaluateEscalation({
+				channel: "nightly",
+				stagedAt: now,
+				now,
+				important: false,
+				runningVersion: "not-a-version",
+				latestStableVersion: "0.10.4",
+			}),
+		).toBe(false);
+	});
+});

--- a/frontend/src/main/escalation-evaluator.ts
+++ b/frontend/src/main/escalation-evaluator.ts
@@ -1,0 +1,44 @@
+import semver from "semver";
+import type { UpdateChannel } from "./update-settings";
+
+const H48 = 48 * 60 * 60 * 1000;
+
+/**
+ * Pure escalation decision. Returns true when the user should be nudged harder
+ * to restart and install a downloaded update.
+ *
+ * latest channel: escalated after 48 hours of sitting staged.
+ * nightly channel: escalated when the feed marks the staged build important, OR
+ *   when the running version is behind the latest stable release (time to jump
+ *   to stable). The semver term is skipped when latestStableVersion could not
+ *   be fetched.
+ */
+export function evaluateEscalation(opts: {
+	channel: UpdateChannel;
+	stagedAt: number;
+	now: number;
+	important: boolean;
+	runningVersion: string;
+	latestStableVersion: string | undefined;
+}): boolean {
+	const { channel, stagedAt, now, important, runningVersion, latestStableVersion } = opts;
+
+	if (channel === "latest") {
+		return now - stagedAt >= H48;
+	}
+
+	// nightly channel
+	if (important) return true;
+	if (latestStableVersion !== undefined) {
+		// semver.lt handles pre-release comparisons correctly:
+		// "0.10.4-nightly.202607031330" < "0.10.4" (pre-release < release),
+		// but not < "0.10.3" (major.minor.patch is higher).
+		try {
+			return semver.lt(runningVersion, latestStableVersion);
+		} catch {
+			// Unparseable version strings: do not escalate.
+			return false;
+		}
+	}
+	return false;
+}

--- a/frontend/src/main/update-settings.ts
+++ b/frontend/src/main/update-settings.ts
@@ -19,6 +19,11 @@ export interface UpdateStatus {
 	version?: string;
 	percent?: number;
 	message?: string;
+	// Present only when state === "downloaded".
+	// stagedAt: epoch ms when the update finished downloading.
+	// escalated: true when per-channel rules say the user should be nudged harder.
+	stagedAt?: number;
+	escalated?: boolean;
 }
 
 /** File holding the user's auto-update preferences under the ~/.ao state dir. */

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -7,11 +7,12 @@ import { Sidebar } from "./Sidebar";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { agentsQueryKey } from "../hooks/useAgentsQuery";
 
-const { getMock, navigateMock, mockParams, renameSessionMock } = vi.hoisted(() => ({
+const { getMock, navigateMock, mockParams, renameSessionMock, updateStatusMock } = vi.hoisted(() => ({
 	getMock: vi.fn(),
 	navigateMock: vi.fn(),
 	mockParams: { projectId: undefined as string | undefined },
 	renameSessionMock: vi.fn().mockResolvedValue(undefined),
+	updateStatusMock: vi.fn(),
 }));
 
 vi.mock("../lib/rename-session", () => ({ renameSession: renameSessionMock }));
@@ -24,6 +25,16 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 		useParams: () => ({}),
 		useRouterState: ({ select }: { select: (state: { location: { pathname: string } }) => unknown }) =>
 			select({ location: { pathname: "/" } }),
+	};
+});
+
+vi.mock("../lib/bridge", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/bridge")>();
+	return {
+		aoBridge: {
+			...actual.aoBridge,
+			updates: { ...actual.aoBridge.updates, getStatus: updateStatusMock },
+		},
 	};
 });
 
@@ -183,6 +194,7 @@ beforeEach(() => {
 	});
 	navigateMock.mockReset();
 	renameSessionMock.mockReset().mockResolvedValue(undefined);
+	updateStatusMock.mockReset().mockResolvedValue({ state: "idle" });
 	mockParams.projectId = undefined;
 });
 
@@ -859,5 +871,31 @@ describe("Sidebar", () => {
 
 		const workingDot = screen.getByLabelText("Open working task").querySelector('span[aria-hidden="true"]');
 		expect(workingDot).toHaveClass("animate-status-pulse", "bg-working");
+	});
+
+	it("does not render the restart-to-update row unless an update is downloaded", async () => {
+		updateStatusMock.mockResolvedValue({ state: "available", version: "9.9.9" });
+		renderSidebar();
+
+		await waitFor(() => expect(updateStatusMock).toHaveBeenCalled());
+		expect(screen.queryByLabelText(/Restart to install update/)).not.toBeInTheDocument();
+	});
+
+	it("renders the restart-to-update row with the working-orange treatment when escalated", async () => {
+		updateStatusMock.mockResolvedValue({
+			state: "downloaded",
+			version: "9.9.9",
+			stagedAt: Date.now(),
+			escalated: true,
+		});
+		renderSidebar();
+
+		// Both footer variants (expanded row and collapsed rail icon) are mounted.
+		const buttons = await screen.findAllByLabelText("Restart to install update v9.9.9");
+		expect(buttons.length).toBeGreaterThan(0);
+		for (const button of buttons) {
+			expect(button).toHaveClass("text-working", "bg-working/12");
+		}
+		expect(screen.getByText("v9.9.9 ready")).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -32,6 +32,7 @@ import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { renameSession } from "../lib/rename-session";
 import { useEventsConnection } from "../hooks/useEventsConnection";
 import { useResizable } from "../hooks/useResizable";
+import { useUpdateStatus } from "../hooks/useUpdateStatus";
 import { ConnectMobileModal } from "./ConnectMobileModal";
 import {
 	DropdownMenu,
@@ -826,26 +827,6 @@ function SessionRow({ session, active, onOpen }: { session: WorkspaceSession; ac
 			</button>
 		</SidebarMenuSubItem>
 	);
-}
-
-// Live update status for the footer's restart prompt: seeded from getStatus,
-// then streamed via updates:status (same idiom as UpdatesSection). Subscribed
-// once in Sidebar and passed down so the row and rail variants share one IPC
-// subscription.
-function useUpdateStatus(): UpdateStatus {
-	const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
-	useEffect(() => {
-		let live = true;
-		void aoBridge.updates.getStatus().then((s) => {
-			if (live) setStatus(s);
-		});
-		const off = aoBridge.updates.onStatus(setStatus);
-		return () => {
-			live = false;
-			off?.();
-		};
-	}, []);
-	return status;
 }
 
 // RestartToUpdateRow sits directly above the Settings row when an update is

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
 	MoreVertical,
 	Pencil,
 	Plus,
+	RefreshCw,
 	Search,
 	Settings,
 	Smartphone,
@@ -16,6 +17,7 @@ import {
 	Trash2,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import type { UpdateStatus } from "../../main/update-settings";
 import {
 	attentionZone,
 	newestActiveOrchestrator,
@@ -158,6 +160,8 @@ export function Sidebar({
 	const theme = useUiStore((s) => s.theme);
 	const toggleTheme = useUiStore((s) => s.toggleTheme);
 	const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
+	// One IPC subscription for both footer variants of the restart-to-update prompt.
+	const updateStatus = useUpdateStatus();
 
 	useEffect(() => {
 		if (isCollapsed) {
@@ -346,6 +350,7 @@ export function Sidebar({
 						<MessageSquare aria-hidden="true" />
 						<span className="tracking-tight">Feedback</span>
 					</button>
+					<RestartToUpdateRow status={updateStatus} />
 					<DropdownMenu>
 						<DropdownMenuTrigger asChild>
 							<button
@@ -402,6 +407,7 @@ export function Sidebar({
 					</Tooltip>
 				</div>
 				<div className="pointer-events-none absolute inset-x-1.5 top-[7px] flex min-h-[74px] flex-col items-center justify-center gap-1 opacity-0 transition-opacity duration-150 ease-out group-data-[collapsible=icon]:pointer-events-auto group-data-[collapsible=icon]:opacity-100">
+					<RestartToUpdateRailButton status={updateStatus} />
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<button
@@ -819,6 +825,92 @@ function SessionRow({ session, active, onOpen }: { session: WorkspaceSession; ac
 				<Pencil aria-hidden="true" />
 			</button>
 		</SidebarMenuSubItem>
+	);
+}
+
+// Live update status for the footer's restart prompt: seeded from getStatus,
+// then streamed via updates:status (same idiom as UpdatesSection). Subscribed
+// once in Sidebar and passed down so the row and rail variants share one IPC
+// subscription.
+function useUpdateStatus(): UpdateStatus {
+	const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
+	useEffect(() => {
+		let live = true;
+		void aoBridge.updates.getStatus().then((s) => {
+			if (live) setStatus(s);
+		});
+		const off = aoBridge.updates.onStatus(setStatus);
+		return () => {
+			live = false;
+			off?.();
+		};
+	}, []);
+	return status;
+}
+
+// RestartToUpdateRow sits directly above the Settings row when an update is
+// downloaded and staged. Transparent while fresh; orange (working tokens) once
+// the main-process evaluator flags it escalated. Clicking installs immediately;
+// the row itself is the prompt, so no confirmation dialog. Renders nothing in
+// every other update state.
+function RestartToUpdateRow({ status }: { status: UpdateStatus }) {
+	if (status.state !== "downloaded") return null;
+	const escalated = status.escalated === true;
+	return (
+		<button
+			aria-label={`Restart to install update${status.version ? ` v${status.version}` : ""}`}
+			className={cn(
+				"flex w-full items-center gap-2.5 rounded-md p-2 text-left text-control font-medium transition-colors",
+				escalated
+					? "border border-working/35 bg-working/12 text-working hover:bg-working/18 [&_svg]:text-working"
+					: "text-passive hover:bg-interactive-hover hover:text-foreground [&_svg]:text-passive",
+			)}
+			onClick={() => void aoBridge.updates.install()}
+			type="button"
+		>
+			<RefreshCw aria-hidden="true" className="size-icon-lg shrink-0" />
+			<span className="min-w-0 flex-1">
+				<span className="block truncate tracking-tight">Restart to update</span>
+				{status.version && (
+					<span className={cn("block truncate text-caption font-normal", escalated ? "text-working" : "text-passive")}>
+						v{status.version} ready
+					</span>
+				)}
+			</span>
+			<span
+				aria-hidden="true"
+				className={cn("h-1.5 w-1.5 shrink-0 rounded-full", escalated ? "bg-working" : "bg-passive")}
+			/>
+		</button>
+	);
+}
+
+// Icon-rail variant of RestartToUpdateRow for the collapsed sidebar: icon-only
+// with the two-line copy in the tooltip.
+function RestartToUpdateRailButton({ status }: { status: UpdateStatus }) {
+	if (status.state !== "downloaded") return null;
+	const escalated = status.escalated === true;
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					aria-label={`Restart to install update${status.version ? ` v${status.version}` : ""}`}
+					className={cn(
+						"grid size-9 place-items-center rounded-lg transition-colors [&_svg]:size-4",
+						escalated
+							? "bg-working/12 text-working hover:bg-working/18"
+							: "text-passive hover:bg-interactive-hover hover:text-foreground",
+					)}
+					onClick={() => void aoBridge.updates.install()}
+					type="button"
+				>
+					<RefreshCw aria-hidden="true" />
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="right">
+				Restart to update{status.version ? ` · v${status.version} ready` : ""}
+			</TooltipContent>
+		</Tooltip>
 	);
 }
 

--- a/frontend/src/renderer/components/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/UpdatesSection.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { aoBridge } from "../lib/bridge";
+import { useUpdateStatus } from "../hooks/useUpdateStatus";
 import type { UpdateChannel, UpdateSettings, UpdateStatus } from "../../main/update-settings";
 import { Button } from "./ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
@@ -116,20 +117,8 @@ export function UpdatesSection() {
 // an Update button that downloads then installs. It works even when automatic
 // updates are off, so users who never opted in can still pull the latest build.
 function UpdateActions() {
-	const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
+	const status = useUpdateStatus();
 	const version = useQuery({ queryKey: ["app-version"], queryFn: () => aoBridge.app.getVersion() });
-
-	useEffect(() => {
-		let live = true;
-		void aoBridge.updates.getStatus().then((s) => {
-			if (live) setStatus(s);
-		});
-		const off = aoBridge.updates.onStatus(setStatus);
-		return () => {
-			live = false;
-			off?.();
-		};
-	}, []);
 
 	const checking = status.state === "checking";
 	const downloading = status.state === "downloading";

--- a/frontend/src/renderer/hooks/useUpdateStatus.ts
+++ b/frontend/src/renderer/hooks/useUpdateStatus.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+import type { UpdateStatus } from "../../main/update-settings";
+import { aoBridge } from "../lib/bridge";
+
+/**
+ * Live desktop update status: seeded from updates.getStatus, then streamed via
+ * the updates:status push channel. Used by the sidebar restart-to-update row
+ * and the Global Settings Updates section.
+ */
+export function useUpdateStatus(): UpdateStatus {
+	const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
+	useEffect(() => {
+		let live = true;
+		void aoBridge.updates.getStatus().then((s) => {
+			if (live) setStatus(s);
+		});
+		const off = aoBridge.updates.onStatus(setStatus);
+		return () => {
+			live = false;
+			off?.();
+		};
+	}, []);
+	return status;
+}


### PR DESCRIPTION
## What

Implements T2 and T3 of the staged-update escalation work:

- Extends `UpdateStatus` with optional `stagedAt` (epoch ms) and `escalated` fields, present on the `downloaded` state.
- Adds a pure `evaluateEscalation()` function (`frontend/src/main/escalation-evaluator.ts`) with 8 unit tests.
- Wires a 30-minute unref'd `setInterval` in `auto-updater.ts` that re-evaluates escalation after each `update-downloaded` and rebroadcasts the status.
- Adds a "Restart to update" row in the sidebar footer, directly above Settings, in both expanded and collapsed (icon rail) variants. Clicking calls `updates.install()`; no confirmation dialog, the row itself is the prompt. Zero footprint unless an update is downloaded.

## Escalation rules

| Channel | Escalates when |
|---|---|
| latest | `now - stagedAt >= 48h` |
| nightly | feed `important: true` on the staged release yml, OR `semver.lt(runningVersion, latestStableVersion)` (skipped if stable version could not be fetched) |

Feed data comes from read-only fetches of the GitHub release yml files (owner/repo regex-parsed from the bundled `app-update.yml`, platform suffix per the feed.mjs convention, 10s abort timeout). Every failure is silent: this path never broadcasts an error state (see #2270) and dev builds skip it entirely, so `escalated` stays false outside the packaged app. No yaml dependency; regex on flat keys is deliberate.

## UI

- Fresh: transparent row inheriting the sidebar background, passive label plus small neutral dot, Settings-row hover treatment.
- Escalated: orange text and dot reusing the `--orange` / `bg-working` tokens, with a subtle `color-mix` orange fill and border matching the existing styles.css idiom.
- Collapsed rail: icon-only RefreshCw button with both lines in the tooltip.

## Verification

- `npm run typecheck`: clean.
- Full vite builds of all three bundles (`vite.main.config.ts`, `vite.preload.config.ts`, `vite.renderer.config.ts`, there is no aggregate `build` script in frontend/package.json): all exit 0.
- `npm test`: 383/383 tests pass across 41 files, including the 8 new escalation-evaluator tests (stable under/at/over 48h, nightly important, nightly behind stable 0.10.4 vs ahead of 0.10.3, missing stable info, unparseable versions).

## Notes

- The `important` feed key ships separately (publish side is a sibling PR); until then the key is absent from nightly release ymls and reads as false, so nightly escalation relies only on the behind-stable semver check.
- New direct dependency: `semver` (plus `@types/semver` dev). It was previously only transitive.

Part of #2377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)