### PR TITLE
fix(frontend): show session display name in terminal toolbar header

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { WorkspaceSession } from "../types/workspace";
+import { CenterPane } from "./CenterPane";
+
+// The terminal body pulls in xterm/SSE machinery irrelevant to the toolbar under test.
+vi.mock("./TerminalPane", () => ({ TerminalPane: () => <div>terminal body</div> }));
+
+const worker = {
+	id: "sess-1",
+	workspaceId: "proj-1",
+	workspaceName: "my-app",
+	title: "do the thing",
+	provider: "claude-code",
+	kind: "worker",
+	branch: "ao/sess-1",
+	status: "working",
+	updatedAt: "2026-06-10T00:00:00Z",
+	prs: [],
+} satisfies WorkspaceSession;
+
+describe("CenterPane toolbar session label", () => {
+	it("shows the session display name for a worker", () => {
+		render(<CenterPane session={worker} theme="dark" daemonReady />);
+		expect(screen.getByText("do the thing")).toBeInTheDocument();
+		expect(screen.queryByText("sess-1")).not.toBeInTheDocument();
+	});
+
+	it("shows 'Orchestrator' for an orchestrator session", () => {
+		render(<CenterPane session={{ ...worker, id: "sess-orch", kind: "orchestrator" }} theme="dark" daemonReady />);
+		expect(screen.getByText("Orchestrator")).toBeInTheDocument();
+	});
+
+	it("shows 'No session' when there is no session", () => {
+		render(<CenterPane theme="dark" daemonReady />);
+		expect(screen.getByText("No session")).toBeInTheDocument();
+	});
+});

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -2,7 +2,7 @@ import { ChevronLeft, Maximize2, Minimize2, Shield } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type WheelEvent } from "react";
 import type { Theme } from "../stores/ui-store";
 import type { TerminalTarget } from "../types/terminal";
-import type { WorkspaceSession } from "../types/workspace";
+import { isOrchestratorSession, type WorkspaceSession } from "../types/workspace";
 import { TerminalPane } from "./TerminalPane";
 
 type CenterPaneProps = {
@@ -99,7 +99,9 @@ export function CenterPane({ session, theme, daemonReady, terminalTarget, onSele
 			<div className="terminal-toolbar">
 				<div className="terminal-toolbar__label">
 					<span className="terminal-toolbar__eyebrow">TERMINAL</span>
-					<span className="terminal-toolbar__session">{session?.id ?? "No session"}</span>
+					<span className="terminal-toolbar__session">
+						{!session ? "No session" : isOrchestratorSession(session) ? "Orchestrator" : session.title}
+					</span>
 				</div>
 				<div className="terminal-toolbar__controls">
 					<button


### PR DESCRIPTION
## Summary

Fixes #2380.

The terminal toolbar header showed the raw session id (e.g. `agent-orchestrator-23`). It now shows:

- Worker session: the display name (`session.title`, the same field the sidebar renders, so the header stays in sync with the sidebar and with inline rename #2301)
- Orchestrator session: `Orchestrator` (via the existing `isOrchestratorSession` helper)
- No session: `No session` (unchanged)

The label reads straight from the `session` prop, so rename updates propagate live.

## Verification

- `npm run typecheck` passes; renderer vite build passes; full vitest suite passes (377 tests) plus a new `CenterPane.test.tsx` covering all three label cases.
- Verified live via `dev:web` against a running daemon: selecting a worker session renders its display name in the toolbar instead of the id.

Note: no changeset added; this repo has no changeset tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)