### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+We love contributions! Join our community on Discord to get started.
+
+## Join us on Discord
+
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?style=for-the-badge&logo=discord&logoColor=white&logoSize=auto)](https://discord.com/invite/UZv7JjxbwG)
+
+**Daily contributor sync:** Every day at **10:00 PM IST**
+
+Get your issues verified by core contributors, ask questions, share progress, and learn from the community. New contributors are always welcome!
+
+**Why join Discord?**
+
+- Get your issues and PRs verified by core contributors before investing time
+- Learn from experienced contributors in daily sync calls
+- Share your progress and get feedback
+- Get help troubleshooting in real-time
+- Stay updated on the latest developments and roadmap
+
+## Quick Start
+
+1. **Join the Discord** - Connect with the community and get guidance
+2. **Read the contributor contract** - See [AGENTS.md](AGENTS.md) for repo layout, daemon/API boundaries, and coding conventions
+3. **Pick a focused problem** - Browse [open issues](https://github.com/AgentWrapper/agent-orchestrator/issues) and choose one small enough for a focused PR
+4. **Open a clear PR** - Keep changes narrow, explain user-visible impact, link issues, include tests
+5. **Iterate with contributors** - Use review feedback to tighten the PR until verified


### PR DESCRIPTION
Adds a standalone CONTRIBUTING.md using the existing contributor onboarding content: Discord community, daily sync, why to join, and quick-start contribution steps.\n\nVerification:\n- git diff --cached --check\n- git rev-list --left-right --count origin/main...HEAD\n- git diff --name-only origin/main...HEAD