### PR TITLE
fix(ci): gofmt manager_test.go to unbreak main

### DIFF
--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -1913,7 +1913,7 @@ func TestReconcile_AdoptAcrossDaemonRestart(t *testing.T) {
 	st.sessions["mer-4"] = domain.SessionRecord{
 		ID: "mer-4", ProjectID: "mer", Kind: domain.KindWorker, Harness: domain.HarnessClaudeCode,
 		IsTerminated: true, Activity: domain.Activity{State: domain.ActivityExited},
-		Metadata:     domain.SessionMetadata{Branch: "ao/mer-4/root", WorkspacePath: "/ws/mer-4"},
+		Metadata: domain.SessionMetadata{Branch: "ao/mer-4/root", WorkspacePath: "/ws/mer-4"},
 	}
 
 	if err := m.Reconcile(ctx); err != nil {


### PR DESCRIPTION
## Problem

`main` is red on the **Go** workflow (`build-test` + `lint`). Both steps flag one file:

```
backend/internal/session_manager/manager_test.go:1915: File is not properly formatted
```

The struct field is misaligned with extra spaces that `gofmt` collapses:

```go
-		Metadata:     domain.SessionMetadata{Branch: "ao/mer-4/root", WorkspacePath: "/ws/mer-4"},
+		Metadata: domain.SessionMetadata{Branch: "ao/mer-4/root", WorkspacePath: "/ws/mer-4"},
```

## Why it slipped through

This file landed via #2350. That merge push never ran the Go workflow (no run recorded for its merge commit), so the violation went unnoticed until the next push to `main` triggered the Go workflow and failed.

## Fix

Pure `gofmt -w backend/internal/session_manager/manager_test.go` output: one whitespace-only line, no behavior change. `gofmt -l`, goimports (with the repo's local-prefix), and `go vet ./internal/session_manager/` are all clean after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)