### PR TITLE
fix(session): keep terminated status when an open PR remains

### DIFF
--- a/backend/internal/service/session/status.go
+++ b/backend/internal/service/session/status.go
@@ -26,7 +26,11 @@ const noSignalGrace = 90 * time.Second
 // until the parent does. Merged/closed PRs only matter once no open PR remains.
 func deriveStatus(rec domain.SessionRecord, prs []domain.PRFacts, now time.Time, signalCapable bool) domain.SessionStatus {
 	if rec.IsTerminated {
-		if anyMerged(prs) {
+		// Merged only wins once no open PR remains: a session killed while it
+		// still owns an open PR (e.g. only the bottom of a stack merged) did not
+		// complete, and reporting it as merged would hide the abandoned open PR.
+		// The non-terminated branch below enforces the same ordering.
+		if len(openPRs(prs)) == 0 && anyMerged(prs) {
 			return domain.StatusMerged
 		}
 		return domain.StatusTerminated

--- a/backend/internal/service/session/status_test.go
+++ b/backend/internal/service/session/status_test.go
@@ -41,6 +41,17 @@ func TestServiceDerivesStatusFromSessionFactsAndPR(t *testing.T) {
 	}{
 		{"terminated", statusRec(domain.ActivityExited, true), nil, false, domain.StatusTerminated},
 		{"merged-pr", statusRec(domain.ActivityIdle, true), statusPR(domain.PRFacts{Merged: true}), false, domain.StatusMerged},
+		// A terminated session that still owns an open PR did not complete: the
+		// merged short-circuit must not fire while an open PR remains, matching
+		// the invariant that merged only wins once no open PR is left (the
+		// non-terminated branch already enforces this).
+		{
+			"terminated-with-open-pr-stays-terminated",
+			statusRec(domain.ActivityIdle, true),
+			[]domain.PRFacts{{URL: "merged", Merged: true}, {URL: "open", SourceBranch: "ao/x", TargetBranch: "main"}},
+			false,
+			domain.StatusTerminated,
+		},
 		{"needs-input", statusRec(domain.ActivityWaitingInput, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusNeedsInput},
 		{"ci-failed", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusCIFailed},
 		{"draft", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{Draft: true}), false, domain.StatusDraft},


### PR DESCRIPTION
Closes #2390.

## What

`deriveStatus`'s terminated branch returned `merged` whenever any owned PR was merged, even when the session still owned an **open** PR. That contradicts the function's documented invariant — *"Merged/closed PRs only matter once no open PR remains"* — and is inconsistent with the non-terminated branch, which gates on `openPRs` before falling back to `anyMerged`.

## Why

Regression from the single-PR → multi-PR change (#230). The branch used to be `if pr != nil && pr.Merged`, which in the single-PR world implied "no open PR remains." Generalizing to `anyMerged(prs)` dropped that implicit condition. A session killed while it still owns an open PR (e.g. only the bottom of a stack merged, or one of two independent PRs merged) was shown as cleanly "merged", hiding the abandoned open PR.

## Change

Gate the merged short-circuit on there being no open PR, mirroring the non-terminated branch:

```go
if len(openPRs(prs)) == 0 && anyMerged(prs) {
    return domain.StatusMerged
}
```

Existing behavior is preserved — a terminated session whose only PR is merged still reports `merged` (the existing `merged-pr` case). Only the `merged + open` combination changes to `terminated`.

## Tests

- Added `terminated-with-open-pr-stays-terminated` to the `deriveStatus` table test. It fails before the change (`got "merged" want "terminated"`) and passes after.
- `go test ./internal/service/session/...` green; full `go test ./...` green apart from the pre-existing Windows-only `TestApplySymlinks`, which needs the symlink privilege and fails on `main` too (unrelated to this change).
- `go vet` and gofmt clean. I couldn't run `go test -race` locally (no 64-bit CGO toolchain on my box) — leaving that to CI.

cc @harshitsinghbhandari — small correctness fix, happy to adjust if you'd rather gate it another way.
