### PR TITLE
fix(cli): exit 2 for arg-count misuse on review submit and preview

### DIFF
--- a/backend/internal/cli/preview.go
+++ b/backend/internal/cli/preview.go
@@ -31,7 +31,12 @@ func newPreviewCommand(ctx *commandContext) *cobra.Command {
   ao preview file://$(pwd)/index.html
   ao preview http://localhost:5173
   ao preview clear`,
-		Args: cobra.MaximumNArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.MaximumNArgs(1)(cmd, args); err != nil {
+				return usageError{err}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var target string
 			if len(args) == 1 {
@@ -43,7 +48,7 @@ func newPreviewCommand(ctx *commandContext) *cobra.Command {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "clear",
 		Short: "Clear the desktop browser panel for the current session",
-		Args:  cobra.NoArgs,
+		Args:  noArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return ctx.clearPreview(cmd.Context())
 		},

--- a/backend/internal/cli/preview_test.go
+++ b/backend/internal/cli/preview_test.go
@@ -154,6 +154,46 @@ func TestPreview_MissingSessionIDIsUsageError(t *testing.T) {
 	}
 }
 
+func TestPreview_TooManyArgsIsUsageError(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "aa-47")
+	cfg := setConfigEnv(t)
+	srv, capture := previewServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "preview", "http://a", "http://b")
+	if err == nil {
+		t.Fatal("expected too-many-args to fail")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+	if capture.called {
+		t.Fatal("daemon should not be contacted on arg-count misuse")
+	}
+}
+
+func TestPreviewClear_TooManyArgsIsUsageError(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "aa-47")
+	cfg := setConfigEnv(t)
+	srv, capture := previewServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "preview", "clear", "extra")
+	if err == nil {
+		t.Fatal("expected too-many-args to fail")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+	if capture.called {
+		t.Fatal("daemon should not be contacted on arg-count misuse")
+	}
+}
+
 func TestPreview_HelpIncludesExamples(t *testing.T) {
 	out, _, err := executeCLI(t, Deps{}, "preview", "--help")
 	if err != nil {

--- a/backend/internal/cli/review.go
+++ b/backend/internal/cli/review.go
@@ -77,7 +77,12 @@ func newReviewSubmitCommand(ctx *commandContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "submit [worker-session-id]",
 		Short: "Record a reviewer's result for a worker's PR",
-		Args:  cobra.MaximumNArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.MaximumNArgs(1)(cmd, args); err != nil {
+				return usageError{err}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ctx.submitReview(cmd, args, opts)
 		},

--- a/backend/internal/cli/review_test.go
+++ b/backend/internal/cli/review_test.go
@@ -166,3 +166,14 @@ func TestReviewSubmitMissingRunIsUsageError(t *testing.T) {
 		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
 	}
 }
+
+func TestReviewSubmitTooManyArgsIsUsageError(t *testing.T) {
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, aliveDeps(), "review", "submit", "mer-1", "mer-2")
+	if err == nil {
+		t.Fatal("expected too-many-args to fail")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+}


### PR DESCRIPTION
Closes #2391.

## What

`ao review submit` and `ao preview` (and `ao preview clear`) exited `1` instead of `2` when given too many positional args, breaking the `usageError` → exit-2 convention in AGENTS.md (*"Return usage errors as `usageError` so CLI misuse exits 2; runtime/daemon failures should exit 1."*).

## Why

Their `Args` validators were a bare `cobra.MaximumNArgs(1)` / `cobra.NoArgs`. Cobra's arg-count error is a plain error, and the root's `SetFlagErrorFunc` only wraps **flag**-parse errors as `usageError` — not `Args` validation — so `ExitCode` returned 1. Every other command wraps its validator (`noArgs`, `oneSessionIDArg`, the inline wrappers in `project.go` / `completion.go`).

## Change

Wrap the validators so arg-count misuse returns `usageError` (exit 2), and reuse the existing `noArgs` helper for `preview clear`.

## Tests

- Added `TestReviewSubmitTooManyArgsIsUsageError`, `TestPreview_TooManyArgsIsUsageError`, and `TestPreviewClear_TooManyArgsIsUsageError`. Each fails before the change (exit 1) and passes after (exit 2).
- These match the commands' existing usage-error tests, which already assert exit 2 for other misuse.
- `go test ./internal/cli/...` green; `go vet` and gofmt clean.

cc @harshitsinghbhandari — matches the existing usage-error tests on these commands; happy to tweak.
