### PR TITLE
ci(nightly): format frontend-nightly.yml so the PR-triggered Prettier gate passes again

### DIFF
--- a/.github/workflows/frontend-nightly.yml
+++ b/.github/workflows/frontend-nightly.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       important:
-        description: 'Mark this nightly as an important update (escalates the in-app restart prompt). Retro-flag an already-published nightly by re-running only the publish-feed job with this input set.'
+        description: "Mark this nightly as an important update (escalates the in-app restart prompt). Retro-flag an already-published nightly by re-running only the publish-feed job with this input set."
         type: boolean
         default: false
 


### PR DESCRIPTION
One-line quote-style fix. The `important` input description added in #2378 merged with single-quoted YAML that Prettier rewrites to double quotes. Since #2356 made the Prettier workflow check-only and it triggers on PRs (not pushes to main), main itself was never re-checked and every currently open PR inherits a red `format` check for a file it does not touch (e.g. #2394).

Verified with `prettier@3 --check .`: this was the only tracked file failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)