### PR TITLE
ci(prettier): run on pull_request and check only changed files

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,17 +1,13 @@
 name: Prettier
 
 # Check-only: reports formatting issues without modifying the branch.
-# The job fails (and annotates unformatted files) when `prettier --check`
-# finds files that are not formatted, but it never writes, commits, or
-# pushes anything back to the PR. Developers run `npx prettier@3 --write .`
+# Runs on pull_request (so fork PRs are checked too) and only checks the
+# files the PR actually changed, so a PR can never go red for unformatted
+# files it did not touch. Developers run `npx prettier@3 --write <files>`
 # locally to fix the reported files.
 
 on:
-  push:
-    branches-ignore:
-      - main
-      - "entire/**"
-      - "worktree-**"
+  pull_request:
 
 jobs:
   format:
@@ -20,6 +16,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the merge-base with the PR base branch exists.
+          fetch-depth: 0
 
-      - name: Check formatting with Prettier
-        run: npx --yes prettier@3 --check .
+      - name: Check formatting of changed files with Prettier
+        run: |
+          git diff --name-only -z --diff-filter=d \
+            "origin/${{ github.base_ref }}...HEAD" \
+            | xargs -0 --no-run-if-empty npx --yes prettier@3 --check --ignore-unknown


### PR DESCRIPTION
Kills the recurring +1/-1 formatting-fix-PR treadmill at the source. Two defects in the current `prettier.yml`:

1. **It triggers on branch `push`, not `pull_request`**, so fork PRs get no format check at all. That is how #2378 merged the unformatted nightly workflow: its checks were only `scan` and `test`, `format` never ran.
2. **It checks the whole repo**, so once one unformatted file lands on main, every open PR goes red for a file it never touched (see #2394, red on `frontend-nightly.yml`, a docs-only PR). The wrong people pay for someone else's miss, and the fix is always another +1/-1 PR like #2396 or the gofmt equivalent #2386.

This changes the trigger to `pull_request` (covers same-repo and fork PRs) and checks only the files changed since the merge base (`git diff -z ... | xargs -0 prettier --check --ignore-unknown`, NUL-safe, no-op on empty diff, deleted files excluded). A PR can now only ever be red for its own files, and pre-existing rot on main cannot spread to unrelated PRs.

Verified locally: the changed-files invocation passes on this branch's own diff and is a no-op on an empty diff.

**Companion admin change (not possible in YAML):** none of this blocks a merge while main's branch protection requires zero status checks (`contexts: []` today). To actually end the treadmill, `format` (and `test`/`scan`) should be added as required status checks on main; with the `pull_request` trigger and no path filter, `format` always runs, so requiring it cannot wedge docs-only PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)