### PR TITLE
fix(scm): don't downgrade an UNSTABLE PR to blocked when CI is failing

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -488,6 +488,15 @@ func mergeabilityObservation(providerMergeable, providerMergeState, ci, review s
 		out.State = string(domain.MergeBlocked)
 		addBlocker("blocked_by_provider")
 	}
+	if state == "UNSTABLE" {
+		// UNSTABLE means the PR is mergeable but has a failing/pending NON-required
+		// check (a required failure yields BLOCKED instead). Per the documented
+		// priority (rule 3 before rules 5 and 6) and the sibling
+		// mergeabilityFromGraphQL, UNSTABLE outranks the changes-requested/CI-failing
+		// blockers below, which would otherwise mask a mergeable PR as blocked.
+		out.State = string(domain.MergeUnstable)
+		return out
+	}
 	if draft {
 		out.State = string(domain.MergeBlocked)
 		addBlocker("draft")
@@ -505,10 +514,6 @@ func mergeabilityObservation(providerMergeable, providerMergeState, ci, review s
 		addBlocker("review_required")
 	}
 	if out.State == string(domain.MergeBlocked) {
-		return out
-	}
-	if state == "UNSTABLE" {
-		out.State = string(domain.MergeUnstable)
 		return out
 	}
 	if mergeable == "MERGEABLE" && (state == "CLEAN" || state == "HAS_HOOKS" || state == "") &&

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -1239,6 +1239,29 @@ func TestSCMMergeabilityBlocksReviewRequiredAndDraft(t *testing.T) {
 	}
 }
 
+func TestSCMMergeabilityUnstableNotDowngradedByBlockers(t *testing.T) {
+	// UNSTABLE = mergeable with a failing/pending NON-required check (a required
+	// failure yields BLOCKED). Per doc.go rule (3) before (5)/(6) and the sibling
+	// mergeabilityFromGraphQL, it must stay Unstable even when CI is failing or
+	// changes are requested — otherwise a mergeable PR is wrongly reported blocked.
+	cases := []struct {
+		name   string
+		ci     string
+		review string
+	}{
+		{name: "failing CI", ci: string(domain.CIFailing), review: string(domain.ReviewApproved)},
+		{name: "changes requested", ci: string(domain.CIPassing), review: string(domain.ReviewChangesRequest)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeabilityObservation("MERGEABLE", "UNSTABLE", tc.ci, tc.review, false)
+			if got.State != string(domain.MergeUnstable) {
+				t.Fatalf("mergeability = %+v, want unstable (UNSTABLE must outrank CI/review blockers)", got)
+			}
+		})
+	}
+}
+
 func TestFetchPullRequestsDoesNotFallbackWhenContextPageComplete(t *testing.T) {
 	fake := newFakeGH(t)
 	fx := basePRFixture()

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -1151,6 +1151,15 @@ func mergeabilityFromProviderFacts(providerMergeable, providerMergeState, ci, re
 		out.State = string(domain.MergeBlocked)
 		addBlocker("blocked_by_provider")
 	}
+	if state == "UNSTABLE" {
+		// UNSTABLE means the PR is mergeable but has a failing/pending NON-required
+		// check (a required failure yields BLOCKED instead). Per the documented
+		// priority (rule 3 before rules 5 and 6) and the sibling
+		// mergeabilityFromGraphQL, UNSTABLE outranks the changes-requested/CI-failing
+		// blockers below, which would otherwise mask a mergeable PR as blocked.
+		out.State = string(domain.MergeUnstable)
+		return out
+	}
 	if draft {
 		out.State = string(domain.MergeBlocked)
 		addBlocker("draft")
@@ -1168,10 +1177,6 @@ func mergeabilityFromProviderFacts(providerMergeable, providerMergeState, ci, re
 		addBlocker("review_required")
 	}
 	if out.State == string(domain.MergeBlocked) {
-		return out
-	}
-	if state == "UNSTABLE" {
-		out.State = string(domain.MergeUnstable)
 		return out
 	}
 	if mergeable == "MERGEABLE" && (state == "CLEAN" || state == "HAS_HOOKS" || state == "") &&

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -245,6 +245,29 @@ func knownPR(num int) domain.PullRequest {
 	return pr
 }
 
+func TestMergeabilityFromProviderFactsUnstableNotDowngraded(t *testing.T) {
+	// UNSTABLE means the PR is mergeable but has a failing/pending NON-required
+	// check. It must outrank the CI-failing and changes-requested blockers rather
+	// than being downgraded to blocked, matching the documented priority and the
+	// github provider's mergeabilityFromGraphQL.
+	cases := []struct {
+		name   string
+		ci     string
+		review string
+	}{
+		{name: "failing CI", ci: string(domain.CIFailing), review: string(domain.ReviewApproved)},
+		{name: "changes requested", ci: string(domain.CIPassing), review: string(domain.ReviewChangesRequest)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeabilityFromProviderFacts("MERGEABLE", "UNSTABLE", tc.ci, tc.review, false)
+			if got.State != string(domain.MergeUnstable) {
+				t.Fatalf("state = %+v, want unstable (UNSTABLE must outrank CI/review blockers)", got)
+			}
+		})
+	}
+}
+
 func TestStartAsyncPerformsImmediatePollAndStopsOnCancel(t *testing.T) {
 	store := testStoreWithSession()
 	store.listEntered = make(chan struct{})


### PR DESCRIPTION
Closes #2401.

## What

The observer's mergeability derivation downgraded an `UNSTABLE` PR to `blocked` whenever CI was failing (or changes were requested), even though `UNSTABLE` means the PR *is* mergeable (it has a failing/pending **non-required** check; a required failure yields `BLOCKED`). Both `mergeabilityObservation` (`adapters/scm/github`) and its byte-identical twin `mergeabilityFromProviderFacts` (`observe/scm`) checked draft/CI/review and returned `blocked` before ever reaching the `UNSTABLE` branch at the bottom.

## Why it's wrong

`doc.go` documents the priority order (first rule wins): `BLOCKED` (2) → `UNSTABLE` (3) → changes_requested (5) → CI failing (6). `UNSTABLE` must win over CI-failing and changes-requested. The sibling `mergeabilityFromGraphQL` (`provider.go`) already implements this — it switches on `state` first. Because an `UNSTABLE` PR's status rollup is `FAILURE` (→ `ci = failing`), the bottom `UNSTABLE` branch was effectively dead for the common case, and a genuinely mergeable PR was persisted as `Mergeability = blocked`.

## Change

Move the `UNSTABLE` check above the draft/CI/review blockers in both functions, matching `doc.go` and the GraphQL sibling. Existing behavior is otherwise unchanged.

## Tests

- Added a regression test to each package (`TestSCMMergeabilityUnstableNotDowngradedByBlockers`, `TestMergeabilityFromProviderFactsUnstableNotDowngraded`) covering `UNSTABLE` + failing CI and `UNSTABLE` + changes-requested. Both fail before the change (`blocked`) and pass after (`unstable`).
- `go test ./internal/adapters/scm/github/... ./internal/observe/scm/...` green; `go vet` and gofmt clean. `-race` left to CI (no 64-bit CGO locally).

cc @harshitsinghbhandari — followed doc.go's stated order and the GraphQL sibling; happy to adjust if a failing CI is intended to always read as blocked.
