### PR TITLE
fix(agent): mark claude-compat harnesses (grok/devin/continue) signal-capable

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -58,13 +58,30 @@ func Derive(agent, event string, payload []byte) (domain.ActivityState, bool) {
 	return derive(event, payload)
 }
 
-// SupportsHarness reports whether a harness has an activity pipeline at all:
-// a registered deriver here means its adapter installs `ao hooks <harness>`
-// callbacks that can reach the daemon. Status derivation uses this to decide
+// claudeCompatHarnesses are harnesses whose GetAgentHooks delegates to the
+// claude-code plugin, installing byte-identical `ao hooks claude-code <evt>`
+// callbacks. They have no deriver of their own (the token they emit at runtime is
+// "claude-code", which the registered claude-code deriver handles), so they are
+// absent from Derivers — but they DO have a working activity pipeline. Status
+// derivation must therefore treat them as signal-capable, otherwise a broken-hook
+// session of one of these harnesses is shown a confident "idle" forever instead of
+// "no_signal", unlike an identical claude-code session installing the same bytes.
+var claudeCompatHarnesses = map[string]bool{
+	string(domain.HarnessGrok):     true,
+	string(domain.HarnessDevin):    true,
+	string(domain.HarnessContinue): true,
+}
+
+// SupportsHarness reports whether a harness has an activity pipeline at all: a
+// registered deriver means its adapter installs `ao hooks <harness>` callbacks
+// that can reach the daemon, and a claude-compat harness installs `ao hooks
+// claude-code` callbacks by delegation. Status derivation uses this to decide
 // whether prolonged silence is suspicious (no_signal) or simply all a hook-less
 // harness can ever report (idle). Harness names and `ao hooks` agent tokens are
-// the same strings by convention.
+// the same strings by convention, except for the claude-compat delegators above.
 func SupportsHarness(h domain.AgentHarness) bool {
-	_, ok := Derivers[string(h)]
-	return ok
+	if _, ok := Derivers[string(h)]; ok {
+		return true
+	}
+	return claudeCompatHarnesses[string(h)]
 }

--- a/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
@@ -31,3 +31,17 @@ func TestSupportsHarness(t *testing.T) {
 		}
 	}
 }
+
+// grok/devin/continue install byte-identical claude-code hooks via GetAgentHooks
+// delegation, so they have a working activity pipeline and must be signal-capable
+// — otherwise a broken-hook session of one is shown a confident "idle" forever
+// instead of "no_signal", unlike an identical claude-code session. They are
+// intentionally absent from Derivers (the token they emit at runtime is
+// "claude-code"), so their capability is tracked separately.
+func TestSupportsHarnessClaudeCompatDelegates(t *testing.T) {
+	for _, h := range []domain.AgentHarness{domain.HarnessGrok, domain.HarnessDevin, domain.HarnessContinue} {
+		if !SupportsHarness(h) {
+			t.Errorf("SupportsHarness(%q) = false, want true (delegates to claude-code hooks)", h)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2402.

## What

`SupportsHarness` backs the `SignalCapable` input to status derivation: a signal-capable harness that goes silent past the 90s `noSignalGrace` is shown `no_signal` (broken hook pipeline), while a hook-less harness stays `idle`. It decided capability by looking the harness name up in `Derivers`.

`grok`, `devin`, and `continue` are Claude-compat harnesses — their `GetAgentHooks` delegates to the claude-code plugin, installing byte-identical `ao hooks claude-code <evt>` callbacks, so they have a fully working activity pipeline (routed through the registered claude-code deriver at runtime). But their harness names aren't `Derivers` keys, so `SupportsHarness` returned false for them: a grok session and a claude-code session install the same bytes, yet a broken-hook grok session was shown a confident `idle` forever instead of `no_signal`.

## Change

Track the three delegating harnesses in a small `claudeCompatHarnesses` set and have `SupportsHarness` consult it, without polluting the runtime dispatch `Derivers` map (nothing emits `ao hooks grok`). Kept as a dedicated set so `Derivers` stays the single source of truth for runtime dispatch.

## Tests

- Added `TestSupportsHarnessClaudeCompatDelegates` asserting grok/devin/continue are signal-capable. Fails before the change (all false), passes after.
- Existing `TestSupportsHarness` (hook-less harnesses stay false) and `TestDeriverTokensAreKnownHarnesses` still pass.
- `go test ./internal/adapters/agent/activitydispatch/...` green; `go vet` and gofmt clean.

cc @harshitsinghbhandari — these three delegate to claude-code's hooks, so they seemed like they should match claude-code's no_signal behavior; open to a different shape if you prefer.
