### PR TITLE
Fix ao start reusing stale desktop builds

### DIFF
--- a/.github/workflows/frontend-nightly.yml
+++ b/.github/workflows/frontend-nightly.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       important:
-        description: 'Mark this nightly as an important update (escalates the in-app restart prompt). Retro-flag an already-published nightly by re-running only the publish-feed job with this input set.'
+        description: "Mark this nightly as an important update (escalates the in-app restart prompt). Retro-flag an already-published nightly by re-running only the publish-feed job with this input set."
         type: boolean
         default: false
 

--- a/backend/internal/cli/start.go
+++ b/backend/internal/cli/start.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -116,12 +118,22 @@ func (c *commandContext) runStart(ctx context.Context, cmd *cobra.Command, opts 
 
 // resolveApp returns the path to a usable desktop bundle, or "" when none is
 // found (spec §6.2). Resolution order is fixed: marker path -> stat -> known
-// location scan. It never compares versions (invariant 5).
+// location scan. Known-broken desktop versions are treated as stale so `ao
+// start` can fetch a current app instead of relaunching a bad bundle forever.
 func (c *commandContext) resolveApp() string {
-	if p := c.markerAppPath(); p != "" && isUsableBundle(p) {
-		return p
+	marker, hasMarker := c.markerAppState()
+	var blockedPath string
+	if hasMarker {
+		if knownBrokenAppVersion(marker.Version) {
+			blockedPath = filepath.Clean(marker.AppPath)
+		} else if isUsableBundle(marker.AppPath) {
+			return marker.AppPath
+		}
 	}
 	for _, p := range appScanLocations() {
+		if blockedPath != "" && filepath.Clean(p) == blockedPath {
+			continue
+		}
 		if isUsableBundle(p) {
 			return p
 		}
@@ -133,22 +145,59 @@ func (c *commandContext) resolveApp() string {
 // tests can point the scan at a temp bundle instead of real system paths.
 var appScanLocations = knownAppLocations
 
-// markerAppPath reads ~/.ao/app-state.json and returns its recorded appPath, or
-// "" if the marker is missing/unreadable. It does not stat the path; callers do.
-func (c *commandContext) markerAppPath() string {
+// markerAppState reads ~/.ao/app-state.json and returns its recorded app state,
+// or ok=false if the marker is missing/unreadable.
+func (c *commandContext) markerAppState() (appState, bool) {
 	dir, err := aoStateDir()
 	if err != nil {
-		return ""
+		return appState{}, false
 	}
 	data, err := os.ReadFile(filepath.Join(dir, appStateFileName))
 	if err != nil {
-		return ""
+		return appState{}, false
 	}
 	var st appState
 	if err := json.Unmarshal(data, &st); err != nil {
-		return ""
+		return appState{}, false
 	}
-	return st.AppPath
+	if st.AppPath == "" {
+		return appState{}, false
+	}
+	return st, true
+}
+
+// knownBrokenAppVersion reports desktop app versions that should not be reused
+// by `ao start`. Pre-0.10.0 Next.js builds could bake the build machine's
+// absolute `file://` path into the server bundle (for example
+// /private/tmp/ao-release-0.9.5), which breaks Windows launches. Treating those
+// markers as stale forces the bootstrapper to fetch a current release.
+func knownBrokenAppVersion(version string) bool {
+	major, minor, _, ok := parseAppVersion(version)
+	if !ok {
+		return false
+	}
+	return major == 0 && minor < 10
+}
+
+func parseAppVersion(version string) (major, minor, patch int, ok bool) {
+	v := strings.TrimSpace(version)
+	v = strings.TrimPrefix(v, "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) < 2 {
+		return 0, 0, 0, false
+	}
+	nums := [3]int{}
+	for i := 0; i < len(parts) && i < len(nums); i++ {
+		n, err := strconv.Atoi(parts[i])
+		if err != nil {
+			return 0, 0, 0, false
+		}
+		nums[i] = n
+	}
+	return nums[0], nums[1], nums[2], true
 }
 
 // aoStateDir resolves the canonical ~/.ao home, honoring AO_DATA_DIR exactly as

--- a/backend/internal/cli/start_test.go
+++ b/backend/internal/cli/start_test.go
@@ -20,7 +20,12 @@ import (
 // configured state dir (AO_RUN_FILE's directory).
 func writeMarker(t *testing.T, cfg testConfig, appPath string) {
 	t.Helper()
-	st := appState{SchemaVersion: 1, AppPath: appPath, InstallSource: "npm-bootstrap"}
+	writeMarkerVersion(t, cfg, appPath, "")
+}
+
+func writeMarkerVersion(t *testing.T, cfg testConfig, appPath, version string) {
+	t.Helper()
+	st := appState{SchemaVersion: 1, AppPath: appPath, Version: version, InstallSource: "npm-bootstrap"}
 	data, err := json.Marshal(st)
 	if err != nil {
 		t.Fatal(err)
@@ -80,6 +85,20 @@ func TestResolveApp_MarkerMissThenScanHit(t *testing.T) {
 	}
 }
 
+func TestResolveApp_IgnoresKnownBrokenMarkerVersion(t *testing.T) {
+	cfg := setConfigEnv(t)
+	brokenBundle := makeBundle(t, appBundleName)
+	replacementBundle := makeBundle(t, "replacement-"+appBundleName)
+	writeMarkerVersion(t, cfg, brokenBundle, "0.9.5")
+	t.Cleanup(swapScanLocations(func() []string { return []string{brokenBundle, replacementBundle} }))
+
+	c := &commandContext{deps: Deps{}.withDefaults()}
+	got := c.resolveApp()
+	if got != replacementBundle {
+		t.Fatalf("resolveApp = %q, want replacement path %q", got, replacementBundle)
+	}
+}
+
 func TestResolveApp_ScanMissReturnsEmpty(t *testing.T) {
 	setConfigEnv(t) // no marker written
 	t.Cleanup(swapScanLocations(func() []string {
@@ -90,6 +109,25 @@ func TestResolveApp_ScanMissReturnsEmpty(t *testing.T) {
 	got := c.resolveApp()
 	if got != "" {
 		t.Fatalf("resolveApp = %q, want empty", got)
+	}
+}
+
+func TestKnownBrokenAppVersion(t *testing.T) {
+	tests := map[string]bool{
+		"":                            false,
+		"bogus":                       false,
+		"0.9.5":                       true,
+		"v0.9.5":                      true,
+		"0.9.5-nightly.20260519":      true,
+		"0.10.0":                      false,
+		"0.10.2":                      false,
+		"0.10.3-nightly.202607041403": false,
+		"1.0.0":                       false,
+	}
+	for version, want := range tests {
+		if got := knownBrokenAppVersion(version); got != want {
+			t.Errorf("knownBrokenAppVersion(%q) = %v, want %v", version, got, want)
+		}
 	}
 }
 

--- a/frontend/src/landing/content/docs/installation.mdx
+++ b/frontend/src/landing/content/docs/installation.mdx
@@ -44,29 +44,12 @@ If you plan to use GitLab or Linear, install and authenticate their CLIs or cred
 ## Install AO
 
 <Tabs items={["npm", "pnpm", "yarn", "from source"]}>
-	<Tab value="npm">
-		```bash
-		npm install -g @aoagents/ao
-		```
-	</Tab>
-	<Tab value="pnpm">
-		```bash
-		pnpm add -g @aoagents/ao
-		```
-	</Tab>
-	<Tab value="yarn">
-		```bash
-		yarn global add @aoagents/ao
-		```
-	</Tab>
+	<Tab value="npm">```bash npm install -g @aoagents/ao ```</Tab>
+	<Tab value="pnpm">```bash pnpm add -g @aoagents/ao ```</Tab>
+	<Tab value="yarn">```bash yarn global add @aoagents/ao ```</Tab>
 	<Tab value="from source">
-		```bash
-		git clone https://github.com/AgentWrapper/agent-orchestrator
-		cd agent-orchestrator
-		pnpm install
-		pnpm build
-		pnpm --filter @aoagents/ao link --global
-		```
+		```bash git clone https://github.com/AgentWrapper/agent-orchestrator cd agent-orchestrator pnpm install pnpm build
+		pnpm --filter @aoagents/ao link --global ```
 	</Tab>
 </Tabs>
 

--- a/frontend/src/landing/content/docs/installation.mdx
+++ b/frontend/src/landing/content/docs/installation.mdx
@@ -44,12 +44,29 @@ If you plan to use GitLab or Linear, install and authenticate their CLIs or cred
 ## Install AO
 
 <Tabs items={["npm", "pnpm", "yarn", "from source"]}>
-	<Tab value="npm">```bash npm install -g @aoagents/ao ```</Tab>
-	<Tab value="pnpm">```bash pnpm add -g @aoagents/ao ```</Tab>
-	<Tab value="yarn">```bash yarn global add @aoagents/ao ```</Tab>
+	<Tab value="npm">
+		```bash
+		npm install -g @aoagents/ao
+		```
+	</Tab>
+	<Tab value="pnpm">
+		```bash
+		pnpm add -g @aoagents/ao
+		```
+	</Tab>
+	<Tab value="yarn">
+		```bash
+		yarn global add @aoagents/ao
+		```
+	</Tab>
 	<Tab value="from source">
-		```bash git clone https://github.com/ComposioHQ/agent-orchestrator cd agent-orchestrator pnpm install pnpm build
-		pnpm --filter @aoagents/ao link --global ```
+		```bash
+		git clone https://github.com/AgentWrapper/agent-orchestrator
+		cd agent-orchestrator
+		pnpm install
+		pnpm build
+		pnpm --filter @aoagents/ao link --global
+		```
 	</Tab>
 </Tabs>
 

--- a/frontend/src/landing/content/docs/troubleshooting.mdx
+++ b/frontend/src/landing/content/docs/troubleshooting.mdx
@@ -94,6 +94,9 @@ Covers: install health, plugin resolution, notifier connectivity, stale temp fil
 ## Windows-specific
 
 <Accordions>
+  <Accordion title="`ao start` opens a broken old dashboard with `file:///private/tmp/ao-release-0.9.5`">
+    That is a stale pre-0.10 desktop build. Upgrade `@aoagents/ao`, stop AO, then run `ao start` again so the launcher can fetch the current desktop app. If the stale app still opens, delete `%USERPROFILE%\.ao\app-state.json` and `%USERPROFILE%\.ao\staging`, then retry.
+  </Accordion>
   <Accordion title="`ao open` prints a URL instead of opening a tab">
     Expected on Windows. The iTerm2 helper only runs on macOS. Use the dashboard's built-in terminal (the printed URL takes you there).
   </Accordion>

--- a/frontend/src/renderer/components/OrchestratorReplacementDialog.tsx
+++ b/frontend/src/renderer/components/OrchestratorReplacementDialog.tsx
@@ -41,13 +41,18 @@ export function OrchestratorReplacementDialog({
 							<AlertTriangle className="size-4" aria-hidden="true" />
 						</div>
 						<div className="min-w-0 flex-1">
-							<Dialog.Title className="text-sm font-medium text-foreground">Orchestrator replacement failed</Dialog.Title>
+							<Dialog.Title className="text-sm font-medium text-foreground">
+								Orchestrator replacement failed
+							</Dialog.Title>
 							<Dialog.Description className="mt-2 text-[13px] leading-5 text-muted-foreground">
 								{error ?? "The project orchestrator could not be replaced."}
 							</Dialog.Description>
 						</div>
 						<Dialog.Close asChild>
-							<button className="rounded-md p-1 text-passive hover:bg-interactive-hover hover:text-foreground" type="button">
+							<button
+								className="rounded-md p-1 text-passive hover:bg-interactive-hover hover:text-foreground"
+								type="button"
+							>
 								<X className="size-4" aria-hidden="true" />
 								<span className="sr-only">Close</span>
 							</button>

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -95,7 +95,11 @@ beforeEach(() => {
 	putMock.mockReset();
 	postMock.mockReset();
 	putMock.mockResolvedValue({ data: { project: {} }, error: undefined });
-	postMock.mockResolvedValue({ data: { orchestrator: { id: "proj-1-orch-2" } }, error: undefined, response: { status: 200 } });
+	postMock.mockResolvedValue({
+		data: { orchestrator: { id: "proj-1-orch-2" } },
+		error: undefined,
+		response: { status: 200 },
+	});
 });
 
 describe("ProjectSettingsForm", () => {

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -169,7 +169,13 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				type="button"
 			>
 				<OrchestratorIcon className="h-3.5 w-3.5" aria-hidden="true" />
-				{isProjectRestarting ? "Restarting..." : isSpawning ? "Spawning..." : orchestrator ? "Orchestrator" : "Spawn Orchestrator"}
+				{isProjectRestarting
+					? "Restarting..."
+					: isSpawning
+						? "Spawning..."
+						: orchestrator
+							? "Orchestrator"
+							: "Spawn Orchestrator"}
 			</button>
 		</>
 	) : undefined;

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -557,7 +557,13 @@ function ProjectItem({
 						</button>
 					</TooltipTrigger>
 					<TooltipContent>
-						{isProjectRestarting ? "Restarting…" : isSpawning ? "Spawning…" : orchestrator ? "Orchestrator" : "Spawn orchestrator"}
+						{isProjectRestarting
+							? "Restarting…"
+							: isSpawning
+								? "Spawning…"
+								: orchestrator
+									? "Orchestrator"
+									: "Spawn orchestrator"}
 					</TooltipContent>
 				</Tooltip>
 				<DropdownMenu>

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
@@ -101,7 +101,12 @@ describe("useWorkspaceQuery", () => {
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
 		const [workspace] = result.current.data ?? [];
-		expect(workspace).toMatchObject({ id: "proj-1", name: "my-app", path: "/home/me/my-app", orchestratorAgent: "codex" });
+		expect(workspace).toMatchObject({
+			id: "proj-1",
+			name: "my-app",
+			path: "/home/me/my-app",
+			orchestratorAgent: "codex",
+		});
 		expect(workspace.sessions).toHaveLength(2);
 		expect(workspace.sessions[0]).toMatchObject({
 			id: "sess-1",

--- a/frontend/src/renderer/lib/restart-orchestrator.ts
+++ b/frontend/src/renderer/lib/restart-orchestrator.ts
@@ -44,7 +44,10 @@ export async function restartProjectOrchestrator({
 		});
 	} catch (error) {
 		await refreshWorkspaceState(queryClient);
-		setOrchestratorReplacementError(projectId, error instanceof Error ? error.message : "Could not replace orchestrator");
+		setOrchestratorReplacementError(
+			projectId,
+			error instanceof Error ? error.message : "Could not replace orchestrator",
+		);
 		onError?.(error);
 	} finally {
 		setProjectRestarting(projectId, false);

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -239,7 +239,8 @@ describe("orchestratorHealth", () => {
 			}),
 		).toEqual({
 			state: "duplicates",
-			message: "Multiple orchestrators are active. The newest one is used; stale ones will be cleaned up on daemon reconcile.",
+			message:
+				"Multiple orchestrators are active. The newest one is used; stale ones will be cleaned up on daemon reconcile.",
 		});
 
 		expect(

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -386,7 +386,8 @@ export function orchestratorHealth(workspace: WorkspaceSummary, restarting = fal
 	if (active.length > 1) {
 		return {
 			state: "duplicates",
-			message: "Multiple orchestrators are active. The newest one is used; stale ones will be cleaned up on daemon reconcile.",
+			message:
+				"Multiple orchestrators are active. The newest one is used; stale ones will be cleaned up on daemon reconcile.",
 		};
 	}
 	const orchestrator = newestActiveOrchestrator(workspace.sessions);


### PR DESCRIPTION
## Summary
- Treat pre-0.10 desktop app markers as stale so `ao start` fetches a current release instead of relaunching broken 0.9.x builds
- Skip the same stale marker path during known-location scan to avoid immediately reusing the bad executable
- Document the Windows `file:///private/tmp/ao-release-0.9.5` recovery path and fix malformed install-tab MDX while touching docs

## Validation
- `go test ./internal/cli`
- `go test ./...` from `backend`
- `npm --prefix frontend/src/landing run build` gets past MDX compile/typecheck after the install-tab fix, then fails on an existing unrelated Next.js /404 `<Html>` prerender issue