### PR TITLE
fix(cli): exit 2 on arg-count misuse for review submit and preview

### DIFF
--- a/backend/internal/cli/preview.go
+++ b/backend/internal/cli/preview.go
@@ -31,7 +31,7 @@ func newPreviewCommand(ctx *commandContext) *cobra.Command {
   ao preview file://$(pwd)/index.html
   ao preview http://localhost:5173
   ao preview clear`,
-		Args: cobra.MaximumNArgs(1),
+		Args: atMostOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var target string
 			if len(args) == 1 {
@@ -43,7 +43,7 @@ func newPreviewCommand(ctx *commandContext) *cobra.Command {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "clear",
 		Short: "Clear the desktop browser panel for the current session",
-		Args:  cobra.NoArgs,
+		Args:  noArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return ctx.clearPreview(cmd.Context())
 		},

--- a/backend/internal/cli/preview_test.go
+++ b/backend/internal/cli/preview_test.go
@@ -172,6 +172,28 @@ func TestPreview_HelpIncludesExamples(t *testing.T) {
 	}
 }
 
+func TestPreview_TooManyArgsIsUsageError(t *testing.T) {
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, Deps{}, "preview", "http://localhost:5173", "extra")
+	if err == nil {
+		t.Fatal("expected too many args to fail")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+}
+
+func TestPreviewClear_TooManyArgsIsUsageError(t *testing.T) {
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, Deps{}, "preview", "clear", "extra")
+	if err == nil {
+		t.Fatal("expected too many args to fail")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+}
+
 func TestPreview_BlankSessionIDIsUsageError(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", " \t ")
 	cfg := setConfigEnv(t)

--- a/backend/internal/cli/review.go
+++ b/backend/internal/cli/review.go
@@ -77,7 +77,7 @@ func newReviewSubmitCommand(ctx *commandContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "submit [worker-session-id]",
 		Short: "Record a reviewer's result for a worker's PR",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  atMostOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ctx.submitReview(cmd, args, opts)
 		},

--- a/backend/internal/cli/review_test.go
+++ b/backend/internal/cli/review_test.go
@@ -166,3 +166,14 @@ func TestReviewSubmitMissingRunIsUsageError(t *testing.T) {
 		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
 	}
 }
+
+func TestReviewSubmitTooManyArgsIsUsageError(t *testing.T) {
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, aliveDeps(), "review", "submit", "mer-1", "mer-2")
+	if err == nil {
+		t.Fatal("expected too many args to fail")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+}

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -257,6 +257,13 @@ func noArgs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func atMostOneArg(cmd *cobra.Command, args []string) error {
+	if err := cobra.MaximumNArgs(1)(cmd, args); err != nil {
+		return usageError{err}
+	}
+	return nil
+}
+
 func newDaemonCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:    "daemon",


### PR DESCRIPTION
## Summary

- Wrap Cobra arg-count validators for `ao review submit`, `ao preview`, and `ao preview clear` as `usageError` so misuse exits **2** instead of **1**
- Add shared `atMostOneArg` helper in `root.go` (same pattern as `noArgs`)
- Add table tests for too-many-args cases

Closes #2391

## Test plan

- [x] `go test ./internal/cli/ -run 'TestReviewSubmit|TestPreview' -count=1`
- [x] `go test ./internal/cli/ -count=1`