### PR TITLE
fix(browser): remove excess padding around the inspector browser tab

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -125,7 +125,15 @@ export function SessionInspector({
 				))}
 			</div>
 
-			<div className="session-inspector__body">
+			<div
+				className={cn(
+					"session-inspector__body",
+					// The Browser tab renders its own bordered panel edge-to-edge, so
+					// drop the body padding for it (except when popped out, where the
+					// body only holds the "return to panel" empty state).
+					view === "browser" && !browserPoppedOut && "session-inspector__body--browser",
+				)}
+			>
 				{view === "summary" ? <SummaryView session={session} /> : null}
 				{view === "reviews" ? <ReviewsView onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} /> : null}
 				{view === "browser" ? (

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -773,6 +773,18 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	padding: 18px 18px 40px;
 }
 
+/* Browser tab: the panel fills the rail edge-to-edge, so drop the body padding
+   and the panel's own border/radius so it sits flush against the resize handle. */
+.session-inspector__body.session-inspector__body--browser {
+	padding: 0;
+	overflow: hidden;
+}
+
+.session-inspector__body--browser .browser-panel {
+	border: 0;
+	border-radius: 0;
+}
+
 /* Inspector resize handle (shadcn resizable separator, AO visual): a 7px
  * transparent grab strip whose centered 1px line lights accent on hover, drag
  * (rrp sets data-separator="active"), and keyboard focus. */


### PR DESCRIPTION
The inspector rail's Browser tab renders inside `.session-inspector__body`, which applies `18px` padding to every tab. That's correct for the Summary and Reviews tabs, but on the Browser tab it insets the whole preview panel, leaving a visible gap between the terminal (resize handle) and the browser. The panel's own `1px` border and `8px` radius add to the effect.

This drops the body padding and the panel border/radius when the Browser tab is active (and not popped out), so the preview sits flush against the resize handle. The native WebContentsView re-measures from the slot box automatically, so it grows to fill the reclaimed space with no JS change.

The padding removal uses a two-class selector so the narrow-width container query that re-adds inline padding can't override it.