### PR TITLE
UI : add graceful shutdown on SIGINT/SIGTERM to prevent multiple instances being created

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "agent-orchestrator",
-	"version": "0.0.0",
+	"version": "0.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "agent-orchestrator",
-			"version": "0.0.0",
+			"version": "0.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"@radix-ui/react-dialog": "^1.1.16",
@@ -58,6 +58,7 @@
 				"openapi-typescript": "^7.13.0",
 				"playwright": "^1.60.0",
 				"tailwindcss": "^4.3.0",
+				"tree-kill": "^1.2.2",
 				"typescript": "^5.6.0",
 				"vite": "^8.0.16",
 				"vitest": "^4.1.8"
@@ -14894,6 +14895,16 @@
 			},
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/tree-kill": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"tree-kill": "cli.js"
 			}
 		},
 		"node_modules/trim-repeated": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
 	},
 	"scripts": {
 		"build:daemon": "node ./scripts/build-daemon.mjs",
-		"dev": "electron-forge start",
+		"dev": "node scripts/dev.mjs",
 		"dev:web": "VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts",
 		"prepackage": "npm run build:daemon",
 		"package": "electron-forge package",
@@ -49,6 +49,7 @@
 		"openapi-typescript": "^7.13.0",
 		"playwright": "^1.60.0",
 		"tailwindcss": "^4.3.0",
+		"tree-kill": "^1.2.2",
 		"typescript": "^5.6.0",
 		"vite": "^8.0.16",
 		"vitest": "^4.1.8"

--- a/frontend/scripts/dev.mjs
+++ b/frontend/scripts/dev.mjs
@@ -1,0 +1,33 @@
+import { spawn } from 'node:child_process';
+import kill from 'tree-kill';
+import process from 'node:process';
+
+// Spawn electron-forge start and inherit stdio
+const child = spawn('npx', ['electron-forge', 'start'], {
+	stdio: 'inherit',
+	shell: process.platform === 'win32'
+});
+
+// Capture SIGINT (Ctrl+C in terminal) and kill the whole tree forcefully
+process.on('SIGINT', () => {
+	if (child.pid) {
+		kill(child.pid, 'SIGKILL', (err) => {
+			if (err) console.error('Failed to kill child tree:', err);
+			process.exit(0);
+		});
+	} else {
+		process.exit(0);
+	}
+});
+
+// Also handle SIGTERM (e.g. standard kill command)
+process.on('SIGTERM', () => {
+	if (child.pid) {
+		kill(child.pid, 'SIGKILL', (err) => {
+			if (err) console.error('Failed to kill child tree:', err);
+			process.exit(0);
+		});
+	} else {
+		process.exit(0);
+	}
+});

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -991,6 +991,7 @@ app.on("before-quit", () => {
 // exits without tearing down sessions, which survive for the next boot to adopt.
 // When the link IS connected we do nothing here and rely on the OS closing the
 // fd on exit, which covers crash and SIGKILL uniformly.
+
 process.on("exit", () => {
 	if (daemonProcess && !supervisorLink?.connected) {
 		killDaemon(daemonProcess);


### PR DESCRIPTION
### Issue:
- When running  npm run dev  in the frontend directory and then stopping the terminal process using  Ctrl + C , the underlying Electron app fails to shut down. Running  npm run dev  again spawns a new instance, resulting in multiple orphaned instances of the Electron app piling up in the macOS Dock.
### Why?

- The  Ctrl + C  (SIGINT) command successfully kills the Vite/Node development server, but the detached Electron process ignores the signal and continues running in the background as an orphaned process.


<img width="1441" height="83" alt="Screenshot 2026-07-05 at 11 09 40 AM" src="https://github.com/user-attachments/assets/dca488d0-6b6d-4374-8181-cf9335b411c5" />

# It Doesnt fix this issue will look deep into it. 
