### PR TITLE
fix(sidebar): open New Project tooltip rightward when collapsed

### DIFF
--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -748,7 +748,7 @@ function CreateProjectListItem({ onCreateProject }: Pick<SidebarProps, "onCreate
 								<Plus className="h-[13px] w-[13px]" aria-hidden="true" />
 							</button>
 						</TooltipTrigger>
-						<TooltipContent>{label}</TooltipContent>
+						<TooltipContent side="right">{label}</TooltipContent>
 					</Tooltip>
 				</SidebarMenuItem>
 			)}


### PR DESCRIPTION
Fixes #2430

## Summary
- In the collapsed (icon-only) sidebar, every other rail tooltip (Settings, Expand sidebar, daemon status, project rows) opens `side="right"` since the icons sit flush against the left edge. The "+ New Project" icon was the one exception, hand-rolling its own `Tooltip`/`TooltipContent` without a `side` prop and falling back to Radix's default `side="top"`.
- Adds `side="right"` to `CreateProjectListItem`'s `TooltipContent` (`frontend/src/renderer/components/Sidebar.tsx`), matching the convention used by the other collapsed-rail icons.
- The expanded-state `CreateProjectButton` tooltip is untouched since that button isn't part of the collapsed icon rail.

## Screenshots

**Current (buggy):** tooltip opens upward (`side="top"`), overlapping/blocking the project icon directly above the "+" — hard to access while the tooltip is visible.

<img width="151" height="130" alt="Current: New Project tooltip opens upward, covering the icon above it" src="https://github.com/user-attachments/assets/f10a38e2-4837-4049-9094-1c50bb44e8e1" />

**Proposed (fixed):** tooltip opens to the right (`side="right"`), matching every other collapsed-rail icon (Settings, Expand sidebar, daemon status) and no longer blocking adjacent icons.

<img width="210" height="76" alt="Proposed: New Project tooltip opens rightward, matching other rail icons" src="https://github.com/user-attachments/assets/004fb09d-a5e3-4cd9-a4f1-41c32d674700" />


## Test
- `cd frontend && npm run typecheck` — passes.
- Manually verified via code inspection against the sibling components (`Sidebar.tsx:205`, `338`, `358`, `393`) that use `side="right"`/`side="top"` explicitly for the collapsed rail.