### PR TITLE
fix(web): auto-focus terminal when opening a session/agent view

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -122,6 +122,9 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 			terminal.clear();
 		}
 		hadAttachmentRef.current = true;
+		if (handleId) {
+			terminal.focus();
+		}
 		return attach(terminal);
 	}, [terminal, handleId, attach, attachSession?.id]);
 

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -518,6 +518,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			write: (data) => term.write(data),
 			writeln: (line) => term.writeln(line),
 			clear: () => term.write(CLEAR_SEQUENCE),
+			focus: () => term.focus(),
 			onUserInput: (listener) => {
 				userInputListeners.add(listener);
 				return { dispose: () => userInputListeners.delete(listener) };

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -110,6 +110,7 @@ function createFakeTerminal(): FakeTerminal {
 		clear: () => {
 			terminal.clears += 1;
 		},
+		focus: () => {},
 		onUserInput: (listener) => {
 			inputListeners.add(listener);
 			return { dispose: () => inputListeners.delete(listener) };

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -32,6 +32,7 @@ export type AttachableTerminal = {
 	 * with wheel scroll dead (see XtermTerminal's CLEAR_SEQUENCE).
 	 */
 	clear: () => void;
+	focus: () => void;
 	onUserInput: (listener: (data: string, source: TerminalUserInputSource) => void) => { dispose: () => void };
 	onResize: (listener: (size: { cols: number; rows: number }) => void) => { dispose: () => void };
 };


### PR DESCRIPTION
Fixes #2434

## Summary
- Add `focus: () => term.focus()` to the `AttachableTerminal` handle in `XtermTerminal.tsx`, wiring through xterm.js's built-in focus method. `XtermTerminal` only exposes the *mechanism* — it has no knowledge of sessions or when focusing makes sense.
- Add `focus: () => void` to the `AttachableTerminal` type in `useTerminalSession.ts` (and a no-op stub on the test's fake terminal to satisfy the now-required field).
- Call `terminal.focus()` in `TerminalPane.tsx`'s existing mount effect, gated on `handleId` (`if (handleId) terminal.focus()`), right after clearing and before `attach(terminal)`. `TerminalPane` owns the *policy* of when to focus, since it's the layer that knows whether there's an actual session/handle attached (`showEmptyState = !handleId`) — without the gate, the terminal would steal keyboard focus even on the empty-state pane ("No session selected"), which always mounts `XtermTerminal` regardless of whether a session is picked.

Since `TerminalPane` keys `AttachedTerminal` by `terminalHandleId`, every session/agent switch already forces a full remount of `XtermTerminal` — so this effect fires exactly once per fresh terminal view, giving a reliable "user just opened a live terminal" hook with no extra plumbing.

## Screen Recording
[![Screen Recording](https://img.youtube.com/vi/zBYWUGjXw6I/0.jpg)](https://youtu.be/zBYWUGjXw6I)

## Test plan
- [x] `npx tsc --noEmit -p .` passes
- [x] `npx vitest run --config vite.renderer.config.ts src/renderer/hooks/useTerminalSession.test.tsx` — 17/17 pass
- [ ] Manual: open a session from Kanban / switch between agent sessions and confirm typing works immediately without an extra click; confirm the empty-state pane (no session selected) does not steal focus