### PR TITLE
fix(browser): maximize the browser preview over the whole app window

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -12,7 +12,6 @@ import { canonicalTrackerIssueId, sortedPRs } from "../types/workspace";
 import { BrowserPanelView } from "./BrowserPanel";
 import type { BrowserViewModel } from "../hooks/useBrowserView";
 import { Badge } from "./ui/badge";
-import { Button } from "./ui/button";
 import { cn } from "../lib/utils";
 import { PRAttentionPanel, PRSummaryMeta } from "./PRSummaryDisplay";
 
@@ -693,17 +692,12 @@ function BrowserView({
 	onTogglePopOut?: (next: boolean) => void;
 	browserView?: BrowserViewModel;
 }) {
+	// While maximized, the browser is a full-window overlay that covers the rail,
+	// so the inspector's Browser tab has nothing to show (and must not mount a
+	// second BrowserPanelView — it would fight the overlay over the shared native
+	// view slot). Exit is via the overlay's own minimize button.
 	if (browserPoppedOut) {
-		return (
-			<div role="tabpanel">
-				<div className="inspector-empty inspector-empty--browser">
-					<p>Browser preview is maximized.</p>
-					<Button onClick={() => onTogglePopOut?.(false)} size="sm" type="button" variant="outline">
-						Return to panel
-					</Button>
-				</div>
-			</div>
-		);
+		return null;
 	}
 
 	if (!browserView) {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -697,7 +697,7 @@ function BrowserView({
 		return (
 			<div role="tabpanel">
 				<div className="inspector-empty inspector-empty--browser">
-					<p>Browser preview is in the center pane.</p>
+					<p>Browser preview is maximized.</p>
 					<Button onClick={() => onTogglePopOut?.(false)} size="sm" type="button" variant="outline">
 						Return to panel
 					</Button>

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -301,16 +301,18 @@ describe("SessionView", () => {
 		expect(useUiStore.getState().isInspectorOpen).toBe(true);
 	});
 
-	it("lets the browser take over the center pane and return to the rail", () => {
+	it("maximizes the browser over the whole app window and returns to the rail", () => {
 		render(<SessionView sessionId="sess-1" />);
 
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 		fireEvent.click(screen.getByRole("button", { name: "pop browser" }));
 
-		expect(screen.queryByText("terminal center")).not.toBeInTheDocument();
+		// The maximized overlay appears; the terminal stays mounted behind it.
 		expect(screen.getByRole("button", { name: "browser center" })).toBeInTheDocument();
+		expect(screen.getByText("terminal center")).toBeInTheDocument();
 
 		fireEvent.click(screen.getByRole("button", { name: "browser center" }));
+		expect(screen.queryByRole("button", { name: "browser center" })).not.toBeInTheDocument();
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 		expect(browserDestroy).not.toHaveBeenCalled();
 	});

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
 import { BrowserPanelView } from "./BrowserPanel";
 import { CenterPane } from "./CenterPane";
@@ -182,23 +183,13 @@ export function SessionView({ sessionId }: SessionViewProps) {
 				{/* react-resizable-panels v4: bare numbers are PIXELS; percentages must
             be strings. Numeric sizes here once clamped the inspector to 45px. */}
 				<ResizablePanel defaultSize="72%" id="terminal" minSize="45%">
-					{browserPoppedOut && session ? (
-						<BrowserPanelView
-							active
-							browserView={browserView}
-							onTogglePopOut={setBrowserPoppedOut}
-							poppedOut
-							session={session}
-						/>
-					) : (
-						<CenterPane
-							daemonReady={daemonStatus.state === "ready"}
-							onSelectWorkerTerminal={() => setTerminalTarget({ kind: "worker" })}
-							session={session}
-							terminalTarget={terminalTarget}
-							theme={theme}
-						/>
-					)}
+					<CenterPane
+						daemonReady={daemonStatus.state === "ready"}
+						onSelectWorkerTerminal={() => setTerminalTarget({ kind: "worker" })}
+						session={session}
+						terminalTarget={terminalTarget}
+						theme={theme}
+					/>
 				</ResizablePanel>
 				{hasInspector ? (
 					<>
@@ -238,6 +229,25 @@ export function SessionView({ sessionId }: SessionViewProps) {
 					</>
 				) : null}
 			</ResizablePanelGroup>
+			{/* Maximized browser: a fixed overlay across the whole app window,
+          portaled to <body> so it escapes the shell layout (covering the
+          sidebar + topbar, not just the session area) and sits outside any
+          `[data-panel]` column, so the native WebContentsView is not clamped
+          and fills the entire window. */}
+			{browserPoppedOut && session
+				? createPortal(
+						<div className="browser-popout-overlay">
+							<BrowserPanelView
+								active
+								browserView={browserView}
+								onTogglePopOut={setBrowserPoppedOut}
+								poppedOut
+								session={session}
+							/>
+						</div>,
+						document.body,
+					)
+				: null}
 		</div>
 	);
 }

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1510,6 +1510,21 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	background: var(--bg);
 }
 
+/* Maximized browser overlay: a fixed layer over the whole app window (portaled
+   to <body>, so it covers the sidebar + topbar too, not just the session area).
+   The panel goes edge-to-edge, so drop its border/radius. */
+.browser-popout-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 40;
+	background: var(--bg);
+}
+
+.browser-popout-overlay .browser-panel {
+	border: 0;
+	border-radius: 0;
+}
+
 .browser-panel__toolbar {
 	display: flex;
 	align-items: center;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1312,32 +1312,6 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	text-align: center;
 }
 
-.inspector-empty--browser {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 9px;
-	padding: 48px 18px;
-	text-align: center;
-}
-
-.inspector-empty--browser svg {
-	width: 30px;
-	height: 30px;
-	color: var(--fg-passive);
-}
-
-.inspector-empty--browser p {
-	font-size: 12.5px;
-	color: var(--fg-muted);
-}
-
-.inspector-empty--browser span {
-	font-size: 11.5px;
-	color: var(--fg-passive);
-	line-height: 1.5;
-}
-
 .inspector-kv {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
The browser preview's "maximize" button (the pop-out toggle in the toolbar) used to swap the preview into the terminal's ResizablePanel, so it only covered the center column (~72% width) and left the inspector rail, sidebar, and topbar visible. That's not a real maximize.

This renders the maximized preview as a fixed overlay portaled to <body>, so it escapes the shell layout and covers the whole app window — sidebar and topbar included. Because it sits outside any resizable panel, the native WebContentsView is no longer clamped to a single column and fills the entire window. Exit via the same toolbar button (now a minimize icon) to return to the rail.

The terminal now stays mounted behind the overlay instead of being torn down and remounted on restore. Also updated the inspector's now-stale "in the center pane" copy to "maximized" and the pop-out test to match.
<img width="1626" height="1011" alt="Screenshot 2026-07-05 220648" src="https://github.com/user-attachments/assets/80ec638f-4b8d-4e73-a8c0-fc3842a19596" />
