### PR TITLE
fix: replace native project removal prompt with in-app dialog

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -1,6 +1,6 @@
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Sidebar } from "./Sidebar";
@@ -84,8 +84,6 @@ beforeEach(() => {
 	navigateMock.mockReset();
 	renameSessionMock.mockReset().mockResolvedValue(undefined);
 	mockParams.projectId = undefined;
-	vi.spyOn(window, "confirm").mockReturnValue(true);
-	vi.spyOn(window, "alert").mockImplementation(() => undefined);
 });
 
 afterEach(() => {
@@ -93,28 +91,33 @@ afterEach(() => {
 });
 
 describe("Sidebar", () => {
-	it("confirms project removal before calling the remove handler", async () => {
+	it("confirms project removal in an in-app dialog before calling the remove handler", async () => {
 		const user = userEvent.setup();
 		const onRemoveProject = renderSidebar();
 
 		await user.click(screen.getByLabelText("Project actions for Project One"));
 		await user.click(await screen.findByRole("menuitem", { name: "Remove project" }));
 
-		expect(window.confirm).toHaveBeenCalledWith(
-			"Remove project Project One? This stops its live sessions and removes it from the sidebar, but keeps the repository folder and stored history on disk.",
-		);
+		const dialog = await screen.findByRole("dialog", { name: "Remove project Project One?" });
+		expect(onRemoveProject).not.toHaveBeenCalled();
+
+		await user.click(within(dialog).getByRole("button", { name: "Remove project" }));
+
 		await waitFor(() => expect(onRemoveProject).toHaveBeenCalledTimes(1));
 	});
 
-	it("does not remove the project when confirmation is cancelled", async () => {
-		vi.mocked(window.confirm).mockReturnValue(false);
+	it("does not remove the project when the dialog is cancelled", async () => {
 		const user = userEvent.setup();
 		const onRemoveProject = renderSidebar();
 
 		await user.click(screen.getByLabelText("Project actions for Project One"));
 		await user.click(await screen.findByRole("menuitem", { name: "Remove project" }));
 
+		const dialog = await screen.findByRole("dialog", { name: "Remove project Project One?" });
+		await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
 		expect(onRemoveProject).not.toHaveBeenCalled();
+		await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
 	});
 
 	it("reveals dashboard and orchestrator buttons alongside the kebab on the project row", () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -36,6 +36,8 @@ import {
 	DropdownMenuShortcut,
 	DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
+import { Button } from "./ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog";
 import {
 	Sidebar as SidebarRoot,
 	SidebarContent,
@@ -404,6 +406,7 @@ function ProjectItem({
 	const queryClient = useQueryClient();
 	const [removeError, setRemoveError] = useState<string | null>(null);
 	const [isRemoving, setIsRemoving] = useState(false);
+	const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
 	const [isSpawning, setIsSpawning] = useState(false);
 	// Live workers only: merged/terminated sessions leave the sidebar and stay
 	// reachable through the board's Done / Terminated bar (SessionsBoard).
@@ -442,22 +445,17 @@ function ProjectItem({
 		}
 	};
 
-	const removeProject = async () => {
+	const confirmRemoveProject = async () => {
 		setRemoveError(null);
-		const confirmed = window.confirm(
-			`Remove project ${workspace.name}? This stops its live sessions and removes it from the sidebar, but keeps the repository folder and stored history on disk.`,
-		);
-		if (!confirmed) return;
-
 		setIsRemoving(true);
 		try {
 			await onRemoveProject(workspace.id);
 			// The route for a removed project no longer resolves; fall back home.
 			if (selection.activeProjectId === workspace.id) selection.goHome();
+			setConfirmRemoveOpen(false);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : "Could not remove project";
 			setRemoveError(message);
-			window.alert(message);
 		} finally {
 			setIsRemoving(false);
 		}
@@ -551,7 +549,10 @@ function ProjectItem({
 						<DropdownMenuItem
 							className="text-destructive focus:text-destructive [&_svg]:text-destructive"
 							disabled={isRemoving}
-							onSelect={() => void removeProject()}
+							onSelect={() => {
+								setRemoveError(null);
+								setConfirmRemoveOpen(true);
+							}}
 						>
 							<Trash2 aria-hidden="true" />
 							Remove project
@@ -559,11 +560,40 @@ function ProjectItem({
 					</DropdownMenuContent>
 				</DropdownMenu>
 			</div>
-			{removeError && (
-				<span className="sr-only" role="status">
-					{removeError}
-				</span>
-			)}
+			<Dialog
+				open={confirmRemoveOpen}
+				onOpenChange={(open) => {
+					if (isRemoving) return;
+					setConfirmRemoveOpen(open);
+					if (!open) setRemoveError(null);
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Remove project {workspace.name}?</DialogTitle>
+						<DialogDescription>
+							This stops its live sessions and removes it from the sidebar, but keeps the repository folder and stored
+							history on disk.
+						</DialogDescription>
+					</DialogHeader>
+					{removeError && (
+						<p
+							className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-[12px] leading-5 text-destructive"
+							role="alert"
+						>
+							{removeError}
+						</p>
+					)}
+					<DialogFooter>
+						<Button variant="outline" disabled={isRemoving} onClick={() => setConfirmRemoveOpen(false)}>
+							Cancel
+						</Button>
+						<Button variant="destructive" disabled={isRemoving} onClick={() => void confirmRemoveProject()}>
+							{isRemoving ? "Removing…" : "Remove project"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 			{/* project-sidebar__sessions: indented under the project parent so worker
           sessions read as children without adding a persistent guide rail. */}
 			{expanded && sessions.length > 0 && (

--- a/frontend/src/renderer/components/ui/button.tsx
+++ b/frontend/src/renderer/components/ui/button.tsx
@@ -11,6 +11,7 @@ const buttonVariants = cva(
 		variants: {
 			variant: {
 				primary: "border border-primary bg-primary text-primary-foreground hover:opacity-90",
+				destructive: "border border-destructive bg-destructive text-destructive-foreground hover:opacity-90",
 				outline: "border border-border bg-background text-foreground hover:bg-surface",
 				secondary: "bg-raised text-muted-foreground hover:text-foreground",
 				ghost: "text-muted-foreground hover:bg-surface hover:text-foreground",

--- a/frontend/src/renderer/components/ui/dialog.tsx
+++ b/frontend/src/renderer/components/ui/dialog.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as React from "react";
+import { XIcon } from "lucide-react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+	return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+	return (
+		<DialogPrimitive.Overlay
+			data-slot="dialog-overlay"
+			className={cn("fixed inset-0 z-50 bg-black/55 data-[state=open]:animate-overlay-in", className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogContent({
+	className,
+	children,
+	showCloseButton = true,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+	showCloseButton?: boolean;
+}) {
+	return (
+		<DialogPortal>
+			<DialogOverlay />
+			<DialogPrimitive.Content
+				data-slot="dialog-content"
+				className={cn(
+					"fixed top-1/2 left-1/2 z-50 grid w-[min(420px,calc(100vw-32px))] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border border-border bg-popover p-5 text-popover-foreground shadow-xl data-[state=open]:animate-modal-in",
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				{showCloseButton && (
+					<DialogPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+						<XIcon className="size-4" />
+						<span className="sr-only">Close</span>
+					</DialogPrimitive.Close>
+				)}
+			</DialogPrimitive.Content>
+		</DialogPortal>
+	);
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return <div data-slot="dialog-header" className={cn("flex flex-col gap-1.5", className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="dialog-footer"
+			className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+	return (
+		<DialogPrimitive.Title
+			data-slot="dialog-title"
+			className={cn("text-[15px] font-semibold text-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
+	return (
+		<DialogPrimitive.Description
+			data-slot="dialog-description"
+			className={cn("text-[12px] leading-5 text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogOverlay,
+	DialogPortal,
+	DialogTitle,
+	DialogTrigger,
+};

--- a/frontend/src/renderer/components/ui/dialog.tsx
+++ b/frontend/src/renderer/components/ui/dialog.tsx
@@ -46,7 +46,7 @@ function DialogContent({
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
 				className={cn(
-					"fixed top-1/2 left-1/2 z-50 grid w-[min(420px,calc(100vw-32px))] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border border-border bg-popover p-5 text-popover-foreground shadow-xl data-[state=open]:animate-modal-in",
+					"fixed top-1/2 left-1/2 z-50 grid w-[min(420px,calc(100vw-32px))] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border border-border bg-popover p-5 text-popover-foreground shadow-xl",
 					className,
 				)}
 				{...props}


### PR DESCRIPTION
Fixes : #2052 

**What was done** -  Replaced the native project removal prompt with an in-app confirmation dialog. 

> Note: The original issue was filed against the old web app, but the same native confirmation/alert behavior also exists in the current Electron app. This PR addresses the Electron implementation.


### Before 
<img width="1800" height="1130" alt="Screenshot 2026-07-03 at 10 09 44 PM" src="https://github.com/user-attachments/assets/ff99598e-d0f3-47d4-86a6-139ce6c6292d" />

### After 
<img width="1912" height="1241" alt="Screenshot 2026-07-03 at 10 07 36 PM" src="https://github.com/user-attachments/assets/1155c7fc-569e-4ae4-a246-a45d5892866f" />


### Tests 
<img width="942" height="398" alt="image" src="https://github.com/user-attachments/assets/3856a01f-c1fc-4311-8d25-55a48f300726" />






