### PR TITLE
 fix: omit unsupported Amp system prompt flags

### DIFF
--- a/backend/internal/adapters/agent/amp/amp.go
+++ b/backend/internal/adapters/agent/amp/amp.go
@@ -50,11 +50,12 @@ func (p *Plugin) Manifest() adapters.Manifest {
 
 // GetLaunchCommand builds the argv to start a new interactive Amp session:
 //
-//	amp [--permission-mode <mode>] [--append-system-prompt <system prompt>] [-- <prompt>]
+//	amp [--permission-mode <mode>] [-- <prompt>]
 //
 // The prompt is passed after `--` so a prompt beginning with "-" is not
-// mistaken for a flag. System prompts are appended to Amp's defaults, mirroring
-// the Claude Code adapter's launch shape.
+// mistaken for a flag. Amp has no documented system-prompt flag, so
+// SystemPrompt and SystemPromptFile are intentionally ignored until Amp exposes
+// a supported instruction mechanism.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -66,11 +67,6 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd = []string{binary}
 	appendPermissionFlags(&cmd, cfg.Permissions)
-	if cfg.SystemPromptFile != "" {
-		cmd = append(cmd, "--append-system-prompt-file", cfg.SystemPromptFile)
-	} else if cfg.SystemPrompt != "" {
-		cmd = append(cmd, "--append-system-prompt", cfg.SystemPrompt)
-	}
 	if cfg.Prompt != "" {
 		cmd = append(cmd, "--", cfg.Prompt)
 	}

--- a/backend/internal/adapters/agent/amp/amp_test.go
+++ b/backend/internal/adapters/agent/amp/amp_test.go
@@ -100,7 +100,7 @@ func TestGetLaunchCommandMapsPermissionModes(t *testing.T) {
 	}
 }
 
-func TestGetLaunchCommandAppendsSystemPrompt(t *testing.T) {
+func TestGetLaunchCommandIgnoresInlineSystemPrompt(t *testing.T) {
 	p := &Plugin{resolvedBinary: "amp"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		SystemPrompt: "follow repo rules",
@@ -110,13 +110,14 @@ func TestGetLaunchCommandAppendsSystemPrompt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"amp", "--append-system-prompt", "follow repo rules", "--", "do the thing"}
+	want := []string{"amp", "--", "do the thing"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
+	assertAmpSystemPromptFlagsAbsent(t, cmd)
 }
 
-func TestGetLaunchCommandPrefersSystemPromptFileFlag(t *testing.T) {
+func TestGetLaunchCommandIgnoresSystemPromptFile(t *testing.T) {
 	p := &Plugin{resolvedBinary: "amp"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		SystemPromptFile: "/tmp/system.md",
@@ -126,9 +127,20 @@ func TestGetLaunchCommandPrefersSystemPromptFileFlag(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"amp", "--append-system-prompt-file", "/tmp/system.md"}
+	want := []string{"amp"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+	assertAmpSystemPromptFlagsAbsent(t, cmd)
+}
+
+func assertAmpSystemPromptFlagsAbsent(t *testing.T, cmd []string) {
+	t.Helper()
+	for _, arg := range cmd {
+		switch arg {
+		case "--append-system-prompt", "--append-system-prompt-file":
+			t.Fatalf("cmd = %#v unexpectedly contains unsupported Amp system prompt flag %q", cmd, arg)
+		}
 	}
 }
 


### PR DESCRIPTION


---

## What changed
- Removed Amp launch args for `--append-system-prompt` and `--append-system-prompt-file`.
- Updated Amp adapter comments to document that `SystemPrompt` and `SystemPromptFile` are ignored until Amp exposes a supported instruction mechanism.
- Updated Amp adapter tests to assert:
  - inline system prompts are ignored
  - file-based system prompts are ignored
  - unsupported Amp system prompt flags are not emitted
  - normal prompt delivery via `-- <prompt>` still works

## Why
Amp does not support the Claude-style system prompt flags AO was passing. When Amp is selected as an orchestrator agent, AO launched a command like:

```sh
amp --append-system-prompt "<orchestrator system prompt>"
```

Amp rejects that immediately with:

```
error: unknown option '--append-system-prompt'
```

This caused Amp orchestrator sessions to exit on startup. The safest fix is to stop passing unsupported flags and keep Amp launch behavior limited to supported CLI args.

## Validation
```sh
GOCACHE=/private/tmp/go-build-ao-amp go test ./internal/adapters/agent/amp
```

https://github.com/user-attachments/assets/22b5aa12-9627-4c03-8bf7-4077490a52c7

Closes #2438

---

