### PR TITLE
Add codex-fugu agent adapter

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -29,6 +29,7 @@ var Derivers = map[string]DeriveFunc{
 	// deriver; the rest share the name-only StandardDeriveActivityState.
 	"claude-code": claudecode.DeriveActivityState,
 	"codex":       codex.DeriveActivityState,
+	"codex-fugu":  codex.DeriveActivityState,
 	"droid":       droid.DeriveActivityState,
 	"agy":         agy.DeriveActivityState,
 	"opencode":    opencode.DeriveActivityState,

--- a/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
@@ -18,7 +18,7 @@ func TestDeriverTokensAreKnownHarnesses(t *testing.T) {
 }
 
 func TestSupportsHarness(t *testing.T) {
-	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessOpenCode} {
+	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessCodexFugu, domain.HarnessClaudeCode, domain.HarnessOpenCode} {
 		if !SupportsHarness(h) {
 			t.Errorf("SupportsHarness(%q) = false, want true", h)
 		}

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -82,6 +82,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	}
 
 	cmd = []string{binary}
+	p.appendWrapperFlags(&cmd)
 	appendNoUpdateCheckFlag(&cmd)
 	appendHideRateLimitNudgeFlag(&cmd)
 	appendHookTrustBypassFlag(&cmd)
@@ -121,8 +122,10 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 
-	cmd = make([]string, 0, 24)
-	cmd = append(cmd, binary, "resume")
+	cmd = make([]string, 0, 25)
+	cmd = append(cmd, binary)
+	p.appendWrapperFlags(&cmd)
+	cmd = append(cmd, "resume")
 	appendNoUpdateCheckFlag(&cmd)
 	appendHideRateLimitNudgeFlag(&cmd)
 	appendHookTrustBypassFlag(&cmd)
@@ -164,6 +167,12 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 		return ports.AgentAuthStatusUnauthorized, nil
 	}
 	return ports.AgentAuthStatusUnknown, nil
+}
+
+func (p *Plugin) appendWrapperFlags(cmd *[]string) {
+	if p.adapterID() == "codex-fugu" {
+		*cmd = append(*cmd, "--no-update")
+	}
 }
 
 func loginStatusForBinary(ctx context.Context, binary string) (ports.AgentAuthStatus, string, error, error) {

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -27,13 +27,30 @@ import (
 // path is resolved once and cached under binaryMu.
 type Plugin struct {
 	agentbase.Base
-	binaryMu       sync.Mutex
-	resolvedBinary string
+	manifestID          string
+	manifestName        string
+	manifestDescription string
+	binaryName          string
+	hookAgentToken      string
+	binaryMu            sync.Mutex
+	resolvedBinary      string
 }
 
 // New returns a ready-to-register Codex adapter.
 func New() *Plugin {
 	return &Plugin{}
+}
+
+// NewFugu returns a Codex-compatible adapter that launches the codex-fugu
+// binary while preserving Codex's flags, hooks, auth probe, and activity model.
+func NewFugu() *Plugin {
+	return &Plugin{
+		manifestID:          "codex-fugu",
+		manifestName:        "Codex Fugu",
+		manifestDescription: "Run Codex Fugu worker sessions.",
+		binaryName:          "codex-fugu",
+		hookAgentToken:      "codex-fugu",
+	}
 }
 
 var _ adapters.Adapter = (*Plugin)(nil)
@@ -43,9 +60,9 @@ var _ ports.AgentAuthChecker = (*Plugin)(nil)
 // Manifest returns the adapter's static self-description.
 func (p *Plugin) Manifest() adapters.Manifest {
 	return adapters.Manifest{
-		ID:          "codex",
-		Name:        "Codex",
-		Description: "Run Codex worker sessions.",
+		ID:          p.adapterID(),
+		Name:        p.adapterName(),
+		Description: p.adapterDescription(),
 		Version:     "0.0.1",
 		Capabilities: []adapters.Capability{
 			adapters.CapabilityAgent,
@@ -59,7 +76,7 @@ func (p *Plugin) Manifest() adapters.Manifest {
 // instructions, and the initial prompt (passed after `--` so a leading "-" is
 // not read as a flag).
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
-	binary, err := p.codexBinary(ctx)
+	binary, err := p.agentBinary(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +86,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	appendHideRateLimitNudgeFlag(&cmd)
 	appendHookTrustBypassFlag(&cmd)
 	appendApprovalFlags(&cmd, cfg.Permissions)
-	appendSessionHookFlags(&cmd)
+	appendSessionHookFlagsFor(&cmd, p.hookToken())
 	appendTerminalCompatibilityFlags(&cmd)
 	appendWorkspaceTrustFlag(&cmd, cfg.WorkspacePath)
 
@@ -99,7 +116,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, nil
 	}
 
-	binary, err := p.codexBinary(ctx)
+	binary, err := p.agentBinary(ctx)
 	if err != nil {
 		return nil, false, err
 	}
@@ -110,7 +127,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	appendHideRateLimitNudgeFlag(&cmd)
 	appendHookTrustBypassFlag(&cmd)
 	appendApprovalFlags(&cmd, cfg.Permissions)
-	appendSessionHookFlags(&cmd)
+	appendSessionHookFlagsFor(&cmd, p.hookToken())
 	appendTerminalCompatibilityFlags(&cmd)
 	appendWorkspaceTrustFlag(&cmd, cfg.Session.WorkspacePath)
 	cmd = append(cmd, agentSessionID)
@@ -129,7 +146,7 @@ func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (por
 
 // AuthStatus checks Codex's local login state without making a model call.
 func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
-	binary, err := p.codexBinary(ctx)
+	binary, err := p.agentBinary(ctx)
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
@@ -147,10 +164,26 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	if strings.Contains(text, "logged in") {
 		return ports.AgentAuthStatusAuthorized, nil
 	}
+	if p.adapterID() == "codex-fugu" && err != nil && strings.Contains(text, "--profile only applies") {
+		return p.fuguRuntimeAuthStatus(ctx, binary)
+	}
 	if err != nil {
 		return ports.AgentAuthStatusUnauthorized, nil
 	}
 	return ports.AgentAuthStatusUnknown, nil
+}
+
+func (p *Plugin) fuguRuntimeAuthStatus(ctx context.Context, binary string) (ports.AgentAuthStatus, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	if err := exec.CommandContext(probeCtx, binary, "exec", "--help").Run(); err != nil {
+		if probeCtx.Err() != nil {
+			return ports.AgentAuthStatusUnknown, probeCtx.Err()
+		}
+		return ports.AgentAuthStatusUnauthorized, nil
+	}
+	return ports.AgentAuthStatusAuthorized, nil
 }
 
 // ResolveCodexBinary returns the path to the codex binary on this machine,
@@ -159,15 +192,28 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 // fallback so callers see a clear "command not found" rather than an empty
 // argv.
 func ResolveCodexBinary(ctx context.Context) (string, error) {
+	return ResolveAgentBinary(ctx, "codex")
+}
+
+// ResolveAgentBinary returns the path to the requested Codex-family binary on
+// this machine, searching PATH then common install locations.
+func ResolveAgentBinary(ctx context.Context, binaryName string) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
+	binaryName = strings.TrimSpace(binaryName)
+	if binaryName == "" {
+		binaryName = "codex"
+	}
 
 	if runtime.GOOS == "windows" {
-		for _, name := range []string{"codex.exe", "codex.cmd", "codex"} {
+		for _, name := range []string{binaryName + ".exe", binaryName + ".cmd", binaryName} {
 			path, err := exec.LookPath(name)
 			if err == nil && path != "" {
-				return resolveNativeWindowsCodex(path), nil
+				if binaryName == "codex" {
+					return resolveNativeWindowsCodex(path), nil
+				}
+				return path, nil
 			}
 			if err := ctx.Err(); err != nil {
 				return "", err
@@ -176,42 +222,47 @@ func ResolveCodexBinary(ctx context.Context) (string, error) {
 
 		candidates := []string{}
 		if appData := os.Getenv("APPDATA"); appData != "" {
-			shim := filepath.Join(appData, "npm", "codex.cmd")
-			candidates = append(candidates, windowsNativeCodexCandidatesForShim(shim)...)
+			shim := filepath.Join(appData, "npm", binaryName+".cmd")
+			if binaryName == "codex" {
+				candidates = append(candidates, windowsNativeCodexCandidatesForShim(shim)...)
+			}
 			candidates = append(candidates,
-				filepath.Join(appData, "npm", "codex.exe"),
+				filepath.Join(appData, "npm", binaryName+".exe"),
 				shim,
 			)
 		}
 		if home, err := os.UserHomeDir(); err == nil {
-			candidates = append(candidates, filepath.Join(home, ".cargo", "bin", "codex.exe"))
+			candidates = append(candidates, filepath.Join(home, ".cargo", "bin", binaryName+".exe"))
 		}
 		for _, candidate := range candidates {
 			if fileExists(candidate) {
-				return resolveNativeWindowsCodex(candidate), nil
+				if binaryName == "codex" {
+					return resolveNativeWindowsCodex(candidate), nil
+				}
+				return candidate, nil
 			}
 			if err := ctx.Err(); err != nil {
 				return "", err
 			}
 		}
 
-		return "", fmt.Errorf("codex: %w", ports.ErrAgentBinaryNotFound)
+		return "", fmt.Errorf("%s: %w", binaryName, ports.ErrAgentBinaryNotFound)
 	}
 
-	if path, err := exec.LookPath("codex"); err == nil && path != "" {
+	if path, err := exec.LookPath(binaryName); err == nil && path != "" {
 		return path, nil
 	}
 
 	candidates := []string{
-		"/usr/local/bin/codex",
-		"/opt/homebrew/bin/codex",
+		filepath.Join("/usr/local/bin", binaryName),
+		filepath.Join("/opt/homebrew/bin", binaryName),
 	}
 	if home, err := os.UserHomeDir(); err == nil {
 		candidates = append(candidates,
-			filepath.Join(home, ".cargo", "bin", "codex"),
-			filepath.Join(home, ".npm", "bin", "codex"),
+			filepath.Join(home, ".cargo", "bin", binaryName),
+			filepath.Join(home, ".npm", "bin", binaryName),
 		)
-		candidates = append(candidates, nvmNodeBinCandidates(home, "codex")...)
+		candidates = append(candidates, nvmNodeBinCandidates(home, binaryName)...)
 	}
 
 	for _, candidate := range candidates {
@@ -223,7 +274,7 @@ func ResolveCodexBinary(ctx context.Context) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("codex: %w", ports.ErrAgentBinaryNotFound)
+	return "", fmt.Errorf("%s: %w", binaryName, ports.ErrAgentBinaryNotFound)
 }
 
 func nvmNodeBinCandidates(home, binary string) []string {
@@ -254,7 +305,7 @@ func windowsNativeCodexCandidatesForShim(shim string) []string {
 	}
 }
 
-func (p *Plugin) codexBinary(ctx context.Context) (string, error) {
+func (p *Plugin) agentBinary(ctx context.Context) (string, error) {
 	p.binaryMu.Lock()
 	defer p.binaryMu.Unlock()
 
@@ -262,12 +313,51 @@ func (p *Plugin) codexBinary(ctx context.Context) (string, error) {
 		return p.resolvedBinary, nil
 	}
 
-	binary, err := ResolveCodexBinary(ctx)
+	binary, err := ResolveAgentBinary(ctx, p.binaryCommand())
 	if err != nil {
 		return "", err
 	}
 	p.resolvedBinary = binary
 	return binary, nil
+}
+
+func (p *Plugin) codexBinary(ctx context.Context) (string, error) {
+	return p.agentBinary(ctx)
+}
+
+func (p *Plugin) adapterID() string {
+	if p.manifestID != "" {
+		return p.manifestID
+	}
+	return "codex"
+}
+
+func (p *Plugin) adapterName() string {
+	if p.manifestName != "" {
+		return p.manifestName
+	}
+	return "Codex"
+}
+
+func (p *Plugin) adapterDescription() string {
+	if p.manifestDescription != "" {
+		return p.manifestDescription
+	}
+	return "Run Codex worker sessions."
+}
+
+func (p *Plugin) binaryCommand() string {
+	if p.binaryName != "" {
+		return p.binaryName
+	}
+	return "codex"
+}
+
+func (p *Plugin) hookToken() string {
+	if p.hookAgentToken != "" {
+		return p.hookAgentToken
+	}
+	return "codex"
 }
 
 // DoctorLaunchProbes returns argv tails `ao doctor` runs against the installed

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -150,40 +150,56 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	if err != nil {
 		return ports.AgentAuthStatusUnknown, err
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	out, err := exec.CommandContext(probeCtx, binary, "login", "status").CombinedOutput()
-	if probeCtx.Err() != nil {
-		return ports.AgentAuthStatusUnknown, probeCtx.Err()
-	}
-	text := strings.ToLower(string(out))
-	if strings.Contains(text, "not logged in") || strings.Contains(text, "logged out") {
-		return ports.AgentAuthStatusUnauthorized, nil
-	}
-	if strings.Contains(text, "logged in") {
-		return ports.AgentAuthStatusAuthorized, nil
-	}
-	if p.adapterID() == "codex-fugu" && err != nil && strings.Contains(text, "--profile only applies") {
-		return p.fuguRuntimeAuthStatus(ctx, binary)
-	}
+	status, text, cmdErr, err := loginStatusForBinary(ctx, binary)
 	if err != nil {
+		return ports.AgentAuthStatusUnknown, err
+	}
+	if status != ports.AgentAuthStatusUnknown {
+		return status, nil
+	}
+	if p.adapterID() == "codex-fugu" && cmdErr != nil && strings.Contains(text, "--profile only applies") {
+		return fuguSharedCodexAuthStatus(ctx)
+	}
+	if cmdErr != nil {
 		return ports.AgentAuthStatusUnauthorized, nil
 	}
 	return ports.AgentAuthStatusUnknown, nil
 }
 
-func (p *Plugin) fuguRuntimeAuthStatus(ctx context.Context, binary string) (ports.AgentAuthStatus, error) {
+func loginStatusForBinary(ctx context.Context, binary string) (ports.AgentAuthStatus, string, error, error) {
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	if err := exec.CommandContext(probeCtx, binary, "exec", "--help").Run(); err != nil {
-		if probeCtx.Err() != nil {
-			return ports.AgentAuthStatusUnknown, probeCtx.Err()
-		}
+	out, err := exec.CommandContext(probeCtx, binary, "login", "status").CombinedOutput()
+	if probeCtx.Err() != nil {
+		return ports.AgentAuthStatusUnknown, "", err, probeCtx.Err()
+	}
+	text := strings.ToLower(string(out))
+	if strings.Contains(text, "not logged in") || strings.Contains(text, "logged out") {
+		return ports.AgentAuthStatusUnauthorized, text, err, nil
+	}
+	if strings.Contains(text, "logged in") {
+		return ports.AgentAuthStatusAuthorized, text, err, nil
+	}
+	return ports.AgentAuthStatusUnknown, text, err, nil
+}
+
+func fuguSharedCodexAuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) {
+	codexBinary, err := ResolveCodexBinary(ctx)
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, err
+	}
+	status, _, cmdErr, err := loginStatusForBinary(ctx, codexBinary)
+	if err != nil {
+		return ports.AgentAuthStatusUnknown, err
+	}
+	if status != ports.AgentAuthStatusUnknown {
+		return status, nil
+	}
+	if cmdErr != nil {
 		return ports.AgentAuthStatusUnauthorized, nil
 	}
-	return ports.AgentAuthStatusAuthorized, nil
+	return ports.AgentAuthStatusUnknown, nil
 }
 
 // ResolveCodexBinary returns the path to the codex binary on this machine,

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -29,11 +29,19 @@ func canonicalTempDir(t *testing.T) string {
 // asserted literally so accidental format drift fails loudly: Codex parses
 // these values as TOML.
 func sessionHookFlags() []string {
+	return sessionHookFlagsFor("codex")
+}
+
+func fuguSessionHookFlags() []string {
+	return sessionHookFlagsFor("codex-fugu")
+}
+
+func sessionHookFlagsFor(agentToken string) []string {
 	return []string{
-		"-c", `hooks.SessionStart=[{hooks=[{type="command",command="ao hooks codex session-start",timeout=5}]}]`,
-		"-c", `hooks.UserPromptSubmit=[{hooks=[{type="command",command="ao hooks codex user-prompt-submit",timeout=5}]}]`,
-		"-c", `hooks.PermissionRequest=[{hooks=[{type="command",command="ao hooks codex permission-request",timeout=5}]}]`,
-		"-c", `hooks.Stop=[{hooks=[{type="command",command="ao hooks codex stop",timeout=5}]}]`,
+		"-c", `hooks.SessionStart=[{hooks=[{type="command",command="ao hooks ` + agentToken + ` session-start",timeout=5}]}]`,
+		"-c", `hooks.UserPromptSubmit=[{hooks=[{type="command",command="ao hooks ` + agentToken + ` user-prompt-submit",timeout=5}]}]`,
+		"-c", `hooks.PermissionRequest=[{hooks=[{type="command",command="ao hooks ` + agentToken + ` permission-request",timeout=5}]}]`,
+		"-c", `hooks.Stop=[{hooks=[{type="command",command="ao hooks ` + agentToken + ` stop",timeout=5}]}]`,
 	}
 }
 
@@ -70,6 +78,50 @@ func TestGetLaunchCommandBuildsCrossPlatformArgv(t *testing.T) {
 	)
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestFuguManifestAndLaunchCommandMirrorCodex(t *testing.T) {
+	plugin := NewFugu()
+	plugin.resolvedBinary = "codex-fugu"
+	workspace := canonicalTempDir(t)
+
+	manifest := plugin.Manifest()
+	if manifest.ID != "codex-fugu" {
+		t.Fatalf("Manifest ID = %q, want codex-fugu", manifest.ID)
+	}
+	if manifest.Name != "Codex Fugu" {
+		t.Fatalf("Manifest Name = %q, want Codex Fugu", manifest.Name)
+	}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Permissions:      ports.PermissionModeBypassPermissions,
+		Prompt:           "-fix this",
+		SystemPromptFile: filepath.Join("tmp", "prompt with spaces.md"),
+		WorkspacePath:    workspace,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"codex-fugu",
+		"-c", "check_for_update_on_startup=false",
+		"-c", "notice.hide_rate_limit_model_nudge=true",
+		"--dangerously-bypass-hook-trust",
+		"--dangerously-bypass-approvals-and-sandbox",
+	}
+	want = append(want, fuguSessionHookFlags()...)
+	if runtime.GOOS == "windows" {
+		want = append(want, "--no-alt-screen")
+	}
+	want = append(want,
+		"-c", `projects={`+codexTOMLConfigString(workspace)+`={trust_level="trusted"}}`,
+		"-c", "model_instructions_file="+filepath.Join("tmp", "prompt with spaces.md"),
+		"--", "-fix this",
+	)
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected fugu command\nwant: %#v\n got: %#v", want, cmd)
 	}
 }
 
@@ -119,6 +171,69 @@ func TestResolveCodexBinaryFindsNVMInstallWhenPathIsSparse(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("ResolveCodexBinary = %q, want %q", got, want)
+	}
+}
+
+func TestResolveAgentBinaryFindsNamedNVMInstallWhenPathIsSparse(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("NVM install discovery is Unix-specific")
+	}
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".nvm", "versions", "node", "v20.19.4", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(binDir, "codex-fugu")
+	if err := os.WriteFile(want, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "")
+	origFileExists := fileExists
+	fileExists = func(path string) bool {
+		return strings.HasPrefix(path, home+string(os.PathSeparator)) && origFileExists(path)
+	}
+	t.Cleanup(func() {
+		fileExists = origFileExists
+	})
+
+	got, err := ResolveAgentBinary(context.Background(), "codex-fugu")
+	if err != nil {
+		t.Fatalf("ResolveAgentBinary: %v", err)
+	}
+	if got != want {
+		t.Fatalf("ResolveAgentBinary = %q, want %q", got, want)
+	}
+}
+
+func TestFuguAuthStatusFallsBackWhenLoginStatusRejectsProfile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake is Unix-specific")
+	}
+	bin := filepath.Join(t.TempDir(), "codex-fugu")
+	script := `#!/bin/sh
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo 'Error: --profile only applies to runtime commands and codex mcp' >&2
+  exit 1
+fi
+if [ "$1" = "exec" ] && [ "$2" = "--help" ]; then
+  echo 'Run Codex non-interactively'
+  exit 0
+fi
+exit 2
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin := NewFugu()
+	plugin.resolvedBinary = bin
+	got, err := plugin.AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("AuthStatus = %q, want authorized", got)
 	}
 }
 
@@ -452,6 +567,46 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 		"-c", `approvals_reviewer="auto_review"`,
 	}
 	want = append(want, sessionHookFlags()...)
+	if runtime.GOOS == "windows" {
+		want = append(want, "--no-alt-screen")
+	}
+	want = append(want,
+		"-c", `projects={`+codexTOMLConfigString(workspace)+`={trust_level="trusted"}}`,
+		"thread-123",
+	)
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestFuguGetRestoreCommandReadsAgentSessionID(t *testing.T) {
+	plugin := NewFugu()
+	plugin.resolvedBinary = "codex-fugu"
+	workspace := canonicalTempDir(t)
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Permissions: ports.PermissionModeAuto,
+		Session: ports.SessionRef{
+			Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: "thread-123"},
+			WorkspacePath: workspace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	want := []string{
+		"codex-fugu",
+		"resume",
+		"-c", "check_for_update_on_startup=false",
+		"-c", "notice.hide_rate_limit_model_nudge=true",
+		"--dangerously-bypass-hook-trust",
+		"--ask-for-approval", "on-request",
+		"-c", `approvals_reviewer="auto_review"`,
+	}
+	want = append(want, fuguSessionHookFlags()...)
 	if runtime.GOOS == "windows" {
 		want = append(want, "--no-alt-screen")
 	}

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -106,6 +106,7 @@ func TestFuguManifestAndLaunchCommandMirrorCodex(t *testing.T) {
 
 	want := []string{
 		"codex-fugu",
+		"--no-update",
 		"-c", "check_for_update_on_startup=false",
 		"-c", "notice.hide_rate_limit_model_nudge=true",
 		"--dangerously-bypass-hook-trust",
@@ -656,6 +657,7 @@ func TestFuguGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 	}
 	want := []string{
 		"codex-fugu",
+		"--no-update",
 		"resume",
 		"-c", "check_for_update_on_startup=false",
 		"-c", "notice.hide_rate_limit_model_nudge=true",

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -210,8 +210,9 @@ func TestFuguAuthStatusFallsBackWhenLoginStatusRejectsProfile(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script fake is Unix-specific")
 	}
-	bin := filepath.Join(t.TempDir(), "codex-fugu")
-	script := `#!/bin/sh
+	binDir := t.TempDir()
+	fuguBin := filepath.Join(binDir, "codex-fugu")
+	fuguScript := `#!/bin/sh
 if [ "$1" = "login" ] && [ "$2" = "status" ]; then
   echo 'Error: --profile only applies to runtime commands and codex mcp' >&2
   exit 1
@@ -222,18 +223,74 @@ if [ "$1" = "exec" ] && [ "$2" = "--help" ]; then
 fi
 exit 2
 `
-	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+	if err := os.WriteFile(fuguBin, []byte(fuguScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	codexBin := filepath.Join(binDir, "codex")
+	codexScript := `#!/bin/sh
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo 'Logged in as test@example.com'
+  exit 0
+fi
+exit 2
+`
+	if err := os.WriteFile(codexBin, []byte(codexScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
 
 	plugin := NewFugu()
-	plugin.resolvedBinary = bin
+	plugin.resolvedBinary = fuguBin
 	got, err := plugin.AuthStatus(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got != ports.AgentAuthStatusAuthorized {
 		t.Fatalf("AuthStatus = %q, want authorized", got)
+	}
+}
+
+func TestFuguAuthStatusDoesNotTreatRuntimeHelpAsAuthorized(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake is Unix-specific")
+	}
+	binDir := t.TempDir()
+	fuguBin := filepath.Join(binDir, "codex-fugu")
+	fuguScript := `#!/bin/sh
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo 'Error: --profile only applies to runtime commands and codex mcp' >&2
+  exit 1
+fi
+if [ "$1" = "exec" ] && [ "$2" = "--help" ]; then
+  echo 'Run Codex non-interactively'
+  exit 0
+fi
+exit 2
+`
+	if err := os.WriteFile(fuguBin, []byte(fuguScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codexBin := filepath.Join(binDir, "codex")
+	codexScript := `#!/bin/sh
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo 'Not logged in'
+  exit 1
+fi
+exit 2
+`
+	if err := os.WriteFile(codexBin, []byte(codexScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	plugin := NewFugu()
+	plugin.resolvedBinary = fuguBin
+	got, err := plugin.AuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != ports.AgentAuthStatusUnauthorized {
+		t.Fatalf("AuthStatus = %q, want unauthorized", got)
 	}
 }
 

--- a/backend/internal/adapters/agent/codex/hooks.go
+++ b/backend/internal/adapters/agent/codex/hooks.go
@@ -76,9 +76,14 @@ var codexManagedHooks = []codexHookSpec{
 // appendSessionHookFlags adds AO's activity hooks to the argv as `-c`
 // session-flag config, one flag per managed event.
 func appendSessionHookFlags(cmd *[]string) {
+	appendSessionHookFlagsFor(cmd, "codex")
+}
+
+func appendSessionHookFlagsFor(cmd *[]string, agentToken string) {
 	for _, spec := range codexManagedHooks {
+		command := strings.Replace(spec.Command, codexHookCommandPrefix, "ao hooks "+agentToken+" ", 1)
 		flag := fmt.Sprintf(`hooks.%s=[{hooks=[{type="command",command=%s,timeout=%d}]}]`,
-			spec.Event, codexTOMLBasicString(spec.Command), codexHookTimeout)
+			spec.Event, codexTOMLBasicString(command), codexHookTimeout)
 		*cmd = append(*cmd, "-c", flag)
 	}
 }

--- a/backend/internal/adapters/agent/codex/install.go
+++ b/backend/internal/adapters/agent/codex/install.go
@@ -4,5 +4,5 @@ import "context"
 
 // ResolveBinary resolves the executable path for the plugin.
 func (p *Plugin) ResolveBinary(ctx context.Context) (string, error) {
-	return p.codexBinary(ctx)
+	return p.agentBinary(ctx)
 }

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -42,6 +42,7 @@ func Constructors() []adapters.Adapter {
 	return []adapters.Adapter{
 		claudecode.New(),
 		codex.New(),
+		codex.NewFugu(),
 		opencode.New(),
 		grok.New(),
 		cursor.New(),

--- a/backend/internal/adapters/agent/registry/registry_test.go
+++ b/backend/internal/adapters/agent/registry/registry_test.go
@@ -72,6 +72,18 @@ func TestEveryHarnessReportsAuthStatus(t *testing.T) {
 	}
 }
 
+func TestHarnessedIncludesCodexFugu(t *testing.T) {
+	for _, ha := range Harnessed() {
+		if ha.Harness == "codex-fugu" {
+			if ha.Manifest.Name != "Codex Fugu" {
+				t.Fatalf("codex-fugu manifest name = %q, want Codex Fugu", ha.Manifest.Name)
+			}
+			return
+		}
+	}
+	t.Fatal("Harnessed() missing codex-fugu")
+}
+
 // workspaceFiles returns every regular file under root, relative to root.
 func workspaceFiles(t *testing.T, root string) []string {
 	t.Helper()

--- a/backend/internal/cli/doctor.go
+++ b/backend/internal/cli/doctor.go
@@ -62,6 +62,7 @@ type harnessProbe struct {
 var doctorHarnesses = []harnessProbe{
 	{Name: "claude-code", BinaryName: "claude", VersionArg: "--version"},
 	{Name: "codex", BinaryName: "codex", VersionArg: "--version"},
+	{Name: "codex-fugu", BinaryName: "codex-fugu", VersionArg: "--version"},
 }
 
 func newDoctorCommand(ctx *commandContext) *cobra.Command {

--- a/backend/internal/cli/doctor_test.go
+++ b/backend/internal/cli/doctor_test.go
@@ -117,15 +117,16 @@ func TestDoctorWarnsWhenTmuxMissing(t *testing.T) {
 func TestDoctorChecksHarnessVersions(t *testing.T) {
 	setConfigEnv(t)
 	cmdPath := map[string]string{
-		"git":    "/bin/git",
-		"claude": "/bin/claude",
-		"codex":  "/bin/codex",
+		"git":        "/bin/git",
+		"claude":     "/bin/claude",
+		"codex":      "/bin/codex",
+		"codex-fugu": "/bin/codex-fugu",
 	}
 	c := doctorContext(t, cmdPath, func(_ context.Context, name string, args ...string) ([]byte, error) {
 		switch name {
 		case "/bin/git":
 			return []byte("git version 2.43.0\n"), nil
-		case "/bin/claude", "/bin/codex":
+		case "/bin/claude", "/bin/codex", "/bin/codex-fugu":
 			if len(args) == 1 && args[0] == "--version" {
 				return []byte(strings.TrimPrefix(name, "/bin/") + " 1.2.3\n"), nil
 			}
@@ -142,7 +143,7 @@ func TestDoctorChecksHarnessVersions(t *testing.T) {
 	})
 
 	checks := c.runDoctor(context.Background())
-	for _, name := range []string{"claude-code", "codex"} {
+	for _, name := range []string{"claude-code", "codex", "codex-fugu"} {
 		check := findDoctorCheck(t, checks, name)
 		if check.Level != doctorPass || !strings.Contains(check.Message, "resolves to") {
 			t.Fatalf("%s check = %+v, want PASS with path/version", name, check)
@@ -302,7 +303,7 @@ func TestDoctorTextOutputIsGrouped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("doctor failed: %v\nstderr=%s\nstdout=%s", err, errOut, out)
 	}
-	for _, want := range []string{"Core:\nPASS config:", "Tools:\nPASS git:", "Agent harnesses:\nWARN claude-code:", "WARN codex:", "GitHub:\nWARN github-token:"} {
+	for _, want := range []string{"Core:\nPASS config:", "Tools:\nPASS git:", "Agent harnesses:\nWARN claude-code:", "WARN codex:", "WARN codex-fugu:", "GitHub:\nWARN github-token:"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("doctor output missing %q:\n%s", want, out)
 		}

--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -157,7 +157,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 		return pflag.NormalizedName(name)
 	})
 	f.StringVar(&opts.project, "project", "", "Project id to spawn the session in (default: AO_PROJECT_ID or current registered repo)")
-	f.StringVar(&opts.harness, "harness", "", "Agent harness / --agent: claude-code, codex, aider, opencode, grok, droid, amp, agy, crush, cursor, qwen, copilot, goose, auggie, continue, devin, cline, kimi, kiro, kilocode, vibe, pi, autohand (default: project worker.agent; required if the project has none)")
+	f.StringVar(&opts.harness, "harness", "", "Agent harness / --agent: claude-code, codex, codex-fugu, aider, opencode, grok, droid, amp, agy, crush, cursor, qwen, copilot, goose, auggie, continue, devin, cline, kimi, kiro, kilocode, vibe, pi, autohand (default: project worker.agent; required if the project has none)")
 	f.StringVar(&opts.branch, "branch", "", "Branch for the session worktree (default: ao/<session-id>/root)")
 	f.StringVar(&opts.prompt, "prompt", "", "Initial prompt for the agent")
 	f.StringVar(&opts.issue, "issue", "", "Issue id to associate with the session")

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -93,6 +93,7 @@ func TestWiring_AgentResolverResolvesRealAdapters(t *testing.T) {
 	}{
 		{domain.HarnessClaudeCode, "claude-code"},
 		{domain.HarnessCodex, "codex"},
+		{domain.HarnessCodexFugu, "codex-fugu"},
 		{domain.HarnessOpenCode, "opencode"},
 		{domain.HarnessGrok, "grok"},
 		{domain.HarnessCursor, "cursor"},

--- a/backend/internal/domain/harness.go
+++ b/backend/internal/domain/harness.go
@@ -7,6 +7,7 @@ type AgentHarness string
 const (
 	HarnessClaudeCode AgentHarness = "claude-code"
 	HarnessCodex      AgentHarness = "codex"
+	HarnessCodexFugu  AgentHarness = "codex-fugu"
 	HarnessAider      AgentHarness = "aider"
 	HarnessOpenCode   AgentHarness = "opencode"
 	HarnessGrok       AgentHarness = "grok"
@@ -33,7 +34,7 @@ const (
 // AllHarnesses lists every supported harness. It is the canonical set used to
 // validate user-supplied harness names (e.g. per-project role overrides).
 var AllHarnesses = []AgentHarness{
-	HarnessClaudeCode, HarnessCodex, HarnessAider, HarnessOpenCode, HarnessGrok,
+	HarnessClaudeCode, HarnessCodex, HarnessCodexFugu, HarnessAider, HarnessOpenCode, HarnessGrok,
 	HarnessDroid, HarnessAmp, HarnessAgy, HarnessCrush, HarnessCursor, HarnessQwen,
 	HarnessCopilot, HarnessGoose, HarnessAuggie, HarnessContinue, HarnessDevin,
 	HarnessCline, HarnessKimi, HarnessKiro, HarnessKilocode, HarnessVibe, HarnessPi,

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2620,6 +2620,7 @@ components:
           enum:
           - claude-code
           - codex
+          - codex-fugu
           - aider
           - opencode
           - grok

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -149,7 +149,7 @@ type SpawnSessionRequest struct {
 	ProjectID domain.ProjectID    `json:"projectId"`
 	IssueID   domain.IssueID      `json:"issueId,omitempty"`
 	Kind      domain.SessionKind  `json:"kind,omitempty" enum:"worker,orchestrator"`
-	Harness   domain.AgentHarness `json:"harness,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,kiro,kilocode,vibe,pi,autohand"`
+	Harness   domain.AgentHarness `json:"harness,omitempty" enum:"claude-code,codex,codex-fugu,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,kiro,kilocode,vibe,pi,autohand"`
 	Branch    string              `json:"branch,omitempty"`
 	Prompt    string              `json:"prompt,omitempty" maxLength:"4096"`
 	// DisplayName is the sidebar label for the session, capped at 20 characters.

--- a/backend/internal/skillassets/using-ao/commands/spawn.md
+++ b/backend/internal/skillassets/using-ao/commands/spawn.md
@@ -23,7 +23,7 @@ ao spawn [flags]
 
 `--agent` is an alias for `--harness`.
 
-Available harnesses: `claude-code`, `codex`, `aider`, `opencode`, `grok`, `droid`, `amp`, `agy`, `crush`, `cursor`, `qwen`, `copilot`, `goose`, `auggie`, `continue`, `devin`, `cline`, `kimi`, `kiro`, `kilocode`, `vibe`, `pi`, `autohand`.
+Available harnesses: `claude-code`, `codex`, `codex-fugu`, `aider`, `opencode`, `grok`, `droid`, `amp`, `agy`, `crush`, `cursor`, `qwen`, `copilot`, `goose`, `auggie`, `continue`, `devin`, `cline`, `kimi`, `kiro`, `kilocode`, `vibe`, `pi`, `autohand`.
 
 ## Examples
 

--- a/backend/internal/storage/sqlite/migrate_test.go
+++ b/backend/internal/storage/sqlite/migrate_test.go
@@ -34,33 +34,7 @@ func TestMigrateAllowsEveryShippedHarness(t *testing.T) {
 		t.Fatalf("read sessions schema: %v", err)
 	}
 
-	harnesses := []domain.AgentHarness{
-		domain.HarnessClaudeCode,
-		domain.HarnessCodex,
-		domain.HarnessAider,
-		domain.HarnessOpenCode,
-		domain.HarnessGrok,
-		domain.HarnessDroid,
-		domain.HarnessAmp,
-		domain.HarnessAgy,
-		domain.HarnessCrush,
-		domain.HarnessCursor,
-		domain.HarnessQwen,
-		domain.HarnessCopilot,
-		domain.HarnessGoose,
-		domain.HarnessAuggie,
-		domain.HarnessContinue,
-		domain.HarnessDevin,
-		domain.HarnessCline,
-		domain.HarnessKimi,
-		domain.HarnessKiro,
-		domain.HarnessKilocode,
-		domain.HarnessVibe,
-		domain.HarnessPi,
-		domain.HarnessAutohand,
-	}
-
-	for _, h := range harnesses {
+	for _, h := range domain.AllHarnesses {
 		if !strings.Contains(schema, "'"+string(h)+"'") {
 			t.Errorf("sessions.harness CHECK is missing harness %q — the migration that widens it silently no-opped; schema:\n%s", h, schema)
 		}

--- a/backend/internal/storage/sqlite/migrations/0023_allow_codex_fugu_harness.sql
+++ b/backend/internal/storage/sqlite/migrations/0023_allow_codex_fugu_harness.sql
@@ -1,0 +1,38 @@
+-- Widen the sessions.harness CHECK for the codex-fugu agent adapter. Existing
+-- databases have already applied 0007, so this must be a new migration rather
+-- than an edit to the earlier collapsed harness-list rewrite.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+PRAGMA writable_schema = ON;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (harness IN ('''', ''claude-code'', ''codex'', ''aider'', ''opencode'', ''grok'', ''droid'', ''amp'', ''agy'', ''crush'', ''cursor'', ''qwen'', ''copilot'', ''goose'', ''auggie'', ''continue'', ''devin'', ''cline'', ''kimi'', ''kiro'', ''kilocode'', ''vibe'', ''pi'', ''autohand''))',
+    'CHECK (harness IN ('''', ''claude-code'', ''codex'', ''codex-fugu'', ''aider'', ''opencode'', ''grok'', ''droid'', ''amp'', ''agy'', ''crush'', ''cursor'', ''qwen'', ''copilot'', ''goose'', ''auggie'', ''continue'', ''devin'', ''cline'', ''kimi'', ''kiro'', ''kilocode'', ''vibe'', ''pi'', ''autohand''))'
+)
+WHERE type = 'table' AND name = 'sessions';
+-- +goose StatementEnd
+-- +goose StatementBegin
+PRAGMA writable_schema = RESET;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+PRAGMA writable_schema = ON;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (harness IN ('''', ''claude-code'', ''codex'', ''codex-fugu'', ''aider'', ''opencode'', ''grok'', ''droid'', ''amp'', ''agy'', ''crush'', ''cursor'', ''qwen'', ''copilot'', ''goose'', ''auggie'', ''continue'', ''devin'', ''cline'', ''kimi'', ''kiro'', ''kilocode'', ''vibe'', ''pi'', ''autohand''))',
+    'CHECK (harness IN ('''', ''claude-code'', ''codex'', ''aider'', ''opencode'', ''grok'', ''droid'', ''amp'', ''agy'', ''crush'', ''cursor'', ''qwen'', ''copilot'', ''goose'', ''auggie'', ''continue'', ''devin'', ''cline'', ''kimi'', ''kiro'', ''kilocode'', ''vibe'', ''pi'', ''autohand''))'
+)
+WHERE type = 'table' AND name = 'sessions';
+-- +goose StatementEnd
+-- +goose StatementBegin
+PRAGMA writable_schema = RESET;
+-- +goose StatementEnd

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -957,7 +957,7 @@ export interface components {
             branch?: string;
             displayName?: string;
             /** @enum {string} */
-            harness?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "kiro" | "kilocode" | "vibe" | "pi" | "autohand";
+            harness?: "claude-code" | "codex" | "codex-fugu" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "kiro" | "kilocode" | "vibe" | "pi" | "autohand";
             issueId?: string;
             /** @enum {string} */
             kind?: "worker" | "orchestrator";

--- a/frontend/src/landing/content/docs/cli.mdx
+++ b/frontend/src/landing/content/docs/cli.mdx
@@ -78,7 +78,7 @@ If AO is already running, you'll get an interactive prompt to open/restart/spawn
 | Flag                 | Default        | Purpose                                                                           |
 | -------------------- | -------------- | --------------------------------------------------------------------------------- |
 | `--open`             | —              | Open the session in a terminal tab                                                |
-| `--agent <name>`     | config default | Override the agent plugin (`claude-code`, `codex`, `cursor`, `aider`, `opencode`) |
+| `--agent <name>`     | config default | Override the agent plugin (`claude-code`, `codex`, `codex-fugu`, `cursor`, `aider`, `opencode`) |
 | `--claim-pr <pr>`    | —              | Immediately claim an existing PR for the spawned session                          |
 | `--assign-on-github` | —              | Assign the claimed PR to the authenticated GitHub user                            |
 | `--prompt <text>`    | —              | Use an inline prompt instead of an issue (max 4096 chars, newlines stripped)      |

--- a/frontend/src/landing/content/docs/configuration/index.mdx
+++ b/frontend/src/landing/content/docs/configuration/index.mdx
@@ -91,7 +91,7 @@ Do not manually edit `storageKey`, `path`, or `originUrl` unless you are repairi
 A practical local config usually starts with the agent, runtime, workspace, setup, and rules:
 
 ```yaml title="agent-orchestrator.yaml"
-agent: claude-code # claude-code | codex | aider | opencode
+agent: claude-code # claude-code | codex | codex-fugu | aider | opencode
 runtime: tmux # tmux | process
 workspace: worktree # worktree | clone
 

--- a/frontend/src/landing/content/docs/configuration/projects.mdx
+++ b/frontend/src/landing/content/docs/configuration/projects.mdx
@@ -38,6 +38,7 @@ Built-in agents:
 | ------------- | ------------------------------------------------------ |
 | `claude-code` | You want the default, most tested path                 |
 | `codex`       | You want OpenAI Codex CLI sessions                     |
+| `codex-fugu`  | You want Codex-compatible Fugu worker sessions         |
 | `aider`       | You already use Aider workflows                        |
 | `opencode`    | You want OpenCode session discovery and resume support |
 

--- a/frontend/src/landing/content/docs/faq.mdx
+++ b/frontend/src/landing/content/docs/faq.mdx
@@ -11,7 +11,7 @@ import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
   </Accordion>
 
 <Accordion title="Do I have to use Claude Code?">
-	No. AO supports Claude Code, Codex, Cursor, Aider, and OpenCode today. Set `agent:` per project (or per spawn with
+	No. AO supports Claude Code, Codex, Codex Fugu, Cursor, Aider, and OpenCode today. Set `agent:` per project (or per spawn with
 	`--agent`). See [Agents](/docs/plugins/agents).
 </Accordion>
 

--- a/frontend/src/landing/content/docs/plugins/agents/codex-fugu.mdx
+++ b/frontend/src/landing/content/docs/plugins/agents/codex-fugu.mdx
@@ -1,0 +1,66 @@
+---
+title: Codex Fugu
+description: Codex-compatible Fugu worker CLI. Full session resume and Codex-family hooks.
+---
+
+import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
+
+<div style={{ display: "flex", alignItems: "center", gap: "0.75rem", margin: "0.5rem 0 1.25rem" }}>
+	<Logo name="codex" size={28} />
+	<span style={{ fontSize: "0.8125rem", color: "var(--color-fd-muted-foreground)" }}>
+		Slot: <code>agent</code> · Name: <code>codex-fugu</code> · Binary: <code>codex-fugu</code>
+	</span>
+</div>
+
+Codex Fugu is a Codex-compatible worker profile exposed through the `codex-fugu` CLI. AO launches it with the same Codex-family session hooks, permissions, workspace trust, and resume flow as the standard Codex adapter.
+
+<PlatformSupport macos="full" linux="full" windows="partial" />
+
+## Install
+
+Install the `codex-fugu` binary on the worker host and make sure it is on `PATH`.
+
+```bash
+codex-fugu --version
+```
+
+## Use
+
+```yaml title="agent-orchestrator.yaml"
+agent: codex-fugu
+```
+
+No plugin-level config.
+
+## How it works
+
+- **Launch:** `codex-fugu` runs inside the worktree with AO's Codex-family launch flags and session hooks.
+- **Activity tracking:** AO derives activity from Codex session events and uses the `codex-fugu` hook token for session metadata.
+- **PR + git tracking:** AO installs wrappers at `~/.ao/bin/gh` and `~/.ao/bin/git`. When Codex Fugu runs `gh pr create`, the wrapper records the PR number in the session metadata.
+- **Session resume:** `codex-fugu resume <threadId>` — AO stores the thread id in session metadata and replays it.
+
+## Environment variables
+
+| Variable                     | Set by AO | Purpose                                             |
+| ---------------------------- | --------- | --------------------------------------------------- |
+| `AO_SESSION_ID`              | ✓         | AO session id                                       |
+| `AO_ISSUE_ID`                | ✓         | Issue identifier                                    |
+| `PATH`                       | ✓         | Prepends `~/.ao/bin` for the wrappers               |
+| `GH_PATH`                    | ✓         | Absolute path to the real `gh`, used by the wrapper |
+| `CODEX_DISABLE_UPDATE_CHECK` | ✓ (`1`)   | Skip version check                                  |
+
+Authentication comes from the same Codex credentials that the `codex-fugu` CLI reads. AO does not set API credentials.
+
+## Troubleshooting
+
+<Accordions>
+  <Accordion title="`codex-fugu` not found">
+    Confirm `codex-fugu --version` works in the same shell that starts AO. If it does not, add the binary's install directory to PATH and restart the daemon.
+  </Accordion>
+  <Accordion title="Auth status looks wrong">
+    Some `codex-fugu` wrappers reject `login status` because they inject a runtime profile. AO falls back to the shared `codex login status` signal in that case, so make sure the standard Codex CLI is authenticated too.
+  </Accordion>
+  <Accordion title="PR created but dashboard doesn't know">
+    The PATH wrapper writes session metadata on `gh pr create`. If `gh` was invoked with an absolute path (bypassing the wrapper) AO won't see it. `ao session claim-pr <pr> <sessionId>` fixes this retroactively.
+  </Accordion>
+</Accordions>

--- a/frontend/src/landing/content/docs/plugins/agents/codex-fugu.mdx
+++ b/frontend/src/landing/content/docs/plugins/agents/codex-fugu.mdx
@@ -34,7 +34,7 @@ No plugin-level config.
 
 ## How it works
 
-- **Launch:** `codex-fugu` runs inside the worktree with AO's Codex-family launch flags and session hooks.
+- **Launch:** `codex-fugu` runs inside the worktree with AO's Codex-family launch flags, update-suppression flags, and session hooks.
 - **Activity tracking:** AO derives activity from Codex session events and uses the `codex-fugu` hook token for session metadata.
 - **PR + git tracking:** AO installs wrappers at `~/.ao/bin/gh` and `~/.ao/bin/git`. When Codex Fugu runs `gh pr create`, the wrapper records the PR number in the session metadata.
 - **Session resume:** `codex-fugu resume <threadId>` — AO stores the thread id in session metadata and replays it.
@@ -47,7 +47,6 @@ No plugin-level config.
 | `AO_ISSUE_ID`                | ✓         | Issue identifier                                    |
 | `PATH`                       | ✓         | Prepends `~/.ao/bin` for the wrappers               |
 | `GH_PATH`                    | ✓         | Absolute path to the real `gh`, used by the wrapper |
-| `CODEX_DISABLE_UPDATE_CHECK` | ✓ (`1`)   | Skip version check                                  |
 
 Authentication comes from the same Codex credentials that the `codex-fugu` CLI reads. AO does not set API credentials.
 

--- a/frontend/src/landing/content/docs/plugins/agents/index.mdx
+++ b/frontend/src/landing/content/docs/plugins/agents/index.mdx
@@ -1,14 +1,14 @@
 ---
 title: Agents overview
-description: Pick the agent that writes the code. AO supports five today, and they're swappable per-project.
+description: Pick the agent that writes the code. AO supports six today, and they're swappable per-project.
 ---
 
 The agent is the piece that actually writes code. Everything else in AO — worktrees, runtimes, notifiers — is plumbing around it.
 
 <Callout type="info">
-	**PR metadata is captured automatically.** Non-Claude-Code agents (Codex, Cursor, Aider, OpenCode) use `~/.ao/bin/gh`
-	and `~/.ao/bin/git` PATH wrappers that intercept commands like `gh pr create` and record the resulting PR number and
-	branch so the dashboard stays in sync. Claude Code uses PostToolUse hooks in `.claude/settings.json` instead — the
+	**PR metadata is captured automatically.** Non-Claude-Code agents (Codex, Codex Fugu, Cursor, Aider, OpenCode) use
+	`~/.ao/bin/gh` and `~/.ao/bin/git` PATH wrappers that intercept commands like `gh pr create` and record the resulting
+	PR number and branch so the dashboard stays in sync. Claude Code uses PostToolUse hooks in `.claude/settings.json` instead — the
 	same metadata is written through Claude Code's native hook system. Both approaches are set up transparently by AO; you
 	don't need to configure anything.
 </Callout>
@@ -19,6 +19,7 @@ The agent is the piece that actually writes code. Everything else in AO — work
 | ----------------------------------------------- | ------------- | ---------- | ---------------------------- |
 | [Claude Code](/docs/plugins/agents/claude-code) | `claude-code` | `claude`   | ✅ `--resume`                |
 | [Codex](/docs/plugins/agents/codex)             | `codex`       | `codex`    | ✅ `codex resume <threadId>` |
+| [Codex Fugu](/docs/plugins/agents/codex-fugu)   | `codex-fugu`  | `codex-fugu` | ✅ `codex-fugu resume <threadId>` |
 | [Cursor](/docs/plugins/agents/cursor)           | `cursor`      | `agent`    | ❌                           |
 | [Aider](/docs/plugins/agents/aider)             | `aider`       | `aider`    | ❌                           |
 | [OpenCode](/docs/plugins/agents/opencode)       | `opencode`    | `opencode` | ✅ via OpenCode session API  |
@@ -31,6 +32,12 @@ The agent is the piece that actually writes code. Everything else in AO — work
 		description="Anthropic's CLI coding agent."
 	/>
 	<PluginCard name="Codex" logo="codex" href="/docs/plugins/agents/codex" description="OpenAI's Codex CLI." />
+	<PluginCard
+		name="Codex Fugu"
+		logo="codex"
+		href="/docs/plugins/agents/codex-fugu"
+		description="Codex-compatible Fugu worker CLI."
+	/>
 	<PluginCard name="Cursor" logo="cursor" href="/docs/plugins/agents/cursor" description="Cursor Agent CLI." />
 	<PluginCard name="Aider" logo="aider" href="/docs/plugins/agents/aider" description="Aider pair-programming CLI." />
 	<PluginCard
@@ -44,7 +51,7 @@ The agent is the piece that actually writes code. Everything else in AO — work
 ## Choosing
 
 - **Want session resume** (pick up where you left off)? Claude Code, Codex, or OpenCode.
-- **One-shot per session** is fine? Any of the five.
+- **One-shot per session** is fine? Any of the six.
 - **Pair-programming style editor**? Aider.
 - **Native IDE-like behavior in the terminal**? Cursor.
 
@@ -53,7 +60,7 @@ The agent is the piece that actually writes code. Everything else in AO — work
 Two patterns exist:
 
 - **Agent-native hooks** — Claude Code ships a PostToolUse hook in `.claude/settings.json`. AO's workspace bootstrap installs it; the agent writes activity events directly to AO's JSONL.
-- **PATH wrappers** — Codex, Cursor, Aider, and OpenCode don't have a hook system. AO installs small shell wrappers in `~/.ao/bin/gh` and `~/.ao/bin/git` and prepends them to `PATH`. When the agent runs `gh pr create` or `git commit`, the wrapper records metadata (PR number, branch, etc.) so the dashboard knows what the agent did.
+- **PATH wrappers** — Codex, Codex Fugu, Cursor, Aider, and OpenCode don't have a hook system. AO installs small shell wrappers in `~/.ao/bin/gh` and `~/.ao/bin/git` and prepends them to `PATH`. When the agent runs `gh pr create` or `git commit`, the wrapper records metadata (PR number, branch, etc.) so the dashboard knows what the agent did.
 
 Neither approach requires you to change your agent's config — AO sets it up transparently.
 
@@ -76,6 +83,7 @@ You can also override at spawn time:
 
 ```bash
 ao spawn 42 --agent codex
+ao spawn 43 --agent codex-fugu
 ```
 
 Great for A/B testing which agent does better on a specific kind of issue.

--- a/frontend/src/landing/content/docs/plugins/agents/index.mdx
+++ b/frontend/src/landing/content/docs/plugins/agents/index.mdx
@@ -50,7 +50,7 @@ The agent is the piece that actually writes code. Everything else in AO — work
 
 ## Choosing
 
-- **Want session resume** (pick up where you left off)? Claude Code, Codex, or OpenCode.
+- **Want session resume** (pick up where you left off)? Claude Code, Codex, Codex Fugu, or OpenCode.
 - **One-shot per session** is fine? Any of the six.
 - **Pair-programming style editor**? Aider.
 - **Native IDE-like behavior in the terminal**? Cursor.

--- a/frontend/src/landing/content/docs/plugins/agents/meta.json
+++ b/frontend/src/landing/content/docs/plugins/agents/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Agents",
-	"pages": ["claude-code", "codex", "cursor", "aider", "opencode"]
+	"pages": ["claude-code", "codex", "codex-fugu", "cursor", "aider", "opencode"]
 }

--- a/frontend/src/renderer/lib/agent-options.ts
+++ b/frontend/src/renderer/lib/agent-options.ts
@@ -1,6 +1,7 @@
 export const AGENT_OPTIONS = [
 	"claude-code",
 	"codex",
+	"codex-fugu",
 	"aider",
 	"opencode",
 	"grok",

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -269,6 +269,7 @@ describe("workerStatusPulses", () => {
 describe("toAgentProvider", () => {
 	it("passes through a known provider", () => {
 		expect(toAgentProvider("opencode")).toBe("opencode");
+		expect(toAgentProvider("codex-fugu")).toBe("codex-fugu");
 	});
 
 	it("defaults unknown and undefined providers to codex", () => {

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -59,6 +59,7 @@ export function toSessionActivity(
 
 export type AgentProvider =
 	| "codex"
+	| "codex-fugu"
 	| "claude-code"
 	| "opencode"
 	| "aider"
@@ -405,6 +406,7 @@ export function orchestratorHealth(workspace: WorkspaceSummary, restarting = fal
 
 export function toAgentProvider(provider?: string): AgentProvider {
 	switch (provider) {
+		case "codex-fugu":
 		case "claude-code":
 		case "opencode":
 		case "aider":


### PR DESCRIPTION
## Summary
- add a codex-fugu Codex-family adapter variant with its own manifest, binary resolution, hook token, auth probe fallback, and registry wiring
- add codex-fugu to harness validation, activity dispatch, API schema, CLI help, and frontend provider constants
- regenerate OpenAPI and TypeScript API schema

## Tests
- cd backend && go test ./internal/adapters/agent/codex ./internal/adapters/agent/registry ./internal/adapters/agent/activitydispatch ./internal/daemon ./internal/httpd/apispec/specgen

## Downstream Carry PR
Downstream carry PR: https://github.com/polymath-ventures/agent-orchestrator/pull/7

Note: this upstream branch is based directly on AgentWrapper/main and intentionally does not include downstream-only per-session model support.
