### PR TITLE
Improve prompt delivery strategy and update launch command logic

### DIFF
--- a/backend/internal/adapters/agent/continueagent/continueagent.go
+++ b/backend/internal/adapters/agent/continueagent/continueagent.go
@@ -14,10 +14,11 @@
 // callbacks through the existing "ao hooks claude-code <evt>" dispatcher — no
 // Continue-specific native hook config or activity deriver is needed.
 //
-// Launch is headless via `cn --print [--auto|--readonly] <prompt>`; the prompt
-// is the positional argument (in-command delivery). Restore continues a specific
-// native session by id with `cn --fork <sessionId>` (Continue's `--resume` only
-// continues the *last* session, so it cannot target a particular AO session).
+// Prompted launch is headless via `cn --print [--auto|--readonly] <prompt>`;
+// promptless launch is interactive via `cn [--auto|--readonly]`. Restore
+// continues a specific native session by id with `cn --fork <sessionId>`
+// (Continue's `--resume` only continues the *last* session, so it cannot target
+// a particular AO session).
 package continueagent
 
 import (
@@ -77,19 +78,24 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
-// GetLaunchCommand builds `cn --print [--auto|--readonly] <prompt>`.
+// GetLaunchCommand builds the Continue CLI argv for a fresh launch.
 //
-// `--print` runs Continue in non-interactive (headless) mode. The prompt is the
-// positional argument and is delivered in-command. Permission flags map AO's 4
-// modes onto Continue's two booleans (--auto / --readonly); Default and
-// AcceptEdits emit no flag so Continue resolves behavior from the user's config.
+// `--print` runs Continue in non-interactive (headless) mode, but Continue
+// rejects it without a prompt. Prompted launches therefore use
+// `cn --print ... -- <prompt>`, while promptless AO orchestrator launches stay
+// interactive as `cn ...`. Permission flags map AO's 4 modes onto Continue's
+// two booleans (--auto / --readonly); Default and AcceptEdits emit no flag so
+// Continue resolves behavior from the user's config.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	binary, err := p.continueBinary(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd = []string{binary, "--print"}
+	cmd = []string{binary}
+	if cfg.Prompt != "" {
+		cmd = append(cmd, "--print")
+	}
 	appendApprovalFlags(&cmd, cfg.Permissions)
 
 	if cfg.Prompt != "" {
@@ -97,6 +103,19 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	}
 
 	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports how Continue receives the initial prompt.
+// Prompted launches carry the prompt in `cn --print ... -- <prompt>`;
+// promptless launches start interactively and have no command prompt to deliver.
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if cfg.Prompt != "" {
+		return ports.PromptDeliveryInCommand, nil
+	}
+	return ports.PromptDeliveryAfterStart, nil
 }
 
 // GetAgentHooks reuses the Claude Code hook installer because the Continue CLI

--- a/backend/internal/adapters/agent/continueagent/continueagent_test.go
+++ b/backend/internal/adapters/agent/continueagent/continueagent_test.go
@@ -45,13 +45,31 @@ func TestGetConfigSpecEmpty(t *testing.T) {
 	}
 }
 
-func TestGetPromptDeliveryStrategy(t *testing.T) {
+func TestGetPromptDeliveryStrategyNoPrompt(t *testing.T) {
 	s, err := (&Plugin{}).GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s != ports.PromptDeliveryAfterStart {
+		t.Fatalf("strategy = %q, want after_start", s)
+	}
+}
+
+func TestGetPromptDeliveryStrategyWithPrompt(t *testing.T) {
+	s, err := (&Plugin{}).GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{Prompt: "fix it"})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if s != ports.PromptDeliveryInCommand {
 		t.Fatalf("strategy = %q, want in_command", s)
+	}
+}
+
+func TestGetPromptDeliveryStrategyContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := (&Plugin{}).GetPromptDeliveryStrategy(ctx, ports.LaunchConfig{}); err == nil {
+		t.Fatal("expected error from canceled context, got nil")
 	}
 }
 
@@ -124,7 +142,21 @@ func TestGetLaunchCommandNoPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := []string{"cn", "--print"}
+	want := []string{"cn"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandNoPromptWithAuto(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Permissions: ports.PermissionModeAuto,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"cn", "--auto"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}


### PR DESCRIPTION

  AO orchestrator sessions are promptless by design, but the Continue adapter always launched fresh sessions with
  cn --print. Continue rejects --print unless a prompt, --prompt, --agent, or resume target is provided, causing
  promptless orchestrator launches to fail immediately with:

  Error: A prompt is required when using the -p/--print flag, unless --prompt, --agent, or --resume is provided.

  The adapter now only uses --print for prompted launches and starts promptless Continue sessions interactively.

  Changes

  - Updated Continue launch command construction:
      - Prompted launch remains:

        cn --print [permission flags] -- <prompt>

      - Promptless launch is now:

        cn [permission flags]

  - Added a Continue-specific prompt delivery strategy:
      - Prompted launches return PromptDeliveryInCommand.
      - Promptless launches return PromptDeliveryAfterStart.

  - Preserved existing permission behavior:
      - default and accept-edits emit no Continue permission flag.
      - auto and bypass-permissions emit --auto.

  - Left restore behavior unchanged:

    cn --print [permission flags] --fork <agentSessionId>
    This remains valid because --fork provides a resume target.

  Why
  Continue’s --print mode is for non-interactive prompt/resume execution. For promptless AO orchestrator sessions,
  there is no prompt to pass, so launching cn --print produces a CLI usage error before the session can start.

  Tests
  Updated backend/internal/adapters/agent/continueagent tests to cover:

  - Promptless launch uses cn without --print.
  - Promptless launch still applies permission flags such as --auto.
  - Prompted launch still uses cn --print -- <prompt>.
  - Prompted launch returns PromptDeliveryInCommand.
  - Promptless launch returns PromptDeliveryAfterStart.
  - Prompt delivery strategy honors canceled context.
  - Restore still uses cn --print --fork <agentSessionId>.
  
  closes #2439 
