### PR TITLE
fix(workspace): preserve uncommitted edits to tracked-but-gitignored files

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/commands.go
+++ b/backend/internal/adapters/workspace/gitworktree/commands.go
@@ -50,9 +50,20 @@ func worktreeListPorcelainArgs(repo string) []string {
 	return []string{"-C", repo, "worktree", "list", "--porcelain"}
 }
 
+// readTreeHeadArgs seeds a temp index from the HEAD tree so a subsequent
+// `git add -A` knows which paths are already tracked. GIT_INDEX_FILE must be set
+// in the command's environment. Fails on an unborn HEAD (no commits), which the
+// caller tolerates.
+func readTreeHeadArgs(worktree string) []string {
+	return []string{"-C", worktree, "read-tree", "HEAD"}
+}
+
 // addAllTempIndexArgs stages all tracked and non-ignored untracked files into a
 // temp index file without touching the real index or the working tree.
-// GIT_INDEX_FILE must be set in the command's environment before calling.
+// GIT_INDEX_FILE must be set in the command's environment before calling. The
+// temp index must first be seeded from HEAD (see readTreeHeadArgs), otherwise git
+// treats every path as untracked and a tracked file that also matches .gitignore
+// is dropped instead of captured.
 func addAllTempIndexArgs(worktree string) []string {
 	return []string{"-C", worktree, "add", "-A"}
 }

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -280,6 +280,18 @@ func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceIn
 	// Deferred remove is a best-effort cleanup in case git leaves the file.
 	defer func() { _ = os.Remove(tmpIdxPath) }()
 
+	// Seed the temp index from HEAD so `git add -A` knows which paths are already
+	// tracked. Without this the index starts empty, and git's "already-tracked
+	// files bypass .gitignore" rule can't fire: a file committed in HEAD that also
+	// matches a .gitignore pattern is treated as an untracked-ignored file and
+	// silently skipped, so its uncommitted edit is dropped from the preserve tree
+	// (which then reads as a deletion on restore, losing the agent's work). An
+	// unborn HEAD has nothing to seed, so a read-tree failure is expected and
+	// ignored there — `add -A` then behaves as before for a fresh repo.
+	seedCmd := exec.CommandContext(ctx, w.binary, readTreeHeadArgs(info.Path)...)
+	seedCmd.Env = append(os.Environ(), "GIT_INDEX_FILE="+tmpIdxPath)
+	_ = seedCmd.Run()
+
 	// Stage all tracked and non-ignored untracked files into the temp index.
 	// GIT_INDEX_FILE overrides the index so the real index is never touched.
 	addCmd := exec.CommandContext(ctx, w.binary, addAllTempIndexArgs(info.Path)...)

--- a/backend/internal/adapters/workspace/gitworktree/workspace_preserve_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_preserve_test.go
@@ -120,6 +120,87 @@ func TestWorkspaceIntegrationStashApplyRoundTrip(t *testing.T) {
 	}
 }
 
+// TestWorkspaceIntegrationStashPreservesTrackedButIgnoredEdit guards a data-loss
+// case: an uncommitted edit to a file that is tracked in HEAD but also matches a
+// .gitignore pattern must still be captured and replayed on restore. With an
+// empty capture index git treats it as an untracked-ignored file and drops it,
+// which reads as a deletion on restore and loses the agent's edit. A genuinely
+// untracked ignored file must still be skipped.
+func TestWorkspaceIntegrationStashPreservesTrackedButIgnoredEdit(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, tmp)
+	root := filepath.Join(tmp, "managed")
+	ws, err := New(Options{Binary: git, ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx := context.Background()
+	cfg := ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess-tracked-ignored", Branch: "feature/tracked-ignored"}
+
+	info, err := ws.Create(ctx, cfg)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Commit config.yaml first, then commit a .gitignore that covers it (and a
+	// yet-to-exist untracked secret): config.yaml stays tracked in HEAD while
+	// matching an ignore pattern.
+	if err := os.WriteFile(filepath.Join(info.Path, "config.yaml"), []byte("v1\n"), 0o644); err != nil {
+		t.Fatalf("write config v1: %v", err)
+	}
+	runGit(t, git, info.Path, "add", "config.yaml")
+	runGit(t, git, info.Path, "commit", "-m", "add config")
+	if err := os.WriteFile(filepath.Join(info.Path, ".gitignore"), []byte("config.yaml\nuntracked-secret.txt\n"), 0o644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+	runGit(t, git, info.Path, "add", ".gitignore")
+	runGit(t, git, info.Path, "commit", "-m", "ignore config and secret")
+
+	// Uncommitted agent edit to the tracked-but-ignored file, plus a genuinely
+	// untracked ignored file that must NOT be captured.
+	if err := os.WriteFile(filepath.Join(info.Path, "config.yaml"), []byte("v2-agent\n"), 0o644); err != nil {
+		t.Fatalf("write config v2: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(info.Path, "untracked-secret.txt"), []byte("super-secret\n"), 0o644); err != nil {
+		t.Fatalf("write untracked secret: %v", err)
+	}
+
+	ref, err := ws.StashUncommitted(ctx, info)
+	if err != nil {
+		t.Fatalf("StashUncommitted: %v", err)
+	}
+	if ref == "" {
+		t.Fatal("StashUncommitted returned empty ref for dirty worktree")
+	}
+
+	if err := ws.ForceDestroy(ctx, info); err != nil {
+		t.Fatalf("ForceDestroy: %v", err)
+	}
+	restored, err := ws.Restore(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if err := ws.ApplyPreserved(ctx, restored, ref); err != nil {
+		t.Fatalf("ApplyPreserved: %v", err)
+	}
+
+	// The tracked-but-ignored edit must survive (not be deleted). Compare newline-
+	// insensitively so a CRLF autocrlf checkout doesn't mask the real assertion.
+	got, err := os.ReadFile(filepath.Join(restored.Path, "config.yaml"))
+	if err != nil {
+		t.Fatalf("config.yaml was lost across preserve/restore (tracked-but-ignored edit dropped): %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "v2-agent" {
+		t.Fatalf("config.yaml content = %q, want %q", strings.TrimSpace(string(got)), "v2-agent")
+	}
+
+	// The genuinely untracked ignored file must still be skipped.
+	if _, err := os.Stat(filepath.Join(restored.Path, "untracked-secret.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("untracked-secret.txt exists after apply but must not (it was .gitignore-d and untracked)")
+	}
+}
+
 // TestWorkspaceIntegrationApplyPreservedConflict verifies the spec for a
 // conflicting apply (plan edge case 5):
 //


### PR DESCRIPTION
Closes #2451.

## What

`StashUncommitted` preserves a session's uncommitted work by pointing `GIT_INDEX_FILE` at a fresh temp index and running `git add -A`. The temp index started **empty**, so git had no record that any path was tracked. git's "already-tracked files bypass `.gitignore`" rule keys off the index, so a file that is committed in HEAD but also matches a `.gitignore` pattern (e.g. a config/template committed once, then ignored so local edits aren't pushed) was treated as an untracked-ignored file and silently skipped.

The preserve tree then omitted the file; since the preserve commit's parent is HEAD (which still contains it), the diff read as a **deletion**, and `ApplyPreserved` (cherry-pick) **deleted** the file on restore — losing the agent's uncommitted edit.

## Change

Seed the temp index from HEAD with `git read-tree HEAD` before `git add -A`, so git knows which paths are tracked and captures edits to tracked-but-ignored files as modifications. Genuinely untracked ignored files are still skipped, and an unborn HEAD (fresh repo) tolerates the read-tree failure and behaves exactly as before.

## Verification

I confirmed the mechanism against real git before fixing:
- Empty-index `git add -A` → `git diff --name-status HEAD <tree>` shows `D config.yaml` (the deletion that loses the edit).
- After seeding with `read-tree HEAD` → `M config.yaml` (captured), and a genuinely untracked ignored file is still correctly absent from the tree.

## Tests

- Added `TestWorkspaceIntegrationStashPreservesTrackedButIgnoredEdit`: commit a file, then ignore it, edit it uncommitted, round-trip through StashUncommitted → ForceDestroy → Restore → ApplyPreserved, and assert the edit survives while an untracked ignored file stays skipped. Fails before the change (`config.yaml was lost across preserve/restore`), passes after.
- Full `gitworktree` package: no new failures vs `main` (the two pre-existing failures on my Windows box, `TestWorkspaceIntegrationStashApplyRoundTrip` and `TestAddWorktreeRefusesBranchCheckedOutElsewhere`, are `core.autocrlf`/worktree-locking environment artifacts unrelated to this change and fail identically on clean `main`). The new test is newline-insensitive so it isn't affected. `-race` left to CI (no 64-bit CGO locally).

cc @harshitsinghbhandari — this one is a quiet data-loss path (tracked file later added to .gitignore); happy to adjust the approach if you'd prefer a different capture mechanism.
