### PR TITLE
fix(review): a superseded run must not strand its sibling reviews in a batch

### DIFF
--- a/backend/internal/service/review/review.go
+++ b/backend/internal/service/review/review.go
@@ -6,6 +6,7 @@ package review
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,6 +15,13 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	reviewcore "github.com/aoagents/agent-orchestrator/backend/internal/review"
 )
+
+// errRunSuperseded marks a run that is no longer in a submittable state — it was
+// superseded or terminated (e.g. a new commit fired SupersedeStaleRunningReviewRuns
+// and moved it to failed) before its result arrived. It is an internal sentinel:
+// SubmitMany skips such a run so it cannot strand the valid sibling results in the
+// same submission, per SubmitMany's documented delivery-scoping guarantee.
+var errRunSuperseded = errors.New("review: run is no longer running")
 
 // ErrInvalid and ErrNotFound re-export the engine sentinels so the HTTP
 // controller maps service failures to 422/404 without importing the core.
@@ -129,9 +137,18 @@ func (s *Service) SubmitMany(ctx context.Context, workerID domain.SessionID, rev
 	for _, review := range reviews {
 		run, err := s.submitOne(ctx, workerID, review)
 		if err != nil {
+			// A run superseded/terminated by a newer trigger is not submittable, but
+			// it must not strand the valid sibling results in this submission — skip
+			// it and keep delivering the rest. Genuine input errors still abort.
+			if errors.Is(err, errRunSuperseded) {
+				continue
+			}
 			return nil, err
 		}
 		runs = append(runs, run)
+	}
+	if len(runs) == 0 {
+		return nil, fmt.Errorf("%w: no submittable review runs in submission", ErrInvalid)
 	}
 	if s.lifecycle == nil {
 		return runs, nil
@@ -184,7 +201,7 @@ func (s *Service) submitOne(ctx context.Context, workerID domain.SessionID, revi
 			return domain.ReviewRun{}, err
 		}
 		if !updated {
-			return domain.ReviewRun{}, fmt.Errorf("%w: review run %q is not running", ErrInvalid, runID)
+			return domain.ReviewRun{}, fmt.Errorf("%w: review run %q is not running", errRunSuperseded, runID)
 		}
 		run.Status = domain.ReviewRunComplete
 		run.Verdict = verdict
@@ -203,7 +220,7 @@ func (s *Service) submitOne(ctx context.Context, workerID domain.SessionID, revi
 	case domain.ReviewRunDelivered:
 		return run, nil
 	default:
-		return domain.ReviewRun{}, fmt.Errorf("%w: review run %q is not running", ErrInvalid, runID)
+		return domain.ReviewRun{}, fmt.Errorf("%w: review run %q is not running", errRunSuperseded, runID)
 	}
 	return run, nil
 }

--- a/backend/internal/service/review/review_test.go
+++ b/backend/internal/service/review/review_test.go
@@ -206,6 +206,38 @@ func TestSubmitManySendsCombinedChangesRequested(t *testing.T) {
 	}
 }
 
+func TestSubmitManySkipsSupersededRunAndDeliversSiblings(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	st := &fakeStore{
+		ok: true,
+		batchRuns: []domain.ReviewRun{
+			{ID: "run-1", SessionID: "mer-1", BatchID: "batch-1", PRURL: "pr1", TargetSHA: "sha1", Status: domain.ReviewRunRunning},
+			// run-2 was superseded to failed by a newer-commit trigger while the
+			// reviewer was still working, so its result is no longer submittable.
+			{ID: "run-2", SessionID: "mer-1", BatchID: "batch-1", PRURL: "pr2", TargetSHA: "sha2", Status: domain.ReviewRunFailed},
+		},
+		prs: []domain.PullRequest{{URL: "pr1", HeadSHA: "sha1"}, {URL: "pr2", HeadSHA: "sha2new"}},
+	}
+	reducer := &fakeReducer{outcome: lifecycle.ReviewDeliverySent}
+	svc := New(nil, st, WithLifecycleReducer(reducer), WithClock(func() time.Time { return now }))
+
+	// The reviewer submits both results, unaware run-2 was superseded. The stale
+	// run-2 must not strand run-1's feedback.
+	runs, err := svc.SubmitMany(context.Background(), "mer-1", []SubmittedReview{
+		{RunID: "run-1", Verdict: domain.VerdictChangesRequested, Body: "fix pr1"},
+		{RunID: "run-2", Verdict: domain.VerdictChangesRequested, Body: "fix pr2"},
+	})
+	if err != nil {
+		t.Fatalf("SubmitMany must not fail when a sibling run was superseded: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ID != "run-1" || runs[0].Status != domain.ReviewRunDelivered {
+		t.Fatalf("want only run-1 delivered (run-2 skipped), got %+v", runs)
+	}
+	if reducer.batchCalls != 1 || len(reducer.gotBatch) != 1 || reducer.gotBatch[0].RunID != "run-1" {
+		t.Fatalf("want run-1 delivered independently; batchCalls=%d got=%+v", reducer.batchCalls, reducer.gotBatch)
+	}
+}
+
 func TestSubmitBatchApprovedOnlySendsNothing(t *testing.T) {
 	st := &fakeStore{
 		ok:  true,


### PR DESCRIPTION
Closes #2452.

## What

`SubmitMany` records a reviewer's results for one or more PR-scoped runs sharing a trigger. Its documented contract: *"Delivery is scoped to the runs in this submission, so a missing/stuck result for another PR in the same trigger cannot block feedback."* But the loop aborted the whole submission on the first `submitOne` error, before reaching delivery.

When a worker pushes a new commit mid-review, `SupersedeStaleRunningReviewRuns` marks that PR's run `failed`. If the reviewer then submits the original batch, `submitOne` hits the terminal-state branch (`"review run ... is not running"`) for the superseded run and `SubmitMany` returns that error — so none of the already-valid sibling runs are delivered. The valid run is left complete-but-undelivered, and because the superseded run stays `failed`, every retry re-produces the error: the sibling PR's requested changes are stranded permanently.

## Change

Mark the not-running/terminal case with an internal `errRunSuperseded` sentinel and have `SubmitMany` **skip** such runs (`continue`) instead of aborting, so valid siblings are still completed and delivered. Genuine input errors (bad verdict, empty body, unknown run, wrong worker, verdict conflict) still abort as before. If every run in a submission is unsubmittable, it returns an invalid-input error. The sentinel is internal to the package (the single-submit path and HTTP mapping are unchanged: a lone superseded submit still returns 422).

## Tests

- Added `TestSubmitManySkipsSupersededRunAndDeliversSiblings`: a batch of `{run-A running, run-B failed}` must deliver run-A and skip run-B. Fails before the change (`review run "run-2" is not running`), passes after.
- Full `service/review` package green; `go vet` and gofmt clean. `-race` left to CI (no 64-bit CGO locally).

cc @harshitsinghbhandari — the fix keeps genuine input errors fail-fast; only superseded/terminal runs are skipped. Happy to tighten the skip condition further if you'd prefer.
