### PR TITLE
fix(cli): wrong exit code on too many args for review submit and preview

### DIFF
--- a/backend/internal/cli/preview.go
+++ b/backend/internal/cli/preview.go
@@ -31,7 +31,7 @@ func newPreviewCommand(ctx *commandContext) *cobra.Command {
   ao preview file://$(pwd)/index.html
   ao preview http://localhost:5173
   ao preview clear`,
-		Args: cobra.MaximumNArgs(1),
+		Args: atMostOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var target string
 			if len(args) == 1 {
@@ -43,7 +43,7 @@ func newPreviewCommand(ctx *commandContext) *cobra.Command {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "clear",
 		Short: "Clear the desktop browser panel for the current session",
-		Args:  cobra.NoArgs,
+		Args:  noArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return ctx.clearPreview(cmd.Context())
 		},

--- a/backend/internal/cli/preview_test.go
+++ b/backend/internal/cli/preview_test.go
@@ -154,6 +154,24 @@ func TestPreview_MissingSessionIDIsUsageError(t *testing.T) {
 	}
 }
 
+func TestPreview_TooManyArgsIsUsageError(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "aa-47")
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, Deps{}, "preview", "url1", "url2")
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+}
+
+func TestPreviewClear_TooManyArgsIsUsageError(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "aa-47")
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, Deps{}, "preview", "clear", "extra")
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+}
+
 func TestPreview_HelpIncludesExamples(t *testing.T) {
 	out, _, err := executeCLI(t, Deps{}, "preview", "--help")
 	if err != nil {

--- a/backend/internal/cli/review.go
+++ b/backend/internal/cli/review.go
@@ -77,7 +77,7 @@ func newReviewSubmitCommand(ctx *commandContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "submit [worker-session-id]",
 		Short: "Record a reviewer's result for a worker's PR",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  atMostOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ctx.submitReview(cmd, args, opts)
 		},

--- a/backend/internal/cli/review_test.go
+++ b/backend/internal/cli/review_test.go
@@ -143,6 +143,14 @@ func TestReviewSubmitUsesSessionFlag(t *testing.T) {
 	}
 }
 
+func TestReviewSubmitTooManyArgsIsUsageError(t *testing.T) {
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, aliveDeps(), "review", "submit", "mer-1", "mer-2")
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
+	}
+}
+
 func TestReviewSubmitMissingVerdictIsUsageError(t *testing.T) {
 	setConfigEnv(t)
 	_, _, err := executeCLI(t, aliveDeps(), "review", "submit", "mer-1", "--run", "run-1")

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -258,6 +258,13 @@ func noArgs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func atMostOneArg(cmd *cobra.Command, args []string) error {
+	if err := cobra.MaximumNArgs(1)(cmd, args); err != nil {
+		return usageError{err}
+	}
+	return nil
+}
+
 func newDaemonCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:    "daemon",


### PR DESCRIPTION
Cobra's built-in arg validators (`cobra.MaximumNArgs(1)`, `cobra.NoArgs`) return plain errors, not `usageError`. The root command's `SetFlagErrorFunc` only wraps flag parse errors, so arg-count misuse exits code 1 instead of the documented convention of 2.

Adds an `atMostOneArg` helper (same pattern as the existing `noArgs`) that wraps `cobra.MaximumNArgs(1)` in `usageError`. Uses it for `review submit` and `preview`. Uses the existing `noArgs` for `preview clear`.

Adds three table tests asserting exit code 2 for too-many-args misuse.

Closes #2418