### PR TITLE
[codex] Guard latest desktop release

### DIFF
--- a/.github/workflows/release-latest-guard.yml
+++ b/.github/workflows/release-latest-guard.yml
@@ -1,0 +1,57 @@
+name: Release latest guard
+
+# Guard against accidental non-stable GitHub releases taking over
+# /releases/latest and breaking electron-updater's stable channel.
+on:
+  release:
+    types: [published, edited, released]
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+jobs:
+  latest-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify latest stable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_json="$(gh release view --repo "$REPO" --json tagName,isPrerelease,isDraft,assets)"
+          tag="$(jq -r '.tagName' <<<"$release_json")"
+          prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
+          draft="$(jq -r '.isDraft' <<<"$release_json")"
+
+          echo "Latest release: $tag"
+
+          if [[ "$draft" == "true" || "$prerelease" == "true" ]]; then
+            echo "::error::GitHub latest resolved to draft/prerelease '$tag'; stable latest must be a published non-prerelease."
+            exit 1
+          fi
+
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::GitHub latest resolved to '$tag'; expected a stable semver tag like v0.10.2."
+            exit 1
+          fi
+
+          mapfile -t assets < <(jq -r '.assets[].name' <<<"$release_json")
+          printf 'Assets:\n%s\n' "${assets[@]}"
+
+          required_assets=(
+            latest.yml
+            latest-mac.yml
+            latest-linux.yml
+          )
+
+          for required in "${required_assets[@]}"; do
+            if ! printf '%s\n' "${assets[@]}" | grep -Fxq "$required"; then
+              echo "::error::Latest stable release '$tag' is missing updater feed asset '$required'."
+              exit 1
+            fi
+          done

--- a/.github/workflows/release-latest-guard.yml
+++ b/.github/workflows/release-latest-guard.yml
@@ -13,8 +13,48 @@ jobs:
   latest-release:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # write is required to delete a hijacking junk release + its tag. The
+      # remediation step below only ever deletes a release that cannot be a real
+      # one (non-prerelease, non-semver tag, and shipping zero updater feed
+      # assets), so this permission cannot touch a legitimate stable release.
+      contents: write
     steps:
+      - name: Remediate hijacking junk release
+        # Only self-heal on the schedule / manual runs, never on a `release`
+        # event: a real release-in-progress fires `published` before its assets
+        # finish uploading, and we must not race-delete it. Scheduled runs only
+        # ever see the settled state.
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_json="$(gh release view --repo "$REPO" --json tagName,isPrerelease,isDraft,assets)"
+          tag="$(jq -r '.tagName' <<<"$release_json")"
+          prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
+          draft="$(jq -r '.isDraft' <<<"$release_json")"
+          feed_assets="$(jq -r '[.assets[].name] | map(select(. == "latest.yml" or . == "latest-mac.yml" or . == "latest-linux.yml")) | length' <<<"$release_json")"
+
+          # A hijack is a *published, non-prerelease* release whose tag is not a
+          # stable vX.Y.Z AND that ships none of the electron-updater feed files
+          # (issue #2462: `gh-attach-assets`). A real stable release always has a
+          # semver tag and the feed assets, so this signature cannot match one;
+          # an in-progress real release carries a semver tag, so it is excluded
+          # even before its assets finish uploading. Anything outside this exact
+          # signature is left for the verify step below to flag for a human.
+          if [[ "$draft" == "false" && "$prerelease" == "false" ]] \
+            && [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            && [[ "$feed_assets" == "0" ]]; then
+            echo "::warning::Latest release '$tag' is a non-stable hijack with no updater feed; deleting it and its tag so GitHub re-points latest to the newest stable release."
+            gh release delete "$tag" --repo "$REPO" --yes --cleanup-tag
+            echo "Deleted hijacking release and tag '$tag'."
+          else
+            echo "Latest release '$tag' is not a hijack; nothing to remediate."
+          fi
+
       - name: Verify latest stable release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -55,3 +95,5 @@ jobs:
               exit 1
             fi
           done
+
+          echo "Latest stable release '$tag' is valid and serves the updater feed."

--- a/.github/workflows/release-latest-guard.yml
+++ b/.github/workflows/release-latest-guard.yml
@@ -13,48 +13,8 @@ jobs:
   latest-release:
     runs-on: ubuntu-latest
     permissions:
-      # write is required to delete a hijacking junk release + its tag. The
-      # remediation step below only ever deletes a release that cannot be a real
-      # one (non-prerelease, non-semver tag, and shipping zero updater feed
-      # assets), so this permission cannot touch a legitimate stable release.
-      contents: write
+      contents: read
     steps:
-      - name: Remediate hijacking junk release
-        # Only self-heal on the schedule / manual runs, never on a `release`
-        # event: a real release-in-progress fires `published` before its assets
-        # finish uploading, and we must not race-delete it. Scheduled runs only
-        # ever see the settled state.
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          release_json="$(gh release view --repo "$REPO" --json tagName,isPrerelease,isDraft,assets)"
-          tag="$(jq -r '.tagName' <<<"$release_json")"
-          prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
-          draft="$(jq -r '.isDraft' <<<"$release_json")"
-          feed_assets="$(jq -r '[.assets[].name] | map(select(. == "latest.yml" or . == "latest-mac.yml" or . == "latest-linux.yml")) | length' <<<"$release_json")"
-
-          # A hijack is a *published, non-prerelease* release whose tag is not a
-          # stable vX.Y.Z AND that ships none of the electron-updater feed files
-          # (issue #2462: `gh-attach-assets`). A real stable release always has a
-          # semver tag and the feed assets, so this signature cannot match one;
-          # an in-progress real release carries a semver tag, so it is excluded
-          # even before its assets finish uploading. Anything outside this exact
-          # signature is left for the verify step below to flag for a human.
-          if [[ "$draft" == "false" && "$prerelease" == "false" ]] \
-            && [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
-            && [[ "$feed_assets" == "0" ]]; then
-            echo "::warning::Latest release '$tag' is a non-stable hijack with no updater feed; deleting it and its tag so GitHub re-points latest to the newest stable release."
-            gh release delete "$tag" --repo "$REPO" --yes --cleanup-tag
-            echo "Deleted hijacking release and tag '$tag'."
-          else
-            echo "Latest release '$tag' is not a hijack; nothing to remediate."
-          fi
-
       - name: Verify latest stable release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -95,5 +55,3 @@ jobs:
               exit 1
             fi
           done
-
-          echo "Latest stable release '$tag' is valid and serves the updater feed."


### PR DESCRIPTION
## What changed

Adds a GitHub Actions guard for the desktop updater's stable release pointer.

The workflow runs when releases are published/edited, on an hourly schedule, and manually. It verifies that GitHub's current `releases/latest` target is a published non-prerelease stable tag matching `vX.Y.Z`, and that the release includes the electron-updater feed assets:

- `latest.yml`
- `latest-mac.yml`
- `latest-linux.yml`

## Why

Issue #2462 shows that an accidental non-prerelease release, `gh-attach-assets`, became GitHub's `latest` release. `electron-updater` then resolved `latest.yml` against that release and hit a 404, breaking in-app update checks for desktop users.

This PR does **not** delete the already-bad release, and it does not by itself clear the current outage. Per the issue, the immediate fix is a maintainer deleting the `gh-attach-assets` release and tag so GitHub points `latest` back to `v0.10.2`. This guard is the issue's *optional preventive follow-up*: it makes the failure visible quickly if the latest pointer is hijacked again or if a stable release is missing feed assets.

## Validation

- `npx prettier --check .github/workflows/release-latest-guard.yml`
- Live `gh release view` currently reports `gh-attach-assets` as latest, which would fail this guard as intended.