### PR TITLE
fix(installer): point Windows NSIS shortcut at the real binary (#2414)

### DIFF
--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -8,6 +8,12 @@ import { writeFileSync } from "node:fs";
 // home; releases land on AgentWrapper (spec §1.1).
 const DEFAULT_RELEASE_REPO = "AgentWrapper/agent-orchestrator";
 
+// The packaged binary name (no extension). Single source of truth: the packager
+// names the exe/ELF from this, and the NSIS + deb makers must point their
+// shortcut/launcher at the SAME name. Drift here means a broken Start menu
+// shortcut on Windows (#2414) or "could not find the Electron app binary" on deb.
+const EXECUTABLE_NAME = "agent-orchestrator";
+
 // parseReleaseRepo turns an "owner/repo" string (from AO_RELEASE_REPO) into the
 // publisher-github { owner, name } shape, falling back to the production default
 // when unset or malformed.
@@ -25,7 +31,7 @@ const config: ForgeConfig = {
 		asar: true,
 		appBundleId: "dev.agent-orchestrator.desktop",
 		name: "Agent Orchestrator",
-		executableName: "agent-orchestrator",
+		executableName: EXECUTABLE_NAME,
 		appCategoryType: "public.app-category.developer-tools",
 		// App icon. electron-packager appends the per-platform extension
 		// (.icns on macOS, .ico on Windows); Linux menu icons come from the
@@ -84,6 +90,9 @@ const config: ForgeConfig = {
 			{
 				appId: "dev.agent-orchestrator.desktop",
 				productName: "Agent Orchestrator",
+				// Match the packaged binary name so the Start menu shortcut targets
+				// the real "agent-orchestrator.exe" (not "Agent Orchestrator.exe").
+				executableName: EXECUTABLE_NAME,
 				icon: "assets/icon.ico",
 			},
 			["win32"],
@@ -108,7 +117,7 @@ const config: ForgeConfig = {
 					// Must match packagerConfig.executableName, or the deb maker
 					// looks for the package name and fails with "could not find
 					// the Electron app binary". (Both are "agent-orchestrator".)
-					bin: "agent-orchestrator",
+					bin: EXECUTABLE_NAME,
 					icon: "assets/icon.png",
 					maintainer: "Agent Orchestrator",
 					homepage: "https://github.com/aoagents/agent-orchestrator",

--- a/frontend/makers/maker-nsis.test.ts
+++ b/frontend/makers/maker-nsis.test.ts
@@ -46,4 +46,21 @@ describe("MakerNSIS", () => {
 		expect(options.config.nsis.oneClick).toBe(false);
 		expect(options.config.nsis.allowToChangeInstallationDirectory).toBe(true);
 	});
+
+	it("forwards executableName so the Start menu shortcut targets the real binary (#2414)", async () => {
+		const maker = new MakerNSIS(
+			{ appId: "dev.agent-orchestrator.desktop", executableName: "agent-orchestrator", icon: "assets/icon.ico" },
+			["win32"],
+		);
+		await maker.prepareConfig(makeOptions.targetArch);
+		await maker.make(makeOptions);
+
+		const [, options] = buildForge.mock.calls.at(-1)!;
+		// electron-builder derives the exe name — and thus the shortcut's TargetPath
+		// and icon — from win.executableName, falling back to productName otherwise.
+		// It must match Forge's packaged "agent-orchestrator.exe", not the
+		// "Agent Orchestrator.exe" it would infer from productName.
+		expect(options.config.win.executableName).toBe("agent-orchestrator");
+		expect(options.config.win.icon).toBe("assets/icon.ico");
+	});
 });

--- a/frontend/makers/maker-nsis.ts
+++ b/frontend/makers/maker-nsis.ts
@@ -16,6 +16,12 @@ export type MakerNSISConfig = {
 	appId?: string;
 	// Display name for the installer + Start menu shortcut. Defaults to appName.
 	productName?: string;
+	// The packaged binary name WITHOUT ".exe" — must match Forge's
+	// packagerConfig.executableName ("agent-orchestrator"). electron-builder
+	// otherwise derives the exe name from productName and points the Start menu
+	// shortcut at "Agent Orchestrator.exe", which does not exist, so the app
+	// silently fails to launch and the shortcut shows a generic icon (#2414).
+	executableName?: string;
 	// Path to the Windows .ico used for the app and installer.
 	icon?: string;
 	// Any extra electron-builder `nsis` options, merged over our defaults.
@@ -36,6 +42,15 @@ export default class MakerNSIS extends MakerBase<MakerNSISConfig> {
 		// Mirror buildForge's own output layout (<dir>/../make) so artifacts land
 		// where Forge's publisher expects them.
 		const output = path.join(path.dirname(path.resolve(dir)), "make");
+		// electron-builder derives the Windows exe name — and thus the Start menu
+		// shortcut's target path and icon — from `win.executableName`, falling back
+		// to productName when it is unset. Forge's packager already named the binary
+		// "agent-orchestrator.exe" (packagerConfig.executableName), so we forward the
+		// same name here; otherwise the shortcut targets a nonexistent
+		// "Agent Orchestrator.exe" and the app never launches (#2414).
+		const win: Record<string, unknown> = {};
+		if (cfg.icon) win.icon = cfg.icon;
+		if (cfg.executableName) win.executableName = cfg.executableName;
 		return buildForge(
 			{ dir },
 			{
@@ -49,7 +64,7 @@ export default class MakerNSIS extends MakerBase<MakerNSISConfig> {
 					// target from package.json `repository` and trying to upload,
 					// which fails in CI with no GH_TOKEN set.
 					publish: null,
-					...(cfg.icon ? { win: { icon: cfg.icon } } : {}),
+					...(Object.keys(win).length ? { win } : {}),
 					nsis: {
 						// A real installer, not Squirrel's silent per-user drop.
 						oneClick: false,


### PR DESCRIPTION
## Summary
Fixes #2414. On Windows the installer created a Start menu shortcut targeting `Agent Orchestrator.exe`, but the packaged binary is `agent-orchestrator.exe`. The shortcut pointed at a file that does not exist, so clicking it **silently did nothing** and the icon fell back to a generic Windows glyph. Affected every Windows user on a fresh install.

## Root cause
electron-builder derives the Windows exe name — and therefore the shortcut's `TargetPath` and `IconLocation` — from `win.executableName`, falling back to `productName` when it is unset. Our custom NSIS maker (`frontend/makers/maker-nsis.ts`) forwarded `productName` (`"Agent Orchestrator"`) but never `executableName`, so electron-builder assumed the binary was `Agent Orchestrator.exe`. Forge's packager, however, names the binary from `packagerConfig.executableName` = `agent-orchestrator` → `agent-orchestrator.exe`. Hence the mismatch.

## Fix
- Forward `win.executableName` through the NSIS maker so electron-builder targets the real binary (this fixes both the broken launch **and** the empty icon, since `IconLocation` defaults to the target exe).
- Hoist the binary name into a single `EXECUTABLE_NAME` constant in `forge.config.ts`, shared by the packager and the NSIS/deb makers, so they can't drift apart again.
- Add a regression test asserting the maker forwards `executableName` to electron-builder.

## Verification
Built the installer on **Windows 11** (`npm run make`), silent-installed it, and read the generated `.lnk` back with `WScript.Shell`:

| Field | Reported bug | After this PR |
|---|---|---|
| `TargetPath` | `…\Agent Orchestrator\Agent Orchestrator.exe` (missing) | `…\Programs\agent-orchestrator\agent-orchestrator.exe` — exists ✅ |
| `IconLocation` | *(empty)* | `…\agent-orchestrator.exe,0` ✅ |

Then silent-uninstalled to restore the machine. Also: `maker-nsis.test.ts` 3/3 pass, `tsc --noEmit` clean.