### PR TITLE
feat(trackerintake): add label filters and concurrency cap

### DIFF
--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -87,10 +87,13 @@ type roleOverride struct {
 
 // trackerIntakeConfig mirrors domain.TrackerIntakeConfig.
 type trackerIntakeConfig struct {
-	Enabled  bool   `json:"enabled,omitempty"`
-	Provider string `json:"provider,omitempty"`
-	Repo     string `json:"repo,omitempty"`
-	Assignee string `json:"assignee,omitempty"`
+	Enabled       bool     `json:"enabled,omitempty"`
+	Provider      string   `json:"provider,omitempty"`
+	Repo          string   `json:"repo,omitempty"`
+	Assignee      string   `json:"assignee,omitempty"`
+	Labels        []string `json:"labels,omitempty"`
+	ExcludeLabels []string `json:"excludeLabels,omitempty"`
+	MaxConcurrent int      `json:"maxConcurrent,omitempty"`
 }
 
 // projectConfig mirrors the daemon's typed domain.ProjectConfig for the CLI
@@ -115,21 +118,24 @@ type setConfigRequest struct {
 }
 
 type projectSetConfigOptions struct {
-	defaultBranch     string
-	sessionPrefix     string
-	model             string
-	permission        string
-	workerAgent       string
-	orchestratorAgent string
-	env               []string
-	symlink           []string
-	postCreate        []string
-	trackerIntake     bool
-	trackerRepo       string
-	trackerAssignee   string
-	configJSON        string
-	clear             bool
-	json              bool
+	defaultBranch        string
+	sessionPrefix        string
+	model                string
+	permission           string
+	workerAgent          string
+	orchestratorAgent    string
+	env                  []string
+	symlink              []string
+	postCreate           []string
+	trackerIntake        bool
+	trackerRepo          string
+	trackerAssignee      string
+	trackerLabels        []string
+	trackerExcludeLabels []string
+	trackerMaxConcurrent int
+	configJSON           string
+	clear                bool
+	json                 bool
 }
 
 type projectListResult struct {
@@ -315,6 +321,9 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 	f.BoolVar(&opts.trackerIntake, "tracker-intake", false, "Enable GitHub issue intake for matching issues")
 	f.StringVar(&opts.trackerRepo, "tracker-repo", "", "GitHub repo for issue intake (owner/repo; default: derive from git origin)")
 	f.StringVar(&opts.trackerAssignee, "tracker-assignee", "", "GitHub issue assignee required for intake eligibility")
+	f.StringArrayVar(&opts.trackerLabels, "tracker-label", nil, "Only intake issues carrying this label (repeatable; any-match)")
+	f.StringArrayVar(&opts.trackerExcludeLabels, "tracker-exclude-label", nil, "Never intake issues carrying this label (repeatable; wins over --tracker-label)")
+	f.IntVar(&opts.trackerMaxConcurrent, "tracker-max-concurrent", 0, "Cap live intake-spawned workers per project (0 = no cap)")
 	f.StringVar(&opts.configJSON, "config-json", "", "Full config as a JSON object (overrides field flags)")
 	f.BoolVar(&opts.clear, "clear", false, "Clear all config")
 	f.BoolVar(&opts.json, "json", false, "Output the updated project as JSON")
@@ -351,10 +360,13 @@ func buildProjectConfig(opts projectSetConfigOptions) (projectConfig, error) {
 		Worker:        roleOverride{Agent: opts.workerAgent},
 		Orchestrator:  roleOverride{Agent: opts.orchestratorAgent},
 		TrackerIntake: trackerIntakeConfig{
-			Enabled:  opts.trackerIntake,
-			Provider: trackerProviderForFlags(opts),
-			Repo:     opts.trackerRepo,
-			Assignee: opts.trackerAssignee,
+			Enabled:       opts.trackerIntake,
+			Provider:      trackerProviderForFlags(opts),
+			Repo:          opts.trackerRepo,
+			Assignee:      opts.trackerAssignee,
+			Labels:        opts.trackerLabels,
+			ExcludeLabels: opts.trackerExcludeLabels,
+			MaxConcurrent: opts.trackerMaxConcurrent,
 		},
 	}
 	if reflect.DeepEqual(cfg, projectConfig{}) {
@@ -364,7 +376,8 @@ func buildProjectConfig(opts projectSetConfigOptions) (projectConfig, error) {
 }
 
 func trackerProviderForFlags(opts projectSetConfigOptions) string {
-	if opts.trackerIntake || opts.trackerRepo != "" || opts.trackerAssignee != "" {
+	if opts.trackerIntake || opts.trackerRepo != "" || opts.trackerAssignee != "" ||
+		len(opts.trackerLabels) > 0 || len(opts.trackerExcludeLabels) > 0 || opts.trackerMaxConcurrent != 0 {
 		return "github"
 	}
 	return ""

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -41,7 +41,15 @@ func TestProjectSetConfig_TrackerIntakeFlags(t *testing.T) {
 
 	_, errOut, err := executeCLI(t, Deps{
 		ProcessAlive: func(int) bool { return true },
-	}, "project", "set-config", "demo", "--tracker-intake", "--tracker-repo", "acme/demo", "--tracker-assignee", "alice")
+	}, "project", "set-config", "demo",
+		"--tracker-intake",
+		"--tracker-repo", "acme/demo",
+		"--tracker-assignee", "alice",
+		"--tracker-label", "agent-ok",
+		"--tracker-label", "needs-agent",
+		"--tracker-exclude-label", "agent:noauto",
+		"--tracker-max-concurrent", "4",
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
 	}
@@ -53,6 +61,11 @@ func TestProjectSetConfig_TrackerIntakeFlags(t *testing.T) {
 		t.Fatalf("decode request: %v\nbody=%s", err, capture.body)
 	}
 	if !got.Config.TrackerIntake.Enabled || got.Config.TrackerIntake.Provider != "github" || got.Config.TrackerIntake.Repo != "acme/demo" || got.Config.TrackerIntake.Assignee != "alice" {
+		t.Fatalf("tracker intake request = %#v", got.Config.TrackerIntake)
+	}
+	if strings.Join(got.Config.TrackerIntake.Labels, ",") != "agent-ok,needs-agent" ||
+		strings.Join(got.Config.TrackerIntake.ExcludeLabels, ",") != "agent:noauto" ||
+		got.Config.TrackerIntake.MaxConcurrent != 4 {
 		t.Fatalf("tracker intake request = %#v", got.Config.TrackerIntake)
 	}
 }
@@ -82,11 +95,21 @@ func TestBuildProjectConfigTrackerIntakeFlags(t *testing.T) {
 		trackerIntake:   true,
 		trackerRepo:     "acme/demo",
 		trackerAssignee: "alice",
+		trackerLabels:   []string{"agent-ok", "needs-agent"},
+		trackerExcludeLabels: []string{
+			"agent:noauto",
+		},
+		trackerMaxConcurrent: 4,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !got.TrackerIntake.Enabled || got.TrackerIntake.Provider != "github" || got.TrackerIntake.Repo != "acme/demo" || got.TrackerIntake.Assignee != "alice" {
+		t.Fatalf("tracker intake config = %#v", got.TrackerIntake)
+	}
+	if strings.Join(got.TrackerIntake.Labels, ",") != "agent-ok,needs-agent" ||
+		strings.Join(got.TrackerIntake.ExcludeLabels, ",") != "agent:noauto" ||
+		got.TrackerIntake.MaxConcurrent != 4 {
 		t.Fatalf("tracker intake config = %#v", got.TrackerIntake)
 	}
 }

--- a/backend/internal/domain/projectconfig_test.go
+++ b/backend/internal/domain/projectconfig_test.go
@@ -35,6 +35,12 @@ func TestProjectConfigValidate(t *testing.T) {
 		{"tracker intake unknown provider", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Provider: "linear", Assignee: "alice"}}, true},
 		{"tracker intake repo with whitespace", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Repo: " acme/demo", Assignee: "alice"}}, true},
 		{"tracker intake assignee with whitespace", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Assignee: " alice"}}, true},
+		{"tracker intake good labels", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Assignee: "alice", Labels: []string{"agent-ok"}, ExcludeLabels: []string{"agent:noauto"}}}, false},
+		{"tracker intake label with whitespace", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Assignee: "alice", Labels: []string{" agent-ok"}}}, true},
+		{"tracker intake empty label", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Assignee: "alice", Labels: []string{""}}}, true},
+		{"tracker intake exclude label with whitespace", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Assignee: "alice", ExcludeLabels: []string{"agent:noauto "}}}, true},
+		{"tracker intake good max concurrent", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Assignee: "alice", MaxConcurrent: 4}}, false},
+		{"tracker intake negative max concurrent", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Assignee: "alice", MaxConcurrent: -1}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/backend/internal/domain/tracker.go
+++ b/backend/internal/domain/tracker.go
@@ -91,6 +91,20 @@ type TrackerIntakeConfig struct {
 	// Assignee narrows eligible issues to one assignee. Provider-specific values
 	// such as "*" are passed through unchanged.
 	Assignee string `json:"assignee,omitempty"`
+	// Labels, when non-empty, narrows eligible issues to those carrying at least
+	// one of the listed labels (case-insensitive). An empty list imposes no
+	// label requirement. Applied client-side alongside the assignee rule.
+	Labels []string `json:"labels,omitempty"`
+	// ExcludeLabels rejects any issue carrying at least one of the listed labels
+	// (case-insensitive), even if it satisfies the assignee and Labels rules.
+	// This expresses opt-outs like "agent:noauto". Exclusion wins over inclusion.
+	ExcludeLabels []string `json:"excludeLabels,omitempty"`
+	// MaxConcurrent caps the number of live intake-spawned worker sessions the
+	// loop will keep running for this project at once. Zero means no cap. When at
+	// the cap the loop defers remaining eligible issues to a later tick (they are
+	// never permanently dropped) so a bulk assignment burst cannot spawn an
+	// unbounded number of workers.
+	MaxConcurrent int `json:"maxConcurrent,omitempty"`
 }
 
 // WithDefaults fills the provider only when intake is enabled. Disabled intake
@@ -119,6 +133,25 @@ func (c TrackerIntakeConfig) Validate() error {
 	}
 	if strings.TrimSpace(c.Assignee) == "" {
 		return fmt.Errorf("trackerIntake: assignee is required when enabled")
+	}
+	for i, label := range c.Labels {
+		if err := validateNoWhitespaceField(fmt.Sprintf("trackerIntake.labels[%d]", i), label); err != nil {
+			return err
+		}
+		if strings.TrimSpace(label) == "" {
+			return fmt.Errorf("trackerIntake.labels[%d]: must not be empty", i)
+		}
+	}
+	for i, label := range c.ExcludeLabels {
+		if err := validateNoWhitespaceField(fmt.Sprintf("trackerIntake.excludeLabels[%d]", i), label); err != nil {
+			return err
+		}
+		if strings.TrimSpace(label) == "" {
+			return fmt.Errorf("trackerIntake.excludeLabels[%d]: must not be empty", i)
+		}
+	}
+	if c.MaxConcurrent < 0 {
+		return fmt.Errorf("trackerIntake.maxConcurrent: must not be negative")
 	}
 	return nil
 }

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2775,6 +2775,16 @@ components:
           type: string
         enabled:
           type: boolean
+        excludeLabels:
+          items:
+            type: string
+          type: array
+        labels:
+          items:
+            type: string
+          type: array
+        maxConcurrent:
+          type: integer
         provider:
           enum:
           - github

--- a/backend/internal/observe/trackerintake/observer.go
+++ b/backend/internal/observe/trackerintake/observer.go
@@ -286,9 +286,10 @@ func seenIssueIDs(sessions []domain.SessionRecord) map[domain.IssueID]bool {
 }
 
 // liveIntakeWorkersByProject counts the live (non-terminated) worker sessions
-// that carry a tracker issue id, per project. These are the sessions intake is
-// responsible for; the count feeds the per-project MaxConcurrent cap so a bulk
-// assignment burst cannot spawn an unbounded number of workers.
+// that carry canonical tracker issue ids, per project. Canonical ids are the
+// sessions intake creates and dedupes against; manual ad-hoc --issue values do
+// not consume intake capacity. The count feeds the per-project MaxConcurrent cap
+// so a bulk assignment burst cannot spawn an unbounded number of workers.
 func liveIntakeWorkersByProject(sessions []domain.SessionRecord) map[string]int {
 	counts := make(map[string]int)
 	for _, sess := range sessions {

--- a/backend/internal/observe/trackerintake/observer.go
+++ b/backend/internal/observe/trackerintake/observer.go
@@ -298,12 +298,20 @@ func liveIntakeWorkersByProject(sessions []domain.SessionRecord) map[string]int 
 		if sess.Kind != domain.KindWorker {
 			continue
 		}
-		if sess.IssueID == "" {
+		if !isCanonicalIssueID(sess.IssueID) {
 			continue
 		}
 		counts[string(sess.ProjectID)]++
 	}
 	return counts
+}
+
+func isCanonicalIssueID(id domain.IssueID) bool {
+	provider, native, ok := strings.Cut(string(id), ":")
+	if !ok || provider == "" || native == "" {
+		return false
+	}
+	return strings.Contains(native, "#")
 }
 
 // CanonicalIssueID stores tracker issue ids in sessions.issue_id with the

--- a/backend/internal/observe/trackerintake/observer.go
+++ b/backend/internal/observe/trackerintake/observer.go
@@ -142,6 +142,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 		return err
 	}
 	seen := seenIssueIDs(sessions)
+	liveByProject := liveIntakeWorkersByProject(sessions)
 	for _, project := range enabledProjects {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -150,7 +151,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 			o.logger.Debug("tracker intake: project in failure backoff", "project", project.ID, "until", until)
 			continue
 		}
-		if failed := o.pollProject(ctx, project, seen); failed {
+		if failed := o.pollProject(ctx, project, seen, liveByProject[project.ID]); failed {
 			o.backoffUntil[project.ID] = now.Add(o.failureBackoff)
 		} else {
 			delete(o.backoffUntil, project.ID)
@@ -161,7 +162,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 
 // pollProject returns failed=true for conditions that should be retried after a
 // backoff window rather than logged on every poll.
-func (o *Observer) pollProject(ctx context.Context, project domain.ProjectRecord, seen map[domain.IssueID]bool) (failed bool) {
+func (o *Observer) pollProject(ctx context.Context, project domain.ProjectRecord, seen map[domain.IssueID]bool, liveWorkers int) (failed bool) {
 	cfg := project.Config.TrackerIntake.WithDefaults()
 	if !cfg.Enabled {
 		return false
@@ -169,6 +170,10 @@ func (o *Observer) pollProject(ctx context.Context, project domain.ProjectRecord
 	if err := cfg.Validate(); err != nil {
 		o.logger.Warn("tracker intake: skipping project with invalid config", "project", project.ID, "err", err)
 		return true
+	}
+	if cfg.MaxConcurrent > 0 && liveWorkers >= cfg.MaxConcurrent {
+		o.logger.Debug("tracker intake: project at concurrency cap, deferring", "project", project.ID, "live", liveWorkers, "cap", cfg.MaxConcurrent)
+		return false
 	}
 	repo, ok := trackerRepo(project, cfg)
 	if !ok {
@@ -188,10 +193,15 @@ func (o *Observer) pollProject(ctx context.Context, project domain.ProjectRecord
 		o.logger.Error("tracker intake: list issues failed", "project", project.ID, "repo", repo.Native, "err", err)
 		return true
 	}
+	spawnedThisPass := 0
 	var spawnFailed bool
 	for _, issue := range issues {
 		if ctx.Err() != nil {
 			return true
+		}
+		if cfg.MaxConcurrent > 0 && liveWorkers+spawnedThisPass >= cfg.MaxConcurrent {
+			o.logger.Debug("tracker intake: reached concurrency cap mid-pass, deferring remaining issues", "project", project.ID, "cap", cfg.MaxConcurrent)
+			break
 		}
 		if issue.State != domain.IssueOpen {
 			continue
@@ -214,11 +224,15 @@ func (o *Observer) pollProject(ctx context.Context, project domain.ProjectRecord
 			continue
 		}
 		seen[issueID] = true
+		spawnedThisPass++
 	}
 	return spawnFailed
 }
 
 func issueMatchesConfig(issue domain.Issue, cfg domain.TrackerIntakeConfig) bool {
+	if !issueMatchesLabels(issue, cfg) {
+		return false
+	}
 	assignee := strings.TrimSpace(cfg.Assignee)
 	switch {
 	case assignee == "":
@@ -230,6 +244,26 @@ func issueMatchesConfig(issue domain.Issue, cfg domain.TrackerIntakeConfig) bool
 	default:
 		return containsFold(issue.Assignees, assignee)
 	}
+}
+
+// issueMatchesLabels applies the include/exclude label rules. Exclusion wins: an
+// issue carrying any excluded label is rejected even if it also carries an
+// included one. An empty include list imposes no positive requirement.
+func issueMatchesLabels(issue domain.Issue, cfg domain.TrackerIntakeConfig) bool {
+	for _, excluded := range cfg.ExcludeLabels {
+		if containsFold(issue.Labels, strings.TrimSpace(excluded)) {
+			return false
+		}
+	}
+	if len(cfg.Labels) == 0 {
+		return true
+	}
+	for _, required := range cfg.Labels {
+		if containsFold(issue.Labels, strings.TrimSpace(required)) {
+			return true
+		}
+	}
+	return false
 }
 
 func containsFold(values []string, needle string) bool {
@@ -249,6 +283,27 @@ func seenIssueIDs(sessions []domain.SessionRecord) map[domain.IssueID]bool {
 		}
 	}
 	return seen
+}
+
+// liveIntakeWorkersByProject counts the live (non-terminated) worker sessions
+// that carry a tracker issue id, per project. These are the sessions intake is
+// responsible for; the count feeds the per-project MaxConcurrent cap so a bulk
+// assignment burst cannot spawn an unbounded number of workers.
+func liveIntakeWorkersByProject(sessions []domain.SessionRecord) map[string]int {
+	counts := make(map[string]int)
+	for _, sess := range sessions {
+		if sess.IsTerminated {
+			continue
+		}
+		if sess.Kind != domain.KindWorker {
+			continue
+		}
+		if sess.IssueID == "" {
+			continue
+		}
+		counts[string(sess.ProjectID)]++
+	}
+	return counts
 }
 
 // CanonicalIssueID stores tracker issue ids in sessions.issue_id with the

--- a/backend/internal/observe/trackerintake/observer_test.go
+++ b/backend/internal/observe/trackerintake/observer_test.go
@@ -243,6 +243,150 @@ func TestIssueMatchesConfigAssigneeSpecialValues(t *testing.T) {
 	}
 }
 
+func TestIssueMatchesConfigLabelFilters(t *testing.T) {
+	withLabels := func(labels ...string) domain.Issue {
+		return domain.Issue{Assignees: []string{"alice"}, Labels: labels}
+	}
+	// Include rule: only issues carrying an included label match.
+	includeCfg := domain.TrackerIntakeConfig{Assignee: "alice", Labels: []string{"agent-ok"}}
+	if !issueMatchesConfig(withLabels("Agent-OK"), includeCfg) {
+		t.Fatal("issue with included label (case-insensitive) should match")
+	}
+	if issueMatchesConfig(withLabels("other"), includeCfg) {
+		t.Fatal("issue without any included label should not match")
+	}
+	if issueMatchesConfig(withLabels(), includeCfg) {
+		t.Fatal("issue with no labels should not match an include rule")
+	}
+	// Exclude rule wins over everything else.
+	excludeCfg := domain.TrackerIntakeConfig{Assignee: "alice", ExcludeLabels: []string{"agent:noauto"}}
+	if issueMatchesConfig(withLabels("Agent:NoAuto"), excludeCfg) {
+		t.Fatal("issue with excluded label should never match")
+	}
+	if !issueMatchesConfig(withLabels("something"), excludeCfg) {
+		t.Fatal("issue without the excluded label should match")
+	}
+	// Exclusion beats inclusion when both apply.
+	bothCfg := domain.TrackerIntakeConfig{Assignee: "alice", Labels: []string{"agent-ok"}, ExcludeLabels: []string{"agent:noauto"}}
+	if issueMatchesConfig(withLabels("agent-ok", "agent:noauto"), bothCfg) {
+		t.Fatal("exclusion must win over inclusion")
+	}
+	if !issueMatchesConfig(withLabels("agent-ok"), bothCfg) {
+		t.Fatal("included-only issue should match when not excluded")
+	}
+}
+
+func TestPollAppliesLabelFilters(t *testing.T) {
+	store := &fakeStore{projects: []domain.ProjectRecord{{
+		ID:            "demo",
+		RepoOriginURL: "https://github.com/acme/demo.git",
+		Config: domain.ProjectConfig{TrackerIntake: domain.TrackerIntakeConfig{
+			Enabled:       true,
+			Assignee:      "alice",
+			Labels:        []string{"agent-ok"},
+			ExcludeLabels: []string{"agent:noauto"},
+		}},
+	}}}
+	tracker := &fakeTracker{issues: []domain.Issue{
+		{ID: domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/demo#1"}, Title: "no included label", State: domain.IssueOpen, Assignees: []string{"alice"}, Labels: []string{"chore"}},
+		{ID: domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/demo#2"}, Title: "excluded", State: domain.IssueOpen, Assignees: []string{"alice"}, Labels: []string{"agent-ok", "agent:noauto"}},
+		{ID: domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/demo#3"}, Title: "eligible", State: domain.IssueOpen, Assignees: []string{"alice"}, Labels: []string{"Agent-OK"}},
+	}}
+	spawner := &fakeSpawner{}
+
+	if err := New(singleResolver(tracker), store, spawner, Config{Logger: discardLogger()}).Poll(context.Background()); err != nil {
+		t.Fatalf("Poll() error = %v", err)
+	}
+	if len(spawner.calls) != 1 || spawner.calls[0].IssueID != "github:acme/demo#3" {
+		t.Fatalf("spawn calls = %+v, want only eligible issue #3", spawner.calls)
+	}
+}
+
+func TestPollHonorsMaxConcurrentAgainstLiveWorkers(t *testing.T) {
+	// One live intake worker already exists; cap is 2, so only ONE more may spawn
+	// even though two more issues are eligible.
+	store := &fakeStore{
+		projects: []domain.ProjectRecord{{
+			ID:            "demo",
+			RepoOriginURL: "https://github.com/acme/demo.git",
+			Config: domain.ProjectConfig{TrackerIntake: domain.TrackerIntakeConfig{
+				Enabled:       true,
+				Assignee:      "alice",
+				MaxConcurrent: 2,
+			}},
+		}},
+		sessions: []domain.SessionRecord{
+			{ID: "demo-live", ProjectID: "demo", Kind: domain.KindWorker, IssueID: "github:acme/demo#100"},
+		},
+	}
+	tracker := &fakeTracker{issues: []domain.Issue{
+		{ID: domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/demo#1"}, Title: "first", State: domain.IssueOpen, Assignees: []string{"alice"}},
+		{ID: domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/demo#2"}, Title: "second", State: domain.IssueOpen, Assignees: []string{"alice"}},
+	}}
+	spawner := &fakeSpawner{}
+
+	if err := New(singleResolver(tracker), store, spawner, Config{Logger: discardLogger()}).Poll(context.Background()); err != nil {
+		t.Fatalf("Poll() error = %v", err)
+	}
+	if len(spawner.calls) != 1 {
+		t.Fatalf("spawn calls = %d, want 1 (cap of 2 minus 1 live worker)", len(spawner.calls))
+	}
+	if spawner.calls[0].IssueID != "github:acme/demo#1" {
+		t.Fatalf("first spawn issue = %q, want github:acme/demo#1", spawner.calls[0].IssueID)
+	}
+}
+
+func TestPollDefersWhenAlreadyAtMaxConcurrent(t *testing.T) {
+	// Two live intake workers already exist and the cap is 2: no new spawn, and
+	// the tracker is never even queried for this project.
+	store := &fakeStore{
+		projects: []domain.ProjectRecord{{
+			ID:            "demo",
+			RepoOriginURL: "https://github.com/acme/demo.git",
+			Config: domain.ProjectConfig{TrackerIntake: domain.TrackerIntakeConfig{
+				Enabled:       true,
+				Assignee:      "alice",
+				MaxConcurrent: 2,
+			}},
+		}},
+		sessions: []domain.SessionRecord{
+			{ID: "demo-a", ProjectID: "demo", Kind: domain.KindWorker, IssueID: "github:acme/demo#100"},
+			{ID: "demo-b", ProjectID: "demo", Kind: domain.KindWorker, IssueID: "github:acme/demo#101"},
+		},
+	}
+	tracker := &fakeTracker{issues: []domain.Issue{
+		{ID: domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/demo#1"}, Title: "eligible", State: domain.IssueOpen, Assignees: []string{"alice"}},
+	}}
+	spawner := &fakeSpawner{}
+
+	if err := New(singleResolver(tracker), store, spawner, Config{Logger: discardLogger()}).Poll(context.Background()); err != nil {
+		t.Fatalf("Poll() error = %v", err)
+	}
+	if len(spawner.calls) != 0 {
+		t.Fatalf("spawn calls = %d, want 0 (already at cap)", len(spawner.calls))
+	}
+	if len(tracker.repos) != 0 {
+		t.Fatalf("tracker queried %d times, want 0 when already at cap", len(tracker.repos))
+	}
+}
+
+func TestLiveIntakeWorkersByProjectIgnoresTerminatedAndNonWorkers(t *testing.T) {
+	sessions := []domain.SessionRecord{
+		{ID: "a", ProjectID: "demo", Kind: domain.KindWorker, IssueID: "github:acme/demo#1"},
+		{ID: "b", ProjectID: "demo", Kind: domain.KindWorker, IssueID: "github:acme/demo#2", IsTerminated: true},
+		{ID: "c", ProjectID: "demo", Kind: domain.KindOrchestrator, IssueID: "github:acme/demo#3"},
+		{ID: "d", ProjectID: "demo", Kind: domain.KindWorker}, // no issue id (ad-hoc worker)
+		{ID: "e", ProjectID: "other", Kind: domain.KindWorker, IssueID: "github:acme/other#1"},
+	}
+	counts := liveIntakeWorkersByProject(sessions)
+	if counts["demo"] != 1 {
+		t.Fatalf("demo live intake workers = %d, want 1", counts["demo"])
+	}
+	if counts["other"] != 1 {
+		t.Fatalf("other live intake workers = %d, want 1", counts["other"])
+	}
+}
+
 func TestBuildIssuePromptCapsLargeIssueBody(t *testing.T) {
 	prompt := BuildIssuePrompt(domain.Issue{
 		ID:    domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/demo#99"},

--- a/backend/internal/observe/trackerintake/observer_test.go
+++ b/backend/internal/observe/trackerintake/observer_test.go
@@ -375,7 +375,8 @@ func TestLiveIntakeWorkersByProjectIgnoresTerminatedAndNonWorkers(t *testing.T) 
 		{ID: "a", ProjectID: "demo", Kind: domain.KindWorker, IssueID: "github:acme/demo#1"},
 		{ID: "b", ProjectID: "demo", Kind: domain.KindWorker, IssueID: "github:acme/demo#2", IsTerminated: true},
 		{ID: "c", ProjectID: "demo", Kind: domain.KindOrchestrator, IssueID: "github:acme/demo#3"},
-		{ID: "d", ProjectID: "demo", Kind: domain.KindWorker}, // no issue id (ad-hoc worker)
+		{ID: "d", ProjectID: "demo", Kind: domain.KindWorker},                     // no issue id (ad-hoc worker)
+		{ID: "manual", ProjectID: "demo", Kind: domain.KindWorker, IssueID: "47"}, // manual --issue, not intake-spawned
 		{ID: "e", ProjectID: "other", Kind: domain.KindWorker, IssueID: "github:acme/other#1"},
 	}
 	counts := liveIntakeWorkersByProject(sessions)

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1015,6 +1015,9 @@ export interface components {
         TrackerIntakeConfig: {
             assignee?: string;
             enabled?: boolean;
+            excludeLabels?: string[];
+            labels?: string[];
+            maxConcurrent?: number;
             /** @enum {string} */
             provider?: "github";
             repo?: string;


### PR DESCRIPTION
## Summary

Hardens the GitHub tracker intake loop with two generally useful controls:

- include/exclude label filters on `TrackerIntakeConfig`, applied client-side alongside the existing assignee rule; exclusions win over inclusions
- `maxConcurrent` cap per project so intake defers eligible issues once live intake workers reach the cap, then picks them up on a later poll

## Notes

This is the upstream-shaped half of polymath-ventures/agent-orchestrator#49. The branch is based on `AgentWrapper/main` and intentionally excludes Polymath-local carry commits.

## Tests

- `cd backend && go test ./internal/domain ./internal/observe/trackerintake`
- `cd backend && go test ./internal/cli -run 'TestProject|TestBuildProjectConfig'`

Full `go test ./internal/cli` currently has unrelated failures on this checkout around spawn project-context HTTP 404 expectations, so I ran the project-config subset relevant to these CLI flag additions.
