### PR TITLE
feat(pi): update Pi agent to support interactive sessions and adjust …

### DIFF
--- a/backend/internal/adapters/agent/pi/pi.go
+++ b/backend/internal/adapters/agent/pi/pi.go
@@ -1,11 +1,11 @@
-// Package pi implements the Pi agent adapter: launching new headless Pi
+// Package pi implements the Pi agent adapter: launching new interactive Pi
 // sessions and resuming sessions when a native Pi session id is known.
 //
 // Pi (badlogic / "@earendil-works/pi-coding-agent", binary "pi") is a minimal
-// terminal coding harness. AO drives it non-interactively with `-p` / `--print`
-// ("process prompt and exit"). The initial prompt is delivered in-command as a
-// trailing positional message; Pi's argument parser does not honor a `--`
-// options terminator, so AO relies on prompts not beginning with a literal "-".
+// terminal coding harness. AO runs Pi interactively in the session terminal
+// pane. The initial prompt is delivered in-command as a trailing positional
+// message; Pi's argument parser does not honor a `--` options terminator, so AO
+// relies on prompts not beginning with a literal "-".
 //
 // System prompts are appended to Pi's default coding-assistant prompt via
 // `--append-system-prompt <text>`. Pi's flag takes inline text only (no file
@@ -16,12 +16,12 @@
 // confirmation flows are built via TypeScript extensions), so AO emits no
 // permission flag and defers to Pi's own behavior.
 //
-// Restore: Pi persists sessions to ~/.pi/agent/sessions/ and resumes by id with
-// `--session <id>` (partial UUIDs accepted). The native session id is emitted on
-// the first line of `--mode json` output as {"type":"session","id":"<uuid>",...}
-// and is captured into session metadata out-of-band; GetRestoreCommand reads it
-// back from metadata. ok=false when no native id is known (manager falls back to
-// a fresh launch).
+// Restore: Pi persists sessions to ~/.pi/agent/sessions/ and resumes
+// interactively by id with `--session <id>` (partial UUIDs accepted). The native
+// session id is emitted on the first line of `--mode json` output as
+// {"type":"session","id":"<uuid>",...} and is captured into session metadata
+// out-of-band; GetRestoreCommand reads it back from metadata. ok=false when no
+// native id is known (manager falls back to a fresh launch).
 //
 // Hooks/activity: Pi exposes lifecycle hooks only through in-process TypeScript
 // extensions (pi.on("session_start", ...), etc.), not a config file AO can
@@ -74,9 +74,9 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
-// GetLaunchCommand builds the argv to start a new headless Pi session:
+// GetLaunchCommand builds the argv to start a new interactive Pi session:
 //
-//	pi --print [--append-system-prompt <system prompt>] [<prompt>]
+//	pi [--append-system-prompt <system prompt>] [<prompt>]
 //
 // The prompt is delivered in-command as a trailing positional message. Pi does
 // not honor a `--` options terminator, so the prompt must not begin with "-".
@@ -87,7 +87,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 		return nil, err
 	}
 
-	cmd = []string{binary, "--print"}
+	cmd = []string{binary}
 	if cfg.SystemPromptFile != "" {
 		data, err := os.ReadFile(cfg.SystemPromptFile) //nolint:gosec // path is AO-owned launch config
 		if err != nil {
@@ -120,7 +120,11 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if err != nil {
 		return nil, false, err
 	}
-	cmd = []string{binary, "--print", "--session", agentSessionID}
+	cmd = []string{binary}
+	if cfg.SystemPrompt != "" {
+		cmd = append(cmd, "--append-system-prompt", cfg.SystemPrompt)
+	}
+	cmd = append(cmd, "--session", agentSessionID)
 	return cmd, true, nil
 }
 

--- a/backend/internal/adapters/agent/pi/pi_test.go
+++ b/backend/internal/adapters/agent/pi/pi_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -51,16 +52,34 @@ func TestGetPromptDeliveryStrategy(t *testing.T) {
 	}
 }
 
-func TestGetLaunchCommandWithPrompt(t *testing.T) {
+func TestGetLaunchCommandWorkerWithPromptIsInteractive(t *testing.T) {
 	p := &Plugin{resolvedBinary: "pi"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Kind:   domain.KindWorker,
 		Prompt: "add a health check",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	want := []string{"pi", "--print", "add a health check"}
+	want := []string{"pi", "add a health check"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandOrchestratorAppendsSystemPromptInteractively(t *testing.T) {
+	p := &Plugin{resolvedBinary: "pi"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Kind:         domain.KindOrchestrator,
+		SystemPrompt: "coordinate work and avoid implementation",
+		Prompt:       "plan the issue",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"pi", "--append-system-prompt", "coordinate work and avoid implementation", "plan the issue"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
 	}
@@ -84,7 +103,7 @@ func TestGetLaunchCommandEmitsNoPermissionFlag(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := []string{"pi", "--print"}
+			want := []string{"pi"}
 			if !reflect.DeepEqual(cmd, want) {
 				t.Fatalf("cmd = %#v, want %#v", cmd, want)
 			}
@@ -107,7 +126,7 @@ func TestGetLaunchCommandAppendsSystemPrompt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"pi", "--print", "--append-system-prompt", "follow repo rules", "do the thing"}
+	want := []string{"pi", "--append-system-prompt", "follow repo rules", "do the thing"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
@@ -129,7 +148,7 @@ func TestGetLaunchCommandInlinesSystemPromptFileContents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"pi", "--print", "--append-system-prompt", "file contents win"}
+	want := []string{"pi", "--append-system-prompt", "file contents win"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
@@ -161,7 +180,27 @@ func TestGetRestoreCommand(t *testing.T) {
 		t.Fatal("ok=false, want true")
 	}
 
-	want := []string{"pi", "--print", "--session", "019e950e-52e0-7411-961b-d380ca7e610f"}
+	want := []string{"pi", "--session", "019e950e-52e0-7411-961b-d380ca7e610f"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandReappendsSystemPromptInteractively(t *testing.T) {
+	p := &Plugin{resolvedBinary: "pi"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Kind:         domain.KindOrchestrator,
+		Session:      ports.SessionRef{Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "019e950e-52e0-7411-961b-d380ca7e610f"}},
+		SystemPrompt: "coordinate work and avoid implementation",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+
+	want := []string{"pi", "--append-system-prompt", "coordinate work and avoid implementation", "--session", "019e950e-52e0-7411-961b-d380ca7e610f"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}


### PR DESCRIPTION

  ## Summary

  This updates the Pi adapter so AO launches Pi as a long-lived interactive terminal session instead of using Pi's headless `--print` mode.

  Previously, Pi sessions were launched as:

 
  pi --print [--append-system-prompt <system prompt>] [prompt]

  That made both worker and orchestrator sessions behave like one-shot/headless commands, which does not match AO's terminal-pane session model.

  After this change, Pi launches as:

  pi [--append-system-prompt <system prompt>] [prompt]

  Restore commands also drop --print and now resume interactively:

  pi --session <agentSessionId>

  When a restore includes standing system instructions, AO re-applies them:

  pi --append-system-prompt <system prompt> --session <agentSessionId>

  ## What Changed

  - Removed --print from GetLaunchCommand.
  - Removed --print from GetRestoreCommand.
  - Kept inline AO system prompt injection through --append-system-prompt.
  - Preserved in-command prompt delivery for the initial task prompt.
  - Re-applied SystemPrompt during restore when provided, so orchestrator sessions retain their coordination instructions.
  - Updated adapter comments to describe Pi as interactive instead of headless.
  - Updated Pi adapter tests to assert the new interactive command shape.

  ## Why

  AO sessions are meant to be long-lived agent sessions inside a terminal pane.

  Using --print starts Pi in non-interactive/headless mode, which is a poor fit for both AO workers and orchestrators:

  - Workers should remain usable as terminal-backed agent sessions.
  - Orchestrators need to stay alive over time to coordinate workers.
  - The orchestrator system prompt was already being passed, but --print caused the session mode to be wrong.

  ## Test Coverage

  Updated backend/internal/adapters/agent/pi/pi_test.go to cover:

  - Worker launch with prompt:
      - pi "add a health check"

  - Orchestrator launch with system prompt:
      - pi --append-system-prompt <prompt> <task>

  - System prompt file inlining still works.
  - Permission modes still emit no Pi-specific permission flag.
  - Restore command no longer uses --print.
  - Restore command re-applies system prompt when provided.
  - Prompt delivery strategy remains PromptDeliveryInCommand.


closes #2478 
