### PR TITLE
fix(web): terminal doesn't get keyboard focus when opening a session/agent view

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -75,6 +75,7 @@ vi.mock("./XtermTerminal", () => ({
 				writeln: vi.fn(),
 				showLatestOutput: vi.fn(),
 				prepareForActivation: prepareForActivationMock,
+				focus: vi.fn(),
 				onUserInput: vi.fn(() => disposable),
 				onResize: vi.fn(() => disposable),
 			});

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -1023,6 +1023,11 @@ function AttachedTerminal({
 		// before attaching so the daemon receives only the authoritative size.
 		void terminal.prepareForActivation().then(() => {
 			if (!current) return;
+			// Focus once the terminal is actually attached to a session — not the
+			// empty-state pane when nothing is selected (handleId tells us which).
+			if (handleId) {
+				terminal.focus();
+			}
 			detach = attach(terminal);
 		});
 		return () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -865,6 +865,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				return { dispose: () => userInputListeners.delete(listener) };
 			},
 			onResize: (listener) => term.onResize(listener),
+			focus: () => term.focus(),
 		};
 		callbacksRef.current.onReady?.(handle);
 

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -123,6 +123,7 @@ function createFakeTerminal(): FakeTerminal {
 			terminal.latestOutputRequests += 1;
 		},
 		prepareForActivation: async () => undefined,
+		focus: () => {},
 		onUserInput: (listener) => {
 			inputListeners.add(listener);
 			return { dispose: () => inputListeners.delete(listener) };

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -47,6 +47,7 @@ export type AttachableTerminal = {
 	prepareForActivation: () => Promise<void>;
 	onUserInput: (listener: (data: string, source: TerminalUserInputSource) => void) => { dispose: () => void };
 	onResize: (listener: (size: { cols: number; rows: number }) => void) => { dispose: () => void };
+	focus: () => void;
 };
 
 export type TerminalSessionState =


### PR DESCRIPTION
## Summary
- `XtermTerminal.tsx`'s `AttachableTerminal` handle now exposes `focus: () => term.focus()`, and the type in `useTerminalSession.ts` declares it.
- `TerminalPane.tsx`'s `AttachedTerminal` mount effect calls `terminal.focus()` once a session is actually attached (`handleId` present), so the empty-state pane never steals focus.

Fixes #2434.

## Screen Recording

[![Screen Recording](https://img.youtube.com/vi/zBYWUGjXw6I/0.jpg)](https://youtu.be/zBYWUGjXw6I)


## Test plan
- [x] `npm run typecheck` (frontend)
- [x] `npx vitest run` (frontend, 466 tests pass)
- [ ] Manual: open a session from the Kanban board and confirm typing works without clicking the terminal first

🤖 Generated with [Claude Code](https://claude.com/claude-code)