### PR TITLE
fix(scm): hydrate tracked PR repo owner and name

### DIFF
--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -573,7 +573,11 @@ func (o *Observer) workspaceSCMSessionRepos(ctx context.Context, proj domain.Pro
 
 func repoForTrackedPR(pr domain.PullRequest, repos []ports.SCMRepo) (ports.SCMRepo, bool) {
 	if pr.Provider != "" && pr.Host != "" && pr.Repo != "" {
-		return ports.SCMRepo{Provider: pr.Provider, Host: pr.Host, Repo: pr.Repo}, true
+		owner, name, ok := strings.Cut(pr.Repo, "/")
+		if !ok || owner == "" || name == "" {
+			return ports.SCMRepo{}, false
+		}
+		return ports.SCMRepo{Provider: pr.Provider, Host: pr.Host, Owner: owner, Name: name, Repo: pr.Repo}, true
 	}
 	if pr.Repo != "" {
 		for _, repo := range repos {

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -281,6 +281,9 @@ func TestRepoForTrackedPRUsesPersistedRepoWhenCurrentScanDropsUpstream(t *testin
 	if repo.Provider != "github" || repo.Host != "github.com" || repo.Repo != "upstream/api" {
 		t.Fatalf("repo = %#v, want persisted upstream/api tuple", repo)
 	}
+	if repo.Owner != "upstream" || repo.Name != "api" {
+		t.Fatalf("repo owner/name = %q/%q, want upstream/api", repo.Owner, repo.Name)
+	}
 }
 
 func TestStartAsyncPerformsImmediatePollAndStopsOnCancel(t *testing.T) {


### PR DESCRIPTION
Fixes #2509

## Summary
- Rehydrate `Owner` and `Name` when SCM polling rebuilds a `ports.SCMRepo` from persisted PR facts.
- Extend the existing tracked-PR repo test to assert the provider-ready owner/name fields are populated.

## Test
- `cd backend && go test ./internal/observe/scm ./internal/adapters/scm/github ./internal/integration ./internal/lifecycle ./internal/service/session ./internal/storage/sqlite/store && go build ./...`
- `cd backend && go test ./internal/observe/scm && go test ./internal/observe/...`

## Notes
- `cd backend && go test ./...` was attempted. Relevant SCM/lifecycle/storage/session packages passed, but the full suite has unrelated failures in `internal/adapters/agent/kilocode` (`TestAuthStatusUnknownWhenKeyOnlyComesFromInteractiveShell` timeout) and `internal/cli` spawn tests returning daemon HTTP 404.