### PR TITLE
fix: launch grok prompts interactively

### DIFF
--- a/backend/internal/adapters/agent/grok/grok.go
+++ b/backend/internal/adapters/agent/grok/grok.go
@@ -5,8 +5,8 @@
 // hook installation (which writes .claude/settings.local.json with AO
 // hook commands). Grok will pick them up via its compat layer.
 //
-// Launch uses `-p <prompt>` for the initial task (in-command delivery).
-// Permission bypass uses `--always-approve`. We also pass `--no-auto-update`
+// Launch uses a positional prompt for the initial task (in-command delivery).
+// Permission handling uses `--permission-mode`. We also pass `--no-auto-update`
 // for headless/scripted use (parity with Codex no-update).
 // Restore prefers the hook-captured native session id via `-r <id>`.
 //
@@ -67,8 +67,8 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
-// GetLaunchCommand builds `grok --no-auto-update [--permission-mode <mode>] -p <prompt>`.
-// Prompt is delivered via -p (in command).
+// GetLaunchCommand builds `grok --no-auto-update [--permission-mode <mode>] [prompt]`.
+// Prompt is delivered positionally so Grok starts an interactive coding session.
 //
 // Uses --permission-mode (acceptEdits / auto / bypassPermissions) to match
 // `grok -h` output. Default omits the flag so Grok uses its config.
@@ -82,7 +82,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	appendApprovalFlags(&cmd, cfg.Permissions)
 
 	if cfg.Prompt != "" {
-		cmd = append(cmd, "-p", cfg.Prompt)
+		cmd = append(cmd, cfg.Prompt)
 	}
 
 	return cmd, nil

--- a/backend/internal/adapters/agent/grok/grok_test.go
+++ b/backend/internal/adapters/agent/grok/grok_test.go
@@ -58,10 +58,11 @@ func TestGetLaunchCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	wantPrefix := []string{"grok", "--no-auto-update", "--permission-mode", "bypassPermissions", "-p", "do the thing"}
+	wantPrefix := []string{"grok", "--no-auto-update", "--permission-mode", "bypassPermissions", "do the thing"}
 	if !reflect.DeepEqual(cmd, wantPrefix) {
 		t.Fatalf("cmd = %#v, want prefix %#v", cmd, wantPrefix)
 	}
+	assertNoPromptFlag(t, cmd)
 }
 
 func TestGetLaunchCommandDefaultPerms(t *testing.T) {
@@ -72,12 +73,14 @@ func TestGetLaunchCommandDefaultPerms(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(cmd) < 4 || cmd[0] != "grok" || cmd[1] != "--no-auto-update" || cmd[2] != "-p" {
-		t.Fatalf("cmd = %#v, want grok --no-auto-update -p ...", cmd)
+	want := []string{"grok", "--no-auto-update", "fix it"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
 	if strings.Contains(strings.Join(cmd, " "), "permission-mode") {
 		t.Fatal("should not have --permission-mode for default perms")
 	}
+	assertNoPromptFlag(t, cmd)
 }
 
 func TestGetLaunchCommandAcceptEdits(t *testing.T) {
@@ -89,9 +92,19 @@ func TestGetLaunchCommandAcceptEdits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := []string{"grok", "--no-auto-update", "--permission-mode", "acceptEdits", "-p", "refactor auth"}
+	want := []string{"grok", "--no-auto-update", "--permission-mode", "acceptEdits", "refactor auth"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+	assertNoPromptFlag(t, cmd)
+}
+
+func assertNoPromptFlag(t *testing.T, cmd []string) {
+	t.Helper()
+	for _, arg := range cmd {
+		if arg == "-p" || arg == "--single" {
+			t.Fatalf("cmd = %#v unexpectedly contains single-turn prompt flag %q", cmd, arg)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- launch Grok worker prompts as positional args instead of `-p` single-turn mode
- update Grok launch arg tests to assert normal prompts do not use `-p` / `--single`
- refresh Grok adapter comments to match the current interactive launch behavior

Closes #2516

## Tests
- `cd backend && go test ./internal/adapters/agent/grok`
- `cd backend && go test ./internal/adapters/agent/...` *(fails in unrelated `internal/adapters/agent/kilocode`: `TestAuthStatusUnknownWhenKeyOnlyComesFromInteractiveShell` times out; reproduced with `go test ./internal/adapters/agent/kilocode`)*

## Risks
- Low: preserves existing `--no-auto-update`, permission flags, and restore args; only changes fresh Grok prompt delivery.