### PR TITLE
Add prompt readiness hints for interactive agents

### DIFF
--- a/backend/internal/adapters/agent/cline/cline.go
+++ b/backend/internal/adapters/agent/cline/cline.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
@@ -78,6 +79,25 @@ func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, _ ports.LaunchCo
 		return "", err
 	}
 	return ports.PromptDeliveryAfterStart, nil
+}
+
+// PromptReadinessHints waits briefly for Cline's interactive prompt before AO
+// injects the worker's first task.
+func (p *Plugin) PromptReadinessHints(ctx context.Context, _ ports.LaunchConfig) (ports.PromptReadinessHints, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.PromptReadinessHints{}, err
+	}
+	return ports.PromptReadinessHints{
+		InitialDelay: 750 * time.Millisecond,
+		Patterns: []string{
+			"Type a message",
+			"What can I help",
+			">",
+		},
+		PollInterval: 200 * time.Millisecond,
+		Timeout:      8 * time.Second,
+		Lines:        80,
+	}, nil
 }
 
 // GetRestoreCommand rebuilds the argv that continues an existing Cline session:

--- a/backend/internal/adapters/agent/cline/cline_test.go
+++ b/backend/internal/adapters/agent/cline/cline_test.go
@@ -129,6 +129,16 @@ func TestGetPromptDeliveryStrategyIsAfterStart(t *testing.T) {
 	}
 }
 
+func TestPromptReadinessHints(t *testing.T) {
+	hints, err := (&Plugin{}).PromptReadinessHints(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hints.Timeout <= 0 || len(hints.Patterns) == 0 {
+		t.Fatalf("hints = %#v, want bounded readiness patterns", hints)
+	}
+}
+
 func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
 	plugin := &Plugin{}
 

--- a/backend/internal/adapters/agent/copilot/copilot.go
+++ b/backend/internal/adapters/agent/copilot/copilot.go
@@ -7,8 +7,10 @@
 // suggest/explain extension.
 //
 // Launch runs the CLI in interactive mode so AO can keep a durable terminal
-// pane attached to the session. Permission modes map onto the CLI's allow flags
-// (`--allow-tool`, `--allow-all-tools`, `--allow-all`).
+// pane attached to the session. When AO has an initial task, it uses Copilot's
+// `--interactive <prompt>` mode so the task executes immediately instead of
+// waiting in the terminal input buffer. Permission modes map onto the CLI's allow
+// flags (`--allow-tool`, `--allow-all-tools`, `--allow-all`).
 // Restore continues an existing session via `--resume <agentSessionId>`; the
 // native session id (a UUID under ~/.copilot/session-state/) is captured by the
 // SessionStart hook AO installs (see hooks.go).
@@ -66,12 +68,13 @@ func (p *Plugin) Manifest() adapters.Manifest {
 
 // GetLaunchCommand builds the argv to start a new interactive Copilot session:
 //
-//	copilot [permission flags]
+//	copilot [permission flags] [--interactive <prompt>]
 //
-// The prompt is delivered after the process starts; using `-p` runs Copilot in
-// programmatic mode and exits when done, which leaves AO's terminal pane blank
-// or dead. Copilot CLI does not have a documented system-prompt-injection flag,
-// so SystemPrompt/SystemPromptFile are ignored.
+// `--interactive <prompt>` keeps the durable Copilot terminal session open while
+// automatically submitting the initial task. `-p` is deliberately avoided
+// because it runs Copilot in programmatic mode and exits when done, which leaves
+// AO's terminal pane blank or dead. Copilot CLI does not have a documented
+// system-prompt-injection flag, so SystemPrompt/SystemPromptFile are ignored.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	binary, err := p.copilotBinary(ctx)
 	if err != nil {
@@ -80,23 +83,25 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd = []string{binary}
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	if cfg.Prompt != "" {
+		cmd = append(cmd, "--interactive", cfg.Prompt)
+	}
 
 	return cmd, nil
 }
 
-// GetPromptDeliveryStrategy reports that Copilot receives its prompt after the
-// interactive process starts. This overrides the agentbase.Base default
-// (in-command) because Copilot's `-p` programmatic mode exits when done, which
-// would leave AO's terminal pane dead.
+// GetPromptDeliveryStrategy reports that Copilot receives its prompt in the
+// launch command. This uses `--interactive <prompt>`, not `-p`, so Copilot starts
+// executing immediately while keeping the interactive terminal session alive.
 func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
-	return ports.PromptDeliveryAfterStart, nil
+	return ports.PromptDeliveryInCommand, nil
 }
 
 // GetRestoreCommand rebuilds the argv that continues an existing Copilot
-// session: `copilot [permission flags] --resume <agentSessionId> [-p <prompt>]`.
+// session: `copilot [permission flags] --resume <agentSessionId>`.
 // ok is false when the hook-derived native session id has not landed yet, so
 // callers can fall back to fresh launch behavior.
 //

--- a/backend/internal/adapters/agent/copilot/copilot_test.go
+++ b/backend/internal/adapters/agent/copilot/copilot_test.go
@@ -33,7 +33,7 @@ func TestGetLaunchCommandBuildsArgv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"copilot", "--allow-all"}
+	want := []string{"copilot", "--allow-all", "--interactive", "-fix this"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
 	}
@@ -48,6 +48,9 @@ func TestGetLaunchCommandOmitsPromptWhenEmpty(t *testing.T) {
 	}
 	if contains(cmd, "-p") {
 		t.Fatalf("command %#v unexpectedly contains -p", cmd)
+	}
+	if contains(cmd, "--interactive") {
+		t.Fatalf("command %#v unexpectedly contains --interactive", cmd)
 	}
 }
 
@@ -123,7 +126,7 @@ func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != ports.PromptDeliveryAfterStart {
+	if got != ports.PromptDeliveryInCommand {
 		t.Fatalf("unexpected strategy: %q", got)
 	}
 }

--- a/backend/internal/adapters/agent/crush/crush.go
+++ b/backend/internal/adapters/agent/crush/crush.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
-	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -91,13 +90,13 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	return cmd, nil
 }
 
-// GetPromptDeliveryStrategy reports that prompted workers receive their task
+// GetPromptDeliveryStrategy reports that prompted sessions receive their task
 // after the interactive Crush UI starts.
 func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
-	if cfg.Prompt != "" && cfg.Kind != domain.KindOrchestrator {
+	if cfg.Prompt != "" {
 		return ports.PromptDeliveryAfterStart, nil
 	}
 	return ports.PromptDeliveryInCommand, nil

--- a/backend/internal/adapters/agent/crush/crush.go
+++ b/backend/internal/adapters/agent/crush/crush.go
@@ -10,10 +10,12 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -55,12 +57,14 @@ func (p *Plugin) Manifest() adapters.Manifest {
 // GetLaunchCommand builds the argv to start an interactive Crush session.
 // Shape:
 //
-//	crush [--cwd <WorkspacePath>] [--yolo] [-- <Prompt>]
+//	crush [--cwd <WorkspacePath>] [--yolo]
 //
 // The session runs in the worktree (cwd is set by the runtime). Crush doesn't
 // have native system prompt support, so cfg.SystemPrompt / SystemPromptFile are
-// intentionally ignored. The initial task prompt is delivered as a positional
-// argument after `--`. The --yolo flag corresponds to bypass-permissions mode.
+// intentionally ignored. Worker task prompts are delivered after startup so AO
+// keeps the interactive TUI; Crush's documented `run` command is intentionally
+// not used here because it is non-interactive. The --yolo flag corresponds to
+// bypass-permissions mode.
 //
 // We intentionally do not pass --session on launch: cfg.SessionID is the
 // AO-internal id, not a Crush-native session id. Letting Crush mint its own
@@ -84,12 +88,34 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 		cmd = append(cmd, "--yolo")
 	}
 
-	// Prompt is passed after `--` so a leading "-" is not read as a flag
-	if cfg.Prompt != "" {
-		cmd = append(cmd, "--", cfg.Prompt)
-	}
-
 	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports that prompted workers receive their task
+// after the interactive Crush UI starts.
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if cfg.Prompt != "" && cfg.Kind != domain.KindOrchestrator {
+		return ports.PromptDeliveryAfterStart, nil
+	}
+	return ports.PromptDeliveryInCommand, nil
+}
+
+// PromptReadinessHints waits for Crush's ready prompt before AO injects the
+// worker's first task.
+func (p *Plugin) PromptReadinessHints(ctx context.Context, _ ports.LaunchConfig) (ports.PromptReadinessHints, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.PromptReadinessHints{}, err
+	}
+	return ports.PromptReadinessHints{
+		InitialDelay: 500 * time.Millisecond,
+		Patterns:     []string{"Ready..."},
+		PollInterval: 200 * time.Millisecond,
+		Timeout:      8 * time.Second,
+		Lines:        80,
+	}, nil
 }
 
 // GetRestoreCommand rebuilds the argv that continues an existing Crush session:

--- a/backend/internal/adapters/agent/crush/crush_test.go
+++ b/backend/internal/adapters/agent/crush/crush_test.go
@@ -103,19 +103,31 @@ func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
 	}
 }
 
-func TestGetPromptDeliveryStrategyPromptedWorkerIsAfterStart(t *testing.T) {
-	plugin := &Plugin{}
-
-	got, err := plugin.GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{
-		Kind:   domain.KindWorker,
-		Prompt: "fix this",
-	})
-	if err != nil {
-		t.Fatal(err)
+func TestGetPromptDeliveryStrategyPromptedSessionsAreAfterStart(t *testing.T) {
+	tests := []struct {
+		name string
+		kind domain.SessionKind
+	}{
+		{name: "worker", kind: domain.KindWorker},
+		{name: "orchestrator", kind: domain.KindOrchestrator},
 	}
 
-	if got != ports.PromptDeliveryAfterStart {
-		t.Fatalf("unexpected prompt delivery strategy: got %v, want %v", got, ports.PromptDeliveryAfterStart)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{}
+
+			got, err := plugin.GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{
+				Kind:   tt.kind,
+				Prompt: "fix this",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got != ports.PromptDeliveryAfterStart {
+				t.Fatalf("unexpected prompt delivery strategy: got %v, want %v", got, ports.PromptDeliveryAfterStart)
+			}
+		})
 	}
 }
 

--- a/backend/internal/adapters/agent/crush/crush_test.go
+++ b/backend/internal/adapters/agent/crush/crush_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -13,6 +14,7 @@ func TestGetLaunchCommandBuildsCrossPlatformArgv(t *testing.T) {
 
 	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		Permissions:   ports.PermissionModeBypassPermissions,
+		Kind:          domain.KindWorker,
 		Prompt:        "fix this",
 		WorkspacePath: "/tmp/workspace",
 		SessionID:     "test-session-id",
@@ -27,7 +29,6 @@ func TestGetLaunchCommandBuildsCrossPlatformArgv(t *testing.T) {
 		"crush",
 		"--cwd", "/tmp/workspace",
 		"--yolo",
-		"--", "fix this",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
@@ -99,6 +100,32 @@ func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
 
 	if got != ports.PromptDeliveryInCommand {
 		t.Fatalf("unexpected prompt delivery strategy: got %v, want %v", got, ports.PromptDeliveryInCommand)
+	}
+}
+
+func TestGetPromptDeliveryStrategyPromptedWorkerIsAfterStart(t *testing.T) {
+	plugin := &Plugin{}
+
+	got, err := plugin.GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{
+		Kind:   domain.KindWorker,
+		Prompt: "fix this",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got != ports.PromptDeliveryAfterStart {
+		t.Fatalf("unexpected prompt delivery strategy: got %v, want %v", got, ports.PromptDeliveryAfterStart)
+	}
+}
+
+func TestPromptReadinessHints(t *testing.T) {
+	hints, err := (&Plugin{}).PromptReadinessHints(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hints.Timeout <= 0 || len(hints.Patterns) == 0 {
+		t.Fatalf("hints = %#v, want bounded readiness patterns", hints)
 	}
 }
 

--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
@@ -86,6 +87,21 @@ func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, _ ports.LaunchCo
 		return "", err
 	}
 	return ports.PromptDeliveryAfterStart, nil
+}
+
+// PromptReadinessHints waits for Kimi's interactive prompt before AO injects
+// the worker's first task.
+func (p *Plugin) PromptReadinessHints(ctx context.Context, _ ports.LaunchConfig) (ports.PromptReadinessHints, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.PromptReadinessHints{}, err
+	}
+	return ports.PromptReadinessHints{
+		InitialDelay: 750 * time.Millisecond,
+		Patterns:     []string{"│ >"},
+		PollInterval: 200 * time.Millisecond,
+		Timeout:      8 * time.Second,
+		Lines:        80,
+	}, nil
 }
 
 // GetRestoreCommand rebuilds the argv that continues an existing Kimi session

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -49,6 +49,16 @@ func TestGetPromptDeliveryStrategy(t *testing.T) {
 	}
 }
 
+func TestPromptReadinessHints(t *testing.T) {
+	hints, err := (&Plugin{}).PromptReadinessHints(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if hints.Timeout <= 0 || len(hints.Patterns) == 0 {
+		t.Fatalf("hints = %#v, want bounded readiness patterns", hints)
+	}
+}
+
 // Kimi prompt mode is non-interactive, so AO launches the TUI and lets the
 // session manager inject the task after startup. Because the prompt is not
 // carried with `-p`, approval flags remain valid for prompted workers.

--- a/backend/internal/adapters/agent/kiro/kiro.go
+++ b/backend/internal/adapters/agent/kiro/kiro.go
@@ -1,4 +1,4 @@
-// Package kiro implements the Kiro (AWS) agent adapter: launching new headless
+// Package kiro implements the Kiro (AWS) agent adapter: launching interactive
 // sessions, resuming hook-tracked sessions, installing workspace-local hooks,
 // and reading hook-derived session info.
 //
@@ -8,9 +8,9 @@
 // approval flow. See https://kiro.dev/docs/cli/headless/ and
 // https://kiro.dev/docs/cli/reference/cli-commands/.
 //
-// Launch delivers the initial prompt as a positional argument after `--` so a
-// leading "-" is not parsed as a flag. Permission/approval modes map onto
-// Kiro's tool-trust flags (`--trust-all-tools`, `--trust-tools=<categories>`).
+// Worker prompts are delivered after startup so AO keeps Kiro's interactive
+// TUI. Permission/approval modes map onto Kiro's tool-trust flags
+// (`--trust-all-tools`, `--trust-tools=<categories>`).
 // Restore uses `kiro-cli chat --resume-id <UUID>` with the native session id
 // captured from a Kiro hook payload.
 //
@@ -22,6 +22,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
@@ -63,8 +64,10 @@ func (p *Plugin) Manifest() adapters.Manifest {
 // `kiro-cli chat --agent ao [trust flags] [-- <prompt>]`.
 //
 // The prompt is passed as a positional argument after `--` so a leading "-" is
-// not read as a flag. Kiro runs interactively for both workers and orchestrators;
-// standing instructions come from the generated custom agent.
+// not read as a flag for non-worker launches. Worker prompts are sent after
+// startup so AO keeps the interactive TUI and avoids Kiro's current positional
+// input submission gap. Kiro runs interactively for both workers and
+// orchestrators; standing instructions come from the generated custom agent.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	binary, err := p.kiroBinary(ctx)
 	if err != nil {
@@ -75,7 +78,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	appendApprovalFlags(&cmd, cfg.Permissions)
 
 	prompt := cfg.Prompt
-	if prompt != "" {
+	if prompt != "" && cfg.Kind == domain.KindOrchestrator {
 		cmd = append(cmd, "--", prompt)
 	}
 
@@ -90,13 +93,31 @@ func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.Launch
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
-	if cfg.Prompt != "" {
+	if cfg.Prompt != "" && cfg.Kind == domain.KindOrchestrator {
 		return ports.PromptDeliveryInCommand, nil
+	}
+	if cfg.Prompt != "" && cfg.Kind != domain.KindOrchestrator {
+		return ports.PromptDeliveryAfterStart, nil
 	}
 	if cfg.Kind == domain.KindOrchestrator {
 		return ports.PromptDeliveryCustomAgent, nil
 	}
 	return ports.PromptDeliveryInCommand, nil
+}
+
+// PromptReadinessHints waits for Kiro's interactive prompt before AO injects
+// the worker's first task.
+func (p *Plugin) PromptReadinessHints(ctx context.Context, _ ports.LaunchConfig) (ports.PromptReadinessHints, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.PromptReadinessHints{}, err
+	}
+	return ports.PromptReadinessHints{
+		InitialDelay: 500 * time.Millisecond,
+		Patterns:     []string{"ask a question or describe a task"},
+		PollInterval: 200 * time.Millisecond,
+		Timeout:      8 * time.Second,
+		Lines:        80,
+	}, nil
 }
 
 // GetRestoreCommand rebuilds the argv that continues an existing Kiro session.

--- a/backend/internal/adapters/agent/kiro/kiro_test.go
+++ b/backend/internal/adapters/agent/kiro/kiro_test.go
@@ -33,6 +33,7 @@ func TestGetLaunchCommandBuildsInteractiveArgv(t *testing.T) {
 
 	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		Permissions: ports.PermissionModeBypassPermissions,
+		Kind:        domain.KindWorker,
 		Prompt:      "-fix this",
 	})
 	if err != nil {
@@ -43,7 +44,6 @@ func TestGetLaunchCommandBuildsInteractiveArgv(t *testing.T) {
 		"kiro-cli", "chat",
 		"--agent", "ao",
 		"--trust-all-tools",
-		"--", "-fix this",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
@@ -87,10 +87,11 @@ func TestGetLaunchCommandPromptlessWorkerStaysInteractive(t *testing.T) {
 	}
 }
 
-func TestGetLaunchCommandPromptTakesPrecedenceOverSystemPrompt(t *testing.T) {
+func TestGetLaunchCommandPromptedWorkerKeepsPromptOutOfArgv(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "kiro-cli"}
 
 	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Kind:         domain.KindWorker,
 		Prompt:       "fix the failing test",
 		SystemPrompt: "standing role instructions",
 	})
@@ -101,7 +102,27 @@ func TestGetLaunchCommandPromptTakesPrecedenceOverSystemPrompt(t *testing.T) {
 	want := []string{
 		"kiro-cli", "chat",
 		"--agent", "ao",
-		"--", "fix the failing test",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandPromptedOrchestratorCarriesPrompt(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Kind:   domain.KindOrchestrator,
+		Prompt: "do the explicit task",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"kiro-cli", "chat",
+		"--agent", "ao",
+		"--", "do the explicit task",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
@@ -184,6 +205,21 @@ func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
 	}
 }
 
+func TestGetPromptDeliveryStrategyPromptedWorkerIsAfterStart(t *testing.T) {
+	plugin := &Plugin{}
+
+	got, err := plugin.GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{
+		Kind:   domain.KindWorker,
+		Prompt: "do this task",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != ports.PromptDeliveryAfterStart {
+		t.Fatalf("unexpected strategy: %q", got)
+	}
+}
+
 func TestGetPromptDeliveryStrategyOrchestratorUsesCustomAgent(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "kiro-cli"}
 
@@ -208,6 +244,16 @@ func TestGetPromptDeliveryStrategyPromptedOrchestratorUsesCommand(t *testing.T) 
 	}
 	if got != ports.PromptDeliveryInCommand {
 		t.Fatalf("unexpected strategy: %q", got)
+	}
+}
+
+func TestPromptReadinessHints(t *testing.T) {
+	hints, err := (&Plugin{}).PromptReadinessHints(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hints.Timeout <= 0 || len(hints.Patterns) == 0 {
+		t.Fatalf("hints = %#v, want bounded readiness patterns", hints)
 	}
 }
 

--- a/backend/internal/integration/lifecycle_sqlite_test.go
+++ b/backend/internal/integration/lifecycle_sqlite_test.go
@@ -42,6 +42,9 @@ func (s *stubRuntime) IsAlive(_ context.Context, h ports.RuntimeHandle) (bool, e
 	}
 	return true, nil
 }
+func (s *stubRuntime) GetOutput(_ context.Context, _ ports.RuntimeHandle, _ int) (string, error) {
+	return "", nil
+}
 
 // wasDestroyed reports whether Destroy was called with the given handle ID.
 func (s *stubRuntime) wasDestroyed(handleID string) bool {

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -3,6 +3,7 @@ package ports
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
@@ -68,6 +69,23 @@ type AgentAuthChecker interface {
 // binary can be checked without constructing a real session launch command.
 type AgentBinaryResolver interface {
 	ResolveBinary(ctx context.Context) (path string, err error)
+}
+
+// AgentPromptReadinessProvider is an optional capability for interactive
+// adapters that receive their first task after startup. It lets AO wait until a
+// terminal UI is ready before injecting text through the runtime.
+type AgentPromptReadinessProvider interface {
+	PromptReadinessHints(ctx context.Context, cfg LaunchConfig) (PromptReadinessHints, error)
+}
+
+// PromptReadinessHints describes when an after-start prompt should be sent.
+// Empty hints mean "send immediately" to preserve existing adapter behavior.
+type PromptReadinessHints struct {
+	InitialDelay time.Duration
+	Patterns     []string
+	PollInterval time.Duration
+	Timeout      time.Duration
+	Lines        int
 }
 
 // AgentResolver maps a session's harness onto the Agent adapter that drives it,

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1911,6 +1911,16 @@ func (m *Manager) waitForPromptReadiness(ctx context.Context, agent ports.Agent,
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-deadline.C:
+			// Prompt readiness is best-effort: a missing terminal marker must not
+			// block spawn forever or be treated as confirmed readiness. Fall back
+			// to delivering the prompt and make the degraded path observable.
+			m.logger.Warn("prompt readiness timed out; falling back to after-start prompt delivery",
+				"sessionID", cfg.SessionID,
+				"kind", string(cfg.Kind),
+				"timeout", hints.Timeout.String(),
+				"pollInterval", poll.String(),
+				"lines", lines,
+			)
 			return nil
 		case <-ticker.C:
 		}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -72,6 +72,7 @@ type lifecycleRecorder interface {
 type runtimeController interface {
 	Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error)
 	Destroy(ctx context.Context, handle ports.RuntimeHandle) error
+	GetOutput(ctx context.Context, handle ports.RuntimeHandle, lines int) (string, error)
 	// IsAlive reports whether the handle's runtime session still exists. Used by
 	// Reconcile on boot to adopt crash-surviving sessions and reap leaked ones.
 	IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error)
@@ -316,7 +317,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: completed: %w", id, err)
 	}
 	if delivery == ports.PromptDeliveryAfterStart && prompt != "" {
-		if err := m.messenger.Send(ctx, id, prompt); err != nil {
+		if err := m.deliverAfterStartPrompt(ctx, agent, launchCfg, handle, id, prompt); err != nil {
 			_ = m.runtime.Destroy(ctx, handle)
 			m.destroySpawnWorkspace(ctx, ws, workspaceProject)
 			m.markSpawnFailedTerminatedWithoutWorkspace(ctx, id)
@@ -757,7 +758,17 @@ func (m *Manager) relaunchRestoredSession(ctx context.Context, rec domain.Sessio
 		return domain.SessionRecord{}, fmt.Errorf("restore %s: completed: %w", rec.ID, err)
 	}
 	if delivery == ports.PromptDeliveryAfterStart && rec.Metadata.Prompt != "" {
-		if err := m.messenger.Send(ctx, rec.ID, rec.Metadata.Prompt); err != nil {
+		launchCfg := ports.LaunchConfig{
+			DataDir:       m.dataDir,
+			SessionID:     string(rec.ID),
+			WorkspacePath: ws.Path,
+			Kind:          rec.Kind,
+			Prompt:        rec.Metadata.Prompt,
+			SystemPrompt:  systemPrompt,
+			Config:        agentConfig,
+			Permissions:   agentConfig.Permissions,
+		}
+		if err := m.deliverAfterStartPrompt(ctx, agent, launchCfg, handle, rec.ID, rec.Metadata.Prompt); err != nil {
 			_ = m.runtime.Destroy(ctx, handle)
 			_ = m.lcm.MarkTerminated(ctx, rec.ID)
 			return domain.SessionRecord{}, fmt.Errorf("restore %s: deliver prompt: %w", rec.ID, err)
@@ -1851,6 +1862,79 @@ func (m *Manager) prepareWorkspace(ctx context.Context, agent ports.Agent, id do
 		}
 	}
 	return nil
+}
+
+func (m *Manager) deliverAfterStartPrompt(ctx context.Context, agent ports.Agent, cfg ports.LaunchConfig, handle ports.RuntimeHandle, id domain.SessionID, prompt string) error {
+	if err := m.waitForPromptReadiness(ctx, agent, cfg, handle); err != nil {
+		return err
+	}
+	return m.messenger.Send(ctx, id, prompt)
+}
+
+func (m *Manager) waitForPromptReadiness(ctx context.Context, agent ports.Agent, cfg ports.LaunchConfig, handle ports.RuntimeHandle) error {
+	provider, ok := agent.(ports.AgentPromptReadinessProvider)
+	if !ok {
+		return nil
+	}
+	hints, err := provider.PromptReadinessHints(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("prompt readiness: %w", err)
+	}
+	if hints.InitialDelay > 0 {
+		if err := sleepContext(ctx, hints.InitialDelay); err != nil {
+			return err
+		}
+	}
+	if len(hints.Patterns) == 0 || hints.Timeout <= 0 {
+		return nil
+	}
+	poll := hints.PollInterval
+	if poll <= 0 {
+		poll = 200 * time.Millisecond
+	}
+	lines := hints.Lines
+	if lines <= 0 {
+		lines = 80
+	}
+
+	deadline := time.NewTimer(hints.Timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
+	for {
+		output, err := m.runtime.GetOutput(ctx, handle, lines)
+		if err == nil && promptOutputContains(output, hints.Patterns) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func promptOutputContains(output string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if pattern != "" && strings.Contains(output, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // restoreArgv builds the argv to relaunch a torn-down session: the agent's

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -659,6 +659,7 @@ func TestSpawn_AfterStartPromptFallsBackWhenReadinessTimesOut(t *testing.T) {
 	ws := &fakeWorkspace{}
 	msg := &fakeMessenger{}
 	agent := &recordingAgent{}
+	var logBuf bytes.Buffer
 	m := New(Deps{
 		Runtime: rt,
 		Agents: singleAgent{agent: readinessAgent{
@@ -674,6 +675,7 @@ func TestSpawn_AfterStartPromptFallsBackWhenReadinessTimesOut(t *testing.T) {
 		Messenger: msg,
 		Lifecycle: &fakeLCM{store: st},
 		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+		Logger:    slog.New(slog.NewTextHandler(&logBuf, nil)),
 	})
 
 	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, Prompt: "fix the button"}); err != nil {
@@ -684,6 +686,16 @@ func TestSpawn_AfterStartPromptFallsBackWhenReadinessTimesOut(t *testing.T) {
 	}
 	if len(msg.msgs) != 1 || msg.msgs[0] != "fix the button" {
 		t.Fatalf("delivered prompts = %#v, want fallback prompt delivery", msg.msgs)
+	}
+	logText := logBuf.String()
+	if !strings.Contains(logText, "prompt readiness timed out") {
+		t.Fatalf("log = %q, want readiness timeout warning", logText)
+	}
+	if !strings.Contains(logText, "falling back to after-start prompt delivery") {
+		t.Fatalf("log = %q, want fallback delivery context", logText)
+	}
+	if !strings.Contains(logText, "sessionID=mer-1") {
+		t.Fatalf("log = %q, want session id", logText)
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -163,6 +163,9 @@ type fakeRuntime struct {
 	destroyErr         error
 	created, destroyed int
 	lastCfg            ports.RuntimeConfig
+	outputs            []string
+	outputCalls        int
+	outputErr          error
 	// aliveByHandle maps a RuntimeHandle.ID to its liveness; missing = false.
 	aliveByHandle map[string]bool
 	aliveErr      error
@@ -187,6 +190,20 @@ func (r *fakeRuntime) IsAlive(_ context.Context, handle ports.RuntimeHandle) (bo
 		return false, r.aliveErr
 	}
 	return r.aliveByHandle[handle.ID], nil
+}
+func (r *fakeRuntime) GetOutput(_ context.Context, _ ports.RuntimeHandle, _ int) (string, error) {
+	r.outputCalls++
+	if r.outputErr != nil {
+		return "", r.outputErr
+	}
+	if len(r.outputs) == 0 {
+		return "", nil
+	}
+	out := r.outputs[0]
+	if len(r.outputs) > 1 {
+		r.outputs = r.outputs[1:]
+	}
+	return out, nil
 }
 
 type fakeAgent struct{}
@@ -248,6 +265,15 @@ type afterStartAgent struct {
 
 func (a afterStartAgent) GetPromptDeliveryStrategy(context.Context, ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
 	return ports.PromptDeliveryAfterStart, nil
+}
+
+type readinessAgent struct {
+	afterStartAgent
+	hints ports.PromptReadinessHints
+}
+
+func (a readinessAgent) PromptReadinessHints(context.Context, ports.LaunchConfig) (ports.PromptReadinessHints, error) {
+	return a.hints, nil
 }
 
 type promptStrategyErrorAgent struct {
@@ -588,6 +614,76 @@ func TestSpawn_DeliversPromptAfterStartWhenAgentRequestsIt(t *testing.T) {
 	}
 	if st.sessions["mer-1"].Metadata.Prompt != "fix the button" {
 		t.Fatalf("stored prompt = %q, want original prompt", st.sessions["mer-1"].Metadata.Prompt)
+	}
+}
+
+func TestSpawn_AfterStartPromptWaitsForReadinessHint(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	rt := &fakeRuntime{outputs: []string{"booting", "agent Ready..."}}
+	ws := &fakeWorkspace{}
+	msg := &fakeMessenger{}
+	agent := &recordingAgent{}
+	m := New(Deps{
+		Runtime: rt,
+		Agents: singleAgent{agent: readinessAgent{
+			afterStartAgent: afterStartAgent{recordingAgent: agent},
+			hints: ports.PromptReadinessHints{
+				Patterns:     []string{"Ready..."},
+				PollInterval: time.Millisecond,
+				Timeout:      50 * time.Millisecond,
+			},
+		}},
+		Workspace: ws,
+		Store:     st,
+		Messenger: msg,
+		Lifecycle: &fakeLCM{store: st},
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, Prompt: "fix the button"}); err != nil {
+		t.Fatal(err)
+	}
+	if rt.outputCalls != 2 {
+		t.Fatalf("GetOutput calls = %d, want 2", rt.outputCalls)
+	}
+	if len(msg.msgs) != 1 || msg.msgs[0] != "fix the button" {
+		t.Fatalf("delivered prompts = %#v, want one original prompt", msg.msgs)
+	}
+}
+
+func TestSpawn_AfterStartPromptFallsBackWhenReadinessTimesOut(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	rt := &fakeRuntime{outputs: []string{"still booting"}}
+	ws := &fakeWorkspace{}
+	msg := &fakeMessenger{}
+	agent := &recordingAgent{}
+	m := New(Deps{
+		Runtime: rt,
+		Agents: singleAgent{agent: readinessAgent{
+			afterStartAgent: afterStartAgent{recordingAgent: agent},
+			hints: ports.PromptReadinessHints{
+				Patterns:     []string{"Ready..."},
+				PollInterval: time.Millisecond,
+				Timeout:      time.Millisecond,
+			},
+		}},
+		Workspace: ws,
+		Store:     st,
+		Messenger: msg,
+		Lifecycle: &fakeLCM{store: st},
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, Prompt: "fix the button"}); err != nil {
+		t.Fatal(err)
+	}
+	if rt.outputCalls == 0 {
+		t.Fatal("GetOutput was not called")
+	}
+	if len(msg.msgs) != 1 || msg.msgs[0] != "fix the button" {
+		t.Fatalf("delivered prompts = %#v, want fallback prompt delivery", msg.msgs)
 	}
 }
 


### PR DESCRIPTION
 ## Summary

  Adds prompt-readiness handling for interactive agent adapters that receive their initial worker task after the CLI starts.

  ## Why

  Some terminal-based agents are not ready to accept input immediately after process launch. AO could send the worker prompt
  too early, causing it to be ignored, misparsed, or injected before the interactive prompt was active.

  ## Changes

  - Added optional `AgentPromptReadinessProvider` support for adapters.
  - Added `PromptReadinessHints` with delay, polling, output patterns, timeout, and line count.
  - Updated the session manager to wait for readiness before sending `PromptDeliveryAfterStart` prompts.
  - Falls back to sending the prompt after timeout so startup does not block indefinitely.
  - Added readiness hints for Cline, Kimi, Kiro, and Crush.
  - Adjusted Kiro and Crush worker launches so prompted workers stay interactive and receive prompts after startup.
  - Added tests for readiness waits, timeout fallback, and adapter hint coverage.

  ## Verification

  ```bash
  GOCACHE=/private/tmp/go-build-ao-agent-readiness go test ./internal/adapters/agent/cline ./internal/adapters/agent/kimi ./
  internal/adapters/agent/kiro ./internal/adapters/agent/crush ./internal/session_manager
