### PR TITLE
Constrain browser panel native view

### DIFF
--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -32,8 +32,8 @@ function setupHost() {
 	};
 	const view = {
 		webContents,
-		setBounds: () => undefined,
-		setVisible: () => undefined,
+		setBounds: vi.fn(),
+		setVisible: vi.fn(),
 	};
 	const handlers = new Map<string, InvokeHandler>();
 	const sent: BrowserNavState[] = [];
@@ -58,7 +58,7 @@ function setupHost() {
 	});
 	const invoke = (channel: string, ...args: unknown[]) =>
 		handlers.get(channel)!({ sender: { id: 1 } }, ...args) as Promise<BrowserNavState>;
-	return { host, invoke, webContents };
+	return { host, invoke, setCurrentURL: (url: string) => (currentURL = url), view, webContents };
 }
 
 describe("normalizeBrowserURL", () => {
@@ -111,6 +111,35 @@ describe("browser:clear", () => {
 
 		expect(webContents.loadURL).toHaveBeenLastCalledWith("about:blank");
 		expect(state.url).toBe("");
+	});
+});
+
+describe("browser:navigate", () => {
+	it("reports failed loads as an error state and hides the native view", async () => {
+		const { invoke, view, webContents } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+		vi.mocked(webContents.loadURL).mockRejectedValueOnce(new Error("ERR_NAME_NOT_RESOLVED"));
+
+		const state = await invoke("browser:navigate", { viewId: "1:sess-1", url: "e" });
+
+		expect(state.url).toBe("https://e/");
+		expect(state.error).toContain("ERR_NAME_NOT_RESOLVED");
+		expect(view.setVisible).toHaveBeenLastCalledWith(false);
+	});
+
+	it("keeps the load error when stopping the failed page", async () => {
+		const { invoke, setCurrentURL, webContents } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+		vi.mocked(webContents.loadURL).mockImplementationOnce(async (url: string) => {
+			setCurrentURL(url);
+			throw new Error("ERR_CONNECTION_REFUSED");
+		});
+		await invoke("browser:navigate", { viewId: "1:sess-1", url: "http://localhost:3000/" });
+
+		const state = await invoke("browser:stop", "1:sess-1");
+
+		expect(state.url).toBe("http://localhost:3000/");
+		expect(state.error).toContain("ERR_CONNECTION_REFUSED");
 	});
 });
 

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -181,8 +181,21 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		if (!isAllowedBrowserURL(normalized.href, options.rendererOrigin)) {
 			throw new Error("Unsupported browser URL");
 		}
-		await entry.view.webContents.loadURL(normalized.href);
-		return pushNavState(options, entry);
+		try {
+			await entry.view.webContents.loadURL(normalized.href);
+			return pushNavState(options, entry);
+		} catch (error) {
+			entry.view.setVisible?.(false);
+			entry.view.setBounds(OFFSCREEN_BOUNDS);
+			entry.state = {
+				...readNavState(entry),
+				url: normalized.href,
+				error: error instanceof Error ? error.message : "Unable to load page",
+				isLoading: false,
+			};
+			options.mainWindow.webContents.send("browser:navState", entry.state);
+			return entry.state;
+		}
 	};
 
 	// clear resets the view to a blank page (`ao preview clear`). about:blank is
@@ -212,10 +225,21 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		entry.view.webContents.close?.();
 	};
 
-	const invokeNav = (viewId: string, action: (contents: BrowserWebContents) => void): BrowserNavState => {
+	const invokeNav = (
+		viewId: string,
+		action: (contents: BrowserWebContents) => void,
+		navOptions?: { preserveLoadError?: boolean },
+	): BrowserNavState => {
 		const entry = entries.get(viewId);
 		if (!entry) return emptyNavState(viewId);
 		action(entry.view.webContents);
+		if (navOptions?.preserveLoadError && entry.state.error) {
+			const next = readNavState(entry);
+			if (next.url === entry.state.url) {
+				entry.state = { ...next, error: entry.state.error };
+				return entry.state;
+			}
+		}
 		return pushNavState(options, entry);
 	};
 
@@ -238,7 +262,9 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	handle("browser:goBack", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.goBack()));
 	handle("browser:goForward", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.goForward()));
 	handle("browser:reload", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.reload()));
-	handle("browser:stop", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.stop()));
+	handle("browser:stop", (_event, viewId: string) =>
+		invokeNav(viewId, (contents) => contents.stop(), { preserveLoadError: true }),
+	);
 	on("browser:destroy", (_event, viewId: string) => destroy(viewId));
 
 	return {
@@ -323,15 +349,21 @@ function hardenWebContents(contents: BrowserWebContents, options: BrowserViewHos
 }
 
 function wireNavEvents(contents: BrowserWebContents, options: BrowserViewHostOptions, entry: BrowserEntry): void {
-	const update = () => {
+	const update = (preserveLoadError = false) => {
+		if (preserveLoadError && entry.state.error) {
+			const next = readNavState(entry);
+			if (next.url === entry.state.url) return;
+		}
 		pushNavState(options, entry);
 	};
-	contents.on("did-navigate", update);
-	contents.on("did-navigate-in-page", update);
-	contents.on("page-title-updated", update);
-	contents.on("did-start-loading", update);
-	contents.on("did-stop-loading", update);
+	contents.on("did-navigate", () => update());
+	contents.on("did-navigate-in-page", () => update());
+	contents.on("page-title-updated", () => update());
+	contents.on("did-start-loading", () => update());
+	contents.on("did-stop-loading", () => update(true));
 	contents.on("did-fail-load", (_event, _errorCode, errorDescription) => {
+		entry.view.setVisible?.(false);
+		entry.view.setBounds(OFFSCREEN_BOUNDS);
 		entry.state = { ...readNavState(entry), error: String(errorDescription || "Unable to load page") };
 		options.mainWindow.webContents.send("browser:navState", entry.state);
 	});

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -53,7 +53,7 @@ export function BrowserPanelView({
 
 	return (
 		<div
-			className="flex h-full min-h-browser-min flex-col overflow-hidden rounded-lg border border-border bg-background"
+			className="flex h-full w-full min-w-0 min-h-browser-min flex-col overflow-hidden rounded-lg border border-border bg-background"
 			role="tabpanel"
 		>
 			<form
@@ -120,7 +120,7 @@ export function BrowserPanelView({
 					)}
 				</Button>
 			</form>
-			<div className="relative min-h-0 flex-1 overflow-hidden bg-background">
+			<div className="relative min-h-0 flex-1 overflow-hidden bg-background" data-browser-view-clip>
 				<div className="absolute inset-0 min-h-px min-w-px" ref={slotRef} />
 				{showStaticPreview ? <StaticPreview url={navState.url} /> : null}
 				{navState.url === "" ? (

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -209,21 +209,23 @@ export function SessionView({ sessionId }: SessionViewProps) {
 							panelRef={inspectorRef}
 							style={{ overflow: "hidden" }}
 						>
-							{/* Stable content width while the panel animates (yyork pattern):
-                  the pane clips instead of reflowing the inspector mid-collapse. */}
-							<div className="h-full min-w-inspector-min">
-								<SessionInspector
-									browserPoppedOut={browserPoppedOut}
-									isInspectorVisible={isInspectorOpen}
-									onOpenReviewerTerminal={({ handleId, harness }) =>
-										setTerminalTarget({ kind: "reviewer", handleId, harness })
-									}
-									onToggleBrowserPopOut={setBrowserPoppedOut}
-									onViewChange={setInspectorView}
-									view={inspectorView}
-									browserView={browserView}
-									session={session}
-								/>
+							<div className="h-full w-full min-w-0 overflow-hidden" data-browser-view-clip>
+								{/* Stable content width while the panel animates (yyork pattern):
+	                  the pane clips instead of reflowing the inspector mid-collapse. */}
+								<div className="h-full min-w-inspector-min">
+									<SessionInspector
+										browserPoppedOut={browserPoppedOut}
+										isInspectorVisible={isInspectorOpen}
+										onOpenReviewerTerminal={({ handleId, harness }) =>
+											setTerminalTarget({ kind: "reviewer", handleId, harness })
+										}
+										onToggleBrowserPopOut={setBrowserPoppedOut}
+										onViewChange={setInspectorView}
+										view={inspectorView}
+										browserView={browserView}
+										session={session}
+									/>
+								</div>
 							</div>
 						</ResizablePanel>
 					</>

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -35,14 +35,16 @@ function setupBridge() {
 				isLoading: false,
 			};
 		},
-		ensure: vi.fn(async (sessionId: string): Promise<BrowserNavState> => ({
-			viewId: `42:${sessionId}`,
-			url: "",
-			title: "",
-			canGoBack: false,
-			canGoForward: false,
-			isLoading: false,
-		})),
+		ensure: vi.fn(
+			async (sessionId: string): Promise<BrowserNavState> => ({
+				viewId: `42:${sessionId}`,
+				url: "",
+				title: "",
+				canGoBack: false,
+				canGoForward: false,
+				isLoading: false,
+			}),
+		),
 		setBounds: vi.fn(),
 		navigate: vi.fn(async ({ viewId }: { viewId: string }) => bridge.stateFor(viewId)),
 		clear: vi.fn(async (viewId: string) => bridge.stateFor(viewId)),
@@ -139,6 +141,73 @@ describe("useBrowserView", () => {
 			expect(bridge.setBounds).toHaveBeenCalledWith({
 				viewId: "42:sess-1",
 				rect: { x: 100, y: 34, width: 150, height: 240 },
+				visible: true,
+			}),
+		);
+	});
+
+	it("clamps the native view to every browser clip boundary", async () => {
+		const bridge = setupBridge();
+		const outerClip = document.createElement("div");
+		outerClip.setAttribute("data-browser-view-clip", "");
+		outerClip.getBoundingClientRect = vi.fn(() => ({
+			x: 1500,
+			y: 200,
+			width: 420,
+			height: 906,
+			top: 200,
+			right: 1920,
+			bottom: 1106,
+			left: 1500,
+			toJSON: () => ({}),
+		}));
+		const clip = document.createElement("div");
+		clip.setAttribute("data-browser-view-clip", "");
+		clip.getBoundingClientRect = vi.fn(() => ({
+			x: 1440,
+			y: 206,
+			width: 480,
+			height: 900,
+			top: 206,
+			right: 1920,
+			bottom: 1106,
+			left: 1440,
+			toJSON: () => ({}),
+		}));
+		const slot = createSlot({
+			x: 1320,
+			y: 242,
+			width: 432,
+			height: 862,
+			top: 242,
+			right: 1752,
+			bottom: 1104,
+			left: 1320,
+		});
+		const stableWidthWrapper = document.createElement("div");
+		stableWidthWrapper.appendChild(slot);
+		clip.appendChild(stableWidthWrapper);
+		outerClip.appendChild(clip);
+		document.body.appendChild(outerClip);
+
+		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+		await waitFor(() => expect(bridge.ensure).toHaveBeenCalledWith("sess-1"));
+		act(() =>
+			bridge.emit({
+				viewId: "42:sess-1",
+				url: "http://localhost:3000/",
+				title: "",
+				canGoBack: false,
+				canGoForward: false,
+				isLoading: false,
+			}),
+		);
+		act(() => result.current.slotRef(slot));
+
+		await waitFor(() =>
+			expect(bridge.setBounds).toHaveBeenCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 1500, y: 242, width: 252, height: 862 },
 				visible: true,
 			}),
 		);

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -59,9 +59,12 @@ const HIDDEN_RECT: BrowserRect = { x: 0, y: 0, width: 0, height: 0 };
 function visibleSlotRect(node: HTMLElement): BrowserRect {
 	const rect = node.getBoundingClientRect();
 	let { left, top, right, bottom } = rect;
-	const column = node.closest<HTMLElement>("[data-panel]");
-	if (column) {
-		const bounds = column.getBoundingClientRect();
+	const clips: HTMLElement[] = [];
+	for (let current = node.parentElement; current; current = current.parentElement) {
+		if (current.hasAttribute("data-browser-view-clip") || current.hasAttribute("data-panel")) clips.push(current);
+	}
+	for (const clip of clips) {
+		const bounds = clip.getBoundingClientRect();
 		left = Math.max(left, bounds.left);
 		top = Math.max(top, bounds.top);
 		right = Math.min(right, bounds.right);
@@ -87,7 +90,7 @@ export function useBrowserView({
 	const settleTimerRef = useRef<number | null>(null);
 	const observerRef = useRef<ResizeObserver | null>(null);
 	const previewTriggerRef = useRef<{ revision: number | null; target: string } | null>(null);
-	const hasUrlRef = useRef(false);
+	const shouldShowNativeRef = useRef(false);
 	const hasNativeBrowser = Boolean(window.ao?.browser);
 
 	useEffect(() => {
@@ -95,8 +98,8 @@ export function useBrowserView({
 	}, [active]);
 
 	useEffect(() => {
-		hasUrlRef.current = Boolean(navState.url);
-	}, [navState.url]);
+		shouldShowNativeRef.current = Boolean(navState.url && !navState.error && !navState.isLoading);
+	}, [navState.error, navState.isLoading, navState.url]);
 
 	const sendHiddenBounds = useCallback((id = viewIdRef.current) => {
 		if (!id) return;
@@ -108,7 +111,7 @@ export function useBrowserView({
 		const id = viewIdRef.current;
 		const node = slotNodeRef.current;
 		if (!id) return;
-		if (!activeRef.current || !node || !node.isConnected || !hasUrlRef.current) {
+		if (!activeRef.current || !node || !node.isConnected || !shouldShowNativeRef.current) {
 			sendHiddenBounds(id);
 			return;
 		}
@@ -168,6 +171,9 @@ export function useBrowserView({
 				// through the whole animation so the view never lags behind.
 				const column = node.closest("[data-panel]");
 				if (column) observer.observe(column);
+				for (let current = node.parentElement; current; current = current.parentElement) {
+					if (current.hasAttribute("data-browser-view-clip")) observer.observe(current);
+				}
 				observerRef.current = observer;
 			}
 			scheduleMeasure();
@@ -217,12 +223,12 @@ export function useBrowserView({
 	}, []);
 
 	useEffect(() => {
-		if (navState.url && active) {
+		if (navState.url && active && !navState.error && !navState.isLoading) {
 			scheduleSettleMeasure();
 		} else {
 			sendHiddenBounds();
 		}
-	}, [active, navState.url, poppedOut, scheduleSettleMeasure, sendHiddenBounds]);
+	}, [active, navState.error, navState.isLoading, navState.url, poppedOut, scheduleSettleMeasure, sendHiddenBounds]);
 
 	useEffect(() => {
 		const handle = () => scheduleMeasure();
@@ -256,9 +262,12 @@ export function useBrowserView({
 				}));
 				return Promise.resolve();
 			}
-			return withView((id) => window.ao!.browser.navigate({ viewId: id, url }));
+			scheduleSettleMeasure();
+			return withView((id) => window.ao!.browser.navigate({ viewId: id, url })).finally(() => {
+				scheduleSettleMeasure();
+			});
 		},
-		[hasNativeBrowser, withView],
+		[hasNativeBrowser, scheduleSettleMeasure, withView],
 	);
 
 	const clear = useCallback(() => {


### PR DESCRIPTION
## Summary
- Clamp the native BrowserView to all browser/inspector clip boundaries so it cannot paint over the terminal.
- Hide native browser content while loads are pending or failed, and preserve failed-load errors on stop.
- Add regression coverage for failed loads and nested browser clip bounds.

## Validation
- npm --prefix frontend test -- src/main/browser-view-host.test.ts src/renderer/hooks/useBrowserView.test.tsx
- npm run frontend:typecheck
- git diff --check