### PR TITLE
feat: implement real PR merge and resolve-comments

### DIFF
--- a/backend/internal/adapters/scm/github/actions.go
+++ b/backend/internal/adapters/scm/github/actions.go
@@ -1,0 +1,180 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const defaultMergeMethod = "squash"
+
+// MergePR performs PUT /repos/{owner}/{repo}/pulls/{number}/merge with the
+// given merge method (defaults to squash). On success it returns the provider
+// merge result; failures map to the client sentinels (not found / not mergeable
+// / unprocessable / auth / rate limit).
+func (p *Provider) MergePR(ctx context.Context, ref ports.SCMPRRef, method string) (ports.PRMergeResult, error) {
+	owner, name, number, err := resolveActionRef(ref)
+	if err != nil {
+		return ports.PRMergeResult{}, err
+	}
+	if method == "" {
+		method = defaultMergeMethod
+	}
+	body := map[string]any{"merge_method": method}
+	path := repoPath(owner, name, "pulls", strconv.Itoa(number), "merge")
+	resp, err := p.client.doREST(ctx, http.MethodPut, path, nil, body)
+	if err != nil {
+		return ports.PRMergeResult{}, mapActionError(err)
+	}
+	var payload struct {
+		Merged  bool   `json:"merged"`
+		SHA     string `json:"sha"`
+		Message string `json:"message"`
+	}
+	if len(resp.Body) > 0 {
+		if err := json.Unmarshal(resp.Body, &payload); err != nil {
+			return ports.PRMergeResult{}, fmt.Errorf("github scm: decode merge response: %w", err)
+		}
+	}
+	// GitHub returns 200 with merged:true on success. A body without confirmation
+	// is treated as a failed merge so we never report fake success.
+	if !payload.Merged && payload.SHA == "" {
+		return ports.PRMergeResult{}, fmt.Errorf("%w: merge response did not confirm merge", ErrNotMergeable)
+	}
+	return ports.PRMergeResult{
+		Merged: true,
+		SHA:    payload.SHA,
+		Method: method,
+	}, nil
+}
+
+const listUnresolvedThreadsQuery = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviewThreads(last:100){
+        nodes{ id isResolved }
+      }
+    }
+  }
+}`
+
+// ListUnresolvedThreadIDs returns GraphQL node IDs for unresolved review threads
+// on the PR. Used by resolve-all and as an existence probe when explicit IDs are
+// supplied by the caller.
+func (p *Provider) ListUnresolvedThreadIDs(ctx context.Context, ref ports.SCMPRRef) ([]string, error) {
+	owner, name, number, err := resolveActionRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	data, err := p.client.doGraphQL(ctx, listUnresolvedThreadsQuery, map[string]any{
+		"owner": owner, "repo": name, "number": number,
+	})
+	if err != nil {
+		return nil, mapActionError(err)
+	}
+	repoData, _ := data["repository"].(map[string]any)
+	if repoData == nil {
+		return nil, fmt.Errorf("%w: repository not found", ErrNotFound)
+	}
+	pr, _ := repoData["pullRequest"].(map[string]any)
+	if pr == nil {
+		return nil, fmt.Errorf("%w: pull request not found", ErrNotFound)
+	}
+	threads, _ := pr["reviewThreads"].(map[string]any)
+	var out []string
+	for _, n := range nodes(threads["nodes"]) {
+		if boolv(n["isResolved"]) {
+			continue
+		}
+		id := str(n["id"])
+		if id == "" {
+			continue
+		}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+const resolveThreadMutation = `mutation($id:ID!){
+  resolveReviewThread(input:{threadId:$id}){
+    thread{ id isResolved }
+  }
+}`
+
+// ResolveThread marks one review thread resolved via the GraphQL mutation.
+func (p *Provider) ResolveThread(ctx context.Context, threadID string) error {
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return fmt.Errorf("%w: empty thread id", ErrUnprocessable)
+	}
+	data, err := p.client.doGraphQL(ctx, resolveThreadMutation, map[string]any{"id": threadID})
+	if err != nil {
+		return mapActionError(err)
+	}
+	// GraphQL may return data with a null payload when the thread id is invalid.
+	payload, _ := data["resolveReviewThread"].(map[string]any)
+	if payload == nil {
+		return fmt.Errorf("%w: resolveReviewThread returned no payload", ErrUnprocessable)
+	}
+	thread, _ := payload["thread"].(map[string]any)
+	if thread == nil {
+		return fmt.Errorf("%w: resolveReviewThread returned no thread", ErrUnprocessable)
+	}
+	return nil
+}
+
+// Compile-time check that *Provider satisfies ports.PRActioner.
+var _ ports.PRActioner = (*Provider)(nil)
+
+func resolveActionRef(ref ports.SCMPRRef) (owner, name string, number int, err error) {
+	owner = strings.TrimSpace(ref.Repo.Owner)
+	name = strings.TrimSpace(ref.Repo.Name)
+	number = ref.Number
+	if (owner == "" || name == "") && ref.URL != "" {
+		o, r, n, parseErr := parsePRURL(ref.URL)
+		if parseErr != nil {
+			return "", "", 0, fmt.Errorf("%w: %v", ErrNotFound, parseErr)
+		}
+		if owner == "" {
+			owner = o
+		}
+		if name == "" {
+			name = r
+		}
+		if number <= 0 {
+			number = n
+		}
+	}
+	if owner == "" || name == "" || number <= 0 {
+		return "", "", 0, fmt.Errorf("%w: incomplete PR ref", ErrNotFound)
+	}
+	return owner, name, number, nil
+}
+
+func mapActionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, ErrNotFound):
+		return err
+	case errors.Is(err, ErrNotMergeable):
+		return err
+	case errors.Is(err, ErrUnprocessable):
+		return err
+	case errors.Is(err, ErrAuthFailed):
+		return fmt.Errorf("%w: %w", ports.ErrSCMAuthFailed, err)
+	case errors.Is(err, ErrRateLimited):
+		return err
+	case errors.Is(err, ErrNoToken):
+		return fmt.Errorf("%w: %w", ports.ErrSCMAuthFailed, err)
+	default:
+		return err
+	}
+}

--- a/backend/internal/adapters/scm/github/actions_test.go
+++ b/backend/internal/adapters/scm/github/actions_test.go
@@ -1,0 +1,184 @@
+package github
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestMergePR_Success(t *testing.T) {
+	f := newFakeGH(t)
+	f.on(http.MethodPut, "/repos/octocat/hello/pulls/42/merge", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["merge_method"] != "squash" {
+			t.Fatalf("merge_method = %v, want squash", body["merge_method"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"merged": true, "sha": "deadbeef", "message": "Pull Request successfully merged"})
+	})
+	p := newProviderForTest(t, f)
+
+	res, err := p.MergePR(ctx(), ports.SCMPRRef{
+		Repo:   ports.SCMRepo{Owner: "octocat", Name: "hello", Repo: "octocat/hello"},
+		Number: 42,
+	}, "squash")
+	if err != nil {
+		t.Fatalf("MergePR: %v", err)
+	}
+	if !res.Merged || res.SHA != "deadbeef" || res.Method != "squash" {
+		t.Fatalf("result = %+v", res)
+	}
+	if f.callsTo(http.MethodPut, "/repos/octocat/hello/pulls/42/merge") != 1 {
+		t.Fatalf("expected one merge PUT")
+	}
+}
+
+func TestMergePR_NotMergeable_405(t *testing.T) {
+	f := newFakeGH(t)
+	f.on(http.MethodPut, "/repos/o/r/pulls/1/merge", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		_, _ = w.Write([]byte(`{"message":"Pull Request is not mergeable"}`))
+	})
+	p := newProviderForTest(t, f)
+
+	_, err := p.MergePR(ctx(), ports.SCMPRRef{Repo: ports.SCMRepo{Owner: "o", Name: "r"}, Number: 1}, "squash")
+	if !errors.Is(err, ErrNotMergeable) {
+		t.Fatalf("err = %v, want ErrNotMergeable", err)
+	}
+}
+
+func TestMergePR_Conflict_409(t *testing.T) {
+	f := newFakeGH(t)
+	f.on(http.MethodPut, "/repos/o/r/pulls/1/merge", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"message":"Head branch was modified"}`))
+	})
+	p := newProviderForTest(t, f)
+
+	_, err := p.MergePR(ctx(), ports.SCMPRRef{Repo: ports.SCMRepo{Owner: "o", Name: "r"}, Number: 1}, "")
+	if !errors.Is(err, ErrUnprocessable) {
+		t.Fatalf("err = %v, want ErrUnprocessable", err)
+	}
+}
+
+func TestMergePR_Auth_401(t *testing.T) {
+	f := newFakeGH(t)
+	f.on(http.MethodPut, "/repos/o/r/pulls/1/merge", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	})
+	p := newProviderForTest(t, f)
+
+	_, err := p.MergePR(ctx(), ports.SCMPRRef{Repo: ports.SCMRepo{Owner: "o", Name: "r"}, Number: 1}, "squash")
+	if !errors.Is(err, ports.ErrSCMAuthFailed) {
+		t.Fatalf("err = %v, want ErrSCMAuthFailed", err)
+	}
+}
+
+func TestMergePR_FromURLRef(t *testing.T) {
+	f := newFakeGH(t)
+	f.on(http.MethodPut, "/repos/acme/app/pulls/9/merge", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"merged": true, "sha": "s1"})
+	})
+	p := newProviderForTest(t, f)
+
+	res, err := p.MergePR(ctx(), ports.SCMPRRef{URL: "https://github.com/acme/app/pull/9"}, "squash")
+	if err != nil {
+		t.Fatalf("MergePR: %v", err)
+	}
+	if !res.Merged {
+		t.Fatal("expected merged")
+	}
+}
+
+func TestListUnresolvedThreadIDs(t *testing.T) {
+	f := newFakeGH(t)
+	f.on(http.MethodPost, "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if !strings.Contains(body.Query, "reviewThreads") {
+			t.Fatalf("unexpected query: %s", body.Query)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"pullRequest": map[string]any{
+						"reviewThreads": map[string]any{
+							"nodes": []any{
+								map[string]any{"id": "T_open", "isResolved": false},
+								map[string]any{"id": "T_done", "isResolved": true},
+								map[string]any{"id": "T_open2", "isResolved": false},
+							},
+						},
+					},
+				},
+			},
+		})
+	})
+	p := newProviderForTest(t, f)
+
+	ids, err := p.ListUnresolvedThreadIDs(ctx(), ports.SCMPRRef{
+		Repo: ports.SCMRepo{Owner: "o", Name: "r"}, Number: 1,
+	})
+	if err != nil {
+		t.Fatalf("ListUnresolvedThreadIDs: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "T_open" || ids[1] != "T_open2" {
+		t.Fatalf("ids = %v, want [T_open T_open2]", ids)
+	}
+}
+
+func TestResolveThread_Success(t *testing.T) {
+	f := newFakeGH(t)
+	f.on(http.MethodPost, "/graphql", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Variables["id"] != "PRRT_1" {
+			t.Fatalf("variables = %#v", body.Variables)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"resolveReviewThread": map[string]any{
+					"thread": map[string]any{"id": "PRRT_1", "isResolved": true},
+				},
+			},
+		})
+	})
+	p := newProviderForTest(t, f)
+
+	if err := p.ResolveThread(ctx(), "PRRT_1"); err != nil {
+		t.Fatalf("ResolveThread: %v", err)
+	}
+}
+
+func TestResolveThread_EmptyID(t *testing.T) {
+	p := newProviderForTest(t, newFakeGH(t))
+	if err := p.ResolveThread(ctx(), "  "); !errors.Is(err, ErrUnprocessable) {
+		t.Fatalf("err = %v, want ErrUnprocessable", err)
+	}
+}
+
+func TestResolveThread_NullPayload(t *testing.T) {
+	f := newFakeGH(t)
+	f.on(http.MethodPost, "/graphql", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"resolveReviewThread": nil},
+		})
+	})
+	p := newProviderForTest(t, f)
+	if err := p.ResolveThread(ctx(), "T_x"); !errors.Is(err, ErrUnprocessable) {
+		t.Fatalf("err = %v, want ErrUnprocessable", err)
+	}
+}

--- a/backend/internal/adapters/scm/github/client.go
+++ b/backend/internal/adapters/scm/github/client.go
@@ -27,9 +27,11 @@ const (
 // errors.Is; the orchestrator's lifecycle code is intentionally insulated
 // from raw HTTP status codes.
 var (
-	ErrNotFound    = ports.ErrSCMNotFound
-	ErrAuthFailed  = errors.New("github scm: authentication failed")
-	ErrRateLimited = errors.New("github scm: rate limited")
+	ErrNotFound      = ports.ErrSCMNotFound
+	ErrAuthFailed    = errors.New("github scm: authentication failed")
+	ErrRateLimited   = errors.New("github scm: rate limited")
+	ErrNotMergeable  = ports.ErrSCMNotMergeable
+	ErrUnprocessable = ports.ErrSCMUnprocessable
 )
 
 // RateLimitError carries the structured backoff hints from a rate-limit
@@ -439,6 +441,16 @@ func classifyError(resp *http.Response, body []byte) error {
 			return rateLimited(resp, msg)
 		}
 		return fmt.Errorf("%w: %s", ErrAuthFailed, msg)
+	case http.StatusMethodNotAllowed:
+		// PUT /pulls/{n}/merge returns 405 when the PR cannot be merged
+		// (conflicts, already merged, merge method disabled, etc.).
+		return fmt.Errorf("%w: %s", ErrNotMergeable, msg)
+	case http.StatusConflict:
+		// 409: head changed under us, or other merge conflict preconditions.
+		return fmt.Errorf("%w: %s", ErrUnprocessable, msg)
+	case http.StatusUnprocessableEntity:
+		// 422: validation failed (bad SHA, required status checks, etc.).
+		return fmt.Errorf("%w: %s", ErrUnprocessable, msg)
 	}
 	return fmt.Errorf("github scm: %d %s", resp.StatusCode, msg)
 }

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	agentsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/agent"
 	importsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/importer"
 	notificationsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/notification"
+	prsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pr"
 	projectsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/project"
 	"github.com/aoagents/agent-orchestrator/backend/internal/skillassets"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
@@ -139,11 +140,28 @@ func Run() error {
 		}
 	}()
 
+	// PR action service (merge / resolve-comments): reuse the same GitHub
+	// provider construction as the SCM observer. When provider setup fails
+	// (should be rare with SkipTokenPreflight), leave PRs nil so the routes
+	// return 501 rather than a fake-success stub.
+	var prActions prsvc.ActionManager
+	if scmProvider, err := newGitHubSCMProvider(log); err != nil {
+		logSCMProviderDisabled(log, err)
+	} else {
+		prActions = prsvc.NewActionServiceWithDeps(prsvc.ActionDeps{
+			Store:     store,
+			Writer:    store,
+			SCM:       scmProvider,
+			Lifecycle: lcStack.LCM,
+		})
+	}
+
 	srv, err := httpd.NewWithDeps(cfg, log, termMgr, httpd.APIDeps{
 		Projects:           projectsvc.NewWithDeps(projectsvc.Deps{Store: store, Sessions: sessionSvc, DefaultHarness: domain.AgentHarness(cfg.Agent), Telemetry: telemetrySink}),
 		Agents:             agentSvc,
 		Sessions:           sessionSvc,
 		Reviews:            reviewSvc,
+		PRs:                prActions,
 		Notifications:      notifier,
 		NotificationStream: notificationHub,
 		Import:             importsvc.New(importsvc.Deps{Store: store}),

--- a/backend/internal/ports/pr_actions.go
+++ b/backend/internal/ports/pr_actions.go
@@ -1,0 +1,42 @@
+package ports
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrSCMNotMergeable reports the provider refused a merge because the PR is
+// not currently mergeable (conflicts, method disabled, already merged, etc.).
+var ErrSCMNotMergeable = errors.New("scm: pr not mergeable")
+
+// ErrSCMUnprocessable reports the provider rejected a PR action for a
+// precondition that is not a simple "not mergeable" state (e.g. required
+// checks pending, SHA mismatch, invalid thread id).
+var ErrSCMUnprocessable = errors.New("scm: pr action unprocessable")
+
+// ErrSCMAuthFailed reports the provider rejected credentials or permissions.
+var ErrSCMAuthFailed = errors.New("scm: authentication failed")
+
+// PRMergeResult is the provider outcome of a successful squash (or other) merge.
+type PRMergeResult struct {
+	// Merged is true when the provider reports the PR is merged.
+	Merged bool
+	// SHA is the merge commit SHA when the provider returns one.
+	SHA string
+	// Method is the merge method that was applied (e.g. "squash").
+	Method string
+}
+
+// PRActioner performs mutating SCM operations on pull requests. It is
+// intentionally separate from observation ports so the action service can
+// depend only on write-capable providers without dragging in the poller surface.
+type PRActioner interface {
+	// MergePR squash-merges (or merges with the given method) the pull request
+	// identified by ref. method is typically "squash".
+	MergePR(ctx context.Context, ref SCMPRRef, method string) (PRMergeResult, error)
+	// ListUnresolvedThreadIDs returns GraphQL node IDs of unresolved review
+	// threads on the PR. An empty slice means nothing to resolve.
+	ListUnresolvedThreadIDs(ctx context.Context, ref SCMPRRef) ([]string, error)
+	// ResolveThread marks one review thread resolved on the provider.
+	ResolveThread(ctx context.Context, threadID string) error
+}

--- a/backend/internal/service/pr/action_service.go
+++ b/backend/internal/service/pr/action_service.go
@@ -2,7 +2,14 @@ package pr
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 // ActionManager is the controller-facing contract for /prs/{id} action routes.
@@ -14,7 +21,7 @@ type ActionManager interface {
 // MergeResult is the successful outcome of a PR merge.
 type MergeResult struct {
 	PRNumber int
-	Method   string // always "squash"
+	Method   string // always "squash" for V1
 }
 
 // ResolveResult is the successful outcome of a resolve-comments operation.
@@ -22,25 +29,357 @@ type ResolveResult struct {
 	Resolved int
 }
 
-// ActionService implements ActionManager. Business logic is not yet implemented.
-type ActionService struct{}
+// prLocator loads a tracked PR by path id (number or URL) and its related rows.
+type prLocator interface {
+	GetPR(ctx context.Context, url string) (domain.PullRequest, bool, error)
+	GetPRByNumber(ctx context.Context, number int) (domain.PullRequest, bool, error)
+	ListChecks(ctx context.Context, prURL string) ([]domain.PullRequestCheck, error)
+	ListPRComments(ctx context.Context, prURL string) ([]domain.PullRequestComment, error)
+	ListPRReviewThreads(ctx context.Context, prURL string) ([]domain.PullRequestReviewThread, error)
+	ListPRReviews(ctx context.Context, prURL string) ([]domain.PullRequestReview, error)
+}
+
+// prPersister writes local PR facts after a remote action succeeds.
+type prPersister interface {
+	WritePR(ctx context.Context, pr domain.PullRequest, checks []domain.PullRequestCheck, comments []domain.PullRequestComment) error
+	WriteSCMObservation(ctx context.Context, pr domain.PullRequest, checks []domain.PullRequestCheck, reviews []domain.PullRequestReview, threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment, reviewMode ports.ReviewWriteMode) error
+}
+
+// actionLifecycle receives PR observations after local facts are updated so
+// session termination / nudges stay consistent with the new state.
+type actionLifecycle interface {
+	ApplyPRObservation(ctx context.Context, id domain.SessionID, o ports.PRObservation) error
+}
+
+// ActionService implements ActionManager over a local PR store and SCM actioner.
+// Local state is updated only after the remote SCM operation reports success.
+type ActionService struct {
+	store     prLocator
+	writer    prPersister
+	scm       ports.PRActioner
+	lifecycle actionLifecycle
+	clock     func() time.Time
+}
+
+// ActionDeps are the collaborators a real ActionService needs.
+type ActionDeps struct {
+	Store     prLocator
+	Writer    prPersister
+	SCM       ports.PRActioner
+	Lifecycle actionLifecycle
+	Clock     func() time.Time
+}
+
+// NewActionService builds an ActionService. Prefer NewActionServiceWithDeps in
+// production; this zero-arg constructor remains for tests that inject deps via
+// the struct fields after construction is not needed — use WithDeps.
+func NewActionService() *ActionService {
+	return &ActionService{clock: time.Now}
+}
+
+// NewActionServiceWithDeps returns a fully wired ActionService.
+func NewActionServiceWithDeps(d ActionDeps) *ActionService {
+	s := &ActionService{
+		store:     d.Store,
+		writer:    d.Writer,
+		scm:       d.SCM,
+		lifecycle: d.Lifecycle,
+		clock:     d.Clock,
+	}
+	if s.clock == nil {
+		s.clock = time.Now
+	}
+	return s
+}
 
 var _ ActionManager = (*ActionService)(nil)
 
-// NewActionService returns a stub ActionService.
-func NewActionService() *ActionService {
-	return &ActionService{}
+const mergeMethodSquash = "squash"
+
+// Merge squash-merges the PR identified by prID via the SCM provider, then
+// persists the merged fact locally and notifies lifecycle.
+func (s *ActionService) Merge(ctx context.Context, prID string) (MergeResult, error) {
+	if err := s.requireConfigured(); err != nil {
+		return MergeResult{}, err
+	}
+	pr, err := s.lookupPR(ctx, prID)
+	if err != nil {
+		return MergeResult{}, err
+	}
+	if pr.Merged {
+		// Already recorded as merged locally — do not invent a remote success.
+		// Surface not-mergeable so the UI can refresh rather than reporting OK.
+		return MergeResult{}, fmt.Errorf("%w: already merged", ErrPRNotMergeable)
+	}
+	if pr.Closed {
+		return MergeResult{}, fmt.Errorf("%w: pr is closed", ErrPRPreconditions)
+	}
+
+	ref, err := scmPRRefFromPR(pr)
+	if err != nil {
+		return MergeResult{}, err
+	}
+	remote, err := s.scm.MergePR(ctx, ref, mergeMethodSquash)
+	if err != nil {
+		return MergeResult{}, mapSCMError(err)
+	}
+	if !remote.Merged {
+		return MergeResult{}, fmt.Errorf("%w: provider did not confirm merge", ErrPRNotMergeable)
+	}
+
+	method := remote.Method
+	if method == "" {
+		method = mergeMethodSquash
+	}
+	now := s.clock()
+	pr.Merged = true
+	pr.Closed = false
+	pr.Draft = false
+	if remote.SHA != "" {
+		pr.MergeCommitSHA = remote.SHA
+	}
+	pr.UpdatedAt = now
+	pr.MergedAtProvider = now
+
+	checks, err := s.store.ListChecks(ctx, pr.URL)
+	if err != nil {
+		return MergeResult{}, fmt.Errorf("list checks after merge: %w", err)
+	}
+	comments, err := s.store.ListPRComments(ctx, pr.URL)
+	if err != nil {
+		return MergeResult{}, fmt.Errorf("list comments after merge: %w", err)
+	}
+	if err := s.writer.WritePR(ctx, pr, checks, comments); err != nil {
+		return MergeResult{}, fmt.Errorf("persist merged pr: %w", err)
+	}
+	if s.lifecycle != nil {
+		obs := ports.PRObservation{
+			Fetched:      true,
+			URL:          pr.URL,
+			Number:       pr.Number,
+			Draft:        pr.Draft,
+			Merged:       true,
+			Closed:       false,
+			CI:           pr.CI,
+			Review:       pr.Review,
+			Mergeability: pr.Mergeability,
+		}
+		if err := s.lifecycle.ApplyPRObservation(ctx, pr.SessionID, obs); err != nil {
+			return MergeResult{}, fmt.Errorf("lifecycle after merge: %w", err)
+		}
+	}
+	return MergeResult{PRNumber: pr.Number, Method: method}, nil
 }
 
-// Merge squash-merges the PR identified by prID.
-// TODO: implement — squash-merge the PR via the SCM provider.
-func (s *ActionService) Merge(_ context.Context, prID string) (MergeResult, error) {
-	n, _ := strconv.Atoi(prID)
-	return MergeResult{PRNumber: n, Method: "squash"}, nil
+// ResolveComments resolves review threads on the PR via the SCM provider, then
+// marks the matching local threads/comments resolved. When commentIDs is empty
+// every unresolved thread on the remote PR is resolved.
+func (s *ActionService) ResolveComments(ctx context.Context, prID string, commentIDs []string) (ResolveResult, error) {
+	if err := s.requireConfigured(); err != nil {
+		return ResolveResult{}, err
+	}
+	pr, err := s.lookupPR(ctx, prID)
+	if err != nil {
+		return ResolveResult{}, err
+	}
+	ref, err := scmPRRefFromPR(pr)
+	if err != nil {
+		return ResolveResult{}, err
+	}
+
+	// Always probe the remote PR first so an explicit-id resolve still fails
+	// with PR_NOT_FOUND when the path id does not resolve to a live PR.
+	unresolved, err := s.scm.ListUnresolvedThreadIDs(ctx, ref)
+	if err != nil {
+		return ResolveResult{}, mapSCMError(err)
+	}
+
+	var threadIDs []string
+	if len(commentIDs) == 0 {
+		threadIDs = unresolved
+	} else {
+		// Caller-supplied ids are treated as thread node IDs (frontend may pass
+		// either). Dedupe and drop blanks.
+		seen := map[string]struct{}{}
+		for _, id := range commentIDs {
+			id = strings.TrimSpace(id)
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			threadIDs = append(threadIDs, id)
+		}
+	}
+	if len(threadIDs) == 0 {
+		return ResolveResult{}, ErrNothingToResolve
+	}
+
+	resolvedIDs := make([]string, 0, len(threadIDs))
+	for _, id := range threadIDs {
+		if err := s.scm.ResolveThread(ctx, id); err != nil {
+			// If nothing has succeeded yet, surface the mapped error directly.
+			if len(resolvedIDs) == 0 {
+				return ResolveResult{}, mapSCMError(err)
+			}
+			// Partial remote success: still persist what completed, then fail.
+			if persistErr := s.persistResolved(ctx, pr, resolvedIDs); persistErr != nil {
+				return ResolveResult{}, fmt.Errorf("persist partial resolve: %w (also: %v)", persistErr, err)
+			}
+			return ResolveResult{Resolved: len(resolvedIDs)}, mapSCMError(err)
+		}
+		resolvedIDs = append(resolvedIDs, id)
+	}
+
+	if err := s.persistResolved(ctx, pr, resolvedIDs); err != nil {
+		return ResolveResult{}, fmt.Errorf("persist resolved threads: %w", err)
+	}
+	return ResolveResult{Resolved: len(resolvedIDs)}, nil
 }
 
-// ResolveComments resolves review threads on the PR identified by prID.
-// TODO: implement — resolve review threads via the SCM provider.
-func (s *ActionService) ResolveComments(_ context.Context, _ string, _ []string) (ResolveResult, error) {
-	return ResolveResult{Resolved: 0}, nil
+func (s *ActionService) persistResolved(ctx context.Context, pr domain.PullRequest, resolvedIDs []string) error {
+	set := make(map[string]struct{}, len(resolvedIDs))
+	for _, id := range resolvedIDs {
+		set[id] = struct{}{}
+	}
+	now := s.clock()
+	pr.UpdatedAt = now
+
+	checks, err := s.store.ListChecks(ctx, pr.URL)
+	if err != nil {
+		return err
+	}
+	reviews, err := s.store.ListPRReviews(ctx, pr.URL)
+	if err != nil {
+		return err
+	}
+	threads, err := s.store.ListPRReviewThreads(ctx, pr.URL)
+	if err != nil {
+		return err
+	}
+	comments, err := s.store.ListPRComments(ctx, pr.URL)
+	if err != nil {
+		return err
+	}
+
+	for i := range threads {
+		if _, ok := set[threads[i].ThreadID]; ok {
+			threads[i].Resolved = true
+			threads[i].UpdatedAt = now
+		}
+	}
+	for i := range comments {
+		if _, ok := set[comments[i].ThreadID]; ok {
+			comments[i].Resolved = true
+			continue
+		}
+		// Also match comment node IDs when the caller passed those.
+		if _, ok := set[comments[i].ID]; ok {
+			comments[i].Resolved = true
+		}
+	}
+
+	// Prefer the SCM write path so review-thread CDC fires on resolved flips.
+	// Fall back to WritePR for legacy comment-only rows when there are no threads.
+	if len(threads) > 0 || len(reviews) > 0 {
+		return s.writer.WriteSCMObservation(ctx, pr, checks, reviews, threads, comments, ports.ReviewWriteMerge)
+	}
+	return s.writer.WritePR(ctx, pr, checks, comments)
+}
+
+// lookupPR resolves the /prs/{id} path parameter against the local database.
+// Numeric ids are PR numbers; URL-shaped ids look up by canonical PR URL.
+func (s *ActionService) lookupPR(ctx context.Context, prID string) (domain.PullRequest, error) {
+	prID = strings.TrimSpace(prID)
+	if prID == "" {
+		return domain.PullRequest{}, ErrPRNotFound
+	}
+	if strings.Contains(prID, "://") || strings.HasPrefix(prID, "github.com/") {
+		url := prID
+		if strings.HasPrefix(url, "github.com/") {
+			url = "https://" + url
+		}
+		pr, ok, err := s.store.GetPR(ctx, url)
+		if err != nil {
+			return domain.PullRequest{}, fmt.Errorf("get pr by url: %w", err)
+		}
+		if !ok {
+			return domain.PullRequest{}, ErrPRNotFound
+		}
+		return pr, nil
+	}
+	n, err := strconv.Atoi(prID)
+	if err != nil || n <= 0 {
+		return domain.PullRequest{}, ErrPRNotFound
+	}
+	pr, ok, err := s.store.GetPRByNumber(ctx, n)
+	if err != nil {
+		return domain.PullRequest{}, fmt.Errorf("get pr by number: %w", err)
+	}
+	if !ok {
+		return domain.PullRequest{}, ErrPRNotFound
+	}
+	return pr, nil
+}
+
+func scmPRRefFromPR(pr domain.PullRequest) (ports.SCMPRRef, error) {
+	ref := ports.SCMPRRef{
+		Number: pr.Number,
+		URL:    firstNonEmptyStr(pr.HTMLURL, pr.URL),
+		Repo: ports.SCMRepo{
+			Provider: firstNonEmptyStr(pr.Provider, "github"),
+			Host:     firstNonEmptyStr(pr.Host, "github.com"),
+			Repo:     pr.Repo,
+		},
+	}
+	if pr.Repo != "" {
+		parts := strings.SplitN(pr.Repo, "/", 2)
+		if len(parts) == 2 {
+			ref.Repo.Owner = parts[0]
+			ref.Repo.Name = parts[1]
+		}
+	}
+	if ref.Repo.Owner == "" || ref.Repo.Name == "" || ref.Number <= 0 {
+		// Fall through to URL parsing in the provider when possible.
+		if ref.URL == "" {
+			return ports.SCMPRRef{}, fmt.Errorf("%w: pr row missing repo and url", ErrPRNotFound)
+		}
+	}
+	return ref, nil
+}
+
+func mapSCMError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, ports.ErrSCMNotFound), errors.Is(err, ports.ErrSCMPRNotFound):
+		return fmt.Errorf("%w: %w", ErrPRNotFound, err)
+	case errors.Is(err, ports.ErrSCMNotMergeable):
+		return fmt.Errorf("%w: %w", ErrPRNotMergeable, err)
+	case errors.Is(err, ports.ErrSCMUnprocessable):
+		return fmt.Errorf("%w: %w", ErrPRPreconditions, err)
+	case errors.Is(err, ports.ErrSCMAuthFailed):
+		// Auth failures stay as opaque operation failures (500) so we do not
+		// claim the PR is missing or unmergeable.
+		return fmt.Errorf("pr operation auth failed: %w", err)
+	default:
+		return err
+	}
+}
+
+func firstNonEmptyStr(a, b string) string {
+	if strings.TrimSpace(a) != "" {
+		return a
+	}
+	return b
+}
+
+func (s *ActionService) requireConfigured() error {
+	if s == nil || s.scm == nil || s.store == nil || s.writer == nil {
+		return errors.New("pr: action service is not configured")
+	}
+	return nil
 }

--- a/backend/internal/service/pr/action_service_test.go
+++ b/backend/internal/service/pr/action_service_test.go
@@ -2,27 +2,491 @@ package pr
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-func TestMerge_ReturnsSquash(t *testing.T) {
-	svc := NewActionService()
-	res, err := svc.Merge(context.Background(), "42")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res.Method != "squash" {
-		t.Errorf("method = %q, want squash", res.Method)
-	}
-	if res.PRNumber != 42 {
-		t.Errorf("PRNumber = %d, want 42", res.PRNumber)
+// ---- fakes ----
+
+type fakePRStore struct {
+	byURL    map[string]domain.PullRequest
+	byNumber map[int]domain.PullRequest
+	checks   map[string][]domain.PullRequestCheck
+	comments map[string][]domain.PullRequestComment
+	threads  map[string][]domain.PullRequestReviewThread
+	reviews  map[string][]domain.PullRequestReview
+
+	// written captures the last WritePR / WriteSCMObservation call.
+	wrotePR       *domain.PullRequest
+	wroteComments []domain.PullRequestComment
+	wroteThreads  []domain.PullRequestReviewThread
+	writeErr      error
+	writeCalls    int
+}
+
+func newFakePRStore() *fakePRStore {
+	return &fakePRStore{
+		byURL:    map[string]domain.PullRequest{},
+		byNumber: map[int]domain.PullRequest{},
+		checks:   map[string][]domain.PullRequestCheck{},
+		comments: map[string][]domain.PullRequestComment{},
+		threads:  map[string][]domain.PullRequestReviewThread{},
+		reviews:  map[string][]domain.PullRequestReview{},
 	}
 }
 
-func TestResolveComments_ReturnsOK(t *testing.T) {
-	svc := NewActionService()
-	_, err := svc.ResolveComments(context.Background(), "1", nil)
+func (f *fakePRStore) put(pr domain.PullRequest) {
+	f.byURL[pr.URL] = pr
+	f.byNumber[pr.Number] = pr
+}
+
+func (f *fakePRStore) GetPR(_ context.Context, url string) (domain.PullRequest, bool, error) {
+	pr, ok := f.byURL[url]
+	return pr, ok, nil
+}
+
+func (f *fakePRStore) GetPRByNumber(_ context.Context, number int) (domain.PullRequest, bool, error) {
+	pr, ok := f.byNumber[number]
+	return pr, ok, nil
+}
+
+func (f *fakePRStore) ListChecks(_ context.Context, prURL string) ([]domain.PullRequestCheck, error) {
+	return append([]domain.PullRequestCheck(nil), f.checks[prURL]...), nil
+}
+
+func (f *fakePRStore) ListPRComments(_ context.Context, prURL string) ([]domain.PullRequestComment, error) {
+	return append([]domain.PullRequestComment(nil), f.comments[prURL]...), nil
+}
+
+func (f *fakePRStore) ListPRReviewThreads(_ context.Context, prURL string) ([]domain.PullRequestReviewThread, error) {
+	return append([]domain.PullRequestReviewThread(nil), f.threads[prURL]...), nil
+}
+
+func (f *fakePRStore) ListPRReviews(_ context.Context, prURL string) ([]domain.PullRequestReview, error) {
+	return append([]domain.PullRequestReview(nil), f.reviews[prURL]...), nil
+}
+
+func (f *fakePRStore) WritePR(_ context.Context, pr domain.PullRequest, _ []domain.PullRequestCheck, comments []domain.PullRequestComment) error {
+	f.writeCalls++
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	cp := pr
+	f.wrotePR = &cp
+	f.wroteComments = append([]domain.PullRequestComment(nil), comments...)
+	f.put(pr)
+	f.comments[pr.URL] = append([]domain.PullRequestComment(nil), comments...)
+	return nil
+}
+
+func (f *fakePRStore) WriteSCMObservation(_ context.Context, pr domain.PullRequest, _ []domain.PullRequestCheck, _ []domain.PullRequestReview, threads []domain.PullRequestReviewThread, comments []domain.PullRequestComment, _ ports.ReviewWriteMode) error {
+	f.writeCalls++
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	cp := pr
+	f.wrotePR = &cp
+	f.wroteThreads = append([]domain.PullRequestReviewThread(nil), threads...)
+	f.wroteComments = append([]domain.PullRequestComment(nil), comments...)
+	f.put(pr)
+	f.threads[pr.URL] = append([]domain.PullRequestReviewThread(nil), threads...)
+	f.comments[pr.URL] = append([]domain.PullRequestComment(nil), comments...)
+	return nil
+}
+
+type fakeSCMActioner struct {
+	mergeResult  ports.PRMergeResult
+	mergeErr     error
+	mergeCalls   int
+	lastMergeRef ports.SCMPRRef
+	lastMethod   string
+
+	unresolved    []string
+	listErr       error
+	listCalls     int
+	resolveErr    error
+	resolvedIDs   []string
+	failOnResolve map[string]error
+}
+
+func (f *fakeSCMActioner) MergePR(_ context.Context, ref ports.SCMPRRef, method string) (ports.PRMergeResult, error) {
+	f.mergeCalls++
+	f.lastMergeRef = ref
+	f.lastMethod = method
+	if f.mergeErr != nil {
+		return ports.PRMergeResult{}, f.mergeErr
+	}
+	return f.mergeResult, nil
+}
+
+func (f *fakeSCMActioner) ListUnresolvedThreadIDs(_ context.Context, _ ports.SCMPRRef) ([]string, error) {
+	f.listCalls++
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return append([]string(nil), f.unresolved...), nil
+}
+
+func (f *fakeSCMActioner) ResolveThread(_ context.Context, threadID string) error {
+	if err, ok := f.failOnResolve[threadID]; ok {
+		return err
+	}
+	if f.resolveErr != nil {
+		return f.resolveErr
+	}
+	f.resolvedIDs = append(f.resolvedIDs, threadID)
+	return nil
+}
+
+type fakeActionLifecycle struct {
+	observed []ports.PRObservation
+	err      error
+}
+
+func (f *fakeActionLifecycle) ApplyPRObservation(_ context.Context, _ domain.SessionID, o ports.PRObservation) error {
+	f.observed = append(f.observed, o)
+	return f.err
+}
+
+func samplePR(n int) domain.PullRequest {
+	return domain.PullRequest{
+		URL:       fmt.Sprintf("https://github.com/acme/repo/pull/%d", n),
+		HTMLURL:   fmt.Sprintf("https://github.com/acme/repo/pull/%d", n),
+		SessionID: "sess-1",
+		Number:    n,
+		Repo:      "acme/repo",
+		Provider:  "github",
+		Host:      "github.com",
+		CI:        domain.CIPassing,
+		Review:    domain.ReviewApproved,
+		UpdatedAt: time.Unix(1000, 0).UTC(),
+	}
+}
+
+func newTestService(store *fakePRStore, scm *fakeSCMActioner, lc *fakeActionLifecycle) *ActionService {
+	deps := ActionDeps{
+		Store:  store,
+		Writer: store,
+		SCM:    scm,
+		Clock:  func() time.Time { return time.Unix(2000, 0).UTC() },
+	}
+	// Assign only a non-nil pointer so ActionDeps.Lifecycle stays a true nil
+	// interface (avoids the classic typed-nil interface trap).
+	if lc != nil {
+		deps.Lifecycle = lc
+	}
+	return NewActionServiceWithDeps(deps)
+}
+
+// ---- Merge ----
+
+func TestMerge_Success_CallsRemoteAndPersists(t *testing.T) {
+	store := newFakePRStore()
+	store.put(samplePR(42))
+	scm := &fakeSCMActioner{mergeResult: ports.PRMergeResult{Merged: true, SHA: "abc123", Method: "squash"}}
+	lc := &fakeActionLifecycle{}
+	svc := newTestService(store, scm, lc)
+
+	res, err := svc.Merge(context.Background(), "42")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Merge: %v", err)
+	}
+	if res.PRNumber != 42 || res.Method != "squash" {
+		t.Fatalf("result = %+v, want {42 squash}", res)
+	}
+	if scm.mergeCalls != 1 {
+		t.Fatalf("remote merge calls = %d, want 1", scm.mergeCalls)
+	}
+	if scm.lastMethod != "squash" {
+		t.Fatalf("method = %q, want squash", scm.lastMethod)
+	}
+	if scm.lastMergeRef.Number != 42 || scm.lastMergeRef.Repo.Owner != "acme" {
+		t.Fatalf("merge ref = %+v", scm.lastMergeRef)
+	}
+	if store.writeCalls != 1 || store.wrotePR == nil || !store.wrotePR.Merged {
+		t.Fatalf("local write missing or not merged: calls=%d pr=%+v", store.writeCalls, store.wrotePR)
+	}
+	if store.wrotePR.MergeCommitSHA != "abc123" {
+		t.Fatalf("merge sha = %q, want abc123", store.wrotePR.MergeCommitSHA)
+	}
+	if len(lc.observed) != 1 || !lc.observed[0].Merged {
+		t.Fatalf("lifecycle obs = %+v, want one merged observation", lc.observed)
+	}
+}
+
+func TestMerge_DoesNotPersistWhenRemoteSkippedOrFails(t *testing.T) {
+	store := newFakePRStore()
+	store.put(samplePR(7))
+	scm := &fakeSCMActioner{mergeErr: ports.ErrSCMNotMergeable}
+	svc := newTestService(store, scm, &fakeActionLifecycle{})
+
+	_, err := svc.Merge(context.Background(), "7")
+	if !errors.Is(err, ErrPRNotMergeable) {
+		t.Fatalf("err = %v, want ErrPRNotMergeable", err)
+	}
+	if store.writeCalls != 0 {
+		t.Fatalf("writeCalls = %d, want 0 (no local update on remote failure)", store.writeCalls)
+	}
+}
+
+func TestMerge_NotFound(t *testing.T) {
+	svc := newTestService(newFakePRStore(), &fakeSCMActioner{}, nil)
+	_, err := svc.Merge(context.Background(), "99")
+	if !errors.Is(err, ErrPRNotFound) {
+		t.Fatalf("err = %v, want ErrPRNotFound", err)
+	}
+}
+
+func TestMerge_LookupByURL(t *testing.T) {
+	store := newFakePRStore()
+	pr := samplePR(3)
+	store.put(pr)
+	scm := &fakeSCMActioner{mergeResult: ports.PRMergeResult{Merged: true, SHA: "s", Method: "squash"}}
+	svc := newTestService(store, scm, nil)
+
+	res, err := svc.Merge(context.Background(), pr.URL)
+	if err != nil {
+		t.Fatalf("Merge by URL: %v", err)
+	}
+	if res.PRNumber != 3 {
+		t.Fatalf("PRNumber = %d, want 3", res.PRNumber)
+	}
+}
+
+func TestMerge_AlreadyMergedLocally(t *testing.T) {
+	store := newFakePRStore()
+	pr := samplePR(1)
+	pr.Merged = true
+	store.put(pr)
+	scm := &fakeSCMActioner{mergeResult: ports.PRMergeResult{Merged: true, Method: "squash"}}
+	svc := newTestService(store, scm, nil)
+
+	_, err := svc.Merge(context.Background(), "1")
+	if !errors.Is(err, ErrPRNotMergeable) {
+		t.Fatalf("err = %v, want ErrPRNotMergeable", err)
+	}
+	if scm.mergeCalls != 0 {
+		t.Fatalf("should not call remote when already merged locally")
+	}
+}
+
+func TestMerge_ClosedPR(t *testing.T) {
+	store := newFakePRStore()
+	pr := samplePR(2)
+	pr.Closed = true
+	store.put(pr)
+	scm := &fakeSCMActioner{}
+	svc := newTestService(store, scm, nil)
+
+	_, err := svc.Merge(context.Background(), "2")
+	if !errors.Is(err, ErrPRPreconditions) {
+		t.Fatalf("err = %v, want ErrPRPreconditions", err)
+	}
+	if scm.mergeCalls != 0 {
+		t.Fatalf("should not call remote for closed PR")
+	}
+}
+
+func TestMerge_AuthFailure_NoLocalWrite(t *testing.T) {
+	store := newFakePRStore()
+	store.put(samplePR(5))
+	scm := &fakeSCMActioner{mergeErr: ports.ErrSCMAuthFailed}
+	svc := newTestService(store, scm, nil)
+
+	_, err := svc.Merge(context.Background(), "5")
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+	if errors.Is(err, ErrPRNotFound) || errors.Is(err, ErrPRNotMergeable) {
+		t.Fatalf("auth should not map to not-found/not-mergeable: %v", err)
+	}
+	if store.writeCalls != 0 {
+		t.Fatalf("no local write on auth failure")
+	}
+}
+
+func TestMerge_PersistenceError_AfterRemoteSuccess(t *testing.T) {
+	store := newFakePRStore()
+	store.put(samplePR(8))
+	store.writeErr = errors.New("disk full")
+	scm := &fakeSCMActioner{mergeResult: ports.PRMergeResult{Merged: true, SHA: "x", Method: "squash"}}
+	svc := newTestService(store, scm, nil)
+
+	_, err := svc.Merge(context.Background(), "8")
+	if err == nil {
+		t.Fatal("expected persistence error")
+	}
+	if scm.mergeCalls != 1 {
+		t.Fatalf("remote should have been called once")
+	}
+}
+
+func TestMerge_RemoteUnprocessable(t *testing.T) {
+	store := newFakePRStore()
+	store.put(samplePR(9))
+	scm := &fakeSCMActioner{mergeErr: ports.ErrSCMUnprocessable}
+	svc := newTestService(store, scm, nil)
+
+	_, err := svc.Merge(context.Background(), "9")
+	if !errors.Is(err, ErrPRPreconditions) {
+		t.Fatalf("err = %v, want ErrPRPreconditions", err)
+	}
+}
+
+func TestMerge_RemoteReportsNotMerged_NoLocalWrite(t *testing.T) {
+	store := newFakePRStore()
+	store.put(samplePR(10))
+	// Provider returns success envelope but Merged=false and empty SHA is rejected
+	// inside the GitHub adapter; here we simulate a bad result object.
+	scm := &fakeSCMActioner{mergeResult: ports.PRMergeResult{Merged: false}}
+	svc := newTestService(store, scm, nil)
+
+	_, err := svc.Merge(context.Background(), "10")
+	if !errors.Is(err, ErrPRNotMergeable) {
+		t.Fatalf("err = %v, want ErrPRNotMergeable", err)
+	}
+	if store.writeCalls != 0 {
+		t.Fatalf("must not persist when provider did not confirm merge")
+	}
+}
+
+// ---- ResolveComments ----
+
+func TestResolveComments_ResolveAll_RemoteThenLocal(t *testing.T) {
+	store := newFakePRStore()
+	pr := samplePR(42)
+	store.put(pr)
+	store.threads[pr.URL] = []domain.PullRequestReviewThread{
+		{ThreadID: "T_1", Resolved: false},
+		{ThreadID: "T_2", Resolved: false},
+	}
+	store.comments[pr.URL] = []domain.PullRequestComment{
+		{ThreadID: "T_1", ID: "C_1", Resolved: false},
+		{ThreadID: "T_2", ID: "C_2", Resolved: false},
+	}
+	scm := &fakeSCMActioner{unresolved: []string{"T_1", "T_2"}}
+	svc := newTestService(store, scm, nil)
+
+	res, err := svc.ResolveComments(context.Background(), "42", nil)
+	if err != nil {
+		t.Fatalf("ResolveComments: %v", err)
+	}
+	if res.Resolved != 2 {
+		t.Fatalf("Resolved = %d, want 2", res.Resolved)
+	}
+	if scm.listCalls != 1 || len(scm.resolvedIDs) != 2 {
+		t.Fatalf("remote list=%d resolved=%v", scm.listCalls, scm.resolvedIDs)
+	}
+	if store.writeCalls != 1 {
+		t.Fatalf("writeCalls = %d, want 1", store.writeCalls)
+	}
+	for _, th := range store.wroteThreads {
+		if !th.Resolved {
+			t.Fatalf("thread %s not marked resolved locally", th.ThreadID)
+		}
+	}
+	for _, c := range store.wroteComments {
+		if !c.Resolved {
+			t.Fatalf("comment %s not marked resolved locally", c.ID)
+		}
+	}
+}
+
+func TestResolveComments_ExplicitIDs(t *testing.T) {
+	store := newFakePRStore()
+	pr := samplePR(1)
+	store.put(pr)
+	store.threads[pr.URL] = []domain.PullRequestReviewThread{{ThreadID: "T_only", Resolved: false}}
+	scm := &fakeSCMActioner{unresolved: []string{"T_only", "T_other"}}
+	svc := newTestService(store, scm, nil)
+
+	res, err := svc.ResolveComments(context.Background(), "1", []string{"T_only", "", "T_only"})
+	if err != nil {
+		t.Fatalf("ResolveComments: %v", err)
+	}
+	if res.Resolved != 1 {
+		t.Fatalf("Resolved = %d, want 1 (deduped)", res.Resolved)
+	}
+	if len(scm.resolvedIDs) != 1 || scm.resolvedIDs[0] != "T_only" {
+		t.Fatalf("resolvedIDs = %v", scm.resolvedIDs)
+	}
+}
+
+func TestResolveComments_NothingToResolve(t *testing.T) {
+	store := newFakePRStore()
+	store.put(samplePR(1))
+	scm := &fakeSCMActioner{unresolved: nil}
+	svc := newTestService(store, scm, nil)
+
+	_, err := svc.ResolveComments(context.Background(), "1", nil)
+	if !errors.Is(err, ErrNothingToResolve) {
+		t.Fatalf("err = %v, want ErrNothingToResolve", err)
+	}
+	if store.writeCalls != 0 {
+		t.Fatalf("no local write when nothing to resolve")
+	}
+}
+
+func TestResolveComments_NotFound(t *testing.T) {
+	svc := newTestService(newFakePRStore(), &fakeSCMActioner{}, nil)
+	_, err := svc.ResolveComments(context.Background(), "404", nil)
+	if !errors.Is(err, ErrPRNotFound) {
+		t.Fatalf("err = %v, want ErrPRNotFound", err)
+	}
+}
+
+func TestResolveComments_RemoteFail_NoLocalWrite(t *testing.T) {
+	store := newFakePRStore()
+	store.put(samplePR(1))
+	scm := &fakeSCMActioner{
+		unresolved: []string{"T_1"},
+		resolveErr: ports.ErrSCMAuthFailed,
+	}
+	svc := newTestService(store, scm, nil)
+
+	_, err := svc.ResolveComments(context.Background(), "1", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if store.writeCalls != 0 {
+		t.Fatalf("must not write local state when remote resolve fails")
+	}
+}
+
+func TestResolveComments_ListFail_NoLocalWrite(t *testing.T) {
+	store := newFakePRStore()
+	store.put(samplePR(1))
+	scm := &fakeSCMActioner{listErr: ports.ErrSCMNotFound}
+	svc := newTestService(store, scm, nil)
+
+	_, err := svc.ResolveComments(context.Background(), "1", nil)
+	if !errors.Is(err, ErrPRNotFound) {
+		t.Fatalf("err = %v, want ErrPRNotFound", err)
+	}
+	if store.writeCalls != 0 {
+		t.Fatalf("no write on list failure")
+	}
+}
+
+func TestResolveComments_InvalidPathID(t *testing.T) {
+	svc := newTestService(newFakePRStore(), &fakeSCMActioner{}, nil)
+	_, err := svc.ResolveComments(context.Background(), "not-a-number", nil)
+	if !errors.Is(err, ErrPRNotFound) {
+		t.Fatalf("err = %v, want ErrPRNotFound", err)
+	}
+}
+
+func TestActionService_NotConfigured(t *testing.T) {
+	svc := NewActionService()
+	if _, err := svc.Merge(context.Background(), "1"); err == nil {
+		t.Fatal("expected not-configured error for Merge")
+	}
+	if _, err := svc.ResolveComments(context.Background(), "1", nil); err == nil {
+		t.Fatal("expected not-configured error for ResolveComments")
 	}
 }

--- a/backend/internal/storage/sqlite/gen/pr.sql.go
+++ b/backend/internal/storage/sqlite/gen/pr.sql.go
@@ -149,6 +149,64 @@ func (q *Queries) GetPR(ctx context.Context, url string) (PR, error) {
 	return i, err
 }
 
+const getPRByNumber = `-- name: GetPRByNumber :one
+SELECT url, session_id, number, pr_state, review_decision, ci_state, mergeability, updated_at, provider, host, repo, source_branch, target_branch, head_sha, title, additions, deletions, changed_files, author, base_sha, merge_commit_sha, is_draft, is_merged, is_closed, provider_state, provider_mergeable, provider_merge_state_status, html_url, created_at_provider, updated_at_provider, merged_at_provider, closed_at_provider, metadata_hash, ci_hash, review_hash, observed_at, ci_observed_at, review_observed_at, last_nudge_signature FROM pr
+WHERE number = ?
+ORDER BY
+    CASE WHEN pr_state NOT IN ('merged', 'closed') THEN 0 ELSE 1 END,
+    updated_at DESC
+LIMIT 1
+`
+
+// Locates a tracked PR by its provider number (the /prs/{id} path id). Prefer
+// open/draft rows over terminal ones, then the most recently updated.
+func (q *Queries) GetPRByNumber(ctx context.Context, number int64) (PR, error) {
+	row := q.db.QueryRowContext(ctx, getPRByNumber, number)
+	var i PR
+	err := row.Scan(
+		&i.URL,
+		&i.SessionID,
+		&i.Number,
+		&i.PRState,
+		&i.ReviewDecision,
+		&i.CIState,
+		&i.Mergeability,
+		&i.UpdatedAt,
+		&i.Provider,
+		&i.Host,
+		&i.Repo,
+		&i.SourceBranch,
+		&i.TargetBranch,
+		&i.HeadSha,
+		&i.Title,
+		&i.Additions,
+		&i.Deletions,
+		&i.ChangedFiles,
+		&i.Author,
+		&i.BaseSha,
+		&i.MergeCommitSha,
+		&i.IsDraft,
+		&i.IsMerged,
+		&i.IsClosed,
+		&i.ProviderState,
+		&i.ProviderMergeable,
+		&i.ProviderMergeStateStatus,
+		&i.HtmlURL,
+		&i.CreatedAtProvider,
+		&i.UpdatedAtProvider,
+		&i.MergedAtProvider,
+		&i.ClosedAtProvider,
+		&i.MetadataHash,
+		&i.CIHash,
+		&i.ReviewHash,
+		&i.ObservedAt,
+		&i.CIObservedAt,
+		&i.ReviewObservedAt,
+		&i.LastNudgeSignature,
+	)
+	return i, err
+}
+
 const getPRClaimAndOwner = `-- name: GetPRClaimAndOwner :one
 SELECT pr.session_id, sessions.is_terminated
 FROM pr

--- a/backend/internal/storage/sqlite/queries/pr.sql
+++ b/backend/internal/storage/sqlite/queries/pr.sql
@@ -67,6 +67,16 @@ ON CONFLICT (url) DO UPDATE SET
 -- name: GetPR :one
 SELECT * FROM pr WHERE url = ?;
 
+-- name: GetPRByNumber :one
+-- Locates a tracked PR by its provider number (the /prs/{id} path id). Prefer
+-- open/draft rows over terminal ones, then the most recently updated.
+SELECT * FROM pr
+WHERE number = ?
+ORDER BY
+    CASE WHEN pr_state NOT IN ('merged', 'closed') THEN 0 ELSE 1 END,
+    updated_at DESC
+LIMIT 1;
+
 -- name: ListPRsBySession :many
 SELECT * FROM pr
 WHERE session_id = ?

--- a/backend/internal/storage/sqlite/store/pr_store.go
+++ b/backend/internal/storage/sqlite/store/pr_store.go
@@ -240,6 +240,24 @@ func (s *Store) GetPR(ctx context.Context, url string) (domain.PullRequest, bool
 	return prRowFromGen(p), true, nil
 }
 
+// GetPRByNumber returns the best matching tracked PR for a provider PR number
+// (the /prs/{id} path identifier). Open/draft rows are preferred over merged
+// or closed ones; ties break on most recently updated. ok=false when no row
+// exists for that number.
+func (s *Store) GetPRByNumber(ctx context.Context, number int) (domain.PullRequest, bool, error) {
+	if number <= 0 {
+		return domain.PullRequest{}, false, nil
+	}
+	p, err := s.qr.GetPRByNumber(ctx, int64(number))
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.PullRequest{}, false, nil
+	}
+	if err != nil {
+		return domain.PullRequest{}, false, fmt.Errorf("get pr by number %d: %w", number, err)
+	}
+	return prRowFromGen(p), true, nil
+}
+
 // ListPRsBySession returns every PR owned by a session, newest first.
 func (s *Store) ListPRsBySession(ctx context.Context, sessionID domain.SessionID) ([]domain.PullRequest, error) {
 	rows, err := s.qr.ListPRsBySession(ctx, sessionID)

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -323,6 +323,44 @@ func TestPRCRUD(t *testing.T) {
 	if list, _ := s.ListPRsBySession(ctx, r.ID); len(list) != 1 {
 		t.Fatalf("list prs = %d, want 1", len(list))
 	}
+	byNum, ok, err := s.GetPRByNumber(ctx, 1)
+	if err != nil || !ok || byNum.URL != pr.URL {
+		t.Fatalf("GetPRByNumber: ok=%v err=%v got=%+v", ok, err, byNum)
+	}
+	if _, ok, err := s.GetPRByNumber(ctx, 999); err != nil || ok {
+		t.Fatalf("GetPRByNumber missing: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestGetPRByNumber_PrefersOpenOverMerged(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	r, _ := s.CreateSession(ctx, sampleRecord("mer"))
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Same provider number can exist across repos; path-id lookup prefers open.
+	merged := domain.PullRequest{
+		URL: "https://github.com/a/b/pull/7", SessionID: r.ID, Number: 7,
+		Merged: true, UpdatedAt: now.Add(time.Hour),
+	}
+	open := domain.PullRequest{
+		URL: "https://github.com/c/d/pull/7", SessionID: r.ID, Number: 7,
+		UpdatedAt: now,
+	}
+	if err := s.WritePR(ctx, merged, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WritePR(ctx, open, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.GetPRByNumber(ctx, 7)
+	if err != nil || !ok {
+		t.Fatalf("GetPRByNumber: ok=%v err=%v", ok, err)
+	}
+	if got.URL != open.URL || got.Merged {
+		t.Fatalf("got %+v, want open PR %s", got, open.URL)
+	}
 }
 
 func TestWritePRRejectsSessionReassignment(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace the stub `ActionService` with real GitHub-backed **squash-merge** and **resolve review threads** for `POST /api/v1/prs/{id}/merge` and `POST /api/v1/prs/{id}/resolve-comments`.
- Look up the PR from SQLite by path id (PR number, preferring open/draft rows, or URL).
- Run the remote SCM operation first; **update local PR / thread state only after success** (then notify lifecycle on merge).
- Wire the service into the daemon via the existing GitHub provider (lazy token); leave `PRs` nil → 501 if provider setup fails (no fake-success stub).
- Map not found / not mergeable / preconditions / nothing-to-resolve / auth failures to the existing HTTP envelopes.
- Replace stub tests with coverage that fails if the remote step is skipped or local state is written too early.

Closes #2543

## Test plan

- [x] `go test ./internal/service/pr/`
- [x] `go test ./internal/adapters/scm/github/`
- [x] `go test ./internal/storage/sqlite/store/`
- [x] `go test ./internal/daemon/`
- [x] `go test ./internal/httpd/controllers/`
- [x] `go build` of changed packages
- [ ] CI green on Linux
- [ ] Manual: with a GitHub token, merge an open tracked PR from the desktop/API and confirm GitHub + local board update
- [ ] Manual: resolve-comments with empty body (all threads) and with explicit thread ids