### PR TITLE
feat: add hosted install scripts

### DIFF
--- a/frontend/src/landing/components/LandingHero.tsx
+++ b/frontend/src/landing/components/LandingHero.tsx
@@ -1192,6 +1192,18 @@ export function LandingHero() {
 							</span>
 						</a>
 					</div>
+					<div className="gsap-reveal mx-auto mt-4 flex w-full max-w-[560px] items-start gap-3 rounded-[6px] border border-white/10 bg-white/[0.035] px-4 py-3 text-left shadow-[0_16px_44px_-36px_rgba(130,170,255,0.35)] sm:items-center">
+						<span className="shrink-0 pt-[2px] font-mono text-[13px] text-[color:var(--fg-dim)] sm:pt-0">$</span>
+						<code className="min-w-0 flex-1 break-words font-mono text-[12px] leading-5 text-[#b9c9ff] [overflow-wrap:anywhere] sm:overflow-x-auto sm:whitespace-nowrap sm:text-[13px] sm:leading-none sm:[scrollbar-width:none]">
+							curl -fsSL https://aoagents.dev/install.sh | sh
+						</code>
+						<a
+							href="/docs/installation"
+							className="shrink-0 text-[12px] font-semibold text-[color:var(--fg-muted)] transition-colors hover:text-[color:var(--fg)]"
+						>
+							Install
+						</a>
+					</div>
 				</div>
 
 				<div className="gsap-reveal mx-auto mt-20 flex max-w-[1200px] items-center gap-4 px-1 text-left">

--- a/frontend/src/landing/components/docs/InstallDownloads.tsx
+++ b/frontend/src/landing/components/docs/InstallDownloads.tsx
@@ -38,10 +38,10 @@ export function InstallDownloads() {
 		<section className="ao-install-downloads" aria-label="Download Agent Orchestrator">
 			<div className="ao-install-downloads__header">
 				<div className="ao-install-downloads__copy">
-					<div className="ao-install-downloads__eyebrow">Recommended install</div>
-					<div className="ao-install-downloads__title">Desktop app from GitHub Releases</div>
+					<div className="ao-install-downloads__eyebrow">Manual downloads</div>
+					<div className="ao-install-downloads__title">Latest desktop release assets</div>
 					<div className="ao-install-downloads__description">
-						Bundles the daemon, dashboard, plugins, and auto-updates. No global CLI is required.
+						Use these direct links if you prefer to install without the terminal bootstrap script.
 					</div>
 				</div>
 				<a className="ao-install-downloads__release" href={RELEASE_BASE}>

--- a/frontend/src/landing/content/docs/installation.mdx
+++ b/frontend/src/landing/content/docs/installation.mdx
@@ -44,7 +44,28 @@ If you plan to use GitLab or Linear, install and authenticate their CLIs or cred
 
 ## Install AO
 
-Download the desktop app for your platform. This is the supported default path after the GitHub workspace installer change.
+Install the desktop app from the terminal, or download the release asset for your platform.
+
+<div className="ao-compact-tabs ao-install-script-tabs">
+
+<Tabs items={["macOS / Linux", "Windows PowerShell"]}>
+	<Tab value="macOS / Linux">
+
+```bash
+curl -fsSL https://aoagents.dev/install.sh | sh
+```
+
+	</Tab>
+	<Tab value="Windows PowerShell">
+
+```powershell
+irm https://aoagents.dev/install.ps1 | iex
+```
+
+	</Tab>
+</Tabs>
+
+</div>
 
 <InstallDownloads />
 

--- a/frontend/src/landing/public/install.ps1
+++ b/frontend/src/landing/public/install.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = "Stop"
+
+$repo = if ($env:AO_INSTALL_REPO) { $env:AO_INSTALL_REPO } else { "AgentWrapper/agent-orchestrator" }
+$baseUrl = if ($env:AO_INSTALL_BASE_URL) {
+	$env:AO_INSTALL_BASE_URL
+} else {
+	"https://github.com/$repo/releases/latest/download"
+}
+
+if (-not [Environment]::Is64BitOperatingSystem) {
+	throw "Agent Orchestrator currently requires 64-bit Windows."
+}
+
+$asset = "agent-orchestrator-win32-x64.exe"
+$url = "$baseUrl/$asset"
+$destination = Join-Path ([IO.Path]::GetTempPath()) $asset
+
+Write-Host "Downloading Agent Orchestrator from $url"
+Invoke-WebRequest -Uri $url -OutFile $destination
+
+if ($env:AO_INSTALL_NO_RUN -eq "1") {
+	Write-Host "Downloaded installer to $destination"
+	Write-Host "Run it to install Agent Orchestrator."
+	exit 0
+}
+
+Write-Host "Starting installer..."
+$process = Start-Process -FilePath $destination -Wait -PassThru
+if ($process.ExitCode -ne 0) {
+	throw "Installer exited with code $($process.ExitCode)."
+}
+
+Write-Host "Agent Orchestrator installer finished."

--- a/frontend/src/landing/public/install.sh
+++ b/frontend/src/landing/public/install.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+set -eu
+
+REPO="${AO_INSTALL_REPO:-AgentWrapper/agent-orchestrator}"
+BASE_URL="${AO_INSTALL_BASE_URL:-https://github.com/$REPO/releases/latest/download}"
+
+say() {
+	printf '%s\n' "$*"
+}
+
+fail() {
+	printf 'ao install: %s\n' "$*" >&2
+	exit 1
+}
+
+has() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+download() {
+	url="$1"
+	dest="$2"
+
+	if has curl; then
+		curl -fsSL --retry 3 --retry-delay 2 -o "$dest" "$url"
+		return
+	fi
+
+	if has wget; then
+		wget -qO "$dest" "$url"
+		return
+	fi
+
+	fail "curl or wget is required"
+}
+
+os="$(uname -s)"
+arch="$(uname -m)"
+
+case "$os:$arch" in
+	Darwin:arm64 | Darwin:aarch64)
+		platform="macos"
+		asset="agent-orchestrator-darwin-arm64.zip"
+		;;
+	Darwin:x86_64 | Darwin:amd64)
+		platform="macos"
+		asset="agent-orchestrator-darwin-x64.zip"
+		;;
+	Linux:x86_64 | Linux:amd64)
+		platform="linux"
+		asset="agent-orchestrator-linux-x64.AppImage"
+		;;
+	MINGW* | MSYS* | CYGWIN*)
+		fail "use PowerShell instead: irm https://aoagents.dev/install.ps1 | iex"
+		;;
+	*)
+		fail "unsupported platform: $os $arch"
+		;;
+esac
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/ao-install.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+url="$BASE_URL/$asset"
+say "Downloading Agent Orchestrator from $url"
+
+case "$platform" in
+	macos)
+		has unzip || fail "unzip is required"
+		archive="$tmp/$asset"
+		unpack_dir="$tmp/unpack"
+		mkdir -p "$unpack_dir"
+		download "$url" "$archive"
+		unzip -q "$archive" -d "$unpack_dir"
+
+		app_path="$(find "$unpack_dir" -maxdepth 3 -type d -name '*.app' | head -n 1)"
+		[ -n "$app_path" ] || fail "download did not contain a .app bundle"
+
+		app_name="$(basename "$app_path")"
+		if [ -n "${AO_INSTALL_DIR:-}" ]; then
+			install_dir="$AO_INSTALL_DIR"
+		elif [ -d /Applications ] && [ -w /Applications ]; then
+			install_dir="/Applications"
+		else
+			install_dir="$HOME/Applications"
+		fi
+
+		mkdir -p "$install_dir"
+		rm -rf "$install_dir/$app_name"
+		cp -R "$app_path" "$install_dir/"
+		say "Installed $app_name to $install_dir"
+		say "Open it with: open '$install_dir/$app_name'"
+		;;
+	linux)
+		install_dir="${AO_INSTALL_DIR:-$HOME/.local/bin}"
+		dest="$install_dir/agent-orchestrator"
+		mkdir -p "$install_dir"
+		download "$url" "$dest"
+		chmod +x "$dest"
+		say "Installed Agent Orchestrator AppImage to $dest"
+		case ":$PATH:" in
+			*":$install_dir:"*) ;;
+			*) say "Add $install_dir to PATH or run it directly: $dest" ;;
+		esac
+		;;
+esac
+
+say "Next: open Agent Orchestrator and add your repository."


### PR DESCRIPTION
## Summary
- add static /install.sh and /install.ps1 bootstrap scripts for release-based desktop installs
- make the landing hero and installation docs lead with the hosted curl/PowerShell install commands
- keep direct GitHub release assets as manual downloads and leave the legacy npm CLI flow collapsed in the repo-start step

## Test plan
- sh -n frontend/src/landing/public/install.sh
- bash -n frontend/src/landing/public/install.sh
- git diff --check
- npm run build (frontend/src/landing)
- browser check at http://localhost:3003 for home, docs install tab switching, legacy CLI details, static /install.sh and /install.ps1 endpoints, and mobile overflow

Note: pwsh is not installed locally, so PowerShell syntax was not parsed here.