### PR TITLE
fix: align landing install docs

### DIFF
--- a/frontend/src/landing/app/docs/[[...slug]]/page.tsx
+++ b/frontend/src/landing/app/docs/[[...slug]]/page.tsx
@@ -24,10 +24,10 @@ export default async function DocsSlugPage({ params }: PageProps) {
 				single: true,
 			}}
 			editOnGithub={{
-				owner: "ComposioHQ",
+				owner: "AgentWrapper",
 				repo: "agent-orchestrator",
 				sha: "main",
-				path: `website/content/docs/${page.file?.path ?? ""}`,
+				path: `frontend/src/landing/content/docs/${page.file?.path ?? ""}`,
 			}}
 			breadcrumb={{
 				enabled: true,

--- a/frontend/src/landing/app/docs/docs.css
+++ b/frontend/src/landing/app/docs/docs.css
@@ -467,14 +467,7 @@ pre.shiki code {
 /* Installation page download picker. Keeps the recommended desktop path more
    scannable than a markdown table while staying inside the docs visual system. */
 #nd-docs-layout .ao-install-downloads {
-	margin: 1.5rem 0 1.75rem;
-	overflow: hidden;
-	border: 1px solid var(--color-border-subtle);
-	border-radius: 12px;
-	background:
-		linear-gradient(135deg, color-mix(in srgb, var(--docs-accent) 8%, transparent), transparent 46%),
-		var(--color-fd-card);
-	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03) inset;
+	margin: 1.25rem 0 2rem;
 }
 
 #nd-docs-layout .ao-install-downloads__header {
@@ -482,52 +475,28 @@ pre.shiki code {
 	align-items: flex-start;
 	justify-content: space-between;
 	gap: 1rem;
-	padding: 1.1rem 1.15rem;
-	border-bottom: 1px solid var(--color-border-subtle);
+	margin-bottom: 0.85rem;
 }
 
 #nd-docs-layout .ao-install-downloads__copy {
 	min-width: 0;
 }
 
-#nd-docs-layout .ao-install-downloads__eyebrow {
-	margin-bottom: 0.35rem;
-	color: var(--docs-accent);
-	font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
-	font-size: 0.7rem;
-	font-weight: 650;
-	letter-spacing: 0.06em;
-	line-height: 1.2;
-	text-transform: uppercase;
-}
-
 #nd-docs-layout .ao-install-downloads__title {
 	color: var(--color-text-primary);
-	font-size: 1rem;
+	font-size: 1.05rem;
 	font-weight: 700;
 	letter-spacing: 0;
 	line-height: 1.35;
 }
 
-#nd-docs-layout .ao-install-downloads__description {
-	max-width: 54ch;
-	margin-top: 0.25rem;
-	color: var(--color-text-secondary);
-	font-size: 0.875rem;
-	line-height: 1.6;
-}
-
-#nd-docs-layout .ao-install-downloads__description code {
-	font-size: 0.82em;
-}
-
 #nd-docs-layout .prose a.ao-install-downloads__release {
 	flex: 0 0 auto;
 	margin-top: 0.05rem;
-	padding: 0.42rem 0.62rem;
+	padding: 0.45rem 0.65rem;
 	border: 1px solid var(--color-border-subtle);
 	border-radius: 7px;
-	background: var(--color-bg-subtle);
+	background: transparent;
 	color: var(--color-text-primary);
 	font-size: 0.8125rem;
 	font-weight: 600;
@@ -546,68 +515,10 @@ pre.shiki code {
 	text-decoration: none;
 }
 
-#nd-docs-layout .ao-install-downloads__steps {
-	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 0.65rem;
-	margin: 0;
-	padding: 0.85rem 1rem 0.15rem;
-	list-style: none;
-}
-
-#nd-docs-layout .ao-install-downloads__step {
-	display: grid;
-	grid-template-columns: auto minmax(0, 1fr);
-	gap: 0.65rem;
-	align-items: flex-start;
-	min-width: 0;
-	padding: 0.85rem;
-	border: 1px solid var(--color-border-subtle);
-	border-radius: 9px;
-	background: color-mix(in srgb, var(--color-fd-card) 78%, var(--color-bg-elevated));
-}
-
-#nd-docs-layout .ao-install-downloads__step-index {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 1.45rem;
-	height: 1.45rem;
-	border: 1px solid var(--docs-accent-border);
-	border-radius: 999px;
-	background: var(--docs-accent-dim);
-	color: var(--docs-accent);
-	font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
-	font-size: 0.75rem;
-	font-weight: 700;
-	line-height: 1;
-}
-
-#nd-docs-layout .ao-install-downloads__step-copy {
-	display: flex;
-	min-width: 0;
-	flex-direction: column;
-	gap: 0.18rem;
-}
-
-#nd-docs-layout .ao-install-downloads__step-title {
-	color: var(--color-text-primary);
-	font-size: 0.875rem;
-	font-weight: 680;
-	line-height: 1.35;
-}
-
-#nd-docs-layout .ao-install-downloads__step-body {
-	color: var(--color-text-tertiary);
-	font-size: 0.78rem;
-	line-height: 1.5;
-}
-
 #nd-docs-layout .ao-install-downloads__grid {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
 	gap: 0.6rem;
-	padding: 0.85rem 1rem;
 }
 
 #nd-docs-layout .prose a.ao-install-downloads__item {
@@ -616,10 +527,10 @@ pre.shiki code {
 	align-items: center;
 	gap: 0.75rem;
 	min-width: 0;
-	padding: 0.82rem 0.85rem;
+	padding: 0.9rem;
 	border: 1px solid var(--color-border-subtle);
-	border-radius: 9px;
-	background: color-mix(in srgb, var(--color-fd-card) 82%, var(--color-bg-elevated));
+	border-radius: 8px;
+	background: color-mix(in srgb, var(--color-fd-card) 92%, var(--color-bg-elevated));
 	color: var(--color-text-primary);
 	text-decoration: none;
 	transition:
@@ -656,7 +567,7 @@ pre.shiki code {
 #nd-docs-layout .ao-install-downloads__platform {
 	overflow: hidden;
 	color: var(--color-text-primary);
-	font-size: 0.91rem;
+	font-size: 0.94rem;
 	font-weight: 650;
 	line-height: 1.25;
 	text-overflow: ellipsis;
@@ -672,32 +583,22 @@ pre.shiki code {
 	white-space: nowrap;
 }
 
-#nd-docs-layout .ao-install-downloads__hint {
-	display: block;
-	margin-top: 0.24rem;
-	color: var(--color-text-secondary);
-	font-size: 0.76rem;
-	line-height: 1.35;
-	white-space: normal;
-}
-
 #nd-docs-layout .ao-install-downloads__type {
 	display: inline-flex;
 	align-items: center;
 	min-width: max-content;
-	padding: 0.18rem 0.45rem;
+	padding: 0.28rem 0.55rem;
 	border: 1px solid var(--docs-accent-border);
-	border-radius: 999px;
+	border-radius: 7px;
 	background: var(--docs-accent-dim);
 	color: var(--docs-accent);
-	font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
-	font-size: 0.72rem;
+	font-size: 0.76rem;
 	font-weight: 650;
 	line-height: 1.3;
 }
 
 #nd-docs-layout .ao-install-downloads__note {
-	padding: 0 1.15rem 1rem;
+	margin-top: 0.75rem;
 	color: var(--color-text-secondary);
 	font-size: 0.86rem;
 	line-height: 1.55;
@@ -819,14 +720,9 @@ pre.shiki code {
 		width: fit-content;
 	}
 
-	#nd-docs-layout .ao-install-downloads__steps {
-		grid-template-columns: 1fr;
-	}
-
 	#nd-docs-layout .ao-install-downloads__grid {
 		grid-template-columns: 1fr;
 	}
-
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════

--- a/frontend/src/landing/app/docs/docs.css
+++ b/frontend/src/landing/app/docs/docs.css
@@ -471,7 +471,9 @@ pre.shiki code {
 	overflow: hidden;
 	border: 1px solid var(--color-border-subtle);
 	border-radius: 12px;
-	background: var(--color-fd-card);
+	background:
+		linear-gradient(135deg, color-mix(in srgb, var(--docs-accent) 8%, transparent), transparent 46%),
+		var(--color-fd-card);
 	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03) inset;
 }
 
@@ -515,6 +517,10 @@ pre.shiki code {
 	line-height: 1.6;
 }
 
+#nd-docs-layout .ao-install-downloads__description code {
+	font-size: 0.82em;
+}
+
 #nd-docs-layout .prose a.ao-install-downloads__release {
 	flex: 0 0 auto;
 	margin-top: 0.05rem;
@@ -540,11 +546,68 @@ pre.shiki code {
 	text-decoration: none;
 }
 
+#nd-docs-layout .ao-install-downloads__steps {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 0.65rem;
+	margin: 0;
+	padding: 0.85rem 1rem 0.15rem;
+	list-style: none;
+}
+
+#nd-docs-layout .ao-install-downloads__step {
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr);
+	gap: 0.65rem;
+	align-items: flex-start;
+	min-width: 0;
+	padding: 0.85rem;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 9px;
+	background: color-mix(in srgb, var(--color-fd-card) 78%, var(--color-bg-elevated));
+}
+
+#nd-docs-layout .ao-install-downloads__step-index {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.45rem;
+	height: 1.45rem;
+	border: 1px solid var(--docs-accent-border);
+	border-radius: 999px;
+	background: var(--docs-accent-dim);
+	color: var(--docs-accent);
+	font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+	font-size: 0.75rem;
+	font-weight: 700;
+	line-height: 1;
+}
+
+#nd-docs-layout .ao-install-downloads__step-copy {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	gap: 0.18rem;
+}
+
+#nd-docs-layout .ao-install-downloads__step-title {
+	color: var(--color-text-primary);
+	font-size: 0.875rem;
+	font-weight: 680;
+	line-height: 1.35;
+}
+
+#nd-docs-layout .ao-install-downloads__step-body {
+	color: var(--color-text-tertiary);
+	font-size: 0.78rem;
+	line-height: 1.5;
+}
+
 #nd-docs-layout .ao-install-downloads__grid {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
 	gap: 0.6rem;
-	padding: 0.8rem;
+	padding: 0.85rem 1rem;
 }
 
 #nd-docs-layout .prose a.ao-install-downloads__item {
@@ -607,6 +670,15 @@ pre.shiki code {
 	line-height: 1.35;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+#nd-docs-layout .ao-install-downloads__hint {
+	display: block;
+	margin-top: 0.24rem;
+	color: var(--color-text-secondary);
+	font-size: 0.76rem;
+	line-height: 1.35;
+	white-space: normal;
 }
 
 #nd-docs-layout .ao-install-downloads__type {
@@ -747,9 +819,14 @@ pre.shiki code {
 		width: fit-content;
 	}
 
+	#nd-docs-layout .ao-install-downloads__steps {
+		grid-template-columns: 1fr;
+	}
+
 	#nd-docs-layout .ao-install-downloads__grid {
 		grid-template-columns: 1fr;
 	}
+
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════

--- a/frontend/src/landing/app/docs/docs.css
+++ b/frontend/src/landing/app/docs/docs.css
@@ -464,12 +464,291 @@ pre.shiki code {
 	opacity: 1;
 }
 
+/* Installation page download picker. Keeps the recommended desktop path more
+   scannable than a markdown table while staying inside the docs visual system. */
+#nd-docs-layout .ao-install-downloads {
+	margin: 1.5rem 0 1.75rem;
+	overflow: hidden;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 12px;
+	background: var(--color-fd-card);
+	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03) inset;
+}
+
+#nd-docs-layout .ao-install-downloads__header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 1rem;
+	padding: 1.1rem 1.15rem;
+	border-bottom: 1px solid var(--color-border-subtle);
+}
+
+#nd-docs-layout .ao-install-downloads__copy {
+	min-width: 0;
+}
+
+#nd-docs-layout .ao-install-downloads__eyebrow {
+	margin-bottom: 0.35rem;
+	color: var(--docs-accent);
+	font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+	font-size: 0.7rem;
+	font-weight: 650;
+	letter-spacing: 0.06em;
+	line-height: 1.2;
+	text-transform: uppercase;
+}
+
+#nd-docs-layout .ao-install-downloads__title {
+	color: var(--color-text-primary);
+	font-size: 1rem;
+	font-weight: 700;
+	letter-spacing: 0;
+	line-height: 1.35;
+}
+
+#nd-docs-layout .ao-install-downloads__description {
+	max-width: 54ch;
+	margin-top: 0.25rem;
+	color: var(--color-text-secondary);
+	font-size: 0.875rem;
+	line-height: 1.6;
+}
+
+#nd-docs-layout .prose a.ao-install-downloads__release {
+	flex: 0 0 auto;
+	margin-top: 0.05rem;
+	padding: 0.42rem 0.62rem;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 7px;
+	background: var(--color-bg-subtle);
+	color: var(--color-text-primary);
+	font-size: 0.8125rem;
+	font-weight: 600;
+	line-height: 1.2;
+	text-decoration: none;
+	transition:
+		border-color 0.16s ease,
+		background-color 0.16s ease,
+		color 0.16s ease;
+}
+
+#nd-docs-layout .prose a.ao-install-downloads__release:hover {
+	border-color: var(--docs-accent-border);
+	background: var(--docs-accent-dim);
+	color: var(--docs-accent);
+	text-decoration: none;
+}
+
+#nd-docs-layout .ao-install-downloads__grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 0.6rem;
+	padding: 0.8rem;
+}
+
+#nd-docs-layout .prose a.ao-install-downloads__item {
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 0.75rem;
+	min-width: 0;
+	padding: 0.82rem 0.85rem;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 9px;
+	background: color-mix(in srgb, var(--color-fd-card) 82%, var(--color-bg-elevated));
+	color: var(--color-text-primary);
+	text-decoration: none;
+	transition:
+		border-color 0.16s ease,
+		background-color 0.16s ease,
+		transform 0.16s ease;
+}
+
+#nd-docs-layout .prose a.ao-install-downloads__item:hover {
+	border-color: var(--docs-accent-border);
+	background: color-mix(in srgb, var(--color-fd-card) 86%, var(--docs-accent));
+	text-decoration: none;
+	transform: translateY(-1px);
+}
+
+#nd-docs-layout .ao-install-downloads__icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	background: var(--color-bg-subtle);
+}
+
+#nd-docs-layout .ao-install-downloads__meta {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	gap: 0.1rem;
+}
+
+#nd-docs-layout .ao-install-downloads__platform {
+	overflow: hidden;
+	color: var(--color-text-primary);
+	font-size: 0.91rem;
+	font-weight: 650;
+	line-height: 1.25;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+#nd-docs-layout .ao-install-downloads__detail {
+	overflow: hidden;
+	color: var(--color-text-tertiary);
+	font-size: 0.78rem;
+	line-height: 1.35;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+#nd-docs-layout .ao-install-downloads__type {
+	display: inline-flex;
+	align-items: center;
+	min-width: max-content;
+	padding: 0.18rem 0.45rem;
+	border: 1px solid var(--docs-accent-border);
+	border-radius: 999px;
+	background: var(--docs-accent-dim);
+	color: var(--docs-accent);
+	font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+	font-size: 0.72rem;
+	font-weight: 650;
+	line-height: 1.3;
+}
+
+#nd-docs-layout .ao-install-downloads__note {
+	padding: 0 1.15rem 1rem;
+	color: var(--color-text-secondary);
+	font-size: 0.86rem;
+	line-height: 1.55;
+}
+
+#nd-docs-layout .ao-install-downloads__note a {
+	font-weight: 650;
+}
+
+#nd-docs-layout .ao-compact-tabs {
+	margin-top: 1rem;
+}
+
+#nd-docs-layout .ao-compact-tabs [role="tabpanel"] {
+	min-height: 0;
+}
+
+#nd-docs-layout .ao-compact-tabs figure,
+#nd-docs-layout .ao-compact-tabs pre {
+	margin-bottom: 0;
+}
+
+#nd-docs-layout .ao-legacy-cli-details {
+	margin: 1rem 0 0;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 12px;
+	background: color-mix(in srgb, var(--color-fd-card) 88%, var(--color-bg-elevated));
+	overflow: hidden;
+}
+
+#nd-docs-layout .ao-legacy-cli-details > summary {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	padding: 0.9rem 1rem;
+	cursor: pointer;
+	list-style: none;
+}
+
+#nd-docs-layout .ao-legacy-cli-details > summary::-webkit-details-marker {
+	display: none;
+}
+
+#nd-docs-layout .ao-legacy-cli-summary-copy {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	gap: 0.18rem;
+}
+
+#nd-docs-layout .ao-legacy-cli-summary-title {
+	color: var(--color-text-primary);
+	font-size: 0.94rem;
+	font-weight: 680;
+	line-height: 1.35;
+}
+
+#nd-docs-layout .ao-legacy-cli-summary-note {
+	color: var(--color-text-tertiary);
+	font-size: 0.84rem;
+	line-height: 1.5;
+}
+
+#nd-docs-layout .ao-legacy-cli-summary-icon {
+	width: 1rem;
+	height: 1rem;
+	flex: 0 0 auto;
+	color: var(--color-text-tertiary);
+	font-size: 1.15rem;
+	font-weight: 450;
+	line-height: 0.9rem;
+	text-align: center;
+}
+
+#nd-docs-layout .ao-legacy-cli-summary-icon::before {
+	content: "+";
+}
+
+#nd-docs-layout .ao-legacy-cli-details[open] .ao-legacy-cli-summary-icon::before {
+	content: "-";
+}
+
+#nd-docs-layout .ao-legacy-cli-details__content {
+	padding: 0 1rem 1rem;
+	border-top: 1px solid var(--color-border-subtle);
+}
+
+#nd-docs-layout .ao-legacy-cli-details__content > *:first-child {
+	margin-top: 1rem;
+}
+
+#nd-docs-layout .ao-legacy-cli-details__content > *:last-child {
+	margin-bottom: 0;
+}
+
+#nd-docs-layout .ao-legacy-cli-details__content figure,
+#nd-docs-layout .ao-legacy-cli-details__content pre {
+	margin-top: 1rem;
+	margin-bottom: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
 	#nd-docs-layout figure[data-rehype-pretty-code-figure] button,
 	#nd-docs-layout [data-rehype-pretty-code-figure] button[aria-label],
 	#nd-docs-layout [role="tab"],
 	#nd-docs-layout [role="tabpanel"] {
 		transition: none;
+	}
+}
+
+@media (max-width: 720px) {
+	#nd-docs-layout .ao-install-downloads__header {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	#nd-docs-layout .prose a.ao-install-downloads__release {
+		width: fit-content;
+	}
+
+	#nd-docs-layout .ao-install-downloads__grid {
+		grid-template-columns: 1fr;
 	}
 }
 

--- a/frontend/src/landing/components/docs/InstallDownloads.tsx
+++ b/frontend/src/landing/components/docs/InstallDownloads.tsx
@@ -47,7 +47,11 @@ export function InstallDownloads() {
 
 			<div className="ao-install-downloads__grid">
 				{DOWNLOADS.map((download) => (
-					<a key={`${download.platform}-${download.detail}`} className="ao-install-downloads__item" href={download.href}>
+					<a
+						key={`${download.platform}-${download.detail}`}
+						className="ao-install-downloads__item"
+						href={download.href}
+					>
 						<span className="ao-install-downloads__icon">
 							<Logo name={download.logo} size={20} />
 						</span>

--- a/frontend/src/landing/components/docs/InstallDownloads.tsx
+++ b/frontend/src/landing/components/docs/InstallDownloads.tsx
@@ -6,6 +6,7 @@ const DOWNLOADS = [
 	{
 		platform: "macOS",
 		detail: "Apple silicon",
+		hint: "Unzip, then open Agent Orchestrator.app",
 		logo: "apple",
 		type: ".zip",
 		href: `${RELEASE_BASE}/download/agent-orchestrator-darwin-arm64.zip`,
@@ -13,6 +14,7 @@ const DOWNLOADS = [
 	{
 		platform: "macOS",
 		detail: "Intel",
+		hint: "Unzip, then open Agent Orchestrator.app",
 		logo: "apple",
 		type: ".zip",
 		href: `${RELEASE_BASE}/download/agent-orchestrator-darwin-x64.zip`,
@@ -20,6 +22,7 @@ const DOWNLOADS = [
 	{
 		platform: "Windows",
 		detail: "x64 installer",
+		hint: "Run the installer, then launch the app",
 		logo: "windows",
 		type: ".exe",
 		href: `${RELEASE_BASE}/download/agent-orchestrator-win32-x64.exe`,
@@ -27,9 +30,25 @@ const DOWNLOADS = [
 	{
 		platform: "Linux",
 		detail: "x64 AppImage",
+		hint: "Make executable if needed, then run it",
 		logo: "linux",
 		type: ".AppImage",
 		href: `${RELEASE_BASE}/download/agent-orchestrator-linux-x64.AppImage`,
+	},
+];
+
+const SETUP_STEPS = [
+	{
+		title: "Download the app",
+		body: "Choose the release asset for your OS. This is the supported fresh-install path.",
+	},
+	{
+		title: "Open AO",
+		body: "The desktop app owns the daemon, dashboard, and project sessions.",
+	},
+	{
+		title: "Add a repository",
+		body: "Pick a local repo or paste a GitHub URL; AO prepares an isolated git worktree.",
 	},
 ];
 
@@ -38,16 +57,29 @@ export function InstallDownloads() {
 		<section className="ao-install-downloads" aria-label="Download Agent Orchestrator">
 			<div className="ao-install-downloads__header">
 				<div className="ao-install-downloads__copy">
-					<div className="ao-install-downloads__eyebrow">Recommended install</div>
-					<div className="ao-install-downloads__title">Desktop app from GitHub Releases</div>
+					<div className="ao-install-downloads__eyebrow">Recommended for new installs</div>
+					<div className="ao-install-downloads__title">Install the desktop app</div>
 					<div className="ao-install-downloads__description">
-						Bundles the daemon, dashboard, plugins, and auto-updates. No global CLI is required.
+						The desktop build is the canonical AO install. It opens your repository in the app-managed
+						workspace flow; no global <code>ao</code> CLI is required.
 					</div>
 				</div>
 				<a className="ao-install-downloads__release" href={RELEASE_BASE}>
 					Latest release
 				</a>
 			</div>
+
+			<ol className="ao-install-downloads__steps" aria-label="Install steps">
+				{SETUP_STEPS.map((step, index) => (
+					<li key={step.title} className="ao-install-downloads__step">
+						<span className="ao-install-downloads__step-index">{index + 1}</span>
+						<span className="ao-install-downloads__step-copy">
+							<span className="ao-install-downloads__step-title">{step.title}</span>
+							<span className="ao-install-downloads__step-body">{step.body}</span>
+						</span>
+					</li>
+				))}
+			</ol>
 
 			<div className="ao-install-downloads__grid">
 				{DOWNLOADS.map((download) => (
@@ -58,6 +90,7 @@ export function InstallDownloads() {
 						<span className="ao-install-downloads__meta">
 							<span className="ao-install-downloads__platform">{download.platform}</span>
 							<span className="ao-install-downloads__detail">{download.detail}</span>
+							<span className="ao-install-downloads__hint">{download.hint}</span>
 						</span>
 						<span className="ao-install-downloads__type">{download.type}</span>
 					</a>
@@ -65,8 +98,7 @@ export function InstallDownloads() {
 			</div>
 
 			<div className="ao-install-downloads__note">
-				Open the app after downloading, then continue to{" "}
-				<a href="#authenticate-your-tools">Authenticate Your Tools</a>.
+				Already using the npm CLI? Keep that path under <a href="#start-ao-in-a-repo">Start AO in a repo</a>.
 			</div>
 		</section>
 	);

--- a/frontend/src/landing/components/docs/InstallDownloads.tsx
+++ b/frontend/src/landing/components/docs/InstallDownloads.tsx
@@ -6,49 +6,30 @@ const DOWNLOADS = [
 	{
 		platform: "macOS",
 		detail: "Apple silicon",
-		hint: "Unzip, then open Agent Orchestrator.app",
 		logo: "apple",
-		type: ".zip",
+		type: "Download .zip",
 		href: `${RELEASE_BASE}/download/agent-orchestrator-darwin-arm64.zip`,
 	},
 	{
 		platform: "macOS",
 		detail: "Intel",
-		hint: "Unzip, then open Agent Orchestrator.app",
 		logo: "apple",
-		type: ".zip",
+		type: "Download .zip",
 		href: `${RELEASE_BASE}/download/agent-orchestrator-darwin-x64.zip`,
 	},
 	{
 		platform: "Windows",
 		detail: "x64 installer",
-		hint: "Run the installer, then launch the app",
 		logo: "windows",
-		type: ".exe",
+		type: "Download .exe",
 		href: `${RELEASE_BASE}/download/agent-orchestrator-win32-x64.exe`,
 	},
 	{
 		platform: "Linux",
 		detail: "x64 AppImage",
-		hint: "Make executable if needed, then run it",
 		logo: "linux",
-		type: ".AppImage",
+		type: "Download .AppImage",
 		href: `${RELEASE_BASE}/download/agent-orchestrator-linux-x64.AppImage`,
-	},
-];
-
-const SETUP_STEPS = [
-	{
-		title: "Download the app",
-		body: "Choose the release asset for your OS. This is the supported fresh-install path.",
-	},
-	{
-		title: "Open AO",
-		body: "The desktop app owns the daemon, dashboard, and project sessions.",
-	},
-	{
-		title: "Add a repository",
-		body: "Pick a local repo or paste a GitHub URL; AO prepares an isolated git worktree.",
 	},
 ];
 
@@ -57,29 +38,12 @@ export function InstallDownloads() {
 		<section className="ao-install-downloads" aria-label="Download Agent Orchestrator">
 			<div className="ao-install-downloads__header">
 				<div className="ao-install-downloads__copy">
-					<div className="ao-install-downloads__eyebrow">Recommended for new installs</div>
-					<div className="ao-install-downloads__title">Install the desktop app</div>
-					<div className="ao-install-downloads__description">
-						The desktop build is the canonical AO install. It opens your repository in the app-managed
-						workspace flow; no global <code>ao</code> CLI is required.
-					</div>
+					<div className="ao-install-downloads__title">Choose your platform</div>
 				</div>
 				<a className="ao-install-downloads__release" href={RELEASE_BASE}>
-					Latest release
+					View release
 				</a>
 			</div>
-
-			<ol className="ao-install-downloads__steps" aria-label="Install steps">
-				{SETUP_STEPS.map((step, index) => (
-					<li key={step.title} className="ao-install-downloads__step">
-						<span className="ao-install-downloads__step-index">{index + 1}</span>
-						<span className="ao-install-downloads__step-copy">
-							<span className="ao-install-downloads__step-title">{step.title}</span>
-							<span className="ao-install-downloads__step-body">{step.body}</span>
-						</span>
-					</li>
-				))}
-			</ol>
 
 			<div className="ao-install-downloads__grid">
 				{DOWNLOADS.map((download) => (
@@ -90,7 +54,6 @@ export function InstallDownloads() {
 						<span className="ao-install-downloads__meta">
 							<span className="ao-install-downloads__platform">{download.platform}</span>
 							<span className="ao-install-downloads__detail">{download.detail}</span>
-							<span className="ao-install-downloads__hint">{download.hint}</span>
 						</span>
 						<span className="ao-install-downloads__type">{download.type}</span>
 					</a>
@@ -98,7 +61,7 @@ export function InstallDownloads() {
 			</div>
 
 			<div className="ao-install-downloads__note">
-				Already using the npm CLI? Keep that path under <a href="#start-ao-in-a-repo">Start AO in a repo</a>.
+				No CLI required. Already using npm? See <a href="#start-ao-in-a-repo">Start AO in a repo</a>.
 			</div>
 		</section>
 	);

--- a/frontend/src/landing/components/docs/InstallDownloads.tsx
+++ b/frontend/src/landing/components/docs/InstallDownloads.tsx
@@ -1,0 +1,73 @@
+import { Logo } from "./Logo";
+
+const RELEASE_BASE = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest";
+
+const DOWNLOADS = [
+	{
+		platform: "macOS",
+		detail: "Apple silicon",
+		logo: "apple",
+		type: ".zip",
+		href: `${RELEASE_BASE}/download/agent-orchestrator-darwin-arm64.zip`,
+	},
+	{
+		platform: "macOS",
+		detail: "Intel",
+		logo: "apple",
+		type: ".zip",
+		href: `${RELEASE_BASE}/download/agent-orchestrator-darwin-x64.zip`,
+	},
+	{
+		platform: "Windows",
+		detail: "x64 installer",
+		logo: "windows",
+		type: ".exe",
+		href: `${RELEASE_BASE}/download/agent-orchestrator-win32-x64.exe`,
+	},
+	{
+		platform: "Linux",
+		detail: "x64 AppImage",
+		logo: "linux",
+		type: ".AppImage",
+		href: `${RELEASE_BASE}/download/agent-orchestrator-linux-x64.AppImage`,
+	},
+];
+
+export function InstallDownloads() {
+	return (
+		<section className="ao-install-downloads" aria-label="Download Agent Orchestrator">
+			<div className="ao-install-downloads__header">
+				<div className="ao-install-downloads__copy">
+					<div className="ao-install-downloads__eyebrow">Recommended install</div>
+					<div className="ao-install-downloads__title">Desktop app from GitHub Releases</div>
+					<div className="ao-install-downloads__description">
+						Bundles the daemon, dashboard, plugins, and auto-updates. No global CLI is required.
+					</div>
+				</div>
+				<a className="ao-install-downloads__release" href={RELEASE_BASE}>
+					Latest release
+				</a>
+			</div>
+
+			<div className="ao-install-downloads__grid">
+				{DOWNLOADS.map((download) => (
+					<a key={`${download.platform}-${download.detail}`} className="ao-install-downloads__item" href={download.href}>
+						<span className="ao-install-downloads__icon">
+							<Logo name={download.logo} size={20} />
+						</span>
+						<span className="ao-install-downloads__meta">
+							<span className="ao-install-downloads__platform">{download.platform}</span>
+							<span className="ao-install-downloads__detail">{download.detail}</span>
+						</span>
+						<span className="ao-install-downloads__type">{download.type}</span>
+					</a>
+				))}
+			</div>
+
+			<div className="ao-install-downloads__note">
+				Open the app after downloading, then continue to{" "}
+				<a href="#authenticate-your-tools">Authenticate Your Tools</a>.
+			</div>
+		</section>
+	);
+}

--- a/frontend/src/landing/components/docs/PlatformSupport.tsx
+++ b/frontend/src/landing/components/docs/PlatformSupport.tsx
@@ -16,7 +16,7 @@ export interface PlatformSupportProps {
 
 const LABEL: Record<Status, string> = {
 	full: "Supported",
-	partial: "In progress",
+	partial: "Limited",
 	none: "Not supported",
 };
 

--- a/frontend/src/landing/components/docs/mdx-components.tsx
+++ b/frontend/src/landing/components/docs/mdx-components.tsx
@@ -5,6 +5,7 @@
 import type { ReactNode } from "react";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import { InstallDownloads } from "./InstallDownloads";
 import { Logo } from "./Logo";
 import { PlatformSupport } from "./PlatformSupport";
 import { PluginCard, PluginGrid } from "./PluginCard";
@@ -29,6 +30,7 @@ export function getMDXComponents(): MDXComponents {
 		...defaultMdxComponents,
 		Accordion,
 		Accordions,
+		InstallDownloads,
 		Logo,
 		PlatformSupport,
 		PluginCard,

--- a/frontend/src/landing/content/docs/changelog.mdx
+++ b/frontend/src/landing/content/docs/changelog.mdx
@@ -26,6 +26,6 @@ April 25, 2026
 
 ## Sources
 
-- [Package changelogs on GitHub](https://github.com/ComposioHQ/agent-orchestrator/tree/main/packages)
-- [GitHub Releases](https://github.com/ComposioHQ/agent-orchestrator/releases)
-- [`main` commit history](https://github.com/ComposioHQ/agent-orchestrator/commits/main)
+- [Package changelogs on GitHub](https://github.com/AgentWrapper/agent-orchestrator/tree/main/packages)
+- [GitHub Releases](https://github.com/AgentWrapper/agent-orchestrator/releases)
+- [`main` commit history](https://github.com/AgentWrapper/agent-orchestrator/commits/main)

--- a/frontend/src/landing/content/docs/examples.mdx
+++ b/frontend/src/landing/content/docs/examples.mdx
@@ -3,7 +3,7 @@ title: Examples
 description: Five annotated starter configurations covering GitHub, Linear, multi-project, auto-merge, and Codex setups.
 ---
 
-All examples live in the [`examples/` directory](https://github.com/ComposioHQ/agent-orchestrator/tree/main/examples) of the AO repository. Pick the one closest to your setup, copy it to your project root as `agent-orchestrator.yaml`, fill in your repo path and any API keys, and you're ready to spawn agents.
+All examples live in the [`examples/` directory](https://github.com/AgentWrapper/agent-orchestrator/tree/main/examples) of the AO repository. Pick the one closest to your setup, copy it to your project root as `agent-orchestrator.yaml`, fill in your repo path and any API keys, and you're ready to spawn agents.
 
 ```bash
 cp examples/simple-github.yaml agent-orchestrator.yaml
@@ -35,7 +35,7 @@ projects:
 - No `defaults:` block needed — AO's built-in defaults (`tmux` runtime, `claude-code` agent, `worktree` workspace) apply automatically.
 - Replace `owner/my-app` and `~/my-app` with your actual GitHub slug and local checkout path.
 
-[View raw file on GitHub](https://github.com/ComposioHQ/agent-orchestrator/blob/main/examples/simple-github.yaml)
+[View raw file on GitHub](https://github.com/AgentWrapper/agent-orchestrator/blob/main/examples/simple-github.yaml)
 
 ---
 
@@ -75,7 +75,7 @@ projects:
 - Requires a `LINEAR_API_KEY` environment variable (set it in your shell profile or CI secrets).
 - `agentRules` injects project-specific instructions into every agent's prompt — useful for enforcing commit conventions or test requirements.
 
-[View raw file on GitHub](https://github.com/ComposioHQ/agent-orchestrator/blob/main/examples/linear-team.yaml)
+[View raw file on GitHub](https://github.com/AgentWrapper/agent-orchestrator/blob/main/examples/linear-team.yaml)
 
 ---
 
@@ -151,7 +151,7 @@ notificationRouting:
 - `notifiers.slack.webhook: ${SLACK_WEBHOOK_URL}` reads the webhook URL from an environment variable — never hardcode secrets in config files.
 - `notificationRouting` routes urgent and actionable events to both desktop and Slack, while lower-priority events go to Slack only.
 
-[View raw file on GitHub](https://github.com/ComposioHQ/agent-orchestrator/blob/main/examples/multi-project.yaml)
+[View raw file on GitHub](https://github.com/AgentWrapper/agent-orchestrator/blob/main/examples/multi-project.yaml)
 
 ---
 
@@ -207,7 +207,7 @@ reactions:
 - `changes-requested.escalateAfter: 1h` ensures a human is notified if an agent can't resolve review comments within an hour.
 - `agent-stuck.threshold: 10m` triggers an urgent desktop notification if an agent goes silent for 10 minutes.
 
-[View raw file on GitHub](https://github.com/ComposioHQ/agent-orchestrator/blob/main/examples/auto-merge.yaml)
+[View raw file on GitHub](https://github.com/AgentWrapper/agent-orchestrator/blob/main/examples/auto-merge.yaml)
 
 ---
 
@@ -251,7 +251,7 @@ projects:
 - `agentConfig.permissions: default` uses the plugin's built-in permission set — change to `full` to allow broader file access, or `readonly` to restrict writes.
 - Requires an `OPENAI_API_KEY` environment variable.
 
-[View raw file on GitHub](https://github.com/ComposioHQ/agent-orchestrator/blob/main/examples/codex-integration.yaml)
+[View raw file on GitHub](https://github.com/AgentWrapper/agent-orchestrator/blob/main/examples/codex-integration.yaml)
 
 ---
 

--- a/frontend/src/landing/content/docs/guides/multi-project.mdx
+++ b/frontend/src/landing/content/docs/guides/multi-project.mdx
@@ -15,7 +15,7 @@ agent: claude-code
 
 projects:
   web:
-    repo: ComposioHQ/agent-orchestrator
+    repo: AgentWrapper/agent-orchestrator
     agent: claude-code
 
   api:

--- a/frontend/src/landing/content/docs/index.mdx
+++ b/frontend/src/landing/content/docs/index.mdx
@@ -65,12 +65,11 @@ Most users start with the defaults and only edit `agent-orchestrator.yaml` when 
 <PlatformSupport
 	macos="full"
 	linux="full"
-	windows="partial"
+	windows="full"
 	note={
 		<>
-			Windows support is actively improving. Use the process runtime instead of tmux by setting{" "}
-			<code>defaults.runtime: process</code> in <code>agent-orchestrator.yaml</code>. See{" "}
-			<a href="/docs/platforms">Platforms</a> for details.
+			Windows uses the process runtime; tmux and iTerm2 integrations are macOS/Linux-only. See{" "}
+			<a href="/docs/platforms">Platforms</a> for the recommended setup.
 		</>
 	}
 />

--- a/frontend/src/landing/content/docs/installation.mdx
+++ b/frontend/src/landing/content/docs/installation.mdx
@@ -8,12 +8,12 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 
-This page gets your machine ready to run Agent Orchestrator. By the end, the desktop app (or the legacy `ao` CLI) should be installed, your source-control CLI should be authenticated, and an agent CLI should be ready to do the coding.
+This page gets your machine ready to run Agent Orchestrator. By the end, the desktop app should be installed, your source-control CLI should be authenticated, and an agent CLI should be ready to do the coding.
 
 <Callout type="info" title="What AO installs">
-	The recommended install is the **desktop app** from GitHub Releases. It bundles the daemon, dashboard, and plugins,
-	and updates itself. The `@aoagents/ao` npm package is the legacy on-ramp: it ships the `ao` CLI, whose `ao start`
-	fetches and opens the same desktop app. The npm package is frozen and no longer updated.
+	The supported fresh install is the **desktop app** from GitHub Releases. It owns the daemon, dashboard, and
+	repository workspace flow. The `@aoagents/ao` npm package is the legacy on-ramp: it ships the `ao` CLI, whose
+	`ao start` fetches and opens the same desktop app. The npm package is frozen and no longer updated.
 </Callout>
 
 ## Prerequisites
@@ -34,17 +34,17 @@ Install these before running AO:
 
 | Tool            | Required               | Why AO needs it                                                                      |
 | --------------- | ---------------------- | ------------------------------------------------------------------------------------ |
-| Node.js 20+     | Yes                    | Runs the AO CLI, dashboard, and plugins.                                             |
 | Git             | Yes                    | Creates worktrees, branches, commits, and cleanup operations.                        |
 | GitHub CLI `gh` | For GitHub projects    | Reads issues, PRs, reviews, and CI status as your user.                              |
 | tmux            | Default on macOS/Linux | Keeps long-running agent sessions attachable and recoverable.                        |
 | An agent CLI    | Yes                    | The worker that writes code, such as Claude Code, Codex, Cursor, Aider, or OpenCode. |
+| Node.js 20+     | Legacy/source installs | Needed only if you use the frozen npm CLI package or build AO from source.           |
 
 If you plan to use GitLab or Linear, install and authenticate their CLIs or credentials as described on the related plugin pages. A GitHub-only setup only needs `gh`.
 
 ## Install AO
 
-Download the desktop app for your platform. This is the supported default path after the GitHub workspace installer change.
+Download the desktop app for your platform. This is the supported path for new setups: open the app, add a repository, and let AO start the daemon plus an app-managed git workspace.
 
 <InstallDownloads />
 
@@ -193,24 +193,16 @@ ao start ~/code/my-repo
 ao start https://github.com/org/repo
 ```
 
-</div>
-
-</details>
-
-</Step>
-<Step>
-
-### Run the doctor check
+Run the CLI doctor only if you are using the legacy `ao` command:
 
 ```bash
 ao doctor
-```
-
-`ao doctor` checks the launcher, config, plugin resolution, runtime tools, source-control authentication, notifier setup, and stale temporary files. If it reports a fixable issue, run:
-
-```bash
 ao doctor --fix
 ```
+
+</div>
+
+</details>
 
 </Step>
 </Steps>
@@ -229,9 +221,9 @@ Use Slack, Discord, webhook, or another network notifier for alerts. Desktop not
 ## Common Install Issues
 
 <Accordions>
-	<Accordion title="`ao` is not found after install">
-		Your global package bin directory is not on `PATH`. Check your package manager's global bin path, then reopen your
-		shell and run `ao --version` again.
+	<Accordion title="The legacy `ao` command is not found">
+		The desktop app does not require a global `ao` command. If you intentionally installed the legacy CLI, check your
+		package manager's global bin path, then reopen your shell and run `ao --version` again.
 	</Accordion>
 	<Accordion title="`gh` is not authenticated">
 		Run `gh auth login`, then `gh auth status`. AO cannot read GitHub issues, PRs, reviews, or CI checks until `gh` is

--- a/frontend/src/landing/content/docs/installation.mdx
+++ b/frontend/src/landing/content/docs/installation.mdx
@@ -122,22 +122,22 @@ opencode --help
 npm install -g @aoagents/ao
 ```
 
-	</Tab>
-	<Tab value="pnpm">
+    </Tab>
+    <Tab value="pnpm">
 
 ```bash
 pnpm add -g @aoagents/ao
 ```
 
-	</Tab>
-	<Tab value="yarn">
+    </Tab>
+    <Tab value="yarn">
 
 ```bash
 yarn global add @aoagents/ao
 ```
 
-	</Tab>
-	<Tab value="from source">
+    </Tab>
+    <Tab value="from source">
 
 ```bash
 git clone https://github.com/AgentWrapper/agent-orchestrator
@@ -147,7 +147,8 @@ pnpm build
 pnpm --filter @aoagents/ao link --global
 ```
 
-	</Tab>
+    </Tab>
+
 </Tabs>
 
 </div>

--- a/frontend/src/landing/content/docs/installation.mdx
+++ b/frontend/src/landing/content/docs/installation.mdx
@@ -1,36 +1,17 @@
 ---
 title: Installation
-description: Install AO, authenticate the tools it controls, and verify your first project.
+description: Download AO, open it, and connect your tools.
 ---
 
-import { Callout } from "fumadocs-ui/components/callout";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 
-This page gets your machine ready to run Agent Orchestrator. By the end, the desktop app should be installed, your source-control CLI should be authenticated, and an agent CLI should be ready to do the coding.
-
-<Callout type="info" title="What AO installs">
-	The supported fresh install is the **desktop app** from GitHub Releases. It owns the daemon, dashboard, and
-	repository workspace flow. The `@aoagents/ao` npm package is the legacy on-ramp: it ships the `ao` CLI, whose
-	`ao start` fetches and opens the same desktop app. The npm package is frozen and no longer updated.
-</Callout>
+<InstallDownloads />
 
 ## Prerequisites
 
-<PlatformSupport
-	macos="full"
-	linux="full"
-	windows="partial"
-	note={
-		<>
-			Windows support is actively improving. Use <code>defaults.runtime: process</code> instead of tmux. See{" "}
-			<a href="/docs/platforms#windows">Platforms</a>.
-		</>
-	}
-/>
-
-Install these before running AO:
+After the app is installed, make sure these tools are available before you start an AO project.
 
 | Tool            | Required               | Why AO needs it                                                                      |
 | --------------- | ---------------------- | ------------------------------------------------------------------------------------ |
@@ -41,12 +22,6 @@ Install these before running AO:
 | Node.js 20+     | Legacy/source installs | Needed only if you use the frozen npm CLI package or build AO from source.           |
 
 If you plan to use GitLab or Linear, install and authenticate their CLIs or credentials as described on the related plugin pages. A GitHub-only setup only needs `gh`.
-
-## Install AO
-
-Download the desktop app for your platform. This is the supported path for new setups: open the app, add a repository, and let AO start the daemon plus an app-managed git workspace.
-
-<InstallDownloads />
 
 ## Authenticate Your Tools
 

--- a/frontend/src/landing/content/docs/installation.mdx
+++ b/frontend/src/landing/content/docs/installation.mdx
@@ -44,37 +44,9 @@ If you plan to use GitLab or Linear, install and authenticate their CLIs or cred
 
 ## Install AO
 
-The recommended way to install AO is the desktop build from GitHub Releases. Download the latest build for your platform, then open it:
+Download the desktop app for your platform. This is the supported default path after the GitHub workspace installer change.
 
-| Platform              | Download                                                                                                                       |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| macOS (Apple silicon) | [.zip](https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-arm64.zip)        |
-| macOS (Intel)         | [.zip](https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-darwin-x64.zip)          |
-| Windows               | [.exe](https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-win32-x64.exe)           |
-| Linux                 | [.AppImage](https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download/agent-orchestrator-linux-x64.AppImage) |
-
-The desktop app owns the daemon, dashboard, and auto-updates, so a desktop install needs no CLI. Skip ahead to [Authenticate Your Tools](#authenticate-your-tools).
-
-<Callout type="warn" title="npm is the legacy path, no longer recommended">
-	The `@aoagents/ao` npm package is frozen and no longer receives updates. It ships the `ao` CLI for existing users; `ao
-	start` fetches and opens the same desktop build above. Use it only if you already run AO from the CLI:
-</Callout>
-
-<Tabs items={["npm", "pnpm", "yarn", "from source"]}>
-	<Tab value="npm">```bash npm install -g @aoagents/ao ```</Tab>
-	<Tab value="pnpm">```bash pnpm add -g @aoagents/ao ```</Tab>
-	<Tab value="yarn">```bash yarn global add @aoagents/ao ```</Tab>
-	<Tab value="from source">
-		```bash git clone https://github.com/AgentWrapper/agent-orchestrator cd agent-orchestrator pnpm install pnpm build
-		pnpm --filter @aoagents/ao link --global ```
-	</Tab>
-</Tabs>
-
-If you installed the CLI, confirm it is available (desktop users can skip this):
-
-```bash
-ao --version
-```
+<InstallDownloads />
 
 ## Authenticate Your Tools
 
@@ -98,6 +70,8 @@ The authenticated account must be able to read the repository, create branches, 
 ### Install and sign in to one agent
 
 AO launches an agent CLI inside each worker session. Start with the one you already use, then add more later if you want per-project or per-role choices.
+
+<div className="ao-compact-tabs">
 
 <Tabs items={["Claude Code", "Codex", "Cursor", "Aider", "OpenCode"]}>
 	<Tab value="Claude Code">
@@ -144,6 +118,8 @@ opencode --help
 
 </Tabs>
 
+</div>
+
 </Step>
 <Step>
 
@@ -151,7 +127,59 @@ opencode --help
 
 **Desktop app:** open Agent Orchestrator and add the repository you want it to manage. The app starts the daemon, dashboard, and an orchestrator session for the project.
 
-**CLI (legacy):** run `ao start` from a repository you want AO to manage:
+<details className="ao-legacy-cli-details">
+<summary>
+	<span className="ao-legacy-cli-summary-copy">
+		<span className="ao-legacy-cli-summary-title">Using the legacy CLI?</span>
+		<span className="ao-legacy-cli-summary-note">Install or verify the frozen <code>@aoagents/ao</code> package, then run <code>ao start</code>.</span>
+	</span>
+	<span className="ao-legacy-cli-summary-icon" aria-hidden="true" />
+</summary>
+
+<div className="ao-legacy-cli-details__content">
+
+<div className="ao-compact-tabs ao-legacy-install-tabs">
+
+<Tabs items={["npm", "pnpm", "yarn", "from source"]}>
+	<Tab value="npm">
+
+```bash
+npm install -g @aoagents/ao
+```
+
+	</Tab>
+	<Tab value="pnpm">
+
+```bash
+pnpm add -g @aoagents/ao
+```
+
+	</Tab>
+	<Tab value="yarn">
+
+```bash
+yarn global add @aoagents/ao
+```
+
+	</Tab>
+	<Tab value="from source">
+
+```bash
+git clone https://github.com/AgentWrapper/agent-orchestrator
+cd agent-orchestrator
+pnpm install
+pnpm build
+pnpm --filter @aoagents/ao link --global
+```
+
+	</Tab>
+</Tabs>
+
+</div>
+
+```bash
+ao --version
+```
 
 ```bash
 cd ~/code/my-repo
@@ -162,8 +190,12 @@ If there is no `agent-orchestrator.yaml`, AO creates one. You can also start fro
 
 ```bash
 ao start ~/code/my-repo
-ao start https://github.com/your-org/your-repo
+ao start https://github.com/org/repo
 ```
+
+</div>
+
+</details>
 
 </Step>
 <Step>

--- a/frontend/src/landing/content/docs/installation.mdx
+++ b/frontend/src/landing/content/docs/installation.mdx
@@ -182,17 +182,6 @@ ao doctor --fix
 </Step>
 </Steps>
 
-## Windows Setup
-
-Windows support is in progress. Use the process runtime instead of tmux:
-
-```yaml title="agent-orchestrator.yaml"
-defaults:
-  runtime: process
-```
-
-Use Slack, Discord, webhook, or another network notifier for alerts. Desktop notifications and iTerm2 integration are not available on Windows.
-
 ## Common Install Issues
 
 <Accordions>
@@ -205,7 +194,8 @@ Use Slack, Discord, webhook, or another network notifier for alerts. Desktop not
 		authenticated.
 	</Accordion>
 	<Accordion title="tmux is missing">
-		Install tmux on macOS or Linux, or set `defaults.runtime: process` if you are on Windows or running in a container.
+		Install tmux on macOS or Linux. On Windows, use the process runtime instead; the Windows desktop installer does not
+		require tmux.
 	</Accordion>
 	<Accordion title="No agent runtime is detected">
 		Install one supported agent CLI and run it once outside AO so it can complete its own sign-in flow.

--- a/frontend/src/landing/content/docs/migration.mdx
+++ b/frontend/src/landing/content/docs/migration.mdx
@@ -18,7 +18,7 @@ npm uninstall -g @composio/agent-orchestrator
 npm install -g @aoagents/ao
 ```
 
-Your config and data directory (`~/.agent-orchestrator`) don't change — no data migration needed. GitHub org and repo URLs (`ComposioHQ/agent-orchestrator`) didn't change either.
+Your config and data directory (`~/.agent-orchestrator`) don't change — no data migration needed. Use the current GitHub repo URL (`AgentWrapper/agent-orchestrator`) for docs, releases, and issue links.
 
 ## `ao spawn <project> <issue>` → `ao spawn <issue>`
 

--- a/frontend/src/landing/content/docs/platforms.mdx
+++ b/frontend/src/landing/content/docs/platforms.mdx
@@ -93,8 +93,8 @@ If you are running AO on a headless Linux host, prefer Slack, Discord, or webhoo
 ## Windows
 
 <Callout type="info" title="Windows uses the process runtime">
-	The native Windows path uses `runtime: process`. The core spawn and PR workflow is available; tmux-specific
-	workflows and iTerm2 helpers do not apply.
+	The native Windows path uses `runtime: process`. The core spawn and PR workflow is available; tmux-specific workflows
+	and iTerm2 helpers do not apply.
 </Callout>
 
 Recommended config:

--- a/frontend/src/landing/content/docs/platforms.mdx
+++ b/frontend/src/landing/content/docs/platforms.mdx
@@ -12,8 +12,8 @@ The platform differences come from the tools used to run and attach to long-live
 <PlatformSupport
 	macos="full"
 	linux="full"
-	windows="partial"
-	note={<>Windows support is actively improving. Use the process runtime instead of tmux.</>}
+	windows="full"
+	note={<>Windows uses the process runtime. tmux and iTerm2 integrations are macOS/Linux-only.</>}
 />
 
 ## Recommended Setup
@@ -22,7 +22,7 @@ The platform differences come from the tools used to run and attach to long-live
 | ---------------------- | ------------------- | ---------------------------------- | -------------------------------------------------------------------------------- |
 | macOS                  | `tmux`              | `desktop`, Slack, Discord, webhook | Best local experience. iTerm2 attach support is macOS-only.                      |
 | Linux                  | `tmux`              | `desktop`, Slack, Discord, webhook | Best server and workstation setup. Desktop notifications need `notify-send`.     |
-| Windows                | `process`           | Slack, Discord, webhook            | Native tmux and iTerm2 are unavailable. Windows support is in progress.          |
+| Windows                | `process`           | Slack, Discord, webhook            | Native tmux and iTerm2 are unavailable; use the browser dashboard terminal.      |
 | Container or remote VM | `process` or `tmux` | Slack, Discord, webhook            | Use persistent storage for AO data and protect the dashboard with your own auth. |
 
 ## macOS
@@ -92,8 +92,8 @@ If you are running AO on a headless Linux host, prefer Slack, Discord, or webhoo
 
 ## Windows
 
-<Callout type="warn" title="Windows support is in progress">
-	The native Windows path uses `runtime: process`. The core spawn and PR workflow is available, but tmux-specific
+<Callout type="info" title="Windows uses the process runtime">
+	The native Windows path uses `runtime: process`. The core spawn and PR workflow is available; tmux-specific
 	workflows and iTerm2 helpers do not apply.
 </Callout>
 

--- a/frontend/src/landing/content/docs/troubleshooting.mdx
+++ b/frontend/src/landing/content/docs/troubleshooting.mdx
@@ -105,7 +105,7 @@ Covers: install health, plugin resolution, notifier connectivity, stale temp fil
 ## Still stuck
 
 - Check the [FAQ](/docs/faq).
-- Open an issue: [`ComposioHQ/agent-orchestrator`](https://github.com/ComposioHQ/agent-orchestrator/issues).
+- Open an issue: [`AgentWrapper/agent-orchestrator`](https://github.com/AgentWrapper/agent-orchestrator/issues).
   When opening an issue, include:
 
 - Output of `ao --version`

--- a/frontend/src/landing/lib/github-repo.ts
+++ b/frontend/src/landing/lib/github-repo.ts
@@ -6,9 +6,9 @@ export interface GitHubRepoStats {
 }
 
 const FALLBACK_STATS: GitHubRepoStats = {
-	stars: 6295,
-	forks: 853,
-	openIssues: 622,
+	stars: 8200,
+	forks: 1200,
+	openIssues: 320,
 	watchers: 21,
 };
 


### PR DESCRIPTION
## Summary
- align the landing/docs install flow with the desktop app as the supported fresh-install path
- replace the plain release table with a more guided desktop install module
- make prerequisites and legacy CLI guidance less npm-first, including moving `ao doctor` into the legacy CLI path

## Test plan
- git diff --check
- npm run build (frontend/src/landing)

To check before
https://aoagents.dev/ 

After:
<img width="1506" height="908" alt="image" src="https://github.com/user-attachments/assets/fd0b61fa-5999-4490-878a-68d123a12128" />
<img width="1500" height="858" alt="image" src="https://github.com/user-attachments/assets/d0d0095e-9c87-4b63-bef8-2a5607c52155" />
<img width="1497" height="858" alt="image" src="https://github.com/user-attachments/assets/b7eab8f4-d86c-4567-bacf-dd2d0783c164" />
<img width="1492" height="856" alt="image" src="https://github.com/user-attachments/assets/6ac2fab5-5ca3-4a36-a2dc-71d59b8c624b" />
