### PR TITLE
feat(browser): add in-preview annotations

### DIFF
--- a/frontend/src/annotate-preload.ts
+++ b/frontend/src/annotate-preload.ts
@@ -1,1 +1,271 @@
-export {};
+import { ipcRenderer } from "electron";
+import {
+	createBrowserAnnotationContext,
+	type BrowserAnnotationCancelReason,
+	type BrowserAnnotationContext,
+	type BrowserAnnotationPageSubmitPayload,
+} from "./shared/browser-annotations";
+
+let enabled = false;
+let selectedElement: Element | null = null;
+let selectedContext: BrowserAnnotationContext | null = null;
+let host: HTMLDivElement | null = null;
+let shadow: ShadowRoot | null = null;
+
+ipcRenderer.on("browser:annotation:setMode", (_event, input: { enabled?: boolean }) => {
+	setEnabled(Boolean(input?.enabled), "disabled");
+});
+
+window.addEventListener("beforeunload", () => {
+	if (enabled) sendCancel("navigation");
+	cleanupOverlay();
+	enabled = false;
+});
+
+function setEnabled(next: boolean, cancelReason: BrowserAnnotationCancelReason): void {
+	if (enabled === next) return;
+	enabled = next;
+	selectedElement = null;
+	selectedContext = null;
+	if (enabled) {
+		ensureOverlay();
+		installListeners();
+		renderHint();
+	} else {
+		removeListeners();
+		cleanupOverlay();
+		if (cancelReason !== "disabled") sendCancel(cancelReason);
+	}
+}
+
+function installListeners(): void {
+	document.addEventListener("pointerover", handlePointerMove, true);
+	document.addEventListener("pointermove", handlePointerMove, true);
+	document.addEventListener("click", handleClick, true);
+	document.addEventListener("keydown", handleKeyDown, true);
+	window.addEventListener("scroll", refreshHighlight, true);
+	window.addEventListener("resize", refreshHighlight, true);
+}
+
+function removeListeners(): void {
+	document.removeEventListener("pointerover", handlePointerMove, true);
+	document.removeEventListener("pointermove", handlePointerMove, true);
+	document.removeEventListener("click", handleClick, true);
+	document.removeEventListener("keydown", handleKeyDown, true);
+	window.removeEventListener("scroll", refreshHighlight, true);
+	window.removeEventListener("resize", refreshHighlight, true);
+}
+
+function handlePointerMove(event: PointerEvent): void {
+	if (!enabled || isOverlayEvent(event)) return;
+	const target = annotationTarget(event.target);
+	if (!target || target === selectedElement) return;
+	selectedElement = target;
+	selectedContext = null;
+	renderHighlight(target, false);
+}
+
+function handleClick(event: MouseEvent): void {
+	if (!enabled || isOverlayEvent(event)) return;
+	const target = annotationTarget(event.target);
+	if (!target) return;
+	event.preventDefault();
+	event.stopPropagation();
+	event.stopImmediatePropagation();
+	selectedElement = target;
+	selectedContext = createBrowserAnnotationContext(target);
+	renderPrompt(target, selectedContext);
+}
+
+function handleKeyDown(event: KeyboardEvent): void {
+	if (!enabled || event.key !== "Escape") return;
+	event.preventDefault();
+	event.stopPropagation();
+	event.stopImmediatePropagation();
+	setEnabled(false, "escape");
+}
+
+function refreshHighlight(): void {
+	if (!enabled || !selectedElement) return;
+	renderHighlight(selectedElement, Boolean(selectedContext));
+}
+
+function annotationTarget(target: EventTarget | null): Element | null {
+	if (!(target instanceof Element)) return null;
+	const element =
+		target.closest("button, a, input, textarea, select, [role]") ??
+		target.closest("[data-testid], [id], [class]") ??
+		target;
+	if (element === document.documentElement || element === document.body) return null;
+	return element;
+}
+
+function ensureOverlay(): ShadowRoot {
+	if (shadow && host?.isConnected) return shadow;
+	host = document.createElement("div");
+	host.setAttribute("data-ao-annotation-root", "");
+	host.style.position = "fixed";
+	host.style.inset = "0";
+	host.style.zIndex = "2147483647";
+	host.style.pointerEvents = "none";
+	(document.documentElement ?? document.body).appendChild(host);
+	shadow = host.attachShadow({ mode: "open" });
+	shadow.innerHTML = `
+		<style>
+			:host { all: initial; }
+			.highlight {
+				position: fixed;
+				box-sizing: border-box;
+				border: 2px solid #4d8dff;
+				border-radius: 6px;
+				background: rgba(77, 141, 255, 0.12);
+				box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.08);
+				pointer-events: none;
+			}
+			.prompt {
+				position: fixed;
+				width: min(360px, calc(100vw - 24px));
+				box-sizing: border-box;
+				border: 1px solid rgba(255, 255, 255, 0.14);
+				border-radius: 8px;
+				background: #15171b;
+				color: #f4f5f7;
+				box-shadow: 0 16px 40px rgba(0, 0, 0, 0.42);
+				padding: 10px;
+				font: 13px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+				pointer-events: auto;
+			}
+			.prompt textarea {
+				width: 100%;
+				min-height: 92px;
+				box-sizing: border-box;
+				resize: vertical;
+				border: 1px solid rgba(255, 255, 255, 0.12);
+				border-radius: 6px;
+				background: #0a0b0d;
+				color: #f4f5f7;
+				padding: 8px;
+				font: inherit;
+				outline: none;
+			}
+			.prompt textarea:focus { border-color: #4d8dff; }
+			.actions {
+				display: flex;
+				justify-content: flex-end;
+				gap: 8px;
+				margin-top: 8px;
+			}
+			.actions button {
+				height: 30px;
+				border-radius: 6px;
+				border: 1px solid rgba(255, 255, 255, 0.12);
+				background: #1b1d22;
+				color: #f4f5f7;
+				padding: 0 10px;
+				font: inherit;
+			}
+			.actions button[type="submit"] {
+				border-color: #4d8dff;
+				background: #4d8dff;
+				color: #fff;
+			}
+			.hint {
+				position: fixed;
+				left: 12px;
+				bottom: 12px;
+				border-radius: 6px;
+				background: #15171b;
+				color: #f4f5f7;
+				padding: 7px 9px;
+				font: 12px/1.3 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+				box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+				pointer-events: none;
+			}
+		</style>
+		<div class="highlight" hidden></div>
+		<div class="mount"></div>
+	`;
+	return shadow;
+}
+
+function renderHint(): void {
+	const root = ensureOverlay();
+	const mount = root.querySelector<HTMLDivElement>(".mount");
+	if (!mount) return;
+	mount.innerHTML = `<div class="hint">Click an element to annotate. Press Esc to cancel.</div>`;
+}
+
+function renderHighlight(element: Element, locked: boolean): void {
+	const root = ensureOverlay();
+	const highlight = root.querySelector<HTMLDivElement>(".highlight");
+	if (!highlight) return;
+	const rect = element.getBoundingClientRect();
+	highlight.hidden = false;
+	highlight.style.left = `${Math.max(0, rect.left)}px`;
+	highlight.style.top = `${Math.max(0, rect.top)}px`;
+	highlight.style.width = `${Math.max(0, rect.width)}px`;
+	highlight.style.height = `${Math.max(0, rect.height)}px`;
+	highlight.style.borderColor = locked ? "#74b98a" : "#4d8dff";
+}
+
+function renderPrompt(element: Element, context: BrowserAnnotationContext): void {
+	renderHighlight(element, true);
+	const root = ensureOverlay();
+	const mount = root.querySelector<HTMLDivElement>(".mount");
+	if (!mount) return;
+	const rect = element.getBoundingClientRect();
+	const { left, top } = promptPosition(rect);
+	mount.innerHTML = `
+		<form class="prompt" style="left: ${left}px; top: ${top}px;">
+			<textarea aria-label="Annotation request" placeholder="Describe what to change"></textarea>
+			<div class="actions">
+				<button type="button" data-action="cancel">Cancel</button>
+				<button type="submit">Send</button>
+			</div>
+		</form>
+	`;
+	const form = mount.querySelector<HTMLFormElement>("form")!;
+	const textarea = form.querySelector<HTMLTextAreaElement>("textarea")!;
+	form.addEventListener("submit", (event) => {
+		event.preventDefault();
+		const instruction = textarea.value.trim();
+		if (!instruction) {
+			textarea.focus();
+			return;
+		}
+		const payload: BrowserAnnotationPageSubmitPayload = { instruction, context };
+		ipcRenderer.send("browser:annotation:submit", payload);
+		setEnabled(false, "disabled");
+	});
+	form.querySelector<HTMLButtonElement>('[data-action="cancel"]')?.addEventListener("click", () => {
+		setEnabled(false, "cancel");
+	});
+	setTimeout(() => textarea.focus(), 0);
+}
+
+function promptPosition(rect: DOMRect): { left: number; top: number } {
+	const width = Math.min(360, window.innerWidth - 24);
+	const height = 150;
+	const left = clamp(rect.left, 12, Math.max(12, window.innerWidth - width - 12));
+	const below = rect.bottom + 8;
+	const top = below + height <= window.innerHeight - 12 ? below : Math.max(12, rect.top - height - 8);
+	return { left, top };
+}
+
+function cleanupOverlay(): void {
+	host?.remove();
+	host = null;
+	shadow = null;
+}
+
+function sendCancel(reason: BrowserAnnotationCancelReason): void {
+	ipcRenderer.send("browser:annotation:cancel", { reason });
+}
+
+function isOverlayEvent(event: Event): boolean {
+	return Boolean(host && event.composedPath().includes(host));
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(max, Math.max(min, value));
+}

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -8,10 +8,12 @@ import {
 } from "./browser-view-host";
 
 type InvokeHandler = (event: unknown, ...args: unknown[]) => unknown;
+type EventHandler = (event: unknown, ...args: unknown[]) => void;
 
 function setupHost() {
 	let currentURL = "";
 	const webContents = {
+		id: 99,
 		canGoBack: () => false,
 		canGoForward: () => false,
 		clearHistory: () => undefined,
@@ -25,7 +27,7 @@ function setupHost() {
 		}),
 		on: () => undefined,
 		reload: () => undefined,
-		send: () => undefined,
+		send: vi.fn(),
 		setWindowOpenHandler: () => undefined,
 		stop: () => undefined,
 		close: () => undefined,
@@ -36,16 +38,17 @@ function setupHost() {
 		setVisible: () => undefined,
 	};
 	const handlers = new Map<string, InvokeHandler>();
-	const sent: BrowserNavState[] = [];
+	const eventHandlers = new Map<string, EventHandler>();
+	const sent: Array<{ channel: string; payload: unknown }> = [];
 	const host = createBrowserViewHost({
 		mainWindow: {
 			contentView: { addChildView: () => undefined, removeChildView: () => undefined },
 			getContentBounds: () => ({ x: 0, y: 0, width: 800, height: 600 }),
-			webContents: { id: 1, send: (_channel: string, state: BrowserNavState) => sent.push(state) },
+			webContents: { id: 1, send: (channel: string, payload: unknown) => sent.push({ channel, payload }) },
 		} as never,
 		ipcMain: {
 			handle: (channel: string, fn: InvokeHandler) => handlers.set(channel, fn),
-			on: () => undefined,
+			on: (channel: string, fn: EventHandler) => eventHandlers.set(channel, fn),
 			removeHandler: () => undefined,
 			off: () => undefined,
 		} as never,
@@ -58,7 +61,9 @@ function setupHost() {
 	});
 	const invoke = (channel: string, ...args: unknown[]) =>
 		handlers.get(channel)!({ sender: { id: 1 } }, ...args) as Promise<BrowserNavState>;
-	return { host, invoke, webContents };
+	const send = (channel: string, senderId: number, ...args: unknown[]) =>
+		eventHandlers.get(channel)!({ sender: { id: senderId } }, ...args);
+	return { host, invoke, send, sent, webContents };
 }
 
 describe("normalizeBrowserURL", () => {
@@ -111,6 +116,62 @@ describe("browser:clear", () => {
 
 		expect(webContents.loadURL).toHaveBeenLastCalledWith("about:blank");
 		expect(state.url).toBe("");
+	});
+});
+
+describe("browser annotation IPC", () => {
+	it("routes renderer mode changes to the matching preview webContents", async () => {
+		const { invoke, webContents } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		await invoke("browser:annotation:setMode", { viewId: "1:sess-1", enabled: true });
+
+		expect(webContents.send).toHaveBeenCalledWith("browser:annotation:setMode", { enabled: true });
+	});
+
+	it("ignores annotation mode changes for views owned by a different renderer", async () => {
+		const { invoke, webContents } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		await invoke("browser:annotation:setMode", { viewId: "2:sess-1", enabled: true });
+
+		expect(webContents.send).not.toHaveBeenCalledWith("browser:annotation:setMode", { enabled: true });
+	});
+
+	it("forwards preview annotation submissions to the renderer-owned view", async () => {
+		const { invoke, send, sent } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		send("browser:annotation:submit", 99, {
+			instruction: "Make this button blue.",
+			context: {
+				url: "http://localhost:5173/",
+				tag: "button",
+				classes: [],
+				selector: "button",
+				rect: { x: 0, y: 0, width: 80, height: 30 },
+				computedStyle: {},
+			},
+		});
+
+		expect(sent).toContainEqual({
+			channel: "browser:annotation:submitted",
+			payload: expect.objectContaining({
+				viewId: "1:sess-1",
+				instruction: "Make this button blue.",
+				context: expect.objectContaining({ selector: "button" }),
+			}),
+		});
+	});
+
+	it("ignores preview annotation events after the view is destroyed", async () => {
+		const { host, invoke, send, sent } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		host.destroy("1:sess-1");
+		send("browser:annotation:cancel", 99, { reason: "escape" });
+
+		expect(sent.some((entry) => entry.channel === "browser:annotation:canceled")).toBe(false);
 	});
 });
 

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -1,4 +1,11 @@
 import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent, Rectangle, View, WebContents } from "electron";
+import type {
+	BrowserAnnotationCancelPayload,
+	BrowserAnnotationModeInput,
+	BrowserAnnotationPageCancelPayload,
+	BrowserAnnotationPageSubmitPayload,
+	BrowserAnnotationSubmitPayload,
+} from "../shared/browser-annotations";
 
 export type BrowserRect = Pick<Rectangle, "x" | "y" | "width" | "height">;
 
@@ -25,6 +32,7 @@ type BrowserNavigateInput = {
 
 type BrowserWebContents = Pick<
 	WebContents,
+	| "id"
 	| "canGoBack"
 	| "canGoForward"
 	| "clearHistory"
@@ -83,6 +91,7 @@ export type BrowserViewHost = {
 type BrowserEntry = {
 	view: BrowserViewLike;
 	state: BrowserNavState;
+	annotationEnabled: boolean;
 };
 
 const OFFSCREEN_BOUNDS: BrowserRect = { x: -10_000, y: -10_000, width: 0, height: 0 };
@@ -136,6 +145,7 @@ export function clampBoundsToWindow(
 
 export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserViewHost {
 	const entries = new Map<string, BrowserEntry>();
+	const viewIdsByWebContentsId = new Map<number, string>();
 	const ipcDisposers: Array<() => void> = [];
 
 	const ensure = (viewId: string): BrowserEntry => {
@@ -155,8 +165,9 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		options.mainWindow.contentView.addChildView(view);
 
 		const state: BrowserNavState = emptyNavState(viewId);
-		const entry = { view, state };
+		const entry = { view, state, annotationEnabled: false };
 		entries.set(viewId, entry);
+		viewIdsByWebContentsId.set(view.webContents.id, viewId);
 		hardenWebContents(view.webContents, options, entry);
 		wireNavEvents(view.webContents, options, entry);
 		return entry;
@@ -177,6 +188,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 
 	const navigate = async ({ viewId, url }: BrowserNavigateInput): Promise<BrowserNavState> => {
 		const entry = ensure(viewId);
+		cancelAnnotation(options, entry, "navigation");
 		const normalized = normalizeBrowserURL(url);
 		if (!isAllowedBrowserURL(normalized.href, options.rendererOrigin)) {
 			throw new Error("Unsupported browser URL");
@@ -191,6 +203,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	// empty state.
 	const clear = async (viewId: string): Promise<BrowserNavState> => {
 		const entry = ensure(viewId);
+		cancelAnnotation(options, entry, "navigation");
 		entry.view.setVisible?.(false);
 		entry.view.setBounds(OFFSCREEN_BOUNDS);
 		await entry.view.webContents.loadURL("about:blank");
@@ -202,6 +215,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		const entry = entries.get(viewId);
 		if (!entry) return;
 		entries.delete(viewId);
+		viewIdsByWebContentsId.delete(entry.view.webContents.id);
 		// When the window is already gone (dispose fired from mainWindow "closed"),
 		// Electron has torn down contentView and the child WebContentsViews. Touching
 		// them throws "Object has been destroyed", so just drop our reference.
@@ -212,11 +226,64 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		entry.view.webContents.close?.();
 	};
 
-	const invokeNav = (viewId: string, action: (contents: BrowserWebContents) => void): BrowserNavState => {
+	const invokeNav = (
+		viewId: string,
+		action: (contents: BrowserWebContents) => void,
+		cancelForNavigation = false,
+	): BrowserNavState => {
 		const entry = entries.get(viewId);
 		if (!entry) return emptyNavState(viewId);
+		if (cancelForNavigation) cancelAnnotation(options, entry, "navigation");
 		action(entry.view.webContents);
 		return pushNavState(options, entry);
+	};
+
+	const setAnnotationMode = (event: IpcMainInvokeEvent, input: BrowserAnnotationModeInput): void => {
+		if (!isRendererOwnedViewId(event, input.viewId)) return;
+		const entry = entries.get(input.viewId);
+		if (!entry) return;
+		entry.annotationEnabled = input.enabled;
+		entry.view.webContents.send("browser:annotation:setMode", { enabled: input.enabled });
+	};
+
+	const forwardAnnotationSubmit = (
+		event: IpcMainEvent,
+		payload: BrowserAnnotationPageSubmitPayload | undefined,
+	): void => {
+		const viewId = viewIdsByWebContentsId.get(event.sender.id);
+		const entry = viewId ? entries.get(viewId) : undefined;
+		if (
+			!viewId ||
+			!entry ||
+			!payload ||
+			typeof payload.instruction !== "string" ||
+			typeof payload.context !== "object" ||
+			payload.context === null
+		) {
+			return;
+		}
+		entry.annotationEnabled = false;
+		const forwarded: BrowserAnnotationSubmitPayload = {
+			viewId,
+			instruction: payload.instruction,
+			context: payload.context,
+		};
+		options.mainWindow.webContents.send("browser:annotation:submitted", forwarded);
+	};
+
+	const forwardAnnotationCancel = (
+		event: IpcMainEvent,
+		payload: BrowserAnnotationPageCancelPayload | undefined,
+	): void => {
+		const viewId = viewIdsByWebContentsId.get(event.sender.id);
+		const entry = viewId ? entries.get(viewId) : undefined;
+		if (!viewId || !entry) return;
+		entry.annotationEnabled = false;
+		const forwarded: BrowserAnnotationCancelPayload = {
+			viewId,
+			reason: payload?.reason ?? "cancel",
+		};
+		options.mainWindow.webContents.send("browser:annotation:canceled", forwarded);
 	};
 
 	const handle = <Args extends unknown[], Result>(
@@ -235,11 +302,18 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	on("browser:setBounds", (_event, input: BrowserBoundsInput) => setBounds(input));
 	handle("browser:navigate", (_event, input: BrowserNavigateInput) => navigate(input));
 	handle("browser:clear", (_event, viewId: string) => clear(viewId));
-	handle("browser:goBack", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.goBack()));
-	handle("browser:goForward", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.goForward()));
-	handle("browser:reload", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.reload()));
+	handle("browser:goBack", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.goBack(), true));
+	handle("browser:goForward", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.goForward(), true));
+	handle("browser:reload", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.reload(), true));
 	handle("browser:stop", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.stop()));
+	handle("browser:annotation:setMode", (event, input: BrowserAnnotationModeInput) => setAnnotationMode(event, input));
 	on("browser:destroy", (_event, viewId: string) => destroy(viewId));
+	on("browser:annotation:submit", (event, payload: BrowserAnnotationPageSubmitPayload) =>
+		forwardAnnotationSubmit(event, payload),
+	);
+	on("browser:annotation:cancel", (event, payload: BrowserAnnotationPageCancelPayload) =>
+		forwardAnnotationCancel(event, payload),
+	);
 
 	return {
 		dispose: () => {
@@ -304,6 +378,10 @@ function scopedViewId(event: IpcMainInvokeEvent, sessionId: string): string {
 	return `${event.sender.id}:${sessionId}`;
 }
 
+function isRendererOwnedViewId(event: IpcMainInvokeEvent, viewId: string): boolean {
+	return viewId.startsWith(`${event.sender.id}:`);
+}
+
 function hardenWebContents(contents: BrowserWebContents, options: BrowserViewHostOptions, entry: BrowserEntry): void {
 	contents.setWindowOpenHandler(({ url }) => {
 		if (isAllowedBrowserURL(url, options.rendererOrigin)) {
@@ -329,12 +407,26 @@ function wireNavEvents(contents: BrowserWebContents, options: BrowserViewHostOpt
 	contents.on("did-navigate", update);
 	contents.on("did-navigate-in-page", update);
 	contents.on("page-title-updated", update);
-	contents.on("did-start-loading", update);
+	contents.on("did-start-loading", () => {
+		cancelAnnotation(options, entry, "navigation");
+		update();
+	});
 	contents.on("did-stop-loading", update);
 	contents.on("did-fail-load", (_event, _errorCode, errorDescription) => {
 		entry.state = { ...readNavState(entry), error: String(errorDescription || "Unable to load page") };
 		options.mainWindow.webContents.send("browser:navState", entry.state);
 	});
+}
+
+function cancelAnnotation(
+	options: BrowserViewHostOptions,
+	entry: BrowserEntry,
+	reason: BrowserAnnotationCancelPayload["reason"],
+): void {
+	if (!entry.annotationEnabled) return;
+	entry.annotationEnabled = false;
+	entry.view.webContents.send("browser:annotation:setMode", { enabled: false });
+	options.mainWindow.webContents.send("browser:annotation:canceled", { viewId: entry.state.viewId, reason });
 }
 
 function pushNavState(options: BrowserViewHostOptions, entry: BrowserEntry): BrowserNavState {

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -4,6 +4,11 @@ import type { DaemonStatus } from "./shared/daemon-status";
 import type { TelemetryBootstrap } from "./shared/telemetry";
 import type { MigrationState } from "./main/app-state";
 import type { UpdateSettings, UpdateStatus } from "./main/update-settings";
+import type {
+	BrowserAnnotationCancelPayload,
+	BrowserAnnotationModeInput,
+	BrowserAnnotationSubmitPayload,
+} from "./shared/browser-annotations";
 
 export type BrowserBoundsInput = {
 	viewId: string;
@@ -71,11 +76,27 @@ const api = {
 		reload: (viewId: string) => ipcRenderer.invoke("browser:reload", viewId) as Promise<BrowserNavState>,
 		stop: (viewId: string) => ipcRenderer.invoke("browser:stop", viewId) as Promise<BrowserNavState>,
 		destroy: (viewId: string) => ipcRenderer.send("browser:destroy", viewId),
+		setAnnotationMode: (input: BrowserAnnotationModeInput) =>
+			ipcRenderer.invoke("browser:annotation:setMode", input) as Promise<void>,
 		onNavState: (listener: (state: BrowserNavState) => void) => {
 			const wrapped = (_event: Electron.IpcRendererEvent, state: BrowserNavState) => listener(state);
 			ipcRenderer.on("browser:navState", wrapped);
 			return () => {
 				ipcRenderer.off("browser:navState", wrapped);
+			};
+		},
+		onAnnotationSubmit: (listener: (payload: BrowserAnnotationSubmitPayload) => void) => {
+			const wrapped = (_event: Electron.IpcRendererEvent, payload: BrowserAnnotationSubmitPayload) => listener(payload);
+			ipcRenderer.on("browser:annotation:submitted", wrapped);
+			return () => {
+				ipcRenderer.off("browser:annotation:submitted", wrapped);
+			};
+		},
+		onAnnotationCancel: (listener: (payload: BrowserAnnotationCancelPayload) => void) => {
+			const wrapped = (_event: Electron.IpcRendererEvent, payload: BrowserAnnotationCancelPayload) => listener(payload);
+			ipcRenderer.on("browser:annotation:canceled", wrapped);
+			return () => {
+				ipcRenderer.off("browser:annotation:canceled", wrapped);
 			};
 		},
 	},

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -1,9 +1,20 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserPanel } from "./BrowserPanel";
 import type { BrowserNavState } from "../hooks/useBrowserView";
 import type { WorkspaceSession } from "../types/workspace";
+import type { BrowserAnnotationCancelPayload, BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
+
+const postMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: { POST: postMock },
+	apiErrorMessage: (error: unknown, fallback = "Request failed") =>
+		typeof error === "object" && error !== null && "message" in error
+			? String((error as { message: unknown }).message)
+			: fallback,
+}));
 
 const hookState = vi.hoisted(() => ({
 	navigate: vi.fn(),
@@ -11,6 +22,7 @@ const hookState = vi.hoisted(() => ({
 	goForward: vi.fn(),
 	reload: vi.fn(),
 	stop: vi.fn(),
+	setAnnotationMode: vi.fn(),
 	previewUrl: undefined as string | undefined,
 	navState: {
 		viewId: "42:sess-1",
@@ -34,6 +46,8 @@ vi.mock("../hooks/useBrowserView", () => ({
 			goForward: hookState.goForward,
 			reload: hookState.reload,
 			stop: hookState.stop,
+			annotationMode: false,
+			setAnnotationMode: hookState.setAnnotationMode,
 		};
 	},
 }));
@@ -46,18 +60,39 @@ const session: WorkspaceSession = {
 	provider: "claude-code",
 	kind: "worker",
 	branch: "feat/ns",
-	status: "working",
+	status: "needs_input",
 	updatedAt: "2026-06-15T00:00:00Z",
 	prs: [],
 };
 
 describe("BrowserPanel", () => {
+	const annotationSubmitListeners = new Set<(payload: BrowserAnnotationSubmitPayload) => void>();
+	const annotationCancelListeners = new Set<(payload: BrowserAnnotationCancelPayload) => void>();
+
 	beforeEach(() => {
 		hookState.navigate.mockReset();
 		hookState.goBack.mockReset();
 		hookState.goForward.mockReset();
 		hookState.reload.mockReset();
 		hookState.stop.mockReset();
+		hookState.setAnnotationMode.mockReset();
+		hookState.setAnnotationMode.mockResolvedValue(undefined);
+		postMock.mockReset();
+		postMock.mockResolvedValue({ data: {} });
+		annotationSubmitListeners.clear();
+		annotationCancelListeners.clear();
+		window.ao!.browser.onAnnotationSubmit = vi.fn((listener: (payload: BrowserAnnotationSubmitPayload) => void) => {
+			annotationSubmitListeners.add(listener);
+			return () => {
+				annotationSubmitListeners.delete(listener);
+			};
+		});
+		window.ao!.browser.onAnnotationCancel = vi.fn((listener: (payload: BrowserAnnotationCancelPayload) => void) => {
+			annotationCancelListeners.add(listener);
+			return () => {
+				annotationCancelListeners.delete(listener);
+			};
+		});
 		hookState.previewUrl = undefined;
 		hookState.navState = {
 			viewId: "42:sess-1",
@@ -126,5 +161,272 @@ describe("BrowserPanel", () => {
 		await userEvent.click(screen.getByRole("button", { name: /pop out/i }));
 
 		expect(onTogglePopOut).toHaveBeenCalledWith(true);
+	});
+
+	it("enables annotation mode from the toolbar when a page is loaded", async () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		await userEvent.click(screen.getByRole("button", { name: /annotate/i }));
+
+		expect(hookState.setAnnotationMode).toHaveBeenCalledWith(true);
+	});
+
+	it("keeps annotation mode available while the session is working", () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		render(
+			<BrowserPanel
+				active
+				onTogglePopOut={() => undefined}
+				poppedOut={false}
+				session={{ ...session, status: "working" }}
+			/>,
+		);
+
+		expect(screen.getByRole("button", { name: /annotate/i })).toBeEnabled();
+		expect(screen.getByText("Agent working")).toBeInTheDocument();
+	});
+
+	it("disables annotation mode when no page is loaded", () => {
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		expect(screen.getByRole("button", { name: /annotate/i })).toBeDisabled();
+	});
+
+	it("sends submitted annotation instructions to the session agent", async () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		act(() => {
+			annotationSubmitListeners.forEach((listener) =>
+				listener({
+					viewId: "42:sess-1",
+					instruction: "Make this button blue.",
+					context: {
+						url: "http://localhost:5173/",
+						title: "Preview",
+						tag: "button",
+						id: "save",
+						classes: ["primary"],
+						selector: "button#save",
+						rect: { x: 16, y: 24, width: 140, height: 36 },
+						visibleText: "Save changes",
+						nearbyText: ["Profile settings"],
+						computedStyle: {},
+					},
+				}),
+			);
+		});
+
+		expect(await screen.findByText("Sent")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/send", {
+			params: { path: { sessionId: "sess-1" } },
+			body: {
+				message: expect.stringContaining("Make this button blue."),
+			},
+		});
+		const body = postMock.mock.calls[0][1].body as { message: string };
+		expect(body.message).toContain("button#save");
+		expect(body.message.length).toBeLessThanOrEqual(4096);
+	});
+
+	it("queues annotation submissions while one is being sent", async () => {
+		let resolvePost: (value: unknown) => void = () => undefined;
+		postMock
+			.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolvePost = resolve;
+				}),
+			)
+			.mockResolvedValueOnce({ data: {} });
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		const { rerender } = render(
+			<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />,
+		);
+		const firstPayload = {
+			viewId: "42:sess-1",
+			instruction: "Make this button blue.",
+			context: {
+				url: "http://localhost:5173/",
+				tag: "button",
+				classes: [],
+				selector: "button",
+				rect: { x: 0, y: 0, width: 80, height: 30 },
+				nearbyText: [],
+				computedStyle: {},
+			},
+		};
+		const secondPayload = {
+			...firstPayload,
+			instruction: "Make this heading shorter.",
+		};
+
+		act(() => {
+			annotationSubmitListeners.forEach((listener) => {
+				listener(firstPayload);
+				listener(secondPayload);
+			});
+		});
+
+		expect(postMock).toHaveBeenCalledTimes(1);
+		expect((postMock.mock.calls[0][1].body as { message: string }).message).toContain("Make this button blue.");
+		await act(async () => {
+			resolvePost({ data: {} });
+		});
+		expect(screen.getByText("Queued")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(1);
+
+		rerender(
+			<BrowserPanel
+				active
+				onTogglePopOut={() => undefined}
+				poppedOut={false}
+				session={{ ...session, status: "working" }}
+			/>,
+		);
+		expect(postMock).toHaveBeenCalledTimes(1);
+
+		rerender(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		expect(await screen.findByText("Sent")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(2);
+		expect((postMock.mock.calls[1][1].body as { message: string }).message).toContain("Make this heading shorter.");
+	});
+
+	it("does not drain queued annotations on the idle state before needs input", async () => {
+		let resolvePost: (value: unknown) => void = () => undefined;
+		postMock
+			.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolvePost = resolve;
+				}),
+			)
+			.mockResolvedValueOnce({ data: {} });
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		const { rerender } = render(
+			<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />,
+		);
+		const payload = {
+			viewId: "42:sess-1",
+			instruction: "Make this button yellow.",
+			context: {
+				url: "http://localhost:5173/",
+				tag: "button",
+				classes: [],
+				selector: "button",
+				rect: { x: 0, y: 0, width: 80, height: 30 },
+				nearbyText: [],
+				computedStyle: {},
+			},
+		};
+
+		act(() => {
+			annotationSubmitListeners.forEach((listener) => {
+				listener(payload);
+				listener({ ...payload, instruction: "Make this button blue." });
+			});
+		});
+		await act(async () => {
+			resolvePost({ data: {} });
+		});
+
+		rerender(
+			<BrowserPanel
+				active
+				onTogglePopOut={() => undefined}
+				poppedOut={false}
+				session={{ ...session, status: "working" }}
+			/>,
+		);
+		rerender(
+			<BrowserPanel
+				active
+				onTogglePopOut={() => undefined}
+				poppedOut={false}
+				session={{ ...session, status: "idle" }}
+			/>,
+		);
+		expect(screen.getByText("Queued")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(1);
+
+		rerender(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		expect(await screen.findByText("Sent")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("queues submitted annotations while the session is working", async () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		const { rerender } = render(
+			<BrowserPanel
+				active
+				onTogglePopOut={() => undefined}
+				poppedOut={false}
+				session={{ ...session, status: "working" }}
+			/>,
+		);
+
+		act(() => {
+			annotationSubmitListeners.forEach((listener) =>
+				listener({
+					viewId: "42:sess-1",
+					instruction: "Move this card higher.",
+					context: {
+						url: "http://localhost:5173/",
+						tag: "section",
+						classes: [],
+						selector: "section",
+						rect: { x: 0, y: 0, width: 320, height: 180 },
+						nearbyText: [],
+						computedStyle: {},
+					},
+				}),
+			);
+		});
+
+		expect(screen.getByText("Queued")).toBeInTheDocument();
+		expect(postMock).not.toHaveBeenCalled();
+
+		rerender(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		expect(await screen.findByText("Sent")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("shows annotation send errors", async () => {
+		postMock.mockResolvedValue({ error: { message: "AO daemon is not ready." } });
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		act(() => {
+			annotationSubmitListeners.forEach((listener) =>
+				listener({
+					viewId: "42:sess-1",
+					instruction: "Make this button blue.",
+					context: {
+						url: "http://localhost:5173/",
+						tag: "button",
+						classes: [],
+						selector: "button",
+						rect: { x: 0, y: 0, width: 80, height: 30 },
+						nearbyText: [],
+						computedStyle: {},
+					},
+				}),
+			);
+		});
+
+		expect(await screen.findByText("AO daemon is not ready.")).toBeInTheDocument();
+	});
+
+	it("clears picking state when the page cancels annotation mode", async () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+
+		await userEvent.click(screen.getByRole("button", { name: /annotate/i }));
+		expect(screen.getByText("Pick element")).toBeInTheDocument();
+
+		act(() => {
+			annotationCancelListeners.forEach((listener) => listener({ viewId: "42:sess-1", reason: "escape" }));
+		});
+
+		expect(screen.queryByText("Pick element")).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -536,6 +536,36 @@ describe("BrowserPanel", () => {
 		expect(await screen.findByText("AO daemon is not ready.")).toBeInTheDocument();
 	});
 
+	it("keeps a failed annotation queued so the user can retry it", async () => {
+		postMock.mockResolvedValueOnce({ error: { message: "AO daemon is not ready." } }).mockResolvedValueOnce({ data: {} });
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		const payload = annotationPayload("Keep my original annotation request.");
+
+		act(() => {
+			annotationSubmitListeners.forEach((listener) =>
+				listener({
+					...payload,
+					context: {
+						...payload.context,
+						selector: "button#save",
+					},
+				}),
+			);
+		});
+
+		expect(await screen.findByText("AO daemon is not ready.")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(1);
+
+		await userEvent.click(screen.getByRole("button", { name: /retry annotation/i }));
+
+		expect(await screen.findByText("Sent")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(2);
+		const retryBody = postMock.mock.calls[1][1].body as { message: string };
+		expect(retryBody.message).toContain("Keep my original annotation request.");
+		expect(retryBody.message).toContain("button#save");
+	});
+
 	it("clears picking state when the page cancels annotation mode", async () => {
 		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
 		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -537,7 +537,9 @@ describe("BrowserPanel", () => {
 	});
 
 	it("keeps a failed annotation queued so the user can retry it", async () => {
-		postMock.mockResolvedValueOnce({ error: { message: "AO daemon is not ready." } }).mockResolvedValueOnce({ data: {} });
+		postMock
+			.mockResolvedValueOnce({ error: { message: "AO daemon is not ready." } })
+			.mockResolvedValueOnce({ data: {} });
 		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
 		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 		const payload = annotationPayload("Keep my original annotation request.");

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -1,8 +1,8 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { BrowserPanel } from "./BrowserPanel";
-import type { BrowserNavState } from "../hooks/useBrowserView";
+import { BrowserPanel, BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
+import { useBrowserView, type BrowserNavState } from "../hooks/useBrowserView";
 import type { WorkspaceSession } from "../types/workspace";
 import type { BrowserAnnotationCancelPayload, BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
 
@@ -64,6 +64,54 @@ const session: WorkspaceSession = {
 	updatedAt: "2026-06-15T00:00:00Z",
 	prs: [],
 };
+
+function annotationPayload(instruction: string): BrowserAnnotationSubmitPayload {
+	return {
+		viewId: "42:sess-1",
+		instruction,
+		context: {
+			url: "http://localhost:5173/",
+			tag: "button",
+			classes: [],
+			selector: "button",
+			rect: { x: 0, y: 0, width: 80, height: 30 },
+			nearbyText: [],
+			computedStyle: {},
+		},
+	};
+}
+
+function PersistentBrowserPanelView({
+	currentSession,
+	visible,
+}: {
+	currentSession: WorkspaceSession;
+	visible: boolean;
+}) {
+	const browserView = useBrowserView({
+		sessionId: currentSession.id,
+		active: true,
+		poppedOut: false,
+		previewUrl: currentSession.previewUrl,
+		previewRevision: currentSession.previewRevision,
+	});
+	const annotationQueue = useBrowserAnnotationQueue({
+		sessionId: currentSession.id,
+		sessionStatus: currentSession.status,
+		navUrl: browserView.navState.url,
+	});
+	if (!visible) return null;
+	return (
+		<BrowserPanelView
+			active
+			annotationQueue={annotationQueue}
+			browserView={browserView}
+			onTogglePopOut={() => undefined}
+			poppedOut={false}
+			session={currentSession}
+		/>
+	);
+}
 
 describe("BrowserPanel", () => {
 	const annotationSubmitListeners = new Set<(payload: BrowserAnnotationSubmitPayload) => void>();
@@ -230,6 +278,41 @@ describe("BrowserPanel", () => {
 		expect(body.message.length).toBeLessThanOrEqual(4096);
 	});
 
+	it("waits for the agent turn cycle before sending a follow-up annotation", async () => {
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		const { rerender } = render(
+			<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />,
+		);
+
+		act(() => {
+			annotationSubmitListeners.forEach((listener) => listener(annotationPayload("Make this button blue.")));
+		});
+		expect(await screen.findByText("Sent")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			annotationSubmitListeners.forEach((listener) => listener(annotationPayload("Make this button green.")));
+		});
+
+		expect(screen.getByText("Queued")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(1);
+
+		rerender(
+			<BrowserPanel
+				active
+				onTogglePopOut={() => undefined}
+				poppedOut={false}
+				session={{ ...session, status: "working" }}
+			/>,
+		);
+		expect(postMock).toHaveBeenCalledTimes(1);
+
+		rerender(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		expect(await screen.findByText("Sent")).toBeInTheDocument();
+		expect(postMock).toHaveBeenCalledTimes(2);
+		expect((postMock.mock.calls[1][1].body as { message: string }).message).toContain("Make this button green.");
+	});
+
 	it("queues annotation submissions while one is being sent", async () => {
 		let resolvePost: (value: unknown) => void = () => undefined;
 		postMock
@@ -289,6 +372,43 @@ describe("BrowserPanel", () => {
 		rerender(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 		expect(await screen.findByText("Sent")).toBeInTheDocument();
 		expect(postMock).toHaveBeenCalledTimes(2);
+		expect((postMock.mock.calls[1][1].body as { message: string }).message).toContain("Make this heading shorter.");
+	});
+
+	it("preserves queued annotations while the BrowserPanelView is unmounted", async () => {
+		let resolvePost: (value: unknown) => void = () => undefined;
+		postMock
+			.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolvePost = resolve;
+				}),
+			)
+			.mockResolvedValueOnce({ data: {} });
+		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
+		const { rerender } = render(<PersistentBrowserPanelView currentSession={session} visible />);
+
+		act(() => {
+			annotationSubmitListeners.forEach((listener) => {
+				listener(annotationPayload("Make this button blue."));
+				listener(annotationPayload("Make this heading shorter."));
+			});
+		});
+		expect(postMock).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			resolvePost({ data: {} });
+		});
+		expect(screen.getByText("Queued")).toBeInTheDocument();
+
+		rerender(<PersistentBrowserPanelView currentSession={session} visible={false} />);
+		rerender(<PersistentBrowserPanelView currentSession={{ ...session, status: "working" }} visible={false} />);
+		expect(postMock).toHaveBeenCalledTimes(1);
+
+		rerender(<PersistentBrowserPanelView currentSession={session} visible={false} />);
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
+
+		rerender(<PersistentBrowserPanelView currentSession={session} visible />);
+		expect(await screen.findByText("Sent")).toBeInTheDocument();
 		expect((postMock.mock.calls[1][1].body as { message: string }).message).toContain("Make this heading shorter.");
 	});
 

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState, type FormEvent } from "react";
-import { ArrowLeft, ArrowRight, Globe2, Maximize2, Minimize2, RefreshCw, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
+import { ArrowLeft, ArrowRight, Globe2, Maximize2, Minimize2, MousePointer2, RefreshCw, X } from "lucide-react";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { useBrowserView, type BrowserViewModel } from "../hooks/useBrowserView";
+import { formatBrowserAnnotationMessage, type BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
 import type { WorkspaceSession } from "../types/workspace";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
@@ -11,6 +13,8 @@ type BrowserPanelProps = {
 	poppedOut: boolean;
 	onTogglePopOut: (next: boolean) => void;
 };
+
+type AnnotationStatus = "idle" | "picking" | "queued" | "sending" | "sent" | "error";
 
 export function BrowserPanel({ session, active, poppedOut, onTogglePopOut }: BrowserPanelProps) {
 	const browserView = useBrowserView({
@@ -32,23 +36,178 @@ export function BrowserPanel({ session, active, poppedOut, onTogglePopOut }: Bro
 }
 
 export function BrowserPanelView({
+	session,
 	poppedOut,
 	onTogglePopOut,
 	browserView,
 }: BrowserPanelProps & { browserView: BrowserViewModel }) {
-	const { navState, slotRef, navigate, goBack, goForward, reload, stop } = browserView;
+	const { viewId, navState, slotRef, navigate, goBack, goForward, reload, stop, annotationMode, setAnnotationMode } =
+		browserView;
 	const [urlInput, setUrlInput] = useState(navState.url);
+	const [annotationStatus, setAnnotationStatus] = useState<AnnotationStatus>("idle");
+	const [annotationError, setAnnotationError] = useState("");
+	const [annotationQueuedCount, setAnnotationQueuedCount] = useState(0);
+	const annotationQueueRef = useRef<BrowserAnnotationSubmitPayload[]>([]);
+	const annotationSendingRef = useRef(false);
+	const annotationWaitingForAgentCycleRef = useRef(false);
+	const annotationSawAgentWorkingRef = useRef(false);
+	const sessionBusyRef = useRef(session.status === "working");
+	const sessionReadyForAnnotationRef = useRef(session.status === "needs_input");
 	const showStaticPreview = !window.ao?.browser && navState.url !== "";
+	const sessionBusy = session.status === "working";
+	const canAnnotate = Boolean(window.ao?.browser && viewId && navState.url);
 
 	useEffect(() => {
 		setUrlInput(navState.url);
 	}, [navState.url]);
+
+	useEffect(() => {
+		if (navState.url) return;
+		annotationQueueRef.current = [];
+		annotationWaitingForAgentCycleRef.current = false;
+		annotationSawAgentWorkingRef.current = false;
+		setAnnotationQueuedCount(0);
+		setAnnotationStatus("idle");
+		setAnnotationError("");
+	}, [navState.url]);
+
+	const setQueuedStatus = useCallback(() => {
+		const count = annotationQueueRef.current.length;
+		setAnnotationQueuedCount(count);
+		if (count > 0) setAnnotationStatus("queued");
+	}, []);
+
+	const drainAnnotationQueue = useCallback(() => {
+		if (
+			annotationSendingRef.current ||
+			!sessionReadyForAnnotationRef.current ||
+			annotationWaitingForAgentCycleRef.current
+		) {
+			return;
+		}
+
+		const payload = annotationQueueRef.current.shift();
+		setAnnotationQueuedCount(annotationQueueRef.current.length);
+		if (!payload) return;
+
+		annotationSendingRef.current = true;
+		setAnnotationStatus("sending");
+		setAnnotationError("");
+
+		void (async () => {
+			let sent = false;
+			try {
+				const message = formatBrowserAnnotationMessage(payload);
+				const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/send", {
+					params: { path: { sessionId: session.id } },
+					body: { message },
+				});
+				if (error) {
+					setAnnotationStatus("error");
+					setAnnotationError(apiErrorMessage(error, "Unable to send annotation."));
+					return;
+				}
+				sent = true;
+			} catch (error) {
+				setAnnotationStatus("error");
+				setAnnotationError(apiErrorMessage(error, "Unable to send annotation."));
+			} finally {
+				annotationSendingRef.current = false;
+				setAnnotationQueuedCount(annotationQueueRef.current.length);
+				if (!sent) return;
+
+				if (annotationQueueRef.current.length > 0) {
+					annotationWaitingForAgentCycleRef.current = true;
+					annotationSawAgentWorkingRef.current = sessionBusyRef.current;
+					setAnnotationStatus("queued");
+					return;
+				}
+
+				setAnnotationStatus("sent");
+			}
+		})();
+	}, [session.id]);
+
+	useEffect(() => {
+		const nextBusy = session.status === "working";
+		const nextReady = session.status === "needs_input";
+		sessionBusyRef.current = nextBusy;
+		sessionReadyForAnnotationRef.current = nextReady;
+		if (nextBusy) {
+			if (annotationWaitingForAgentCycleRef.current) {
+				annotationSawAgentWorkingRef.current = true;
+			}
+			return;
+		}
+		if (!nextReady) return;
+		if (annotationWaitingForAgentCycleRef.current) {
+			if (!annotationSawAgentWorkingRef.current) return;
+			annotationWaitingForAgentCycleRef.current = false;
+			annotationSawAgentWorkingRef.current = false;
+		}
+		drainAnnotationQueue();
+	}, [drainAnnotationQueue, session.status]);
+
+	const enqueueAnnotation = useCallback(
+		(payload: BrowserAnnotationSubmitPayload) => {
+			annotationQueueRef.current.push(payload);
+			setAnnotationError("");
+			setQueuedStatus();
+			drainAnnotationQueue();
+		},
+		[drainAnnotationQueue, setQueuedStatus],
+	);
+
+	useEffect(() => {
+		const offSubmit = window.ao?.browser.onAnnotationSubmit((payload) => {
+			if (payload.viewId !== viewId) return;
+			enqueueAnnotation(payload);
+		});
+		const offCancel = window.ao?.browser.onAnnotationCancel((payload) => {
+			if (payload.viewId !== viewId) return;
+			setQueuedStatus();
+			if (!annotationSendingRef.current && annotationQueueRef.current.length === 0) setAnnotationStatus("idle");
+			setAnnotationError("");
+		});
+		return () => {
+			offSubmit?.();
+			offCancel?.();
+		};
+	}, [enqueueAnnotation, setQueuedStatus, viewId]);
 
 	const submit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		const nextURL = urlInput.trim();
 		if (nextURL) void navigate(nextURL);
 	};
+
+	const toggleAnnotationMode = async () => {
+		if (!canAnnotate || annotationStatus === "sending") return;
+		const next = !(annotationMode || annotationStatus === "picking");
+		setAnnotationError("");
+		try {
+			await setAnnotationMode(next);
+			setAnnotationStatus(next ? "picking" : "idle");
+		} catch (error) {
+			setAnnotationStatus("error");
+			setAnnotationError(error instanceof Error ? error.message : "Unable to start annotation.");
+		}
+	};
+
+	const annotationStatusLabel =
+		annotationStatus === "picking"
+			? "Pick element"
+			: annotationStatus === "queued"
+				? annotationQueuedCount > 1
+					? `Queued (${annotationQueuedCount})`
+					: "Queued"
+				: annotationStatus === "sending"
+					? "Sending"
+					: annotationStatus === "sent"
+						? "Sent"
+						: annotationStatus === "error"
+							? annotationError
+							: "";
 
 	return (
 		<div className="browser-panel" role="tabpanel">
@@ -86,6 +245,32 @@ export function BrowserPanelView({
 						<RefreshCw aria-hidden="true" className="h-4 w-4" />
 					)}
 				</Button>
+				<Button
+					aria-label={annotationMode || annotationStatus === "picking" ? "Cancel annotation" : "Annotate page"}
+					aria-pressed={annotationMode || annotationStatus === "picking"}
+					className="browser-panel__annotate-btn"
+					disabled={!canAnnotate || annotationStatus === "sending"}
+					onClick={() => void toggleAnnotationMode()}
+					size="icon-sm"
+					title="Annotate page"
+					type="button"
+					variant="ghost"
+				>
+					<MousePointer2 aria-hidden="true" className="h-4 w-4" />
+				</Button>
+				{annotationStatusLabel ? (
+					<span
+						className={
+							annotationStatus === "error"
+								? "browser-panel__annotation-status browser-panel__annotation-status--error"
+								: "browser-panel__annotation-status"
+						}
+					>
+						{annotationStatusLabel}
+					</span>
+				) : sessionBusy ? (
+					<span className="browser-panel__annotation-status">Agent working</span>
+				) : null}
 				<div className="browser-panel__url">
 					<Globe2 aria-hidden="true" className="browser-panel__url-icon" />
 					<Input

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -24,6 +24,7 @@ export type BrowserAnnotationQueueModel = {
 	cancelPicking: () => void;
 	enqueue: (payload: BrowserAnnotationSubmitPayload) => void;
 	failPicking: (message: string) => void;
+	retryQueued: () => void;
 };
 
 export function useBrowserAnnotationQueue({
@@ -81,6 +82,7 @@ export function useBrowserAnnotationQueue({
 
 		void (async () => {
 			let sent = false;
+			let failureMessage = "Unable to send annotation.";
 			try {
 				const message = formatBrowserAnnotationMessage(payload);
 				const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/send", {
@@ -88,28 +90,24 @@ export function useBrowserAnnotationQueue({
 					body: { message },
 				});
 				if (error) {
-					if (sendGeneration === generationRef.current && sendSessionId === sessionIdRef.current) {
-						setState({
-							status: "error",
-							error: apiErrorMessage(error, "Unable to send annotation."),
-							queuedCount: annotationQueueRef.current.length,
-						});
-					}
+					failureMessage = apiErrorMessage(error, "Unable to send annotation.");
 					return;
 				}
 				sent = true;
 			} catch (error) {
-				if (sendGeneration === generationRef.current && sendSessionId === sessionIdRef.current) {
-					setState({
-						status: "error",
-						error: apiErrorMessage(error, "Unable to send annotation."),
-						queuedCount: annotationQueueRef.current.length,
-					});
-				}
+				failureMessage = apiErrorMessage(error, "Unable to send annotation.");
 			} finally {
 				if (sendGeneration !== generationRef.current || sendSessionId !== sessionIdRef.current) return;
 				annotationSendingRef.current = false;
-				if (!sent) return;
+				if (!sent) {
+					annotationQueueRef.current.unshift(payload);
+					setState({
+						status: "error",
+						error: failureMessage,
+						queuedCount: annotationQueueRef.current.length,
+					});
+					return;
+				}
 
 				annotationWaitingForAgentCycleRef.current = true;
 				annotationWaitAfterCycleRef.current = sendCycle;
@@ -185,6 +183,12 @@ export function useBrowserAnnotationQueue({
 		[drainAnnotationQueue],
 	);
 
+	const retryQueued = useCallback(() => {
+		if (annotationQueueRef.current.length === 0) return;
+		setState({ status: "queued", error: "", queuedCount: annotationQueueRef.current.length });
+		drainAnnotationQueue();
+	}, [drainAnnotationQueue]);
+
 	return {
 		status: state.status,
 		error: state.error,
@@ -193,6 +197,7 @@ export function useBrowserAnnotationQueue({
 		cancelPicking,
 		enqueue,
 		failPicking,
+		retryQueued,
 	};
 }
 
@@ -231,10 +236,11 @@ export function BrowserPanelView({
 	const { viewId, navState, slotRef, navigate, goBack, goForward, reload, stop, annotationMode, setAnnotationMode } =
 		browserView;
 	const [urlInput, setUrlInput] = useState(navState.url);
-	const { beginPicking, cancelPicking, enqueue, error, failPicking, queuedCount, status } = annotationQueue;
+	const { beginPicking, cancelPicking, enqueue, error, failPicking, queuedCount, retryQueued, status } = annotationQueue;
 	const showStaticPreview = !window.ao?.browser && navState.url !== "";
 	const sessionBusy = session.status === "working";
 	const canAnnotate = Boolean(window.ao?.browser && viewId && navState.url);
+	const canRetryAnnotation = status === "error" && queuedCount > 0;
 
 	useEffect(() => {
 		setUrlInput(navState.url);
@@ -263,6 +269,10 @@ export function BrowserPanelView({
 
 	const toggleAnnotationMode = async () => {
 		if (!canAnnotate || status === "sending") return;
+		if (canRetryAnnotation) {
+			retryQueued();
+			return;
+		}
 		const next = !(annotationMode || status === "picking");
 		try {
 			await setAnnotationMode(next);
@@ -328,13 +338,19 @@ export function BrowserPanelView({
 					)}
 				</Button>
 				<Button
-					aria-label={annotationMode || status === "picking" ? "Cancel annotation" : "Annotate page"}
+					aria-label={
+						canRetryAnnotation
+							? "Retry annotation"
+							: annotationMode || status === "picking"
+								? "Cancel annotation"
+								: "Annotate page"
+					}
 					aria-pressed={annotationMode || status === "picking"}
 					className="browser-panel__annotate-btn"
 					disabled={!canAnnotate || status === "sending"}
 					onClick={() => void toggleAnnotationMode()}
 					size="icon-sm"
-					title="Annotate page"
+					title={canRetryAnnotation ? "Retry annotation" : "Annotate page"}
 					type="button"
 					variant="ghost"
 				>

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -236,7 +236,8 @@ export function BrowserPanelView({
 	const { viewId, navState, slotRef, navigate, goBack, goForward, reload, stop, annotationMode, setAnnotationMode } =
 		browserView;
 	const [urlInput, setUrlInput] = useState(navState.url);
-	const { beginPicking, cancelPicking, enqueue, error, failPicking, queuedCount, retryQueued, status } = annotationQueue;
+	const { beginPicking, cancelPicking, enqueue, error, failPicking, queuedCount, retryQueued, status } =
+		annotationQueue;
 	const showStaticPreview = !window.ao?.browser && navState.url !== "";
 	const sessionBusy = session.status === "working";
 	const canAnnotate = Boolean(window.ao?.browser && viewId && navState.url);

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -16,6 +16,186 @@ type BrowserPanelProps = {
 
 type AnnotationStatus = "idle" | "picking" | "queued" | "sending" | "sent" | "error";
 
+export type BrowserAnnotationQueueModel = {
+	status: AnnotationStatus;
+	error: string;
+	queuedCount: number;
+	beginPicking: () => void;
+	cancelPicking: () => void;
+	enqueue: (payload: BrowserAnnotationSubmitPayload) => void;
+	failPicking: (message: string) => void;
+};
+
+export function useBrowserAnnotationQueue({
+	sessionId,
+	sessionStatus,
+	navUrl,
+}: {
+	sessionId?: string;
+	sessionStatus?: WorkspaceSession["status"];
+	navUrl?: string;
+}): BrowserAnnotationQueueModel {
+	const [state, setState] = useState<{ status: AnnotationStatus; error: string; queuedCount: number }>({
+		status: "idle",
+		error: "",
+		queuedCount: 0,
+	});
+	const annotationQueueRef = useRef<BrowserAnnotationSubmitPayload[]>([]);
+	const annotationSendingRef = useRef(false);
+	const annotationWaitingForAgentCycleRef = useRef(false);
+	const annotationWaitAfterCycleRef = useRef(0);
+	const annotationSawAgentWorkingRef = useRef(sessionStatus === "working");
+	const annotationAgentCycleRef = useRef(0);
+	const sessionReadyForAnnotationRef = useRef(sessionStatus === "needs_input");
+	const sessionIdRef = useRef(sessionId ?? "");
+	const generationRef = useRef(0);
+
+	const resetQueue = useCallback(() => {
+		generationRef.current += 1;
+		annotationQueueRef.current = [];
+		annotationSendingRef.current = false;
+		annotationWaitingForAgentCycleRef.current = false;
+		annotationWaitAfterCycleRef.current = annotationAgentCycleRef.current;
+		setState({ status: "idle", error: "", queuedCount: 0 });
+	}, []);
+
+	const drainAnnotationQueue = useCallback(() => {
+		if (
+			annotationSendingRef.current ||
+			!sessionIdRef.current ||
+			!sessionReadyForAnnotationRef.current ||
+			annotationWaitingForAgentCycleRef.current
+		) {
+			return;
+		}
+
+		const payload = annotationQueueRef.current.shift();
+		setState((current) => ({ ...current, queuedCount: annotationQueueRef.current.length }));
+		if (!payload) return;
+
+		annotationSendingRef.current = true;
+		const sendGeneration = generationRef.current;
+		const sendSessionId = sessionIdRef.current;
+		const sendCycle = annotationAgentCycleRef.current;
+		setState({ status: "sending", error: "", queuedCount: annotationQueueRef.current.length });
+
+		void (async () => {
+			let sent = false;
+			try {
+				const message = formatBrowserAnnotationMessage(payload);
+				const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/send", {
+					params: { path: { sessionId: sendSessionId } },
+					body: { message },
+				});
+				if (error) {
+					if (sendGeneration === generationRef.current && sendSessionId === sessionIdRef.current) {
+						setState({
+							status: "error",
+							error: apiErrorMessage(error, "Unable to send annotation."),
+							queuedCount: annotationQueueRef.current.length,
+						});
+					}
+					return;
+				}
+				sent = true;
+			} catch (error) {
+				if (sendGeneration === generationRef.current && sendSessionId === sessionIdRef.current) {
+					setState({
+						status: "error",
+						error: apiErrorMessage(error, "Unable to send annotation."),
+						queuedCount: annotationQueueRef.current.length,
+					});
+				}
+			} finally {
+				if (sendGeneration !== generationRef.current || sendSessionId !== sessionIdRef.current) return;
+				annotationSendingRef.current = false;
+				if (!sent) return;
+
+				annotationWaitingForAgentCycleRef.current = true;
+				annotationWaitAfterCycleRef.current = sendCycle;
+				if (
+					sessionReadyForAnnotationRef.current &&
+					annotationAgentCycleRef.current > annotationWaitAfterCycleRef.current
+				) {
+					annotationWaitingForAgentCycleRef.current = false;
+				}
+
+				const queuedCount = annotationQueueRef.current.length;
+				setState({ status: queuedCount > 0 ? "queued" : "sent", error: "", queuedCount });
+				if (!annotationWaitingForAgentCycleRef.current && queuedCount > 0) drainAnnotationQueue();
+			}
+		})();
+	}, []);
+
+	useEffect(() => {
+		sessionIdRef.current = sessionId ?? "";
+		annotationAgentCycleRef.current = 0;
+		resetQueue();
+	}, [resetQueue, sessionId]);
+
+	useEffect(() => {
+		if (navUrl) return;
+		resetQueue();
+	}, [navUrl, resetQueue]);
+
+	useEffect(() => {
+		const nextWorking = sessionStatus === "working";
+		const nextReady = sessionStatus === "needs_input";
+		sessionReadyForAnnotationRef.current = nextReady;
+
+		if (nextWorking) {
+			annotationSawAgentWorkingRef.current = true;
+			return;
+		}
+
+		if (!nextReady) return;
+		if (annotationSawAgentWorkingRef.current) {
+			annotationAgentCycleRef.current += 1;
+			annotationSawAgentWorkingRef.current = false;
+		}
+		if (annotationWaitingForAgentCycleRef.current) {
+			if (annotationAgentCycleRef.current <= annotationWaitAfterCycleRef.current) return;
+			annotationWaitingForAgentCycleRef.current = false;
+		}
+		drainAnnotationQueue();
+	}, [drainAnnotationQueue, sessionStatus]);
+
+	const beginPicking = useCallback(() => {
+		setState((current) => ({ ...current, status: "picking", error: "" }));
+	}, []);
+
+	const cancelPicking = useCallback(() => {
+		setState((current) => ({
+			status: annotationQueueRef.current.length > 0 ? "queued" : current.status === "sending" ? "sending" : "idle",
+			error: "",
+			queuedCount: annotationQueueRef.current.length,
+		}));
+	}, []);
+
+	const failPicking = useCallback((message: string) => {
+		setState({ status: "error", error: message, queuedCount: annotationQueueRef.current.length });
+	}, []);
+
+	const enqueue = useCallback(
+		(payload: BrowserAnnotationSubmitPayload) => {
+			annotationQueueRef.current.push(payload);
+			setState({ status: "queued", error: "", queuedCount: annotationQueueRef.current.length });
+			drainAnnotationQueue();
+		},
+		[drainAnnotationQueue],
+	);
+
+	return {
+		status: state.status,
+		error: state.error,
+		queuedCount: state.queuedCount,
+		beginPicking,
+		cancelPicking,
+		enqueue,
+		failPicking,
+	};
+}
+
 export function BrowserPanel({ session, active, poppedOut, onTogglePopOut }: BrowserPanelProps) {
 	const browserView = useBrowserView({
 		sessionId: session.id,
@@ -24,9 +204,15 @@ export function BrowserPanel({ session, active, poppedOut, onTogglePopOut }: Bro
 		previewUrl: session.previewUrl,
 		previewRevision: session.previewRevision,
 	});
+	const annotationQueue = useBrowserAnnotationQueue({
+		sessionId: session.id,
+		sessionStatus: session.status,
+		navUrl: browserView.navState.url,
+	});
 	return (
 		<BrowserPanelView
 			active={active}
+			annotationQueue={annotationQueue}
 			browserView={browserView}
 			onTogglePopOut={onTogglePopOut}
 			poppedOut={poppedOut}
@@ -40,19 +226,12 @@ export function BrowserPanelView({
 	poppedOut,
 	onTogglePopOut,
 	browserView,
-}: BrowserPanelProps & { browserView: BrowserViewModel }) {
+	annotationQueue,
+}: BrowserPanelProps & { annotationQueue: BrowserAnnotationQueueModel; browserView: BrowserViewModel }) {
 	const { viewId, navState, slotRef, navigate, goBack, goForward, reload, stop, annotationMode, setAnnotationMode } =
 		browserView;
 	const [urlInput, setUrlInput] = useState(navState.url);
-	const [annotationStatus, setAnnotationStatus] = useState<AnnotationStatus>("idle");
-	const [annotationError, setAnnotationError] = useState("");
-	const [annotationQueuedCount, setAnnotationQueuedCount] = useState(0);
-	const annotationQueueRef = useRef<BrowserAnnotationSubmitPayload[]>([]);
-	const annotationSendingRef = useRef(false);
-	const annotationWaitingForAgentCycleRef = useRef(false);
-	const annotationSawAgentWorkingRef = useRef(false);
-	const sessionBusyRef = useRef(session.status === "working");
-	const sessionReadyForAnnotationRef = useRef(session.status === "needs_input");
+	const { beginPicking, cancelPicking, enqueue, error, failPicking, queuedCount, status } = annotationQueue;
 	const showStaticPreview = !window.ao?.browser && navState.url !== "";
 	const sessionBusy = session.status === "working";
 	const canAnnotate = Boolean(window.ao?.browser && viewId && navState.url);
@@ -62,118 +241,19 @@ export function BrowserPanelView({
 	}, [navState.url]);
 
 	useEffect(() => {
-		if (navState.url) return;
-		annotationQueueRef.current = [];
-		annotationWaitingForAgentCycleRef.current = false;
-		annotationSawAgentWorkingRef.current = false;
-		setAnnotationQueuedCount(0);
-		setAnnotationStatus("idle");
-		setAnnotationError("");
-	}, [navState.url]);
-
-	const setQueuedStatus = useCallback(() => {
-		const count = annotationQueueRef.current.length;
-		setAnnotationQueuedCount(count);
-		if (count > 0) setAnnotationStatus("queued");
-	}, []);
-
-	const drainAnnotationQueue = useCallback(() => {
-		if (
-			annotationSendingRef.current ||
-			!sessionReadyForAnnotationRef.current ||
-			annotationWaitingForAgentCycleRef.current
-		) {
-			return;
-		}
-
-		const payload = annotationQueueRef.current.shift();
-		setAnnotationQueuedCount(annotationQueueRef.current.length);
-		if (!payload) return;
-
-		annotationSendingRef.current = true;
-		setAnnotationStatus("sending");
-		setAnnotationError("");
-
-		void (async () => {
-			let sent = false;
-			try {
-				const message = formatBrowserAnnotationMessage(payload);
-				const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/send", {
-					params: { path: { sessionId: session.id } },
-					body: { message },
-				});
-				if (error) {
-					setAnnotationStatus("error");
-					setAnnotationError(apiErrorMessage(error, "Unable to send annotation."));
-					return;
-				}
-				sent = true;
-			} catch (error) {
-				setAnnotationStatus("error");
-				setAnnotationError(apiErrorMessage(error, "Unable to send annotation."));
-			} finally {
-				annotationSendingRef.current = false;
-				setAnnotationQueuedCount(annotationQueueRef.current.length);
-				if (!sent) return;
-
-				if (annotationQueueRef.current.length > 0) {
-					annotationWaitingForAgentCycleRef.current = true;
-					annotationSawAgentWorkingRef.current = sessionBusyRef.current;
-					setAnnotationStatus("queued");
-					return;
-				}
-
-				setAnnotationStatus("sent");
-			}
-		})();
-	}, [session.id]);
-
-	useEffect(() => {
-		const nextBusy = session.status === "working";
-		const nextReady = session.status === "needs_input";
-		sessionBusyRef.current = nextBusy;
-		sessionReadyForAnnotationRef.current = nextReady;
-		if (nextBusy) {
-			if (annotationWaitingForAgentCycleRef.current) {
-				annotationSawAgentWorkingRef.current = true;
-			}
-			return;
-		}
-		if (!nextReady) return;
-		if (annotationWaitingForAgentCycleRef.current) {
-			if (!annotationSawAgentWorkingRef.current) return;
-			annotationWaitingForAgentCycleRef.current = false;
-			annotationSawAgentWorkingRef.current = false;
-		}
-		drainAnnotationQueue();
-	}, [drainAnnotationQueue, session.status]);
-
-	const enqueueAnnotation = useCallback(
-		(payload: BrowserAnnotationSubmitPayload) => {
-			annotationQueueRef.current.push(payload);
-			setAnnotationError("");
-			setQueuedStatus();
-			drainAnnotationQueue();
-		},
-		[drainAnnotationQueue, setQueuedStatus],
-	);
-
-	useEffect(() => {
 		const offSubmit = window.ao?.browser.onAnnotationSubmit((payload) => {
 			if (payload.viewId !== viewId) return;
-			enqueueAnnotation(payload);
+			enqueue(payload);
 		});
 		const offCancel = window.ao?.browser.onAnnotationCancel((payload) => {
 			if (payload.viewId !== viewId) return;
-			setQueuedStatus();
-			if (!annotationSendingRef.current && annotationQueueRef.current.length === 0) setAnnotationStatus("idle");
-			setAnnotationError("");
+			cancelPicking();
 		});
 		return () => {
 			offSubmit?.();
 			offCancel?.();
 		};
-	}, [enqueueAnnotation, setQueuedStatus, viewId]);
+	}, [cancelPicking, enqueue, viewId]);
 
 	const submit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
@@ -182,31 +262,33 @@ export function BrowserPanelView({
 	};
 
 	const toggleAnnotationMode = async () => {
-		if (!canAnnotate || annotationStatus === "sending") return;
-		const next = !(annotationMode || annotationStatus === "picking");
-		setAnnotationError("");
+		if (!canAnnotate || status === "sending") return;
+		const next = !(annotationMode || status === "picking");
 		try {
 			await setAnnotationMode(next);
-			setAnnotationStatus(next ? "picking" : "idle");
+			if (next) {
+				beginPicking();
+			} else {
+				cancelPicking();
+			}
 		} catch (error) {
-			setAnnotationStatus("error");
-			setAnnotationError(error instanceof Error ? error.message : "Unable to start annotation.");
+			failPicking(error instanceof Error ? error.message : "Unable to start annotation.");
 		}
 	};
 
 	const annotationStatusLabel =
-		annotationStatus === "picking"
+		status === "picking"
 			? "Pick element"
-			: annotationStatus === "queued"
-				? annotationQueuedCount > 1
-					? `Queued (${annotationQueuedCount})`
+			: status === "queued"
+				? queuedCount > 1
+					? `Queued (${queuedCount})`
 					: "Queued"
-				: annotationStatus === "sending"
+				: status === "sending"
 					? "Sending"
-					: annotationStatus === "sent"
+					: status === "sent"
 						? "Sent"
-						: annotationStatus === "error"
-							? annotationError
+						: status === "error"
+							? error
 							: "";
 
 	return (
@@ -246,10 +328,10 @@ export function BrowserPanelView({
 					)}
 				</Button>
 				<Button
-					aria-label={annotationMode || annotationStatus === "picking" ? "Cancel annotation" : "Annotate page"}
-					aria-pressed={annotationMode || annotationStatus === "picking"}
+					aria-label={annotationMode || status === "picking" ? "Cancel annotation" : "Annotate page"}
+					aria-pressed={annotationMode || status === "picking"}
 					className="browser-panel__annotate-btn"
-					disabled={!canAnnotate || annotationStatus === "sending"}
+					disabled={!canAnnotate || status === "sending"}
 					onClick={() => void toggleAnnotationMode()}
 					size="icon-sm"
 					title="Annotate page"
@@ -261,7 +343,7 @@ export function BrowserPanelView({
 				{annotationStatusLabel ? (
 					<span
 						className={
-							annotationStatus === "error"
+							status === "error"
 								? "browser-panel__annotation-status browser-panel__annotation-status--error"
 								: "browser-panel__annotation-status"
 						}

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -9,7 +9,7 @@ import { useSessionScmSummary, type SessionPRSummary } from "../hooks/useSession
 import { prBrowserUrl, sessionPRDisplaySummaries } from "../lib/pr-display";
 import type { SessionActivityState, WorkspaceSession } from "../types/workspace";
 import { canonicalTrackerIssueId, sortedPRs } from "../types/workspace";
-import { BrowserPanelView } from "./BrowserPanel";
+import { BrowserPanelView, type BrowserAnnotationQueueModel } from "./BrowserPanel";
 import type { BrowserViewModel } from "../hooks/useBrowserView";
 import { Badge } from "./ui/badge";
 import { cn } from "../lib/utils";
@@ -75,6 +75,7 @@ export function SessionInspector({
 	session,
 	onOpenReviewerTerminal,
 	browserPoppedOut = false,
+	browserAnnotationQueue,
 	isInspectorVisible = true,
 	onToggleBrowserPopOut,
 	browserView,
@@ -84,6 +85,7 @@ export function SessionInspector({
 	session?: WorkspaceSession;
 	onOpenReviewerTerminal?: OpenReviewerTerminal;
 	browserPoppedOut?: boolean;
+	browserAnnotationQueue?: BrowserAnnotationQueueModel;
 	isInspectorVisible?: boolean;
 	onToggleBrowserPopOut?: (next: boolean) => void;
 	browserView?: BrowserViewModel;
@@ -140,6 +142,7 @@ export function SessionInspector({
 				{view === "browser" ? (
 					<BrowserView
 						browserPoppedOut={browserPoppedOut}
+						browserAnnotationQueue={browserAnnotationQueue}
 						browserView={browserView}
 						isActive={isInspectorVisible && !browserPoppedOut}
 						onTogglePopOut={onToggleBrowserPopOut}
@@ -736,12 +739,14 @@ function BrowserView({
 	session,
 	isActive,
 	browserPoppedOut,
+	browserAnnotationQueue,
 	onTogglePopOut,
 	browserView,
 }: {
 	session: WorkspaceSession;
 	isActive: boolean;
 	browserPoppedOut: boolean;
+	browserAnnotationQueue?: BrowserAnnotationQueueModel;
 	onTogglePopOut?: (next: boolean) => void;
 	browserView?: BrowserViewModel;
 }) {
@@ -753,13 +758,14 @@ function BrowserView({
 		return null;
 	}
 
-	if (!browserView) {
+	if (!browserView || !browserAnnotationQueue) {
 		return null;
 	}
 
 	return (
 		<BrowserPanelView
 			active={isActive}
+			annotationQueue={browserAnnotationQueue}
 			browserView={browserView}
 			onTogglePopOut={(next) => onTogglePopOut?.(next)}
 			poppedOut={false}

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -66,6 +66,7 @@ vi.mock("./BrowserPanel", () => ({
 		cancelPicking: vi.fn(),
 		enqueue: vi.fn(),
 		failPicking: vi.fn(),
+		retryQueued: vi.fn(),
 	}),
 }));
 const browserDestroy = vi.hoisted(() => vi.fn());

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -58,6 +58,15 @@ vi.mock("./BrowserPanel", () => ({
 			{poppedOut ? "browser center" : "browser rail"}
 		</button>
 	),
+	useBrowserAnnotationQueue: () => ({
+		status: "idle",
+		error: "",
+		queuedCount: 0,
+		beginPicking: vi.fn(),
+		cancelPicking: vi.fn(),
+		enqueue: vi.fn(),
+		failPicking: vi.fn(),
+	}),
 }));
 const browserDestroy = vi.hoisted(() => vi.fn());
 vi.mock("../hooks/useBrowserView", () => ({

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
-import { BrowserPanelView } from "./BrowserPanel";
+import { BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { CenterPane } from "./CenterPane";
 import { SessionInspector, type InspectorView } from "./SessionInspector";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "./ui/resizable";
@@ -64,6 +64,11 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		terminated: session?.status === "terminated",
 		previewUrl,
 		previewRevision,
+	});
+	const browserAnnotationQueue = useBrowserAnnotationQueue({
+		sessionId: session?.id,
+		sessionStatus: session?.status,
+		navUrl: browserView.navState.url,
 	});
 
 	useEffect(() => {
@@ -213,6 +218,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
                   the pane clips instead of reflowing the inspector mid-collapse. */}
 							<div className="h-full min-w-[280px]">
 								<SessionInspector
+									browserAnnotationQueue={browserAnnotationQueue}
 									browserPoppedOut={browserPoppedOut}
 									isInspectorVisible={isInspectorOpen}
 									onOpenReviewerTerminal={({ handleId, harness }) =>
@@ -239,6 +245,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 						<div className="browser-popout-overlay">
 							<BrowserPanelView
 								active
+								annotationQueue={browserAnnotationQueue}
 								browserView={browserView}
 								onTogglePopOut={setBrowserPoppedOut}
 								poppedOut

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -51,10 +51,13 @@ function setupBridge() {
 		reload: vi.fn(async (viewId: string) => bridge.stateFor(viewId)),
 		stop: vi.fn(async (viewId: string) => bridge.stateFor(viewId)),
 		destroy: vi.fn(),
+		setAnnotationMode: vi.fn(async () => undefined),
 		onNavState: vi.fn((listener: Listener) => {
 			listeners.add(listener);
 			return () => listeners.delete(listener);
 		}),
+		onAnnotationSubmit: vi.fn(() => () => undefined),
+		onAnnotationCancel: vi.fn(() => () => undefined),
 		emit(state: BrowserNavState) {
 			listeners.forEach((listener) => listener(state));
 		},

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { BrowserNavState, BrowserRect } from "../../main/browser-view-host";
+import type { BrowserAnnotationCancelPayload, BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
 
 export type { BrowserNavState };
 
@@ -37,6 +38,8 @@ export type BrowserViewModel = {
 	reload: () => Promise<void>;
 	stop: () => Promise<void>;
 	destroy: () => void;
+	annotationMode: boolean;
+	setAnnotationMode: (enabled: boolean) => Promise<void>;
 };
 
 const EMPTY_NAV_STATE: BrowserNavState = {
@@ -80,8 +83,10 @@ export function useBrowserView({
 }: UseBrowserViewOptions): BrowserViewModel {
 	const [viewId, setViewId] = useState("");
 	const [navState, setNavState] = useState<BrowserNavState>(EMPTY_NAV_STATE);
+	const [annotationMode, setAnnotationModeState] = useState(false);
 	const slotNodeRef = useRef<HTMLDivElement | null>(null);
 	const viewIdRef = useRef("");
+	const annotationModeRef = useRef(false);
 	const activeRef = useRef(active);
 	const frameRef = useRef<number | null>(null);
 	const settleTimerRef = useRef<number | null>(null);
@@ -97,6 +102,10 @@ export function useBrowserView({
 	useEffect(() => {
 		hasUrlRef.current = Boolean(navState.url);
 	}, [navState.url]);
+
+	useEffect(() => {
+		annotationModeRef.current = annotationMode;
+	}, [annotationMode]);
 
 	const sendHiddenBounds = useCallback((id = viewIdRef.current) => {
 		if (!id) return;
@@ -203,6 +212,10 @@ export function useBrowserView({
 			disposed = true;
 			const id = viewIdRef.current;
 			if (id) {
+				if (annotationModeRef.current) {
+					void window.ao?.browser.setAnnotationMode({ viewId: id, enabled: false });
+					setAnnotationModeState(false);
+				}
 				sendHiddenBounds(id);
 			}
 			viewIdRef.current = "";
@@ -243,6 +256,37 @@ export function useBrowserView({
 		const next = await fn(id);
 		if (next) setNavState(next);
 	}, []);
+
+	const setAnnotationMode = useCallback(
+		async (enabled: boolean) => {
+			const id = viewIdRef.current;
+			if (!id || !hasNativeBrowser) {
+				setAnnotationModeState(false);
+				return;
+			}
+			await window.ao!.browser.setAnnotationMode({ viewId: id, enabled });
+			setAnnotationModeState(enabled);
+		},
+		[hasNativeBrowser],
+	);
+
+	useEffect(() => {
+		const handleDone = (payload: BrowserAnnotationSubmitPayload | BrowserAnnotationCancelPayload) => {
+			if (payload.viewId !== viewIdRef.current) return;
+			setAnnotationModeState(false);
+		};
+		const offSubmit = window.ao?.browser.onAnnotationSubmit(handleDone);
+		const offCancel = window.ao?.browser.onAnnotationCancel(handleDone);
+		return () => {
+			offSubmit?.();
+			offCancel?.();
+		};
+	}, []);
+
+	useEffect(() => {
+		if (navState.url || !annotationModeRef.current) return;
+		void setAnnotationMode(false);
+	}, [navState.url, setAnnotationMode]);
 
 	const navigate = useCallback(
 		(url: string) => {
@@ -297,6 +341,10 @@ export function useBrowserView({
 	const destroy = useCallback(() => {
 		const id = viewIdRef.current;
 		if (!id) return;
+		if (annotationModeRef.current) {
+			void window.ao?.browser.setAnnotationMode({ viewId: id, enabled: false });
+			setAnnotationModeState(false);
+		}
 		sendHiddenBounds(id);
 		window.ao?.browser.destroy(id);
 		viewIdRef.current = "";
@@ -312,5 +360,7 @@ export function useBrowserView({
 		reload: () => (hasNativeBrowser ? withView((id) => window.ao!.browser.reload(id)) : Promise.resolve()),
 		stop: () => (hasNativeBrowser ? withView((id) => window.ao!.browser.stop(id)) : Promise.resolve()),
 		destroy,
+		annotationMode,
+		setAnnotationMode,
 	};
 }

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -87,7 +87,10 @@ export const aoBridge: AoBridge =
 				isLoading: false,
 			}),
 			destroy: () => undefined,
+			setAnnotationMode: async () => undefined,
 			onNavState: () => () => undefined,
+			onAnnotationSubmit: () => () => undefined,
+			onAnnotationCancel: () => () => undefined,
 		},
 		notifications: {
 			show: async () => undefined,

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1528,6 +1528,27 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	flex: 1;
 }
 
+.browser-panel__annotate-btn[aria-pressed="true"] {
+	background: var(--accent-weak);
+	color: var(--fg);
+}
+
+.browser-panel__annotation-status {
+	max-width: 96px;
+	overflow: hidden;
+	color: var(--fg-muted);
+	font-size: 11px;
+	font-weight: 650;
+	line-height: 1;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.browser-panel__annotation-status--error {
+	max-width: 160px;
+	color: var(--red);
+}
+
 .browser-panel__url-icon {
 	position: absolute;
 	left: 9px;

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -132,7 +132,10 @@ if (typeof window !== "undefined") {
 				isLoading: false,
 			}),
 			destroy: () => undefined,
+			setAnnotationMode: async () => undefined,
 			onNavState: () => () => undefined,
+			onAnnotationSubmit: () => () => undefined,
+			onAnnotationCancel: () => () => undefined,
 		},
 		notifications: {
 			show: async () => undefined,

--- a/frontend/src/shared/browser-annotations.test.ts
+++ b/frontend/src/shared/browser-annotations.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	MAX_BROWSER_ANNOTATION_MESSAGE_LENGTH,
+	createBrowserAnnotationContext,
+	formatBrowserAnnotationMessage,
+} from "./browser-annotations";
+
+describe("createBrowserAnnotationContext", () => {
+	it("captures bounded DOM context for the selected element", () => {
+		document.body.innerHTML = `
+			<main>
+				<label for="email">Email address</label>
+				<section>
+					<button id="save" class="primary cta" aria-label="Save profile" style="font-size: 18px; font-weight: 700;">
+						Save changes
+					</button>
+					<p>Changes apply to the active customer profile.</p>
+				</section>
+			</main>
+		`;
+		const button = document.querySelector<HTMLButtonElement>("#save")!;
+		button.getBoundingClientRect = vi.fn(() => ({
+			x: 16,
+			y: 24,
+			width: 140,
+			height: 36,
+			top: 24,
+			right: 156,
+			bottom: 60,
+			left: 16,
+			toJSON: () => ({}),
+		}));
+
+		const context = createBrowserAnnotationContext(button);
+
+		expect(context.tag).toBe("button");
+		expect(context.id).toBe("save");
+		expect(context.classes).toEqual(["primary", "cta"]);
+		expect(context.selector).toBe("button#save");
+		expect(context.rect).toEqual({ x: 16, y: 24, width: 140, height: 36 });
+		expect(context.visibleText).toBe("Save changes");
+		expect(context.ariaLabel).toBe("Save profile");
+		expect(context.nearbyText.join(" ")).toContain("Changes apply to the active customer profile.");
+		expect(context.computedStyle.fontSize).toBe("18px");
+		expect(context.computedStyle.fontWeight).toBe("700");
+	});
+
+	it("keeps nearby text local to the selected element instead of capturing the whole page", () => {
+		document.body.innerHTML = `
+			<main>
+				<section id="chart">
+					<h2>Revenue chart</h2>
+					<p>Monthly sales by region.</p>
+				</section>
+				<section>
+					<h2>Alerts</h2>
+					<p>${"Unrelated alert copy. ".repeat(80)}</p>
+				</section>
+			</main>
+		`;
+		const chart = document.querySelector<HTMLElement>("#chart")!;
+
+		const context = createBrowserAnnotationContext(chart);
+
+		expect(context.nearbyText.join(" ")).toContain("Revenue chart");
+		expect(context.nearbyText.join(" ")).not.toContain("Unrelated alert copy");
+	});
+});
+
+describe("formatBrowserAnnotationMessage", () => {
+	it("formats the user instruction and selected element context for the agent", () => {
+		const message = formatBrowserAnnotationMessage({
+			viewId: "42:sess-1",
+			instruction: "Make the save button blue and larger.",
+			context: {
+				url: "http://localhost:5173/settings",
+				title: "Settings",
+				tag: "button",
+				id: "save",
+				classes: ["primary"],
+				selector: "button#save",
+				rect: { x: 16, y: 24, width: 140, height: 36 },
+				visibleText: "Save changes",
+				ariaLabel: "Save profile",
+				nearbyText: ["Profile settings"],
+				computedStyle: {
+					display: "inline-flex",
+					position: "static",
+					color: "rgb(255, 255, 255)",
+					backgroundColor: "rgb(0, 0, 0)",
+					fontSize: "14px",
+					fontWeight: "600",
+					padding: "8px 12px",
+					margin: "0px",
+				},
+			},
+		});
+
+		expect(message).toContain("Make the save button blue and larger.");
+		expect(message).toContain("http://localhost:5173/settings");
+		expect(message).toContain("button#save");
+		expect(message).toContain("Save changes");
+		expect(message).toContain("Do not start, restart, or background a dev server");
+		expect(message).toContain("Do not run watch-mode or long-running commands");
+	});
+
+	it("keeps the message below the daemon send-message limit", () => {
+		const message = formatBrowserAnnotationMessage({
+			viewId: "42:sess-1",
+			instruction: "Change this. ".repeat(800),
+			context: {
+				url: "http://localhost:5173/",
+				title: "Preview",
+				tag: "div",
+				classes: [],
+				selector: "body > div:nth-of-type(1)",
+				rect: { x: 0, y: 0, width: 100, height: 100 },
+				visibleText: "Long visible text ".repeat(500),
+				nearbyText: ["Nearby copy ".repeat(500)],
+				computedStyle: {},
+			},
+		});
+
+		expect(message.length).toBeLessThanOrEqual(MAX_BROWSER_ANNOTATION_MESSAGE_LENGTH);
+		expect(message).toContain("[truncated]");
+	});
+});

--- a/frontend/src/shared/browser-annotations.ts
+++ b/frontend/src/shared/browser-annotations.ts
@@ -1,0 +1,266 @@
+export const MAX_BROWSER_ANNOTATION_MESSAGE_LENGTH = 4096;
+
+const MAX_INSTRUCTION_LENGTH = 1400;
+const MAX_TEXT_FIELD_LENGTH = 700;
+const MAX_NEARBY_TEXT_LENGTH = 500;
+const MAX_SELECTOR_DEPTH = 6;
+
+export type BrowserAnnotationRect = {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+};
+
+export type BrowserAnnotationComputedStyle = Partial<{
+	display: string;
+	position: string;
+	color: string;
+	backgroundColor: string;
+	fontSize: string;
+	fontWeight: string;
+	padding: string;
+	margin: string;
+}>;
+
+export type BrowserAnnotationContext = {
+	url: string;
+	title?: string;
+	tag: string;
+	id?: string;
+	classes: string[];
+	selector: string;
+	rect: BrowserAnnotationRect;
+	visibleText?: string;
+	selectedText?: string;
+	ariaRole?: string;
+	ariaLabel?: string;
+	nearbyText: string[];
+	computedStyle: BrowserAnnotationComputedStyle;
+};
+
+export type BrowserAnnotationModeInput = {
+	viewId: string;
+	enabled: boolean;
+};
+
+export type BrowserAnnotationPageSubmitPayload = {
+	instruction: string;
+	context: BrowserAnnotationContext;
+};
+
+export type BrowserAnnotationSubmitPayload = BrowserAnnotationPageSubmitPayload & {
+	viewId: string;
+};
+
+export type BrowserAnnotationCancelReason = "escape" | "cancel" | "navigation" | "disabled";
+
+export type BrowserAnnotationPageCancelPayload = {
+	reason: BrowserAnnotationCancelReason;
+};
+
+export type BrowserAnnotationCancelPayload = BrowserAnnotationPageCancelPayload & {
+	viewId: string;
+};
+
+export function createBrowserAnnotationContext(element: Element): BrowserAnnotationContext {
+	const doc = element.ownerDocument;
+	const view = doc.defaultView;
+	const rect = element.getBoundingClientRect();
+	const classList = Array.from(element.classList).slice(0, 8);
+	const visibleText = elementText(element, MAX_TEXT_FIELD_LENGTH);
+	const selectedText = compactText(view?.getSelection?.()?.toString() ?? "", MAX_TEXT_FIELD_LENGTH);
+	const style = view?.getComputedStyle ? view.getComputedStyle(element) : null;
+
+	return {
+		url: view?.location.href ?? "",
+		title: doc.title || undefined,
+		tag: element.tagName.toLowerCase(),
+		id: element.id || undefined,
+		classes: classList,
+		selector: selectorFor(element),
+		rect: {
+			x: Math.round(rect.x),
+			y: Math.round(rect.y),
+			width: Math.round(rect.width),
+			height: Math.round(rect.height),
+		},
+		visibleText: visibleText || undefined,
+		selectedText: selectedText || undefined,
+		ariaRole: element.getAttribute("role") || undefined,
+		ariaLabel: ariaName(element) || undefined,
+		nearbyText: nearbyText(element),
+		computedStyle: style
+			? {
+					display: style.display,
+					position: style.position,
+					color: style.color,
+					backgroundColor: style.backgroundColor,
+					fontSize: style.fontSize,
+					fontWeight: style.fontWeight,
+					padding: style.padding,
+					margin: style.margin,
+				}
+			: {},
+	};
+}
+
+export function formatBrowserAnnotationMessage(payload: BrowserAnnotationSubmitPayload): string {
+	const context = payload.context;
+	const lines = [
+		"The user selected an element in the AO browser preview and asked for a change.",
+		"",
+		"Change request:",
+		compactText(payload.instruction, MAX_INSTRUCTION_LENGTH) || "(empty)",
+		"",
+		"Selected element context:",
+		`- URL: ${context.url || "(unknown)"}`,
+		context.title ? `- Title: ${compactText(context.title, 160)}` : null,
+		`- Element: ${elementSummary(context)}`,
+		`- Selector: ${context.selector}`,
+		`- Bounds: x=${context.rect.x}, y=${context.rect.y}, width=${context.rect.width}, height=${context.rect.height}`,
+		context.visibleText ? `- Visible text: ${compactText(context.visibleText, MAX_TEXT_FIELD_LENGTH)}` : null,
+		context.selectedText ? `- Selected text: ${compactText(context.selectedText, MAX_TEXT_FIELD_LENGTH)}` : null,
+		context.ariaRole ? `- ARIA role: ${compactText(context.ariaRole, 120)}` : null,
+		context.ariaLabel ? `- ARIA/name: ${compactText(context.ariaLabel, 180)}` : null,
+		context.nearbyText.length > 0
+			? `- Nearby text: ${compactText(context.nearbyText.join(" | "), MAX_NEARBY_TEXT_LENGTH)}`
+			: null,
+		Object.keys(context.computedStyle).length > 0
+			? `- Computed style: ${compactText(JSON.stringify(context.computedStyle), 700)}`
+			: null,
+		"",
+		"Execution constraints:",
+		"- Make the smallest source change that satisfies the request.",
+		"- Do not start, restart, or background a dev server.",
+		"- Do not run watch-mode or long-running commands.",
+		"- If verification is needed, use a finite command only; otherwise rely on the existing preview watcher or dev-server refresh.",
+	].filter((line): line is string => line !== null);
+
+	return limitMessage(lines.join("\n"), MAX_BROWSER_ANNOTATION_MESSAGE_LENGTH);
+}
+
+function elementSummary(context: BrowserAnnotationContext): string {
+	const id = context.id ? `#${context.id}` : "";
+	const classes = context.classes.length > 0 ? `.${context.classes.join(".")}` : "";
+	return `${context.tag}${id}${classes}`;
+}
+
+function selectorFor(element: Element): string {
+	if (element.id) return `${element.tagName.toLowerCase()}#${cssEscape(element.id)}`;
+	const parts: string[] = [];
+	let current: Element | null = element;
+	while (current && current.nodeType === Node.ELEMENT_NODE && parts.length < MAX_SELECTOR_DEPTH) {
+		const tag = current.tagName.toLowerCase();
+		if (tag === "html") break;
+		let part = tag;
+		const classes = Array.from(current.classList).slice(0, 2);
+		if (classes.length > 0) part += `.${classes.map(cssEscape).join(".")}`;
+		const index = nthOfType(current);
+		if (index > 1 || hasSameTagSibling(current)) part += `:nth-of-type(${index})`;
+		parts.unshift(part);
+		current = current.parentElement;
+	}
+	return parts.join(" > ") || element.tagName.toLowerCase();
+}
+
+function nthOfType(element: Element): number {
+	let index = 1;
+	let sibling = element.previousElementSibling;
+	while (sibling) {
+		if (sibling.tagName === element.tagName) index += 1;
+		sibling = sibling.previousElementSibling;
+	}
+	return index;
+}
+
+function hasSameTagSibling(element: Element): boolean {
+	let sibling = element.previousElementSibling;
+	while (sibling) {
+		if (sibling.tagName === element.tagName) return true;
+		sibling = sibling.previousElementSibling;
+	}
+	sibling = element.nextElementSibling;
+	while (sibling) {
+		if (sibling.tagName === element.tagName) return true;
+		sibling = sibling.nextElementSibling;
+	}
+	return false;
+}
+
+function ariaName(element: Element): string {
+	const label = compactText(element.getAttribute("aria-label") ?? "", 180);
+	if (label) return label;
+	const labelledBy = element.getAttribute("aria-labelledby");
+	if (!labelledBy) return "";
+	const doc = element.ownerDocument;
+	return compactText(
+		labelledBy
+			.split(/\s+/)
+			.map((id) => doc.getElementById(id)?.textContent ?? "")
+			.join(" "),
+		180,
+	);
+}
+
+function nearbyText(element: Element): string[] {
+	const values: string[] = [];
+	const add = (value: string | null | undefined) => {
+		const text = compactText(value ?? "", 180);
+		if (text && !values.includes(text)) values.push(text);
+	};
+
+	if (element.id) {
+		const label = element.ownerDocument.querySelector(`label[for="${cssAttributeEscape(element.id)}"]`);
+		add(label?.textContent);
+	}
+	for (const candidate of Array.from(element.querySelectorAll("label, legend, h1, h2, h3, h4")).slice(0, 4)) {
+		add(candidate.textContent);
+	}
+	const compactTarget = isCompactAnnotationTarget(element);
+	if (compactTarget) {
+		add(element.previousElementSibling?.textContent);
+		add(element.nextElementSibling?.textContent);
+	}
+	const parent = element.parentElement;
+	if (parent && compactTarget) {
+		for (const candidate of Array.from(
+			parent.querySelectorAll(
+				":scope > label, :scope > legend, :scope > h1, :scope > h2, :scope > h3, :scope > h4, :scope > p",
+			),
+		).slice(0, 6)) {
+			if (candidate !== element && !element.contains(candidate)) add(candidate.textContent);
+		}
+	}
+	return values.slice(0, 5);
+}
+
+function isCompactAnnotationTarget(element: Element): boolean {
+	return element.matches("button, a, input, textarea, select, [role]");
+}
+
+function elementText(element: Element, maxLength: number): string {
+	const htmlElement = element as HTMLElement;
+	return compactText(htmlElement.innerText ?? element.textContent ?? "", maxLength);
+}
+
+function compactText(value: string, maxLength: number): string {
+	const compact = value.replace(/\s+/g, " ").trim();
+	if (compact.length <= maxLength) return compact;
+	const suffix = " [truncated]";
+	return `${compact.slice(0, Math.max(0, maxLength - suffix.length)).trimEnd()}${suffix}`;
+}
+
+function limitMessage(message: string, maxLength: number): string {
+	if (message.length <= maxLength) return message;
+	const suffix = "\n[truncated]";
+	return `${message.slice(0, Math.max(0, maxLength - suffix.length)).trimEnd()}${suffix}`;
+}
+
+function cssEscape(value: string): string {
+	return globalThis.CSS?.escape ? globalThis.CSS.escape(value) : value.replace(/[^a-zA-Z0-9_-]/g, "\\$&");
+}
+
+function cssAttributeEscape(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}


### PR DESCRIPTION
  - Adds in-preview browser annotation mode for selecting elements directly inside the AO browser.
  - Opens an inline annotation prompt on selected page elements.
  - Captures selected element context: URL, title, selector, bounds, visible text, nearby text, ARIA data, and computed styles.
  - Formats annotation requests into structured agent prompts with execution constraints.
  - Sends annotation requests to the session agent through the existing session send API.
  - Queues multiple annotation requests so later requests do not interrupt the current agent turn.
  - Waits until the agent reports needs_input before sending queued annotations.
  - Adds Electron IPC/preload plumbing for annotation submit/cancel events.
  - Adds renderer UI state for picking, queued, sending, sent, and error states.
  - Adds focused tests for annotation context formatting, browser host IPC, renderer hook behavior, and queued annotation send behavior.