### PR TITLE
fix: enable Kilo terminal wheel scrolling

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -2,10 +2,18 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession } from "../types/workspace";
-import { TerminalPane, providerScrollsByKeyboard } from "./TerminalPane";
+import { TerminalPane } from "./TerminalPane";
+import type { XtermTerminalProps } from "./XtermTerminal";
+
+const terminalProps = vi.hoisted(() => ({
+	last: undefined as XtermTerminalProps | undefined,
+}));
 
 vi.mock("./XtermTerminal", () => ({
-	XtermTerminal: () => <div data-testid="xterm" />,
+	XtermTerminal: (props: XtermTerminalProps) => {
+		terminalProps.last = props;
+		return <div data-testid="xterm" />;
+	},
 }));
 
 vi.mock("../hooks/useTerminalSession", () => ({
@@ -36,7 +44,17 @@ const orchestrator = {
 	kind: "orchestrator",
 } satisfies WorkspaceSession;
 
+function workerWithProvider(provider: WorkspaceSession["provider"]): WorkspaceSession {
+	return {
+		...worker,
+		id: `sess-${provider}`,
+		terminalHandleId: `term-${provider}`,
+		provider,
+	};
+}
+
 function renderPane(session?: WorkspaceSession) {
+	terminalProps.last = undefined;
 	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	const previousAO = window.ao;
 	window.ao = {} as typeof window.ao;
@@ -95,21 +113,24 @@ describe("TerminalPane empty states", () => {
 	});
 });
 
-describe("providerScrollsByKeyboard", () => {
-	// opencode and its fork kilocode share a TUI that scrolls its own transcript
-	// by keyboard and ignores SGR wheel reports, so both must opt into the
-	// PageUp/PageDown wheel routing (see XtermTerminal's paneScrollsByKeyboard).
-	it("is true for keyboard-scroll TUIs (opencode and its kilocode fork)", () => {
-		expect(providerScrollsByKeyboard("opencode")).toBe(true);
-		expect(providerScrollsByKeyboard("kilocode")).toBe(true);
+describe("TerminalPane keyboard-scroll providers", () => {
+	it("passes keyboard wheel scrolling through to Kilo Code terminals", () => {
+		const view = renderPane(workerWithProvider("kilocode"));
+		try {
+			expect(screen.getByTestId("xterm")).toBeInTheDocument();
+			expect(terminalProps.last?.paneScrollsByKeyboard).toBe(true);
+		} finally {
+			view.restore();
+		}
 	});
 
-	it("is false for mouse-report/native-scroll providers", () => {
-		expect(providerScrollsByKeyboard("codex")).toBe(false);
-		expect(providerScrollsByKeyboard("claude-code")).toBe(false);
-	});
-
-	it("is false when the provider is unknown", () => {
-		expect(providerScrollsByKeyboard(undefined)).toBe(false);
+	it("leaves ordinary terminal sessions on SGR wheel reports", () => {
+		const view = renderPane(workerWithProvider("codex"));
+		try {
+			expect(screen.getByTestId("xterm")).toBeInTheDocument();
+			expect(terminalProps.last?.paneScrollsByKeyboard).toBe(false);
+		} finally {
+			view.restore();
+		}
 	});
 });

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -124,11 +124,6 @@ function reviewerPreviewLines(session: WorkspaceSession | undefined): string[] {
 // same way.
 const KEYBOARD_SCROLL_PROVIDERS = new Set(["opencode", "kilocode"]);
 
-// Whether the given provider's TUI is one of the keyboard-scroll agents above.
-export function providerScrollsByKeyboard(provider?: string): boolean {
-	return provider ? KEYBOARD_SCROLL_PROVIDERS.has(provider) : false;
-}
-
 function bannerText(state: TerminalSessionState, error?: string): string | undefined {
 	if (state === "reattaching") return "Terminal disconnected — reattaching…";
 	if (state === "error") return `Terminal error: ${error ?? "connection failed"}`;
@@ -238,7 +233,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 					fontSize={fontSize}
 					onError={handleInitError}
 					onReady={handleReady}
-					paneScrollsByKeyboard={providerScrollsByKeyboard(provider)}
+					paneScrollsByKeyboard={provider ? KEYBOARD_SCROLL_PROVIDERS.has(provider) : false}
 					theme={theme}
 				/>
 				{showEmptyState && (

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -542,7 +542,7 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
 	});
 
-	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode on macOS/Linux)", () => {
+	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (OpenCode/Kilo Code on macOS/Linux)", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" paneScrollsByKeyboard onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Linux (beforeEach) + mouse tracking on: without the paneScrollsByKeyboard


### PR DESCRIPTION
## Summary
- rebase onto upstream main after the terminal scrolling changes landed there
- add focused TerminalPane coverage proving Kilo Code sessions pass paneScrollsByKeyboard=true into XtermTerminal
- update the existing Xterm wheel behavior test wording to name Kilo Code alongside OpenCode

## Validation
- npm run test -- TerminalPane XtermTerminal
- npm run typecheck

Fixes #2550