### PR TITLE
fix: preserve Kilo Code terminal scroll behavior

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -4,8 +4,12 @@ import { describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession } from "../types/workspace";
 import { TerminalPane, providerScrollsByKeyboard } from "./TerminalPane";
 
+const xtermTerminalMock = vi.hoisted(() =>
+	vi.fn((_: { paneScrollsByKeyboard?: boolean }) => <div data-testid="xterm" />),
+);
+
 vi.mock("./XtermTerminal", () => ({
-	XtermTerminal: () => <div data-testid="xterm" />,
+	XtermTerminal: xtermTerminalMock,
 }));
 
 vi.mock("../hooks/useTerminalSession", () => ({
@@ -51,6 +55,10 @@ function renderPane(session?: WorkspaceSession) {
 			window.ao = previousAO;
 		},
 	};
+}
+
+function terminalPaneProps() {
+	return xtermTerminalMock.mock.calls.at(-1)?.[0] as { paneScrollsByKeyboard?: boolean } | undefined;
 }
 
 describe("TerminalPane empty states", () => {
@@ -111,5 +119,27 @@ describe("providerScrollsByKeyboard", () => {
 
 	it("is false when the provider is unknown", () => {
 		expect(providerScrollsByKeyboard(undefined)).toBe(false);
+	});
+});
+
+describe("TerminalPane keyboard-scroll providers", () => {
+	it("enables PageUp/PageDown wheel routing for Kilo Code sessions", () => {
+		const view = renderPane({ ...worker, provider: "kilocode", terminalHandleId: "sess-1/terminal_0" });
+		try {
+			expect(screen.getByTestId("xterm")).toBeInTheDocument();
+			expect(terminalPaneProps()?.paneScrollsByKeyboard).toBe(true);
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("leaves non-keyboard-scroll providers on normal wheel routing", () => {
+		const view = renderPane({ ...worker, provider: "codex", terminalHandleId: "sess-1/terminal_0" });
+		try {
+			expect(screen.getByTestId("xterm")).toBeInTheDocument();
+			expect(terminalPaneProps()?.paneScrollsByKeyboard).toBe(false);
+		} finally {
+			view.restore();
+		}
 	});
 });

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -542,7 +542,7 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[<64;1;1M".repeat(3), "wheel");
 	});
 
-	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode on macOS/Linux)", () => {
+	it("sends PageUp/PageDown for keyboard-scroll panes even under a mux (opencode/kilocode)", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" paneScrollsByKeyboard onReady={(terminal) => terminal.onUserInput(onInput)} />);
 		// Linux (beforeEach) + mouse tracking on: without the paneScrollsByKeyboard
@@ -551,6 +551,9 @@ describe("XtermTerminal", () => {
 
 		expect(state.lastTerminal!.wheelHandler!({ deltaY: -50 } as WheelEvent)).toBe(false);
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
+
+		expect(state.lastTerminal!.wheelHandler!({ deltaY: 20 } as WheelEvent)).toBe(false);
+		expect(onInput).toHaveBeenLastCalledWith("\x1b[6~", "wheel");
 	});
 
 	it("opens terminal links via window.open so Electron routes them to the OS browser", () => {


### PR DESCRIPTION
## Summary

  - Add regression coverage that Kilo Code sessions enable keyboard-based terminal scrolling in the AO UI
  - Verify keyboard-scroll panes translate wheel up/down into PageUp/PageDown
  - Keep normal providers on the existing wheel routing path

  ## Testing

  - `npm --prefix frontend test -- TerminalPane XtermTerminal`
  - `npm --prefix frontend run typecheck`
  - `git diff --check`

  ## Notes

  `npm ci` currently fails because `frontend/package-lock.json` is out of sync (`Missing: encoding@ from lock file`), so local test dependencies
  were installed with `npm --prefix frontend install --package-lock=false` without modifying lockfiles.