### PR TITLE
fix: recover stale orchestrator worktrees during replacement

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/commands.go
+++ b/backend/internal/adapters/workspace/gitworktree/commands.go
@@ -46,6 +46,10 @@ func statusPorcelainArgs(path string) []string {
 	return []string{"-C", path, "status", "--porcelain"}
 }
 
+func isInsideWorktreeArgs(path string) []string {
+	return []string{"-C", path, "rev-parse", "--is-inside-work-tree"}
+}
+
 func worktreeListPorcelainArgs(repo string) []string {
 	return []string{"-C", repo, "worktree", "list", "--porcelain"}
 }

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -142,7 +142,7 @@ func (w *Workspace) Create(ctx context.Context, cfg ports.WorkspaceConfig) (port
 	if nonEmpty, err := pathExistsNonEmpty(path); err != nil {
 		return ports.WorkspaceInfo{}, err
 	} else if nonEmpty {
-		if _, err := moveStrayPathAside(path); err != nil {
+		if err := moveStrayPathAside(path); err != nil {
 			return ports.WorkspaceInfo{}, err
 		}
 	}
@@ -574,7 +574,7 @@ func (w *Workspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (por
 		if cfg.Path == "" {
 			return ports.WorkspaceInfo{}, fmt.Errorf("gitworktree: refusing to restore %q: path exists and is not a registered worktree", path)
 		}
-		if _, err := moveStrayPathAside(path); err != nil {
+		if err := moveStrayPathAside(path); err != nil {
 			return ports.WorkspaceInfo{}, err
 		}
 	}
@@ -1144,7 +1144,7 @@ func pathExistsNonEmpty(path string) (bool, error) {
 	return false, fmt.Errorf("gitworktree: inspect path %q: %w", path, err)
 }
 
-func moveStrayPathAside(path string) (string, error) {
+func moveStrayPathAside(path string) error {
 	for i := 0; i < 100; i++ {
 		candidate := path + ".stray"
 		if i > 0 {
@@ -1153,14 +1153,14 @@ func moveStrayPathAside(path string) (string, error) {
 		if _, err := os.Lstat(candidate); err == nil {
 			continue
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("gitworktree: inspect stray destination %q: %w", candidate, err)
+			return fmt.Errorf("gitworktree: inspect stray destination %q: %w", candidate, err)
 		}
 		if err := os.Rename(path, candidate); err != nil {
-			return "", fmt.Errorf("gitworktree: move stray path %q aside to %q: %w", path, candidate, err)
+			return fmt.Errorf("gitworktree: move stray path %q aside to %q: %w", path, candidate, err)
 		}
-		return candidate, nil
+		return nil
 	}
-	return "", fmt.Errorf("gitworktree: move stray path %q aside: no available destination", path)
+	return fmt.Errorf("gitworktree: move stray path %q aside: no available destination", path)
 }
 
 func moveUnavailablePathAside(path string) error {
@@ -1174,7 +1174,7 @@ func moveUnavailablePathAside(path string) error {
 		}
 		return nil
 	}
-	if _, err := moveStrayPathAside(path); err != nil {
+	if err := moveStrayPathAside(path); err != nil {
 		return fmt.Errorf("%w: %w", ErrWorkspaceUnavailable, err)
 	}
 	return nil

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -42,6 +42,7 @@ var (
 	ErrBranchCheckedOutElsewhere = ports.ErrWorkspaceBranchCheckedOutElsewhere
 	ErrBranchNotFetched          = ports.ErrWorkspaceBranchNotFetched
 	ErrBranchInvalid             = ports.ErrWorkspaceBranchInvalid
+	ErrWorkspaceUnavailable      = ports.ErrWorkspaceUnavailable
 )
 
 // RepoResolver maps a project to the absolute path of its source git repo.
@@ -137,6 +138,13 @@ func (w *Workspace) Create(ctx context.Context, cfg ports.WorkspaceConfig) (port
 		return ports.WorkspaceInfo{}, err
 	} else if ok {
 		return info, nil
+	}
+	if nonEmpty, err := pathExistsNonEmpty(path); err != nil {
+		return ports.WorkspaceInfo{}, err
+	} else if nonEmpty {
+		if _, err := moveStrayPathAside(path); err != nil {
+			return ports.WorkspaceInfo{}, err
+		}
 	}
 	if err := w.addWorktree(ctx, repo, path, cfg.Branch, cfg.BaseBranch); err != nil {
 		return ports.WorkspaceInfo{}, err
@@ -319,6 +327,19 @@ func (w *Workspace) ForceDestroy(ctx context.Context, info ports.WorkspaceInfo) 
 	if err != nil {
 		return err
 	}
+	available, err := w.isUsableWorktreePath(ctx, path)
+	if err != nil {
+		return err
+	}
+	if !available {
+		if err := moveUnavailablePathAside(path); err != nil {
+			return err
+		}
+		if _, err := w.run(ctx, w.binary, worktreePruneArgs(repo)...); err != nil {
+			return fmt.Errorf("gitworktree: worktree prune: %w", err)
+		}
+		return nil
+	}
 	// --force bypasses git's dirty check; errors here are advisory (the path may
 	// already be gone). We proceed to prune regardless.
 	_, _ = w.run(ctx, w.binary, worktreeForceRemoveArgs(repo, path)...)
@@ -350,6 +371,13 @@ func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceIn
 	}
 	if info.SessionID == "" {
 		return "", errors.New("gitworktree: session id is required for StashUncommitted")
+	}
+	available, err := w.isUsableWorktreePath(ctx, info.Path)
+	if err != nil {
+		return "", err
+	}
+	if !available {
+		return "", fmt.Errorf("%w: %q", ErrWorkspaceUnavailable, info.Path)
 	}
 
 	// Early exit for clean worktrees: nothing to preserve.
@@ -816,6 +844,35 @@ func (w *Workspace) isDirty(ctx context.Context, path string) (bool, error) {
 	return strings.TrimSpace(string(out)) != "", nil
 }
 
+func (w *Workspace) isUsableWorktreePath(ctx context.Context, path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("gitworktree: inspect worktree path %q: %w", path, err)
+	}
+	if !info.IsDir() {
+		return false, nil
+	}
+	out, err := w.run(ctx, w.binary, isInsideWorktreeArgs(path)...)
+	if err != nil {
+		if isNotGitWorktreeError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("gitworktree: inspect worktree %q: %w", path, err)
+	}
+	return strings.TrimSpace(string(out)) == "true", nil
+}
+
+func isNotGitWorktreeError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not a git repository") ||
+		strings.Contains(msg, "not a git worktree") ||
+		strings.Contains(msg, "cannot change to") ||
+		strings.Contains(msg, "no such file or directory")
+}
+
 func (w *Workspace) listRecords(ctx context.Context, repo string) ([]worktreeRecord, error) {
 	out, err := w.run(ctx, w.binary, worktreeListPorcelainArgs(repo)...)
 	if err != nil {
@@ -1104,6 +1161,23 @@ func moveStrayPathAside(path string) (string, error) {
 		return candidate, nil
 	}
 	return "", fmt.Errorf("gitworktree: move stray path %q aside: no available destination", path)
+}
+
+func moveUnavailablePathAside(path string) error {
+	nonEmpty, err := pathExistsNonEmpty(path)
+	if err != nil {
+		return err
+	}
+	if !nonEmpty {
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("%w: remove stale path %q: %w", ErrWorkspaceUnavailable, path, err)
+		}
+		return nil
+	}
+	if _, err := moveStrayPathAside(path); err != nil {
+		return fmt.Errorf("%w: %w", ErrWorkspaceUnavailable, err)
+	}
+	return nil
 }
 
 func runCommand(ctx context.Context, binary string, args ...string) ([]byte, error) {

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -35,6 +35,7 @@ func TestCommandArgs(t *testing.T) {
 		{"prune", worktreePruneArgs(repo), []string{"-C", repo, "worktree", "prune"}},
 		{"list", worktreeListPorcelainArgs(repo), []string{"-C", repo, "worktree", "list", "--porcelain"}},
 		{"status", statusPorcelainArgs(path), []string{"-C", path, "status", "--porcelain"}},
+		{"inside worktree", isInsideWorktreeArgs(path), []string{"-C", path, "rev-parse", "--is-inside-work-tree"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -399,6 +400,126 @@ func TestRestoreWithRepoPathMovesStrayPathAside(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(path, "keep.txt")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("original path still has stray file: %v", err)
+	}
+}
+
+func TestCreateMovesUnregisteredNonEmptyPathAside(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "orchestrator", "proj-orchestrator")
+	if err := mkdirFile(path, "agent-config.json"); err != nil {
+		t.Fatalf("seed stale path: %v", err)
+	}
+	var addPath string
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "check-ref-format"):
+			return nil, nil
+		case strings.Contains(joined, "worktree list --porcelain"):
+			return []byte("worktree " + repo + "\nbranch refs/heads/main\n"), nil
+		case strings.Contains(joined, "rev-parse"):
+			return []byte("commit"), nil
+		case strings.Contains(joined, "worktree add"):
+			if len(args) >= 2 {
+				addPath = args[len(args)-2]
+			}
+			return nil, nil
+		default:
+			t.Fatalf("unexpected git invocation: %v", args)
+			return nil, nil
+		}
+	}
+
+	_, err = ws.Create(context.Background(), ports.WorkspaceConfig{
+		ProjectID: "proj",
+		SessionID: "proj-2",
+		Kind:      domain.KindOrchestrator,
+		Branch:    "ao/proj-orchestrator",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if addPath != path {
+		t.Fatalf("worktree add path = %q, want %q", addPath, path)
+	}
+	if _, err := os.Stat(filepath.Join(path+".stray", "agent-config.json")); err != nil {
+		t.Fatalf("stale path was not moved aside: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(path, "agent-config.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("original stale file still present: %v", err)
+	}
+}
+
+func TestStashUncommittedUnavailablePathReturnsTypedError(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "sess")
+	if err := mkdirFile(path, "agent-config.json"); err != nil {
+		t.Fatalf("seed stale path: %v", err)
+	}
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if strings.Contains(strings.Join(args, " "), "rev-parse --is-inside-work-tree") {
+			return nil, errors.New("fatal: not a git repository")
+		}
+		t.Fatalf("unexpected git invocation: %v", args)
+		return nil, nil
+	}
+
+	_, err = ws.StashUncommitted(context.Background(), ports.WorkspaceInfo{Path: path, ProjectID: "proj", SessionID: "sess"})
+	if !errors.Is(err, ports.ErrWorkspaceUnavailable) {
+		t.Fatalf("StashUncommitted err = %v, want ErrWorkspaceUnavailable", err)
+	}
+}
+
+func TestForceDestroyMovesUnavailablePathAside(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "sess")
+	if err := mkdirFile(path, "agent-config.json"); err != nil {
+		t.Fatalf("seed stale path: %v", err)
+	}
+	var removeCalled bool
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "rev-parse --is-inside-work-tree"):
+			return nil, errors.New("fatal: not a git repository")
+		case strings.Contains(joined, "worktree prune"):
+			return nil, nil
+		case strings.Contains(joined, "worktree remove"):
+			removeCalled = true
+			return nil, nil
+		default:
+			t.Fatalf("unexpected git invocation: %v", args)
+			return nil, nil
+		}
+	}
+
+	err = ws.ForceDestroy(context.Background(), ports.WorkspaceInfo{Path: path, ProjectID: "proj", SessionID: "sess"})
+	if err != nil {
+		t.Fatalf("ForceDestroy: %v", err)
+	}
+	if removeCalled {
+		t.Fatal("ForceDestroy must not call git worktree remove for an unavailable non-git path")
+	}
+	if _, err := os.Stat(filepath.Join(path+".stray", "agent-config.json")); err != nil {
+		t.Fatalf("stale path was not moved aside: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(path, "agent-config.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("original stale file still present: %v", err)
 	}
 }
 

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -167,6 +167,11 @@ var (
 	// it holds uncommitted changes or untracked files. Teardown is never
 	// forced; callers treat the workspace as intentionally preserved.
 	ErrWorkspaceDirty = errors.New("workspace: uncommitted changes present")
+	// ErrWorkspaceUnavailable reports a recorded workspace path is missing or is
+	// no longer a usable Git worktree. This is distinct from ErrWorkspaceDirty:
+	// dirty worktrees hold user/agent work and must not be force-deleted, while
+	// unavailable managed paths can be moved aside during recovery.
+	ErrWorkspaceUnavailable = errors.New("workspace: worktree unavailable")
 	// ErrPreservedConflict is returned by ApplyPreserved when replaying a
 	// preserved ref onto the worktree produces merge conflicts. The ref is
 	// kept intact (never deleted on conflict); the working tree is left with

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -571,6 +571,8 @@ func toAPIError(err error) error {
 		return apierr.Invalid("BRANCH_NOT_FETCHED", err.Error(), nil)
 	case errors.Is(err, ports.ErrWorkspaceBranchInvalid):
 		return apierr.Invalid("INVALID_BRANCH", err.Error(), nil)
+	case errors.Is(err, ports.ErrWorkspaceUnavailable):
+		return apierr.Conflict("WORKTREE_UNAVAILABLE", "Stale worktree could not be retired", nil)
 	case errors.Is(err, ports.ErrAgentBinaryNotFound):
 		return apierr.Invalid("AGENT_BINARY_NOT_FOUND", err.Error(), nil)
 	case errors.Is(err, ports.ErrRuntimePrerequisite):

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -579,6 +579,7 @@ func TestToAPIErrorMapsWorkspaceBranchSentinels(t *testing.T) {
 		{"checked out elsewhere", fmt.Errorf("spawn mer-1: workspace: %w: \"x\" is checked out at \"/tmp\"", ports.ErrWorkspaceBranchCheckedOutElsewhere), apierr.KindConflict, "BRANCH_CHECKED_OUT_ELSEWHERE"},
 		{"not fetched", fmt.Errorf("spawn mer-1: workspace: %w: \"x\" has no local head", ports.ErrWorkspaceBranchNotFetched), apierr.KindInvalid, "BRANCH_NOT_FETCHED"},
 		{"invalid branch", fmt.Errorf("spawn mer-1: workspace: %w: \"bad!!\" (exit 1)", ports.ErrWorkspaceBranchInvalid), apierr.KindInvalid, "INVALID_BRANCH"},
+		{"workspace unavailable", fmt.Errorf("retire replacement mer-orch: force destroy: %w", ports.ErrWorkspaceUnavailable), apierr.KindConflict, "WORKTREE_UNAVAILABLE"},
 		{"agent binary not found", fmt.Errorf("spawn mer-1: %w", ports.ErrAgentBinaryNotFound), apierr.KindInvalid, "AGENT_BINARY_NOT_FOUND"},
 		{"runtime prerequisite missing", fmt.Errorf("spawn: %w: tmux required on macOS/Linux but not in PATH", ports.ErrRuntimePrerequisite), apierr.KindInvalid, "RUNTIME_PREREQUISITE_MISSING"},
 		{"unknown harness", fmt.Errorf("spawn: %w: %q", sessionmanager.ErrUnknownHarness, "bogus"), apierr.KindInvalid, "UNKNOWN_HARNESS"},

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -635,7 +635,8 @@ func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID)
 	}
 
 	ws := workspaceInfo(rec)
-	if _, err := m.workspace.StashUncommitted(ctx, ws); err != nil && !errors.Is(err, ports.ErrWorkspaceUnavailable) {
+	if _, err := m.workspace.StashUncommitted(ctx, ws); err != nil &&
+		!errors.Is(err, ports.ErrWorkspaceUnavailable) {
 		return fmt.Errorf("retire replacement %s: stash: %w", id, err)
 	}
 	if err := m.store.DeleteSessionWorktrees(ctx, rec.ID); err != nil {
@@ -658,7 +659,8 @@ func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID)
 
 func (m *Manager) retireWorkspaceProjectForReplacement(ctx context.Context, rec domain.SessionRecord, rows []ports.WorkspaceRepoInfo) error {
 	for _, row := range rows {
-		if _, err := m.workspace.StashUncommitted(ctx, workspaceInfoFromRepoInfo(row)); err != nil && !errors.Is(err, ports.ErrWorkspaceUnavailable) {
+		if _, err := m.workspace.StashUncommitted(ctx, workspaceInfoFromRepoInfo(row)); err != nil &&
+			!errors.Is(err, ports.ErrWorkspaceUnavailable) {
 			return fmt.Errorf("retire replacement %s repo %s: stash: %w", rec.ID, row.RepoName, err)
 		}
 	}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -635,7 +635,7 @@ func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID)
 	}
 
 	ws := workspaceInfo(rec)
-	if _, err := m.workspace.StashUncommitted(ctx, ws); err != nil {
+	if _, err := m.workspace.StashUncommitted(ctx, ws); err != nil && !errors.Is(err, ports.ErrWorkspaceUnavailable) {
 		return fmt.Errorf("retire replacement %s: stash: %w", id, err)
 	}
 	if err := m.store.DeleteSessionWorktrees(ctx, rec.ID); err != nil {
@@ -658,7 +658,7 @@ func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID)
 
 func (m *Manager) retireWorkspaceProjectForReplacement(ctx context.Context, rec domain.SessionRecord, rows []ports.WorkspaceRepoInfo) error {
 	for _, row := range rows {
-		if _, err := m.workspace.StashUncommitted(ctx, workspaceInfoFromRepoInfo(row)); err != nil {
+		if _, err := m.workspace.StashUncommitted(ctx, workspaceInfoFromRepoInfo(row)); err != nil && !errors.Is(err, ports.ErrWorkspaceUnavailable) {
 			return fmt.Errorf("retire replacement %s repo %s: stash: %w", rec.ID, row.RepoName, err)
 		}
 	}

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2207,6 +2207,56 @@ func TestRetireForReplacementCapturesAndReleasesWorkspace(t *testing.T) {
 	}
 }
 
+func TestRetireForReplacementTreatsUnavailableWorktreeAsRecoverable(t *testing.T) {
+	m, st, rt, ws := newLifecycleManager()
+	var sharedLog []string
+	st.sharedLog = &sharedLog
+	ws.sharedLog = &sharedLog
+	ws.stashErr = fmt.Errorf("stale path: %w", ports.ErrWorkspaceUnavailable)
+	st.sessions["mer-orch"] = domain.SessionRecord{
+		ID:        "mer-orch",
+		ProjectID: "mer",
+		Kind:      domain.KindOrchestrator,
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-orch", Branch: "ao/mer-orchestrator", RuntimeHandleID: "orch-handle"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+	st.worktrees["mer-orch"] = []domain.SessionWorktreeRecord{{
+		SessionID:    "mer-orch",
+		RepoName:     domain.RootWorkspaceRepoName,
+		Branch:       "ao/mer-orchestrator",
+		WorktreePath: "/ws/mer-orch",
+		PreservedRef: "refs/ao/preserved/old",
+	}}
+
+	if err := m.RetireForReplacement(ctx, "mer-orch"); err != nil {
+		t.Fatalf("RetireForReplacement err = %v", err)
+	}
+
+	if !st.sessions["mer-orch"].IsTerminated {
+		t.Fatal("stale orchestrator must be marked terminated after replacement retirement")
+	}
+	if rt.destroyed != 1 || rt.destroyedIDs[0] != "orch-handle" {
+		t.Fatalf("runtime destroyed = %d ids=%v, want orch-handle", rt.destroyed, rt.destroyedIDs)
+	}
+	if rows := st.worktrees["mer-orch"]; len(rows) != 0 {
+		t.Fatalf("replacement retirement must clear restore markers for stale worktree, got %#v", rows)
+	}
+	wantOrder := []string{
+		"StashUncommitted:mer-orch",
+		"DeleteSessionWorktrees:mer-orch",
+		"ForceDestroy:mer-orch",
+	}
+	next := 0
+	for _, call := range sharedLog {
+		if next < len(wantOrder) && call == wantOrder[next] {
+			next++
+		}
+	}
+	if next != len(wantOrder) {
+		t.Fatalf("stale replacement retire order missing %v in log %v", wantOrder, sharedLog)
+	}
+}
+
 func TestRetireForReplacementWorkspaceProjectCapturesAndReleasesEveryRepo(t *testing.T) {
 	m, st, rt, ws := newLifecycleManager()
 	var sharedLog []string

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -433,7 +433,7 @@ describe("ProjectSettingsForm", () => {
 		await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
 		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
 		expect(await screen.findByText("Saved.")).toBeInTheDocument();
-		expect(await screen.findByText("Orchestrator restart failed: missing goose binary")).toBeInTheDocument();
+		expect(await screen.findByText("Saved, but orchestrator restart failed: missing goose binary")).toBeInTheDocument();
 		expect(screen.queryByText("Save failed")).not.toBeInTheDocument();
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["project", "proj-1"] });
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: workspaceQueryKey });

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -360,7 +360,7 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 					<span className="text-[12px] text-success">Saved.</span>
 				)}
 				{replacementError && !mutation.isPending && !mutation.isError && (
-					<span className="text-[12px] text-warning">Orchestrator restart failed: {replacementError}</span>
+					<span className="text-[12px] text-warning">Saved, but orchestrator restart failed: {replacementError}</span>
 				)}
 			</div>
 		</form>


### PR DESCRIPTION
## Summary

  Fixes orchestrator replacement when the existing orchestrator session points at a stale or broken managed worktree path.

  Previously, saving project settings could succeed, but the follow-up orchestrator restart could fail with a generic `INTERNAL_ERROR` if the old
  orchestrator row referenced a path that existed on disk but was no longer a valid Git worktree. AO attempted to preserve/stash work before
  freeing the canonical branch, but the stale non-git directory caused retirement to fail.

  This PR makes stale/non-git worktree paths a recoverable replacement case while preserving the existing protection for valid dirty worktrees.

  ## Changes

  - Added a typed backend sentinel: `ErrWorkspaceUnavailable`.
  - Detect recorded workspace paths that are missing or no longer usable Git worktrees.
  - During replacement retirement, treat unavailable worktrees as recoverable instead of failing during stash.
  - Preserve stray non-git directory contents by moving them aside to a `.stray` path.
  - Allow replacement worktree creation to move aside non-empty unregistered canonical paths before running `git worktree add`.
  - Keep valid dirty worktrees protected from forced deletion.
  - Map stale worktree retirement failures to `WORKTREE_UNAVAILABLE` instead of a generic 500.
  - Improve the settings UI partial-success message to:
    - `Saved, but orchestrator restart failed: ...`
  - Added focused tests for:
    - moving aside stale canonical paths before create
    - typed unavailable errors from stash
    - force-destroy recovery for unavailable paths
    - replacement retirement continuing after stale worktree detection
    - API error mapping
    - settings UI restart-failure messaging

  ## Validation

  - `npm --prefix frontend test -- ProjectSettingsForm`
  - `npm --prefix frontend run typecheck`
  - `git diff --check`

  Backend validation was not run locally because this environment does not have `go` or `gofmt` installed.