### PR TITLE
fix: launch Amp workers interactively

### DIFF
--- a/backend/internal/adapters/agent/amp/amp.go
+++ b/backend/internal/adapters/agent/amp/amp.go
@@ -50,12 +50,12 @@ func (p *Plugin) Manifest() adapters.Manifest {
 
 // GetLaunchCommand builds the argv to start a new interactive Amp session:
 //
-//	amp [--permission-mode <mode>] [-- <prompt>]
+//	amp [--permission-mode <mode>]
 //
-// The prompt is passed after `--` so a prompt beginning with "-" is not
-// mistaken for a flag. Amp has no documented system-prompt flag, so
-// SystemPrompt and SystemPromptFile are intentionally ignored until Amp exposes
-// a supported instruction mechanism.
+// Prompted tasks are delivered after startup through the runtime pane so Amp
+// opens its normal TUI instead of an execute/transcript mode. Amp has no
+// documented system-prompt flag, so SystemPrompt and SystemPromptFile are
+// intentionally ignored until Amp exposes a supported instruction mechanism.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -67,10 +67,16 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd = []string{binary}
 	appendPermissionFlags(&cmd, cfg.Permissions)
-	if cfg.Prompt != "" {
-		cmd = append(cmd, "--", cfg.Prompt)
-	}
 	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports that AO should inject prompted Amp tasks
+// into the interactive terminal after startup.
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, _ ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return ports.PromptDeliveryAfterStart, nil
 }
 
 // GetRestoreCommand rebuilds the argv that continues an existing Amp session

--- a/backend/internal/adapters/agent/amp/amp_test.go
+++ b/backend/internal/adapters/agent/amp/amp_test.go
@@ -44,12 +44,12 @@ func TestGetPromptDeliveryStrategy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if s != ports.PromptDeliveryInCommand {
-		t.Fatalf("strategy = %q, want %q", s, ports.PromptDeliveryInCommand)
+	if s != ports.PromptDeliveryAfterStart {
+		t.Fatalf("strategy = %q, want %q", s, ports.PromptDeliveryAfterStart)
 	}
 }
 
-func TestGetLaunchCommandBypassWithPrompt(t *testing.T) {
+func TestGetLaunchCommandBypassIgnoresPromptForInteractiveLaunch(t *testing.T) {
 	p := &Plugin{resolvedBinary: "amp"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		Permissions: ports.PermissionModeBypassPermissions,
@@ -59,7 +59,7 @@ func TestGetLaunchCommandBypassWithPrompt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"amp", "--permission-mode", "bypassPermissions", "--", "-add a health check"}
+	want := []string{"amp", "--permission-mode", "bypassPermissions"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
 	}
@@ -110,7 +110,7 @@ func TestGetLaunchCommandIgnoresInlineSystemPrompt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"amp", "--", "do the thing"}
+	want := []string{"amp"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}


### PR DESCRIPTION
## Summary

  Fixes Amp worker startup so prompted workers open the interactive Amp TUI instead of sending the prompt through the launch command.

  Previously, Amp launches included the worker prompt in argv:

  ```sh
  amp -- "<prompt>"

  Older reports also referenced amp -x "<prompt>". In both cases, passing the prompt during process launch can select Amp's execute/non-
  interactive path instead of the normal terminal UI.

  This PR makes Amp match other TUI-first adapters such as Kimi and Cline: AO starts Amp interactively, then delivers the initial worker prompt
  after startup through the runtime pane.

  ## Changes

      - acceptEdits -> --permission-mode acceptEdits
      - auto -> --permission-mode auto
      - bypassPermissions -> --permission-mode bypassPermissions

  - Add GetPromptDeliveryStrategy for Amp.
  - Return ports.PromptDeliveryAfterStart so AO injects prompted worker tasks after the TUI starts.
  - Keep system prompt behavior unchanged:
      - Amp still does not receive unsupported system-prompt flags.

  - Update Amp adapter tests to verify:
      - prompted launches do not include the prompt in argv
      - Amp uses after-start prompt delivery
      - permission flags still map as before
      - unsupported system-prompt flags remain absent

  ## Validation

  - go test ./internal/adapters/agent/amp
  - git diff --check
