### PR TITLE
fix: omit unsupported amp permission flags

### DIFF
--- a/backend/internal/adapters/agent/amp/amp.go
+++ b/backend/internal/adapters/agent/amp/amp.go
@@ -50,12 +50,12 @@ func (p *Plugin) Manifest() adapters.Manifest {
 
 // GetLaunchCommand builds the argv to start a new interactive Amp session:
 //
-//	amp [--permission-mode <mode>] [-- <prompt>]
+//	amp [-- <prompt>]
 //
 // The prompt is passed after `--` so a prompt beginning with "-" is not
-// mistaken for a flag. Amp has no documented system-prompt flag, so
-// SystemPrompt and SystemPromptFile are intentionally ignored until Amp exposes
-// a supported instruction mechanism.
+// mistaken for a flag. Amp has no documented CLI permission-mode or
+// system-prompt flags, so Permissions, SystemPrompt, and SystemPromptFile are
+// intentionally ignored until Amp exposes supported instruction mechanisms.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -66,7 +66,6 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	}
 
 	cmd = []string{binary}
-	appendPermissionFlags(&cmd, cfg.Permissions)
 	if cfg.Prompt != "" {
 		cmd = append(cmd, "--", cfg.Prompt)
 	}
@@ -89,23 +88,11 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if err != nil {
 		return nil, false, err
 	}
-	// Capacity fits binary + up to two permission flags + --resume + sessionID.
-	cmd = make([]string, 0, 5)
+	// Capacity fits binary + --resume + sessionID.
+	cmd = make([]string, 0, 3)
 	cmd = append(cmd, binary)
-	appendPermissionFlags(&cmd, cfg.Permissions)
 	cmd = append(cmd, "--resume", agentSessionID)
 	return cmd, true, nil
-}
-
-func appendPermissionFlags(cmd *[]string, mode ports.PermissionMode) {
-	switch mode {
-	case ports.PermissionModeAcceptEdits:
-		*cmd = append(*cmd, "--permission-mode", "acceptEdits")
-	case ports.PermissionModeAuto:
-		*cmd = append(*cmd, "--permission-mode", "auto")
-	case ports.PermissionModeBypassPermissions:
-		*cmd = append(*cmd, "--permission-mode", "bypassPermissions")
-	}
 }
 
 var ampBinarySpec = binaryutil.BinarySpec{

--- a/backend/internal/adapters/agent/amp/amp_test.go
+++ b/backend/internal/adapters/agent/amp/amp_test.go
@@ -49,7 +49,7 @@ func TestGetPromptDeliveryStrategy(t *testing.T) {
 	}
 }
 
-func TestGetLaunchCommandBypassWithPrompt(t *testing.T) {
+func TestGetLaunchCommandIgnoresPermissionsWithPrompt(t *testing.T) {
 	p := &Plugin{resolvedBinary: "amp"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
 		Permissions: ports.PermissionModeBypassPermissions,
@@ -59,24 +59,22 @@ func TestGetLaunchCommandBypassWithPrompt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"amp", "--permission-mode", "bypassPermissions", "--", "-add a health check"}
+	want := []string{"amp", "--", "-add a health check"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
 	}
 }
 
-func TestGetLaunchCommandMapsPermissionModes(t *testing.T) {
+func TestGetLaunchCommandIgnoresPermissionModes(t *testing.T) {
 	tests := []struct {
-		name       string
-		mode       ports.PermissionMode
-		want       []string
-		wantAbsent string
+		name string
+		mode ports.PermissionMode
 	}{
-		{"default omits flag", ports.PermissionModeDefault, []string{"amp"}, "--permission-mode"},
-		{"empty omits flag", "", []string{"amp"}, "--permission-mode"},
-		{"accept edits", ports.PermissionModeAcceptEdits, []string{"amp", "--permission-mode", "acceptEdits"}, ""},
-		{"auto", ports.PermissionModeAuto, []string{"amp", "--permission-mode", "auto"}, ""},
-		{"bypass", ports.PermissionModeBypassPermissions, []string{"amp", "--permission-mode", "bypassPermissions"}, ""},
+		{"default", ports.PermissionModeDefault},
+		{"empty", ""},
+		{"accept edits", ports.PermissionModeAcceptEdits},
+		{"auto", ports.PermissionModeAuto},
+		{"bypass", ports.PermissionModeBypassPermissions},
 	}
 
 	for _, tt := range tests {
@@ -86,14 +84,13 @@ func TestGetLaunchCommandMapsPermissionModes(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(cmd, tt.want) {
-				t.Fatalf("cmd = %#v, want %#v", cmd, tt.want)
+			want := []string{"amp"}
+			if !reflect.DeepEqual(cmd, want) {
+				t.Fatalf("cmd = %#v, want %#v", cmd, want)
 			}
-			if tt.wantAbsent != "" {
-				for _, arg := range cmd {
-					if arg == tt.wantAbsent {
-						t.Fatalf("cmd = %#v unexpectedly contains %q", cmd, tt.wantAbsent)
-					}
+			for _, arg := range cmd {
+				if arg == "--permission-mode" {
+					t.Fatalf("cmd = %#v unexpectedly contains unsupported Amp permission flag", cmd)
 				}
 			}
 		})
@@ -159,7 +156,7 @@ func TestGetRestoreCommand(t *testing.T) {
 		t.Fatal("ok=false, want true")
 	}
 
-	want := []string{"amp", "--permission-mode", "bypassPermissions", "--resume", "T-abc123"}
+	want := []string{"amp", "--resume", "T-abc123"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}


### PR DESCRIPTION
## Summary

  Removes Amp’s AO permission-mode CLI mapping because Amp does not document support for `--permission-mode`.

  Previously, AO could launch Amp with commands like:

  ```sh
  amp --permission-mode acceptEdits
  amp --permission-mode auto
  amp --permission-mode bypassPermissions

  Those flags appear to be Claude-style permission flags, not Amp CLI flags. When a project or session config sets a non-default permission mode,
  Amp workers may fail to start before opening the terminal UI.

  ## Changes

  - Stop appending --permission-mode <mode> in Amp launch commands.
  - Stop appending permission flags in Amp restore commands.
  - Keep prompt behavior unchanged for this PR.
  - Keep system prompt behavior unchanged:
      - Amp still does not receive unsupported system-prompt flags.

  - Update Amp adapter tests to verify:
      - restore uses amp --resume <thread-id> without permission flags

  ## Validation

  - go test ./internal/adapters/agent/amp
  - git diff --check

  I also ran:

  go test ./internal/adapters/agent/...

  That broader run passed the Amp package but failed in an unrelated Kilo Code auth timeout test:

  TestAuthStatusUnknownWhenKeyOnlyComesFromInteractiveShell
  context deadline exceeded