### PR TITLE
Guard and audit project config intake disables

### DIFF
--- a/backend/internal/cdc/event.go
+++ b/backend/internal/cdc/event.go
@@ -28,6 +28,7 @@ const (
 	EventPRSessionChanged       EventType = "pr_session_changed"
 	EventPRReviewThreadAdded    EventType = "pr_review_thread_added"
 	EventPRReviewThreadResolved EventType = "pr_review_thread_resolved"
+	EventProjectConfigChanged   EventType = "project_config_changed"
 )
 
 // Event is one CDC change read from change_log. Seq is the monotonic ordering +

--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -111,7 +111,19 @@ type projectConfig struct {
 // setConfigRequest mirrors the daemon's SetConfigInput body for
 // PUT /api/v1/projects/{id}/config.
 type setConfigRequest struct {
-	Config projectConfig `json:"config"`
+	Config    projectConfig `json:"config"`
+	rawConfig json.RawMessage
+}
+
+func (r setConfigRequest) MarshalJSON() ([]byte, error) {
+	if len(r.rawConfig) > 0 {
+		return json.Marshal(struct {
+			Config json.RawMessage `json:"config"`
+		}{Config: r.rawConfig})
+	}
+	return json.Marshal(struct {
+		Config projectConfig `json:"config"`
+	}{Config: r.Config})
 }
 
 type projectSetConfigOptions struct {
@@ -127,6 +139,7 @@ type projectSetConfigOptions struct {
 	trackerIntake     bool
 	trackerRepo       string
 	trackerAssignee   string
+	trackerIntakeSet  bool
 	configJSON        string
 	clear             bool
 	json              bool
@@ -286,11 +299,29 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id := strings.TrimSpace(args[0])
+			opts.trackerIntakeSet = cmd.Flags().Changed("tracker-intake")
+			if opts.configJSON != "" && trackerConfigFlagChanged(cmd) {
+				return usageError{errors.New("usage: tracker intake flags cannot be combined with --config-json; include trackerIntake in the JSON object instead")}
+			}
+			if opts.clear && trackerConfigFlagChanged(cmd) {
+				return usageError{errors.New("usage: tracker intake flags cannot be combined with --clear; clear sends an explicit trackerIntake disable sentinel")}
+			}
 			config, err := buildProjectConfig(opts)
 			if err != nil {
 				return err
 			}
 			req := setConfigRequest{Config: config}
+			if opts.clear {
+				req.rawConfig = json.RawMessage(`{"trackerIntake":{"enabled":false}}`)
+			} else if opts.configJSON != "" {
+				req.rawConfig = json.RawMessage(opts.configJSON)
+			} else if opts.trackerIntakeSet && !opts.trackerIntake {
+				rawConfig, err := configWithExplicitTrackerIntakeEnabled(config, false)
+				if err != nil {
+					return err
+				}
+				req.rawConfig = rawConfig
+			}
 			var res projectResult
 			if err := ctx.putJSON(cmd.Context(), "projects/"+url.PathEscape(id)+"/config", req, &res); err != nil {
 				return err
@@ -318,6 +349,7 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 	f.StringVar(&opts.configJSON, "config-json", "", "Full config as a JSON object (overrides field flags)")
 	f.BoolVar(&opts.clear, "clear", false, "Clear all config")
 	f.BoolVar(&opts.json, "json", false, "Output the updated project as JSON")
+	cmd.MarkFlagsMutuallyExclusive("clear", "config-json")
 	return cmd
 }
 
@@ -361,6 +393,50 @@ func buildProjectConfig(opts projectSetConfigOptions) (projectConfig, error) {
 		return projectConfig{}, usageError{errors.New("usage: provide at least one config flag, --config-json, or --clear")}
 	}
 	return cfg, nil
+}
+
+func trackerConfigFlagChanged(cmd *cobra.Command) bool {
+	for _, name := range []string{
+		"tracker-intake",
+		"tracker-repo",
+		"tracker-assignee",
+	} {
+		if cmd.Flags().Changed(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func configWithExplicitTrackerIntakeEnabled(config projectConfig, enabled bool) (json.RawMessage, error) {
+	data, err := json.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	var tracker map[string]json.RawMessage
+	if trackerRaw, ok := raw["trackerIntake"]; ok {
+		if err := json.Unmarshal(trackerRaw, &tracker); err != nil {
+			return nil, err
+		}
+	}
+	if tracker == nil {
+		tracker = make(map[string]json.RawMessage)
+	}
+	enabledData, err := json.Marshal(enabled)
+	if err != nil {
+		return nil, err
+	}
+	tracker["enabled"] = enabledData
+	trackerData, err := json.Marshal(tracker)
+	if err != nil {
+		return nil, err
+	}
+	raw["trackerIntake"] = trackerData
+	return json.Marshal(raw)
 }
 
 func trackerProviderForFlags(opts projectSetConfigOptions) string {

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -77,6 +77,103 @@ func TestProjectSetConfig_TrackerIntakeJSON(t *testing.T) {
 	}
 }
 
+func TestProjectSetConfig_TrackerIntakeExplicitDisableJSON(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectServer(t, http.StatusOK, `{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--config-json", `{"trackerIntake":{"enabled":false}}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if !strings.Contains(string(capture.body), `"enabled":false`) {
+		t.Fatalf("request body = %s, want raw explicit enabled:false preserved", capture.body)
+	}
+}
+
+func TestProjectSetConfig_ClearSendsExplicitTrackerIntakeDisable(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectServer(t, http.StatusOK, `{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--clear")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if !strings.Contains(string(capture.body), `"trackerIntake":{"enabled":false}`) {
+		t.Fatalf("request body = %s, want explicit tracker intake disable sentinel", capture.body)
+	}
+}
+
+func TestProjectSetConfig_TrackerIntakeFalseFlagIsExplicit(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectServer(t, http.StatusOK, `{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--default-branch", "main", "--tracker-intake=false")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	body := string(capture.body)
+	if !strings.Contains(body, `"defaultBranch":"main"`) || !strings.Contains(body, `"trackerIntake":{"enabled":false}`) {
+		t.Fatalf("request body = %s, want defaultBranch plus explicit tracker intake disable", capture.body)
+	}
+}
+
+func TestProjectSetConfig_TrackerIntakeFalseAloneRequiresAnotherConfigField(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := projectServer(t, http.StatusOK, `{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--tracker-intake=false")
+	if err == nil {
+		t.Fatal("expected usage error for tracker-intake=false without a full replacement field")
+	}
+	if !strings.Contains(err.Error(), "provide at least one config flag") {
+		t.Fatalf("error = %v, want config flag usage guidance", err)
+	}
+}
+
+func TestProjectSetConfig_TrackerFlagsCannotMixWithConfigJSON(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := projectServer(t, http.StatusOK, `{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--config-json", `{"defaultBranch":"main"}`, "--tracker-intake=false")
+	if err == nil {
+		t.Fatal("expected usage error for tracker flags with config-json")
+	}
+	if !strings.Contains(err.Error(), "tracker intake flags cannot be combined with --config-json") {
+		t.Fatalf("error = %v, want config-json tracker flag guidance", err)
+	}
+}
+
+func TestProjectSetConfig_TrackerFlagsCannotMixWithClear(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := projectServer(t, http.StatusOK, `{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--clear", "--tracker-intake")
+	if err == nil {
+		t.Fatal("expected usage error for tracker flags with clear")
+	}
+	if !strings.Contains(err.Error(), "tracker intake flags cannot be combined with --clear") {
+		t.Fatalf("error = %v, want clear tracker flag guidance", err)
+	}
+}
+
 func TestBuildProjectConfigTrackerIntakeFlags(t *testing.T) {
 	got, err := buildProjectConfig(projectSetConfigOptions{
 		trackerIntake:   true,

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -708,6 +708,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
           description: Not Found
+        "413":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Request Entity Too Large
         "500":
           content:
             application/json:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -560,6 +560,7 @@ func projectOperations() []operation {
 				{http.StatusOK, controllers.ProjectResponse{}},
 				{http.StatusBadRequest, envelope.APIError{}},
 				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusRequestEntityTooLarge, envelope.APIError{}},
 				{http.StatusInternalServerError, envelope.APIError{}},
 			},
 		},

--- a/backend/internal/httpd/controllers/projects.go
+++ b/backend/internal/httpd/controllers/projects.go
@@ -5,7 +5,10 @@
 package controllers
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -15,6 +18,8 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
 	projectsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/project"
 )
+
+const maxSetConfigBodyBytes = 1 << 20
 
 // ProjectsController owns the /projects routes. The controller depends only on
 // projectsvc.Manager; nil keeps routes registered but returns OpenAPI-backed 501s.
@@ -88,8 +93,13 @@ func (c *ProjectsController) setConfig(w http.ResponseWriter, r *http.Request) {
 		apispec.NotImplemented(w, r, "PUT", "/api/v1/projects/{id}/config")
 		return
 	}
-	var in projectsvc.SetConfigInput
-	if err := decodeJSONStrict(r, &in); err != nil {
+	in, err := decodeSetConfigInputStrict(w, r)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			envelope.WriteAPIError(w, r, http.StatusRequestEntityTooLarge, "request_entity_too_large", "REQUEST_BODY_TOO_LARGE", "Request body too large", nil)
+			return
+		}
 		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
 		return
 	}
@@ -129,4 +139,31 @@ func decodeJSONStrict(r *http.Request, out any) error {
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 	return dec.Decode(out)
+}
+
+func decodeSetConfigInputStrict(w http.ResponseWriter, r *http.Request) (projectsvc.SetConfigInput, error) {
+	var in projectsvc.SetConfigInput
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxSetConfigBodyBytes))
+	if err != nil {
+		return in, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return in, err
+	}
+	var raw struct {
+		Config *struct {
+			TrackerIntake *struct {
+				Enabled *bool `json:"enabled"`
+			} `json:"trackerIntake"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return in, err
+	}
+	if raw.Config != nil && raw.Config.TrackerIntake != nil && raw.Config.TrackerIntake.Enabled != nil {
+		in.ConfigIncludesTrackerIntakeEnabled = true
+	}
+	return in, nil
 }

--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -346,6 +346,48 @@ func TestProjectsAPI_RejectsUnknownConfigKeys(t *testing.T) {
 	assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_JSON")
 }
 
+func TestProjectsAPI_TrackerIntakeDisableMustBeExplicit(t *testing.T) {
+	srv := newTestServer(t)
+	repo := gitRepo(t, "explicit-disable")
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/projects", `{"path":`+quote(repo)+`,"projectId":"disable"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("seed create = %d, want 201; body=%s", status, body)
+	}
+
+	body, status, _ = doRequest(t, srv, "PUT", "/api/v1/projects/disable/config", `{"config":{"trackerIntake":{"enabled":true,"provider":"github","assignee":"alice"}}}`)
+	if status != http.StatusOK {
+		t.Fatalf("enable intake = %d, want 200; body=%s", status, body)
+	}
+
+	body, status, _ = doRequest(t, srv, "PUT", "/api/v1/projects/disable/config", `{"config":{"defaultBranch":"main"}}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_PROJECT_CONFIG")
+
+	body, status, _ = doRequest(t, srv, "PUT", "/api/v1/projects/disable/config", `{"config":{"trackerIntake":{"enabled":null}}}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_PROJECT_CONFIG")
+
+	body, status, _ = doRequest(t, srv, "PUT", "/api/v1/projects/disable/config", `{"config":{"trackerIntake":{"enabled":false}}}`)
+	if status != http.StatusOK {
+		t.Fatalf("explicit disable = %d, want 200; body=%s", status, body)
+	}
+
+	body, status, _ = doRequest(t, srv, "PUT", "/api/v1/projects/disable/config", `{"config":{"trackerIntake":{"Enabled":false}}}`)
+	if status != http.StatusOK {
+		t.Fatalf("case-insensitive explicit disable = %d, want 200; body=%s", status, body)
+	}
+}
+
+func TestProjectsAPI_SetConfigRejectsOversizedBody(t *testing.T) {
+	srv := newTestServer(t)
+	repo := gitRepo(t, "oversized-config")
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/projects", `{"path":`+quote(repo)+`,"projectId":"oversized"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("seed create = %d, want 201; body=%s", status, body)
+	}
+
+	body, status, _ = doRequest(t, srv, "PUT", "/api/v1/projects/oversized/config", `{"config":{}}`+strings.Repeat(" ", 1<<20))
+	assertErrorCode(t, body, status, http.StatusRequestEntityTooLarge, "REQUEST_BODY_TOO_LARGE")
+}
+
 func TestProjectsRoutes_LegacyUnregistered(t *testing.T) {
 
 	srv := newTestServer(t)

--- a/backend/internal/service/project/dto.go
+++ b/backend/internal/service/project/dto.go
@@ -21,7 +21,8 @@ type AddInput struct {
 // SetConfigInput is the body shape for PUT /api/v1/projects/{id}/config. Config
 // replaces the project's stored config wholesale; a zero-value config clears it.
 type SetConfigInput struct {
-	Config domain.ProjectConfig `json:"config"`
+	Config                             domain.ProjectConfig `json:"config"`
+	ConfigIncludesTrackerIntakeEnabled bool                 `json:"-"`
 }
 
 // RemoveResult reports what DELETE /api/v1/projects/{id} actually did.

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -288,15 +288,18 @@ func (m *Service) SetConfig(ctx context.Context, id domain.ProjectID, in SetConf
 	if err := validateProjectID(id); err != nil {
 		return Project{}, err
 	}
-	if err := in.Config.Validate(); err != nil {
-		return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
-	}
 	row, ok, err := m.store.GetProject(ctx, string(id))
 	if err != nil {
 		return Project{}, apierr.Internal("PROJECT_LOAD_FAILED", "Failed to load project")
 	}
 	if !ok || !row.ArchivedAt.IsZero() {
 		return Project{}, apierr.NotFound("PROJECT_NOT_FOUND", "Unknown project")
+	}
+	if row.Config.TrackerIntake.Enabled && !in.Config.TrackerIntake.Enabled && !in.ConfigIncludesTrackerIntakeEnabled {
+		return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", "trackerIntake.enabled must be explicitly set to false to disable previously-enabled tracker intake", nil)
+	}
+	if err := in.Config.Validate(); err != nil {
+		return Project{}, apierr.Invalid("INVALID_PROJECT_CONFIG", err.Error(), nil)
 	}
 	row.Config = in.Config
 	if err := m.store.UpsertProject(ctx, row); err != nil {

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -436,6 +436,72 @@ func TestManager_SetConfig(t *testing.T) {
 	wantCode(t, err, "PROJECT_NOT_FOUND")
 }
 
+func TestManager_SetConfigRejectsImplicitTrackerIntakeDisable(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	if _, err := m.Add(ctx, project.AddInput{Path: gitRepo(t), ProjectID: ptr("ao")}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	enabled := domain.ProjectConfig{
+		DefaultBranch: "main",
+		TrackerIntake: domain.TrackerIntakeConfig{
+			Enabled:  true,
+			Provider: domain.TrackerProviderGitHub,
+			Repo:     "owner/repo",
+			Assignee: "alice",
+		},
+	}
+	if _, err := m.SetConfig(ctx, "ao", project.SetConfigInput{Config: enabled, ConfigIncludesTrackerIntakeEnabled: true}); err != nil {
+		t.Fatalf("enable tracker intake: %v", err)
+	}
+
+	_, err := m.SetConfig(ctx, "ao", project.SetConfigInput{
+		Config: domain.ProjectConfig{DefaultBranch: "main"},
+	})
+	wantCode(t, err, "INVALID_PROJECT_CONFIG")
+	if !strings.Contains(err.Error(), "trackerIntake") || !strings.Contains(err.Error(), "enabled") {
+		t.Fatalf("implicit disable error = %v, want trackerIntake explicit-disable rule", err)
+	}
+
+	got, err := m.Get(ctx, "ao")
+	if err != nil {
+		t.Fatalf("Get after rejected disable: %v", err)
+	}
+	if got.Project == nil || got.Project.Config == nil || got.Project.Config.TrackerIntake.Assignee != "alice" {
+		t.Fatalf("tracker intake config was not preserved after rejected disable: %#v", got.Project)
+	}
+}
+
+func TestManager_SetConfigAcceptsExplicitTrackerIntakeDisable(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	if _, err := m.Add(ctx, project.AddInput{Path: gitRepo(t), ProjectID: ptr("ao")}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	enabled := domain.ProjectConfig{
+		TrackerIntake: domain.TrackerIntakeConfig{
+			Enabled:  true,
+			Provider: domain.TrackerProviderGitHub,
+			Assignee: "alice",
+		},
+	}
+	if _, err := m.SetConfig(ctx, "ao", project.SetConfigInput{Config: enabled, ConfigIncludesTrackerIntakeEnabled: true}); err != nil {
+		t.Fatalf("enable tracker intake: %v", err)
+	}
+
+	proj, err := m.SetConfig(ctx, "ao", project.SetConfigInput{
+		Config:                             domain.ProjectConfig{TrackerIntake: domain.TrackerIntakeConfig{Enabled: false}},
+		ConfigIncludesTrackerIntakeEnabled: true,
+	})
+	if err != nil {
+		t.Fatalf("explicit disable tracker intake: %v", err)
+	}
+	if proj.Config != nil {
+		t.Fatalf("explicit disable should clear the now-zero config, got %#v", proj.Config)
+	}
+}
+
 func TestManager_ListIncludesOnlySummarySafeProjectConfig(t *testing.T) {
 	ctx := context.Background()
 	m := newManager(t)

--- a/backend/internal/storage/sqlite/migrate_test.go
+++ b/backend/internal/storage/sqlite/migrate_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pressly/goose/v3"
+
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
@@ -64,5 +66,81 @@ func TestMigrateAllowsEveryShippedHarness(t *testing.T) {
 		if !strings.Contains(schema, "'"+string(h)+"'") {
 			t.Errorf("sessions.harness CHECK is missing harness %q — the migration that widens it silently no-opped; schema:\n%s", h, schema)
 		}
+	}
+}
+
+func downTo(t *testing.T, db *sql.DB, version int64) {
+	t.Helper()
+	gooseMu.Lock()
+	defer gooseMu.Unlock()
+	goose.SetBaseFS(migrationsFS)
+	goose.SetLogger(goose.NopLogger())
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		t.Fatalf("set dialect: %v", err)
+	}
+	if err := goose.DownTo(db, "migrations", version); err != nil {
+		t.Fatalf("migrate down to %d: %v", version, err)
+	}
+}
+
+func TestProjectConfigCDCMigrationPreservesChangeLogHighWaterMark(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	upTo(t, db, 30)
+	if _, err := db.Exec(
+		`INSERT INTO projects (id, path, registered_at) VALUES ('p1', '/tmp/p1', '2026-01-01T00:00:00Z')`,
+	); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if _, err := db.Exec(
+			`INSERT INTO change_log (project_id, event_type, payload) VALUES ('p1', 'session_updated', '{}')`,
+		); err != nil {
+			t.Fatalf("seed change_log row %d: %v", i+1, err)
+		}
+	}
+	if _, err := db.Exec(`DELETE FROM change_log WHERE seq IN (4, 5)`); err != nil {
+		t.Fatalf("delete tail rows: %v", err)
+	}
+
+	upTo(t, db, 31)
+	assertSQLiteSequence(t, db, "change_log", 5)
+	assertNextChangeLogSeq(t, db, 6)
+
+	if _, err := db.Exec(`DELETE FROM change_log WHERE seq = 6`); err != nil {
+		t.Fatalf("delete post-upgrade row: %v", err)
+	}
+	downTo(t, db, 30)
+	assertSQLiteSequence(t, db, "change_log", 6)
+	assertNextChangeLogSeq(t, db, 7)
+}
+
+func assertSQLiteSequence(t *testing.T, db *sql.DB, table string, want int64) {
+	t.Helper()
+	var got int64
+	if err := db.QueryRow(`SELECT seq FROM sqlite_sequence WHERE name = ?`, table).Scan(&got); err != nil {
+		t.Fatalf("read sqlite_sequence for %s: %v", table, err)
+	}
+	if got != want {
+		t.Fatalf("sqlite_sequence[%s] = %d, want %d", table, got, want)
+	}
+}
+
+func assertNextChangeLogSeq(t *testing.T, db *sql.DB, want int64) {
+	t.Helper()
+	res, err := db.Exec(`INSERT INTO change_log (project_id, event_type, payload) VALUES ('p1', 'session_updated', '{}')`)
+	if err != nil {
+		t.Fatalf("insert change_log row: %v", err)
+	}
+	got, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	if got != want {
+		t.Fatalf("next change_log seq = %d, want %d", got, want)
 	}
 }

--- a/backend/internal/storage/sqlite/migrations/0031_project_config_cdc.sql
+++ b/backend/internal/storage/sqlite/migrations/0031_project_config_cdc.sql
@@ -1,0 +1,433 @@
+-- +goose Up
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS project_config_cdc_insert;
+DROP TRIGGER IF EXISTS project_config_cdc_update;
+DROP TRIGGER IF EXISTS pr_review_threads_cdc_update;
+DROP TRIGGER IF EXISTS pr_review_threads_cdc_insert;
+DROP TRIGGER IF EXISTS sessions_cdc_insert;
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+DROP TRIGGER IF EXISTS pr_cdc_insert;
+DROP TRIGGER IF EXISTS pr_cdc_update;
+DROP TRIGGER IF EXISTS pr_session_cdc_update;
+DROP TRIGGER IF EXISTS pr_checks_cdc_insert;
+DROP TRIGGER IF EXISTS pr_checks_cdc_update;
+
+CREATE TABLE change_log_new (
+    seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL REFERENCES projects (id),
+    session_id TEXT REFERENCES sessions (id),
+    event_type TEXT NOT NULL
+        CHECK (event_type IN (
+            'session_created',
+            'session_updated',
+            'pr_created',
+            'pr_updated',
+            'pr_check_recorded',
+            'pr_session_changed',
+            'pr_review_thread_added',
+            'pr_review_thread_resolved',
+            'project_config_changed'
+        )),
+    payload    TEXT NOT NULL CHECK (json_valid(payload)),
+    created_at TIMESTAMP NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TEMP TABLE change_log_upgrade_seq (seq INTEGER NOT NULL);
+INSERT INTO change_log_upgrade_seq (seq)
+SELECT CAST(MAX(
+    COALESCE((SELECT seq FROM sqlite_sequence WHERE name = 'change_log'), 0),
+    COALESCE((SELECT MAX(seq) FROM change_log), 0)
+) AS INTEGER);
+
+INSERT INTO change_log_new (seq, project_id, session_id, event_type, payload, created_at)
+SELECT seq, project_id, session_id, event_type, payload, created_at
+FROM change_log;
+
+DROP INDEX IF EXISTS idx_change_log_project;
+DROP TABLE change_log;
+ALTER TABLE change_log_new RENAME TO change_log;
+CREATE INDEX idx_change_log_project ON change_log (project_id, seq);
+DELETE FROM sqlite_sequence WHERE name = 'change_log';
+INSERT INTO sqlite_sequence (name, seq)
+SELECT 'change_log', seq FROM change_log_upgrade_seq;
+DROP TABLE change_log_upgrade_seq;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER project_config_cdc_insert
+AFTER INSERT ON projects
+WHEN NEW.config IS NOT NULL
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.id, NULL, 'project_config_changed',
+        json_object(
+            'id', NEW.id,
+            'before', json('{}'),
+            'after', json_remove(COALESCE(json(NULLIF(NEW.config, '')), json('{}')), '$.env')
+        ),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER project_config_cdc_update
+AFTER UPDATE OF config ON projects
+WHEN OLD.config IS NOT NEW.config
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.id, NULL, 'project_config_changed',
+        json_object(
+            'id', NEW.id,
+            'before', json_remove(COALESCE(json(NULLIF(OLD.config, '')), json('{}')), '$.env'),
+            'after', json_remove(COALESCE(json(NULLIF(NEW.config, '')), json('{}')), '$.env')
+        ),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_review_threads_cdc_insert
+AFTER INSERT ON pr_review_threads
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_review_thread_added',
+        json_object(
+            'pr', NEW.pr_url,
+            'thread', NEW.thread_id,
+            'path', NEW.path,
+            'line', NEW.line,
+            'resolved', json(CASE WHEN NEW.resolved THEN 'true' ELSE 'false' END),
+            'isBot', json(CASE WHEN NEW.is_bot THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_review_threads_cdc_update
+AFTER UPDATE ON pr_review_threads
+WHEN OLD.resolved <> NEW.resolved
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_review_thread_resolved',
+        json_object(
+            'pr', NEW.pr_url,
+            'thread', NEW.thread_id,
+            'path', NEW.path,
+            'line', NEW.line,
+            'resolved', json(CASE WHEN NEW.resolved THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_insert
+AFTER INSERT ON sessions
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_created',
+        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END)),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.harness <> NEW.harness
+    OR OLD.runtime_handle_id <> NEW.runtime_handle_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END), 'previewUrl', NEW.preview_url, 'previewRevision', NEW.preview_revision, 'harness', NEW.harness, 'terminalHandleId', NEW.runtime_handle_id),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_insert
+AFTER INSERT ON pr
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_created',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_session_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.session_id <> NEW.session_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT project_id FROM sessions WHERE id = NEW.session_id),
+        NEW.session_id,
+        'pr_session_changed',
+        json_object(
+            'url', NEW.url,
+            'fromSession', OLD.session_id,
+            'toSession', NEW.session_id),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_checks_cdc_insert
+AFTER INSERT ON pr_checks
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_check_recorded',
+        json_object('pr', NEW.pr_url, 'name', NEW.name, 'commit', NEW.commit_hash, 'status', NEW.status),
+        NEW.created_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_checks_cdc_update
+AFTER UPDATE ON pr_checks
+WHEN OLD.status <> NEW.status
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_check_recorded',
+        json_object('pr', NEW.pr_url, 'name', NEW.name, 'commit', NEW.commit_hash, 'status', NEW.status),
+        datetime('now'));
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS project_config_cdc_insert;
+DROP TRIGGER IF EXISTS project_config_cdc_update;
+DROP TRIGGER IF EXISTS pr_review_threads_cdc_update;
+DROP TRIGGER IF EXISTS pr_review_threads_cdc_insert;
+DROP TRIGGER IF EXISTS sessions_cdc_insert;
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+DROP TRIGGER IF EXISTS pr_cdc_insert;
+DROP TRIGGER IF EXISTS pr_cdc_update;
+DROP TRIGGER IF EXISTS pr_session_cdc_update;
+DROP TRIGGER IF EXISTS pr_checks_cdc_insert;
+DROP TRIGGER IF EXISTS pr_checks_cdc_update;
+
+CREATE TABLE change_log_old (
+    seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL REFERENCES projects (id),
+    session_id TEXT REFERENCES sessions (id),
+    event_type TEXT NOT NULL
+        CHECK (event_type IN (
+            'session_created',
+            'session_updated',
+            'pr_created',
+            'pr_updated',
+            'pr_check_recorded',
+            'pr_session_changed',
+            'pr_review_thread_added',
+            'pr_review_thread_resolved'
+        )),
+    payload    TEXT NOT NULL CHECK (json_valid(payload)),
+    created_at TIMESTAMP NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TEMP TABLE change_log_rollback_seq (seq INTEGER NOT NULL);
+INSERT INTO change_log_rollback_seq (seq)
+SELECT CAST(MAX(
+    COALESCE((SELECT seq FROM sqlite_sequence WHERE name = 'change_log'), 0),
+    COALESCE((SELECT MAX(seq) FROM change_log), 0)
+) AS INTEGER);
+
+INSERT INTO change_log_old (seq, project_id, session_id, event_type, payload, created_at)
+SELECT seq, project_id, session_id, event_type, payload, created_at
+FROM change_log
+WHERE event_type <> 'project_config_changed';
+
+DROP INDEX IF EXISTS idx_change_log_project;
+DROP TABLE change_log;
+ALTER TABLE change_log_old RENAME TO change_log;
+CREATE INDEX idx_change_log_project ON change_log (project_id, seq);
+DELETE FROM sqlite_sequence WHERE name = 'change_log';
+INSERT INTO sqlite_sequence (name, seq)
+SELECT 'change_log', seq FROM change_log_rollback_seq;
+DROP TABLE change_log_rollback_seq;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_review_threads_cdc_insert
+AFTER INSERT ON pr_review_threads
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_review_thread_added',
+        json_object(
+            'pr', NEW.pr_url,
+            'thread', NEW.thread_id,
+            'path', NEW.path,
+            'line', NEW.line,
+            'resolved', json(CASE WHEN NEW.resolved THEN 'true' ELSE 'false' END),
+            'isBot', json(CASE WHEN NEW.is_bot THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_review_threads_cdc_update
+AFTER UPDATE ON pr_review_threads
+WHEN OLD.resolved <> NEW.resolved
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_review_thread_resolved',
+        json_object(
+            'pr', NEW.pr_url,
+            'thread', NEW.thread_id,
+            'path', NEW.path,
+            'line', NEW.line,
+            'resolved', json(CASE WHEN NEW.resolved THEN 'true' ELSE 'false' END)
+        ),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_insert
+AFTER INSERT ON sessions
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_created',
+        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END)),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.harness <> NEW.harness
+    OR OLD.runtime_handle_id <> NEW.runtime_handle_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END), 'previewUrl', NEW.preview_url, 'previewRevision', NEW.preview_revision, 'harness', NEW.harness, 'terminalHandleId', NEW.runtime_handle_id),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_insert
+AFTER INSERT ON pr
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_created',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.pr_state <> NEW.pr_state
+    OR OLD.ci_state <> NEW.ci_state
+    OR OLD.review_decision <> NEW.review_decision
+    OR OLD.mergeability <> NEW.mergeability
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES ((SELECT project_id FROM sessions WHERE id = NEW.session_id), NEW.session_id, 'pr_updated',
+        json_object('url', NEW.url, 'session', NEW.session_id, 'state', NEW.pr_state,
+                    'ci', NEW.ci_state, 'review', NEW.review_decision, 'mergeability', NEW.mergeability),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_session_cdc_update
+AFTER UPDATE ON pr
+WHEN OLD.session_id <> NEW.session_id
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT project_id FROM sessions WHERE id = NEW.session_id),
+        NEW.session_id,
+        'pr_session_changed',
+        json_object(
+            'url', NEW.url,
+            'fromSession', OLD.session_id,
+            'toSession', NEW.session_id),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_checks_cdc_insert
+AFTER INSERT ON pr_checks
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_check_recorded',
+        json_object('pr', NEW.pr_url, 'name', NEW.name, 'commit', NEW.commit_hash, 'status', NEW.status),
+        NEW.created_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_checks_cdc_update
+AFTER UPDATE ON pr_checks
+WHEN OLD.status <> NEW.status
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_check_recorded',
+        json_object('pr', NEW.pr_url, 'name', NEW.name, 'commit', NEW.commit_hash, 'status', NEW.status),
+        datetime('now'));
+END;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -665,6 +665,166 @@ func TestCDCTriggersPopulateChangeLog(t *testing.T) {
 	}
 }
 
+func TestProjectConfigCDCTriggersPopulateChangeLog(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	base, err := s.LatestSeq(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := s.UpsertProject(ctx, domain.ProjectRecord{
+		ID:           "mer",
+		Path:         "/tmp/mer",
+		RegisteredAt: now,
+		Config: domain.ProjectConfig{
+			Env: map[string]string{"GITHUB_TOKEN": "secret"},
+			TrackerIntake: domain.TrackerIntakeConfig{
+				Enabled:  true,
+				Provider: domain.TrackerProviderGitHub,
+				Assignee: "alice",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("update project config: %v", err)
+	}
+
+	evs, err := s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("events = %d, want 1 project config event: %#v", len(evs), evs)
+	}
+	if evs[0].ProjectID != "mer" || evs[0].SessionID != "" || evs[0].Type != "project_config_changed" {
+		t.Fatalf("event = %#v, want project_config_changed for mer without session", evs[0])
+	}
+	var payload struct {
+		ID     string         `json:"id"`
+		Before map[string]any `json:"before"`
+		After  map[string]any `json:"after"`
+	}
+	if err := json.Unmarshal(evs[0].Payload, &payload); err != nil {
+		t.Fatalf("config payload JSON: %v", err)
+	}
+	if payload.ID != "mer" || len(payload.Before) != 0 {
+		t.Fatalf("payload before = %#v, want empty config for mer", payload)
+	}
+	if _, ok := payload.After["trackerIntake"].(map[string]any); !ok {
+		t.Fatalf("payload after missing trackerIntake object: %#v", payload.After)
+	}
+	if _, ok := payload.After["env"]; ok {
+		t.Fatalf("payload after leaked env secrets: %#v", payload.After)
+	}
+
+	base = evs[0].Seq
+	if err := s.UpsertProject(ctx, domain.ProjectRecord{
+		ID:           "mer",
+		Path:         "/tmp/mer",
+		RegisteredAt: now,
+		Config: domain.ProjectConfig{
+			Env: map[string]string{"GITHUB_TOKEN": "secret"},
+			TrackerIntake: domain.TrackerIntakeConfig{
+				Enabled:  true,
+				Provider: domain.TrackerProviderGitHub,
+				Assignee: "alice",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("rewrite same project config: %v", err)
+	}
+	evs, err = s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs) != 0 {
+		t.Fatalf("same-value config rewrite events = %#v, want none", evs)
+	}
+
+	base, err = s.LatestSeq(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpsertProject(ctx, domain.ProjectRecord{
+		ID:           "mer",
+		Path:         "/tmp/mer",
+		RegisteredAt: now,
+		Config: domain.ProjectConfig{
+			Env: map[string]string{"GITHUB_TOKEN": "rotated-secret"},
+			TrackerIntake: domain.TrackerIntakeConfig{
+				Enabled:  true,
+				Provider: domain.TrackerProviderGitHub,
+				Assignee: "bob",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("rewrite changed project config: %v", err)
+	}
+	evs, err = s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs) != 1 || evs[0].Type != "project_config_changed" {
+		t.Fatalf("changed config rewrite events = %#v, want one project_config_changed", evs)
+	}
+	payload = struct {
+		ID     string         `json:"id"`
+		Before map[string]any `json:"before"`
+		After  map[string]any `json:"after"`
+	}{}
+	if err := json.Unmarshal(evs[0].Payload, &payload); err != nil {
+		t.Fatalf("changed config payload JSON: %v", err)
+	}
+	if _, ok := payload.Before["trackerIntake"].(map[string]any); !ok {
+		t.Fatalf("payload before missing trackerIntake object: %#v", payload.Before)
+	}
+	if _, ok := payload.Before["env"]; ok {
+		t.Fatalf("payload before leaked env secrets: %#v", payload.Before)
+	}
+	if _, ok := payload.After["env"]; ok {
+		t.Fatalf("payload after leaked env secrets: %#v", payload.After)
+	}
+
+	base, err = s.LatestSeq(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpsertProject(ctx, domain.ProjectRecord{
+		ID:           "newcfg",
+		Path:         "/tmp/newcfg",
+		RegisteredAt: now,
+		Config: domain.ProjectConfig{
+			DefaultBranch: "develop",
+			Env:           map[string]string{"API_TOKEN": "secret"},
+		},
+	}); err != nil {
+		t.Fatalf("insert project with config: %v", err)
+	}
+	evs, err = s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs) != 1 || evs[0].ProjectID != "newcfg" || evs[0].Type != "project_config_changed" {
+		t.Fatalf("insert config events = %#v, want one project_config_changed for newcfg", evs)
+	}
+	payload = struct {
+		ID     string         `json:"id"`
+		Before map[string]any `json:"before"`
+		After  map[string]any `json:"after"`
+	}{}
+	if err := json.Unmarshal(evs[0].Payload, &payload); err != nil {
+		t.Fatalf("insert config payload JSON: %v", err)
+	}
+	if payload.ID != "newcfg" || len(payload.Before) != 0 || payload.After["defaultBranch"] != "develop" {
+		t.Fatalf("insert config payload = %#v, want redacted before/after config", payload)
+	}
+	if _, ok := payload.After["env"]; ok {
+		t.Fatalf("insert config payload leaked env secrets: %#v", payload.After)
+	}
+}
+
 func TestSetSessionPreviewURLBumpsRevisionAndFiresCDCOnSameURL(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -58,6 +58,16 @@ Every product command resolves to a daemon HTTP route. Run `ao <command>
 | `ao preview [url]`                  | `POST /api/v1/sessions/{id}/preview`           |
 | `ao hooks <agent> <event>`          | `POST /api/v1/sessions/{id}/activity` (hidden) |
 
+`ao project set-config` replaces the full project config; GET the current
+config first, edit it, then send the full replacement. If issue intake is
+enabled, disabling it must be explicit: set `trackerIntake.enabled=false` in
+that full replacement JSON. Omitting
+`trackerIntake` from an enabled project is rejected so stale writers cannot
+silently erase intake caps and filters. A one-field replacement such as
+`{"trackerIntake":{"enabled":false}}` clears every other config key; use it only
+when that is intentional. Use the first-class pause/resume control for
+intentional fleet pauses when available.
+
 `ao agent ls` prints the daemon-supported agent catalog with local install/auth
 readiness. Use `--refresh` to rerun the bounded local probes and `--json` to
 print the raw inventory response.


### PR DESCRIPTION
## Summary
- require explicit trackerIntake.enabled=false when a config replace disables previously-enabled issue intake
- preserve raw CLI JSON/clear disable intent so false is not omitted
- add project_config_changed CDC events for project config writes
- document explicit-disable guidance

Companion for polymath-ventures/agent-orchestrator#150 and polymath-ventures/agent-orchestrator#178.

## Tests
- cd backend && go test ./internal/httpd/controllers ./internal/service/project ./internal/storage/sqlite ./internal/storage/sqlite/store ./internal/cdc ./internal/httpd/apispec ./internal/httpd/apispec/specgen
- cd backend && go test ./internal/cli -run 'TestProject'