### PR TITLE
windows custom titlebar

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -970,6 +970,9 @@ ipcMain.handle("window:setOverlay", (_event, overlay: { color: string; symbolCol
 	}
 });
 
+// Renderer calls this when focus lands on real shell UI (not the titlebar menu), so menu:action's panel fallback below doesn't go stale.
+ipcMain.on("shell:focus", () => browserViewHost?.forgetLastFocusedPanel());
+
 // Backs the custom title-bar menu (WindowTitlebar). Each item maps to the same
 // action the native default menu would have performed.
 ipcMain.handle("menu:action", (_event, action: string) => {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -975,10 +975,11 @@ ipcMain.handle("window:setOverlay", (_event, overlay: { color: string; symbolCol
 ipcMain.handle("menu:action", (_event, action: string) => {
 	const win = mainWindow;
 	if (!win) return;
-	// Edit/reload/zoom/devtools mirror native menu roles: act on whichever
-	// webContents holds focus (e.g. a BrowserView panel), falling back to the
-	// shell window. Window-level actions below stay on the shell window itself.
-	const wc = webContents.getFocusedWebContents() ?? win.webContents;
+	// Clicking this shell-painted menu moves focus off the panel, so prefer the last-focused panel, else the focused contents, else the shell.
+	const focused = webContents.getFocusedWebContents();
+	const wc =
+		(focused && focused !== win.webContents ? focused : browserViewHost?.getLastFocusedPanelContents()) ??
+		win.webContents;
 	switch (action) {
 		case "edit.undo":
 			return wc.undo();

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,6 +4,7 @@ import {
 	clipboard,
 	dialog,
 	ipcMain,
+	Menu,
 	net,
 	nativeImage,
 	Notification as ElectronNotification,
@@ -140,6 +141,11 @@ const isDev = !app.isPackaged;
 const DEV_DAEMON_PORT = 3002;
 const DEV_STATE_SUBDIR = "dev"; // ~/.ao/dev/
 
+// Height (px) of the custom Windows title bar. Must stay in sync with the Window
+// Controls Overlay height passed to BrowserWindow and the .window-titlebar height
+// in styles.css, so the native min/max/close buttons line up with the app's bar.
+const TITLEBAR_HEIGHT = 36;
+
 const RENDERER_SCHEME = "app";
 const RENDERER_HOST = "renderer";
 const RENDERER_ORIGIN = `${RENDERER_SCHEME}://${RENDERER_HOST}`;
@@ -233,12 +239,24 @@ function createWindow(): void {
 		title: "Agent Orchestrator",
 		icon: windowIconPath(),
 		backgroundColor: "#0f1014",
-		titleBarStyle: "hiddenInset",
-		// Lights visually centered at y=28 — the 56px topbar/.titlebar-nav center
-		// line — so lights + nav cluster + header content share one row. macOS
-		// draws the 12pt disc 2pt below the given y (measured: center = y + 8),
-		// hence 20, not 22.
-		trafficLightPosition: { x: 14, y: 20 },
+		// Windows goes frameless with a Window Controls Overlay: Electron still draws
+		// native min/max/close on the right, while the renderer paints its own
+		// VS Code-style title bar (logo + menu) on the left. macOS/Linux keep the
+		// inset traffic-light chrome. Overlay colours are re-synced to the active
+		// theme from the renderer via the window:setOverlay IPC.
+		...(process.platform === "win32"
+			? {
+					titleBarStyle: "hidden" as const,
+					titleBarOverlay: { color: "#0f1014", symbolColor: "#c7ccd4", height: TITLEBAR_HEIGHT },
+				}
+			: {
+					titleBarStyle: "hiddenInset" as const,
+					// Lights visually centered at y=28 — the 56px topbar/.titlebar-nav
+					// center line — so lights + nav cluster + header content share one
+					// row. macOS draws the 12pt disc 2pt below the given y (measured:
+					// center = y + 8), hence 20, not 22.
+					trafficLightPosition: { x: 14, y: 20 },
+				}),
 		webPreferences: {
 			preload: preloadPath(),
 			contextIsolation: true,
@@ -246,6 +264,23 @@ function createWindow(): void {
 			sandbox: true,
 		},
 	});
+
+	// On Windows the app paints its own title bar (WindowTitlebar), so drop
+	// Electron's default application menu — otherwise its File/Edit/View/… strip
+	// renders below the frame. macOS/Linux keep their native menus. Removing the
+	// menu also drops its accelerators, so re-bind DevTools + reload by key.
+	if (process.platform === "win32") {
+		Menu.setApplicationMenu(null);
+		mainWindow.webContents.on("before-input-event", (_event, input) => {
+			if (input.type !== "keyDown") return;
+			const key = input.key.toLowerCase();
+			if (key === "f12" || (input.control && input.shift && key === "i")) {
+				mainWindow?.webContents.toggleDevTools();
+			} else if (isDev && (key === "f5" || (input.control && key === "r"))) {
+				mainWindow?.webContents.reload();
+			}
+		});
+	}
 
 	// Harden navigation: never let renderer/terminal content open in-app windows or
 	// navigate the privileged window away from the app origin. External links go to
@@ -887,6 +922,69 @@ ipcMain.handle("daemon:getStatus", () => refreshDaemonStatus());
 ipcMain.handle("daemon:start", () => startDaemon());
 ipcMain.handle("daemon:stop", () => stopDaemon());
 ipcMain.handle("app:getVersion", () => app.getVersion());
+
+// Re-tint the native window-button overlay (min/max/close) to match the active
+// theme; the renderer calls this on theme change. No-op unless the window was
+// created with a titleBarOverlay (Windows only).
+ipcMain.handle("window:setOverlay", (_event, overlay: { color: string; symbolColor: string }) => {
+	if (process.platform !== "win32" || !mainWindow) return;
+	try {
+		mainWindow.setTitleBarOverlay({ ...overlay, height: TITLEBAR_HEIGHT });
+	} catch {
+		// Window has no overlay on this platform; ignore.
+	}
+});
+
+// Backs the custom title-bar menu (WindowTitlebar). Each item maps to the same
+// action the native default menu would have performed.
+ipcMain.handle("menu:action", (_event, action: string) => {
+	const win = mainWindow;
+	if (!win) return;
+	const wc = win.webContents;
+	switch (action) {
+		case "edit.undo":
+			return wc.undo();
+		case "edit.redo":
+			return wc.redo();
+		case "edit.cut":
+			return wc.cut();
+		case "edit.copy":
+			return wc.copy();
+		case "edit.paste":
+			return wc.paste();
+		case "edit.selectAll":
+			return wc.selectAll();
+		case "view.reload":
+			return wc.reload();
+		case "view.devtools":
+			return wc.toggleDevTools();
+		case "view.zoomIn":
+			return wc.setZoomLevel(wc.getZoomLevel() + 0.5);
+		case "view.zoomOut":
+			return wc.setZoomLevel(wc.getZoomLevel() - 0.5);
+		case "view.zoomReset":
+			return wc.setZoomLevel(0);
+		case "view.fullscreen":
+			return win.setFullScreen(!win.isFullScreen());
+		case "window.minimize":
+			return win.minimize();
+		case "window.maximize":
+			return win.isMaximized() ? win.unmaximize() : win.maximize();
+		case "window.close":
+			return win.close();
+		case "app.quit":
+			return app.quit();
+		case "help.about":
+			void dialog.showMessageBox(win, {
+				type: "info",
+				title: "About Agent Orchestrator",
+				message: "Agent Orchestrator",
+				detail: `Version ${app.getVersion()}`,
+				buttons: ["OK"],
+			});
+			return;
+	}
+});
 ipcMain.handle("telemetry:getBootstrap", () =>
 	buildTelemetryBootstrap(process.env, app.getVersion(), process.platform),
 );

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -11,6 +11,7 @@ import {
 	protocol,
 	shell,
 	WebContentsView,
+	webContents,
 	type OpenDialogOptions,
 } from "electron";
 import {
@@ -228,6 +229,44 @@ function setDaemonStatus(nextStatus: DaemonStatus): void {
 	mainWindow?.webContents.send("daemon:status", daemonStatus);
 }
 
+// Role-based menu installed on Windows where the native menu bar is hidden. The
+// bar stays out of sight, but the roles keep their accelerators alive (Reload,
+// DevTools, zoom, full screen, edit commands) and each acts on the *focused*
+// webContents — including a BrowserView panel — matching native menu behaviour.
+function buildWindowsAppMenu(): Menu {
+	return Menu.buildFromTemplate([
+		{
+			label: "Edit",
+			submenu: [
+				{ role: "undo" },
+				{ role: "redo" },
+				{ type: "separator" },
+				{ role: "cut" },
+				{ role: "copy" },
+				{ role: "paste" },
+				{ role: "selectAll" },
+			],
+		},
+		{
+			label: "View",
+			submenu: [
+				{ role: "reload" },
+				{ role: "toggleDevTools" },
+				{ type: "separator" },
+				{ role: "resetZoom" },
+				{ role: "zoomIn" },
+				{ role: "zoomOut" },
+				{ type: "separator" },
+				{ role: "togglefullscreen" },
+			],
+		},
+		{
+			label: "Window",
+			submenu: [{ role: "minimize" }, { role: "close" }],
+		},
+	]);
+}
+
 function createWindow(): void {
 	browserViewHost?.dispose();
 	browserViewHost = null;
@@ -247,6 +286,9 @@ function createWindow(): void {
 		...(process.platform === "win32"
 			? {
 					titleBarStyle: "hidden" as const,
+					// Hide the native menu bar. A role-based menu is still installed (for
+					// accelerators) below; the visible menu is painted by WindowTitlebar.
+					autoHideMenuBar: true,
 					titleBarOverlay: { color: "#0f1014", symbolColor: "#c7ccd4", height: TITLEBAR_HEIGHT },
 				}
 			: {
@@ -265,21 +307,14 @@ function createWindow(): void {
 		},
 	});
 
-	// On Windows the app paints its own title bar (WindowTitlebar), so drop
-	// Electron's default application menu — otherwise its File/Edit/View/… strip
-	// renders below the frame. macOS/Linux keep their native menus. Removing the
-	// menu also drops its accelerators, so re-bind DevTools + reload by key.
+	// On Windows the app paints its own title bar (WindowTitlebar), so the native
+	// menu bar is hidden (autoHideMenuBar above). The role-based menu is still
+	// installed so its accelerators keep working and act on the focused pane;
+	// setMenuBarVisibility(false) keeps the strip itself out of view. macOS/Linux
+	// keep their native menus.
 	if (process.platform === "win32") {
-		Menu.setApplicationMenu(null);
-		mainWindow.webContents.on("before-input-event", (_event, input) => {
-			if (input.type !== "keyDown") return;
-			const key = input.key.toLowerCase();
-			if (key === "f12" || (input.control && input.shift && key === "i")) {
-				mainWindow?.webContents.toggleDevTools();
-			} else if (isDev && (key === "f5" || (input.control && key === "r"))) {
-				mainWindow?.webContents.reload();
-			}
-		});
+		Menu.setApplicationMenu(buildWindowsAppMenu());
+		mainWindow.setMenuBarVisibility(false);
 	}
 
 	// Harden navigation: never let renderer/terminal content open in-app windows or
@@ -940,7 +975,10 @@ ipcMain.handle("window:setOverlay", (_event, overlay: { color: string; symbolCol
 ipcMain.handle("menu:action", (_event, action: string) => {
 	const win = mainWindow;
 	if (!win) return;
-	const wc = win.webContents;
+	// Edit/reload/zoom/devtools mirror native menu roles: act on whichever
+	// webContents holds focus (e.g. a BrowserView panel), falling back to the
+	// shell window. Window-level actions below stay on the shell window itself.
+	const wc = webContents.getFocusedWebContents() ?? win.webContents;
 	switch (action) {
 		case "edit.undo":
 			return wc.undo();

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -9,10 +9,7 @@ import {
 } from "./browser-view-host";
 
 type InvokeHandler = (event: unknown, ...args: unknown[]) => unknown;
-type EventHandler = (
-	event: { sender: { id: number; getZoomFactor?: () => number } },
-	...args: unknown[]
-) => unknown;
+type EventHandler = (event: { sender: { id: number; getZoomFactor?: () => number } }, ...args: unknown[]) => unknown;
 
 function setupHost() {
 	let currentURL = "";

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -258,6 +258,75 @@ describe("dispose after the window is destroyed", () => {
 	});
 });
 
+describe("getLastFocusedPanelContents", () => {
+	// Mock that captures each panel's "focus" listener so the test can fire it.
+	function setup() {
+		let focusListener: (() => void) | undefined;
+		const webContents = {
+			canGoBack: () => false,
+			canGoForward: () => false,
+			clearHistory: () => undefined,
+			getTitle: () => "",
+			getURL: () => "",
+			goBack: () => undefined,
+			goForward: () => undefined,
+			isLoading: () => false,
+			loadURL: async () => undefined,
+			reload: () => undefined,
+			send: () => undefined,
+			setWindowOpenHandler: () => undefined,
+			stop: () => undefined,
+			close: () => undefined,
+			isDestroyed: () => false,
+			on: (event: string, listener: () => void) => {
+				if (event === "focus") focusListener = listener;
+			},
+		};
+		const view = { webContents, setBounds: () => undefined, setVisible: () => undefined };
+		const handlers = new Map<string, InvokeHandler>();
+		const record = (channel: string, fn: InvokeHandler) => handlers.set(channel, fn);
+		const host = createBrowserViewHost({
+			mainWindow: {
+				contentView: { addChildView: () => undefined, removeChildView: () => undefined },
+				getContentBounds: () => ({ x: 0, y: 0, width: 800, height: 600 }),
+				webContents: { id: 1, send: () => undefined },
+			} as never,
+			ipcMain: { handle: record, on: record, removeHandler: () => undefined, off: () => undefined } as never,
+			shell: { openExternal: async () => undefined },
+			WebContentsView: function () {
+				return view;
+			} as never,
+			annotatePreloadPath: "/preload.js",
+			rendererOrigin: "http://localhost:5173",
+		});
+		const call = (channel: string, ...args: unknown[]) => handlers.get(channel)!({ sender: { id: 1 } }, ...args);
+		return { host, call, webContents, focus: () => focusListener?.() };
+	}
+
+	it("is null until a panel is focused", async () => {
+		const { host, call } = setup();
+		await call("browser:ensure", "s");
+		expect(host.getLastFocusedPanelContents()).toBeNull();
+	});
+
+	it("tracks the focused panel, then clears on hide and destroy", async () => {
+		const { host, call, webContents, focus } = setup();
+		await call("browser:ensure", "s");
+
+		focus();
+		expect(host.getLastFocusedPanelContents()).toBe(webContents);
+
+		call("browser:setBounds", { viewId: "1:s", rect: { x: 0, y: 0, width: 10, height: 10 }, visible: false });
+		expect(host.getLastFocusedPanelContents()).toBeNull();
+
+		focus();
+		expect(host.getLastFocusedPanelContents()).toBe(webContents);
+
+		call("browser:destroy", "1:s");
+		expect(host.getLastFocusedPanelContents()).toBeNull();
+	});
+});
+
 describe("clampBoundsToWindow", () => {
 	it("rounds and clamps bounds to the window content area", () => {
 		expect(

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -299,7 +299,8 @@ describe("getLastFocusedPanelContents", () => {
 			annotatePreloadPath: "/preload.js",
 			rendererOrigin: "http://localhost:5173",
 		});
-		const call = (channel: string, ...args: unknown[]) => handlers.get(channel)!({ sender: { id: 1 } }, ...args);
+		const call = (channel: string, ...args: unknown[]) =>
+			handlers.get(channel)!({ sender: { id: 1, getZoomFactor: () => 1 } }, ...args);
 		return { host, call, webContents, focus: () => focusListener?.() };
 	}
 

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -86,6 +86,8 @@ export type BrowserViewHost = {
 	dispose: () => void;
 	destroy: (viewId: string) => void;
 	destroyAll: () => void;
+	// webContents of the most recently focused browser panel (or null); the titlebar menu targets it for Edit/Reload/Zoom/DevTools.
+	getLastFocusedPanelContents: () => WebContents | null;
 };
 
 type BrowserEntry = {
@@ -157,6 +159,11 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	const entries = new Map<string, BrowserEntry>();
 	const viewIdsByWebContentsId = new Map<number, string>();
 	const ipcDisposers: Array<() => void> = [];
+	// viewId of the panel that most recently held focus; cleared when it is hidden or destroyed.
+	let lastFocusedViewId: string | null = null;
+	const forgetIfFocused = (viewId: string): void => {
+		if (lastFocusedViewId === viewId) lastFocusedViewId = null;
+	};
 
 	const ensure = (viewId: string): BrowserEntry => {
 		const existing = entries.get(viewId);
@@ -180,6 +187,9 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		viewIdsByWebContentsId.set(view.webContents.id, viewId);
 		hardenWebContents(view.webContents, options, entry);
 		wireNavEvents(view.webContents, options, entry);
+		view.webContents.on("focus", () => {
+			lastFocusedViewId = viewId;
+		});
 		return entry;
 	};
 
@@ -189,6 +199,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		if (!visible) {
 			entry.view.setVisible?.(false);
 			entry.view.setBounds(OFFSCREEN_BOUNDS);
+			forgetIfFocused(viewId);
 			return;
 		}
 		// The renderer measures the slot in page-zoomed CSS pixels, while
@@ -219,6 +230,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		cancelAnnotation(options, entry, "navigation");
 		entry.view.setVisible?.(false);
 		entry.view.setBounds(OFFSCREEN_BOUNDS);
+		forgetIfFocused(viewId);
 		await entry.view.webContents.loadURL("about:blank");
 		entry.view.webContents.clearHistory();
 		return pushNavState(options, entry);
@@ -229,6 +241,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		if (!entry) return;
 		entries.delete(viewId);
 		viewIdsByWebContentsId.delete(entry.view.webContents.id);
+		forgetIfFocused(viewId);
 		// When the window is already gone (dispose fired from mainWindow "closed"),
 		// Electron has torn down contentView and the child WebContentsViews. Touching
 		// them throws "Object has been destroyed", so just drop our reference.
@@ -340,6 +353,14 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			for (const viewId of [...entries.keys()]) {
 				destroy(viewId);
 			}
+		},
+		getLastFocusedPanelContents: () => {
+			if (lastFocusedViewId === null) return null;
+			const entry = entries.get(lastFocusedViewId);
+			if (!entry) return null;
+			// Stored narrowed as BrowserWebContents but is a full WebContents at runtime.
+			const contents = entry.view.webContents as unknown as WebContents;
+			return contents.isDestroyed() ? null : contents;
 		},
 	};
 }

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -88,6 +88,8 @@ export type BrowserViewHost = {
 	destroyAll: () => void;
 	// webContents of the most recently focused browser panel (or null); the titlebar menu targets it for Edit/Reload/Zoom/DevTools.
 	getLastFocusedPanelContents: () => WebContents | null;
+	// Drop the remembered panel; call when the shell gains focus for a real reason so a stale panel stops absorbing menu actions.
+	forgetLastFocusedPanel: () => void;
 };
 
 type BrowserEntry = {
@@ -361,6 +363,9 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 			// Stored narrowed as BrowserWebContents but is a full WebContents at runtime.
 			const contents = entry.view.webContents as unknown as WebContents;
 			return contents.isDestroyed() ? null : contents;
+		},
+		forgetLastFocusedPanel: () => {
+			lastFocusedViewId = null;
 		},
 	};
 }

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -46,6 +46,13 @@ const api = {
 		scanImportFolder: (input: { path: string; mode: ImportFolderMode }) =>
 			ipcRenderer.invoke("app:scanImportFolder", input) as Promise<ImportFolderScan>,
 	},
+	window: {
+		setOverlay: (overlay: { color: string; symbolColor: string }) =>
+			ipcRenderer.invoke("window:setOverlay", overlay) as Promise<void>,
+	},
+	menu: {
+		action: (action: string) => ipcRenderer.invoke("menu:action", action) as Promise<void>,
+	},
 	clipboard: {
 		writeText: (text: string) => ipcRenderer.invoke("clipboard:writeText", text) as Promise<void>,
 		readText: () => ipcRenderer.invoke("clipboard:readText") as Promise<string>,

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -52,6 +52,7 @@ const api = {
 	},
 	menu: {
 		action: (action: string) => ipcRenderer.invoke("menu:action", action) as Promise<void>,
+		notifyShellFocus: () => ipcRenderer.send("shell:focus"),
 	},
 	clipboard: {
 		writeText: (text: string) => ipcRenderer.invoke("clipboard:writeText", text) as Promise<void>,

--- a/frontend/src/renderer/components/WindowTitlebar.tsx
+++ b/frontend/src/renderer/components/WindowTitlebar.tsx
@@ -131,7 +131,7 @@ export function WindowTitlebar() {
 					</DropdownMenuItem>
 					<DropdownMenuItem onSelect={act("view.devtools")}>
 						Toggle DevTools
-						<DropdownMenuShortcut>F12</DropdownMenuShortcut>
+						<DropdownMenuShortcut>Ctrl+Shift+I</DropdownMenuShortcut>
 					</DropdownMenuItem>
 					<DropdownMenuSeparator />
 					<DropdownMenuItem onSelect={act("view.zoomIn")}>Zoom In</DropdownMenuItem>

--- a/frontend/src/renderer/components/WindowTitlebar.tsx
+++ b/frontend/src/renderer/components/WindowTitlebar.tsx
@@ -80,6 +80,18 @@ export function WindowTitlebar() {
 		void window.ao?.window?.setOverlay(overlay);
 	}, [theme]);
 
+	// Tell main to forget the last-focused panel whenever real shell UI (not this menu) gets focus, so its fallback target doesn't go stale.
+	useEffect(() => {
+		if (!isWindows) return;
+		const onFocusIn = (event: FocusEvent) => {
+			const target = event.target as HTMLElement | null;
+			if (target?.closest('[class*="window-titlebar"]')) return;
+			void window.ao?.menu?.notifyShellFocus();
+		};
+		document.addEventListener("focusin", onFocusIn);
+		return () => document.removeEventListener("focusin", onFocusIn);
+	}, []);
+
 	if (!isWindows) return null;
 
 	return (

--- a/frontend/src/renderer/components/WindowTitlebar.tsx
+++ b/frontend/src/renderer/components/WindowTitlebar.tsx
@@ -1,0 +1,159 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import aoLogo from "../assets/ao-logo.png";
+import { useUiStore } from "../stores/ui-store";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuShortcut,
+	DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+
+// Windows-only: macOS keeps its system menu bar and inset traffic lights; Linux
+// keeps the existing minimal chrome. Only Windows loses the native title bar and
+// needs the app to paint its own (see the win32 branch in main.ts).
+const isWindows =
+	typeof navigator !== "undefined" &&
+	/win/i.test(
+		(navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform ??
+			navigator.platform ??
+			"",
+	);
+
+type MenuKey = "file" | "edit" | "view" | "window" | "help";
+
+// Dispatch a native-menu action to the main process (see menu:action in main.ts).
+const act = (action: string) => () => {
+	void window.ao?.menu?.action(action);
+};
+
+// One top-level menu (File/Edit/…). Declared at module scope, not inside
+// WindowTitlebar, so React keeps it mounted across renders and the open dropdown
+// doesn't reset while `openMenu` state changes.
+function TopMenu({
+	id,
+	label,
+	openMenu,
+	setOpenMenu,
+	children,
+}: {
+	id: MenuKey;
+	label: string;
+	openMenu: MenuKey | null;
+	setOpenMenu: (key: MenuKey | null) => void;
+	children: React.ReactNode;
+}) {
+	return (
+		// modal={false} so pointer events still reach the sibling triggers while a
+		// menu is open — that's what lets hover switch File → Edit like a real menu bar.
+		<DropdownMenu modal={false} open={openMenu === id} onOpenChange={(open) => setOpenMenu(open ? id : null)}>
+			<DropdownMenuTrigger asChild>
+				<button
+					className="window-titlebar__menu-btn"
+					data-active={openMenu === id ? "" : undefined}
+					onMouseEnter={() => setOpenMenu(openMenu === null ? null : id)}
+					type="button"
+				>
+					{label}
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" className="window-titlebar__menu" sideOffset={4}>
+				{children}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+export function WindowTitlebar() {
+	const navigate = useNavigate();
+	const theme = useUiStore((state) => state.theme);
+	const [openMenu, setOpenMenu] = useState<MenuKey | null>(null);
+
+	// Electron draws the min/max/close overlay natively and can't read our CSS, so
+	// push theme-matched colours to it whenever the theme changes.
+	useEffect(() => {
+		if (!isWindows) return;
+		const overlay =
+			theme === "light" ? { color: "#ffffff", symbolColor: "#3f444c" } : { color: "#0f1014", symbolColor: "#c7ccd4" };
+		void window.ao?.window?.setOverlay(overlay);
+	}, [theme]);
+
+	if (!isWindows) return null;
+
+	return (
+		<header className="window-titlebar">
+			<img alt="" aria-hidden="true" className="window-titlebar__logo" draggable={false} src={aoLogo} />
+			<span className="window-titlebar__title">Agent Orchestrator</span>
+			<nav className="window-titlebar__menus">
+				<TopMenu id="file" label="File" openMenu={openMenu} setOpenMenu={setOpenMenu}>
+					<DropdownMenuItem onSelect={() => void navigate({ to: "/settings" })}>Settings</DropdownMenuItem>
+					<DropdownMenuSeparator />
+					<DropdownMenuItem onSelect={act("app.quit")}>
+						Quit
+						<DropdownMenuShortcut>Alt+F4</DropdownMenuShortcut>
+					</DropdownMenuItem>
+				</TopMenu>
+
+				<TopMenu id="edit" label="Edit" openMenu={openMenu} setOpenMenu={setOpenMenu}>
+					<DropdownMenuItem onSelect={act("edit.undo")}>
+						Undo
+						<DropdownMenuShortcut>Ctrl+Z</DropdownMenuShortcut>
+					</DropdownMenuItem>
+					<DropdownMenuItem onSelect={act("edit.redo")}>
+						Redo
+						<DropdownMenuShortcut>Ctrl+Y</DropdownMenuShortcut>
+					</DropdownMenuItem>
+					<DropdownMenuSeparator />
+					<DropdownMenuItem onSelect={act("edit.cut")}>
+						Cut
+						<DropdownMenuShortcut>Ctrl+X</DropdownMenuShortcut>
+					</DropdownMenuItem>
+					<DropdownMenuItem onSelect={act("edit.copy")}>
+						Copy
+						<DropdownMenuShortcut>Ctrl+C</DropdownMenuShortcut>
+					</DropdownMenuItem>
+					<DropdownMenuItem onSelect={act("edit.paste")}>
+						Paste
+						<DropdownMenuShortcut>Ctrl+V</DropdownMenuShortcut>
+					</DropdownMenuItem>
+					<DropdownMenuItem onSelect={act("edit.selectAll")}>
+						Select All
+						<DropdownMenuShortcut>Ctrl+A</DropdownMenuShortcut>
+					</DropdownMenuItem>
+				</TopMenu>
+
+				<TopMenu id="view" label="View" openMenu={openMenu} setOpenMenu={setOpenMenu}>
+					<DropdownMenuItem onSelect={act("view.reload")}>
+						Reload
+						<DropdownMenuShortcut>Ctrl+R</DropdownMenuShortcut>
+					</DropdownMenuItem>
+					<DropdownMenuItem onSelect={act("view.devtools")}>
+						Toggle DevTools
+						<DropdownMenuShortcut>F12</DropdownMenuShortcut>
+					</DropdownMenuItem>
+					<DropdownMenuSeparator />
+					<DropdownMenuItem onSelect={act("view.zoomIn")}>Zoom In</DropdownMenuItem>
+					<DropdownMenuItem onSelect={act("view.zoomOut")}>Zoom Out</DropdownMenuItem>
+					<DropdownMenuItem onSelect={act("view.zoomReset")}>Reset Zoom</DropdownMenuItem>
+					<DropdownMenuSeparator />
+					<DropdownMenuItem onSelect={act("view.fullscreen")}>
+						Toggle Full Screen
+						<DropdownMenuShortcut>F11</DropdownMenuShortcut>
+					</DropdownMenuItem>
+				</TopMenu>
+
+				<TopMenu id="window" label="Window" openMenu={openMenu} setOpenMenu={setOpenMenu}>
+					<DropdownMenuItem onSelect={act("window.minimize")}>Minimize</DropdownMenuItem>
+					<DropdownMenuItem onSelect={act("window.maximize")}>Maximize / Restore</DropdownMenuItem>
+					<DropdownMenuItem onSelect={act("window.close")}>Close</DropdownMenuItem>
+				</TopMenu>
+
+				<TopMenu id="help" label="Help" openMenu={openMenu} setOpenMenu={setOpenMenu}>
+					<DropdownMenuItem onSelect={act("help.about")}>About Agent Orchestrator</DropdownMenuItem>
+				</TopMenu>
+			</nav>
+		</header>
+	);
+}

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -13,6 +13,7 @@ export const aoBridge: AoBridge =
 		},
 		menu: {
 			action: async () => undefined,
+			notifyShellFocus: () => undefined,
 		},
 		clipboard: {
 			writeText: async (text: string) => {

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -8,6 +8,12 @@ export const aoBridge: AoBridge =
 			chooseDirectory: async () => null,
 			scanImportFolder: async ({ path }) => ({ path, repos: [] }),
 		},
+		window: {
+			setOverlay: async () => undefined,
+		},
+		menu: {
+			action: async () => undefined,
+		},
 		clipboard: {
 			writeText: async (text: string) => {
 				if (navigator.clipboard?.writeText) {

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -7,6 +7,7 @@ import { OrchestratorReplacementDialog } from "../components/OrchestratorReplace
 import { Sidebar } from "../components/Sidebar";
 import { SidebarProvider } from "../components/ui/sidebar";
 import { TitlebarNav } from "../components/TitlebarNav";
+import { WindowTitlebar } from "../components/WindowTitlebar";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
 import { useDaemonStatus } from "../hooks/useDaemonStatus";
 import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
@@ -248,6 +249,9 @@ function ShellLayout() {
           in the layout, not the screens, so the crumb and actions never shift
           when the outlet content swaps. */}
 			<div className="flex h-screen min-h-0 flex-col bg-background text-foreground">
+				{/* Windows-only custom title bar (logo + File/Edit/View/… menu); paints
+            the chrome the frameless window drops. Renders null on macOS/Linux. */}
+				<WindowTitlebar />
 				<ShellTopbar />
 				{/* Controlled by the ui-store so TitlebarNav / Topbar toggles (which
             call the store directly) stay in sync. --sidebar-width chains to

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -647,6 +647,68 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	height: 28px;
 }
 
+/* Windows custom title bar (WindowTitlebar): the app paints the logo + menu on
+ * one row while Electron overlays the native min/max/close buttons on the right.
+ * Height must match TITLEBAR_HEIGHT + the Window Controls Overlay height in
+ * main.ts so the native buttons line up. The whole strip is the window-drag
+ * region; interactive children opt out with -webkit-app-region: no-drag. */
+.window-titlebar {
+	display: flex;
+	height: 36px;
+	flex-shrink: 0;
+	align-items: center;
+	gap: 8px;
+	padding: 0 10px;
+	border-bottom: 1px solid var(--border);
+	background: var(--bg);
+	-webkit-app-region: drag;
+	user-select: none;
+}
+
+.window-titlebar__logo {
+	width: 20px;
+	height: 20px;
+	object-fit: contain;
+}
+
+.window-titlebar__title {
+	margin-right: 6px;
+	font-size: 12.5px;
+	font-weight: 600;
+	letter-spacing: -0.01em;
+	color: var(--fg);
+	white-space: nowrap;
+}
+
+.window-titlebar__menus {
+	display: flex;
+	align-items: center;
+	gap: 1px;
+	-webkit-app-region: no-drag;
+}
+
+.window-titlebar__menu-btn {
+	height: 24px;
+	padding: 0 8px;
+	border-radius: 6px;
+	font-size: 12.5px;
+	line-height: 1;
+	color: var(--fg-muted);
+	transition:
+		background-color 0.12s ease,
+		color 0.12s ease;
+}
+
+.window-titlebar__menu-btn:hover,
+.window-titlebar__menu-btn[data-active] {
+	background: color-mix(in srgb, var(--fg) 8%, transparent);
+	color: var(--fg);
+}
+
+.window-titlebar__menu {
+	min-width: 200px;
+}
+
 /* macOS: the full-width header starts its content past the lights + fixed
  * cluster: cluster right edge 79 + 3×28 + 2×2 = 167px, + the header's 13px
  * group gap = 180px. */

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -65,6 +65,7 @@ if (typeof window !== "undefined") {
 		},
 		menu: {
 			action: async () => undefined,
+			notifyShellFocus: () => undefined,
 		},
 		clipboard: {
 			writeText: async () => undefined,

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -60,6 +60,12 @@ if (typeof window !== "undefined") {
 			chooseDirectory: async () => null,
 			scanImportFolder: async ({ path }: { path: string }) => ({ path, repos: [] }),
 		},
+		window: {
+			setOverlay: async () => undefined,
+		},
+		menu: {
+			action: async () => undefined,
+		},
 		clipboard: {
 			writeText: async () => undefined,
 			readText: async () => "",


### PR DESCRIPTION
## Screenshot

Before:
<img width="275" height="65" alt="image" src="https://github.com/user-attachments/assets/b75a2ee6-ec9b-4c9a-9260-aceb93810a31" />


After:
<img width="551" height="48" alt="image" src="https://github.com/user-attachments/assets/3b7acbf9-6b3e-4988-ae5a-2aaa3ad0399b" />

- **Paint a custom title bar with menu on Windows**
  titleBarStyle "hiddenInset" is macOS-only, so on Windows the window kept
  the native frame plus a File/Edit/View menu row stacked above the app's
  own topbar.
  
  Make the Windows window frameless (titleBarStyle "hidden" + a Window
  Controls Overlay for the native min/max/close buttons) and draw the title
  bar in the renderer: logo, app name, and File/Edit/View/Window/Help menus
  wired to a menu:action IPC. macOS/Linux keep their existing chrome.
  

- **Restore menu accelerators and focus-aware actions on Windows**
  Removing the native menu dropped its keyboard accelerators (F11, zoom,
  reload) and the menu:action handler always targeted the shell window, so
  actions ignored a focused BrowserView panel.
  
  Install a hidden role-based application menu on Windows instead of
  setApplicationMenu(null): the bar stays hidden (autoHideMenuBar +
  setMenuBarVisibility) but the roles keep their accelerators and act on the
  focused webContents. Route the click-path menu:action IPC through the
  focused webContents too, and fix the DevTools shortcut label to Ctrl+Shift+I.
  

- **Target the focused browser panel from the custom titlebar menu**
  The visible titlebar menu is painted in the shell webContents, so clicking
  it moves focus off any browser panel before menu:action runs -
  getFocusedWebContents() then returns the shell and Edit/Reload/Zoom/DevTools
  hit AO instead of the panel. Track the last-focused panel in browser-view-host
  and prefer it when focus is the shell.
  