### PR TITLE
refactor: simplify launch and restore command construction in cursor

### DIFF
--- a/backend/internal/adapters/agent/cursor/cursor.go
+++ b/backend/internal/adapters/agent/cursor/cursor.go
@@ -54,12 +54,18 @@ func (p *Plugin) Manifest() adapters.Manifest {
 
 // GetLaunchCommand builds the argv to start a new Cursor CLI session:
 //
-//	cursor-agent -p --output-format stream-json --trust [permission flags] <prompt>
+//	cursor-agent [permission flags] <prompt>
 //
-// `-p` runs print/non-interactive mode, `--output-format stream-json` emits the
-// machine-readable event stream AO consumes, and `--trust` skips the
-// workspace-trust prompt. The prompt is positional and must come last, so a
-// leading "-" is not read as a flag.
+// This runs cursor-agent in its normal interactive TUI mode (no -p/
+// --output-format, which are cursor-agent's headless/scripting flags and
+// would silence the interactive UI AO's terminal pane is meant to show).
+// `--trust` is deliberately NOT appended here: cursor-agent rejects it outside
+// print/headless mode ("--trust can only be used with --print/headless
+// mode"). Cursor has no interactive-mode equivalent to auto-skip the
+// workspace-trust prompt (open cursor-agent feature request), so a new
+// workspace's first interactive launch will show that prompt in the terminal
+// pane for the user to accept manually. The prompt is positional and must
+// come last, so a leading "-" is not read as a flag.
 //
 // Cursor has no inline/file system-prompt flag: it reads workspace rule files
 // (AGENTS.md, .cursor/rules, CLAUDE.md). SystemPrompt/SystemPromptFile are
@@ -70,7 +76,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 		return nil, err
 	}
 
-	cmd = []string{binary, "-p", "--output-format", "stream-json", "--trust"}
+	cmd = []string{binary}
 	appendApprovalFlags(&cmd, cfg.Permissions)
 
 	// Prompt is positional and must be last. The `--` sentinel ends option
@@ -85,11 +91,13 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 // GetRestoreCommand rebuilds the argv that continues an existing Cursor CLI
 // session:
 //
-//	cursor-agent -p --output-format stream-json --trust [perm flags] --resume <id>
+//	cursor-agent [perm flags] --resume <id>
 //
-// ok is false when the hook-derived native session id has not landed yet, so
-// callers can fall back to fresh launch behavior. ports.RestoreConfig carries no
-// prompt, so none is appended.
+// Like GetLaunchCommand, this runs interactively (no -p/--output-format,
+// no --trust — see GetLaunchCommand for why) so resumed sessions render the
+// normal Cursor Agent TUI. ok is false when the hook-derived native session id
+// has not landed yet, so callers can fall back to fresh launch behavior.
+// ports.RestoreConfig carries no prompt, so none is appended.
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
@@ -104,8 +112,8 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 
-	cmd = make([]string, 0, 10)
-	cmd = append(cmd, binary, "-p", "--output-format", "stream-json", "--trust")
+	cmd = make([]string, 0, 5)
+	cmd = append(cmd, binary)
 	appendApprovalFlags(&cmd, cfg.Permissions)
 	cmd = append(cmd, "--resume", agentSessionID)
 	return cmd, true, nil
@@ -194,6 +202,9 @@ func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
 	case ports.PermissionModeAuto:
 		*cmd = append(*cmd, "--force")
 	case ports.PermissionModeBypassPermissions:
+		// --yolo is cursor-agent's documented alias for --force, not a
+		// stronger bypass: Cursor has no separate "full bypass" tier, so
+		// Auto and BypassPermissions are behaviorally identical here.
 		*cmd = append(*cmd, "--yolo")
 	}
 }

--- a/backend/internal/adapters/agent/cursor/cursor_test.go
+++ b/backend/internal/adapters/agent/cursor/cursor_test.go
@@ -30,7 +30,6 @@ func TestGetLaunchCommandBuildsArgv(t *testing.T) {
 	// leading "-" is not parsed as a flag.
 	want := []string{
 		"cursor-agent",
-		"-p", "--output-format", "stream-json", "--trust",
 		"--yolo",
 		"--", "-fix this",
 	}
@@ -49,7 +48,7 @@ func TestGetLaunchCommandOmitsPromptWhenEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"cursor-agent", "-p", "--output-format", "stream-json", "--trust"}
+	want := []string{"cursor-agent"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
 	}
@@ -153,7 +152,6 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 	}
 	want := []string{
 		"cursor-agent",
-		"-p", "--output-format", "stream-json", "--trust",
 		"--force",
 		"--resume", "chat-123",
 	}


### PR DESCRIPTION
Cherry-pick of 1660651 onto current main.

Removes unnecessary flags from the launch and restore command arguments for the Cursor CLI so the commands run in interactive mode without the print/non-interactive flags, aligning with the intended user experience.

Supersedes #2567.