### PR TITLE
fix: resolve default reviewer harness

### DIFF
--- a/backend/internal/domain/projectconfig.go
+++ b/backend/internal/domain/projectconfig.go
@@ -59,10 +59,15 @@ type ReviewerConfig struct {
 const FallbackReviewerHarness = ReviewerClaudeCode
 
 // ResolveReviewerHarness picks the reviewer harness for a worker. A configured
-// reviewer wins; otherwise claude-code is used.
-func (c ProjectConfig) ResolveReviewerHarness(_ AgentHarness) ReviewerHarness {
+// reviewer wins. Otherwise the worker's own harness is reused when it is itself
+// a supported reviewer (e.g. a codex worker is reviewed by codex); a worker
+// whose harness is not a reviewer (e.g. crush) falls back to claude-code.
+func (c ProjectConfig) ResolveReviewerHarness(worker AgentHarness) ReviewerHarness {
 	if len(c.Reviewers) > 0 {
 		return c.Reviewers[0].Harness
+	}
+	if rh := ReviewerHarness(worker); rh.IsKnown() {
+		return rh
 	}
 	return FallbackReviewerHarness
 }

--- a/backend/internal/domain/projectconfig_test.go
+++ b/backend/internal/domain/projectconfig_test.go
@@ -98,19 +98,23 @@ func TestResolveReviewerHarness(t *testing.T) {
 		t.Fatalf("configured reviewer = %q, want claude-code", got)
 	}
 
-	// No reviewer configured: always use claude-code, regardless of the worker
-	// harness (see #2241).
+	// No reviewer configured: reuse the worker's harness when it is itself a
+	// supported reviewer.
 	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessClaudeCode); got != ReviewerClaudeCode {
-		t.Fatalf("default = %q, want reviewer claude-code", got)
+		t.Fatalf("claude-code worker = %q, want reviewer claude-code", got)
 	}
-	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessCodex); got != ReviewerClaudeCode {
-		t.Fatalf("default = %q, want reviewer claude-code", got)
+	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessCodex); got != ReviewerCodex {
+		t.Fatalf("codex worker = %q, want reviewer codex", got)
 	}
-	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessOpenCode); got != ReviewerClaudeCode {
-		t.Fatalf("default = %q, want reviewer claude-code", got)
+	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessOpenCode); got != ReviewerOpenCode {
+		t.Fatalf("opencode worker = %q, want reviewer opencode", got)
 	}
 
-	// A worker harness that is not claude-code also falls back to claude-code.
+	// A worker harness that is not itself a reviewer (e.g. crush, aider) falls
+	// back to claude-code.
+	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessCrush); got != FallbackReviewerHarness {
+		t.Fatalf("crush worker = %q, want %q", got, FallbackReviewerHarness)
+	}
 	if got := (ProjectConfig{}).ResolveReviewerHarness(HarnessAider); got != FallbackReviewerHarness {
 		t.Fatalf("fallback = %q, want %q", got, FallbackReviewerHarness)
 	}

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -375,7 +375,8 @@ func (e *Engine) List(ctx stdctx.Context, workerID domain.SessionID) (SessionRev
 }
 
 // reviewerHarness resolves which harness reviews the worker's PR: a configured
-// reviewer wins, otherwise claude-code is used, per domain.ResolveReviewerHarness.
+// reviewer wins, otherwise worker's own harness is reused when it is a
+// supported reviewer, otherwise fallback to claude-code.
 func (e *Engine) reviewerHarness(ctx stdctx.Context, worker domain.SessionRecord) (domain.ReviewerHarness, error) {
 	var cfg domain.ProjectConfig
 	if e.projects != nil {


### PR DESCRIPTION
## Summary
- resolve the default reviewer harness to the worker harness when that harness can review
- keep falling back to claude-code for worker harnesses that are not reviewer-capable

## Why
Before a reviewer was explicitly configured, the effective reviewer could surface as a vague project default. This gives the default path a concrete reviewer value.

Closes #2570

## Tests
- `go test ./internal/domain ./internal/review`