### PR TITLE
fix: omit unsupported Amp permission flags

### DIFF
--- a/backend/internal/adapters/agent/amp/amp.go
+++ b/backend/internal/adapters/agent/amp/amp.go
@@ -57,8 +57,9 @@ func (p *Plugin) Manifest() adapters.Manifest {
 // Amp opens its normal interactive TUI instead of an execute-mode transcript.
 // Amp has no documented --permission-mode flag: it runs tools without approval
 // by default and configures permissions via settings and the Plugin API, not
-// CLI flags. So cfg.Permissions is intentionally not translated to argv (a
-// non-default mode would otherwise emit a flag Amp rejects at startup).
+// CLI flags. So cfg.Permissions is intentionally not translated to argv because
+// Amp does not document that flag, and relying on hidden or permissively parsed
+// options would make launches version-fragile.
 // SystemPrompt and SystemPromptFile are likewise ignored until Amp exposes a
 // supported instruction mechanism.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {

--- a/backend/internal/adapters/agent/amp/amp.go
+++ b/backend/internal/adapters/agent/amp/amp.go
@@ -50,12 +50,15 @@ func (p *Plugin) Manifest() adapters.Manifest {
 
 // GetLaunchCommand builds the argv to start a new interactive Amp session:
 //
-//	amp [--permission-mode <mode>] [-- <prompt>]
+//	amp [-- <prompt>]
 //
 // The prompt is passed after `--` so a prompt beginning with "-" is not
-// mistaken for a flag. Amp has no documented system-prompt flag, so
-// SystemPrompt and SystemPromptFile are intentionally ignored until Amp exposes
-// a supported instruction mechanism.
+// mistaken for a flag. Amp has no documented --permission-mode flag: it runs
+// tools without approval by default and configures permissions via settings and
+// the Plugin API, not CLI flags. So cfg.Permissions is intentionally not
+// translated to argv (a non-default mode would otherwise emit a flag Amp
+// rejects at startup). SystemPrompt and SystemPromptFile are likewise ignored
+// until Amp exposes a supported instruction mechanism.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -66,7 +69,6 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	}
 
 	cmd = []string{binary}
-	appendPermissionFlags(&cmd, cfg.Permissions)
 	if cfg.Prompt != "" {
 		cmd = append(cmd, "--", cfg.Prompt)
 	}
@@ -89,23 +91,10 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if err != nil {
 		return nil, false, err
 	}
-	// Capacity fits binary + up to two permission flags + --resume + sessionID.
-	cmd = make([]string, 0, 5)
-	cmd = append(cmd, binary)
-	appendPermissionFlags(&cmd, cfg.Permissions)
-	cmd = append(cmd, "--resume", agentSessionID)
+	// Capacity fits binary + --resume + sessionID.
+	cmd = make([]string, 0, 3)
+	cmd = append(cmd, binary, "--resume", agentSessionID)
 	return cmd, true, nil
-}
-
-func appendPermissionFlags(cmd *[]string, mode ports.PermissionMode) {
-	switch mode {
-	case ports.PermissionModeAcceptEdits:
-		*cmd = append(*cmd, "--permission-mode", "acceptEdits")
-	case ports.PermissionModeAuto:
-		*cmd = append(*cmd, "--permission-mode", "auto")
-	case ports.PermissionModeBypassPermissions:
-		*cmd = append(*cmd, "--permission-mode", "bypassPermissions")
-	}
 }
 
 var ampBinarySpec = binaryutil.BinarySpec{

--- a/backend/internal/adapters/agent/amp/amp_test.go
+++ b/backend/internal/adapters/agent/amp/amp_test.go
@@ -49,53 +49,42 @@ func TestGetPromptDeliveryStrategy(t *testing.T) {
 	}
 }
 
-func TestGetLaunchCommandBypassWithPrompt(t *testing.T) {
+func TestGetLaunchCommandPromptAfterSeparator(t *testing.T) {
 	p := &Plugin{resolvedBinary: "amp"}
 	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
-		Permissions: ports.PermissionModeBypassPermissions,
-		Prompt:      "-add a health check",
+		Prompt: "-add a health check",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	want := []string{"amp", "--permission-mode", "bypassPermissions", "--", "-add a health check"}
+	want := []string{"amp", "--", "-add a health check"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
 	}
 }
 
-func TestGetLaunchCommandMapsPermissionModes(t *testing.T) {
-	tests := []struct {
-		name       string
-		mode       ports.PermissionMode
-		want       []string
-		wantAbsent string
-	}{
-		{"default omits flag", ports.PermissionModeDefault, []string{"amp"}, "--permission-mode"},
-		{"empty omits flag", "", []string{"amp"}, "--permission-mode"},
-		{"accept edits", ports.PermissionModeAcceptEdits, []string{"amp", "--permission-mode", "acceptEdits"}, ""},
-		{"auto", ports.PermissionModeAuto, []string{"amp", "--permission-mode", "auto"}, ""},
-		{"bypass", ports.PermissionModeBypassPermissions, []string{"amp", "--permission-mode", "bypassPermissions"}, ""},
+func TestGetLaunchCommandPermissionModesEmitNoFlag(t *testing.T) {
+	modes := []ports.PermissionMode{
+		ports.PermissionModeDefault,
+		"",
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions,
 	}
+	want := []string{"amp"}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, mode := range modes {
+		t.Run(string(mode), func(t *testing.T) {
 			p := &Plugin{resolvedBinary: "amp"}
-			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{Permissions: tt.mode})
+			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{Permissions: mode})
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(cmd, tt.want) {
-				t.Fatalf("cmd = %#v, want %#v", cmd, tt.want)
+			if !reflect.DeepEqual(cmd, want) {
+				t.Fatalf("cmd = %#v, want %#v", cmd, want)
 			}
-			if tt.wantAbsent != "" {
-				for _, arg := range cmd {
-					if arg == tt.wantAbsent {
-						t.Fatalf("cmd = %#v unexpectedly contains %q", cmd, tt.wantAbsent)
-					}
-				}
-			}
+			assertAmpPermissionFlagsAbsent(t, cmd)
 		})
 	}
 }
@@ -134,6 +123,15 @@ func TestGetLaunchCommandIgnoresSystemPromptFile(t *testing.T) {
 	assertAmpSystemPromptFlagsAbsent(t, cmd)
 }
 
+func assertAmpPermissionFlagsAbsent(t *testing.T, cmd []string) {
+	t.Helper()
+	for _, arg := range cmd {
+		if arg == "--permission-mode" {
+			t.Fatalf("cmd = %#v unexpectedly contains unsupported Amp permission flag", cmd)
+		}
+	}
+}
+
 func assertAmpSystemPromptFlagsAbsent(t *testing.T, cmd []string) {
 	t.Helper()
 	for _, arg := range cmd {
@@ -159,7 +157,7 @@ func TestGetRestoreCommand(t *testing.T) {
 		t.Fatal("ok=false, want true")
 	}
 
-	want := []string{"amp", "--permission-mode", "bypassPermissions", "--resume", "T-abc123"}
+	want := []string{"amp", "--resume", "T-abc123"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}


### PR DESCRIPTION
## Summary
- stop the Amp adapter from emitting Claude-style `--permission-mode` flags
- keep Amp launch and restore commands limited to documented Amp argv shapes
- update Amp adapter tests so all AO permission modes emit no Amp permission flag

## Root cause
The Amp adapter copied Claude Code permission-mode argv mapping, but Amp does not document a `--permission-mode` CLI flag. Non-default AO permission settings could therefore make Amp fail before opening the TUI.

## Validation
- `cd backend && go test ./internal/adapters/agent/amp`

Fixes #2561