### PR TITLE
fix: landing nav Features link scrolls to features section

### DIFF
--- a/frontend/src/landing/components/LandingFeaturesScroll.tsx
+++ b/frontend/src/landing/components/LandingFeaturesScroll.tsx
@@ -408,7 +408,7 @@ export function LandingFeaturesScroll() {
 	];
 
 	return (
-		<section ref={containerRef} id="features-scroll" data-testid="features-scroll" className="relative">
+		<section ref={containerRef} id="features" data-testid="features-scroll" className="relative">
 			{/* Desktop: pinned pi-style scroll — mockup centered first, shifts right as text appears. */}
 			<div ref={pinRef} className="relative hidden h-screen overflow-hidden lg:block">
 				<div className="container-page flex h-full w-full flex-col pt-17">


### PR DESCRIPTION
## Summary
- Align the active features section id with the existing `#features` navbar and footer anchors
- `LandingFeaturesScroll` used `id="features-scroll"` after replacing the old `LandingFeatures` component (`id="features"`), so clicking **Features** did not scroll anywhere

## Test plan
- [ ] Open the landing page at `/`
- [ ] Click **Features** in the desktop navbar — page scrolls to the features section
- [ ] Open the mobile nav menu and click **Features** — same behavior
- [ ] Click **Features** in the footer — same behavior
- [ ] Confirm **Demo** (`#see-it`) still scrolls to the video section

##Before

https://github.com/user-attachments/assets/24b49481-1109-4699-83e7-941a42c0621a

##After

https://github.com/user-attachments/assets/d7620d31-6084-4410-a27c-27267e58719d

