### PR TITLE
fix: align docs accordion sizing with legacy CLI dropdown style

### DIFF
--- a/frontend/src/landing/app/docs/docs.css
+++ b/frontend/src/landing/app/docs/docs.css
@@ -701,6 +701,48 @@ pre.shiki code {
 	margin-bottom: 0;
 }
 
+/* Fumadocs accordions — match ao-legacy-cli-details sizing and visual weight */
+#nd-docs-layout .prose [data-orientation="vertical"].divide-y.rounded-lg.border {
+	border-color: var(--color-border-subtle);
+	border-radius: 12px;
+	background: color-mix(in srgb, var(--color-fd-card) 88%, var(--color-bg-elevated));
+}
+
+#nd-docs-layout .prose [data-orientation="vertical"].divide-y.rounded-lg.border h3 {
+	margin: 0;
+	font-size: inherit;
+	font-weight: inherit;
+}
+
+#nd-docs-layout .prose [data-orientation="vertical"].divide-y.rounded-lg.border h3 button {
+	gap: 0.45rem;
+	padding: 0.72rem 1rem;
+	color: var(--color-text-primary);
+	font-size: 0.94rem;
+	font-weight: 620;
+	line-height: 1.35;
+}
+
+#nd-docs-layout .prose [data-orientation="vertical"].divide-y.rounded-lg.border h3 button svg {
+	width: 0.85rem;
+	height: 0.85rem;
+	flex-shrink: 0;
+	color: var(--color-text-tertiary);
+}
+
+#nd-docs-layout .prose [data-orientation="vertical"].divide-y.rounded-lg.border [role="region"] > div {
+	padding: 0 1rem 0.9rem;
+	color: var(--color-text-secondary);
+	font-size: 0.86rem;
+	line-height: 1.55;
+}
+
+#nd-docs-layout .prose [data-orientation="vertical"].divide-y.rounded-lg.border [role="region"] > div :is(p, li) {
+	color: inherit;
+	font-size: inherit;
+	line-height: inherit;
+}
+
 @media (prefers-reduced-motion: reduce) {
 	#nd-docs-layout figure[data-rehype-pretty-code-figure] button,
 	#nd-docs-layout [data-rehype-pretty-code-figure] button[aria-label],


### PR DESCRIPTION
## Summary
- Reduce fumadocs accordion visual weight in docs prose so it matches the existing `ao-legacy-cli-details` dropdown style
- Tighten trigger typography, chevron size, padding, and content text sizing in `docs.css`
- Apply consistently across docs pages that use fumadocs `<Accordions>` (installation, troubleshooting, FAQ, plugin pages)

## Test plan
- [ ] Open `/docs/installation` and compare "Common Install Issues" accordions with the "Using the legacy CLI?" dropdown above
- [ ] Verify accordion titles feel similar in size/weight, chevrons are subtler, and expanded content uses secondary body text sizing
- [ ] Expand/collapse several install issue items and confirm spacing still reads cleanly
- [ ] Spot-check another docs page with accordions (e.g. `/docs/troubleshooting` or `/docs/faq`) to confirm the global override looks correct

##Before 
<img width="1470" height="926" alt="image" src="https://github.com/user-attachments/assets/847852d0-286d-441e-8baf-690e8d6c76de" />

##After
<img width="1470" height="883" alt="image" src="https://github.com/user-attachments/assets/5a8d0a48-9c83-4375-89b1-736598a643ef" />
