### PR TITLE
fix(frontend): disable unavailable PR actions

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 Current `main` ships a working single-user local loop: the Go daemon and the
 Electron/React frontend both drive a live daemon over HTTP/SSE/WebSocket. The
 core GitHub flow works end-to-end: add project → spawn session/orchestrator →
-attach terminal → observe PR → merge.
+attach terminal → observe PR → ready for manual merge.
 
 This file tracks progress. For what the product _is_ and how to run it, see the
 top-level [`README.md`](../README.md); for the backend mental model see
@@ -36,8 +36,6 @@ surface (`npm run sqlc`, `npm run api`).
   rollback, cleanup, send, activity, PR claim/list. Orchestrator routes
   (list/spawn/get) are wired too.
 - Project CRUD plus per-project config (`PUT /projects/{id}/config`).
-- PR action engine wired into the API: `POST /prs/{id}/merge` and
-  `/prs/{id}/resolve-comments`.
 - Review routes registered: `GET /reviews`, `POST /reviews/execute`,
   `POST /reviews/{id}/send`.
 - Durable dashboard notifications for `needs_input`, `ready_to_merge`,
@@ -93,7 +91,10 @@ surface (`npm run sqlc`, `npm run api`).
   `ao session get` ([#111](https://github.com/aoagents/agent-orchestrator/issues/111))
   is still open.
 - **CLI parity for PR/review actions**: merge, resolve-comments, and review are
-  HTTP-only (frontend-driven); there are no `ao pr` / `ao review` commands.
+  not exposed through `ao pr` / `ao review` commands.
+- **Runtime PR actions**: `POST /prs/{id}/merge` and
+  `/prs/{id}/resolve-comments` exist in the API surface, but the production
+  daemon does not wire merge/comment-resolution behavior yet.
 
 Tracking milestone:
 [`rewrite`](https://github.com/aoagents/agent-orchestrator/milestone/1).

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -82,9 +82,9 @@ opens that URL verbatim (`file://`, `http`, `https`).
 
 `go run .` in `backend/` remains a compatibility wrapper around the daemon.
 
-PR and review actions (merge, resolve-comments, review execute/send) are
-HTTP-only today and driven by the frontend; there are no `ao pr` / `ao review`
-commands yet.
+Review actions are HTTP-only today and driven by the frontend. PR merge and
+resolve-comments routes exist in the API surface, but the daemon does not wire
+runtime behavior for them yet. There are no `ao pr` / `ao review` commands yet.
 
 ## Configuration
 

--- a/frontend/src/renderer/components/PullRequestsPage.test.tsx
+++ b/frontend/src/renderer/components/PullRequestsPage.test.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PullRequestsPage } from "./PullRequestsPage";
 import type { PRState, PullRequestFacts, WorkspaceSession, WorkspaceSummary } from "../types/workspace";
@@ -75,16 +74,15 @@ describe("PullRequestsPage", () => {
 		expect(numbers).toEqual(["#41", "#42", "#40"]);
 	});
 
-	it("merges the PR by its own number, not the session's", async () => {
+	it("shows PR actions as unavailable instead of calling unwired action endpoints", () => {
 		setWorkspaces([session("auth", [pr(41, "open"), pr(42, "draft")])]);
 		renderPage();
-		const user = userEvent.setup();
 
 		const childRow = screen.getByText("#42").closest("tr")!;
-		await user.click(within(childRow).getByRole("button", { name: "Merge" }));
+		const action = within(childRow).getByRole("button", { name: "PR actions unavailable" });
 
-		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
-		expect(postMock).toHaveBeenCalledWith("/api/v1/prs/{id}/merge", { params: { path: { id: "42" } } });
+		expect(action).toBeDisabled();
+		expect(postMock).not.toHaveBeenCalled();
 	});
 
 	it("shows an empty state when no session has a PR", () => {

--- a/frontend/src/renderer/components/PullRequestsPage.tsx
+++ b/frontend/src/renderer/components/PullRequestsPage.tsx
@@ -1,10 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
-import { apiClient, apiErrorMessage } from "../lib/api-client";
-import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { useQueries } from "@tanstack/react-query";
+import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import {
-	sessionScmSummaryQueryKey,
 	sessionScmSummaryQueryOptions,
 	type SessionPRSummary,
 } from "../hooks/useSessionScmSummary";
@@ -33,9 +30,8 @@ type PRRow = {
 
 // The PR board, ported from agent-orchestrator's PullRequestsPage. One row per
 // attributed PR — a session can own several (a stack or independent PRs), so we
-// flatMap the session's prs list rather than assuming one. Actions hit
-// /prs/{number}/merge and /resolve-comments. Per-PR CI/review facts also live on
-// the session route's inspector.
+// flatMap the session's prs list rather than assuming one. Per-PR CI/review
+// facts also live on the session route's inspector.
 export function PullRequestsPage() {
 	const navigate = useNavigate();
 	const workspaceQuery = useWorkspaceQuery();
@@ -53,7 +49,7 @@ export function PullRequestsPage() {
 		<div className="flex h-full min-h-0 flex-col bg-background text-foreground">
 			<DashboardSubhead
 				title="Pull requests"
-				subtitle="Open PRs across every agent session, ready to resolve and merge."
+				subtitle="Open PRs across every agent session."
 				count={rows.length}
 			/>
 
@@ -92,42 +88,6 @@ export function PullRequestsPage() {
 }
 
 function PRRowView({ row, onOpen }: { row: PRRow; onOpen: () => void }) {
-	const queryClient = useQueryClient();
-	const [note, setNote] = useState<{ ok: boolean; text: string } | null>(null);
-	const refresh = () => {
-		void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-		void queryClient.invalidateQueries({ queryKey: sessionScmSummaryQueryKey() });
-	};
-
-	const merge = useMutation({
-		mutationFn: async () => {
-			const { data, error } = await apiClient.POST("/api/v1/prs/{id}/merge", {
-				params: { path: { id: String(row.pr.number) } },
-			});
-			if (error) throw new Error(apiErrorMessage(error));
-			return data;
-		},
-		onSuccess: (data) => {
-			setNote({ ok: true, text: `merged (${data?.method ?? "squash"})` });
-			refresh();
-		},
-		onError: (e) => setNote({ ok: false, text: e instanceof Error ? e.message : "merge failed" }),
-	});
-
-	const resolve = useMutation({
-		mutationFn: async () => {
-			const { error } = await apiClient.POST("/api/v1/prs/{id}/resolve-comments", {
-				params: { path: { id: String(row.pr.number) } },
-			});
-			if (error) throw new Error(apiErrorMessage(error));
-		},
-		onSuccess: () => {
-			setNote({ ok: true, text: "comments resolved" });
-			refresh();
-		},
-		onError: (e) => setNote({ ok: false, text: e instanceof Error ? e.message : "resolve failed" }),
-	});
-
 	const actionable = row.pr.state === "open" || row.pr.state === "draft";
 
 	return (
@@ -153,29 +113,17 @@ function PRRowView({ row, onOpen }: { row: PRRow; onOpen: () => void }) {
 				</Badge>
 			</TableCell>
 			<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
-				{note ? (
-					<span className={cn("text-[11px]", note.ok ? "text-success" : "text-error")}>{note.text}</span>
-				) : actionable ? (
-					<div className="flex items-center justify-end gap-1.5">
-						<Button
-							size="sm"
-							variant="ghost"
-							className="h-6 px-2 text-[11px]"
-							disabled={resolve.isPending}
-							onClick={() => resolve.mutate()}
-						>
-							{resolve.isPending ? "…" : "Resolve"}
-						</Button>
-						<Button
-							size="sm"
-							variant="primary"
-							className="h-6 px-2 text-[11px]"
-							disabled={merge.isPending}
-							onClick={() => merge.mutate()}
-						>
-							{merge.isPending ? "Merging…" : "Merge"}
-						</Button>
-					</div>
+				{actionable ? (
+					<Button
+						size="sm"
+						variant="secondary"
+						className="h-6 px-2 text-[11px]"
+						disabled
+						aria-label="PR actions unavailable"
+						title="PR merge and comment resolution are unavailable in this build"
+					>
+						Unavailable
+					</Button>
 				) : (
 					<span className="text-[11px] text-passive">—</span>
 				)}


### PR DESCRIPTION

  ## Summary

  - Disable PR merge/comment-resolution actions in the Pull Requests page because the production daemon does not wire those
    runtime actions yet.

  - Replace active Merge/Resolve buttons with a disabled unavailable state for open/draft PRs.
  - Update docs to clarify that PR action routes exist in the API surface but are not runtime features yet.

  ## Why

  The UI previously presented Merge/Resolve as executable actions, but production requests to those routes return 501
  NOT_IMPLEMENTED because no PR action service is wired. This made the Pull Requests page advertise behavior that is not
  currently available.

  ## Tests

  - npm --prefix frontend test -- PullRequestsPage
  - npm --prefix frontend run typecheck
  - git diff --check