### PR TITLE
fix(session): checkout claimed PR branch

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/commands.go
+++ b/backend/internal/adapters/workspace/gitworktree/commands.go
@@ -18,6 +18,10 @@ func worktreeAddNewBranchArgs(repo, branch, path, baseRef string) []string {
 	return []string{"-C", repo, "worktree", "add", "-b", branch, path, baseRef}
 }
 
+func switchBranchArgs(path, branch string) []string {
+	return []string{"-C", path, "switch", branch}
+}
+
 // worktreeRemoveArgs intentionally omits --force: a dirty worktree (uncommitted
 // agent work) MUST cause `git worktree remove` to fail, so the post-prune
 // "still registered" check in Destroy surfaces the refusal to the Session

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -559,6 +559,69 @@ func (w *Workspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (por
 	return ports.WorkspaceInfo{Path: path, Branch: cfg.Branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID, RepoPath: repo}, nil
 }
 
+// CheckoutBranch switches an existing session worktree to branch.
+func (w *Workspace) CheckoutBranch(ctx context.Context, info ports.WorkspaceInfo, branch string) (ports.WorkspaceInfo, bool, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return ports.WorkspaceInfo{}, false, errors.New("gitworktree: branch is required")
+	}
+	if strings.TrimSpace(info.Path) == "" {
+		return ports.WorkspaceInfo{}, false, errors.New("gitworktree: workspace path is required")
+	}
+	repo, err := w.repoPathForInfo(info)
+	if err != nil {
+		return ports.WorkspaceInfo{}, false, err
+	}
+	path, err := w.validateManagedPath(info.Path)
+	if err != nil {
+		return ports.WorkspaceInfo{}, false, err
+	}
+	if err := w.validateBranch(ctx, repo, branch); err != nil {
+		return ports.WorkspaceInfo{}, false, err
+	}
+	records, err := w.listRecords(ctx, repo)
+	if err != nil {
+		return ports.WorkspaceInfo{}, false, err
+	}
+	rec, ok := findWorktree(records, path)
+	if !ok {
+		return ports.WorkspaceInfo{}, false, fmt.Errorf("gitworktree: workspace %q is not a registered worktree", path)
+	}
+	current := rec.Branch
+	if current == branch {
+		info.Path = path
+		info.Branch = branch
+		info.RepoPath = repo
+		return info, false, nil
+	}
+	if conflict, ok := findWorktreeByBranch(records, branch); ok && filepath.Clean(conflict.Path) != filepath.Clean(path) {
+		return ports.WorkspaceInfo{}, false, fmt.Errorf("%w: %q is checked out at %q", ErrBranchCheckedOutElsewhere, branch, conflict.Path)
+	}
+	dirty, err := w.isDirty(ctx, path)
+	if err != nil {
+		return ports.WorkspaceInfo{}, false, err
+	}
+	if dirty {
+		return ports.WorkspaceInfo{}, false, fmt.Errorf("gitworktree: refusing to switch %q to %q: %w", path, branch, ports.ErrWorkspaceDirty)
+	}
+	if ok, err := w.refExists(ctx, repo, "refs/heads/"+branch); err != nil {
+		return ports.WorkspaceInfo{}, false, err
+	} else if !ok {
+		if remote, err := w.refExists(ctx, repo, "refs/remotes/origin/"+branch); err != nil {
+			return ports.WorkspaceInfo{}, false, err
+		} else if !remote {
+			return ports.WorkspaceInfo{}, false, fmt.Errorf("%w: %q has no local head or remote-tracking branch - run `git fetch` then retry", ErrBranchNotFetched, branch)
+		}
+	}
+	if _, err := w.run(ctx, w.binary, switchBranchArgs(path, branch)...); err != nil {
+		return ports.WorkspaceInfo{}, false, fmt.Errorf("gitworktree: switch %q to branch %q: %w", path, branch, err)
+	}
+	info.Path = path
+	info.Branch = branch
+	info.RepoPath = repo
+	return info, true, nil
+}
+
 func (w *Workspace) existingWorktree(ctx context.Context, repo, path string, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, bool, error) {
 	records, err := w.listRecords(ctx, repo)
 	if err != nil {

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -28,6 +28,7 @@ func TestCommandArgs(t *testing.T) {
 		{"rev parse", revParseVerifyArgs(repo, "origin/main"), []string{"-C", repo, "rev-parse", "--verify", "--quiet", "origin/main"}},
 		{"add existing", worktreeAddBranchArgs(repo, path, branch), []string{"-C", repo, "worktree", "add", path, branch}},
 		{"add new", worktreeAddNewBranchArgs(repo, branch, path, "origin/main"), []string{"-C", repo, "worktree", "add", "-b", branch, path, "origin/main"}},
+		{"switch", switchBranchArgs(path, branch), []string{"-C", path, "switch", branch}},
 		// No --force: a dirty worktree must cause `git worktree remove` to fail so
 		// the post-prune safety check surfaces the refusal instead of deleting
 		// uncommitted agent work (review item RA).
@@ -208,6 +209,82 @@ func TestCreateReusesRegisteredWorktreeAtExpectedPath(t *testing.T) {
 	}
 	if info.Path != path || info.Branch != "ao/proj-orchestrator" {
 		t.Fatalf("info = %#v, want path %q branch ao/proj-orchestrator", info, path)
+	}
+}
+
+func TestCheckoutBranchSwitchesCleanRegisteredWorktree(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "sess")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	var switched bool
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "check-ref-format --branch fix/pr"):
+			return nil, nil
+		case strings.Contains(joined, "worktree list --porcelain"):
+			return []byte("worktree " + path + "\nbranch refs/heads/ao/sess\n"), nil
+		case strings.Contains(joined, "status --porcelain"):
+			return nil, nil
+		case strings.Contains(joined, "rev-parse --verify --quiet refs/heads/fix/pr"):
+			return nil, nil
+		case strings.Contains(joined, "switch fix/pr"):
+			switched = true
+			return nil, nil
+		default:
+			t.Fatalf("unexpected git invocation: %v", args)
+			return nil, nil
+		}
+	}
+
+	info, changed, err := ws.CheckoutBranch(context.Background(), ports.WorkspaceInfo{Path: path, ProjectID: "proj", SessionID: "sess", Branch: "ao/sess"}, "fix/pr")
+	if err != nil {
+		t.Fatalf("CheckoutBranch: %v", err)
+	}
+	if !changed || !switched {
+		t.Fatalf("changed=%v switched=%v, want checkout to switch", changed, switched)
+	}
+	if info.Branch != "fix/pr" || info.Path != path || info.ProjectID != "proj" || info.SessionID != "sess" {
+		t.Fatalf("info = %+v", info)
+	}
+}
+
+func TestCheckoutBranchRefusesDirtyWorktree(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "sess")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "check-ref-format --branch fix/pr"):
+			return nil, nil
+		case strings.Contains(joined, "worktree list --porcelain"):
+			return []byte("worktree " + path + "\nbranch refs/heads/ao/sess\n"), nil
+		case strings.Contains(joined, "status --porcelain"):
+			return []byte(" M main.go\n"), nil
+		default:
+			t.Fatalf("unexpected git invocation: %v", args)
+			return nil, nil
+		}
+	}
+
+	_, _, err = ws.CheckoutBranch(context.Background(), ports.WorkspaceInfo{Path: path, ProjectID: "proj", SessionID: "sess", Branch: "ao/sess"}, "fix/pr")
+	if !errors.Is(err, ports.ErrWorkspaceDirty) {
+		t.Fatalf("CheckoutBranch error = %v, want ports.ErrWorkspaceDirty", err)
 	}
 }
 

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -119,6 +119,7 @@ func startSession(cfg config.Config, runtime runtimeselect.Runtime, store *sqlit
 		Manager:   mgr,
 		Store:     store,
 		PRClaimer: store,
+		Workspace: ws,
 		SCM:       scmProvider,
 		Telemetry: telemetry,
 		// no_signal only makes sense for harnesses whose adapters install

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -584,6 +584,14 @@ func writeSessionPRError(w http.ResponseWriter, r *http.Request, err error) {
 		envelope.WriteAPIError(w, r, http.StatusUnprocessableEntity, "unprocessable", "PR_PROJECT_MISMATCH", "PR does not belong to the session project", nil)
 	case errors.Is(err, sessionsvc.ErrSCMUnavailable):
 		envelope.WriteAPIError(w, r, http.StatusServiceUnavailable, "unavailable", "SCM_UNAVAILABLE", "SCM unavailable", nil)
+	case errors.Is(err, ports.ErrWorkspaceBranchCheckedOutElsewhere):
+		envelope.WriteAPIError(w, r, http.StatusConflict, "conflict", "BRANCH_CHECKED_OUT_ELSEWHERE", err.Error(), nil)
+	case errors.Is(err, ports.ErrWorkspaceDirty):
+		envelope.WriteAPIError(w, r, http.StatusConflict, "conflict", "WORKSPACE_DIRTY", "Workspace has uncommitted changes", nil)
+	case errors.Is(err, ports.ErrWorkspaceBranchNotFetched):
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "BRANCH_NOT_FETCHED", err.Error(), nil)
+	case errors.Is(err, ports.ErrWorkspaceBranchInvalid):
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_BRANCH", err.Error(), nil)
 	default:
 		envelope.WriteError(w, r, err)
 	}

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -928,6 +928,10 @@ func TestSessionsAPI_ClaimPRErrors(t *testing.T) {
 		{"not claimable", `{"pr":"142"}`, sessionsvc.ErrSessionNotClaimable, http.StatusUnprocessableEntity, "SESSION_NOT_CLAIMABLE"},
 		{"mismatch", `{"pr":"142"}`, sessionsvc.ErrProjectMismatch, http.StatusUnprocessableEntity, "PR_PROJECT_MISMATCH"},
 		{"scm", `{"pr":"142"}`, sessionsvc.ErrSCMUnavailable, http.StatusServiceUnavailable, "SCM_UNAVAILABLE"},
+		{"branch elsewhere", `{"pr":"142"}`, ports.ErrWorkspaceBranchCheckedOutElsewhere, http.StatusConflict, "BRANCH_CHECKED_OUT_ELSEWHERE"},
+		{"dirty workspace", `{"pr":"142"}`, ports.ErrWorkspaceDirty, http.StatusConflict, "WORKSPACE_DIRTY"},
+		{"branch missing", `{"pr":"142"}`, ports.ErrWorkspaceBranchNotFetched, http.StatusBadRequest, "BRANCH_NOT_FETCHED"},
+		{"bad branch", `{"pr":"142"}`, ports.ErrWorkspaceBranchInvalid, http.StatusBadRequest, "INVALID_BRANCH"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/internal/integration/lifecycle_sqlite_test.go
+++ b/backend/internal/integration/lifecycle_sqlite_test.go
@@ -92,6 +92,11 @@ func (s *stubWorkspace) Destroy(context.Context, ports.WorkspaceInfo) error {
 func (s *stubWorkspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
 	return s.Create(ctx, cfg)
 }
+func (s *stubWorkspace) CheckoutBranch(_ context.Context, info ports.WorkspaceInfo, branch string) (ports.WorkspaceInfo, bool, error) {
+	changed := info.Branch != branch
+	info.Branch = branch
+	return info, changed, nil
+}
 func (s *stubWorkspace) ForceDestroy(context.Context, ports.WorkspaceInfo) error { return nil }
 func (s *stubWorkspace) StashUncommitted(_ context.Context, _ ports.WorkspaceInfo) (string, error) {
 	return "", nil

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -121,6 +121,9 @@ type Workspace interface {
 	Create(ctx context.Context, cfg WorkspaceConfig) (WorkspaceInfo, error)
 	Destroy(ctx context.Context, info WorkspaceInfo) error
 	Restore(ctx context.Context, cfg WorkspaceConfig) (WorkspaceInfo, error)
+	// CheckoutBranch switches an existing session worktree to branch. It must
+	// refuse dirty worktrees and branches checked out in another worktree.
+	CheckoutBranch(ctx context.Context, info WorkspaceInfo, branch string) (WorkspaceInfo, bool, error)
 	// ForceDestroy removes the worktree unconditionally, bypassing the
 	// dirty-worktree refusal that Destroy enforces. It is only safe to call
 	// AFTER the session's uncommitted work has been captured via StashUncommitted.

--- a/backend/internal/service/session/claim_pr.go
+++ b/backend/internal/service/session/claim_pr.go
@@ -125,14 +125,45 @@ func (s *Service) ClaimPR(ctx context.Context, id domain.SessionID, ref string, 
 		return ClaimPRResult{}, err
 	}
 	prs = claimedFirst(prs, prURL)
-	// TODO: implement workspace branch checkout. Until then, leave BranchChanged
-	// false and let CLI output omit the checkout line rather than claiming the
-	// session was already on the PR branch.
-	res := ClaimPRResult{PRs: prs, BranchChanged: false, DonorWasTerminated: outcome.OwnerTerminated}
+	branchChanged, err := s.checkoutClaimBranch(ctx, rec, pr.SourceBranch)
+	if err != nil {
+		return ClaimPRResult{}, err
+	}
+	res := ClaimPRResult{PRs: prs, BranchChanged: branchChanged, DonorWasTerminated: outcome.OwnerTerminated}
 	if outcome.PreviousOwner != "" && outcome.PreviousOwner != id {
 		res.TakenOverFrom = []domain.SessionID{outcome.PreviousOwner}
 	}
 	return res, nil
+}
+
+type sessionRecordUpdater interface {
+	UpdateSession(ctx context.Context, rec domain.SessionRecord) error
+}
+
+func (s *Service) checkoutClaimBranch(ctx context.Context, rec domain.SessionRecord, branch string) (bool, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" || s.workspace == nil {
+		return false, nil
+	}
+	info := ports.WorkspaceInfo{
+		Path:      rec.Metadata.WorkspacePath,
+		Branch:    rec.Metadata.Branch,
+		SessionID: rec.ID,
+		ProjectID: rec.ProjectID,
+	}
+	checked, changed, err := s.workspace.CheckoutBranch(ctx, info, branch)
+	if err != nil {
+		return false, err
+	}
+	if checked.Branch != "" && checked.Branch != rec.Metadata.Branch {
+		rec.Metadata.Branch = checked.Branch
+		if updater, ok := s.store.(sessionRecordUpdater); ok {
+			if err := updater.UpdateSession(ctx, rec); err != nil {
+				return false, fmt.Errorf("update session branch %s: %w", rec.ID, err)
+			}
+		}
+	}
+	return changed, nil
 }
 
 func (s *Service) fetchClaimObservation(ctx context.Context, ref ports.SCMPRRef) (ports.SCMObservation, error) {

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -86,6 +86,7 @@ type Service struct {
 	manager             commander
 	store               Store
 	prClaimer           ports.PRClaimer
+	workspace           ports.Workspace
 	scm                 scmProvider
 	clock               func() time.Time
 	telemetry           ports.EventSink
@@ -110,6 +111,7 @@ type Deps struct {
 	Manager   commander
 	Store     Store
 	PRClaimer ports.PRClaimer
+	Workspace ports.Workspace
 	SCM       scmProvider
 	Clock     func() time.Time
 	Telemetry ports.EventSink
@@ -121,7 +123,7 @@ type Deps struct {
 
 // NewWithDeps wires a session service with optional PR-claim dependencies.
 func NewWithDeps(d Deps) *Service {
-	s := &Service{manager: d.Manager, store: d.Store, prClaimer: d.PRClaimer, scm: d.SCM, clock: d.Clock, signalCapable: d.SignalCapable, telemetry: d.Telemetry}
+	s := &Service{manager: d.Manager, store: d.Store, prClaimer: d.PRClaimer, workspace: d.Workspace, scm: d.SCM, clock: d.Clock, signalCapable: d.SignalCapable, telemetry: d.Telemetry}
 	if s.prClaimer == nil {
 		if w, ok := d.Store.(ports.PRClaimer); ok {
 			s.prClaimer = w
@@ -571,6 +573,8 @@ func toAPIError(err error) error {
 		return apierr.Invalid("BRANCH_NOT_FETCHED", err.Error(), nil)
 	case errors.Is(err, ports.ErrWorkspaceBranchInvalid):
 		return apierr.Invalid("INVALID_BRANCH", err.Error(), nil)
+	case errors.Is(err, ports.ErrWorkspaceDirty):
+		return apierr.Conflict("WORKSPACE_DIRTY", "Workspace has uncommitted changes", nil)
 	case errors.Is(err, ports.ErrAgentBinaryNotFound):
 		return apierr.Invalid("AGENT_BINARY_NOT_FOUND", err.Error(), nil)
 	case errors.Is(err, ports.ErrRuntimePrerequisite):

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -51,6 +51,11 @@ func (f *fakeStore) CreateSession(_ context.Context, rec domain.SessionRecord) (
 	return rec, nil
 }
 
+func (f *fakeStore) UpdateSession(_ context.Context, rec domain.SessionRecord) error {
+	f.sessions[rec.ID] = rec
+	return nil
+}
+
 func (f *fakeStore) GetSession(_ context.Context, id domain.SessionID) (domain.SessionRecord, bool, error) {
 	r, ok := f.sessions[id]
 	return r, ok, nil
@@ -731,6 +736,45 @@ func (f fakeSCM) FetchReviewThreads(context.Context, ports.SCMPRRef) (ports.SCMR
 	return f.review, f.reviewErr
 }
 
+type fakeClaimWorkspace struct {
+	info   ports.WorkspaceInfo
+	branch string
+	err    error
+	calls  int
+}
+
+func (f *fakeClaimWorkspace) Create(context.Context, ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
+	return ports.WorkspaceInfo{}, nil
+}
+
+func (f *fakeClaimWorkspace) Destroy(context.Context, ports.WorkspaceInfo) error { return nil }
+
+func (f *fakeClaimWorkspace) Restore(context.Context, ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
+	return ports.WorkspaceInfo{}, nil
+}
+
+func (f *fakeClaimWorkspace) CheckoutBranch(_ context.Context, info ports.WorkspaceInfo, branch string) (ports.WorkspaceInfo, bool, error) {
+	f.calls++
+	f.info = info
+	f.branch = branch
+	if f.err != nil {
+		return ports.WorkspaceInfo{}, false, f.err
+	}
+	changed := info.Branch != branch
+	info.Branch = branch
+	return info, changed, nil
+}
+
+func (f *fakeClaimWorkspace) ForceDestroy(context.Context, ports.WorkspaceInfo) error { return nil }
+
+func (f *fakeClaimWorkspace) StashUncommitted(context.Context, ports.WorkspaceInfo) (string, error) {
+	return "", nil
+}
+
+func (f *fakeClaimWorkspace) ApplyPreserved(context.Context, ports.WorkspaceInfo, string) error {
+	return nil
+}
+
 func TestClaimPRMapsObserverAndStoreErrors(t *testing.T) {
 	st := newFakeStore()
 	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
@@ -756,14 +800,39 @@ func TestClaimPRMapsObserverAndStoreErrors(t *testing.T) {
 		})
 	}
 
+	rec := st.sessions["mer-1"]
+	rec.Metadata.Branch = "ao/mer-1"
+	st.sessions["mer-1"] = rec
 	st.pr["mer-1"] = domain.PRFacts{URL: "https://github.com/acme/repo/pull/7", Number: 7, CI: domain.CIPassing, UpdatedAt: now}
-	svc := NewWithDeps(Deps{Store: st, PRClaimer: fakePRClaimer{out: errorFreeClaimOutcome{ports.ClaimOutcome{PreviousOwner: "mer-2"}}}, SCM: fakeSCM{obs: ports.SCMObservation{Fetched: true, Provider: "github", Host: "github.com", Repo: "acme/repo", PR: ports.SCMPRObservation{URL: "https://github.com/acme/repo/pull/7", Number: 7}}}})
+	ws := &fakeClaimWorkspace{}
+	svc := NewWithDeps(Deps{
+		Store:     st,
+		PRClaimer: fakePRClaimer{out: errorFreeClaimOutcome{ports.ClaimOutcome{PreviousOwner: "mer-2"}}},
+		Workspace: ws,
+		SCM: fakeSCM{obs: ports.SCMObservation{
+			Fetched:  true,
+			Provider: "github",
+			Host:     "github.com",
+			Repo:     "acme/repo",
+			PR: ports.SCMPRObservation{
+				URL:          "https://github.com/acme/repo/pull/7",
+				Number:       7,
+				SourceBranch: "fix/dashboard",
+			},
+		}},
+	})
 	res, err := svc.ClaimPR(context.Background(), "mer-1", "7", ClaimPROptions{AllowTakeover: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res.TakenOverFrom) != 1 || res.TakenOverFrom[0] != "mer-2" || len(res.PRs) != 1 || res.PRs[0].URL == "" {
+	if len(res.TakenOverFrom) != 1 || res.TakenOverFrom[0] != "mer-2" || len(res.PRs) != 1 || res.PRs[0].URL == "" || !res.BranchChanged {
 		t.Fatalf("claim result = %+v", res)
+	}
+	if ws.calls != 1 || ws.info.Path != "/ws" || ws.info.Branch != "ao/mer-1" || ws.branch != "fix/dashboard" {
+		t.Fatalf("checkout call = calls=%d info=%+v branch=%q", ws.calls, ws.info, ws.branch)
+	}
+	if got := st.sessions["mer-1"].Metadata.Branch; got != "fix/dashboard" {
+		t.Fatalf("session branch = %q, want PR source branch", got)
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -294,6 +294,7 @@ type fakeWorkspace struct {
 	stashErr        error
 	applyErr        error
 	forceDestroyErr error
+	checkoutErr     error
 	// stashCalls counts StashUncommitted invocations.
 	stashCalls int
 	// calls records the sequence of workspace method calls for ordering assertions.
@@ -314,6 +315,16 @@ func (w *fakeWorkspace) Create(_ context.Context, cfg ports.WorkspaceConfig) (po
 	}
 	return ports.WorkspaceInfo{Path: path, Branch: cfg.Branch, SessionID: cfg.SessionID, ProjectID: cfg.ProjectID}, nil
 }
+
+func (w *fakeWorkspace) CheckoutBranch(_ context.Context, info ports.WorkspaceInfo, branch string) (ports.WorkspaceInfo, bool, error) {
+	if w.checkoutErr != nil {
+		return ports.WorkspaceInfo{}, false, w.checkoutErr
+	}
+	changed := info.Branch != branch
+	info.Branch = branch
+	return info, changed, nil
+}
+
 func (w *fakeWorkspace) CreateWorkspaceProject(_ context.Context, cfg ports.WorkspaceProjectConfig) (ports.WorkspaceProjectInfo, error) {
 	if w.projectErr != nil {
 		return ports.WorkspaceProjectInfo{}, w.projectErr


### PR DESCRIPTION
## Summary

  - Switch a session workspace to the claimed PR source branch during claim-pr.
  - Return branchChanged: true when checkout actually changes the workspace branch.
  - Persist updated session branch metadata after a successful checkout.
  - Surface typed errors for dirty worktrees, missing branches, invalid branches, and branches checked out elsewhere.

  ## Why

  ClaimPR previously persisted PR ownership and facts but always returned BranchChanged: false. The session workspace could
  remain on its old AO branch even after claiming an existing PR, which made the CLI/API checkout status misleading and left
  the worker in the wrong branch.

  ## Implementation Notes

  - Added Workspace.CheckoutBranch.
  - Implemented gitworktree checkout via git switch.
  - Refuses dirty worktrees before switching branches to avoid carrying unrelated local edits across branches.
  - Uses existing branch sentinel errors where possible.

  ## Tests

  - go test ./internal/service/session
  - go test ./internal/adapters/workspace/gitworktree
  - go test ./internal/httpd/controllers
  - go test ./internal/session_manager ./internal/integration
  - npm run lint
  - git diff --check