### PR TITLE
fix(pr): report unavailable actions explicitly

### DIFF
--- a/backend/internal/httpd/controllers/prs.go
+++ b/backend/internal/httpd/controllers/prs.go
@@ -31,7 +31,7 @@ func (c *PRsController) merge(w http.ResponseWriter, r *http.Request) {
 	prID := chi.URLParam(r, "id")
 	res, err := c.Svc.Merge(r.Context(), prID)
 	if err != nil {
-		writePRError(w, r, err)
+		writePRError(w, r, err, "POST", "/api/v1/prs/{id}/merge")
 		return
 	}
 	envelope.WriteJSON(w, http.StatusOK, MergePRResponse{OK: true, PRNumber: res.PRNumber, Method: res.Method})
@@ -53,7 +53,7 @@ func (c *PRsController) resolveComments(w http.ResponseWriter, r *http.Request) 
 
 	res, err := c.Svc.ResolveComments(r.Context(), prID, in.CommentIDs)
 	if err != nil {
-		writePRError(w, r, err)
+		writePRError(w, r, err, "POST", "/api/v1/prs/{id}/resolve-comments")
 		return
 	}
 	envelope.WriteJSON(w, http.StatusOK, ResolveCommentsResponse{OK: true, Resolved: res.Resolved})
@@ -61,8 +61,10 @@ func (c *PRsController) resolveComments(w http.ResponseWriter, r *http.Request) 
 
 // writePRError maps PR sentinel errors to their locked HTTP envelopes,
 // falling back to 500 for unexpected failures.
-func writePRError(w http.ResponseWriter, r *http.Request, err error) {
+func writePRError(w http.ResponseWriter, r *http.Request, err error, method, path string) {
 	switch {
+	case errors.Is(err, prsvc.ErrPRActionsUnavailable):
+		apispec.NotImplemented(w, r, method, path)
 	case errors.Is(err, prsvc.ErrPRNotFound):
 		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "PR_NOT_FOUND", "Unknown PR", nil)
 	case errors.Is(err, prsvc.ErrPRNotMergeable):

--- a/backend/internal/httpd/controllers/prs_test.go
+++ b/backend/internal/httpd/controllers/prs_test.go
@@ -52,6 +52,20 @@ func TestPRsRoutes_NilService_ResolveCommentsReturns501(t *testing.T) {
 	assertErrorCode(t, body, status, http.StatusNotImplemented, "NOT_IMPLEMENTED")
 }
 
+func TestPRsRoutes_ActionService_MergeReturns501(t *testing.T) {
+	srv := newPRTestServer(t, prsvc.NewActionService())
+	body, status, headers := doRequest(t, srv, "POST", "/api/v1/prs/1/merge", "")
+	assertJSON(t, headers)
+	assertErrorCode(t, body, status, http.StatusNotImplemented, "NOT_IMPLEMENTED")
+}
+
+func TestPRsRoutes_ActionService_ResolveCommentsReturns501(t *testing.T) {
+	srv := newPRTestServer(t, prsvc.NewActionService())
+	body, status, headers := doRequest(t, srv, "POST", "/api/v1/prs/1/resolve-comments", "")
+	assertJSON(t, headers)
+	assertErrorCode(t, body, status, http.StatusNotImplemented, "NOT_IMPLEMENTED")
+}
+
 // ---- Merge: 200 ----
 
 func TestPRsRoutes_Merge_200(t *testing.T) {

--- a/backend/internal/service/pr/action_service.go
+++ b/backend/internal/service/pr/action_service.go
@@ -2,7 +2,6 @@ package pr
 
 import (
 	"context"
-	"strconv"
 )
 
 // ActionManager is the controller-facing contract for /prs/{id} action routes.
@@ -34,13 +33,12 @@ func NewActionService() *ActionService {
 
 // Merge squash-merges the PR identified by prID.
 // TODO: implement — squash-merge the PR via the SCM provider.
-func (s *ActionService) Merge(_ context.Context, prID string) (MergeResult, error) {
-	n, _ := strconv.Atoi(prID)
-	return MergeResult{PRNumber: n, Method: "squash"}, nil
+func (s *ActionService) Merge(_ context.Context, _ string) (MergeResult, error) {
+	return MergeResult{}, ErrPRActionsUnavailable
 }
 
 // ResolveComments resolves review threads on the PR identified by prID.
 // TODO: implement — resolve review threads via the SCM provider.
 func (s *ActionService) ResolveComments(_ context.Context, _ string, _ []string) (ResolveResult, error) {
-	return ResolveResult{Resolved: 0}, nil
+	return ResolveResult{}, ErrPRActionsUnavailable
 }

--- a/backend/internal/service/pr/action_service_test.go
+++ b/backend/internal/service/pr/action_service_test.go
@@ -2,27 +2,22 @@ package pr
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
-func TestMerge_ReturnsSquash(t *testing.T) {
+func TestMerge_ReturnsUnavailable(t *testing.T) {
 	svc := NewActionService()
-	res, err := svc.Merge(context.Background(), "42")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res.Method != "squash" {
-		t.Errorf("method = %q, want squash", res.Method)
-	}
-	if res.PRNumber != 42 {
-		t.Errorf("PRNumber = %d, want 42", res.PRNumber)
+	_, err := svc.Merge(context.Background(), "42")
+	if !errors.Is(err, ErrPRActionsUnavailable) {
+		t.Fatalf("err = %v, want ErrPRActionsUnavailable", err)
 	}
 }
 
-func TestResolveComments_ReturnsOK(t *testing.T) {
+func TestResolveComments_ReturnsUnavailable(t *testing.T) {
 	svc := NewActionService()
 	_, err := svc.ResolveComments(context.Background(), "1", nil)
-	if err != nil {
-		t.Fatal(err)
+	if !errors.Is(err, ErrPRActionsUnavailable) {
+		t.Fatalf("err = %v, want ErrPRActionsUnavailable", err)
 	}
 }

--- a/backend/internal/service/pr/errors.go
+++ b/backend/internal/service/pr/errors.go
@@ -4,8 +4,9 @@ import "errors"
 
 // Sentinel errors returned by the PR action service.
 var (
-	ErrPRNotFound       = errors.New("pr: not found")
-	ErrPRNotMergeable   = errors.New("pr: not mergeable")
-	ErrPRPreconditions  = errors.New("pr: merge preconditions unmet")
-	ErrNothingToResolve = errors.New("pr: nothing to resolve")
+	ErrPRNotFound           = errors.New("pr: not found")
+	ErrPRNotMergeable       = errors.New("pr: not mergeable")
+	ErrPRPreconditions      = errors.New("pr: merge preconditions unmet")
+	ErrNothingToResolve     = errors.New("pr: nothing to resolve")
+	ErrPRActionsUnavailable = errors.New("pr: actions unavailable")
 )


### PR DESCRIPTION
## Summary

  - Stop ActionService from returning fake successful merge/comment-resolution results.
  - Add ErrPRActionsUnavailable for PR actions that are present in the API surface but not implemented yet.
  - Map unavailable PR actions to the existing OpenAPI-backed 501 NOT_IMPLEMENTED response.
  - Update service and route tests.

  ## Why

  ActionService.Merge previously returned a fake squash-merge success, and ResolveComments returned OK even though neither
  operation has real SCM mutation support yet. If this service were wired before implementation, AO could report successful
  PR actions that never happened.

  ## Tests

  - go test ./internal/service/pr
  - go test ./internal/httpd/controllers
  - npm run lint
  - git diff --check