### PR TITLE
fix(preview): reject unsafe local file URLs

### DIFF
--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -28,7 +28,10 @@ const (
 	maxDisplayNameLen = 20
 )
 
-var errPreviewFileNotFound = errors.New("preview file not found")
+var (
+	errPreviewFileNotFound         = errors.New("preview file not found")
+	errPreviewFileOutsideWorkspace = errors.New("preview file outside workspace")
+)
 
 // SessionService is the controller-facing session service contract.
 type SessionService interface {
@@ -224,7 +227,9 @@ func (c *SessionsController) servePreviewMarkdown(w http.ResponseWriter, r *http
 //     when no entry point exists.
 //   - An explicit workspace-local path (e.g. `index.html`, `./dist/index.html`)
 //     is served through the preview/files route so local files load.
-//   - Anything else (http(s)/file URLs, host:port dev servers) is kept verbatim.
+//   - Explicit file URLs and absolute file paths must resolve inside the
+//     workspace and are served through the preview/files route.
+//   - Anything else (http(s) URLs, host:port dev servers) is kept verbatim.
 //
 // Every call bumps the session's preview revision, so re-running `ao preview`
 // with the same target still refreshes the panel.
@@ -245,7 +250,6 @@ func (c *SessionsController) setPreview(w http.ResponseWriter, r *http.Request) 
 		envelope.WriteError(w, r, err)
 		return
 	}
-	// ponytail: no URL sanitization on preview target; agent-trusted for now
 	previewURL := strings.TrimSpace(in.URL)
 	if previewURL == "" {
 		if entry, ok := discoverPreviewEntry(sess.Metadata.WorkspacePath); ok {
@@ -619,8 +623,13 @@ func resolveLocalPreview(r *http.Request, id domain.SessionID, workspacePath, ra
 
 func resolvePreviewTarget(r *http.Request, id domain.SessionID, workspacePath, raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
+	if file, ok, err := previewFileURLPath(raw); err != nil {
+		return "", err
+	} else if ok {
+		return absolutePreviewFileURL(r, id, workspacePath, file)
+	}
 	if isAbsolutePreviewPath(raw) {
-		return absolutePreviewFileURL(raw)
+		return absolutePreviewFileURL(r, id, workspacePath, raw)
 	}
 	if resolved, ok := resolveLocalPreview(r, id, workspacePath, raw); ok {
 		return resolved, nil
@@ -636,25 +645,50 @@ func isWindowsAbsolutePath(raw string) bool {
 	return len(raw) >= 3 && ((raw[0] >= 'a' && raw[0] <= 'z') || (raw[0] >= 'A' && raw[0] <= 'Z')) && raw[1] == ':' && (raw[2] == '\\' || raw[2] == '/')
 }
 
-func absolutePreviewFileURL(raw string) (string, error) {
+func previewFileURLPath(raw string) (string, bool, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", false, err
+	}
+	if !strings.EqualFold(u.Scheme, "file") {
+		return "", false, nil
+	}
+	if u.Host != "" && u.Host != "localhost" {
+		return "", false, errPreviewFileOutsideWorkspace
+	}
+	return filepath.FromSlash(u.Path), true, nil
+}
+
+func absolutePreviewFileURL(r *http.Request, id domain.SessionID, workspacePath, raw string) (string, error) {
+	if strings.TrimSpace(workspacePath) == "" {
+		return "", errPreviewFileOutsideWorkspace
+	}
+	root, err := filepath.Abs(workspacePath)
+	if err != nil {
+		return "", errPreviewFileNotFound
+	}
 	file, err := filepath.Abs(raw)
 	if err != nil {
 		return "", errPreviewFileNotFound
+	}
+	rel, err := filepath.Rel(root, file)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return "", errPreviewFileOutsideWorkspace
 	}
 	info, err := os.Stat(file)
 	if err != nil || info.IsDir() {
 		return "", errPreviewFileNotFound
 	}
-	filePath := filepath.ToSlash(file)
-	if filepath.VolumeName(file) != "" || isWindowsAbsolutePath(filePath) {
-		filePath = "/" + filePath
-	}
-	return (&url.URL{Scheme: "file", Path: filePath}).String(), nil
+	return previewFileURL(r, id, filepath.ToSlash(rel)), nil
 }
 
 func writePreviewResolveError(w http.ResponseWriter, r *http.Request, err error) {
 	if errors.Is(err, errPreviewFileNotFound) {
 		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "PREVIEW_FILE_NOT_FOUND", "Preview file not found", nil)
+		return
+	}
+	if errors.Is(err, errPreviewFileOutsideWorkspace) {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "PREVIEW_FILE_OUTSIDE_WORKSPACE", "Preview file must be inside the session workspace", nil)
 		return
 	}
 	envelope.WriteError(w, r, err)

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -555,12 +555,16 @@ func TestSessionsAPI_SetPreviewLocalRelativePathResolvesToFilesURL(t *testing.T)
 	}
 }
 
-func TestSessionsAPI_SetPreviewAbsoluteFilePathPersistsFileURL(t *testing.T) {
+func TestSessionsAPI_SetPreviewAbsoluteWorkspaceFileUsesPreviewProxy(t *testing.T) {
 	svc := newFakeSessionService()
-	file := filepath.Join(t.TempDir(), "implementation_plan.html")
+	workspace := t.TempDir()
+	file := filepath.Join(workspace, "implementation_plan.html")
 	if err := os.WriteFile(file, []byte(`<html></html>`), 0o644); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
+	s := svc.sessions["ao-1"]
+	s.Metadata = domain.SessionMetadata{WorkspacePath: workspace}
+	svc.sessions["ao-1"] = s
 	srv := newSessionTestServer(t, svc)
 
 	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/preview", `{"url":`+strconv.Quote(file)+`}`)
@@ -573,20 +577,39 @@ func TestSessionsAPI_SetPreviewAbsoluteFilePathPersistsFileURL(t *testing.T) {
 		} `json:"session"`
 	}
 	mustJSON(t, body, &resp)
-	parsed, err := url.Parse(resp.Session.PreviewURL)
-	if err != nil {
-		t.Fatalf("parse preview url: %v", err)
-	}
-	if parsed.Scheme != "file" {
-		t.Fatalf("previewUrl = %q, want file URL", resp.Session.PreviewURL)
+	if !strings.HasSuffix(resp.Session.PreviewURL, "/preview/files/implementation_plan.html") {
+		t.Fatalf("previewUrl = %q, want preview/files URL", resp.Session.PreviewURL)
 	}
 }
 
-func TestSessionsAPI_SetPreviewMissingAbsoluteFilePathFailsWithoutOverwriting(t *testing.T) {
+func TestSessionsAPI_SetPreviewFileURLOutsideWorkspaceFailsWithoutOverwriting(t *testing.T) {
 	svc := newFakeSessionService()
-	missing := filepath.Join(t.TempDir(), "implmentation_plan.html")
+	workspace := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "implementation_plan.html")
+	if err := os.WriteFile(outside, []byte(`<html></html>`), 0o644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
 	s := svc.sessions["ao-1"]
-	s.Metadata = domain.SessionMetadata{PreviewURL: "http://localhost:4321/docs"}
+	s.Metadata = domain.SessionMetadata{WorkspacePath: workspace, PreviewURL: "http://localhost:4321/docs"}
+	svc.sessions["ao-1"] = s
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/preview", `{"url":`+strconv.Quote((&url.URL{Scheme: "file", Path: outside}).String())+`}`)
+	if status != http.StatusBadRequest {
+		t.Fatalf("set outside file preview = %d, want 400; body=%s", status, body)
+	}
+	assertErrorCode(t, body, status, http.StatusBadRequest, "PREVIEW_FILE_OUTSIDE_WORKSPACE")
+	if got := svc.sessions["ao-1"].Metadata.PreviewURL; got != "http://localhost:4321/docs" {
+		t.Fatalf("persisted previewUrl = %q, want existing target preserved", got)
+	}
+}
+
+func TestSessionsAPI_SetPreviewMissingAbsoluteWorkspaceFileFailsWithoutOverwriting(t *testing.T) {
+	svc := newFakeSessionService()
+	workspace := t.TempDir()
+	missing := filepath.Join(workspace, "implementation_plan.html")
+	s := svc.sessions["ao-1"]
+	s.Metadata = domain.SessionMetadata{WorkspacePath: workspace, PreviewURL: "http://localhost:4321/docs"}
 	svc.sessions["ao-1"] = s
 	srv := newSessionTestServer(t, svc)
 

--- a/backend/internal/skillassets/using-ao/commands/preview.md
+++ b/backend/internal/skillassets/using-ao/commands/preview.md
@@ -1,6 +1,6 @@
 # ao preview
 
-Open a URL in the desktop browser panel for the current session. With no argument it opens the workspace's static entry point, falling back to this session's existing preview target when no entry point exists. A local file can be opened by its absolute `file://` URL. Use `ao preview clear` to empty the panel.
+Open a URL in the desktop browser panel for the current session. With no argument it opens the workspace's static entry point, falling back to this session's existing preview target when no entry point exists. Workspace-local files can be opened by relative path and are served through AO's preview proxy. Use `ao preview clear` to empty the panel.
 
 ## Syntax
 
@@ -35,8 +35,8 @@ ao preview http://localhost:5173
 ```
 
 ```bash
-# Open a local HTML file
-ao preview file://$(pwd)/index.html
+# Open a workspace-local HTML file
+ao preview ./index.html
 ```
 
 ---

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -77,8 +77,9 @@ spawn remains the authoritative runtime validation point. Use
 
 `ao preview` resolves its session from the `AO_SESSION_ID` environment variable
 (it is meant to run inside a session), not a flag. With no argument it
-autodetects an `index.html` in the session workspace; with a URL argument it
-opens that URL verbatim (`file://`, `http`, `https`).
+autodetects an `index.html` in the session workspace; with an explicit target it
+opens `http`/`https` URLs directly and serves workspace-local files through the
+daemon preview proxy.
 
 `go run .` in `backend/` remains a compatibility wrapper around the daemon.
 

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -72,17 +72,18 @@ describe("normalizeBrowserURL", () => {
 		expect(normalizeBrowserURL("example.com").href).toBe("https://example.com/");
 	});
 
-	it("allows file:// preview targets without mangling the scheme", () => {
-		expect(normalizeBrowserURL("file:///tmp/preview/index.html").href).toBe("file:///tmp/preview/index.html");
-		expect(normalizeBrowserURL("file:///C:/tmp/index.html").protocol).toBe("file:");
+	it("allows daemon preview file proxy URLs", () => {
+		expect(
+			normalizeBrowserURL("http://127.0.0.1:3001/api/v1/sessions/ao-1/preview/files/index.html").href,
+		).toBe("http://127.0.0.1:3001/api/v1/sessions/ao-1/preview/files/index.html");
 	});
 
-	it("converts absolute local file paths to file URLs", () => {
-		expect(normalizeBrowserURL("C:\\Users\\Lenovo\\Downloads\\sm5\\paper_explainer.html").href).toBe(
-			"file:///C:/Users/Lenovo/Downloads/sm5/paper_explainer.html",
+	it("rejects local file URLs and absolute local paths", () => {
+		expect(() => normalizeBrowserURL("file:///tmp/preview/index.html")).toThrow(/unsupported/i);
+		expect(() => normalizeBrowserURL("C:\\Users\\Lenovo\\Downloads\\sm5\\paper_explainer.html")).toThrow(
+			/local file paths/i,
 		);
-		expect(normalizeBrowserURL("C:/Users/Lenovo/My File.html").href).toBe("file:///C:/Users/Lenovo/My%20File.html");
-		expect(normalizeBrowserURL("/tmp/preview/index.html").href).toBe("file:///tmp/preview/index.html");
+		expect(() => normalizeBrowserURL("/tmp/preview/index.html")).toThrow(/local file paths/i);
 	});
 
 	it("rejects privileged or unsupported schemes", () => {
@@ -92,8 +93,8 @@ describe("normalizeBrowserURL", () => {
 });
 
 describe("isAllowedBrowserURL", () => {
-	it("allows file:// even when a renderer origin is set", () => {
-		expect(isAllowedBrowserURL("file:///tmp/preview/index.html", "http://localhost:5173")).toBe(true);
+	it("rejects file:// even when a renderer origin is set", () => {
+		expect(isAllowedBrowserURL("file:///tmp/preview/index.html", "http://localhost:5173")).toBe(false);
 	});
 
 	it("still blocks the renderer's own http origin", () => {

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -86,13 +86,15 @@ type BrowserEntry = {
 };
 
 const OFFSCREEN_BOUNDS: BrowserRect = { x: -10_000, y: -10_000, width: 0, height: 0 };
-// ponytail: file:// allowed unsanitized; preview targets are agent-trusted for now
-const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "file:"]);
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
 
 export function normalizeBrowserURL(input: string): URL {
 	const raw = input.trim();
 	if (raw === "") {
 		throw new Error("URL is required");
+	}
+	if (isWindowsAbsolutePath(raw) || isPosixAbsolutePath(raw)) {
+		throw new Error("Local file paths are not supported");
 	}
 	const candidate = withDefaultScheme(raw);
 	const url = new URL(candidate);
@@ -258,7 +260,6 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 }
 
 function withDefaultScheme(raw: string): string {
-	if (isWindowsAbsolutePath(raw) || isPosixAbsolutePath(raw)) return localPathToFileURL(raw);
 	if (/^https?:\/\//i.test(raw)) return raw;
 	if (isLocalhostLike(raw)) return `http://${raw}`;
 	if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(raw)) return raw;
@@ -271,18 +272,6 @@ function isWindowsAbsolutePath(raw: string): boolean {
 
 function isPosixAbsolutePath(raw: string): boolean {
 	return raw.startsWith("/");
-}
-
-function localPathToFileURL(raw: string): string {
-	if (isWindowsAbsolutePath(raw)) {
-		const normalized = raw.replace(/\\/g, "/");
-		return `file:///${encodePathSegments(normalized).replace(/^([A-Za-z])%3A(?=\/)/, "$1:")}`;
-	}
-	return `file://${encodePathSegments(raw)}`;
-}
-
-function encodePathSegments(pathname: string): string {
-	return pathname.split("/").map(encodeURIComponent).join("/");
 }
 
 function isLocalhostLike(raw: string): boolean {

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -85,11 +85,16 @@ describe("BrowserPanel", () => {
 				active
 				onTogglePopOut={() => undefined}
 				poppedOut={false}
-				session={{ ...session, previewUrl: "file:///tmp/preview/index.html" }}
+				session={{
+					...session,
+					previewUrl: "http://127.0.0.1:3001/api/v1/sessions/sess-1/preview/files/index.html",
+				}}
 			/>,
 		);
 
-		expect(hookState.previewUrl).toBe("file:///tmp/preview/index.html");
+		expect(hookState.previewUrl).toBe(
+			"http://127.0.0.1:3001/api/v1/sessions/sess-1/preview/files/index.html",
+		);
 	});
 
 	it("binds navigation controls to nav state", async () => {

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -292,9 +292,15 @@ describe("useBrowserView", () => {
 		await waitFor(() => expect(bridge.navigate).toHaveBeenCalledTimes(2));
 
 		// A changed target with a fresh revision navigates to the new URL.
-		rerender({ previewUrl: "file:///tmp/preview/index.html", previewRevision: 3 });
+		rerender({
+			previewUrl: "http://127.0.0.1:3001/api/v1/sessions/sess-1/preview/files/index.html",
+			previewRevision: 3,
+		});
 		await waitFor(() =>
-			expect(bridge.navigate).toHaveBeenCalledWith({ viewId: "42:sess-1", url: "file:///tmp/preview/index.html" }),
+			expect(bridge.navigate).toHaveBeenCalledWith({
+				viewId: "42:sess-1",
+				url: "http://127.0.0.1:3001/api/v1/sessions/sess-1/preview/files/index.html",
+			}),
 		);
 		expect(bridge.navigate).toHaveBeenCalledTimes(3);
 	});


### PR DESCRIPTION
 ## Summary

  - Create each supervisor-link test socket inside a unique temporary directory.
  - Track accepted sockets and destroy them during teardown.
  - Remove temporary socket directories in afterEach.
  - Centralize test server creation so cleanup stays consistent.

  ## Why

  The supervisor-link tests previously used timestamp-based socket paths directly under os.tmpdir() and did not clean up the
  parent path afterward. Unique temp dirs plus explicit socket cleanup reduce stale socket/collision risk across repeated or
  parallel test runs.

  ## Tests

  - npm --prefix frontend test -- supervisor-link
  - npm --prefix frontend test
  - npm --prefix frontend run typecheck
  - npm run lint
  - git diff --check
