### PR TITLE
fix(codex): prefer npm binary over WindowsApps

### DIFF
--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -154,26 +154,13 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 }
 
 // ResolveCodexBinary returns the path to the codex binary on this machine,
-// searching PATH then a handful of well-known install locations
-// (Homebrew, Cargo, npm global, NVM). Returns "codex" as a last-ditch
-// fallback so callers see a clear "command not found" rather than an empty
-// argv.
+// searching platform-specific well-known install locations and PATH.
 func ResolveCodexBinary(ctx context.Context) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
 
 	if runtime.GOOS == "windows" {
-		for _, name := range []string{"codex.exe", "codex.cmd", "codex"} {
-			path, err := exec.LookPath(name)
-			if err == nil && path != "" {
-				return resolveNativeWindowsCodex(path), nil
-			}
-			if err := ctx.Err(); err != nil {
-				return "", err
-			}
-		}
-
 		candidates := []string{}
 		if appData := os.Getenv("APPDATA"); appData != "" {
 			shim := filepath.Join(appData, "npm", "codex.cmd")
@@ -189,6 +176,19 @@ func ResolveCodexBinary(ctx context.Context) (string, error) {
 		for _, candidate := range candidates {
 			if fileExists(candidate) {
 				return resolveNativeWindowsCodex(candidate), nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+
+		for _, name := range []string{"codex.cmd", "codex", "codex.exe"} {
+			path, err := exec.LookPath(name)
+			if err == nil && path != "" {
+				if isWindowsAppsCodexExecutable(path) {
+					continue
+				}
+				return resolveNativeWindowsCodex(path), nil
 			}
 			if err := ctx.Err(); err != nil {
 				return "", err
@@ -252,6 +252,16 @@ func windowsNativeCodexCandidatesForShim(shim string) []string {
 		filepath.Join(dir, "node_modules", "@openai", "codex", "node_modules", "@openai", "codex-win32-x64", "vendor", "x86_64-pc-windows-msvc", "bin", "codex.exe"),
 		filepath.Join(dir, "node_modules", "@openai", "codex", "bin", "codex.exe"),
 	}
+}
+
+func isWindowsAppsCodexExecutable(path string) bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	clean := strings.ToLower(filepath.Clean(path))
+	base := filepath.Base(clean)
+	return (base == "codex.exe" || base == "codex") &&
+		strings.Contains(clean, string(filepath.Separator)+"windowsapps"+string(filepath.Separator)+"openai.codex_")
 }
 
 func (p *Plugin) codexBinary(ctx context.Context) (string, error) {

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -122,6 +122,44 @@ func TestResolveCodexBinaryFindsNVMInstallWhenPathIsSparse(t *testing.T) {
 	}
 }
 
+func TestResolveCodexBinaryPrefersNPMOverWindowsAppsExecutable(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows resolver only")
+	}
+	root := t.TempDir()
+	appData := filepath.Join(root, "Roaming")
+	npmDir := filepath.Join(appData, "npm")
+	want := filepath.Join(npmDir, "node_modules", "@openai", "codex", "node_modules", "@openai", "codex-win32-x64", "vendor", "x86_64-pc-windows-msvc", "bin", "codex.exe")
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(want, []byte("native codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shim := filepath.Join(npmDir, "codex.cmd")
+	if err := os.WriteFile(shim, []byte("@echo off\r\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	windowsApps := filepath.Join(root, "WindowsApps", "OpenAI.Codex_1.0.0.0_x64__test", "app", "resources")
+	if err := os.MkdirAll(windowsApps, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	blocked := filepath.Join(windowsApps, "codex.exe")
+	if err := os.WriteFile(blocked, []byte("blocked codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("APPDATA", appData)
+	t.Setenv("PATH", windowsApps)
+
+	got, err := ResolveCodexBinary(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveCodexBinary: %v", err)
+	}
+	if got != want {
+		t.Fatalf("ResolveCodexBinary = %q, want %q", got, want)
+	}
+}
+
 func TestGetLaunchCommandMapsApprovalModes(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Fixes #2582

## Summary
- Prefer the npm-installed Codex shim/native binary on Windows before probing PATH.
- Skip the packaged WindowsApps OpenAI Codex executable when it appears in PATH, because it can shadow the authenticated npm install and return false auth failures.
- Add a Windows regression test for the npm-vs-WindowsApps resolver ordering.

## Test
- cd backend && go test ./internal/adapters/agent/codex