### PR TITLE
fix(frontend): surface daemon failure reason instead of generic "not ready" error

### DIFF
--- a/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
+++ b/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
@@ -24,6 +24,7 @@ vi.mock("../lib/event-transport", () => ({
 
 vi.mock("../lib/api-client", () => ({
 	setApiBaseUrl: setApiBaseUrlMock,
+	setDaemonUnavailableMessage: vi.fn(),
 }));
 
 import { useDaemonStatus } from "./useDaemonStatus";

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -11,6 +11,15 @@ const initialApiBaseUrl = explicitApiBaseUrl ?? (import.meta.env.DEV ? devApiBas
 
 let runtimeApiBaseUrl: string | null = explicitApiBaseUrl ?? null;
 
+// Human-facing reason the daemon base URL is untrusted (identity mismatch,
+// spawn failure, exit code, …), surfaced by runtimeFetch's 503 short-circuit
+// so callers see the actual cause instead of the generic fallback (#2481).
+let daemonUnavailableMessage: string | null = null;
+
+export function setDaemonUnavailableMessage(message: string | null): void {
+	daemonUnavailableMessage = message;
+}
+
 const baseUrlListeners = new Set<() => void>();
 
 export function getApiBaseUrl(): string {
@@ -161,7 +170,7 @@ async function runtimeFetch(input: Request): Promise<Response> {
 	const baseUrl = runtimeApiBaseUrl;
 	if (baseUrl === null) {
 		reportApiError(operation, "daemon_unavailable", 503);
-		return new Response(JSON.stringify({ message: "AO daemon is not ready." }), {
+		return new Response(JSON.stringify({ message: daemonUnavailableMessage ?? "AO daemon is not ready." }), {
 			status: 503,
 			headers: { "Content-Type": "application/json" },
 		});

--- a/frontend/src/renderer/lib/daemon-status.test.ts
+++ b/frontend/src/renderer/lib/daemon-status.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { apiClient, setApiBaseUrl } from "./api-client";
+import { applyDaemonStatus } from "./daemon-status";
+
+describe("applyDaemonStatus failure messages", () => {
+	afterEach(() => {
+		// Restore the trusted-base default other suites expect.
+		applyDaemonStatus({ state: "ready", port: 3001 });
+	});
+
+	it("surfaces the specific daemon failure reason through the api-client 503 body", async () => {
+		// Regression for #2481: the identity-mismatch diagnostic was computed in
+		// the main process, sent over IPC, and then dropped — every API call
+		// surfaced only the generic "AO daemon is not ready." fallback.
+		const identityMessage =
+			"Another AO daemon is already running from /other/checkout; expected this checkout at /this/checkout. Stop the other daemon before using this checkout.";
+		applyDaemonStatus({ state: "error", code: "identity_mismatch", message: identityMessage });
+
+		const { error } = await apiClient.GET("/api/v1/projects");
+
+		expect(error).toEqual({ message: identityMessage });
+	});
+
+	it("falls back to the generic message when the status carries no reason", async () => {
+		applyDaemonStatus({ state: "starting" });
+
+		const { error } = await apiClient.GET("/api/v1/projects");
+
+		expect(error).toEqual({ message: "AO daemon is not ready." });
+	});
+
+	it("clears a stale failure reason once the daemon is ready again", async () => {
+		applyDaemonStatus({ state: "error", code: "spawn_failed", message: "spawn ENOENT" });
+		applyDaemonStatus({ state: "ready", port: 3001 });
+
+		// The daemon later vanishes without a diagnostic (e.g. status listener
+		// pushes a bare stop); the old reason must not resurface.
+		setApiBaseUrl(null);
+
+		const { error } = await apiClient.GET("/api/v1/projects");
+
+		expect(error).toEqual({ message: "AO daemon is not ready." });
+	});
+});

--- a/frontend/src/renderer/lib/daemon-status.ts
+++ b/frontend/src/renderer/lib/daemon-status.ts
@@ -1,12 +1,18 @@
 import { aoBridge } from "./bridge";
-import { setApiBaseUrl } from "./api-client";
+import { setApiBaseUrl, setDaemonUnavailableMessage } from "./api-client";
 
 export type DaemonStatus = Awaited<ReturnType<typeof aoBridge.daemon.getStatus>>;
 
 export function applyDaemonStatus(nextStatus: DaemonStatus): void {
 	if (nextStatus.state === "ready" && nextStatus.port) {
+		setDaemonUnavailableMessage(null);
 		setApiBaseUrl(`http://127.0.0.1:${nextStatus.port}`);
 	} else {
+		// Keep the specific failure reason (identity mismatch, exit code, …) so
+		// the api-client's 503 short-circuit surfaces it instead of the generic
+		// "AO daemon is not ready." (#2481). Set it before the base URL so
+		// listeners reacting to the change never see a stale reason.
+		setDaemonUnavailableMessage(nextStatus.message ?? null);
 		setApiBaseUrl(null);
 	}
 }


### PR DESCRIPTION
## Bug

When a second checkout's Electron instance cannot attach to the daemon (checkout identity mismatch — but also spawn failure or unexpected exit), the main process computes a specific, actionable diagnostic and sends it over the `daemon:status` IPC. The renderer drops it: every API call surfaces only the generic `"AO daemon is not ready."` error, so the user never learns another checkout owns the daemon or how to fix it.

## Root cause

- `applyDaemonStatus()` (`renderer/lib/daemon-status.ts`) quarantines the base URL for non-ready statuses but discards `status.message`.
- `runtimeFetch()`'s 503 short-circuit (`renderer/lib/api-client.ts`) hardcodes the generic body, so `apiErrorMessage()` can only ever surface the fallback.

The diagnostic is computed in `main.ts` (`daemonIdentityError()`), shipped over IPC, and then dead on arrival.

## Fix

Keep the status message alongside the quarantined base URL (`setDaemonUnavailableMessage`), and let the 503 short-circuit prefer it over the generic fallback — the same `status.message || "AO daemon is not ready."` pattern `_shell.tsx` already uses for project creation. This benefits every `daemonStatus` failure path (identity mismatch, spawn failure, daemon exit), not just the issue's trigger, and complements #2253 (which disables actions and adds a Restart button but does not fix the message masking).

## Testing

- New `renderer/lib/daemon-status.test.ts` regression test: fails before the fix (generic message masks the identity diagnostic), passes after. Also covers the no-message fallback and that a stale reason is cleared once the daemon is ready again.
- `useDaemonStatus.test.tsx`: completed the partial `api-client` mock with the new export.
- Full frontend vitest suite, `tsc --noEmit`, and `prettier --check` on the changed files all pass.

Fixes #2481