### PR TITLE
fix(web): give xterm keyboard focus when a terminal is attached

### DIFF
--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -122,6 +122,9 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 			terminal.clear();
 		}
 		hadAttachmentRef.current = true;
+		if (handleId) {
+			terminal.focus();
+		}
 		return attach(terminal);
 	}, [terminal, handleId, attach, attachSession?.id]);
 

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -518,6 +518,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			write: (data) => term.write(data),
 			writeln: (line) => term.writeln(line),
 			clear: () => term.write(CLEAR_SEQUENCE),
+			focus: () => term.focus(),
 			onUserInput: (listener) => {
 				userInputListeners.add(listener);
 				return { dispose: () => userInputListeners.delete(listener) };

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -110,6 +110,7 @@ function createFakeTerminal(): FakeTerminal {
 		clear: () => {
 			terminal.clears += 1;
 		},
+		focus: () => {},
 		onUserInput: (listener) => {
 			inputListeners.add(listener);
 			return { dispose: () => inputListeners.delete(listener) };

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -32,6 +32,7 @@ export type AttachableTerminal = {
 	 * with wheel scroll dead (see XtermTerminal's CLEAR_SEQUENCE).
 	 */
 	clear: () => void;
+	focus: () => void;
 	onUserInput: (listener: (data: string, source: TerminalUserInputSource) => void) => { dispose: () => void };
 	onResize: (listener: (size: { cols: number; rows: number }) => void) => { dispose: () => void };
 };


### PR DESCRIPTION
Fixes #2434

## Summary
Independent implementation of the fix for #2434: the xterm.js terminal never received keyboard focus when opening a session/agent view, requiring a manual click before typing worked.

- `XtermTerminal.tsx`: added `focus: () => term.focus()` to the `AttachableTerminal` handle.
- `useTerminalSession.ts`: added `focus: () => void` to the `AttachableTerminal` type.
- `TerminalPane.tsx`: calls `terminal.focus()` in the existing mount effect, gated on `handleId` being present so focus isn't stolen onto the empty-state pane when no session is selected.
- `useTerminalSession.test.tsx`: added a no-op `focus` to the test's fake terminal handle to satisfy the type.

Verified via a separate, extensive live reproduction (isolated Electron instance, 6 repeated runs) that this fix correctly reclaims terminal focus even after a session previously had the browser-preview (`WebContentsView`) panel opened and later revisited — no additional handling needed for that interaction.

## Test plan
- `cd frontend && npm run typecheck && npm test` (473 tests pass)