### PR TITLE
fix(lifecycle): require consecutive dead probes before terminating a session

### DIFF
--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -59,6 +59,11 @@ type Manager struct {
 	clock     func() time.Time
 	react     reactionState
 	telemetry ports.EventSink
+	// deadStreaks counts consecutive ProbeDead readings per session, guarded
+	// by mu. Kept in memory only: a probe streak is arbitration state, not a
+	// durable session fact, and losing it on daemon restart merely delays a
+	// termination by a few reaper ticks.
+	deadStreaks map[domain.SessionID]int
 }
 
 // New builds a Lifecycle Manager over the session store it writes and the messenger it uses for agent nudges.
@@ -68,7 +73,7 @@ func New(store sessionStore, messenger ports.AgentMessenger, opts ...Option) *Ma
 	// `ao session get` showing created in UTC but updated in local time. A
 	// WithClock option may still override this in tests.
 	clock := func() time.Time { return time.Now().UTC() }
-	m := &Manager{store: store, messenger: messenger, window: defaultRecentActivityWindow, clock: clock, react: newReactionState()}
+	m := &Manager{store: store, messenger: messenger, window: defaultRecentActivityWindow, clock: clock, react: newReactionState(), deadStreaks: map[domain.SessionID]int{}}
 	for _, opt := range opts {
 		opt(m)
 	}
@@ -97,11 +102,31 @@ func (m *Manager) mutate(ctx context.Context, id domain.SessionID, fn func(domai
 
 // ApplyRuntimeObservation only writes when runtime liveness is unambiguous. A
 // failed probe or liveness disagreement is ignored; no transient lifecycle state is stored.
+// A dead reading terminates only after it has repeated for deadProbeConfirmations
+// consecutive probes AND recent activity does not contradict it — a single dead
+// sample is no more proof of death than a failed one (#2501).
 func (m *Manager) ApplyRuntimeObservation(ctx context.Context, id domain.SessionID, f ports.RuntimeFacts) error {
 	return m.mutate(ctx, id, func(cur domain.SessionRecord, now time.Time) (domain.SessionRecord, bool) {
-		if cur.IsTerminated || !runtimeClearlyDead(f, cur.Activity, now, m.window) {
+		if cur.IsTerminated {
+			delete(m.deadStreaks, id)
 			return cur, false
 		}
+		switch f.Probe {
+		case ports.ProbeDead:
+			m.deadStreaks[id]++
+		case ports.ProbeAlive:
+			delete(m.deadStreaks, id)
+			return cur, false
+		default:
+			// A failed probe carries no liveness information: it neither
+			// builds the dead streak nor resets it (a flaky probe must not
+			// shield a really-dead session from the backstop).
+			return cur, false
+		}
+		if m.deadStreaks[id] < deadProbeConfirmations || !runtimeClearlyDead(f, cur.Activity, now, m.window) {
+			return cur, false
+		}
+		delete(m.deadStreaks, id)
 		next := cur
 		next.IsTerminated = true
 		next.Activity = domain.Activity{State: domain.ActivityExited, LastActivityAt: timeOr(f.ObservedAt, now)}
@@ -149,6 +174,7 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	}
 	if s.State == domain.ActivityExited {
 		next.IsTerminated = true
+		delete(m.deadStreaks, id)
 	}
 	next.UpdatedAt = now
 	if err := m.store.UpdateSession(ctx, next); err != nil {
@@ -242,6 +268,8 @@ func (m *Manager) MarkSpawned(ctx context.Context, id domain.SessionID, metadata
 	now := m.clock()
 	rec.IsTerminated = false
 	rec.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}
+	// A fresh runtime voids any dead readings taken against the previous one.
+	delete(m.deadStreaks, id)
 	// Each spawn/restore must re-prove its hook pipeline: clear the receipt so
 	// a relaunch with broken hooks degrades to no_signal instead of inheriting
 	// a stale "signals worked once" fact.
@@ -254,6 +282,7 @@ func (m *Manager) MarkSpawned(ctx context.Context, id domain.SessionID, metadata
 // MarkTerminated marks a session terminated without tearing down external resources.
 func (m *Manager) MarkTerminated(ctx context.Context, id domain.SessionID) error {
 	return m.mutate(ctx, id, func(cur domain.SessionRecord, now time.Time) (domain.SessionRecord, bool) {
+		delete(m.deadStreaks, id)
 		if cur.IsTerminated {
 			return cur, false
 		}

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -89,17 +89,110 @@ func working(id domain.SessionID) domain.SessionRecord {
 	return domain.SessionRecord{ID: id, ProjectID: "mer", Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: time.Now()}}
 }
 
+// stale returns a session whose last activity predates the recent-activity
+// window, so only the dead-probe streak stands between it and termination.
+func stale(id domain.SessionID) domain.SessionRecord {
+	rec := working(id)
+	rec.Activity.LastActivityAt = time.Now().Add(-2 * time.Minute)
+	return rec
+}
+
+func observe(t *testing.T, m *Manager, id domain.SessionID, probe ports.ProbeResult, times int) {
+	t.Helper()
+	for i := 0; i < times; i++ {
+		if err := m.ApplyRuntimeObservation(ctx, id, ports.RuntimeFacts{Probe: probe}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func TestRuntimeObservation_InferredDeathSetsTerminated(t *testing.T) {
 	m, st, _ := newManager()
-	rec := working("mer-1")
-	rec.Activity.LastActivityAt = time.Now().Add(-2 * time.Minute)
-	st.sessions["mer-1"] = rec
-	if err := m.ApplyRuntimeObservation(ctx, "mer-1", ports.RuntimeFacts{Probe: ports.ProbeDead}); err != nil {
-		t.Fatal(err)
-	}
+	st.sessions["mer-1"] = stale("mer-1")
+	observe(t, m, "mer-1", ports.ProbeDead, deadProbeConfirmations)
 	got := st.sessions["mer-1"]
 	if !got.IsTerminated || got.Activity.State != domain.ActivityExited {
 		t.Fatalf("want terminated/exited, got %+v", got)
+	}
+}
+
+func TestRuntimeObservation_UnconfirmedDeadProbeDoesNotTerminate(t *testing.T) {
+	// Regression for #2501: hook delivery is best-effort, so activity can go
+	// stale on a genuinely live session; a transient dead reading landing in
+	// that window must not kill the session irreversibly.
+	m, st, _ := newManager()
+	st.sessions["mer-1"] = stale("mer-1")
+	observe(t, m, "mer-1", ports.ProbeDead, deadProbeConfirmations-1)
+	if st.sessions["mer-1"].IsTerminated {
+		t.Fatalf("dead streak below confirmation threshold must not terminate, got %+v", st.sessions["mer-1"])
+	}
+}
+
+func TestRuntimeObservation_AliveResetsDeadStreak(t *testing.T) {
+	m, st, _ := newManager()
+	st.sessions["mer-1"] = stale("mer-1")
+	observe(t, m, "mer-1", ports.ProbeDead, deadProbeConfirmations-1)
+	observe(t, m, "mer-1", ports.ProbeAlive, 1)
+	observe(t, m, "mer-1", ports.ProbeDead, deadProbeConfirmations-1)
+	if st.sessions["mer-1"].IsTerminated {
+		t.Fatalf("an alive reading must reset the dead streak, got %+v", st.sessions["mer-1"])
+	}
+}
+
+func TestRuntimeObservation_FailedProbeKeepsDeadStreak(t *testing.T) {
+	// A failed probe carries no liveness information: it must not reset the
+	// streak (a flaky probe would shield a really-dead session from the
+	// backstop) and must not extend it either.
+	m, st, _ := newManager()
+	st.sessions["mer-1"] = stale("mer-1")
+	observe(t, m, "mer-1", ports.ProbeDead, deadProbeConfirmations-1)
+	observe(t, m, "mer-1", ports.ProbeFailed, 1)
+	if st.sessions["mer-1"].IsTerminated {
+		t.Fatalf("failed probe must not extend the dead streak, got %+v", st.sessions["mer-1"])
+	}
+	observe(t, m, "mer-1", ports.ProbeDead, 1)
+	got := st.sessions["mer-1"]
+	if !got.IsTerminated {
+		t.Fatalf("dead streak interrupted only by failed probes must still terminate, got %+v", got)
+	}
+}
+
+func TestRuntimeObservation_DeadStreakAccruesWhileActivityRecent(t *testing.T) {
+	// Readings taken while recent activity still vetoes termination count
+	// toward confirmation, so a genuinely dead runtime terminates the moment
+	// its activity goes stale — the streak adds no latency on top of the
+	// recent-activity window.
+	m, st, _ := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	observe(t, m, "mer-1", ports.ProbeDead, deadProbeConfirmations)
+	if st.sessions["mer-1"].IsTerminated {
+		t.Fatal("recent activity must veto termination")
+	}
+	rec := st.sessions["mer-1"]
+	rec.Activity.LastActivityAt = time.Now().Add(-2 * time.Minute)
+	st.sessions["mer-1"] = rec
+	observe(t, m, "mer-1", ports.ProbeDead, 1)
+	if !st.sessions["mer-1"].IsTerminated {
+		t.Fatalf("confirmed-dead runtime must terminate once activity goes stale, got %+v", st.sessions["mer-1"])
+	}
+}
+
+func TestRuntimeObservation_RespawnResetsDeadStreak(t *testing.T) {
+	m, st, _ := newManager()
+	st.sessions["mer-1"] = stale("mer-1")
+	observe(t, m, "mer-1", ports.ProbeDead, deadProbeConfirmations-1)
+	if err := m.MarkSpawned(ctx, "mer-1", domain.SessionMetadata{RuntimeHandleID: "h2"}); err != nil {
+		t.Fatal(err)
+	}
+	// The fresh runtime's activity goes stale and reads dead once (e.g. a
+	// probe races a slow relaunch); the prior spawn's readings must not count
+	// toward its confirmation.
+	rec := st.sessions["mer-1"]
+	rec.Activity.LastActivityAt = time.Now().Add(-2 * time.Minute)
+	st.sessions["mer-1"] = rec
+	observe(t, m, "mer-1", ports.ProbeDead, deadProbeConfirmations-1)
+	if st.sessions["mer-1"].IsTerminated {
+		t.Fatalf("respawn must reset the dead streak, got %+v", st.sessions["mer-1"])
 	}
 }
 

--- a/backend/internal/lifecycle/runtime.go
+++ b/backend/internal/lifecycle/runtime.go
@@ -9,6 +9,16 @@ import (
 
 const defaultRecentActivityWindow = 60 * time.Second
 
+// deadProbeConfirmations is how many consecutive ProbeDead readings the
+// reducer requires before it terminates a session. Hook delivery is
+// best-effort, so recorded activity can be stale on a genuinely live session;
+// a single dead sample landing in that window must not kill it irreversibly
+// (#2501). At the reaper's 5s cadence three readings confirm death within
+// ~15s — and the streak accrues while recent activity still vetoes
+// termination, so a genuinely dead runtime is typically terminated the moment
+// its activity goes stale, with no added latency.
+const deadProbeConfirmations = 3
+
 func hasRecentActivity(a domain.Activity, now time.Time, window time.Duration) bool {
 	switch {
 	case a.State == domain.ActivityExited:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -576,7 +576,7 @@ flowchart TD
 
 ```
 
-**Key principle:** Failed probes are NOT proof of death. A session is only terminated when the runtime and process are **both** clearly dead and recent activity doesn't contradict that.
+**Key principle:** Failed probes are NOT proof of death — and neither is a single dead reading. A session is only terminated when the runtime has read dead for several consecutive probes, the runtime and process are **both** clearly dead, and recent activity doesn't contradict that.
 
 ---
 


### PR DESCRIPTION
## Bug

A single `ProbeDead` reading from the reaper, landing while a session's recorded activity happened to be stale (>60s), terminated the session **immediately and irreversibly**. Hook delivery is explicitly best-effort (`manager.go`), so activity routinely goes stale on genuinely live sessions — long tool calls, dropped hook deliveries. One transient tmux misreading could kill a live orchestrator mid-turn, which is exactly the incident traced in #2501: `pledg-turbo-monolith-4` was marked terminated ~5 minutes *before* its own transcript's `stop_hook_summary`, then silently replaced.

## Root cause

`ApplyRuntimeObservation` killed on the first observation where `Probe == ProbeDead && !hasRecentActivity(60s)`. There was no retry, no requirement for multiple consecutive dead readings, and no reconciliation if the pane turned out to still be alive. `docs/architecture.md`'s own key principle — *failed probes are NOT proof of death* — stopped one step short: a single dead sample against stale activity is no more trustworthy.

## Fix

The lifecycle manager now counts consecutive `ProbeDead` readings per session (in memory, under the existing `mu` — a probe streak is arbitration state, not a durable session fact, honoring the "no transient lifecycle state is stored" rule) and terminates only once the runtime has read dead for **3 consecutive probes** (~10–15s at the reaper's 5s cadence) *and* the existing stale-activity gate agrees.

- An **alive** reading resets the streak — a transient blip can never accumulate into a kill.
- A **failed** probe neither builds nor resets it — a flaky probe must not shield a really-dead session from the backstop, nor count toward its death.
- **Spawn/restore** (`MarkSpawned`) voids readings taken against the previous runtime.
- The streak **accrues while recent activity still vetoes termination**, so a genuinely dead runtime still terminates the moment its activity goes stale — no added latency in the common case. The only slower path is a runtime that dies while activity is *already* stale: 3 ticks (~10s) instead of 1. `SessionEnd` hooks remain the fast path either way.

Updated the key-principle line in `docs/architecture.md` accordingly.

## Testing

New regression tests in `manager_test.go` (all fail against the previous behavior): unconfirmed dead probe does not terminate; alive resets the streak; failed probes preserve but do not extend it; the streak accrues under recent activity; respawn resets it. `go test ./internal/lifecycle/` and `go test -race` pass; `go vet` and golangci-lint clean on the package; full `go test ./...` shows no new failures against main.

Part of #2501 — this addresses the probe-race kill (defect 1). The unlinked, notification-less orchestrator respawn (defect 2) is left for a separate change.