### PR TITLE
fix: remove daemon status dot from settings footer

### DIFF
--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -326,15 +326,6 @@ export function Sidebar({
 						</DropdownMenuContent>
 					</DropdownMenu>
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<span
-								aria-label={`Daemon ${daemonStatus.state}`}
-								className={cn(
-									"absolute right-1.5 top-1/2 h-1.5 w-1.5 -translate-y-1/2 rounded-full",
-									daemonStatus.state === "ready" && eventsConnection !== "disconnected" ? "bg-success" : "bg-amber",
-								)}
-							/>
-						</TooltipTrigger>
 						<TooltipContent side="top">
 							daemon {daemonStatus.state}
 							{eventsConnection === "disconnected" && " · events offline"}


### PR DESCRIPTION
## Summary
Removes the green/amber daemon status dot next to the Settings button in the expanded sidebar footer.

## Test plan
- [ ] Expanded sidebar: Settings footer has no status dot; dropdown still works
- [ ] Collapsed sidebar: icon Settings + expand still work

## Before
<img width="280" height="182" alt="image" src="https://github.com/user-attachments/assets/83823a49-e25d-40a9-8f76-d7c5b79bac2e" />

## After
<img width="249" height="165" alt="image" src="https://github.com/user-attachments/assets/5f05351a-452a-4c30-9d83-644aa25d35a5" />
