### PR TITLE
docs(skill): tell orchestrators to report spawn display name, not the id

### DIFF
--- a/backend/internal/skillassets/using-ao/SKILL.md
+++ b/backend/internal/skillassets/using-ao/SKILL.md
@@ -32,5 +32,6 @@ trigger: Using the ao CLI in an AO workspace: spawning workers, managing session
 - Session and project ids are shown by `ao session ls` and `ao project ls`.
 - `--agent` is an alias for `--harness` on `ao spawn`.
 - Every command accepts `-h / --help` for the full flag list.
+- A session's display name is not permanent — it can change after spawn via `ao session rename <id> <name>`. Unlike the session id (fixed for the session's lifetime), a name you learned earlier in a conversation may now be stale. When accuracy matters (long conversations, or after any renaming activity), re-confirm the current name with `ao session get`/`ao session ls` rather than relying on memory.
 
 See [references.md](references.md) for natural-language-to-command mappings.

--- a/backend/internal/skillassets/using-ao/commands/spawn.md
+++ b/backend/internal/skillassets/using-ao/commands/spawn.md
@@ -39,4 +39,4 @@ ao spawn --project agent-orchestrator --name "review-pr-88" --claim-pr 88 --harn
 
 ## Reporting back to the user
 
-When telling the user a session was spawned, lead with the `--name` you gave it, not the generated session id (e.g. "spawned `review-pr-88`" rather than "spawned `agent-orchestrator-15`"). The id is only useful when it's needed for a command (`ao session get <id>`, `ao send --session <id>`) — it's not meaningful on its own to a human reading your summary. `ao spawn`'s confirmation output leads with the name for this reason; carry that through to your own prose instead of just repeating the raw output.
+When telling the user a session was spawned, lead with the `--name` you gave it, not the generated session id (e.g. "spawned `review-pr-88`" rather than "spawned `agent-orchestrator-15`"). The id is only useful when it's needed for a command (`ao session get <id>`, `ao send --session <id>`) — it's not meaningful on its own to a human reading your summary. `ao spawn`'s own confirmation output still leads with the id, not the name; don't just repeat it verbatim in your own prose.

--- a/backend/internal/skillassets/using-ao/commands/spawn.md
+++ b/backend/internal/skillassets/using-ao/commands/spawn.md
@@ -36,3 +36,7 @@ ao spawn --project agent-orchestrator --issue 142 --name "fix-session-leak" --pr
 # Spawn a worker and immediately claim an open PR
 ao spawn --project agent-orchestrator --name "review-pr-88" --claim-pr 88 --harness claude-code
 ```
+
+## Reporting back to the user
+
+When telling the user a session was spawned, lead with the `--name` you gave it, not the generated session id (e.g. "spawned `review-pr-88`" rather than "spawned `agent-orchestrator-15`"). The id is only useful when it's needed for a command (`ao session get <id>`, `ao send --session <id>`) — it's not meaningful on its own to a human reading your summary. `ao spawn`'s confirmation output leads with the name for this reason; carry that through to your own prose instead of just repeating the raw output.


### PR DESCRIPTION
Fixes [#2592](https://github.com/AgentWrapper/agent-orchestrator/issues/2592)

## Summary

Originally this PR also changed `ao spawn`'s CLI confirmation output to echo the display name. That code change has been dropped after reconsidering the actual problem: an orchestrator agent already knows the name it just passed via `--name` in that same tool call, so echoing it back in the CLI's output doesn't give the agent new information. The "CLI output shapes what gets relayed" argument doesn't hold up either — an agent careless enough to ignore an explicit reporting instruction is also careless enough to not faithfully transcribe a specific CLI line; these aren't independent failure modes.

The actual fix is a documentation change only: `backend/internal/skillassets/using-ao/commands/spawn.md` now explicitly tells orchestrator agents to report a spawned session by its `--name`, not its generated id, when summarizing for the user. This targets the real problem directly (what the orchestrator chooses to say) instead of indirectly (hoping a reshaped CLI string gets copied faithfully).

## A second bug this surfaced: stale names after rename

Preferring the display name over the id introduces a new failure mode: **a session's display name is not permanent** — it can be changed after spawn via `ao session rename <id> <name>`, unlike the id, which is fixed for the session's lifetime. An orchestrator agent has no automatic way to learn that a rename happened after it last observed a session — its only "knowledge" of the name is whatever is still in its own conversation memory (from spawning it, or a prior query), which is never invalidated or refreshed automatically. So without a further caveat, the "report by name" instruction could make an orchestrator confidently repeat a **stale, now-wrong** name — arguably worse than reporting the id, which never goes stale.

This was caught live during review: a worker session's display name changed from `investigate-glyphs` to `glyphs` sometime after it was spawned, and the orchestrator only noticed because it happened to re-query the session's current state rather than trust its own memory — it would otherwise have kept reporting the original, now-incorrect name indefinitely.

**Fix**: added a note to `SKILL.md`'s general Conventions section (not `spawn.md`, since staleness applies whenever a session is referenced, not just at spawn time) telling orchestrator agents to re-confirm a session's current name via `ao session get`/`ao session ls` rather than relying on memory, whenever accuracy matters (long conversations, or after any renaming activity).

`ao spawn`'s CLI output itself remains as it was on `main` — this is a docs-only PR.

## Test plan
N/A — documentation-only change, no code touched.
