### PR TITLE
fix: return project removal teardown conflicts

### DIFF
--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -631,6 +631,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
           description: Not Found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Conflict
         "500":
           content:
             application/json:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -594,6 +594,7 @@ func projectOperations() []operation {
 			resps: []respUnit{
 				{http.StatusOK, projectsvc.RemoveResult{}},
 				{http.StatusBadRequest, envelope.APIError{}},
+				{http.StatusConflict, envelope.APIError{}},
 				{http.StatusNotFound, envelope.APIError{}},
 				{http.StatusInternalServerError, envelope.APIError{}},
 			},

--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -55,10 +55,12 @@ type removeConflictManager struct{ projectsvc.Manager }
 func (removeConflictManager) Remove(context.Context, domain.ProjectID) (projectsvc.RemoveResult, error) {
 	return projectsvc.RemoveResult{}, apierr.Conflict("PROJECT_REMOVE_BLOCKED", "Project removal is blocked by session workspaces that could not be removed. Resolve the listed sessions, then retry.", map[string]any{
 		"projectId": "proj",
-		"blockers": []map[string]string{{
-			"sessionId": "proj-1",
-			"phase":     "workspace",
-			"reason":    "workspace has uncommitted changes",
+		"blockers": []map[string]any{{
+			"sessionId":     "proj-1",
+			"phase":         "workspace",
+			"reason":        "workspace has uncommitted changes",
+			"paths":         []string{"/ws/proj-1"},
+			"recoverySteps": []string{"Commit, stash, or remove the uncommitted changes in the listed workspace path, then retry project removal."},
 		}},
 	})
 }
@@ -375,9 +377,11 @@ func TestProjectsAPI_DeleteBlockedReturns409Details(t *testing.T) {
 		Details struct {
 			ProjectID string `json:"projectId"`
 			Blockers  []struct {
-				SessionID string `json:"sessionId"`
-				Phase     string `json:"phase"`
-				Reason    string `json:"reason"`
+				SessionID     string   `json:"sessionId"`
+				Phase         string   `json:"phase"`
+				Reason        string   `json:"reason"`
+				Paths         []string `json:"paths"`
+				RecoverySteps []string `json:"recoverySteps"`
 			} `json:"blockers"`
 		} `json:"details"`
 	}
@@ -387,6 +391,9 @@ func TestProjectsAPI_DeleteBlockedReturns409Details(t *testing.T) {
 	}
 	if blocker := got.Details.Blockers[0]; blocker.SessionID != "proj-1" || blocker.Phase != "workspace" || blocker.Reason != "workspace has uncommitted changes" {
 		t.Fatalf("blocker = %#v, want dirty workspace blocker", blocker)
+	}
+	if blocker := got.Details.Blockers[0]; len(blocker.Paths) != 1 || blocker.Paths[0] != "/ws/proj-1" || len(blocker.RecoverySteps) == 0 {
+		t.Fatalf("blocker details = %#v, want path and recovery steps", blocker)
 	}
 }
 

--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
+
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
 
 	projectsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/project"
@@ -46,6 +48,19 @@ func (emptyGetManager) Get(context.Context, domain.ProjectID) (projectsvc.GetRes
 
 	return projectsvc.GetResult{}, nil
 
+}
+
+type removeConflictManager struct{ projectsvc.Manager }
+
+func (removeConflictManager) Remove(context.Context, domain.ProjectID) (projectsvc.RemoveResult, error) {
+	return projectsvc.RemoveResult{}, apierr.Conflict("PROJECT_REMOVE_BLOCKED", "Project removal is blocked by session workspaces that could not be removed. Resolve the listed sessions, then retry.", map[string]any{
+		"projectId": "proj",
+		"blockers": []map[string]string{{
+			"sessionId": "proj-1",
+			"phase":     "workspace",
+			"reason":    "workspace has uncommitted changes",
+		}},
+	})
 }
 
 // TestProjectsAPI_GetEmptyResultIs500 locks the fix for the discriminated-union
@@ -342,6 +357,37 @@ func TestProjectsAPI_Delete(t *testing.T) {
 
 	}
 
+}
+
+func TestProjectsAPI_DeleteBlockedReturns409Details(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{
+		Projects: removeConflictManager{},
+	}, httpd.ControlDeps{}))
+	t.Cleanup(srv.Close)
+
+	body, status, headers := doRequest(t, srv, "DELETE", "/api/v1/projects/proj", "")
+
+	assertJSON(t, headers)
+	assertErrorCode(t, body, status, http.StatusConflict, "PROJECT_REMOVE_BLOCKED")
+
+	var got struct {
+		Details struct {
+			ProjectID string `json:"projectId"`
+			Blockers  []struct {
+				SessionID string `json:"sessionId"`
+				Phase     string `json:"phase"`
+				Reason    string `json:"reason"`
+			} `json:"blockers"`
+		} `json:"details"`
+	}
+	mustJSON(t, body, &got)
+	if got.Details.ProjectID != "proj" || len(got.Details.Blockers) != 1 {
+		t.Fatalf("details = %#v, want project blocker", got.Details)
+	}
+	if blocker := got.Details.Blockers[0]; blocker.SessionID != "proj-1" || blocker.Phase != "workspace" || blocker.Reason != "workspace has uncommitted changes" {
+		t.Fatalf("blocker = %#v, want dirty workspace blocker", blocker)
+	}
 }
 
 // TestProjectsAPI_RejectsUnknownConfigKeys locks the strict-decoder gate on the

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -73,6 +73,22 @@ type CleanupSkipped struct {
 	Reason    string           `json:"reason"`
 }
 
+// ProjectTeardownBlocker is one session-level reason project removal cannot
+// safely unregister the project yet.
+type ProjectTeardownBlocker struct {
+	SessionID domain.SessionID `json:"sessionId"`
+	Phase     string           `json:"phase"`
+	Reason    string           `json:"reason"`
+}
+
+// ProjectTeardownDetails is embedded in PROJECT_REMOVE_BLOCKED error details.
+type ProjectTeardownDetails struct {
+	ProjectID domain.ProjectID         `json:"projectId"`
+	Killed    []domain.SessionID       `json:"killed"`
+	Cleaned   []domain.SessionID       `json:"cleaned"`
+	Blockers  []ProjectTeardownBlocker `json:"blockers"`
+}
+
 type scmProvider interface {
 	ParseRepository(remote string) (ports.SCMRepo, bool)
 	FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error)
@@ -466,22 +482,92 @@ func (s *Service) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 
 // TeardownProject stops every live session in a project, then asks the session
 // manager to reclaim terminal workspaces. Dirty worktrees are preserved by Kill
-// and Cleanup; callers only see hard teardown failures.
+// and Cleanup; project removal receives a typed conflict with per-session
+// blockers instead of archiving a project that still has managed workspaces.
 func (s *Service) TeardownProject(ctx context.Context, project domain.ProjectID) error {
 	recs, err := s.listRecords(ctx, project)
 	if err != nil {
 		return err
 	}
+	details := ProjectTeardownDetails{
+		ProjectID: project,
+		Killed:    []domain.SessionID{},
+		Cleaned:   []domain.SessionID{},
+		Blockers:  []ProjectTeardownBlocker{},
+	}
 	for _, rec := range recs {
 		if rec.IsTerminated {
 			continue
 		}
-		if _, err := s.Kill(ctx, rec.ID); err != nil {
-			return err
+		freed, err := s.Kill(ctx, rec.ID)
+		if err != nil {
+			details.Blockers = append(details.Blockers, teardownBlockerFromError(rec.ID, err))
+			continue
+		}
+		if freed {
+			details.Killed = append(details.Killed, rec.ID)
+			continue
+		}
+		after, ok, err := s.store.GetSession(ctx, rec.ID)
+		if err != nil {
+			return fmt.Errorf("load session after teardown %s: %w", rec.ID, err)
+		}
+		if !ok || after.IsTerminated {
+			details.Killed = append(details.Killed, rec.ID)
+			continue
+		}
+		if rec.Metadata.WorkspacePath != "" {
+			details.Blockers = append(details.Blockers, ProjectTeardownBlocker{
+				SessionID: rec.ID,
+				Phase:     string(sessionmanager.TeardownPhaseWorkspace),
+				Reason:    "workspace has uncommitted changes",
+			})
 		}
 	}
-	_, err = s.Cleanup(ctx, project)
-	return err
+	cleanup, err := s.Cleanup(ctx, project)
+	if err != nil {
+		return err
+	}
+	details.Cleaned = append(details.Cleaned, cleanup.Cleaned...)
+	for _, skip := range cleanup.Skipped {
+		details.Blockers = append(details.Blockers, ProjectTeardownBlocker{
+			SessionID: skip.SessionID,
+			Phase:     string(sessionmanager.TeardownPhaseWorkspace),
+			Reason:    skip.Reason,
+		})
+	}
+	if len(details.Blockers) > 0 {
+		return projectRemoveBlocked(details)
+	}
+	return nil
+}
+
+func teardownBlockerFromError(sessionID domain.SessionID, err error) ProjectTeardownBlocker {
+	blocker := ProjectTeardownBlocker{
+		SessionID: sessionID,
+		Phase:     "session",
+		Reason:    "session teardown failed",
+	}
+	var teardownErr *sessionmanager.TeardownError
+	if errors.As(err, &teardownErr) {
+		blocker.Phase = string(teardownErr.Phase)
+		switch teardownErr.Phase {
+		case sessionmanager.TeardownPhaseRuntime:
+			blocker.Reason = "runtime teardown failed"
+		case sessionmanager.TeardownPhaseWorkspace:
+			blocker.Reason = "workspace teardown failed"
+		}
+	}
+	return blocker
+}
+
+func projectRemoveBlocked(details ProjectTeardownDetails) error {
+	return apierr.Conflict("PROJECT_REMOVE_BLOCKED", "Project removal is blocked by session workspaces that could not be removed. Resolve the listed sessions, then retry.", map[string]any{
+		"projectId": string(details.ProjectID),
+		"killed":    details.Killed,
+		"cleaned":   details.Cleaned,
+		"blockers":  details.Blockers,
+	})
 }
 
 // List returns sessions as enriched display models after applying API filters.

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -66,19 +66,23 @@ type CleanupOutcome struct {
 	Skipped []CleanupSkipped   `json:"skipped"`
 }
 
-// CleanupSkipped is one terminal session whose workspace was preserved by
-// cleanup (never force-deleted), with the user-facing reason.
+// CleanupSkipped is one terminal session whose workspace cleanup was skipped,
+// with enough context for callers to tell preservation from best-effort failure.
 type CleanupSkipped struct {
-	SessionID domain.SessionID `json:"sessionId"`
-	Reason    string           `json:"reason"`
+	SessionID         domain.SessionID `json:"sessionId"`
+	Reason            string           `json:"reason"`
+	Path              string           `json:"path,omitempty"`
+	UserWorkPreserved bool             `json:"userWorkPreserved,omitempty"`
 }
 
 // ProjectTeardownBlocker is one session-level reason project removal cannot
 // safely unregister the project yet.
 type ProjectTeardownBlocker struct {
-	SessionID domain.SessionID `json:"sessionId"`
-	Phase     string           `json:"phase"`
-	Reason    string           `json:"reason"`
+	SessionID     domain.SessionID `json:"sessionId"`
+	Phase         string           `json:"phase"`
+	Reason        string           `json:"reason"`
+	Paths         []string         `json:"paths,omitempty"`
+	RecoverySteps []string         `json:"recoverySteps,omitempty"`
 }
 
 // ProjectTeardownDetails is embedded in PROJECT_REMOVE_BLOCKED error details.
@@ -475,7 +479,7 @@ func (s *Service) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 		out.Cleaned = []domain.SessionID{}
 	}
 	for _, skip := range res.Skipped {
-		out.Skipped = append(out.Skipped, CleanupSkipped{SessionID: skip.SessionID, Reason: skip.Reason})
+		out.Skipped = append(out.Skipped, CleanupSkipped{SessionID: skip.SessionID, Reason: skip.Reason, Path: skip.Path, UserWorkPreserved: skip.UserWorkPreserved})
 	}
 	return out, nil
 }
@@ -483,7 +487,9 @@ func (s *Service) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 // TeardownProject stops every live session in a project, then asks the session
 // manager to reclaim terminal workspaces. Dirty worktrees are preserved by Kill
 // and Cleanup; project removal receives a typed conflict with per-session
-// blockers instead of archiving a project that still has managed workspaces.
+// blockers only for preserved user work. Stale runtime/workspace metadata and
+// other local teardown failures are best effort so legacy projects can still be
+// unregistered.
 func (s *Service) TeardownProject(ctx context.Context, project domain.ProjectID) error {
 	recs, err := s.listRecords(ctx, project)
 	if err != nil {
@@ -501,7 +507,6 @@ func (s *Service) TeardownProject(ctx context.Context, project domain.ProjectID)
 		}
 		freed, err := s.Kill(ctx, rec.ID)
 		if err != nil {
-			details.Blockers = append(details.Blockers, teardownBlockerFromError(rec.ID, err))
 			continue
 		}
 		if freed {
@@ -517,11 +522,7 @@ func (s *Service) TeardownProject(ctx context.Context, project domain.ProjectID)
 			continue
 		}
 		if rec.Metadata.WorkspacePath != "" {
-			details.Blockers = append(details.Blockers, ProjectTeardownBlocker{
-				SessionID: rec.ID,
-				Phase:     string(sessionmanager.TeardownPhaseWorkspace),
-				Reason:    "workspace has uncommitted changes",
-			})
+			details.Blockers = append(details.Blockers, dirtyWorkspaceBlocker(rec.ID, rec.Metadata.WorkspacePath))
 		}
 	}
 	cleanup, err := s.Cleanup(ctx, project)
@@ -530,11 +531,9 @@ func (s *Service) TeardownProject(ctx context.Context, project domain.ProjectID)
 	}
 	details.Cleaned = append(details.Cleaned, cleanup.Cleaned...)
 	for _, skip := range cleanup.Skipped {
-		details.Blockers = append(details.Blockers, ProjectTeardownBlocker{
-			SessionID: skip.SessionID,
-			Phase:     string(sessionmanager.TeardownPhaseWorkspace),
-			Reason:    skip.Reason,
-		})
+		if skip.UserWorkPreserved {
+			details.Blockers = append(details.Blockers, dirtyWorkspaceBlocker(skip.SessionID, skip.Path))
+		}
 	}
 	if len(details.Blockers) > 0 {
 		return projectRemoveBlocked(details)
@@ -542,21 +541,15 @@ func (s *Service) TeardownProject(ctx context.Context, project domain.ProjectID)
 	return nil
 }
 
-func teardownBlockerFromError(sessionID domain.SessionID, err error) ProjectTeardownBlocker {
+func dirtyWorkspaceBlocker(sessionID domain.SessionID, path string) ProjectTeardownBlocker {
 	blocker := ProjectTeardownBlocker{
-		SessionID: sessionID,
-		Phase:     "session",
-		Reason:    "session teardown failed",
+		SessionID:     sessionID,
+		Phase:         string(sessionmanager.TeardownPhaseWorkspace),
+		Reason:        "workspace has uncommitted changes",
+		RecoverySteps: []string{"Commit, stash, or remove the uncommitted changes in the listed workspace path, then retry project removal."},
 	}
-	var teardownErr *sessionmanager.TeardownError
-	if errors.As(err, &teardownErr) {
-		blocker.Phase = string(teardownErr.Phase)
-		switch teardownErr.Phase {
-		case sessionmanager.TeardownPhaseRuntime:
-			blocker.Reason = "runtime teardown failed"
-		case sessionmanager.TeardownPhaseWorkspace:
-			blocker.Reason = "workspace teardown failed"
-		}
+	if path != "" {
+		blocker.Paths = []string{path}
 	}
 	return blocker
 }

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -205,10 +205,12 @@ type fakeCommander struct {
 	retired         []domain.SessionID
 	sent            []domain.SessionID
 	cleanupProjects []domain.ProjectID
+	killFreed       map[domain.SessionID]bool
 	killErr         error
 	retireErr       error
 	sendErr         error
 	cleanupErr      error
+	cleanupResult   *sessionmanager.CleanupResult
 	spawnErr        error
 	spawnRecord     domain.SessionRecord
 	spawned         bool
@@ -236,6 +238,9 @@ func (f *fakeCommander) Kill(_ context.Context, id domain.SessionID) (bool, erro
 		return false, f.killErr
 	}
 	f.killed = append(f.killed, id)
+	if f.killFreed != nil {
+		return f.killFreed[id], nil
+	}
 	return true, nil
 }
 func (f *fakeCommander) RetireForReplacement(_ context.Context, id domain.SessionID) error {
@@ -256,6 +261,9 @@ func (f *fakeCommander) Cleanup(_ context.Context, project domain.ProjectID) (se
 	f.cleanupProjects = append(f.cleanupProjects, project)
 	if f.cleanupErr != nil {
 		return sessionmanager.CleanupResult{}, f.cleanupErr
+	}
+	if f.cleanupResult != nil {
+		return *f.cleanupResult, nil
 	}
 	return sessionmanager.CleanupResult{
 		Cleaned: []domain.SessionID{"mer-1"},
@@ -287,7 +295,7 @@ func TestTeardownProjectKillsActiveSessionsThenCleansProject(t *testing.T) {
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer"}
 	st.sessions["mer-2"] = domain.SessionRecord{ID: "mer-2", ProjectID: "mer", IsTerminated: true}
 	st.sessions["other-1"] = domain.SessionRecord{ID: "other-1", ProjectID: "other"}
-	fc := &fakeCommander{}
+	fc := &fakeCommander{cleanupResult: &sessionmanager.CleanupResult{}}
 	svc := &Service{manager: fc, store: st}
 
 	if err := svc.TeardownProject(context.Background(), "mer"); err != nil {
@@ -301,19 +309,80 @@ func TestTeardownProjectKillsActiveSessionsThenCleansProject(t *testing.T) {
 	}
 }
 
-func TestTeardownProjectStopsOnKillError(t *testing.T) {
+func TestTeardownProjectBlocksOnKillError(t *testing.T) {
 	st := newFakeStore()
-	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer"}
-	boom := errors.New("boom")
-	fc := &fakeCommander{killErr: boom}
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1"}}
+	boom := &sessionmanager.TeardownError{SessionID: "mer-1", Phase: sessionmanager.TeardownPhaseWorkspace, Err: errors.New("boom")}
+	fc := &fakeCommander{killErr: boom, cleanupResult: &sessionmanager.CleanupResult{}}
 	svc := &Service{manager: fc, store: st}
 
 	err := svc.TeardownProject(context.Background(), "mer")
-	if !errors.Is(err, boom) {
-		t.Fatalf("TeardownProject err = %v, want boom", err)
+	var apiErr *apierr.Error
+	if !errors.As(err, &apiErr) || apiErr.Code != "PROJECT_REMOVE_BLOCKED" {
+		t.Fatalf("TeardownProject err = %v, want PROJECT_REMOVE_BLOCKED", err)
 	}
-	if len(fc.cleanupProjects) != 0 {
-		t.Fatalf("cleanup projects = %#v, want none after kill failure", fc.cleanupProjects)
+	if len(fc.cleanupProjects) != 1 || fc.cleanupProjects[0] != "mer" {
+		t.Fatalf("cleanup projects = %#v, want cleanup after aggregating kill failure", fc.cleanupProjects)
+	}
+	blockers := apiErr.Details["blockers"].([]ProjectTeardownBlocker)
+	if len(blockers) != 1 || blockers[0].SessionID != "mer-1" || blockers[0].Phase != "workspace" || blockers[0].Reason != "workspace teardown failed" {
+		t.Fatalf("blockers = %#v, want workspace teardown blocker", blockers)
+	}
+}
+
+func TestTeardownProjectBlocksLiveDirtyWorktree(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1"}}
+	fc := &fakeCommander{
+		killFreed:     map[domain.SessionID]bool{"mer-1": false},
+		cleanupResult: &sessionmanager.CleanupResult{},
+	}
+	svc := &Service{manager: fc, store: st}
+
+	err := svc.TeardownProject(context.Background(), "mer")
+	var apiErr *apierr.Error
+	if !errors.As(err, &apiErr) || apiErr.Code != "PROJECT_REMOVE_BLOCKED" {
+		t.Fatalf("TeardownProject err = %v, want PROJECT_REMOVE_BLOCKED", err)
+	}
+	blockers := apiErr.Details["blockers"].([]ProjectTeardownBlocker)
+	if len(blockers) != 1 || blockers[0].SessionID != "mer-1" || blockers[0].Reason != "workspace has uncommitted changes" {
+		t.Fatalf("blockers = %#v, want dirty workspace blocker", blockers)
+	}
+}
+
+func TestTeardownProjectCleansStalePrunableWorktree(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", IsTerminated: true, Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1"}}
+	fc := &fakeCommander{cleanupResult: &sessionmanager.CleanupResult{Cleaned: []domain.SessionID{"mer-1"}}}
+	svc := &Service{manager: fc, store: st}
+
+	if err := svc.TeardownProject(context.Background(), "mer"); err != nil {
+		t.Fatalf("TeardownProject: %v", err)
+	}
+	if len(fc.killed) != 0 {
+		t.Fatalf("killed = %#v, want no kill for terminal stale session", fc.killed)
+	}
+	if len(fc.cleanupProjects) != 1 || fc.cleanupProjects[0] != "mer" {
+		t.Fatalf("cleanup projects = %#v, want [mer]", fc.cleanupProjects)
+	}
+}
+
+func TestTeardownProjectBlocksCleanupFailure(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", IsTerminated: true, Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1"}}
+	fc := &fakeCommander{cleanupResult: &sessionmanager.CleanupResult{
+		Skipped: []sessionmanager.CleanupSkip{{SessionID: "mer-1", Reason: "workspace teardown failed"}},
+	}}
+	svc := &Service{manager: fc, store: st}
+
+	err := svc.TeardownProject(context.Background(), "mer")
+	var apiErr *apierr.Error
+	if !errors.As(err, &apiErr) || apiErr.Code != "PROJECT_REMOVE_BLOCKED" {
+		t.Fatalf("TeardownProject err = %v, want PROJECT_REMOVE_BLOCKED", err)
+	}
+	blockers := apiErr.Details["blockers"].([]ProjectTeardownBlocker)
+	if len(blockers) != 1 || blockers[0].SessionID != "mer-1" || blockers[0].Phase != "workspace" || blockers[0].Reason != "workspace teardown failed" {
+		t.Fatalf("blockers = %#v, want cleanup workspace blocker", blockers)
 	}
 }
 

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -267,7 +267,7 @@ func (f *fakeCommander) Cleanup(_ context.Context, project domain.ProjectID) (se
 	}
 	return sessionmanager.CleanupResult{
 		Cleaned: []domain.SessionID{"mer-1"},
-		Skipped: []sessionmanager.CleanupSkip{{SessionID: "mer-2", Reason: "workspace has uncommitted changes"}},
+		Skipped: []sessionmanager.CleanupSkip{{SessionID: "mer-2", Reason: "workspace has uncommitted changes", Path: "/ws/mer-2", UserWorkPreserved: true}},
 	}, nil
 }
 func (f *fakeCommander) RollbackSpawn(context.Context, domain.SessionID) (bool, bool, error) {
@@ -309,24 +309,18 @@ func TestTeardownProjectKillsActiveSessionsThenCleansProject(t *testing.T) {
 	}
 }
 
-func TestTeardownProjectBlocksOnKillError(t *testing.T) {
+func TestTeardownProjectIgnoresKillTeardownError(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1"}}
 	boom := &sessionmanager.TeardownError{SessionID: "mer-1", Phase: sessionmanager.TeardownPhaseWorkspace, Err: errors.New("boom")}
 	fc := &fakeCommander{killErr: boom, cleanupResult: &sessionmanager.CleanupResult{}}
 	svc := &Service{manager: fc, store: st}
 
-	err := svc.TeardownProject(context.Background(), "mer")
-	var apiErr *apierr.Error
-	if !errors.As(err, &apiErr) || apiErr.Code != "PROJECT_REMOVE_BLOCKED" {
-		t.Fatalf("TeardownProject err = %v, want PROJECT_REMOVE_BLOCKED", err)
+	if err := svc.TeardownProject(context.Background(), "mer"); err != nil {
+		t.Fatalf("TeardownProject: %v, want nil for best-effort teardown error", err)
 	}
 	if len(fc.cleanupProjects) != 1 || fc.cleanupProjects[0] != "mer" {
-		t.Fatalf("cleanup projects = %#v, want cleanup after aggregating kill failure", fc.cleanupProjects)
-	}
-	blockers := apiErr.Details["blockers"].([]ProjectTeardownBlocker)
-	if len(blockers) != 1 || blockers[0].SessionID != "mer-1" || blockers[0].Phase != "workspace" || blockers[0].Reason != "workspace teardown failed" {
-		t.Fatalf("blockers = %#v, want workspace teardown blocker", blockers)
+		t.Fatalf("cleanup projects = %#v, want cleanup after best-effort kill failure", fc.cleanupProjects)
 	}
 }
 
@@ -348,6 +342,9 @@ func TestTeardownProjectBlocksLiveDirtyWorktree(t *testing.T) {
 	if len(blockers) != 1 || blockers[0].SessionID != "mer-1" || blockers[0].Reason != "workspace has uncommitted changes" {
 		t.Fatalf("blockers = %#v, want dirty workspace blocker", blockers)
 	}
+	if len(blockers[0].Paths) != 1 || blockers[0].Paths[0] != "/ws/mer-1" || len(blockers[0].RecoverySteps) == 0 {
+		t.Fatalf("blocker details = %#v, want path and recovery steps", blockers[0])
+	}
 }
 
 func TestTeardownProjectCleansStalePrunableWorktree(t *testing.T) {
@@ -367,11 +364,24 @@ func TestTeardownProjectCleansStalePrunableWorktree(t *testing.T) {
 	}
 }
 
-func TestTeardownProjectBlocksCleanupFailure(t *testing.T) {
+func TestTeardownProjectIgnoresNonDirtyCleanupFailure(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", IsTerminated: true, Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1"}}
 	fc := &fakeCommander{cleanupResult: &sessionmanager.CleanupResult{
-		Skipped: []sessionmanager.CleanupSkip{{SessionID: "mer-1", Reason: "workspace teardown failed"}},
+		Skipped: []sessionmanager.CleanupSkip{{SessionID: "mer-1", Reason: "workspace teardown failed", Path: "/ws/mer-1"}},
+	}}
+	svc := &Service{manager: fc, store: st}
+
+	if err := svc.TeardownProject(context.Background(), "mer"); err != nil {
+		t.Fatalf("TeardownProject: %v, want nil for non-dirty cleanup failure", err)
+	}
+}
+
+func TestTeardownProjectBlocksDirtyCleanupSkip(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", IsTerminated: true, Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1"}}
+	fc := &fakeCommander{cleanupResult: &sessionmanager.CleanupResult{
+		Skipped: []sessionmanager.CleanupSkip{{SessionID: "mer-1", Reason: "workspace has uncommitted changes", Path: "/ws/mer-1", UserWorkPreserved: true}},
 	}}
 	svc := &Service{manager: fc, store: st}
 
@@ -381,8 +391,11 @@ func TestTeardownProjectBlocksCleanupFailure(t *testing.T) {
 		t.Fatalf("TeardownProject err = %v, want PROJECT_REMOVE_BLOCKED", err)
 	}
 	blockers := apiErr.Details["blockers"].([]ProjectTeardownBlocker)
-	if len(blockers) != 1 || blockers[0].SessionID != "mer-1" || blockers[0].Phase != "workspace" || blockers[0].Reason != "workspace teardown failed" {
-		t.Fatalf("blockers = %#v, want cleanup workspace blocker", blockers)
+	if len(blockers) != 1 || blockers[0].SessionID != "mer-1" || blockers[0].Phase != "workspace" || blockers[0].Reason != "workspace has uncommitted changes" {
+		t.Fatalf("blockers = %#v, want dirty cleanup blocker", blockers)
+	}
+	if len(blockers[0].Paths) != 1 || blockers[0].Paths[0] != "/ws/mer-1" || len(blockers[0].RecoverySteps) == 0 {
+		t.Fatalf("blocker details = %#v, want path and recovery steps", blockers[0])
 	}
 }
 

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -62,7 +62,9 @@ var (
 type TeardownPhase string
 
 const (
-	TeardownPhaseRuntime   TeardownPhase = "runtime"
+	// TeardownPhaseRuntime identifies runtime-adapter teardown failures.
+	TeardownPhaseRuntime TeardownPhase = "runtime"
+	// TeardownPhaseWorkspace identifies workspace-adapter teardown failures.
 	TeardownPhaseWorkspace TeardownPhase = "workspace"
 )
 
@@ -1726,11 +1728,13 @@ func (m *Manager) waitForActive(ctx context.Context, id domain.SessionID) (waitO
 	}
 }
 
-// CleanupSkip reports one terminal session whose workspace was preserved
-// rather than reclaimed, and why.
+// CleanupSkip reports one terminal session whose workspace cleanup was skipped,
+// and whether the skip protects user work.
 type CleanupSkip struct {
-	SessionID domain.SessionID
-	Reason    string
+	SessionID         domain.SessionID
+	Reason            string
+	Path              string
+	UserWorkPreserved bool
 }
 
 // CleanupResult reports what Cleanup reclaimed and what it preserved.
@@ -1762,14 +1766,14 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 		}
 		if rows, ok, rowErr := m.workspaceProjectRows(ctx, rec); rowErr != nil {
 			m.logger.Warn("cleanup: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
-			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: "workspace teardown failed"})
+			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: "workspace teardown failed", Path: ws.Path})
 			continue
 		} else if ok {
 			if _, err := m.destroyWorkspaceProjectRows(ctx, rows); err != nil {
 				if !errors.Is(err, ports.ErrWorkspaceDirty) {
 					m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
 				}
-				result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(err)})
+				result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(err), Path: ws.Path, UserWorkPreserved: cleanupSkipPreservesUserWork(err)})
 				continue
 			}
 			m.cleanupAgentWorkspace(ctx, rec, ws.Path)
@@ -1779,7 +1783,7 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 				// internal filesystem paths); the full cause lands here.
 				m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
 			}
-			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(err)})
+			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(err), Path: ws.Path, UserWorkPreserved: cleanupSkipPreservesUserWork(err)})
 			continue
 		} else {
 			m.cleanupAgentWorkspace(ctx, rec, ws.Path)
@@ -1799,6 +1803,10 @@ func cleanupSkipReason(err error) string {
 		return "workspace has uncommitted changes"
 	}
 	return "workspace teardown failed"
+}
+
+func cleanupSkipPreservesUserWork(err error) bool {
+	return errors.Is(err, ports.ErrWorkspaceDirty)
 }
 
 func (m *Manager) cleanupRecords(ctx context.Context, project domain.ProjectID) ([]domain.SessionRecord, error) {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -56,6 +56,38 @@ var (
 	ErrAwaitingDecision = errors.New("session: awaiting a user decision")
 )
 
+// TeardownPhase identifies which part of explicit session teardown failed.
+// Project removal uses it to turn adapter failures into actionable conflict
+// details without leaking raw filesystem/runtime errors to the API response.
+type TeardownPhase string
+
+const (
+	TeardownPhaseRuntime   TeardownPhase = "runtime"
+	TeardownPhaseWorkspace TeardownPhase = "workspace"
+)
+
+// TeardownError wraps runtime/workspace adapter failures from Kill while
+// preserving errors.Is/As behavior for the underlying cause.
+type TeardownError struct {
+	SessionID domain.SessionID
+	Phase     TeardownPhase
+	Err       error
+}
+
+func (e *TeardownError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("kill %s: %s: %v", e.SessionID, e.Phase, e.Err)
+}
+
+func (e *TeardownError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
 // Env vars a spawned process reads to learn who it is.
 const (
 	EnvSessionID = "AO_SESSION_ID"
@@ -630,7 +662,7 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 
 	if handle.ID != "" {
 		if err := m.runtime.Destroy(ctx, handle); err != nil {
-			return false, fmt.Errorf("kill %s: runtime: %w", id, err)
+			return false, &TeardownError{SessionID: id, Phase: TeardownPhaseRuntime, Err: err}
 		}
 	}
 	freed := false
@@ -640,7 +672,7 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 			if errors.Is(err, ports.ErrWorkspaceDirty) {
 				return false, nil
 			}
-			return false, fmt.Errorf("kill %s: workspace: %w", id, err)
+			return false, &TeardownError{SessionID: id, Phase: TeardownPhaseWorkspace, Err: err}
 		}
 		freed = cleaned
 		if cleaned {
@@ -651,7 +683,7 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 			if errors.Is(err, ports.ErrWorkspaceDirty) {
 				return false, nil
 			}
-			return false, fmt.Errorf("kill %s: workspace: %w", id, err)
+			return false, &TeardownError{SessionID: id, Phase: TeardownPhaseWorkspace, Err: err}
 		}
 		freed = true
 		m.cleanupAgentWorkspace(ctx, rec, ws.Path)

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2038,6 +2038,15 @@ export interface operations {
                     "application/json": components["schemas"]["APIError"];
                 };
             };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
             /** @description Internal Server Error */
             500: {
                 headers: {


### PR DESCRIPTION
## Summary
- wrap session manager runtime/workspace kill failures with a teardown phase
- aggregate project teardown killed/cleaned/blocker outcomes and return PROJECT_REMOVE_BLOCKED 409 details
- document DELETE /projects 409 and regenerate OpenAPI/frontend schema

Fixes #2598

## Tests
- cd backend && go test ./internal/service/project ./internal/service/session ./internal/session_manager ./internal/httpd/controllers
- cd backend && go test ./internal/httpd/...