### PR TITLE
 fix(workspace): recover stale orchestrator worktrees during replacement

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -351,10 +351,34 @@ func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceIn
 	if info.SessionID == "" {
 		return "", errors.New("gitworktree: session id is required for StashUncommitted")
 	}
+	repo, err := w.repoPathForInfo(info)
+	if err != nil {
+		return "", err
+	}
+	path, err := w.validateManagedPath(info.Path)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("gitworktree: stale worktree %q: %w", path, ports.ErrWorkspaceStale)
+		}
+		return "", fmt.Errorf("gitworktree: stat worktree %q: %w", path, err)
+	}
+	records, err := w.listRecords(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	if _, ok := findWorktree(records, path); !ok {
+		return "", fmt.Errorf("gitworktree: worktree %q is not registered: %w", path, ports.ErrWorkspaceStale)
+	}
 
 	// Early exit for clean worktrees: nothing to preserve.
-	dirty, err := w.isDirty(ctx, info.Path)
+	dirty, err := w.isDirty(ctx, path)
 	if err != nil {
+		if isNotGitRepositoryError(err) {
+			return "", fmt.Errorf("gitworktree: stale worktree %q: %w", path, ports.ErrWorkspaceStale)
+		}
 		return "", fmt.Errorf("gitworktree: StashUncommitted dirty check: %w", err)
 	}
 	if !dirty {
@@ -362,7 +386,7 @@ func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceIn
 	}
 
 	// Log the count of ignored paths that will be skipped.
-	if skipCount, err := w.countIgnoredPaths(ctx, info.Path); err == nil {
+	if skipCount, err := w.countIgnoredPaths(ctx, path); err == nil {
 		slog.InfoContext(ctx, "gitworktree: StashUncommitted skipping ignored paths",
 			"session", string(info.SessionID),
 			"skipped_count", skipCount,
@@ -386,24 +410,24 @@ func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceIn
 
 	// Stage all tracked and non-ignored untracked files into the temp index.
 	// GIT_INDEX_FILE overrides the index so the real index is never touched.
-	addCmd := exec.CommandContext(ctx, w.binary, addAllTempIndexArgs(info.Path)...)
+	addCmd := exec.CommandContext(ctx, w.binary, addAllTempIndexArgs(path)...)
 	addCmd.Env = append(os.Environ(), "GIT_INDEX_FILE="+tmpIdxPath)
 	if out, err := addCmd.CombinedOutput(); err != nil {
-		return "", commandError{args: append([]string{w.binary}, addAllTempIndexArgs(info.Path)...), output: string(out), err: err}
+		return "", commandError{args: append([]string{w.binary}, addAllTempIndexArgs(path)...), output: string(out), err: err}
 	}
 
 	// Write the staged tree to get a tree SHA.
-	writeTreeCmd := exec.CommandContext(ctx, w.binary, writeTreeArgs(info.Path)...)
+	writeTreeCmd := exec.CommandContext(ctx, w.binary, writeTreeArgs(path)...)
 	writeTreeCmd.Env = append(os.Environ(), "GIT_INDEX_FILE="+tmpIdxPath)
 	treeOut, err := writeTreeCmd.CombinedOutput()
 	if err != nil {
-		return "", commandError{args: append([]string{w.binary}, writeTreeArgs(info.Path)...), output: string(treeOut), err: err}
+		return "", commandError{args: append([]string{w.binary}, writeTreeArgs(path)...), output: string(treeOut), err: err}
 	}
 	treeSHA := strings.TrimSpace(string(treeOut))
 
 	// Resolve HEAD. An unborn HEAD (no commits yet) means we omit the -p flag
 	// from commit-tree so the preserve commit has no parent.
-	headOut, headErr := w.run(ctx, w.binary, revParseHeadArgs(info.Path)...)
+	headOut, headErr := w.run(ctx, w.binary, revParseHeadArgs(path)...)
 	headSHA := ""
 	if headErr == nil {
 		headSHA = strings.TrimSpace(string(headOut))
@@ -413,7 +437,7 @@ func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceIn
 	// If the preserve tree SHA equals HEAD's tree SHA the working tree is
 	// effectively clean from git's perspective (only ignored files differ).
 	if headSHA != "" {
-		headTreeOut, err := w.run(ctx, w.binary, "-C", info.Path, "rev-parse", headSHA+"^{tree}")
+		headTreeOut, err := w.run(ctx, w.binary, "-C", path, "rev-parse", headSHA+"^{tree}")
 		if err == nil {
 			headTreeSHA := strings.TrimSpace(string(headTreeOut))
 			if headTreeSHA == treeSHA {
@@ -425,7 +449,7 @@ func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceIn
 
 	// Create a commit object that wraps the preserve tree.
 	msg := "ao preserved " + string(info.SessionID)
-	commitOut, err := w.run(ctx, w.binary, commitTreeArgs(info.Path, treeSHA, headSHA, msg)...)
+	commitOut, err := w.run(ctx, w.binary, commitTreeArgs(path, treeSHA, headSHA, msg)...)
 	if err != nil {
 		return "", fmt.Errorf("gitworktree: commit-tree: %w", err)
 	}
@@ -433,10 +457,14 @@ func (w *Workspace) StashUncommitted(ctx context.Context, info ports.WorkspaceIn
 
 	// Point the preserve ref at the commit.
 	ref := "refs/ao/preserved/" + string(info.SessionID)
-	if _, err := w.run(ctx, w.binary, updateRefArgs(info.Path, ref, commitSHA)...); err != nil {
+	if _, err := w.run(ctx, w.binary, updateRefArgs(path, ref, commitSHA)...); err != nil {
 		return "", fmt.Errorf("gitworktree: update-ref %q: %w", ref, err)
 	}
 	return ref, nil
+}
+
+func isNotGitRepositoryError(err error) bool {
+	return strings.Contains(err.Error(), "not a git repository")
 }
 
 // countIgnoredPaths returns the number of entries listed by

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -491,6 +491,92 @@ func TestDestroyClassifiesDirtyWorktree(t *testing.T) {
 	}
 }
 
+func TestStashUncommittedClassifiesMissingManagedPathAsStale(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "sess")
+
+	_, err = ws.StashUncommitted(context.Background(), ports.WorkspaceInfo{Path: path, ProjectID: "proj", SessionID: "sess", Branch: "feature/one"})
+	if !errors.Is(err, ports.ErrWorkspaceStale) {
+		t.Fatalf("stash error = %v, want ports.ErrWorkspaceStale", err)
+	}
+}
+
+func TestStashUncommittedClassifiesUnregisteredManagedPathAsStale(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "sess")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("seed path: %v", err)
+	}
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if strings.Contains(strings.Join(args, " "), "worktree list --porcelain") {
+			return []byte("worktree " + repo + "\nbranch refs/heads/main\n"), nil
+		}
+		return nil, nil
+	}
+
+	_, err = ws.StashUncommitted(context.Background(), ports.WorkspaceInfo{Path: path, ProjectID: "proj", SessionID: "sess", Branch: "feature/one"})
+	if !errors.Is(err, ports.ErrWorkspaceStale) {
+		t.Fatalf("stash error = %v, want ports.ErrWorkspaceStale", err)
+	}
+}
+
+func TestStashUncommittedClassifiesNotGitRepositoryAsStale(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "sess")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("seed path: %v", err)
+	}
+	ws.run = func(_ context.Context, binary string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "worktree list --porcelain"):
+			return []byte("worktree " + path + "\nbranch refs/heads/feature/one\n"), nil
+		case strings.Contains(joined, "status --porcelain"):
+			return nil, commandError{args: append([]string{binary}, args...), output: "fatal: not a git repository", err: errors.New("exit status 128")}
+		default:
+			return nil, nil
+		}
+	}
+
+	_, err = ws.StashUncommitted(context.Background(), ports.WorkspaceInfo{Path: path, ProjectID: "proj", SessionID: "sess", Branch: "feature/one"})
+	if !errors.Is(err, ports.ErrWorkspaceStale) {
+		t.Fatalf("stash error = %v, want ports.ErrWorkspaceStale", err)
+	}
+}
+
+func TestStashUncommittedOutsideManagedPathIsUnsafeNotStale(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	outside := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	_, err = ws.StashUncommitted(context.Background(), ports.WorkspaceInfo{Path: outside, ProjectID: "proj", SessionID: "sess", Branch: "feature/one"})
+	if !errors.Is(err, ErrUnsafePath) {
+		t.Fatalf("stash error = %v, want ErrUnsafePath", err)
+	}
+	if errors.Is(err, ports.ErrWorkspaceStale) {
+		t.Fatalf("outside managed path must not be classified stale: %v", err)
+	}
+}
+
 // TestAddWorktreeRefusesBranchCheckedOutElsewhere covers Bug 3 (a): if the
 // requested branch is already checked out in another worktree of the same repo,
 // Create must surface ports.ErrWorkspaceBranchCheckedOutElsewhere so the HTTP

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -168,6 +168,11 @@ var (
 	// it holds uncommitted changes or untracked files. Teardown is never
 	// forced; callers treat the workspace as intentionally preserved.
 	ErrWorkspaceDirty = errors.New("workspace: uncommitted changes present")
+	// ErrWorkspaceStale reports an AO-managed workspace path no longer points
+	// at a registered git worktree. Replacement paths may skip preservation for
+	// this state after path-safety checks, while real preserve failures remain
+	// fatal.
+	ErrWorkspaceStale = errors.New("workspace: stale managed worktree")
 	// ErrPreservedConflict is returned by ApplyPreserved when replaying a
 	// preserved ref onto the worktree produces merge conflicts. The ref is
 	// kept intact (never deleted on conflict); the working tree is left with

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -644,9 +644,6 @@ func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID)
 		staleWorkspace = true
 		m.logger.Warn("retire replacement: stale workspace; skipping preserve", "sessionID", id, "path", ws.Path, "error", err)
 	}
-	if err := m.store.DeleteSessionWorktrees(ctx, rec.ID); err != nil {
-		return fmt.Errorf("retire replacement %s: clear restore markers: %w", id, err)
-	}
 	handle := runtimeHandle(rec.Metadata)
 	if handle.ID != "" {
 		if err := m.runtime.Destroy(ctx, handle); err != nil {
@@ -655,10 +652,12 @@ func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID)
 	}
 	if err := m.workspace.ForceDestroy(ctx, ws); err != nil {
 		if staleWorkspace {
-			m.logger.Warn("retire replacement: stale workspace cleanup failed; continuing", "sessionID", id, "path", ws.Path, "error", err)
-		} else {
-			return fmt.Errorf("retire replacement %s: force destroy: %w", id, err)
+			m.logger.Warn("retire replacement: stale workspace cleanup failed", "sessionID", id, "path", ws.Path, "error", err)
 		}
+		return fmt.Errorf("retire replacement %s: force destroy: %w", id, err)
+	}
+	if err := m.store.DeleteSessionWorktrees(ctx, rec.ID); err != nil {
+		return fmt.Errorf("retire replacement %s: clear restore markers: %w", id, err)
 	}
 	if err := m.lcm.MarkTerminated(ctx, rec.ID); err != nil {
 		return fmt.Errorf("retire replacement %s: mark terminated: %w", id, err)
@@ -686,8 +685,7 @@ func (m *Manager) retireWorkspaceProjectForReplacement(ctx context.Context, rec 
 	for i := len(rows) - 1; i >= 0; i-- {
 		if err := m.workspace.ForceDestroy(ctx, workspaceInfoFromRepoInfo(rows[i])); err != nil {
 			if staleRepos[rows[i].RepoName] {
-				m.logger.Warn("retire replacement: stale workspace repo cleanup failed; continuing", "sessionID", rec.ID, "repo", rows[i].RepoName, "path", rows[i].Path, "error", err)
-				continue
+				m.logger.Warn("retire replacement: stale workspace repo cleanup failed", "sessionID", rec.ID, "repo", rows[i].RepoName, "path", rows[i].Path, "error", err)
 			}
 			return fmt.Errorf("retire replacement %s repo %s: force destroy: %w", rec.ID, rows[i].RepoName, err)
 		}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -636,8 +636,13 @@ func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID)
 	}
 
 	ws := workspaceInfo(rec)
+	staleWorkspace := false
 	if _, err := m.workspace.StashUncommitted(ctx, ws); err != nil {
-		return fmt.Errorf("retire replacement %s: stash: %w", id, err)
+		if !errors.Is(err, ports.ErrWorkspaceStale) {
+			return fmt.Errorf("retire replacement %s: stash: %w", id, err)
+		}
+		staleWorkspace = true
+		m.logger.Warn("retire replacement: stale workspace; skipping preserve", "sessionID", id, "path", ws.Path, "error", err)
 	}
 	if err := m.store.DeleteSessionWorktrees(ctx, rec.ID); err != nil {
 		return fmt.Errorf("retire replacement %s: clear restore markers: %w", id, err)
@@ -649,7 +654,11 @@ func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID)
 		}
 	}
 	if err := m.workspace.ForceDestroy(ctx, ws); err != nil {
-		return fmt.Errorf("retire replacement %s: force destroy: %w", id, err)
+		if staleWorkspace {
+			m.logger.Warn("retire replacement: stale workspace cleanup failed; continuing", "sessionID", id, "path", ws.Path, "error", err)
+		} else {
+			return fmt.Errorf("retire replacement %s: force destroy: %w", id, err)
+		}
 	}
 	if err := m.lcm.MarkTerminated(ctx, rec.ID); err != nil {
 		return fmt.Errorf("retire replacement %s: mark terminated: %w", id, err)
@@ -658,9 +667,14 @@ func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID)
 }
 
 func (m *Manager) retireWorkspaceProjectForReplacement(ctx context.Context, rec domain.SessionRecord, rows []ports.WorkspaceRepoInfo) error {
+	staleRepos := make(map[string]bool)
 	for _, row := range rows {
 		if _, err := m.workspace.StashUncommitted(ctx, workspaceInfoFromRepoInfo(row)); err != nil {
-			return fmt.Errorf("retire replacement %s repo %s: stash: %w", rec.ID, row.RepoName, err)
+			if !errors.Is(err, ports.ErrWorkspaceStale) {
+				return fmt.Errorf("retire replacement %s repo %s: stash: %w", rec.ID, row.RepoName, err)
+			}
+			staleRepos[row.RepoName] = true
+			m.logger.Warn("retire replacement: stale workspace repo; skipping preserve", "sessionID", rec.ID, "repo", row.RepoName, "path", row.Path, "error", err)
 		}
 	}
 	handle := runtimeHandle(rec.Metadata)
@@ -671,6 +685,10 @@ func (m *Manager) retireWorkspaceProjectForReplacement(ctx context.Context, rec 
 	}
 	for i := len(rows) - 1; i >= 0; i-- {
 		if err := m.workspace.ForceDestroy(ctx, workspaceInfoFromRepoInfo(rows[i])); err != nil {
+			if staleRepos[rows[i].RepoName] {
+				m.logger.Warn("retire replacement: stale workspace repo cleanup failed; continuing", "sessionID", rec.ID, "repo", rows[i].RepoName, "path", rows[i].Path, "error", err)
+				continue
+			}
 			return fmt.Errorf("retire replacement %s repo %s: force destroy: %w", rec.ID, rows[i].RepoName, err)
 		}
 	}

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2310,8 +2310,8 @@ func TestRetireForReplacementCapturesAndReleasesWorkspace(t *testing.T) {
 	if stashIdx == -1 || deleteIdx == -1 || forceIdx == -1 {
 		t.Fatalf("missing expected calls in shared log: %v", sharedLog)
 	}
-	if stashIdx >= deleteIdx || deleteIdx >= forceIdx {
-		t.Fatalf("replacement retire must capture, clear restore marker, then force release; log=%v", sharedLog)
+	if stashIdx >= forceIdx || forceIdx >= deleteIdx {
+		t.Fatalf("replacement retire must capture, force release, then clear restore marker; log=%v", sharedLog)
 	}
 }
 
@@ -2321,7 +2321,6 @@ func TestRetireForReplacementStaleWorkspaceSkipsPreserveAndTerminates(t *testing
 	st.sharedLog = &sharedLog
 	ws.sharedLog = &sharedLog
 	ws.stashErr = ports.ErrWorkspaceStale
-	ws.forceDestroyErr = errors.New("stale cleanup failed")
 	st.sessions["mer-orch"] = domain.SessionRecord{
 		ID:        "mer-orch",
 		ProjectID: "mer",
@@ -2352,8 +2351,8 @@ func TestRetireForReplacementStaleWorkspaceSkipsPreserveAndTerminates(t *testing
 	}
 	wantOrder := []string{
 		"StashUncommitted:mer-orch",
-		"DeleteSessionWorktrees:mer-orch",
 		"ForceDestroy:mer-orch",
+		"DeleteSessionWorktrees:mer-orch",
 	}
 	next := 0
 	for _, call := range sharedLog {
@@ -2363,6 +2362,40 @@ func TestRetireForReplacementStaleWorkspaceSkipsPreserveAndTerminates(t *testing
 	}
 	if next != len(wantOrder) {
 		t.Fatalf("stale replacement order missing %v in log %v", wantOrder, sharedLog)
+	}
+}
+
+func TestRetireForReplacementStaleWorkspaceCleanupFailureLeavesSessionActive(t *testing.T) {
+	m, st, rt, ws := newLifecycleManager()
+	ws.stashErr = ports.ErrWorkspaceStale
+	ws.forceDestroyErr = errors.New("stale cleanup failed")
+	st.sessions["mer-orch"] = domain.SessionRecord{
+		ID:        "mer-orch",
+		ProjectID: "mer",
+		Kind:      domain.KindOrchestrator,
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-orch", Branch: "ao/mer-orchestrator", RuntimeHandleID: "orch-handle"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+	st.worktrees["mer-orch"] = []domain.SessionWorktreeRecord{{
+		SessionID:    "mer-orch",
+		RepoName:     domain.RootWorkspaceRepoName,
+		Branch:       "ao/mer-orchestrator",
+		WorktreePath: "/ws/mer-orch",
+		PreservedRef: "refs/ao/preserved/old",
+	}}
+
+	err := m.RetireForReplacement(ctx, "mer-orch")
+	if err == nil || !strings.Contains(err.Error(), "force destroy") {
+		t.Fatalf("RetireForReplacement err = %v, want force destroy failure", err)
+	}
+	if st.sessions["mer-orch"].IsTerminated {
+		t.Fatal("session must remain active when stale cleanup fails")
+	}
+	if rows := st.worktrees["mer-orch"]; len(rows) != 1 {
+		t.Fatalf("restore markers after stale cleanup failure = %v, want retained", rows)
+	}
+	if rt.destroyed != 1 || rt.destroyedIDs[0] != "orch-handle" {
+		t.Fatalf("runtime destroyed = %d ids=%v, want orch-handle", rt.destroyed, rt.destroyedIDs)
 	}
 }
 
@@ -2544,6 +2577,40 @@ func TestRetireForReplacementWorkspaceProjectForceDestroyFailureKeepsRepoInvento
 	}
 	if rows := st.worktrees["mer-orch"]; len(rows) != 2 {
 		t.Fatalf("workspace repo inventory after force destroy failure = %v, want root and child retained", rows)
+	}
+}
+
+func TestRetireForReplacementWorkspaceProjectStaleCleanupFailureKeepsRepoInventory(t *testing.T) {
+	m, st, _, ws := newLifecycleManager()
+	ws.stashErr = ports.ErrWorkspaceStale
+	ws.forceDestroyErr = errors.New("stale cleanup failed")
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repos/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{
+		ProjectID:    "mer",
+		Name:         "api",
+		RelativePath: "api",
+	}}
+	st.sessions["mer-orch"] = domain.SessionRecord{
+		ID:        "mer-orch",
+		ProjectID: "mer",
+		Kind:      domain.KindOrchestrator,
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-orch", Branch: "ao/mer-orchestrator", RuntimeHandleID: "orch-handle"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+	st.worktrees["mer-orch"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-orch", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-orchestrator", WorktreePath: "/ws/mer-orch", State: "active"},
+		{SessionID: "mer-orch", RepoName: "api", Branch: "ao/mer-orchestrator", WorktreePath: "/ws/mer-orch/api", State: "active"},
+	}
+
+	err := m.RetireForReplacement(ctx, "mer-orch")
+	if err == nil || !strings.Contains(err.Error(), "force destroy") {
+		t.Fatalf("RetireForReplacement err = %v, want force destroy failure", err)
+	}
+	if st.sessions["mer-orch"].IsTerminated {
+		t.Fatal("session must remain active when stale repo cleanup fails")
+	}
+	if rows := st.worktrees["mer-orch"]; len(rows) != 2 {
+		t.Fatalf("workspace repo inventory after stale cleanup failure = %v, want root and child retained", rows)
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2315,6 +2315,95 @@ func TestRetireForReplacementCapturesAndReleasesWorkspace(t *testing.T) {
 	}
 }
 
+func TestRetireForReplacementStaleWorkspaceSkipsPreserveAndTerminates(t *testing.T) {
+	m, st, rt, ws := newLifecycleManager()
+	var sharedLog []string
+	st.sharedLog = &sharedLog
+	ws.sharedLog = &sharedLog
+	ws.stashErr = ports.ErrWorkspaceStale
+	ws.forceDestroyErr = errors.New("stale cleanup failed")
+	st.sessions["mer-orch"] = domain.SessionRecord{
+		ID:        "mer-orch",
+		ProjectID: "mer",
+		Kind:      domain.KindOrchestrator,
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-orch", Branch: "ao/mer-orchestrator", RuntimeHandleID: "orch-handle"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+	st.worktrees["mer-orch"] = []domain.SessionWorktreeRecord{{
+		SessionID:    "mer-orch",
+		RepoName:     domain.RootWorkspaceRepoName,
+		Branch:       "ao/mer-orchestrator",
+		WorktreePath: "/ws/mer-orch",
+		PreservedRef: "refs/ao/preserved/old",
+	}}
+
+	if err := m.RetireForReplacement(ctx, "mer-orch"); err != nil {
+		t.Fatalf("RetireForReplacement err = %v", err)
+	}
+
+	if rows := st.worktrees["mer-orch"]; len(rows) != 0 {
+		t.Fatalf("stale replacement must clear restore markers, got %#v", rows)
+	}
+	if !st.sessions["mer-orch"].IsTerminated {
+		t.Fatal("stale replaced orchestrator must be marked terminated")
+	}
+	if rt.destroyed != 1 || rt.destroyedIDs[0] != "orch-handle" {
+		t.Fatalf("runtime destroyed = %d ids=%v, want orch-handle", rt.destroyed, rt.destroyedIDs)
+	}
+	wantOrder := []string{
+		"StashUncommitted:mer-orch",
+		"DeleteSessionWorktrees:mer-orch",
+		"ForceDestroy:mer-orch",
+	}
+	next := 0
+	for _, call := range sharedLog {
+		if next < len(wantOrder) && call == wantOrder[next] {
+			next++
+		}
+	}
+	if next != len(wantOrder) {
+		t.Fatalf("stale replacement order missing %v in log %v", wantOrder, sharedLog)
+	}
+}
+
+func TestRetireForReplacementStashFailureLeavesSessionActive(t *testing.T) {
+	m, st, rt, ws := newLifecycleManager()
+	ws.stashErr = errors.New("preserve failed")
+	st.sessions["mer-orch"] = domain.SessionRecord{
+		ID:        "mer-orch",
+		ProjectID: "mer",
+		Kind:      domain.KindOrchestrator,
+		Metadata:  domain.SessionMetadata{WorkspacePath: "/ws/mer-orch", Branch: "ao/mer-orchestrator", RuntimeHandleID: "orch-handle"},
+		Activity:  domain.Activity{State: domain.ActivityActive},
+	}
+	st.worktrees["mer-orch"] = []domain.SessionWorktreeRecord{{
+		SessionID:    "mer-orch",
+		RepoName:     domain.RootWorkspaceRepoName,
+		Branch:       "ao/mer-orchestrator",
+		WorktreePath: "/ws/mer-orch",
+		PreservedRef: "refs/ao/preserved/old",
+	}}
+
+	err := m.RetireForReplacement(ctx, "mer-orch")
+	if err == nil || !strings.Contains(err.Error(), "stash") {
+		t.Fatalf("RetireForReplacement err = %v, want stash failure", err)
+	}
+	if st.sessions["mer-orch"].IsTerminated {
+		t.Fatal("session must remain active when preserve fails")
+	}
+	if rows := st.worktrees["mer-orch"]; len(rows) != 1 {
+		t.Fatalf("restore markers after preserve failure = %v, want retained", rows)
+	}
+	if rt.destroyed != 0 {
+		t.Fatalf("runtime destroyed = %d, want 0 after preserve failure", rt.destroyed)
+	}
+	for _, call := range ws.calls {
+		if call == "ForceDestroy:mer-orch" {
+			t.Fatalf("ForceDestroy must not run after preserve failure; calls=%v", ws.calls)
+		}
+	}
+}
+
 func TestRetireForReplacementWorkspaceProjectCapturesAndReleasesEveryRepo(t *testing.T) {
 	m, st, rt, ws := newLifecycleManager()
 	var sharedLog []string


### PR DESCRIPTION
 ## Summary

  This fixes clean orchestrator replacement when AO has an active old orchestrator row whose recorded workspace path is stale.

  Previously, `RetireForReplacement` always called `StashUncommitted` before removing the old orchestrator worktree. If the stored path still existed
  but was no longer a valid git worktree, `git status` failed with `not a git repository`, which bubbled up as an error and blocked replacement. The
  user saw a failed restart even though the stale path was AO-managed state that could be safely recovered.

  ## What Changed

  - Added `ports.ErrWorkspaceStale` to represent AO-managed workspace paths that no longer point to a valid registered git worktree.
  - Updated `gitworktree.StashUncommitted` to return `ErrWorkspaceStale` only after path safety checks, for:
    - missing managed workspace paths
    - existing paths not present in `git worktree list`
    - paths where `git status` reports `not a git repository`
  - Updated `RetireForReplacement` to handle only `ErrWorkspaceStale` as recoverable:
    - skip stash/preserve for the stale workspace
    - clear `session_worktrees` restore markers
    - destroy runtime if present
    - best-effort remove the stale AO-managed folder
    - mark the old orchestrator session terminated
    - continue spawning the fresh orchestrator
  - Kept all other stash/preserve errors fatal, so AO does not delete a real workspace when it cannot preserve work.
  - Added tests for stale classification, unsafe-path behavior, stale replacement recovery, and non-stale preserve failure behavior.

  ## Behavior Covered

  - Valid dirty git worktree: preserve changes, remove old worktree, mark old orchestrator terminated, spawn fresh orchestrator.
  - Valid clean git worktree: remove old worktree, mark old orchestrator terminated, spawn fresh orchestrator.
  - Missing / unregistered / non-git AO-managed path: treat as stale AO-owned state and recover.
  - Real git worktree with preserve failure: fail replacement and leave session/worktree state intact.
  - Path outside AO’s managed workspace root: fail safely and do not touch it.

  ## Data Model

  This does not delete the old orchestrator session row. The old row remains as durable history/debug context. The fix only clears restore/worktree
  markers that could cause incorrect restore behavior, then marks the old orchestrator terminated.
  
  closes #2551 