### PR TITLE
fix(terminal): force UTF-8 client mode on tmux attach

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -241,12 +241,28 @@ func (r *Runtime) Attach(ctx context.Context, handle ports.RuntimeHandle, rows, 
 
 // attachCommand returns the argv to attach a terminal to the session.
 // tmux needs no per-session env block.
+//
+// -u forces tmux's client-side CLIENT_UTF8 flag on. Without it, tmux infers
+// UTF-8 capability from LC_ALL/LC_CTYPE/LANG in the attaching process's env
+// (see tmux's main()); AO's daemon is typically started without an
+// interactive shell's locale, so that inference silently fails. A non-UTF8
+// client makes tmux's tty_check_codeset (tty.c) replace any character it
+// can't map through the legacy ACS table with underscores matching the
+// glyph's display width. Box-drawing glyphs are in that ACS table so they
+// still looked fine; agent CLI status icons outside it (e.g. Claude Code's
+// spinner "✻" U+273B, its "⎿" U+23BF continuation marker) were silently
+// rewritten to "_", which is the underscore corruption reported in #2484.
+// Confirmed byte-for-byte: attaching with a stripped, locale-less env
+// reproduces "_ _ _" for those glyphs; adding -u fixes it, with no observable
+// difference for the still-correct box-drawing case. AO already treats the
+// PTY byte stream as UTF-8 end to end, so forcing the flag is always
+// correct here regardless of the daemon's own environment.
 func (r *Runtime) attachCommand(handle ports.RuntimeHandle) ([]string, error) {
 	id, err := handleID(handle)
 	if err != nil {
 		return nil, err
 	}
-	return []string{r.binary, "attach-session", "-t", id}, nil
+	return []string{r.binary, "-u", "attach-session", "-t", id}, nil
 }
 
 func attachEnv(base []string) []string {

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -537,7 +537,7 @@ func TestAttachCommandReturnsExpectedArgv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AttachCommand: %v", err)
 	}
-	want := []string{"/usr/bin/tmux", "attach-session", "-t", "sess-1"}
+	want := []string{"/usr/bin/tmux", "-u", "attach-session", "-t", "sess-1"}
 	if !reflect.DeepEqual(argv, want) {
 		t.Fatalf("argv = %#v, want %#v", argv, want)
 	}


### PR DESCRIPTION
## Summary
Fixes #2603.

- Root-causes and fixes the garbled box-drawing/underscore rendering symptom.
- `tmux attach-session` infers UTF-8 client capability from `LC_ALL`/`LC_CTYPE`/`LANG` in the attaching process's environment. AO's daemon typically runs without an interactive shell's locale, so tmux silently treats the attach client as non-UTF-8.
- A non-UTF-8 client makes tmux's `tty_check_codeset` (tty.c) replace any character it can't map through its legacy ACS table with underscores matching the glyph's display width. Common box-drawing glyphs (│ ─ etc.) are in that ACS table, so they still rendered correctly — which is why an earlier investigation attempt, testing only a box-drawing border character, concluded locale had no effect and marked the theory disproven. Agent CLI status icons outside the ACS table (e.g. Claude Code's spinner `✻` U+273B, its `⎿` U+23BF continuation marker) are not covered and were silently rewritten to `_`.
- Passing `-u` to `tmux attach-session` forces `CLIENT_UTF8` on regardless of the daemon's environment, matching how a bare `tmux attach` from an interactive shell (which does have a UTF-8 locale) already behaves — which is why the bug only reproduced through AO, never through a bare terminal attach to the same session.

Confirmed with a byte-level repro outside AO/Electron entirely: spawning `tmux attach-session` via a pty with a stripped, locale-less env reproduces `_ _ _` for `✻ ⎿ ←` while `│` still renders correctly; adding `-u` fixes the icons with no change to the box-drawing case.

## Screenshots

**Before** (`-u` not passed) — agent status icons (spinner, continuation marker) render as `_`:
<img width="900" alt="before_glyphs" src="https://github.com/user-attachments/assets/37402afb-8177-461e-8a5d-7ed0523ae058" />

**After** (`-u` passed) — icons render correctly; box-drawing glyphs unaffected either way:
<img width="900" alt="after_glyphs" src="https://github.com/user-attachments/assets/c843679c-e484-4a9b-bf30-dc6381509c2e" />

## Test plan
- [x] `go build ./...` (backend)
- [x] `go test ./internal/adapters/runtime/tmux/...` — updated `TestAttachCommandReturnsExpectedArgv` for the new `-u` flag, both attach-command tests pass
- [x] `go test ./...` (backend) — no new failures (4 pre-existing, unrelated `internal/cli` failures confirmed present on a clean checkout too)
- [x] Manual byte-level repro: pty-attached to a live tmux session with a stripped env, with and without `-u`, confirmed the underscore substitution and the fix directly against tmux 3.4's actual output bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)