### PR TITLE
Add platform-specific landing page downloads

### DIFF
--- a/frontend/src/landing/components/LandingHero.tsx
+++ b/frontend/src/landing/components/LandingHero.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import gsap from "gsap";
 import { useGSAP } from "@gsap/react";
+import { DESKTOP_DOWNLOADS, getDownloadOptions, getDownloadTarget } from "../lib/desktop-downloads";
 import { ScaledMockup } from "./ScaledMockup";
 
 if (typeof window !== "undefined") {
@@ -45,42 +46,6 @@ function StarIcon({ className = "" }: { className?: string }) {
 }
 
 const GITHUB_REPO_API_URL = "https://api.github.com/repos/AgentWrapper/agent-orchestrator";
-const RELEASE_DOWNLOAD_BASE = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download";
-
-const desktopDownloads = [
-	{ label: "macOS (Apple silicon)", href: `${RELEASE_DOWNLOAD_BASE}/agent-orchestrator-darwin-arm64.zip` },
-	{ label: "macOS (Intel)", href: `${RELEASE_DOWNLOAD_BASE}/agent-orchestrator-darwin-x64.zip` },
-	{ label: "Windows", href: `${RELEASE_DOWNLOAD_BASE}/agent-orchestrator-win32-x64.exe` },
-	{ label: "Linux", href: `${RELEASE_DOWNLOAD_BASE}/agent-orchestrator-linux-x64.AppImage` },
-];
-
-function isPortableDevice() {
-	if (typeof navigator === "undefined" || typeof window === "undefined") return false;
-	const platform = `${navigator.platform} ${navigator.userAgent}`.toLowerCase();
-	return (
-		/android|iphone|ipad|ipod|mobile|tablet/.test(platform) ||
-		(platform.includes("mac") && navigator.maxTouchPoints > 1) ||
-		window.innerWidth <= 1024
-	);
-}
-
-function getDownloadTarget() {
-	if (typeof navigator === "undefined") return null;
-	const platform = `${navigator.platform} ${navigator.userAgent}`.toLowerCase();
-
-	if (isPortableDevice()) return null;
-	if (platform.includes("win")) return { label: "Download for Windows", href: desktopDownloads[2].href };
-	if (platform.includes("linux") || platform.includes("x11"))
-		return { label: "Download for Linux", href: desktopDownloads[3].href };
-	return null;
-}
-
-function getDownloadOptions() {
-	if (typeof navigator === "undefined") return desktopDownloads;
-	const platform = `${navigator.platform} ${navigator.userAgent}`.toLowerCase();
-	const isTouchMac = platform.includes("mac") && navigator.maxTouchPoints > 1;
-	return platform.includes("mac") && !isTouchMac ? desktopDownloads.slice(0, 2) : desktopDownloads;
-}
 
 function formatCompactNumber(value: number): string {
 	if (value >= 1_000_000) {
@@ -640,7 +605,7 @@ function HeroDashboardMockup() {
 										className="hero-pressable inline-flex h-[34px] items-center gap-1.5 rounded-[7px] bg-[color:var(--accent)] px-[15px] text-[13px] font-semibold leading-none text-[#11140c] hover:brightness-110"
 									>
 										<NetworkIcon className="h-3.5 w-3.5" />
-										Orchestrator
+										Spawn Orchestrator
 									</button>
 								</div>
 							</div>
@@ -1105,19 +1070,13 @@ export function LandingHero() {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [starCount, setStarCount] = useState<string | null>(null);
 	const [downloadTarget, setDownloadTarget] = useState<ReturnType<typeof getDownloadTarget>>(null);
-	const [downloadOptions, setDownloadOptions] = useState(desktopDownloads);
-	const [showInstallGuide, setShowInstallGuide] = useState(false);
+	const [downloadOptions, setDownloadOptions] = useState<readonly (typeof DESKTOP_DOWNLOADS)[number][]>(
+		DESKTOP_DOWNLOADS,
+	);
 
 	useEffect(() => {
-		const updateDownloadTarget = () => {
-			setShowInstallGuide(isPortableDevice());
-			setDownloadTarget(getDownloadTarget());
-			setDownloadOptions(getDownloadOptions());
-		};
-
-		updateDownloadTarget();
-		window.addEventListener("resize", updateDownloadTarget);
-		return () => window.removeEventListener("resize", updateDownloadTarget);
+		setDownloadTarget(getDownloadTarget(navigator));
+		setDownloadOptions(getDownloadOptions(navigator));
 	}, []);
 
 	useEffect(() => {
@@ -1211,16 +1170,7 @@ export function LandingHero() {
 						</span>
 					</h1>
 					<div className="gsap-reveal mt-8 flex w-full flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row sm:items-center">
-						{showInstallGuide ? (
-							<a
-								href="/docs/installation"
-								className="hero-pressable group inline-flex h-12 w-full items-center justify-center gap-2 rounded-[6px] border border-[color:var(--accent)] bg-[color:var(--accent)] px-6 text-[15px] font-semibold text-[#11140c] hover:brightness-110 sm:w-auto"
-								style={{ color: "#11140c" }}
-							>
-								Installation guide
-								<ArrowRightIcon className="h-4 w-4 transition-transform duration-[450ms] group-hover:translate-x-1" />
-							</a>
-						) : downloadTarget ? (
+						{downloadTarget ? (
 							<a
 								href={downloadTarget.href}
 								className="hero-pressable group inline-flex h-12 w-full items-center justify-center gap-2 rounded-[6px] border border-[color:var(--accent)] bg-[color:var(--accent)] px-6 text-[15px] font-semibold text-[#11140c] hover:brightness-110 sm:w-auto"
@@ -1237,7 +1187,7 @@ export function LandingHero() {
 								>
 									<DownloadIcon className="h-4 w-4" />
 									Desktop downloads
-									<ArrowRightIcon className="h-4 w-4 rotate-90 transition-transform group-open/download:-rotate-90" />
+									<ArrowRightIcon className="h-4 w-4 rotate-90 transition-transform duration-150 group-open/download:-rotate-90 motion-reduce:transition-none" />
 								</summary>
 								<div className="absolute left-0 right-0 top-[calc(100%+8px)] z-30 overflow-hidden rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--bg-elevated)] p-1.5 text-left shadow-2xl sm:min-w-[260px]">
 									<p className="px-3 py-2 text-xs leading-relaxed text-[color:var(--fg-muted)]">

--- a/frontend/src/landing/components/LandingHero.tsx
+++ b/frontend/src/landing/components/LandingHero.tsx
@@ -45,6 +45,34 @@ function StarIcon({ className = "" }: { className?: string }) {
 }
 
 const GITHUB_REPO_API_URL = "https://api.github.com/repos/AgentWrapper/agent-orchestrator";
+const RELEASE_DOWNLOAD_BASE = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest/download";
+
+const desktopDownloads = [
+	{ label: "macOS (Apple silicon)", href: `${RELEASE_DOWNLOAD_BASE}/agent-orchestrator-darwin-arm64.zip` },
+	{ label: "macOS (Intel)", href: `${RELEASE_DOWNLOAD_BASE}/agent-orchestrator-darwin-x64.zip` },
+	{ label: "Windows", href: `${RELEASE_DOWNLOAD_BASE}/agent-orchestrator-win32-x64.exe` },
+	{ label: "Linux", href: `${RELEASE_DOWNLOAD_BASE}/agent-orchestrator-linux-x64.AppImage` },
+];
+
+function getDownloadTarget() {
+	if (typeof navigator === "undefined") return null;
+	const platform = `${navigator.platform} ${navigator.userAgent}`.toLowerCase();
+	const portable =
+		/android|iphone|ipad|ipod|mobile|tablet/.test(platform) ||
+		(platform.includes("mac") && navigator.maxTouchPoints > 1);
+
+	if (portable) return null;
+	if (platform.includes("win")) return { label: "Download for Windows", href: desktopDownloads[2].href };
+	if (platform.includes("linux") || platform.includes("x11")) return { label: "Download for Linux", href: desktopDownloads[3].href };
+	return null;
+}
+
+function getDownloadOptions() {
+	if (typeof navigator === "undefined") return desktopDownloads;
+	const platform = `${navigator.platform} ${navigator.userAgent}`.toLowerCase();
+	const isTouchMac = platform.includes("mac") && navigator.maxTouchPoints > 1;
+	return platform.includes("mac") && !isTouchMac ? desktopDownloads.slice(0, 2) : desktopDownloads;
+}
 
 function formatCompactNumber(value: number): string {
 	if (value >= 1_000_000) {
@@ -1068,6 +1096,13 @@ function SessionDot({ zone }: { zone: string }) {
 export function LandingHero() {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [starCount, setStarCount] = useState<string | null>(null);
+	const [downloadTarget, setDownloadTarget] = useState<ReturnType<typeof getDownloadTarget>>(null);
+	const [downloadOptions, setDownloadOptions] = useState(desktopDownloads);
+
+	useEffect(() => {
+		setDownloadTarget(getDownloadTarget());
+		setDownloadOptions(getDownloadOptions());
+	}, []);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -1160,14 +1195,33 @@ export function LandingHero() {
 						</span>
 					</h1>
 					<div className="gsap-reveal mt-8 flex w-full flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row sm:items-center">
+					{downloadTarget ? (
 						<a
-							href="/docs/installation"
-							className="hero-pressable group inline-flex h-12 w-full items-center justify-center gap-2 rounded-[6px] border border-white/12 bg-[#23221d] px-6 text-[15px] font-semibold text-[#f4f1e8] shadow-[0_10px_28px_-24px_rgba(255,255,255,0.22)] hover:border-white/18 hover:bg-[#2c2a23] hover:text-white sm:w-auto"
+							href={downloadTarget.href}
+							className="hero-pressable group inline-flex h-12 w-full items-center justify-center gap-2 rounded-[6px] border border-[color:var(--border-strong)] bg-transparent px-6 text-[15px] font-semibold text-[color:var(--fg)] hover:border-white/25 hover:bg-white/[0.04] sm:w-auto"
 						>
 							<DownloadIcon className="h-4 w-4" />
-							Install Agent Orchestrator
-							<ArrowRightIcon className="h-4 w-4 transition-transform duration-[450ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:translate-x-1" />
+							{downloadTarget.label}
+							<ArrowRightIcon className="h-4 w-4 transition-transform duration-[450ms] group-hover:translate-x-1" />
 						</a>
+					) : (
+						<details className="group/download relative w-full sm:w-auto">
+							<summary className="hero-pressable flex h-12 cursor-pointer list-none items-center justify-center gap-2 rounded-[6px] border border-[color:var(--border-strong)] bg-transparent px-6 text-[15px] font-semibold text-[color:var(--fg)] hover:border-white/25 hover:bg-white/[0.04] [&::-webkit-details-marker]:hidden">
+								<DownloadIcon className="h-4 w-4" />
+								Desktop downloads
+								<ArrowRightIcon className="h-4 w-4 rotate-90 transition-transform group-open/download:-rotate-90" />
+							</summary>
+							<div className="absolute left-0 right-0 top-[calc(100%+8px)] z-30 overflow-hidden rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--bg-elevated)] p-1.5 text-left shadow-2xl sm:min-w-[260px]">
+								<p className="px-3 py-2 text-xs leading-relaxed text-[color:var(--fg-muted)]">Choose the computer where you’ll run AO.</p>
+								{downloadOptions.map((download) => (
+									<a key={download.label} href={download.href} className="flex items-center justify-between gap-4 rounded-md px-3 py-2.5 text-sm font-medium text-[color:var(--fg)] hover:bg-white/[0.06]">
+										{download.label}
+										<DownloadIcon className="h-3.5 w-3.5 text-[color:var(--fg-muted)]" />
+									</a>
+								))}
+							</div>
+						</details>
+					)}
 						<a
 							href="https://github.com/AgentWrapper/agent-orchestrator"
 							target="_blank"

--- a/frontend/src/landing/components/LandingHero.tsx
+++ b/frontend/src/landing/components/LandingHero.tsx
@@ -54,14 +54,21 @@ const desktopDownloads = [
 	{ label: "Linux", href: `${RELEASE_DOWNLOAD_BASE}/agent-orchestrator-linux-x64.AppImage` },
 ];
 
+function isPortableDevice() {
+	if (typeof navigator === "undefined" || typeof window === "undefined") return false;
+	const platform = `${navigator.platform} ${navigator.userAgent}`.toLowerCase();
+	return (
+		/android|iphone|ipad|ipod|mobile|tablet/.test(platform) ||
+		(platform.includes("mac") && navigator.maxTouchPoints > 1) ||
+		window.innerWidth <= 1024
+	);
+}
+
 function getDownloadTarget() {
 	if (typeof navigator === "undefined") return null;
 	const platform = `${navigator.platform} ${navigator.userAgent}`.toLowerCase();
-	const portable =
-		/android|iphone|ipad|ipod|mobile|tablet/.test(platform) ||
-		(platform.includes("mac") && navigator.maxTouchPoints > 1);
 
-	if (portable) return null;
+	if (isPortableDevice()) return null;
 	if (platform.includes("win")) return { label: "Download for Windows", href: desktopDownloads[2].href };
 	if (platform.includes("linux") || platform.includes("x11"))
 		return { label: "Download for Linux", href: desktopDownloads[3].href };
@@ -633,7 +640,7 @@ function HeroDashboardMockup() {
 										className="hero-pressable inline-flex h-[34px] items-center gap-1.5 rounded-[7px] bg-[color:var(--accent)] px-[15px] text-[13px] font-semibold leading-none text-[#11140c] hover:brightness-110"
 									>
 										<NetworkIcon className="h-3.5 w-3.5" />
-										Spawn Orchestrator
+										Orchestrator
 									</button>
 								</div>
 							</div>
@@ -1099,10 +1106,18 @@ export function LandingHero() {
 	const [starCount, setStarCount] = useState<string | null>(null);
 	const [downloadTarget, setDownloadTarget] = useState<ReturnType<typeof getDownloadTarget>>(null);
 	const [downloadOptions, setDownloadOptions] = useState(desktopDownloads);
+	const [showInstallGuide, setShowInstallGuide] = useState(false);
 
 	useEffect(() => {
-		setDownloadTarget(getDownloadTarget());
-		setDownloadOptions(getDownloadOptions());
+		const updateDownloadTarget = () => {
+			setShowInstallGuide(isPortableDevice());
+			setDownloadTarget(getDownloadTarget());
+			setDownloadOptions(getDownloadOptions());
+		};
+
+		updateDownloadTarget();
+		window.addEventListener("resize", updateDownloadTarget);
+		return () => window.removeEventListener("resize", updateDownloadTarget);
 	}, []);
 
 	useEffect(() => {
@@ -1196,18 +1211,30 @@ export function LandingHero() {
 						</span>
 					</h1>
 					<div className="gsap-reveal mt-8 flex w-full flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row sm:items-center">
-						{downloadTarget ? (
+						{showInstallGuide ? (
+							<a
+								href="/docs/installation"
+								className="hero-pressable group inline-flex h-12 w-full items-center justify-center gap-2 rounded-[6px] border border-[color:var(--accent)] bg-[color:var(--accent)] px-6 text-[15px] font-semibold text-[#11140c] hover:brightness-110 sm:w-auto"
+								style={{ color: "#11140c" }}
+							>
+								Installation guide
+								<ArrowRightIcon className="h-4 w-4 transition-transform duration-[450ms] group-hover:translate-x-1" />
+							</a>
+						) : downloadTarget ? (
 							<a
 								href={downloadTarget.href}
-								className="hero-pressable group inline-flex h-12 w-full items-center justify-center gap-2 rounded-[6px] border border-[color:var(--border-strong)] bg-transparent px-6 text-[15px] font-semibold text-[color:var(--fg)] hover:border-white/25 hover:bg-white/[0.04] sm:w-auto"
+								className="hero-pressable group inline-flex h-12 w-full items-center justify-center gap-2 rounded-[6px] border border-[color:var(--accent)] bg-[color:var(--accent)] px-6 text-[15px] font-semibold text-[#11140c] hover:brightness-110 sm:w-auto"
+								style={{ color: "#11140c" }}
 							>
 								<DownloadIcon className="h-4 w-4" />
 								{downloadTarget.label}
-								<ArrowRightIcon className="h-4 w-4 transition-transform duration-[450ms] group-hover:translate-x-1" />
 							</a>
 						) : (
 							<details className="group/download relative w-full sm:w-auto">
-								<summary className="hero-pressable flex h-12 cursor-pointer list-none items-center justify-center gap-2 rounded-[6px] border border-[color:var(--border-strong)] bg-transparent px-6 text-[15px] font-semibold text-[color:var(--fg)] hover:border-white/25 hover:bg-white/[0.04] [&::-webkit-details-marker]:hidden">
+								<summary
+									className="hero-pressable flex h-12 cursor-pointer list-none items-center justify-center gap-2 rounded-[6px] border border-[color:var(--accent)] bg-[color:var(--accent)] px-6 text-[15px] font-semibold text-[#11140c] hover:brightness-110 [&::-webkit-details-marker]:hidden"
+									style={{ color: "#11140c" }}
+								>
 									<DownloadIcon className="h-4 w-4" />
 									Desktop downloads
 									<ArrowRightIcon className="h-4 w-4 rotate-90 transition-transform group-open/download:-rotate-90" />

--- a/frontend/src/landing/components/LandingHero.tsx
+++ b/frontend/src/landing/components/LandingHero.tsx
@@ -1070,9 +1070,8 @@ export function LandingHero() {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [starCount, setStarCount] = useState<string | null>(null);
 	const [downloadTarget, setDownloadTarget] = useState<ReturnType<typeof getDownloadTarget>>(null);
-	const [downloadOptions, setDownloadOptions] = useState<readonly (typeof DESKTOP_DOWNLOADS)[number][]>(
-		DESKTOP_DOWNLOADS,
-	);
+	const [downloadOptions, setDownloadOptions] =
+		useState<readonly (typeof DESKTOP_DOWNLOADS)[number][]>(DESKTOP_DOWNLOADS);
 
 	useEffect(() => {
 		setDownloadTarget(getDownloadTarget(navigator));

--- a/frontend/src/landing/components/LandingHero.tsx
+++ b/frontend/src/landing/components/LandingHero.tsx
@@ -63,7 +63,8 @@ function getDownloadTarget() {
 
 	if (portable) return null;
 	if (platform.includes("win")) return { label: "Download for Windows", href: desktopDownloads[2].href };
-	if (platform.includes("linux") || platform.includes("x11")) return { label: "Download for Linux", href: desktopDownloads[3].href };
+	if (platform.includes("linux") || platform.includes("x11"))
+		return { label: "Download for Linux", href: desktopDownloads[3].href };
 	return null;
 }
 
@@ -1195,33 +1196,39 @@ export function LandingHero() {
 						</span>
 					</h1>
 					<div className="gsap-reveal mt-8 flex w-full flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row sm:items-center">
-					{downloadTarget ? (
-						<a
-							href={downloadTarget.href}
-							className="hero-pressable group inline-flex h-12 w-full items-center justify-center gap-2 rounded-[6px] border border-[color:var(--border-strong)] bg-transparent px-6 text-[15px] font-semibold text-[color:var(--fg)] hover:border-white/25 hover:bg-white/[0.04] sm:w-auto"
-						>
-							<DownloadIcon className="h-4 w-4" />
-							{downloadTarget.label}
-							<ArrowRightIcon className="h-4 w-4 transition-transform duration-[450ms] group-hover:translate-x-1" />
-						</a>
-					) : (
-						<details className="group/download relative w-full sm:w-auto">
-							<summary className="hero-pressable flex h-12 cursor-pointer list-none items-center justify-center gap-2 rounded-[6px] border border-[color:var(--border-strong)] bg-transparent px-6 text-[15px] font-semibold text-[color:var(--fg)] hover:border-white/25 hover:bg-white/[0.04] [&::-webkit-details-marker]:hidden">
+						{downloadTarget ? (
+							<a
+								href={downloadTarget.href}
+								className="hero-pressable group inline-flex h-12 w-full items-center justify-center gap-2 rounded-[6px] border border-[color:var(--border-strong)] bg-transparent px-6 text-[15px] font-semibold text-[color:var(--fg)] hover:border-white/25 hover:bg-white/[0.04] sm:w-auto"
+							>
 								<DownloadIcon className="h-4 w-4" />
-								Desktop downloads
-								<ArrowRightIcon className="h-4 w-4 rotate-90 transition-transform group-open/download:-rotate-90" />
-							</summary>
-							<div className="absolute left-0 right-0 top-[calc(100%+8px)] z-30 overflow-hidden rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--bg-elevated)] p-1.5 text-left shadow-2xl sm:min-w-[260px]">
-								<p className="px-3 py-2 text-xs leading-relaxed text-[color:var(--fg-muted)]">Choose the computer where you’ll run AO.</p>
-								{downloadOptions.map((download) => (
-									<a key={download.label} href={download.href} className="flex items-center justify-between gap-4 rounded-md px-3 py-2.5 text-sm font-medium text-[color:var(--fg)] hover:bg-white/[0.06]">
-										{download.label}
-										<DownloadIcon className="h-3.5 w-3.5 text-[color:var(--fg-muted)]" />
-									</a>
-								))}
-							</div>
-						</details>
-					)}
+								{downloadTarget.label}
+								<ArrowRightIcon className="h-4 w-4 transition-transform duration-[450ms] group-hover:translate-x-1" />
+							</a>
+						) : (
+							<details className="group/download relative w-full sm:w-auto">
+								<summary className="hero-pressable flex h-12 cursor-pointer list-none items-center justify-center gap-2 rounded-[6px] border border-[color:var(--border-strong)] bg-transparent px-6 text-[15px] font-semibold text-[color:var(--fg)] hover:border-white/25 hover:bg-white/[0.04] [&::-webkit-details-marker]:hidden">
+									<DownloadIcon className="h-4 w-4" />
+									Desktop downloads
+									<ArrowRightIcon className="h-4 w-4 rotate-90 transition-transform group-open/download:-rotate-90" />
+								</summary>
+								<div className="absolute left-0 right-0 top-[calc(100%+8px)] z-30 overflow-hidden rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--bg-elevated)] p-1.5 text-left shadow-2xl sm:min-w-[260px]">
+									<p className="px-3 py-2 text-xs leading-relaxed text-[color:var(--fg-muted)]">
+										Choose the computer where you’ll run AO.
+									</p>
+									{downloadOptions.map((download) => (
+										<a
+											key={download.label}
+											href={download.href}
+											className="flex items-center justify-between gap-4 rounded-md px-3 py-2.5 text-sm font-medium text-[color:var(--fg)] hover:bg-white/[0.06]"
+										>
+											{download.label}
+											<DownloadIcon className="h-3.5 w-3.5 text-[color:var(--fg-muted)]" />
+										</a>
+									))}
+								</div>
+							</details>
+						)}
 						<a
 							href="https://github.com/AgentWrapper/agent-orchestrator"
 							target="_blank"

--- a/frontend/src/landing/components/LandingNav.tsx
+++ b/frontend/src/landing/components/LandingNav.tsx
@@ -1,22 +1,12 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useState, useRef } from "react";
 import gsap from "gsap";
 import ScrollTrigger from "gsap/ScrollTrigger";
 import { useGSAP } from "@gsap/react";
 
 if (typeof window !== "undefined") {
 	gsap.registerPlugin(ScrollTrigger, useGSAP);
-}
-
-function DownloadIcon({ className = "" }: { className?: string }) {
-	return (
-		<svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-			<path d="M12 3v12" />
-			<path d="m7 10 5 5 5-5" />
-			<path d="M5 21h14" />
-		</svg>
-	);
 }
 
 function MenuIcon({ className = "" }: { className?: string }) {
@@ -46,6 +36,14 @@ function XSocialIcon({ className = "" }: { className?: string }) {
 	);
 }
 
+function GithubIcon({ className = "" }: { className?: string }) {
+	return (
+		<svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+			<path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.38 7.86 10.9.58.1.79-.25.79-.56v-2.15c-3.2.7-3.88-1.37-3.88-1.37-.52-1.34-1.28-1.7-1.28-1.7-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.56-.29-5.26-1.28-5.26-5.7 0-1.26.45-2.29 1.19-3.1-.12-.3-.52-1.47.11-3.05 0 0 .97-.31 3.18 1.18A10.96 10.96 0 0 1 12 5.99c.98 0 1.97.13 2.9.38 2.2-1.49 3.17-1.18 3.17-1.18.63 1.58.23 2.75.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.7 5.4-5.27 5.69.41.36.78 1.07.78 2.16v3.2c0 .31.21.67.8.55A11.51 11.51 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
+		</svg>
+	);
+}
+
 function DiscordIcon({ className = "" }: { className?: string }) {
 	return (
 		<svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -55,6 +53,11 @@ function DiscordIcon({ className = "" }: { className?: string }) {
 }
 
 const socials = [
+	{
+		label: "GitHub",
+		href: "https://github.com/AgentWrapper/agent-orchestrator",
+		icon: GithubIcon,
+	},
 	{
 		label: "Discord",
 		href: "https://discord.com/invite/UZv7JjxbwG",
@@ -73,36 +76,10 @@ const navLinks = [
 	{ label: "Docs", href: "/docs" },
 ];
 
-function getPlatformLabel() {
-	if (typeof navigator === "undefined") return "Install AO";
-
-	const isSmallViewport = typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches;
-	const platform = `${navigator.platform} ${navigator.userAgent}`.toLowerCase();
-	const isPortableDevice =
-		isSmallViewport ||
-		/android|iphone|ipad|ipod|mobile|tablet/.test(platform) ||
-		(platform.includes("mac") && navigator.maxTouchPoints > 1);
-
-	if (isPortableDevice) return "Setup guide";
-	if (platform.includes("mac")) return "Install for macOS";
-	if (platform.includes("win")) return "Install for Windows";
-	if (platform.includes("linux") || platform.includes("x11")) return "Install for Linux";
-	return "Install AO";
-}
-
 export function LandingNav() {
 	const [open, setOpen] = useState(false);
-	const [installLabel, setInstallLabel] = useState("Install AO");
 	const navRef = useRef<HTMLDivElement>(null);
 	const innerRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		const updatePlatformLabel = () => setInstallLabel(getPlatformLabel());
-
-		updatePlatformLabel();
-		window.addEventListener("resize", updatePlatformLabel);
-		return () => window.removeEventListener("resize", updatePlatformLabel);
-	}, []);
 
 	useGSAP(() => {
 		// Shrink + hide-on-scroll only on desktop (>=768px). On mobile/tablet the
@@ -150,7 +127,7 @@ export function LandingNav() {
 		>
 			<div
 				ref={innerRef}
-				className="w-full max-w-6xl mx-auto flex h-14 items-center justify-between gap-6 rounded-full border border-[color:var(--border)] bg-[color:var(--bg)]/70 px-6 backdrop-blur-xl shadow-lg transition-all duration-500 ease-out [.nav-scrolled_&]:h-12 [.nav-scrolled_&]:max-w-4xl [.nav-scrolled_&]:bg-[color:var(--bg)]/90"
+				className="relative mx-auto flex h-14 w-full max-w-4xl items-center justify-between gap-5 rounded-full border border-[color:var(--border)] bg-[color:var(--bg)]/70 px-5 backdrop-blur-xl shadow-lg transition-all duration-500 ease-out [.nav-scrolled_&]:h-12 [.nav-scrolled_&]:max-w-3xl [.nav-scrolled_&]:bg-[color:var(--bg)]/90"
 			>
 				<a href="/" data-testid="nav-logo" className="group inline-flex h-10 shrink-0 items-center gap-3">
 					<img
@@ -163,7 +140,7 @@ export function LandingNav() {
 					</span>
 				</a>
 
-				<nav className="hidden items-center gap-8 md:flex" aria-label="Primary">
+				<nav className="absolute left-1/2 hidden -translate-x-1/2 items-center gap-7 md:flex" aria-label="Primary">
 					{navLinks.map((item) => (
 						<a
 							key={item.label}
@@ -175,7 +152,8 @@ export function LandingNav() {
 					))}
 				</nav>
 
-				<div className="flex items-center gap-3">
+				<div className="flex items-center gap-2">
+					<div className="mx-1 hidden h-4 w-px bg-[color:var(--border)] lg:block" />
 					<div className="hidden items-center gap-3 lg:flex">
 						{socials.map((item) => {
 							const Icon = item.icon;
@@ -194,17 +172,6 @@ export function LandingNav() {
 							);
 						})}
 					</div>
-					<div className="mx-1 hidden h-4 w-px bg-[color:var(--border)] lg:block" />
-					<a
-						href="/docs/installation"
-						data-testid="nav-cta-btn"
-						style={{ color: "#000000" }}
-						className="fluid-press group/cta inline-flex h-9 items-center gap-2 rounded-full bg-[color:var(--accent)] px-5 text-[13px] font-semibold shadow-[0_8px_24px_-14px_var(--accent-glow)] hover:shadow-[0_14px_34px_-12px_var(--accent-glow)] hover:brightness-[1.07] max-[365px]:hidden [.nav-scrolled_&]:h-8 [.nav-scrolled_&]:px-4 [.nav-scrolled_&]:text-[12px]"
-					>
-						<DownloadIcon className="h-3.5 w-3.5 transition-transform duration-[450ms] ease-[cubic-bezier(0.16,1,0.3,1)] group-hover/cta:translate-y-0.5" />
-						<span>{installLabel}</span>
-					</a>
-
 					<button
 						type="button"
 						aria-label={open ? "Close navigation menu" : "Open navigation menu"}
@@ -223,15 +190,6 @@ export function LandingNav() {
 					id="mobile-navigation-menu"
 					className="absolute inset-x-0 top-full mt-4 flex flex-col gap-1 rounded-2xl border border-[color:var(--border)] bg-[color:var(--bg)]/95 p-4 mx-4 backdrop-blur-xl shadow-2xl md:hidden"
 				>
-					<a
-						href="/docs/installation"
-						onClick={() => setOpen(false)}
-						style={{ color: "#000000" }}
-						className="mb-1 hidden items-center justify-center gap-2 rounded-lg bg-[color:var(--accent)] px-4 py-3 text-[15px] font-semibold max-[365px]:flex"
-					>
-						<DownloadIcon className="h-4 w-4" />
-						<span>{installLabel}</span>
-					</a>
 					{navLinks.map((item) => (
 						<a
 							key={item.label}

--- a/frontend/src/landing/components/docs/InstallDownloads.tsx
+++ b/frontend/src/landing/components/docs/InstallDownloads.tsx
@@ -1,37 +1,5 @@
 import { Logo } from "./Logo";
-
-const RELEASE_BASE = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest";
-
-const DOWNLOADS = [
-	{
-		platform: "macOS",
-		detail: "Apple silicon",
-		logo: "apple",
-		type: "Download .zip",
-		href: `${RELEASE_BASE}/download/agent-orchestrator-darwin-arm64.zip`,
-	},
-	{
-		platform: "macOS",
-		detail: "Intel",
-		logo: "apple",
-		type: "Download .zip",
-		href: `${RELEASE_BASE}/download/agent-orchestrator-darwin-x64.zip`,
-	},
-	{
-		platform: "Windows",
-		detail: "x64 installer",
-		logo: "windows",
-		type: "Download .exe",
-		href: `${RELEASE_BASE}/download/agent-orchestrator-win32-x64.exe`,
-	},
-	{
-		platform: "Linux",
-		detail: "x64 AppImage",
-		logo: "linux",
-		type: "Download .AppImage",
-		href: `${RELEASE_BASE}/download/agent-orchestrator-linux-x64.AppImage`,
-	},
-];
+import { DESKTOP_DOWNLOADS, RELEASE_URL } from "../../lib/desktop-downloads";
 
 export function InstallDownloads() {
 	return (
@@ -40,13 +8,13 @@ export function InstallDownloads() {
 				<div className="ao-install-downloads__copy">
 					<div className="ao-install-downloads__title">Choose your platform</div>
 				</div>
-				<a className="ao-install-downloads__release" href={RELEASE_BASE}>
+				<a className="ao-install-downloads__release" href={RELEASE_URL}>
 					View release
 				</a>
 			</div>
 
 			<div className="ao-install-downloads__grid">
-				{DOWNLOADS.map((download) => (
+				{DESKTOP_DOWNLOADS.map((download) => (
 					<a
 						key={`${download.platform}-${download.detail}`}
 						className="ao-install-downloads__item"

--- a/frontend/src/landing/lib/desktop-downloads.test.ts
+++ b/frontend/src/landing/lib/desktop-downloads.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { DESKTOP_DOWNLOADS, getDownloadOptions, getDownloadTarget } from "./desktop-downloads";
+
+function device(platform: string, userAgent: string, maxTouchPoints = 0) {
+	return { platform, userAgent, maxTouchPoints };
+}
+
+describe("desktop download selection", () => {
+	it("links Windows desktops directly to the installer", () => {
+		expect(getDownloadTarget(device("Win32", "Windows NT 10.0"))).toEqual({
+			label: "Download for Windows",
+			href: DESKTOP_DOWNLOADS[2].href,
+		});
+	});
+
+	it("links Linux desktops directly to the AppImage regardless of viewport width", () => {
+		const linux = device("Linux x86_64", "X11; Linux x86_64");
+		const previousWidth = window.innerWidth;
+		Object.defineProperty(window, "innerWidth", { configurable: true, value: 640 });
+		try {
+			expect(getDownloadTarget(linux)).toEqual({
+				label: "Download for Linux",
+				href: DESKTOP_DOWNLOADS[3].href,
+			});
+		} finally {
+			Object.defineProperty(window, "innerWidth", { configurable: true, value: previousWidth });
+		}
+	});
+
+	it("offers both macOS architectures on Mac desktops", () => {
+		const mac = device("MacIntel", "Macintosh; Intel Mac OS X 10_15_7");
+		expect(getDownloadTarget(mac)).toBeNull();
+		expect(getDownloadOptions(mac)).toEqual(DESKTOP_DOWNLOADS.slice(0, 2));
+	});
+
+	it.each([
+		["iPhone", "Mobile Safari", 5],
+		["Linux armv8l", "Android Tablet", 5],
+		["MacIntel", "Macintosh", 5],
+	])("offers the full desktop chooser to portable device %s", (platform, userAgent, maxTouchPoints) => {
+		const portable = device(platform, userAgent, maxTouchPoints);
+		expect(getDownloadTarget(portable)).toBeNull();
+		expect(getDownloadOptions(portable)).toEqual(DESKTOP_DOWNLOADS);
+	});
+});

--- a/frontend/src/landing/lib/desktop-downloads.ts
+++ b/frontend/src/landing/lib/desktop-downloads.ts
@@ -1,0 +1,67 @@
+export const RELEASE_URL = "https://github.com/AgentWrapper/agent-orchestrator/releases/latest";
+
+export const DESKTOP_DOWNLOADS = [
+	{
+		platform: "macOS",
+		detail: "Apple silicon",
+		label: "macOS (Apple silicon)",
+		logo: "apple",
+		type: "Download .zip",
+		href: `${RELEASE_URL}/download/agent-orchestrator-darwin-arm64.zip`,
+	},
+	{
+		platform: "macOS",
+		detail: "Intel",
+		label: "macOS (Intel)",
+		logo: "apple",
+		type: "Download .zip",
+		href: `${RELEASE_URL}/download/agent-orchestrator-darwin-x64.zip`,
+	},
+	{
+		platform: "Windows",
+		detail: "x64 installer",
+		label: "Windows",
+		logo: "windows",
+		type: "Download .exe",
+		href: `${RELEASE_URL}/download/agent-orchestrator-win32-x64.exe`,
+	},
+	{
+		platform: "Linux",
+		detail: "x64 AppImage",
+		label: "Linux",
+		logo: "linux",
+		type: "Download .AppImage",
+		href: `${RELEASE_URL}/download/agent-orchestrator-linux-x64.AppImage`,
+	},
+] as const;
+
+type PlatformNavigator = Pick<Navigator, "maxTouchPoints" | "platform" | "userAgent">;
+
+function platformDescription(navigator: PlatformNavigator): string {
+	return `${navigator.platform} ${navigator.userAgent}`.toLowerCase();
+}
+
+export function isPortableDevice(navigator: PlatformNavigator): boolean {
+	const platform = platformDescription(navigator);
+	return (
+		/android|iphone|ipad|ipod|mobile|tablet/.test(platform) ||
+		(platform.includes("mac") && navigator.maxTouchPoints > 1)
+	);
+}
+
+export function getDownloadTarget(navigator: PlatformNavigator) {
+	const platform = platformDescription(navigator);
+
+	if (isPortableDevice(navigator)) return null;
+	if (platform.includes("win")) return { label: "Download for Windows", href: DESKTOP_DOWNLOADS[2].href };
+	if (platform.includes("linux") || platform.includes("x11"))
+		return { label: "Download for Linux", href: DESKTOP_DOWNLOADS[3].href };
+	return null;
+}
+
+export function getDownloadOptions(navigator: PlatformNavigator) {
+	const platform = platformDescription(navigator);
+	return platform.includes("mac") && !isPortableDevice(navigator)
+		? DESKTOP_DOWNLOADS.slice(0, 2)
+		: DESKTOP_DOWNLOADS;
+}

--- a/frontend/src/landing/lib/desktop-downloads.ts
+++ b/frontend/src/landing/lib/desktop-downloads.ts
@@ -61,7 +61,5 @@ export function getDownloadTarget(navigator: PlatformNavigator) {
 
 export function getDownloadOptions(navigator: PlatformNavigator) {
 	const platform = platformDescription(navigator);
-	return platform.includes("mac") && !isPortableDevice(navigator)
-		? DESKTOP_DOWNLOADS.slice(0, 2)
-		: DESKTOP_DOWNLOADS;
+	return platform.includes("mac") && !isPortableDevice(navigator) ? DESKTOP_DOWNLOADS.slice(0, 2) : DESKTOP_DOWNLOADS;
 }


### PR DESCRIPTION
## Summary

- replace the landing-page install CTA with direct, platform-specific desktop downloads sourced from the documented latest-release assets
- provide architecture choices for macOS and a full desktop platform chooser for mobile and tablet visitors
- remove the navbar install button, tighten the navbar layout, and keep the primary navigation geometrically centered
- add GitHub to the navbar's social links

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/22dbfd4c-5f08-4d55-a27c-874081e92d8f" />

