### PR TITLE
Send browser annotations despite stale activity status

### DIFF
--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -97,7 +97,6 @@ function PersistentBrowserPanelView({
 	});
 	const annotationQueue = useBrowserAnnotationQueue({
 		sessionId: currentSession.id,
-		sessionStatus: currentSession.status,
 		navUrl: browserView.navState.url,
 	});
 	if (!visible) return null;
@@ -243,7 +242,14 @@ describe("BrowserPanel", () => {
 
 	it("sends submitted annotation instructions to the session agent", async () => {
 		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
-		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
+		render(
+			<BrowserPanel
+				active
+				onTogglePopOut={() => undefined}
+				poppedOut={false}
+				session={{ ...session, status: "idle" }}
+			/>,
+		);
 
 		act(() => {
 			annotationSubmitListeners.forEach((listener) =>
@@ -278,11 +284,9 @@ describe("BrowserPanel", () => {
 		expect(body.message.length).toBeLessThanOrEqual(4096);
 	});
 
-	it("waits for the agent turn cycle before sending a follow-up annotation", async () => {
+	it("sends a follow-up annotation without waiting for an activity-state cycle", async () => {
 		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
-		const { rerender } = render(
-			<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />,
-		);
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 
 		act(() => {
 			annotationSubmitListeners.forEach((listener) => listener(annotationPayload("Make this button blue.")));
@@ -294,20 +298,6 @@ describe("BrowserPanel", () => {
 			annotationSubmitListeners.forEach((listener) => listener(annotationPayload("Make this button green.")));
 		});
 
-		expect(screen.getByText("Queued")).toBeInTheDocument();
-		expect(postMock).toHaveBeenCalledTimes(1);
-
-		rerender(
-			<BrowserPanel
-				active
-				onTogglePopOut={() => undefined}
-				poppedOut={false}
-				session={{ ...session, status: "working" }}
-			/>,
-		);
-		expect(postMock).toHaveBeenCalledTimes(1);
-
-		rerender(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 		expect(await screen.findByText("Sent")).toBeInTheDocument();
 		expect(postMock).toHaveBeenCalledTimes(2);
 		expect((postMock.mock.calls[1][1].body as { message: string }).message).toContain("Make this button green.");
@@ -323,9 +313,7 @@ describe("BrowserPanel", () => {
 			)
 			.mockResolvedValueOnce({ data: {} });
 		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
-		const { rerender } = render(
-			<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />,
-		);
+		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 		const firstPayload = {
 			viewId: "42:sess-1",
 			instruction: "Make this button blue.",
@@ -356,20 +344,6 @@ describe("BrowserPanel", () => {
 		await act(async () => {
 			resolvePost({ data: {} });
 		});
-		expect(screen.getByText("Queued")).toBeInTheDocument();
-		expect(postMock).toHaveBeenCalledTimes(1);
-
-		rerender(
-			<BrowserPanel
-				active
-				onTogglePopOut={() => undefined}
-				poppedOut={false}
-				session={{ ...session, status: "working" }}
-			/>,
-		);
-		expect(postMock).toHaveBeenCalledTimes(1);
-
-		rerender(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 		expect(await screen.findByText("Sent")).toBeInTheDocument();
 		expect(postMock).toHaveBeenCalledTimes(2);
 		expect((postMock.mock.calls[1][1].body as { message: string }).message).toContain("Make this heading shorter.");
@@ -398,21 +372,17 @@ describe("BrowserPanel", () => {
 		await act(async () => {
 			resolvePost({ data: {} });
 		});
-		expect(screen.getByText("Queued")).toBeInTheDocument();
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
 
 		rerender(<PersistentBrowserPanelView currentSession={session} visible={false} />);
 		rerender(<PersistentBrowserPanelView currentSession={{ ...session, status: "working" }} visible={false} />);
-		expect(postMock).toHaveBeenCalledTimes(1);
-
-		rerender(<PersistentBrowserPanelView currentSession={session} visible={false} />);
-		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
 
 		rerender(<PersistentBrowserPanelView currentSession={session} visible />);
 		expect(await screen.findByText("Sent")).toBeInTheDocument();
 		expect((postMock.mock.calls[1][1].body as { message: string }).message).toContain("Make this heading shorter.");
 	});
 
-	it("does not drain queued annotations on the idle state before needs input", async () => {
+	it("continues queued delivery across activity status changes", async () => {
 		let resolvePost: (value: unknown) => void = () => undefined;
 		postMock
 			.mockReturnValueOnce(
@@ -445,10 +415,6 @@ describe("BrowserPanel", () => {
 				listener({ ...payload, instruction: "Make this button blue." });
 			});
 		});
-		await act(async () => {
-			resolvePost({ data: {} });
-		});
-
 		rerender(
 			<BrowserPanel
 				active
@@ -457,6 +423,9 @@ describe("BrowserPanel", () => {
 				session={{ ...session, status: "working" }}
 			/>,
 		);
+		await act(async () => {
+			resolvePost({ data: {} });
+		});
 		rerender(
 			<BrowserPanel
 				active
@@ -465,17 +434,13 @@ describe("BrowserPanel", () => {
 				session={{ ...session, status: "idle" }}
 			/>,
 		);
-		expect(screen.getByText("Queued")).toBeInTheDocument();
-		expect(postMock).toHaveBeenCalledTimes(1);
-
-		rerender(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 		expect(await screen.findByText("Sent")).toBeInTheDocument();
 		expect(postMock).toHaveBeenCalledTimes(2);
 	});
 
-	it("queues submitted annotations while the session is working", async () => {
+	it("sends submitted annotations while the session status is working", async () => {
 		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
-		const { rerender } = render(
+		render(
 			<BrowserPanel
 				active
 				onTogglePopOut={() => undefined}
@@ -502,10 +467,6 @@ describe("BrowserPanel", () => {
 			);
 		});
 
-		expect(screen.getByText("Queued")).toBeInTheDocument();
-		expect(postMock).not.toHaveBeenCalled();
-
-		rerender(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 		expect(await screen.findByText("Sent")).toBeInTheDocument();
 		expect(postMock).toHaveBeenCalledTimes(1);
 	});

--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -303,50 +303,54 @@ describe("BrowserPanel", () => {
 		expect((postMock.mock.calls[1][1].body as { message: string }).message).toContain("Make this button green.");
 	});
 
-	it("queues annotation submissions while one is being sent", async () => {
-		let resolvePost: (value: unknown) => void = () => undefined;
+	it("serializes annotations in order exactly once while status remains working", async () => {
+		let resolveFirstPost: (value: unknown) => void = () => undefined;
+		let resolveSecondPost: (value: unknown) => void = () => undefined;
 		postMock
 			.mockReturnValueOnce(
 				new Promise((resolve) => {
-					resolvePost = resolve;
+					resolveFirstPost = resolve;
+				}),
+			)
+			.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolveSecondPost = resolve;
 				}),
 			)
 			.mockResolvedValueOnce({ data: {} });
 		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
-		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
-		const firstPayload = {
-			viewId: "42:sess-1",
-			instruction: "Make this button blue.",
-			context: {
-				url: "http://localhost:5173/",
-				tag: "button",
-				classes: [],
-				selector: "button",
-				rect: { x: 0, y: 0, width: 80, height: 30 },
-				nearbyText: [],
-				computedStyle: {},
-			},
-		};
-		const secondPayload = {
-			...firstPayload,
-			instruction: "Make this heading shorter.",
-		};
+		render(
+			<BrowserPanel
+				active
+				onTogglePopOut={() => undefined}
+				poppedOut={false}
+				session={{ ...session, status: "working" }}
+			/>,
+		);
+		const instructions = ["Make this button blue.", "Make this heading shorter.", "Reduce the card padding."];
 
 		act(() => {
 			annotationSubmitListeners.forEach((listener) => {
-				listener(firstPayload);
-				listener(secondPayload);
+				instructions.forEach((instruction) => listener(annotationPayload(instruction)));
 			});
 		});
 
 		expect(postMock).toHaveBeenCalledTimes(1);
-		expect((postMock.mock.calls[0][1].body as { message: string }).message).toContain("Make this button blue.");
 		await act(async () => {
-			resolvePost({ data: {} });
+			resolveFirstPost({ data: {} });
+		});
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
+		expect(postMock).toHaveBeenCalledTimes(2);
+		await act(async () => {
+			resolveSecondPost({ data: {} });
 		});
 		expect(await screen.findByText("Sent")).toBeInTheDocument();
-		expect(postMock).toHaveBeenCalledTimes(2);
-		expect((postMock.mock.calls[1][1].body as { message: string }).message).toContain("Make this heading shorter.");
+		expect(postMock).toHaveBeenCalledTimes(3);
+		expect(
+			postMock.mock.calls.map(
+				(call) => (call[1].body as { message: string }).message.match(/Change request:\n(.+)/)?.[1],
+			),
+		).toEqual(instructions);
 	});
 
 	it("preserves queued annotations while the BrowserPanelView is unmounted", async () => {
@@ -369,13 +373,16 @@ describe("BrowserPanel", () => {
 		});
 		expect(postMock).toHaveBeenCalledTimes(1);
 
+		rerender(<PersistentBrowserPanelView currentSession={session} visible={false} />);
+		expect(postMock).toHaveBeenCalledTimes(1);
+
 		await act(async () => {
 			resolvePost({ data: {} });
 		});
 		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
-
-		rerender(<PersistentBrowserPanelView currentSession={session} visible={false} />);
-		rerender(<PersistentBrowserPanelView currentSession={{ ...session, status: "working" }} visible={false} />);
+		expect(postMock).toHaveBeenCalledTimes(2);
+		expect((postMock.mock.calls[0][1].body as { message: string }).message).toContain("Make this button blue.");
+		expect((postMock.mock.calls[1][1].body as { message: string }).message).toContain("Make this heading shorter.");
 
 		rerender(<PersistentBrowserPanelView currentSession={session} visible />);
 		expect(await screen.findByText("Sent")).toBeInTheDocument();

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -30,11 +30,9 @@ export type BrowserAnnotationQueueModel = {
 
 export function useBrowserAnnotationQueue({
 	sessionId,
-	sessionStatus,
 	navUrl,
 }: {
 	sessionId?: string;
-	sessionStatus?: WorkspaceSession["status"];
 	navUrl?: string;
 }): BrowserAnnotationQueueModel {
 	const [state, setState] = useState<{ status: AnnotationStatus; error: string; queuedCount: number }>({
@@ -44,11 +42,6 @@ export function useBrowserAnnotationQueue({
 	});
 	const annotationQueueRef = useRef<BrowserAnnotationSubmitPayload[]>([]);
 	const annotationSendingRef = useRef(false);
-	const annotationWaitingForAgentCycleRef = useRef(false);
-	const annotationWaitAfterCycleRef = useRef(0);
-	const annotationSawAgentWorkingRef = useRef(sessionStatus === "working");
-	const annotationAgentCycleRef = useRef(0);
-	const sessionReadyForAnnotationRef = useRef(sessionStatus === "needs_input");
 	const sessionIdRef = useRef(sessionId ?? "");
 	const generationRef = useRef(0);
 
@@ -56,18 +49,11 @@ export function useBrowserAnnotationQueue({
 		generationRef.current += 1;
 		annotationQueueRef.current = [];
 		annotationSendingRef.current = false;
-		annotationWaitingForAgentCycleRef.current = false;
-		annotationWaitAfterCycleRef.current = annotationAgentCycleRef.current;
 		setState({ status: "idle", error: "", queuedCount: 0 });
 	}, []);
 
 	const drainAnnotationQueue = useCallback(() => {
-		if (
-			annotationSendingRef.current ||
-			!sessionIdRef.current ||
-			!sessionReadyForAnnotationRef.current ||
-			annotationWaitingForAgentCycleRef.current
-		) {
+		if (annotationSendingRef.current || !sessionIdRef.current) {
 			return;
 		}
 
@@ -78,7 +64,6 @@ export function useBrowserAnnotationQueue({
 		annotationSendingRef.current = true;
 		const sendGeneration = generationRef.current;
 		const sendSessionId = sessionIdRef.current;
-		const sendCycle = annotationAgentCycleRef.current;
 		setState({ status: "sending", error: "", queuedCount: annotationQueueRef.current.length });
 
 		void (async () => {
@@ -110,25 +95,15 @@ export function useBrowserAnnotationQueue({
 					return;
 				}
 
-				annotationWaitingForAgentCycleRef.current = true;
-				annotationWaitAfterCycleRef.current = sendCycle;
-				if (
-					sessionReadyForAnnotationRef.current &&
-					annotationAgentCycleRef.current > annotationWaitAfterCycleRef.current
-				) {
-					annotationWaitingForAgentCycleRef.current = false;
-				}
-
 				const queuedCount = annotationQueueRef.current.length;
 				setState({ status: queuedCount > 0 ? "queued" : "sent", error: "", queuedCount });
-				if (!annotationWaitingForAgentCycleRef.current && queuedCount > 0) drainAnnotationQueue();
+				if (queuedCount > 0) drainAnnotationQueue();
 			}
 		})();
 	}, []);
 
 	useEffect(() => {
 		sessionIdRef.current = sessionId ?? "";
-		annotationAgentCycleRef.current = 0;
 		resetQueue();
 	}, [resetQueue, sessionId]);
 
@@ -136,28 +111,6 @@ export function useBrowserAnnotationQueue({
 		if (navUrl) return;
 		resetQueue();
 	}, [navUrl, resetQueue]);
-
-	useEffect(() => {
-		const nextWorking = sessionStatus === "working";
-		const nextReady = sessionStatus === "needs_input";
-		sessionReadyForAnnotationRef.current = nextReady;
-
-		if (nextWorking) {
-			annotationSawAgentWorkingRef.current = true;
-			return;
-		}
-
-		if (!nextReady) return;
-		if (annotationSawAgentWorkingRef.current) {
-			annotationAgentCycleRef.current += 1;
-			annotationSawAgentWorkingRef.current = false;
-		}
-		if (annotationWaitingForAgentCycleRef.current) {
-			if (annotationAgentCycleRef.current <= annotationWaitAfterCycleRef.current) return;
-			annotationWaitingForAgentCycleRef.current = false;
-		}
-		drainAnnotationQueue();
-	}, [drainAnnotationQueue, sessionStatus]);
 
 	const beginPicking = useCallback(() => {
 		setState((current) => ({ ...current, status: "picking", error: "" }));
@@ -212,7 +165,6 @@ export function BrowserPanel({ session, active, poppedOut, onTogglePopOut }: Bro
 	});
 	const annotationQueue = useBrowserAnnotationQueue({
 		sessionId: session.id,
-		sessionStatus: session.status,
 		navUrl: browserView.navState.url,
 	});
 	return (

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -67,7 +67,6 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	});
 	const browserAnnotationQueue = useBrowserAnnotationQueue({
 		sessionId: session?.id,
-		sessionStatus: session?.status,
 		navUrl: browserView.navState.url,
 	});
 


### PR DESCRIPTION
Fixes #2606

## Summary

- decouple browser annotation delivery from the session's activity status
- send annotations through the existing runtime messenger even when activity is stale as `working`
- retain serialized delivery, queue preservation across Browser tab unmounts, and retry behavior
- update browser panel tests for status-independent delivery

Serialized delivery means one `/send` request is in flight at a time. The next annotation is sent when the previous request succeeds; it does not wait for the agent to finish the previous instruction.

## Root cause

The annotation queue waited for specific activity-state transitions before calling the session send endpoint. Normal completed turns can report `idle`, and Codex activity can remain stale as `working` even when the terminal is ready. That left valid annotation messages queued indefinitely.

The backend send endpoint already supports injecting messages into a live runtime without imposing an activity-status restriction, so the frontend gate was unnecessary and unreliable.

## Before

<img width="1920" height="1200" alt="Screenshot From 2026-07-11 18-10-15" src="https://github.com/user-attachments/assets/0eba2c32-d628-4278-beef-f86e0fb08b43" />

## After

<img width="1920" height="1200" alt="Screenshot From 2026-07-11 18-47-27" src="https://github.com/user-attachments/assets/d5ad0d95-f1d3-423c-826d-595f8cca2dd1" />

## Validation

- `npm test -- src/renderer/components/BrowserPanel.test.tsx` — 17/17 passed
- `npm test` — 527/527 passed
- `npm run typecheck`
- Prettier check for all three changed files
- `git diff --check`
- manual Electron verification on Fedora Linux
- confirmed successful HTTP 200 responses from the session send endpoint
