### PR TITLE
Open terminal localhost links in the Browser preview

### DIFF
--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -198,7 +198,7 @@ describe("BrowserPanel", () => {
 		hookState.navState = { ...hookState.navState, error: "Connection refused" };
 		render(<BrowserPanel active onTogglePopOut={() => undefined} poppedOut={false} session={session} />);
 
-		expect(screen.getByText("Enter a dev-server URL to preview it here.")).toBeInTheDocument();
+		expect(screen.getByText("Enter a URL or click one in the terminal.")).toBeInTheDocument();
 		expect(screen.getByText("Connection refused")).toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -409,7 +409,7 @@ export function BrowserPanelView({
 				{showStaticPreview ? <StaticPreview url={navState.url} /> : null}
 				{navState.url === "" ? (
 					<div className="pointer-events-none absolute inset-0 grid place-items-center p-5 text-center font-mono text-xs text-passive">
-						<p>Enter a dev-server URL to preview it here.</p>
+						<p>Enter a URL or click one in the terminal.</p>
 					</div>
 				) : null}
 				{navState.error ? (

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -1,11 +1,22 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession } from "../types/workspace";
-import { TerminalPane, providerScrollsByKeyboard } from "./TerminalPane";
+import { isLoopbackPreviewURL, TerminalPane, providerScrollsByKeyboard } from "./TerminalPane";
+
+const postMock = vi.fn();
+let terminalLinkHandler: ((uri: string) => void) | undefined;
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: { POST: (...args: unknown[]) => postMock(...args) },
+	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
+}));
 
 vi.mock("./XtermTerminal", () => ({
-	XtermTerminal: () => <div data-testid="xterm" />,
+	XtermTerminal: (props: { onLinkOpen?: (uri: string) => void }) => {
+		terminalLinkHandler = props.onLinkOpen;
+		return <div data-testid="xterm" />;
+	},
 }));
 
 vi.mock("../hooks/useTerminalSession", () => ({
@@ -35,6 +46,12 @@ const orchestrator = {
 	title: "orchestrate",
 	kind: "orchestrator",
 } satisfies WorkspaceSession;
+
+beforeEach(() => {
+	postMock.mockReset();
+	postMock.mockResolvedValue({ data: {} });
+	terminalLinkHandler = undefined;
+});
 
 function renderPane(session?: WorkspaceSession) {
 	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -111,5 +128,50 @@ describe("providerScrollsByKeyboard", () => {
 
 	it("is false when the provider is unknown", () => {
 		expect(providerScrollsByKeyboard(undefined)).toBe(false);
+	});
+});
+
+describe("isLoopbackPreviewURL", () => {
+	it.each(["http://localhost:3000/simple", "https://app.localhost:5173", "http://127.0.0.1:8080", "http://[::1]:4173"])(
+		"accepts local development URL %s",
+		(url) => {
+			expect(isLoopbackPreviewURL(url)).toBe(true);
+		},
+	);
+
+	it.each(["https://example.com", "file:///tmp/index.html", "javascript:alert(1)", "not a URL"])(
+		"rejects non-loopback URL %s",
+		(url) => {
+			expect(isLoopbackPreviewURL(url)).toBe(false);
+		},
+	);
+});
+
+describe("terminal link preview", () => {
+	it("mirrors a localhost terminal link into the session Browser preview", async () => {
+		const view = renderPane(worker);
+		try {
+			expect(terminalLinkHandler).toBeTypeOf("function");
+			act(() => terminalLinkHandler?.("http://localhost:3000/simple"));
+
+			await waitFor(() =>
+				expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/preview", {
+					params: { path: { sessionId: "sess-1" } },
+					body: { url: "http://localhost:3000/simple" },
+				}),
+			);
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("does not mirror an external terminal link into the Browser preview", () => {
+		const view = renderPane(worker);
+		try {
+			act(() => terminalLinkHandler?.("https://example.com"));
+			expect(postMock).not.toHaveBeenCalled();
+		} finally {
+			view.restore();
+		}
 	});
 });

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession } from "../types/workspace";
-import { isLoopbackPreviewURL, TerminalPane, providerScrollsByKeyboard } from "./TerminalPane";
+import { TerminalPane, providerScrollsByKeyboard } from "./TerminalPane";
 
 const postMock = vi.fn();
 let terminalLinkHandler: ((uri: string) => void) | undefined;
@@ -64,6 +64,7 @@ function renderPane(session?: WorkspaceSession) {
 	);
 	return {
 		...result,
+		queryClient,
 		restore: () => {
 			window.ao = previousAO;
 		},
@@ -131,39 +132,26 @@ describe("providerScrollsByKeyboard", () => {
 	});
 });
 
-describe("isLoopbackPreviewURL", () => {
-	it.each(["http://localhost:3000/simple", "https://app.localhost:5173", "http://127.0.0.1:8080", "http://[::1]:4173"])(
-		"accepts local development URL %s",
-		(url) => {
-			expect(isLoopbackPreviewURL(url)).toBe(true);
-		},
-	);
-
-	it.each(["https://example.com", "file:///tmp/index.html", "javascript:alert(1)", "not a URL"])(
-		"rejects non-loopback URL %s",
-		(url) => {
-			expect(isLoopbackPreviewURL(url)).toBe(false);
-		},
-	);
-});
-
 describe("terminal link preview", () => {
-	it("mirrors a localhost terminal link into the session Browser preview", async () => {
-		const view = renderPane(worker);
-		try {
-			expect(terminalLinkHandler).toBeTypeOf("function");
-			act(() => terminalLinkHandler?.("http://localhost:3000/simple"));
+	it.each(["http://localhost:3000/simple", "https://app.localhost:5173", "http://127.0.0.1:8080", "http://[::1]:4173"])(
+		"mirrors worker loopback link %s into the session Browser preview",
+		async (url) => {
+			const view = renderPane(worker);
+			try {
+				expect(terminalLinkHandler).toBeTypeOf("function");
+				act(() => terminalLinkHandler?.(url));
 
-			await waitFor(() =>
-				expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/preview", {
-					params: { path: { sessionId: "sess-1" } },
-					body: { url: "http://localhost:3000/simple" },
-				}),
-			);
-		} finally {
-			view.restore();
-		}
-	});
+				await waitFor(() =>
+					expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/preview", {
+						params: { path: { sessionId: "sess-1" } },
+						body: { url },
+					}),
+				);
+			} finally {
+				view.restore();
+			}
+		},
+	);
 
 	it("does not mirror an external terminal link into the Browser preview", () => {
 		const view = renderPane(worker);
@@ -171,6 +159,59 @@ describe("terminal link preview", () => {
 			act(() => terminalLinkHandler?.("https://example.com"));
 			expect(postMock).not.toHaveBeenCalled();
 		} finally {
+			view.restore();
+		}
+	});
+
+	it("does not POST without a selected session", () => {
+		const view = renderPane();
+		try {
+			act(() => terminalLinkHandler?.("http://localhost:3000"));
+			expect(postMock).not.toHaveBeenCalled();
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("does not mirror orchestrator links because orchestrators have no Browser inspector", () => {
+		const view = renderPane(orchestrator);
+		try {
+			act(() => terminalLinkHandler?.("http://localhost:3000"));
+			expect(postMock).not.toHaveBeenCalled();
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("does not invalidate workspace data when the preview endpoint returns an error", async () => {
+		postMock.mockResolvedValueOnce({ error: { code: "INVALID_PREVIEW_URL" } });
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const view = renderPane(worker);
+		const invalidate = vi.spyOn(view.queryClient, "invalidateQueries");
+		try {
+			act(() => terminalLinkHandler?.("http://localhost:3000"));
+			await waitFor(() => expect(warning).toHaveBeenCalled());
+			expect(invalidate).not.toHaveBeenCalled();
+		} finally {
+			warning.mockRestore();
+			view.restore();
+		}
+	});
+
+	it("handles a rejected preview request without an unhandled rejection", async () => {
+		const error = new Error("daemon unavailable");
+		postMock.mockRejectedValueOnce(error);
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const view = renderPane(worker);
+		const invalidate = vi.spyOn(view.queryClient, "invalidateQueries");
+		try {
+			act(() => terminalLinkHandler?.("http://localhost:3000"));
+			await waitFor(() =>
+				expect(warning).toHaveBeenCalledWith("Unable to open terminal link in Browser preview", error),
+			);
+			expect(invalidate).not.toHaveBeenCalled();
+		} finally {
+			warning.mockRestore();
 			view.restore();
 		}
 	});

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -183,6 +183,16 @@ describe("terminal link preview", () => {
 		}
 	});
 
+	it("does not mirror links for terminated workers because their Browser inspector is cleared", () => {
+		const view = renderPane({ ...worker, status: "terminated" });
+		try {
+			act(() => terminalLinkHandler?.("http://localhost:3000"));
+			expect(postMock).not.toHaveBeenCalled();
+		} finally {
+			view.restore();
+		}
+	});
+
 	it("does not invalidate workspace data when the preview endpoint returns an error", async () => {
 		postMock.mockResolvedValueOnce({ error: { code: "INVALID_PREVIEW_URL" } });
 		const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -5,6 +5,7 @@ import type { WorkspaceSession } from "../types/workspace";
 import type { Theme } from "../stores/ui-store";
 import { useTerminalSession, type AttachableTerminal, type TerminalSessionState } from "../hooks/useTerminalSession";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { isLoopbackHostname } from "../lib/loopback";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { XtermTerminal } from "./XtermTerminal";
 import { RestoreUnavailableDialog } from "./RestoreUnavailableDialog";
@@ -129,18 +130,11 @@ export function providerScrollsByKeyboard(provider?: string): boolean {
 	return provider ? KEYBOARD_SCROLL_PROVIDERS.has(provider) : false;
 }
 
-export function isLoopbackPreviewURL(value: string): boolean {
+function isLoopbackPreviewURL(value: string): boolean {
 	try {
 		const url = new URL(value);
 		if (url.protocol !== "http:" && url.protocol !== "https:") return false;
-		const hostname = url.hostname.toLowerCase();
-		return (
-			hostname === "localhost" ||
-			hostname.endsWith(".localhost") ||
-			hostname === "127.0.0.1" ||
-			hostname === "::1" ||
-			hostname === "[::1]"
-		);
+		return isLoopbackHostname(url.hostname);
 	} catch {
 		return false;
 	}
@@ -181,20 +175,24 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 	}, []);
 	const handleLinkOpen = useCallback(
 		(uri: string) => {
-			if (!session?.id || !isLoopbackPreviewURL(uri)) return;
+			if (!session?.id || session.kind !== "worker" || !isLoopbackPreviewURL(uri)) return;
 			void (async () => {
-				const { error: previewError } = await apiClient.POST("/api/v1/sessions/{sessionId}/preview", {
-					params: { path: { sessionId: session.id } },
-					body: { url: uri },
-				});
-				if (previewError) {
-					console.warn("Unable to open terminal link in Browser preview", previewError);
-					return;
+				try {
+					const { error: previewError } = await apiClient.POST("/api/v1/sessions/{sessionId}/preview", {
+						params: { path: { sessionId: session.id } },
+						body: { url: uri },
+					});
+					if (previewError) {
+						console.warn("Unable to open terminal link in Browser preview", previewError);
+						return;
+					}
+					await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+				} catch (error) {
+					console.warn("Unable to open terminal link in Browser preview", error);
 				}
-				await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
 			})();
 		},
-		[queryClient, session?.id],
+		[queryClient, session?.id, session?.kind],
 	);
 	const restoreSession = useCallback(async () => {
 		if (!session?.id || !canRestoreSession || isRestoring) return;

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -130,16 +130,6 @@ export function providerScrollsByKeyboard(provider?: string): boolean {
 	return provider ? KEYBOARD_SCROLL_PROVIDERS.has(provider) : false;
 }
 
-function isLoopbackPreviewURL(value: string): boolean {
-	try {
-		const url = new URL(value);
-		if (url.protocol !== "http:" && url.protocol !== "https:") return false;
-		return isLoopbackHostname(url.hostname);
-	} catch {
-		return false;
-	}
-}
-
 function bannerText(state: TerminalSessionState, error?: string): string | undefined {
 	if (state === "reattaching") return "Terminal disconnected — reattaching…";
 	if (state === "error") return `Terminal error: ${error ?? "connection failed"}`;
@@ -175,7 +165,13 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 	}, []);
 	const handleLinkOpen = useCallback(
 		(uri: string) => {
-			if (!session?.id || session.kind !== "worker" || !isLoopbackPreviewURL(uri)) return;
+			if (!session?.id || session.kind !== "worker") return;
+			try {
+				const url = new URL(uri);
+				if ((url.protocol !== "http:" && url.protocol !== "https:") || !isLoopbackHostname(url.hostname)) return;
+			} catch {
+				return;
+			}
 			void (async () => {
 				try {
 					const { error: previewError } = await apiClient.POST("/api/v1/sessions/{sessionId}/preview", {

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -165,7 +165,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 	}, []);
 	const handleLinkOpen = useCallback(
 		(uri: string) => {
-			if (!session?.id || session.kind !== "worker") return;
+			if (!session?.id || session.kind !== "worker" || session.status === "terminated") return;
 			try {
 				const url = new URL(uri);
 				if ((url.protocol !== "http:" && url.protocol !== "https:") || !isLoopbackHostname(url.hostname)) return;
@@ -188,7 +188,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 				}
 			})();
 		},
-		[queryClient, session?.id, session?.kind],
+		[queryClient, session?.id, session?.kind, session?.status],
 	);
 	const restoreSession = useCallback(async () => {
 		if (!session?.id || !canRestoreSession || isRestoring) return;

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -129,6 +129,23 @@ export function providerScrollsByKeyboard(provider?: string): boolean {
 	return provider ? KEYBOARD_SCROLL_PROVIDERS.has(provider) : false;
 }
 
+export function isLoopbackPreviewURL(value: string): boolean {
+	try {
+		const url = new URL(value);
+		if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+		const hostname = url.hostname.toLowerCase();
+		return (
+			hostname === "localhost" ||
+			hostname.endsWith(".localhost") ||
+			hostname === "127.0.0.1" ||
+			hostname === "::1" ||
+			hostname === "[::1]"
+		);
+	} catch {
+		return false;
+	}
+}
+
 function bannerText(state: TerminalSessionState, error?: string): string | undefined {
 	if (state === "reattaching") return "Terminal disconnected — reattaching…";
 	if (state === "error") return `Terminal error: ${error ?? "connection failed"}`;
@@ -162,6 +179,23 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 		console.error("xterm failed to initialize", err);
 		setInitFailed(true);
 	}, []);
+	const handleLinkOpen = useCallback(
+		(uri: string) => {
+			if (!session?.id || !isLoopbackPreviewURL(uri)) return;
+			void (async () => {
+				const { error: previewError } = await apiClient.POST("/api/v1/sessions/{sessionId}/preview", {
+					params: { path: { sessionId: session.id } },
+					body: { url: uri },
+				});
+				if (previewError) {
+					console.warn("Unable to open terminal link in Browser preview", previewError);
+					return;
+				}
+				await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+			})();
+		},
+		[queryClient, session?.id],
+	);
 	const restoreSession = useCallback(async () => {
 		if (!session?.id || !canRestoreSession || isRestoring) return;
 		setIsRestoring(true);
@@ -237,6 +271,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 					ariaLabel="Session terminal"
 					fontSize={fontSize}
 					onError={handleInitError}
+					onLinkOpen={handleLinkOpen}
 					onReady={handleReady}
 					paneScrollsByKeyboard={providerScrollsByKeyboard(provider)}
 					theme={theme}

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -619,6 +619,21 @@ describe("XtermTerminal", () => {
 		open.mockRestore();
 	});
 
+	it("opens OSC 8 links externally and reports the clicked URL", () => {
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		const onLinkOpen = vi.fn();
+		render(<XtermTerminal onLinkOpen={onLinkOpen} theme="dark" />);
+		const oscLinkHandler = state.lastTerminal!.options.linkHandler as {
+			activate: (event: MouseEvent, uri: string) => void;
+		};
+
+		oscLinkHandler.activate({} as MouseEvent, "http://localhost:3000");
+
+		expect(open).toHaveBeenCalledWith("http://localhost:3000", "_blank", "noopener");
+		expect(onLinkOpen).toHaveBeenCalledWith("http://localhost:3000");
+		open.mockRestore();
+	});
+
 	it("forces plain drag selection without raw xterm data forwarding", () => {
 		render(<XtermTerminal theme="dark" />);
 

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -604,9 +604,10 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
 	});
 
-	it("opens terminal links via window.open so Electron routes them to the OS browser", () => {
+	it("opens terminal links externally and reports the clicked URL", () => {
 		const open = vi.spyOn(window, "open").mockReturnValue(null);
-		render(<XtermTerminal theme="dark" />);
+		const onLinkOpen = vi.fn();
+		render(<XtermTerminal onLinkOpen={onLinkOpen} theme="dark" />);
 
 		// The default WebLinksAddon handler opens an empty window first, which the
 		// Electron main process denies; ours must pass the matched URL directly.
@@ -614,6 +615,7 @@ describe("XtermTerminal", () => {
 		state.linkHandler!({} as MouseEvent, "https://example.com");
 
 		expect(open).toHaveBeenCalledWith("https://example.com", "_blank", "noopener");
+		expect(onLinkOpen).toHaveBeenCalledWith("https://example.com");
 		open.mockRestore();
 	});
 

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -47,6 +47,8 @@ export type XtermTerminalProps = {
 	paneScrollsByKeyboard?: boolean;
 	/** Terminal construction failed; the owner decides how to surface it. */
 	onError?: (error: unknown) => void;
+	/** Called after a terminal hyperlink is opened in the OS browser. */
+	onLinkOpen?: (uri: string) => void;
 	/**
 	 * The terminal is open in the DOM and ready to be attached to a PTY. The
 	 * handle stays valid until unmount; cols/rows are live getters.
@@ -289,6 +291,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		term.loadAddon(
 			new WebLinksAddon((_event, uri) => {
 				window.open(uri, "_blank", "noopener");
+				callbacksRef.current.onLinkOpen?.(uri);
 			}),
 		);
 		term.loadAddon(new SearchAddon());

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -235,6 +235,10 @@ export function XtermTerminal(props: XtermTerminalProps) {
 	useEffect(() => {
 		const host = hostRef.current;
 		if (!host) return undefined;
+		const activateLink = (_event: MouseEvent, uri: string) => {
+			window.open(uri, "_blank", "noopener");
+			callbacksRef.current.onLinkOpen?.(uri);
+		};
 
 		let term: Terminal;
 		try {
@@ -253,6 +257,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 					'ui-monospace, Menlo, Monaco, "Courier New", monospace',
 				fontSize: props.fontSize ?? TERMINAL_FONT_SIZE_DEFAULT,
 				lineHeight: 1.35,
+				linkHandler: { activate: activateLink },
 				// Agent TUIs leave SGR bold active while using ANSI black for
 				// separators; keep bold weight-only so black stays black.
 				drawBoldTextInBrightColors: false,
@@ -282,18 +287,13 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		const unicode = new Unicode11Addon();
 		term.loadAddon(unicode);
 		term.unicode.activeVersion = "11";
-		// Open links in the OS browser. The default WebLinksAddon handler calls
+		// Open plain and OSC 8 links in the OS browser. The default handlers call
 		// window.open() with no URL and then assigns location.href, but the
 		// Electron main process denies every window.open and only forwards the URL
-		// passed to it (main.ts setWindowOpenHandler), so the default handler's
+		// passed to it (main.ts setWindowOpenHandler), so the default handlers'
 		// empty open is dropped and clicks silently no-op. Pass the matched URL to
 		// window.open directly so the main process routes it to shell.openExternal.
-		term.loadAddon(
-			new WebLinksAddon((_event, uri) => {
-				window.open(uri, "_blank", "noopener");
-				callbacksRef.current.onLinkOpen?.(uri);
-			}),
-		);
+		term.loadAddon(new WebLinksAddon(activateLink));
 		term.loadAddon(new SearchAddon());
 
 		term.open(host);

--- a/frontend/src/renderer/lib/loopback.ts
+++ b/frontend/src/renderer/lib/loopback.ts
@@ -1,0 +1,9 @@
+export function isLoopbackHostname(value: string): boolean {
+	const hostname = value.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+	return (
+		hostname === "localhost" ||
+		hostname.endsWith(".localhost") ||
+		hostname === "127.0.0.1" ||
+		hostname === "::1"
+	);
+}

--- a/frontend/src/renderer/lib/loopback.ts
+++ b/frontend/src/renderer/lib/loopback.ts
@@ -1,9 +1,4 @@
 export function isLoopbackHostname(value: string): boolean {
 	const hostname = value.toLowerCase().replace(/^\[(.*)\]$/, "$1");
-	return (
-		hostname === "localhost" ||
-		hostname.endsWith(".localhost") ||
-		hostname === "127.0.0.1" ||
-		hostname === "::1"
-	);
+	return hostname === "localhost" || hostname.endsWith(".localhost") || hostname === "127.0.0.1" || hostname === "::1";
 }

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -83,6 +83,7 @@ describe("telemetry sanitizers", () => {
 			properties: {
 				$current_url: "app://renderer/index.html?token=secret",
 				$initial_current_url: "file:///Users/alice/private/index.html",
+				$referrer: "https://app.localhost:5173/private?token=secret",
 				message:
 					"failed to fetch http://localhost:3037/api/v1/projects?token=secret from app://renderer/index.html?token=secret and open /Users/alice/reverb/file.txt",
 				$exception_list: [
@@ -103,6 +104,7 @@ describe("telemetry sanitizers", () => {
 		const props = event.properties as Record<string, unknown>;
 		expect(props.$current_url).toBe("[redacted-local-url]");
 		expect(props.$initial_current_url).toBe("[redacted-local-url]");
+		expect(props.$referrer).toBe("[redacted-local-url]");
 		expect(props.message).toBe(
 			"failed to fetch [redacted-local-url] from [redacted-local-url] and open [redacted-local-path]",
 		);

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -1,5 +1,6 @@
 import posthog from "posthog-js/dist/module.full.no-external";
 import { aoBridge } from "./bridge";
+import { isLoopbackHostname } from "./loopback";
 import { DEFAULT_POSTHOG_HOST, DEFAULT_POSTHOG_PROJECT_KEY } from "../../shared/posthog-config";
 
 const POSTHOG_KEY = import.meta.env.VITE_AO_POSTHOG_KEY?.trim() || DEFAULT_POSTHOG_PROJECT_KEY;
@@ -70,13 +71,10 @@ async function hashedTelemetryID(value: unknown): Promise<string | undefined> {
 function isLocalURL(value: string): boolean {
 	try {
 		const url = new URL(value);
-		const hostname = url.hostname.replace(/^\[(.*)\]$/, "$1");
 		return (
 			url.protocol === "file:" ||
 			(url.protocol === "app:" && url.host === "renderer") ||
-			hostname === "localhost" ||
-			hostname === "127.0.0.1" ||
-			hostname === "::1"
+			isLoopbackHostname(url.hostname)
 		);
 	} catch {
 		return false;


### PR DESCRIPTION
## Summary

- keep terminal hyperlinks opening in the user's system browser
- mirror loopback HTTP(S) links into the current worker session's AO Browser preview
- reuse the existing session preview endpoint so the inspector opens and navigates through the normal CDC flow
- clarify the empty Browser state with “Enter a URL or click one in the terminal.”

## Behavior

Clicked URLs for `localhost`, `*.localhost`, `127.0.0.1`, and `::1` in worker sessions open both externally and in AO's Browser panel. External and non-HTTP(S) links retain the existing external-only behavior.

<img width="1920" height="1200" alt="Screenshot From 2026-07-11 19-19-00" src="https://github.com/user-attachments/assets/0e2c20fd-ed11-45a1-8aeb-2595ba399583" />
<img width="1920" height="1200" alt="Screenshot From 2026-07-11 19-19-10" src="https://github.com/user-attachments/assets/e7650f92-dee3-47a9-adfe-f07d10251eaa" />

## Validation

- `npm test -- src/renderer/components/BrowserPanel.test.tsx src/renderer/components/XtermTerminal.test.tsx src/renderer/components/TerminalPane.test.tsx src/renderer/components/SessionView.test.tsx` — 77/77 passed
- `npm run typecheck`
- Prettier check for all changed files
- manual Electron verification on Fedora Linux
