### PR TITLE
fix: hide root topbar crumb on macOS

### DIFF
--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -82,6 +82,7 @@ export function ShellTopbar() {
 	// route slug. "agent-orchestrator" is the root-board crumb only.
 	const projectId = session?.workspaceId ?? params.projectId;
 	const isProjectBoardRoute = !isSessionRoute && Boolean(projectId);
+	const isRootBoardRoute = !isSessionRoute && !isProjectBoardRoute;
 	const project = projectId ? all.find((workspace) => workspace.id === projectId) : undefined;
 	const projectLabel = project?.name ?? session?.workspaceName ?? (projectId ? "" : "agent-orchestrator");
 	const orchestrator = projectId ? findProjectOrchestrator(all, projectId) : undefined;
@@ -169,7 +170,7 @@ export function ShellTopbar() {
 						</div>
 						{session ? <SessionStatusPill session={session} /> : null}
 					</div>
-				) : isProjectBoardRoute ? null : (
+				) : isProjectBoardRoute || (isMac && isRootBoardRoute) ? null : (
 					<div className="inline-flex min-w-0 items-center gap-1.5">
 						<span className={topbarProjectLabelClass}>{projectLabel}</span>
 					</div>


### PR DESCRIPTION
## Summary

- Hide the root-board `agent-orchestrator` crumb in `ShellTopbar` on macOS only.
- The label is redundant with the native title bar on Mac; Windows and Linux are unchanged.
- Sidebar branding, project-board routes, and session topbar crumbs are unaffected.

## Test plan

- [ ] On macOS, open the home board (`/`) — top bar should not show `agent-orchestrator`; sidebar still shows **Agent Orchestrator**.
- [ ] On macOS, open a project board — top bar crumb stays hidden (unchanged).
- [ ] On macOS, open a session — project name / branch crumb still appears as before.
- [ ] On Windows or Linux, home board still shows the `agent-orchestrator` topbar crumb.

## Before
<img width="1470" height="513" alt="image" src="https://github.com/user-attachments/assets/e90ad8d8-dae7-42e8-8b3c-3bbfe1a0ac7b" />


## After
<img width="1470" height="882" alt="image" src="https://github.com/user-attachments/assets/0e91601d-9548-48e1-ba61-0587cb7f93e1" />
