### PR TITLE
Add app-wide MiniMax provider settings

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -46,12 +46,13 @@ type Options struct {
 // Runtime runs agent sessions inside tmux sessions, driving them via the tmux
 // CLI. It implements ports.Runtime.
 type Runtime struct {
-	binary     string
-	shell      string
-	timeout    time.Duration
-	chunkSize  int
-	enterDelay time.Duration
-	runner     runner
+	binary          string
+	shell           string
+	timeout         time.Duration
+	chunkSize       int
+	enterDelay      time.Duration
+	runner          runner
+	waitEnvConsumed func(context.Context, string) error
 }
 
 var _ ports.Runtime = (*Runtime)(nil)
@@ -101,12 +102,13 @@ func New(opts Options) *Runtime {
 		enterDelay = defaultEnterDelay
 	}
 	return &Runtime{
-		binary:     binary,
-		shell:      shellPath,
-		timeout:    timeout,
-		chunkSize:  chunkSize,
-		enterDelay: enterDelay,
-		runner:     execRunner{},
+		binary:          binary,
+		shell:           shellPath,
+		timeout:         timeout,
+		chunkSize:       chunkSize,
+		enterDelay:      enterDelay,
+		runner:          execRunner{},
+		waitEnvConsumed: waitForFileRemoval,
 	}
 }
 
@@ -127,10 +129,24 @@ func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.Ru
 		return ports.RuntimeHandle{}, err
 	}
 
-	launchCmd := buildLaunchCommand(cfg)
+	envPath, err := writeEnvFile(cfg.Env)
+	if err != nil {
+		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: write environment: %w", err)
+	}
+	launchCmd := buildLaunchCommand(cfg, envPath)
 	args := newSessionArgs(id, cfg.WorkspacePath, r.shell, launchCmd)
 	if _, err := r.run(ctx, args...); err != nil {
+		_ = os.Remove(envPath)
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: create session %s: %w", id, err)
+	}
+	waitEnvConsumed := r.waitEnvConsumed
+	if waitEnvConsumed == nil {
+		waitEnvConsumed = waitForFileRemoval
+	}
+	if err := waitEnvConsumed(ctx, envPath); err != nil {
+		_ = os.Remove(envPath)
+		_ = r.Destroy(context.Background(), ports.RuntimeHandle{ID: id})
+		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: consume environment for %s: %w", id, err)
 	}
 
 	// Hide the status bar in the embedded terminal: it clutters the view and
@@ -498,32 +514,15 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
-// buildLaunchCommand builds the shell command string passed to `sh -c`. It
-// exports env vars, then runs argv, then execs a keep-alive interactive shell
-// so the tmux session survives the agent exiting.
-//
-// PATH from cfg.Env is exported last, after all other keys, so an explicit
-// override takes effect.
-func buildLaunchCommand(cfg ports.RuntimeConfig) string {
-	path := cfg.Env["PATH"]
-	if path == "" {
-		path = getenv("PATH")
-	}
-
+// buildLaunchCommand sources a mode-0600 one-shot environment file before
+// running argv. Environment values never enter the `sh -c` process argv.
+func buildLaunchCommand(cfg ports.RuntimeConfig, envPath string) string {
 	var b strings.Builder
-	for _, key := range sortedKeys(cfg.Env) {
-		if key == "PATH" {
-			continue
-		}
-		b.WriteString("export ")
-		b.WriteString(key)
-		b.WriteString("=")
-		b.WriteString(shellQuote(cfg.Env[key]))
-		b.WriteString("; ")
-	}
-	if path != "" {
-		b.WriteString("export PATH=")
-		b.WriteString(shellQuote(path))
+	if envPath != "" {
+		b.WriteString(". ")
+		b.WriteString(shellQuote(envPath))
+		b.WriteString("; rm -f ")
+		b.WriteString(shellQuote(envPath))
 		b.WriteString("; ")
 	}
 	// Quote each argv word so spaces inside a word are preserved.
@@ -537,6 +536,60 @@ func buildLaunchCommand(cfg ports.RuntimeConfig) string {
 	// the process env if set, otherwise falls back to /bin/sh.
 	b.WriteString(`; exec "${SHELL:-/bin/sh}" -i`)
 	return b.String()
+}
+
+func writeEnvFile(env map[string]string) (string, error) {
+	file, err := os.CreateTemp("", "ao-tmux-env-*")
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	failed := true
+	defer func() {
+		_ = file.Close()
+		if failed {
+			_ = os.Remove(path)
+		}
+	}()
+	for _, key := range sortedKeys(env) {
+		if key == "PATH" {
+			continue
+		}
+		if _, err := fmt.Fprintf(file, "export %s=%s\n", key, shellQuote(env[key])); err != nil {
+			return "", err
+		}
+	}
+	pathValue := env["PATH"]
+	if pathValue == "" {
+		pathValue = getenv("PATH")
+	}
+	if pathValue != "" {
+		if _, err := fmt.Fprintf(file, "export PATH=%s\n", shellQuote(pathValue)); err != nil {
+			return "", err
+		}
+	}
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	failed = false
+	return path, nil
+}
+
+func waitForFileRemoval(ctx context.Context, path string) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 // -- error type --

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -46,6 +47,7 @@ func newTestRuntime(chunkSize int) (*Runtime, *fakeRunner) {
 	fr := &fakeRunner{}
 	r := New(Options{Binary: "tmux-test", Timeout: time.Second, Shell: "/bin/sh", ChunkSize: chunkSize})
 	r.runner = fr
+	r.waitEnvConsumed = func(_ context.Context, path string) error { return os.Remove(path) }
 	r.enterDelay = 0 // tests must not pay the real 300ms pre-Enter pause
 	return r, fr
 }
@@ -234,7 +236,7 @@ func TestCreateLaunchCommandContainsKeepAliveShell(t *testing.T) {
 	}
 }
 
-func TestCreateLaunchCommandExportsEnvVars(t *testing.T) {
+func TestCreateLaunchCommandKeepsEnvValuesOutOfArgv(t *testing.T) {
 	oldGetenv := getenv
 	getenv = func(key string) string {
 		if key == "PATH" {
@@ -262,13 +264,13 @@ func TestCreateLaunchCommandExportsEnvVars(t *testing.T) {
 	}
 	args := fr.calls[0].args
 	launchCmd := args[len(args)-1]
-	for _, want := range []string{
-		"export AO_SESSION_ID='sess-1';",
-		"export ODD='can'\\''t';",
-		"export PATH='/custom/bin:/usr/bin';",
+	for _, forbidden := range []string{
+		"sess-1",
+		"can't",
+		"/custom/bin:/usr/bin",
 	} {
-		if !strings.Contains(launchCmd, want) {
-			t.Fatalf("launch command missing %q in: %q", want, launchCmd)
+		if strings.Contains(launchCmd, forbidden) {
+			t.Fatalf("launch command leaked env value %q in: %q", forbidden, launchCmd)
 		}
 	}
 }

--- a/backend/internal/cli/client.go
+++ b/backend/internal/cli/client.go
@@ -14,10 +14,10 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
 )
 
-// commandTimeout bounds a mutating daemon call. Spawns do real work (git
-// worktree add, tmux launch, hook install), so it is generous compared to the
-// status probe timeout.
-const commandTimeout = 2 * time.Minute
+// commandTimeout bounds a mutating daemon call. A spawn may have to check out
+// tens of thousands of files and durably install workspace hooks before the
+// daemon can return a session, so this must cover large-repository cold starts.
+const commandTimeout = 10 * time.Minute
 
 // apiError is the subset of the daemon's JSON error envelope the CLI surfaces.
 // RequestID is surfaced so a failed command can be correlated with daemon logs.

--- a/backend/internal/cli/client_test.go
+++ b/backend/internal/cli/client_test.go
@@ -1,6 +1,15 @@
 package cli
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+func TestCommandTimeoutCoversLargeRepositoryProvisioning(t *testing.T) {
+	if commandTimeout < 10*time.Minute {
+		t.Fatalf("commandTimeout = %s, want at least 10m for large repository provisioning", commandTimeout)
+	}
+}
 
 // TestAPIErrorString covers how the CLI renders the daemon's error envelope,
 // including the requestId it now surfaces for log correlation.

--- a/backend/internal/providersettings/providersettings.go
+++ b/backend/internal/providersettings/providersettings.go
@@ -1,0 +1,56 @@
+package providersettings
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const minimaxBaseURL = "https://api.minimax.io/anthropic"
+
+// State is the app-wide provider settings payload stored under the AO data dir.
+// It is intentionally small for now: one MiniMax credential shared across
+// projects, used only for Claude-compatible launches that explicitly select a
+// MiniMax model.
+type State struct {
+	MinimaxAPIKey string `json:"minimaxApiKey,omitempty"`
+}
+
+// Path returns the app-wide provider settings file under the AO data dir.
+func Path(dataDir string) string {
+	return filepath.Join(dataDir, "provider-settings.json")
+}
+
+// Load reads provider settings from path. A missing file is not an error.
+func Load(path string) (State, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return State{}, nil
+	}
+	if err != nil {
+		return State{}, fmt.Errorf("read provider settings: %w", err)
+	}
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return State{}, fmt.Errorf("parse provider settings: %w", err)
+	}
+	return state, nil
+}
+
+// ClaudeEnvForModel returns the Claude-compatible provider environment for a
+// selected model. Project env should be layered on top of this so explicit
+// project overrides still win.
+func ClaudeEnvForModel(model string, state State) map[string]string {
+	model = strings.TrimSpace(model)
+	key := strings.TrimSpace(state.MinimaxAPIKey)
+	if !strings.HasPrefix(strings.ToLower(model), "minimax-") || key == "" {
+		return nil
+	}
+	return map[string]string{
+		"ANTHROPIC_API_KEY":    key,
+		"ANTHROPIC_AUTH_TOKEN": key,
+		"ANTHROPIC_BASE_URL":   minimaxBaseURL,
+	}
+}

--- a/backend/internal/providersettings/providersettings.go
+++ b/backend/internal/providersettings/providersettings.go
@@ -18,6 +18,11 @@ type State struct {
 	MinimaxAPIKey string `json:"minimaxApiKey,omitempty"`
 }
 
+type persistedState struct {
+	MinimaxAPIKey      string `json:"minimaxApiKey,omitempty"`
+	MinimaxAPIKeySnake string `json:"minimax_api_key,omitempty"`
+}
+
 // Path returns the app-wide provider settings file under the AO data dir.
 func Path(dataDir string) string {
 	return filepath.Join(dataDir, "provider-settings.json")
@@ -32,9 +37,13 @@ func Load(path string) (State, error) {
 	if err != nil {
 		return State{}, fmt.Errorf("read provider settings: %w", err)
 	}
-	var state State
-	if err := json.Unmarshal(data, &state); err != nil {
+	var raw persistedState
+	if err := json.Unmarshal(data, &raw); err != nil {
 		return State{}, fmt.Errorf("parse provider settings: %w", err)
+	}
+	state := State{MinimaxAPIKey: strings.TrimSpace(raw.MinimaxAPIKey)}
+	if state.MinimaxAPIKey == "" {
+		state.MinimaxAPIKey = strings.TrimSpace(raw.MinimaxAPIKeySnake)
 	}
 	return state, nil
 }

--- a/backend/internal/providersettings/providersettings.go
+++ b/backend/internal/providersettings/providersettings.go
@@ -23,6 +23,12 @@ type persistedState struct {
 	MinimaxAPIKeySnake string `json:"minimax_api_key,omitempty"`
 }
 
+// FromEnvironment resolves app-wide provider credentials from the daemon
+// environment. AO never needs to persist the credential itself.
+func FromEnvironment(getenv func(string) string) State {
+	return State{MinimaxAPIKey: strings.TrimSpace(getenv("MINIMAX_API_KEY"))}
+}
+
 // Path returns the app-wide provider settings file under the AO data dir.
 func Path(dataDir string) string {
 	return filepath.Join(dataDir, "provider-settings.json")

--- a/backend/internal/providersettings/providersettings_test.go
+++ b/backend/internal/providersettings/providersettings_test.go
@@ -1,0 +1,31 @@
+package providersettings
+
+import "testing"
+
+func TestFromEnvironmentReadsMiniMaxKeyWithoutPersistence(t *testing.T) {
+	getenv := func(key string) string {
+		if key == "MINIMAX_API_KEY" {
+			return "  test-key  "
+		}
+		return ""
+	}
+	state := FromEnvironment(getenv)
+	if state.MinimaxAPIKey != "test-key" {
+		t.Fatalf("MinimaxAPIKey = %q, want trimmed environment value", state.MinimaxAPIKey)
+	}
+}
+
+func TestClaudeEnvForModelIsCaseInsensitiveAndRequiresKey(t *testing.T) {
+	for _, model := range []string{"MiniMax-M3", "minimax-M3", "MINIMAX-M3"} {
+		env := ClaudeEnvForModel(model, State{MinimaxAPIKey: "test-key"})
+		if env["ANTHROPIC_AUTH_TOKEN"] != "test-key" || env["ANTHROPIC_BASE_URL"] != minimaxBaseURL {
+			t.Fatalf("model %q env = %#v", model, env)
+		}
+	}
+	if env := ClaudeEnvForModel("sonnet", State{MinimaxAPIKey: "test-key"}); env != nil {
+		t.Fatalf("sonnet env = %#v, want nil", env)
+	}
+	if env := ClaudeEnvForModel("MiniMax-M3", State{}); env != nil {
+		t.Fatalf("empty-key env = %#v, want nil", env)
+	}
+}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1942,12 +1942,7 @@ func (m *Manager) runtimeEnv(id domain.SessionID, project domain.ProjectID, issu
 }
 
 func (m *Manager) providerEnv(model string) map[string]string {
-	state, err := providersettings.Load(providersettings.Path(m.dataDir))
-	if err != nil {
-		m.logger.Warn("provider settings unavailable; continuing without app-wide provider credentials",
-			"model", model, "error", err)
-		return nil
-	}
+	state := providersettings.FromEnvironment(os.Getenv)
 	return providersettings.ClaudeEnvForModel(model, state)
 }
 

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+	"github.com/aoagents/agent-orchestrator/backend/internal/providersettings"
 	"github.com/aoagents/agent-orchestrator/backend/internal/sessionguard"
 	"github.com/aoagents/agent-orchestrator/backend/internal/skillassets"
 )
@@ -349,7 +350,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		SessionID:     id,
 		WorkspacePath: ws.Path,
 		Argv:          argv,
-		Env:           m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, project.Config.Env),
+		Env:           m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, project.Config.Env, agentConfig.Model),
 	})
 	if err != nil {
 		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
@@ -811,7 +812,7 @@ func (m *Manager) relaunchRestoredSession(ctx context.Context, rec domain.Sessio
 		SessionID:     rec.ID,
 		WorkspacePath: ws.Path,
 		Argv:          argv,
-		Env:           m.runtimeEnv(rec.ID, rec.ProjectID, rec.IssueID, project.Config.Env),
+		Env:           m.runtimeEnv(rec.ID, rec.ProjectID, rec.IssueID, project.Config.Env, agentConfig.Model),
 	})
 	if err != nil {
 		return domain.SessionRecord{}, fmt.Errorf("restore %s: runtime: %w", rec.ID, err)
@@ -1906,8 +1907,11 @@ Keep branch names within your session's branch namespace so AO can track every P
 // spawnEnv builds the runtime environment: the per-project env vars first, then
 // the AO-internal vars last so they always win (a project cannot override
 // AO_SESSION_ID and friends).
-func spawnEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, dataDir string, projectEnv map[string]string) map[string]string {
-	env := make(map[string]string, len(projectEnv)+4)
+func spawnEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, dataDir string, baseEnv, projectEnv map[string]string) map[string]string {
+	env := make(map[string]string, len(baseEnv)+len(projectEnv)+4)
+	for k, v := range baseEnv {
+		env[k] = v
+	}
 	for k, v := range projectEnv {
 		env[k] = v
 	}
@@ -1925,8 +1929,8 @@ func spawnEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueI
 // command, which fails every callback and silently kills activity tracking).
 // When the pin cannot be applied the inherited PATH is kept and a warning is
 // logged so the degradation isn't silent.
-func (m *Manager) runtimeEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, projectEnv map[string]string) map[string]string {
-	env := spawnEnv(id, project, issue, m.dataDir, projectEnv)
+func (m *Manager) runtimeEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, projectEnv map[string]string, model string) map[string]string {
+	env := spawnEnv(id, project, issue, m.dataDir, m.providerEnv(model), projectEnv)
 	path, err := HookPATH(m.executable, os.Getenv, projectEnv)
 	if err != nil {
 		m.logger.Warn("session PATH not pinned to the daemon binary; `ao hooks` callbacks may resolve to a different ao and activity tracking will stall",
@@ -1935,6 +1939,16 @@ func (m *Manager) runtimeEnv(id domain.SessionID, project domain.ProjectID, issu
 	}
 	env["PATH"] = path
 	return env
+}
+
+func (m *Manager) providerEnv(model string) map[string]string {
+	state, err := providersettings.Load(providersettings.Path(m.dataDir))
+	if err != nil {
+		m.logger.Warn("provider settings unavailable; continuing without app-wide provider credentials",
+			"model", model, "error", err)
+		return nil
+	}
+	return providersettings.ClaudeEnvForModel(model, state)
 }
 
 // HookPATH builds the PATH value pinned into a spawned session: the daemon

--- a/backend/internal/session_manager/provision_test.go
+++ b/backend/internal/session_manager/provision_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSpawnEnvProjectVarsCannotOverrideInternal(t *testing.T) {
-	env := spawnEnv("mer-1", "mer", "issue-9", "/data", map[string]string{
+	env := spawnEnv("mer-1", "mer", "issue-9", "/data", nil, map[string]string{
 		"FOO":        "bar",
 		EnvSessionID: "hacked", // a project must not override AO-internal vars
 		EnvProjectID: "hacked",


### PR DESCRIPTION
Adds user-scope MiniMax provider settings for Go AO so registered projects can resolve the provider across repos without per-project env. Also accepts the legacy minimax settings key for migration. Upstream request: https://github.com/AgentWrapper/agent-orchestrator/issues/2614