### PR TITLE
fix(browser): keep preview live and under modal dialogs

### DIFF
--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -9,17 +9,22 @@ import {
 } from "./browser-view-host";
 
 type InvokeHandler = (event: unknown, ...args: unknown[]) => unknown;
-type EventHandler = (
-	event: { sender: { id: number; getZoomFactor?: () => number } },
-	...args: unknown[]
-) => unknown;
+type EventHandler = (event: { sender: { id: number; getZoomFactor?: () => number } }, ...args: unknown[]) => unknown;
+
+type DisplayHandler = (request: unknown, callback: (streams: { video?: unknown }) => void) => void;
 
 function setupHost() {
 	let currentURL = "";
+	let displayHandler: DisplayHandler | null = null;
 	const webContents = {
 		id: 99,
+		mainFrame: { frameToken: "preview-frame" },
 		canGoBack: () => false,
 		canGoForward: () => false,
+		capturePage: vi.fn(async () => ({
+			isEmpty: () => false,
+			toJPEG: () => Buffer.from("snapshot"),
+		})),
 		clearHistory: () => undefined,
 		getTitle: () => "",
 		getURL: () => currentURL,
@@ -48,7 +53,15 @@ function setupHost() {
 		mainWindow: {
 			contentView: { addChildView: () => undefined, removeChildView: () => undefined },
 			getContentBounds: () => ({ x: 0, y: 0, width: 800, height: 600 }),
-			webContents: { id: 1, send: (channel: string, payload: unknown) => sent.push({ channel, payload }) },
+			webContents: {
+				id: 1,
+				send: (channel: string, payload: unknown) => sent.push({ channel, payload }),
+				session: {
+					setDisplayMediaRequestHandler: (handler: DisplayHandler | null) => {
+						displayHandler = handler;
+					},
+				},
+			},
 		} as never,
 		ipcMain: {
 			handle: (channel: string, fn: InvokeHandler) => handlers.set(channel, fn),
@@ -63,13 +76,14 @@ function setupHost() {
 		annotatePreloadPath: "/preload.js",
 		rendererOrigin: "http://localhost:5173",
 	});
+	const rendererFrame = { processId: 5, routingId: 7 };
 	const invoke = (channel: string, ...args: unknown[]) =>
-		handlers.get(channel)!({ sender: { id: 1 } }, ...args) as Promise<BrowserNavState>;
+		handlers.get(channel)!({ sender: { id: 1 }, senderFrame: rendererFrame }, ...args) as Promise<BrowserNavState>;
 	const emit = (channel: string, zoomFactor: number, ...args: unknown[]) =>
 		eventHandlers.get(channel)!({ sender: { id: 1, getZoomFactor: () => zoomFactor } }, ...args);
 	const send = (channel: string, senderId: number, ...args: unknown[]) =>
 		eventHandlers.get(channel)!({ sender: { id: senderId } }, ...args);
-	return { emit, host, invoke, send, sent, view, webContents };
+	return { emit, host, invoke, rendererFrame, send, sent, view, webContents, getDisplayHandler: () => displayHandler };
 }
 
 describe("normalizeBrowserURL", () => {
@@ -122,6 +136,108 @@ describe("browser:clear", () => {
 
 		expect(webContents.loadURL).toHaveBeenLastCalledWith("about:blank");
 		expect(state.url).toBe("");
+	});
+});
+
+describe("browser:capture", () => {
+	it("returns the current page as a data URL", async () => {
+		const { invoke } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		const snapshot = await invoke("browser:capture", "1:sess-1");
+
+		expect(snapshot).toBe(`data:image/jpeg;base64,${Buffer.from("snapshot").toString("base64")}`);
+	});
+
+	it("returns an empty string for an unknown view", async () => {
+		const { invoke } = setupHost();
+
+		const snapshot = await invoke("browser:capture", "1:missing");
+
+		expect(snapshot).toBe("");
+	});
+});
+
+describe("browser:requestMirror", () => {
+	it("grants the display-media request from the frame that armed the mirror", async () => {
+		const { getDisplayHandler, invoke, rendererFrame, webContents } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		const granted = await invoke("browser:requestMirror", "1:sess-1");
+		expect(granted).toBe(true);
+
+		const streams: Array<{ video?: unknown }> = [];
+		getDisplayHandler()!({ frame: rendererFrame }, (result) => streams.push(result));
+		expect(streams).toEqual([{ video: webContents.mainFrame }]);
+	});
+
+	it("denies display-media requests from a different frame", async () => {
+		const { getDisplayHandler, invoke } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+		await invoke("browser:requestMirror", "1:sess-1");
+
+		const streams: Array<{ video?: unknown }> = [];
+		getDisplayHandler()!({ frame: { processId: 9, routingId: 3 } }, (result) => streams.push(result));
+		expect(streams).toEqual([{}]);
+	});
+
+	it("denies display-media requests with no pending mirror", async () => {
+		const { getDisplayHandler, invoke, rendererFrame } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		const streams: Array<{ video?: unknown }> = [];
+		getDisplayHandler()!({ frame: rendererFrame }, (result) => streams.push(result));
+		expect(streams).toEqual([{}]);
+	});
+
+	it("rejects mirror requests for views the renderer does not own", async () => {
+		const { invoke } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		const granted = await invoke("browser:requestMirror", "7:sess-1");
+		expect(granted).toBe(false);
+	});
+
+	it("expires a mirror grant that is never consumed", async () => {
+		vi.useFakeTimers();
+		try {
+			const { getDisplayHandler, invoke, rendererFrame } = setupHost();
+			await invoke("browser:ensure", "sess-1");
+			await invoke("browser:requestMirror", "1:sess-1");
+
+			vi.advanceTimersByTime(6000);
+
+			const streams: Array<{ video?: unknown }> = [];
+			getDisplayHandler()!({ frame: rendererFrame }, (result) => streams.push(result));
+			expect(streams).toEqual([{}]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("denies capture of views the renderer does not own", async () => {
+		const { invoke } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		const snapshot = await invoke("browser:capture", "7:sess-1");
+		expect(snapshot).toBe("");
+	});
+});
+
+describe("browser:setBounds parked", () => {
+	it("moves the view offscreen at full size while keeping it visible", async () => {
+		const { emit, invoke, view } = setupHost();
+		await invoke("browser:ensure", "sess-1");
+
+		emit("browser:setBounds", 1, {
+			viewId: "1:sess-1",
+			rect: { x: 12, y: 34, width: 320, height: 240 },
+			visible: true,
+			parked: true,
+		});
+
+		expect(view.setBounds).toHaveBeenLastCalledWith({ x: -10_000, y: 0, width: 320, height: 240 });
+		expect(view.setVisible).toHaveBeenLastCalledWith(true);
 	});
 });
 

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -1,4 +1,13 @@
-import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent, Rectangle, View, WebContents } from "electron";
+import type {
+	IpcMain,
+	IpcMainEvent,
+	IpcMainInvokeEvent,
+	Rectangle,
+	Session,
+	View,
+	WebContents,
+	WebFrameMain,
+} from "electron";
 import type {
 	BrowserAnnotationCancelPayload,
 	BrowserAnnotationModeInput,
@@ -23,6 +32,7 @@ type BrowserBoundsInput = {
 	viewId: string;
 	rect: BrowserRect;
 	visible: boolean;
+	parked?: boolean;
 };
 
 type BrowserNavigateInput = {
@@ -35,7 +45,9 @@ type BrowserWebContents = Pick<
 	| "id"
 	| "canGoBack"
 	| "canGoForward"
+	| "capturePage"
 	| "clearHistory"
+	| "mainFrame"
 	| "getTitle"
 	| "getURL"
 	| "goBack"
@@ -63,7 +75,9 @@ type BrowserWindowLike = {
 		removeChildView?: (view: BrowserViewLike) => void;
 	};
 	getContentBounds: () => BrowserRect;
-	webContents: Pick<WebContents, "id" | "send">;
+	webContents: Pick<WebContents, "id" | "send"> & {
+		session?: Pick<Session, "setDisplayMediaRequestHandler">;
+	};
 	isDestroyed?: () => boolean;
 };
 
@@ -157,6 +171,39 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	const entries = new Map<string, BrowserEntry>();
 	const viewIdsByWebContentsId = new Map<number, string>();
 	const ipcDisposers: Array<() => void> = [];
+	let pendingMirror: { viewId: string; expires: number; frame: WebFrameMain } | null = null;
+
+	const sameFrame = (a: WebFrameMain, b: WebFrameMain | null | undefined): boolean =>
+		Boolean(b) && a.processId === b!.processId && a.routingId === b!.routingId;
+
+	const displayMediaSession = options.mainWindow.webContents.session;
+	const mirrorSupported = Boolean(displayMediaSession?.setDisplayMediaRequestHandler);
+	if (mirrorSupported) {
+		displayMediaSession!.setDisplayMediaRequestHandler((request, callback) => {
+			const pending = pendingMirror;
+			pendingMirror = null;
+			const entry =
+				pending && pending.expires > Date.now() && sameFrame(pending.frame, request.frame)
+					? entries.get(pending.viewId)
+					: undefined;
+			try {
+				if (entry) {
+					callback({ video: entry.view.webContents.mainFrame });
+				} else {
+					callback({});
+				}
+			} catch {
+				return;
+			}
+		});
+		ipcDisposers.push(() => {
+			try {
+				displayMediaSession?.setDisplayMediaRequestHandler(null);
+			} catch {
+				return;
+			}
+		});
+	}
 
 	const ensure = (viewId: string): BrowserEntry => {
 		const existing = entries.get(viewId);
@@ -183,9 +230,17 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		return entry;
 	};
 
-	const setBounds = ({ viewId, rect, visible }: BrowserBoundsInput, zoomFactor = 1): void => {
+	const setBounds = ({ viewId, rect, visible, parked }: BrowserBoundsInput, zoomFactor = 1): void => {
 		const entry = entries.get(viewId);
 		if (!entry) return;
+		if (parked) {
+			const scaled = scaleBoundsForZoom(rect, zoomFactor);
+			const width = Math.max(1, Math.round(scaled.width));
+			const height = Math.max(1, Math.round(scaled.height));
+			entry.view.setBounds({ x: OFFSCREEN_BOUNDS.x, y: 0, width, height });
+			entry.view.setVisible?.(true);
+			return;
+		}
 		if (!visible) {
 			entry.view.setVisible?.(false);
 			entry.view.setBounds(OFFSCREEN_BOUNDS);
@@ -222,6 +277,18 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		await entry.view.webContents.loadURL("about:blank");
 		entry.view.webContents.clearHistory();
 		return pushNavState(options, entry);
+	};
+
+	const capture = async (viewId: string): Promise<string> => {
+		const entry = entries.get(viewId);
+		if (!entry) return "";
+		try {
+			const image = await entry.view.webContents.capturePage();
+			if (image.isEmpty()) return "";
+			return `data:image/jpeg;base64,${image.toJPEG(70).toString("base64")}`;
+		} catch {
+			return "";
+		}
 	};
 
 	const destroy = (viewId: string): void => {
@@ -315,6 +382,14 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 	on("browser:setBounds", (event, input: BrowserBoundsInput) => setBounds(input, event.sender.getZoomFactor()));
 	handle("browser:navigate", (_event, input: BrowserNavigateInput) => navigate(input));
 	handle("browser:clear", (_event, viewId: string) => clear(viewId));
+	handle("browser:capture", (event, viewId: string) => (isRendererOwnedViewId(event, viewId) ? capture(viewId) : ""));
+	handle("browser:requestMirror", (event, viewId: string) => {
+		if (!mirrorSupported || !isRendererOwnedViewId(event, viewId) || !entries.has(viewId)) return false;
+		const frame = event.senderFrame;
+		if (!frame) return false;
+		pendingMirror = { viewId, expires: Date.now() + 5000, frame };
+		return true;
+	});
 	handle("browser:goBack", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.goBack(), true));
 	handle("browser:goForward", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.goForward(), true));
 	handle("browser:reload", (_event, viewId: string) => invokeNav(viewId, (contents) => contents.reload(), true));

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -14,6 +14,7 @@ export type BrowserBoundsInput = {
 	viewId: string;
 	rect: BrowserRect;
 	visible: boolean;
+	parked?: boolean;
 };
 
 export type BrowserNavigateInput = {
@@ -71,6 +72,8 @@ const api = {
 		navigate: (input: BrowserNavigateInput) =>
 			ipcRenderer.invoke("browser:navigate", input) as Promise<BrowserNavState>,
 		clear: (viewId: string) => ipcRenderer.invoke("browser:clear", viewId) as Promise<BrowserNavState>,
+		capture: (viewId: string) => ipcRenderer.invoke("browser:capture", viewId) as Promise<string>,
+		requestMirror: (viewId: string) => ipcRenderer.invoke("browser:requestMirror", viewId) as Promise<boolean>,
 		goBack: (viewId: string) => ipcRenderer.invoke("browser:goBack", viewId) as Promise<BrowserNavState>,
 		goForward: (viewId: string) => ipcRenderer.invoke("browser:goForward", viewId) as Promise<BrowserNavState>,
 		reload: (viewId: string) => ipcRenderer.invoke("browser:reload", viewId) as Promise<BrowserNavState>,

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -186,8 +186,20 @@ export function BrowserPanelView({
 	browserView,
 	annotationQueue,
 }: BrowserPanelProps & { annotationQueue: BrowserAnnotationQueueModel; browserView: BrowserViewModel }) {
-	const { viewId, navState, slotRef, navigate, goBack, goForward, reload, stop, annotationMode, setAnnotationMode } =
-		browserView;
+	const {
+		viewId,
+		navState,
+		mirrorUrl,
+		mirrorStream,
+		slotRef,
+		navigate,
+		goBack,
+		goForward,
+		reload,
+		stop,
+		annotationMode,
+		setAnnotationMode,
+	} = browserView;
 	const [urlInput, setUrlInput] = useState(navState.url);
 	const { beginPicking, cancelPicking, enqueue, error, failPicking, queuedCount, retryQueued, status } =
 		annotationQueue;
@@ -358,6 +370,11 @@ export function BrowserPanelView({
 			</form>
 			<div className="relative min-h-0 flex-1 overflow-hidden bg-background">
 				<div className="absolute inset-0 min-h-px min-w-px" ref={slotRef} />
+				{mirrorStream ? (
+					<MirrorVideo stream={mirrorStream} />
+				) : mirrorUrl ? (
+					<img alt="" className="absolute inset-0 h-full w-full object-cover" src={mirrorUrl} />
+				) : null}
 				{showStaticPreview ? <StaticPreview url={navState.url} /> : null}
 				{navState.url === "" ? (
 					<div className="pointer-events-none absolute inset-0 grid place-items-center p-5 text-center font-mono text-xs text-passive">
@@ -377,6 +394,18 @@ export function BrowserPanelView({
 			</div>
 		</div>
 	);
+}
+
+function MirrorVideo({ stream }: { stream: MediaStream }) {
+	const attach = useCallback(
+		(node: HTMLVideoElement | null) => {
+			if (node && node.srcObject !== stream) {
+				node.srcObject = stream;
+			}
+		},
+		[stream],
+	);
+	return <video autoPlay className="absolute inset-0 h-full w-full object-cover" muted playsInline ref={attach} />;
 }
 
 function StaticPreview({ url }: { url: string }) {

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -44,6 +44,8 @@ function setupBridge() {
 			isLoading: false,
 		})),
 		setBounds: vi.fn(),
+		capture: vi.fn(async () => "data:image/jpeg;base64,snapshot"),
+		requestMirror: vi.fn(async () => false),
 		navigate: vi.fn(async ({ viewId }: { viewId: string }) => bridge.stateFor(viewId)),
 		clear: vi.fn(async (viewId: string) => bridge.stateFor(viewId)),
 		goBack: vi.fn(async (viewId: string) => bridge.stateFor(viewId)),
@@ -238,6 +240,65 @@ describe("useBrowserView", () => {
 			visible: false,
 		});
 		expect(bridge.destroy).not.toHaveBeenCalled();
+	});
+
+	it("parks the view and mirrors frames while a modal dialog is open, then restores it on close", async () => {
+		const bridge = setupBridge();
+		const slot = createSlot();
+		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+
+		await waitFor(() => expect(bridge.ensure).toHaveBeenCalledWith("sess-1"));
+		act(() =>
+			bridge.emit({
+				viewId: "42:sess-1",
+				url: "http://localhost:3000/",
+				title: "",
+				canGoBack: false,
+				canGoForward: false,
+				isLoading: false,
+			}),
+		);
+		act(() => result.current.slotRef(slot));
+		await waitFor(() =>
+			expect(bridge.setBounds).toHaveBeenCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 12, y: 34, width: 320, height: 240 },
+				visible: true,
+			}),
+		);
+
+		bridge.setBounds.mockClear();
+		const dialog = document.createElement("div");
+		dialog.setAttribute("role", "dialog");
+		dialog.setAttribute("data-state", "open");
+		await act(async () => {
+			document.body.appendChild(dialog);
+			await Promise.resolve();
+		});
+		await waitFor(() =>
+			expect(bridge.setBounds).toHaveBeenLastCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 12, y: 34, width: 320, height: 240 },
+				visible: true,
+				parked: true,
+			}),
+		);
+		expect(bridge.capture).toHaveBeenCalledWith("42:sess-1");
+		await waitFor(() => expect(result.current.mirrorUrl).toBe("data:image/jpeg;base64,snapshot"));
+
+		bridge.setBounds.mockClear();
+		await act(async () => {
+			dialog.remove();
+			await Promise.resolve();
+		});
+		await waitFor(() =>
+			expect(bridge.setBounds).toHaveBeenLastCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 12, y: 34, width: 320, height: 240 },
+				visible: true,
+			}),
+		);
+		await waitFor(() => expect(result.current.mirrorUrl).toBe(""));
 	});
 
 	it("updates nav state only for the current view", async () => {

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -31,6 +31,8 @@ type UseBrowserViewOptions = {
 export type BrowserViewModel = {
 	viewId: string;
 	navState: BrowserNavState;
+	mirrorUrl: string;
+	mirrorStream: MediaStream | null;
 	slotRef: (node: HTMLDivElement | null) => void;
 	navigate: (url: string) => Promise<void>;
 	goBack: () => Promise<void>;
@@ -52,6 +54,8 @@ const EMPTY_NAV_STATE: BrowserNavState = {
 };
 
 const HIDDEN_RECT: BrowserRect = { x: 0, y: 0, width: 0, height: 0 };
+
+const OPEN_MODAL_SELECTOR = '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]';
 
 // The native WebContentsView is a window-level overlay, so DOM `overflow:
 // hidden` never clips it — it paints wherever the slot's bounding box lands.
@@ -83,6 +87,8 @@ export function useBrowserView({
 }: UseBrowserViewOptions): BrowserViewModel {
 	const [viewId, setViewId] = useState("");
 	const [navState, setNavState] = useState<BrowserNavState>(EMPTY_NAV_STATE);
+	const [mirrorUrl, setMirrorUrl] = useState("");
+	const [mirrorStream, setMirrorStream] = useState<MediaStream | null>(null);
 	const [annotationMode, setAnnotationModeState] = useState(false);
 	const slotNodeRef = useRef<HTMLDivElement | null>(null);
 	const viewIdRef = useRef("");
@@ -93,6 +99,10 @@ export function useBrowserView({
 	const observerRef = useRef<ResizeObserver | null>(null);
 	const previewTriggerRef = useRef<{ revision: number | null; target: string } | null>(null);
 	const hasUrlRef = useRef(false);
+	const modalOpenRef = useRef(false);
+	const mirrorTokenRef = useRef(0);
+	const mirrorTimerRef = useRef<number | null>(null);
+	const mirrorStreamRef = useRef<MediaStream | null>(null);
 	const hasNativeBrowser = Boolean(window.ao?.browser);
 
 	useEffect(() => {
@@ -122,6 +132,14 @@ export function useBrowserView({
 			return;
 		}
 		const rect = visibleSlotRect(node);
+		if (modalOpenRef.current) {
+			if (rect.width > 0 && rect.height > 0) {
+				window.ao?.browser.setBounds({ viewId: id, rect, visible: true, parked: true });
+			} else {
+				sendHiddenBounds(id);
+			}
+			return;
+		}
 		const payload = {
 			viewId: id,
 			rect,
@@ -237,6 +255,93 @@ export function useBrowserView({
 		}
 	}, [active, navState.url, poppedOut, scheduleSettleMeasure, sendHiddenBounds]);
 
+	const stopMirrorStream = useCallback(() => {
+		mirrorStreamRef.current?.getTracks().forEach((track) => track.stop());
+		mirrorStreamRef.current = null;
+		setMirrorStream(null);
+	}, []);
+
+	const runMirror = useCallback(
+		(id: string) => {
+			const token = ++mirrorTokenRef.current;
+			const live = () => mirrorTokenRef.current === token && modalOpenRef.current && viewIdRef.current === id;
+			const streamMirror = async (): Promise<boolean> => {
+				if (!navigator.mediaDevices?.getDisplayMedia) return false;
+				const granted = await window.ao?.browser.requestMirror?.(id).catch(() => false);
+				if (!granted || !live()) return false;
+				const stream = await navigator.mediaDevices.getDisplayMedia({ audio: false, video: true });
+				if (!live()) {
+					stream.getTracks().forEach((track) => track.stop());
+					return true;
+				}
+				stopMirrorStream();
+				mirrorStreamRef.current = stream;
+				setMirrorStream(stream);
+				return true;
+			};
+			const frameMirror = async () => {
+				while (live()) {
+					const pending = window.ao?.browser.capture?.(id) ?? Promise.resolve("");
+					const frame = await pending.catch(() => "");
+					if (!live()) return;
+					if (frame) setMirrorUrl(frame);
+					await new Promise((resolve) => {
+						window.setTimeout(resolve, 66);
+					});
+				}
+			};
+			const tick = async () => {
+				const streamed = await streamMirror().catch(() => false);
+				if (streamed || !live()) return;
+				await frameMirror();
+			};
+			void tick();
+		},
+		[stopMirrorStream],
+	);
+
+	useEffect(() => {
+		if (!hasNativeBrowser) return;
+		const clearMirrorTimer = () => {
+			if (mirrorTimerRef.current === null) return;
+			window.clearTimeout(mirrorTimerRef.current);
+			mirrorTimerRef.current = null;
+		};
+		const update = () => {
+			const open = document.querySelector(OPEN_MODAL_SELECTOR) !== null;
+			if (open === modalOpenRef.current) return;
+			modalOpenRef.current = open;
+			if (open) {
+				clearMirrorTimer();
+				const id = viewIdRef.current;
+				if (id && activeRef.current && hasUrlRef.current) {
+					runMirror(id);
+					scheduleMeasure();
+				} else {
+					sendHiddenBounds();
+				}
+			} else {
+				mirrorTokenRef.current += 1;
+				scheduleSettleMeasure();
+				clearMirrorTimer();
+				mirrorTimerRef.current = window.setTimeout(() => {
+					mirrorTimerRef.current = null;
+					setMirrorUrl("");
+					stopMirrorStream();
+				}, 320);
+			}
+		};
+		update();
+		const observer = new MutationObserver(update);
+		observer.observe(document.body, { childList: true });
+		return () => {
+			observer.disconnect();
+			clearMirrorTimer();
+			mirrorTokenRef.current += 1;
+			stopMirrorStream();
+		};
+	}, [hasNativeBrowser, runMirror, scheduleMeasure, scheduleSettleMeasure, sendHiddenBounds, stopMirrorStream]);
+
 	useEffect(() => {
 		const handle = () => scheduleMeasure();
 		window.addEventListener("resize", handle);
@@ -345,14 +450,19 @@ export function useBrowserView({
 			void window.ao?.browser.setAnnotationMode({ viewId: id, enabled: false });
 			setAnnotationModeState(false);
 		}
+		mirrorTokenRef.current += 1;
+		stopMirrorStream();
+		setMirrorUrl("");
 		sendHiddenBounds(id);
 		window.ao?.browser.destroy(id);
 		viewIdRef.current = "";
-	}, [sendHiddenBounds]);
+	}, [sendHiddenBounds, stopMirrorStream]);
 
 	return {
 		viewId,
 		navState,
+		mirrorUrl,
+		mirrorStream,
 		slotRef,
 		navigate,
 		goBack: () => (hasNativeBrowser ? withView((id) => window.ao!.browser.goBack(id)) : Promise.resolve()),

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -87,6 +87,8 @@ export const aoBridge: AoBridge =
 				isLoading: false,
 			}),
 			destroy: () => undefined,
+			capture: async () => "",
+			requestMirror: async () => false,
 			setAnnotationMode: async () => undefined,
 			onNavState: () => () => undefined,
 			onAnnotationSubmit: () => () => undefined,

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -83,6 +83,8 @@ if (typeof window !== "undefined") {
 				isLoading: false,
 			}),
 			setBounds: () => undefined,
+			capture: async () => "",
+			requestMirror: async () => false,
 			navigate: async ({ viewId }: { viewId: string }) => ({
 				viewId,
 				url: "",


### PR DESCRIPTION
Fixes #2615

## Problem

With the Browser tab active, any modal dialog opens underneath the browser preview. The preview is a native WebContentsView that Electron composites above the renderer DOM, so no z-index can place a dialog over it. The dialog close button is unreachable until the dialog is dismissed by clicking outside.

## Solution

While a dialog is open, the native view is parked offscreen at full size, still visible, so video and animation playback never pauses. The panel mirrors the view into the DOM under the dialog, using a live display-media stream of the view frame with a capturePage polling fallback. Closing the dialog restores the view and drops the mirror. Mirror grants are one-shot, expire in 5 seconds, and capture and mirror requests are denied for views the renderer does not own.

## Testing

- npx vitest run: 545 passed
- npm run typecheck: clean
- prettier check on changed files: clean
- Verified in the desktop app: dialog stacks above the preview, close button clickable, page animations keep playing while the dialog is open


https://github.com/user-attachments/assets/5e6e52a2-f6c1-4fa4-9d26-c19a1648d122

