### PR TITLE
test: reject duplicate root command names

### DIFF
--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -35,6 +35,16 @@ func TestRootHelpDoesNotShowDaemon(t *testing.T) {
 	}
 }
 
+func TestRootCommandsHaveUniqueNames(t *testing.T) {
+	seen := make(map[string]struct{})
+	for _, cmd := range NewRootCommand(Deps{}).Commands() {
+		if _, exists := seen[cmd.Name()]; exists {
+			t.Fatalf("root command %q is registered more than once", cmd.Name())
+		}
+		seen[cmd.Name()] = struct{}{}
+	}
+}
+
 func TestCommandsRejectUnexpectedArgs(t *testing.T) {
 	for _, args := range [][]string{
 		{"daemon", "extra"},


### PR DESCRIPTION
## Summary

Add a focused root-command invariant test that fails when the same Cobra command name is registered twice.

A downstream architecture audit (polymath-ventures/agent-orchestrator#233) found a duplicate registration in a locally added command; the parent does not contain that command or bug, so this upstreams the generally applicable regression guard without downstream-specific behavior.

## Verification

- `cd backend && go build ./... && go vet ./... && go test ./...`