### PR TITLE
feat(desktop+config): AO_KEEP_DAEMON keep-alive + per-role worker env profile (claude-code)

### DIFF
--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -184,6 +185,9 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 		cmd = append(cmd, "--append-system-prompt", systemPrompt)
 	}
 
+	appendMCPFlags(&cmd, cfg.Config.MCP)
+	appendPluginFlags(&cmd, cfg.Config.PluginDirs)
+
 	if cfg.Prompt != "" {
 		cmd = append(cmd, "--", cfg.Prompt)
 	}
@@ -228,6 +232,12 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
 	}
+	// Defense-in-depth, symmetric with GetLaunchCommand: the config was
+	// validated on write, but re-check here so a config mutated later (by a
+	// bug or a different code path) is caught at restore too, not only launch.
+	if err := cfg.Config.Validate(); err != nil {
+		return nil, false, fmt.Errorf("claude-code: %w", err)
+	}
 
 	sessionID := strings.TrimSpace(cfg.Session.Metadata[ports.MetadataKeyAgentSessionID])
 	if sessionID == "" && cfg.Session.ID != "" {
@@ -256,6 +266,11 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		// re-appended or a restored orchestrator loses its role.
 		cmd = append(cmd, "--append-system-prompt", systemPrompt)
 	}
+	// MCP/plugin flags are also rebuilt from flags on resume (they are not part
+	// of the transcript), so re-apply them or a restored worker loses its scoped
+	// MCP set and plugins.
+	appendMCPFlags(&cmd, cfg.Config.MCP)
+	appendPluginFlags(&cmd, cfg.Config.PluginDirs)
 	cmd = append(cmd, "--resume", sessionID)
 	return cmd, true, nil
 }
@@ -452,6 +467,49 @@ func appendToolFlags(cmd *[]string, allowed, disallowed []string) {
 	if len(disallowed) > 0 {
 		*cmd = append(*cmd, "--disallowedTools", strings.Join(disallowed, ","))
 	}
+}
+
+// appendMCPFlags emits claude-code's per-session MCP flags. Each MCPConfig
+// entry is passed to the repeatable --mcp-config as-is (a JSON string or a path
+// to a JSON file — both accepted by the CLI). Strict adds --strict-mcp-config
+// so the session ignores every other MCP source, isolating the worker. A nil
+// MCPConfig emits nothing, so an unset config inherits the global MCP set as
+// before. Strict alone (empty Configs) is valid: it means "no MCP at all".
+func appendMCPFlags(cmd *[]string, mcp *domain.MCPConfig) {
+	if mcp == nil {
+		return
+	}
+	for _, c := range mcp.Configs {
+		if c = strings.TrimSpace(c); c != "" {
+			*cmd = append(*cmd, "--mcp-config", c)
+		}
+	}
+	if mcp.Strict {
+		*cmd = append(*cmd, "--strict-mcp-config")
+	}
+}
+
+// appendPluginFlags emits --plugin-dir / --plugin-url for each entry. An
+// http(s):// entry maps to --plugin-url (a fetched zip); any other value is
+// treated as a local path and mapped to --plugin-dir. Both flags are repeatable,
+// so one is emitted per entry. Empty/whitespace entries are skipped.
+func appendPluginFlags(cmd *[]string, dirs []string) {
+	for _, d := range dirs {
+		if d = strings.TrimSpace(d); d == "" {
+			continue
+		}
+		if isPluginURL(d) {
+			*cmd = append(*cmd, "--plugin-url", d)
+		} else {
+			*cmd = append(*cmd, "--plugin-dir", d)
+		}
+	}
+}
+
+// isPluginURL reports whether s is an http(s) plugin URL rather than a local
+// path, deciding --plugin-url vs --plugin-dir.
+func isPluginURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
 }
 
 // claudeBinarySpec locates the claude binary: PATH first, then the native

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hooksjson"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -145,6 +146,116 @@ func TestGetLaunchCommandInjectsSessionID(t *testing.T) {
 	if contains(cmd, "--session-id") {
 		t.Fatalf("command %#v unexpectedly contains --session-id", cmd)
 	}
+}
+
+// TestGetLaunchCommandMCPAndPluginFlags: a per-role MCP set and plugin list are
+// emitted as claude-code flags. MCP configs go to --mcp-config (one per entry),
+// Strict adds --strict-mcp-config, local plugin paths go to --plugin-dir, and
+// http(s) URLs go to --plugin-url.
+func TestGetLaunchCommandMCPAndPluginFlags(t *testing.T) {
+	p := &Plugin{resolvedBinary: "claude"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{
+			MCP:        &domain.MCPConfig{Configs: []string{"{\"a\":1}", "/p/m.json"}, Strict: true},
+			PluginDirs: []string{"/local/plugin", "https://example.com/p.zip"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsSubsequence(cmd, []string{"--mcp-config", "{\"a\":1}"}) {
+		t.Fatalf("cmd %#v missing --mcp-config inline entry", cmd)
+	}
+	if !containsSubsequence(cmd, []string{"--mcp-config", "/p/m.json"}) {
+		t.Fatalf("cmd %#v missing --mcp-config path entry", cmd)
+	}
+	if !contains(cmd, "--strict-mcp-config") {
+		t.Fatalf("cmd %#v missing --strict-mcp-config", cmd)
+	}
+	if !containsSubsequence(cmd, []string{"--plugin-dir", "/local/plugin"}) {
+		t.Fatalf("cmd %#v missing --plugin-dir for local path", cmd)
+	}
+	if !containsSubsequence(cmd, []string{"--plugin-url", "https://example.com/p.zip"}) {
+		t.Fatalf("cmd %#v missing --plugin-url for URL", cmd)
+	}
+}
+
+// TestGetLaunchCommandNoMCPFlagsWhenUnset: a config with no MCP/plugin
+// configuration emits nothing, so an unset role inherits the global set.
+func TestGetLaunchCommandNoMCPFlagsWhenUnset(t *testing.T) {
+	p := &Plugin{resolvedBinary: "claude"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, flag := range []string{"--mcp-config", "--strict-mcp-config", "--plugin-dir", "--plugin-url"} {
+		if contains(cmd, flag) {
+			t.Fatalf("cmd %#v unexpectedly contains %s", cmd, flag)
+		}
+	}
+}
+
+// TestGetLaunchCommandMCPStrictAlone: Strict with no configs is valid isolation
+// and emits just --strict-mcp-config.
+func TestGetLaunchCommandMCPStrictAlone(t *testing.T) {
+	p := &Plugin{resolvedBinary: "claude"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{MCP: &domain.MCPConfig{Strict: true}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(cmd, "--strict-mcp-config") {
+		t.Fatalf("cmd %#v missing --strict-mcp-config", cmd)
+	}
+	if contains(cmd, "--mcp-config") {
+		t.Fatalf("cmd %#v unexpectedly contains --mcp-config", cmd)
+	}
+}
+
+// TestGetRestoreCommandReappliesMCPAndPluginFlags: like the system prompt, MCP
+// and plugin flags are rebuilt from flags on resume, so a restored worker keeps
+// its scoped MCP set and plugins.
+func TestGetRestoreCommandReappliesMCPAndPluginFlags(t *testing.T) {
+	cmd, ok, err := (&Plugin{resolvedBinary: "claude"}).GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{
+			MCP:        &domain.MCPConfig{Configs: []string{"{\"a\":1}"}, Strict: true},
+			PluginDirs: []string{"https://example.com/p.zip"},
+		},
+		Session: ports.SessionRef{
+			ID:       "sess-r",
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "claude-native-1"},
+		},
+	})
+	if err != nil || !ok {
+		t.Fatalf("restore = (ok=%v, err=%v), want ok", ok, err)
+	}
+	if !containsSubsequence(cmd, []string{"--mcp-config", "{\"a\":1}"}) {
+		t.Fatalf("restore cmd %#v missing --mcp-config", cmd)
+	}
+	if !contains(cmd, "--strict-mcp-config") {
+		t.Fatalf("restore cmd %#v missing --strict-mcp-config", cmd)
+	}
+	if !containsSubsequence(cmd, []string{"--plugin-url", "https://example.com/p.zip"}) {
+		t.Fatalf("restore cmd %#v missing --plugin-url", cmd)
+	}
+	// Flags must precede --resume.
+	if !flagsBeforeResume(cmd, "--strict-mcp-config") {
+		t.Fatalf("restore cmd %#v: MCP flag not before --resume", cmd)
+	}
+}
+
+// flagsBeforeResume reports whether flag appears before --resume in cmd.
+func flagsBeforeResume(cmd []string, flag string) bool {
+	for _, v := range cmd {
+		if v == "--resume" {
+			return false
+		}
+		if v == flag {
+			return true
+		}
+	}
+	return false
 }
 
 func TestClaudeSessionUUIDDeterministicAndUnique(t *testing.T) {

--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -75,8 +75,18 @@ type workspaceRepoDetails struct {
 
 // agentConfig mirrors the daemon's typed domain.AgentConfig for the CLI client.
 type agentConfig struct {
-	Model       string `json:"model,omitempty"`
-	Permissions string `json:"permissions,omitempty"`
+	Model        string            `json:"model,omitempty"`
+	Permissions  string            `json:"permissions,omitempty"`
+	SystemPrompt string            `json:"systemPrompt,omitempty"`
+	Env          map[string]string `json:"env,omitempty"`
+	MCP          *mcpConfig        `json:"mcp,omitempty"`
+	PluginDirs   []string          `json:"pluginDirs,omitempty"`
+}
+
+// mcpConfig mirrors domain.MCPConfig.
+type mcpConfig struct {
+	Configs []string `json:"configs,omitempty"`
+	Strict  bool     `json:"strict,omitempty"`
 }
 
 // roleOverride mirrors domain.RoleOverride.
@@ -124,6 +134,9 @@ type projectSetConfigOptions struct {
 	permission        string
 	workerAgent       string
 	orchestratorAgent string
+	workerMCPConfig   []string
+	workerStrictMCP   bool
+	workerPluginDir   []string
 	agentRules        string
 	agentRulesFile    string
 	orchestratorRules string
@@ -315,6 +328,9 @@ func newProjectSetConfigCommand(ctx *commandContext) *cobra.Command {
 	f.StringVar(&opts.permission, "permission", "", "Permission mode: default, accept-edits, auto, bypass-permissions")
 	f.StringVar(&opts.workerAgent, "worker-agent", "", "Harness override for worker sessions")
 	f.StringVar(&opts.orchestratorAgent, "orchestrator-agent", "", "Harness override for orchestrator sessions")
+	f.StringArrayVar(&opts.workerMCPConfig, "worker-mcp-config", nil, "MCP config (JSON string or path to JSON file) passed to claude-code workers via --mcp-config (repeatable)")
+	f.BoolVar(&opts.workerStrictMCP, "worker-strict-mcp", false, "Isolate claude-code workers from every other MCP source (--strict-mcp-config)")
+	f.StringArrayVar(&opts.workerPluginDir, "worker-plugin-dir", nil, "Plugin path or http(s):// URL loaded by claude-code workers only (repeatable)")
 	f.StringVar(&opts.agentRules, "agent-rules", "", "Project-specific standing instructions for worker sessions")
 	f.StringVar(&opts.agentRulesFile, "agent-rules-file", "", "Repo-relative file containing worker standing instructions")
 	f.StringVar(&opts.orchestratorRules, "orchestrator-rules", "", "Project-specific standing instructions for orchestrator sessions")
@@ -368,6 +384,12 @@ func buildProjectConfig(opts projectSetConfigOptions) (projectConfig, error) {
 			Repo:     opts.trackerRepo,
 			Assignee: opts.trackerAssignee,
 		},
+	}
+	if len(opts.workerMCPConfig) > 0 || opts.workerStrictMCP {
+		cfg.Worker.AgentConfig.MCP = &mcpConfig{Configs: opts.workerMCPConfig, Strict: opts.workerStrictMCP}
+	}
+	if len(opts.workerPluginDir) > 0 {
+		cfg.Worker.AgentConfig.PluginDirs = opts.workerPluginDir
 	}
 	if reflect.DeepEqual(cfg, projectConfig{}) {
 		return projectConfig{}, usageError{errors.New("usage: provide at least one config flag, --config-json, or --clear")}

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -95,6 +95,41 @@ func TestBuildProjectConfigTrackerIntakeFlags(t *testing.T) {
 	}
 }
 
+// TestBuildProjectConfigWorkerProfileFlags: the worker MCP/plugin flags are
+// assembled into the per-role AgentConfig that the daemon validates and
+// claude-code maps to --mcp-config / --strict-mcp-config / --plugin-dir[-url].
+func TestBuildProjectConfigWorkerProfileFlags(t *testing.T) {
+	got, err := buildProjectConfig(projectSetConfigOptions{
+		workerMCPConfig: []string{`{"a":1}`, "/p/m.json"},
+		workerStrictMCP: true,
+		workerPluginDir: []string{"/local/plugin", "https://example.com/p.zip"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mcp := got.Worker.AgentConfig.MCP
+	if mcp == nil || !mcp.Strict || len(mcp.Configs) != 2 || mcp.Configs[0] != `{"a":1}` || mcp.Configs[1] != "/p/m.json" {
+		t.Fatalf("worker MCP = %#v, want strict with 2 configs", mcp)
+	}
+	if len(got.Worker.AgentConfig.PluginDirs) != 2 || got.Worker.AgentConfig.PluginDirs[1] != "https://example.com/p.zip" {
+		t.Fatalf("worker pluginDirs = %#v", got.Worker.AgentConfig.PluginDirs)
+	}
+}
+
+// TestBuildProjectConfigWorkerStrictMCPAlone: --worker-strict-mcp without any
+// --worker-mcp-config is a valid isolation request (empty MCP set), so it must
+// still build a present MCPConfig with Strict=true rather than dropping it.
+func TestBuildProjectConfigWorkerStrictMCPAlone(t *testing.T) {
+	got, err := buildProjectConfig(projectSetConfigOptions{workerStrictMCP: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mcp := got.Worker.AgentConfig.MCP
+	if mcp == nil || !mcp.Strict || len(mcp.Configs) != 0 {
+		t.Fatalf("worker MCP = %#v, want strict isolation with empty configs", mcp)
+	}
+}
+
 func TestProjectList_Success(t *testing.T) {
 	cfg := setConfigEnv(t)
 	srv, capture := projectServer(t, http.StatusOK, `{"projects":[{"id":"zeta","name":"Zeta","sessionPrefix":"zeta"},{"id":"alpha","name":"Alpha","sessionPrefix":"alpha","resolveError":"config missing"}]}`)

--- a/backend/internal/domain/agentconfig.go
+++ b/backend/internal/domain/agentconfig.go
@@ -1,6 +1,10 @@
 package domain
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
 
 // PermissionMode controls how much review an agent requires before acting. It
 // lives in domain (not ports) so the typed AgentConfig can carry it; ports
@@ -28,12 +32,49 @@ type AgentConfig struct {
 	// Permissions sets the agent's starting permission mode. Empty is treated
 	// like the adapter's default mode.
 	Permissions PermissionMode `json:"permissions,omitempty"`
+
+	// SystemPrompt is a per-role base prompt appended to AO's role-derived
+	// system prompt at spawn/restore. It lets a project layer standing
+	// instructions onto a worker (or orchestrator) beyond the built-in role.
+	// A role SystemPrompt replaces (not concatenates) a base AgentConfig
+	// SystemPrompt; today only the role level is configurable, so this matters
+	// only if the base level is ever exposed.
+	SystemPrompt string `json:"systemPrompt,omitempty"`
+	// Env are extra environment variables forwarded into the session runtime,
+	// merged on top of the project's Env so a per-role value wins on key
+	// collision. AO-internal vars (AO_SESSION_ID, …) always win.
+	Env map[string]string `json:"env,omitempty"`
+	// MCP scopes the MCP servers a session loads. When set, adapters that
+	// support per-session MCP (claude-code) pass it as --mcp-config; Strict
+	// additionally passes --strict-mcp-config so the session ignores every
+	// other MCP source (isolation). nil means inherit the global config.
+	MCP *MCPConfig `json:"mcp,omitempty"`
+	// PluginDirs are plugin paths or URLs loaded for this session only
+	// (claude-code: a local path maps to --plugin-dir, an http(s):// URL to
+	// --plugin-url). nil/empty means inherit the global plugin set.
+	PluginDirs []string `json:"pluginDirs,omitempty"`
+}
+
+// MCPConfig narrows the MCP servers a session sees. It is a pointer on
+// AgentConfig so an empty (default) config stays a zero value for storage and
+// resolution, while a present-but-empty MCPConfig is meaningful: Strict on its
+// own isolates a worker from every MCP source.
+type MCPConfig struct {
+	// Configs are the values passed to claude-code's repeatable --mcp-config
+	// flag. Each is either a JSON string defining servers inline or a path to
+	// a JSON file, exactly as claude-code's CLI accepts.
+	Configs []string `json:"configs,omitempty"`
+	// Strict, when true, adds --strict-mcp-config so claude-code uses only the
+	// servers in Configs and ignores all other MCP configurations. Strict with
+	// empty Configs is valid and means "this session gets no MCP servers".
+	Strict bool `json:"strict,omitempty"`
 }
 
 // IsZero reports whether the config carries no settings, so storage can persist
-// SQL NULL and resolution can skip an empty config.
+// SQL NULL and resolution can skip an empty config. Map, slice, and pointer
+// fields are compared by value via reflect (a bare == would not compile).
 func (c AgentConfig) IsZero() bool {
-	return c == AgentConfig{}
+	return reflect.DeepEqual(c, AgentConfig{})
 }
 
 // Validate rejects values outside the typed vocabulary so a bad config is
@@ -41,8 +82,21 @@ func (c AgentConfig) IsZero() bool {
 func (c AgentConfig) Validate() error {
 	switch c.Permissions {
 	case "", PermissionModeDefault, PermissionModeAcceptEdits, PermissionModeAuto, PermissionModeBypassPermissions:
-		return nil
 	default:
 		return fmt.Errorf("invalid permissions %q: want one of default, accept-edits, auto, bypass-permissions", c.Permissions)
 	}
+	if c.MCP != nil {
+		for i, cfg := range c.MCP.Configs {
+			if strings.TrimSpace(cfg) == "" {
+				return fmt.Errorf("mcp.configs[%d]: empty entry", i)
+			}
+		}
+		// Strict with empty Configs is intentional isolation, not an error.
+	}
+	for i, dir := range c.PluginDirs {
+		if strings.TrimSpace(dir) == "" {
+			return fmt.Errorf("pluginDirs[%d]: empty entry", i)
+		}
+	}
+	return nil
 }

--- a/backend/internal/domain/agentconfig_test.go
+++ b/backend/internal/domain/agentconfig_test.go
@@ -1,0 +1,58 @@
+package domain
+
+import "testing"
+
+func TestAgentConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     AgentConfig
+		wantErr bool
+	}{
+		{"empty ok", AgentConfig{}, false},
+		{"good model", AgentConfig{Model: "claude-opus-4-5"}, false},
+		{"good permission", AgentConfig{Permissions: PermissionModeAuto}, false},
+		{"bad permission", AgentConfig{Permissions: "yolo"}, true},
+
+		{"mcp nil ok", AgentConfig{}, false},
+		{"mcp configs ok", AgentConfig{MCP: &MCPConfig{Configs: []string{"{\"a\":1}", "/path/to/mcp.json"}}}, false},
+		{"mcp empty config entry", AgentConfig{MCP: &MCPConfig{Configs: []string{"  "}}}, true},
+		{"mcp strict alone ok (isolation)", AgentConfig{MCP: &MCPConfig{Strict: true}}, false},
+		{"mcp strict with configs ok", AgentConfig{MCP: &MCPConfig{Configs: []string{"{\"a\":1}"}, Strict: true}}, false},
+
+		{"plugin dir path ok", AgentConfig{PluginDirs: []string{"/abs/path", "rel/path"}}, false},
+		{"plugin url ok", AgentConfig{PluginDirs: []string{"https://example.com/p.zip"}}, false},
+		{"plugin empty entry", AgentConfig{PluginDirs: []string{"ok", "  "}}, true},
+
+		{"env map ok", AgentConfig{Env: map[string]string{"FOO": "bar"}}, false},
+		{"system prompt ok", AgentConfig{SystemPrompt: "extra standing instructions"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.cfg.Validate(); (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAgentConfigIsZero(t *testing.T) {
+	if !(AgentConfig{}).IsZero() {
+		t.Fatalf("empty AgentConfig should be zero")
+	}
+	// Each new field, when set, makes the config non-zero.
+	setters := map[string]func() AgentConfig{
+		"model":        func() AgentConfig { return AgentConfig{Model: "m"} },
+		"permissions":  func() AgentConfig { return AgentConfig{Permissions: PermissionModeAuto} },
+		"systemPrompt": func() AgentConfig { return AgentConfig{SystemPrompt: "x"} },
+		"env":          func() AgentConfig { return AgentConfig{Env: map[string]string{"K": "v"}} },
+		"mcp":          func() AgentConfig { return AgentConfig{MCP: &MCPConfig{Strict: true}} },
+		"pluginDirs":   func() AgentConfig { return AgentConfig{PluginDirs: []string{"/p"}} },
+	}
+	for name, mk := range setters {
+		t.Run(name, func(t *testing.T) {
+			if mk().IsZero() {
+				t.Fatalf("AgentConfig with %s set should not be zero", name)
+			}
+		})
+	}
+}

--- a/backend/internal/domain/projectconfig_test.go
+++ b/backend/internal/domain/projectconfig_test.go
@@ -40,6 +40,16 @@ func TestProjectConfigValidate(t *testing.T) {
 		{"tracker intake unknown provider", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Provider: "linear", Assignee: "alice"}}, true},
 		{"tracker intake repo with whitespace", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Repo: " acme/demo", Assignee: "alice"}}, true},
 		{"tracker intake assignee with whitespace", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Assignee: " alice"}}, true},
+
+		// Per-role environment profile (#2195): systemPrompt, env, mcp, pluginDirs.
+		{"worker mcp strict isolation ok", ProjectConfig{Worker: RoleOverride{AgentConfig: AgentConfig{MCP: &MCPConfig{Strict: true}}}}, false},
+		{"worker mcp configs ok", ProjectConfig{Worker: RoleOverride{AgentConfig: AgentConfig{MCP: &MCPConfig{Configs: []string{"{\"a\":1}"}}}}}, false},
+		{"worker mcp empty config entry", ProjectConfig{Worker: RoleOverride{AgentConfig: AgentConfig{MCP: &MCPConfig{Configs: []string{""}}}}}, true},
+		{"worker plugin dirs ok", ProjectConfig{Worker: RoleOverride{AgentConfig: AgentConfig{PluginDirs: []string{"/p", "https://x/y.zip"}}}}, false},
+		{"worker plugin empty entry", ProjectConfig{Worker: RoleOverride{AgentConfig: AgentConfig{PluginDirs: []string{" "}}}}, true},
+		{"orchestrator system prompt ok", ProjectConfig{Orchestrator: RoleOverride{AgentConfig: AgentConfig{SystemPrompt: "be terse"}}}, false},
+		{"worker env ok", ProjectConfig{Worker: RoleOverride{AgentConfig: AgentConfig{Env: map[string]string{"NODE_ENV": "test"}}}}, false},
+		{"orchestrator bad mcp", ProjectConfig{Orchestrator: RoleOverride{AgentConfig: AgentConfig{MCP: &MCPConfig{Configs: []string{"  "}}}}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -1836,9 +1836,21 @@ components:
       type: object
     AgentConfig:
       properties:
+        env:
+          additionalProperties:
+            type: string
+          type: object
+        mcp:
+          $ref: '#/components/schemas/DomainMCPConfig'
         model:
           type: string
         permissions:
+          type: string
+        pluginDirs:
+          items:
+            type: string
+          type: array
+        systemPrompt:
           type: string
       type: object
     AgentInfo:
@@ -2026,6 +2038,15 @@ components:
       required:
       - state
       - lastActivityAt
+      type: object
+    DomainMCPConfig:
+      properties:
+        configs:
+          items:
+            type: string
+          type: array
+        strict:
+          type: boolean
       type: object
     DomainReviewerConfig:
       properties:

--- a/backend/internal/runfile/runfile.go
+++ b/backend/internal/runfile/runfile.go
@@ -24,10 +24,12 @@ type Info struct {
 	Port int `json:"port"`
 	// StartedAt is when the daemon came up (RFC 3339).
 	StartedAt time.Time `json:"startedAt"`
-	// Owner is "app" when the desktop Electron app spawned this daemon; empty
-	// for a headless `ao start` daemon. Used by the app to decide whether to
-	// hold a supervisor link on attach (app-owned: re-link; headless: skip so
-	// the daemon stays persistent across app quit).
+	// Owner records how this daemon was spawned, so the app can decide whether
+	// to hold a supervisor link on attach from the daemon's own durable record
+	// rather than the current process env. "app" = normal desktop-spawned daemon
+	// (re-link on attach); "persistent" = spawned under AO_KEEP_DAEMON, stays
+	// alive across app quit and is never re-linked; empty = headless `ao start`
+	// daemon, stays persistent across app quit.
 	Owner string `json:"owner,omitempty"`
 }
 

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -310,7 +310,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: no agent adapter for harness %q", id, cfg.Harness)
 	}
 	agentConfig := effectiveAgentConfig(cfg.Kind, project.Config)
-	env := m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, project.Config.Env)
+	env := m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, mergeEnv(project.Config.Env, effectiveAgentConfig(cfg.Kind, project.Config).Env))
 	m.augmentAgentRuntimeEnv(agent, env)
 	if err := m.prepareWorkspace(ctx, agent, id, ws.Path, systemPrompt, systemPromptFile, agentConfig, env); err != nil {
 		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
@@ -505,6 +505,30 @@ func effectiveAgentConfig(kind domain.SessionKind, cfg domain.ProjectConfig) por
 	}
 	if override.Permissions != "" {
 		merged.Permissions = override.Permissions
+	}
+	if override.SystemPrompt != "" {
+		merged.SystemPrompt = override.SystemPrompt
+	}
+	if len(override.Env) > 0 {
+		// mergeEnv returns a fresh map (deep copy) so the role override cannot
+		// mutate the project's base Env — an earlier inline write aliased it
+		// (Go copies the map header by value on struct copy), leaking role env
+		// into every later session of the project.
+		merged.Env = mergeEnv(cfg.AgentConfig.Env, override.Env)
+	}
+	if override.MCP != nil {
+		// Copy the MCPConfig (and its Configs slice) rather than aliasing the
+		// override pointer — same defense-in-depth as Env: the merged config
+		// flows to adapters, and a future adapter/hook that mutated it would
+		// otherwise corrupt the stored project config for the daemon's lifetime.
+		cp := *override.MCP
+		if len(cp.Configs) > 0 {
+			cp.Configs = append([]string(nil), cp.Configs...)
+		}
+		merged.MCP = &cp
+	}
+	if len(override.PluginDirs) > 0 {
+		merged.PluginDirs = append([]string(nil), override.PluginDirs...)
 	}
 	return merged
 }
@@ -831,7 +855,7 @@ func (m *Manager) relaunchRestoredSession(ctx context.Context, rec domain.Sessio
 	// Restore re-applies the project's resolved agent config so a configured
 	// model/permissions carry across a restore, matching fresh spawn.
 	agentConfig := effectiveAgentConfig(rec.Kind, project.Config)
-	env := m.runtimeEnv(rec.ID, rec.ProjectID, rec.IssueID, project.Config.Env)
+	env := m.runtimeEnv(rec.ID, rec.ProjectID, rec.IssueID, mergeEnv(project.Config.Env, agentConfig.Env))
 	m.augmentAgentRuntimeEnv(agent, env)
 	if err := m.prepareWorkspace(ctx, agent, rec.ID, ws.Path, systemPrompt, systemPromptFile, agentConfig, env); err != nil {
 		return domain.SessionRecord{}, fmt.Errorf("restore %s: %w", rec.ID, err)
@@ -1904,6 +1928,13 @@ func (m *Manager) buildSystemPrompt(ctx context.Context, kind domain.SessionKind
 	if workspacePrompt != "" {
 		cfg.AdditionalSections = append(cfg.AdditionalSections, workspacePrompt)
 	}
+	// A per-role base prompt (agentConfig.systemPrompt) layers on top of the
+	// role-derived instructions so a project can hand a worker (or orchestrator)
+	// standing context beyond the built-in role. It sits before the skill pointer
+	// and the confidentiality guard so it is covered by both.
+	if up := strings.TrimSpace(effectiveAgentConfig(kind, project.Config).SystemPrompt); up != "" {
+		cfg.RolePrompt = up
+	}
 	if pointer := strings.TrimSpace(m.aoSkillPointer()); pointer != "" {
 		cfg.AdditionalSections = append(cfg.AdditionalSections, pointer)
 	}
@@ -2046,6 +2077,21 @@ func workspaceRepoList(repos []domain.WorkspaceRepoRecord) string {
 		lines = append(lines, fmt.Sprintf("- %s: %s", repo.Name, repo.RelativePath))
 	}
 	return strings.Join(lines, "\n")
+}
+
+// mergeEnv overlays roleEnv on top of projectEnv so a per-role value wins on
+// key collision, mirroring the effectiveAgentConfig merge for Env. nil inputs
+// are treated as empty. The result is always a fresh map so callers can mutate
+// it freely (spawnEnv adds AO-internal keys on top).
+func mergeEnv(projectEnv, roleEnv map[string]string) map[string]string {
+	out := make(map[string]string, len(projectEnv)+len(roleEnv))
+	for k, v := range projectEnv {
+		out[k] = v
+	}
+	for k, v := range roleEnv {
+		out[k] = v
+	}
+	return out
 }
 
 // spawnEnv builds the runtime environment: the per-project env vars first, then

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -310,7 +310,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: no agent adapter for harness %q", id, cfg.Harness)
 	}
 	agentConfig := effectiveAgentConfig(cfg.Kind, project.Config)
-	env := m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, mergeEnv(project.Config.Env, effectiveAgentConfig(cfg.Kind, project.Config).Env))
+	env := m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, mergeEnv(project.Config.Env, agentConfig.Env))
 	m.augmentAgentRuntimeEnv(agent, env)
 	if err := m.prepareWorkspace(ctx, agent, id, ws.Path, systemPrompt, systemPromptFile, agentConfig, env); err != nil {
 		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
@@ -509,11 +509,13 @@ func effectiveAgentConfig(kind domain.SessionKind, cfg domain.ProjectConfig) por
 	if override.SystemPrompt != "" {
 		merged.SystemPrompt = override.SystemPrompt
 	}
-	if len(override.Env) > 0 {
+	if len(override.Env) > 0 || len(cfg.AgentConfig.Env) > 0 {
 		// mergeEnv returns a fresh map (deep copy) so the role override cannot
 		// mutate the project's base Env — an earlier inline write aliased it
 		// (Go copies the map header by value on struct copy), leaking role env
-		// into every later session of the project.
+		// into every later session of the project. Defense-in-depth matches the
+		// MCP pointer copy below. Guard both inputs empty so a project with no
+		// config still resolves to a zero AgentConfig.
 		merged.Env = mergeEnv(cfg.AgentConfig.Env, override.Env)
 	}
 	if override.MCP != nil {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -4783,3 +4783,156 @@ func (m *flipOnNudgeMessenger) Send(_ context.Context, _ domain.SessionID, msg s
 	}
 	return nil
 }
+
+// TestEffectiveAgentConfig_MergesProfileFields: the per-role override's
+// SystemPrompt/Env/MCP/PluginDirs merge over the project base, mirroring the
+// pre-existing Model/Permissions merge. Role wins on key collision for Env.
+func TestEffectiveAgentConfig_MergesProfileFields(t *testing.T) {
+	base := domain.AgentConfig{
+		Model:        "base-model",
+		Env:          map[string]string{"KEEP": "base", "OVER": "base"},
+		SystemPrompt: "base-prompt",
+		PluginDirs:   []string{"/base"},
+	}
+	cfg := domain.ProjectConfig{
+		AgentConfig: base,
+		Worker: domain.RoleOverride{AgentConfig: domain.AgentConfig{
+			Model:        "worker-model",
+			Env:          map[string]string{"OVER": "worker", "EXTRA": "worker"},
+			SystemPrompt: "worker-prompt",
+			MCP:          &domain.MCPConfig{Strict: true, Configs: []string{"{\"a\":1}"}},
+			PluginDirs:   []string{"/worker"},
+		}},
+	}
+
+	got := effectiveAgentConfig(domain.KindWorker, cfg)
+
+	if got.Model != "worker-model" {
+		t.Fatalf("Model = %q, want worker-model", got.Model)
+	}
+	if got.SystemPrompt != "worker-prompt" {
+		t.Fatalf("SystemPrompt = %q, want worker-prompt", got.SystemPrompt)
+	}
+	if got.MCP == nil || !got.MCP.Strict || len(got.MCP.Configs) != 1 {
+		t.Fatalf("MCP not merged from override: %+v", got.MCP)
+	}
+	if len(got.PluginDirs) != 1 || got.PluginDirs[0] != "/worker" {
+		t.Fatalf("PluginDirs = %v, want [/worker]", got.PluginDirs)
+	}
+	// Env: base keys preserved, role override wins on collision, extra keys added.
+	if got.Env["KEEP"] != "base" {
+		t.Fatalf("base Env key KEEP lost: %v", got.Env)
+	}
+	if got.Env["OVER"] != "worker" {
+		t.Fatalf("role Env did not win on OVER: %v", got.Env)
+	}
+	if got.Env["EXTRA"] != "worker" {
+		t.Fatalf("role Env extra key missing: %v", got.Env)
+	}
+}
+
+// TestEffectiveAgentConfig_DoesNotMutateProjectEnv: merging a role's Env must
+// not mutate the project's base AgentConfig.Env. The earlier inline merge wrote
+// into merged.Env, which aliased the project map (Go copies the map header by
+// value on struct copy), so a worker's role-specific env leaked into every
+// later session of the project for the daemon's lifetime. Regression guard.
+func TestEffectiveAgentConfig_DoesNotMutateProjectEnv(t *testing.T) {
+	cfg := domain.ProjectConfig{
+		AgentConfig: domain.AgentConfig{Env: map[string]string{"BASE": "b"}},
+		Worker: domain.RoleOverride{AgentConfig: domain.AgentConfig{
+			Env: map[string]string{"ROLE_ONLY": "secret"},
+		}},
+	}
+
+	_ = effectiveAgentConfig(domain.KindWorker, cfg)
+	_ = effectiveAgentConfig(domain.KindWorker, cfg) // a second call surfaces cross-call leakage
+
+	if _, leaked := cfg.AgentConfig.Env["ROLE_ONLY"]; leaked {
+		t.Fatalf("role-only env leaked into project config after merge: %#v", cfg.AgentConfig.Env)
+	}
+	if cfg.AgentConfig.Env["BASE"] != "b" {
+		t.Fatalf("project base env mutated: %#v", cfg.AgentConfig.Env)
+	}
+}
+
+// TestEffectiveAgentConfig_OrchestratorRoleUsesOrchestratorOverride: the role
+// selector picks Worker vs Orchestrator, not just Worker for every call.
+func TestEffectiveAgentConfig_OrchestratorRoleUsesOrchestratorOverride(t *testing.T) {
+	cfg := domain.ProjectConfig{
+		Worker:       domain.RoleOverride{AgentConfig: domain.AgentConfig{SystemPrompt: "w"}},
+		Orchestrator: domain.RoleOverride{AgentConfig: domain.AgentConfig{SystemPrompt: "o"}},
+	}
+	if got := effectiveAgentConfig(domain.KindWorker, cfg); got.SystemPrompt != "w" {
+		t.Fatalf("worker prompt = %q, want w", got.SystemPrompt)
+	}
+	if got := effectiveAgentConfig(domain.KindOrchestrator, cfg); got.SystemPrompt != "o" {
+		t.Fatalf("orchestrator prompt = %q, want o", got.SystemPrompt)
+	}
+}
+
+// TestMergeEnv_RoleWinsOnCollision: a per-role value overrides a project value
+// on key collision; both nil inputs yield an empty (non-nil) map.
+func TestMergeEnv_RoleWinsOnCollision(t *testing.T) {
+	got := mergeEnv(
+		map[string]string{"A": "proj", "B": "proj"},
+		map[string]string{"B": "role", "C": "role"},
+	)
+	want := map[string]string{"A": "proj", "B": "role", "C": "role"}
+	if len(got) != len(want) {
+		t.Fatalf("mergeEnv = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("mergeEnv[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+	if mergeEnv(nil, nil) == nil {
+		t.Fatalf("mergeEnv(nil,nil) should be non-nil empty map")
+	}
+}
+
+// TestBuildSystemPrompt_AppendsRoleSystemPrompt: a per-role agentConfig
+// systemPrompt is layered into the derived system prompt so a project can hand
+// a worker standing context beyond the built-in role block.
+func TestBuildSystemPrompt_AppendsRoleSystemPrompt(t *testing.T) {
+	const marker = "ALWAYS COMMIT AFTER EACH STEP"
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: domain.ProjectConfig{
+		Worker: domain.RoleOverride{AgentConfig: domain.AgentConfig{SystemPrompt: marker}},
+	}}
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{Runtime: &fakeRuntime{}, Agents: singleAgent{agent: &recordingAgent{}}, Workspace: &fakeWorkspace{}, Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LookPath: lookPath})
+
+	sp, err := m.buildSystemPrompt(ctx, domain.KindWorker, "mer")
+	if err != nil {
+		t.Fatalf("buildSystemPrompt: %v", err)
+	}
+	if !strings.Contains(sp, marker) {
+		t.Fatalf("worker system prompt missing per-role marker %q:\n%s", marker, sp)
+	}
+	// The marker must sit inside the guarded region (before the skill pointer and
+	// the confidentiality guard), so it is itself protected from disclosure.
+	if !strings.Contains(sp, "Standing-instruction confidentiality") {
+		t.Fatalf("guard lost:\n%s", sp)
+	}
+}
+
+// TestBuildSystemPrompt_NoRolePromptWhenUnset: a project without a per-role
+// systemPrompt produces the same prompt as before (no stray sections).
+func TestBuildSystemPrompt_NoRolePromptWhenUnset(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer"}
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{Runtime: &fakeRuntime{}, Agents: singleAgent{agent: &recordingAgent{}}, Workspace: &fakeWorkspace{}, Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LookPath: lookPath})
+
+	sp, err := m.buildSystemPrompt(ctx, domain.KindWorker, "mer")
+	if err != nil {
+		t.Fatalf("buildSystemPrompt: %v", err)
+	}
+	if !strings.Contains(sp, "Multi-PR workflow") && !strings.Contains(sp, "branch namespace") {
+		// worker prompt still assembled; we only assert it does not error and is non-empty.
+		if sp == "" {
+			t.Fatalf("expected non-empty worker system prompt")
+		}
+	}
+}

--- a/backend/internal/session_manager/prompt.go
+++ b/backend/internal/session_manager/prompt.go
@@ -35,6 +35,7 @@ type systemPromptConfig struct {
 	OrchestratorSessionID string
 	ProjectRules          string
 	OrchestratorRules     string
+	RolePrompt            string
 	AdditionalSections    []string
 }
 
@@ -86,6 +87,9 @@ func buildSystemPromptText(cfg systemPromptConfig) string {
 		}
 	default:
 		return ""
+	}
+	if rolePrompt := strings.TrimSpace(cfg.RolePrompt); rolePrompt != "" {
+		sections = append(sections, rolePrompt)
 	}
 	sections = append(sections, systemPromptGuard())
 	for _, section := range cfg.AdditionalSections {

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -90,13 +90,14 @@ commands yet.
 
 The CLI and daemon share the same environment-driven config:
 
-| Var                   | Default              | Purpose                |
-| --------------------- | -------------------- | ---------------------- |
-| `AO_PORT`             | `3001`               | Loopback daemon port.  |
-| `AO_RUN_FILE`         | `~/.ao/running.json` | PID/port handshake.    |
-| `AO_DATA_DIR`         | `~/.ao/data`         | SQLite data directory. |
-| `AO_REQUEST_TIMEOUT`  | `60s`                | REST request timeout.  |
-| `AO_SHUTDOWN_TIMEOUT` | `10s`                | Graceful shutdown cap. |
+| Var                   | Default              | Purpose                                                                                        |
+| --------------------- | -------------------- | ---------------------------------------------------------------------------------------------- |
+| `AO_PORT`             | `3001`               | Loopback daemon port.                                                                          |
+| `AO_RUN_FILE`         | `~/.ao/running.json` | PID/port handshake.                                                                            |
+| `AO_DATA_DIR`         | `~/.ao/data`         | SQLite data directory.                                                                         |
+| `AO_REQUEST_TIMEOUT`  | `60s`                | REST request timeout.                                                                          |
+| `AO_SHUTDOWN_TIMEOUT` | `10s`                | Graceful shutdown cap.                                                                         |
+| `AO_KEEP_DAEMON`      | unset (off)          | Keep the desktop app's daemon running after the window closes; stop only via `ao stop`. (fork) |
 
 The daemon always binds `127.0.0.1`.
 

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -696,8 +696,14 @@ export interface components {
             projectId?: null | string;
         };
         AgentConfig: {
+            env?: {
+                [key: string]: string;
+            };
+            mcp?: components["schemas"]["DomainMCPConfig"];
             model?: string;
             permissions?: string;
+            pluginDirs?: string[];
+            systemPrompt?: string;
         };
         AgentInfo: {
             /**
@@ -765,6 +771,10 @@ export interface components {
             /** Format: date-time */
             lastActivityAt: string;
             state: string;
+        };
+        DomainMCPConfig: {
+            configs?: string[];
+            strict?: boolean;
         };
         DomainReviewerConfig: {
             harness: string;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -28,8 +28,8 @@ import {
 	type UpdateSettings,
 	type UpdateStatus,
 } from "./main/update-settings";
-import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { existsSync } from "node:fs";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { closeSync, existsSync, openSync } from "node:fs";
 import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -52,7 +52,7 @@ import { DEFAULT_POSTHOG_HOST, DEFAULT_POSTHOG_PROJECT_KEY } from "./shared/post
 import { buildTelemetryBootstrap } from "./shared/telemetry";
 import { createBrowserViewHost, type BrowserViewHost } from "./main/browser-view-host";
 import { connectSupervisor, type SupervisorLinkHandle } from "./main/supervisor-link";
-import { shouldLinkOnAttach } from "./main/daemon-owner";
+import { keepDaemonAlive, shouldLinkOnAttach } from "./main/daemon-owner";
 import { readMigrationState, updateMigration, writeAppStateMarker, type MigrationState } from "./main/app-state";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
 
@@ -92,8 +92,8 @@ if (process.platform === "win32") {
 app.setPath("userData", path.join(os.homedir(), ".ao", "electron"));
 
 let mainWindow: BrowserWindow | null = null;
-let daemonProcess: ChildProcessWithoutNullStreams | null = null;
-let daemonStoppingProcess: ChildProcessWithoutNullStreams | null = null;
+let daemonProcess: ChildProcess | null = null;
+let daemonStoppingProcess: ChildProcess | null = null;
 let daemonStartPromise: Promise<DaemonStatus> | null = null;
 let daemonStartEpoch = 0;
 let daemonStatus: DaemonStatus = { state: "stopped" };
@@ -465,10 +465,14 @@ function ensureShellEnv(): Promise<void> {
 }
 
 function daemonEnv(): NodeJS.ProcessEnv {
-	// AO_OWNER=app marks this daemon as app-spawned so the app can re-link the
-	// supervisor on attach (headless `ao start` daemons get no AO_OWNER and stay
-	// unlinked, preserving their persistence across app quit).
-	const ownerTag = { AO_OWNER: "app" };
+	// AO_OWNER is the daemon's durable spawn-mode record: the daemon writes it
+	// into running.json and the attach path reads it to decide the supervisor
+	// link from the daemon's own state (not this Electron process's env, which
+	// differs across launches). A keep-alive daemon is "persistent" (never
+	// re-linked, survives app quit); a normal app-owned daemon is "app";
+	// headless `ao start` sets none (stays unlinked, persistent by default).
+	const AO_OWNER = keepDaemonAlive(process.env) ? "persistent" : "app";
+	const ownerTag = { AO_OWNER };
 	// In dev mode, inject isolation defaults so the dev daemon never collides with
 	// the installed app. User-set env vars take priority (checked first).
 	const devExtras: Record<string, string> = {};
@@ -688,9 +692,10 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 	}
 	if (existing) {
 		setDaemonStatus(existing.status);
-		// Re-link the supervisor only when attaching to an app-owned daemon (one we
-		// previously spawned). Headless `ao start` daemons (owner unset) stay unlinked
-		// so they remain persistent after app quit.
+		// Re-link the supervisor only when attaching to a normal app-owned daemon
+		// (owner "app"). The keep decision is durable: a daemon spawned keep-alive
+		// is owner "persistent" and stays unlinked even when the app reopens
+		// without AO_KEEP_DAEMON, so closing it does not stop the persistent daemon.
 		if (shouldLinkOnAttach(existing.owner)) {
 			establishSupervisorLink();
 		}
@@ -815,14 +820,60 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 	// runs the command through /bin/sh, a plain kill() would only signal the shell
 	// wrapper and orphan the real daemon (which keeps holding the port). Killing
 	// the whole group via killDaemon() reaches the daemon and any PTY children.
-	const child = spawn(launch.command, launch.args, {
-		cwd: launch.cwd,
-		env: daemonEnv(),
-		shell: launch.shell,
-		detached: true,
-		// Hide the daemon's console on a Windows GUI launch (no flashing terminal).
-		windowsHide: true,
-	});
+	//
+	// AO_KEEP_DAEMON: the daemon must survive this app, so it cannot inherit
+	// Electron-owned stdout/stderr pipes — when Electron exits, the pipe read
+	// ends close and the daemon's next stderr log write (SIGPIPE/EPIPE) kills it,
+	// defeating the keep-alive. Redirect stdio to ~/.ao/daemon.log and unref the
+	// child so the parent does not wait on it. Port discovery then relies on the
+	// running.json handshake (the log pipe scan is skipped).
+	const keep = keepDaemonAlive(process.env);
+	let keepDaemonLogFd: number | undefined;
+	const stdio: "pipe" | "ignore" | ["ignore", number, number] = keep
+		? (() => {
+				const logPath = path.join(os.homedir(), ".ao", "daemon.log");
+				try {
+					keepDaemonLogFd = openSync(logPath, "a");
+				} catch {
+					keepDaemonLogFd = undefined;
+				}
+				return keepDaemonLogFd !== undefined ? ["ignore", keepDaemonLogFd, keepDaemonLogFd] : "ignore";
+			})()
+		: "pipe";
+	let child: ChildProcess;
+	try {
+		child = spawn(launch.command, launch.args, {
+			cwd: launch.cwd,
+			env: daemonEnv(),
+			shell: launch.shell,
+			detached: true,
+			// Hide the daemon's console on a Windows GUI launch (no flashing terminal).
+			windowsHide: true,
+			stdio,
+		});
+	} catch (err) {
+		// spawn can throw synchronously for invalid args; don't leak the log fd.
+		if (keepDaemonLogFd !== undefined) {
+			try {
+				closeSync(keepDaemonLogFd);
+			} catch {
+				// best-effort — the throw below is the real error
+			}
+		}
+		throw err;
+	}
+	// The child inherited its own copy of the log fd via stdio at spawn time;
+	// close the parent's copy now so each keep-alive start/stop cycle does not
+	// accumulate open descriptors until the process limit.
+	if (keepDaemonLogFd !== undefined) {
+		try {
+			closeSync(keepDaemonLogFd);
+		} catch {
+			// best-effort — the child still holds its inherited copy
+		}
+		keepDaemonLogFd = undefined;
+	}
+	if (keep) child.unref();
 	daemonProcess = child;
 
 	// Discover the port the daemon ACTUALLY bound rather than trusting AO_PORT:
@@ -847,31 +898,43 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		stopDiscovery();
 		setDaemonStatus({ state: "ready", port });
 
-		// Establish the OS-native liveness link unconditionally: this callback fires
-		// only on the spawn path (we own this daemon). Holding the connection keeps
-		// the daemon alive; when Electron exits for any reason, the OS closes the fd
-		// and the daemon detects EOF, then self-stops after its ~5s grace period.
-		// The attach paths link only when the daemon is app-owned (see
-		// establishSupervisorLink + shouldLinkOnAttach); headless `ao start` daemons
-		// stay unlinked so they remain persistent across app quit.
-		establishSupervisorLink();
+		// Establish the OS-native liveness link on the spawn path (we own this
+		// daemon). Holding the connection keeps the daemon alive; when Electron
+		// exits for any reason, the OS closes the fd and the daemon detects EOF,
+		// then self-stops after its ~5s grace period. The attach paths link only
+		// when the daemon is app-owned (see establishSupervisorLink +
+		// shouldLinkOnAttach); headless `ao start` daemons stay unlinked so they
+		// remain persistent across app quit.
+		//
+		// AO_KEEP_DAEMON opts out of the link entirely: the daemon is spawned but
+		// survives the window closing, stopping only on an explicit `ao stop`.
+		// Reuse the `keep` captured at spawn rather than re-reading process.env:
+		// the flag is a property of this spawn, not a value that should be able to
+		// flip between spawn and port-confirmation.
+		if (!keep) {
+			establishSupervisorLink();
+		}
 	};
 
 	// One scanner per stream: each keeps its own partial-line buffer.
-	const scanStdout = createListenPortScanner(reportBoundPort);
-	const scanStderr = createListenPortScanner(reportBoundPort);
+	// Skipped under AO_KEEP_DAEMON: stdio is redirected to a log file (no pipes
+	// to scan), so port discovery falls back to the running.json handshake below.
+	if (!keep) {
+		const scanStdout = createListenPortScanner(reportBoundPort);
+		const scanStderr = createListenPortScanner(reportBoundPort);
 
-	child.stdout.on("data", (chunk: Buffer) => {
-		const text = chunk.toString("utf8");
-		console.log(text.trimEnd());
-		scanStdout(text);
-	});
+		child.stdout?.on("data", (chunk: Buffer) => {
+			const text = chunk.toString("utf8");
+			console.log(text.trimEnd());
+			scanStdout(text);
+		});
 
-	child.stderr.on("data", (chunk: Buffer) => {
-		const text = chunk.toString("utf8");
-		console.error(text.trimEnd());
-		scanStderr(text);
-	});
+		child.stderr?.on("data", (chunk: Buffer) => {
+			const text = chunk.toString("utf8");
+			console.error(text.trimEnd());
+			scanStderr(text);
+		});
+	}
 
 	const handshakePath = runFilePath();
 	if (handshakePath) {
@@ -940,7 +1003,7 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 // behind the /bin/sh wrapper (and any PTY children it forked), not just the
 // shell. Falls back to a direct kill if the group signal can't be delivered
 // (e.g. the process already exited).
-function killDaemon(child: ChildProcessWithoutNullStreams): void {
+function killDaemon(child: ChildProcess): void {
 	if (child.pid === undefined) return;
 	try {
 		process.kill(-child.pid, "SIGTERM");
@@ -1408,8 +1471,12 @@ app.on("before-quit", () => {
 // exits without tearing down sessions, which survive for the next boot to adopt.
 // When the link IS connected we do nothing here and rely on the OS closing the
 // fd on exit, which covers crash and SIGKILL uniformly.
+//
+// AO_KEEP_DAEMON opts out entirely: the daemon is deliberately spawned without a
+// supervisor link so it persists across app quit, so this orphan-cleanup kill
+// must be skipped — otherwise it would defeat the whole point on quit.
 process.on("exit", () => {
-	if (daemonProcess && !supervisorLink?.connected) {
+	if (daemonProcess && !supervisorLink?.connected && !keepDaemonAlive(process.env)) {
 		killDaemon(daemonProcess);
 	}
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -908,9 +908,12 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		//
 		// AO_KEEP_DAEMON opts out of the link entirely: the daemon is spawned but
 		// survives the window closing, stopping only on an explicit `ao stop`.
-		// Reuse the `keep` captured at spawn rather than re-reading process.env:
-		// the flag is a property of this spawn, not a value that should be able to
-		// flip between spawn and port-confirmation.
+		// Reuse the `keep` captured at spawn rather than re-reading process.env
+		// here: the flag is a property of this spawn, not a value that should be
+		// able to flip between spawn and port-confirmation. (The process.on("exit")
+		// orphan-cleanup below re-reads process.env because this `keep` is scoped
+		// to the spawn function — AO_KEEP_DAEMON is set once at startup and never
+		// mutated, so both reads agree.)
 		if (!keep) {
 			establishSupervisorLink();
 		}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -829,17 +829,21 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 	// running.json handshake (the log pipe scan is skipped).
 	const keep = keepDaemonAlive(process.env);
 	let keepDaemonLogFd: number | undefined;
-	const stdio: "pipe" | "ignore" | ["ignore", number, number] = keep
-		? (() => {
-				const logPath = path.join(os.homedir(), ".ao", "daemon.log");
-				try {
-					keepDaemonLogFd = openSync(logPath, "a");
-				} catch {
-					keepDaemonLogFd = undefined;
-				}
-				return keepDaemonLogFd !== undefined ? ["ignore", keepDaemonLogFd, keepDaemonLogFd] : "ignore";
-			})()
-		: "pipe";
+	// Under AO_KEEP_DAEMON the daemon's stdio is redirected to ~/.ao/daemon.log
+	// (stdin ignored) and the child is unref()'d below, so Electron-owned pipes
+	// don't kill the kept-alive daemon on the next stderr log write. If the log
+	// open fails, fall back to "ignore" — the daemon still runs, just unlogged.
+	let stdio: "pipe" | "ignore" | ["ignore", number, number] = "pipe";
+	if (keep) {
+		const logPath = path.join(os.homedir(), ".ao", "daemon.log");
+		try {
+			keepDaemonLogFd = openSync(logPath, "a");
+			stdio = ["ignore", keepDaemonLogFd, keepDaemonLogFd];
+		} catch {
+			keepDaemonLogFd = undefined;
+			stdio = "ignore";
+		}
+	}
 	let child: ChildProcess;
 	try {
 		child = spawn(launch.command, launch.args, {

--- a/frontend/src/main/daemon-owner.test.ts
+++ b/frontend/src/main/daemon-owner.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { shouldLinkOnAttach } from "./daemon-owner";
+import { keepDaemonAlive, shouldLinkOnAttach } from "./daemon-owner";
 
 describe("shouldLinkOnAttach", () => {
 	it('returns true when owner is "app"', () => {
@@ -17,5 +17,48 @@ describe("shouldLinkOnAttach", () => {
 
 	it('returns false when owner is "cli"', () => {
 		expect(shouldLinkOnAttach("cli")).toBe(false);
+	});
+
+	// Cross-launch regression (PR #2231 review): a daemon spawned with
+	// AO_KEEP_DAEMON is stamped owner:"persistent" in running.json. A LATER
+	// launch of the app — which may have AO_KEEP_DAEMON unset — must NOT
+	// re-establish the supervisor link from that durable owner, or closing the
+	// second instance would kill the supposedly-persistent daemon. The decision
+	// is read only from the daemon's record, never from the current process env.
+	it("does NOT re-link a persistent daemon on attach, even when AO_KEEP_DAEMON is unset now", () => {
+		expect(shouldLinkOnAttach("persistent")).toBe(false);
+	});
+});
+
+describe("keepDaemonAlive", () => {
+	it("returns false when AO_KEEP_DAEMON is unset", () => {
+		expect(keepDaemonAlive({})).toBe(false);
+	});
+
+	it("returns false when AO_KEEP_DAEMON is empty", () => {
+		expect(keepDaemonAlive({ AO_KEEP_DAEMON: "" })).toBe(false);
+	});
+
+	it.each(["1", "true", "TRUE", "yes", "on", "ON", "Yes"])("returns true for truthy value %j", (value) => {
+		expect(keepDaemonAlive({ AO_KEEP_DAEMON: value })).toBe(true);
+	});
+
+	// Explicit allowlist (PR #2231 review): conventional falsy values and any
+	// unrecognized string must NOT retain the daemon — "off"/"no" previously
+	// fell through the old "anything but 0/false" check and kept it alive.
+	it.each(["0", "false", "FALSE", "off", "OFF", "no", "No"])("returns false for conventional off value %j", (value) => {
+		expect(keepDaemonAlive({ AO_KEEP_DAEMON: value })).toBe(false);
+	});
+
+	it.each(["2", "random", "yep", "disable"])(
+		"returns false for unrecognized value %j (allowlist, not truthiness)",
+		(value) => {
+			expect(keepDaemonAlive({ AO_KEEP_DAEMON: value })).toBe(false);
+		},
+	);
+
+	it("trims surrounding whitespace before evaluating", () => {
+		expect(keepDaemonAlive({ AO_KEEP_DAEMON: "  0  " })).toBe(false);
+		expect(keepDaemonAlive({ AO_KEEP_DAEMON: "  1  " })).toBe(true);
 	});
 });

--- a/frontend/src/main/daemon-owner.ts
+++ b/frontend/src/main/daemon-owner.ts
@@ -1,7 +1,27 @@
 /**
+ * Whether the user opted the app's own daemon out of the app-lifetime link via
+ * the AO_KEEP_DAEMON env var. When set to an explicit truthy value ("1",
+ * "true", "yes", "on"), the app spawns the daemon but does NOT hold the
+ * supervisor link, so the daemon survives the window closing and stops only on
+ * an explicit `ao stop`. Any other value — including conventional falsy ones
+ * like "0"/"false"/"off"/"no" and unrecognized strings — is treated as unset, so
+ * the default desktop behavior holds: the daemon self-stops shortly after the
+ * app quits. An allowlist (rather than "anything but 0/false") keeps "off"/"no"
+ * from unexpectedly retaining the daemon.
+ */
+export function keepDaemonAlive(env: { AO_KEEP_DAEMON?: string }): boolean {
+	const raw = env.AO_KEEP_DAEMON?.trim().toLowerCase();
+	return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+/**
  * Whether the app should hold a supervisor link to a daemon it ATTACHED to
- * (did not spawn). Only re-link app-owned daemons (owner === "app"); leave
- * headless `ao start` daemons (owner unset or empty) unlinked so they stay
+ * (did not spawn). The decision is read from the daemon's durable owner record
+ * in running.json — NOT the current Electron process env, which can differ
+ * across launches (a cross-launch regression: a daemon spawned keep-alive must
+ * stay unlinked even when the app is later reopened without AO_KEEP_DAEMON).
+ * Only a normal app-owned daemon ("app") is linked; a keep-alive daemon
+ * ("persistent") and headless `ao start` daemons (owner unset/empty) stay
  * persistent across app quit.
  */
 export function shouldLinkOnAttach(owner: string | undefined): boolean {

--- a/frontend/src/shared/daemon-discovery.ts
+++ b/frontend/src/shared/daemon-discovery.ts
@@ -67,8 +67,11 @@ export type RunFileInfo = {
 	/** startedAt in epoch ms; 0 when missing/unparseable. */
 	startedAtMs: number;
 	/**
-	 * Daemon ownership tag. "app" when the desktop app spawned this daemon;
-	 * undefined/empty for a headless `ao start` daemon.
+	 * Daemon ownership tag — read from running.json so the attach-path link
+	 * decision uses the daemon's durable record, not the current process env.
+	 * "app" = desktop-spawned (re-link on attach); "persistent" = spawned under
+	 * AO_KEEP_DAEMON (stays alive across app quit, never re-linked);
+	 * undefined/empty = headless `ao start` daemon.
 	 */
 	owner?: string;
 };


### PR DESCRIPTION
Combines two independent, non-overlapping changes into one PR (frontend desktop layer + backend config layer; no shared files). Each was previously open separately (#2231 and #2611) and closed by accident when their head branches were removed during a fork cleanup — this re-opens both, with all maintainer review comments addressed.

Closes #2230. Closes #2195.

---

## Part 1 — `AO_KEEP_DAEMON` (desktop keep-alive) — closes #2230

Opt-in env var: when set, the desktop app spawns its daemon **without** the OS-native supervisor link and skips the orphan-cleanup kill on exit, so the daemon persists across app quit and stops only on an explicit `ao stop`. Default (unset) is byte-for-byte unchanged — the daemon self-stops shortly after the app quits.

Beyond \"power users with long sessions,\" the persistent-daemon mode is a prerequisite for a **detached / remote** topology (a headless daemon in a container, attached from the desktop over an SSH tunnel): without it, closing the desktop window arms-then-fires the supervisor watchdog and kills every running agent session in the container.

Both maintainer (illegalcall) review comments are addressed in the included commits:

- **Cross-launch regression (persist the keep decision with the daemon):** the keep decision is read from the daemon's durable `running.json` owner record (`\"persistent\"` vs `\"app\"`), never the current Electron process env. A daemon spawned keep-alive stays persistent even when the app is later reopened **without** `AO_KEEP_DAEMON`. `shouldLinkOnAttach(\"persistent\") === false` is encoded as a regression test.
- **fd leak:** the parent's `keepDaemonLogFd` is closed immediately after `spawn()` (the child holds its own inherited copy via stdio) and on the spawn-throw path, so each keep-alive start/stop cycle no longer accumulates descriptors.
- **stdio lifetime:** under the flag the daemon's stdio is redirected to `~/.ao/daemon.log` (stdin ignored) and the child is `unref()`'d, so Electron-owned pipes no longer kill the kept-alive daemon on the next stderr log write.
- **truthy parsing:** `keepDaemonAlive` uses an explicit allowlist (`1`/`true`/`yes`/`on`); `off`/`no` and any unrecognized string keep the default self-stop behavior.

Files: `frontend/src/main.ts`, `frontend/src/main/daemon-owner.ts(.test.ts)`, `frontend/src/shared/daemon-discovery.ts`, `backend/internal/runfile/runfile.go`, `docs/cli/README.md`.

## Part 2 — per-role worker environment profile (claude-code) — closes #2195

Widens the per-role `RoleOverride` beyond `{agent, model, permissions}` into a full worker environment profile: **system prompt, env, MCP servers, plugins** — scoped per role (worker/orchestrator), defaulting to inherit-everything so nothing breaks. claude-code ships a CLI flag for each aspect (`--append-system-prompt`, `--mcp-config`, `--strict-mcp-config`, `--plugin-dir`/`--plugin-url`).

- **domain** (`agentconfig.go`): `AgentConfig` gains `SystemPrompt`, `Env`, `MCP *MCPConfig`, `PluginDirs`; `MCPConfig{Configs, Strict}` (Strict alone = isolation, valid).
- **session manager**: `effectiveAgentConfig` merges the new fields — Env per-key via deep-copying `mergeEnv` (a regression test pins that it never mutates the project config), and the MCP pointer / PluginDirs slice are copied rather than aliased (same defense-in-depth). `buildSystemPrompt` appends the per-role prompt; role `Env` layers onto `project.Env` at spawn + restore.
- **adapter claudecode**: `appendMCPFlags` / `appendPluginFlags` emit in **both** `GetLaunchCommand` and `GetRestoreCommand` (resume rebuilds from flags); both paths call `cfg.Config.Validate()` for symmetry. nil/empty → inherit global, unchanged.
- **CLI**: `--worker-mcp-config` (repeatable), `--worker-strict-mcp`, `--worker-plugin-dir` (repeatable); full surface also via `--config-json`. UI deferred to a follow-up.
- Regen: `openapi.yaml` + `frontend/src/api/schema.ts`.

**Scope of Part 2:** claude-code only this pass. codex/other adapters inherit as today (follow-up).

## Verification

- `gofmt` + `go vet` clean; affected Go suites pass (`session_manager`, `claudecode`, `domain`, `cli`, `runfile`).
- `tsc --noEmit` clean; 26 `daemon-owner` tests pass (incl. the cross-launch and allowlist cases).
- Local review (Claude subagent + Codex adversarial, both approve) on each part independently: no critical issues, all high-risk areas pass (env-merge mutation leak fixed; restore re-applies MCP/plugin flags; nil/empty preserves default behavior; cross-launch keep decision persisted on the daemon record).

## Note

claude-code requires `--mcp-config` values in the `{\"mcpServers\": {...}}` shape (not a bare server JSON) — a user-config detail worth documenting when the UI lands.