### PR TITLE
fix: attribute cross-fork PRs pushed to a non-origin remote

### DIFF
--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -193,11 +193,17 @@ type subject struct {
 
 // sessionRepo pairs a live session with a repo to scan and its branch for
 // per-repo branch-prefix discovery of new (including stacked) pull requests.
-// A session is scanned against its push origin plus every other remote in the
-// project checkout, so repo is the repo whose open-PR list is listed while
-// headRepo is the repo the session's head branch actually lives in (the push
-// origin). For same-repo PRs repo == headRepo; for a cross-fork PR (fork head,
-// upstream base) repo is the upstream base and headRepo is the fork origin.
+// repo is the repo whose open-PR list is scanned; headRepo is a candidate for
+// the repo the session's head branch actually lives in (the push remote).
+// Since the actual push remote isn't tracked per-session, discoverSubjects
+// pairs each scanned remote with every remote in the project checkout
+// (including itself) as a headRepo candidate. For same-repo PRs repo ==
+// headRepo; for a cross-fork PR (e.g. project origin is the upstream repo,
+// session pushes to a separate fork remote) repo is the upstream base being
+// scanned and headRepo is the fork the branch actually lives in.
+// candidatesForHeadRepo strictly matches a candidate's headRepo against the
+// PR's actual GitHub head repo, so pairing extra combinations only enables
+// correct attribution and can never misattribute a stranger's PR.
 type sessionRepo struct {
 	session  domain.SessionRecord
 	repo     ports.SCMRepo
@@ -471,8 +477,21 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 			o.logger.Debug("scm observer: project has no supported SCM origin", "project", proj.ID, "origin", proj.RepoOriginURL)
 			continue
 		}
-		for _, repo := range scanRepos[sess.ProjectID] {
-			sessionRepos = append(sessionRepos, sessionRepo{session: sess, repo: repo, headRepo: origin, branch: branch})
+		projRepos := scanRepos[sess.ProjectID]
+		for _, repo := range projRepos {
+			// The push remote for this session's branch is not tracked
+			// per-session, so pair this scanned repo's open-PR list against
+			// every remote in the checkout as a headRepo candidate (including
+			// itself). candidatesForHeadRepo below strictly matches against
+			// the PR's actual GitHub head repo, and matchSession additionally
+			// requires a branch-prefix match, so over-generating candidates
+			// here cannot misattribute a stranger's PR -- it only allows a
+			// genuine cross-fork PR (e.g. project origin is the upstream repo,
+			// session pushes to a separate 'fork' remote) to be attributed
+			// correctly instead of being silently dropped.
+			for _, head := range projRepos {
+				sessionRepos = append(sessionRepos, sessionRepo{session: sess, repo: repo, headRepo: head, branch: branch})
+			}
 		}
 		prs, err := o.store.ListPRsBySession(ctx, sess.ID)
 		if err != nil {
@@ -495,11 +514,11 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 }
 
 // resolveScanRepos returns the deduped set of repos whose open-PR lists should be
-// scanned to attribute PRs to this project's sessions: the push origin plus every
-// other GitHub remote configured in the project checkout (upstreams, mirrors).
-// Attribution still requires a PR's head branch to live in the origin, so scanning
-// extra remotes only surfaces cross-fork PRs (fork head, upstream base) and can
-// never misattribute a stranger's PR.
+// scanned to attribute PRs to this project's sessions: the project origin plus
+// every other GitHub remote configured in the project checkout (upstreams,
+// mirrors, fork remotes used to push branches). Attribution still requires a
+// PR's head branch to live in one of these same remotes (see sessionRepo), so
+// scanning extra remotes can never misattribute a stranger's PR.
 //
 // ponytail: remotes are read once per project per process (memoized by the
 // caller); a remote added after the daemon started is picked up on restart. Move

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -621,6 +621,71 @@ func TestPoll_DiscoversCrossForkPRFromUpstreamRemote(t *testing.T) {
 	}
 }
 
+// When the project's registered origin is itself the upstream base (the usual
+// AO project-add flow) and the session pushes its branch to a separate 'fork'
+// remote configured in the checkout, the PR opened against origin has its head
+// in the fork, not the origin. This must still be attributed to the owning
+// session (issue #2609): scanning origin's own open-PR list must consider
+// every other checkout remote, not just origin itself, as a headRepo
+// candidate.
+func TestPoll_DiscoversCrossForkPRPushedToForkRemote(t *testing.T) {
+	dir := t.TempDir()
+	mustGit(t, "init", dir)
+	mustGit(t, "-C", dir, "remote", "add", "origin", "https://github.com/o/r.git")
+	mustGit(t, "-C", dir, "remote", "add", "fork", "https://github.com/contributor/r.git")
+
+	fork := ports.SCMRepo{Provider: "github", Host: "github.com", Owner: "contributor", Name: "r", Repo: "contributor/r"}
+	store := &fakeStore{
+		sessions: []domain.SessionRecord{{ID: "p-1", ProjectID: "p", Metadata: domain.SessionMetadata{Branch: "ao/p-1/root"}}},
+		projects: map[string]domain.ProjectRecord{"p": {ID: "p", Path: dir, RepoOriginURL: "https://github.com/o/r.git"}},
+		prs:      map[domain.SessionID][]domain.PullRequest{},
+		checks:   map[string][]domain.PullRequestCheck{},
+	}
+	forkObs := ports.SCMObservation{
+		Fetched: true, Provider: "github", Host: "github.com", Repo: "o/r",
+		PR:           ports.SCMPRObservation{URL: "https://github.com/o/r/pull/1", Number: 1, State: "open", SourceBranch: "ao/p-1/feat", HeadRepo: "contributor/r", TargetBranch: "main", HeadSHA: "sha1", Title: "PR"},
+		CI:           ports.SCMCIObservation{Summary: string(domain.CIPassing), HeadSHA: "sha1"},
+		Review:       ports.SCMReviewObservation{Decision: string(domain.ReviewNone)},
+		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeMergeable), Mergeable: true},
+	}
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "origin"}, prKey(fork, 0): {ETag: "fork"}},
+		openPRs: map[string][]ports.SCMPRObservation{
+			prKey(testRepo, 0): {{URL: "https://github.com/o/r/pull/1", Number: 1, SourceBranch: "ao/p-1/feat", HeadRepo: "contributor/r", TargetBranch: "main", HeadSHA: "sha1"}},
+		},
+		observations: map[string]ports.SCMObservation{prKey(testRepo, 1): forkObs},
+	}
+	lc := &fakeLifecycle{}
+	obs := newTestObserver(store, provider, lc, time.Unix(1, 0).UTC())
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.writes) == 0 {
+		t.Fatal("expected cross-fork PR write")
+	}
+	got := store.writes[0].pr
+	if got.SessionID != "p-1" {
+		t.Fatalf("session id = %q, want p-1", got.SessionID)
+	}
+	if got.Repo != "o/r" {
+		t.Fatalf("pr repo = %q, want o/r (project origin)", got.Repo)
+	}
+	if got.SourceBranch != "ao/p-1/feat" {
+		t.Fatalf("source branch = %q, want ao/p-1/feat", got.SourceBranch)
+	}
+	fetched := false
+	for _, batch := range provider.fetchBatches {
+		for _, ref := range batch {
+			if ref.Repo.Repo == "o/r" && ref.Number == 1 {
+				fetched = true
+			}
+		}
+	}
+	if !fetched {
+		t.Fatalf("cross-fork PR must be refreshed against origin, batches=%#v", provider.fetchBatches)
+	}
+}
+
 // A PR on a scanned upstream remote whose head lives in some third-party fork
 // (not this project's origin) must never be attributed, even though its branch
 // name matches a session. Scanning extra remotes stays safe.


### PR DESCRIPTION
## Summary
- `discoverSubjects` hardcoded `headRepo` to the project's registered origin for every scanned remote, so a PR whose head branch actually lives in a different checkout remote (e.g. a personal `fork` remote used to push branches — the standard OSS contribution pattern) never matched in `candidatesForHeadRepo` and was silently dropped, leaving "no PR yet" forever even though the PR was real and open.
- Fix: pair each scanned repo against every remote in the checkout (including itself) as a `headRepo` candidate, instead of always using origin. `candidatesForHeadRepo` still strictly matches against the PR's actual GitHub head repo, and `matchSession` still requires a branch-prefix match, so over-generating candidates cannot misattribute a stranger's PR — it only allows a genuine cross-fork PR to be attributed correctly instead of dropped.

Fixes #2609

## Test plan
- [x] `cd backend && go build ./...`
- [x] `cd backend && go test ./...` (all pass except 4 pre-existing, unrelated `internal/cli` spawn-command failures that also fail on `main` without this change)
- [x] Added `TestPoll_DiscoversCrossForkPRPushedToForkRemote` covering the exact scenario from the issue: project origin is the upstream base, session pushes to a separate `fork` remote, and the PR opened against origin has its head in the fork — verified this test fails without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)