### PR TITLE
fix(amp): remove unsupported --permission-mode CLI flags

### DIFF
--- a/backend/internal/adapters/agent/amp/amp.go
+++ b/backend/internal/adapters/agent/amp/amp.go
@@ -68,7 +68,6 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	}
 
 	cmd = []string{binary}
-	appendPermissionFlags(&cmd, cfg.Permissions)
 	return cmd, nil
 }
 
@@ -125,16 +124,6 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	return cmd, true, nil
 }
 
-func appendPermissionFlags(cmd *[]string, mode ports.PermissionMode) {
-	switch mode {
-	case ports.PermissionModeAcceptEdits:
-		*cmd = append(*cmd, "--permission-mode", "acceptEdits")
-	case ports.PermissionModeAuto:
-		*cmd = append(*cmd, "--permission-mode", "auto")
-	case ports.PermissionModeBypassPermissions:
-		*cmd = append(*cmd, "--permission-mode", "bypassPermissions")
-	}
-}
 
 var ampBinarySpec = binaryutil.BinarySpec{
 	Label:         "amp",

--- a/backend/internal/adapters/agent/amp/amp.go
+++ b/backend/internal/adapters/agent/amp/amp.go
@@ -116,10 +116,8 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if err != nil {
 		return nil, false, err
 	}
-	// Capacity fits binary + up to two permission flags + --resume + sessionID.
-	cmd = make([]string, 0, 5)
+	cmd = make([]string, 0, 3)
 	cmd = append(cmd, binary)
-	appendPermissionFlags(&cmd, cfg.Permissions)
 	cmd = append(cmd, "--resume", agentSessionID)
 	return cmd, true, nil
 }

--- a/backend/internal/adapters/agent/amp/amp_test.go
+++ b/backend/internal/adapters/agent/amp/amp_test.go
@@ -69,7 +69,7 @@ func TestGetLaunchCommandBypassWithPromptLeavesPromptForAfterStartDelivery(t *te
 		t.Fatal(err)
 	}
 
-	want := []string{"amp", "--permission-mode", "bypassPermissions"}
+	want := []string{"amp"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
 	}
@@ -84,9 +84,9 @@ func TestGetLaunchCommandMapsPermissionModes(t *testing.T) {
 	}{
 		{"default omits flag", ports.PermissionModeDefault, []string{"amp"}, "--permission-mode"},
 		{"empty omits flag", "", []string{"amp"}, "--permission-mode"},
-		{"accept edits", ports.PermissionModeAcceptEdits, []string{"amp", "--permission-mode", "acceptEdits"}, ""},
-		{"auto", ports.PermissionModeAuto, []string{"amp", "--permission-mode", "auto"}, ""},
-		{"bypass", ports.PermissionModeBypassPermissions, []string{"amp", "--permission-mode", "bypassPermissions"}, ""},
+		{"accept edits omits flag", ports.PermissionModeAcceptEdits, []string{"amp"}, "--permission-mode"},
+		{"auto omits flag", ports.PermissionModeAuto, []string{"amp"}, "--permission-mode"},
+		{"bypass omits flag", ports.PermissionModeBypassPermissions, []string{"amp"}, "--permission-mode"},
 	}
 
 	for _, tt := range tests {
@@ -169,7 +169,7 @@ func TestGetRestoreCommand(t *testing.T) {
 		t.Fatal("ok=false, want true")
 	}
 
-	want := []string{"amp", "--permission-mode", "bypassPermissions", "--resume", "T-abc123"}
+	want := []string{"amp", "--resume", "T-abc123"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}


### PR DESCRIPTION
## What

Removes `appendPermissionFlags` from the Amp adapter. Amp does not support `--permission-mode` CLI flags - its permission model is configured through settings/plugins (`amp.permissions`, `amp.guardedFiles.allowlist`, `amp.dangerouslyAllowAll`), not CLI arguments.

## Why

When AO launches Amp with a non-default permission mode, it builds commands like `amp --permission-mode acceptEdits` which can fail on startup or exit before opening the TUI. Projects that configure worker permissions globally make Amp workers fail to start even though plain `amp` works fine.

Closes #2561

## Changes

- Removed `appendPermissionFlags` function from `amp.go`
- Removed the call to `appendPermissionFlags` in `GetLaunchCommand`
- Removed the call to `appendPermissionFlags` in `GetRestoreCommand`
- Updated comment on `GetLaunchCommand` to reflect `amp` (no flags)
- Updated tests: all permission modes now produce just `{"amp"}` with no `--permission-mode` flags
- Updated restore command test to expect `{"amp", "--resume", "T-abc123"}` without permission flags

## Testing

All existing tests pass with the updated expectations. The test table in `TestGetLaunchCommandMapsPermissionModes` now verifies that every permission mode (default, acceptEdits, auto, bypass) omits `--permission-mode` from the command.