### PR TITLE
docs: enrich CONTRIBUTING.md and add issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug Report
+description: Report a bug to help us improve Agent Orchestrator
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below.
+        Make sure to search existing issues first to avoid duplicates.
+  
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      value: |
+        1. 
+        2. 
+        3. 
+    validations:
+      required: true
+  
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+  
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened.
+    validations:
+      required: true
+  
+  - type: input
+    id: version
+    attributes:
+      label: Agent Orchestrator version
+      description: Run `ao version` or check the desktop app About page.
+    validations:
+      required: true
+  
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS (Apple silicon)
+        - macOS (Intel)
+        - Windows
+        - Linux
+    validations:
+      required: true
+  
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant log output. Use code blocks.
+      render: shell
+  
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, or configuration details.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord Community
+    url: https://discord.com/invite/UZv7JjxbwG
+    about: Ask questions and get help from the community on Discord.
+  - name: Documentation
+    url: https://ao-agents.com/docs
+    about: Read the documentation for installation, usage, and architecture.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[feat] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please search existing issues first.
+  
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve?
+    validations:
+      required: true
+  
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What alternatives have you considered?
+  
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, or links that help explain the idea.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## What
+
+Brief description of what this PR changes.
+
+## Why
+
+Why is this change needed? Link the issue it addresses (e.g., Closes #NNN).
+
+## How
+
+How does this change work? Keep it concise but enough for a reviewer to understand the approach.
+
+## Testing
+
+- [ ] `cd backend && go build ./...` passes
+- [ ] `cd backend && go test ./...` passes
+- [ ] `cd frontend && npm run typecheck` passes (if frontend changes)
+- [ ] Tests cover the new or changed behavior
+- [ ] No unrelated changes or formatting churn
+
+## Checklist
+
+- [ ] Changes are surgical and focused on one concern
+- [ ] Follows coding conventions in [AGENTS.md](../AGENTS.md)
+- [ ] No changes to daemon bind host or auth (see AGENTS.md hard rules)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,18 +10,41 @@ We love contributions! Join our community on Discord to get started.
 
 Get your issues verified by core contributors, ask questions, share progress, and learn from the community. New contributors are always welcome!
 
-**Why join Discord?**
+## Ways to contribute
 
-- Get your issues and PRs verified by core contributors before investing time
-- Learn from experienced contributors in daily sync calls
-- Share your progress and get feedback
-- Get help troubleshooting in real-time
-- Stay updated on the latest developments and roadmap
+- **Code** - Fix a bug, add a feature, or improve performance. Browse [open issues](https://github.com/AgentWrapper/agent-orchestrator/issues) to find something to work on.
+- **Docs** - Improve README, architecture docs, or inline documentation. Clear docs help every contributor.
+- **Bug reports** - Found a bug? Open an issue using the Bug Report template and include reproduction steps.
+- **Feature requests** - Have an idea? Open an issue using the Feature Request template.
+- **Reviews** - Review open PRs. Testing and feedback on others' work is valuable.
+- **Community** - Help answer questions on Discord, share workflows, and welcome new contributors.
 
-## Quick Start
+## Before you start
 
-1. **Join the Discord** - Connect with the community and get guidance
-2. **Read the contributor contract** - See [AGENTS.md](AGENTS.md) for repo layout, daemon/API boundaries, and coding conventions
-3. **Pick a focused problem** - Browse [open issues](https://github.com/AgentWrapper/agent-orchestrator/issues) and choose one small enough for a focused PR
-4. **Open a clear PR** - Keep changes narrow, explain user-visible impact, link issues, include tests
-5. **Iterate with contributors** - Use review feedback to tighten the PR until verified
+1. **Read [AGENTS.md](AGENTS.md)** - It covers repo layout, daemon/API boundaries, coding conventions, and hard rules.
+2. **Check [docs/architecture.md](docs/architecture.md)** - Backend mental model, lifecycle, and persistence.
+3. **Read [docs/STATUS.md](docs/STATUS.md)** - What ships on `main` today and what is in flight.
+4. **Build and test locally** - `cd backend && go build ./... && go test ./...`
+
+## Claiming work
+
+To avoid duplicate effort:
+
+1. Find an issue you want to work on.
+2. Leave a comment on the issue saying you are picking it up.
+3. If no one has claimed it, start working. If someone already claimed it, coordinate with them on Discord.
+4. If you cannot finish, leave a comment so someone else can pick it up.
+
+## Opening a pull request
+
+1. Keep changes small and focused. One concern per PR.
+2. Use the pull request template (it will appear automatically when you create a PR).
+3. Run `cd backend && go build ./... && go test ./...` before pushing.
+4. For frontend changes, also run `cd frontend && npm run typecheck`.
+5. Link the issue your PR addresses using `Closes #NNN` syntax.
+6. Explain the **what**, **why**, and **how** in the PR description.
+7. Do not include unrelated changes or formatting churn.
+
+## Code of conduct
+
+Be respectful. Be patient. Be helpful. We are all here because we care about building something useful together. If you experience or witness behavior that makes the community unwelcoming, reach out to a maintainer on Discord.


### PR DESCRIPTION
## What

Enriches `CONTRIBUTING.md` and adds GitHub issue/PR templates to improve the contributor experience.

## Why

The current `CONTRIBUTING.md` is Discord-first and short (good), but thin on:
- Non-code contribution paths
- Issue claiming workflow
- Clear handoff to bug/feature/PR structure

There are also no GitHub issue/PR templates under `.github/`, so the guidance has nowhere to land in the UI.

Closes #2590

## Changes

### CONTRIBUTING.md
- Added "Ways to contribute" section (code, docs, bug reports, feature requests, reviews, community)
- Added "Before you start" section pointing to AGENTS.md, architecture.md, STATUS.md
- Added "Claiming work" section with issue claiming workflow to avoid duplicate effort
- Added "Opening a pull request" section with checklist
- Added "Code of conduct" one-liner
- Kept it short and CX-focused, still links AGENTS.md for deep technical details

### Issue templates (.github/ISSUE_TEMPLATE/)
- `bug_report.yml` - Structured bug report form (summary, reproduction, expected/actual, version, OS, logs)
- `feature_request.yml` - Feature request form (problem, solution, alternatives, context)
- `config.yml` - Disables blank issues, adds Discord and docs contact links

### PR template (.github/pull_request_template.md)
- What / Why / How / Testing structure
- Checklist for build, test, typecheck, conventions
- References AGENTS.md for hard rules

## Scope

No changes to AGENTS.md, no new CODE_OF_CONDUCT.md, no setup/command dump in CONTRIBUTING (stays in README / AGENTS.md / docs/).