### PR TITLE
fix: make project deletion tolerant of stale session state

### DIFF
--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -586,9 +586,7 @@ func (m *Service) Remove(ctx context.Context, id domain.ProjectID) (RemoveResult
 		return RemoveResult{}, apierr.NotFound("PROJECT_NOT_FOUND", "Unknown project")
 	}
 	if m.sessions != nil {
-		if err := m.sessions.TeardownProject(ctx, id); err != nil {
-			return RemoveResult{}, err
-		}
+		_ = m.sessions.TeardownProject(ctx, id)
 	}
 	ok, err = m.store.ArchiveProject(ctx, string(id), time.Now())
 	if err != nil {

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -238,7 +238,7 @@ func TestManager_RemoveTeardownsBeforeArchive(t *testing.T) {
 	wantCode(t, err, "PROJECT_NOT_FOUND")
 }
 
-func TestManager_RemoveDoesNotArchiveWhenTeardownFails(t *testing.T) {
+func TestManager_RemoveToleratesTeardownFailure(t *testing.T) {
 	ctx := context.Background()
 	store, err := sqlite.Open(t.TempDir())
 	if err != nil {
@@ -251,11 +251,15 @@ func TestManager_RemoveDoesNotArchiveWhenTeardownFails(t *testing.T) {
 	if _, err := m.Add(ctx, project.AddInput{Path: gitRepo(t), ProjectID: ptr("ao")}); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	if _, err := m.Remove(ctx, "ao"); !errors.Is(err, boom) {
-		t.Fatalf("Remove err = %v, want teardown failure", err)
+	rm, err := m.Remove(ctx, "ao")
+	if err != nil {
+		t.Fatalf("Remove err = %v, want nil (teardown failures should not block removal)", err)
 	}
-	if got, err := m.Get(ctx, "ao"); err != nil || got.Project == nil || got.Project.ID != "ao" {
-		t.Fatalf("project after failed remove = %#v, %v; want still active", got, err)
+	if rm.ProjectID != "ao" {
+		t.Fatalf("Remove result = %#v", rm)
+	}
+	if got, err := m.Get(ctx, "ao"); err == nil && got.Project != nil && got.Project.ID == "ao" {
+		t.Fatalf("project still active after remove despite teardown failure: %#v", got)
 	}
 }
 


### PR DESCRIPTION
## What

Makes project deletion (`DELETE /api/v1/projects/{id}`) robust to stale, legacy, or inconsistent session state by making session teardown errors non-fatal during project removal.

## Why

When a project has stale sessions (locked worktrees, archived project refs, missing runtime handles, etc.), `TeardownProject` returns an error and the entire `Remove` call fails with `INTERNAL_ERROR`. The project stays registered and the user has no recovery path from the UI.

The issue (#2598) explicitly says: "local project removal must be robust to stale, legacy, partially missing, or otherwise inconsistent AO-managed state. If the user asks to remove a local project registration, AO should work around bad session/worktree/runtime records and complete the unregister flow wherever it can do so without deleting unpurged session state."

Closes #2598

## How

Changed `Service.Remove` in `backend/internal/service/project/service.go` to ignore the error from `m.sessions.TeardownProject(ctx, id)` instead of propagating it. The project is still archived (soft-deleted) regardless of whether session teardown succeeded.

This means:
- Sessions that can be torn down, will be
- Sessions that cannot (stale, locked, missing) are left for later cleanup
- The project is always archived, so the user can re-add it without a blocked delete

## Testing

Updated `TestManager_RemoveDoesNotArchiveWhenTeardownFails` to `TestManager_RemoveToleratesTeardownFailure`. The test now verifies that:
- Remove succeeds (no error) even when teardown fails
- The project is archived (no longer active) after Remove returns

Run: `cd backend && go test ./internal/service/project/...`