### PR TITLE
fix(codex): prefer npm/cargo paths over WindowsApps on Windows

### DIFF
--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -175,16 +175,6 @@ func ResolveCodexBinary(ctx context.Context) (string, error) {
 	}
 
 	if runtime.GOOS == "windows" {
-		for _, name := range []string{"codex.exe", "codex.cmd", "codex"} {
-			path, err := exec.LookPath(name)
-			if err == nil && path != "" {
-				return resolveNativeWindowsCodex(path), nil
-			}
-			if err := ctx.Err(); err != nil {
-				return "", err
-			}
-		}
-
 		candidates := []string{}
 		if appData := os.Getenv("APPDATA"); appData != "" {
 			shim := filepath.Join(appData, "npm", "codex.cmd")
@@ -200,6 +190,16 @@ func ResolveCodexBinary(ctx context.Context) (string, error) {
 		for _, candidate := range candidates {
 			if fileExists(candidate) {
 				return resolveNativeWindowsCodex(candidate), nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+
+		for _, name := range []string{"codex.exe", "codex.cmd", "codex"} {
+			path, err := exec.LookPath(name)
+			if err == nil && path != "" && !isWindowsAppsPath(path) {
+				return resolveNativeWindowsCodex(path), nil
 			}
 			if err := ctx.Err(); err != nil {
 				return "", err
@@ -348,4 +348,8 @@ func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
 var fileExists = func(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
+}
+
+func isWindowsAppsPath(path string) bool {
+	return strings.Contains(strings.ToLower(filepath.ToSlash(path)), "windowsapps")
 }

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -122,6 +122,28 @@ func TestResolveCodexBinaryFindsNVMInstallWhenPathIsSparse(t *testing.T) {
 	}
 }
 
+
+func TestIsWindowsAppsPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"WindowsApps exe", "C:\\Program Files\\WindowsApps\\OpenAI.Codex_1.0\\app\\resources\\codex.exe", true},
+		{"npm codex.cmd", "C:\\Users\\user\\AppData\\Roaming\\npm\\codex.cmd", false},
+		{"cargo codex", "C:\\Users\\user\\.cargo\\bin\\codex.exe", false},
+		{"lowercase windowsApps", "c:\\program files\\windowsapps\\test\\codex.exe", true},
+		{"forward slashes", "C:/Program Files/WindowsApps/OpenAI.Codex/codex.exe", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isWindowsAppsPath(tt.path); got != tt.want {
+				t.Fatalf("isWindowsAppsPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetLaunchCommandMapsApprovalModes(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## What

On Windows, `ResolveCodexBinary` now checks known user-install paths (npm `codex.cmd`/`codex.exe`, cargo `codex.exe`) before falling back to `exec.LookPath`. When `exec.LookPath` is used as a last resort, paths under `WindowsApps` are skipped.

## Why

On Windows machines with both the WindowsApps packaged Codex and an npm-installed Codex CLI, `exec.LookPath("codex.exe")` resolves to the WindowsApps executable first. That binary cannot be launched directly by AO (Access denied), so the auth probe fails and the UI incorrectly shows `Codex - Needs auth` even though the npm Codex CLI is logged in.

Closes #2582

## How

1. Reorder the Windows resolution: check known npm/cargo candidate paths first, then fall back to `exec.LookPath` only if none exist.
2. Add `isWindowsAppsPath` filter to skip WindowsApps results from `exec.LookPath`, since those binaries cannot be spawned directly by the daemon.
3. Add `TestIsWindowsAppsPath` covering forward/back slashes, case sensitivity, and non-WindowsApps paths.

## Testing

- `TestIsWindowsAppsPath` passes on all platforms (pure string matching, no Windows required).
- Existing `TestResolveCodexBinaryFindsNVMInstallWhenPathIsSparse` still passes (Unix path resolution unchanged).
- The reorder only affects the Windows branch; non-Windows code paths are untouched.