### PR TITLE
feat: add PostHog active user heartbeat

### DIFF
--- a/backend/internal/adapters/telemetry/posthog_test.go
+++ b/backend/internal/adapters/telemetry/posthog_test.go
@@ -134,6 +134,64 @@ func TestPostHogSinkSanitizesPayloads(t *testing.T) {
 	}
 }
 
+func TestPostHogSinkSanitizesAppActivePayload(t *testing.T) {
+	requests := make(chan map[string]any, 1)
+	sink, err := NewPostHogSink(t.TempDir(), "phc_test", "https://us.i.posthog.com", roundTripClient(func(req *http.Request) (*http.Response, error) {
+		defer req.Body.Close()
+		var body map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			return nil, err
+		}
+		requests <- body
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       http.NoBody,
+		}, nil
+	}), nil)
+	if err != nil {
+		t.Fatalf("NewPostHogSink: %v", err)
+	}
+
+	sink.Emit(context.Background(), ports.TelemetryEvent{
+		Name:       "ao.app.active",
+		Source:     "cli",
+		OccurredAt: time.Unix(1700000000, 0).UTC(),
+		Level:      ports.TelemetryLevelInfo,
+		Payload: map[string]any{
+			"channel":      "cli",
+			"command":      "spawn",
+			"command_path": "ao spawn",
+			"ip":           "203.0.113.10",
+			"country":      "US",
+			"city":         "San Francisco",
+			"latitude":     37.7749,
+			"longitude":    -122.4194,
+		},
+	})
+	if err := sink.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	select {
+	case req := <-requests:
+		props, ok := req["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("properties type = %T, want map[string]any", req["properties"])
+		}
+		if props["channel"] != "cli" || props["command"] != "spawn" || props["command_path"] != "ao spawn" {
+			t.Fatalf("sanitized properties = %#v, want active CLI metadata", props)
+		}
+		for _, key := range []string{"ip", "country", "city", "latitude", "longitude"} {
+			if _, ok := props[key]; ok {
+				t.Fatalf("%s property should be dropped: %#v", key, props)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("PostHog sink did not send request")
+	}
+}
+
 type roundTripClient func(*http.Request) (*http.Response, error)
 
 func (f roundTripClient) Do(req *http.Request) (*http.Response, error) { return f(req) }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,36 +1,96 @@
 # Telemetry
 
-The Electron renderer sends anonymous usage events to PostHog automatically. The daemon is not involved.
+AO uses anonymous telemetry to understand reliability and product usage. The
+Electron renderer sends sanitized PostHog events directly, and the Go daemon can
+persist allowlisted events locally and fan them out to PostHog when remote
+telemetry is enabled.
 
 ## What is collected
 
-- App activation and renderer load events
-- Route views (home, project board, session detail, etc.)
-- Project add / remove actions (project path is SHA-256 hashed before transmission)
-- Unhandled renderer exceptions (error name and surface only)
-- AO app version context (`app_version` / `ao_version`, platform, build mode)
+- App activation events: `ao.app.active` from the renderer and CLI
+- Renderer load and route views, grouped by coarse surface names
+- Project/task/session UI actions, with project identifiers SHA-256 hashed
+- Renderer exceptions, reduced to error name and coarse context
+- Daemon operational events: CLI invocation, session spawn/failure, waiting-input
+  transitions, HTTP 5xx, and daemon panics
+- AO version context (`app_version` / `ao_version`), platform, and build mode
 
-PostHog session recording is also enabled. Network request names are masked before recording.
+PostHog session recording is enabled for the renderer. Network request names are
+masked before recording.
 
 ## Privacy
 
-Before any event or recording is transmitted:
+Before any renderer event or recording is transmitted:
 
-- Absolute file paths (`/home/…`, `/Users/…`, `C:\…`) are replaced with `[redacted-local-path]`
-- Local URLs (`file://`, `app://renderer`, `localhost`, `127.0.0.1`, `[::1]`) are replaced with `[redacted-local-url]`
-- Project IDs are one-way hashed (SHA-256) and never sent in plain text
+- Absolute file paths (`/home/...`, `/Users/...`, `C:\...`) are replaced with
+  `[redacted-local-path]`
+- Local URLs (`file://`, `app://renderer`, `localhost`, `127.0.0.1`, `[::1]`)
+  are replaced with `[redacted-local-url]`
+- Project IDs are one-way hashed and never sent in plain text
+
+Daemon events use a remote payload allowlist before PostHog export. Project and
+session IDs are hashed, and raw location/IP fields are not accepted from AO
+payloads. Geographic reporting should use PostHog's GeoIP enrichment only.
 
 ## Install ID
 
-On first run, a random install identifier is generated and stored at `~/.ao/data/telemetry_install_id` (or `$AO_DATA_DIR/telemetry_install_id`). This ID is used to deduplicate events across sessions. It is not linked to any personal account.
+On first run, a random install identifier is generated and stored at
+`~/.ao/data/telemetry_install_id` (or `$AO_DATA_DIR/telemetry_install_id`). The
+renderer and daemon both use this ID as the PostHog distinct ID so activity is
+deduplicated across app launches and CLI invocations. It is not linked to any
+personal account.
 
-## Overriding the PostHog endpoint or key
+## Configuration
 
-The key and host are baked in at build time. To point at your own PostHog instance, set these environment variables before building:
+Renderer PostHog key and host are baked in at build time. To point a build at
+another PostHog project, set these environment variables before building:
 
-```
+```bash
 VITE_AO_POSTHOG_KEY=phc_yourkey
 VITE_AO_POSTHOG_HOST=https://your-posthog-host.com
 ```
 
-Setting `VITE_AO_POSTHOG_KEY` to an empty string disables transmission entirely.
+Daemon event capture is off by default when the daemon is launched directly. The
+Electron supervisor starts the daemon with these defaults unless the environment
+already provides explicit values:
+
+```bash
+AO_TELEMETRY_EVENTS=on
+AO_TELEMETRY_REMOTE=posthog
+AO_TELEMETRY_POSTHOG_KEY=phc_yourkey
+AO_TELEMETRY_POSTHOG_HOST=https://us.i.posthog.com
+```
+
+Local daemon telemetry is retained in SQLite for 30 days.
+
+## PostHog Retention And Geography Dashboard
+
+Use `ao.app.active` as the active-user event for DAU, weekly retention, and
+country-level active-user maps. AO emits it from:
+
+- `channel=renderer` when the desktop app initializes and at most once per UTC
+  day while the app stays open
+- `channel=cli` when the CLI reports a command invocation to the local daemon
+
+Recommended PostHog setup:
+
+1. Enable PostHog GeoIP enrichment for the project.
+2. Create an "AO Active Users" dashboard.
+3. Add a Trends insight:
+   - Event: `ao.app.active`
+   - Aggregation: unique users
+   - Chart type: world map
+   - Breakdown: GeoIP country code, for example `$geoip_country_code`
+4. Add a Retention insight:
+   - Start event: `ao.app.active`
+   - Return event: `ao.app.active`
+   - Interval: weekly
+   - Range: last 12 weeks
+5. Add optional filters or breakdowns for `channel=renderer` and `channel=cli`
+   when comparing desktop app and CLI activity.
+
+PostHog references:
+
+- GeoIP enrichment: https://posthog.com/docs/cdp/geoip-enrichment
+- Trends insights: https://posthog.com/docs/product-analytics/trends
+- Retention insights: https://posthog.com/docs/product-analytics/retention

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildTelemetryContext,
+	reserveDailyActiveCapture,
 	routeSurface,
 	sanitizePostHogEvent,
 	sanitizeReplayRequestName,
 	sanitizeRendererExceptionProperties,
 	sanitizeRendererProperties,
+	startDailyActiveHeartbeat,
 } from "./telemetry";
+
+function memoryStorage(initial: Record<string, string> = {}) {
+	const values = new Map(Object.entries(initial));
+	return {
+		getItem: (key: string) => values.get(key) ?? null,
+		setItem: (key: string, value: string) => {
+			values.set(key, value);
+		},
+	};
+}
 
 describe("telemetry sanitizers", () => {
 	it("builds stable AO version context for PostHog events", () => {
@@ -41,6 +53,18 @@ describe("telemetry sanitizers", () => {
 			search: "?token=secret",
 		});
 		expect(routeProps).toEqual({ surface: "project_board" });
+	});
+
+	it("keeps only the renderer channel on app active events", async () => {
+		const props = await sanitizeRendererProperties("ao.app.active", {
+			channel: "renderer",
+			project_id: "demo-project",
+			ip: "203.0.113.10",
+			country: "US",
+		});
+
+		expect(props).toEqual({ channel: "renderer" });
+		expect(await sanitizeRendererProperties("ao.app.active", { channel: "cli" })).toEqual({});
 	});
 
 	it("strips exception details down to coarse metadata", async () => {
@@ -221,5 +245,42 @@ describe("telemetry sanitizers", () => {
 		expect(
 			await sanitizeRendererProperties("ao.renderer.terminal_attach_failed", { reason: "something else" }),
 		).toEqual({});
+	});
+});
+
+describe("daily active heartbeat", () => {
+	it("reserves one active capture per UTC date", () => {
+		const storage = memoryStorage();
+
+		expect(reserveDailyActiveCapture(storage, new Date("2026-07-12T23:59:00.000Z"))).toBe(true);
+		expect(reserveDailyActiveCapture(storage, new Date("2026-07-12T23:59:59.000Z"))).toBe(false);
+		expect(reserveDailyActiveCapture(storage, new Date("2026-07-13T00:00:00.000Z"))).toBe(true);
+	});
+
+	it("emits at startup and then only after a later UTC date is observed on user activity", () => {
+		const storage = memoryStorage();
+		const captured: string[] = [];
+		let now = new Date("2026-07-12T08:00:00.000Z");
+
+		const stop = startDailyActiveHeartbeat({
+			storage,
+			now: () => now,
+			capture: () => captured.push(now.toISOString()),
+			window,
+			document,
+		});
+		try {
+			expect(captured).toEqual(["2026-07-12T08:00:00.000Z"]);
+
+			window.dispatchEvent(new Event("focus"));
+			document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+			expect(captured).toHaveLength(1);
+
+			now = new Date("2026-07-13T09:00:00.000Z");
+			window.dispatchEvent(new Event("focus"));
+			expect(captured).toEqual(["2026-07-12T08:00:00.000Z", "2026-07-13T09:00:00.000Z"]);
+		} finally {
+			stop();
+		}
 	});
 });

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -7,14 +7,29 @@ const POSTHOG_HOST = import.meta.env.VITE_AO_POSTHOG_HOST?.trim() || DEFAULT_POS
 const RELEASE_TAG = "2026-01-30";
 const REDACTED_LOCAL_URL = "[redacted-local-url]";
 const REDACTED_LOCAL_PATH = "[redacted-local-path]";
+const DAILY_ACTIVE_STORAGE_KEY = "ao.telemetry.lastActiveDate";
 const EMBEDDED_LOCAL_URL_PATTERN =
 	/(?:\bfile:\/\/\/\S+|\bapp:\/\/renderer\/\S+|\bhttps?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?\S*)/gi;
 
 let initPromise: Promise<boolean> | null = null;
 let errorHandlersBound = false;
 let telemetryContext: TelemetryProperties = {};
+let fallbackDailyActiveDate = "";
 
 type TelemetryProperties = Record<string, unknown>;
+type DailyActiveStorage = Pick<Storage, "getItem" | "setItem">;
+type DailyActiveEventTarget = {
+	addEventListener: (type: string, listener: EventListener, options?: AddEventListenerOptions) => void;
+	removeEventListener: (type: string, listener: EventListener, options?: EventListenerOptions) => void;
+};
+
+export type DailyActiveHeartbeatOptions = {
+	storage?: DailyActiveStorage;
+	now?: () => Date;
+	capture: () => void;
+	window: DailyActiveEventTarget;
+	document: DailyActiveEventTarget & Pick<Document, "visibilityState">;
+};
 
 export function buildTelemetryContext(appVersion: string, platform: string): TelemetryProperties {
 	const version = appVersion.trim() || "unknown";
@@ -28,6 +43,60 @@ export function buildTelemetryContext(appVersion: string, platform: string): Tel
 
 function withTelemetryContext(properties: TelemetryProperties): TelemetryProperties {
 	return { ...telemetryContext, ...properties };
+}
+
+export function reserveDailyActiveCapture(storage?: DailyActiveStorage, now = new Date()): boolean {
+	const utcDate = now.toISOString().slice(0, 10);
+	if (!storage) {
+		if (fallbackDailyActiveDate === utcDate) return false;
+		fallbackDailyActiveDate = utcDate;
+		return true;
+	}
+	try {
+		if (storage.getItem(DAILY_ACTIVE_STORAGE_KEY) === utcDate) return false;
+		storage.setItem(DAILY_ACTIVE_STORAGE_KEY, utcDate);
+		return true;
+	} catch {
+		if (fallbackDailyActiveDate === utcDate) return false;
+		fallbackDailyActiveDate = utcDate;
+		return true;
+	}
+}
+
+export function startDailyActiveHeartbeat({
+	storage,
+	now = () => new Date(),
+	capture,
+	window,
+	document,
+}: DailyActiveHeartbeatOptions): () => void {
+	const maybeCapture = () => {
+		if (reserveDailyActiveCapture(storage, now())) {
+			capture();
+		}
+	};
+	const onVisibilityChange = () => {
+		if (document.visibilityState === "visible") {
+			maybeCapture();
+		}
+	};
+	const activityEvents = ["pointerdown", "keydown"] as const;
+	const passiveOptions = { passive: true };
+
+	maybeCapture();
+	window.addEventListener("focus", maybeCapture);
+	document.addEventListener("visibilitychange", onVisibilityChange);
+	for (const event of activityEvents) {
+		document.addEventListener(event, maybeCapture, passiveOptions);
+	}
+
+	return () => {
+		window.removeEventListener("focus", maybeCapture);
+		document.removeEventListener("visibilitychange", onVisibilityChange);
+		for (const event of activityEvents) {
+			document.removeEventListener(event, maybeCapture);
+		}
+	};
 }
 
 function normalizeException(reason: unknown): Error {
@@ -293,10 +362,25 @@ export async function initTelemetry(): Promise<boolean> {
 			surface: "renderer",
 		});
 		bindErrorHandlers();
-		posthog.capture(
-			"ao.app.active",
-			withTelemetryContext(await sanitizeRendererProperties("ao.app.active", { channel: "renderer" })),
-		);
+		let storage: DailyActiveStorage | undefined;
+		try {
+			storage = window.localStorage;
+		} catch {
+			storage = undefined;
+		}
+		startDailyActiveHeartbeat({
+			storage,
+			window,
+			document,
+			capture: () => {
+				void (async () => {
+					posthog.capture(
+						"ao.app.active",
+						withTelemetryContext(await sanitizeRendererProperties("ao.app.active", { channel: "renderer" })),
+					);
+				})();
+			},
+		});
 		posthog.capture("ao.renderer.loaded", withTelemetryContext(await sanitizeRendererProperties("ao.renderer.loaded")));
 		return true;
 	})().catch(() => false);


### PR DESCRIPTION
Adds a daily PostHog ao.app.active heartbeat for the Electron renderer so active-user retention and country-level geography dashboards can count users who keep AO open across days. Keeps telemetry payloads sanitized, including backend coverage that location/IP-like fields are dropped before PostHog export.

Also updates telemetry docs to describe the current renderer plus daemon telemetry paths and adds a PostHog setup recipe for GeoIP, trends, and retention dashboards.