### PR TITLE
chore(release): stamp desktop app version 0.10.3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "agent-orchestrator",
 	"productName": "Agent Orchestrator",
-	"version": "0.10.0",
+	"version": "0.10.3",
 	"private": true,
 	"description": "Electron + TypeScript frontend for the agent-orchestrator rewrite",
 	"author": "Agent Orchestrator",


### PR DESCRIPTION
## What

Stamp the desktop app version to **0.10.3** in `frontend/package.json` so the stable release cut resolves as `v0.10.3`.

## Why

Stable release builds read the version straight from `frontend/package.json` (`frontend-release.yml` does `v$(node -p "require('./package.json').version")`); unlike the nightly pipeline, the stable workflow does **not** stamp the version from the git tag. The committed value was still `0.10.0` (last touched in the 0.10.0 stamp, #2248), so cutting a release today would publish as `v0.10.0` and clobber the existing 0.10.0 release, and the stable update channel would never advance. This mirrors #2248 exactly (one-line stamp, `frontend/package.json` only).

## Scope

Bumps only `frontend/package.json` (the release-driving pin), matching the #2248 pattern. The `packages/ao*` npm CLI pins stayed at `0.10.0` through both the 0.10.1 and 0.10.2 stable cuts (they are not gated on the desktop release and are not published by CI), so they are intentionally left untouched here. Say the word if you want them synced too.

## Verification (local, on this branch)

- `backend`: `go build ./...` ✅, `go test ./...` ✅ (79 packages, clean env)
- `frontend`: `npm ci` ✅, `tsc --noEmit` ✅ (post-build), `vitest run` ✅, `electron-forge package` (full release build path) ✅
- Release workflow would now read `v0.10.3`.

## Release cut (maintainer, after merge — not done here)

This PR only bumps the version. Tagging, workflow dispatch, and the GitHub Release remain the release owner's manual step from `main`. The `publish-feed` job (needs `release` + `release-intel`) emits `latest.yml` / `latest-mac.yml` / `latest-linux.yml`, and `release-latest-guard.yml` enforces all three are present, so the #2270 missing-`latest-mac.yml` regression is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
