### PR TITLE
fix(board): show idle sessions as idle, not working

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -17,11 +17,11 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 
 import { SessionsBoard } from "./SessionsBoard";
 
-function renderBoard() {
+function renderBoard(projectId?: string) {
 	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	render(
 		<QueryClientProvider client={queryClient}>
-			<SessionsBoard />
+			<SessionsBoard projectId={projectId} />
 		</QueryClientProvider>,
 	);
 }
@@ -36,5 +36,36 @@ describe("SessionsBoard", () => {
 		renderBoard();
 
 		expect(screen.queryByText(/reload agents/i)).not.toBeInTheDocument();
+	});
+
+	it("labels an idle session as Idle, not Working", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					id: "p1",
+					name: "radic",
+					path: "/tmp/radic",
+					sessions: [
+						{
+							id: "s1",
+							workspaceId: "p1",
+							workspaceName: "radic",
+							title: "brand-font-pipeline",
+							provider: "claude-code",
+							branch: "ao/radic-5",
+							status: "idle",
+							activity: { state: "idle", lastActivityAt: "2026-01-01T00:00:00Z" },
+							updatedAt: "2026-01-01T00:00:00Z",
+							prs: [],
+						},
+					],
+				},
+			],
+			isError: false,
+		});
+
+		renderBoard("p1");
+
+		expect(screen.getByText("Idle")).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -525,6 +525,8 @@ function sessionBadge(session: WorkspaceSession): { label: string; className: st
 			return { label: "Merged", className: "text-passive" };
 		case "terminated":
 			return { label: "Terminated", className: "text-passive" };
+		case "idle":
+			return { label: "Idle", className: "text-passive" };
 		default:
 			return { label: "Working", className: "text-working" };
 	}

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -704,4 +704,25 @@ describe("Sidebar", () => {
 			cancelAnimationFrameSpy.mockRestore();
 		}
 	});
+
+	it("renders a calm non-pulsing dot for an idle session and a pulsing one for a working session", () => {
+		renderSidebar({
+			workspaces: [
+				{
+					...workspace,
+					sessions: [
+						{ ...session, id: "proj-1-idle", title: "idle task", status: "idle" },
+						{ ...session, id: "proj-1-work", title: "working task", status: "working" },
+					],
+				},
+			],
+		});
+
+		const idleDot = screen.getByLabelText("Open idle task").querySelector('span[aria-hidden="true"]');
+		expect(idleDot).toHaveClass("bg-passive");
+		expect(idleDot).not.toHaveClass("animate-status-pulse");
+
+		const workingDot = screen.getByLabelText("Open working task").querySelector('span[aria-hidden="true"]');
+		expect(workingDot).toHaveClass("animate-status-pulse", "bg-working");
+	});
 });

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -124,7 +124,8 @@ function SessionDot({ session }: { session: WorkspaceSession }) {
 			aria-hidden="true"
 			className={cn(
 				"mt-px h-1.5 w-1.5 shrink-0 rounded-full",
-				zone === "working" && "animate-status-pulse bg-working",
+				zone === "working" && session.status === "idle" && "bg-passive",
+				zone === "working" && session.status !== "idle" && "animate-status-pulse bg-working",
 				zone === "action" && (session.status === "ci_failed" ? "bg-error" : "bg-warning"),
 				zone === "pending" && "bg-passive",
 				zone === "merge" && "bg-success",


### PR DESCRIPTION
Idle agents that finished a turn were rendered as "Working" on the board, in the same orange style and with the same pulsing sidebar dot as an actively running agent, so a finished, waiting agent looked identical to a busy one. This change renders idle sessions as a distinct calm state: a gray "Idle" badge on the board card and a non-pulsing dot in the sidebar. Actively working agents keep the "Working" style, and sessions awaiting a real decision stay in "Needs you", so no new column is added and the four-zone board is unchanged.

## Testing

- `npm test`: 550 passed
- `npm run typecheck`: clean
- prettier check on changed files: clean
- Verified in the desktop app: a finished agent shows "Idle" instead of "Working", flips back to "Working" when it resumes, and a permission prompt shows "Needs you"

Fixes #2641