### PR TITLE
feat(terminal): insert dropped file paths like native terminals

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -30,7 +30,7 @@ import {
 } from "./main/update-settings";
 import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
-import { readdir, readFile, rm, stat } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -1203,6 +1203,20 @@ ipcMain.handle("clipboard:writeText", (_event, text: string) => {
 	}
 });
 ipcMain.handle("clipboard:readText", () => clipboard.readText());
+
+// A file dropped onto the terminal is delivered as raw bytes (its original path
+// is unavailable to the sandboxed renderer on macOS — see webUtils.getPathForFile
+// regressions in Electron 30-33). Stash the bytes under the app's own state dir
+// and return the path so the terminal can insert it, mirroring how a native
+// terminal inserts a dropped file's path.
+ipcMain.handle("terminal:saveDroppedFile", async (_event, input: { name: string; bytes: Uint8Array }) => {
+	const dir = path.join(app.getPath("userData"), "terminal-drops");
+	await mkdir(dir, { recursive: true });
+	const base = path.basename(input.name || "").replace(/[^\w.-]+/g, "_") || "dropped";
+	const target = path.join(dir, `${Date.now()}-${base}`);
+	await writeFile(target, Buffer.from(input.bytes));
+	return target;
+});
 
 ipcMain.handle("appState:getMigration", async (): Promise<MigrationState> => {
 	const runFile = runFilePath();

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -47,6 +47,10 @@ const api = {
 		scanImportFolder: (input: { path: string; mode: ImportFolderMode }) =>
 			ipcRenderer.invoke("app:scanImportFolder", input) as Promise<ImportFolderScan>,
 	},
+	terminal: {
+		saveDroppedFile: (input: { name: string; bytes: Uint8Array }) =>
+			ipcRenderer.invoke("terminal:saveDroppedFile", input) as Promise<string>,
+	},
 	window: {
 		setOverlay: (overlay: { color: string; symbolColor: string }) =>
 			ipcRenderer.invoke("window:setOverlay", overlay) as Promise<void>,

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -556,6 +556,39 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		host.addEventListener("paste", pasteInput, true);
 		host.addEventListener("compositionend", compositionInput, true);
 
+		// A file dropped on the pane inserts its path, mirroring a native terminal
+		// so an agent (e.g. Claude Code) attaches it. The sandboxed renderer cannot
+		// read a dropped file's original path on macOS, so the bytes are stashed to
+		// a temp file by the main process and that path is inserted instead.
+		const isFileDrag = (event: DragEvent) => Array.from(event.dataTransfer?.types ?? []).includes("Files");
+		const dragOverInput = (event: DragEvent) => {
+			if (!isFileDrag(event)) return;
+			event.preventDefault();
+			if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+		};
+		const dropInput = (event: DragEvent) => {
+			const files = Array.from(event.dataTransfer?.files ?? []);
+			if (files.length === 0) return;
+			event.preventDefault();
+			event.stopPropagation();
+			void (async () => {
+				const paths: string[] = [];
+				for (const file of files) {
+					try {
+						const bytes = new Uint8Array(await file.arrayBuffer());
+						const saved = await aoBridge.terminal.saveDroppedFile({ name: file.name, bytes });
+						if (saved) paths.push(saved);
+					} catch (error) {
+						console.warn("Unable to attach dropped file", error);
+					}
+				}
+				if (paths.length === 0) return;
+				pasteText(`${paths.map((p) => (/\s/.test(p) ? `'${p}'` : p)).join(" ")} `);
+			})();
+		};
+		host.addEventListener("dragover", dragOverInput);
+		host.addEventListener("drop", dropInput);
+
 		// Live cols/rows getters: the owner reads the current grid at attach time,
 		// not a snapshot taken at ready time (the first fit may not have run yet).
 		const handle: AttachableTerminal = {
@@ -589,6 +622,8 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			selectionChange.dispose();
 			host.removeEventListener("paste", pasteInput, true);
 			host.removeEventListener("compositionend", compositionInput, true);
+			host.removeEventListener("dragover", dragOverInput);
+			host.removeEventListener("drop", dropInput);
 			clearSuppressNativePaste();
 			keyInput.dispose();
 			userInputListeners.clear();

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -8,6 +8,9 @@ export const aoBridge: AoBridge =
 			chooseDirectory: async () => null,
 			scanImportFolder: async ({ path }) => ({ path, repos: [] }),
 		},
+		terminal: {
+			saveDroppedFile: async () => "",
+		},
 		window: {
 			setOverlay: async () => undefined,
 		},

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -60,6 +60,9 @@ if (typeof window !== "undefined") {
 			chooseDirectory: async () => null,
 			scanImportFolder: async ({ path }: { path: string }) => ({ path, repos: [] }),
 		},
+		terminal: {
+			saveDroppedFile: async () => "",
+		},
 		window: {
 			setOverlay: async () => undefined,
 		},


### PR DESCRIPTION
Dragging a file onto a session terminal did nothing, so a screenshot could not be attached to an agent from inside AO. This adds drop handling: the dropped file's bytes are stashed to a temp file by the main process and its path is inserted through the terminal's paste channel, mirroring a native terminal. Bytes are used rather than the path because a sandboxed renderer cannot resolve a dropped file's path on macOS (getPathForFile is empty for drag-drop in Electron 30-33).

Fixes #2643

Testing
- npm run typecheck / npm test / prettier: clean
- Verified in the app: dropping a screenshot inserts its path and the agent attaches it


https://github.com/user-attachments/assets/d4881b80-cc35-49a5-bb5b-b7f0ecfb823d

