### PR TITLE
fix(tmux): reap pane descendants on destroy

### DIFF
--- a/backend/internal/adapters/runtime/tmux/commands.go
+++ b/backend/internal/adapters/runtime/tmux/commands.go
@@ -45,8 +45,9 @@ func hasSessionArgs(id string) []string {
 
 // exactSessionTarget wraps id in tmux's exact-match prefix `=` so session-
 // selection commands (-t) target only the session with that precise name.
-// Only kill-session and has-session support this prefix; pane-targeting
-// commands (send-keys, capture-pane, set-option) use a plain session name.
+// Session-selection commands like kill-session, has-session, and list-panes
+// support this prefix; pane-targeting commands (send-keys, capture-pane,
+// set-option) use a plain session name.
 func exactSessionTarget(id string) string {
 	return "=" + id
 }

--- a/backend/internal/adapters/runtime/tmux/commands.go
+++ b/backend/internal/adapters/runtime/tmux/commands.go
@@ -51,6 +51,15 @@ func exactSessionTarget(id string) string {
 	return "=" + id
 }
 
+// listPanePIDsArgs builds args for `tmux list-panes -s -t =<id> -F #{pane_pid}`.
+// -s lists every pane in the whole session (not just the active window); the
+// exact-match target `=` avoids prefix collisions (see killSessionArgs). Each
+// #{pane_pid} is the pane's session-leader pid, used to reap the pane's
+// descendants when the session is destroyed.
+func listPanePIDsArgs(id string) []string {
+	return []string{"list-panes", "-s", "-t", exactSessionTarget(id), "-F", "#{pane_pid}"}
+}
+
 // sendKeysLiteralArgs builds args for `tmux send-keys -t <id> -l <chunk>`.
 // The -l flag stops tmux interpreting words like "Enter" as key names so the
 // text is sent verbatim.

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -31,7 +31,7 @@ const (
 	// defaultReapGrace is how long Destroy waits between SIGTERM and SIGKILL when
 	// reaping a pane's leftover background processes, giving them a chance to
 	// exit cleanly (release ports) before being forced (issue #2523).
-	defaultReapGrace = 2 * time.Second
+	defaultReapGrace = 5 * time.Second
 )
 
 var sessionIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
@@ -84,12 +84,19 @@ func killSessionsByPID(ctx context.Context, pids []int, grace time.Duration) {
 	defer cancel()
 
 	signalSessions(cleanupCtx, pids, "-TERM")
+	if !sessionsHaveProcesses(cleanupCtx, pids) {
+		return
+	}
+
 	timer := time.NewTimer(grace)
 	defer timer.Stop()
 	select {
 	case <-cleanupCtx.Done():
 		return
 	case <-timer.C:
+	}
+	if !sessionsHaveProcesses(cleanupCtx, pids) {
+		return
 	}
 	signalSessions(cleanupCtx, pids, "-KILL")
 }
@@ -100,6 +107,23 @@ func signalSessions(ctx context.Context, pids []int, sig string) {
 	for _, pid := range pids {
 		_ = exec.CommandContext(ctx, "pkill", sig, "-s", strconv.Itoa(pid)).Run()
 	}
+}
+
+// sessionsHaveProcesses reports whether any process remains in the pane
+// sessions. `pgrep` exit 1 means no matches; other failures are treated as
+// survivors so Destroy stays conservative and still attempts SIGKILL.
+func sessionsHaveProcesses(ctx context.Context, pids []int) bool {
+	for _, pid := range pids {
+		err := exec.CommandContext(ctx, "pgrep", "-s", strconv.Itoa(pid)).Run()
+		if err == nil || ctx.Err() != nil {
+			return true
+		}
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+			return true
+		}
+	}
+	return false
 }
 
 type execRunner struct{}

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -80,13 +80,18 @@ func killSessionsByPID(ctx context.Context, pids []int, grace time.Duration) {
 	if len(pids) == 0 {
 		return
 	}
-	signalSessions(ctx, pids, "-TERM")
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), grace+5*time.Second)
+	defer cancel()
+
+	signalSessions(cleanupCtx, pids, "-TERM")
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
 	select {
-	case <-ctx.Done():
+	case <-cleanupCtx.Done():
 		return
-	case <-time.After(grace):
+	case <-timer.C:
 	}
-	signalSessions(ctx, pids, "-KILL")
+	signalSessions(cleanupCtx, pids, "-KILL")
 }
 
 // signalSessions sends a pkill signal flag (e.g. "-TERM") to every process in

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -27,6 +28,10 @@ const (
 	// a non-empty message, before the trailing Enter, so a large multiline paste
 	// does not absorb the Enter and leave the prompt unsubmitted (issue #2342).
 	defaultEnterDelay = 300 * time.Millisecond
+	// defaultReapGrace is how long Destroy waits between SIGTERM and SIGKILL when
+	// reaping a pane's leftover background processes, giving them a chance to
+	// exit cleanly (release ports) before being forced (issue #2523).
+	defaultReapGrace = 2 * time.Second
 )
 
 var sessionIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
@@ -41,17 +46,20 @@ type Options struct {
 	Timeout    time.Duration // default 5s
 	ChunkSize  int           // default 16*1024
 	EnterDelay time.Duration // pause after pasting a non-empty message before pressing Enter; default defaultEnterDelay. Conpty already does this (ptyInputEnterDelay); tmux lacked it, so a large multiline paste could absorb the trailing Enter and leave the prompt unsubmitted (issue #2342).
+	ReapGrace  time.Duration // grace between SIGTERM and SIGKILL when reaping a pane's leftover background processes on Destroy; default defaultReapGrace.
 }
 
 // Runtime runs agent sessions inside tmux sessions, driving them via the tmux
 // CLI. It implements ports.Runtime.
 type Runtime struct {
-	binary     string
-	shell      string
-	timeout    time.Duration
-	chunkSize  int
-	enterDelay time.Duration
-	runner     runner
+	binary       string
+	shell        string
+	timeout      time.Duration
+	chunkSize    int
+	enterDelay   time.Duration
+	reapGrace    time.Duration
+	runner       runner
+	reapSessions func(ctx context.Context, pids []int, grace time.Duration)
 }
 
 var _ ports.Runtime = (*Runtime)(nil)
@@ -59,6 +67,34 @@ var _ ports.Attacher = (*Runtime)(nil)
 
 type runner interface {
 	Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error)
+}
+
+// killSessionsByPID force-terminates every process in each pid's tmux pane
+// session. tmux runs each pane in its own session (pane pid == session id), so
+// signaling the session reaps the pane's background children — e.g. a dev
+// server a worker started with `&` — that `kill-session`'s SIGHUP leaves
+// running. It SIGTERMs, waits grace for a clean exit, then
+// SIGKILLs survivors. Best-effort: `pkill` is absent on Windows, where tmux is
+// never the runtime, so the calls simply no-op there.
+func killSessionsByPID(ctx context.Context, pids []int, grace time.Duration) {
+	if len(pids) == 0 {
+		return
+	}
+	signalSessions(ctx, pids, "-TERM")
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(grace):
+	}
+	signalSessions(ctx, pids, "-KILL")
+}
+
+// signalSessions sends a pkill signal flag (e.g. "-TERM") to every process in
+// each pane session, matched by session id via `pkill -s`.
+func signalSessions(ctx context.Context, pids []int, sig string) {
+	for _, pid := range pids {
+		_ = exec.CommandContext(ctx, "pkill", sig, "-s", strconv.Itoa(pid)).Run()
+	}
 }
 
 type execRunner struct{}
@@ -100,13 +136,19 @@ func New(opts Options) *Runtime {
 	if enterDelay <= 0 {
 		enterDelay = defaultEnterDelay
 	}
+	reapGrace := opts.ReapGrace
+	if reapGrace <= 0 {
+		reapGrace = defaultReapGrace
+	}
 	return &Runtime{
-		binary:     binary,
-		shell:      shellPath,
-		timeout:    timeout,
-		chunkSize:  chunkSize,
-		enterDelay: enterDelay,
-		runner:     execRunner{},
+		binary:       binary,
+		shell:        shellPath,
+		timeout:      timeout,
+		chunkSize:    chunkSize,
+		enterDelay:   enterDelay,
+		reapGrace:    reapGrace,
+		runner:       execRunner{},
+		reapSessions: killSessionsByPID,
 	}
 }
 
@@ -160,14 +202,29 @@ func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.Ru
 	return handle, nil
 }
 
-// Destroy kills the handle's tmux session. An already-gone session is treated
-// as success (idempotent).
+// Destroy kills the handle's tmux session and reaps the pane processes it
+// leaves behind. `tmux kill-session` only SIGHUPs each pane's foreground
+// process, so a worker's backgrounded children (e.g. a dev server started with
+// `&`, later reparented to init) survive it and hold their ports indefinitely
+// (issue #2523). To catch those, Destroy records each pane's session id before
+// teardown and, after kill-session, signals the whole session (see
+// killSessionsByPID). An already-gone session is treated as success (idempotent).
 func (r *Runtime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error {
 	id, err := handleID(handle)
 	if err != nil {
 		return err
 	}
+	// Capture pane session ids while the session still exists; a missing
+	// session lists no panes and reaps nothing. Best-effort: failures here must
+	// not block the kill-session below.
+	sessionIDs := r.paneSessionIDs(ctx, id)
+
 	out, err := r.run(ctx, killSessionArgs(id)...)
+	// Reap regardless of the kill-session result: orphaned children outlive the
+	// session, so they must be cleaned up even when the session was already
+	// gone (a benign double-kill).
+	r.reapSessions(ctx, sessionIDs, r.reapGrace)
+
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && killSessionMissingOutput(string(out)) {
@@ -176,6 +233,27 @@ func (r *Runtime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 		return fmt.Errorf("tmux runtime: destroy session %s: %w", id, err)
 	}
 	return nil
+}
+
+// paneSessionIDs lists the pid of every pane in the session. tmux launches each
+// pane in its own session (setsid), so a pane's pid is also its session id —
+// the handle killSessionsByPID uses to reap the pane's descendants. Best-effort:
+// any error (including a missing session) or unparseable line yields no ids,
+// and pids <= 1 are skipped so we never signal init or the "current session".
+func (r *Runtime) paneSessionIDs(ctx context.Context, id string) []int {
+	out, err := r.run(ctx, listPanePIDsArgs(id)...)
+	if err != nil {
+		return nil
+	}
+	var ids []int
+	for _, line := range strings.Split(string(out), "\n") {
+		pid, convErr := strconv.Atoi(strings.TrimSpace(line))
+		if convErr != nil || pid <= 1 {
+			continue
+		}
+		ids = append(ids, pid)
+	}
+	return ids
 }
 
 // IsAlive reports whether the handle's session still exists via `tmux

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -40,13 +40,29 @@ func (f *fakeRunner) Run(_ context.Context, env []string, name string, args ...s
 	return out, nil
 }
 
+// -- reapSessions test seam --
+
+// recordingReaper captures reapSessions calls instead of signaling real
+// processes, so unit tests exercising Destroy never touch the host's process
+// table.
+type recordingReaper struct {
+	pids   [][]int
+	graces []time.Duration
+}
+
+func (rr *recordingReaper) reap(_ context.Context, pids []int, grace time.Duration) {
+	rr.pids = append(rr.pids, append([]int(nil), pids...))
+	rr.graces = append(rr.graces, grace)
+}
+
 // -- helpers --
 
 func newTestRuntime(chunkSize int) (*Runtime, *fakeRunner) {
 	fr := &fakeRunner{}
 	r := New(Options{Binary: "tmux-test", Timeout: time.Second, Shell: "/bin/sh", ChunkSize: chunkSize})
 	r.runner = fr
-	r.enterDelay = 0 // tests must not pay the real 300ms pre-Enter pause
+	r.enterDelay = 0                           // tests must not pay the real 300ms pre-Enter pause
+	r.reapSessions = (&recordingReaper{}).reap // never signal real processes from unit tests
 	return r, fr
 }
 
@@ -88,6 +104,10 @@ func TestCommandBuilders(t *testing.T) {
 	}
 	if got, want := hasSessionArgs("sess-1"), []string{"has-session", "-t", "=sess-1"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("hasSessionArgs = %#v, want %#v", got, want)
+	}
+	// list-panes reaps whole-session (-s) with exact-match target and prints pane pids.
+	if got, want := listPanePIDsArgs("sess-1"), []string{"list-panes", "-s", "-t", "=sess-1", "-F", "#{pane_pid}"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("listPanePIDsArgs = %#v, want %#v", got, want)
 	}
 	if got, want := sendKeysLiteralArgs("sess-1", "hello"), []string{"send-keys", "-t", "sess-1", "-l", "hello"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("sendKeysLiteralArgs = %#v, want %#v", got, want)
@@ -328,20 +348,22 @@ func (f *fakeRunnerSelectiveErr) Run(_ context.Context, env []string, name strin
 
 func TestDestroyIsIdempotentWhenSessionMissing(t *testing.T) {
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{[]byte("can't find session: sess-1")}
+	// First output feeds list-panes (which also errors here → no sids); the
+	// missing-session marker must land on the kill-session call.
+	fr.outputs = [][]byte{nil, []byte("can't find session: sess-1")}
 	fr.err = &exec.ExitError{}
 
 	if err := r.Destroy(context.Background(), ports.RuntimeHandle{ID: "sess-1"}); err != nil {
 		t.Fatalf("Destroy: %v", err)
 	}
-	if len(fr.calls) != 1 || fr.calls[0].args[0] != "kill-session" {
-		t.Fatalf("calls = %#v, want only kill-session", fr.calls)
+	if len(fr.calls) != 2 || fr.calls[0].args[0] != "list-panes" || fr.calls[1].args[0] != "kill-session" {
+		t.Fatalf("calls = %#v, want list-panes then kill-session", fr.calls)
 	}
 }
 
 func TestDestroyIsIdempotentWhenNoServer(t *testing.T) {
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{[]byte("no server running on /tmp/tmux-1000/default")}
+	fr.outputs = [][]byte{nil, []byte("no server running on /tmp/tmux-1000/default")}
 	fr.err = &exec.ExitError{}
 
 	if err := r.Destroy(context.Background(), ports.RuntimeHandle{ID: "sess-1"}); err != nil {
@@ -351,7 +373,7 @@ func TestDestroyIsIdempotentWhenNoServer(t *testing.T) {
 
 func TestDestroyReportsUnexpectedFailures(t *testing.T) {
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{[]byte("permission denied")}
+	fr.outputs = [][]byte{nil, []byte("permission denied")}
 	fr.err = &exec.ExitError{}
 
 	if err := r.Destroy(context.Background(), ports.RuntimeHandle{ID: "sess-1"}); err == nil {
@@ -361,14 +383,43 @@ func TestDestroyReportsUnexpectedFailures(t *testing.T) {
 
 func TestDestroyArgs(t *testing.T) {
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{nil}
+	fr.outputs = [][]byte{nil, nil}
 
 	if err := r.Destroy(context.Background(), ports.RuntimeHandle{ID: "sess-1"}); err != nil {
 		t.Fatalf("Destroy: %v", err)
 	}
-	// killSessionArgs uses exact-match target =<id>.
-	if got, want := fr.calls[0].args, killSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	// list-panes discovers pane sessions; kill-session (exact-match target
+	// =<id>) tears the session down.
+	if got, want := fr.calls[0].args, listPanePIDsArgs("sess-1"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("list-panes args = %#v, want %#v", got, want)
+	}
+	if got, want := fr.calls[1].args, killSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("destroy args = %#v, want %#v", got, want)
+	}
+}
+
+// Destroy must reap the pane sessions it discovered so a worker's backgrounded
+// dev servers do not outlive the session.
+func TestDestroyReapsDiscoveredPaneSessions(t *testing.T) {
+	r, fr := newTestRuntime(0)
+	// list-panes lists two pane pids (one per line, plus noise the parser must
+	// drop); kill-session then succeeds.
+	fr.outputs = [][]byte{[]byte("4242\n4243\n\n1\n"), nil}
+	reaper := &recordingReaper{}
+	r.reapSessions = reaper.reap
+
+	if err := r.Destroy(context.Background(), ports.RuntimeHandle{ID: "sess-1"}); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if len(reaper.pids) != 1 {
+		t.Fatalf("reaper called %d times, want 1", len(reaper.pids))
+	}
+	// pids <= 1 and blank lines are dropped; the real sids reach the reaper.
+	if got, want := reaper.pids[0], []int{4242, 4243}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("reaped session ids = %#v, want %#v", got, want)
+	}
+	if reaper.graces[0] != r.reapGrace {
+		t.Fatalf("reap grace = %v, want %v", reaper.graces[0], r.reapGrace)
 	}
 }
 


### PR DESCRIPTION
## Summary
- list tmux pane session PIDs before destroying a session
- after kill-session, SIGTERM/SIGKILL those pane sessions to reap background descendants like dev servers
- add unit coverage for pane PID discovery and reaper invocation

## Scope
- This runs only when AO explicitly tears down the runtime, such as ao session kill, cleanup/reconcile paths, or other callers of Runtime.Destroy.
- It does not make lifecycle-manager terminal transitions call runtime teardown. That is intentional: lifecycle terminal state is a durable fact, not a resource-destruction command.
- Normal agent exit still leaves the tmux session available for user monitoring and terminal inspection; this change only tightens cleanup once teardown is explicitly requested.

## Validation
- go test ./internal/adapters/runtime/tmux

Refs #2523