### PR TITLE
feat(mobile): haptic feedback, and stop long session ids overflowing the card

### DIFF
--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -1,12 +1,14 @@
 import { Feather } from "@expo/vector-icons";
 import { Tabs } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { haptics } from "../../lib/haptics";
 import { theme } from "../../lib/theme";
 
 export default function TabsLayout() {
 	const insets = useSafeAreaInsets();
 	return (
 		<Tabs
+			screenListeners={{ tabPress: () => haptics.select() }}
 			screenOptions={{
 				headerShown: false,
 				tabBarActiveTintColor: theme.blue,

--- a/packages/mobile/app/(tabs)/index.tsx
+++ b/packages/mobile/app/(tabs)/index.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import { ActivityIndicator, Pressable, RefreshControl, SectionList, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { attentionOf, type DashboardSession } from "../../lib/api";
+import { haptics } from "../../lib/haptics";
 import { ProjectSwitcher } from "../../lib/ProjectSwitcher";
 import { SessionCard } from "../../lib/SessionCard";
 import { useApp, useVisibleSessions } from "../../lib/store";
@@ -54,6 +55,7 @@ export default function FleetScreen() {
 	}, [sessions]);
 
 	const onRefresh = useCallback(async () => {
+		haptics.tap();
 		setRefreshing(true);
 		await refresh();
 		setRefreshing(false);
@@ -127,7 +129,10 @@ export default function FleetScreen() {
 
 			{/* Spawn FAB */}
 			<Pressable
-				onPress={() => router.push("/spawn")}
+				onPress={() => {
+					haptics.tap();
+					router.push("/spawn");
+				}}
 				style={({ pressed }) => [styles.fab, pressed && { opacity: 0.85 }]}
 			>
 				<Feather name="plus" size={24} color="#06101f" />

--- a/packages/mobile/app/(tabs)/orchestrator.tsx
+++ b/packages/mobile/app/(tabs)/orchestrator.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Alert, RefreshControl, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { attentionOf, type DashboardSession, type OrchestratorLink } from "../../lib/api";
+import { haptics } from "../../lib/haptics";
 import { useApp } from "../../lib/store";
 import { attentionMeta, statusVisual, theme, type AttentionLevel, type StatusVisual } from "../../lib/theme";
 import { Button, ConnectionPill, Dot, EmptyState, ScreenHeader } from "../../lib/ui";
@@ -19,6 +20,7 @@ export default function OrchestratorScreen() {
 	const visibleProjects = projects;
 
 	const onRefresh = async () => {
+		haptics.tap();
 		setRefreshing(true);
 		await refresh();
 		setRefreshing(false);

--- a/packages/mobile/app/(tabs)/prs.tsx
+++ b/packages/mobile/app/(tabs)/prs.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import { Linking, RefreshControl, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { DashboardPR, DashboardSession } from "../../lib/api";
+import { haptics } from "../../lib/haptics";
 import { ProjectSwitcher } from "../../lib/ProjectSwitcher";
 import { useApp, usePRs } from "../../lib/store";
 import { ciVisual, theme } from "../../lib/theme";
@@ -28,6 +29,7 @@ export default function PRsScreen() {
 	}, [prs, filter]);
 
 	const onRefresh = async () => {
+		haptics.tap();
 		setRefreshing(true);
 		await refresh();
 		setRefreshing(false);

--- a/packages/mobile/app/(tabs)/settings.tsx
+++ b/packages/mobile/app/(tabs)/settings.tsx
@@ -17,6 +17,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { pingServer } from "../../lib/api";
 import { DEFAULT_CONFIG, loadConfig, saveConfig, type ServerConfig } from "../../lib/config";
+import { haptics } from "../../lib/haptics";
 import { useApp } from "../../lib/store";
 import { theme } from "../../lib/theme";
 import { Button, ConnectionPill, ScreenHeader } from "../../lib/ui";
@@ -68,9 +69,11 @@ export default function SettingsScreen() {
 		try {
 			await saveConfig(target);
 			const count = await pingServer(target);
+			haptics.success();
 			setResult({ ok: true, msg: `Connected — ${count} session(s) found.` });
 			await reloadConfig();
 		} catch (e) {
+			haptics.error();
 			const msg = e instanceof Error ? e.message : "Could not reach server.";
 			setResult({ ok: false, msg });
 			// Wrong/missing password — reopen the prompt instead of leaving the

--- a/packages/mobile/app/session/[id].tsx
+++ b/packages/mobile/app/session/[id].tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
 import { getPreview, isTerminalStatus, killSession, sendMessage } from "../../lib/api";
 import { authHeaders, isConfigured, loadConfig, type ServerConfig } from "../../lib/config";
+import { haptics } from "../../lib/haptics";
 import { MuxClient, type MuxStatus } from "../../lib/mux";
 import { useApp } from "../../lib/store";
 import { theme } from "../../lib/theme";
@@ -721,9 +722,11 @@ export default function TerminalScreen() {
 		try {
 			const config = cfg ?? (await loadConfig());
 			await sendMessage(config, id, text);
+			haptics.success();
 			setMsg("");
 			setCompose(false);
 		} catch (e) {
+			haptics.error();
 			setBanner(`Send failed: ${e instanceof Error ? e.message : String(e)}`);
 		} finally {
 			setSending(false);
@@ -734,6 +737,7 @@ export default function TerminalScreen() {
 	// just shows/hides the overlay. A bare README (the detector's markdown fallback)
 	// reports "no preview yet" instead of surfacing an unbuilt repo doc.
 	const toggleBrowser = useCallback(() => {
+		haptics.tap();
 		if (browserOpen) {
 			setBrowserOpen(false);
 			return;
@@ -750,8 +754,10 @@ export default function TerminalScreen() {
 			try {
 				const config = cfg ?? (await loadConfig());
 				await killSession(config, id);
+				haptics.success();
 				leave();
 			} catch (e) {
+				haptics.error();
 				setBanner(`Kill failed: ${e instanceof Error ? e.message : String(e)}`);
 			}
 		};
@@ -759,6 +765,8 @@ export default function TerminalScreen() {
 			doKill();
 			return;
 		}
+		// Cautionary buzz as the destructive confirmation dialog is raised.
+		haptics.warning();
 		Alert.alert("Kill session?", `This stops ${id}.`, [
 			{ text: "Cancel", style: "cancel" },
 			{ text: "Kill", style: "destructive", onPress: doKill },

--- a/packages/mobile/app/spawn.tsx
+++ b/packages/mobile/app/spawn.tsx
@@ -13,6 +13,7 @@ import {
 	View,
 } from "react-native";
 import { getAgents, refreshAgents, type AgentCatalog, type AgentInfo } from "../lib/api";
+import { haptics } from "../lib/haptics";
 import { useApp } from "../lib/store";
 import { theme } from "../lib/theme";
 import { Button } from "../lib/ui";
@@ -112,8 +113,10 @@ export default function SpawnModal() {
 		setError(null);
 		try {
 			await spawn(prompt.trim() || undefined, projectId, harness || undefined);
+			haptics.success();
 			router.back();
 		} catch (e) {
+			haptics.error();
 			setError(e instanceof Error ? e.message : "Failed to spawn agent.");
 			setBusy(false);
 		}
@@ -132,7 +135,10 @@ export default function SpawnModal() {
 						<Pressable
 							key={p.id}
 							style={[styles.chip, projectId === p.id && styles.chipActive]}
-							onPress={() => setProjectId(p.id)}
+							onPress={() => {
+								haptics.select();
+								setProjectId(p.id);
+							}}
 						>
 							<Text style={[styles.chipText, projectId === p.id && styles.chipTextActive]}>{p.name}</Text>
 						</Pressable>
@@ -192,6 +198,7 @@ export default function SpawnModal() {
 									style={[styles.modalItem, harness === a.id && styles.modalItemActive]}
 									onPress={() => {
 										if (a.selectable) {
+											haptics.select();
 											setHarness(a.id);
 											setPickerOpen(false);
 										}

--- a/packages/mobile/lib/SessionCard.tsx
+++ b/packages/mobile/lib/SessionCard.tsx
@@ -1,7 +1,8 @@
 import { Feather } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { Pressable, StyleSheet, Text, View } from "react-native";
-import { sessionTitle, type DashboardSession } from "./api";
+import { sessionTitle, shortLabel, shortSessionId, type DashboardSession } from "./api";
+import { haptics } from "./haptics";
 import { ciColor, statusVisual, theme } from "./theme";
 import { Dot } from "./ui";
 
@@ -13,20 +14,27 @@ export function SessionCard({ session, showProject = false }: { session: Dashboa
 
 	return (
 		<Pressable
-			onPress={() =>
+			onPress={() => {
+				haptics.tap();
 				router.push({
 					pathname: "/session/[id]",
 					params: { id: session.id, projectId: session.projectId },
-				})
-			}
+				});
+			}}
 			style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
 		>
 			<View style={styles.top}>
 				<Dot color={v.color} breathing={v.breathing} size={8} />
 				<Text style={[styles.status, { color: v.color }]}>{v.label}</Text>
 				<View style={{ flex: 1 }} />
-				{showProject ? <Text style={styles.project}>{session.projectId}</Text> : null}
-				<Text style={styles.id}>{session.id}</Text>
+				{showProject ? (
+					<Text style={styles.project} numberOfLines={1}>
+						{shortLabel(session.projectId)}
+					</Text>
+				) : null}
+				<Text style={styles.id} numberOfLines={1}>
+					{shortSessionId(session)}
+				</Text>
 			</View>
 
 			<Text style={styles.title} numberOfLines={2}>
@@ -80,8 +88,12 @@ const styles = StyleSheet.create({
 		fontSize: 11,
 		fontFamily: theme.fontMono,
 		marginRight: 8,
+		// The labels are pre-shortened, but let the project still give way rather
+		// than push anything off the card if a name ever outgrows its budget.
+		flexShrink: 1,
 	},
-	id: { color: theme.textTertiary, fontSize: 11, fontFamily: theme.fontMono },
+	// The `#n` discriminator is what tells sibling sessions apart - never shrink it.
+	id: { color: theme.textTertiary, fontSize: 11, fontFamily: theme.fontMono, flexShrink: 0 },
 	title: { color: theme.textPrimary, fontSize: 15, fontWeight: "500", lineHeight: 20 },
 	meta: { flexDirection: "row", alignItems: "center", gap: 10, marginTop: 10 },
 	metaItem: { flexDirection: "row", alignItems: "center", gap: 4, flexShrink: 1 },

--- a/packages/mobile/lib/api.ts
+++ b/packages/mobile/lib/api.ts
@@ -423,6 +423,33 @@ export function sessionTitle(s: DashboardSession): string {
 	return s.displayName || s.issueTitle || s.userPrompt || s.summary || s.id;
 }
 
+// Project ids/names carry a generated hash suffix (`my-app_98d163a851`) and
+// session ids are minted as `<projectId>-<n>`. Printed in full on a phone that's
+// the same slug twice, wider than the card. These two helpers shorten each label
+// to something that still identifies it — only when it's actually too long.
+
+const MAX_LABEL = 20;
+
+// Middle-truncate. A plain tail-cut would drop the hash and make two projects
+// that share a base name render identically, so keep the head (the readable
+// part) AND the tail (the part that disambiguates).
+export function shortLabel(value: string, max = MAX_LABEL): string {
+	if (value.length <= max) return value;
+	const keep = max - 1; // room for the ellipsis
+	const head = Math.ceil(keep / 2);
+	const tail = Math.floor(keep / 2);
+	return `${value.slice(0, head)}…${value.slice(value.length - tail)}`;
+}
+
+// A session id is its project id plus a `-n` discriminator, so when that holds
+// the only new information is the discriminator — show `#n` rather than
+// reprinting the project slug. Ids that don't follow the convention fall back to
+// a middle-truncated label.
+export function shortSessionId(s: DashboardSession): string {
+	const rest = s.projectId && s.id.startsWith(s.projectId) ? s.id.slice(s.projectId.length).replace(/^[-_]/, "") : "";
+	return rest ? `#${rest}` : shortLabel(s.id);
+}
+
 // All PRs across sessions, de-duplicated by number+repo.
 export function collectPRs(sessions: DashboardSession[]): { pr: DashboardPR; session: DashboardSession }[] {
 	const seen = new Set<string>();

--- a/packages/mobile/lib/api.ts
+++ b/packages/mobile/lib/api.ts
@@ -446,8 +446,12 @@ export function shortLabel(value: string, max = MAX_LABEL): string {
 // reprinting the project slug. Ids that don't follow the convention fall back to
 // a middle-truncated label.
 export function shortSessionId(s: DashboardSession): string {
-	const rest = s.projectId && s.id.startsWith(s.projectId) ? s.id.slice(s.projectId.length).replace(/^[-_]/, "") : "";
-	return rest ? `#${rest}` : shortLabel(s.id);
+	const { projectId, id } = s;
+	// The separator is required: a bare `startsWith(projectId)` would also match a
+	// longer sibling slug (project `app`, session `apple-1`) and print `#le-1`.
+	const prefixed = projectId && (id.startsWith(`${projectId}-`) || id.startsWith(`${projectId}_`));
+	const rest = prefixed ? id.slice(projectId.length + 1) : "";
+	return rest ? `#${rest}` : shortLabel(id);
 }
 
 // All PRs across sessions, de-duplicated by number+repo.

--- a/packages/mobile/lib/haptics.ts
+++ b/packages/mobile/lib/haptics.ts
@@ -1,0 +1,39 @@
+import * as Haptics from "expo-haptics";
+import { Platform } from "react-native";
+
+// Thin, best-effort wrapper over expo-haptics. Every call is fire-and-forget: a
+// device without a haptic engine (or the web target, where expo-haptics is a
+// no-op) must never throw into a press handler. The named API mirrors intent —
+// callers ask for `tap`/`select`/`success`, not raw enum members — so the choice
+// of impact vs. selection vs. notification lives in exactly one place.
+
+const isWeb = Platform.OS === "web";
+
+function run(fire: () => Promise<void>): void {
+	if (isWeb) return;
+	// Swallow rejections — haptics are a nicety, never a failure path.
+	fire().catch(() => {});
+}
+
+export const haptics = {
+	// Generic light press — buttons, cards, pull-to-refresh.
+	tap() {
+		run(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light));
+	},
+	// A selection change — tabs, filter pills, list-item selection.
+	select() {
+		run(() => Haptics.selectionAsync());
+	},
+	// An action succeeded — spawn started, session killed, connection made.
+	success() {
+		run(() => Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success));
+	},
+	// A cautionary moment — a destructive confirmation is being raised.
+	warning() {
+		run(() => Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning));
+	},
+	// An action failed.
+	error() {
+		run(() => Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error));
+	},
+};

--- a/packages/mobile/lib/ui.tsx
+++ b/packages/mobile/lib/ui.tsx
@@ -12,6 +12,7 @@ import {
 	type TextStyle,
 	type ViewStyle,
 } from "react-native";
+import { haptics } from "./haptics";
 import { statusVisual, theme } from "./theme";
 // AO mascot glyph (transparent) shown beside each screen heading.
 import MASCOT from "../assets/mascot.png";
@@ -70,7 +71,13 @@ export function Pill({
 	textStyle?: StyleProp<TextStyle>;
 }) {
 	return (
-		<Pressable onPress={onPress} style={[s.pill, active && s.pillActive, style]}>
+		<Pressable
+			onPress={() => {
+				haptics.select();
+				onPress();
+			}}
+			style={[s.pill, active && s.pillActive, style]}
+		>
 			<Text numberOfLines={1} style={[s.pillText, active && s.pillTextActive, textStyle]}>
 				{label}
 			</Text>
@@ -122,7 +129,13 @@ export function Card({
 }) {
 	if (!onPress) return <View style={[s.card, style]}>{children}</View>;
 	return (
-		<Pressable onPress={onPress} style={({ pressed }) => [s.card, pressed && s.cardPressed, style]}>
+		<Pressable
+			onPress={() => {
+				haptics.tap();
+				onPress();
+			}}
+			style={({ pressed }) => [s.card, pressed && s.cardPressed, style]}
+		>
 			{children}
 		</Pressable>
 	);
@@ -179,7 +192,12 @@ export function Button({
 	const fg = isPrimary ? "#06101f" : isDanger ? theme.red : theme.blue;
 	return (
 		<Pressable
-			onPress={onPress}
+			onPress={() => {
+				// Danger actions get a cautionary buzz; everything else a light tap.
+				if (isDanger) haptics.warning();
+				else haptics.tap();
+				onPress();
+			}}
 			disabled={disabled || loading}
 			style={({ pressed }) => [
 				s.btn,

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -16,6 +16,7 @@
         "expo-build-properties": "~1.0.10",
         "expo-camera": "~17.0.10",
         "expo-constants": "~18.0.13",
+        "expo-haptics": "~15.0.8",
         "expo-linking": "~8.0.12",
         "expo-router": "6.0.24",
         "expo-secure-store": "~15.0.8",
@@ -5028,6 +5029,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-15.0.8.tgz",
+      "integrity": "sha512-lftutojy8Qs8zaDzzjwM3gKHFZ8bOOEZDCkmh2Ddpe95Ra6kt2izeOfOfKuP/QEh0MZ1j9TfqippyHdRd1ZM9g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "@agent-orchestrator/mobile",
-  "version": "0.0.0",
-  "private": true,
-  "description": "Expo mobile supervisor for Agent Orchestrator",
-  "main": "expo-router/entry",
-  "scripts": {
-    "start": "expo start",
-    "android": "expo run:android",
-    "ios": "expo run:ios",
-    "typecheck": "tsc --noEmit",
-    "build": "npm run typecheck",
-    "postinstall": "patch-package"
-  },
-  "dependencies": {
-    "@expo/vector-icons": "^15.0.3",
-    "@fressh/react-native-xtermjs-webview": "^0.0.8",
-    "@react-native-async-storage/async-storage": "2.2.0",
-    "expo": "^54.0.0",
-    "expo-build-properties": "~1.0.10",
-    "expo-camera": "~17.0.10",
-    "expo-constants": "~18.0.13",
-    "expo-haptics": "~15.0.8",
-    "expo-linking": "~8.0.12",
-    "expo-router": "6.0.24",
-    "expo-secure-store": "~15.0.8",
-    "expo-status-bar": "~3.0.9",
-    "react": "19.1.0",
-    "react-native": "0.81.5",
-    "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.16.0",
-    "react-native-webview": "13.15.0"
-  },
-  "devDependencies": {
-    "@types/react": "~19.1.10",
-    "patch-package": "^8.0.1",
-    "typescript": "~5.9.2"
-  }
+	"name": "@agent-orchestrator/mobile",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Expo mobile supervisor for Agent Orchestrator",
+	"main": "expo-router/entry",
+	"scripts": {
+		"start": "expo start",
+		"android": "expo run:android",
+		"ios": "expo run:ios",
+		"typecheck": "tsc --noEmit",
+		"build": "npm run typecheck",
+		"postinstall": "patch-package"
+	},
+	"dependencies": {
+		"@expo/vector-icons": "^15.0.3",
+		"@fressh/react-native-xtermjs-webview": "^0.0.8",
+		"@react-native-async-storage/async-storage": "2.2.0",
+		"expo": "^54.0.0",
+		"expo-build-properties": "~1.0.10",
+		"expo-camera": "~17.0.10",
+		"expo-constants": "~18.0.13",
+		"expo-haptics": "~15.0.8",
+		"expo-linking": "~8.0.12",
+		"expo-router": "6.0.24",
+		"expo-secure-store": "~15.0.8",
+		"expo-status-bar": "~3.0.9",
+		"react": "19.1.0",
+		"react-native": "0.81.5",
+		"react-native-safe-area-context": "~5.6.2",
+		"react-native-screens": "~4.16.0",
+		"react-native-webview": "13.15.0"
+	},
+	"devDependencies": {
+		"@types/react": "~19.1.10",
+		"patch-package": "^8.0.1",
+		"typescript": "~5.9.2"
+	}
 }

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,38 +1,39 @@
 {
-	"name": "@agent-orchestrator/mobile",
-	"version": "0.0.0",
-	"private": true,
-	"description": "Expo mobile supervisor for Agent Orchestrator",
-	"main": "expo-router/entry",
-	"scripts": {
-		"start": "expo start",
-		"android": "expo run:android",
-		"ios": "expo run:ios",
-		"typecheck": "tsc --noEmit",
-		"build": "npm run typecheck",
-		"postinstall": "patch-package"
-	},
-	"dependencies": {
-		"@expo/vector-icons": "^15.0.3",
-		"@fressh/react-native-xtermjs-webview": "^0.0.8",
-		"@react-native-async-storage/async-storage": "2.2.0",
-		"expo": "^54.0.0",
-		"expo-build-properties": "~1.0.10",
-		"expo-camera": "~17.0.10",
-		"expo-constants": "~18.0.13",
-		"expo-linking": "~8.0.12",
-		"expo-router": "6.0.24",
-		"expo-secure-store": "~15.0.8",
-		"expo-status-bar": "~3.0.9",
-		"react": "19.1.0",
-		"react-native": "0.81.5",
-		"react-native-safe-area-context": "~5.6.2",
-		"react-native-screens": "~4.16.0",
-		"react-native-webview": "13.15.0"
-	},
-	"devDependencies": {
-		"@types/react": "~19.1.10",
-		"patch-package": "^8.0.1",
-		"typescript": "~5.9.2"
-	}
+  "name": "@agent-orchestrator/mobile",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Expo mobile supervisor for Agent Orchestrator",
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "typecheck": "tsc --noEmit",
+    "build": "npm run typecheck",
+    "postinstall": "patch-package"
+  },
+  "dependencies": {
+    "@expo/vector-icons": "^15.0.3",
+    "@fressh/react-native-xtermjs-webview": "^0.0.8",
+    "@react-native-async-storage/async-storage": "2.2.0",
+    "expo": "^54.0.0",
+    "expo-build-properties": "~1.0.10",
+    "expo-camera": "~17.0.10",
+    "expo-constants": "~18.0.13",
+    "expo-haptics": "~15.0.8",
+    "expo-linking": "~8.0.12",
+    "expo-router": "6.0.24",
+    "expo-secure-store": "~15.0.8",
+    "expo-status-bar": "~3.0.9",
+    "react": "19.1.0",
+    "react-native": "0.81.5",
+    "react-native-safe-area-context": "~5.6.2",
+    "react-native-screens": "~4.16.0",
+    "react-native-webview": "13.15.0"
+  },
+  "devDependencies": {
+    "@types/react": "~19.1.10",
+    "patch-package": "^8.0.1",
+    "typescript": "~5.9.2"
+  }
 }


### PR DESCRIPTION
## What

Two small mobile changes.

**1. Haptic feedback.** The app had none — every interaction was a silent `Pressable`. Adds `expo-haptics` behind a thin `lib/haptics.ts` wrapper (`tap` / `select` / `success` / `warning` / `error`), wired through the shared `ui.tsx` primitives (`Button` / `Pill` / `Card`) so most of the app gets feedback from one place, plus the moments that carry real meaning:

- selection tick on tab switches and filter pills
- light tap on cards, buttons, the spawn FAB, and pull-to-refresh
- `success` / `error` on spawn, send-prompt, kill, and the Settings connection test
- `warning` as the destructive kill confirmation is raised

Terminal keystrokes are deliberately left **silent** — a buzz per key makes heavy typing unpleasant. Every call is fire-and-forget and no-ops on web, so it can never throw into a press handler.

**2. Long session/project labels overflowed the card.** Session ids are minted as `<projectId>-<n>`, so a card printed the project slug twice (plus a third time in the title, which falls back to the id) and ran off the right edge of the screen.

- `shortSessionId()` strips the known project prefix and renders just the `#n` discriminator — this removes a duplicate, so **no information is lost**.
- `shortLabel()` middle-truncates the project (`agent-orch…8d163a851`), keeping the head *and* the hash tail — a plain tail-cut would make two projects sharing a base name render identically.
- Both are length-gated: short names (`web`) pass through untouched.
- Belt-and-braces: `numberOfLines={1}` on both, `flexShrink: 1` on the project so it yields first, `flexShrink: 0` on `#n` so the discriminator always survives.

## Verification

- `npm run typecheck` in `packages/mobile` — clean.
- `expo-haptics` ships native code, so this needs a rebuild (`expo run:ios` / `run:android`) and a **physical device** — haptics don't fire on simulators. On-device pass: tabs/pills tick, buttons and cards tap, spawn/kill/connect buzz correctly, terminal keys stay silent.