### PR TITLE
docs(mobile): rewrite README as a dev-build run guide

### DIFF
--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -1,35 +1,244 @@
-# Agent Orchestrator - Mobile
+# Agent Orchestrator — Mobile
 
-Expo (expo-router) mobile supervisor for Agent Orchestrator. Four tabs - Kanban,
-PRs, Orchestrator, Settings - plus a spawn flow and a session screen. It talks to
-your AO server's HTTP API over your LAN or Tailscale.
+Expo (expo-router) mobile supervisor for Agent Orchestrator. Four tabs — Kanban, PRs,
+Orchestrator, Settings — plus a spawn flow, a session screen with a live terminal, and a
+preview browser. It is a **thin client**: it talks to the AO daemon running on your
+computer over your local network (or Tailscale). It never runs agents itself.
 
-## Run
+> **Development builds only — Expo Go is not supported.** The app depends on native modules,
+> so it must be compiled onto the device (`npx expo run:ios|run:android`). Expo Go can't load
+> it; don't file bugs from it.
+
+- [How the phone reaches your machine](#how-the-phone-reaches-your-machine)
+- [Prerequisites](#prerequisites)
+- [Install](#install)
+- [Step 1 — Turn on Connect Mobile on the desktop](#step-1--turn-on-connect-mobile-on-the-desktop)
+- [Step 2 — Build and install the dev build](#step-2--build-and-install-the-dev-build)
+- [Step 3 — Pair the phone](#step-3--pair-the-phone)
+- [Everyday dev loop](#everyday-dev-loop)
+- [Troubleshooting](#troubleshooting)
+- [Project layout](#project-layout)
+- [Verify](#verify)
+
+## How the phone reaches your machine
+
+The daemon's primary listener is loopback-only (`127.0.0.1:3001`) and unauthenticated — a
+phone can never reach it. To let a phone in, the desktop app opens a **second, opt-in LAN
+listener** (default port **3011**) bound to `0.0.0.0`, protected by a rotating bearer
+password, serving only the app API. It exists only while **Connect Mobile** is switched on
+in the desktop app; switching it off closes the socket.
+
+```
+phone ──HTTP/WS── 0.0.0.0:3011   (LAN listener, bearer password, opt-in)
+                       │
+                 same daemon process
+                       │
+desktop/CLI ───── 127.0.0.1:3001 (loopback, no auth, unchanged)
+```
+
+Transport is **plaintext HTTP by design** — this is a trusted-home-network tool. On
+untrusted Wi-Fi, use Tailscale instead and point the app at the `100.x` address or MagicDNS
+name. Background: [`docs/adr/0001-lan-listener-for-mobile.md`](../../docs/adr/0001-lan-listener-for-mobile.md).
+
+## Prerequisites
+
+| For             | You need                                                                              |
+| --------------- | ------------------------------------------------------------------------------------- |
+| Everything      | Node 20+, and AO running on your machine (desktop app, or the daemon from source)     |
+| Phone ↔ machine | Same Wi-Fi network, or both on the same Tailnet                                       |
+| iOS build       | macOS, Xcode 16+, an Apple ID (a free one gives a 7-day signing profile), a USB cable |
+| Android build   | Android Studio (SDK + platform-tools for `adb`), a USB cable                          |
+
+## Install
+
+This package is **not** part of an npm workspace — install from inside it:
 
 ```bash
 cd packages/mobile
-npm install
-npm start          # then press i (iOS), a (Android), or scan the QR in Expo Go
+npm install       # .npmrc sets legacy-peer-deps; postinstall runs patch-package
 ```
 
-## Connect
+Two rules worth knowing before you fight an install:
 
-Open **Settings** and set:
+- **Do not run `npm install --force` here.** It hoists SDK-incompatible transitive Expo deps
+  and the app crashes on launch. Plain `npm install` in this directory is correct.
+- `metro.config.js` pins `react` and `react-native` to this package's copies. Don't remove
+  that — two React instances kill the app at startup with _"main has not been registered"_.
 
-- **Host** - your PC's Tailscale name / `100.x` address, or its LAN IP on the same Wi-Fi.
-- **API Port** - the AO server HTTP API port.
-- **Terminal Port** - legacy setting kept for older configs. The Go daemon serves REST and terminal mux on the API port.
-- **Use TLS** - on only if AO is served over HTTPS (e.g. a Tailscale funnel).
+## Step 1 — Turn on Connect Mobile on the desktop
 
-Tap **Test connection**, then **Save**.
+Nothing on the phone works until the desktop opens the LAN bridge. Do this first.
 
-## Status
+**1. Start the desktop app.** Either launch the packaged AO app, or run it from source
+(it starts its own daemon):
 
-The board, PR list, orchestrator controls, spawn flow, settings, in-app terminal,
-restore flow, and static preview browser are live against the Go daemon API.
+```bash
+cd frontend && npm run dev      # Electron supervisor + daemon
+```
+
+**2. Open the pairing modal:** in the desktop app, **Sidebar → Settings menu → Connect Mobile**.
+
+**3. Flip the "Enable mobile" toggle on.** The bridge binds immediately and the modal reveals
+the pairing details:
+
+- a **QR code** (encodes `{v:1, host, port, password}`),
+- the plaintext **host:port**, e.g. `192.168.1.84:3011`,
+- the 8-character **connection password** (copyable),
+- **Regenerate password**, which rotates the secret and drops any connected phone.
+
+Leave the modal open — you scan that QR in step 3. Toggling **off** tears the bridge down,
+so the phone goes offline until you turn it back on.
+
+**Headless (daemon only, no Electron UI)?** Start the daemon and drive the same routes over
+loopback:
+
+```bash
+cd backend && go run ./cmd/ao start
+
+curl -X POST http://127.0.0.1:3001/api/v1/mobile/enable
+curl -s      http://127.0.0.1:3001/api/v1/mobile/status    # → {enabled, host, port, password}
+curl -X POST http://127.0.0.1:3001/api/v1/mobile/disable
+```
+
+Type the `host`/`port`/`password` from `status` into the app's Settings by hand (step 3).
+
+## Step 2 — Build and install the dev build
+
+You compile the app onto the device once; after that, JS changes hot-reload from Metro and
+you only rebuild when native config changes. `ios/` and `android/` are **generated and
+gitignored** — the run commands prebuild them for you.
+
+### On a cabled device (the main path)
+
+**iOS, over the cable:**
+
+1. Plug the iPhone in and tap **Trust This Computer**.
+2. On the phone: **Settings → Privacy & Security → Developer Mode → On** (the phone reboots).
+3. Build and install:
+
+   ```bash
+   npx expo run:ios --device      # pick your iPhone from the list
+   ```
+
+   If Xcode rejects the bundle identifier or team, open `ios/AO.xcworkspace`, select the
+   **AO** target → **Signing & Capabilities**, choose your personal team and let Xcode manage
+   signing, then re-run the command.
+4. On first launch iOS asks for **Local Network** access. Allow it, or the app cannot reach
+   the daemon on your LAN.
+
+**Android, over the cable:**
+
+1. On the phone, enable **Developer options** (tap Build number 7×), then **USB debugging**.
+2. Plug in, accept the RSA fingerprint prompt, and confirm the device is visible:
+
+   ```bash
+   adb devices      # must list your device as "device", not "unauthorized"
+   ```
+
+3. Build and install:
+
+   ```bash
+   npx expo run:android --device
+   ```
+
+4. Let the phone reach Metro through the cable:
+
+   ```bash
+   adb reverse tcp:8081 tcp:8081
+   ```
+
+   Optional if the phone is on the same Wi-Fi, but it makes JS reloads immune to flaky Wi-Fi.
+   It does **not** cover the daemon connection — that still goes over Wi-Fi (or Tailscale) to
+   `host:3011`.
+
+Cleartext HTTP to the bridge already works on both platforms: Android through
+`usesCleartextTraffic` in `app.json`, iOS through `NSAllowsLocalNetworking` in the prebuilt
+`Info.plist`.
+
+> **On `expo-dev-client`:** this package doesn't depend on it today, so the debug build
+> connects straight to Metro and has no in-app launcher or URL switcher. If you want the
+> launcher UI (scan a Metro QR from inside the app, switch bundler URLs), run
+> `npx expo install expo-dev-client`, rebuild with `npx expo run:*`, and serve with
+> `npx expo start --dev-client`.
+
+### On a simulator / emulator
+
+Same build commands without `--device`. The daemon host differs — a simulator isn't "on your
+Wi-Fi" the way a phone is:
+
+```bash
+npx expo run:ios         # iOS Simulator    → daemon host 127.0.0.1
+npx expo run:android     # Android emulator → daemon host 10.0.2.2
+```
+
+Port is `3011` either way. The pairing QR encodes your LAN IP, which usually works here too;
+if it doesn't, type the host above by hand (step 3).
+
+## Step 3 — Pair the phone
+
+In the app: **Settings → scan the pairing QR** (grant camera access when asked). One scan
+writes host, port, and password, then reconnects — no typing.
+
+Manual entry, if you prefer (or for simulators / Tailscale):
+
+| Field             | Value                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| **Host**          | Your machine's LAN IP (`ipconfig getifaddr en0` on macOS), or Tailscale name/`100.x` |
+| **API Port**      | `3011` — the Connect Mobile bridge, **not** the loopback `3001`                       |
+| **Password**      | The 8-character password from the Connect Mobile modal                               |
+| **Terminal Port** | Legacy, ignored. The daemon serves REST and the `/mux` terminal on the API port      |
+| **Use TLS**       | Off for the LAN bridge. On only for real HTTPS, e.g. a Tailscale funnel              |
+
+Tap **Test connection**, then **Save**. The password lives in the device keystore (iOS
+Keychain / Android Keystore), never in AsyncStorage.
+
+## Everyday dev loop
+
+With the dev build installed on the device, JS changes need no rebuild — just start Metro
+and launch the app from the home screen:
+
+```bash
+npm start        # Metro; save a file and the phone hot-reloads
+```
+
+Rebuild with `npx expo run:ios|run:android` only when **native** config changes: `app.json`
+plugins or permissions, native dependencies, `expo-build-properties`. After dependency
+surgery, regenerate the native projects from scratch with `npx expo prebuild --clean`.
+
+## Troubleshooting
+
+| Symptom                                           | Fix                                                                                                                                     |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Crash at launch, _"main has not been registered"_ | Two React copies. Keep `metro.config.js` intact, reinstall with plain `npm install` (never `--force`), then `npx expo prebuild --clean`. |
+| **Test connection** fails, everything times out   | Connect Mobile is off on the desktop, wrong port (`3011`, not `3001`), phone on a different network, or the macOS firewall is blocking incoming connections. |
+| 401 / invalid password                            | The password was regenerated on the desktop. Re-scan the QR.                                                                             |
+| Locked out after repeated failures                | The bridge locks out a source after 5 failed attempts. Wait it out, or toggle Connect Mobile off and on.                                 |
+| `adb devices` shows `unauthorized`                | Re-accept the USB debugging prompt on the phone.                                                                                        |
+| iOS app installs, then closes immediately         | Untrusted developer profile: **Settings → General → VPN & Device Management → trust your Apple ID**.                                     |
+| App runs but can't reach the daemon (iOS)         | The Local Network prompt was denied: **Settings → Privacy & Security → Local Network → AO** → on.                                        |
+| Phone can't reach Metro                           | `adb reverse tcp:8081 tcp:8081` (Android), or `npx expo start --tunnel` (either platform).                                               |
+| Terminal renders blank                            | The xterm WebView is patched via `patch-package`; confirm `postinstall` ran (`npx patch-package`).                                       |
+
+## Project layout
+
+```
+app/                 expo-router routes
+  (tabs)/            Kanban (index), PRs, Orchestrator, Settings
+  session/[id].tsx   session detail + live terminal
+  spawn.tsx          spawn flow
+  pair.tsx           pairing-QR scanner
+lib/
+  api.ts             REST client for the daemon API
+  mux.ts             /mux WebSocket terminal transport
+  config.ts          server config — password in SecureStore, the rest in AsyncStorage
+  pairing.ts         pairing-QR payload parser
+  store.tsx          app state + connection polling
+  theme.ts, ui.tsx   design primitives
+scripts/             ao-phone-proxy.js — superseded by Connect Mobile, kept for reference
+```
 
 ## Verify
 
 ```bash
-npm run typecheck   # tsc --noEmit
+npm run typecheck    # tsc --noEmit
 ```

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -123,6 +123,7 @@ gitignored** — the run commands prebuild them for you.
    If Xcode rejects the bundle identifier or team, open `ios/AO.xcworkspace`, select the
    **AO** target → **Signing & Capabilities**, choose your personal team and let Xcode manage
    signing, then re-run the command.
+
 4. On first launch iOS asks for **Local Network** access. Allow it, or the app cannot reach
    the daemon on your LAN.
 
@@ -184,7 +185,7 @@ Manual entry, if you prefer (or for simulators / Tailscale):
 | Field             | Value                                                                                |
 | ----------------- | ------------------------------------------------------------------------------------ |
 | **Host**          | Your machine's LAN IP (`ipconfig getifaddr en0` on macOS), or Tailscale name/`100.x` |
-| **API Port**      | `3011` — the Connect Mobile bridge, **not** the loopback `3001`                       |
+| **API Port**      | `3011` — the Connect Mobile bridge, **not** the loopback `3001`                      |
 | **Password**      | The 8-character password from the Connect Mobile modal                               |
 | **Terminal Port** | Legacy, ignored. The daemon serves REST and the `/mux` terminal on the API port      |
 | **Use TLS**       | Off for the LAN bridge. On only for real HTTPS, e.g. a Tailscale funnel              |
@@ -207,17 +208,17 @@ surgery, regenerate the native projects from scratch with `npx expo prebuild --c
 
 ## Troubleshooting
 
-| Symptom                                           | Fix                                                                                                                                     |
-| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Crash at launch, _"main has not been registered"_ | Two React copies. Keep `metro.config.js` intact, reinstall with plain `npm install` (never `--force`), then `npx expo prebuild --clean`. |
+| Symptom                                           | Fix                                                                                                                                                          |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Crash at launch, _"main has not been registered"_ | Two React copies. Keep `metro.config.js` intact, reinstall with plain `npm install` (never `--force`), then `npx expo prebuild --clean`.                     |
 | **Test connection** fails, everything times out   | Connect Mobile is off on the desktop, wrong port (`3011`, not `3001`), phone on a different network, or the macOS firewall is blocking incoming connections. |
-| 401 / invalid password                            | The password was regenerated on the desktop. Re-scan the QR.                                                                             |
-| Locked out after repeated failures                | The bridge locks out a source after 5 failed attempts. Wait it out, or toggle Connect Mobile off and on.                                 |
-| `adb devices` shows `unauthorized`                | Re-accept the USB debugging prompt on the phone.                                                                                        |
-| iOS app installs, then closes immediately         | Untrusted developer profile: **Settings → General → VPN & Device Management → trust your Apple ID**.                                     |
-| App runs but can't reach the daemon (iOS)         | The Local Network prompt was denied: **Settings → Privacy & Security → Local Network → AO** → on.                                        |
-| Phone can't reach Metro                           | `adb reverse tcp:8081 tcp:8081` (Android), or `npx expo start --tunnel` (either platform).                                               |
-| Terminal renders blank                            | The xterm WebView is patched via `patch-package`; confirm `postinstall` ran (`npx patch-package`).                                       |
+| 401 / invalid password                            | The password was regenerated on the desktop. Re-scan the QR.                                                                                                 |
+| Locked out after repeated failures                | The bridge locks out a source after 5 failed attempts. Wait it out, or toggle Connect Mobile off and on.                                                     |
+| `adb devices` shows `unauthorized`                | Re-accept the USB debugging prompt on the phone.                                                                                                             |
+| iOS app installs, then closes immediately         | Untrusted developer profile: **Settings → General → VPN & Device Management → trust your Apple ID**.                                                         |
+| App runs but can't reach the daemon (iOS)         | The Local Network prompt was denied: **Settings → Privacy & Security → Local Network → AO** → on.                                                            |
+| Phone can't reach Metro                           | `adb reverse tcp:8081 tcp:8081` (Android), or `npx expo start --tunnel` (either platform).                                                                   |
+| Terminal renders blank                            | The xterm WebView is patched via `patch-package`; confirm `postinstall` ran (`npx patch-package`).                                                           |
 
 ## Project layout
 


### PR DESCRIPTION
## What

Rewrites `packages/mobile/README.md` into an actual end-to-end run guide for the mobile app.

The old README was misleading in two load-bearing ways:

- It told you to run the app in **Expo Go**.
- It told you to point Settings at *"the AO server HTTP API port"*, which reads as `3001` — the **loopback** port a phone can never reach.

## The README now covers

- **Connect Mobile, from the desktop.** Start the desktop app (packaged or `cd frontend && npm run dev`), open **Sidebar → Settings menu → Connect Mobile**, flip **Enable mobile** on, and read the pairing QR / `host:port` / 8-char password. Also documents the loopback `POST /api/v1/mobile/enable|disable` + `GET /status` routes for a headless daemon.
- **The right port.** The phone talks to the LAN bridge on **3011**, not the loopback **3001**.
- **Development builds only — Expo Go is unsupported.** `expo-build-properties` (the Android `usesCleartextTraffic` flag the plaintext LAN bridge depends on) is a build-time config plugin that doesn't exist in Expo Go; the custom `scheme` and app identity don't apply either; and `expo-notifications` remote push doesn't work there at all.
- **Cabled-device setup.** iOS: Developer Mode, `npx expo run:ios --device`, the Xcode signing-team fixup, and the iOS **Local Network** permission (deny it and the app silently can't reach the daemon). Android: USB debugging, `adb devices`, `npx expo run:android --device`, `adb reverse tcp:8081 tcp:8081`. Plus simulator/emulator daemon hosts (`127.0.0.1` / `10.0.2.2`).
- **Install traps that actually bite here.** Never `npm install --force` (it hoists SDK-incompatible transitive Expo deps → native crash on launch), and don't remove the `metro.config.js` React pin (two React instances → *"main has not been registered"* at startup).
- Troubleshooting table, project layout, and `npm run typecheck`.

## Notes

- Docs only — no code, config, or dependency changes.
- The package has no `expo-dev-client` dependency today, so `expo run:*` produces a plain RN debug build that talks to Metro with no in-app launcher. The README says so and gives the one-liner to add it, rather than pretending the launcher is there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuoXahoJ1bqVbP8n4Zoq4i