### PR TITLE
fix(terminal): portable dropped-path escaping and drop-file cleanup

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -30,7 +30,7 @@ import {
 } from "./main/update-settings";
 import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { readdir, readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -54,6 +54,7 @@ import { connectSupervisor, type SupervisorLinkHandle } from "./main/supervisor-
 import { shouldLinkOnAttach } from "./main/daemon-owner";
 import { readMigrationState, updateMigration, writeAppStateMarker, type MigrationState } from "./main/app-state";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
+import { saveDroppedFile } from "./main/terminal-drops";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -1208,19 +1209,9 @@ ipcMain.handle("clipboard:writeText", (_event, text: string) => {
 });
 ipcMain.handle("clipboard:readText", () => clipboard.readText());
 
-// A file dropped onto the terminal is delivered as raw bytes (its original path
-// is unavailable to the sandboxed renderer on macOS — see webUtils.getPathForFile
-// regressions in Electron 30-33). Stash the bytes under the app's own state dir
-// and return the path so the terminal can insert it, mirroring how a native
-// terminal inserts a dropped file's path.
-ipcMain.handle("terminal:saveDroppedFile", async (_event, input: { name: string; bytes: Uint8Array }) => {
-	const dir = path.join(app.getPath("userData"), "terminal-drops");
-	await mkdir(dir, { recursive: true });
-	const base = path.basename(input.name || "").replace(/[^\w.-]+/g, "_") || "dropped";
-	const target = path.join(dir, `${Date.now()}-${base}`);
-	await writeFile(target, Buffer.from(input.bytes));
-	return target;
-});
+ipcMain.handle("terminal:saveDroppedFile", (_event, input: { name: string; bytes: Uint8Array }) =>
+	saveDroppedFile(path.join(app.getPath("userData"), "terminal-drops"), input, Date.now()),
+);
 
 ipcMain.handle("appState:getMigration", async (): Promise<MigrationState> => {
 	const runFile = runFilePath();

--- a/frontend/src/main/terminal-drops.test.ts
+++ b/frontend/src/main/terminal-drops.test.ts
@@ -1,0 +1,93 @@
+import { mkdtemp, readFile, readdir, rm, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { saveDroppedFile } from "./terminal-drops";
+
+const tmpDirs: string[] = [];
+
+async function tempDir(): Promise<string> {
+	const dir = await mkdtemp(path.join(os.tmpdir(), "ao-drops-"));
+	tmpDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tmpDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("saveDroppedFile", () => {
+	it("writes the bytes and keeps only a sanitized basename so a drop cannot escape the dir", async () => {
+		const dir = await tempDir();
+		const bytes = new Uint8Array([1, 2, 3, 4]);
+
+		const target = await saveDroppedFile(dir, { name: "../../etc/pa ss!.png", bytes }, 1700000000000);
+
+		expect(path.dirname(target)).toBe(dir);
+		expect(path.basename(target)).toMatch(/^1700000000000-[0-9a-f-]{36}-pa_ss_\.png$/);
+		expect(new Uint8Array(await readFile(target))).toEqual(bytes);
+	});
+
+	it("falls back to a default name when the dropped name is empty or all-unsafe", async () => {
+		const dir = await tempDir();
+		const target = await saveDroppedFile(dir, { name: "///", bytes: new Uint8Array([0]) }, 1700000000000);
+		expect(path.basename(target)).toMatch(/-dropped$/);
+	});
+
+	it("gives distinct targets to two files saved in the same millisecond with the same name", async () => {
+		const dir = await tempDir();
+		const a = await saveDroppedFile(dir, { name: "shot.png", bytes: new Uint8Array([1]) }, 1700000000000);
+		const b = await saveDroppedFile(dir, { name: "shot.png", bytes: new Uint8Array([2]) }, 1700000000000);
+
+		expect(a).not.toBe(b);
+		expect(new Uint8Array(await readFile(a))).toEqual(new Uint8Array([1]));
+		expect(new Uint8Array(await readFile(b))).toEqual(new Uint8Array([2]));
+		expect((await readdir(dir)).length).toBe(2);
+	});
+
+	it("prunes copies older than the retention window but keeps still-fresh ones", async () => {
+		const dir = await tempDir();
+		const now = Date.parse("2026-01-02T00:00:00Z");
+		const stale = path.join(dir, "stale.png");
+		await writeFile(stale, "old");
+		const twoDaysBefore = new Date(now - 2 * 24 * 60 * 60 * 1000);
+		await utimes(stale, twoDaysBefore, twoDaysBefore);
+		const recent = path.join(dir, "recent.png");
+		await writeFile(recent, "keep");
+		const oneHourBefore = new Date(now - 60 * 60 * 1000);
+		await utimes(recent, oneHourBefore, oneHourBefore);
+
+		await saveDroppedFile(dir, { name: "fresh.png", bytes: new Uint8Array([9]) }, now);
+
+		const remaining = await readdir(dir);
+		expect(remaining).not.toContain("stale.png");
+		expect(remaining).toContain("recent.png");
+		expect(remaining.some((name) => name.endsWith("-fresh.png"))).toBe(true);
+	});
+
+	it("rejects malformed input before touching the filesystem", async () => {
+		const dir = await tempDir();
+
+		await expect(
+			saveDroppedFile(dir, { name: "shot.png", bytes: "text" as unknown as Uint8Array }, 1700000000000),
+		).rejects.toThrow(/Uint8Array/);
+		await expect(
+			saveDroppedFile(dir, { name: 123 as unknown as string, bytes: new Uint8Array([1]) }, 1700000000000),
+		).rejects.toThrow();
+		await expect(
+			saveDroppedFile(dir, undefined as unknown as { name: string; bytes: Uint8Array }, 1700000000000),
+		).rejects.toThrow();
+
+		expect(await readdir(dir)).toEqual([]);
+	});
+
+	it("rejects when the target directory cannot be created", async () => {
+		const dir = await tempDir();
+		const fileWhereDirExpected = path.join(dir, "not-a-dir");
+		await writeFile(fileWhereDirExpected, "x");
+
+		await expect(
+			saveDroppedFile(fileWhereDirExpected, { name: "shot.png", bytes: new Uint8Array([1]) }, 1700000000000),
+		).rejects.toThrow();
+	});
+});

--- a/frontend/src/main/terminal-drops.ts
+++ b/frontend/src/main/terminal-drops.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const DROP_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+export async function saveDroppedFile(
+	dir: string,
+	input: { name: string; bytes: Uint8Array },
+	now: number,
+): Promise<string> {
+	if (!input || typeof input.name !== "string" || !(input.bytes instanceof Uint8Array)) {
+		throw new Error("saveDroppedFile: expected { name: string, bytes: Uint8Array }");
+	}
+
+	await mkdir(dir, { recursive: true });
+
+	const entries = await readdir(dir).catch(() => [] as string[]);
+	await Promise.all(
+		entries.map(async (entry) => {
+			const stale = path.join(dir, entry);
+			try {
+				const info = await stat(stale);
+				if (now - info.mtimeMs > DROP_RETENTION_MS) await rm(stale, { force: true });
+			} catch {
+				return;
+			}
+		}),
+	);
+
+	const base = path.basename(input.name).replace(/[^\w.-]+/g, "_") || "dropped";
+	const target = path.join(dir, `${now}-${randomUUID()}-${base}`);
+	await writeFile(target, Buffer.from(input.bytes));
+	return target;
+}

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { XtermTerminal } from "./XtermTerminal";
 
@@ -376,6 +376,119 @@ describe("XtermTerminal", () => {
 		expect(pasteEvent.defaultPrevented).toBe(true);
 		expect(onInput).toHaveBeenCalledTimes(1);
 		expect(onInput).toHaveBeenCalledWith("shortcut paste", "paste");
+	});
+
+	function fakeDropFile(name: string, bytes: number[]) {
+		return { name, arrayBuffer: async () => new Uint8Array(bytes).buffer };
+	}
+
+	function fireDrop(el: Element, files: ReturnType<typeof fakeDropFile>[]) {
+		const event = new Event("drop", { bubbles: true, cancelable: true }) as DragEvent;
+		Object.defineProperty(event, "dataTransfer", { value: { files, types: ["Files"] } });
+		el.dispatchEvent(event);
+		return event;
+	}
+
+	it("prevents default and forwards the dropped file's bytes, then inserts the returned path", async () => {
+		const onInput = vi.fn();
+		const save = vi.fn(async (_input: { name: string; bytes: Uint8Array }) => "/drops/shot.png");
+		window.ao!.terminal.saveDroppedFile = save;
+		const { container } = render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		const event = fireDrop(container.firstElementChild!, [fakeDropFile("shot.png", [1, 2, 3])]);
+
+		await waitFor(() => expect(onInput).toHaveBeenCalled());
+		expect(event.defaultPrevented).toBe(true);
+		expect(save).toHaveBeenCalledTimes(1);
+		expect(save.mock.calls[0][0].name).toBe("shot.png");
+		expect(Array.from(save.mock.calls[0][0].bytes)).toEqual([1, 2, 3]);
+		expect(onInput).toHaveBeenCalledWith("/drops/shot.png ", "paste");
+	});
+
+	it("ignores a drop with no files", () => {
+		const onInput = vi.fn();
+		const save = vi.fn(async () => "/drops/x");
+		window.ao!.terminal.saveDroppedFile = save;
+		const { container } = render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		fireDrop(container.firstElementChild!, []);
+
+		expect(save).not.toHaveBeenCalled();
+		expect(onInput).not.toHaveBeenCalled();
+	});
+
+	it("inserts every dropped file but skips ones whose save fails", async () => {
+		const onInput = vi.fn();
+		window.ao!.terminal.saveDroppedFile = vi.fn(async ({ name }) => {
+			if (name === "bad.png") throw new Error("write failed");
+			return `/drops/${name}`;
+		});
+		const { container } = render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		fireDrop(container.firstElementChild!, [
+			fakeDropFile("a.png", [1]),
+			fakeDropFile("bad.png", [2]),
+			fakeDropFile("c.png", [3]),
+		]);
+
+		await waitFor(() => expect(onInput).toHaveBeenCalled());
+		expect(onInput).toHaveBeenCalledWith("/drops/a.png /drops/c.png ", "paste");
+	});
+
+	it("single-quotes a POSIX path containing a space", async () => {
+		setNavigatorPlatform("MacIntel");
+		const onInput = vi.fn();
+		window.ao!.terminal.saveDroppedFile = vi.fn(async () => "/Users/John Doe/shot.png");
+		const { container } = render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		fireDrop(container.firstElementChild!, [fakeDropFile("shot.png", [1])]);
+
+		await waitFor(() => expect(onInput).toHaveBeenCalled());
+		expect(onInput).toHaveBeenCalledWith("'/Users/John Doe/shot.png' ", "paste");
+	});
+
+	it("escapes embedded apostrophes when single-quoting a POSIX path", async () => {
+		setNavigatorPlatform("MacIntel");
+		const onInput = vi.fn();
+		window.ao!.terminal.saveDroppedFile = vi.fn(async () => "/Users/O'Brien/shot.png");
+		const { container } = render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		fireDrop(container.firstElementChild!, [fakeDropFile("shot.png", [1])]);
+
+		await waitFor(() => expect(onInput).toHaveBeenCalled());
+		expect(onInput).toHaveBeenCalledWith("'/Users/O'\\''Brien/shot.png' ", "paste");
+	});
+
+	it("quotes a POSIX path with shell metacharacters even without whitespace", async () => {
+		setNavigatorPlatform("MacIntel");
+		const onInput = vi.fn();
+		window.ao!.terminal.saveDroppedFile = vi.fn(async () => "/tmp/a$b;c.png");
+		const { container } = render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		fireDrop(container.firstElementChild!, [fakeDropFile("shot.png", [1])]);
+
+		await waitFor(() => expect(onInput).toHaveBeenCalled());
+		expect(onInput).toHaveBeenCalledWith("'/tmp/a$b;c.png' ", "paste");
+	});
+
+	it("double-quotes a Windows path containing a space", async () => {
+		setNavigatorPlatform("Win32");
+		const onInput = vi.fn();
+		window.ao!.terminal.saveDroppedFile = vi.fn(async () => "C:\\Users\\John Doe\\shot.png");
+		const { container } = render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		fireDrop(container.firstElementChild!, [fakeDropFile("shot.png", [1])]);
+
+		await waitFor(() => expect(onInput).toHaveBeenCalled());
+		expect(onInput).toHaveBeenCalledWith('"C:\\Users\\John Doe\\shot.png" ', "paste");
+	});
+
+	it("prevents default on dragover for a file drag so the drop can fire", () => {
+		const { container } = render(<XtermTerminal theme="dark" />);
+		const event = new Event("dragover", { bubbles: true, cancelable: true }) as DragEvent;
+		Object.defineProperty(event, "dataTransfer", { value: { files: [], types: ["Files"] } });
+		container.firstElementChild!.dispatchEvent(event);
+		expect(event.defaultPrevented).toBe(true);
 	});
 
 	it("supports classic Windows terminal copy and paste shortcuts", async () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -575,18 +575,26 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			event.preventDefault();
 			event.stopPropagation();
 			void (async () => {
-				const paths: string[] = [];
+				const windows = isWindowsPlatform();
+				const safePattern = windows ? /^[A-Za-z0-9_.:\\/-]+$/ : /^[A-Za-z0-9_./-]+$/;
+				const quoted: string[] = [];
 				for (const file of files) {
 					try {
 						const bytes = new Uint8Array(await file.arrayBuffer());
 						const saved = await aoBridge.terminal.saveDroppedFile({ name: file.name, bytes });
-						if (saved) paths.push(saved);
+						if (!saved) continue;
+						if (safePattern.test(saved)) {
+							quoted.push(saved);
+						} else if (windows) {
+							quoted.push(`"${saved.replace(/"/g, '\\"')}"`);
+						} else {
+							quoted.push(`'${saved.replace(/'/g, "'\\''")}'`);
+						}
 					} catch (error) {
 						console.warn("Unable to attach dropped file", error);
 					}
 				}
-				if (paths.length === 0) return;
-				pasteText(`${paths.map((p) => (/\s/.test(p) ? `'${p}'` : p)).join(" ")} `);
+				if (quoted.length > 0) pasteText(`${quoted.join(" ")} `);
 			})();
 		};
 		host.addEventListener("dragover", dragOverInput);


### PR DESCRIPTION
Follow-up to review feedback on #2644 (terminal file drop). Three gaps raised in review are addressed here:

- Path escaping is now platform-aware (POSIX single-quote with `'\''` escaping, double-quote on Windows) and quotes on any unsafe character, not just whitespace. Clean paths stay raw, so the common drop is unchanged.
- Dropped temp copies are pruned when older than a day, before every save, so terminal-drops no longer grows without bound.
- The save and drop logic is extracted into tested modules: basename sanitization and path-traversal refusal, age-based pruning, POSIX and Windows quoting, and the drop flow (single file, multiple files, partial failure, empty).

Testing
- npm test: 599 passed
- npm run typecheck / prettier: clean
- Verified in the app: dropping a screenshot inserts its path and the agent attaches it
