### PR TITLE
fix(runtime): scope session side effects per data dir

### DIFF
--- a/backend/internal/adapters/runtime/runtimeselect/runtimeselect.go
+++ b/backend/internal/adapters/runtime/runtimeselect/runtimeselect.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/conpty"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/tmux"
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -28,11 +29,12 @@ type Runtime interface {
 var _ Runtime = (*tmux.Runtime)(nil)
 var _ Runtime = (*conpty.Runtime)(nil)
 
-// New returns the per-platform runtime: tmux on Darwin/Linux, conpty on Windows.
-// log is accepted for signature stability with callers but is currently unused.
-func New(_ *slog.Logger) Runtime {
+// New returns the per-platform runtime: tmux on Darwin/Linux, conpty on
+// Windows. On Unix, tmux gets a per-instance namespace derived from dataDir so
+// multiple AO instances on one machine do not collide on session names.
+func New(dataDir string, _ *slog.Logger) Runtime {
 	if runtime.GOOS != "windows" {
-		return tmux.New(tmux.Options{})
+		return tmux.New(tmux.Options{Namespace: config.InstanceNamespace(dataDir)})
 	}
 	return conpty.New(conpty.Options{})
 }

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -38,6 +38,7 @@ var getenv = os.Getenv
 type Options struct {
 	Binary     string        // default "tmux" (resolved via exec.LookPath)
 	Shell      string        // default $SHELL else /bin/sh
+	Namespace  string        // optional per-instance prefix applied before sanitization
 	Timeout    time.Duration // default 5s
 	ChunkSize  int           // default 16*1024
 	EnterDelay time.Duration // pause after pasting a non-empty message before pressing Enter; default defaultEnterDelay. Conpty already does this (ptyInputEnterDelay); tmux lacked it, so a large multiline paste could absorb the trailing Enter and leave the prompt unsubmitted (issue #2342).
@@ -48,6 +49,7 @@ type Options struct {
 type Runtime struct {
 	binary     string
 	shell      string
+	namespace  string
 	timeout    time.Duration
 	chunkSize  int
 	enterDelay time.Duration
@@ -103,6 +105,7 @@ func New(opts Options) *Runtime {
 	return &Runtime{
 		binary:     binary,
 		shell:      shellPath,
+		namespace:  opts.Namespace,
 		timeout:    timeout,
 		chunkSize:  chunkSize,
 		enterDelay: enterDelay,
@@ -113,7 +116,7 @@ func New(opts Options) *Runtime {
 // Create starts a new tmux session in the workspace, running the agent's
 // launch command with a keep-alive shell, and returns a handle to it.
 func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
-	id, err := tmuxSessionName(cfg.SessionID)
+	id, err := tmuxSessionName(r.namespace, cfg.SessionID)
 	if err != nil {
 		return ports.RuntimeHandle{}, err
 	}
@@ -348,22 +351,32 @@ func (r *Runtime) run(ctx context.Context, args ...string) ([]byte, error) {
 
 // -- session name helpers --
 
-func tmuxSessionName(id domain.SessionID) (string, error) {
+func tmuxSessionName(namespace string, id domain.SessionID) (string, error) {
 	raw := string(id)
 	if raw == "" {
 		return "", errors.New("tmux runtime: session id is required")
 	}
-	return SessionName(raw), nil
+	return SessionNameWithNamespace(namespace, raw), nil
 }
 
 // SessionName returns the tmux session name the runtime registers for a given
 // session id, applying the same sanitisation Create does. Callers that print an
 // attach hint must use this rather than the raw id.
 func SessionName(id string) string {
-	if sessionIDPattern.MatchString(id) && len(id) <= 48 {
-		return id
+	return SessionNameWithNamespace("", id)
+}
+
+// SessionNameWithNamespace returns the tmux session name the runtime registers
+// for a given session id and optional per-instance namespace.
+func SessionNameWithNamespace(namespace, id string) string {
+	raw := id
+	if namespace != "" {
+		raw = namespace + "-" + id
 	}
-	return sanitizedSessionName(id)
+	if sessionIDPattern.MatchString(raw) && len(raw) <= 48 {
+		return raw
+	}
+	return sanitizedSessionName(raw)
 }
 
 func sanitizedSessionName(raw string) string {

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -109,7 +109,7 @@ func TestCommandBuilders(t *testing.T) {
 // -- session name sanitization --
 
 func TestSessionNameSanitizesSpecialChars(t *testing.T) {
-	got, err := tmuxSessionName("repo/issue#42.1")
+	got, err := tmuxSessionName("", "repo/issue#42.1")
 	if err != nil {
 		t.Fatalf("tmuxSessionName: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestSessionNamePassesThroughShortConforming(t *testing.T) {
 
 func TestSessionNameMatchesCreateNaming(t *testing.T) {
 	long := domain.SessionID(strings.Repeat("x", 60) + "-1")
-	viaCreate, err := tmuxSessionName(long)
+	viaCreate, err := tmuxSessionName("", long)
 	if err != nil {
 		t.Fatalf("tmuxSessionName: %v", err)
 	}
@@ -141,6 +141,36 @@ func TestSessionNameMatchesCreateNaming(t *testing.T) {
 	}
 	if SessionName(string(long)) == string(long) {
 		t.Fatal("expected long id to be sanitised to a different name")
+	}
+}
+
+func TestSessionNameWithNamespaceMatchesCreateNaming(t *testing.T) {
+	const namespace = "i-abc123"
+	id := domain.SessionID("myproj-1")
+	viaCreate, err := tmuxSessionName(namespace, id)
+	if err != nil {
+		t.Fatalf("tmuxSessionName: %v", err)
+	}
+	if got := SessionNameWithNamespace(namespace, string(id)); got != viaCreate {
+		t.Fatalf("SessionNameWithNamespace = %q, but Create uses %q", got, viaCreate)
+	}
+	if viaCreate != "i-abc123-myproj-1" {
+		t.Fatalf("namespaced session name = %q, want i-abc123-myproj-1", viaCreate)
+	}
+}
+
+func TestSessionNameWithNamespaceSanitizesCombinedName(t *testing.T) {
+	const namespace = "i-abc123"
+	id := strings.Repeat("x", 60) + "/bad"
+	got := SessionNameWithNamespace(namespace, id)
+	if !sessionIDPattern.MatchString(got) {
+		t.Fatalf("SessionNameWithNamespace = %q, want pattern match", got)
+	}
+	if strings.Contains(got, "/") {
+		t.Fatalf("SessionNameWithNamespace = %q, want sanitized slash", got)
+	}
+	if !strings.HasPrefix(got, "i-abc123-") {
+		t.Fatalf("SessionNameWithNamespace = %q, want namespace prefix preserved before sanitize", got)
 	}
 }
 
@@ -222,6 +252,39 @@ func TestCreateIssuesNewSessionAndStatusOff(t *testing.T) {
 	// Call 4: has-session (IsAlive, uses exact-match target =sess-1).
 	if got, want := fr.calls[4].args, hasSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("call[4] = %#v, want %#v", got, want)
+	}
+}
+
+func TestCreateUsesSameNamespacedSessionForCreateAndLookup(t *testing.T) {
+	fr := &fakeRunner{}
+	r := New(Options{Binary: "tmux-test", Timeout: time.Second, Shell: "/bin/sh", Namespace: "i-abc123"})
+	r.runner = fr
+	r.enterDelay = 0
+	fr.outputs = [][]byte{nil, nil, nil, nil}
+
+	h, err := r.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     "sess-1",
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"echo", "hi"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if h.ID != "i-abc123-sess-1" {
+		t.Fatalf("handle ID = %q, want i-abc123-sess-1", h.ID)
+	}
+	for i, want := range [][]string{
+		setStatusOffArgs("i-abc123-sess-1"),
+		setMouseOnArgs("i-abc123-sess-1"),
+		hasSessionArgs("i-abc123-sess-1"),
+	} {
+		got := fr.calls[i+1].args
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("call[%d] = %#v, want %#v", i+1, got, want)
+		}
+	}
+	if !strings.Contains(strings.Join(fr.calls[0].args, " "), "-s i-abc123-sess-1") {
+		t.Fatalf("new-session args missing namespaced id: %v", fr.calls[0].args)
 	}
 }
 

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -260,7 +260,7 @@ func TestCreateUsesSameNamespacedSessionForCreateAndLookup(t *testing.T) {
 	r := New(Options{Binary: "tmux-test", Timeout: time.Second, Shell: "/bin/sh", Namespace: "i-abc123"})
 	r.runner = fr
 	r.enterDelay = 0
-	fr.outputs = [][]byte{nil, nil, nil, nil}
+	fr.outputs = [][]byte{nil, nil, nil, nil, nil, nil}
 
 	h, err := r.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     "sess-1",
@@ -270,21 +270,28 @@ func TestCreateUsesSameNamespacedSessionForCreateAndLookup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if h.ID != "i-abc123-sess-1" {
-		t.Fatalf("handle ID = %q, want i-abc123-sess-1", h.ID)
+	const want = "i-abc123-sess-1"
+	if h.ID != want {
+		t.Fatalf("handle ID = %q, want %q", h.ID, want)
 	}
-	for i, want := range [][]string{
-		setStatusOffArgs("i-abc123-sess-1"),
-		setMouseOnArgs("i-abc123-sess-1"),
-		hasSessionArgs("i-abc123-sess-1"),
-	} {
-		got := fr.calls[i+1].args
-		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("call[%d] = %#v, want %#v", i+1, got, want)
+	// Create names the session with the namespaced id...
+	if !strings.Contains(strings.Join(fr.calls[0].args, " "), "-s "+want) {
+		t.Fatalf("new-session args missing namespaced id: %v", fr.calls[0].args)
+	}
+	// ...and the liveness lookup targets that exact same namespaced id, so create
+	// and lookup can never disagree. Match by command rather than a fixed call
+	// index so unrelated Create steps (e.g. window sizing) don't make this brittle.
+	var found bool
+	for _, c := range fr.calls {
+		if len(c.args) > 0 && c.args[0] == "has-session" {
+			found = true
+			if !reflect.DeepEqual(c.args, hasSessionArgs(want)) {
+				t.Fatalf("has-session args = %#v, want %#v", c.args, hasSessionArgs(want))
+			}
 		}
 	}
-	if !strings.Contains(strings.Join(fr.calls[0].args, " "), "-s i-abc123-sess-1") {
-		t.Fatalf("new-session args missing namespaced id: %v", fr.calls[0].args)
+	if !found {
+		t.Fatalf("no has-session lookup issued; calls = %#v", fr.calls)
 	}
 }
 

--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/tmux"
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 )
 
 // maxDisplayNameLen caps the sidebar label set by `--name`. Mirrored by the
@@ -139,7 +140,11 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 			// On Windows: ConPTY has no user-facing attach CLI; use the AO dashboard.
 			var attach string
 			if runtime.GOOS != "windows" {
-				attach = fmt.Sprintf("tmux attach -t %s", tmux.SessionName(res.Session.ID))
+				namespace := ""
+				if cfg, err := config.Load(); err == nil {
+					namespace = config.InstanceNamespace(cfg.DataDir)
+				}
+				attach = fmt.Sprintf("tmux attach -t %s", tmux.SessionNameWithNamespace(namespace, res.Session.ID))
 			} else {
 				attach = "Attach from the AO dashboard (ConPTY sessions have no CLI attach command)"
 			}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -5,6 +5,8 @@
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"os"
@@ -286,11 +288,7 @@ func resolveDataDir() (string, error) {
 	if p, ok := os.LookupEnv("AO_DATA_DIR"); ok && p != "" {
 		return p, nil
 	}
-	stateDir, err := defaultStateDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(stateDir, "data"), nil
+	return defaultDataDir()
 }
 
 func defaultStateDir() (string, error) {
@@ -299,4 +297,41 @@ func defaultStateDir() (string, error) {
 		return "", fmt.Errorf("resolve state dir: %w", err)
 	}
 	return filepath.Join(homeDir, ".ao"), nil
+}
+
+func defaultDataDir() (string, error) {
+	stateDir, err := defaultStateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stateDir, "data"), nil
+}
+
+// InstanceNamespace returns the per-instance namespace for side effects that
+// must stay unique across multiple AO data directories on one machine.
+//
+// The canonical default data dir intentionally has no namespace so its tmux
+// session names and Git branches remain byte-for-byte compatible with the
+// historical single-instance behavior.
+func InstanceNamespace(dataDir string) string {
+	canonical := canonicalPath(dataDir)
+	if canonical == "" {
+		return ""
+	}
+	if def, err := defaultDataDir(); err == nil && canonical == canonicalPath(def) {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(canonical))
+	return "i-" + hex.EncodeToString(sum[:])[:6]
+}
+
+func canonicalPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	cleaned := filepath.Clean(path)
+	if abs, err := filepath.Abs(cleaned); err == nil {
+		return abs
+	}
+	return cleaned
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -157,4 +158,76 @@ func TestLoadAllowedOrigins(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestInstanceNamespace(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	defaultDir := filepath.Join(homeDir, ".ao", "data")
+	altA := filepath.Join(t.TempDir(), "dev-data")
+	altB := filepath.Join(t.TempDir(), "other-data")
+
+	tests := []struct {
+		name    string
+		dataDir string
+		check   func(t *testing.T, got string)
+	}{
+		{
+			name:    "default data dir stays unscoped",
+			dataDir: defaultDir,
+			check: func(t *testing.T, got string) {
+				t.Helper()
+				if got != "" {
+					t.Fatalf("InstanceNamespace(default) = %q, want empty", got)
+				}
+			},
+		},
+		{
+			name:    "alternate data dir is stable and non-empty",
+			dataDir: altA,
+			check: func(t *testing.T, got string) {
+				t.Helper()
+				if got == "" {
+					t.Fatal("InstanceNamespace(alternate) = empty, want non-empty")
+				}
+				if !strings.HasPrefix(got, "i-") {
+					t.Fatalf("InstanceNamespace(alternate) = %q, want i- prefix", got)
+				}
+				if len(got) != len("i-")+6 {
+					t.Fatalf("InstanceNamespace(alternate) = %q, want 6 hex chars", got)
+				}
+				if again := InstanceNamespace(altA); again != got {
+					t.Fatalf("InstanceNamespace not deterministic: first %q second %q", got, again)
+				}
+			},
+		},
+		{
+			name:    "different dirs produce different namespaces",
+			dataDir: altA,
+			check: func(t *testing.T, got string) {
+				t.Helper()
+				if other := InstanceNamespace(altB); other == got {
+					t.Fatalf("InstanceNamespace(%q) = %q, want different from %q", altB, other, got)
+				}
+			},
+		},
+		{
+			name:    "empty data dir remains unscoped",
+			dataDir: "",
+			check: func(t *testing.T, got string) {
+				t.Helper()
+				if got != "" {
+					t.Fatalf("InstanceNamespace(\"\") = %q, want empty", got)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.check(t, InstanceNamespace(tc.dataDir))
+		})
+	}
 }

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -100,7 +100,7 @@ func Run() error {
 	// attach Stream and liveness; the CDC broadcaster feeds the session-state channel. The manager
 	// is handed to httpd, which mounts it at /mux. Raw PTY bytes never flow
 	// through the CDC change_log -- only session-state events do.
-	runtimeAdapter := runtimeselect.New(log)
+	runtimeAdapter := runtimeselect.New(cfg.DataDir, log)
 	termMgr := terminal.NewManager(runtimeAdapter, cdcPipe.Broadcaster, log)
 	defer termMgr.Close()
 

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -102,14 +102,15 @@ func startSession(cfg config.Config, runtime runtimeselect.Runtime, store *sqlit
 		return nil, nil, nil, fmt.Errorf("session workspace: %w", err)
 	}
 	mgr := sessionmanager.New(sessionmanager.Deps{
-		Runtime:   runtime,
-		Agents:    agents,
-		Workspace: ws,
-		Store:     store,
-		Messenger: messenger,
-		Lifecycle: lcm,
-		DataDir:   cfg.DataDir,
-		Logger:    log,
+		Runtime:     runtime,
+		Agents:      agents,
+		Workspace:   ws,
+		Store:       store,
+		Messenger:   messenger,
+		Lifecycle:   lcm,
+		DataDir:     cfg.DataDir,
+		RunFilePath: cfg.RunFilePath,
+		Logger:      log,
 	})
 	scmProvider, err := newGitHubSCMProvider(log)
 	if err != nil {

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -150,7 +150,7 @@ func TestWiring_StartSessionBuildsSessionService(t *testing.T) {
 	lcm := lifecycle.New(store, nil)
 	cfg := config.Config{DataDir: t.TempDir()}
 
-	rt := runtimeselect.New(nil)
+	rt := runtimeselect.New(cfg.DataDir, nil)
 	messenger := newSessionMessenger(store, rt, log)
 	svc, reviewSvc, lc, err := startSession(cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, log)
 	if err != nil {
@@ -183,7 +183,7 @@ func TestStartTrackerIntake_RunsEvenWithoutEnabledProjects(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	lcm := lifecycle.New(store, nil)
 	cfg := config.Config{DataDir: t.TempDir()}
-	rt := runtimeselect.New(nil)
+	rt := runtimeselect.New(cfg.DataDir, nil)
 	messenger := newSessionMessenger(store, rt, log)
 	svc, _, _, err := startSession(cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, log)
 	if err != nil {

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -1405,3 +1405,22 @@ func TestDiscoverSubjects_NonGitPathDoesNotBackfill(t *testing.T) {
 		t.Fatalf("RepoOriginURL = %q, want empty (no persist on failed backfill)", got)
 	}
 }
+
+func TestMatchSession_IsolatesNamespacedBranches(t *testing.T) {
+	candidates := []sessionRepo{
+		{session: domain.SessionRecord{ID: "who-am-i-4"}, branch: "ao/i-abc123/who-am-i-4/root"},
+		{session: domain.SessionRecord{ID: "who-am-i-4"}, branch: "ao/who-am-i-4/root"},
+	}
+
+	got, ok := matchSession(candidates, "ao/i-abc123/who-am-i-4/feature")
+	if !ok {
+		t.Fatal("matchSession(namespaced branch) = no match, want owner")
+	}
+	if got.branch != "ao/i-abc123/who-am-i-4/root" {
+		t.Fatalf("matchSession(namespaced branch) matched %q, want namespaced owner", got.branch)
+	}
+
+	if _, ok := matchSession(candidates[:1], "ao/who-am-i-4/feature"); ok {
+		t.Fatal("matchSession(unscoped branch) matched namespaced session, want isolation")
+	}
+}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -64,6 +64,8 @@ const (
 	EnvIssueID   = "AO_ISSUE_ID"
 	// EnvDataDir tells a spawned agent's AO hook commands where the store lives.
 	EnvDataDir = "AO_DATA_DIR"
+	// EnvRunFile tells a spawned agent's AO hook commands which daemon run-file to reach.
+	EnvRunFile = "AO_RUN_FILE"
 )
 
 // hookBinaryName is the executable name the workspace hook commands invoke:
@@ -130,10 +132,11 @@ type Manager struct {
 	// each call site re-deriving the check. Send/confirmActive use Deliver for
 	// its Outcome; Spawn/Restore use the interface-level Send for
 	// initial-prompt delivery, where a blocked session is impossible.
-	messenger *sessionguard.Guard
-	lcm       lifecycleRecorder
-	dataDir   string
-	clock     func() time.Time
+	messenger   *sessionguard.Guard
+	lcm         lifecycleRecorder
+	dataDir     string
+	runFilePath string
+	clock       func() time.Time
 	// lookPath is exec.LookPath in production; tests substitute a stub so
 	// they don't need real binaries on PATH. Returns ports.ErrAgentBinaryNotFound
 	// when the binary is missing so the sentinel propagates through toAPIError.
@@ -185,7 +188,10 @@ type Deps struct {
 	// DataDir is exported to spawned agents as AO_DATA_DIR so their hook
 	// commands can open the same store.
 	DataDir string
-	Clock   func() time.Time
+	// RunFilePath is exported to spawned agents as AO_RUN_FILE so their hook
+	// commands can reach the daemon instance that launched them.
+	RunFilePath string
+	Clock       func() time.Time
 	// LookPath overrides exec.LookPath for the pre-launch agent-binary check.
 	// Production wiring leaves this nil and the manager defaults to
 	// exec.LookPath; tests inject a stub so they need not seed real binaries.
@@ -203,15 +209,16 @@ type Deps struct {
 // time.Now when Deps.Clock is nil.
 func New(d Deps) *Manager {
 	m := &Manager{
-		runtime:    d.Runtime,
-		agents:     d.Agents,
-		workspace:  d.Workspace,
-		store:      d.Store,
-		lcm:        d.Lifecycle,
-		dataDir:    d.DataDir,
-		clock:      d.Clock,
-		lookPath:   d.LookPath,
-		executable: d.Executable,
+		runtime:     d.Runtime,
+		agents:      d.Agents,
+		workspace:   d.Workspace,
+		store:       d.Store,
+		lcm:         d.Lifecycle,
+		dataDir:     d.DataDir,
+		runFilePath: d.RunFilePath,
+		clock:       d.Clock,
+		lookPath:    d.LookPath,
+		executable:  d.Executable,
 		sendConfirm: sendConfirmConfig{
 			pollInterval:    sendConfirmPollInterval,
 			attemptDeadline: sendConfirmAttemptDeadline,
@@ -2029,8 +2036,8 @@ func workspaceRepoList(repos []domain.WorkspaceRepoRecord) string {
 // spawnEnv builds the runtime environment: the per-project env vars first, then
 // the AO-internal vars last so they always win (a project cannot override
 // AO_SESSION_ID and friends).
-func spawnEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, dataDir string, projectEnv map[string]string) map[string]string {
-	env := make(map[string]string, len(projectEnv)+4)
+func spawnEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, dataDir, runFilePath string, projectEnv map[string]string) map[string]string {
+	env := make(map[string]string, len(projectEnv)+5)
 	for k, v := range projectEnv {
 		env[k] = v
 	}
@@ -2038,6 +2045,9 @@ func spawnEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueI
 	env[EnvProjectID] = string(project)
 	env[EnvIssueID] = string(issue)
 	env[EnvDataDir] = dataDir
+	if runFilePath != "" {
+		env[EnvRunFile] = runFilePath
+	}
 	return env
 }
 
@@ -2049,7 +2059,7 @@ func spawnEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueI
 // When the pin cannot be applied the inherited PATH is kept and a warning is
 // logged so the degradation isn't silent.
 func (m *Manager) runtimeEnv(id domain.SessionID, project domain.ProjectID, issue domain.IssueID, projectEnv map[string]string) map[string]string {
-	env := spawnEnv(id, project, issue, m.dataDir, projectEnv)
+	env := spawnEnv(id, project, issue, m.dataDir, m.runFilePath, projectEnv)
 	path, err := HookPATH(m.executable, os.Getenv, projectEnv)
 	if err != nil {
 		m.logger.Warn("session PATH not pinned to the daemon binary; `ao hooks` callbacks may resolve to a different ao and activity tracking will stall",

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
@@ -284,7 +285,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 
 	branch := cfg.Branch
 	if branch == "" {
-		branch = defaultSpawnBranch(id, cfg.Kind, sessionPrefix(project), project.Kind.WithDefault())
+		branch = defaultSpawnBranch(config.InstanceNamespace(m.dataDir), id, cfg.Kind, sessionPrefix(project), project.Kind.WithDefault())
 	}
 	ws, workspaceProject, err := m.createSessionWorkspace(ctx, project, cfg, id, branch)
 	if err != nil {
@@ -1762,7 +1763,10 @@ func seedRecord(cfg ports.SpawnConfig, now time.Time) domain.SessionRecord {
 	}
 }
 
-func defaultSessionBranch(id domain.SessionID, kind domain.SessionKind, prefix string) string {
+func defaultSessionBranch(namespace string, id domain.SessionID, kind domain.SessionKind, prefix string) string {
+	if namespace != "" {
+		return "ao/" + namespace + "/" + string(id) + "/root"
+	}
 	if kind == domain.KindOrchestrator {
 		return "ao/" + prefix + "-orchestrator"
 	}
@@ -1773,11 +1777,14 @@ func defaultSessionBranch(id domain.SessionID, kind domain.SessionKind, prefix s
 	return "ao/" + string(id) + "/root"
 }
 
-func defaultSpawnBranch(id domain.SessionID, kind domain.SessionKind, prefix string, projectKind domain.ProjectKind) string {
+func defaultSpawnBranch(namespace string, id domain.SessionID, kind domain.SessionKind, prefix string, projectKind domain.ProjectKind) string {
 	if projectKind == domain.ProjectKindWorkspace {
+		if namespace != "" {
+			return "ao/" + namespace + "/" + string(id)
+		}
 		return "ao/" + string(id)
 	}
-	return defaultSessionBranch(id, kind, prefix)
+	return defaultSessionBranch(namespace, id, kind, prefix)
 }
 
 func buildPrompt(cfg ports.SpawnConfig) string {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -1595,6 +1596,83 @@ func TestSpawn_DefaultsBranchFromSessionID(t *testing.T) {
 	// under a namespace that can also hold sibling PR branches.
 	if got := st.sessions[s.ID].Metadata.Branch; got != "ao/mer-1/root" {
 		t.Fatalf("default branch = %q, want ao/mer-1/root", got)
+	}
+}
+
+func TestSpawn_DefaultsBranchFromInstanceNamespace(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{}
+	dataDir := filepath.Join(t.TempDir(), "dev-data")
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{
+		Runtime:   rt,
+		Agents:    fakeAgents{},
+		Workspace: ws,
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: &fakeLCM{store: st},
+		DataDir:   dataDir,
+		LookPath:  lookPath,
+	})
+
+	s, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespace := config.InstanceNamespace(dataDir)
+	want := "ao/" + namespace + "/mer-1/root"
+	if got := st.sessions[s.ID].Metadata.Branch; got != want {
+		t.Fatalf("default branch = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultSessionBranch(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		id        domain.SessionID
+		kind      domain.SessionKind
+		prefix    string
+		want      string
+	}{
+		{name: "worker default unchanged", id: "mer-1", kind: domain.KindWorker, prefix: "mer", want: "ao/mer-1/root"},
+		{name: "orchestrator default unchanged", id: "mer-1", kind: domain.KindOrchestrator, prefix: "mer", want: "ao/mer-orchestrator"},
+		{name: "namespaced worker uses session id path", namespace: "i-abc123", id: "mer-1", kind: domain.KindWorker, prefix: "mer", want: "ao/i-abc123/mer-1/root"},
+		{name: "namespaced orchestrator uses session id path", namespace: "i-abc123", id: "mer-1", kind: domain.KindOrchestrator, prefix: "mer", want: "ao/i-abc123/mer-1/root"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := defaultSessionBranch(tc.namespace, tc.id, tc.kind, tc.prefix); got != tc.want {
+				t.Fatalf("defaultSessionBranch(%q, %q, %q, %q) = %q, want %q", tc.namespace, tc.id, tc.kind, tc.prefix, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultSpawnBranch(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		id          domain.SessionID
+		kind        domain.SessionKind
+		prefix      string
+		projectKind domain.ProjectKind
+		want        string
+	}{
+		{name: "non-workspace default unchanged", id: "mer-1", kind: domain.KindWorker, prefix: "mer", want: "ao/mer-1/root"},
+		{name: "workspace default unchanged", id: "mer-1", kind: domain.KindWorker, prefix: "mer", projectKind: domain.ProjectKindWorkspace, want: "ao/mer-1"},
+		{name: "namespaced non-workspace uses root branch", namespace: "i-abc123", id: "mer-1", kind: domain.KindWorker, prefix: "mer", want: "ao/i-abc123/mer-1/root"},
+		{name: "namespaced workspace uses namespaced root", namespace: "i-abc123", id: "mer-1", kind: domain.KindWorker, prefix: "mer", projectKind: domain.ProjectKindWorkspace, want: "ao/i-abc123/mer-1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := defaultSpawnBranch(tc.namespace, tc.id, tc.kind, tc.prefix, tc.projectKind); got != tc.want {
+				t.Fatalf("defaultSpawnBranch(%q, %q, %q, %q, %q) = %q, want %q", tc.namespace, tc.id, tc.kind, tc.prefix, tc.projectKind, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2351,6 +2351,35 @@ func TestRestore_PromptlessOrchestratorResumesViaAdapter(t *testing.T) {
 	}
 }
 
+func TestRestore_RuntimeEnvIncludesRunFilePath(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID: "mer-1", ProjectID: "mer", Kind: domain.KindOrchestrator, IsTerminated: true,
+		Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-orchestrator"},
+		Activity: domain.Activity{State: domain.ActivityExited},
+	}
+	rt := &fakeRuntime{}
+	runFilePath := filepath.Join(t.TempDir(), "running.json")
+	lookPath := func(string) (string, error) { return "/bin/true", nil }
+	m := New(Deps{
+		Runtime:     rt,
+		Agents:      singleAgent{agent: alwaysResumeAgent{}},
+		Workspace:   &fakeWorkspace{},
+		Store:       st,
+		Messenger:   &fakeMessenger{},
+		Lifecycle:   &fakeLCM{store: st},
+		RunFilePath: runFilePath,
+		LookPath:    lookPath,
+	})
+
+	if _, err := m.Restore(ctx, "mer-1"); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if got := rt.lastCfg.Env[EnvRunFile]; got != runFilePath {
+		t.Fatalf("runtime env AO_RUN_FILE = %q, want %q", got, runFilePath)
+	}
+}
+
 // TestRestore_PromptlessUnresumableRelaunchesFresh covers the genuine-reboot
 // case: a promptless session whose adapter cannot resume (no native session id,
 // no captured AgentSessionID) must be relaunched fresh via GetLaunchCommand

--- a/backend/internal/session_manager/provision_test.go
+++ b/backend/internal/session_manager/provision_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSpawnEnvProjectVarsCannotOverrideInternal(t *testing.T) {
-	env := spawnEnv("mer-1", "mer", "issue-9", "/data", map[string]string{
+	env := spawnEnv("mer-1", "mer", "issue-9", "/data", "", map[string]string{
 		"FOO":        "bar",
 		EnvSessionID: "hacked", // a project must not override AO-internal vars
 		EnvProjectID: "hacked",
@@ -24,6 +24,17 @@ func TestSpawnEnvProjectVarsCannotOverrideInternal(t *testing.T) {
 	}
 	if env[EnvProjectID] != "mer" {
 		t.Fatalf("AO_PROJECT_ID = %q, want mer (internal wins)", env[EnvProjectID])
+	}
+	if _, ok := env[EnvRunFile]; ok {
+		t.Fatalf("AO_RUN_FILE = %q, want unset when run file path is empty", env[EnvRunFile])
+	}
+}
+
+func TestSpawnEnvIncludesRunFileWhenSet(t *testing.T) {
+	env := spawnEnv("mer-1", "mer", "issue-9", "/data", "/data/running.json", nil)
+
+	if got := env[EnvRunFile]; got != "/data/running.json" {
+		t.Fatalf("AO_RUN_FILE = %q, want /data/running.json", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Several session side effects are keyed on the per-project session id (`<project>-<n>`), which is unique only **within one data dir's SQLite database**. When two AO instances run on the same machine (e.g. a packaged app on the default `~/.ao` and a dev build on `~/.ao/dev`), their id counters drift and their agents address the wrong daemon, so a session created by one instance collides with the other on the shared tmux server, git remote, and agent→daemon hook channel. This scopes those surfaces to the instance that owns the session, leaving the default single-instance behavior byte-for-byte unchanged.

Closes #2662

## What this fixes

1. **Spawn "duplicate session".** A reused session id collides with another instance's live tmux session, so `tmux new-session` fails, the spawn rolls back, and the session disappears (the freed id is retried forever).
2. **Stale PR shown as "ready to merge".** A reused id lands on the branch namespace an earlier session used, so a freshly-spawned session inherits an old open PR and is shown as mergeable.
3. **A working session shows "Needs you", not "Working".** Spawned agents got `AO_DATA_DIR` but not `AO_RUN_FILE`, and the run-file default ignores the data dir, so an agent from a non-default-data-dir daemon runs its activity hooks against the wrong run-file (`AO daemon is not running`). The signal never lands and an actively-working session (before any PR) never shows `working`.

## What this adds

- `config.InstanceNamespace(dataDir)` → `""` for the canonical default data dir, `i-<6 hex of sha256(abs path)>` otherwise.
- **tmux:** the runtime carries the namespace and names the session `<ns>-<id>` once (before the existing sanitize rules), stores it in the `RuntimeHandle`, and reuses that handle for attach/probe/destroy — so the create name and the lookup name are always identical. Threaded via `runtimeselect.New(dataDir, log)`; the CLI attach hint uses the same helper.
- **branches:** worker/orchestrator branches become `ao/<ns>/<id>/...` when the namespace is non-empty. SCM attribution reads the stored branch, so instances isolate with no observer change.
- **run-file:** the daemon exports its resolved run-file to spawned and restored agents as `AO_RUN_FILE` (via the shared spawn/restore env builder), so agent hooks reach the daemon that launched them.

## Design notes

- **Backward compatible.** The default data dir yields an empty namespace, and its run-file already equals what agents resolve today. Existing installs get identical tmux names, branches, and hook behavior; no DB migration. Existing sessions keep their stored non-namespaced handle, so boot reconciliation still re-attaches them. Only sessions on a non-default data dir are scoped.
- Session ids are untouched — UI, worktree paths, and the DB are unaffected. No behavior change on Windows/ConPTY.

## Validation

- `gofmt -l` on touched files — clean
- `cd backend && go build ./... && go vet ./...`
- `go test ./internal/config/... ./internal/adapters/runtime/tmux/... ./internal/session_manager/... ./internal/observe/scm/... ./internal/daemon/...` — all passed (real tmux/socket tests included)
- Full `go test ./...` — green except the pre-existing `kilocode` interactive-shell test, unrelated
- New tests: namespace derivation, tmux create==lookup naming under a namespace (matched by command so it's robust to unrelated Create steps), branch namespacing, SCM attribution isolation across namespaces, and `AO_RUN_FILE` presence on the agent env
- Verified end-to-end on a scratch instance: a namespaced spawn succeeded with no `duplicate session`, and the agent env carried the daemon's own run-file so an activity hook flipped the session to `working` (the same hook fails with `AO daemon is not running` without it)

## Post-Deploy Monitoring

- Healthy: two instances on different data dirs spawn same-id sessions without `duplicate session`; no cross-instance PR attribution; an actively-working session with no PR shows `working`; default installs show unchanged names, branches, and hook delivery.
- Failure: `duplicate session` across instances, a session inheriting a foreign PR, a working session stuck idle, or any default-install name/branch/hook change.
- Validation window: first week after release; owner: Agent Orchestrator maintainers.
