### PR TITLE
security: add environment: nightly to signing jobs in frontend-nightly.yml

### DIFF
--- a/.github/workflows/frontend-nightly.yml
+++ b/.github/workflows/frontend-nightly.yml
@@ -51,6 +51,7 @@ jobs:
   release:
     needs: guard
     if: needs.guard.outputs.should_build == 'true'
+    environment: nightly
     strategy:
       fail-fast: false
       matrix:
@@ -116,6 +117,7 @@ jobs:
   release-intel:
     needs: guard
     if: needs.guard.outputs.should_build == 'true'
+    environment: nightly
     runs-on: macos-15-intel
     permissions:
       contents: write


### PR DESCRIPTION
## What

Adds `environment: nightly` to the two signing jobs in `frontend-nightly.yml`:

- `release` (matrix: macOS, Windows, Linux)
- `release-intel` (macOS Intel)

## Why

The six macOS signing secrets (`CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_API_KEY_BASE64`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`) are currently repo-level secrets. A write-access user could push a `desktop-v*` tag whose commit edits `frontend-release.yml` to drop the `environment: release` line, and the workflow would still read the repo-level secrets and produce a signed release without approval.

Moving secrets to the `nightly` environment closes this: a gate-stripped workflow gets no signing secrets at all. The nightly environment should have **no required reviewers** (it runs unattended on cron) and branch policy set to `main` only.

## Admin steps (before merging)

- [ ] Create a `nightly` environment in repo Settings > Environments
- [ ] Add the same six signing secrets to the `nightly` environment
- [ ] Set branch policy to `main` only (no required reviewers for nightly)

## Admin steps (after verifying)

- [ ] Delete the six repo-level secrets once a nightly build goes green on environment secrets

Closes #2395
