### PR TITLE
fix: use .ico for windows taskbar icon

### DIFF
--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -37,7 +37,7 @@ const config: ForgeConfig = {
 		// (.icns on macOS, .ico on Windows); Linux menu icons come from the
 		// deb/rpm makers below, and the runtime window icon from src/main.ts.
 		icon: "assets/icon",
-		extraResource: ["daemon", "assets/icon.png", "app-update.yml"],
+		extraResource: ["daemon", "assets/icon.png", "assets/icon.ico", "app-update.yml"],
 		// Notarization. Two paths:
 		//  - CI: an App Store Connect API key. APPLE_API_KEY is a PATH to the .p8
 		//    (the workflow decodes APPLE_API_KEY_BASE64 to a temp file), plus the

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -213,7 +213,11 @@ function windowIconPath(): string | undefined {
 	const candidate = app.isPackaged
 		? path.join(process.resourcesPath, iconFile)
 		: path.join(__dirname, `../../assets/${iconFile}`);
-	return existsSync(candidate) ? candidate : undefined;
+	if (existsSync(candidate)) return candidate;
+	const fallback = app.isPackaged
+		? path.join(process.resourcesPath, "icon.png")
+		: path.join(__dirname, "../../assets/icon.png");
+	return existsSync(fallback) ? fallback : undefined;
 }
 
 function applyRuntimeAppIcon(): void {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -209,9 +209,10 @@ function annotatePreloadPath(): string {
 // uses the .app bundle's .icns instead. Packaged: shipped via extraResource to
 // resources/icon.png; dev: the source asset under frontend/assets.
 function windowIconPath(): string | undefined {
+	const iconFile = process.platform === "win32" ? "icon.ico" : "icon.png";
 	const candidate = app.isPackaged
-		? path.join(process.resourcesPath, "icon.png")
-		: path.join(__dirname, "../../assets/icon.png");
+		? path.join(process.resourcesPath, iconFile)
+		: path.join(__dirname, `../../assets/${iconFile}`);
 	return existsSync(candidate) ? candidate : undefined;
 }
 


### PR DESCRIPTION
## Problem

On Windows 10, the app icon shows blank in the taskbar (#2340).

## Root cause

`windowIconPath()` returns `icon.png` on all platforms. While Electron accepts PNG for the BrowserWindow icon, Windows 10 taskbar rendering with frameless windows (`titleBarStyle: "hidden"` + `titleBarOverlay`) is more reliable with a proper `.ico` file that contains multiple sizes.

The `.ico` file (`assets/icon.ico`, 81KB, 6 sizes: 16/32/48/64/128/256 at 32bpp) already exists in the repo but is not shipped as an extraResource and is not used for the BrowserWindow icon at runtime.

## Fix

Two changes:

1. `forge.config.ts`: add `assets/icon.ico` to `extraResource` so the `.ico` is available in the packaged app's Resources directory.

2. `src/main.ts`: `windowIconPath()` now returns `icon.ico` on `win32` and `icon.png` on other platforms. Falls back to `icon.png` if the `.ico` is not found (the `existsSync` check handles this).

No behavior change on macOS or Linux.

Closes #2340
