### PR TITLE
fix: add macos traffic light padding to sidebar header

### DIFF
--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -226,7 +226,7 @@ export function Sidebar({
 			data-expanded-chrome={expandedChromeVisible ? "visible" : "hidden"}
 			className={cn("border-border", underTopbar ? "top-14 h-[calc(100svh-3.5rem)]!" : "top-0 h-svh!")}
 		>
-			<SidebarHeader className="gap-0 p-0 pl-2.5 pr-1.75 pt-3.5 group-data-[collapsible=icon]:px-1.5">
+			<SidebarHeader className={cn("gap-0 p-0 pr-1.75 pt-3.5", isMac ? "pl-titlebar-cluster-left" : "pl-2.5", "group-data-[collapsible=icon]:px-1.5")}>
 				{/* Brand (project-sidebar__brand); in the icon rail it becomes the old
             36px board button wrapping the 22px accent mark. */}
 				<div className="flex shrink-0 items-center gap-2.5 px-2 pb-4.5 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-1 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:pb-2">

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -226,7 +226,13 @@ export function Sidebar({
 			data-expanded-chrome={expandedChromeVisible ? "visible" : "hidden"}
 			className={cn("border-border", underTopbar ? "top-14 h-[calc(100svh-3.5rem)]!" : "top-0 h-svh!")}
 		>
-			<SidebarHeader className={cn("gap-0 p-0 pr-1.75 pt-3.5", isMac ? "pl-titlebar-cluster-left" : "pl-2.5", "group-data-[collapsible=icon]:px-1.5")}>
+			<SidebarHeader
+				className={cn(
+					"gap-0 p-0 pr-1.75 pt-3.5",
+					isMac ? "pl-titlebar-cluster-left" : "pl-2.5",
+					"group-data-[collapsible=icon]:px-1.5",
+				)}
+			>
 				{/* Brand (project-sidebar__brand); in the icon rail it becomes the old
             36px board button wrapping the 22px accent mark. */}
 				<div className="flex shrink-0 items-center gap-2.5 px-2 pb-4.5 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-1 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:pb-2">


### PR DESCRIPTION
## Summary

On macOS, the traffic light buttons (close/minimize/maximize) sit in the topbar's left inset at ~79px from the left edge. The sidebar starts directly below the topbar, but the SidebarHeader uses the same `pl-2.5` (10px) padding on all platforms, so the logo and branding text start at ~18px from the left, directly under the traffic lights.

This adds macOS-specific left padding (`pl-titlebar-cluster-left`, 79px) to the SidebarHeader so the branding aligns with the TitlebarNav cluster position, matching the VS Code pattern. On other platforms, padding stays at `pl-2.5` (10px).

When the sidebar is collapsed to icon mode, the `group-data-[collapsible=icon]:px-1.5` override still applies, so the icon rail is unaffected.

Closes #2164