### PR TITLE
feat: show relaunch to update banner on kanban board

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -4,12 +4,14 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 
-const { navigateMock, notificationShowMock, postMock, workspaceQueryMock, boardActionsInPanelMock } = vi.hoisted(() => ({
+const { navigateMock, notificationShowMock, postMock, workspaceQueryMock, boardActionsInPanelMock, updateStatusMock, installMock } = vi.hoisted(() => ({
 	navigateMock: vi.fn(),
 	notificationShowMock: vi.fn(),
 	postMock: vi.fn(),
 	workspaceQueryMock: vi.fn(),
 	boardActionsInPanelMock: vi.fn(() => false),
+	updateStatusMock: vi.fn(),
+	installMock: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -33,6 +35,11 @@ vi.mock("../lib/bridge", () => ({
 		},
 		notifications: {
 			show: (...args: unknown[]) => notificationShowMock(...args),
+		},
+		updates: {
+			getStatus: () => Promise.resolve(updateStatusMock()),
+			onStatus: vi.fn().mockReturnValue(() => undefined),
+			install: () => installMock(),
 		},
 	},
 }));
@@ -72,6 +79,8 @@ beforeEach(() => {
 	workspaceQueryMock.mockReset().mockReturnValue({ data: [], isError: false });
 	window.localStorage.removeItem("ao.board.archive.layout");
 	boardActionsInPanelMock.mockReset().mockReturnValue(false);
+	updateStatusMock.mockReset().mockReturnValue({ state: "idle" });
+	installMock.mockReset().mockResolvedValue(undefined);
 });
 
 describe("SessionsBoard", () => {

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -48,6 +48,7 @@ import { aoBridge } from "../lib/bridge";
 import { usesPreviewWorkspaceData } from "../lib/preview-mode";
 import { cn } from "../lib/utils";
 import { isLinuxPlatform, isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
+import type { UpdateStatus } from "../../main/update-settings";
 import { useUiStore } from "../stores/ui-store";
 import { RestoreUnavailableDialog } from "./RestoreUnavailableDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -102,6 +103,20 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const setOrchestratorStartupError = useUiStore((state) => state.setOrchestratorStartupError);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
 	const isProjectRestarting = projectId ? restartingProjectIds.has(projectId) : false;
+
+	const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ state: "idle" });
+	useEffect(() => {
+		if (!aoBridge.updates) return;
+		let live = true;
+		void aoBridge.updates.getStatus().then((s) => {
+			if (live) setUpdateStatus(s);
+		});
+		const off = aoBridge.updates.onStatus(setUpdateStatus);
+		return () => {
+			live = false;
+			off?.();
+		};
+	}, []);
 	const health = workspace ? orchestratorHealth(workspace, isProjectRestarting) : { state: "ok" as const };
 	const visibleSpawnError = spawnError ?? orchestratorStartupError;
 	// The board instance survives project-to-project navigation (same route,
@@ -316,6 +331,25 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 								Restart
 							</TopbarButton>
 						) : null}
+					</div>
+				) : null}
+				{updateStatus.state === "downloaded" && !showWelcome ? (
+					<div
+						role="status"
+						aria-live="polite"
+						className={cn(
+							"mx-3 my-3 flex items-center gap-3 rounded-md border bg-surface px-3 py-2 text-xs text-muted-foreground",
+							updateStatus.escalated ? "border-working/35 bg-working/12" : "border-border",
+						)}
+					>
+						<RotateCw className={cn("size-icon-base shrink-0", updateStatus.escalated ? "text-working" : "text-success")} aria-hidden="true" />
+						<span className="min-w-0 flex-1">
+							Update ready{updateStatus.version ? ` (v${updateStatus.version})` : ""}.
+						</span>
+						<TopbarButton variant="primary" onClick={() => void aoBridge.updates.install()}>
+							<RotateCw className="size-3.5" aria-hidden="true" />
+							Restart to update
+					</TopbarButton>
 					</div>
 				) : null}
 				{showStartup ? (


### PR DESCRIPTION
## Summary

When an app update has been downloaded and is ready, surface a "Relaunch to update" banner on the Kanban board so the user can apply it without going to Settings.

The banner appears only when `updateStatus.state === "downloaded"` (the same state the Settings page uses for its "Restart & install" button). It uses the existing `aoBridge.updates.install()` IPC call, which calls `quitAndInstallUpdate()` in the main process to relaunch and apply the update.

Changes are in `SessionsBoard.tsx` only:
- Listen to `aoBridge.updates.onStatus` for live update status
- Render a banner with a "Relaunch to update" button when the update is downloaded
- Styled consistently with the existing orchestrator health warning banner (same layout, same `TopbarButton` component)
- Uses `RotateCw` icon (already imported) with success color to indicate a ready state

Closes #2317