### PR TITLE
fix: remove tmux attach hint from spawn output (#2658)

### DIFF
--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -8,15 +8,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/tmux"
 )
 
 // maxDisplayNameLen caps the sidebar label set by `--name`. Mirrored by the
@@ -131,19 +128,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 			if claimed != "" {
 				claimLabel = fmt.Sprintf(" (claimed %s)", claimed)
 			}
-			if _, err := fmt.Fprintf(out, "spawned session %s (%s)%s\n", res.Session.ID, res.Session.Status, claimLabel); err != nil {
-				return err
-			}
-			// Print a copy-pasteable attach hint for the selected runtime.
-			// On Darwin/Linux: tmux attach-session using the sanitised session name.
-			// On Windows: ConPTY has no user-facing attach CLI; use the AO dashboard.
-			var attach string
-			if runtime.GOOS != "windows" {
-				attach = fmt.Sprintf("tmux attach -t %s", tmux.SessionName(res.Session.ID))
-			} else {
-				attach = "Attach from the AO dashboard (ConPTY sessions have no CLI attach command)"
-			}
-			_, err = fmt.Fprintf(out, "attach with: %s\n", attach)
+			_, err = fmt.Fprintf(out, "spawned session %s (%s)%s\n", res.Session.ID, res.Session.Status, claimLabel)
 			return err
 		},
 	}


### PR DESCRIPTION
## What this does
Removes the `attach with: tmux attach -t <session>` line that `ao spawn` printed after a session started.

## Problem
That hint leaks an internal implementation detail — that sessions run inside tmux — into normal user-facing output. Users drive sessions through AO (dashboard/CLI), not by attaching to tmux directly, so the line is noise and can mislead newcomers into thinking tmux is the intended interface. Closes #2658.

## Changes
- `backend/internal/cli/spawn.go` — drop the `fmt.Println` that emitted the tmux-attach hint from the spawn success output.

## Testing
- Spawn output no longer contains the tmux hint.
- `go build ./...` + `go test ./internal/cli/...` green; remote CI green.


🤖 Generated with [Claude Code](https://claude.com/claude-code)