### PR TITLE
fix: warn on branch-name collision in PR session attribution (#2631)

### DIFF
--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -723,9 +723,17 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 			// dropped (as is an empty head repo from a deleted fork), preserving
 			// the no-misattribution guarantee.
 			eligible := candidatesForHeadRepo(byRepo[repoKey], pr.HeadRepo)
-			sr, ok := matchSession(eligible, pr.SourceBranch)
+			sr, ok, ambiguous := matchSession(eligible, pr.SourceBranch)
 			if !ok {
 				continue
+			}
+			if ambiguous {
+				o.logger.Warn("scm observer: PR branch matches multiple sessions — branch-name collision detected; verify push authorship",
+					"pr", firstNonEmpty(pr.URL, pr.HTMLURL),
+					"source_branch", pr.SourceBranch,
+					"attributed_session", sr.session.ID,
+					"head_repo", pr.HeadRepo,
+				)
 			}
 			known := domain.PullRequest{
 				URL:          firstNonEmpty(pr.URL, pr.HTMLURL),
@@ -790,8 +798,7 @@ func candidatesForHeadRepo(candidates []sessionRepo, headRepo string) []sessionR
 	return out
 }
 
-func matchSession(candidates []sessionRepo, sourceBranch string) (sessionRepo, bool) {
-	var best sessionRepo
+func matchSession(candidates []sessionRepo, sourceBranch string) (best sessionRepo, found bool, ambiguous bool) {
 	bestLen := -1
 	for _, sr := range candidates {
 		if sr.branch == "" {
@@ -806,7 +813,23 @@ func matchSession(candidates []sessionRepo, sourceBranch string) (sessionRepo, b
 			}
 		}
 	}
-	return best, bestLen >= 0
+	if bestLen < 0 {
+		return best, false, false
+	}
+	// Count how many candidates matched at exactly bestLen characters.
+	count := 0
+	for _, sr := range candidates {
+		if sr.branch == "" {
+			continue
+		}
+		for _, prefix := range sessionBranchPrefixes(sr.branch) {
+			if (prefix == sourceBranch || strings.HasPrefix(sourceBranch, prefix+"/")) && len(prefix) == bestLen {
+				count++
+				break
+			}
+		}
+	}
+	return best, true, count > 1
 }
 
 func sessionBranchPrefixes(branch string) []string {


### PR DESCRIPTION
## Summary

- Enhanced `matchSession()` to detect and report branch-name collisions when multiple sessions match the same source branch
- Logs a warning when a PR's source branch matches multiple session candidates at the same specificity level, flagging potential push authorship issues
- Handles the ambiguity case where prefix matching results in identical match lengths for different sessions

## How it was verified

The fix has been verified to:
1. Correctly identify branch-name collisions in the session matching logic
2. Log warning messages with detailed context (PR URL, source branch, attributed session, head repo)
3. Preserve existing behavior for unambiguous session attribution (single best match)
4. Maintain no-misattribution guarantee by still only considering sessions whose head repo matches the PR's head repo

## Testing
- Manual validation confirms the collision detection logic works as expected in edge cases with multiple matching prefixes
- Existing PR discovery and attribution flows remain unchanged for non-ambiguous cases

Closes #2631

🤖 Generated with [Claude Code](https://claude.com/claude-code)