### PR TITLE
fix: match PR head repo against all scan remotes, not just origin (#2609)

### DIFF
--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -495,9 +495,11 @@ func (o *Observer) discoverSubjects(ctx context.Context) (map[string]*subject, [
 			}
 		}
 		repos := make([]ports.SCMRepo, 0, len(scanRepos[sess.ProjectID]))
-		if origin, ok := originRepos[sess.ProjectID]; ok {
+		if _, ok := originRepos[sess.ProjectID]; ok {
 			for _, repo := range scanRepos[sess.ProjectID] {
-				sessionRepos = append(sessionRepos, sessionRepo{session: sess, repo: repo, headRepo: origin, branch: branch})
+				for _, headRepo := range scanRepos[sess.ProjectID] {
+					sessionRepos = append(sessionRepos, sessionRepo{session: sess, repo: repo, headRepo: headRepo, branch: branch})
+				}
 				repos = append(repos, repo)
 			}
 		}


### PR DESCRIPTION
## Summary
Fixed a bug where the PR head repository was only being matched against the origin remote. The fix ensures that the PR head repo is matched against all scanned remotes for a project, allowing proper handling of repositories with multiple configured remotes.

## Changes
- Modified `discoverSubjects()` in `backend/internal/observe/scm/observer.go` to iterate through all scan remotes instead of only using the origin remote
- This prevents missing PR head repository matches when working with non-standard remote configurations

## How it was verified
The fix has been validated through local testing and manual code review of the logic flow.

Closes #2609

🤖 Generated with [Claude Code](https://claude.com/claude-code)