### PR TITLE
fix: validate per-project keys in legacy config on import (#2653)

### DIFF
--- a/backend/internal/cli/doctor.go
+++ b/backend/internal/cli/doctor.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/legacyimport"
 )
 
 type doctorLevel string
@@ -145,6 +146,8 @@ func (c *commandContext) runDoctor(ctx context.Context) []doctorCheck {
 
 	checks = append(checks, checkStore(cfg.DataDir), checkHooksLog(cfg.DataDir, time.Now()))
 
+	checks = append(checks, checkLegacyConfigSchema(legacyimport.DefaultLegacyRootDir()))
+
 	st, err := c.inspectDaemon(ctx)
 	if err != nil {
 		checks = append(checks, doctorCheck{Level: doctorFail, Section: doctorSectionCore, Name: "daemon", Message: err.Error()})
@@ -176,6 +179,20 @@ func (c *commandContext) runDoctor(ctx context.Context) []doctorCheck {
 	}
 	checks = append(checks, c.checkCodexLaunchFlags(ctx), c.checkGitHubToken(ctx))
 	return checks
+}
+
+// checkLegacyConfigSchema validates per-project keys in the legacy config.yaml.
+// Unknown top-level keys (notifiers, power, plugins, …) are tolerated by design;
+// only misspelled or unknown per-project keys are surfaced as a warning.
+func checkLegacyConfigSchema(root string) doctorCheck {
+	const name = "legacy-config-schema"
+	if root == "" {
+		return doctorCheck{Level: doctorPass, Section: doctorSectionCore, Name: name, Message: "legacy root unavailable; skipped"}
+	}
+	if err := legacyimport.ValidateConfigSchema(root); err != nil {
+		return doctorCheck{Level: doctorWarn, Section: doctorSectionCore, Name: name, Message: err.Error()}
+	}
+	return doctorCheck{Level: doctorPass, Section: doctorSectionCore, Name: name, Message: "legacy config.yaml project keys OK"}
 }
 
 // checkStore inspects the SQLite store WITHOUT opening or migrating it. The

--- a/backend/internal/legacyimport/config.go
+++ b/backend/internal/legacyimport/config.go
@@ -1,10 +1,12 @@
 package legacyimport
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	yaml "gopkg.in/yaml.v3"
 )
@@ -76,7 +78,67 @@ func loadLegacyConfig(root string) (legacyConfig, error) {
 		// A type mismatch (e.g. a scalar where a mapping is expected) is a
 		// partial decode: keep the decoded fields and continue.
 	}
+
+	// Second-pass: validate per-project keys using KnownFields(true) so
+	// misspelled or misplaced project-level keys are caught. Top-level unknown
+	// keys (notifiers, power, plugins, …) remain intentionally tolerated.
+	if err := validateProjectKeys(data); err != nil {
+		return legacyConfig{}, err
+	}
+
 	return cfg, nil
+}
+
+// validateProjectKeys decodes only the per-project blocks with KnownFields(true)
+// to surface misspelled or unknown project keys. Type errors are tolerated (they
+// are already handled by the first-pass Unmarshal above); only "field not found"
+// errors from KnownFields propagate.
+func validateProjectKeys(data []byte) error {
+	// Extract raw per-project nodes without strict validation at the top level.
+	var raw struct {
+		Projects map[string]yaml.Node `yaml:"projects"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil // parse failure already handled by caller
+	}
+
+	var errs []string
+	for id, node := range raw.Projects {
+		nodeData, marshalErr := yaml.Marshal(&node)
+		if marshalErr != nil {
+			continue
+		}
+		dec := yaml.NewDecoder(bytes.NewReader(nodeData))
+		dec.KnownFields(true)
+		var pc legacyProjectConfig
+		if decErr := dec.Decode(&pc); decErr != nil {
+			var typeErr *yaml.TypeError
+			if errors.As(decErr, &typeErr) {
+				// Tolerate type mismatches (handled by the first-pass decode).
+				continue
+			}
+			errs = append(errs, fmt.Sprintf("project %q: %v", id, decErr))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("legacy config.yaml: unknown project keys: %w", errors.New(strings.Join(errs, "; ")))
+	}
+	return nil
+}
+
+// ValidateConfigSchema reads root/config.yaml and returns an error if any
+// per-project block contains unknown or misspelled keys. A missing config file
+// is not an error. This is intentionally limited to project blocks — top-level
+// unknown keys (notifiers, power, plugins, …) are tolerated by design.
+func ValidateConfigSchema(root string) error {
+	data, err := os.ReadFile(globalConfigPath(root))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read legacy config: %w", err)
+	}
+	return validateProjectKeys(data)
 }
 
 // preferences is the portfolio/preferences.json overlay: only per-project

--- a/backend/internal/legacyimport/project.go
+++ b/backend/internal/legacyimport/project.go
@@ -61,6 +61,10 @@ func buildAgentConfig(src *legacyAgentConfig, notes *[]string, label string) dom
 			*notes = append(*notes, fmt.Sprintf("%s permission %q mapped lossily to %q", label, src.Permissions, mode))
 		}
 	}
+	if err := out.Validate(); err != nil {
+		*notes = append(*notes, fmt.Sprintf("%s: invalid config ignored: %v", label, err))
+		return domain.AgentConfig{}
+	}
 	return out
 }
 


### PR DESCRIPTION
## Summary
- Add KnownFields second-pass validation for per-project blocks in `loadLegacyConfig` to catch misspelled or misplaced project-level keys
- Reject invalid AgentConfig values in `buildAgentConfig` by calling Validate() and surfacing errors as dropped-field notes
- Surface legacy config schema issues as a doctor warning via new `checkLegacyConfigSchema` check

## What Changed
1. **backend/internal/legacyimport/config.go**: Added `validateProjectKeys()` function that decodes the YAML with `KnownFields(true)` to surface unknown project-level keys during the import process.
2. **backend/internal/legacyimport/project.go**: Enhanced `buildAgentConfig()` to validate the resulting AgentConfig and report invalid configurations as notes instead of silently accepting invalid values.
3. **backend/internal/cli/doctor.go**: Added `checkLegacyConfigSchema()` function and integrated it into the doctor checks to warn users about legacy config schema issues.

## How It Was Verified
- The fix has been verified to correctly identify and report:
  - Misspelled project-level keys in legacy config.yaml
  - Invalid AgentConfig values that fail domain validation
  - Integration of schema validation into the doctor command
- Legacy config imports now properly surface validation errors for user remediation

Closes #2653

🤖 Generated with [Claude Code](https://claude.com/claude-code)