### PR TITLE
fix: force re-fetch open PRs after DefaultPRMaxAge regardless of ETag (#2656)

### DIFF
--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -32,6 +32,9 @@ const (
 	DefaultReviewInterval = 2 * time.Minute
 	// DefaultCacheMax bounds each in-memory ETag/review cache map.
 	DefaultCacheMax = 512
+	// DefaultPRMaxAge is the maximum time a locally-open tracked PR may go
+	// without a forced re-fetch regardless of ETag signals.
+	DefaultPRMaxAge = 5 * time.Minute
 	// BatchSize is the maximum number of PRs in one provider batch fetch.
 	BatchSize = 25
 )
@@ -94,6 +97,10 @@ type ObserverCache struct {
 	// ReviewRefreshFailed marks PRs whose review-thread refresh failed; the
 	// next poll retries regardless of the normal review cadence/status rules.
 	ReviewRefreshFailed map[string]bool
+	// LastPRFetchAt maps PR keys to the last time the PR was successfully fetched from the provider.
+	LastPRFetchAt map[string]time.Time
+	// lastPRFetchOrder tracks FIFO eviction order for LastPRFetchAt.
+	lastPRFetchOrder []string
 	// repoOrder tracks FIFO eviction order for RepoPRListETag.
 	repoOrder []string
 	// commitOrder tracks FIFO eviction order for CommitChecksETag.
@@ -115,6 +122,7 @@ func newCache(maxEntries int) ObserverCache {
 		CommitChecksETag:    map[string]string{},
 		LastReviewPollAt:    map[string]time.Time{},
 		ReviewRefreshFailed: map[string]bool{},
+		LastPRFetchAt:       map[string]time.Time{},
 		max:                 maxEntries,
 	}
 }
@@ -274,7 +282,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 		return err
 	}
 
-	selection := o.selectRefreshCandidates(ctx, subjects, repoGuards, markRepoRefreshFailed)
+	selection := o.selectRefreshCandidates(ctx, subjects, repoGuards, markRepoRefreshFailed, now)
 	observations := map[string]ports.SCMObservation{}
 	prRefreshOK := map[string]bool{}
 	for key := range selection.candidateKeys {
@@ -403,6 +411,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 		if reviewModes[key] != ports.ReviewWritePreserve {
 			o.cacheSetTime(o.Cache.LastReviewPollAt, &o.Cache.lastReviewPollOrder, key, now)
 		}
+		o.cacheSetTime(o.Cache.LastPRFetchAt, &o.Cache.lastPRFetchOrder, key, now)
 	}
 	for key, ok := range repoRefreshOK {
 		if !ok {
@@ -817,7 +826,7 @@ func sessionBranchPrefixes(branch string) []string {
 	return prefixes
 }
 
-func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[string]*subject, guards map[string]repoGuardState, markRepoFailed func(ports.SCMRepo)) refreshSelection {
+func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[string]*subject, guards map[string]repoGuardState, markRepoFailed func(ports.SCMRepo), now time.Time) refreshSelection {
 	selection := refreshSelection{
 		subjectsByPR:  map[string]*subject{},
 		commitETags:   map[string]pendingCacheString{},
@@ -848,6 +857,12 @@ func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[str
 				if res.ETag != "" {
 					selection.commitETags[key] = pendingCacheString{key: commitKey, value: res.ETag}
 				}
+			}
+		}
+		if !candidate {
+			last := o.Cache.LastPRFetchAt[key]
+			if last.IsZero() || now.Sub(last) > DefaultPRMaxAge {
+				candidate = true
 			}
 		}
 		if candidate {

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -32,8 +32,12 @@ const (
 	DefaultReviewInterval = 2 * time.Minute
 	// DefaultCacheMax bounds each in-memory ETag/review cache map.
 	DefaultCacheMax = 512
-	// DefaultPRMaxAge is the maximum time a locally-open tracked PR may go
-	// without a forced re-fetch regardless of ETag signals.
+	// DefaultPRMaxAge bounds how long a locally-open tracked PR may go without a
+	// forced re-fetch. It is a bounded-staleness backstop, not a distrust of the
+	// ETag: the refresh signals the observer consults (the repo PR-list guard and
+	// the per-commit checks guard) do not track a PR's own state, so a merged or
+	// closed PR whose head SHA is unchanged can otherwise read stale. This caps
+	// how long that inference can persist.
 	DefaultPRMaxAge = 5 * time.Minute
 	// BatchSize is the maximum number of PRs in one provider batch fetch.
 	BatchSize = 25

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -860,6 +860,13 @@ func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[str
 			}
 		}
 		if !candidate {
+			// Force an unconditional fetch once the snapshot is older than
+			// DefaultPRMaxAge. Trade-off: GitHub does not bill 304 responses, so
+			// this forgoes the conditional-request savings the ETag path bought.
+			// At the current 30s tick / 5m max-age that is ~12 unconditional
+			// fetches/hour per tracked open PR, and it scales linearly with the
+			// number of tracked PRs. It also fires for every stale PR in the same
+			// tick, so watch secondary-rate-limit burstiness as fleets grow.
 			last := o.Cache.LastPRFetchAt[key]
 			if last.IsZero() || now.Sub(last) > DefaultPRMaxAge {
 				candidate = true

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -1382,6 +1382,75 @@ func TestDiscoverSubjects_BackfillsRepoOriginURL(t *testing.T) {
 	}
 }
 
+// TestPoll_StaleOpenPRForcedRefreshAfterMaxAge verifies that an open PR whose
+// LastPRFetchAt is zero (never fetched) is re-fetched even when both the repo
+// ETag guard and the commit checks guard return NotModified. This covers the
+// post-merge stale-ETag scenario where the PR has been merged server-side but
+// the provider ETag signals no change.
+func TestPoll_StaleOpenPRForcedRefreshAfterMaxAge(t *testing.T) {
+	store := testStoreWithSession()
+	local := knownPR(1)
+	// Fully-populated open PR — all hashes set, not merged, not closed.
+	local.Merged = false
+	local.Closed = false
+	store.prs["p-1"] = []domain.PullRequest{local}
+
+	// Provider: both guards return NotModified, but the observation reports merged.
+	mergedObs := testObs(1)
+	mergedObs.PR.Merged = true
+	mergedObs.PR.State = "merged"
+
+	repoKey := prKey(testRepo, 0)
+	commitCacheKey := commitKey(testRepo, "sha1")
+
+	provider := &fakeProvider{
+		repoGuards:  map[string]ports.SCMGuardResult{repoKey: {ETag: "v1", NotModified: true}},
+		checkGuards: map[string]ports.SCMGuardResult{commitCacheKey: {ETag: "ci1", NotModified: true}},
+		observations: map[string]ports.SCMObservation{
+			prKey(testRepo, 1): mergedObs,
+		},
+	}
+
+	now := time.Unix(1000, 0).UTC()
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, now)
+	// Pre-seed ETags so both guards fire NotModified.
+	obs.Cache.RepoPRListETag[repoKey] = "v1"
+	obs.Cache.CommitChecksETag[commitCacheKey] = "ci1"
+	// Leave LastPRFetchAt empty (zero time) for the PR key — forces refresh.
+
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.fetchBatches) != 1 {
+		t.Fatalf("expected 1 fetch batch (stale PR forced refresh), got %d: %#v", len(provider.fetchBatches), provider.fetchBatches)
+	}
+	var mergedWrite *fakeWrite
+	for i := range store.writes {
+		if store.writes[i].pr.Number == 1 && store.writes[i].pr.Merged {
+			mergedWrite = &store.writes[i]
+			break
+		}
+	}
+	if mergedWrite == nil {
+		t.Fatalf("expected a write with pr.Merged==true, got writes: %#v", store.writes)
+	}
+
+	// Now simulate a recent fetch: set LastPRFetchAt to now and poll again.
+	// The PR is now merged in the store, so openTrackedPRs will not include it.
+	// Reset the store to still have the open PR so we test the max-age guard specifically.
+	store.writes = nil
+	provider.fetchBatches = nil
+	store.prs["p-1"] = []domain.PullRequest{local} // restore open PR
+	obs.Cache.LastPRFetchAt[prKey(testRepo, 1)] = now
+
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.fetchBatches) != 0 {
+		t.Fatalf("expected no fetch batch within max-age window, got %d: %#v", len(provider.fetchBatches), provider.fetchBatches)
+	}
+}
+
 // TestDiscoverSubjects_NonGitPathDoesNotBackfill confirms the backfill is
 // best-effort: a non-git project path leaves RepoOriginURL empty without
 // erroring or persisting a stub, so the project is simply skipped.

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -1449,6 +1449,23 @@ func TestPoll_StaleOpenPRForcedRefreshAfterMaxAge(t *testing.T) {
 	if len(provider.fetchBatches) != 0 {
 		t.Fatalf("expected no fetch batch within max-age window, got %d: %#v", len(provider.fetchBatches), provider.fetchBatches)
 	}
+
+	// Backdate the last fetch beyond DefaultPRMaxAge. This is the behavior the PR
+	// actually adds: the max-age guard (not the never-fetched branch) forces a
+	// refetch. The clock is pinned, so parts 1 and 2 only cover last.IsZero() and
+	// a zero elapsed time; without this, deleting the `> DefaultPRMaxAge` compare
+	// would still pass.
+	store.writes = nil
+	provider.fetchBatches = nil
+	store.prs["p-1"] = []domain.PullRequest{local} // restore open PR
+	obs.Cache.LastPRFetchAt[prKey(testRepo, 1)] = now.Add(-(DefaultPRMaxAge + time.Minute))
+
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.fetchBatches) != 1 {
+		t.Fatalf("expected forced refresh once older than DefaultPRMaxAge, got %d: %#v", len(provider.fetchBatches), provider.fetchBatches)
+	}
 }
 
 // TestDiscoverSubjects_NonGitPathDoesNotBackfill confirms the backfill is


### PR DESCRIPTION
## What this does
Puts a ceiling on how long a session's open PRs can read stale: once the cached snapshot is older than `DefaultPRMaxAge` (5 minutes), the observer forces a full re-fetch instead of relying on the conditional-request fast path.

## Problem
When a PR is merged or closed on GitHub its head SHA does not change, so the per-commit checks guard correctly returns `304 Not Modified` (the check runs really did not change). The observer only consults that guard and the repo-level PR-list guard, and neither is a conditional request against the PR's own state, so it infers "unchanged" from signals that do not track the merged/closed transition. A PR can therefore keep reading "open" in AO until the next unconditional refresh.

This is a bounded-staleness backstop, not a claim that GitHub violates ETag semantics: it caps how long that inference can persist. The deeper fix (a per-PR conditional request, or making the list guard authoritative for PR state) is a larger change still under discussion in the review thread. Refs #2656.

## Changes
- `backend/internal/observe/scm/observer.go` — force an unconditional re-fetch of open PRs once the cached snapshot exceeds `DefaultPRMaxAge`, with the rate-limit trade-off documented (bypasses the 304 savings; all stale PRs refetch in the same tick).
- Adds a regression test for the stale-"open"-PR case that backdates the cache entry past `DefaultPRMaxAge`.

## Testing
- `go test ./internal/observe/scm/...` passes, including the new test.
