### PR TITLE
fix: backfill closed/merged PRs for sessions (#2632)

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -91,6 +91,37 @@ func (p *Provider) ListOpenPRsByRepo(ctx context.Context, repo ports.SCMRepo) ([
 	}
 }
 
+// SearchPRsByBranch searches for any pull request in repo whose head branch
+// matches headBranch, regardless of state (open, closed, merged). It uses the
+// REST pulls endpoint with state=all so the observer can discover PRs that
+// merged or closed before AO ever saw them as open. Results are bounded by
+// perPage=10 since branch-to-PR cardinality is expected to be very low.
+func (p *Provider) SearchPRsByBranch(ctx context.Context, repo ports.SCMRepo, headBranch string) ([]ports.SCMPRObservation, error) {
+	if strings.TrimSpace(headBranch) == "" {
+		return nil, nil
+	}
+	const perPage = 10
+	q := url.Values{}
+	q.Set("state", "all")
+	q.Set("head", repo.Owner+":"+headBranch)
+	q.Set("sort", "updated")
+	q.Set("direction", "desc")
+	q.Set("per_page", strconv.Itoa(perPage))
+	resp, err := p.client.doREST(ctx, http.MethodGet, repoPath(repo.Owner, repo.Name, "pulls"), q, nil)
+	if err != nil {
+		return nil, err
+	}
+	var pulls []restListPull
+	if err := json.Unmarshal(resp.Body, &pulls); err != nil {
+		return nil, fmt.Errorf("github scm: decode branch PR search: %w", err)
+	}
+	out := make([]ports.SCMPRObservation, 0, len(pulls))
+	for _, pull := range pulls {
+		out = append(out, restListPullToSCM(pull))
+	}
+	return out, nil
+}
+
 // CommitChecksGuard checks GitHub's per-commit check-runs ETag guard.
 func (p *Provider) CommitChecksGuard(ctx context.Context, repo ports.SCMRepo, headSHA, etag string) (ports.SCMGuardResult, error) {
 	if strings.TrimSpace(headSHA) == "" {

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -41,6 +41,7 @@ type Provider interface {
 	ParseRepository(remote string) (ports.SCMRepo, bool)
 	RepoPRListGuard(ctx context.Context, repo ports.SCMRepo, etag string) (ports.SCMGuardResult, error)
 	ListOpenPRsByRepo(ctx context.Context, repo ports.SCMRepo) ([]ports.SCMPRObservation, error)
+	SearchPRsByBranch(ctx context.Context, repo ports.SCMRepo, headBranch string) ([]ports.SCMPRObservation, error)
 	CommitChecksGuard(ctx context.Context, repo ports.SCMRepo, headSHA, etag string) (ports.SCMGuardResult, error)
 	FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error)
 	FetchFailedCheckLogTail(ctx context.Context, repo ports.SCMRepo, check ports.SCMCheckObservation) (string, error)
@@ -142,12 +143,16 @@ type Observer struct {
 	disabled bool
 	// Cache holds bounded in-memory provider ETags and review poll timestamps.
 	Cache ObserverCache
+	// backfilledSessions is the set of session IDs for which a per-session
+	// branch search has already been attempted in this process lifetime, so
+	// the (potentially expensive) REST call fires at most once per boot.
+	backfilledSessions map[domain.SessionID]bool
 }
 
 // New constructs an Observer with default cadence/cache settings for zero
 // values in cfg.
 func New(provider Provider, store Store, lifecycle Lifecycle, cfg Config) *Observer {
-	o := &Observer{provider: provider, store: store, lifecycle: lifecycle, tick: cfg.Tick, reviewInterval: cfg.ReviewInterval, clock: cfg.Clock, logger: cfg.Logger, Cache: newCache(cfg.CacheMax)}
+	o := &Observer{provider: provider, store: store, lifecycle: lifecycle, tick: cfg.Tick, reviewInterval: cfg.ReviewInterval, clock: cfg.Clock, logger: cfg.Logger, Cache: newCache(cfg.CacheMax), backfilledSessions: map[domain.SessionID]bool{}}
 	if o.tick <= 0 {
 		o.tick = DefaultTickInterval
 	}
@@ -270,6 +275,10 @@ func (o *Observer) Poll(ctx context.Context) error {
 		return err
 	}
 	o.discoverNewPRs(ctx, sessionRepos, subjects, repoGuards, now, markRepoRefreshFailed)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	o.backfillClosedPRs(ctx, sessionRepos, subjects, now)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -760,6 +769,89 @@ func (o *Observer) discoverNewPRs(ctx context.Context, sessionRepos []sessionRep
 				known:   known,
 				hasPR:   true,
 			}
+		}
+	}
+}
+
+// backfillClosedPRs performs a targeted per-session branch search for sessions
+// that have no tracked open PR and have not yet been backfilled this boot. For
+// each such session it calls SearchPRsByBranch (state=all) against the session's
+// head repo; if a merged/closed PR is found it is written as a terminal baseline
+// row so the normal persistence/lifecycle pass can fire the completion rule.
+// The search is gated by backfilledSessions so the REST call fires at most once
+// per daemon boot per session.
+func (o *Observer) backfillClosedPRs(ctx context.Context, sessionRepos []sessionRepo, subjects map[string]*subject, now time.Time) {
+	// Index which sessions already have a tracked open PR in subjects.
+	sessionsWithPR := map[domain.SessionID]bool{}
+	for _, s := range subjects {
+		if s.hasPR {
+			sessionsWithPR[s.session.ID] = true
+		}
+	}
+	// Collect per-session the first sessionRepo entry; one search per session suffices
+	// because matchSession/attribution logic uses the same branch-prefix rules.
+	type searchTarget struct {
+		sr     sessionRepo
+		branch string
+	}
+	targets := map[domain.SessionID]searchTarget{}
+	for _, sr := range sessionRepos {
+		id := sr.session.ID
+		if sessionsWithPR[id] || o.backfilledSessions[id] {
+			continue
+		}
+		if _, already := targets[id]; !already {
+			targets[id] = searchTarget{sr: sr, branch: sr.branch}
+		}
+	}
+	for sessID, t := range targets {
+		o.backfilledSessions[sessID] = true
+		pulls, err := o.provider.SearchPRsByBranch(ctx, t.sr.headRepo, t.branch)
+		if err != nil {
+			if !errors.Is(err, ports.ErrSCMNotFound) {
+				o.logger.Error("scm observer: backfill branch search failed", "session", sessID, "branch", t.branch, "err", err)
+			}
+			continue
+		}
+		for _, pr := range pulls {
+			if pr.Number <= 0 || pr.SourceBranch == "" {
+				continue
+			}
+			if !pr.Merged && !pr.Closed {
+				// Open PRs are handled by discoverNewPRs; skip.
+				continue
+			}
+			key := prKey(t.sr.headRepo, pr.Number)
+			if _, ok := subjects[key]; ok {
+				continue
+			}
+			known := domain.PullRequest{
+				URL:          firstNonEmpty(pr.URL, pr.HTMLURL),
+				SessionID:    sessID,
+				Number:       pr.Number,
+				Draft:        pr.Draft,
+				Merged:       pr.Merged,
+				Closed:       pr.Closed,
+				SourceBranch: pr.SourceBranch,
+				TargetBranch: pr.TargetBranch,
+				HeadSHA:      pr.HeadSHA,
+				Provider:     t.sr.headRepo.Provider,
+				Host:         t.sr.headRepo.Host,
+				Repo:         repoFullName(t.sr.headRepo),
+				UpdatedAt:    now,
+			}
+			if err := o.store.WriteSCMObservation(ctx, known, nil, nil, nil, nil, ports.ReviewWritePreserve); err != nil {
+				o.logger.Error("scm observer: persist backfilled closed PR failed", "session", sessID, "pr", known.URL, "err", err)
+				continue
+			}
+			subjects[key] = &subject{
+				session: t.sr.session,
+				repo:    t.sr.headRepo,
+				branch:  t.branch,
+				known:   known,
+				hasPR:   true,
+			}
+			o.logger.Info("scm observer: backfilled closed/merged PR for session", "session", sessID, "pr", known.URL)
 		}
 	}
 }

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -137,6 +137,10 @@ type fakeProvider struct {
 	fetchBatches     [][]ports.SCMPRRef
 	logCalls         int
 	reviewCalls      int
+
+	branchSearchPRs   map[string][]ports.SCMPRObservation
+	branchSearchErr   error
+	branchSearchCalls int
 }
 
 func (p *fakeProvider) SCMCredentialsAvailable(context.Context) (bool, error) {
@@ -177,6 +181,15 @@ func (p *fakeProvider) ListOpenPRsByRepo(_ context.Context, repo ports.SCMRepo) 
 		return nil, p.listErr
 	}
 	return p.openPRs[prKey(repo, 0)], nil
+}
+func (p *fakeProvider) SearchPRsByBranch(_ context.Context, repo ports.SCMRepo, branch string) ([]ports.SCMPRObservation, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.branchSearchCalls++
+	if p.branchSearchErr != nil {
+		return nil, p.branchSearchErr
+	}
+	return p.branchSearchPRs[prKey(repo, 0)+"/"+branch], nil
 }
 func (p *fakeProvider) CommitChecksGuard(_ context.Context, repo ports.SCMRepo, sha, _ string) (ports.SCMGuardResult, error) {
 	return p.checkGuards[commitKey(repo, sha)], nil
@@ -1403,5 +1416,61 @@ func TestDiscoverSubjects_NonGitPathDoesNotBackfill(t *testing.T) {
 	}
 	if got := store.projects["p"].RepoOriginURL; got != "" {
 		t.Fatalf("RepoOriginURL = %q, want empty (no persist on failed backfill)", got)
+	}
+}
+
+// TestBackfillClosedPRs_WritesTerminalBaselineRow verifies that backfillClosedPRs
+// writes a terminal PR row for a session that has no tracked open PR but whose
+// branch maps to a merged PR returned by SearchPRsByBranch, and that the
+// once-per-boot gate prevents a second search call on subsequent polls.
+func TestBackfillClosedPRs_WritesTerminalBaselineRow(t *testing.T) {
+	const sessID = domain.SessionID("p-1")
+	const branch = "feat"
+	mergedPR := ports.SCMPRObservation{
+		URL:          "https://github.com/o/r/pull/99",
+		HTMLURL:      "https://github.com/o/r/pull/99",
+		Number:       99,
+		Merged:       true,
+		SourceBranch: branch,
+		TargetBranch: "main",
+		HeadSHA:      "deadbeef",
+	}
+	store := testStoreWithSession()
+	provider := &fakeProvider{
+		repoGuards: map[string]ports.SCMGuardResult{
+			prKey(testRepo, 0): {ETag: "v1"},
+		},
+		openPRs:      map[string][]ports.SCMPRObservation{},
+		observations: map[string]ports.SCMObservation{},
+		branchSearchPRs: map[string][]ports.SCMPRObservation{
+			prKey(testRepo, 0) + "/" + branch: {mergedPR},
+		},
+	}
+	obs := newTestObserver(store, provider, &fakeLifecycle{}, time.Unix(1, 0).UTC())
+
+	// First Poll: backfill should fire and write the terminal row.
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatalf("first Poll: %v", err)
+	}
+	if provider.branchSearchCalls != 1 {
+		t.Fatalf("branchSearchCalls after first poll = %d, want 1", provider.branchSearchCalls)
+	}
+	var found bool
+	for _, w := range store.writes {
+		if w.pr.SessionID == sessID && w.pr.Number == 99 && w.pr.Merged {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a write with Merged=true and SessionID=%q and Number=99; writes=%v", sessID, store.writes)
+	}
+
+	// Second Poll: the once-per-boot gate must prevent a second search call.
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatalf("second Poll: %v", err)
+	}
+	if provider.branchSearchCalls != 1 {
+		t.Fatalf("branchSearchCalls after second poll = %d, want 1 (once-per-boot gate)", provider.branchSearchCalls)
 	}
 }


### PR DESCRIPTION
## Summary
Adds SearchPRsByBranch to the Provider interface and GitHub adapter so the observer can discover PRs that merged or closed before AO first polled them. backfillClosedPRs runs once per daemon boot per session for sessions with no tracked open PR, writing a terminal baseline row so the lifecycle completion rule fires correctly.

## Test plan
- [x] All existing tests pass
- [x] New tests validate the backfill behavior for closed/merged PRs
- [x] Verify sessions without open PRs can properly discover and handle terminal PR states

Closes #2632

🤖 Generated with [Claude Code](https://claude.com/claude-code)