### PR TITLE
update landing demo mux playback id

### DIFF
--- a/frontend/src/landing/components/LandingVideo.tsx
+++ b/frontend/src/landing/components/LandingVideo.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 
 export function LandingVideo() {
-	const muxPlaybackId = process.env.NEXT_PUBLIC_MUX_PLAYBACK_ID ?? "sqEsVHcr01aPubYnAy6Z00pCrjuKmLMkkCgXvDxon84ao";
+	const muxPlaybackId = process.env.NEXT_PUBLIC_MUX_PLAYBACK_ID ?? "JByXWlOrW1kIqAfOVbwIozLv4UEB1b901Zv01CwxArEWs";
 	const [isPlaying, setIsPlaying] = useState(false);
 	const videoTitle = "Agent Orchestrator Launch Demo";
 	const encodedTitle = encodeURIComponent(videoTitle);


### PR DESCRIPTION
Points the landing page demo player at the new Mux asset.

The playback ID in `LandingVideo.tsx` still referenced the previous demo upload. This swaps it for the current one.

Note: the static poster (`/mux-video-preview.jpg`) is still a thumbnail of the old video, so the pre-play frame is stale. Left as-is here to keep this change minimal — happy to fold in a fix if preferred.