### PR TITLE
test(cli): stabilize native e2e daemon shutdown

### DIFF
--- a/backend/internal/cli/e2e_test.go
+++ b/backend/internal/cli/e2e_test.go
@@ -151,9 +151,15 @@ func (e env) startDaemon(t *testing.T) {
 		e.run(t, "stop")
 		select {
 		case <-waitDone:
+			return
 		case <-time.After(5 * time.Second):
-			t.Log("daemon process did not exit during cleanup")
 		}
+		// The daemon did not exit on `ao stop` within the timeout: a shutdown
+		// regression is hiding behind a green test. Fail, force-kill, and wait
+		// for the child to be reaped so it cannot survive the test.
+		t.Errorf("daemon process did not exit within 5s of `ao stop`; forcing kill")
+		_ = cmd.Process.Kill()
+		<-waitDone
 	})
 
 	deadline := time.Now().Add(10 * time.Second)

--- a/backend/internal/cli/e2e_test.go
+++ b/backend/internal/cli/e2e_test.go
@@ -145,9 +145,15 @@ func (e env) startDaemon(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("spawn ao daemon: %v", err)
 	}
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
 	t.Cleanup(func() {
 		e.run(t, "stop")
-		_, _ = cmd.Process.Wait()
+		select {
+		case <-waitDone:
+		case <-time.After(5 * time.Second):
+			t.Log("daemon process did not exit during cleanup")
+		}
 	})
 
 	deadline := time.Now().Add(10 * time.Second)


### PR DESCRIPTION
## Summary

Extracts the `e2e_test.go` daemon-cleanup hunk out of #2227 into its own PR, per @illegalcall's review (https://github.com/AgentWrapper/agent-orchestrator/pull/2227#pullrequestreview).

The `startDaemon` helper called the blocking `cmd.Process.Wait()` inside `t.Cleanup`, which deadlocks when the daemon child does not exit during `ao stop`. Run `cmd.Wait()` in a goroutine and select on its completion with a 5s timeout, logging instead of hanging — matching the production `ao start` reaping behavior.

## Why separate

#2227 is about teaching the orchestrator the worker status commands (fixes #2197). This test-stability hunk is unrelated to that change and was asked to ship on its own so #2227 can land focused.

## Testing

```
go test -tags e2e -run TestE2E_Lifecycle -v ./internal/cli   # PASS (2.52s)
```

Supersedes the `e2e_test.go` portion of #2227. Originally authored by @cneuralnetwork in commit 15eb8c7d; rebased to current `main` as a standalone change.