### PR TITLE
fix(import): surface legacy config parse errors instead of "no data"

### DIFF
--- a/backend/internal/cli/import.go
+++ b/backend/internal/cli/import.go
@@ -63,6 +63,12 @@ func (c *commandContext) runImport(cmd *cobra.Command, opts importOptions) error
 	if root == "" {
 		root = legacyimport.DefaultLegacyRootDir()
 	}
+	// Surface a parse error instead of masking it as "no data" (issue #2186):
+	// a broken legacy store is distinct from an absent or empty one.
+	if parseErr := legacyimport.LegacyConfigError(root); parseErr != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Cannot read legacy config at %s: %v\n", root, parseErr)
+		return parseErr
+	}
 	if !legacyimport.HasLegacyData(root) {
 		_, err := fmt.Fprintf(cmd.OutOrStdout(), "No legacy AO projects found at %s. Nothing to import.\n", root)
 		return err

--- a/backend/internal/cli/import.go
+++ b/backend/internal/cli/import.go
@@ -64,10 +64,11 @@ func (c *commandContext) runImport(cmd *cobra.Command, opts importOptions) error
 		root = legacyimport.DefaultLegacyRootDir()
 	}
 	// Surface a parse error instead of masking it as "no data" (issue #2186):
-	// a broken legacy store is distinct from an absent or empty one.
-	if parseErr := legacyimport.LegacyConfigError(root); parseErr != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Cannot read legacy config at %s: %v\n", root, parseErr)
-		return parseErr
+	// a broken legacy store is distinct from an absent or empty one. Return the
+	// error so cmd/ao/main.go renders it once; printing here too would duplicate
+	// it on stderr.
+	if parseErr := legacyimport.LegacyConfigError(cmd.Context(), root); parseErr != nil {
+		return fmt.Errorf("legacy config at %s: %w", root, parseErr)
 	}
 	if !legacyimport.HasLegacyData(root) {
 		_, err := fmt.Fprintf(cmd.OutOrStdout(), "No legacy AO projects found at %s. Nothing to import.\n", root)

--- a/backend/internal/cli/import.go
+++ b/backend/internal/cli/import.go
@@ -66,7 +66,7 @@ func (c *commandContext) runImport(cmd *cobra.Command, opts importOptions) error
 	// Surface a parse error instead of masking it as "no data" (issue #2186):
 	// a broken legacy store is distinct from an absent or empty one.
 	if parseErr := legacyimport.LegacyConfigError(root); parseErr != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Cannot read legacy config at %s: %v\n", root, parseErr)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Cannot read legacy config at %s: %v\n", root, parseErr)
 		return parseErr
 	}
 	if !legacyimport.HasLegacyData(root) {

--- a/backend/internal/cli/import_test.go
+++ b/backend/internal/cli/import_test.go
@@ -54,6 +54,35 @@ func TestImportCommand_ImportsProjectJSON(t *testing.T) {
 	}
 }
 
+func TestImportCommand_SurfacesParseErrorOnce(t *testing.T) {
+	setConfigEnv(t)
+	// A tab-indented line is a YAML syntax error (not a *yaml.TypeError), so
+	// loadLegacyConfig surfaces it exactly like issue #2186 describes.
+	root := filepath.Join(t.TempDir(), ".agent-orchestrator")
+	if err := os.MkdirAll(root, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "config.yaml"),
+		[]byte("projects:\n\talpha:\n  path: /repos/alpha\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stderr, err := executeCLI(t, Deps{}, "import", "--from", root, "--yes")
+	if err == nil {
+		t.Fatal("import: want non-nil error for a config.yaml that fails to parse")
+	}
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("ExitCode = %d, want 1 (runtime failure)", got)
+	}
+	// The parse error must reach the user exactly once. main.go prints the
+	// returned error, so the command itself must not also Fprintf it — that
+	// doubled the output before this fix.
+	count := strings.Count(stderr, "parse legacy config.yaml") + strings.Count(err.Error(), "parse legacy config.yaml")
+	if count != 1 {
+		t.Fatalf("parse error appeared %d time(s) (stderr=%q, err=%q), want exactly 1", count, stderr, err)
+	}
+}
+
 func TestImportCommand_RefusesWhenDaemonRunning(t *testing.T) {
 	cfg := setConfigEnv(t)
 	root := writeLegacyProject(t)

--- a/backend/internal/cli/import_test.go
+++ b/backend/internal/cli/import_test.go
@@ -75,7 +75,7 @@ func TestImportCommand_SurfacesParseErrorOnce(t *testing.T) {
 		t.Fatalf("ExitCode = %d, want 1 (runtime failure)", got)
 	}
 	// The parse error must reach the user exactly once. main.go prints the
-	// returned error, so the command itself must not also Fprintf it — that
+	// returned error, so the command itself must not also Fprintf it; that
 	// doubled the output before this fix.
 	count := strings.Count(stderr, "parse legacy config.yaml") + strings.Count(err.Error(), "parse legacy config.yaml")
 	if count != 1 {

--- a/backend/internal/legacyimport/importer.go
+++ b/backend/internal/legacyimport/importer.go
@@ -55,6 +55,19 @@ func HasLegacyData(root string) bool {
 	return len(cfg.Projects) > 0
 }
 
+// LegacyConfigError returns the parse error for root's legacy config.yaml, or
+// nil if the store is absent or parsed cleanly. The CLI import path uses it to
+// surface a parse failure instead of swallowing it as "no data" (issue #2186);
+// HasLegacyData stays a bool for the migration-probe service layer, which must
+// not error on a missing or broken store.
+func LegacyConfigError(root string) error {
+	if root == "" {
+		return nil
+	}
+	_, err := loadLegacyConfig(root)
+	return err
+}
+
 // rewriteProjectID gates the rewrite project-id charset (validateProjectID,
 // service.go). Legacy ids are a strict subset, so this all but always passes;
 // it guards against a hand-edited legacy config carrying an illegal id.

--- a/backend/internal/legacyimport/importer.go
+++ b/backend/internal/legacyimport/importer.go
@@ -60,7 +60,7 @@ func HasLegacyData(root string) bool {
 // surface a parse failure instead of swallowing it as "no data" (issue #2186);
 // HasLegacyData stays a bool for the migration-probe service layer, which must
 // not error on a missing or broken store.
-func LegacyConfigError(root string) error {
+func LegacyConfigError(ctx context.Context, root string) error {
 	if root == "" {
 		return nil
 	}

--- a/backend/internal/legacyimport/importer_test.go
+++ b/backend/internal/legacyimport/importer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -124,6 +125,40 @@ func TestHasLegacyData(t *testing.T) {
 	}
 	if HasLegacyData(filepath.Join(t.TempDir(), "nope")) {
 		t.Fatal("HasLegacyData = true for missing root")
+	}
+}
+
+// TestLegacyConfigError_SurfacesParseFailure covers issue #2186 Bug 2: a legacy
+// config.yaml with a syntax error must be surfaced as a parse error, not
+// swallowed as "no data". The tab-indented line below is a YAML syntax error
+// (not a *yaml.TypeError, so it is not a partial decode) — exactly the case
+// HasLegacyData collapses to false today. HasLegacyData's bool contract for the
+// migration-probe service layer must stay intact (still false on a broken store).
+func TestLegacyConfigError_SurfacesParseFailure(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-orchestrator")
+	mustMkdir(t, root)
+	mustWrite(t, filepath.Join(root, "config.yaml"), "projects:\n\talpha:\n  path: /repos/alpha\n")
+
+	err := LegacyConfigError(root)
+	if err == nil {
+		t.Fatal("LegacyConfigError = nil for a config.yaml with a syntax error")
+	}
+	if !strings.Contains(err.Error(), "parse legacy config.yaml") {
+		t.Fatalf("LegacyConfigError = %q, want an error mentioning parse legacy config.yaml", err)
+	}
+	// The bool probe used by the migration UI must keep reporting "not available"
+	// rather than erroring on a broken store.
+	if HasLegacyData(root) {
+		t.Fatal("HasLegacyData = true for a config.yaml that fails to parse")
+	}
+}
+
+func TestLegacyConfigError_NilWhenAbsentOrEmpty(t *testing.T) {
+	if LegacyConfigError("") != nil {
+		t.Fatal("LegacyConfigError(\"\") = non-nil, want nil")
+	}
+	if LegacyConfigError(filepath.Join(t.TempDir(), "nope")) != nil {
+		t.Fatal("LegacyConfigError on a missing root = non-nil, want nil")
 	}
 }
 

--- a/backend/internal/legacyimport/importer_test.go
+++ b/backend/internal/legacyimport/importer_test.go
@@ -131,7 +131,7 @@ func TestHasLegacyData(t *testing.T) {
 // TestLegacyConfigError_SurfacesParseFailure covers issue #2186 Bug 2: a legacy
 // config.yaml with a syntax error must be surfaced as a parse error, not
 // swallowed as "no data". The tab-indented line below is a YAML syntax error
-// (not a *yaml.TypeError, so it is not a partial decode) — exactly the case
+// (not a *yaml.TypeError, so it is not a partial decode), exactly the case
 // HasLegacyData collapses to false today. HasLegacyData's bool contract for the
 // migration-probe service layer must stay intact (still false on a broken store).
 func TestLegacyConfigError_SurfacesParseFailure(t *testing.T) {
@@ -139,7 +139,7 @@ func TestLegacyConfigError_SurfacesParseFailure(t *testing.T) {
 	mustMkdir(t, root)
 	mustWrite(t, filepath.Join(root, "config.yaml"), "projects:\n\talpha:\n  path: /repos/alpha\n")
 
-	err := LegacyConfigError(root)
+	err := LegacyConfigError(context.Background(), root)
 	if err == nil {
 		t.Fatal("LegacyConfigError = nil for a config.yaml with a syntax error")
 	}
@@ -154,10 +154,10 @@ func TestLegacyConfigError_SurfacesParseFailure(t *testing.T) {
 }
 
 func TestLegacyConfigError_NilWhenAbsentOrEmpty(t *testing.T) {
-	if LegacyConfigError("") != nil {
+	if LegacyConfigError(context.Background(), "") != nil {
 		t.Fatal("LegacyConfigError(\"\") = non-nil, want nil")
 	}
-	if LegacyConfigError(filepath.Join(t.TempDir(), "nope")) != nil {
+	if LegacyConfigError(context.Background(), filepath.Join(t.TempDir(), "nope")) != nil {
 		t.Fatal("LegacyConfigError on a missing root = non-nil, want nil")
 	}
 }


### PR DESCRIPTION
## Summary

`ao import` swallows any `loadLegacyConfig` parse error as `false` via `HasLegacyData`, then prints the misleading **“No legacy AO projects found”** for a legacy store whose `config.yaml` has a YAML syntax error — instead of the real parse error. Closes #2186 (Bug 2).

## Why

`HasLegacyData` collapses three distinct cases into one `false`:

- store absent
- store present, zero projects
- store present, **failed to parse**

Only the first two legitimately mean “nothing to import”. A parse failure should reach the user, not masquerade as an empty store.

## Change

- Add `legacyimport.LegacyConfigError(root) error` — returns the parse error, or `nil` for an absent / cleanly-parsed store. It does **not** touch `HasLegacyData`, whose `bool` contract the migration-probe service layer depends on (`Status.Available` → `GET /api/v1/import` → DTO → desktop migration UI).
- The CLI import gate (`cli/import.go`) now surfaces the parse error to stderr with a non-zero exit *before* falling back to the “No legacy … found” message, which stays for the absent / empty cases.

## Scope

- **Bug 1** of #2186 (object-form `repo:` typed as `string`) **already landed upstream** — `Repo *yaml.Node` decodes the mapping cleanly.
- This PR is **Bug 2 only** (the swallowed parse error).
- `*yaml.TypeError` partial-decode behavior is intentionally left unchanged — Bug 1 removed the only real source of type mismatches, and partial decode still imports what parsed.

## Testing

New test `TestLegacyConfigError_SurfacesParseFailure` (tab-indented `config.yaml` = a YAML syntax error, not a `*yaml.TypeError`) asserts:

- `LegacyConfigError` returns an error containing `parse legacy config.yaml`,
- `HasLegacyData` stays `false` (service-layer contract intact).

```
go test ./internal/legacyimport/... ./internal/cli/... ./internal/service/importer/...   # PASS
```

`#2246` covers the same ground but has been stalled (conflicting, no activity since Jun 27); this is a focused re-take of the Bug 2 portion.