### PR TITLE
fix(daemon): nil tracker interface when GitHub token absent (spawn --issue panic)

### DIFF
--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -115,9 +115,17 @@ func startSession(cfg config.Config, runtime runtimeselect.Runtime, store *sqlit
 	if err != nil {
 		logSCMProviderDisabled(log, err)
 	}
-	tracker, err := newGitHubTracker()
-	if err != nil {
+	// Build the GitHub tracker, but keep a true nil ports.Tracker interface on
+	// failure. newGitHubTracker returns (*github.Tracker)(nil) on ErrNoToken,
+	// which Go wraps as a non-nil typed-nil interface — that slips past the
+	// `s.tracker == nil` guard in withIssueContext and dereferences nil on the
+	// first issue lookup (issue #2685). Assigning the concrete value only on
+	// success leaves tracker as a real interface-nil otherwise.
+	var tracker ports.Tracker
+	if t, err := newGitHubTracker(); err != nil {
 		logTrackerDisabled(log, err)
+	} else {
+		tracker = t
 	}
 	sessionSvc := sessionsvc.NewWithDeps(sessionsvc.Deps{
 		Manager:   mgr,

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -167,6 +167,43 @@ func TestWiring_StartSessionBuildsSessionService(t *testing.T) {
 	}
 }
 
+// TestStartSession_SpawnDoesNotPanicWhenNoTrackerToken is a regression test for
+// issue #2685: when no GitHub token is configured, startSession must wire a
+// true-nil ports.Tracker so Spawn's issue-context guard fires instead of
+// dereferencing a typed-nil *github.Tracker. The pre-fix wiring assigned the
+// typed-nil return of newGitHubTracker directly, and `ao spawn --issue` panicked
+// on the first lookup.
+func TestStartSession_SpawnDoesNotPanicWhenNoTrackerToken(t *testing.T) {
+	t.Setenv("AO_GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	ctx := context.Background()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "mer", Path: "/repo/mer", RepoOriginURL: "https://github.com/acme/repo", RegisteredAt: time.Now()}); err != nil {
+		t.Fatalf("UpsertProject: %v", err)
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	lcm := lifecycle.New(store, nil)
+	cfg := config.Config{DataDir: t.TempDir()}
+	rt := runtimeselect.New(nil)
+	messenger := newSessionMessenger(store, rt, log)
+	svc, _, _, err := startSession(cfg, rt, store, lcm, messenger, telemetryadapter.NoopSink{}, log)
+	if err != nil {
+		t.Fatalf("startSession: %v", err)
+	}
+
+	// Spawn reaches withIssueContext (and the tracker guard) before the manager
+	// tries to materialize a workspace. The manager may return an error from the
+	// no-op runtime, but it must not panic — that is the regression.
+	_, _ = svc.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, IssueID: "107"})
+}
+
 // TestStartTrackerIntake_RunsEvenWithoutEnabledProjects is a regression test:
 // startTrackerIntake used to scan projects once at call time and skip starting
 // the observer loop entirely when none had intake enabled yet. Poll() itself

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -489,6 +489,28 @@ func TestSpawnIssueContextFetchFailureFallsBack(t *testing.T) {
 	}
 }
 
+// TestSpawnPreservesIssueIDWhenTrackerIsNil covers the issue #2685 boundary: when
+// the daemon wiring cannot build a GitHub tracker (no token), it hands the session
+// service a true-nil ports.Tracker. Spawn must still create the session, preserve
+// IssueID, and skip only the GitHub issue-context enrichment — not panic on a
+// typed-nil tracker the way the pre-fix wiring did.
+func TestSpawnPreservesIssueIDWhenTrackerIsNil(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", RepoOriginURL: "https://github.com/acme/repo"}
+	fc := &fakeCommander{}
+	svc := NewWithDeps(Deps{Manager: fc, Store: st, Tracker: nil})
+
+	if _, err := svc.Spawn(context.Background(), ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, IssueID: "107"}); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if fc.spawnedCfg.IssueID != "107" {
+		t.Fatalf("IssueID = %q, want 107 preserved", fc.spawnedCfg.IssueID)
+	}
+	if fc.spawnedCfg.IssueContext != "" {
+		t.Fatalf("IssueContext = %q, want empty (no tracker enrichment)", fc.spawnedCfg.IssueContext)
+	}
+}
+
 func TestSpawnIssueContextSkipsUnresolvableIssueRef(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer", RepoOriginURL: "https://github.com/acme/repo"}


### PR DESCRIPTION
Fixes #2685. v2 (per @illegalcall's review on #2686): dropped the one-off helper, inlined the construction, and replaced the nil-interface assertion with behavior tests.

## Root cause

`ao spawn --issue N` panicked with a nil-pointer dereference inside `github.(*Tracker)`. Regression from #2273 (`a345bd22`), which added `cfg = s.withIssueContext(ctx, cfg, project)` to `Service.Spawn` plus a `tracker ports.Tracker` field. When no GitHub token is configured, `newGitHubTracker()` returns `(*github.Tracker)(nil)` on `ErrNoToken`, which Go wraps as a **non-nil typed-nil** `ports.Tracker` interface. That slips past the `s.tracker == nil` guard in `withIssueContext` (`service/session/issue_context.go:17`), so the first issue lookup calls `Get` on a nil `*github.Tracker` and dereferences nil on `t.baseURL` (`adapters/tracker/github/tracker.go`) → HTTP handler panic → `INTERNAL_ERROR`.

100% reproducible: any `ao spawn --issue N` when no GitHub token is configured for the tracker.

## Fix (inline, no helper)

`startSession` assigns the concrete tracker to a `ports.Tracker` variable only on success, so a failed build leaves a true interface-nil the existing guard already handles:

```go
var tracker ports.Tracker
if t, err := newGitHubTracker(); err != nil {
    logTrackerDisabled(log, err)
} else {
    tracker = t
}
```

No one-off abstraction — one call site (AGENTS.md:74). The session is still created with its `IssueID`; only the GitHub issue-context enrichment is skipped when no token is configured. `lazyGitHubTracker` (intake path) was already nil-safe — this fixes only the new Spawn-enrichment path from #2273.

## Scope (3 files, +69/−2)

- `backend/internal/daemon/lifecycle_wiring.go` — inline the nil-safe tracker construction in `startSession`.
- `backend/internal/daemon/wiring_test.go` — `TestStartSession_SpawnDoesNotPanicWhenNoTrackerToken`: drives the real `startSession` → `Spawn` → `withIssueContext` boundary with no token; panics pre-fix, passes post-fix.
- `backend/internal/service/session/service_test.go` — `TestSpawnPreservesIssueIDWhenTrackerIsNil`: `Spawn` with a nil tracker preserves `IssueID == "107"` and leaves `IssueContext` empty.

`withIssueContext`, `newGitHubTracker`, `logTrackerDisabled`, and the tracker adapter are untouched. Both tests use existing fakes / a real in-memory sqlite store / a no-op runtime; no network (AGENTS.md:89).

Supersedes #2686 (same fix, clean scope + behavior tests).