### PR TITLE
fix(conpty): opencode fails to launch on Windows (`env` prefix isn't a Windows executable)

### DIFF
--- a/backend/internal/adapters/runtime/conpty/spawn.go
+++ b/backend/internal/adapters/runtime/conpty/spawn.go
@@ -3,9 +3,46 @@
 // defaultSpawnHost variable; the non-windows stub is in spawn_other.go.
 package conpty
 
-import "context"
+import (
+	"context"
+	"path/filepath"
+	"strings"
+)
 
 // hostSpawner starts a detached pty-host for the session and returns its
 // loopback address ("127.0.0.1:PORT") and OS pid once it prints READY.
 // Injectable for tests: replace this field on Options before calling New.
 type hostSpawner func(ctx context.Context, sessionID, cwd string, argv []string, env map[string]string) (addr string, pid int, err error)
+
+// stripEnvAssignments splits a launch argv that may begin with a Unix-style
+// `env NAME=VALUE ...` prefix into the environment assignments ("NAME=VALUE"
+// strings) and the real command argv that follows.
+//
+// Some agent adapters (e.g. opencode) prepend `env KEY=value` to their launch
+// command to inject process env vars the CLI has no flag for. That is portable
+// on macOS/Linux, where the tmux runtime runs the argv through a shell and the
+// `env` coreutil applies the assignments. Windows has no `env` binary and the
+// ConPTY pty-host execs argv[0] directly, so the spawner must apply the
+// assignments to the child's environment itself — otherwise the launch fails
+// with `env: executable file not found`. This mirrors launchBinary in the
+// session manager, which already skips the same prefix to validate the real
+// binary.
+//
+// If argv does not start with `env`, or the prefix consumes the whole argv with
+// no command left, assignments is nil and rest is argv unchanged (so the
+// caller's normal handling still applies).
+func stripEnvAssignments(argv []string) (assignments, rest []string) {
+	if len(argv) == 0 || filepath.Base(argv[0]) != "env" {
+		return nil, argv
+	}
+	i := 1
+	for i < len(argv) && strings.Contains(argv[i], "=") {
+		i++
+	}
+	if i >= len(argv) {
+		// Only assignments, no command to run: leave argv untouched so the
+		// existing missing-binary path fires instead of silently dropping it.
+		return nil, argv
+	}
+	return argv[1:i], argv[i:]
+}

--- a/backend/internal/adapters/runtime/conpty/spawn_test.go
+++ b/backend/internal/adapters/runtime/conpty/spawn_test.go
@@ -1,0 +1,52 @@
+package conpty
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripEnvAssignments(t *testing.T) {
+	tests := []struct {
+		name            string
+		argv            []string
+		wantAssignments []string
+		wantRest        []string
+	}{
+		{
+			name:            "no env prefix returns argv unchanged",
+			argv:            []string{"opencode", "--agent", "ao-x"},
+			wantAssignments: nil,
+			wantRest:        []string{"opencode", "--agent", "ao-x"},
+		},
+		{
+			name:            "env prefix is split from the real command",
+			argv:            []string{"env", "OPENCODE_CONFIG=C:/cfg.json", "opencode", "--agent", "ao-x"},
+			wantAssignments: []string{"OPENCODE_CONFIG=C:/cfg.json"},
+			wantRest:        []string{"opencode", "--agent", "ao-x"},
+		},
+		{
+			name:            "env with no command left is untouched",
+			argv:            []string{"env", "A=1", "B=2"},
+			wantAssignments: nil,
+			wantRest:        []string{"env", "A=1", "B=2"},
+		},
+		{
+			name:            "a binary merely starting with env is not treated as a prefix",
+			argv:            []string{"envoy", "--config", "x"},
+			wantAssignments: nil,
+			wantRest:        []string{"envoy", "--config", "x"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAssignments, gotRest := stripEnvAssignments(tt.argv)
+			if !reflect.DeepEqual(gotAssignments, tt.wantAssignments) {
+				t.Errorf("assignments = %#v, want %#v", gotAssignments, tt.wantAssignments)
+			}
+			if !reflect.DeepEqual(gotRest, tt.wantRest) {
+				t.Errorf("rest = %#v, want %#v", gotRest, tt.wantRest)
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/runtime/conpty/spawn_windows.go
+++ b/backend/internal/adapters/runtime/conpty/spawn_windows.go
@@ -8,12 +8,12 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/sys/windows"
@@ -23,6 +23,39 @@ import (
 var readyRE = regexp.MustCompile(`READY:(\d+) (\d+)`)
 
 const spawnReadyTimeout = 10 * time.Second
+
+// maxCapturedStderr bounds how much pty-host stderr we retain for diagnostics.
+const maxCapturedStderr = 8192
+
+// boundedBuffer is a thread-safe io.Writer that retains up to max bytes of what
+// is written and discards the rest. It always consumes its input (never blocks
+// or errors), so it is a safe stderr sink for the detached pty-host — matching
+// the previous io.Discard behavior while keeping a capped copy so a startup
+// failure (e.g. newConPTY) can be reported instead of only "exited without
+// printing READY".
+type boundedBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+	max int
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if room := b.max - len(b.buf); room > 0 {
+		if len(p) < room {
+			room = len(p)
+		}
+		b.buf = append(b.buf, p[:room]...)
+	}
+	return len(p), nil
+}
+
+func (b *boundedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.buf)
+}
 
 // defaultSpawnHost resolves the current executable, builds the pty-host argv,
 // and spawns it detached on Windows. It reads stdout for "READY:<pid> <port>"
@@ -34,14 +67,24 @@ func defaultSpawnHost(ctx context.Context, sessionID, cwd string, argv []string,
 		return "", 0, fmt.Errorf("conpty spawn: resolve executable: %w", err)
 	}
 
+	// Translate a leading `env NAME=VALUE ...` prefix into real child env vars.
+	// Windows has no `env` binary and the pty-host execs argv[0] directly, so an
+	// adapter that emits `env KEY=value <bin>` (e.g. opencode, to set
+	// OPENCODE_CONFIG) would otherwise fail with "env: executable file not
+	// found". The assignments are added to the pty-host environment below, which
+	// the ConPTY child inherits (host_conpty_windows.go passes os.Environ()).
+	envAssignments, argv := stripEnvAssignments(argv)
+
 	// Build: <exe> pty-host <sessionID> <cwd> <shellCmd> <shellArgs...>
 	args := append([]string{"pty-host", sessionID, cwd}, argv...)
 
-	// Merge env: inherit parent, then overlay caller-provided vars.
+	// Merge env: inherit parent, overlay caller-provided vars, then apply the
+	// assignments stripped from the argv prefix.
 	merged := os.Environ()
 	for k, v := range env {
 		merged = append(merged, k+"="+v)
 	}
+	merged = append(merged, envAssignments...)
 
 	cmd := exec.CommandContext(ctx, exe, args...)
 	cmd.Dir = cwd
@@ -60,8 +103,11 @@ func defaultSpawnHost(ctx context.Context, sessionID, cwd string, argv []string,
 	if err != nil {
 		return "", 0, fmt.Errorf("conpty spawn: stdout pipe: %w", err)
 	}
-	// Stderr is discarded; pty-host writes diagnostics there but we don't need them.
-	cmd.Stderr = io.Discard
+	// Capture a bounded copy of the pty-host's stderr. It writes its startup
+	// diagnostics there (listen/newConPTY failures) before exiting without
+	// printing READY; retaining them lets us report the real cause below.
+	stderr := &boundedBuffer{max: maxCapturedStderr}
+	cmd.Stderr = stderr
 
 	if err := cmd.Start(); err != nil {
 		return "", 0, fmt.Errorf("conpty spawn: start: %w", err)
@@ -90,11 +136,15 @@ func defaultSpawnHost(ctx context.Context, sessionID, cwd string, argv []string,
 				return
 			}
 		}
+		msg := "conpty spawn: pty-host exited without printing READY"
+		if diag := strings.TrimSpace(stderr.String()); diag != "" {
+			msg += ": " + diag
+		}
 		readyC <- struct {
 			addr string
 			pid  int
 			err  error
-		}{"", 0, fmt.Errorf("conpty spawn: pty-host exited without printing READY")}
+		}{"", 0, fmt.Errorf("%s", msg)}
 	}()
 
 	timer := time.NewTimer(spawnReadyTimeout)


### PR DESCRIPTION
Resolves #2688 
## Problem
On Windows, spawning any opencode session — orchestrator or worker — fails with HTTP 500:
POST /api/v1/orchestrators status=500
error="conpty: spawn pty-host: pty-host exited without printing READY"


The opencode adapter has no CLI flag for its config, so it injects `OPENCODE_CONFIG` by prefixing the launch argv with the Unix `env` coreutil: `["env", "OPENCODE_CONFIG=…", "opencode", …]`. That is portable on macOS/Linux, where the tmux runtime runs the argv through a shell and `env` applies the assignment. On Windows there is no `env` binary and the ConPTY pty-host execs `argv[0]` directly, so `CreateProcess("env")` fails, `newConPTY` errors, and the host exits before printing `READY`. opencode is unusable on Windows as a result. The session manager already understands this prefix (`launchBinary` skips it to validate the real binary), so pre-flight passed and the failure only surfaced inside the runtime.

## Fix
Translate the leading `env NAME=VALUE …` prefix into real child environment variables in the conpty spawner (`defaultSpawnHost`): the assignments are merged into the pty-host environment (inherited by the ConPTY child) and the real binary is executed directly. This mirrors `launchBinary`'s existing handling and matches Unix `env` semantics, so behavior is consistent across platforms.

Scope is limited to the conpty runtime — no adapter or interface changes, and no other agent path is affected (the opencode adapter still emits the same argv; only Windows launch now interprets it correctly).

Also captures the pty-host's stderr into a bounded buffer so a future startup failure reports its real cause instead of the opaque `exited without printing READY`.

## Files changed
- **`backend/internal/adapters/runtime/conpty/spawn.go`** — add `stripEnvAssignments`, which splits a leading `env NAME=VALUE …` prefix into env assignments + the real command argv.
- **`backend/internal/adapters/runtime/conpty/spawn_windows.go`** — `defaultSpawnHost` applies the stripped assignments to the pty-host environment (inherited by the ConPTY child) and runs the real binary; also captures pty-host stderr into a bounded buffer for diagnostics.
- **`backend/internal/adapters/runtime/conpty/spawn_test.go`** *(new)* — unit test covering the prefix-splitting helper.

## Testing
- New unit test for the prefix-splitting helper (`stripEnvAssignments`): no-prefix passthrough, split, env-only-no-command, and `envoy` false-positive guard.
- `go build ./...`, `go vet`, `gofmt`, and the `conpty` package tests pass.
- Manually verified on Windows 11: opencode orchestrator and worker sessions now spawn and run; previously both 500'd.

## Notes
Windows-only in practice — the trigger is any host without `env` on PATH.

