### PR TITLE
fix: show error state instead of white screen on browser navigation failure

### DIFF
--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -274,7 +274,15 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		if (!isAllowedBrowserURL(normalized.href, options.rendererOrigin)) {
 			throw new Error("Unsupported browser URL");
 		}
-		await entry.view.webContents.loadURL(normalized.href);
+		try {
+			await entry.view.webContents.loadURL(normalized.href);
+		} catch (err) {
+			entry.view.setVisible?.(false);
+			entry.state = { ...readNavState(entry), error: String((err as Error)?.message || "Unable to load page") };
+			options.mainWindow.webContents.send("browser:navState", entry.state);
+			return entry.state;
+		}
+		entry.view.setVisible?.(true);
 		return pushNavState(options, entry);
 	};
 
@@ -518,7 +526,10 @@ function wireNavEvents(contents: BrowserWebContents, options: BrowserViewHostOpt
 	const update = () => {
 		pushNavState(options, entry);
 	};
-	contents.on("did-navigate", update);
+	contents.on("did-navigate", () => {
+		entry.view.setVisible?.(true);
+		update();
+	});
 	contents.on("did-navigate-in-page", update);
 	contents.on("page-title-updated", update);
 	contents.on("did-start-loading", () => {
@@ -526,7 +537,9 @@ function wireNavEvents(contents: BrowserWebContents, options: BrowserViewHostOpt
 		update();
 	});
 	contents.on("did-stop-loading", update);
-	contents.on("did-fail-load", (_event, _errorCode, errorDescription) => {
+	contents.on("did-fail-load", (_event, errorCode, errorDescription) => {
+		if (errorCode === -3) return;
+		entry.view.setVisible?.(false);
 		entry.state = { ...readNavState(entry), error: String(errorDescription || "Unable to load page") };
 		options.mainWindow.webContents.send("browser:navState", entry.state);
 	});

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -277,6 +277,7 @@ export function createBrowserViewHost(options: BrowserViewHostOptions): BrowserV
 		try {
 			await entry.view.webContents.loadURL(normalized.href);
 		} catch (err) {
+			if ((err as { errorCode?: number })?.errorCode === -3) return pushNavState(options, entry);
 			entry.view.setVisible?.(false);
 			entry.state = { ...readNavState(entry), error: String((err as Error)?.message || "Unable to load page") };
 			options.mainWindow.webContents.send("browser:navState", entry.state);

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -358,8 +358,12 @@ export function useBrowserView({
 	const withView = useCallback(async (fn: (id: string) => Promise<BrowserNavState | void>) => {
 		const id = viewIdRef.current;
 		if (!id) return;
-		const next = await fn(id);
-		if (next) setNavState(next);
+		try {
+			const next = await fn(id);
+			if (next) setNavState(next);
+		} catch {
+			// navigation errors are handled by the did-fail-load event channel
+		}
 	}, []);
 
 	const setAnnotationMode = useCallback(


### PR DESCRIPTION
## Summary

When browser navigation fails (connection refused, DNS error, timeout), the user sees a blank white screen because the native `WebContentsView` overlay stays visible on top of the DOM error text.

Closes #2373

## Root causes

1. `navigate()` in `browser-view-host.ts` has no try-catch around `loadURL()`. When it rejects, the error propagates as an unhandled promise rejection.
2. The `did-fail-load` handler sends error state to the renderer but never hides the native `WebContentsView` overlay, which paints above the DOM error text.
3. `withView()` in `useBrowserView.ts` has no try-catch, so the rejected promise from `navigate()` becomes an unhandled rejection in the renderer.

## Changes

**`frontend/src/main/browser-view-host.ts`**
- Wrap `loadURL()` in try-catch. On error, hide the view and return error state instead of throwing.
- In `did-fail-load` handler, hide the native view overlay so the renderer's error text is visible.
- Skip `ERR_ABORTED` (errorCode -3) since that indicates intentionally cancelled navigation, not a real failure.
- Restore view visibility on successful navigation via `did-navigate` handler.

**`frontend/src/renderer/hooks/useBrowserView.ts`**
- Add try-catch to `withView()` to prevent unhandled promise rejections from propagating. Navigation errors are already handled by the `did-fail-load` event channel.

## Testing

- Navigate to a valid URL: view shows normally, no regressions.
- Navigate to `http://localhost:9999` (connection refused): white screen replaced with error state text.
- Navigate to `http://invalid.invalid` (DNS failure): same, error state visible.
- Navigate to a valid URL after an error: view visibility restored automatically.
