### PR TITLE
fix: show session id on board cards and terminated chips

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -317,6 +317,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 									type="button"
 								>
 									<span className="text-xs text-muted-foreground">{s.title}</span>
+									<span className="font-mono text-micro text-passive">{s.id}</span>
 								</button>
 							))}
 						</div>

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -413,6 +413,7 @@ function SessionCard({ session, onOpen }: { session: WorkspaceSession; onOpen: (
 				>
 					{session.title}
 				</div>
+				<div className="px-3.25 pb-2 font-mono text-micro text-passive">{session.id}</div>
 				{showBranch && <div className="px-3.25 pb-2.5 font-mono text-2xs text-passive">{branch}</div>}
 			</div>
 			<div


### PR DESCRIPTION
## Summary

Sessions auto-named from the same prompt render identically on the board, making them indistinguishable. The session id is never shown when a display name exists, and terminated chips mix raw ids and prose titles with no visual distinction.

Closes #2703

## Changes

**`frontend/src/renderer/components/SessionsBoard.tsx`**

1. **SessionCard**: Added the session id as a secondary line below the title in `font-mono text-micro text-passive`, so two sessions with the same display name can be told apart at a glance.

2. **Terminated chips**: Added the session id next to the title, so the terminated rail is consistent. Every chip now shows both the title (if it has one) and the id, instead of a mix of raw ids and prose names.

## Testing

- Sessions with display names: id shows below the title in muted mono font
- Sessions without display names: id still shows (title falls back to id, so both lines show the id, which is fine)
- Terminated chips: all chips now show title + id consistently
- Branch line: still shows when applicable, session id appears above it
