### PR TITLE
Add durable reviewer sessions

### DIFF
--- a/backend/internal/adapters/agent/qwen/qwen.go
+++ b/backend/internal/adapters/agent/qwen/qwen.go
@@ -65,10 +65,10 @@ func (p *Plugin) Manifest() adapters.Manifest {
 
 // GetLaunchCommand builds the argv to start a new Qwen Code session: the
 // approval-mode flag, optional system-prompt instructions, and the initial
-// prompt. Workers use Qwen's remote-input bridge so the task is submitted into
-// the interactive TUI after startup; non-workers use `-p` so command-delivered
-// prompts keep their previous one-shot behavior. `-p` takes the prompt as an
-// argument, so a leading "-" is not read as a flag.
+// prompt. Worker and reviewer sessions use Qwen's interactive prompt path so
+// durable reviewer sessions behave like normal sessions instead of one-shot
+// commands. `-i` takes the prompt as an argument, so a leading "-" is not read
+// as a flag.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	binary, err := p.qwenBinary(ctx)
 	if err != nil {
@@ -82,7 +82,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 		cmd = append(cmd, "--append-system-prompt", cfg.SystemPrompt)
 	}
 
-	if cfg.Prompt != "" && cfg.Kind == domain.KindWorker {
+	if cfg.Prompt != "" && qwenInteractivePromptKind(cfg.Kind) {
 		if runtime.GOOS != "windows" {
 			return qwenWorkerRemoteInputCommand(cmd, cfg)
 		}
@@ -92,6 +92,10 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	}
 
 	return cmd, nil
+}
+
+func qwenInteractivePromptKind(kind domain.SessionKind) bool {
+	return kind == domain.KindWorker || kind == domain.KindReviewer
 }
 
 // GetPromptDeliveryStrategy reports that Qwen receives prompted worker tasks via

--- a/backend/internal/adapters/agent/qwen/qwen_test.go
+++ b/backend/internal/adapters/agent/qwen/qwen_test.go
@@ -154,6 +154,39 @@ func TestGetLaunchCommandWorkerStartsInteractive(t *testing.T) {
 	}
 }
 
+func TestGetLaunchCommandReviewerStartsInteractive(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "qwen"}
+	workspace := t.TempDir()
+	dataDir := t.TempDir()
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Kind:          domain.KindReviewer,
+		DataDir:       dataDir,
+		WorkspacePath: workspace,
+		Prompt:        "review this",
+		SessionID:     "repo/review#42",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if runtime.GOOS == "windows" {
+		want := []string{"qwen", "-i", "review this"}
+		if !reflect.DeepEqual(cmd, want) {
+			t.Fatalf("unexpected reviewer command\nwant: %#v\n got: %#v", want, cmd)
+		}
+		return
+	}
+
+	if len(cmd) != 3 || !reflect.DeepEqual(cmd[:2], []string{"sh", "-lc"}) {
+		t.Fatalf("unexpected reviewer command prefix: %#v", cmd)
+	}
+	script := cmd[2]
+	if !strings.Contains(script, `exec 'qwen' '--json-file'`) || strings.Contains(script, "'-p'") {
+		t.Fatalf("reviewer must use durable interactive launch, got: %s", script)
+	}
+}
+
 func TestSafeQwenSessionKeyDisambiguatesSanitizedCollisions(t *testing.T) {
 	first := safeQwenSessionKey("a.b-1")
 	second := safeQwenSessionKey("a_b-1")

--- a/backend/internal/cli/session.go
+++ b/backend/internal/cli/session.go
@@ -741,10 +741,14 @@ func writeSessionDetails(cmd *cobra.Command, sess sessionDTO) error {
 }
 
 func sessionRole(sess sessionDTO) string {
-	if sess.Kind == "orchestrator" {
+	switch sess.Kind {
+	case "orchestrator":
 		return "orchestrator"
+	case "reviewer":
+		return "reviewer"
+	default:
+		return "worker"
 	}
-	return "worker"
 }
 
 func formatSessionAge(d time.Duration) string {

--- a/backend/internal/cli/session_test.go
+++ b/backend/internal/cli/session_test.go
@@ -199,6 +199,12 @@ func TestSessionGet_SuccessWithProjectScope(t *testing.T) {
 	}
 }
 
+func TestSessionRoleReportsReviewer(t *testing.T) {
+	if got := sessionRole(sessionDTO{Kind: "reviewer"}); got != "reviewer" {
+		t.Fatalf("sessionRole(reviewer) = %q, want reviewer", got)
+	}
+}
+
 func TestSessionGet_JSONOutputDecodes(t *testing.T) {
 	cfg := setConfigEnv(t)
 	srv, _ := sessionCommandServer(t)

--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -26,6 +26,7 @@ const maxDisplayNameLen = 20
 type spawnOptions struct {
 	project        string
 	harness        string
+	role           string
 	branch         string
 	prompt         string
 	issue          string
@@ -40,6 +41,7 @@ type spawnOptions struct {
 type spawnRequest struct {
 	ProjectID   string `json:"projectId"`
 	IssueID     string `json:"issueId,omitempty"`
+	Kind        string `json:"kind,omitempty"`
 	Harness     string `json:"harness,omitempty"`
 	Branch      string `json:"branch,omitempty"`
 	Prompt      string `json:"prompt,omitempty"`
@@ -63,12 +65,24 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 	var opts spawnOptions
 	cmd := &cobra.Command{
 		Use:   "spawn",
-		Short: "Spawn a worker agent session in a registered project",
-		Long: "Spawn a worker agent session in a registered project.\n\n" +
+		Short: "Spawn a worker or reviewer agent session in a registered project",
+		Long: "Spawn a worker or reviewer agent session in a registered project.\n\n" +
 			"The session runs the chosen agent in a\n" +
 			"fresh git worktree. Register the project first with `ao project add`.",
 		Args: noArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			switch opts.role {
+			case "worker":
+			case "reviewer":
+				if strings.TrimSpace(opts.harness) == "" {
+					return usageError{fmt.Errorf("--harness is required for reviewer sessions")}
+				}
+				if opts.claimPR != "" {
+					return usageError{fmt.Errorf("reviewer sessions cannot use --claim-pr")}
+				}
+			default:
+				return usageError{fmt.Errorf("--role must be worker or reviewer")}
+			}
 			if opts.noTakeover && opts.claimPR == "" {
 				return usageError{fmt.Errorf("--no-takeover requires --claim-pr")}
 			}
@@ -104,6 +118,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 			req := spawnRequest{
 				ProjectID:   opts.project,
 				IssueID:     opts.issue,
+				Kind:        opts.role,
 				Harness:     opts.harness,
 				Branch:      opts.branch,
 				Prompt:      opts.prompt,
@@ -158,6 +173,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 	})
 	f.StringVar(&opts.project, "project", "", "Project id to spawn the session in (default: AO_PROJECT_ID or current registered repo)")
 	f.StringVar(&opts.harness, "harness", "", "Agent harness / --agent: claude-code, codex, aider, opencode, grok, droid, amp, agy, crush, cursor, qwen, copilot, goose, auggie, continue, devin, cline, kimi, kiro, kilocode, vibe, pi, autohand (default: project worker.agent; required if the project has none)")
+	f.StringVar(&opts.role, "role", "worker", "Session role: worker or reviewer (reviewer requires --harness)")
 	f.StringVar(&opts.branch, "branch", "", "Branch for the session worktree (default: ao/<session-id>/root)")
 	f.StringVar(&opts.prompt, "prompt", "", "Initial prompt for the agent")
 	f.StringVar(&opts.issue, "issue", "", "Issue id to associate with the session")

--- a/backend/internal/cli/spawn_test.go
+++ b/backend/internal/cli/spawn_test.go
@@ -157,6 +157,57 @@ func TestSpawnNoTakeoverRequiresClaimPR(t *testing.T) {
 	}
 }
 
+func TestSpawnReviewerValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "requires explicit harness", args: []string{"spawn", "--project", "demo", "--role", "reviewer"}, want: "--harness is required for reviewer sessions"},
+		{name: "cannot claim pr", args: []string{"spawn", "--project", "demo", "--role", "reviewer", "--harness", "codex", "--claim-pr", "13"}, want: "reviewer sessions cannot use --claim-pr"},
+		{name: "rejects unknown role", args: []string{"spawn", "--project", "demo", "--role", "bogus", "--harness", "codex"}, want: "--role must be worker or reviewer"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := executeCLI(t, Deps{}, tc.args...)
+			if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err=%v exit=%d, want %q", err, ExitCode(err), tc.want)
+			}
+		})
+	}
+}
+
+func TestSpawnReviewerWiring(t *testing.T) {
+	cfg := setConfigEnv(t)
+	var req map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/apl":
+			_, _ = io.WriteString(w, `{"status":"ok","project":{"id":"apl","name":"APL","path":"/repo/apl"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/agents/refresh":
+			_, _ = io.WriteString(w, authorizedAgentsJSON("codex"))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sessions":
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			_, _ = io.WriteString(w, `{"session":{"id":"apl-4","status":"idle"}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{ProcessAlive: func(int) bool { return true }}, "spawn", "--project", "apl", "--issue", "13", "--harness", "codex", "--role", "reviewer", "--name", "rc2-review", "--prompt", "review")
+	if err != nil {
+		t.Fatalf("spawn reviewer failed: %v stderr=%s", err, errOut)
+	}
+	if req["kind"] != "reviewer" || req["issueId"] != "13" || req["harness"] != "codex" || req["displayName"] != "rc2-review" {
+		t.Fatalf("reviewer spawn request = %#v", req)
+	}
+}
+
 // TestSpawnCommand_RejectsOverlongName asserts `ao spawn` rejects a --name
 // longer than 20 characters without contacting the daemon.
 func TestSpawnCommand_RejectsOverlongName(t *testing.T) {

--- a/backend/internal/domain/session.go
+++ b/backend/internal/domain/session.go
@@ -13,13 +13,14 @@ type (
 	IssueID string
 )
 
-// SessionKind distinguishes a worker session from an orchestrator session.
+// SessionKind distinguishes durable session roles.
 type SessionKind string
 
 // Session kinds.
 const (
 	KindWorker       SessionKind = "worker"
 	KindOrchestrator SessionKind = "orchestrator"
+	KindReviewer     SessionKind = "reviewer"
 )
 
 // SessionMetadata is the typed, off-status metadata for a session: operational

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2879,6 +2879,7 @@ components:
           enum:
           - worker
           - orchestrator
+          - reviewer
           type: string
         projectId:
           type: string

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -148,7 +148,7 @@ type ListSessionsResponse struct {
 type SpawnSessionRequest struct {
 	ProjectID domain.ProjectID    `json:"projectId"`
 	IssueID   domain.IssueID      `json:"issueId,omitempty"`
-	Kind      domain.SessionKind  `json:"kind,omitempty" enum:"worker,orchestrator"`
+	Kind      domain.SessionKind  `json:"kind,omitempty" enum:"worker,orchestrator,reviewer"`
 	Harness   domain.AgentHarness `json:"harness,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,kiro,kilocode,vibe,pi,autohand"`
 	Branch    string              `json:"branch,omitempty"`
 	Prompt    string              `json:"prompt,omitempty" maxLength:"4096"`

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -134,6 +134,12 @@ func (c *SessionsController) spawn(w http.ResponseWriter, r *http.Request) {
 	if in.Kind == "" {
 		in.Kind = domain.KindWorker
 	}
+	switch in.Kind {
+	case domain.KindWorker, domain.KindOrchestrator, domain.KindReviewer:
+	default:
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_SESSION_KIND", "kind must be worker, orchestrator, or reviewer", nil)
+		return
+	}
 	sess, err := c.Svc.Spawn(r.Context(), ports.SpawnConfig{ProjectID: in.ProjectID, IssueID: in.IssueID, Kind: in.Kind, Harness: in.Harness, Branch: in.Branch, Prompt: in.Prompt, DisplayName: displayName})
 	if err != nil {
 		envelope.WriteError(w, r, err)

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -694,6 +694,26 @@ func TestSessionsAPI_SpawnRejectsOverlongDisplayName(t *testing.T) {
 	assertErrorCode(t, body, status, http.StatusBadRequest, "DISPLAY_NAME_TOO_LONG")
 }
 
+func TestSessionsAPI_SpawnsReviewerAndRejectsUnknownKind(t *testing.T) {
+	svc := newFakeSessionService()
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions", `{"projectId":"ao","issueId":"13","kind":"reviewer","harness":"codex"}`)
+	if status != http.StatusCreated {
+		t.Fatalf("POST reviewer = %d, want 201; body=%s", status, body)
+	}
+	var spawned struct {
+		Session sessionBody `json:"session"`
+	}
+	mustJSON(t, body, &spawned)
+	if spawned.Session.Kind != "reviewer" || spawned.Session.IssueID != "13" {
+		t.Fatalf("spawned reviewer = %#v", spawned.Session)
+	}
+
+	body, status, _ = doRequest(t, srv, "POST", "/api/v1/sessions", `{"projectId":"ao","kind":"bogus","harness":"codex"}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_SESSION_KIND")
+}
+
 func TestSessionsAPI_RenameNotFound(t *testing.T) {
 	srv := newSessionTestServer(t, newFakeSessionService())
 

--- a/backend/internal/integration/lifecycle_sqlite_test.go
+++ b/backend/internal/integration/lifecycle_sqlite_test.go
@@ -208,6 +208,51 @@ func TestRestoreRoundTripPreservesMetadata(t *testing.T) {
 	}
 }
 
+func TestReviewerSessionSQLiteLifecycle(t *testing.T) {
+	ctx := context.Background()
+	st := newStack(t)
+	sess, err := st.sm.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "mer",
+		IssueID:   "13",
+		Kind:      domain.KindReviewer,
+		Harness:   domain.HarnessClaudeCode,
+		Prompt:    "review issue 13",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.Kind != domain.KindReviewer || sess.IssueID != "13" {
+		t.Fatalf("spawned reviewer wrong: %+v", sess)
+	}
+
+	rec, ok, err := st.store.GetSession(ctx, sess.ID)
+	if err != nil || !ok {
+		t.Fatalf("get reviewer err=%v ok=%v", err, ok)
+	}
+	rec.Metadata.AgentSessionID = "reviewer-native"
+	if err := st.store.UpdateSession(ctx, rec); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.sm.Kill(ctx, sess.ID); err != nil {
+		t.Fatal(err)
+	}
+	restored, err := st.sm.Restore(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored.Kind != domain.KindReviewer || restored.IssueID != "13" || restored.Metadata.AgentSessionID != "reviewer-native" {
+		t.Fatalf("restored reviewer wrong: %+v", restored)
+	}
+
+	list, err := st.sm.List(ctx, sessionsvc.ListFilter{ProjectID: "mer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].Kind != domain.KindReviewer || list[0].IssueID != "13" {
+		t.Fatalf("listed reviewer wrong: %+v", list)
+	}
+}
+
 // TestReconcile_TerminatesDeadLiveSessionAndReapsLeakedTmux exercises
 // Manager.Reconcile against a real sqlite.Store:
 //

--- a/backend/internal/service/session/claim_pr.go
+++ b/backend/internal/service/session/claim_pr.go
@@ -26,7 +26,7 @@ var (
 	ErrSCMUnavailable = errors.New("session: scm unavailable")
 	// ErrProjectMismatch is returned when the PR repository does not match the session project repository.
 	ErrProjectMismatch = errors.New("session: pr project mismatch")
-	// ErrSessionNotClaimable is returned when an orchestrator session tries to claim a PR.
+	// ErrSessionNotClaimable is returned when a non-worker session tries to claim a PR.
 	ErrSessionNotClaimable = errors.New("session: not claimable")
 	// ErrSessionNoWorkspace is returned when a session has no workspace path to associate with PR work.
 	ErrSessionNoWorkspace = errors.New("session: no workspace")
@@ -69,7 +69,7 @@ func (s *Service) ClaimPR(ctx context.Context, id domain.SessionID, ref string, 
 	if rec.IsTerminated {
 		return ClaimPRResult{}, sessionmanagerAPIError("SESSION_TERMINATED", "Session is terminated")
 	}
-	if rec.Kind == domain.KindOrchestrator {
+	if rec.Kind != domain.KindWorker {
 		return ClaimPRResult{}, ErrSessionNotClaimable
 	}
 	if strings.TrimSpace(rec.Metadata.WorkspacePath) == "" {

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -768,6 +768,22 @@ func TestClaimPRMapsObserverAndStoreErrors(t *testing.T) {
 	}
 }
 
+func TestClaimPRRejectsNonWorkerSessions(t *testing.T) {
+	for _, kind := range []domain.SessionKind{domain.KindOrchestrator, domain.KindReviewer} {
+		t.Run(string(kind), func(t *testing.T) {
+			st := newFakeStore()
+			st.sessions["mer-1"] = domain.SessionRecord{
+				ID: "mer-1", ProjectID: "mer", Kind: kind,
+				Metadata: domain.SessionMetadata{WorkspacePath: "/ws"},
+			}
+			_, err := NewWithDeps(Deps{Store: st}).ClaimPR(context.Background(), "mer-1", "7", ClaimPROptions{})
+			if !errors.Is(err, ErrSessionNotClaimable) {
+				t.Fatalf("kind=%q err=%v, want ErrSessionNotClaimable", kind, err)
+			}
+		})
+	}
+}
+
 func TestListPRsOrdersActiveBeforeClosedThenUpdatedDesc(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -462,7 +462,7 @@ func (m *Manager) destroySpawnWorkspace(ctx context.Context, ws ports.WorkspaceI
 
 // effectiveHarness resolves the harness for a spawn: an explicit harness wins;
 // otherwise the project's role override for the session kind applies. Empty is
-// invalid for new worker/orchestrator launches and is rejected by Spawn.
+// invalid for new launches and is rejected by Spawn.
 func effectiveHarness(explicit domain.AgentHarness, kind domain.SessionKind, cfg domain.ProjectConfig) domain.AgentHarness {
 	if explicit != "" {
 		return explicit
@@ -474,10 +474,14 @@ func effectiveHarness(explicit domain.AgentHarness, kind domain.SessionKind, cfg
 }
 
 func roleConfigName(kind domain.SessionKind) string {
-	if kind == domain.KindOrchestrator {
+	switch kind {
+	case domain.KindOrchestrator:
 		return "orchestrator"
+	case domain.KindReviewer:
+		return "reviewer"
+	default:
+		return "worker"
 	}
-	return "worker"
 }
 
 // effectiveAgentConfig merges the role override's agent config over the
@@ -495,10 +499,14 @@ func effectiveAgentConfig(kind domain.SessionKind, cfg domain.ProjectConfig) por
 }
 
 func roleOverride(kind domain.SessionKind, cfg domain.ProjectConfig) domain.RoleOverride {
-	if kind == domain.KindOrchestrator {
+	switch kind {
+	case domain.KindOrchestrator:
 		return cfg.Orchestrator
+	case domain.KindReviewer:
+		return domain.RoleOverride{}
+	default:
+		return cfg.Worker
 	}
-	return cfg.Worker
 }
 
 // sessionPrefix returns the display prefix for a project: the explicit

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -586,6 +586,33 @@ func TestSpawn_AssignsIDAndGoesIdle(t *testing.T) {
 	}
 }
 
+func TestSpawnReviewerPersistsAndRestoresKind(t *testing.T) {
+	m, st, _, _ := newManager()
+	s, err := m.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "mer",
+		IssueID:   "13",
+		Kind:      domain.KindReviewer,
+		Harness:   domain.HarnessCodex,
+		Prompt:    "review issue 13",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Kind != domain.KindReviewer || s.IssueID != "13" || st.sessions[s.ID].Kind != domain.KindReviewer {
+		t.Fatalf("spawned reviewer = %#v stored=%#v", s, st.sessions[s.ID])
+	}
+	if _, err := m.Kill(ctx, s.ID); err != nil {
+		t.Fatal(err)
+	}
+	restored, err := m.Restore(ctx, s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored.Kind != domain.KindReviewer || st.sessions[s.ID].Kind != domain.KindReviewer {
+		t.Fatalf("restored reviewer = %#v stored=%#v", restored, st.sessions[s.ID])
+	}
+}
+
 func TestSpawn_DeliversPromptAfterStartWhenAgentRequestsIt(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}

--- a/backend/internal/session_manager/provision_test.go
+++ b/backend/internal/session_manager/provision_test.go
@@ -117,6 +117,9 @@ func TestEffectiveHarnessAndAgentConfig(t *testing.T) {
 	if h := effectiveHarness("", domain.KindOrchestrator, cfg); h != domain.HarnessClaudeCode {
 		t.Fatalf("orchestrator harness = %q, want claude-code", h)
 	}
+	if h := effectiveHarness("", domain.KindReviewer, cfg); h != "" {
+		t.Fatalf("reviewer harness = %q, want explicit harness requirement", h)
+	}
 
 	// Role override merges over the base agent config (set fields win; unset keep base).
 	got := effectiveAgentConfig(domain.KindWorker, cfg)
@@ -126,6 +129,9 @@ func TestEffectiveHarnessAndAgentConfig(t *testing.T) {
 	// Orchestrator has no agent-config override, so the base config is used as-is.
 	if got := effectiveAgentConfig(domain.KindOrchestrator, cfg); got.Model != "base" {
 		t.Fatalf("orchestrator config = %#v, want base", got)
+	}
+	if got := effectiveAgentConfig(domain.KindReviewer, cfg); got.Model != "base" || got.Permissions != domain.PermissionModeAuto {
+		t.Fatalf("reviewer config = %#v, want base config without worker override", got)
 	}
 }
 

--- a/backend/internal/skillassets/using-ao/commands/spawn.md
+++ b/backend/internal/skillassets/using-ao/commands/spawn.md
@@ -1,6 +1,6 @@
 # ao spawn
 
-Spawn a worker agent session in a registered project. The session runs the chosen agent in a fresh git worktree. Register the project first with `ao project add`.
+Spawn a worker or durable reviewer agent session in a registered project. The session runs the chosen agent in a fresh git worktree. Register the project first with `ao project add`.
 
 ## Syntax
 
@@ -20,6 +20,7 @@ ao spawn [flags]
 | `--no-takeover` | Refuse if another active session owns the claimed PR (requires `--claim-pr`) | - |
 | `--project string` | Project id to spawn the session in | Required |
 | `--prompt string` | Initial prompt for the agent | - |
+| `--role string` | Session role: `worker` or `reviewer` | `worker`; reviewer requires `--harness` |
 
 `--agent` is an alias for `--harness`.
 
@@ -35,4 +36,9 @@ ao spawn --project agent-orchestrator --issue 142 --name "fix-session-leak" --pr
 ```bash
 # Spawn a worker and immediately claim an open PR
 ao spawn --project agent-orchestrator --name "review-pr-88" --claim-pr 88 --harness claude-code
+```
+
+```bash
+# Spawn an issue-bound durable reviewer; reviewers cannot use --claim-pr
+ao spawn --project agent-orchestrator --issue 142 --harness codex --role reviewer --name "review-issue-142" --prompt "Review the canonical records for issue 142."
 ```

--- a/backend/internal/skillassets/using-ao/references.md
+++ b/backend/internal/skillassets/using-ao/references.md
@@ -6,6 +6,7 @@ Natural-language-to-command mappings for common AO tasks.
 |---|---|
 | Show me this webpage / open this page | `ao preview "<url>"` |
 | Spawn a worker on issue N | `ao spawn --project <p> --issue N --name "<=20 chars>" --prompt "..."` |
+| Spawn a durable reviewer on issue N | `ao spawn --project <p> --issue N --harness <agent> --role reviewer --name "<=20 chars>" --prompt "..."` |
 | Message a running agent | `ao send --session <id> --message "..."` |
 | Kill a session | `ao session kill <id>` |
 | List sessions | `ao session ls` |

--- a/backend/internal/storage/sqlite/migrate_test.go
+++ b/backend/internal/storage/sqlite/migrate_test.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/pressly/goose/v3"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
 // TestMigrateAllowsEveryShippedHarness guards against the collapsed-migration

--- a/backend/internal/storage/sqlite/migrate_test.go
+++ b/backend/internal/storage/sqlite/migrate_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/pressly/goose/v3"
 )
 
 // TestMigrateAllowsEveryShippedHarness guards against the collapsed-migration
@@ -64,5 +65,86 @@ func TestMigrateAllowsEveryShippedHarness(t *testing.T) {
 		if !strings.Contains(schema, "'"+string(h)+"'") {
 			t.Errorf("sessions.harness CHECK is missing harness %q — the migration that widens it silently no-opped; schema:\n%s", h, schema)
 		}
+	}
+}
+
+func TestMigrateAllowsReviewerSessionKind(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	var schema string
+	if err := db.QueryRow(
+		"SELECT sql FROM sqlite_master WHERE type='table' AND name='sessions'",
+	).Scan(&schema); err != nil {
+		t.Fatalf("read sessions schema: %v", err)
+	}
+	if !strings.Contains(schema, "'reviewer'") {
+		t.Fatalf("sessions.kind CHECK is missing reviewer; schema:\n%s", schema)
+	}
+}
+
+func TestMigration0024DownRejectsReviewerRows(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO projects (id, path, registered_at) VALUES ('ao', '/tmp/ao', '2026-07-14T00:00:00Z')`); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO sessions (id, project_id, num, kind, activity_last_at, created_at, updated_at) VALUES ('ao-1', 'ao', 1, 'reviewer', '2026-07-14T00:00:00Z', '2026-07-14T00:00:00Z', '2026-07-14T00:00:00Z')`); err != nil {
+		t.Fatalf("seed reviewer session: %v", err)
+	}
+
+	gooseMu.Lock()
+	defer gooseMu.Unlock()
+	goose.SetBaseFS(migrationsFS)
+	goose.SetLogger(goose.NopLogger())
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		t.Fatalf("set goose dialect: %v", err)
+	}
+	if err := goose.DownTo(db, "migrations", 23); err == nil {
+		t.Fatalf("DownTo(23) succeeded with durable reviewer sessions present")
+	}
+	if _, err := db.Exec(`UPDATE sessions SET kind = 'worker' WHERE kind = 'reviewer'`); err != nil {
+		t.Fatalf("remove reviewer session kind: %v", err)
+	}
+	if err := goose.DownTo(db, "migrations", 23); err != nil {
+		t.Fatalf("retry DownTo(23) after deleting reviewer sessions: %v", err)
+	}
+}
+
+func TestMigration0024DownSucceedsWithoutReviewerRows(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	gooseMu.Lock()
+	defer gooseMu.Unlock()
+	goose.SetBaseFS(migrationsFS)
+	goose.SetLogger(goose.NopLogger())
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		t.Fatalf("set goose dialect: %v", err)
+	}
+	if err := goose.DownTo(db, "migrations", 23); err != nil {
+		t.Fatalf("DownTo(23) without reviewer sessions: %v", err)
 	}
 }

--- a/backend/internal/storage/sqlite/migrations/0024_allow_reviewer_session_kind.sql
+++ b/backend/internal/storage/sqlite/migrations/0024_allow_reviewer_session_kind.sql
@@ -1,0 +1,52 @@
+-- Widen sessions.kind for durable reviewer sessions without rebuilding the
+-- sessions table and its foreign keys, indexes, and change-log triggers.
+
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+PRAGMA writable_schema = ON;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (kind IN (''worker'', ''orchestrator''))',
+    'CHECK (kind IN (''worker'', ''orchestrator'', ''reviewer''))'
+)
+WHERE type = 'table' AND name = 'sessions';
+-- +goose StatementEnd
+-- +goose StatementBegin
+PRAGMA writable_schema = RESET;
+-- +goose StatementEnd
+
+-- +goose Down
+-- Downgrade only after removing reviewer sessions through normal product
+-- lifecycle; this migration deliberately does not delete durable records.
+-- +goose StatementBegin
+DROP TABLE IF EXISTS _reviewer_session_down_guard;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE TEMP TABLE _reviewer_session_down_guard (ok INTEGER NOT NULL);
+-- +goose StatementEnd
+-- +goose StatementBegin
+INSERT INTO _reviewer_session_down_guard(ok)
+SELECT NULL WHERE EXISTS (SELECT 1 FROM sessions WHERE kind = 'reviewer');
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP TABLE _reviewer_session_down_guard;
+-- +goose StatementEnd
+-- +goose StatementBegin
+PRAGMA writable_schema = ON;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE sqlite_master
+SET sql = replace(
+    sql,
+    'CHECK (kind IN (''worker'', ''orchestrator'', ''reviewer''))',
+    'CHECK (kind IN (''worker'', ''orchestrator''))'
+)
+WHERE type = 'table' AND name = 'sessions';
+-- +goose StatementEnd
+-- +goose StatementBegin
+PRAGMA writable_schema = RESET;
+-- +goose StatementEnd

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -68,11 +68,13 @@ daemon), then the current working directory matched against registered project
 paths. If `AO_SESSION_ID` is set but the session cannot be fetched, pass
 `--project` explicitly.
 
-If `--agent` / `--harness` is omitted, `ao spawn` uses the resolved project's
-`worker.agent` config. Before spawning, the CLI refreshes the advisory agent
-catalog and fails early when the selected agent is unsupported, not installed,
-or unauthorized. It warns-but-continues when auth remains unknown because daemon
-spawn remains the authoritative runtime validation point. Use
+By default, `ao spawn` creates a worker session and uses the resolved project's
+`worker.agent` config when `--agent` / `--harness` is omitted. Use `--role
+reviewer` with an explicit `--agent` / `--harness` to create a durable reviewer
+session. Reviewer sessions cannot use `--claim-pr`. Before spawning, the CLI
+refreshes the advisory agent catalog and fails early when the selected agent is
+unsupported, not installed, or unauthorized. It warns-but-continues when auth
+remains unknown because daemon spawn remains the authoritative runtime validation point. Use
 `--skip-agent-check` to bypass only this CLI-side preflight.
 
 `ao preview` resolves its session from the `AO_SESSION_ID` environment variable

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1085,7 +1085,7 @@ export interface components {
             harness?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "kiro" | "kilocode" | "vibe" | "pi" | "autohand";
             issueId?: string;
             /** @enum {string} */
-            kind?: "worker" | "orchestrator";
+            kind?: "worker" | "orchestrator" | "reviewer";
             projectId: string;
             prompt?: string;
         };


### PR DESCRIPTION
## Summary
- add durable session kind `reviewer`
- support `ao spawn --role reviewer` with explicit harness and issue binding
- persist/list/restore reviewer sessions and reject PR claiming from non-worker sessions
- update API schema, CLI docs, and targeted tests

## Scope
This only extends the existing durable session lifecycle. It does not change the PR review pane, add a reviewer UI lane, modify APL, or change GitHub writeback behavior.

## Tests
- `go test ./internal/storage/sqlite/...`
- `go test ./internal/storage/sqlite/... ./internal/httpd/controllers ./internal/cli ./internal/service/session ./internal/adapters/agent/qwen ./internal/integration ./internal/skillassets`
- `go test ./internal/session_manager -run "TestSpawnReviewerPersistsAndRestoresKind|TestSpawnReviewerDoesNotInheritWorkerOverride"`
- `npm run api`
- `npm run frontend:typecheck`
- `git diff --check`

## Known not green
- Full `go test ./...` was not used as the gate because existing Windows/environment failures remain outside this reviewer-session change: auth fixture behavior, polluted PTY registry state, Windows mode bits, CRLF worktree expectations, HTTP port fallback, and path separator assertions.