### PR TITLE
Fix maximized browser controls overlapping Windows titlebar

### DIFF
--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -234,11 +234,11 @@ export function SessionView({ sessionId }: SessionViewProps) {
 					</>
 				) : null}
 			</ResizablePanelGroup>
-			{/* Maximized browser: a fixed overlay across the whole app window,
+			{/* Maximized browser: a fixed overlay across the app workspace,
           portaled to <body> so it escapes the shell layout (covering the
           sidebar + topbar, not just the session area) and sits outside any
           `[data-panel]` column, so the native WebContentsView is not clamped
-          and fills the entire window. */}
+          and fills the window below any native titlebar overlay. */}
 			{browserPoppedOut && session
 				? createPortal(
 						<div className="browser-popout-overlay">

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1571,12 +1571,15 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	background: var(--bg);
 }
 
-/* Maximized browser overlay: a fixed layer over the whole app window (portaled
-   to <body>, so it covers the sidebar + topbar too, not just the session area).
-   The panel goes edge-to-edge, so drop its border/radius. */
+/* Maximized browser overlay: a fixed layer over the app workspace (portaled to
+   <body>, so it covers the sidebar + topbar too, not just the session area).
+   Electron's Window Controls Overlay owns the top-right titlebar region on
+   Windows, so start below its reported safe-area height. Platforms without a
+   titleBarOverlay resolve the env() fallback to 0px and keep the existing
+   edge-to-edge layout. */
 .browser-popout-overlay {
 	position: fixed;
-	inset: 0;
+	inset: env(titlebar-area-height, 0px) 0 0;
 	z-index: 40;
 	background: var(--bg);
 }


### PR DESCRIPTION
## Issue

On Windows only, maximizing the in-app browser preview positioned its toolbar at the top edge of the application window. Electron’s native minimize, maximize, and close controls occupy the top-right titlebar region, causing the browser preview’s “Return to panel” button to render underneath them and become inaccessible.

macOS, Linux, and web preview were unaffected.

## Summary

- Keep the maximized browser preview below Electron’s Windows titlebar overlay.
- Prevent the “Return to panel” button from being hidden behind native window controls.
- Preserve the existing edge-to-edge layout on platforms without a titlebar overlay.

## Fix

Updated the maximized browser overlay to respect Electron’s Window Controls Overlay safe-area height:

```css
inset: env(titlebar-area-height, 0px) 0 0;
```
On Windows, this positions the browser preview below the native titlebar controls. Platforms without a titlebar overlay resolve the fallback to 0px, preserving their existing edge-to-edge layout.

## Files affected
 - frontend/src/renderer/styles.css
    - Updated the maximized browser overlay positioning.
    - Documented the Windows titlebar safe-area behavior.

 - frontend/src/renderer/components/SessionView.tsx
    - Updated the browser overlay documentation to describe the native titlebar boundary.

## Validation

- Frontend typecheck passed.
- 28 targeted browser/session tests passed.
- 582 frontend tests passed; 4 socket tests were environment-blocked.
- Production renderer build passed.

Before-
<img width="1673" height="371" alt="Screenshot 2026-07-14 154653" src="https://github.com/user-attachments/assets/5b7876f8-843a-4454-bfb5-6d005ba77f7d" />

After-
<img width="1192" height="100" alt="Screenshot 2026-07-15 140958" src="https://github.com/user-attachments/assets/168061af-6ba0-42a8-b311-dec952517786" />
