### PR TITLE
fix: remove confirm kill button icon

### DIFF
--- a/frontend/src/renderer/components/ConfirmDialog.test.tsx
+++ b/frontend/src/renderer/components/ConfirmDialog.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test, vi } from "vitest";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+test("confirm kill button renders without a leading icon while busy", () => {
+	render(
+		<ConfirmDialog
+			open
+			title="Kill session?"
+			description="This will stop the session."
+			confirmLabel="Confirm kill"
+			destructive
+			busy
+			onConfirm={vi.fn()}
+			onOpenChange={vi.fn()}
+		/>,
+	);
+
+	const confirmButton = screen.getByRole("button", { name: "Confirm kill" });
+
+	expect(confirmButton.querySelector("svg")).toBeNull();
+});

--- a/frontend/src/renderer/components/ConfirmDialog.tsx
+++ b/frontend/src/renderer/components/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
 import * as Dialog from "@radix-ui/react-dialog";
-import { Loader2, XCircle } from "lucide-react";
+import { XCircle } from "lucide-react";
 import { Button } from "./ui/button";
 
 type ConfirmDialogProps = {
@@ -60,7 +60,6 @@ export function ConfirmDialog({
 							disabled={busy}
 							size={size}
 						>
-							{busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
 							{confirmLabel}
 						</Button>
 					</div>


### PR DESCRIPTION
removed the square icon from the "Confirm Kill" button which was making it seem like a checkbox