### PR TITLE
fix: align terminal topbar with inspector

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -35,4 +35,11 @@ describe("CenterPane toolbar session label", () => {
 		render(<CenterPane theme="dark" daemonReady />);
 		expect(screen.getByText("No session")).toBeInTheDocument();
 	});
+
+	it("uses the inspector tab height for the terminal header", () => {
+		render(<CenterPane session={worker} theme="dark" daemonReady />);
+
+		const header = screen.getByText("TERMINAL").parentElement?.parentElement;
+		expect(header).toHaveClass("h-inspector-tabs");
+	});
 });

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -94,7 +94,7 @@ export function CenterPane({ session, theme, daemonReady, terminalTarget, onSele
 			className="terminal-pane-frame flex h-full min-h-0 min-w-0 flex-col bg-background"
 			onWheelCapture={handleWheelZoom}
 		>
-			<div className="flex h-toolbar shrink-0 items-center border-b border-border bg-background px-5">
+			<div className="flex h-inspector-tabs shrink-0 items-center border-b border-border bg-background px-5">
 				<div className="flex min-w-0 items-center gap-3">
 					<span className="shrink-0 font-mono text-caption font-semibold uppercase tracking-wide-lg text-muted-foreground">
 						TERMINAL


### PR DESCRIPTION
aligned the topbar and made it consistent for the terminal as well as the right panel