### PR TITLE
fix: show idle activity as passive in working column

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -68,4 +68,38 @@ describe("SessionsBoard", () => {
 
 		expect(screen.getByText("Idle")).toBeInTheDocument();
 	});
+
+	it("renders idle activity in the working column with passive styling", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					id: "p1",
+					name: "radic",
+					path: "/tmp/radic",
+					sessions: [
+						{
+							id: "s1",
+							workspaceId: "p1",
+							workspaceName: "radic",
+							title: "brand-font-pipeline",
+							provider: "claude-code",
+							branch: "ao/radic-5",
+							status: "working",
+							activity: { state: "idle", lastActivityAt: "2026-01-01T00:00:00Z" },
+							updatedAt: "2026-01-01T00:00:00Z",
+							prs: [],
+						},
+					],
+				},
+			],
+			isError: false,
+		});
+
+		renderBoard("p1");
+
+		expect(screen.getAllByText("Working").length).toBeGreaterThan(0);
+		const badge = screen.getByText("Idle").closest("span");
+		expect(badge).toHaveClass("text-passive");
+		expect(badge).not.toHaveClass("text-working");
+	});
 });

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -502,6 +502,9 @@ function agentLabel(provider: WorkspaceSession["provider"]): string {
 }
 
 function sessionBadge(session: WorkspaceSession): { label: string; className: string } {
+	if (session.status === "working" && session.activity?.state === "idle") {
+		return { label: "Idle", className: "text-passive" };
+	}
 	switch (session.status) {
 		case "needs_input":
 			return { label: "Input needed", className: "text-warning" };

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -873,6 +873,30 @@ describe("Sidebar", () => {
 		expect(workingDot).toHaveClass("animate-status-pulse", "bg-working");
 	});
 
+	it("renders a calm non-pulsing dot for idle activity even when the session is in the working zone", () => {
+		renderSidebar({
+			workspaces: [
+				{
+					...workspace,
+					sessions: [
+						{
+							...session,
+							id: "proj-1-idle-activity",
+							title: "idle activity task",
+							status: "working",
+							activity: { state: "idle", lastActivityAt: "2026-06-30T00:00:00Z" },
+						},
+					],
+				},
+			],
+		});
+
+		const idleDot = screen.getByLabelText("Open idle activity task").querySelector('span[aria-hidden="true"]');
+		expect(idleDot).toHaveClass("bg-passive");
+		expect(idleDot).not.toHaveClass("animate-status-pulse");
+		expect(idleDot).not.toHaveClass("bg-working");
+	});
+
 	it("does not render the restart-to-update row unless an update is downloaded", async () => {
 		updateStatusMock.mockResolvedValue({ state: "available", version: "9.9.9" });
 		renderSidebar();

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -124,13 +124,14 @@ function useSelection() {
 // scanned without opening the project board.
 function SessionDot({ session }: { session: WorkspaceSession }) {
 	const zone = attentionZone(session);
+	const isIdle = session.status === "idle" || (session.status === "working" && session.activity?.state === "idle");
 	return (
 		<span
 			aria-hidden="true"
 			className={cn(
 				"mt-px h-1.5 w-1.5 shrink-0 rounded-full",
-				zone === "working" && session.status === "idle" && "bg-passive",
-				zone === "working" && session.status !== "idle" && "animate-status-pulse bg-working",
+				zone === "working" && isIdle && "bg-passive",
+				zone === "working" && !isIdle && "animate-status-pulse bg-working",
 				zone === "action" && (session.status === "ci_failed" ? "bg-error" : "bg-warning"),
 				zone === "pending" && "bg-passive",
 				zone === "merge" && "bg-success",


### PR DESCRIPTION
fixes the session state in the kanban board 