### PR TITLE
fix: align activity timeline markers

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -298,6 +298,33 @@ describe("SessionInspector Activity section", () => {
 		expect(within(activityRow).getByText("2h ago")).toBeInTheDocument();
 	});
 
+	it("aligns text-row dots lower while keeping the Activity chip dot centered", () => {
+		renderWithQuery(
+			<SessionInspector
+				session={session([pr(7, "open")], {
+					status: "working",
+					createdAt: "2026-06-15T09:00:00Z",
+					activity: { state: "idle", lastActivityAt: "2026-06-15T10:00:00Z" },
+				})}
+			/>,
+		);
+
+		const worktreeRow = activitySection()
+			.getByText(/Created worktree/)
+			.closest("[data-testid='inspector-timeline-event']") as HTMLElement;
+		const worktreeMarker = worktreeRow.querySelector("span[aria-hidden='true'].rounded-full") as HTMLElement;
+		expect(worktreeMarker.parentElement).toHaveClass("relative", "flex", "items-center");
+		expect(worktreeMarker).toHaveClass("top-1.5");
+		expect(worktreeMarker).not.toHaveClass("top-1/2", "-translate-y-1/2");
+
+		const activityRow = activitySection()
+			.getByText("Idle")
+			.closest("[data-testid='inspector-timeline-event']") as HTMLElement;
+		const activityMarker = activityRow.querySelector("span[aria-hidden='true'].rounded-full") as HTMLElement;
+		expect(activityMarker.parentElement).toHaveClass("relative", "flex", "items-center");
+		expect(activityMarker).toHaveClass("top-1/2", "-translate-y-1/2");
+	});
+
 	it("keeps worktree, PR, and SCM context rows in the Activity timeline", () => {
 		renderWithQuery(
 			<SessionInspector

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -372,11 +372,17 @@ function ActivityTimeline({ session }: { session: WorkspaceSession }) {
 		<div className="relative pl-5 before:absolute before:top-1 before:bottom-1.5 before:left-1.25 before:w-px before:bg-border before:content-['']">
 			{events.map((event, index) => (
 				<div key={index} className="relative pb-4 last:pb-0" data-testid="inspector-timeline-event">
-					<span
-						aria-hidden="true"
-						className={cn("absolute -left-4.5 top-0.75 size-icon-xs rounded-full", timelineNodeTone[event.tone])}
-					/>
-					<div className="text-xs leading-normal text-foreground [&_b]:font-semibold">{event.node}</div>
+					<div className="relative flex min-h-icon-xs items-center">
+						<span
+							aria-hidden="true"
+							className={cn(
+								"absolute -left-4.5 size-icon-xs rounded-full",
+								event.tone === "now" ? "top-1/2 -translate-y-1/2" : "top-1.5",
+								timelineNodeTone[event.tone],
+							)}
+						/>
+						<div className="text-xs leading-normal text-foreground [&_b]:font-semibold">{event.node}</div>
+					</div>
 					{event.ts ? <div className="mt-1 font-mono text-2xs text-passive">{event.ts}</div> : null}
 				</div>
 			))}


### PR DESCRIPTION
## Summary
- Align activity timeline dots to the primary content row
- Use a lower optical offset for plain text rows while keeping the current activity chip centered
- Add regression coverage for text-row and chip-row marker alignment

## Verification
- npm.cmd run test -- SessionInspector.test.tsx
- npm.cmd run typecheck