### PR TITLE
feat(release): publish Homebrew cask on every stable desktop release

### DIFF
--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -267,3 +267,61 @@ jobs:
           assets=(dist/latest*.yml dist/*.blockmap)
           if [ ${#assets[@]} -eq 0 ]; then echo "no feed assets generated" >&2; exit 1; fi
           gh release upload "$tag" "${assets[@]}" --clobber
+
+  # Mirror the just-published stable release into the Homebrew cask so
+  # `brew install --cask agentwrapper/homebrew-tap/agent-orchestrator` tracks
+  # every release with no manual step. Runs after the release + updater feed are
+  # fully published, and only on AgentWrapper (fork test releases skip it). It is
+  # a downstream mirror: `continue-on-error` keeps a tap hiccup from failing the
+  # product release. Requires the HOMEBREW_TAP_TOKEN secret (a token with
+  # contents:write on AgentWrapper/homebrew-tap); without it the job no-ops.
+  publish-cask:
+    needs: [publish-feed]
+    if: github.repository == 'AgentWrapper/agent-orchestrator'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Update Homebrew tap cask
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$TAP_TOKEN" ]; then
+            echo "HOMEBREW_TAP_TOKEN not set; skipping cask update." >&2
+            exit 0
+          fi
+          # Forge publishes to v<package.json version> (not the git tag).
+          version="$(node -p "require('./package.json').version")"
+          tag="v$version"
+          work="$(mktemp -d)"
+          gh release download "$tag" --dir "$work" \
+            --pattern 'agent-orchestrator-darwin-arm64.zip' \
+            --pattern 'agent-orchestrator-darwin-x64.zip'
+          arm_sha="$(sha256sum "$work/agent-orchestrator-darwin-arm64.zip" | cut -d' ' -f1)"
+          x64_sha="$(sha256sum "$work/agent-orchestrator-darwin-x64.zip" | cut -d' ' -f1)"
+          git clone --depth 1 \
+            "https://x-access-token:${TAP_TOKEN}@github.com/AgentWrapper/homebrew-tap.git" "$work/tap"
+          mkdir -p "$work/tap/Casks"
+          sed -e "s/__VERSION__/$version/" \
+              -e "s/__ARM_SHA__/$arm_sha/" \
+              -e "s/__X64_SHA__/$x64_sha/" \
+              packaging/homebrew/agent-orchestrator.rb.tmpl \
+              > "$work/tap/Casks/agent-orchestrator.rb"
+          cd "$work/tap"
+          git config user.name "ao-release-bot"
+          git config user.email "release-bot@users.noreply.github.com"
+          git add Casks/agent-orchestrator.rb
+          if git diff --cached --quiet; then
+            echo "Cask already at $version; nothing to push."
+            exit 0
+          fi
+          git commit -m "agent-orchestrator $version"
+          git push

--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -161,6 +161,60 @@ gh api repos/AgentWrapper/agent-orchestrator/environments/release \
   --jq '.protection_rules[] | select(.type=="required_reviewers") | .reviewers[].reviewer.login'
 ```
 
+## Homebrew cask (automated)
+
+The desktop app is also distributed as a Homebrew cask so macOS users can
+`brew install --cask agentwrapper/homebrew-tap/agent-orchestrator`. This is
+part of the same release run: after `publish-feed`, the `publish-cask` job in
+`frontend-release.yml` mirrors the release into the tap, so a normal
+`desktop-vX.Y.Z` cut updates the cask with no manual step.
+
+What the job does, on `AgentWrapper/agent-orchestrator` only (fork test
+releases skip it):
+
+1. Downloads the two stable macOS aliases from the release
+   (`agent-orchestrator-darwin-arm64.zip`, `agent-orchestrator-darwin-x64.zip`)
+   and computes their `sha256`.
+2. Renders `frontend/packaging/homebrew/agent-orchestrator.rb.tmpl` with the
+   version and both hashes.
+3. Commits the result to `AgentWrapper/homebrew-tap` as
+   `Casks/agent-orchestrator.rb` and pushes.
+
+The job is `continue-on-error: true`: it is a downstream mirror, so a tap
+failure never fails the product release. Check the "Desktop release" run's
+`publish-cask` job if a release ships but the cask does not move.
+
+### Prerequisites (one-time)
+
+- Secret **`HOMEBREW_TAP_TOKEN`** on `AgentWrapper/agent-orchestrator`: a
+  fine-grained PAT (or GitHub App token) with **contents: write** on
+  `AgentWrapper/homebrew-tap`. The default `GITHUB_TOKEN` cannot push to a
+  different repo, so without this secret the job no-ops with a log line.
+- The `AgentWrapper/homebrew-tap` repo exists with a `Casks/` directory.
+
+### Update strategy
+
+The cask sets `auto_updates true`. Homebrew installs the initial version; the
+app then self-updates via electron-updater from the Releases feed, exactly as a
+directly-downloaded build does. `brew upgrade` will not fight the in-app
+updater, and there is no "disable updates when brew-installed" logic to
+maintain.
+
+### Changing the cask format
+
+Edit `frontend/packaging/homebrew/agent-orchestrator.rb.tmpl` (the
+`__VERSION__` / `__ARM_SHA__` / `__X64_SHA__` placeholders are filled by the
+job). To hand-publish a cask for an existing release, run the same `sed`
+substitution locally against downloaded zips and push to the tap.
+
+### Not in Homebrew's official cask repo
+
+We ship our own tap, not `Homebrew/homebrew-cask`. Homebrew rejects casks
+whose repo is under **any one** of 90 forks / 90 watchers / 225 stars for
+self-submissions; AO is well over on stars and forks but under on watchers, so
+the official cask is not an option until watchers clear 90. The own tap has no
+such gate.
+
 ## Fork test releases (dev loop)
 
 Test releases go to the fork, never to AgentWrapper: push a `desktop-v*` tag

--- a/frontend/packaging/homebrew/agent-orchestrator.rb.tmpl
+++ b/frontend/packaging/homebrew/agent-orchestrator.rb.tmpl
@@ -19,7 +19,7 @@ cask "agent-orchestrator" do
   # The app self-updates via electron-updater from GitHub Releases, so Homebrew
   # only installs the initial version and must not fight the in-app updater.
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "Agent Orchestrator.app"
 

--- a/frontend/packaging/homebrew/agent-orchestrator.rb.tmpl
+++ b/frontend/packaging/homebrew/agent-orchestrator.rb.tmpl
@@ -1,0 +1,30 @@
+cask "agent-orchestrator" do
+  arch arm: "arm64", intel: "x64"
+
+  version "__VERSION__"
+  sha256 arm:   "__ARM_SHA__",
+         intel: "__X64_SHA__"
+
+  url "https://github.com/AgentWrapper/agent-orchestrator/releases/download/v#{version}/agent-orchestrator-darwin-#{arch}.zip",
+      verified: "github.com/AgentWrapper/agent-orchestrator/"
+  name "Agent Orchestrator"
+  desc "Orchestrator for running parallel coding agents"
+  homepage "https://github.com/AgentWrapper/agent-orchestrator"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  # The app self-updates via electron-updater from GitHub Releases, so Homebrew
+  # only installs the initial version and must not fight the in-app updater.
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Agent Orchestrator.app"
+
+  zap trash: [
+    "~/.ao",
+    "~/Library/Logs/Agent Orchestrator",
+  ]
+end


### PR DESCRIPTION
## What

Ships the desktop app as a Homebrew cask, updated automatically on every stable release. Adds a `publish-cask` job to `frontend-release.yml`, a reviewable cask template, and docs.

## Why

macOS users can install and stay current with:

```
brew install --cask agentwrapper/homebrew-tap/agent-orchestrator
```

We ship our own tap (`AgentWrapper/homebrew-tap`), not `Homebrew/homebrew-cask`: Homebrew rejects self-submitted casks whose repo is under any one of 90 forks / 90 watchers / 225 stars, and we are under on watchers. The own tap has no such gate.

## How it works

`publish-cask` runs after `publish-feed`, only on `AgentWrapper/agent-orchestrator` (fork test releases skip it). It downloads the two stable macOS aliases (`agent-orchestrator-darwin-{arm64,x64}.zip`), computes their sha256, renders `frontend/packaging/homebrew/agent-orchestrator.rb.tmpl`, and pushes `Casks/agent-orchestrator.rb` to the tap. It is `continue-on-error: true`, so a tap hiccup never fails the product release.

The cask sets `auto_updates true`: Homebrew installs the initial version, then electron-updater keeps driving in-app updates from the Releases feed, so `brew upgrade` never fights the in-app updater.

## Required before it works

Add secret **`HOMEBREW_TAP_TOKEN`** on this repo: a fine-grained PAT (or App token) with **contents: write** on `AgentWrapper/homebrew-tap`. The default `GITHUB_TOKEN` cannot push to a different repo. Without it the job no-ops with a log line, so this is safe to merge before the secret exists.

## Validation

- A v0.10.3 cask is already live in the tap (hand-published from this template with the real release sha256s); `brew info --cask` resolves clean (version, `auto_updates`, macOS >= 11, `Agent Orchestrator.app`), no lint warnings.
- Next stable cut (0.10.4) will exercise the automated job.

## Notes

- Homebrew 6.0 requires a one-time `brew trust agentwrapper/tap` when installing from a third-party tap (worth a README line, follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
