### PR TITLE
fix: refresh tracked PR terminal state

### DIFF
--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -274,7 +274,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 		return err
 	}
 
-	selection := o.selectRefreshCandidates(ctx, subjects, repoGuards, markRepoRefreshFailed)
+	selection := o.selectRefreshCandidates(ctx, subjects, markRepoRefreshFailed)
 	observations := map[string]ports.SCMObservation{}
 	prRefreshOK := map[string]bool{}
 	for key := range selection.candidateKeys {
@@ -817,7 +817,7 @@ func sessionBranchPrefixes(branch string) []string {
 	return prefixes
 }
 
-func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[string]*subject, guards map[string]repoGuardState, markRepoFailed func(ports.SCMRepo)) refreshSelection {
+func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[string]*subject, markRepoFailed func(ports.SCMRepo)) refreshSelection {
 	selection := refreshSelection{
 		subjectsByPR:  map[string]*subject{},
 		commitETags:   map[string]pendingCacheString{},
@@ -829,11 +829,10 @@ func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[str
 		}
 		key := prKey(s.repo, s.known.Number)
 		selection.subjectsByPR[key] = s
-		candidate := missingLocalState(s.known)
-		g := guards[prKey(s.repo, 0)]
-		if g.err == nil && !g.result.NotModified {
-			candidate = true
-		}
+		// Locally open tracked PRs need a direct metadata refresh even when the
+		// repo open-list and commit check guards are unchanged: GitHub can merge
+		// or close a PR without changing the head commit checks, and a later
+		// repo-list 304 must not leave the local row permanently open.
 		if s.known.HeadSHA != "" {
 			commitKey := commitKey(s.repo, s.known.HeadSHA)
 			prev := o.Cache.CommitChecksETag[commitKey]
@@ -844,22 +843,15 @@ func (o *Observer) selectRefreshCandidates(ctx context.Context, subjects map[str
 					markRepoFailed(s.repo)
 				}
 			} else if !res.NotModified {
-				candidate = true
 				if res.ETag != "" {
 					selection.commitETags[key] = pendingCacheString{key: commitKey, value: res.ETag}
 				}
 			}
 		}
-		if candidate {
-			selection.refs = append(selection.refs, ports.SCMPRRef{Repo: s.repo, Number: s.known.Number, URL: s.known.URL})
-			selection.candidateKeys[key] = true
-		}
+		selection.refs = append(selection.refs, ports.SCMPRRef{Repo: s.repo, Number: s.known.Number, URL: s.known.URL})
+		selection.candidateKeys[key] = true
 	}
 	return selection
-}
-
-func missingLocalState(pr domain.PullRequest) bool {
-	return pr.URL == "" || pr.HeadSHA == "" || pr.MetadataHash == "" || pr.CIHash == ""
 }
 
 func (o *Observer) enrichFailureLogs(ctx context.Context, obs *ports.SCMObservation, local domain.PullRequest) {

--- a/backend/internal/observe/scm/observer_test.go
+++ b/backend/internal/observe/scm/observer_test.go
@@ -890,6 +890,44 @@ func TestPoll_CIETagChangeRefreshesWhenRepoUnchanged(t *testing.T) {
 	}
 }
 
+func TestPoll_OpenTrackedPRRefreshesWhenRepoAndChecksUnchanged(t *testing.T) {
+	store := testStoreWithSession()
+	local := knownPR(1)
+	store.prs["p-1"] = []domain.PullRequest{local}
+	merged := testObs(1)
+	merged.PR.State = string(domain.PRStateMerged)
+	merged.PR.Merged = true
+	merged.PR.MergeCommitSHA = "merge-sha"
+	merged.PR.MergedAtProvider = time.Unix(10, 0).UTC()
+	provider := &fakeProvider{
+		repoGuards:   map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "repo", NotModified: true}},
+		checkGuards:  map[string]ports.SCMGuardResult{commitKey(testRepo, "sha1"): {ETag: "ci", NotModified: true}},
+		observations: map[string]ports.SCMObservation{prKey(testRepo, 1): merged},
+	}
+	lc := &fakeLifecycle{}
+	obs := newTestObserver(store, provider, lc, time.Unix(20, 0).UTC())
+	obs.Cache.RepoPRListETag[prKey(testRepo, 0)] = "repo"
+	obs.Cache.CommitChecksETag[commitKey(testRepo, "sha1")] = "ci"
+
+	if err := obs.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(provider.fetchBatches) != 1 || len(provider.fetchBatches[0]) != 1 || provider.fetchBatches[0][0].Number != 1 {
+		t.Fatalf("open tracked PR should be fetched despite unchanged guards, got %#v", provider.fetchBatches)
+	}
+	if len(lc.observed) != 1 || !lc.observed[0].PR.Merged {
+		t.Fatalf("merged transition not delivered to lifecycle: %#v", lc.observed)
+	}
+	if len(store.writes) == 0 {
+		t.Fatal("merged transition was not persisted")
+	}
+	last := store.writes[len(store.writes)-1].pr
+	if !last.Merged || last.MergeCommitSHA != "merge-sha" {
+		t.Fatalf("persisted PR = %#v, want merged with merge commit", last)
+	}
+}
+
 func TestPoll_GraphQLBatchChunksAt25(t *testing.T) {
 	store := &fakeStore{projects: map[string]domain.ProjectRecord{"p": {ID: "p", RepoOriginURL: "https://github.com/o/r.git"}}, prs: map[domain.SessionID][]domain.PullRequest{}, checks: map[string][]domain.PullRequestCheck{}}
 	provider := &fakeProvider{repoGuards: map[string]ports.SCMGuardResult{prKey(testRepo, 0): {ETag: "repo"}}, observations: map[string]ports.SCMObservation{}}


### PR DESCRIPTION
## Summary
- Refresh every locally open tracked PR directly during the SCM observer poll so merged/closed transitions cannot be hidden by unchanged repo-list or commit-check guards.
- Keep already merged/closed PRs out of ongoing polling via existing discovery filtering.
- Add a regression test for #2656 where both repo and check guards are not modified but GitHub truth is merged.

Fixes #2656.

## Tests
- `cd backend && go test ./internal/observe/scm`
- `cd backend && go test -count=1 ./internal/observe/scm ./internal/service/session ./internal/service/pr`
- `cd backend && go test ./internal/adapters/agent/kilocode -run TestAuthStatusUnknownWhenKeyOnlyComesFromInteractiveShell -count=1`

## Notes
- `cd backend && go test ./...` was attempted; it hit an unrelated timeout in `internal/adapters/agent/kilocode` on the first run and was later stopped after another unrelated long-running package. The specific kilocode test passed when rerun directly.