### PR TITLE
fix: reject unknown project config JSON keys

### DIFF
--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -93,6 +93,11 @@ type trackerIntakeConfig struct {
 	Assignee string `json:"assignee,omitempty"`
 }
 
+// reviewerConfig mirrors domain.ReviewerConfig.
+type reviewerConfig struct {
+	Harness string `json:"harness"`
+}
+
 // projectConfig mirrors the daemon's typed domain.ProjectConfig for the CLI
 // client. The CLI sets common fields via flags and the whole object via
 // --config-json.
@@ -108,6 +113,7 @@ type projectConfig struct {
 	AgentConfig       agentConfig         `json:"agentConfig,omitempty"`
 	Worker            roleOverride        `json:"worker,omitempty"`
 	Orchestrator      roleOverride        `json:"orchestrator,omitempty"`
+	Reviewers         []reviewerConfig    `json:"reviewers,omitempty"`
 	TrackerIntake     trackerIntakeConfig `json:"trackerIntake,omitempty"`
 }
 
@@ -340,6 +346,9 @@ func buildProjectConfig(opts projectSetConfigOptions) (projectConfig, error) {
 	}
 	if opts.configJSON != "" {
 		var cfg projectConfig
+		if err := validateJSONKeys([]byte(opts.configJSON), reflect.TypeOf(cfg), "config"); err != nil {
+			return projectConfig{}, usageError{fmt.Errorf("--config-json does not match project config schema: %w", err)}
+		}
 		if err := json.Unmarshal([]byte(opts.configJSON), &cfg); err != nil {
 			return projectConfig{}, usageError{fmt.Errorf("--config-json is not a valid JSON object: %w", err)}
 		}
@@ -380,6 +389,103 @@ func trackerProviderForFlags(opts projectSetConfigOptions) string {
 		return "github"
 	}
 	return ""
+}
+
+func validateJSONKeys(data []byte, typ reflect.Type, path string) error {
+	return validateJSONValue(json.RawMessage(data), typ, path)
+}
+
+func validateJSONValue(raw json.RawMessage, typ reflect.Type, path string) error {
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	switch typ.Kind() {
+	case reflect.Struct:
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			return fmt.Errorf("%s must be an object: %w", path, err)
+		}
+		fields := jsonFieldTypes(typ)
+		for key, value := range obj {
+			fieldType, ok := fields[key]
+			if !ok {
+				return fmt.Errorf("unknown config key %q at %s (valid keys: %s)", key, path, strings.Join(sortedJSONKeys(fields), ", "))
+			}
+			if err := validateJSONValue(value, fieldType, path+"."+key); err != nil {
+				return err
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		elem := typ.Elem()
+		if !needsKeyValidation(elem) {
+			return nil
+		}
+		var items []json.RawMessage
+		if err := json.Unmarshal(raw, &items); err != nil {
+			return fmt.Errorf("%s must be an array: %w", path, err)
+		}
+		for i, item := range items {
+			if err := validateJSONValue(item, elem, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		elem := typ.Elem()
+		if !needsKeyValidation(elem) {
+			return nil
+		}
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			return fmt.Errorf("%s must be an object: %w", path, err)
+		}
+		for key, value := range obj {
+			if err := validateJSONValue(value, elem, path+"."+key); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func needsKeyValidation(typ reflect.Type) bool {
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	switch typ.Kind() {
+	case reflect.Struct, reflect.Slice, reflect.Array, reflect.Map:
+		return true
+	default:
+		return false
+	}
+}
+
+func jsonFieldTypes(typ reflect.Type) map[string]reflect.Type {
+	fields := make(map[string]reflect.Type)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+		tag := field.Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "-" {
+			continue
+		}
+		if name == "" {
+			name = field.Name
+		}
+		fields[name] = field.Type
+	}
+	return fields
+}
+
+func sortedJSONKeys(fields map[string]reflect.Type) []string {
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // parseEnvPairs turns repeated KEY=VALUE flags into a map.

--- a/backend/internal/cli/project_test.go
+++ b/backend/internal/cli/project_test.go
@@ -81,6 +81,70 @@ func TestProjectSetConfig_TrackerIntakeJSON(t *testing.T) {
 	}
 }
 
+func TestProjectSetConfig_ConfigJSONRejectsUnknownTopLevelKey(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := projectServer(t, http.StatusOK, `{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--config-json", `{"defaultBranch":"main","defaults":{"agentConfig":{"permissions":"auto"}}}`)
+	if err == nil {
+		t.Fatal("expected unknown top-level key error")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2; stderr=%s", got, errOut)
+	}
+	if !strings.Contains(err.Error(), `unknown config key "defaults" at config`) {
+		t.Fatalf("error did not name offending top-level key and location: %v\nstderr=%s", err, errOut)
+	}
+}
+
+func TestProjectSetConfig_ConfigJSONRejectsMisplacedNestedKey(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := projectServer(t, http.StatusOK, `{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--config-json", `{"worker":{"permissions":"auto"}}`)
+	if err == nil {
+		t.Fatal("expected misplaced nested key error")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2; stderr=%s", got, errOut)
+	}
+	if !strings.Contains(err.Error(), `unknown config key "permissions" at config.worker`) {
+		t.Fatalf("error did not name offending nested key and location: %v\nstderr=%s", err, errOut)
+	}
+}
+
+func TestProjectSetConfig_ConfigJSONAcceptsValidConfig(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := projectServer(t, http.StatusOK, `{"project":{"id":"demo","path":"/repo/demo"}}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "project", "set-config", "demo", "--config-json", `{"worker":{"agent":"codex","agentConfig":{"permissions":"auto"}},"env":{"FOO":"bar"},"reviewers":[{"harness":"codex"}]}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodPut || capture.path != "/api/v1/projects/demo/config" {
+		t.Fatalf("request = %s %s, want PUT /api/v1/projects/demo/config", capture.method, capture.path)
+	}
+	var got setConfigRequest
+	if err := json.Unmarshal(capture.body, &got); err != nil {
+		t.Fatalf("decode request: %v\nbody=%s", err, capture.body)
+	}
+	if got.Config.Worker.Agent != "codex" || got.Config.Worker.AgentConfig.Permissions != "auto" || got.Config.Env["FOO"] != "bar" {
+		t.Fatalf("valid config not preserved: %#v", got.Config)
+	}
+	if len(got.Config.Reviewers) != 1 || got.Config.Reviewers[0].Harness != "codex" {
+		t.Fatalf("reviewers config = %#v", got.Config.Reviewers)
+	}
+}
+
 func TestBuildProjectConfigTrackerIntakeFlags(t *testing.T) {
 	got, err := buildProjectConfig(projectSetConfigOptions{
 		trackerIntake:   true,


### PR DESCRIPTION
## Summary
- add strict recursive key validation for `ao project set-config --config-json` before decoding into the CLI mirror struct
- report unknown or misplaced keys with the offending key and location, e.g. `config.worker`
- preserve valid optional config shape, including the existing `reviewers` field

Fixes #2653

## Tests
- `cd backend && go test ./internal/cli -run 'TestProjectSetConfig_ConfigJSON|TestProjectSetConfig_TrackerIntakeJSON|TestBuildProjectConfigTrackerIntakeFlags'`\n- `cd backend && go test ./internal/domain ./internal/service/project ./internal/httpd/controllers`\n- `cd backend && go test ./internal/cli -run 'TestProjectSetConfig'`\n\nNote: `cd backend && go test ./internal/cli` still shows unrelated pre-existing spawn command failures in this worktree (`TestSpawnCommand_MissingProjectContext`, `TestSpawnResolvesProjectFromAOSessionID`, `TestSpawnAOSessionIDFailureRequiresProject`, `TestSpawnResolvesProjectFromCWD`).