### PR TITLE
fix: harden session and review teardown

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -398,7 +398,7 @@ func handleID(handle ports.RuntimeHandle) (string, error) {
 		return "", errors.New("tmux runtime: session id is required")
 	}
 	if !sessionIDPattern.MatchString(id) {
-		return "", fmt.Errorf("tmux runtime: invalid handle id %q", id)
+		return "", fmt.Errorf("%w: tmux runtime: invalid handle id %q", ports.ErrRuntimeHandleStale, id)
 	}
 	return id, nil
 }

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -386,6 +386,15 @@ func TestDestroyReportsUnexpectedFailures(t *testing.T) {
 	}
 }
 
+func TestDestroyInvalidHandleIsStaleRuntimeHandle(t *testing.T) {
+	r, _ := newTestRuntime(0)
+
+	err := r.Destroy(context.Background(), ports.RuntimeHandle{ID: "legacy/terminal_0"})
+	if !errors.Is(err, ports.ErrRuntimeHandleStale) {
+		t.Fatalf("Destroy err = %v, want ErrRuntimeHandleStale", err)
+	}
+}
+
 func TestDestroyArgs(t *testing.T) {
 	r, fr := newTestRuntime(0)
 	fr.outputs = [][]byte{nil}

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -184,6 +184,10 @@ var (
 	// ErrRuntimePrerequisite reports a missing host prerequisite for the selected
 	// runtime before a session can be created.
 	ErrRuntimePrerequisite = errors.New("runtime: prerequisite missing")
+	// ErrRuntimeHandleStale reports a persisted runtime handle that the selected
+	// runtime cannot resolve. Callers tearing down user-visible records may treat
+	// this as already gone while preserving probe failures as non-fatal signals.
+	ErrRuntimeHandleStale = errors.New("runtime: stale or unknown handle")
 )
 
 // WorkspaceConfig is the spec for creating or restoring a session's workspace.

--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -26,6 +26,9 @@ type Launcher interface {
 	Alive(ctx context.Context, handleID string) (bool, error)
 	// Cancel interrupts a running reviewer pane while keeping the terminal alive.
 	Cancel(ctx context.Context, handleID string, harness domain.ReviewerHarness) error
+	// Destroy forcefully tears down a reviewer pane. It is the fallback when a
+	// cooperative cancellation cannot stop the running reviewer.
+	Destroy(ctx context.Context, handleID string) error
 }
 
 // LaunchSpec is the engine's request to (re)launch a reviewer for one pass.
@@ -45,6 +48,7 @@ type LaunchSpec struct {
 // satisfies it.
 type reviewerRuntime interface {
 	Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error)
+	Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 	Interrupt(ctx context.Context, handle ports.RuntimeHandle) error
 	IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error)
 	SendMessage(ctx context.Context, handle ports.RuntimeHandle, message string) error
@@ -197,4 +201,11 @@ func (l *agentLauncher) Cancel(ctx context.Context, handleID string, harness dom
 	default:
 		return fmt.Errorf("reviewer adapter %q returned unsupported cancel mode %q", harness, spec.Mode)
 	}
+}
+
+func (l *agentLauncher) Destroy(ctx context.Context, handleID string) error {
+	if handleID == "" {
+		return nil
+	}
+	return l.runtime.Destroy(ctx, ports.RuntimeHandle{ID: handleID})
 }

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -70,6 +70,7 @@ type fakeRuntime struct {
 	alive      bool
 	interrupt  string
 	interrupts int
+	destroyed  string
 }
 
 func (f *fakeRuntime) Create(_ context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
@@ -82,6 +83,10 @@ func (f *fakeRuntime) IsAlive(_ context.Context, _ ports.RuntimeHandle) (bool, e
 func (f *fakeRuntime) Interrupt(_ context.Context, handle ports.RuntimeHandle) error {
 	f.interrupt = handle.ID
 	f.interrupts++
+	return nil
+}
+func (f *fakeRuntime) Destroy(_ context.Context, handle ports.RuntimeHandle) error {
+	f.destroyed = handle.ID
 	return nil
 }
 func (f *fakeRuntime) SendMessage(_ context.Context, handle ports.RuntimeHandle, msg string) error {
@@ -187,6 +192,18 @@ func TestLauncherCancelRequiresReviewerSupport(t *testing.T) {
 
 	if err := l.Cancel(context.Background(), "review-mer-1", domain.ReviewerClaudeCode); err == nil || !strings.Contains(err.Error(), "does not support cancellation") {
 		t.Fatalf("err = %v, want unsupported cancellation", err)
+	}
+}
+
+func TestLauncherDestroyUsesRuntimeDestroy(t *testing.T) {
+	rt := &fakeRuntime{}
+	l := NewLauncher(fakeReviewerResolver{ok: true}, rt)
+
+	if err := l.Destroy(context.Background(), "review-mer-1"); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if rt.destroyed != "review-mer-1" {
+		t.Fatalf("destroyed handle = %q, want review-mer-1", rt.destroyed)
 	}
 }
 

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -449,9 +449,9 @@ func (e *Engine) stopReviewer(ctx stdctx.Context, review domain.Review, reason s
 			return true, nil
 		}
 		if aliveErr != nil {
-			return false, fmt.Errorf("%s: reviewer cancel failed: %v; reviewer probe failed: %v; reviewer destroy failed: %w", reason, cancelErr, aliveErr, destroyErr)
+			return false, fmt.Errorf("%s: reviewer cancel failed: %w; reviewer probe failed: %w; reviewer destroy failed: %w", reason, cancelErr, aliveErr, destroyErr)
 		}
-		return false, fmt.Errorf("%s: reviewer cancel failed: %v; reviewer destroy failed: %w", reason, cancelErr, destroyErr)
+		return false, fmt.Errorf("%s: reviewer cancel failed: %w; reviewer destroy failed: %w", reason, cancelErr, destroyErr)
 	}
 	return true, nil
 }

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -201,6 +201,7 @@ func (e *Engine) Trigger(ctx stdctx.Context, workerID domain.SessionID) (Trigger
 	if err != nil {
 		return TriggerResult{}, err
 	}
+	reviewRowForTeardown := reviewRow
 
 	harness, err := e.reviewerHarness(ctx, worker)
 	if err != nil {
@@ -218,6 +219,14 @@ func (e *Engine) Trigger(ctx stdctx.Context, workerID domain.SessionID) (Trigger
 	for _, reviewState := range reviews {
 		if reviewState.Status != ReviewStateNeedsReview && reviewState.Status != ReviewStateChangesRequested {
 			continue
+		}
+		if reviewRowForTeardown.ReviewerHandleID != "" && hasStaleRunningRun(runs, reviewState.PRURL, reviewState.TargetSHA) {
+			if stopped, err := e.stopReviewer(ctx, reviewRowForTeardown, "supersede stale review run"); err != nil {
+				return TriggerResult{}, err
+			} else if stopped {
+				reviewRow.ReviewerHandleID = ""
+				reviewRowForTeardown.ReviewerHandleID = ""
+			}
 		}
 		if _, err := e.store.SupersedeStaleRunningReviewRuns(ctx, workerID, reviewState.PRURL, reviewState.TargetSHA, "superseded by a review trigger for a newer commit"); err != nil {
 			return TriggerResult{}, err
@@ -385,14 +394,8 @@ func (e *Engine) Cancel(ctx stdctx.Context, workerID domain.SessionID) (CancelRe
 	if err != nil {
 		return CancelResult{}, err
 	}
-	if err := e.launcher.Cancel(ctx, review.ReviewerHandleID, review.Harness); err != nil {
-		alive, aliveErr := e.launcher.Alive(ctx, review.ReviewerHandleID)
-		if aliveErr != nil {
-			return CancelResult{}, err
-		}
-		if alive {
-			return CancelResult{}, err
-		}
+	if _, err := e.stopReviewer(ctx, review, "cancel review run"); err != nil {
+		return CancelResult{}, err
 	}
 	if _, err := e.store.CancelRunningReviewRunsBySession(ctx, workerID, "cancelled by user"); err != nil {
 		return CancelResult{}, err
@@ -414,6 +417,43 @@ func (e *Engine) Cancel(ctx stdctx.Context, workerID domain.SessionID) (CancelRe
 		return CancelResult{}, err
 	}
 	return CancelResult{ReviewerHandleID: review.ReviewerHandleID, Reviews: Plan(prs, runs), CancelledRuns: cancelled}, nil
+}
+
+func hasStaleRunningRun(runs []domain.ReviewRun, prURL, targetSHA string) bool {
+	for _, run := range runs {
+		if run.PRURL == prURL && run.TargetSHA != targetSHA && run.Status == domain.ReviewRunRunning && run.Verdict == domain.VerdictNone {
+			return true
+		}
+	}
+	return false
+}
+
+// stopReviewer first asks the reviewer adapter to cancel cooperatively. If that
+// fails and the runtime handle still appears live (or cannot be probed), it
+// escalates to destroying the reviewer pane so stale agents do not keep running
+// after their review runs are marked terminal.
+func (e *Engine) stopReviewer(ctx stdctx.Context, review domain.Review, reason string) (destroyed bool, err error) {
+	if review.ReviewerHandleID == "" {
+		return false, nil
+	}
+	cancelErr := e.launcher.Cancel(ctx, review.ReviewerHandleID, review.Harness)
+	if cancelErr == nil {
+		return false, nil
+	}
+	alive, aliveErr := e.launcher.Alive(ctx, review.ReviewerHandleID)
+	if aliveErr == nil && !alive {
+		return false, nil
+	}
+	if destroyErr := e.launcher.Destroy(ctx, review.ReviewerHandleID); destroyErr != nil {
+		if errors.Is(destroyErr, ports.ErrRuntimeHandleStale) {
+			return true, nil
+		}
+		if aliveErr != nil {
+			return false, fmt.Errorf("%s: reviewer cancel failed: %v; reviewer probe failed: %v; reviewer destroy failed: %w", reason, cancelErr, aliveErr, destroyErr)
+		}
+		return false, fmt.Errorf("%s: reviewer cancel failed: %v; reviewer destroy failed: %w", reason, cancelErr, destroyErr)
+	}
+	return true, nil
 }
 
 // reviewerHarness resolves which harness reviews the worker's PR: a configured

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -158,6 +158,9 @@ type fakeLauncher struct {
 	cancelled        bool
 	cancelErr        error
 	aliveErr         error
+	destroyed        bool
+	destroyErr       error
+	destroyedHandle  string
 	gotSpec          LaunchSpec
 	gotHandle        string
 	cancelledHandle  string
@@ -192,6 +195,11 @@ func (f *fakeLauncher) Cancel(_ context.Context, handleID string, harness domain
 	f.cancelledHandle = handleID
 	f.cancelledHarness = harness
 	return f.cancelErr
+}
+func (f *fakeLauncher) Destroy(_ context.Context, handleID string) error {
+	f.destroyed = true
+	f.destroyedHandle = handleID
+	return f.destroyErr
 }
 
 func liveWorker() domain.SessionRecord {
@@ -312,7 +320,7 @@ func TestCancelMarksRunsCancelledWhenReviewerHandleIsGone(t *testing.T) {
 	}
 }
 
-func TestCancelKeepsRunsRunningWhenReviewerCancelFailsAndHandleIsAlive(t *testing.T) {
+func TestCancelDestroysReviewerWhenCancelFailsAndHandleIsAlive(t *testing.T) {
 	store := &fakeStore{
 		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerCodex, ReviewerHandleID: "review-mer-1"},
 		runs: []domain.ReviewRun{{
@@ -323,11 +331,37 @@ func TestCancelKeepsRunsRunningWhenReviewerCancelFailsAndHandleIsAlive(t *testin
 	launcher := &fakeLauncher{alive: true, cancelErr: errors.New("interrupt failed")}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
-	if _, err := eng.Cancel(context.Background(), "mer-1"); err == nil {
-		t.Fatal("Cancel err = nil, want interrupt failure")
+	res, err := eng.Cancel(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if !launcher.destroyed || launcher.destroyedHandle != "review-mer-1" {
+		t.Fatalf("expected destroy fallback for live reviewer: %+v", launcher)
+	}
+	if got := store.runs[0]; got.Status != domain.ReviewRunCancelled {
+		t.Fatalf("run should be cancelled after destroy fallback: %+v", got)
+	}
+	if len(res.CancelledRuns) != 1 || res.CancelledRuns[0].ID != "run-1" {
+		t.Fatalf("cancelled runs = %+v", res.CancelledRuns)
+	}
+}
+
+func TestCancelKeepsRunsRunningWhenCancelAndDestroyFail(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerCodex, ReviewerHandleID: "review-mer-1"},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", ReviewID: "rev-1", SessionID: "mer-1",
+			PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1", Status: domain.ReviewRunRunning,
+		}},
+	}
+	launcher := &fakeLauncher{alive: true, cancelErr: errors.New("interrupt failed"), destroyErr: errors.New("destroy failed")}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	if _, err := eng.Cancel(context.Background(), "mer-1"); err == nil || !strings.Contains(err.Error(), "destroy failed") {
+		t.Fatalf("Cancel err = %v, want destroy failure", err)
 	}
 	if got := store.runs[0]; got.Status != domain.ReviewRunRunning {
-		t.Fatalf("run should remain running when reviewer is still alive: %+v", got)
+		t.Fatalf("run should remain running when reviewer teardown fails: %+v", got)
 	}
 }
 
@@ -506,6 +540,54 @@ func TestTriggerSupersedesOlderRunningRunOnNewCommit(t *testing.T) {
 	}
 	if !launcher.notified || launcher.spawned {
 		t.Fatalf("expected live reviewer pane reused for new commit: %+v", launcher)
+	}
+}
+
+func TestTriggerSupersedeDestroysReviewerWhenCancelFails(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerCodex, ReviewerHandleID: "review-mer-1"},
+		runs:   []domain.ReviewRun{{ID: "run-old", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha0", Status: domain.ReviewRunRunning}},
+	}
+	launcher := &fakeLauncher{alive: true, cancelErr: errors.New("interrupt failed"), handle: "review-mer-2"}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if !launcher.cancelled || !launcher.destroyed || launcher.destroyedHandle != "review-mer-1" {
+		t.Fatalf("expected cancel then destroy of stale reviewer: %+v", launcher)
+	}
+	if launcher.cancelledHarness != domain.ReviewerCodex {
+		t.Fatalf("cancel harness = %q, want existing reviewer harness codex", launcher.cancelledHarness)
+	}
+	if launcher.notified || !launcher.spawned {
+		t.Fatalf("expected fresh reviewer after destroying stale one: %+v", launcher)
+	}
+	if res.ReviewerHandleID != "review-mer-2" {
+		t.Fatalf("reviewer handle = %q, want review-mer-2", res.ReviewerHandleID)
+	}
+	if old := store.runs[0]; old.ID != "run-old" || old.Status != domain.ReviewRunFailed {
+		t.Fatalf("expected older running run to be failed after teardown, got %+v", old)
+	}
+}
+
+func TestTriggerSupersedeDoesNotMarkRunWhenCancelAndDestroyFail(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerCodex, ReviewerHandleID: "review-mer-1"},
+		runs:   []domain.ReviewRun{{ID: "run-old", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha0", Status: domain.ReviewRunRunning}},
+	}
+	launcher := &fakeLauncher{alive: true, cancelErr: errors.New("interrupt failed"), destroyErr: errors.New("destroy failed")}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	if _, err := eng.Trigger(context.Background(), "mer-1"); err == nil || !strings.Contains(err.Error(), "destroy failed") {
+		t.Fatalf("Trigger err = %v, want destroy failure", err)
+	}
+	if got := store.runs[0]; got.Status != domain.ReviewRunRunning {
+		t.Fatalf("old run should remain running when teardown fails: %+v", got)
+	}
+	if len(store.runs) != 1 {
+		t.Fatalf("new run should not be inserted after teardown failure: %+v", store.runs)
 	}
 }
 

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -621,7 +621,11 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 
 	if handle.ID != "" {
 		if err := m.runtime.Destroy(ctx, handle); err != nil {
-			return false, fmt.Errorf("kill %s: runtime: %w", id, err)
+			if errors.Is(err, ports.ErrRuntimeHandleStale) {
+				m.logger.Warn("kill: stale runtime handle; marking session terminated", "sessionID", id, "handleID", handle.ID, "error", err)
+			} else {
+				return false, fmt.Errorf("kill %s: runtime: %w", id, err)
+			}
 		}
 	}
 	freed := false

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -1377,6 +1377,26 @@ func TestKill_RuntimeDestroyFailureLeavesSessionActive(t *testing.T) {
 	}
 }
 
+func TestKill_StaleRuntimeHandleStillTerminatesSession(t *testing.T) {
+	m, st, rt, ws := newManager()
+	rt.destroyErr = fmt.Errorf("tmux: %w", ports.ErrRuntimeHandleStale)
+	st.sessions["mer-1"] = mkLive("mer-1")
+
+	freed, err := m.Kill(ctx, "mer-1")
+	if err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if !freed {
+		t.Fatal("freed = false, want workspace removed after stale runtime handle")
+	}
+	if rt.destroyed != 1 || ws.destroyed != 1 {
+		t.Fatalf("destroy calls runtime=%d workspace=%d, want both", rt.destroyed, ws.destroyed)
+	}
+	if !st.sessions["mer-1"].IsTerminated {
+		t.Fatal("session should be marked terminated after stale runtime handle")
+	}
+}
+
 func TestRestore_ReopensTerminal(t *testing.T) {
 	m, st, rt, _ := newManager()
 	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", AgentSessionID: "agent-x"})


### PR DESCRIPTION
## Summary
- Treat stale/unresolvable runtime handles as already gone during session kill so the session record still reaches terminated state.
- Add reviewer runtime destroy fallback when cooperative cancel fails, and use it before marking superseded stale review runs terminal.
- Preserve the existing reviewer harness when tearing down an old reviewer handle during supersede.

Fixes #2701.
Fixes #2715.

## Tests
- `cd backend && go test ./internal/review ./internal/session_manager ./internal/adapters/runtime/tmux`
- `cd backend && go test ./...` (fails in existing `backend/internal/cli` spawn tests with HTTP 404/project-context expectations; reproduced standalone with `go test ./internal/cli -run TestSpawnCommand_MissingProjectContext -count=1`)
