### PR TITLE
fix: clean spawn output and default orchestrator harness

### DIFF
--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -8,15 +8,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/tmux"
 )
 
 // maxDisplayNameLen caps the sidebar label set by `--name`. Mirrored by the
@@ -134,17 +131,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 			if _, err := fmt.Fprintf(out, "spawned session %s (%s)%s\n", res.Session.ID, res.Session.Status, claimLabel); err != nil {
 				return err
 			}
-			// Print a copy-pasteable attach hint for the selected runtime.
-			// On Darwin/Linux: tmux attach-session using the sanitised session name.
-			// On Windows: ConPTY has no user-facing attach CLI; use the AO dashboard.
-			var attach string
-			if runtime.GOOS != "windows" {
-				attach = fmt.Sprintf("tmux attach -t %s", tmux.SessionName(res.Session.ID))
-			} else {
-				attach = "Attach from the AO dashboard (ConPTY sessions have no CLI attach command)"
-			}
-			_, err = fmt.Fprintf(out, "attach with: %s\n", attach)
-			return err
+			return nil
 		},
 	}
 	f := cmd.Flags()

--- a/backend/internal/cli/spawn_test.go
+++ b/backend/internal/cli/spawn_test.go
@@ -195,8 +195,8 @@ func TestSpawnResolvesProjectFromEnvAndDefaultAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("spawn failed: %v stderr=%s", err, errOut)
 	}
-	if !strings.Contains(out, "spawned session demo-11") {
-		t.Fatalf("output missing spawn: %s", out)
+	if out != "spawned session demo-11 (idle)\n" {
+		t.Fatalf("output = %q, want only spawned-session line", out)
 	}
 	if req.ProjectID != "demo" || req.Harness != "codex" || req.DisplayName != "Fix failing tests in" {
 		t.Fatalf("spawn request = %#v", req)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -30,8 +30,9 @@ const (
 	// the process exits even if connections are still draining.
 	DefaultShutdownTimeout = 10 * time.Second
 	// DefaultAgent is the compatibility value used when AO_AGENT is unset. The
-	// daemon validates it at startup, but worker/orchestrator spawns resolve from
-	// explicit requests or project role config instead of falling back to it.
+	// daemon validates it at startup; worker spawns still resolve from explicit
+	// requests or project role config, while orchestrator spawns use this built-in
+	// default as their final fallback.
 	DefaultAgent = "claude-code"
 	// DefaultTelemetryPostHogHost is the default PostHog ingestion host when
 	// remote telemetry is enabled and AO_TELEMETRY_POSTHOG_HOST is unset.

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -226,8 +226,8 @@ func (a agentRegistry) Agent(harness domain.AgentHarness) (ports.Agent, bool) {
 // buildAgentResolver constructs the per-session agent resolver the Session
 // Manager consumes (sessionmanager.Deps.Agents): a registry of the shipped
 // adapters. It still validates AO_AGENT at startup for compatibility with the
-// config surface, but worker/orchestrator spawns must provide a resolved
-// harness before calling Agent.
+// config surface, but worker spawns must provide a resolved harness before
+// calling Agent. Orchestrator spawns fall back to the built-in default harness.
 func buildAgentResolver(defaultAgent string, log *slog.Logger) (ports.AgentResolver, error) {
 	if defaultAgent == "" {
 		defaultAgent = config.DefaultAgent

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -764,7 +764,8 @@ func TestSpawnOrchestratorNoCleanReturnsExistingWhenActiveExists(t *testing.T) {
 func TestSpawnOrchestratorNoCleanSpawnsWhenNoneExists(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer"}
-	// No active orchestrator present.
+	// An active worker must not block orchestrator creation.
+	st.sessions["mer-worker"] = domain.SessionRecord{ID: "mer-worker", ProjectID: "mer", Kind: domain.KindWorker}
 
 	fc := &fakeCommander{}
 	svc := &Service{manager: fc, store: st}
@@ -775,6 +776,9 @@ func TestSpawnOrchestratorNoCleanSpawnsWhenNoneExists(t *testing.T) {
 	}
 	if !fc.spawned {
 		t.Fatal("manager.Spawn must be called when no active orchestrator exists")
+	}
+	if fc.spawnedCfg.Kind != domain.KindOrchestrator {
+		t.Fatalf("spawn kind = %q, want orchestrator", fc.spawnedCfg.Kind)
 	}
 	if len(fc.killed) != 0 {
 		t.Fatalf("no kills expected with clean=false, got %v", fc.killed)

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -467,14 +467,19 @@ func (m *Manager) destroySpawnWorkspace(ctx context.Context, ws ports.WorkspaceI
 }
 
 // effectiveHarness resolves the harness for a spawn: an explicit harness wins;
-// otherwise the project's role override for the session kind applies. Empty is
-// invalid for new worker/orchestrator launches and is rejected by Spawn.
+// otherwise the project's role override for the session kind applies. New
+// orchestrators fall back to Claude Code so ensure-on-load can start a
+// coordinator for projects that only configured a worker agent. Empty is still
+// invalid for workers and is rejected by Spawn.
 func effectiveHarness(explicit domain.AgentHarness, kind domain.SessionKind, cfg domain.ProjectConfig) domain.AgentHarness {
 	if explicit != "" {
 		return explicit
 	}
 	if role := roleOverride(kind, cfg).Harness; role != "" {
 		return role
+	}
+	if kind == domain.KindOrchestrator {
+		return domain.HarnessClaudeCode
 	}
 	return ""
 }

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -628,7 +628,7 @@ func TestSpawn_ResolvesProjectConfig(t *testing.T) {
 	}
 }
 
-func TestSpawn_RejectsMissingRoleHarness(t *testing.T) {
+func TestSpawn_RejectsMissingWorkerHarnessAndDefaultsOrchestrator(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer"}
 	m := New(Deps{
@@ -643,8 +643,11 @@ func TestSpawn_RejectsMissingRoleHarness(t *testing.T) {
 	if len(st.sessions) != 0 {
 		t.Fatalf("missing worker harness must not create a session row, got %d", len(st.sessions))
 	}
-	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindOrchestrator}); !errors.Is(err, ErrMissingHarness) {
-		t.Fatalf("orchestrator err = %v, want ErrMissingHarness", err)
+	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindOrchestrator}); err != nil {
+		t.Fatalf("orchestrator spawn with default harness: %v", err)
+	}
+	if got := st.sessions["mer-1"].Harness; got != domain.HarnessClaudeCode {
+		t.Fatalf("orchestrator harness = %q, want %q", got, domain.HarnessClaudeCode)
 	}
 }
 

--- a/backend/internal/session_manager/provision_test.go
+++ b/backend/internal/session_manager/provision_test.go
@@ -117,6 +117,9 @@ func TestEffectiveHarnessAndAgentConfig(t *testing.T) {
 	if h := effectiveHarness("", domain.KindOrchestrator, cfg); h != domain.HarnessClaudeCode {
 		t.Fatalf("orchestrator harness = %q, want claude-code", h)
 	}
+	if h := effectiveHarness("", domain.KindOrchestrator, domain.ProjectConfig{}); h != domain.HarnessClaudeCode {
+		t.Fatalf("unconfigured orchestrator harness = %q, want claude-code", h)
+	}
 
 	// Role override merges over the base agent config (set fields win; unset keep base).
 	got := effectiveAgentConfig(domain.KindWorker, cfg)


### PR DESCRIPTION
## Summary
- stop printing the tmux attach hint after `ao spawn`
- default unconfigured orchestrator spawns to the built-in Claude Code harness while keeping workers explicit/configured
- cover worker-active orchestrator spawning and spawn output with tests

## Tests
- `env -u AO_SESSION_ID -u AO_PROJECT_ID go test ./internal/cli ./internal/session_manager ./internal/service/session ./internal/config ./internal/daemon`

Closes #2658
Closes #2659