### PR TITLE
fix: improve daemon crash observability

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -54,6 +54,7 @@ import { connectSupervisor, type SupervisorLinkHandle } from "./main/supervisor-
 import { shouldLinkOnAttach } from "./main/daemon-owner";
 import { readMigrationState, updateMigration, writeAppStateMarker, type MigrationState } from "./main/app-state";
 import { isAllowedAppExternalURL, openAllowedAppExternalURL } from "./main/external-open";
+import { openDaemonLog, type DaemonLogSink } from "./main/daemon-log";
 
 // Globals injected at compile time by @electron-forge/plugin-vite.
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
@@ -797,6 +798,12 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 	}
 
 	setDaemonStatus({ state: "starting" });
+	let daemonLogSink: DaemonLogSink | null = null;
+	try {
+		daemonLogSink = await openDaemonLog(runFilePath(), os.homedir());
+	} catch (error) {
+		console.error(`AO: could not open daemon log: ${error instanceof Error ? error.message : String(error)}`);
+	}
 
 	// Capture the spawned handle locally so the async lifecycle listeners act only
 	// on THIS process. Without this, a stale exit from an already-stopped daemon
@@ -815,6 +822,9 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		windowsHide: true,
 	});
 	daemonProcess = child;
+	daemonLogSink?.writeMeta(
+		`spawned pid=${child.pid ?? "unknown"} cwd=${launch.cwd} command=${launch.command} args=${launch.args.join(" ")}`,
+	);
 
 	// Discover the port the daemon ACTUALLY bound rather than trusting AO_PORT:
 	// the daemon may fall back to a different port than the one requested. Two
@@ -854,12 +864,14 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 
 	child.stdout.on("data", (chunk: Buffer) => {
 		const text = chunk.toString("utf8");
+		daemonLogSink?.writeOutput("stdout", text);
 		console.log(text.trimEnd());
 		scanStdout(text);
 	});
 
 	child.stderr.on("data", (chunk: Buffer) => {
 		const text = chunk.toString("utf8");
+		daemonLogSink?.writeOutput("stderr", text);
 		console.error(text.trimEnd());
 		scanStderr(text);
 	});
@@ -895,14 +907,24 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 
 	child.once("error", (error) => {
 		stopDiscovery();
+		daemonLogSink?.writeMeta(`spawn error: ${error.message}`);
+		const logPath = daemonLogSink?.path;
+		void daemonLogSink?.close();
 		if (daemonProcess !== child) return;
 		daemonProcess = null;
 		if (daemonStoppingProcess === child) daemonStoppingProcess = null;
-		setDaemonStatus({ state: "error", message: error.message, code: "spawn_failed" });
+		setDaemonStatus({
+			state: "error",
+			message: logPath ? `${error.message}. Daemon log: ${logPath}` : error.message,
+			code: "spawn_failed",
+		});
 	});
 
 	child.once("exit", (code, signal) => {
 		stopDiscovery();
+		daemonLogSink?.writeMeta(signal ? `daemon exited with signal ${signal}` : `daemon exited with code ${code ?? "unknown"}`);
+		const logPath = daemonLogSink?.path;
+		void daemonLogSink?.close();
 		if (daemonProcess !== child) return;
 		daemonProcess = null;
 		// An explicit stopDaemon() already set a clean `{ state: "stopped" }`.
@@ -915,9 +937,10 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 			setDaemonStatus({ state: "stopped" });
 			return;
 		}
+		const exitMessage = signal ? `Daemon exited with ${signal}` : `Daemon exited with code ${code ?? "unknown"}`;
 		setDaemonStatus({
 			state: "stopped",
-			message: signal ? `Daemon exited with ${signal}` : `Daemon exited with code ${code ?? "unknown"}`,
+			message: logPath ? `${exitMessage}. Daemon log: ${logPath}` : exitMessage,
 			code: "exited",
 			exitCode: code,
 			signal,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -922,7 +922,9 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 
 	child.once("exit", (code, signal) => {
 		stopDiscovery();
-		daemonLogSink?.writeMeta(signal ? `daemon exited with signal ${signal}` : `daemon exited with code ${code ?? "unknown"}`);
+		daemonLogSink?.writeMeta(
+			signal ? `daemon exited with signal ${signal}` : `daemon exited with code ${code ?? "unknown"}`,
+		);
 		const logPath = daemonLogSink?.path;
 		void daemonLogSink?.close();
 		if (daemonProcess !== child) return;

--- a/frontend/src/main/daemon-log.test.ts
+++ b/frontend/src/main/daemon-log.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DAEMON_LOG_FILE_NAME, DAEMON_LOG_MAX_BYTES, daemonLogPath, openDaemonLog } from "./daemon-log";
+
+describe("daemon-log", () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await mkdtemp(path.join(os.tmpdir(), "ao-daemon-log-"));
+	});
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("stores daemon logs beside running.json under logs/", () => {
+		expect(daemonLogPath(path.join(dir, "running.json"), "/home/alice")).toBe(
+			path.join(dir, "logs", DAEMON_LOG_FILE_NAME),
+		);
+	});
+
+	it("falls back to ~/.ao/logs when no run-file path is available", () => {
+		expect(daemonLogPath(null, "/home/alice")).toBe(path.join("/home/alice", ".ao", "logs", DAEMON_LOG_FILE_NAME));
+	});
+
+	it("persists stdout and stderr with line prefixes and flushes partial lines on close", async () => {
+		const sink = await openDaemonLog(path.join(dir, "running.json"), "/home/alice");
+		expect(sink).not.toBeNull();
+
+		sink!.writeOutput("stdout", "ready\npartial");
+		sink!.writeOutput("stderr", "panic: boom\n");
+		sink!.writeOutput("stdout", " line\n");
+		await sink!.close();
+
+		const contents = await readFile(sink!.path, "utf8");
+		expect(contents).toContain("[supervisor] daemon launch output started");
+		expect(contents).toContain("[stdout] ready\n");
+		expect(contents).toContain("[stdout] partial line\n");
+		expect(contents).toContain("[stderr] panic: boom\n");
+	});
+
+	it("rotates an oversized prior log before appending a new launch", async () => {
+		const logPath = path.join(dir, "logs", DAEMON_LOG_FILE_NAME);
+		await mkdir(path.dirname(logPath), { recursive: true });
+		await writeFile(logPath, "x".repeat(DAEMON_LOG_MAX_BYTES + 1), "utf8");
+
+		const sink = await openDaemonLog(path.join(dir, "running.json"), "/home/alice");
+		expect(sink).not.toBeNull();
+		await sink!.close();
+
+		const rotated = await stat(`${logPath}.1`);
+		const current = await stat(logPath);
+		expect(rotated.size).toBe(DAEMON_LOG_MAX_BYTES + 1);
+		expect(current.size).toBeGreaterThan(0);
+	});
+});

--- a/frontend/src/main/daemon-log.ts
+++ b/frontend/src/main/daemon-log.ts
@@ -1,0 +1,83 @@
+import { createWriteStream, type WriteStream } from "node:fs";
+import { mkdir, rename, rm, stat } from "node:fs/promises";
+import path from "node:path";
+
+export const DAEMON_LOG_FILE_NAME = "daemon.log";
+export const DAEMON_LOG_MAX_BYTES = 5 * 1024 * 1024;
+
+type DaemonOutputStream = "stdout" | "stderr";
+
+export function daemonLogPath(runFilePath: string | null, homeDir: string): string | null {
+	const stateDir = runFilePath ? path.dirname(runFilePath) : homeDir ? path.join(homeDir, ".ao") : null;
+	if (!stateDir) return null;
+	return path.join(stateDir, "logs", DAEMON_LOG_FILE_NAME);
+}
+
+export class DaemonLogSink {
+	readonly path: string;
+	private readonly stream: WriteStream;
+	private readonly pending: Record<DaemonOutputStream, string> = { stdout: "", stderr: "" };
+	private closed = false;
+
+	constructor(filePath: string, stream: WriteStream) {
+		this.path = filePath;
+		this.stream = stream;
+	}
+
+	writeMeta(message: string): void {
+		this.stream.write(`${new Date().toISOString()} [supervisor] ${message}\n`);
+	}
+
+	writeOutput(source: DaemonOutputStream, chunk: string): void {
+		const combined = this.pending[source] + chunk.replace(/\r\n/g, "\n");
+		const lines = combined.split("\n");
+		this.pending[source] = lines.pop() ?? "";
+		for (const line of lines) {
+			this.writeOutputLine(source, line);
+		}
+	}
+
+	close(): Promise<void> {
+		if (this.closed) return Promise.resolve();
+		this.closed = true;
+		for (const source of ["stdout", "stderr"] as const) {
+			const pending = this.pending[source];
+			if (pending) {
+				this.writeOutputLine(source, pending);
+				this.pending[source] = "";
+			}
+		}
+		return new Promise((resolve) => {
+			this.stream.end(resolve);
+		});
+	}
+
+	private writeOutputLine(source: DaemonOutputStream, line: string): void {
+		this.stream.write(`${new Date().toISOString()} [${source}] ${line}\n`);
+	}
+}
+
+export async function openDaemonLog(runFilePath: string | null, homeDir: string): Promise<DaemonLogSink | null> {
+	const filePath = daemonLogPath(runFilePath, homeDir);
+	if (!filePath) return null;
+	await mkdir(path.dirname(filePath), { recursive: true });
+	await rotateDaemonLogIfNeeded(filePath);
+	const stream = createWriteStream(filePath, { flags: "a" });
+	stream.on("error", () => undefined);
+	const sink = new DaemonLogSink(filePath, stream);
+	sink.writeMeta("daemon launch output started");
+	return sink;
+}
+
+async function rotateDaemonLogIfNeeded(filePath: string): Promise<void> {
+	try {
+		const info = await stat(filePath);
+		if (info.size <= DAEMON_LOG_MAX_BYTES) return;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	const rotated = `${filePath}.1`;
+	await rm(rotated, { force: true });
+	await rename(filePath, rotated);
+}

--- a/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
+++ b/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
@@ -114,7 +114,7 @@ describe("useDaemonStatus", () => {
 		expect(setApiBaseUrlMock).toHaveBeenCalledWith("http://127.0.0.1:4777");
 	});
 
-	it("refreshes ready status so adopted daemon liveness is rechecked", async () => {
+	it("refreshes ready status quickly so adopted daemon crashes are detected promptly", async () => {
 		vi.useFakeTimers();
 		getStatusMock.mockResolvedValueOnce({ state: "ready", port: 4777 }).mockResolvedValueOnce({ state: "stopped" });
 		const queryClient = fakeQueryClient();
@@ -126,7 +126,7 @@ describe("useDaemonStatus", () => {
 		});
 		expect(result.current).toEqual({ state: "ready", port: 4777 });
 		await act(async () => {
-			await vi.advanceTimersByTimeAsync(10_000);
+			await vi.advanceTimersByTimeAsync(500);
 		});
 
 		expect(result.current).toEqual({ state: "stopped" });

--- a/frontend/src/renderer/hooks/useDaemonStatus.ts
+++ b/frontend/src/renderer/hooks/useDaemonStatus.ts
@@ -6,7 +6,7 @@ import { queryClient as defaultQueryClient } from "../lib/query-client";
 import { createEventTransport } from "../lib/event-transport";
 
 const STATUS_REFRESH_MS = 2_000;
-const READY_STATUS_REFRESH_MS = 10_000;
+const READY_STATUS_REFRESH_MS = 500;
 
 export function useDaemonStatus(queryClient: QueryClient = defaultQueryClient) {
 	const [status, setStatus] = useState<DaemonStatus>({ state: "stopped" });

--- a/frontend/src/renderer/lib/api-client.test.ts
+++ b/frontend/src/renderer/lib/api-client.test.ts
@@ -208,6 +208,7 @@ describe("api error telemetry", () => {
 	afterEach(() => {
 		vi.useRealTimers();
 		vi.restoreAllMocks();
+		window.ao!.daemon.getStatus = async () => ({ state: "stopped" });
 		setApiBaseUrl("http://127.0.0.1:3001");
 	});
 
@@ -240,6 +241,8 @@ describe("api error telemetry", () => {
 	});
 
 	it("reports network_error and rethrows", async () => {
+		const getStatusMock = vi.fn().mockResolvedValue({ state: "stopped" });
+		window.ao!.daemon.getStatus = getStatusMock;
 		vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Failed to fetch"));
 		setApiBaseUrl("http://127.0.0.1:3037");
 
@@ -250,6 +253,7 @@ describe("api error telemetry", () => {
 			error_category: "network_error",
 			status: undefined,
 		});
+		expect(getStatusMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("does not report caller-initiated aborts", async () => {

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -1,5 +1,6 @@
 import createClient from "openapi-fetch";
 import type { paths } from "../../api/schema";
+import { aoBridge } from "./bridge";
 import { captureRendererEvent } from "./telemetry";
 
 function devApiBaseUrl(): string {
@@ -143,6 +144,7 @@ type ApiErrorCategory = "daemon_unavailable" | "network_error" | "http_4xx" | "h
 // signal matters, the storm does not.
 const API_ERROR_DEDUPE_MS = 30_000;
 const lastApiErrorAt = new Map<string, number>();
+let daemonStatusRefreshAfterNetworkError: Promise<void> | null = null;
 
 function reportApiError(operation: string, category: ApiErrorCategory, status?: number): void {
 	const key = `${operation}|${category}|${status ?? ""}`;
@@ -155,6 +157,17 @@ function reportApiError(operation: string, category: ApiErrorCategory, status?: 
 		error_category: category,
 		status,
 	});
+}
+
+function refreshDaemonStatusAfterNetworkError(): void {
+	if (daemonStatusRefreshAfterNetworkError) return;
+	daemonStatusRefreshAfterNetworkError = aoBridge.daemon
+		.getStatus()
+		.catch(() => undefined)
+		.then(() => undefined)
+		.finally(() => {
+			daemonStatusRefreshAfterNetworkError = null;
+		});
 }
 
 async function runtimeFetch(input: Request): Promise<Response> {
@@ -207,6 +220,7 @@ async function runtimeFetch(input: Request): Promise<Response> {
 		// Caller-initiated aborts (unmounted components cancelling queries) are not failures.
 		if (!(error instanceof DOMException && error.name === "AbortError")) {
 			reportApiError(operation, "network_error");
+			refreshDaemonStatusAfterNetworkError();
 		}
 		throw error;
 	}


### PR DESCRIPTION
## Summary
- persist Electron-launched daemon stdout/stderr to a bounded log under the AO state dir (`logs/daemon.log`) with one rotated copy
- include the daemon log path in spawn/crash status messages
- reduce ready-state daemon liveness refresh to 500ms and force a status refresh after renderer API network failures

Fixes #2689.
Fixes #2716.

## Tests
- `npx vitest run --config vite.renderer.config.ts src/main/daemon-log.test.ts src/renderer/hooks/useDaemonStatus.test.tsx src/renderer/lib/api-client.test.ts`
- `npm run frontend:typecheck`