### PR TITLE
fix: relaunch restored sessions reliably

### DIFF
--- a/backend/internal/adapters/runtime/tmux/commands.go
+++ b/backend/internal/adapters/runtime/tmux/commands.go
@@ -57,6 +57,13 @@ func hasSessionArgs(id string) []string {
 	return []string{"has-session", "-t", exactSessionTarget(id)}
 }
 
+// foregroundCommandArgs asks tmux for the foreground process command in the
+// session's active pane. This is deliberately pane-targeted (no exact-session
+// prefix) like capture/send commands.
+func foregroundCommandArgs(id string) []string {
+	return []string{"display-message", "-p", "-t", id, "#{pane_current_command}"}
+}
+
 // exactSessionTarget wraps id in tmux's exact-match prefix `=` so session-
 // selection commands (-t) target only the session with that precise name.
 // Only kill-session and has-session support this prefix; pane-targeting

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -208,6 +208,21 @@ func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool
 	return true, nil
 }
 
+// ForegroundCommand reports the active pane's foreground process command. It is
+// used only as a boot-time adoption sanity check: a live tmux session whose
+// foreground command is the keep-alive shell no longer has an agent running.
+func (r *Runtime) ForegroundCommand(ctx context.Context, handle ports.RuntimeHandle) (string, error) {
+	id, err := handleID(handle)
+	if err != nil {
+		return "", err
+	}
+	out, err := r.run(ctx, foregroundCommandArgs(id)...)
+	if err != nil {
+		return "", fmt.Errorf("tmux runtime: foreground command %s: %w", id, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // SendMessage sends literal text to the session (chunked via send-keys -l) then
 // presses Enter to submit. An empty message presses Enter alone (the nudge
 // contract on ports.AgentMessenger).

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -92,6 +92,9 @@ func TestCommandBuilders(t *testing.T) {
 	if got, want := hasSessionArgs("sess-1"), []string{"has-session", "-t", "=sess-1"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("hasSessionArgs = %#v, want %#v", got, want)
 	}
+	if got, want := foregroundCommandArgs("sess-1"), []string{"display-message", "-p", "-t", "sess-1", "#{pane_current_command}"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("foregroundCommandArgs = %#v, want %#v", got, want)
+	}
 	if got, want := sendKeysLiteralArgs("sess-1", "hello"), []string{"send-keys", "-t", "sess-1", "-l", "hello"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("sendKeysLiteralArgs = %#v, want %#v", got, want)
 	}
@@ -472,6 +475,22 @@ func TestIsAliveReportsOtherExitFailuresAsProbeErrors(t *testing.T) {
 	}
 	if alive {
 		t.Fatal("alive = true on probe failure")
+	}
+}
+
+func TestForegroundCommandReturnsTrimmedPaneCommand(t *testing.T) {
+	r, fr := newTestRuntime(0)
+	fr.outputs = [][]byte{[]byte("claude\n")}
+
+	cmd, err := r.ForegroundCommand(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if err != nil {
+		t.Fatalf("ForegroundCommand: %v", err)
+	}
+	if cmd != "claude" {
+		t.Fatalf("ForegroundCommand = %q, want claude", cmd)
+	}
+	if got, want := fr.calls[0].args, foregroundCommandArgs("sess-1"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("foreground command args = %#v, want %#v", got, want)
 	}
 }
 

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1011,7 +1011,7 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 	return nil
 }
 
-func (m *Manager) runtimeHasForegroundAgent(ctx context.Context, handle ports.RuntimeHandle) (agentAlive bool, checked bool, err error) {
+func (m *Manager) runtimeHasForegroundAgent(ctx context.Context, handle ports.RuntimeHandle) (agentAlive, checked bool, err error) {
 	observer, ok := m.runtime.(runtimeForegroundCommander)
 	if !ok {
 		return true, false, nil

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -85,6 +85,10 @@ type runtimeController interface {
 	IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error)
 }
 
+type runtimeForegroundCommander interface {
+	ForegroundCommand(ctx context.Context, handle ports.RuntimeHandle) (string, error)
+}
+
 // Store is the persistence surface needed by the internal session Manager.
 type Store interface {
 	// GetProject loads a project row so spawn can resolve its per-project agent
@@ -824,6 +828,10 @@ func (m *Manager) relaunchRestoredSession(ctx context.Context, rec domain.Sessio
 		m.cleanupSystemPromptDir(rec.ID)
 		return domain.SessionRecord{}, fmt.Errorf("restore %s: %w", rec.ID, err)
 	}
+	if err := m.validateAgentBinary(argv); err != nil {
+		m.cleanupSystemPromptDir(rec.ID)
+		return domain.SessionRecord{}, fmt.Errorf("restore %s: %w", rec.ID, err)
+	}
 	handle, err := m.runtime.Create(ctx, ports.RuntimeConfig{
 		SessionID:     rec.ID,
 		WorkspacePath: ws.Path,
@@ -957,10 +965,11 @@ func (m *Manager) saveAndTeardownOne(ctx context.Context, rec domain.SessionReco
 }
 
 // reconcileLive handles a single non-terminated session on boot. If its runtime
-// session is still alive (tmux is the persistence layer, so it survives a daemon
-// crash) we adopt it: a no-op, the agent keeps running. If the runtime is gone,
-// the agent died with the daemon, so we save-and-tear-down to the SAME end state
-// a graceful shutdown produces: capture uncommitted work into a preserve ref,
+// session is still alive and, where the runtime can tell us, its foreground
+// process is not just the keep-alive shell, we adopt it: a no-op, the agent
+// keeps running. If the runtime is gone (or tmux reports a shell-only pane), the
+// agent died with the daemon, so we save-and-tear-down to the SAME end state a
+// graceful shutdown produces: capture uncommitted work into a preserve ref,
 // record the session_worktrees restore marker, mark terminated, and remove the
 // worktree. RestoreAll (which Reconcile runs immediately after) then relaunches
 // it on this same boot, resuming history. Crash recovery thus matches graceful
@@ -974,6 +983,7 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 		return nil
 	}
 	handle := runtimeHandle(rec.Metadata)
+	destroyRuntime := false
 	if handle.ID != "" {
 		alive, err := m.runtime.IsAlive(ctx, handle)
 		if err != nil {
@@ -981,16 +991,50 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 			return fmt.Errorf("reconcile %s: probe: %w", rec.ID, err)
 		}
 		if alive {
-			return nil // adopt: the session survived the crash.
+			agentAlive, checked, err := m.runtimeHasForegroundAgent(ctx, handle)
+			if err != nil {
+				return fmt.Errorf("reconcile %s: foreground probe: %w", rec.ID, err)
+			}
+			if !checked || agentAlive {
+				return nil // adopt: the session survived the crash.
+			}
+			m.logger.Warn("reconcile: live runtime has no foreground agent; scheduling restore", "sessionID", rec.ID, "runtimeHandle", handle.ID)
+			destroyRuntime = true
 		}
 	}
-	if err := m.saveAndTeardownOne(ctx, rec, false); err != nil {
+	if err := m.saveAndTeardownOne(ctx, rec, destroyRuntime); err != nil {
 		m.logger.Warn("reconcile: save-and-teardown failed; terminating without restore marker", "sessionID", rec.ID, "error", err)
 		if mErr := m.lcm.MarkTerminated(ctx, rec.ID); mErr != nil {
 			return fmt.Errorf("reconcile %s: mark terminated: %w", rec.ID, mErr)
 		}
 	}
 	return nil
+}
+
+func (m *Manager) runtimeHasForegroundAgent(ctx context.Context, handle ports.RuntimeHandle) (agentAlive bool, checked bool, err error) {
+	observer, ok := m.runtime.(runtimeForegroundCommander)
+	if !ok {
+		return true, false, nil
+	}
+	cmd, err := observer.ForegroundCommand(ctx, handle)
+	if err != nil {
+		return false, true, err
+	}
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return true, false, nil
+	}
+	return !isInteractiveShellCommand(cmd), true, nil
+}
+
+func isInteractiveShellCommand(cmd string) bool {
+	base := strings.ToLower(filepath.Base(cmd))
+	switch base {
+	case "sh", "bash", "zsh", "fish", "ksh", "csh", "tcsh", "nu", "elvish", "pwsh", "powershell", "cmd", "cmd.exe":
+		return true
+	default:
+		return false
+	}
 }
 
 // reconcileReap kills the leaked tmux session of a session the DB already marks
@@ -2222,8 +2266,16 @@ func (m *Manager) deliverAfterStartPrompt(ctx context.Context, agent ports.Agent
 	case sessionguard.SuppressedUnknown:
 		return fmt.Errorf("send %s: pre-write session read failed", id)
 	default:
+		if agentNudgeSafe(agent) {
+			m.confirmActive(ctx, m.messenger, id)
+		}
 		return nil
 	}
+}
+
+func agentNudgeSafe(agent ports.Agent) bool {
+	s, ok := agent.(ports.ActivitySignaler)
+	return ok && s.EmitsSubmitActivity() && s.EmitsBlockedActivity()
 }
 
 func (m *Manager) waitForPromptReadiness(ctx context.Context, agent ports.Agent, cfg ports.LaunchConfig, handle ports.RuntimeHandle) error {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -168,9 +168,11 @@ type fakeRuntime struct {
 	outputCalls        int
 	outputErr          error
 	// aliveByHandle maps a RuntimeHandle.ID to its liveness; missing = false.
-	aliveByHandle map[string]bool
-	aliveErr      error
-	destroyedIDs  []string
+	aliveByHandle      map[string]bool
+	aliveErr           error
+	foregroundByHandle map[string]string
+	foregroundErr      error
+	destroyedIDs       []string
 }
 
 func (r *fakeRuntime) Create(_ context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
@@ -205,6 +207,12 @@ func (r *fakeRuntime) GetOutput(_ context.Context, _ ports.RuntimeHandle, _ int)
 		r.outputs = r.outputs[1:]
 	}
 	return out, nil
+}
+func (r *fakeRuntime) ForegroundCommand(_ context.Context, handle ports.RuntimeHandle) (string, error) {
+	if r.foregroundErr != nil {
+		return "", r.foregroundErr
+	}
+	return r.foregroundByHandle[handle.ID], nil
 }
 
 type fakeAgent struct{}
@@ -276,6 +284,13 @@ type afterStartAgent struct {
 func (a afterStartAgent) GetPromptDeliveryStrategy(context.Context, ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
 	return ports.PromptDeliveryAfterStart, nil
 }
+
+type afterStartSignalingAgent struct {
+	afterStartAgent
+}
+
+func (afterStartSignalingAgent) EmitsSubmitActivity() bool  { return true }
+func (afterStartSignalingAgent) EmitsBlockedActivity() bool { return true }
 
 type readinessAgent struct {
 	afterStartAgent
@@ -1392,6 +1407,40 @@ func TestRestore_ReopensTerminal(t *testing.T) {
 	}
 }
 
+func TestRestore_ValidatesAgentBinaryBeforeRuntimeCreate(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:           "mer-1",
+		ProjectID:    "mer",
+		Kind:         domain.KindWorker,
+		Harness:      domain.HarnessClaudeCode,
+		IsTerminated: true,
+		Metadata:     domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", AgentSessionID: "agent-x"},
+		Activity:     domain.Activity{State: domain.ActivityExited},
+	}
+	rt := &fakeRuntime{}
+	m := New(Deps{
+		Runtime:   rt,
+		Agents:    fakeAgents{},
+		Workspace: &fakeWorkspace{},
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: &fakeLCM{store: st},
+		LookPath:  func(string) (string, error) { return "", errors.New("missing") },
+	})
+
+	_, err := m.Restore(ctx, "mer-1")
+	if !errors.Is(err, ports.ErrAgentBinaryNotFound) {
+		t.Fatalf("Restore err = %v, want ErrAgentBinaryNotFound", err)
+	}
+	if rt.created != 0 {
+		t.Fatalf("runtime.Create calls = %d, want 0 (no shell-only zombie)", rt.created)
+	}
+	if !st.sessions["mer-1"].IsTerminated {
+		t.Fatal("restore preflight failure must leave the session terminated")
+	}
+}
+
 func TestRestore_WorkspaceProjectRestoresChildrenAndRecordsInventory(t *testing.T) {
 	m, st, rt, ws := newManager()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
@@ -2244,6 +2293,45 @@ func TestRestore_FallbackLaunchDeliversPromptAfterStartWhenAgentRequestsIt(t *te
 	}
 	if rt.created != 1 {
 		t.Fatalf("runtime.Create = %d, want 1", rt.created)
+	}
+}
+
+func TestRestore_AfterStartPromptConfirmsAndNudgesWhenNotAccepted(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:           "mer-1",
+		ProjectID:    "mer",
+		Kind:         domain.KindWorker,
+		Harness:      domain.HarnessClaudeCode,
+		IsTerminated: true,
+		Metadata:     domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", Prompt: "continue the task"},
+		Activity:     domain.Activity{State: domain.ActivityExited},
+	}
+	msg := &flipOnNudgeMessenger{sessionID: "mer-1", store: st}
+	agent := &recordingAgent{}
+	m := New(Deps{
+		Runtime:   &fakeRuntime{},
+		Agents:    singleAgent{agent: afterStartSignalingAgent{afterStartAgent: afterStartAgent{recordingAgent: agent}}},
+		Workspace: &fakeWorkspace{},
+		Store:     st,
+		Messenger: msg,
+		Lifecycle: &fakeLCM{store: st},
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+	m.sendConfirm = sendConfirmConfig{pollInterval: time.Millisecond, attemptDeadline: 0, maxAttempts: 2}
+
+	if _, err := m.Restore(ctx, "mer-1"); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 2 {
+		t.Fatalf("delivery calls = %#v, want prompt plus Enter-only nudge", msg.msgs)
+	}
+	if msg.msgs[0] != "continue the task" || msg.msgs[1] != "" {
+		t.Fatalf("delivery calls = %#v, want saved prompt then empty nudge", msg.msgs)
+	}
+	if got := st.sessions["mer-1"].Activity.State; got != domain.ActivityActive {
+		t.Fatalf("activity = %q, want active after confirmation nudge", got)
 	}
 }
 
@@ -3898,6 +3986,43 @@ func TestReconcileLive_AliveSessionAdoptedNoop(t *testing.T) {
 	}
 	if ws.stashCalls != 0 || lcm.terminated["s2"] != 0 || rt.destroyed != 0 {
 		t.Fatalf("adopt should be a no-op: stash=%d term=%d destroy=%d", ws.stashCalls, lcm.terminated["s2"], rt.destroyed)
+	}
+}
+
+func TestReconcile_RestoresLiveShellRuntimeInsteadOfAdoptingZombie(t *testing.T) {
+	m, st, rt, ws := newLifecycleManager()
+	ws.stashRef = "refs/ao/preserved/shell-zombie"
+	rt.aliveByHandle = map[string]bool{"s4": true}
+	rt.foregroundByHandle = map[string]string{"s4": "zsh"}
+	st.sessions["s4"] = domain.SessionRecord{
+		ID:           "s4",
+		ProjectID:    "mer",
+		Kind:         domain.KindWorker,
+		Harness:      domain.HarnessClaudeCode,
+		IsTerminated: false,
+		Metadata: domain.SessionMetadata{
+			Branch: "ao/s4/root", WorkspacePath: "/wt/s4", RuntimeHandleID: "s4", AgentSessionID: "agent-s4",
+		},
+		Activity: domain.Activity{State: domain.ActivityIdle},
+	}
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if rt.destroyed != 1 || len(rt.destroyedIDs) != 1 || rt.destroyedIDs[0] != "s4" {
+		t.Fatalf("stale shell runtime destroys = %d ids=%v, want one destroy of s4", rt.destroyed, rt.destroyedIDs)
+	}
+	if rt.created != 1 {
+		t.Fatalf("runtime.Create calls = %d, want relaunch after shell-only runtime", rt.created)
+	}
+	if st.sessions["s4"].IsTerminated {
+		t.Fatal("session should be live after reconcile restores shell-only runtime")
+	}
+	if got := st.sessions["s4"].Metadata.RuntimeHandleID; got != "h1" {
+		t.Fatalf("runtime handle after restore = %q, want h1", got)
+	}
+	if rows := st.worktrees["s4"]; len(rows) != 0 {
+		t.Fatalf("restore marker should be consumed after relaunch, got %+v", rows)
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate restore argv before creating the runtime so a missing agent binary cannot create a live shell-only zombie
- have boot reconciliation reject live tmux panes whose foreground command is just a keep-alive shell, then tear them down and relaunch through RestoreAll
- run after-start prompt delivery through the safe active-confirmation nudge path for agents that emit both submit and blocked activity signals

Fixes #2702
Fixes #2714

## Tests
- go test ./internal/session_manager ./internal/adapters/runtime/tmux
- git diff --check

Note: attempted `cd backend && go test ./...`; after normal package output it left a sleeping `go test ./...` wrapper with no child test process for several minutes, so I terminated that stale wrapper and reran the touched package tests.