### PR TITLE
fix: clean up failed session spawns

### DIFF
--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -581,6 +581,8 @@ func toAPIError(err error) error {
 		return apierr.Invalid("AGENT_BINARY_NOT_FOUND", err.Error(), nil)
 	case errors.Is(err, ports.ErrRuntimePrerequisite):
 		return apierr.Invalid("RUNTIME_PREREQUISITE_MISSING", err.Error(), nil)
+	case errors.Is(err, sessionmanager.ErrRuntimeStartTimeout):
+		return apierr.Internal("TERMINAL_RUNTIME_START_TIMEOUT", "Terminal runtime was slow to create a session. Retry the spawn, run `ao doctor`, and check for stale tmux sessions if this keeps happening.")
 	default:
 		return err
 	}

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -698,6 +698,7 @@ func TestToAPIErrorMapsWorkspaceBranchSentinels(t *testing.T) {
 		{"invalid branch", fmt.Errorf("spawn mer-1: workspace: %w: \"bad!!\" (exit 1)", ports.ErrWorkspaceBranchInvalid), apierr.KindInvalid, "INVALID_BRANCH"},
 		{"agent binary not found", fmt.Errorf("spawn mer-1: %w", ports.ErrAgentBinaryNotFound), apierr.KindInvalid, "AGENT_BINARY_NOT_FOUND"},
 		{"runtime prerequisite missing", fmt.Errorf("spawn: %w: tmux required on macOS/Linux but not in PATH", ports.ErrRuntimePrerequisite), apierr.KindInvalid, "RUNTIME_PREREQUISITE_MISSING"},
+		{"terminal runtime start timeout", fmt.Errorf("spawn mer-1: runtime: %w", sessionmanager.ErrRuntimeStartTimeout), apierr.KindInternal, "TERMINAL_RUNTIME_START_TIMEOUT"},
 		{"unknown harness", fmt.Errorf("spawn: %w: %q", sessionmanager.ErrUnknownHarness, "bogus"), apierr.KindInvalid, "UNKNOWN_HARNESS"},
 		{"missing harness", fmt.Errorf("spawn: %w: configure project worker.agent or pass --harness", sessionmanager.ErrMissingHarness), apierr.KindInvalid, "AGENT_REQUIRED"},
 		{"awaiting decision", fmt.Errorf("send mer-1: %w", sessionmanager.ErrAwaitingDecision), apierr.KindConflict, "SESSION_AWAITING_DECISION"},
@@ -710,6 +711,22 @@ func TestToAPIErrorMapsWorkspaceBranchSentinels(t *testing.T) {
 				t.Fatalf("mapped = %v, want %s %s", mapped, tc.wantCode, e)
 			}
 		})
+	}
+}
+
+func TestToAPIErrorRuntimeStartTimeoutMessageIsActionable(t *testing.T) {
+	mapped := toAPIError(fmt.Errorf("spawn mer-1: runtime: %w", sessionmanager.ErrRuntimeStartTimeout))
+	var e *apierr.Error
+	if !errors.As(mapped, &e) {
+		t.Fatalf("mapped = %v, want apierr.Error", mapped)
+	}
+	if e.Code != "TERMINAL_RUNTIME_START_TIMEOUT" {
+		t.Fatalf("code = %s, want TERMINAL_RUNTIME_START_TIMEOUT", e.Code)
+	}
+	for _, want := range []string{"Terminal runtime was slow", "Retry", "ao doctor", "stale tmux"} {
+		if !strings.Contains(e.Message, want) {
+			t.Fatalf("message = %q, want %q", e.Message, want)
+		}
 	}
 }
 

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -54,6 +54,10 @@ var (
 	// would answer it on the user's behalf. The API maps it to a 409; the
 	// caller retries once the user has answered in the terminal.
 	ErrAwaitingDecision = errors.New("session: awaiting a user decision")
+	// ErrRuntimeStartTimeout means the terminal runtime did not create its
+	// session within the runtime's bounded startup window. The API maps it to a
+	// typed, actionable failure instead of the generic INTERNAL_ERROR envelope.
+	ErrRuntimeStartTimeout = errors.New("session: terminal runtime start timed out")
 )
 
 // Env vars a spawned process reads to learn who it is.
@@ -70,6 +74,8 @@ const (
 // PATH pin (hookPATH) only works when the daemon's own executable carries this
 // name, since prepending its directory must change what `ao` resolves to.
 const hookBinaryName = "ao"
+
+const spawnRollbackTimeout = 30 * time.Second
 
 type lifecycleRecorder interface {
 	MarkSpawned(ctx context.Context, id domain.SessionID, metadata domain.SessionMetadata) error
@@ -243,7 +249,7 @@ func New(d Deps) *Manager {
 // workspace and runtime, then reports completion to the LCM. If workspace
 // materialization fails the still-seed row is deleted outright; a later failure
 // parks the row as terminated and rolls back what was built.
-func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.SessionRecord, error) {
+func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (out domain.SessionRecord, err error) {
 	project, err := m.loadProject(ctx, cfg.ProjectID)
 	if err != nil {
 		return domain.SessionRecord{}, fmt.Errorf("spawn: %w", err)
@@ -276,9 +282,25 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, fmt.Errorf("spawn: create: %w", err)
 	}
 	id := rec.ID
+	var (
+		ws                ports.WorkspaceInfo
+		workspaceProject  *ports.WorkspaceProjectInfo
+		workspaceCreated  bool
+		workspacePrepared bool
+		handle            ports.RuntimeHandle
+		runtimeCreated    bool
+		spawnRecorded     bool
+		spawnComplete     bool
+	)
+	defer func() {
+		if err == nil || spawnComplete {
+			return
+		}
+		m.cleanupFailedSpawn(id, rec, ws, workspaceProject, workspaceCreated, workspacePrepared, handle, runtimeCreated, spawnRecorded)
+	}()
+
 	systemPromptFile, err := m.prepareSystemPromptFile(id, cfg.Harness, systemPrompt)
 	if err != nil {
-		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: system prompt file: %w", id, err)
 	}
 
@@ -286,37 +308,32 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	if branch == "" {
 		branch = defaultSpawnBranch(id, cfg.Kind, sessionPrefix(project), project.Kind.WithDefault())
 	}
-	ws, workspaceProject, err := m.createSessionWorkspace(ctx, project, cfg, id, branch)
+	ws, workspaceProject, err = m.createSessionWorkspace(ctx, project, cfg, id, branch)
 	if err != nil {
 		// Nothing observable exists yet — no worktree, no runtime — so the seed
 		// row is deleted outright instead of accumulating as a terminated orphan
 		// in session lists (e.g. when gitworktree refuses the branch).
-		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: workspace: %w", id, err)
 	}
+	workspaceCreated = true
 
 	// Per-project workspace provisioning: symlink shared files, then run any
 	// post-create commands (e.g. `pnpm install`) before the agent launches.
 	if err := m.provisionWorkspace(ctx, project, ws.Path); err != nil {
-		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: provision: %w", id, err)
 	}
 
 	agent, ok := m.agents.Agent(cfg.Harness)
 	if !ok {
-		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: no agent adapter for harness %q", id, cfg.Harness)
 	}
 	agentConfig := effectiveAgentConfig(cfg.Kind, project.Config)
 	env := m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, project.Config.Env)
 	m.augmentAgentRuntimeEnv(agent, env)
 	if err := m.prepareWorkspace(ctx, agent, id, ws.Path, systemPrompt, systemPromptFile, agentConfig, env); err != nil {
-		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: %w", id, err)
 	}
+	workspacePrepared = true
 	launchCfg := ports.LaunchConfig{
 		DataDir:          m.dataDir,
 		SessionID:        string(id),
@@ -331,8 +348,6 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	}
 	delivery, err := agent.GetPromptDeliveryStrategy(ctx, launchCfg)
 	if err != nil {
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: prompt delivery: %w", id, err)
 	}
 	if delivery == ports.PromptDeliveryAfterStart {
@@ -340,8 +355,6 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	}
 	argv, err := agent.GetLaunchCommand(ctx, launchCfg)
 	if err != nil {
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: launch command: %w", id, err)
 	}
 	// Pre-flight: confirm argv[0] actually exists on PATH (or as an absolute
@@ -349,38 +362,81 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	// tmux happily creates a session+pane around a missing command, so an
 	// unresolved binary would leak through as a "live" session that never ran.
 	if err := m.validateAgentBinary(argv); err != nil {
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: %w", id, err)
 	}
-	handle, err := m.runtime.Create(ctx, ports.RuntimeConfig{
+	handle, err = m.runtime.Create(ctx, ports.RuntimeConfig{
 		SessionID:     id,
 		WorkspacePath: ws.Path,
 		Argv:          argv,
 		Env:           env,
 	})
 	if err != nil {
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
-		return domain.SessionRecord{}, fmt.Errorf("spawn %s: runtime: %w", id, err)
+		return domain.SessionRecord{}, fmt.Errorf("spawn %s: runtime: %w", id, runtimeCreateError(err))
 	}
+	runtimeCreated = true
 
 	metadata := domain.SessionMetadata{Branch: ws.Branch, WorkspacePath: ws.Path, RuntimeHandleID: handle.ID, Prompt: prompt}
 	if err := m.lcm.MarkSpawned(ctx, id, metadata); err != nil {
-		_ = m.runtime.Destroy(ctx, handle)
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-		m.markSpawnFailedTerminated(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: completed: %w", id, err)
 	}
+	spawnRecorded = true
 	if delivery == ports.PromptDeliveryAfterStart && prompt != "" {
 		if err := m.deliverAfterStartPrompt(ctx, agent, launchCfg, handle, id, prompt); err != nil {
-			_ = m.runtime.Destroy(ctx, handle)
-			m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-			m.markSpawnFailedTerminatedWithoutWorkspace(ctx, id)
 			return domain.SessionRecord{}, fmt.Errorf("spawn %s: deliver prompt: %w", id, err)
 		}
 	}
+	spawnComplete = true
 	return m.getRecord(ctx, id)
+}
+
+func runtimeCreateError(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: terminal runtime was slow to create a session; retry the spawn, run `ao doctor`, and check for stale tmux sessions if this keeps happening: %v", ErrRuntimeStartTimeout, err)
+	}
+	return err
+}
+
+func (m *Manager) cleanupFailedSpawn(id domain.SessionID, rec domain.SessionRecord, ws ports.WorkspaceInfo, workspaceProject *ports.WorkspaceProjectInfo, workspaceCreated, workspacePrepared bool, handle ports.RuntimeHandle, runtimeCreated, spawnRecorded bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), spawnRollbackTimeout)
+	defer cancel()
+
+	if spawnRecorded {
+		if runtimeCreated {
+			_ = m.runtime.Destroy(ctx, handle)
+		}
+		if workspaceCreated {
+			m.cleanupFailedSpawnWorkspace(ctx, rec, ws, workspaceProject, workspacePrepared)
+		}
+		m.markSpawnFailedTerminatedWithoutWorkspace(ctx, id)
+		if _, _, err := m.rollbackSpawn(ctx, id); err != nil {
+			m.logger.Warn("spawn rollback failed", "sessionID", id, "error", err)
+		}
+		return
+	}
+
+	if runtimeCreated {
+		_ = m.runtime.Destroy(ctx, handle)
+	}
+	if workspaceCreated {
+		m.cleanupFailedSpawnWorkspace(ctx, rec, ws, workspaceProject, workspacePrepared)
+	}
+	_, killed, err := m.rollbackSpawn(ctx, id)
+	if err != nil {
+		m.logger.Warn("spawn rollback failed", "sessionID", id, "error", err)
+		m.markSpawnFailedTerminated(ctx, id)
+		return
+	}
+	if killed {
+		m.clearSpawnLaunchMetadata(ctx, id)
+	}
+}
+
+func (m *Manager) cleanupFailedSpawnWorkspace(ctx context.Context, rec domain.SessionRecord, ws ports.WorkspaceInfo, workspaceProject *ports.WorkspaceProjectInfo, workspacePrepared bool) {
+	if workspacePrepared {
+		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
+		return
+	}
+	m.destroySpawnWorkspace(ctx, ws, workspaceProject)
 }
 
 // loadProject loads the project record so spawn can resolve its per-project
@@ -543,6 +599,10 @@ func (m *Manager) markSpawnFailedTerminated(ctx context.Context, id domain.Sessi
 // from treating a removed worktree as reusable state.
 func (m *Manager) markSpawnFailedTerminatedWithoutWorkspace(ctx context.Context, id domain.SessionID) {
 	m.markSpawnFailedTerminated(ctx, id)
+	m.clearSpawnLaunchMetadata(ctx, id)
+}
+
+func (m *Manager) clearSpawnLaunchMetadata(ctx context.Context, id domain.SessionID) {
 	rec, ok, err := m.store.GetSession(ctx, id)
 	if err != nil || !ok {
 		return
@@ -587,11 +647,22 @@ func (m *Manager) rollbackSpawn(ctx context.Context, id domain.SessionID) (delet
 		m.cleanupSystemPromptDir(id)
 		return true, false, nil
 	}
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return false, false, fmt.Errorf("rollback %s: %w", id, err)
+	}
+	if !ok || (rec.IsTerminated && !hasLaunchMetadata(rec.Metadata)) {
+		return false, false, nil
+	}
 	killed, err = m.Kill(ctx, id)
 	if err != nil {
 		return false, false, err
 	}
 	return false, killed, nil
+}
+
+func hasLaunchMetadata(metadata domain.SessionMetadata) bool {
+	return metadata.WorkspacePath != "" || metadata.RuntimeHandleID != "" || metadata.AgentSessionID != ""
 }
 
 // RollbackSpawn is the public surface of rollbackSpawn for service-layer callers.

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -391,7 +391,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (out domain.
 
 func runtimeCreateError(err error) error {
 	if errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Errorf("%w: terminal runtime was slow to create a session; retry the spawn, run `ao doctor`, and check for stale tmux sessions if this keeps happening: %v", ErrRuntimeStartTimeout, err)
+		return fmt.Errorf("%w: terminal runtime was slow to create a session; retry the spawn, run `ao doctor`, and check for stale tmux sessions if this keeps happening: %w", ErrRuntimeStartTimeout, err)
 	}
 	return err
 }
@@ -586,8 +586,7 @@ func sessionPrefix(project domain.ProjectRecord) string {
 
 // markSpawnFailedTerminated best-effort parks an orphaned spawn as terminated.
 // A phantom half-spawned row is worse than a terminal one; we only delete the
-// row when nothing observable has landed yet (seed state) via rollbackSpawn or
-// rollbackSpawnSeedRow.
+// row when nothing observable has landed yet (seed state) via rollbackSpawn.
 func (m *Manager) markSpawnFailedTerminated(ctx context.Context, id domain.SessionID) {
 	_ = m.lcm.MarkTerminated(ctx, id)
 	m.cleanupSystemPromptDir(id)
@@ -612,19 +611,6 @@ func (m *Manager) clearSpawnLaunchMetadata(ctx context.Context, id domain.Sessio
 	rec.Metadata.RuntimeHandleID = ""
 	rec.Metadata.AgentSessionID = ""
 	_ = m.store.UpdateSession(ctx, rec)
-}
-
-// rollbackSpawnSeedRow best-effort removes the row of a spawn that failed
-// before anything observable (worktree, runtime) was built, so failed spawns
-// don't accumulate terminated rows in session lists. DeleteSession only removes
-// rows still in seed state; if the row has progressed or the delete itself
-// fails, fall back to parking it terminated so a phantom row never looks live.
-func (m *Manager) rollbackSpawnSeedRow(ctx context.Context, id domain.SessionID) {
-	if deleted, err := m.store.DeleteSession(ctx, id); err == nil && deleted {
-		m.cleanupSystemPromptDir(id)
-		return
-	}
-	m.markSpawnFailedTerminated(ctx, id)
 }
 
 // rollbackSpawn deletes a session row when it is still in seed state — used

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -27,6 +27,7 @@ type fakeStore struct {
 	workspaceRepo map[string][]domain.WorkspaceRepoRecord
 	num           int
 	deleteErr     error
+	deleteCtxErrs []error
 	upsertWTErr   error
 	// worktrees maps session ID to its saved worktree rows (shutdown-saved marker).
 	worktrees map[domain.SessionID][]domain.SessionWorktreeRecord
@@ -81,7 +82,8 @@ func (f *fakeStore) ListAllSessions(context.Context) ([]domain.SessionRecord, er
 	}
 	return out, nil
 }
-func (f *fakeStore) DeleteSession(_ context.Context, id domain.SessionID) (bool, error) {
+func (f *fakeStore) DeleteSession(ctx context.Context, id domain.SessionID) (bool, error) {
+	f.deleteCtxErrs = append(f.deleteCtxErrs, ctx.Err())
 	if f.deleteErr != nil {
 		return false, f.deleteErr
 	}
@@ -388,6 +390,9 @@ type fakeWorkspace struct {
 	stashCalls int
 	// calls records the sequence of workspace method calls for ordering assertions.
 	calls []string
+	// destroyCtxErrs records ctx.Err() for spawn cleanup tests.
+	destroyCtxErrs        []error
+	projectDestroyCtxErrs []error
 	// sharedLog, when non-nil, receives entries alongside calls so ordering
 	// tests can compare workspace calls against store calls in one sequence.
 	sharedLog *[]string
@@ -444,7 +449,8 @@ func (w *fakeWorkspace) CreateWorkspaceProject(_ context.Context, cfg ports.Work
 	}
 	return out, nil
 }
-func (w *fakeWorkspace) Destroy(_ context.Context, info ports.WorkspaceInfo) error {
+func (w *fakeWorkspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error {
+	w.destroyCtxErrs = append(w.destroyCtxErrs, ctx.Err())
 	if info.RepoPath != "" {
 		entry := "Destroy:" + fakeWorkspaceRepoName(info)
 		w.calls = append(w.calls, entry)
@@ -455,7 +461,8 @@ func (w *fakeWorkspace) Destroy(_ context.Context, info ports.WorkspaceInfo) err
 	w.destroyed++
 	return w.destroyErr
 }
-func (w *fakeWorkspace) DestroyWorkspaceProject(context.Context, ports.WorkspaceProjectInfo) error {
+func (w *fakeWorkspace) DestroyWorkspaceProject(ctx context.Context, _ ports.WorkspaceProjectInfo) error {
+	w.projectDestroyCtxErrs = append(w.projectDestroyCtxErrs, ctx.Err())
 	w.projectDestroyed++
 	return w.destroyErr
 }
@@ -1169,6 +1176,30 @@ func TestSpawn_AgentRuntimeEnvAugmenterReachesRuntime(t *testing.T) {
 	}
 	if got, want := rt.lastCfg.Env["AGENT_DATA_DIR"], filepath.Join("/ao/data", "agent"); got != want {
 		t.Fatalf("runtime env AGENT_DATA_DIR = %q, want %q", got, want)
+	}
+}
+
+func TestSpawn_RuntimeDeadlineCleansUpWithFreshContext(t *testing.T) {
+	m, st, _, ws := newManager()
+	m.runtime = &fakeRuntime{createErr: context.DeadlineExceeded}
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.Spawn(canceledCtx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker})
+	if !errors.Is(err, ErrRuntimeStartTimeout) {
+		t.Fatalf("err = %v, want ErrRuntimeStartTimeout", err)
+	}
+	if ws.destroyed != 1 {
+		t.Fatalf("workspace destroyed=%d, want 1", ws.destroyed)
+	}
+	if len(ws.destroyCtxErrs) != 1 || ws.destroyCtxErrs[0] != nil {
+		t.Fatalf("workspace destroy ctx errs = %#v, want fresh non-canceled cleanup context", ws.destroyCtxErrs)
+	}
+	if len(st.deleteCtxErrs) != 1 || st.deleteCtxErrs[0] != nil {
+		t.Fatalf("seed delete ctx errs = %#v, want fresh non-canceled cleanup context", st.deleteCtxErrs)
+	}
+	if rec, present := st.sessions["mer-1"]; present {
+		t.Fatalf("seed row must be deleted after runtime timeout, got %+v", rec)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a guarded deferred cleanup path for session spawns after the seed row is created
- clean up workspaces/runtime handles and roll back seed rows with a fresh cleanup context when spawn fails or the request is canceled
- classify terminal runtime create deadlines as `TERMINAL_RUNTIME_START_TIMEOUT` with an actionable API/CLI message

Fixes #2713
Fixes #2646
Fixes #2699

## Root cause

`Spawn` created the session seed row early, then relied on every later error branch to remember the right cleanup sequence. Some paths returned without rolling back the seed row or releasing the initializing workspace, and cleanup reused the request context that may already have been canceled by a timeout. Runtime create deadline errors also fell through to the generic internal API envelope.

## Validation

Passed:

```bash
cd backend && go test ./internal/session_manager ./internal/service/session ./internal/httpd/...
```

Also ran:

```bash
cd backend && go test ./...
```

That broader run is blocked by existing CLI test harness failures in `backend/internal/cli` where spawn tests receive a plain `daemon returned HTTP 404` from the local test server path. Reproduced independently with:

```bash
cd backend && go test ./internal/cli -run TestSpawnCommand_MissingProjectContext -count=1 -v
```