### PR TITLE
fix: improve desktop updater checks

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1258,8 +1258,8 @@ ipcMain.handle("updates:check", async () => {
 ipcMain.handle("updates:download", async () => {
 	await downloadUpdateNow();
 });
-ipcMain.handle("updates:install", () => {
-	quitAndInstallUpdate();
+ipcMain.handle("updates:install", async () => {
+	await quitAndInstallUpdate();
 });
 
 ipcMain.handle("notifications:show", (_event, notification: { id: string; title: string; body?: string }) => {

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeUpdateSettings } from "./update-settings";
+
+type MockAutoUpdater = EventEmitter & {
+	channel: string;
+	allowPrerelease: boolean;
+	allowDowngrade: boolean;
+	autoDownload: boolean;
+	autoInstallOnAppQuit: boolean;
+	checkForUpdates: ReturnType<typeof vi.fn>;
+	downloadUpdate: ReturnType<typeof vi.fn>;
+	quitAndInstall: ReturnType<typeof vi.fn>;
+};
+
+const electronState = vi.hoisted(() => ({
+	windows: [] as Array<{ isDestroyed: () => boolean; webContents: { send: ReturnType<typeof vi.fn> } }>,
+}));
+
+vi.mock("electron", () => ({
+	app: {
+		isPackaged: true,
+		getVersion: () => "1.0.0",
+	},
+	BrowserWindow: {
+		getAllWindows: () => electronState.windows,
+	},
+	dialog: {
+		showMessageBox: vi.fn(),
+	},
+}));
+
+vi.mock("electron-updater", () => {
+	const updater = Object.assign(new EventEmitter(), {
+		channel: "",
+		allowPrerelease: false,
+		allowDowngrade: false,
+		autoDownload: false,
+		autoInstallOnAppQuit: false,
+		checkForUpdates: vi.fn().mockResolvedValue(undefined),
+		downloadUpdate: vi.fn().mockResolvedValue(undefined),
+		quitAndInstall: vi.fn(),
+	});
+	return { autoUpdater: updater };
+});
+
+async function importUpdater(): Promise<{
+	autoUpdaterModule: typeof import("./auto-updater");
+	autoUpdater: MockAutoUpdater;
+}> {
+	const { autoUpdater } = (await import("electron-updater")) as unknown as { autoUpdater: MockAutoUpdater };
+	autoUpdater.removeAllListeners();
+	autoUpdater.channel = "";
+	autoUpdater.allowPrerelease = false;
+	autoUpdater.allowDowngrade = false;
+	autoUpdater.autoDownload = false;
+	autoUpdater.autoInstallOnAppQuit = false;
+	autoUpdater.checkForUpdates.mockReset().mockResolvedValue(undefined);
+	autoUpdater.downloadUpdate.mockReset().mockResolvedValue(undefined);
+	autoUpdater.quitAndInstall.mockReset();
+
+	const autoUpdaterModule = await import("./auto-updater");
+	return { autoUpdaterModule, autoUpdater };
+}
+
+describe("auto-updater", () => {
+	let dir: string;
+	let intervalCallbacks: Array<() => void>;
+	let setIntervalSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(async () => {
+		vi.resetModules();
+		intervalCallbacks = [];
+		const mockSetInterval = ((handler: TimerHandler) => {
+			if (typeof handler === "function") intervalCallbacks.push(handler as () => void);
+			return { unref: vi.fn() } as unknown as ReturnType<typeof setInterval>;
+		}) as unknown as typeof setInterval;
+		setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation(mockSetInterval);
+		electronState.windows = [{ isDestroyed: () => false, webContents: { send: vi.fn() } }];
+		dir = await mkdtemp(path.join(os.tmpdir(), "ao-auto-updater-"));
+		await writeUpdateSettings(dir, { enabled: true, channel: "latest", nightlyAck: false });
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("checks on launch and then periodically while automatic updates stay enabled", async () => {
+		const { autoUpdaterModule, autoUpdater } = await importUpdater();
+
+		await autoUpdaterModule.startAutoUpdates(dir);
+
+		expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+		expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), autoUpdaterModule.AUTO_UPDATE_CHECK_INTERVAL_MS);
+
+		intervalCallbacks[0]?.();
+		await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2));
+
+		intervalCallbacks[0]?.();
+		await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(3));
+	});
+
+	it("does not start the periodic check timer when automatic updates are disabled", async () => {
+		await writeUpdateSettings(dir, { enabled: false, channel: "latest", nightlyAck: false });
+		const { autoUpdaterModule, autoUpdater } = await importUpdater();
+
+		await autoUpdaterModule.startAutoUpdates(dir);
+
+		expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+		expect(setIntervalSpy).not.toHaveBeenCalled();
+	});
+
+	it("suppresses installing an older staged update after a newer version becomes available", async () => {
+		const { autoUpdaterModule, autoUpdater } = await importUpdater();
+		await autoUpdaterModule.startAutoUpdates(dir);
+
+		autoUpdater.emit("update-downloaded", { version: "1.0.1" });
+		expect(autoUpdaterModule.getUpdateStatus()).toMatchObject({ state: "downloaded", version: "1.0.1" });
+		expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
+
+		autoUpdater.emit("update-available", { version: "1.0.2" });
+
+		expect(autoUpdaterModule.getUpdateStatus()).toEqual({ state: "available", version: "1.0.2" });
+		expect(autoUpdater.autoInstallOnAppQuit).toBe(false);
+
+		autoUpdater.emit("update-downloaded", { version: "1.0.2" });
+
+		expect(autoUpdaterModule.getUpdateStatus()).toMatchObject({ state: "downloaded", version: "1.0.2" });
+		expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
+	});
+
+	it("downloads the superseding update before restart install", async () => {
+		const { autoUpdaterModule, autoUpdater } = await importUpdater();
+		await autoUpdaterModule.startAutoUpdates(dir);
+		autoUpdater.emit("update-downloaded", { version: "1.0.1" });
+		autoUpdater.emit("update-available", { version: "1.0.2" });
+		autoUpdater.downloadUpdate.mockImplementationOnce(async () => {
+			autoUpdater.emit("update-downloaded", { version: "1.0.2" });
+		});
+
+		await autoUpdaterModule.quitAndInstallUpdate();
+
+		expect(autoUpdater.downloadUpdate).toHaveBeenCalledTimes(1);
+		expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+		expect(autoUpdaterModule.getUpdateStatus()).toMatchObject({ state: "downloaded", version: "1.0.2" });
+	});
+});

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -3,14 +3,18 @@ import { app, BrowserWindow, dialog } from "electron";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import semver from "semver";
 import {
 	readUpdateSettings,
 	writeUpdateSettings,
 	UPDATE_SETTINGS_FILE_NAME,
 	type UpdateChannel,
+	type UpdateSettings,
 	type UpdateStatus,
 } from "./update-settings";
 import { evaluateEscalation } from "./escalation-evaluator";
+
+export const AUTO_UPDATE_CHECK_INTERVAL_MS = 2 * 60 * 60 * 1000;
 
 // configureFeed sets the update channel on electron-updater. The repo/owner
 // are loaded automatically from app-update.yml (written by forge.config.ts's
@@ -36,8 +40,11 @@ let eventsWired = false;
 let stagedVersion: string | undefined;
 let stagedAtMs: number | undefined;
 let stagedEscalated = false;
+let supersedingVersion: string | undefined;
 let escalationTimer: ReturnType<typeof setInterval> | undefined;
 let escalationStateDir: string | undefined;
+let autoUpdateTimer: ReturnType<typeof setInterval> | undefined;
+let autoUpdateCheckInFlight: Promise<boolean> | undefined;
 
 // broadcast pushes the latest update status to every renderer window so the
 // Global Settings Updates section can reflect check/download progress live.
@@ -101,6 +108,19 @@ async function fetchNightlyImportant(owner: string, repo: string, version: strin
 // state, so transient check states can restore the row without recomputing.
 function stagedDownloadedStatus(): UpdateStatus {
 	return { state: "downloaded", version: stagedVersion, stagedAt: stagedAtMs, escalated: stagedEscalated };
+}
+
+function isNewerVersion(candidate: string | undefined, current: string | undefined): boolean {
+	if (!candidate || !current) return false;
+	try {
+		return semver.gt(candidate, current);
+	} catch {
+		return false;
+	}
+}
+
+function stagedUpdateIsSuperseded(): boolean {
+	return stagedAtMs !== undefined && isNewerVersion(supersedingVersion, stagedVersion);
 }
 
 // runEscalationCheck re-reads settings and feeds, then rebroadcasts the
@@ -171,6 +191,12 @@ function wireUpdaterEvents(): void {
 			broadcast(stagedDownloadedStatus());
 			return;
 		}
+		if (stagedAtMs !== undefined && isNewerVersion(info?.version, stagedVersion)) {
+			supersedingVersion = info?.version;
+			// Do not let app quit install the older cached build after we know a
+			// newer one exists. update-downloaded re-enables this for the latest.
+			autoUpdater.autoInstallOnAppQuit = false;
+		}
 		broadcast({ state: "available", version: info?.version });
 	});
 	autoUpdater.on("update-not-available", () => {
@@ -186,6 +212,8 @@ function wireUpdaterEvents(): void {
 		stagedVersion = info?.version;
 		stagedAtMs = Date.now();
 		stagedEscalated = false;
+		supersedingVersion = undefined;
+		autoUpdater.autoInstallOnAppQuit = true;
 		broadcast(stagedDownloadedStatus());
 		// Evaluate now (nightly can escalate immediately), then every 30 minutes
 		// while the update sits uninstalled. unref so the timer never holds the
@@ -205,24 +233,60 @@ export function getUpdateStatus(): UpdateStatus {
 	return lastStatus;
 }
 
-// startAutoUpdates configures electron-updater from the user's ~/.ao settings.
-// It is a thin shell: all policy (channel, opt-in) comes from update-settings.
-// Caller guards on app.isPackaged.
-export async function startAutoUpdates(stateDir: string): Promise<void> {
-	const settings = await readUpdateSettings(stateDir);
-	if (!settings.enabled) return;
-
+async function runAutomaticUpdateCheck(stateDir: string, settings?: UpdateSettings): Promise<boolean> {
+	const resolvedSettings = settings ?? (await readUpdateSettings(stateDir));
+	if (!resolvedSettings.enabled) {
+		stopAutoUpdateTimer();
+		return false;
+	}
 	escalationStateDir = stateDir;
 	wireUpdaterEvents();
-	configureFeed(settings.channel);
+	configureFeed(resolvedSettings.channel);
 	autoUpdater.autoDownload = true;
-	autoUpdater.autoInstallOnAppQuit = true;
+	if (!stagedUpdateIsSuperseded()) {
+		autoUpdater.autoInstallOnAppQuit = true;
+	}
 
 	try {
 		await autoUpdater.checkForUpdates();
 	} catch (err) {
 		console.error("auto-update check failed:", err);
 	}
+	return true;
+}
+
+function stopAutoUpdateTimer(): void {
+	if (autoUpdateTimer !== undefined) {
+		clearInterval(autoUpdateTimer);
+		autoUpdateTimer = undefined;
+	}
+}
+
+function startAutoUpdateTimer(stateDir: string): void {
+	if (autoUpdateTimer !== undefined) return;
+	autoUpdateTimer = setInterval(() => {
+		if (autoUpdateCheckInFlight !== undefined) return;
+		autoUpdateCheckInFlight = runAutomaticUpdateCheck(stateDir).finally(() => {
+			autoUpdateCheckInFlight = undefined;
+		});
+	}, AUTO_UPDATE_CHECK_INTERVAL_MS);
+	autoUpdateTimer.unref?.();
+}
+
+// startAutoUpdates configures electron-updater from the user's ~/.ao settings.
+// It is a thin shell: all policy (channel, opt-in) comes from update-settings.
+// Caller guards on app.isPackaged.
+export async function startAutoUpdates(stateDir: string): Promise<void> {
+	const settings = await readUpdateSettings(stateDir);
+	if (!settings.enabled) {
+		stopAutoUpdateTimer();
+		return;
+	}
+
+	autoUpdateCheckInFlight = runAutomaticUpdateCheck(stateDir, settings);
+	const enabled = await autoUpdateCheckInFlight;
+	autoUpdateCheckInFlight = undefined;
+	if (enabled) startAutoUpdateTimer(stateDir);
 }
 
 // checkForUpdatesNow runs a manual update check regardless of the auto-update
@@ -263,10 +327,20 @@ export async function downloadUpdateNow(): Promise<void> {
 	}
 }
 
-// quitAndInstallUpdate installs a downloaded update and relaunches. isSilent
-// false keeps the installer UI on Windows; isForceRunAfter relaunches the app.
-export function quitAndInstallUpdate(): void {
+// quitAndInstallUpdate installs a downloaded update and relaunches. If a newer
+// update has superseded the staged build, download it first so restart applies
+// the newest available version. isSilent false keeps the installer UI on
+// Windows; isForceRunAfter relaunches the app.
+export async function quitAndInstallUpdate(): Promise<void> {
 	if (!app.isPackaged) return;
+	if (stagedUpdateIsSuperseded()) {
+		try {
+			await autoUpdater.downloadUpdate();
+		} catch (err) {
+			broadcast({ state: "error", message: (err as Error)?.message ?? "Download failed" });
+			return;
+		}
+	}
 	autoUpdater.quitAndInstall(false, true);
 }
 


### PR DESCRIPTION
## Summary
- Run automatic desktop update checks every 2 hours after the launch check, reusing the existing silent/log-only updater path.
- Detect when a newer version supersedes an already staged update, suppress installing the older cached build, and download the superseding build before restart install.
- Add main-process updater tests for periodic checks and staged-update superseding.

Fixes #2707.
Fixes #2708.

## Verification
- npm run test -- src/main/auto-updater.test.ts
- npm run typecheck (after Vitest generated the local TanStack route tree; the generated route file is not included in this updater PR)