### PR TITLE
fix: repair desktop split, browser state, and board identity

### DIFF
--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -22,6 +22,7 @@ const hookState = vi.hoisted(() => ({
 	goForward: vi.fn(),
 	reload: vi.fn(),
 	stop: vi.fn(),
+	refreshBounds: vi.fn(),
 	setAnnotationMode: vi.fn(),
 	previewUrl: undefined as string | undefined,
 	navState: {
@@ -46,6 +47,7 @@ vi.mock("../hooks/useBrowserView", () => ({
 			goForward: hookState.goForward,
 			reload: hookState.reload,
 			stop: hookState.stop,
+			refreshBounds: hookState.refreshBounds,
 			annotationMode: false,
 			setAnnotationMode: hookState.setAnnotationMode,
 		};
@@ -122,6 +124,7 @@ describe("BrowserPanel", () => {
 		hookState.goForward.mockReset();
 		hookState.reload.mockReset();
 		hookState.stop.mockReset();
+		hookState.refreshBounds.mockReset();
 		hookState.setAnnotationMode.mockReset();
 		hookState.setAnnotationMode.mockResolvedValue(undefined);
 		postMock.mockReset();

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -77,7 +77,10 @@ vi.mock("./BrowserPanel", () => ({
 		retryQueued: vi.fn(),
 	}),
 }));
-const browserDestroy = vi.hoisted(() => vi.fn());
+const { browserDestroy, browserRefreshBounds } = vi.hoisted(() => ({
+	browserDestroy: vi.fn(),
+	browserRefreshBounds: vi.fn(),
+}));
 vi.mock("../hooks/useBrowserView", () => ({
 	useBrowserView: () => ({
 		viewId: "browser:sess-1",
@@ -95,6 +98,7 @@ vi.mock("../hooks/useBrowserView", () => ({
 		goForward: vi.fn(),
 		reload: vi.fn(),
 		stop: vi.fn(),
+		refreshBounds: browserRefreshBounds,
 		destroy: browserDestroy,
 	}),
 }));
@@ -188,6 +192,7 @@ describe("SessionView", () => {
 		useUiStore.setState({ isInspectorOpen: true, inspectorOpenBySessionId: { "sess-1": true } });
 		panels.clear();
 		browserDestroy.mockReset();
+		browserRefreshBounds.mockReset();
 	});
 
 	// Regression: react-resizable-panels v4 treats bare numeric sizes as PIXELS
@@ -251,6 +256,7 @@ describe("SessionView", () => {
 		// Dragging past minSize collapses the panel → store follows.
 		act(() => entry.onResize?.({ asPercentage: 0, inPixels: 0 }));
 		expect(useUiStore.getState().inspectorOpenBySessionId["sess-1"]).toBe(false);
+		expect(browserRefreshBounds).toHaveBeenCalled();
 
 		// Dragging it back open reopens + persists the width.
 		act(() => entry.onResize?.({ asPercentage: 31.5, inPixels: 400 }));

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -31,6 +31,14 @@ const { workspaces, panels } = vi.hoisted(() => {
 		updatedAt: "2026-06-10T00:00:00Z",
 		prs: [],
 	} satisfies WorkspaceSession;
+	const workerTwo = {
+		...worker,
+		id: "sess-2",
+		title: "do the other thing",
+		branch: "ao/sess-2",
+		previewUrl: "http://localhost:5173/",
+		previewRevision: 4,
+	} satisfies WorkspaceSession;
 	const orchestrator = {
 		...worker,
 		id: "sess-orch",
@@ -38,7 +46,7 @@ const { workspaces, panels } = vi.hoisted(() => {
 		title: "orchestrate",
 	} satisfies WorkspaceSession;
 	const workspaces: WorkspaceSummary[] = [
-		{ id: "proj-1", name: "my-app", path: "/p", type: "main", sessions: [worker, orchestrator] },
+		{ id: "proj-1", name: "my-app", path: "/p", type: "main", sessions: [worker, workerTwo, orchestrator] },
 	];
 	return { workspaces, panels: new Map<string, PanelEntry>() };
 });
@@ -177,7 +185,7 @@ function panelSizes(id: string): unknown[] {
 describe("SessionView", () => {
 	beforeEach(() => {
 		window.localStorage.clear();
-		useUiStore.setState({ isInspectorOpen: true });
+		useUiStore.setState({ isInspectorOpen: true, inspectorOpenBySessionId: { "sess-1": true } });
 		panels.clear();
 		browserDestroy.mockReset();
 	});
@@ -207,14 +215,14 @@ describe("SessionView", () => {
 	});
 
 	it("mounts collapsed and inert when the store says closed", () => {
-		useUiStore.setState({ isInspectorOpen: false });
+		useUiStore.setState({ isInspectorOpen: false, inspectorOpenBySessionId: { "sess-1": false } });
 		render(<SessionView sessionId="sess-1" />);
 
 		expect(panelSizes("inspector")[0]).toBe("0%");
 		const pane = screen.getByTestId("panel-inspector");
 		expect(pane).toHaveAttribute("inert");
 		expect(pane).toHaveAttribute("aria-hidden", "true");
-		expect(panels.get("inspector")!.handle.collapse).toHaveBeenCalled();
+		expect(panels.get("inspector")!.handle.collapse).not.toHaveBeenCalled();
 	});
 
 	it("toggles the inspector with mod+shift+B through the imperative panel API", () => {
@@ -222,16 +230,16 @@ describe("SessionView", () => {
 		const handle = panels.get("inspector")!.handle;
 
 		fireEvent.keyDown(window, { key: "B", metaKey: true, shiftKey: true });
-		expect(useUiStore.getState().isInspectorOpen).toBe(false);
+		expect(useUiStore.getState().inspectorOpenBySessionId["sess-1"]).toBe(false);
 		expect(handle.collapse).toHaveBeenCalledTimes(1);
 
 		fireEvent.keyDown(window, { key: "B", ctrlKey: true, shiftKey: true });
-		expect(useUiStore.getState().isInspectorOpen).toBe(true);
+		expect(useUiStore.getState().inspectorOpenBySessionId["sess-1"]).toBe(true);
 		expect(handle.expand).toHaveBeenCalled();
 
 		// Plain ⌘B belongs to the sidebar — the inspector must not react.
 		fireEvent.keyDown(window, { key: "b", metaKey: true });
-		expect(useUiStore.getState().isInspectorOpen).toBe(true);
+		expect(useUiStore.getState().inspectorOpenBySessionId["sess-1"]).toBe(true);
 	});
 
 	it("syncs drag resizes back into the store and persists the split", () => {
@@ -242,11 +250,11 @@ describe("SessionView", () => {
 
 		// Dragging past minSize collapses the panel → store follows.
 		act(() => entry.onResize?.({ asPercentage: 0, inPixels: 0 }));
-		expect(useUiStore.getState().isInspectorOpen).toBe(false);
+		expect(useUiStore.getState().inspectorOpenBySessionId["sess-1"]).toBe(false);
 
 		// Dragging it back open reopens + persists the width.
 		act(() => entry.onResize?.({ asPercentage: 31.5, inPixels: 400 }));
-		expect(useUiStore.getState().isInspectorOpen).toBe(true);
+		expect(useUiStore.getState().inspectorOpenBySessionId["sess-1"]).toBe(true);
 		expect(window.localStorage.getItem("ao.inspector.split")).toBe("31.5");
 	});
 
@@ -262,12 +270,12 @@ describe("SessionView", () => {
 
 		// Mount-time/layout event at 0% must not collapse the store…
 		act(() => entry.onResize?.({ asPercentage: 0, inPixels: 0 }));
-		expect(useUiStore.getState().isInspectorOpen).toBe(true);
+		expect(useUiStore.getState().inspectorOpenBySessionId["sess-1"]).toBe(true);
 
 		// …and a mid-collapse transition frame must not re-open or persist.
-		act(() => useUiStore.getState().toggleInspector());
+		act(() => useUiStore.getState().toggleInspector("sess-1"));
 		act(() => entry.onResize?.({ asPercentage: 12.4, inPixels: 160 }));
-		expect(useUiStore.getState().isInspectorOpen).toBe(false);
+		expect(useUiStore.getState().inspectorOpenBySessionId["sess-1"]).toBe(false);
 		expect(window.localStorage.getItem("ao.inspector.split")).toBeNull();
 	});
 
@@ -284,13 +292,13 @@ describe("SessionView", () => {
 	// inspector" and unwound the route to the error boundary. The panel must
 	// mount already in sync via defaultSize instead.
 	it("mounts the inspector in sync when navigating from an orchestrator session, without the imperative API", () => {
-		useUiStore.setState({ isInspectorOpen: false });
+		useUiStore.setState({ isInspectorOpen: false, inspectorOpenBySessionId: { "sess-1": false } });
 		const { rerender } = render(<SessionView sessionId="sess-orch" />);
 		expect(screen.queryByTestId("panel-inspector")).not.toBeInTheDocument();
 
 		// Toggled open while on the orchestrator (shell topbar button) — the
 		// panel that mounts later must pick this up from defaultSize alone.
-		act(() => useUiStore.getState().toggleInspector());
+		act(() => useUiStore.getState().toggleInspector("sess-1"));
 		rerender(<SessionView sessionId="sess-1" />);
 
 		expect(panelSizes("inspector")[0]).toMatch(/^[1-9]\d*(\.\d+)?%$/);
@@ -329,19 +337,37 @@ describe("SessionView", () => {
 
 	it("reveals an `ao preview` URL in the inspector Browser tab, not the center pane", () => {
 		const worker = workspaces[0].sessions[0];
-		worker.previewUrl = "http://localhost:5173/";
 		try {
-			useUiStore.setState({ isInspectorOpen: false });
-			render(<SessionView sessionId="sess-1" />);
+			useUiStore.setState({ isInspectorOpen: false, inspectorOpenBySessionId: { "sess-1": false } });
+			delete worker.previewUrl;
+			delete worker.previewRevision;
+			const { rerender } = render(<SessionView sessionId="sess-1" />);
+			worker.previewUrl = "http://localhost:5173/";
+			worker.previewRevision = 1;
+			rerender(<SessionView sessionId="sess-1" />);
 
 			// Center pane keeps the terminal — the preview must not pop out over it.
 			expect(screen.getByText("terminal center")).toBeInTheDocument();
 			expect(screen.queryByRole("button", { name: "browser center" })).not.toBeInTheDocument();
 			// Rail opened and switched to the Browser tab.
-			expect(useUiStore.getState().isInspectorOpen).toBe(true);
+			expect(useUiStore.getState().inspectorOpenBySessionId["sess-1"]).toBe(true);
 			expect(screen.getByRole("button", { name: "pop browser" })).toHaveAttribute("data-view", "browser");
 		} finally {
 			delete worker.previewUrl;
+			delete worker.previewRevision;
 		}
+	});
+
+	it("does not open the browser tab just because a different worker has a stored preview URL", () => {
+		useUiStore.setState({
+			isInspectorOpen: false,
+			inspectorOpenBySessionId: { "sess-1": false, "sess-2": false },
+		});
+		const { rerender } = render(<SessionView sessionId="sess-1" />);
+
+		rerender(<SessionView sessionId="sess-2" />);
+
+		expect(useUiStore.getState().inspectorOpenBySessionId["sess-2"]).toBe(false);
+		expect(screen.getByRole("button", { name: "pop browser", hidden: true })).toHaveAttribute("data-view", "summary");
 	});
 });

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -69,6 +69,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		previewUrl,
 		previewRevision,
 	});
+	const refreshBrowserBounds = browserView.refreshBounds;
 	const browserAnnotationQueue = useBrowserAnnotationQueue({
 		sessionId: session?.id,
 		navUrl: browserView.navState.url,
@@ -181,6 +182,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// with the expand()/collapse() effect above.
 	const handleInspectorResize = useCallback(
 		(size: PanelSize) => {
+			refreshBrowserBounds();
 			if (inspectorSeparatorRef.current?.getAttribute("data-separator") !== "active") return;
 			const open = useUiStore.getState().inspectorOpenBySessionId[sessionId] ?? false;
 			if (size.asPercentage > 0) {
@@ -190,7 +192,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 				setInspectorOpen(false, sessionId);
 			}
 		},
-		[sessionId, setInspectorOpen],
+		[refreshBrowserBounds, sessionId, setInspectorOpen],
 	);
 
 	if (!session && !workspaceQuery.isLoading) {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -41,14 +41,19 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const workspaceQuery = useWorkspaceQuery();
 	const workspaces = workspaceQuery.data ?? [];
 	const { theme } = useUiStore();
-	const isInspectorOpen = useUiStore((state) => state.isInspectorOpen);
+	const isInspectorOpen = useUiStore((state) => state.inspectorOpenBySessionId[sessionId] ?? false);
+	const setInspectorOpen = useUiStore((state) => state.setInspectorOpen);
 	const toggleInspector = useUiStore((state) => state.toggleInspector);
 	const { daemonStatus } = useShell();
 	const inspectorRef = useRef<PanelImperativeHandle | null>(null);
 	const inspectorSeparatorRef = useRef<HTMLDivElement | null>(null);
+	const inspectorPanelMountedRef = useRef(false);
 	const [terminalTarget, setTerminalTarget] = useState<TerminalTarget>({ kind: "worker" });
 	const [browserPoppedOut, setBrowserPoppedOut] = useState(false);
 	const [inspectorView, setInspectorView] = useState<InspectorView>("summary");
+	const inspectorViewRef = useRef<InspectorView>("summary");
+	const inspectorViewBySessionRef = useRef<Map<string, InspectorView>>(new Map());
+	const observedPreviewBySessionRef = useRef<Map<string, { revision: number | null; target: string }>>(new Map());
 
 	const session = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
 	const isOrchestrator = session ? isOrchestratorSession(session) : false;
@@ -56,7 +61,6 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const hasInspector = !isOrchestrator;
 	const previewUrl = session?.previewUrl?.trim() || undefined;
 	const previewRevision = session?.previewRevision;
-	const revealedPreviewRef = useRef<number | null>(null);
 	const browserView = useBrowserView({
 		sessionId,
 		active: Boolean(session && hasInspector && (browserPoppedOut || isInspectorOpen)),
@@ -71,24 +75,35 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	});
 
 	useEffect(() => {
+		inspectorViewRef.current = inspectorView;
+	}, [inspectorView]);
+
+	useEffect(() => {
 		setTerminalTarget({ kind: "worker" });
 		setBrowserPoppedOut(false);
-		setInspectorView("summary");
-		revealedPreviewRef.current = null;
+		setInspectorView(inspectorViewBySessionRef.current.get(sessionId) ?? "summary");
+		return () => {
+			inspectorViewBySessionRef.current.set(sessionId, inspectorViewRef.current);
+		};
 	}, [sessionId]);
 
 	// `ao preview` sets session.previewUrl (streamed over CDC); surface the result
 	// in the inspector rail's Browser tab (opening the rail if collapsed), not the
-	// center pane. Tracked per preview revision so re-revealing fires on every
-	// `ao preview` (even a re-run of the same target) while a manual tab switch
-	// sticks for a given revision. `ao preview clear` (empty url) does not reveal.
+	// center pane. The first preview payload observed for a navigated-to session
+	// is treated as restored daemon state, not a fresh reveal, so switching
+	// sessions never opens the browser on its own. Later revision bumps still
+	// reveal, including `ao preview` re-runs of the same URL.
 	useEffect(() => {
-		const revision = previewRevision ?? 0;
-		if (!previewUrl || revealedPreviewRef.current === revision) return;
-		revealedPreviewRef.current = revision;
+		if (!session || !hasInspector) return;
+		const revision = typeof previewRevision === "number" ? previewRevision : null;
+		const target = previewUrl ?? "";
+		const previous = observedPreviewBySessionRef.current.get(sessionId);
+		if (previous?.revision === revision && previous.target === target) return;
+		observedPreviewBySessionRef.current.set(sessionId, { revision, target });
+		if (!previous || !target) return;
 		setInspectorView("browser");
-		if (!useUiStore.getState().isInspectorOpen) toggleInspector();
-	}, [previewRevision, previewUrl, toggleInspector]);
+		setInspectorOpen(true, sessionId);
+	}, [hasInspector, previewRevision, previewUrl, session, sessionId, setInspectorOpen]);
 
 	// Computed when the inspector panel mounts and frozen while it stays
 	// mounted: rrp re-registers the panel (a layout effect keyed on defaultSize,
@@ -105,6 +120,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const inspectorDefaultSizeRef = useRef<string | null>(null);
 	if (!hasInspector) {
 		inspectorDefaultSizeRef.current = null;
+		inspectorPanelMountedRef.current = false;
 	} else if (inspectorDefaultSizeRef.current === null) {
 		inspectorDefaultSizeRef.current = isInspectorOpen ? `${initialSplitPercent()}%` : "0%";
 	}
@@ -116,11 +132,11 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			if (event.key.toLowerCase() !== "b" || !event.shiftKey) return;
 			if (!event.metaKey && !event.ctrlKey) return;
 			event.preventDefault();
-			toggleInspector();
+			toggleInspector(sessionId);
 		};
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [hasInspector, toggleInspector]);
+	}, [hasInspector, sessionId, toggleInspector]);
 
 	// Drive the collapsible panel from the store so the topbar button, ⌘⇧B, and
 	// drag-to-collapse all stay in sync. hasInspector must NOT be a dep: when
@@ -133,6 +149,10 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	useEffect(() => {
 		const panel = inspectorRef.current;
 		if (!panel) return;
+		if (!inspectorPanelMountedRef.current) {
+			inspectorPanelMountedRef.current = true;
+			return;
+		}
 		if (isInspectorOpen) {
 			panel.expand();
 			// expand() restores the "most recent" size, which is 0 when the panel
@@ -162,15 +182,15 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const handleInspectorResize = useCallback(
 		(size: PanelSize) => {
 			if (inspectorSeparatorRef.current?.getAttribute("data-separator") !== "active") return;
-			const open = useUiStore.getState().isInspectorOpen;
+			const open = useUiStore.getState().inspectorOpenBySessionId[sessionId] ?? false;
 			if (size.asPercentage > 0) {
 				window.localStorage?.setItem(inspectorSplitStorageKey, String(size.asPercentage));
-				if (!open) toggleInspector();
+				if (!open) setInspectorOpen(true, sessionId);
 			} else if (open) {
-				toggleInspector();
+				setInspectorOpen(false, sessionId);
 			}
 		},
-		[toggleInspector],
+		[sessionId, setInspectorOpen],
 	);
 
 	if (!session && !workspaceQuery.isLoading) {

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { navigateMock, workspaceQueryMock } = vi.hoisted(() => ({
@@ -101,5 +101,49 @@ describe("SessionsBoard", () => {
 		const badge = screen.getByText("Idle").closest("span");
 		expect(badge).toHaveClass("text-passive");
 		expect(badge).not.toHaveClass("text-working");
+	});
+
+	it("shows session ids on duplicate-titled board cards and terminated chips", () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					id: "p1",
+					name: "radic",
+					path: "/tmp/radic",
+					sessions: [
+						{
+							id: "radic-3",
+							workspaceId: "p1",
+							workspaceName: "radic",
+							title: "Verify the nav fix",
+							provider: "claude-code",
+							branch: "ao/verify-nav",
+							status: "terminated",
+							updatedAt: "2026-01-01T00:00:00Z",
+							prs: [],
+						},
+						{
+							id: "radic-4",
+							workspaceId: "p1",
+							workspaceName: "radic",
+							title: "Verify the nav fix",
+							provider: "claude-code",
+							branch: "ao/verify-nav",
+							status: "needs_input",
+							updatedAt: "2026-01-01T00:00:00Z",
+							prs: [],
+						},
+					],
+				},
+			],
+			isError: false,
+		});
+
+		renderBoard("p1");
+
+		expect(screen.getByText("radic-4")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: /done \/ terminated/i }));
+		expect(screen.getByText("radic-3")).toBeInTheDocument();
+		expect(screen.getAllByText("Verify the nav fix")).toHaveLength(2);
 	});
 });

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -316,7 +316,10 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 									onClick={() => openSession(s)}
 									type="button"
 								>
-									<span className="text-xs text-muted-foreground">{s.title}</span>
+									<span className="block max-w-56 truncate text-xs text-muted-foreground">{s.title}</span>
+									{!sameLabel(s.title, s.id) ? (
+										<span className="mt-1 block max-w-56 truncate font-mono text-2xs text-passive">{s.id}</span>
+									) : null}
 								</button>
 							))}
 						</div>
@@ -377,6 +380,8 @@ function SessionCard({ session, onOpen }: { session: WorkspaceSession; onOpen: (
 	const branch = session.branch || "";
 	const showBranch = branch !== "" && !sameLabel(branch, session.title) && !sameLabel(branch, session.id);
 	const prSummaries = sessionPRDisplaySummaries(session, useSessionScmSummary(session.id).data);
+	const showSessionId = !sameLabel(session.title, session.id);
+	const metaLines = [showSessionId ? session.id : "", showBranch ? branch : ""].filter(Boolean);
 	const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
 		if (event.currentTarget !== event.target) return;
 		if (event.key !== "Enter" && event.key !== " ") return;
@@ -406,13 +411,21 @@ function SessionCard({ session, onOpen }: { session: WorkspaceSession; onOpen: (
 				<div
 					className={cn(
 						"px-3.25 text-control font-medium leading-snug tracking-tight text-foreground",
-						showBranch ? "pb-2" : "pb-3",
+						metaLines.length > 0 ? "pb-2" : "pb-3",
 						"line-clamp-2 overflow-hidden",
 					)}
 				>
 					{session.title}
 				</div>
-				{showBranch && <div className="px-3.25 pb-2.5 font-mono text-2xs text-passive">{branch}</div>}
+				{metaLines.length > 0 && (
+					<div className="flex flex-col gap-1 px-3.25 pb-2.5 font-mono text-2xs leading-tight text-passive">
+						{metaLines.map((line) => (
+							<span key={line} className="truncate">
+								{line}
+							</span>
+						))}
+					</div>
+				)}
 			</div>
 			<div
 				className="border-t border-border px-3.25 py-2 font-mono text-2xs text-passive"

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -63,7 +63,9 @@ export function ShellTopbar() {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const params = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
-	const isInspectorOpen = useUiStore((state) => state.isInspectorOpen);
+	const isInspectorOpen = useUiStore((state) =>
+		params.sessionId ? (state.inspectorOpenBySessionId[params.sessionId] ?? false) : state.isInspectorOpen,
+	);
 	const toggleInspector = useUiStore((state) => state.toggleInspector);
 	const restartingProjectIds = useUiStore((state) => state.restartingProjectIds);
 	const [isSpawning, setIsSpawning] = useState(false);
@@ -98,6 +100,11 @@ export function ShellTopbar() {
 	const openNewTask = () => {
 		if (!projectId || isProjectRestarting) return;
 		setIsNewTaskOpen(true);
+	};
+
+	const toggleSessionInspector = () => {
+		if (!session?.id) return;
+		toggleInspector(session.id);
 	};
 
 	const handleTaskCreated = async (sessionId: string) => {
@@ -236,7 +243,7 @@ export function ShellTopbar() {
 							<TopbarButton
 								aria-label={isInspectorOpen ? "Close inspector panel" : "Open inspector panel"}
 								aria-pressed={isInspectorOpen}
-								onClick={toggleInspector}
+								onClick={toggleSessionInspector}
 								style={noDragStyle}
 								title={`${isInspectorOpen ? "Close" : "Open"} inspector · ⌘⇧B`}
 								variant="icon"

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -39,6 +39,7 @@ export type BrowserViewModel = {
 	goForward: () => Promise<void>;
 	reload: () => Promise<void>;
 	stop: () => Promise<void>;
+	refreshBounds: () => void;
 	destroy: () => void;
 	annotationMode: boolean;
 	setAnnotationMode: (enabled: boolean) => Promise<void>;
@@ -474,6 +475,7 @@ export function useBrowserView({
 		goForward: () => (hasNativeBrowser ? withView((id) => window.ao!.browser.goForward(id)) : Promise.resolve()),
 		reload: () => (hasNativeBrowser ? withView((id) => window.ao!.browser.reload(id)) : Promise.resolve()),
 		stop: () => (hasNativeBrowser ? withView((id) => window.ao!.browser.stop(id)) : Promise.resolve()),
+		refreshBounds: scheduleSettleMeasure,
 		destroy,
 		annotationMode,
 		setAnnotationMode,

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -14,7 +14,9 @@ export type WorkbenchTab = "changes" | "files" | "terminal";
 type UiState = {
 	workbenchTab: WorkbenchTab;
 	isSidebarOpen: boolean;
+	/** Legacy/global mirror; worker session routes should use inspectorOpenBySessionId. */
 	isInspectorOpen: boolean;
+	inspectorOpenBySessionId: Record<string, boolean>;
 	theme: Theme;
 	restartingProjectIds: ReadonlySet<string>;
 	orchestratorReplacementErrors: Record<string, string>;
@@ -23,7 +25,8 @@ type UiState = {
 	setTheme: (theme: Theme) => void;
 	toggleTheme: () => void;
 	toggleSidebar: () => void;
-	toggleInspector: () => void;
+	setInspectorOpen: (open: boolean, sessionId?: string) => void;
+	toggleInspector: (sessionId?: string) => void;
 	setProjectRestarting: (projectId: string, restarting: boolean) => void;
 	setOrchestratorReplacementError: (projectId: string, message: string | null) => void;
 	setOrchestratorStartupError: (projectId: string, message: string | null) => void;
@@ -42,13 +45,14 @@ function initialSidebarOpen() {
 }
 
 function initialInspectorOpen() {
-	return getLocalStorage()?.getItem(inspectorStorageKey) !== "false";
+	return getLocalStorage()?.getItem(inspectorStorageKey) === "true";
 }
 
 export const useUiStore = create<UiState>((set) => ({
 	workbenchTab: "changes",
 	isSidebarOpen: initialSidebarOpen(),
 	isInspectorOpen: initialInspectorOpen(),
+	inspectorOpenBySessionId: {},
 	theme: resolveTheme(),
 	restartingProjectIds: new Set<string>(),
 	orchestratorReplacementErrors: {},
@@ -70,11 +74,24 @@ export const useUiStore = create<UiState>((set) => ({
 			getLocalStorage()?.setItem(sidebarStorageKey, String(isSidebarOpen));
 			return { isSidebarOpen };
 		}),
-	toggleInspector: () =>
+	setInspectorOpen: (open, sessionId) =>
+		set((state) => ({
+			isInspectorOpen: open,
+			inspectorOpenBySessionId: sessionId
+				? { ...state.inspectorOpenBySessionId, [sessionId]: open }
+				: state.inspectorOpenBySessionId,
+		})),
+	toggleInspector: (sessionId) =>
 		set((state) => {
-			const isInspectorOpen = !state.isInspectorOpen;
-			getLocalStorage()?.setItem(inspectorStorageKey, String(isInspectorOpen));
-			return { isInspectorOpen };
+			const current = sessionId ? (state.inspectorOpenBySessionId[sessionId] ?? false) : state.isInspectorOpen;
+			const isInspectorOpen = !current;
+			if (!sessionId) getLocalStorage()?.setItem(inspectorStorageKey, String(isInspectorOpen));
+			return {
+				isInspectorOpen,
+				inspectorOpenBySessionId: sessionId
+					? { ...state.inspectorOpenBySessionId, [sessionId]: isInspectorOpen }
+					: state.inspectorOpenBySessionId,
+			};
 		}),
 	setProjectRestarting: (projectId, restarting) =>
 		set((state) => {


### PR DESCRIPTION
## Summary
- Fixes #2693 by exposing a browser bounds refresh hook and invoking it during inspector split resize, so native browser content remeasures with the right pane.
- Fixes #2698 by making worker inspector open/closed state per-session, defaulting it closed, and treating existing preview URLs as restored state instead of navigation-triggered browser reveals.
- Fixes #2703 by showing session ids as secondary metadata on board cards and Done / Terminated chips so duplicate auto-named sessions are visually distinguishable.

## Validation
- npm test -- --run src/renderer/components/SessionView.test.tsx src/renderer/components/SessionsBoard.test.tsx src/renderer/components/BrowserPanel.test.tsx src/renderer/hooks/useBrowserView.test.tsx
- npm test
- npm run frontend:typecheck
- ao preview http://127.0.0.1:5173/
- Visual check with local Chrome/Playwright against the same renderer URL: board id metadata visible, no horizontal button overflow, worker inspector starts hidden/inert with Browser tab unselected.

## Notes
- In-app Browser control was unavailable in this session due a node_repl sandbox metadata error, so visual inspection used local Chrome after the requested ao preview step.
- Playwright browser download failed due network resets; local Google Chrome was used as the executable.