### PR TITLE
Resume agent sessions with their existing transcripts

### DIFF
--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/activitydispatch"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
 // sessionIDPattern bounds the AO_SESSION_ID we will place in a request path to
@@ -37,13 +38,14 @@ const (
 // POST /api/v1/sessions/{id}/activity. The CLI keeps its own copy so it need
 // not import httpd. Event carries the AO hook sub-command that produced the
 // state; ToolName/ToolUseID are the tool-use correlation facts lifted from the
-// native payload when present. All three are optional: an old daemon decodes
+// native payload when present. All four are optional: an old daemon decodes
 // the body leniently and simply ignores them.
 type setActivityAPIRequest struct {
-	State     string `json:"state"`
-	Event     string `json:"event,omitempty"`
-	ToolName  string `json:"toolName,omitempty"`
-	ToolUseID string `json:"toolUseId,omitempty"`
+	State          string `json:"state,omitempty"`
+	Event          string `json:"event,omitempty"`
+	ToolName       string `json:"toolName,omitempty"`
+	ToolUseID      string `json:"toolUseId,omitempty"`
+	AgentSessionID string `json:"agentSessionId,omitempty"`
 }
 
 // maxActivityMetaLen caps the correlation fields lifted from a native hook
@@ -70,6 +72,22 @@ func activityMeta(payload []byte) (toolName, toolUseID string) {
 		p.ToolUseID = ""
 	}
 	return p.ToolName, p.ToolUseID
+}
+
+// hookAgentSessionID extracts the native resume handle shared by Codex,
+// Claude Code, and other Claude-format hook payloads. It is independent of
+// activity derivation because SessionStart is intentionally metadata-only for
+// harnesses where process startup is not proof that a turn is active.
+func hookAgentSessionID(payload []byte) string {
+	var p struct {
+		SessionID string `json:"session_id"`
+	}
+	_ = json.Unmarshal(payload, &p)
+	id := strings.TrimSpace(p.SessionID)
+	if len(id) > maxActivityMetaLen {
+		return ""
+	}
+	return id
 }
 
 type sessionStartHookOutput struct {
@@ -118,15 +136,29 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 		c.emitSessionStartContext(agent, event, sessionID)
 	}
 
-	state, ok := activitydispatch.Derive(agent, event, payload)
-	if !ok {
-		// Unknown agent, or an event that carries no activity signal: report nothing.
+	state, hasActivity := activitydispatch.Derive(agent, event, payload)
+	agentSessionID := ""
+	if activitydispatch.SupportsHarness(domain.AgentHarness(agent)) {
+		agentSessionID = hookAgentSessionID(payload)
+	}
+	if !hasActivity && agentSessionID == "" {
+		// Unknown agent, or an event carrying neither activity nor resumable
+		// session metadata: report nothing.
 		return nil
 	}
 
 	toolName, toolUseID := activityMeta(payload)
 	path := "sessions/" + url.PathEscape(sessionID) + "/activity"
-	if err := c.postJSON(ctx, path, setActivityAPIRequest{State: string(state), Event: event, ToolName: toolName, ToolUseID: toolUseID}, nil); err != nil {
+	req := setActivityAPIRequest{
+		Event:          event,
+		ToolName:       toolName,
+		ToolUseID:      toolUseID,
+		AgentSessionID: agentSessionID,
+	}
+	if hasActivity {
+		req.State = string(state)
+	}
+	if err := c.postJSON(ctx, path, req, nil); err != nil {
 		// Surface the failure for diagnosis, but exit 0: a failed activity
 		// report must not disrupt the agent.
 		c.reportHookFailure(agent, event, sessionID, err)

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -130,6 +130,70 @@ func TestHooks_StopReportsIdle(t *testing.T) {
 	}
 }
 
+func TestHooks_SessionStartReportsNativeSessionIDWithoutActivity(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"session_id":"019f6af0-codex-session"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "codex", "session-start")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
+	}
+	want := setActivityAPIRequest{Event: "session-start", AgentSessionID: "019f6af0-codex-session"}
+	if req != want {
+		t.Fatalf("body = %+v, want %+v", req, want)
+	}
+}
+
+func TestHooks_ActivityAlsoReportsNativeSessionID(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"session_id":"claude-session-1"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "claude-code", "stop")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
+	}
+	want := setActivityAPIRequest{State: "idle", Event: "stop", AgentSessionID: "claude-session-1"}
+	if req != want {
+		t.Fatalf("body = %+v, want %+v", req, want)
+	}
+}
+
+func TestHooks_UnknownAgentCannotReportNativeSessionID(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"session_id":"untrusted-session"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "unknown-agent", "session-start")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capture.hits != 0 {
+		t.Fatalf("unknown agent reported metadata; hits=%d body=%s", capture.hits, capture.body)
+	}
+}
+
 func TestHooks_ClaudeCodePermissionRequestReportsBlocked(t *testing.T) {
 	// claude-code installs the pre/post-tool-use trio, so a permission-request
 	// blocked state can be correlated and cleared — it is the one harness that

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2782,11 +2782,15 @@ components:
       type: object
     SetActivityRequest:
       properties:
+        agentSessionId:
+          description: Native agent session identifier used to resume its transcript.
+          type: string
         event:
           description: AO hook sub-command that produced this state (e.g. post-tool-use).
           type: string
         state:
-          description: Agent activity state reported by an agent hook.
+          description: Agent activity state reported by an agent hook. Optional for
+            metadata-only hooks.
           enum:
           - active
           - idle
@@ -2800,8 +2804,6 @@ components:
         toolUseId:
           description: Native tool-use id, for tool-use hook events.
           type: string
-      required:
-      - state
       type: object
     SetActivityResponse:
       properties:

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -413,11 +413,13 @@ type ClaimPRResponse struct {
 // specific approved tool finishes. Absent on old CLIs and on adapters whose
 // payloads carry no tool identity — the signal then keeps its plain
 // state-only semantics.
+// AgentSessionID may arrive without State on metadata-only SessionStart hooks.
 type SetActivityRequest struct {
-	State     string `json:"state" enum:"active,idle,waiting_input,blocked,exited" description:"Agent activity state reported by an agent hook."`
-	Event     string `json:"event,omitempty" description:"AO hook sub-command that produced this state (e.g. post-tool-use)."`
-	ToolName  string `json:"toolName,omitempty" description:"Native tool name, for tool-use hook events."`
-	ToolUseID string `json:"toolUseId,omitempty" description:"Native tool-use id, for tool-use hook events."`
+	State          string `json:"state,omitempty" enum:"active,idle,waiting_input,blocked,exited" description:"Agent activity state reported by an agent hook. Optional for metadata-only hooks."`
+	Event          string `json:"event,omitempty" description:"AO hook sub-command that produced this state (e.g. post-tool-use)."`
+	ToolName       string `json:"toolName,omitempty" description:"Native tool name, for tool-use hook events."`
+	ToolUseID      string `json:"toolUseId,omitempty" description:"Native tool-use id, for tool-use hook events."`
+	AgentSessionID string `json:"agentSessionId,omitempty" description:"Native agent session identifier used to resume its transcript."`
 }
 
 // SetActivityResponse is the body of POST /api/v1/sessions/{sessionId}/activity.

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -459,10 +459,17 @@ func (c *SessionsController) activity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	state := domain.ActivityState(in.State)
-	switch state {
-	case domain.ActivityActive, domain.ActivityIdle, domain.ActivityWaitingInput, domain.ActivityBlocked, domain.ActivityExited:
-	default:
-		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_ACTIVITY_STATE", "Unknown activity state", nil)
+	if state != "" {
+		switch state {
+		case domain.ActivityActive, domain.ActivityIdle, domain.ActivityWaitingInput, domain.ActivityBlocked, domain.ActivityExited:
+		default:
+			envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_ACTIVITY_STATE", "Unknown activity state", nil)
+			return
+		}
+	}
+	agentSessionID := capActivityMeta(domain.SanitizeControlChars(strings.TrimSpace(in.AgentSessionID)))
+	if state == "" && agentSessionID == "" {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "ACTIVITY_OR_SESSION_ID_REQUIRED", "Activity state or agent session ID is required", nil)
 		return
 	}
 	// The correlation fields ride the same lenient decode: absent on old CLIs.
@@ -471,11 +478,12 @@ func (c *SessionsController) activity(w http.ResponseWriter, r *http.Request) {
 	// never match its pre/post counterpart, so overlong values are dropped by
 	// the CLI; the cap here is defense against non-AO callers).
 	sig := ports.ActivitySignal{
-		Valid:     true,
-		State:     state,
-		Event:     capActivityMeta(domain.SanitizeControlChars(in.Event)),
-		ToolName:  capActivityMeta(domain.SanitizeControlChars(in.ToolName)),
-		ToolUseID: capActivityMeta(domain.SanitizeControlChars(in.ToolUseID)),
+		Valid:          state != "",
+		State:          state,
+		Event:          capActivityMeta(domain.SanitizeControlChars(in.Event)),
+		ToolName:       capActivityMeta(domain.SanitizeControlChars(in.ToolName)),
+		ToolUseID:      capActivityMeta(domain.SanitizeControlChars(in.ToolUseID)),
+		AgentSessionID: agentSessionID,
 	}
 	if err := c.Activity.ApplyActivitySignal(r.Context(), sessionID(r), sig); err != nil {
 		if errors.Is(err, ports.ErrSessionNotFound) {

--- a/backend/internal/httpd/controllers/sessions_activity_test.go
+++ b/backend/internal/httpd/controllers/sessions_activity_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
@@ -97,6 +98,36 @@ func TestSessionsAPI_ActivityThreadsCorrelationFields(t *testing.T) {
 	}
 }
 
+func TestSessionsAPI_ActivityAcceptsMetadataOnlyAgentSessionID(t *testing.T) {
+	rec := &fakeActivityRecorder{}
+	srv := newActivityTestServer(t, rec)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/activity",
+		`{"event":"session-start","agentSessionId":"native-session-1"}`)
+	if status != http.StatusOK {
+		t.Fatalf("activity = %d, want 200; body=%s", status, body)
+	}
+	want := ports.ActivitySignal{Event: "session-start", AgentSessionID: "native-session-1"}
+	if rec.gotSignal != want {
+		t.Fatalf("recorder signal = %#v, want %#v", rec.gotSignal, want)
+	}
+}
+
+func TestSessionsAPI_ActivityThreadsAgentSessionIDWithState(t *testing.T) {
+	rec := &fakeActivityRecorder{}
+	srv := newActivityTestServer(t, rec)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/activity",
+		`{"state":"idle","event":"stop","agentSessionId":"native-session-1"}`)
+	if status != http.StatusOK {
+		t.Fatalf("activity = %d, want 200; body=%s", status, body)
+	}
+	want := ports.ActivitySignal{Valid: true, State: domain.ActivityIdle, Event: "stop", AgentSessionID: "native-session-1"}
+	if rec.gotSignal != want {
+		t.Fatalf("recorder signal = %#v, want %#v", rec.gotSignal, want)
+	}
+}
+
 func TestSessionsAPI_ActivityCapsOverlongCorrelationFields(t *testing.T) {
 	// Overlong values are dropped, not truncated: a truncated id could never
 	// match its pre/post counterpart, so an empty value (fail-safe: no
@@ -129,6 +160,30 @@ func TestSessionsAPI_ActivityRejectsUnknownState(t *testing.T) {
 	assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_ACTIVITY_STATE")
 	if rec.calls != 0 {
 		t.Fatalf("recorder should not be called for an invalid state; calls=%d", rec.calls)
+	}
+}
+
+func TestSessionsAPI_ActivityRejectsEmptyMetadataOnlyRequest(t *testing.T) {
+	rec := &fakeActivityRecorder{}
+	srv := newActivityTestServer(t, rec)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/activity", `{"event":"session-start"}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "ACTIVITY_OR_SESSION_ID_REQUIRED")
+	if rec.calls != 0 {
+		t.Fatalf("recorder should not be called for an empty metadata request; calls=%d", rec.calls)
+	}
+}
+
+func TestSessionsAPI_ActivityRejectsOverlongMetadataOnlySessionID(t *testing.T) {
+	rec := &fakeActivityRecorder{}
+	srv := newActivityTestServer(t, rec)
+	longID := strings.Repeat("a", 300)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/activity",
+		`{"event":"session-start","agentSessionId":"`+longID+`"}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "ACTIVITY_OR_SESSION_ID_REQUIRED")
+	if rec.calls != 0 {
+		t.Fatalf("recorder should not be called for an overlong session id; calls=%d", rec.calls)
 	}
 }
 

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -125,9 +125,11 @@ func (m *Manager) ApplyRuntimeObservation(ctx context.Context, id domain.Session
 	})
 }
 
-// ApplyActivitySignal records an authoritative agent activity signal.
+// ApplyActivitySignal records an authoritative agent activity signal and any
+// native agent session id carried alongside it. Metadata-only hooks leave the
+// existing activity and first-signal facts untouched.
 func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, s ports.ActivitySignal) error {
-	if !s.Valid {
+	if !s.Valid && s.AgentSessionID == "" {
 		return nil
 	}
 	var intent *ports.NotificationIntent
@@ -152,10 +154,25 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	// rule, while their tracking side effects still land. Untagged signals
 	// (old CLIs, adapters without tool identity) pass through untouched —
 	// last-writer-wins, exactly as before.
-	s = m.applyToolPrecedenceLocked(id, rec.Activity.State, s)
-	if !s.Valid {
+	metadataChanged := s.AgentSessionID != "" && rec.Metadata.AgentSessionID != s.AgentSessionID
+	if s.Valid {
+		s = m.applyToolPrecedenceLocked(id, rec.Activity.State, s)
+	}
+	if !s.Valid && !metadataChanged {
 		m.mu.Unlock()
 		return nil
+	}
+	if !s.Valid {
+		rec.Metadata.AgentSessionID = s.AgentSessionID
+		rec.UpdatedAt = now
+		err := m.store.UpdateSession(ctx, rec)
+		m.mu.Unlock()
+		return err
+	}
+	if metadataChanged {
+		// Fold metadata into rec before copying it into next below, so the
+		// activity and resume handle land in one store update.
+		rec.Metadata.AgentSessionID = s.AgentSessionID
 	}
 	prevState := rec.Activity.State
 	prevAt := rec.Activity.LastActivityAt
@@ -167,6 +184,12 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	// first to ARRIVE may match the seeded state — e.g. a turn's "active"
 	// POST is lost and its Stop hook lands idle on the idle-seeded row.
 	if sameActivity(rec.Activity, act) && !rec.FirstSignalAt.IsZero() {
+		if metadataChanged {
+			rec.UpdatedAt = now
+			err := m.store.UpdateSession(ctx, rec)
+			m.mu.Unlock()
+			return err
+		}
 		m.mu.Unlock()
 		return nil
 	}

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -127,6 +127,49 @@ func TestActivity_InvalidIsIgnored(t *testing.T) {
 	}
 }
 
+func TestActivity_MetadataOnlyStoresAgentSessionIDWithoutChangingActivity(t *testing.T) {
+	m, st, _ := newManager()
+	rec := working("mer-1")
+	rec.FirstSignalAt = time.Now().Add(-time.Minute)
+	st.sessions["mer-1"] = rec
+
+	if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{AgentSessionID: "native-session-1"}); err != nil {
+		t.Fatal(err)
+	}
+	got := st.sessions["mer-1"]
+	if got.Metadata.AgentSessionID != "native-session-1" {
+		t.Fatalf("AgentSessionID = %q, want native-session-1", got.Metadata.AgentSessionID)
+	}
+	if got.Activity != rec.Activity {
+		t.Fatalf("metadata-only hook changed activity: got %+v, want %+v", got.Activity, rec.Activity)
+	}
+	if !got.FirstSignalAt.Equal(rec.FirstSignalAt) {
+		t.Fatalf("metadata-only hook changed FirstSignalAt: got %v, want %v", got.FirstSignalAt, rec.FirstSignalAt)
+	}
+}
+
+func TestActivity_SameStateSignalStillStoresAgentSessionID(t *testing.T) {
+	m, st, _ := newManager()
+	rec := working("mer-1")
+	rec.FirstSignalAt = time.Now().Add(-time.Minute)
+	st.sessions["mer-1"] = rec
+
+	if err := m.ApplyActivitySignal(ctx, "mer-1", ports.ActivitySignal{
+		Valid:          true,
+		State:          rec.Activity.State,
+		AgentSessionID: "native-session-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := st.sessions["mer-1"]
+	if got.Metadata.AgentSessionID != "native-session-1" {
+		t.Fatalf("AgentSessionID = %q, want native-session-1", got.Metadata.AgentSessionID)
+	}
+	if got.Activity != rec.Activity {
+		t.Fatalf("same-state metadata signal changed activity: got %+v, want %+v", got.Activity, rec.Activity)
+	}
+}
+
 func TestActivity_MissingSessionReturnsNotFound(t *testing.T) {
 	m, _, _ := newManager()
 	err := m.ApplyActivitySignal(ctx, "missing-1", ports.ActivitySignal{Valid: true, State: domain.ActivityWaitingInput})

--- a/backend/internal/ports/runtime_observations.go
+++ b/backend/internal/ports/runtime_observations.go
@@ -24,8 +24,11 @@ type RuntimeFacts struct {
 	Probe      ProbeResult
 }
 
-// ActivitySignal is pushed by the agent hooks. Only a Valid signal is
+// ActivitySignal is pushed by the agent hooks. Only a Valid activity state is
 // authoritative; a stale/absent one is ignored rather than read as idleness.
+// AgentSessionID may be supplied independently by metadata-only hooks such as
+// SessionStart, allowing lifecycle to persist the native resume handle without
+// inventing an activity transition.
 //
 // Event/ToolName/ToolUseID are optional correlation facts: the AO hook
 // sub-command that produced the state and, for tool-use hooks, the native
@@ -34,10 +37,11 @@ type RuntimeFacts struct {
 // (old CLIs, adapters with no tool identity) keeps plain last-writer-wins
 // state semantics.
 type ActivitySignal struct {
-	Valid     bool
-	State     domain.ActivityState
-	Timestamp time.Time
-	Event     string
-	ToolName  string
-	ToolUseID string
+	Valid          bool
+	State          domain.ActivityState
+	Timestamp      time.Time
+	Event          string
+	ToolName       string
+	ToolUseID      string
+	AgentSessionID string
 }

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1050,13 +1050,15 @@ export interface components {
             session: components["schemas"]["ControllersSessionView"];
         };
         SetActivityRequest: {
+            /** @description Native agent session identifier used to resume its transcript. */
+            agentSessionId?: string;
             /** @description AO hook sub-command that produced this state (e.g. post-tool-use). */
             event?: string;
             /**
-             * @description Agent activity state reported by an agent hook.
+             * @description Agent activity state reported by an agent hook. Optional for metadata-only hooks.
              * @enum {string}
              */
-            state: "active" | "idle" | "waiting_input" | "blocked" | "exited";
+            state?: "active" | "idle" | "waiting_input" | "blocked" | "exited";
             /** @description Native tool name, for tool-use hook events. */
             toolName?: string;
             /** @description Native tool-use id, for tool-use hook events. */


### PR DESCRIPTION
## Issue

Restoring an agent session restarted the harness with its original prompt instead of continuing the native agent conversation.

The Codex and Claude Code adapters already supported native resume commands, but AO did not persist the native `session_id` supplied by their hooks. Restore therefore received an empty resume handle and fell back to a fresh launch, losing the active transcript context.

## Fix

Capture `session_id` from supported agent hook payloads and persist it as the session's native resume handle.

The change:

- extracts native session IDs from supported hook payloads
- allows metadata-only `SessionStart` reports without fabricating an activity transition
- persists metadata and activity together when they arrive in the same hook
- preserves existing activity, blocked-state, and first-signal behavior
- rejects metadata from unknown harnesses and drops oversized session IDs
- lets the existing Codex and Claude Code adapters resume by exact native session ID
- keeps existing fallback behavior when no trustworthy native ID is available

No transcript scanning, guessed `--last` session, or database migration is introduced.

## Files affected

- `backend/internal/cli/hooks.go`
  - Extracts native session IDs and includes them in hook reports.
- `backend/internal/cli/hooks_test.go`
  - Covers metadata-only hooks, activity-plus-metadata, and unknown harnesses.
- `backend/internal/ports/runtime_observations.go`
  - Carries the optional native session ID through the lifecycle signal.
- `backend/internal/lifecycle/manager.go`
  - Persists native session metadata without changing activity state.
- `backend/internal/lifecycle/manager_test.go`
  - Verifies metadata-only and same-state signals preserve lifecycle facts.
- `backend/internal/httpd/controllers/dto.go`
  - Adds the optional `agentSessionId` hook request field.
- `backend/internal/httpd/controllers/sessions.go`
  - Validates and forwards activity or metadata-only hook reports.
- `backend/internal/httpd/controllers/sessions_activity_test.go`
  - Covers metadata-only requests, combined reports, empty requests, and oversized IDs.
- `backend/internal/httpd/apispec/openapi.yaml`
  - Regenerates the API contract.
- `frontend/src/api/schema.ts`
  - Regenerates the frontend API types.

## Validation

- `go test ./internal/cli ./internal/lifecycle`
- `go test ./internal/httpd/controllers -run 'TestSessionsAPI_Activity'`
- `go test ./internal/httpd/apispec/...`
- `go test ./internal/session_manager -run 'TestRestore'`
- `go test ./internal/adapters/agent/claudecode`
- Codex adapter suite passed with two Windows temp-path tests skipped because `filepath.EvalSymlinks(t.TempDir())` failed with OS access denied before reaching their assertions.
- `npm run frontend:typecheck`
- OpenAPI and TypeScript API artifacts regenerated successfully.
- `git diff --check`

### Live Codex verification

Tested against the running development daemon:

1. Spawned Codex session `ao-test-2-8`.
2. Confirmed native session ID `019f6abd-998f-77a1-bb78-6a2d47b69b78` was persisted.
3. Sent the secondary transcript marker `BRAVO-942`.
4. Killed and restored the AO session.
5. Confirmed the native session ID remained unchanged.
6. Asked Codex for the pre-restore secondary marker.
7. Codex answered `BRAVO-942` from the same native JSONL transcript.
8. Confirmed the original launch prompt was not replayed as a new turn.