### PR TITLE
fix(browser): re-measure preview overlay on inspector divider drag (#2693)

### DIFF
--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -70,6 +70,7 @@ vi.mock("./BrowserPanel", () => ({
 	}),
 }));
 const browserDestroy = vi.hoisted(() => vi.fn());
+const browserRemeasure = vi.hoisted(() => vi.fn());
 vi.mock("../hooks/useBrowserView", () => ({
 	useBrowserView: () => ({
 		viewId: "browser:sess-1",
@@ -82,6 +83,7 @@ vi.mock("../hooks/useBrowserView", () => ({
 			isLoading: false,
 		},
 		slotRef: vi.fn(),
+		remeasure: browserRemeasure,
 		navigate: vi.fn(),
 		goBack: vi.fn(),
 		goForward: vi.fn(),
@@ -269,6 +271,22 @@ describe("SessionView", () => {
 		act(() => entry.onResize?.({ asPercentage: 12.4, inPixels: 160 }));
 		expect(useUiStore.getState().isInspectorOpen).toBe(false);
 		expect(window.localStorage.getItem("ao.inspector.split")).toBeNull();
+	});
+
+	// #2693: expanding the terminal shrinks the inspector column, but the native
+	// browser overlay's ResizeObserver did not re-measure on a divider drag, so
+	// the preview kept stale bounds and overlapped the terminal. rrp's onResize
+	// (fired every drag frame) must drive a re-measure of the overlay.
+	it("re-measures the browser overlay on an inspector drag (#2693)", () => {
+		render(<SessionView sessionId="sess-1" />);
+		const entry = panels.get("inspector")!;
+		browserRemeasure.mockClear();
+
+		// A live drag frame (separator active) shrinking the inspector must
+		// re-measure the overlay so it follows the divider instead of overlapping.
+		screen.getByTestId("resize-handle").setAttribute("data-separator", "active");
+		act(() => entry.onResize?.({ asPercentage: 24, inPixels: 320 }));
+		expect(browserRemeasure).toHaveBeenCalled();
 	});
 
 	it("restores the persisted split width", () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -161,6 +161,13 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// with the expand()/collapse() effect above.
 	const handleInspectorResize = useCallback(
 		(size: PanelSize) => {
+			// rrp fires onResize on every drag frame — the authoritative signal that
+			// the inspector column changed width. The browser view's ResizeObserver
+			// does not re-measure the native overlay during a divider drag that
+			// expands the terminal, so drive it from here or the preview keeps its
+			// old bounds and overlaps the terminal (#2693). Before the drag-only
+			// guard below so a resize (not just a collapse) always re-measures.
+			browserView.remeasure();
 			if (inspectorSeparatorRef.current?.getAttribute("data-separator") !== "active") return;
 			const open = useUiStore.getState().isInspectorOpen;
 			if (size.asPercentage > 0) {
@@ -170,7 +177,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 				toggleInspector();
 			}
 		},
-		[toggleInspector],
+		[browserView.remeasure, toggleInspector],
 	);
 
 	if (!session && !workspaceQuery.isLoading) {

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -149,6 +149,50 @@ describe("useBrowserView", () => {
 		);
 	});
 
+	it("re-sends the current slot bounds when remeasure() is called (divider-drag re-measure, #2693)", async () => {
+		const bridge = setupBridge();
+		const slot = createSlot();
+		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+		await waitFor(() => expect(bridge.ensure).toHaveBeenCalledWith("sess-1"));
+		act(() =>
+			bridge.emit({
+				viewId: "42:sess-1",
+				url: "http://localhost:3000/",
+				title: "",
+				canGoBack: false,
+				canGoForward: false,
+				isLoading: false,
+			}),
+		);
+		act(() => result.current.slotRef(slot));
+		await waitFor(() => expect(bridge.setBounds).toHaveBeenCalled());
+
+		// The ResizeObserver is a no-op in tests (as it effectively is for a divider
+		// drag in the app), so nothing re-measures on its own. After the slot shrinks
+		// with the inspector column, remeasure() must re-send the fresh, smaller
+		// bounds so the overlay follows the divider instead of overlapping.
+		bridge.setBounds.mockClear();
+		slot.getBoundingClientRect = vi.fn(() => ({
+			x: 12,
+			y: 34,
+			width: 180,
+			height: 240,
+			top: 34,
+			right: 192,
+			bottom: 274,
+			left: 12,
+			toJSON: () => ({}),
+		}));
+		act(() => result.current.remeasure());
+		await waitFor(() =>
+			expect(bridge.setBounds).toHaveBeenCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 12, y: 34, width: 180, height: 240 },
+				visible: true,
+			}),
+		);
+	});
+
 	it("re-measures after a layout transition settles, catching a position-only shift", async () => {
 		// A ResizeObserver fires on size changes only; entering pop-out / opening the
 		// inspector moves the slot to a new x without resizing it, so the transition

--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -193,6 +193,62 @@ describe("useBrowserView", () => {
 		);
 	});
 
+	it("hides the native view while a foreign element is fullscreen, then restores it on exit", async () => {
+		vi.useFakeTimers();
+		try {
+			const bridge = setupBridge();
+			const slot = createSlot();
+			const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+			await act(async () => {
+				await Promise.resolve();
+			});
+			act(() =>
+				bridge.emit({
+					viewId: "42:sess-1",
+					url: "http://localhost:3000/",
+					title: "",
+					canGoBack: false,
+					canGoForward: false,
+					isLoading: false,
+				}),
+			);
+			act(() => result.current.slotRef(slot));
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+			expect(bridge.setBounds).toHaveBeenLastCalledWith(expect.objectContaining({ visible: true }));
+
+			// The terminal pane enters fullscreen (CenterPane's requestFullscreen). It
+			// does not contain the slot, and the native overlay paints above it, so the
+			// preview must hide until fullscreen exits.
+			const fsElement = document.createElement("div");
+			document.body.appendChild(fsElement);
+			Object.defineProperty(document, "fullscreenElement", { configurable: true, value: fsElement });
+			bridge.setBounds.mockClear();
+			act(() => document.dispatchEvent(new Event("fullscreenchange")));
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+			expect(bridge.setBounds).toHaveBeenLastCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 0, y: 0, width: 0, height: 0 },
+				visible: false,
+			});
+
+			// Exiting fullscreen restores the overlay to its slot bounds.
+			Object.defineProperty(document, "fullscreenElement", { configurable: true, value: null });
+			bridge.setBounds.mockClear();
+			act(() => document.dispatchEvent(new Event("fullscreenchange")));
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+			expect(bridge.setBounds).toHaveBeenLastCalledWith(expect.objectContaining({ visible: true }));
+		} finally {
+			Object.defineProperty(document, "fullscreenElement", { configurable: true, value: null });
+			vi.useRealTimers();
+		}
+	});
+
 	it("re-measures after a layout transition settles, catching a position-only shift", async () => {
 		// A ResizeObserver fires on size changes only; entering pop-out / opening the
 		// inspector moves the slot to a new x without resizing it, so the transition

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -135,7 +135,14 @@ export function useBrowserView({
 		const id = viewIdRef.current;
 		const node = slotNodeRef.current;
 		if (!id) return;
-		if (!activeRef.current || !node || !node.isConnected || !hasUrlRef.current) {
+		// The native overlay paints above the whole window, so a foreign fullscreen
+		// element (the terminal pane's `requestFullscreen`, CenterPane) would leave
+		// the preview spilling across the fullscreen terminal. Hide while anything
+		// that does not contain the slot is fullscreen; the fullscreenchange
+		// listener re-measures so exiting restores it.
+		const fullscreen = document.fullscreenElement;
+		const coveredByFullscreen = Boolean(fullscreen && node && !fullscreen.contains(node));
+		if (!activeRef.current || !node || !node.isConnected || !hasUrlRef.current || coveredByFullscreen) {
 			sendHiddenBounds(id);
 			return;
 		}
@@ -352,16 +359,22 @@ export function useBrowserView({
 
 	useEffect(() => {
 		const handle = () => scheduleMeasure();
+		// Element fullscreen (the terminal pane) need not resize the window, so the
+		// resize listener alone can miss it. Settle-measure through the transition
+		// so the overlay hides on enter and returns to its slot on exit.
+		const handleFullscreen = () => scheduleSettleMeasure();
 		window.addEventListener("resize", handle);
 		window.addEventListener("scroll", handle, true);
+		document.addEventListener("fullscreenchange", handleFullscreen);
 		return () => {
 			window.removeEventListener("resize", handle);
 			window.removeEventListener("scroll", handle, true);
+			document.removeEventListener("fullscreenchange", handleFullscreen);
 			observerRef.current?.disconnect();
 			cancelScheduledMeasure();
 			if (settleTimerRef.current !== null) window.clearTimeout(settleTimerRef.current);
 		};
-	}, [cancelScheduledMeasure, scheduleMeasure]);
+	}, [cancelScheduledMeasure, scheduleMeasure, scheduleSettleMeasure]);
 
 	const withView = useCallback(async (fn: (id: string) => Promise<BrowserNavState | void>) => {
 		const id = viewIdRef.current;

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -34,6 +34,13 @@ export type BrowserViewModel = {
 	mirrorUrl: string;
 	mirrorStream: MediaStream | null;
 	slotRef: (node: HTMLDivElement | null) => void;
+	/**
+	 * Force the native overlay to re-measure its slot and re-send bounds. The
+	 * ResizeObserver misses layout changes that don't resize the observed slot
+	 * or column — notably a divider drag that expands the terminal — so callers
+	 * that own such a transition (the inspector's rrp `onResize`) drive it here.
+	 */
+	remeasure: () => void;
 	navigate: (url: string) => Promise<void>;
 	goBack: () => Promise<void>;
 	goForward: () => Promise<void>;
@@ -469,6 +476,7 @@ export function useBrowserView({
 		mirrorUrl,
 		mirrorStream,
 		slotRef,
+		remeasure: scheduleSettleMeasure,
 		navigate,
 		goBack: () => (hasNativeBrowser ? withView((id) => window.ao!.browser.goBack(id)) : Promise.resolve()),
 		goForward: () => (hasNativeBrowser ? withView((id) => window.ao!.browser.goForward(id)) : Promise.resolve()),


### PR DESCRIPTION
## What

Dragging the split-view divider to expand the terminal shrank the inspector column, but the native browser preview kept its old bounds and spilled over the terminal — the "right pane stuck at its previous width / overlapping space" in #2693.

The preview is a native `WebContentsView` overlay positioned from a measured DOM slot. Its `ResizeObserver` does not fire for a divider drag that expands the terminal, so nothing drove a re-measure and the overlay kept stale bounds. This is the fragile `ResizeObserver` interaction #2693 predicted after #2203.

**Fix:** expose `remeasure()` on the browser view model and drive it from the inspector's `react-resizable-panels` `onResize`, which fires on every drag frame and is the authoritative signal that the column changed width. The call sits before the existing drag-only guard so a resize always re-measures, not just a collapse.

Fixes #2693

## Also included (unrelated to #2693)

The second commit is a **separate fix, not required by #2693** — flagging it explicitly so it can be reviewed on its own merits or split out on request.

The same overlay paints above the whole window, so when the terminal pane enters element fullscreen (`CenterPane`'s `requestFullscreen`) the preview painted across it. It now hides whenever a fullscreen element does not contain the preview slot, and settle-measures on `fullscreenchange` so it returns to its slot on exit. Element fullscreen need not resize the window, so the existing `resize` listener alone could miss the transition.

## Testing

- `re-measures the browser overlay on an inspector drag (#2693)` — a live drag frame must drive a re-measure.
- `re-sends the current slot bounds when remeasure() is called` — with the `ResizeObserver` inert (as it effectively is during a divider drag), `remeasure()` must send fresh, smaller bounds.
- `hides the native view while a foreign element is fullscreen, then restores it on exit`.

Full renderer suite green on top of current `main`: **611 tests / 57 files**. `tsc --noEmit` and `prettier --check` clean.

## Notes for reviewers

- Rebased on `main` @ ce98f0f4; no conflicts.
- #2732 (`keep notifications above browser preview`) touched this hook in parallel — it only widened `OPEN_MODAL_SELECTOR`, so the two changes are independent.
