### PR TITLE
feat(frontend): add close button to Global Settings view

### DIFF
--- a/frontend/src/renderer/components/GlobalSettingsForm.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.tsx
@@ -1,15 +1,25 @@
+import { useNavigate } from "@tanstack/react-router"
 import { DashboardSubhead } from "./DashboardSubhead";
 import { MigrationSection } from "./MigrationSection";
 import { UpdatesSection } from "./UpdatesSection";
+import { Button } from "./ui/button";
 
 // App-wide settings, shown from the sidebar when no project is selected. Each
 // section is a self-contained card: Updates (auto-update channel, #2207) and
 // Migration (re-run the legacy-AO import, #2205). Connect Mobile lives in the
 // sidebar Settings menu, not here.
 export function GlobalSettingsForm() {
+	const navigate = useNavigate();
+
 	return (
 		<div className="flex h-full min-h-0 flex-col bg-background text-foreground">
-			<DashboardSubhead title="Global settings" subtitle="Settings that apply across all projects" />
+			<DashboardSubhead
+				title="Global settings"
+				subtitle="Settings that apply across all projects"
+				actions={<Button
+					variant="outline"
+					size="sm"
+					onClick={() => navigate("/")}>Close</Button>}} />
 			<div className="min-h-0 flex-1 overflow-y-auto p-4.5">
 				<div className="mx-auto flex max-w-2xl flex-col gap-4">
 					<UpdatesSection />


### PR DESCRIPTION
### Description
Added a custom `Button` component to the `GlobalSettingsForm` to allow users to easily dismiss or close the Global Settings view and navigate back to the dashboard (`/`).

### Related Issue
Closes #2747

### Changes
- Imported `useNavigate` from `@tanstack/react-router` and initialized it inside `GlobalSettingsForm`.
- Replaced the simple `<DashboardSubhead />` line to pass the custom `<Button>` component with `variant=" outline"` and `size=" sm"` inside the `actions` prop.