### PR TITLE
docs: enrich CONTRIBUTING.md and add GitHub issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Fill this in so we can reproduce it quickly.
+        For realtime help, join [Discord](https://discord.com/invite/UZv7JjxbwG).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong in one or two sentences?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps someone else can follow.
+      placeholder: |
+        1. …
+        2. …
+        3. …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include error messages or screenshots if useful.
+    validations:
+      required: true
+
+  - type: input
+    id: ao-version
+    attributes:
+      label: AO version
+      description: Output of `ao --version` (or how you installed / which commit).
+      placeholder: e.g. ao 0.x.x / commit abc1234
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, arch, and relevant runtime (e.g. macOS 15 arm64, Go/Node versions if known).
+      placeholder: e.g. macOS 15.x arm64
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / extra context
+      description: Relevant daemon logs, terminal output, or notes from `~/.ao` (redact secrets).
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues for duplicates
+          required: true
+        - label: I removed secrets / tokens from logs and screenshots
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discord community
+    url: https://discord.com/invite/UZv7JjxbwG
+    about: Questions, mentoring, and the daily contributor sync (10:00 PM IST).
+  - name: Contributing guide
+    url: https://github.com/AgentWrapper/agent-orchestrator/blob/main/CONTRIBUTING.md
+    about: How to claim issues, open PRs, and work with maintainers.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: Propose a new capability or improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Lead with the **problem**, not only the solution.
+        For larger ideas, confirm scope on [Discord](https://discord.com/invite/UZv7JjxbwG) or the daily sync (10:00 PM IST) before building.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What pain are you hitting? Who does this affect?
+      placeholder: As a … I need … because …
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed direction
+      description: Rough idea of what good looks like. Design sketches welcome; keep it optional.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds or other approaches you already tried.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues / discussions for something similar
+          required: true
+        - label: I am willing to help implement this if maintainers agree on scope
+          required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## What
+
+Brief description of the change.
+
+## Why
+
+Problem this solves / issue it closes (e.g. `Fixes #123`).
+
+## How
+
+Key implementation decisions, trade-offs, or areas reviewers should focus on.
+Call out intentional omissions (especially vs older TypeScript behavior) when relevant.
+
+## Testing
+
+How you validated this locally (commands, scenarios, screenshots if UI).
+
+## Checklist
+
+- [ ] Branched from `main` (or continuing an existing PR branch)
+- [ ] One focused change; links the related issue when applicable
+- [ ] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
+- [ ] Tests added/updated for user-visible behavior where it makes sense
+- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,51 @@
 # Contributing
 
-We love contributions! Join our community on Discord to get started.
+We love contributions — code, docs, triage, examples, and tests.
+Start on Discord so scope is clear before you invest time.
 
 ## Join us on Discord
 
 [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?style=for-the-badge&logo=discord&logoColor=white&logoSize=auto)](https://discord.com/invite/UZv7JjxbwG)
 
-**Daily contributor sync:** Every day at **10:00 PM IST**
+**Daily contributor sync:** every day at **10:00 PM IST**
 
-Get your issues verified by core contributors, ask questions, share progress, and learn from the community. New contributors are always welcome!
+- **Discord** → questions, mentoring, sync, realtime unblocking
+- **GitHub** → bugs, proposals, design threads, review
 
-**Why join Discord?**
+Non-trivial work? Comment on the issue or ping Discord first. Get a thumbs-up, then build.
 
-- Get your issues and PRs verified by core contributors before investing time
-- Learn from experienced contributors in daily sync calls
-- Share your progress and get feedback
-- Get help troubleshooting in real-time
-- Stay updated on the latest developments and roadmap
+## Ways to contribute
 
-## Quick Start
+| Type             | Examples                                       |
+| ---------------- | ---------------------------------------------- |
+| Code             | Fixes, features, adapters, performance         |
+| Docs             | README, `docs/`, architecture notes            |
+| Triage           | Repro bugs, tighten reports, label suggestions |
+| Examples / tests | Recipes, edge cases, flaky-test hunts          |
 
-1. **Join the Discord** - Connect with the community and get guidance
-2. **Read the contributor contract** - See [AGENTS.md](AGENTS.md) for repo layout, daemon/API boundaries, and coding conventions
-3. **Pick a focused problem** - Browse [open issues](https://github.com/AgentWrapper/agent-orchestrator/issues) and choose one small enough for a focused PR
-4. **Open a clear PR** - Keep changes narrow, explain user-visible impact, link issues, include tests
-5. **Iterate with contributors** - Use review feedback to tighten the PR until verified
+## Quick start
+
+1. **Join Discord** — say hi and get guidance
+2. **Read the contract** — [AGENTS.md](AGENTS.md) (layout, commands, hard rules, PR hygiene)
+3. **Pick something focused** — [open issues](https://github.com/AgentWrapper/agent-orchestrator/issues); prefer `good-first-issue` / `help wanted`
+4. **Claim it** — comment `I'd like to work on this` and wait for assignment
+5. **Open a clear PR** — narrow change, link the issue, user-visible impact, tests
+6. **Iterate** — address review; maintainers merge
+
+Need the product/run overview first? Start with [README.md](README.md) and [docs/architecture.md](docs/architecture.md).
+
+### Bugs and features
+
+Use the GitHub issue forms (**Bug report** / **Feature request**) so reports stay reproducible.
+Bug reports should include AO version, environment, repro steps, and expected vs actual behavior.
+
+### Pull requests
+
+New PRs are prefilled from [`.github/pull_request_template.md`](.github/pull_request_template.md).
+Also follow **PR hygiene** in [AGENTS.md](AGENTS.md): branch from `main`, one issue per PR, conventional commits, explain intentional omissions, and keep CI green for the area you touched.
+
+## Code of Conduct
+
+Be respectful, constructive, and assume good intent. Report problems to maintainers via Discord DM.
+
+Thanks for making agent-orchestrator better for the next person who shows up.


### PR DESCRIPTION
## Summary
- Enrich `CONTRIBUTING.md` as the human front door: ways to contribute, Discord vs GitHub, claim-an-issue flow, and pointers to `AGENTS.md` / README / `docs/architecture.md` (no setup dump).
- Add GitHub issue forms for **Bug report** and **Feature request**, plus `config.yml` contact links to Discord and CONTRIBUTING.
- Add `.github/pull_request_template.md` (What / Why / How / Testing + checklist aligned with AGENTS PR hygiene).

Fixes #2590

Replaces the closed [#2591](https://github.com/AgentWrapper/agent-orchestrator/pull/2591) with a clean single conventional commit (no Copilot autofix commit; Prettier-clean; absolute `AGENTS.md` link in the PR template so it resolves in PR bodies).

Design draft: https://app.notion.com/p/batmnnn/Enhanced-CONTRIBUTING-md-Draft-399b156bc37081ba85d7d3d7256cd854

## Test plan
- [x] Skim `CONTRIBUTING.md`: still short, still links `AGENTS.md`, uses real labels (`good-first-issue`, `help wanted`)
- [x] `npx prettier@3 --write CONTRIBUTING.md .github/pull_request_template.md` — unchanged
- [x] After merge (or via this fork): open https://github.com/AgentWrapper/agent-orchestrator/issues/new/choose and confirm Bug report + Feature request forms appear
- [x] Confirm Discord + Contributing contact links show on the issue chooser
- [x] Open a draft PR and confirm the body prefills from `pull_request_template.md`
- [x] No changes to `AGENTS.md` or runtime/CI code
- [x] Single conventional commit on a fresh branch from `main`


Made with [Cursor](https://cursor.com)