### PR TITLE
fix(opencode): materialize using-ao skill for skill tool discovery

### DIFF
--- a/backend/internal/adapters/agent/opencode/hooks.go
+++ b/backend/internal/adapters/agent/opencode/hooks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/skillassets"
 )
 
 const (
@@ -40,6 +42,21 @@ const (
 	// shared contract with the (forthcoming) `ao hooks` CLI and is asserted by
 	// tests so the plugin can't silently drift away from it.
 	opencodeHookCommandPrefix = "ao hooks opencode "
+
+	// opencodeSkillSubDir is where opencode discovers project skills
+	// (`.opencode/skills/<name>/SKILL.md`). AO materializes the using-ao skill
+	// here so opencode's native `skill` tool can see it — the data-dir install
+	// alone is invisible to that discovery path.
+	opencodeSkillSubDir = "skills"
+
+	// opencodeSkillMarkerFile marks a skill directory as AO-managed. Install
+	// overwrites and uninstall deletes only when this marker is present, so a
+	// user-authored skill at the same path is never clobbered or removed.
+	opencodeSkillMarkerFile = ".ao-managed"
+
+	// opencodeSkillSentinel is written into the marker file. Keep it distinct
+	// from the plugin sentinel so ownership checks stay file-specific.
+	opencodeSkillSentinel = "agent-orchestrator: managed opencode using-ao skill"
 )
 
 // opencodePluginSource is the AO-managed opencode plugin, embedded so it ships
@@ -57,13 +74,16 @@ var opencodePluginSource string
 var opencodeManagedEvents = []string{"session-start", "user-prompt-submit", "stop"}
 
 // GetAgentHooks installs AO's opencode activity plugin into the worktree-local
-// .opencode/plugins/ directory. Unlike Claude Code and Codex, opencode has no
-// native command-hook config to merge into; its only lifecycle-extensibility
-// surface is a JS/TS plugin. AO therefore writes a dedicated, AO-owned plugin
-// file. The write is atomic and idempotent: re-installing overwrites AO's own
-// file with identical content. It refuses to overwrite a file that is NOT
-// AO-managed (no sentinel), so a user plugin that happens to occupy our path is
-// never silently destroyed — install fails loudly instead.
+// .opencode/plugins/ directory, and materializes the using-ao skill into
+// .opencode/skills/using-ao/ so opencode's native `skill` tool can discover it.
+// Unlike Claude Code and Codex, opencode has no native command-hook config to
+// merge into; its only lifecycle-extensibility surface is a JS/TS plugin. AO
+// therefore writes a dedicated, AO-owned plugin file. The write is atomic and
+// idempotent: re-installing overwrites AO's own file with identical content. It
+// refuses to overwrite a file that is NOT AO-managed (no sentinel), so a user
+// plugin that happens to occupy our path is never silently destroyed — install
+// fails loudly instead. The skill install uses the same ownership guard via a
+// marker file inside the skill directory.
 func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -97,12 +117,16 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(pluginPath), opencodePluginFileName); err != nil {
 		return fmt.Errorf("opencode.GetAgentHooks: gitignore: %w", err)
 	}
+	if err := installUsingAOSkill(cfg.WorkspacePath); err != nil {
+		return fmt.Errorf("opencode.GetAgentHooks: %w", err)
+	}
 	return nil
 }
 
-// UninstallHooks removes AO's opencode plugin from the workspace-local
-// .opencode/plugins/ directory. It deletes the file only when it carries the AO
-// sentinel, so a user file that happens to share the name is left in place. A
+// UninstallHooks removes AO's opencode plugin and the AO-managed using-ao skill
+// from the workspace-local .opencode/ tree. It deletes the plugin only when it
+// carries the AO sentinel, and the skill directory only when the AO marker is
+// present, so user files that happen to share those paths are left in place. A
 // missing file is a no-op.
 func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error {
 	if err := ctx.Err(); err != nil {
@@ -117,11 +141,13 @@ func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error
 	if err != nil {
 		return fmt.Errorf("opencode.UninstallHooks: %w", err)
 	}
-	if !managed {
-		return nil
+	if managed {
+		if err := os.Remove(pluginPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("opencode.UninstallHooks: remove plugin: %w", err)
+		}
 	}
-	if err := os.Remove(pluginPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("opencode.UninstallHooks: remove plugin: %w", err)
+	if err := uninstallUsingAOSkill(workspacePath); err != nil {
+		return fmt.Errorf("opencode.UninstallHooks: %w", err)
 	}
 	return nil
 }
@@ -147,6 +173,89 @@ func opencodePluginPath(workspacePath string) string {
 	return filepath.Join(workspacePath, opencodePluginDirName, opencodePluginSubDir, opencodePluginFileName)
 }
 
+func opencodeSkillDir(workspacePath string) string {
+	return filepath.Join(workspacePath, opencodePluginDirName, opencodeSkillSubDir, skillassets.SkillName)
+}
+
+func opencodeSkillMarkerPath(workspacePath string) string {
+	return filepath.Join(opencodeSkillDir(workspacePath), opencodeSkillMarkerFile)
+}
+
+// installUsingAOSkill materializes the embedded using-ao skill into
+// .opencode/skills/using-ao/ so opencode's skill tool can discover it. It
+// refuses to overwrite a same-named directory that is not AO-managed.
+func installUsingAOSkill(workspacePath string) error {
+	skillDir := opencodeSkillDir(workspacePath)
+	if info, err := os.Stat(skillDir); err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("refusing to overwrite non-directory at %s — move it so AO can install using-ao", skillDir)
+		}
+		managed, err := isAOManagedSkill(workspacePath)
+		if err != nil {
+			return err
+		}
+		if !managed {
+			return fmt.Errorf("refusing to overwrite non-AO skill at %s — move it so AO can install using-ao", skillDir)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat skill dir: %w", err)
+	}
+
+	if err := skillassets.Materialize(skillDir); err != nil {
+		return fmt.Errorf("materialize using-ao skill: %w", err)
+	}
+	if err := hookutil.AtomicWriteFile(opencodeSkillMarkerPath(workspacePath), []byte(opencodeSkillSentinel+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write skill marker: %w", err)
+	}
+	if err := ensureSkillTreeGitignored(skillDir); err != nil {
+		return fmt.Errorf("skill gitignore: %w", err)
+	}
+	return nil
+}
+
+// ensureSkillTreeGitignored writes AO-managed .gitignore files beside every
+// file in the skill tree so registry's hook-footprint contract holds: each
+// installed path must be ignorable for git worktree teardown.
+func ensureSkillTreeGitignored(skillRoot string) error {
+	byDir := map[string][]string{}
+	err := filepath.WalkDir(skillRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		dir := filepath.Dir(path)
+		byDir[dir] = append(byDir[dir], filepath.Base(path))
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walk skill tree: %w", err)
+	}
+	for dir, names := range byDir {
+		if err := hookutil.EnsureWorkspaceGitignore(dir, names...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// uninstallUsingAOSkill removes the AO-managed using-ao skill directory. A
+// missing directory, or a same-named directory without the AO marker, is a no-op.
+func uninstallUsingAOSkill(workspacePath string) error {
+	managed, err := isAOManagedSkill(workspacePath)
+	if err != nil {
+		return err
+	}
+	if !managed {
+		return nil
+	}
+	if err := os.RemoveAll(opencodeSkillDir(workspacePath)); err != nil {
+		return fmt.Errorf("remove skill dir: %w", err)
+	}
+	return nil
+}
+
 // isAOManagedPlugin reports whether the file at path exists and carries the AO
 // sentinel. A missing file yields (false, nil).
 func isAOManagedPlugin(path string) (bool, error) {
@@ -158,4 +267,17 @@ func isAOManagedPlugin(path string) (bool, error) {
 		return false, fmt.Errorf("read %s: %w", path, err)
 	}
 	return strings.Contains(string(data), opencodePluginSentinel), nil
+}
+
+// isAOManagedSkill reports whether the using-ao skill directory exists and
+// carries the AO marker. A missing directory yields (false, nil).
+func isAOManagedSkill(workspacePath string) (bool, error) {
+	data, err := os.ReadFile(opencodeSkillMarkerPath(workspacePath)) //nolint:gosec // path built from caller-owned workspace dir
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read skill marker: %w", err)
+	}
+	return strings.Contains(string(data), opencodeSkillSentinel), nil
 }

--- a/backend/internal/adapters/agent/opencode/hooks.go
+++ b/backend/internal/adapters/agent/opencode/hooks.go
@@ -49,10 +49,10 @@ const (
 	// alone is invisible to that discovery path.
 	opencodeSkillSubDir = "skills"
 
-	// opencodeSkillMarkerFile marks a skill directory as AO-managed. Install
-	// overwrites and uninstall deletes only when this marker is present, so a
-	// user-authored skill at the same path is never clobbered or removed.
-	opencodeSkillMarkerFile = ".ao-managed"
+	// opencodeSkillMarkerFile lives beside the skill directory (not inside it) so
+	// Materialize's RemoveAll of using-ao/ cannot erase ownership mid-install.
+	// Install overwrites and uninstall deletes only when this marker is present.
+	opencodeSkillMarkerFile = ".using-ao.ao-managed"
 
 	// opencodeSkillSentinel is written into the marker file. Keep it distinct
 	// from the plugin sentinel so ownership checks stay file-specific.
@@ -83,7 +83,7 @@ var opencodeManagedEvents = []string{"session-start", "user-prompt-submit", "sto
 // refuses to overwrite a file that is NOT AO-managed (no sentinel), so a user
 // plugin that happens to occupy our path is never silently destroyed — install
 // fails loudly instead. The skill install uses the same ownership guard via a
-// marker file inside the skill directory.
+// marker file beside the skill directory (written before Materialize runs).
 func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -177,8 +177,12 @@ func opencodeSkillDir(workspacePath string) string {
 	return filepath.Join(workspacePath, opencodePluginDirName, opencodeSkillSubDir, skillassets.SkillName)
 }
 
+func opencodeSkillsDir(workspacePath string) string {
+	return filepath.Join(workspacePath, opencodePluginDirName, opencodeSkillSubDir)
+}
+
 func opencodeSkillMarkerPath(workspacePath string) string {
-	return filepath.Join(opencodeSkillDir(workspacePath), opencodeSkillMarkerFile)
+	return filepath.Join(opencodeSkillsDir(workspacePath), opencodeSkillMarkerFile)
 }
 
 // installUsingAOSkill materializes the embedded using-ao skill into
@@ -201,14 +205,23 @@ func installUsingAOSkill(workspacePath string) error {
 		return fmt.Errorf("stat skill dir: %w", err)
 	}
 
-	if err := skillassets.Materialize(skillDir); err != nil {
-		return fmt.Errorf("materialize using-ao skill: %w", err)
+	skillsParent := opencodeSkillsDir(workspacePath)
+	if err := os.MkdirAll(skillsParent, 0o750); err != nil {
+		return fmt.Errorf("create skills dir: %w", err)
 	}
+	// Write ownership before Materialize clobbers using-ao/, so a crash mid-tree
+	// write leaves a marker that allows the next install attempt to recover.
 	if err := hookutil.AtomicWriteFile(opencodeSkillMarkerPath(workspacePath), []byte(opencodeSkillSentinel+"\n"), 0o600); err != nil {
 		return fmt.Errorf("write skill marker: %w", err)
 	}
+	if err := skillassets.Materialize(skillDir); err != nil {
+		return fmt.Errorf("materialize using-ao skill: %w", err)
+	}
 	if err := ensureSkillTreeGitignored(skillDir); err != nil {
 		return fmt.Errorf("skill gitignore: %w", err)
+	}
+	if err := hookutil.EnsureWorkspaceGitignore(skillsParent, opencodeSkillMarkerFile); err != nil {
+		return fmt.Errorf("skill marker gitignore: %w", err)
 	}
 	return nil
 }
@@ -253,6 +266,10 @@ func uninstallUsingAOSkill(workspacePath string) error {
 	if err := os.RemoveAll(opencodeSkillDir(workspacePath)); err != nil {
 		return fmt.Errorf("remove skill dir: %w", err)
 	}
+	markerPath := opencodeSkillMarkerPath(workspacePath)
+	if err := os.Remove(markerPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove skill marker: %w", err)
+	}
 	return nil
 }
 
@@ -269,8 +286,8 @@ func isAOManagedPlugin(path string) (bool, error) {
 	return strings.Contains(string(data), opencodePluginSentinel), nil
 }
 
-// isAOManagedSkill reports whether the using-ao skill directory exists and
-// carries the AO marker. A missing directory yields (false, nil).
+// isAOManagedSkill reports whether the AO ownership marker beside the skill
+// directory exists. A missing marker yields (false, nil).
 func isAOManagedSkill(workspacePath string) (bool, error) {
 	data, err := os.ReadFile(opencodeSkillMarkerPath(workspacePath)) //nolint:gosec // path built from caller-owned workspace dir
 	if errors.Is(err, os.ErrNotExist) {

--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -1,12 +1,15 @@
 // Package opencode implements the opencode (sst/opencode) agent adapter:
 // launching new TUI sessions, resuming sessions by native id, installing a
-// workspace-local activity plugin, and reading plugin-derived session info.
+// workspace-local activity plugin plus the using-ao skill, and reading
+// plugin-derived session info.
 //
 // opencode differs from Claude Code and Codex in two ways AO has to bridge:
 //   - It has no native command-hook config (no settings.local.json / hooks.json
 //     equivalent). Its only lifecycle-extensibility surface is a JS/TS plugin
 //     loaded from .opencode/plugins/, so GetAgentHooks installs an AO-owned
-//     plugin file (see hooks.go) instead of merging JSON.
+//     plugin file (see hooks.go) instead of merging JSON. The same install also
+//     materializes using-ao under .opencode/skills/ so opencode's skill tool
+//     can discover it (the data-dir skill path alone is invisible to opencode).
 //   - Its CLI exposes only one approval flag (--dangerously-skip-permissions)
 //     and no system-prompt flag, so AO injects standing instructions by writing
 //     an AO-owned per-session config and selecting the generated agent.

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -566,8 +567,36 @@ func TestUninstallHooksRemovesPlugin(t *testing.T) {
 	if _, err := os.Stat(opencodeSkillDir(workspace)); !os.IsNotExist(err) {
 		t.Fatalf("AO using-ao skill still present after uninstall: err=%v", err)
 	}
+	if _, err := os.Stat(opencodeSkillMarkerPath(workspace)); !os.IsNotExist(err) {
+		t.Fatalf("AO skill marker still present after uninstall: err=%v", err)
+	}
 	if _, err := os.Stat(userPlugin); err != nil {
 		t.Fatalf("user plugin removed by uninstall: %v", err)
+	}
+}
+
+func TestGetAgentHooksRecoversPartialSkillInstall(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "opencode"}
+	workspace := t.TempDir()
+	ctx := context.Background()
+
+	skillDir := opencodeSkillDir(workspace)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a crash after the marker was written but before Materialize finished.
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# partial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := hookutil.AtomicWriteFile(opencodeSkillMarkerPath(workspace), []byte(opencodeSkillSentinel+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := plugin.GetAgentHooks(ctx, ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+		t.Fatalf("GetAgentHooks: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(skillDir, "commands", "spawn.md")); err != nil {
+		t.Fatalf("recovered install missing commands/spawn.md: %v", err)
 	}
 }
 

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -485,6 +485,22 @@ func TestGetAgentHooksInstallsPlugin(t *testing.T) {
 	if !reflect.DeepEqual(got, userBody) {
 		t.Fatalf("user plugin modified by install: %q", got)
 	}
+
+	// using-ao must land where opencode's skill tool discovers project skills.
+	skillMD := filepath.Join(opencodeSkillDir(workspace), "SKILL.md")
+	skillBody, err := os.ReadFile(skillMD)
+	if err != nil {
+		t.Fatalf("using-ao SKILL.md missing after install: %v", err)
+	}
+	if !strings.Contains(string(skillBody), "name: using-ao") {
+		t.Fatalf("installed skill missing using-ao frontmatter:\n%s", skillBody)
+	}
+	if managed, err := isAOManagedSkill(workspace); err != nil || !managed {
+		t.Fatalf("isAOManagedSkill after install = (%v, %v), want (true, nil)", managed, err)
+	}
+	if _, err := os.Stat(filepath.Join(opencodeSkillDir(workspace), "commands", "spawn.md")); err != nil {
+		t.Fatalf("using-ao commands/spawn.md missing after install: %v", err)
+	}
 }
 
 func TestGetAgentHooksRefusesToClobberForeignFile(t *testing.T) {
@@ -547,8 +563,66 @@ func TestUninstallHooksRemovesPlugin(t *testing.T) {
 	if _, err := os.Stat(opencodePluginPath(workspace)); !os.IsNotExist(err) {
 		t.Fatalf("AO plugin still present after uninstall: err=%v", err)
 	}
+	if _, err := os.Stat(opencodeSkillDir(workspace)); !os.IsNotExist(err) {
+		t.Fatalf("AO using-ao skill still present after uninstall: err=%v", err)
+	}
 	if _, err := os.Stat(userPlugin); err != nil {
 		t.Fatalf("user plugin removed by uninstall: %v", err)
+	}
+}
+
+func TestGetAgentHooksRefusesToClobberForeignSkill(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "opencode"}
+	workspace := t.TempDir()
+	ctx := context.Background()
+
+	skillDir := opencodeSkillDir(workspace)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreignSkill := []byte("---\nname: using-ao\ndescription: user owned\n---\n# mine\n")
+	foreignPath := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(foreignPath, foreignSkill, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := plugin.GetAgentHooks(ctx, ports.WorkspaceHookConfig{WorkspacePath: workspace})
+	if err == nil {
+		t.Fatal("GetAgentHooks overwrote a non-AO skill; want a loud error")
+	}
+	got, readErr := os.ReadFile(foreignPath)
+	if readErr != nil {
+		t.Fatalf("foreign skill removed by refused install: %v", readErr)
+	}
+	if !reflect.DeepEqual(got, foreignSkill) {
+		t.Fatalf("foreign skill modified by refused install: %q", got)
+	}
+}
+
+func TestUninstallHooksLeavesForeignSkill(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "opencode"}
+	workspace := t.TempDir()
+	ctx := context.Background()
+
+	skillDir := opencodeSkillDir(workspace)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreignSkill := []byte("---\nname: using-ao\ndescription: user owned\n---\n# mine\n")
+	foreignPath := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(foreignPath, foreignSkill, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := plugin.UninstallHooks(ctx, workspace); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(foreignPath)
+	if err != nil {
+		t.Fatalf("foreign skill removed by uninstall: %v", err)
+	}
+	if !reflect.DeepEqual(got, foreignSkill) {
+		t.Fatalf("foreign skill modified by uninstall: %q", got)
 	}
 }
 

--- a/backend/internal/skillassets/skillassets.go
+++ b/backend/internal/skillassets/skillassets.go
@@ -9,6 +9,10 @@
 // on-disk copy on every boot, so a new daemon build always refreshes it and the
 // two can never drift; there is no version marker or hash to keep in sync
 // because the daemon binary already is the version.
+//
+// Materialize writes that same embedded tree into an arbitrary destination
+// directory (used by the opencode adapter to place the skill where opencode's
+// skill tool discovers it under .opencode/skills/).
 package skillassets
 
 import (
@@ -16,6 +20,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"embed"
 )
@@ -39,17 +44,32 @@ func Dir(dataDir string) string {
 // concurrent readers yet. A failure is returned but is non-fatal to boot (the
 // skill enhances `ao --help`, it is not load-bearing).
 func Install(dataDir string) error {
-	dest := Dir(dataDir)
-	if err := os.RemoveAll(dest); err != nil {
-		return fmt.Errorf("clear skill dir %q: %w", dest, err)
+	return Materialize(Dir(dataDir))
+}
+
+// Materialize writes the embedded using-ao skill into destDir (the skill root
+// itself, e.g. <dataDir>/skills/using-ao or <workspace>/.opencode/skills/using-ao),
+// replacing any existing copy. Callers that need AO-ownership guards must apply
+// them before calling Materialize.
+func Materialize(destDir string) error {
+	if strings.TrimSpace(destDir) == "" {
+		return fmt.Errorf("skillassets.Materialize: destDir is required")
 	}
-	// embed.FS always uses forward-slash paths rooted at "using-ao"; map each
-	// onto <dataDir>/skills/<same path> with the platform separator.
+	if err := os.RemoveAll(destDir); err != nil {
+		return fmt.Errorf("clear skill dir %q: %w", destDir, err)
+	}
+	// embed.FS always uses forward-slash paths rooted at "using-ao"; strip that
+	// prefix and map each entry onto destDir with the platform separator.
 	return fs.WalkDir(files, SkillName, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		target := filepath.Join(dataDir, "skills", filepath.FromSlash(p))
+		rel := strings.TrimPrefix(p, SkillName)
+		rel = strings.TrimPrefix(rel, "/")
+		target := destDir
+		if rel != "" {
+			target = filepath.Join(destDir, filepath.FromSlash(rel))
+		}
 		if d.IsDir() {
 			return os.MkdirAll(target, 0o750)
 		}

--- a/backend/internal/skillassets/skillassets_test.go
+++ b/backend/internal/skillassets/skillassets_test.go
@@ -39,3 +39,20 @@ func TestInstall_WritesSkillAndIsIdempotent(t *testing.T) {
 		t.Fatalf("stale file survived reinstall (err=%v)", err)
 	}
 }
+
+// TestMaterialize_WritesIntoArbitraryDest covers the opencode adapter path:
+// materialize the skill into .opencode/skills/using-ao (not the data-dir layout).
+func TestMaterialize_WritesIntoArbitraryDest(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), ".opencode", "skills", SkillName)
+	if err := Materialize(dest); err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if b, err := os.ReadFile(filepath.Join(dest, "SKILL.md")); err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	} else if len(b) == 0 {
+		t.Fatal("SKILL.md is empty")
+	}
+	if _, err := os.Stat(filepath.Join(dest, "commands", "spawn.md")); err != nil {
+		t.Fatalf("commands/spawn.md missing: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Materialize the embedded `using-ao` skill into `.opencode/skills/using-ao/` during opencode `GetAgentHooks`, where opencode's native `skill` tool discovers project skills (the data-dir install alone is invisible to that path).
- Add `skillassets.Materialize()` so daemon boot and opencode hook install share one embedded source of truth.
- Apply AO ownership guards (`.ao-managed` marker), uninstall cleanup, per-file gitignore coverage for the skill tree, and tests for install/refusal/uninstall plus the registry hook-footprint contract.

Fixes #2413

## Test plan

- [x] `go test ./internal/adapters/agent/opencode/ ./internal/adapters/agent/registry/ ./internal/skillassets/`
- [x] `go test ./...`
- [x] golangci-lint on changed packages (0 issues)