### PR TITLE
test: stabilize windows quality baseline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Generated artifacts are compared byte-for-byte by drift tests.
+backend/internal/httpd/apispec/openapi.yaml text eol=lf
+frontend/src/api/schema.ts text eol=lf
+frontend/src/renderer/routeTree.gen.ts text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ frontend/.tanstack/
 
 # Local tooling (not for the team)
 .codegraph/
+.gocache/
 .cursor/
 
 # OS

--- a/backend/internal/adapters/agent/aider/auth_test.go
+++ b/backend/internal/adapters/agent/aider/auth_test.go
@@ -26,6 +26,7 @@ func TestAiderLocalAuthStatusAuthorizedWithConfigFile(t *testing.T) {
 	clearAiderAuthEnv(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	if err := os.WriteFile(filepath.Join(home, ".aider.conf.yml"), []byte("openai-api-key: sk-test\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -43,6 +44,7 @@ func TestAiderLocalAuthStatusAuthorizedWithDotEnv(t *testing.T) {
 	clearAiderAuthEnv(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	if err := os.WriteFile(filepath.Join(home, ".env"), []byte("ANTHROPIC_API_KEY=sk-ant-test\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +60,9 @@ func TestAiderLocalAuthStatusAuthorizedWithDotEnv(t *testing.T) {
 
 func TestAiderLocalAuthStatusUnknownWhenMissing(t *testing.T) {
 	clearAiderAuthEnv(t)
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
 	status, ok, err := aiderLocalAuthStatus(context.Background())
 	if err != nil {

--- a/backend/internal/adapters/agent/amp/amp_test.go
+++ b/backend/internal/adapters/agent/amp/amp_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -251,7 +252,7 @@ func TestGetAgentHooksInstallsSystemPromptPlugin(t *testing.T) {
 	text := string(data)
 	for _, want := range []string{
 		ampPluginSentinel,
-		promptFile,
+		strconv.Quote(promptFile),
 		"agent.start",
 		"display: false",
 		"readFile(systemPromptFile",
@@ -340,7 +341,7 @@ func TestGetAgentHooksSystemPromptFileTakesPrecedenceOverInline(t *testing.T) {
 		t.Fatalf("read plugin: %v", err)
 	}
 	text := string(data)
-	if !strings.Contains(text, promptFile) {
+	if !strings.Contains(text, strconv.Quote(promptFile)) {
 		t.Fatalf("plugin missing prompt file path:\n%s", text)
 	}
 	if strings.Contains(text, "inline rules") {

--- a/backend/internal/adapters/agent/cline/auth_test.go
+++ b/backend/internal/adapters/agent/cline/auth_test.go
@@ -88,7 +88,9 @@ func TestClineProviderAuthStatusUnauthorizedWithExpiredOAuth(t *testing.T) {
 }
 
 func TestClineProviderAuthStatusUnknownWhenMissing(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
 	status, ok, err := clineProviderAuthStatus(context.Background())
 	if err != nil {
@@ -103,6 +105,7 @@ func writeClineProvidersFile(t *testing.T, content string) {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	settingsDir := filepath.Join(home, ".cline", "data", "settings")
 	if err := os.MkdirAll(settingsDir, 0o700); err != nil {
 		t.Fatal(err)

--- a/backend/internal/adapters/agent/cline/cline_test.go
+++ b/backend/internal/adapters/agent/cline/cline_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -263,7 +264,7 @@ func TestGetAgentHooksInstallsClineHooks(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if info.Mode().Perm()&0o100 == 0 {
+		if runtime.GOOS != "windows" && info.Mode().Perm()&0o100 == 0 {
 			t.Fatalf("%s is not executable: %v", spec.Event, info.Mode())
 		}
 	}

--- a/backend/internal/adapters/agent/codex/codex_test.go
+++ b/backend/internal/adapters/agent/codex/codex_test.go
@@ -18,8 +18,12 @@ import (
 // lives under a /var -> /private/var symlink).
 func canonicalTempDir(t *testing.T) string {
 	t.Helper()
-	dir, err := filepath.EvalSymlinks(t.TempDir())
+	raw := t.TempDir()
+	dir, err := filepath.EvalSymlinks(raw)
 	if err != nil {
+		if os.IsPermission(err) {
+			return raw
+		}
 		t.Fatal(err)
 	}
 	return dir

--- a/backend/internal/adapters/agent/goose/goose_test.go
+++ b/backend/internal/adapters/agent/goose/goose_test.go
@@ -244,6 +244,7 @@ func TestAuthStatusAuthorizedFromGooseConfig(t *testing.T) {
 	clearGooseAuthEnv(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	configPath := filepath.Join(home, ".config", "goose", "config.yaml")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
@@ -267,6 +268,7 @@ func TestAuthStatusUnauthorizedFromEmptyGooseConfig(t *testing.T) {
 	clearGooseAuthEnv(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	configPath := filepath.Join(home, ".config", "goose", "config.yaml")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {

--- a/backend/internal/adapters/agent/grok/auth_test.go
+++ b/backend/internal/adapters/agent/grok/auth_test.go
@@ -51,7 +51,9 @@ func TestGrokLocalAuthStatusUnauthorizedWithEmptyAuthFile(t *testing.T) {
 }
 
 func TestGrokLocalAuthStatusUnknownWhenMissing(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
 	status, ok, err := grokLocalAuthStatus(context.Background())
 	if err != nil {
@@ -66,6 +68,7 @@ func writeGrokAuthFile(t *testing.T, content string) {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	grokDir := filepath.Join(home, ".grok")
 	if err := os.MkdirAll(grokDir, 0o700); err != nil {
 		t.Fatal(err)

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -212,7 +212,9 @@ func TestOpenCodeLocalAuthStatusUnauthorizedWithEmptyDBAccounts(t *testing.T) {
 
 func TestOpenCodeLocalAuthStatusUnknownWhenMissing(t *testing.T) {
 	clearOpenCodeAuthEnv(t)
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
 	status, ok, err := opencodeLocalAuthStatus(context.Background())
 	if err != nil {
@@ -227,6 +229,7 @@ func writeOpenCodeDB(t *testing.T, setup func(*sql.DB)) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	dataDir := filepath.Join(home, ".local", "share", "opencode")
 	writeOpenCodeDBAt(t, dataDir, setup)
 	return dataDir
@@ -249,6 +252,7 @@ func writeOpenCodeAuthFile(t *testing.T, content string) {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	authDir := filepath.Join(home, ".local", "share", "opencode")
 	if err := os.MkdirAll(authDir, 0o700); err != nil {
 		t.Fatal(err)

--- a/backend/internal/adapters/runtime/conpty/ptyregistry/ptyregistry_test.go
+++ b/backend/internal/adapters/runtime/conpty/ptyregistry/ptyregistry_test.go
@@ -21,7 +21,8 @@ func setupHome(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
-	return dir + "/.ao/windows-pty-hosts.json"
+	t.Setenv("USERPROFILE", dir)
+	return filepath.Join(dir, ".ao", "windows-pty-hosts.json")
 }
 
 func nowRFC3339() string {

--- a/backend/internal/adapters/runtime/conpty/runtime_test.go
+++ b/backend/internal/adapters/runtime/conpty/runtime_test.go
@@ -105,6 +105,7 @@ func isolateRegistry(t *testing.T) {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -277,6 +277,9 @@ func (w *Workspace) Destroy(ctx context.Context, info ports.WorkspaceInfo) error
 	}
 	if _, ok := findWorktree(records, path); ok {
 		if removeErr != nil {
+			if isLockedWorktreeRemoveError(removeErr) {
+				return fmt.Errorf("gitworktree: refusing to remove %q: path is still registered after git worktree prune (worktree remove: %w)", path, removeErr)
+			}
 			// Distinguish the dirty-worktree refusal (uncommitted agent work)
 			// from other registration leftovers (e.g. a locked worktree) so the
 			// Session Manager can preserve the workspace without erroring.
@@ -804,6 +807,10 @@ func (w *Workspace) pruneWorktrees(ctx context.Context, repo string) error {
 
 func isMissingRegisteredWorktreeError(err error) bool {
 	return strings.Contains(err.Error(), "is a missing but already registered worktree")
+}
+
+func isLockedWorktreeRemoveError(err error) bool {
+	return strings.Contains(err.Error(), "cannot remove a locked working tree")
 }
 
 func (w *Workspace) revParse(ctx context.Context, repo, ref string) (string, error) {

--- a/backend/internal/adapters/workspace/gitworktree/workspace_integration_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_integration_test.go
@@ -163,6 +163,7 @@ func TestWorkspaceIntegrationCreateInRemotelessRepo(t *testing.T) {
 	tmp := t.TempDir()
 	repo := filepath.Join(tmp, "repo")
 	run(t, git, "init", repo)
+	runGit(t, git, repo, "config", "core.autocrlf", "false")
 	runGit(t, git, repo, "config", "user.email", "ao@example.com")
 	runGit(t, git, repo, "config", "user.name", "Ao Agents")
 	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("seed\n"), 0o644); err != nil {
@@ -206,6 +207,7 @@ func setupOriginClone(t *testing.T, git, tmp string) string {
 	repo := filepath.Join(tmp, "repo")
 	run(t, git, "init", "--bare", origin)
 	run(t, git, "init", seed)
+	runGit(t, git, seed, "config", "core.autocrlf", "false")
 	runGit(t, git, seed, "config", "user.email", "ao@example.com")
 	runGit(t, git, seed, "config", "user.name", "Ao Agents")
 	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("seed\n"), 0o644); err != nil {
@@ -217,6 +219,7 @@ func setupOriginClone(t *testing.T, git, tmp string) string {
 	runGit(t, git, seed, "remote", "add", "origin", origin)
 	runGit(t, git, seed, "push", "-u", "origin", "main")
 	run(t, git, "clone", origin, repo)
+	runGit(t, git, repo, "config", "core.autocrlf", "false")
 	// A clone does not copy the seed's local identity, and CI runners have no
 	// global git identity to fall back on, so commit/commit-tree in this repo's
 	// worktrees would fail with "empty ident name". Set it on the clone; worktrees
@@ -224,6 +227,7 @@ func setupOriginClone(t *testing.T, git, tmp string) string {
 	runGit(t, git, repo, "config", "user.email", "ao@example.com")
 	runGit(t, git, repo, "config", "user.name", "Ao Agents")
 	runGit(t, git, repo, "checkout", "main")
+	runGit(t, git, repo, "reset", "--hard", "HEAD")
 	return repo
 }
 

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -219,10 +220,7 @@ func TestCreateWorkspaceProjectRepoPrunesStaleRegisteredWorktree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
-	exitErr := exec.Command("sh", "-c", "exit 1").Run()
-	if exitErr == nil {
-		t.Fatal("expected exit error")
-	}
+	exitErr := exitStatusOne(t)
 	var calls []string
 	addAttempts := 0
 	ws.run = func(_ context.Context, binary string, args ...string) ([]byte, error) {
@@ -607,7 +605,7 @@ func TestAddWorktreeRefusesBranchCheckedOutElsewhere(t *testing.T) {
 	if !errors.Is(err, ports.ErrWorkspaceBranchCheckedOutElsewhere) {
 		t.Fatalf("err = %v, want ports.ErrWorkspaceBranchCheckedOutElsewhere", err)
 	}
-	if !strings.Contains(err.Error(), otherPath) {
+	if !strings.Contains(err.Error(), strconv.Quote(otherPath)) {
 		t.Fatalf("err = %v, want message to include conflicting path %q", err, otherPath)
 	}
 }
@@ -652,10 +650,7 @@ func TestAddWorktreeReportsBranchNotFetched(t *testing.T) {
 		t.Fatalf("new: %v", err)
 	}
 	// Build a real exit-1 error so refExists treats every probe as "absent".
-	exitOne := func() error {
-		cmd := exec.Command("sh", "-c", "exit 1")
-		return cmd.Run()
-	}()
+	exitOne := exitStatusOne(t)
 	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		switch {
@@ -685,10 +680,7 @@ func TestResolveBaseRefInfersRepoDefaultBranchWhenUnset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
-	exitOne := func() error {
-		cmd := exec.Command("sh", "-c", "exit 1")
-		return cmd.Run()
-	}()
+	exitOne := exitStatusOne(t)
 	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		switch {
@@ -716,4 +708,22 @@ func mkdirFile(dir, name string) error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(dir, name), []byte("data"), 0o644)
+}
+
+func exitStatusOne(t *testing.T) error {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestGitWorktreeExitStatusOneHelper")
+	cmd.Env = append(os.Environ(), "GO_WANT_GITWORKTREE_EXIT_STATUS_ONE=1")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected exit error")
+	}
+	return err
+}
+
+func TestGitWorktreeExitStatusOneHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_GITWORKTREE_EXIT_STATUS_ONE") != "1" {
+		return
+	}
+	os.Exit(1)
 }

--- a/backend/internal/httpd/apispec/specgen/build_test.go
+++ b/backend/internal/httpd/apispec/specgen/build_test.go
@@ -17,7 +17,7 @@ func TestBuild_MatchesEmbedded(t *testing.T) {
 		t.Fatalf("Build: %v", err)
 	}
 	embedded := apispec.Default().YAML()
-	if !bytes.Equal(got, embedded) {
+	if !bytes.Equal(normalizeYAML(got), normalizeYAML(embedded)) {
 		t.Fatalf("embedded openapi.yaml is stale — run `go generate ./...` and commit.\n"+
 			"len(fresh)=%d len(embedded)=%d", len(got), len(embedded))
 	}
@@ -37,4 +37,8 @@ func TestBuild_Deterministic(t *testing.T) {
 	if !bytes.Equal(a, b) {
 		t.Fatal("Build() is not deterministic across calls")
 	}
+}
+
+func normalizeYAML(in []byte) []byte {
+	return bytes.ReplaceAll(in, []byte("\r\n"), []byte("\n"))
 }

--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -76,6 +76,7 @@ func TestProjectsAPI_GetEmptyResultIs500(t *testing.T) {
 func newTestServer(t *testing.T) *httptest.Server {
 
 	t.Helper()
+	t.Setenv("GIT_CEILING_DIRECTORIES", os.TempDir())
 
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 

--- a/backend/internal/httpd/lan_listener.go
+++ b/backend/internal/httpd/lan_listener.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -125,7 +124,7 @@ func (m *LANManager) Start(port int) (int, error) {
 	}
 	ln, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
 	if err != nil {
-		if !errors.Is(err, syscall.EADDRINUSE) {
+		if !isAddrInUse(err) {
 			m.mu.Unlock()
 			return 0, fmt.Errorf("bind LAN 0.0.0.0:%d: %w", port, err)
 		}

--- a/backend/internal/mobilebridge/config_test.go
+++ b/backend/internal/mobilebridge/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"testing"
 )
 
@@ -22,7 +23,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		t.Fatalf("round trip: got %+v want %+v", got, want)
 	}
 	info, _ := os.Stat(p)
-	if info.Mode().Perm() != 0o600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("mode = %v want 0600", info.Mode().Perm())
 	}
 }

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -839,21 +839,8 @@ func isGitRepo(path string) bool {
 	if err != nil {
 		return false
 	}
-	top := filepath.Clean(strings.TrimSpace(string(out)))
-	path = filepath.Clean(path)
-	top, err = filepath.EvalSymlinks(top)
-	if err != nil {
-		return false
-	}
-	path, err = filepath.EvalSymlinks(path)
-	if err != nil {
-		return false
-	}
-
-	if strings.EqualFold(top, path) {
-		return true
-	}
-	return top == path
+	top := normalizeGitReportedPath(path, strings.TrimSpace(string(out)))
+	return samePath(top, comparablePath(path))
 }
 
 func defaultProjectID(path string) domain.ProjectID {

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -22,6 +22,7 @@ import (
 // driver, migrations run on Open) — no in-memory store.
 func newManager(t *testing.T) project.Manager {
 	t.Helper()
+	t.Setenv("GIT_CEILING_DIRECTORIES", os.TempDir())
 	store, err := sqlite.Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("open store: %v", err)

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,2 +1,0 @@
-node-linker=hoisted
-minimum-release-age=0


### PR DESCRIPTION
Stabilizes the quality baseline on Windows by fixing test portability issues, normalizing generated-file checks, tightening path handling, and removing noisy npm config.