### PR TITLE
fix(sessions): improve native session restore across agent harnesses

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -37,6 +37,7 @@ var Derivers = map[string]DeriveFunc{
 	"cursor":      activitystate.StandardDeriveActivityState,
 	"qwen":        activitystate.StandardDeriveActivityState,
 	"copilot":     activitystate.StandardDeriveActivityState,
+	"kimi":        activitystate.StandardDeriveActivityState,
 	"cline":       activitystate.StandardDeriveActivityState,
 	"kiro":        activitystate.StandardDeriveActivityState,
 	"kilocode":    activitystate.StandardDeriveActivityState,

--- a/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
@@ -18,7 +18,7 @@ func TestDeriverTokensAreKnownHarnesses(t *testing.T) {
 }
 
 func TestSupportsHarness(t *testing.T) {
-	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessOpenCode} {
+	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessOpenCode, domain.HarnessKimi} {
 		if !SupportsHarness(h) {
 			t.Errorf("SupportsHarness(%q) = false, want true", h)
 		}

--- a/backend/internal/adapters/agent/kilocode/assets/ao-activity.ts
+++ b/backend/internal/adapters/agent/kilocode/assets/ao-activity.ts
@@ -107,6 +107,11 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
     return true
   }
 
+  function readSessionID(value: any): string | null {
+    const id = value?.sessionID ?? value?.sessionId ?? value?.session_id ?? value?.id
+    return typeof id === "string" && id.trim().length > 0 ? id.trim() : null
+  }
+
   // Report a user prompt, preferring the one that carries the prompt text.
   // message.updated can arrive before message.part.updated with no text, so an
   // early empty report must NOT dedup away the later text report — otherwise the
@@ -129,7 +134,7 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
     // is untouched.
     "permission.ask": async (input: any) => {
       try {
-        const sessionID = input?.sessionID ?? input?.sessionId ?? currentSessionID
+        const sessionID = readSessionID(input) ?? currentSessionID
         if (!sessionID) return
         callHookSync("permission-request", { session_id: sessionID, model: currentModel ?? "" })
       } catch (err) {
@@ -142,9 +147,10 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
         switch (event.type) {
           case "session.created": {
             const session = (event as any).properties?.info
-            if (!session?.id) break
-            if (switchedSession(session.id)) {
-              callHookSync("session-start", { session_id: session.id })
+            const sessionID = readSessionID(session)
+            if (!sessionID) break
+            if (switchedSession(sessionID)) {
+              callHookSync("session-start", { session_id: sessionID })
             }
             break
           }
@@ -152,15 +158,16 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
           case "message.updated": {
             const msg = (event as any).properties?.info
             if (!msg) break
-            if (msg.sessionID && switchedSession(msg.sessionID)) {
-              callHookSync("session-start", { session_id: msg.sessionID })
+            const msgSessionID = readSessionID(msg)
+            if (msgSessionID && switchedSession(msgSessionID)) {
+              callHookSync("session-start", { session_id: msgSessionID })
             }
             if (msg.role === "assistant" && msg.modelID) currentModel = msg.modelID
             // Fallback: some `kilo run` flows never deliver message.part.updated
             // for the prompt, so start the turn from the user message itself.
             if (msg.role === "user") {
               rememberMessage(msg.id, msg)
-              const sessionID = msg.sessionID ?? currentSessionID
+              const sessionID = msgSessionID ?? currentSessionID
               if (sessionID) reportUserPrompt(sessionID, msg.id, "")
             }
             break
@@ -171,7 +178,7 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
             if (!part?.messageID) break
             const msg = messageStore.get(part.messageID)
             if (msg?.role === "user" && part.type === "text") {
-              const sessionID = msg.sessionID ?? currentSessionID
+              const sessionID = readSessionID(msg) ?? currentSessionID
               const prompt = part.text ?? ""
               if (sessionID) reportUserPrompt(sessionID, msg.id, prompt)
               if (prompt.length > 0) messageStore.delete(part.messageID)
@@ -187,7 +194,7 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
             // sessions intentionally emit one stop per idle transition.
             const props = (event as any).properties
             if (props?.status?.type !== "idle") break
-            const sessionID = props?.sessionID ?? currentSessionID
+            const sessionID = readSessionID(props) ?? currentSessionID
             if (!sessionID) break
             callHookSync("stop", { session_id: sessionID, model: currentModel ?? "" })
             break

--- a/backend/internal/adapters/agent/kilocode/assets/ao-activity.ts
+++ b/backend/internal/adapters/agent/kilocode/assets/ao-activity.ts
@@ -108,7 +108,12 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
   }
 
   function readSessionID(value: any): string | null {
-    const id = value?.sessionID ?? value?.sessionId ?? value?.session_id ?? value?.id
+    const id = value?.sessionID ?? value?.sessionId ?? value?.session_id
+    return typeof id === "string" && id.trim().length > 0 ? id.trim() : null
+  }
+
+  function readCreatedSessionID(value: any): string | null {
+    const id = readSessionID(value) ?? value?.id
     return typeof id === "string" && id.trim().length > 0 ? id.trim() : null
   }
 
@@ -147,7 +152,7 @@ export const aoActivity: Plugin = async ({ directory, client }) => {
         switch (event.type) {
           case "session.created": {
             const session = (event as any).properties?.info
-            const sessionID = readSessionID(session)
+            const sessionID = readCreatedSessionID(session)
             if (!sessionID) break
             if (switchedSession(sessionID)) {
               callHookSync("session-start", { session_id: sessionID })

--- a/backend/internal/adapters/agent/kilocode/kilocode_test.go
+++ b/backend/internal/adapters/agent/kilocode/kilocode_test.go
@@ -202,6 +202,11 @@ func TestGetAgentHooksInstallsPlugin(t *testing.T) {
 	if strings.Contains(body, `"session.idle"`) {
 		t.Fatalf("plugin subscribes to deprecated session.idle; use session.status(idle):\n%s", body)
 	}
+	for _, marker := range []string{"function readSessionID", "sessionID", "sessionId", "session_id"} {
+		if !strings.Contains(body, marker) {
+			t.Fatalf("installed plugin missing session id normalization marker %q:\n%s", marker, body)
+		}
+	}
 	// A hung `ao hooks` call must not block Kilo forever, so each spawn is
 	// time-boxed (parity with the claude/codex 30s hook timeout).
 	if !strings.Contains(body, "timeout:") {

--- a/backend/internal/adapters/agent/kilocode/kilocode_test.go
+++ b/backend/internal/adapters/agent/kilocode/kilocode_test.go
@@ -202,10 +202,13 @@ func TestGetAgentHooksInstallsPlugin(t *testing.T) {
 	if strings.Contains(body, `"session.idle"`) {
 		t.Fatalf("plugin subscribes to deprecated session.idle; use session.status(idle):\n%s", body)
 	}
-	for _, marker := range []string{"function readSessionID", "sessionID", "sessionId", "session_id"} {
+	for _, marker := range []string{"function readSessionID", "function readCreatedSessionID", "sessionID", "sessionId", "session_id"} {
 		if !strings.Contains(body, marker) {
 			t.Fatalf("installed plugin missing session id normalization marker %q:\n%s", marker, body)
 		}
+	}
+	if strings.Contains(body, "value?.session_id ?? value?.id") {
+		t.Fatalf("readSessionID must not fall back to generic object id:\n%s", body)
 	}
 	// A hung `ao hooks` call must not block Kilo forever, so each spawn is
 	// time-boxed (parity with the claude/codex 30s hook timeout).

--- a/backend/internal/adapters/agent/kimi/auth.go
+++ b/backend/internal/adapters/agent/kimi/auth.go
@@ -50,7 +50,7 @@ func kimiLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 }
 
 func kimiCodeHome() (string, bool) {
-	if home := strings.TrimSpace(os.Getenv("KIMI_CODE_HOME")); home != "" {
+	if home := strings.TrimSpace(os.Getenv(kimiCodeHomeEnv)); home != "" {
 		return home, true
 	}
 	home, err := os.UserHomeDir()

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -17,18 +17,27 @@ const (
 	kimiInstructionsFileName = "AGENTS.md"
 	kimiInstructionsSentinel = "<!-- managed by agent-orchestrator: kimi system prompt -->"
 	kimiInstructionsEnd      = "<!-- /managed by agent-orchestrator: kimi system prompt -->"
+
+	kimiHooksSentinelStart = "# managed by agent-orchestrator: kimi hooks"
+	kimiHooksSentinelEnd   = "# /managed by agent-orchestrator: kimi hooks"
 )
 
 // GetAgentHooks installs AO's standing system prompt through Kimi's
 // project-level instruction file. Kimi has no system-prompt argv flag, and its
 // user-level config lives outside AO's data dir, so a gitignored worktree-local
-// instruction file is the least invasive session-scoped injection point.
+// instruction file is the least invasive session-scoped injection point. It
+// also installs Kimi lifecycle hooks into the user's Kimi config so AO can
+// capture Kimi's native session id for true resume.
 func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	if strings.TrimSpace(cfg.WorkspacePath) == "" {
 		return errors.New("kimi.GetAgentHooks: WorkspacePath is required")
+	}
+
+	if err := installKimiConfigHooks(cfg); err != nil {
+		return fmt.Errorf("kimi.GetAgentHooks: %w", err)
 	}
 
 	systemPrompt, err := kimiSystemPromptText(cfg.SystemPrompt, cfg.SystemPromptFile)
@@ -38,7 +47,6 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	if systemPrompt == "" {
 		return nil
 	}
-
 	instructionsPath := kimiInstructionsPath(cfg.WorkspacePath)
 	var existing []byte
 	existing, err = os.ReadFile(instructionsPath) //nolint:gosec // path built from caller-owned workspace dir
@@ -61,6 +69,97 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 
 func kimiInstructionsPath(workspacePath string) string {
 	return filepath.Join(workspacePath, kimiInstructionsDirName, kimiInstructionsFileName)
+}
+
+func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
+	home, ok := kimiCodeHomeFromEnv(cfg.Env)
+	if !ok {
+		return errors.New("kimi: Kimi Code home is unavailable")
+	}
+	path := filepath.Join(home, "config.toml")
+	data, err := os.ReadFile(path) //nolint:gosec // path is the documented Kimi config under KIMI_CODE_HOME/home.
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	body := mergeKimiHooksConfig(string(data))
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create Kimi config dir: %w", err)
+	}
+	if err := hookutil.AtomicWriteFile(path, []byte(body), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func kimiCodeHomeFromEnv(env map[string]string) (string, bool) {
+	if env != nil {
+		if home := strings.TrimSpace(env["KIMI_CODE_HOME"]); home != "" {
+			return home, true
+		}
+	}
+	return kimiCodeHome()
+}
+
+func mergeKimiHooksConfig(existing string) string {
+	block := kimiHooksConfigBlock()
+	start := strings.Index(existing, kimiHooksSentinelStart)
+	if start < 0 {
+		return joinKimiConfigParts(existing, block, "")
+	}
+	afterStart := existing[start+len(kimiHooksSentinelStart):]
+	endRel := strings.Index(afterStart, kimiHooksSentinelEnd)
+	if endRel < 0 {
+		return joinKimiConfigParts(existing[:start], block, "")
+	}
+	end := start + len(kimiHooksSentinelStart) + endRel + len(kimiHooksSentinelEnd)
+	return joinKimiConfigParts(existing[:start], block, existing[end:])
+}
+
+func kimiHooksConfigBlock() string {
+	return kimiHooksSentinelStart + "\n\n" +
+		kimiHookEntry("SessionStart", "startup", "ao hooks kimi session-start") +
+		kimiHookEntry("UserPromptSubmit", "", "ao hooks kimi user-prompt-submit") +
+		kimiHookEntry("PermissionRequest", "", "ao hooks kimi permission-request") +
+		kimiHookEntry("Stop", "", "ao hooks kimi stop") +
+		kimiHooksSentinelEnd + "\n"
+}
+
+func kimiHookEntry(event, matcher, command string) string {
+	var b strings.Builder
+	b.WriteString("[[hooks]]\n")
+	b.WriteString("event = ")
+	b.WriteString(quoteTOMLString(event))
+	b.WriteByte('\n')
+	if matcher != "" {
+		b.WriteString("matcher = ")
+		b.WriteString(quoteTOMLString(matcher))
+		b.WriteByte('\n')
+	}
+	b.WriteString("command = ")
+	b.WriteString(quoteTOMLString(command))
+	b.WriteByte('\n')
+	b.WriteString("timeout = 5\n\n")
+	return b.String()
+}
+
+func quoteTOMLString(s string) string {
+	return fmt.Sprintf("%q", s)
+}
+
+func joinKimiConfigParts(prefix, block, suffix string) string {
+	var b strings.Builder
+	prefix = strings.TrimRight(prefix, "\n")
+	if prefix != "" {
+		b.WriteString(prefix)
+		b.WriteString("\n\n")
+	}
+	b.WriteString(block)
+	suffix = strings.TrimLeft(suffix, "\n")
+	if suffix != "" {
+		b.WriteString("\n")
+		b.WriteString(suffix)
+	}
+	return b.String()
 }
 
 func kimiSystemPromptText(inline, file string) (string, error) {

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -26,8 +26,9 @@ const (
 // project-level instruction file. Kimi has no system-prompt argv flag, and its
 // user-level config lives outside AO's data dir, so a gitignored worktree-local
 // instruction file is the least invasive session-scoped injection point. It
-// also installs Kimi lifecycle hooks into the user's Kimi config so AO can
-// capture Kimi's native session id for true resume.
+// also installs Kimi lifecycle hooks into the AO-managed Kimi config so AO can
+// capture Kimi's native session id for true resume without mutating the user's
+// global Kimi profile.
 func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -74,10 +75,10 @@ func kimiInstructionsPath(workspacePath string) string {
 func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
 	home, ok := kimiCodeHomeFromEnv(cfg.Env)
 	if !ok {
-		return errors.New("kimi: Kimi Code home is unavailable")
+		return errors.New("kimi: AO-managed Kimi Code home is unavailable")
 	}
 	path := filepath.Join(home, "config.toml")
-	data, err := os.ReadFile(path) //nolint:gosec // path is the documented Kimi config under KIMI_CODE_HOME/home.
+	data, err := os.ReadFile(path) //nolint:gosec // path is the AO-managed Kimi config under KIMI_CODE_HOME.
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
@@ -93,11 +94,11 @@ func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
 
 func kimiCodeHomeFromEnv(env map[string]string) (string, bool) {
 	if env != nil {
-		if home := strings.TrimSpace(env["KIMI_CODE_HOME"]); home != "" {
+		if home := strings.TrimSpace(env[kimiCodeHomeEnv]); home != "" {
 			return home, true
 		}
 	}
-	return kimiCodeHome()
+	return "", false
 }
 
 func mergeKimiHooksConfig(existing string) string {

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -82,6 +82,11 @@ func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
+	if seeded, ok, err := kimiSeedConfig(path, data); err != nil {
+		return err
+	} else if ok {
+		data = seeded
+	}
 	body := mergeKimiHooksConfig(string(data))
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return fmt.Errorf("create Kimi config dir: %w", err)
@@ -99,6 +104,76 @@ func kimiCodeHomeFromEnv(env map[string]string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func kimiSeedConfig(targetPath string, existing []byte) ([]byte, bool, error) {
+	if kimiConfigHasAPIKey(existing) {
+		return nil, false, nil
+	}
+	if !kimiConfigCanSeed(existing) {
+		return nil, false, nil
+	}
+	sourceHome, ok := kimiCodeHome()
+	if !ok {
+		return nil, false, nil
+	}
+	sourcePath := filepath.Join(sourceHome, "config.toml")
+	if sameKimiConfigPath(sourcePath, targetPath) {
+		return nil, false, nil
+	}
+	source, err := os.ReadFile(sourcePath) //nolint:gosec // user/process Kimi config used only as a seed for AO-managed home.
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read source Kimi config %s: %w", sourcePath, err)
+	}
+	if !kimiConfigHasAPIKey(source) {
+		return nil, false, nil
+	}
+	return source, true, nil
+}
+
+func kimiConfigCanSeed(existing []byte) bool {
+	text := strings.TrimSpace(string(existing))
+	if text == "" {
+		return true
+	}
+	return strings.TrimSpace(removeKimiManagedHooks(text)) == ""
+}
+
+func removeKimiManagedHooks(existing string) string {
+	start := strings.Index(existing, kimiHooksSentinelStart)
+	if start < 0 {
+		return existing
+	}
+	afterStart := existing[start+len(kimiHooksSentinelStart):]
+	endRel := strings.Index(afterStart, kimiHooksSentinelEnd)
+	if endRel < 0 {
+		return strings.TrimRight(existing[:start], "\n")
+	}
+	end := start + len(kimiHooksSentinelStart) + endRel + len(kimiHooksSentinelEnd)
+	return existing[:start] + existing[end:]
+}
+
+func kimiConfigHasAPIKey(data []byte) bool {
+	for _, match := range kimiAPIKeyLineRE.FindAllStringSubmatch(string(data), -1) {
+		for _, group := range match[2:] {
+			if strings.TrimSpace(group) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sameKimiConfigPath(a, b string) bool {
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA == nil && errB == nil {
+		return absA == absB
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
 }
 
 func mergeKimiHooksConfig(existing string) string {

--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -11,9 +11,9 @@
 //
 // Kimi exposes no system-prompt launch flag, so AO injects standing
 // instructions through Kimi's documented project instruction file
-// (.kimi-code/AGENTS.md) in the per-session worktree. Kimi lifecycle hooks are
-// not installed yet, so native session metadata and activity are still left to
-// future adapter work.
+// (.kimi-code/AGENTS.md) in the per-session worktree. AO also installs Kimi
+// lifecycle hooks into Kimi's config so native session metadata and activity can
+// flow back through `ao hooks`.
 package kimi
 
 import (

--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -18,6 +18,7 @@ package kimi
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -28,7 +29,11 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-const adapterID = "kimi"
+const (
+	adapterID       = "kimi"
+	kimiCodeHomeEnv = "KIMI_CODE_HOME"
+	kimiDataDirName = "kimi"
+)
 
 // Plugin is the Kimi CLI agent adapter. It is safe for concurrent use; the
 // binary path is resolved once and cached under binaryMu.
@@ -45,6 +50,19 @@ func New() *Plugin {
 
 var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
+
+func kimiCodeHomeDir(dataDir string) string {
+	return filepath.Join(dataDir, kimiDataDirName)
+}
+
+// AugmentRuntimeEnv points Kimi at AO's isolated Kimi home so session hooks and
+// other managed state stay under AO_DATA_DIR instead of the user's profile.
+func (p *Plugin) AugmentRuntimeEnv(env map[string]string, dataDir string) {
+	if strings.TrimSpace(dataDir) == "" {
+		return
+	}
+	env[kimiCodeHomeEnv] = kimiCodeHomeDir(dataDir)
+}
 
 // Manifest returns the adapter's static self-description.
 func (p *Plugin) Manifest() adapters.Manifest {

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -281,6 +281,82 @@ timeout = 7
 	}
 }
 
+func TestGetAgentHooksSeedsAOManagedConfigFromUserKimiConfig(t *testing.T) {
+	workspace := t.TempDir()
+	userHome := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, userHome)
+	userConfig := `api_key = "user-key"
+default_model = "kimi-code/kimi-for-coding"
+`
+	if err := os.WriteFile(filepath.Join(userHome, "config.toml"), []byte(userConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(aoHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read AO config: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`api_key = "user-key"`,
+		`default_model = "kimi-code/kimi-for-coding"`,
+		`command = "ao hooks kimi session-start"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("AO config missing %q:\n%s", want, text)
+		}
+	}
+	source, err := os.ReadFile(filepath.Join(userHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read source config: %v", err)
+	}
+	if string(source) != userConfig {
+		t.Fatalf("source config mutated:\n%s", source)
+	}
+}
+
+func TestGetAgentHooksReseedsAOManagedConfigWithoutAuth(t *testing.T) {
+	workspace := t.TempDir()
+	userHome := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, userHome)
+	if err := os.WriteFile(filepath.Join(userHome, "config.toml"), []byte(`api_key = "user-key"`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(aoHome, "config.toml"), []byte(kimiHooksConfigBlock()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(aoHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read AO config: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{`api_key = "user-key"`, `command = "ao hooks kimi session-start"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("AO config missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Count(text, kimiHooksSentinelStart) != 1 {
+		t.Fatalf("managed hook block duplicated:\n%s", text)
+	}
+}
+
 func TestGetAgentHooksRewritesManagedKimiConfigBlock(t *testing.T) {
 	workspace := t.TempDir()
 	kimiHome := t.TempDir()

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -322,6 +322,29 @@ func TestGetAgentHooksRewritesManagedKimiConfigBlock(t *testing.T) {
 	}
 }
 
+func TestAugmentRuntimeEnvUsesAODataDir(t *testing.T) {
+	env := map[string]string{kimiCodeHomeEnv: "/outside-ao"}
+	dataDir := filepath.Join(t.TempDir(), "ao")
+
+	(&Plugin{}).AugmentRuntimeEnv(env, dataDir)
+
+	if got, want := env[kimiCodeHomeEnv], kimiCodeHomeDir(dataDir); got != want {
+		t.Fatalf("%s = %q, want %q", kimiCodeHomeEnv, got, want)
+	}
+}
+
+func TestGetAgentHooksRequiresAOManagedKimiHome(t *testing.T) {
+	t.Setenv(kimiCodeHomeEnv, t.TempDir())
+
+	err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: t.TempDir(),
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "AO-managed Kimi Code home is unavailable") {
+		t.Fatalf("GetAgentHooks err = %v, want AO-managed Kimi home requirement", err)
+	}
+}
+
 func TestGetAgentHooksReadsSystemPromptFile(t *testing.T) {
 	workspace := t.TempDir()
 	kimiHome := t.TempDir()

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -194,10 +194,12 @@ func TestGetRestoreCommandNoID(t *testing.T) {
 
 func TestGetAgentHooksInstallsSystemPromptInstructions(t *testing.T) {
 	workspace := t.TempDir()
+	kimiHome := t.TempDir()
 
 	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
 		WorkspacePath: workspace,
 		SystemPrompt:  "follow AO rules\n",
+		Env:           map[string]string{"KIMI_CODE_HOME": kimiHome},
 	}); err != nil {
 		t.Fatalf("GetAgentHooks err = %v", err)
 	}
@@ -227,8 +229,102 @@ func TestGetAgentHooksInstallsSystemPromptInstructions(t *testing.T) {
 	}
 }
 
+func TestGetAgentHooksInstallsKimiConfigHooksWithoutSystemPrompt(t *testing.T) {
+	workspace := t.TempDir()
+	kimiHome := t.TempDir()
+	configPath := filepath.Join(kimiHome, "config.toml")
+	existing := `default_model = "kimi-code/kimi-for-coding"
+
+[[hooks]]
+event = "Notification"
+matcher = "task\\.completed"
+command = "notify-send done"
+timeout = 7
+`
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{"KIMI_CODE_HOME": kimiHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`default_model = "kimi-code/kimi-for-coding"`,
+		`command = "notify-send done"`,
+		kimiHooksSentinelStart,
+		`event = "SessionStart"`,
+		`matcher = "startup"`,
+		`command = "ao hooks kimi session-start"`,
+		`event = "UserPromptSubmit"`,
+		`command = "ao hooks kimi user-prompt-submit"`,
+		`event = "PermissionRequest"`,
+		`command = "ao hooks kimi permission-request"`,
+		`event = "Stop"`,
+		`command = "ao hooks kimi stop"`,
+		kimiHooksSentinelEnd,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("config missing %q:\n%s", want, text)
+		}
+	}
+	if _, err := os.Stat(kimiInstructionsPath(workspace)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("instructions path err = %v, want not exist", err)
+	}
+}
+
+func TestGetAgentHooksRewritesManagedKimiConfigBlock(t *testing.T) {
+	workspace := t.TempDir()
+	kimiHome := t.TempDir()
+	configPath := filepath.Join(kimiHome, "config.toml")
+	existing := "before = true\n\n" +
+		kimiHooksSentinelStart + "\nold = true\n" + kimiHooksSentinelEnd + "\n\n" +
+		"after = true\n"
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin := &Plugin{}
+	cfg := ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{"KIMI_CODE_HOME": kimiHome},
+	}
+	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
+		t.Fatalf("second GetAgentHooks err = %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{"before = true", "after = true", `command = "ao hooks kimi session-start"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("config missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "old = true") {
+		t.Fatalf("stale managed block preserved:\n%s", text)
+	}
+	if strings.Count(text, kimiHooksSentinelStart) != 1 {
+		t.Fatalf("managed block duplicated:\n%s", text)
+	}
+}
+
 func TestGetAgentHooksReadsSystemPromptFile(t *testing.T) {
 	workspace := t.TempDir()
+	kimiHome := t.TempDir()
 	promptFile := filepath.Join(t.TempDir(), "system.md")
 	if err := os.WriteFile(promptFile, []byte("file rules\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -237,6 +333,7 @@ func TestGetAgentHooksReadsSystemPromptFile(t *testing.T) {
 	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
 		WorkspacePath:    workspace,
 		SystemPromptFile: promptFile,
+		Env:              map[string]string{"KIMI_CODE_HOME": kimiHome},
 	}); err != nil {
 		t.Fatalf("GetAgentHooks err = %v", err)
 	}
@@ -252,6 +349,7 @@ func TestGetAgentHooksReadsSystemPromptFile(t *testing.T) {
 
 func TestGetAgentHooksPreservesUserInstructions(t *testing.T) {
 	workspace := t.TempDir()
+	kimiHome := t.TempDir()
 	path := kimiInstructionsPath(workspace)
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		t.Fatal(err)
@@ -263,6 +361,7 @@ func TestGetAgentHooksPreservesUserInstructions(t *testing.T) {
 	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
 		WorkspacePath: workspace,
 		SystemPrompt:  "AO rules",
+		Env:           map[string]string{"KIMI_CODE_HOME": kimiHome},
 	}); err != nil {
 		t.Fatalf("GetAgentHooks err = %v", err)
 	}
@@ -288,6 +387,7 @@ func TestGetAgentHooksPreservesUserInstructions(t *testing.T) {
 
 func TestGetAgentHooksRewritesManagedInstructions(t *testing.T) {
 	workspace := t.TempDir()
+	kimiHome := t.TempDir()
 	path := kimiInstructionsPath(workspace)
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		t.Fatal(err)
@@ -299,6 +399,7 @@ func TestGetAgentHooksRewritesManagedInstructions(t *testing.T) {
 	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
 		WorkspacePath: workspace,
 		SystemPrompt:  "new rules",
+		Env:           map[string]string{"KIMI_CODE_HOME": kimiHome},
 	}); err != nil {
 		t.Fatalf("GetAgentHooks err = %v", err)
 	}
@@ -315,6 +416,7 @@ func TestGetAgentHooksRewritesManagedInstructions(t *testing.T) {
 
 func TestGetAgentHooksRewritesManagedBlockAndPreservesSurroundingUserInstructions(t *testing.T) {
 	workspace := t.TempDir()
+	kimiHome := t.TempDir()
 	path := kimiInstructionsPath(workspace)
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		t.Fatal(err)
@@ -327,6 +429,7 @@ func TestGetAgentHooksRewritesManagedBlockAndPreservesSurroundingUserInstruction
 	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
 		WorkspacePath: workspace,
 		SystemPrompt:  "new rules",
+		Env:           map[string]string{"KIMI_CODE_HOME": kimiHome},
 	}); err != nil {
 		t.Fatalf("GetAgentHooks err = %v", err)
 	}

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -605,6 +605,9 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
 	}
+	if contains(cmd, "--continue") || contains(cmd, "--fork") {
+		t.Fatalf("restore cmd must target the captured session directly, got %#v", cmd)
+	}
 }
 
 func TestGetRestoreCommandReappliesSystemPromptConfig(t *testing.T) {

--- a/backend/internal/adapters/agent/registry/registry_test.go
+++ b/backend/internal/adapters/agent/registry/registry_test.go
@@ -26,6 +26,9 @@ func TestGetAgentHooksFootprintIsGitignored(t *testing.T) {
 			if ha.Harness == "autohand" {
 				t.Setenv("AUTOHAND_CONFIG", filepath.Join(t.TempDir(), "config.json"))
 			}
+			if ha.Harness == "kimi" {
+				t.Setenv("KIMI_CODE_HOME", t.TempDir())
+			}
 			cfg := ports.WorkspaceHookConfig{
 				SessionID:     "proj-1",
 				WorkspacePath: ws,

--- a/backend/internal/adapters/agent/registry/registry_test.go
+++ b/backend/internal/adapters/agent/registry/registry_test.go
@@ -26,13 +26,13 @@ func TestGetAgentHooksFootprintIsGitignored(t *testing.T) {
 			if ha.Harness == "autohand" {
 				t.Setenv("AUTOHAND_CONFIG", filepath.Join(t.TempDir(), "config.json"))
 			}
-			if ha.Harness == "kimi" {
-				t.Setenv("KIMI_CODE_HOME", t.TempDir())
-			}
 			cfg := ports.WorkspaceHookConfig{
 				SessionID:     "proj-1",
 				WorkspacePath: ws,
 				DataDir:       t.TempDir(),
+			}
+			if ha.Harness == "kimi" {
+				cfg.Env = map[string]string{"KIMI_CODE_HOME": filepath.Join(cfg.DataDir, "kimi")}
 			}
 			if err := ha.Agent.GetAgentHooks(context.Background(), cfg); err != nil {
 				t.Fatalf("GetAgentHooks: %v", err)

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -74,16 +74,28 @@ func activityMeta(payload []byte) (toolName, toolUseID string) {
 	return p.ToolName, p.ToolUseID
 }
 
-// hookAgentSessionID extracts the native resume handle shared by Codex,
-// Claude Code, and other Claude-format hook payloads. It is independent of
-// activity derivation because SessionStart is intentionally metadata-only for
-// harnesses where process startup is not proof that a turn is active.
+// hookAgentSessionID extracts the native resume handle shared by Agy, Copilot,
+// Codex, Claude Code, and other hook payloads. It is independent of activity
+// derivation because SessionStart is intentionally metadata-only for harnesses
+// where process startup is not proof that a turn is active.
 func hookAgentSessionID(payload []byte) string {
 	var p struct {
-		SessionID string `json:"session_id"`
+		SessionID           string `json:"session_id"`
+		SessionIDCamel      string `json:"sessionId"`
+		ConversationID      string `json:"conversation_id"`
+		ConversationIDCamel string `json:"conversationId"`
 	}
 	_ = json.Unmarshal(payload, &p)
 	id := strings.TrimSpace(p.SessionID)
+	if id == "" {
+		id = strings.TrimSpace(p.SessionIDCamel)
+	}
+	if id == "" {
+		id = strings.TrimSpace(p.ConversationID)
+	}
+	if id == "" {
+		id = strings.TrimSpace(p.ConversationIDCamel)
+	}
 	if len(id) > maxActivityMetaLen {
 		return ""
 	}

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -402,6 +402,68 @@ func TestHooks_RegisteredHarnessSessionStartReportsAgentSessionID(t *testing.T) 
 	}
 }
 
+func TestHooks_AgySessionStartReportsConversationID(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	promptDir := filepath.Join(cfg.dataDir, "prompts", "ao-7")
+	if err := os.MkdirAll(promptDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "system.md"), []byte("follow AO standing instructions\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"conversationId":"agy-native-1"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "agy", "session-start")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("expected Agy session-start context output")
+	}
+	if capture.hits != 1 {
+		t.Fatalf("daemon calls = %d, want 1", capture.hits)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
+	}
+	want := setActivityAPIRequest{Event: "session-start", AgentSessionID: "agy-native-1"}
+	if req != want {
+		t.Fatalf("body = %+v, want %+v", req, want)
+	}
+}
+
+func TestHooks_CopilotSessionStartReportsSessionID(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"sessionId":"copilot-native-1"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "copilot", "session-start")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capture.hits != 1 {
+		t.Fatalf("daemon calls = %d, want 1", capture.hits)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
+	}
+	want := setActivityAPIRequest{State: "active", Event: "session-start", AgentSessionID: "copilot-native-1"}
+	if req != want {
+		t.Fatalf("body = %+v, want %+v", req, want)
+	}
+}
+
 func TestHooks_DevinSessionStartInjectsSystemPromptContext(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-7")
 	cfg := setConfigEnv(t)

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -373,7 +373,7 @@ func TestHooks_ClaudeCodeBlankSessionIDIsIgnored(t *testing.T) {
 }
 
 func TestHooks_RegisteredHarnessSessionStartReportsAgentSessionID(t *testing.T) {
-	for _, agent := range []string{"opencode", "qwen", "kilocode"} {
+	for _, agent := range []string{"opencode", "qwen", "kimi", "kilocode"} {
 		t.Run(agent, func(t *testing.T) {
 			t.Setenv("AO_SESSION_ID", "ao-7")
 			cfg := setConfigEnv(t)

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2401,7 +2401,7 @@ func sleepContext(ctx context.Context, d time.Duration) error {
 // signals via ok=false (e.g. no native session id captured yet). Returns
 // ErrNotResumable when transcript-preserving restore is required but unavailable,
 // or when a promptless, unresumable worker has nothing to restore from.
-func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, workspacePath string, meta domain.SessionMetadata, systemPrompt, systemPromptFile string, agentConfig ports.AgentConfig, kind domain.SessionKind, harness domain.AgentHarness, dataDir string) ([]string, ports.PromptDeliveryStrategy, error) {
+func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, workspacePath string, meta domain.SessionMetadata, systemPrompt, systemPromptFile string, agentConfig ports.AgentConfig, kind domain.SessionKind, _ domain.AgentHarness, dataDir string) ([]string, ports.PromptDeliveryStrategy, error) {
 	ref := ports.SessionRef{
 		ID:            string(id),
 		WorkspacePath: workspacePath,
@@ -2414,16 +2414,9 @@ func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, wo
 	if ok {
 		return cmd, ports.PromptDeliveryInCommand, nil
 	}
-	// OpenCode restore must continue the captured native transcript. Replaying
-	// the saved prompt would silently create a new OpenCode conversation under a
-	// "restore" action, so require a native resume command for that harness.
-	if harness == domain.HarnessOpenCode {
-		return nil, "", ErrNotResumable
-	}
-	// Other adapters keep the historical fallback: a saved prompt is replayed
-	// fresh. An orchestrator is promptless by design and relaunches with the
-	// system prompt only. A promptless WORKER has no task and no session id to
-	// restore from: do not blank-relaunch it.
+	// A saved prompt is replayed fresh. An orchestrator is promptless by design
+	// and relaunches with the system prompt only. A promptless WORKER has no task
+	// and no session id to restore from: do not blank-relaunch it.
 	if meta.Prompt == "" && kind != domain.KindOrchestrator {
 		return nil, "", ErrNotResumable
 	}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -836,7 +836,7 @@ func (m *Manager) relaunchRestoredSession(ctx context.Context, rec domain.Sessio
 	if err := m.prepareWorkspace(ctx, agent, rec.ID, ws.Path, systemPrompt, systemPromptFile, agentConfig, env); err != nil {
 		return domain.SessionRecord{}, fmt.Errorf("restore %s: %w", rec.ID, err)
 	}
-	argv, delivery, err := restoreArgv(ctx, agent, rec.ID, ws.Path, rec.Metadata, systemPrompt, systemPromptFile, agentConfig, rec.Kind, m.dataDir)
+	argv, delivery, err := restoreArgv(ctx, agent, rec.ID, ws.Path, rec.Metadata, systemPrompt, systemPromptFile, agentConfig, rec.Kind, rec.Harness, m.dataDir)
 	if err != nil {
 		m.cleanupSystemPromptDir(rec.ID)
 		return domain.SessionRecord{}, fmt.Errorf("restore %s: %w", rec.ID, err)
@@ -2396,13 +2396,12 @@ func sleepContext(ctx context.Context, d time.Duration) error {
 }
 
 // restoreArgv builds the argv to relaunch a torn-down session: the agent's
-// native resume command when it can continue the session, else a fresh launch.
-// The agent signals via ok=false (e.g. no native session id captured yet).
-// Returns ErrNotResumable only for a promptless, unresumable non-orchestrator:
-// a worker with no prompt and no native session id has nothing to restore from.
-// Orchestrators are promptless by design and always relaunch fresh with the
-// system prompt only.
-func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, workspacePath string, meta domain.SessionMetadata, systemPrompt, systemPromptFile string, agentConfig ports.AgentConfig, kind domain.SessionKind, dataDir string) ([]string, ports.PromptDeliveryStrategy, error) {
+// native resume command when it can continue the session, else a fresh launch
+// for harnesses where replaying the saved prompt is acceptable. The agent
+// signals via ok=false (e.g. no native session id captured yet). Returns
+// ErrNotResumable when transcript-preserving restore is required but unavailable,
+// or when a promptless, unresumable worker has nothing to restore from.
+func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, workspacePath string, meta domain.SessionMetadata, systemPrompt, systemPromptFile string, agentConfig ports.AgentConfig, kind domain.SessionKind, harness domain.AgentHarness, dataDir string) ([]string, ports.PromptDeliveryStrategy, error) {
 	ref := ports.SessionRef{
 		ID:            string(id),
 		WorkspacePath: workspacePath,
@@ -2415,9 +2414,16 @@ func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, wo
 	if ok {
 		return cmd, ports.PromptDeliveryInCommand, nil
 	}
-	// Adapter cannot resume. A saved prompt is replayed fresh. An orchestrator is
-	// promptless by design and relaunches with the system prompt only. A promptless
-	// WORKER has no task and no session id to restore from: do not blank-relaunch it.
+	// OpenCode restore must continue the captured native transcript. Replaying
+	// the saved prompt would silently create a new OpenCode conversation under a
+	// "restore" action, so require a native resume command for that harness.
+	if harness == domain.HarnessOpenCode {
+		return nil, "", ErrNotResumable
+	}
+	// Other adapters keep the historical fallback: a saved prompt is replayed
+	// fresh. An orchestrator is promptless by design and relaunches with the
+	// system prompt only. A promptless WORKER has no task and no session id to
+	// restore from: do not blank-relaunch it.
 	if meta.Prompt == "" && kind != domain.KindOrchestrator {
 		return nil, "", ErrNotResumable
 	}

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2441,7 +2441,7 @@ func TestRestore_CodexWithoutAgentSessionIDFallsBackToSavedPrompt(t *testing.T) 
 	}
 }
 
-func TestRestore_OpenCodeWithoutAgentSessionIDDoesNotReplaySavedPrompt(t *testing.T) {
+func TestRestore_OpenCodeWithoutAgentSessionIDFallsBackToSavedPrompt(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{
 		ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker, Harness: domain.HarnessOpenCode, IsTerminated: true,
@@ -2459,21 +2459,23 @@ func TestRestore_OpenCodeWithoutAgentSessionIDDoesNotReplaySavedPrompt(t *testin
 		LookPath:  func(string) (string, error) { return "/bin/true", nil },
 	})
 
-	_, err := m.Restore(ctx, "mer-1")
-	if !errors.Is(err, ErrNotResumable) {
-		t.Fatalf("Restore err = %v, want ErrNotResumable", err)
+	if _, err := m.Restore(ctx, "mer-1"); err != nil {
+		t.Fatalf("Restore err = %v, want fallback launch", err)
 	}
 	if agent.restoreCalls != 1 {
 		t.Fatalf("GetRestoreCommand calls = %d, want 1", agent.restoreCalls)
 	}
-	if agent.launchCalls != 0 {
-		t.Fatalf("GetLaunchCommand calls = %d, want 0", agent.launchCalls)
+	if agent.launchCalls != 1 {
+		t.Fatalf("GetLaunchCommand calls = %d, want 1", agent.launchCalls)
 	}
-	if rt.created != 0 {
-		t.Fatalf("runtime.Create = %d, want 0", rt.created)
+	if agent.lastLaunch.Prompt != "continue the task" {
+		t.Fatalf("fallback launch prompt = %q, want saved prompt", agent.lastLaunch.Prompt)
 	}
-	if !st.sessions["mer-1"].IsTerminated {
-		t.Fatal("session must remain terminated after missing opencode resume handle")
+	if rt.created != 1 {
+		t.Fatalf("runtime.Create = %d, want 1", rt.created)
+	}
+	if st.sessions["mer-1"].IsTerminated {
+		t.Fatal("session must be live after fallback launch")
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2479,6 +2479,148 @@ func TestRestore_OpenCodeWithoutAgentSessionIDFallsBackToSavedPrompt(t *testing.
 	}
 }
 
+func TestRestore_AgyAndCopilotWithoutAgentSessionIDFallBackToSavedPrompt(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		harness domain.AgentHarness
+	}{
+		{name: "agy", harness: domain.HarnessAgy},
+		{name: "copilot", harness: domain.HarnessCopilot},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := newFakeStore()
+			st.sessions["mer-1"] = domain.SessionRecord{
+				ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker, Harness: tc.harness, IsTerminated: true,
+				Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", Prompt: "continue the task"},
+			}
+			rt := &fakeRuntime{}
+			agent := &recordingAgent{}
+			m := New(Deps{
+				Runtime:   rt,
+				Agents:    singleAgent{agent: agent},
+				Workspace: &fakeWorkspace{},
+				Store:     st,
+				Messenger: &fakeMessenger{},
+				Lifecycle: &fakeLCM{store: st},
+				LookPath:  func(string) (string, error) { return "/bin/true", nil },
+			})
+
+			if _, err := m.Restore(ctx, "mer-1"); err != nil {
+				t.Fatalf("Restore err = %v, want fallback launch", err)
+			}
+			if agent.restoreCalls != 1 {
+				t.Fatalf("GetRestoreCommand calls = %d, want 1", agent.restoreCalls)
+			}
+			if agent.launchCalls != 1 {
+				t.Fatalf("GetLaunchCommand calls = %d, want 1", agent.launchCalls)
+			}
+			if agent.lastLaunch.Prompt != "continue the task" {
+				t.Fatalf("fallback launch prompt = %q, want saved prompt", agent.lastLaunch.Prompt)
+			}
+			if rt.created != 1 {
+				t.Fatalf("runtime.Create = %d, want 1", rt.created)
+			}
+			if st.sessions["mer-1"].IsTerminated {
+				t.Fatal("session must be live after fallback launch")
+			}
+		})
+	}
+}
+
+func TestRestore_AgyAndCopilotWithAgentSessionIDUseNativeResume(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		harness domain.AgentHarness
+	}{
+		{name: "agy", harness: domain.HarnessAgy},
+		{name: "copilot", harness: domain.HarnessCopilot},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := newFakeStore()
+			st.sessions["mer-1"] = domain.SessionRecord{
+				ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker, Harness: tc.harness, IsTerminated: true,
+				Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", AgentSessionID: tc.name + "-native-1", Prompt: "continue the task"},
+			}
+			rt := &fakeRuntime{}
+			agent := &recordingAgent{}
+			m := New(Deps{
+				Runtime:   rt,
+				Agents:    singleAgent{agent: agent},
+				Workspace: &fakeWorkspace{},
+				Store:     st,
+				Messenger: &fakeMessenger{},
+				Lifecycle: &fakeLCM{store: st},
+				LookPath:  func(string) (string, error) { return "/bin/true", nil },
+			})
+
+			if _, err := m.Restore(ctx, "mer-1"); err != nil {
+				t.Fatalf("Restore err = %v, want native resume", err)
+			}
+			if agent.restoreCalls != 1 {
+				t.Fatalf("GetRestoreCommand calls = %d, want 1", agent.restoreCalls)
+			}
+			if got := agent.lastRestore.Session.Metadata[ports.MetadataKeyAgentSessionID]; got != tc.name+"-native-1" {
+				t.Fatalf("restore agent session id = %q, want %s-native-1", got, tc.name)
+			}
+			if agent.launchCalls != 0 {
+				t.Fatalf("GetLaunchCommand calls = %d, want 0", agent.launchCalls)
+			}
+			if rt.created != 1 {
+				t.Fatalf("runtime.Create = %d, want 1", rt.created)
+			}
+			if st.sessions["mer-1"].IsTerminated {
+				t.Fatal("session must be live after native resume")
+			}
+		})
+	}
+}
+
+func TestRestore_AgyAndCopilotPromptlessWorkersWithoutAgentSessionIDNotResumable(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		harness domain.AgentHarness
+	}{
+		{name: "agy", harness: domain.HarnessAgy},
+		{name: "copilot", harness: domain.HarnessCopilot},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := newFakeStore()
+			st.sessions["mer-1"] = domain.SessionRecord{
+				ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker, Harness: tc.harness, IsTerminated: true,
+				Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b"},
+			}
+			rt := &fakeRuntime{}
+			agent := &recordingAgent{}
+			m := New(Deps{
+				Runtime:   rt,
+				Agents:    singleAgent{agent: agent},
+				Workspace: &fakeWorkspace{},
+				Store:     st,
+				Messenger: &fakeMessenger{},
+				Lifecycle: &fakeLCM{store: st},
+				LookPath:  func(string) (string, error) { return "/bin/true", nil },
+			})
+
+			_, err := m.Restore(ctx, "mer-1")
+			if !errors.Is(err, ErrNotResumable) {
+				t.Fatalf("Restore err = %v, want ErrNotResumable", err)
+			}
+			if agent.restoreCalls != 1 {
+				t.Fatalf("GetRestoreCommand calls = %d, want 1", agent.restoreCalls)
+			}
+			if agent.launchCalls != 0 {
+				t.Fatalf("GetLaunchCommand calls = %d, want 0", agent.launchCalls)
+			}
+			if rt.created != 0 {
+				t.Fatalf("runtime.Create = %d, want 0", rt.created)
+			}
+			if !st.sessions["mer-1"].IsTerminated {
+				t.Fatal("session must remain terminated")
+			}
+		})
+	}
+}
+
 func TestRestore_ClaudeCodeWithoutRestoreCommandFallsBackToSavedPrompt(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2441,6 +2441,42 @@ func TestRestore_CodexWithoutAgentSessionIDFallsBackToSavedPrompt(t *testing.T) 
 	}
 }
 
+func TestRestore_OpenCodeWithoutAgentSessionIDDoesNotReplaySavedPrompt(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker, Harness: domain.HarnessOpenCode, IsTerminated: true,
+		Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", Prompt: "continue the task"},
+	}
+	rt := &fakeRuntime{}
+	agent := &recordingAgent{}
+	m := New(Deps{
+		Runtime:   rt,
+		Agents:    singleAgent{agent: agent},
+		Workspace: &fakeWorkspace{},
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: &fakeLCM{store: st},
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	_, err := m.Restore(ctx, "mer-1")
+	if !errors.Is(err, ErrNotResumable) {
+		t.Fatalf("Restore err = %v, want ErrNotResumable", err)
+	}
+	if agent.restoreCalls != 1 {
+		t.Fatalf("GetRestoreCommand calls = %d, want 1", agent.restoreCalls)
+	}
+	if agent.launchCalls != 0 {
+		t.Fatalf("GetLaunchCommand calls = %d, want 0", agent.launchCalls)
+	}
+	if rt.created != 0 {
+		t.Fatalf("runtime.Create = %d, want 0", rt.created)
+	}
+	if !st.sessions["mer-1"].IsTerminated {
+		t.Fatal("session must remain terminated after missing opencode resume handle")
+	}
+}
+
 func TestRestore_ClaudeCodeWithoutRestoreCommandFallsBackToSavedPrompt(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{


### PR DESCRIPTION

  ## Summary

  - Capture native session IDs from additional hook payload shapes, including `sessionId`, `conversation_id`, and `conversationId`, so Agy and Copilot sessions can resume correctly.
  - Allow OpenCode, Agy, and Copilot restores to fall back to the saved prompt when no native session ID has been captured yet, while still rejecting promptless worker restores.
  - Add Kimi lifecycle hook installation into Kimi config so AO can capture Kimi native session metadata and activity through `ao hooks`.
  - Normalize KiloCode session ID handling across `sessionID`, `sessionId`, `session_id`, and `id`.

  ## Testing

  - Added/updated unit coverage for restore fallback and native-resume behavior.
  - Added hook parsing coverage for Agy, Copilot, Kimi, and KiloCode session ID formats.
  - Added Kimi hook config installation and managed-block rewrite coverage.

