### PR TITLE
fix: hide browser preview when terminal enters fullscreen

### DIFF
--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -68,9 +68,20 @@ function setupBridge() {
 	return bridge;
 }
 
+// jsdom does not implement the Fullscreen API, so `document.fullscreenElement`
+// has no property descriptor to spy on. Define it directly, and clear it after
+// each test so state never leaks between cases.
+function setFullscreenElement(element: Element | null): void {
+	Object.defineProperty(document, "fullscreenElement", {
+		configurable: true,
+		get: () => element,
+	});
+}
+
 describe("useBrowserView", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
+		setFullscreenElement(null);
 		document.body.replaceChildren();
 	});
 
@@ -479,5 +490,102 @@ describe("useBrowserView", () => {
 		rerender({ terminated: true });
 		await waitFor(() => expect(bridge.clear).toHaveBeenCalledWith("42:sess-1"));
 		expect(bridge.navigate).toHaveBeenCalledTimes(1);
+	});
+
+	it("hides the native view while an element outside the slot is fullscreen, and restores it on exit", async () => {
+		// The terminal pane's fullscreen button promotes it into the DOM top layer,
+		// which covers every DOM node but not the native view — Chromium composites
+		// that above the page regardless. The transition also leaves the slot's box
+		// untouched, so no observer fires and the view kept painting its stale
+		// bounds over the fullscreen terminal, toolbar-less. Fullscreen must hide it.
+		vi.useFakeTimers();
+		try {
+			const bridge = setupBridge();
+			const slot = createSlot();
+			const terminalPane = document.createElement("div");
+			document.body.appendChild(terminalPane);
+
+			const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+			await act(async () => {
+				await Promise.resolve();
+			});
+			act(() =>
+				bridge.emit({
+					viewId: "42:sess-1",
+					url: "http://localhost:3000/",
+					title: "",
+					canGoBack: false,
+					canGoForward: false,
+					isLoading: false,
+				}),
+			);
+			act(() => result.current.slotRef(slot));
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+			expect(bridge.setBounds).toHaveBeenLastCalledWith(
+				expect.objectContaining({ visible: true, rect: expect.objectContaining({ width: 320 }) }),
+			);
+
+			// Terminal pane enters fullscreen: the slot is not inside it, so the
+			// view must go hidden even though the slot's own box never changed.
+			bridge.setBounds.mockClear();
+			setFullscreenElement(terminalPane);
+			act(() => document.dispatchEvent(new Event("fullscreenchange")));
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+			expect(bridge.setBounds).toHaveBeenLastCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 0, y: 0, width: 0, height: 0 },
+				visible: false,
+			});
+
+			// Exiting fullscreen restores the view at its measured bounds.
+			bridge.setBounds.mockClear();
+			setFullscreenElement(null);
+			act(() => document.dispatchEvent(new Event("fullscreenchange")));
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+			expect(bridge.setBounds).toHaveBeenLastCalledWith(
+				expect.objectContaining({ visible: true, rect: expect.objectContaining({ x: 12, width: 320 }) }),
+			);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps the native view visible when the slot itself is inside the fullscreen element", async () => {
+		// Guards the `contains` check: if the browser subtree is the thing going
+		// fullscreen, the slot is still on screen and must keep painting.
+		const bridge = setupBridge();
+		const host = document.createElement("div");
+		document.body.appendChild(host);
+		const slot = createSlot();
+		host.appendChild(slot);
+
+		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+		await waitFor(() => expect(bridge.ensure).toHaveBeenCalledWith("sess-1"));
+		act(() =>
+			bridge.emit({
+				viewId: "42:sess-1",
+				url: "http://localhost:3000/",
+				title: "",
+				canGoBack: false,
+				canGoForward: false,
+				isLoading: false,
+			}),
+		);
+		act(() => result.current.slotRef(slot));
+
+		setFullscreenElement(host);
+		act(() => document.dispatchEvent(new Event("fullscreenchange")));
+
+		await waitFor(() =>
+			expect(bridge.setBounds).toHaveBeenLastCalledWith(
+				expect.objectContaining({ visible: true, rect: expect.objectContaining({ width: 320 }) }),
+			),
+		);
 	});
 });

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -78,6 +78,21 @@ function visibleSlotRect(node: HTMLElement): BrowserRect {
 	return { x: left, y: top, width: Math.max(0, right - left), height: Math.max(0, bottom - top) };
 }
 
+// `requestFullscreen` (the terminal pane's fullscreen button) promotes an element
+// into the DOM top layer, which covers every other DOM node — but not the native
+// view, which Chromium composites above the page regardless. The transition also
+// leaves the slot's own box untouched, since the top layer does not reflow
+// normal-flow siblings, so neither the ResizeObserver nor `resize` fires and the
+// view would keep painting at its pre-fullscreen bounds, over the fullscreen
+// element and without its own (now hidden) toolbar. Nothing outside the
+// fullscreen subtree is visible, so hide the view unless the slot is inside it.
+function hiddenByFullscreen(node: HTMLElement): boolean {
+	// Truthy, not `!== null`: the spec says null, but jsdom (and older engines)
+	// leave `fullscreenElement` undefined when nothing is fullscreen.
+	const fullscreen = document.fullscreenElement;
+	return Boolean(fullscreen) && !fullscreen!.contains(node);
+}
+
 export function useBrowserView({
 	sessionId,
 	active,
@@ -128,7 +143,7 @@ export function useBrowserView({
 		const id = viewIdRef.current;
 		const node = slotNodeRef.current;
 		if (!id) return;
-		if (!activeRef.current || !node || !node.isConnected || !hasUrlRef.current) {
+		if (!activeRef.current || !node || !node.isConnected || !hasUrlRef.current || hiddenByFullscreen(node)) {
 			sendHiddenBounds(id);
 			return;
 		}
@@ -345,16 +360,21 @@ export function useBrowserView({
 
 	useEffect(() => {
 		const handle = () => scheduleMeasure();
+		// Fullscreen animates on macOS, so settle-measure: hiding lands on the
+		// leading edge, and the restore on exit waits for the final geometry.
+		const handleFullscreenChange = () => scheduleSettleMeasure();
 		window.addEventListener("resize", handle);
 		window.addEventListener("scroll", handle, true);
+		document.addEventListener("fullscreenchange", handleFullscreenChange);
 		return () => {
 			window.removeEventListener("resize", handle);
 			window.removeEventListener("scroll", handle, true);
+			document.removeEventListener("fullscreenchange", handleFullscreenChange);
 			observerRef.current?.disconnect();
 			cancelScheduledMeasure();
 			if (settleTimerRef.current !== null) window.clearTimeout(settleTimerRef.current);
 		};
-	}, [cancelScheduledMeasure, scheduleMeasure]);
+	}, [cancelScheduledMeasure, scheduleMeasure, scheduleSettleMeasure]);
 
 	const withView = useCallback(async (fn: (id: string) => Promise<BrowserNavState | void>) => {
 		const id = viewIdRef.current;


### PR DESCRIPTION
## Summary

In terminal fullscreen, the browser preview overlaps the terminal and renders with no toolbar or window chrome — bare page content painting on top of the fullscreen terminal. This hides the native `WebContentsView` whenever the fullscreen element does not contain its slot, and restores it on exit.

## Before / After

Terminal fullscreen with a browser preview open (`ao preview` active), toggled via the ⤢ button in the terminal pane header.

| Before (bug) | After (fix) |
| --- | --- |
| ![Before — browser preview overlaps the fullscreen terminal with no toolbar](https://raw.githubusercontent.com/AgentWrapper/agent-orchestrator/assets/pr-2770-screenshots/before-terminal-fullscreen-bug.png) | ![After — fullscreen terminal renders clean, preview hidden](https://raw.githubusercontent.com/AgentWrapper/agent-orchestrator/assets/pr-2770-screenshots/after-terminal-fullscreen-fixed.png) |

In **before**, the preview keeps painting over the right half of the fullscreen terminal, its web content flush to the top with no toolbar above it. In **after**, the preview is hidden while fullscreen and the terminal owns the whole surface.

## Root cause

The terminal pane's fullscreen button calls `requestFullscreen()` on the pane (`CenterPane.tsx`), which promotes it into the DOM **top layer**. The top layer paints over all other *DOM* content — but the browser preview is a native Electron `WebContentsView` attached to `mainWindow.contentView` (`browser-view-host.ts`), composited by Chromium *above* the page entirely. The top layer has no authority over it, so it keeps painting where it was.

And nothing tells it to move. `useBrowserView`'s measure loop is driven by a `ResizeObserver` on the slot (plus its column) and `resize` / `scroll` listeners. A fullscreen transition fires **none** of these: top-layer promotion doesn't reflow normal-flow siblings, so the slot stays connected and its `getBoundingClientRect()` returns the same box. `measureAndSend` recomputes the identical rect and keeps sending `visible: true`.

That produces both symptoms at once:

- **Overlap** — the preview holds its pre-fullscreen bounds, now sitting over a terminal that expanded to fill the window.
- **Missing toolbar/buttons** — the `BrowserPanel` toolbar and window chrome are React DOM *outside* the fullscreen element, so the top layer hides them; the native view is not hidden, leaving bare page content with no chrome above it.

## Fix

Three changes in `frontend/src/renderer/hooks/useBrowserView.ts`:

1. **`hiddenByFullscreen(node)`** — returns true when a fullscreen element exists and does **not** contain the slot. The `contains` check keeps the view alive if the browser subtree itself is ever the thing going fullscreen. Uses a truthy check rather than `!== null` because jsdom (and older engines) leave `fullscreenElement` `undefined` when nothing is fullscreen.
2. **Measure guard** — `measureAndSend` hides the native view when `hiddenByFullscreen` is true, in the same early-return that already handles inactive / disconnected slots.
3. **`fullscreenchange` listener** — drives a settle-measure (the same settle-and-remeasure the hook already uses for panel transitions) so the view hides on enter and restores at correct bounds on exit, after the macOS fullscreen animation lands rather than mid-flight.

This mirrors the park/hide approach the hook already applies to open modals (`MutationObserver` → park the native view offscreen), so it slots into an existing pattern rather than introducing a new mechanism.

## Testing

- **2 new regression tests** in `useBrowserView.test.tsx`: hide-on-enter, restore-on-exit at measured bounds, and the `contains` guard (view stays visible when the slot itself is inside the fullscreen element).
- **Negative control**: with the guard removed, the hide test fails with the exact reported bug; restoring it passes — confirming the test exercises the real mechanism, not a tautology.
- 65 tests pass across `useBrowserView`, `BrowserPanel`, `SessionInspector`, `CenterPane`; `tsc --noEmit` clean.

**Verification caveat:** this is verified via the unit tests + negative control above, **not** driven live in Electron by CI. DOM fullscreen combined with native `WebContentsView` compositing is exactly what jsdom can't reproduce. The before/after screenshots above are the manual confirmation in the real app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)