### PR TITLE
(feat): workspace files panel

### DIFF
--- a/backend/internal/cli/dto_drift_e2e_test.go
+++ b/backend/internal/cli/dto_drift_e2e_test.go
@@ -107,6 +107,14 @@ func (f *fakeSessionService) ClaimPR(context.Context, domain.SessionID, string, 
 	return sessionsvc.ClaimPRResult{}, nil
 }
 
+func (f *fakeSessionService) ListWorkspaceFiles(context.Context, domain.SessionID) (sessionsvc.WorkspaceFiles, error) {
+	return sessionsvc.WorkspaceFiles{}, nil
+}
+
+func (f *fakeSessionService) GetWorkspaceFile(context.Context, domain.SessionID, string) (sessionsvc.WorkspaceFileDetail, error) {
+	return sessionsvc.WorkspaceFileDetail{}, nil
+}
+
 type fakeAgentCatalog struct{}
 
 var _ controllers.AgentCatalog = (*fakeAgentCatalog)(nil)

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -1671,6 +1671,96 @@ paths:
       summary: Send a message to a running session's agent
       tags:
       - sessions
+  /api/v1/sessions/{sessionId}/workspace/file:
+    get:
+      operationId: getSessionWorkspaceFile
+      parameters:
+      - description: Session identifier, e.g. project-1.
+        in: path
+        name: sessionId
+        required: true
+        schema:
+          description: Session identifier, e.g. project-1.
+          type: string
+      - description: Session-worktree-relative file path.
+        in: query
+        name: path
+        schema:
+          description: Session-worktree-relative file path.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceFileResponse'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Read one session workspace file and its git diff
+      tags:
+      - sessions
+  /api/v1/sessions/{sessionId}/workspace/files:
+    get:
+      operationId: listSessionWorkspaceFiles
+      parameters:
+      - description: Session identifier, e.g. project-1.
+        in: path
+        name: sessionId
+        required: true
+        schema:
+          description: Session identifier, e.g. project-1.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListWorkspaceFilesResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: List files in a session workspace with git change status
+      tags:
+      - sessions
   /api/v1/sessions/cleanup:
     post:
       operationId: cleanupSessions
@@ -2079,6 +2169,21 @@ components:
           type: array
       required:
       - sessions
+      type: object
+    ListWorkspaceFilesResponse:
+      properties:
+        files:
+          items:
+            $ref: '#/components/schemas/WorkspaceFileSummary'
+          type: array
+        sessionId:
+          type: string
+        truncated:
+          type: boolean
+      required:
+      - sessionId
+      - files
+      - truncated
       type: object
     MarkAllNotificationsReadResponse:
       properties:
@@ -2958,6 +3063,82 @@ components:
       required:
       - reviewerHandleId
       - reviews
+      type: object
+    WorkspaceFileResponse:
+      properties:
+        additions:
+          type: integer
+        binary:
+          type: boolean
+        content:
+          type: string
+        contentTruncated:
+          type: boolean
+        deleted:
+          type: boolean
+        deletions:
+          type: integer
+        diff:
+          type: string
+        diffTruncated:
+          type: boolean
+        path:
+          type: string
+        sessionId:
+          type: string
+        size:
+          format: int64
+          type: integer
+        status:
+          enum:
+          - unmodified
+          - modified
+          - added
+          - deleted
+          - renamed
+          type: string
+      required:
+      - sessionId
+      - path
+      - status
+      - additions
+      - deletions
+      - size
+      - binary
+      - deleted
+      - content
+      - contentTruncated
+      - diff
+      - diffTruncated
+      type: object
+    WorkspaceFileSummary:
+      properties:
+        additions:
+          type: integer
+        binary:
+          type: boolean
+        deletions:
+          type: integer
+        path:
+          type: string
+        size:
+          format: int64
+          type: integer
+        status:
+          enum:
+          - unmodified
+          - modified
+          - added
+          - deleted
+          - renamed
+          type: string
+      required:
+      - path
+      - status
+      - additions
+      - deletions
+      - size
+      - binary
       type: object
     WorkspaceRepo:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -154,6 +154,10 @@ var schemaNames = map[string]string{
 	"ControllersRestoreSessionResponse":           "RestoreSessionResponse",
 	"ControllersCleanupSessionsResponse":          "CleanupSessionsResponse",
 	"ControllersCleanupSkippedSession":            "CleanupSkippedSession",
+	"ControllersWorkspaceFileQuery":               "WorkspaceFileQuery",
+	"ControllersListWorkspaceFilesResponse":       "ListWorkspaceFilesResponse",
+	"ControllersWorkspaceFileSummary":             "WorkspaceFileSummary",
+	"ControllersWorkspaceFileResponse":            "WorkspaceFileResponse",
 	"ControllersKillSessionResponse":              "KillSessionResponse",
 	"ControllersRollbackSessionResponse":          "RollbackSessionResponse",
 	"ControllersSendSessionMessageRequest":        "SendSessionMessageRequest",
@@ -218,6 +222,7 @@ var schemaNames = map[string]string{
 	"ProjectRemoveResult":               "RemoveProjectResult",
 	"ProjectSetConfigInput":             "SetProjectConfigInput",
 	"ProjectWorkspaceRepo":              "WorkspaceRepo",
+	"SessionWorkspaceFileStatus":        "WorkspaceFileStatus",
 }
 
 // markRequestBodyRequired sets requestBody.required: true on the operation's
@@ -680,6 +685,29 @@ func sessionOperations() []operation {
 				{http.StatusNotImplemented, envelope.APIError{}},
 			},
 			contentTypes: map[int]string{http.StatusOK: "text/html"},
+		},
+		{
+			method: http.MethodGet, path: "/api/v1/sessions/{sessionId}/workspace/files", id: "listSessionWorkspaceFiles", tag: "sessions",
+			summary:    "List files in a session workspace with git change status",
+			pathParams: []any{controllers.SessionIDParam{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.ListWorkspaceFilesResponse{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
+			method: http.MethodGet, path: "/api/v1/sessions/{sessionId}/workspace/file", id: "getSessionWorkspaceFile", tag: "sessions",
+			summary:    "Read one session workspace file and its git diff",
+			pathParams: []any{controllers.SessionIDParam{}, controllers.WorkspaceFileQuery{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.WorkspaceFileResponse{}},
+				{http.StatusBadRequest, envelope.APIError{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
 		},
 		{
 			method: http.MethodGet, path: "/api/v1/sessions/{sessionId}/pr", id: "listSessionPRs", tag: "sessions",

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -119,6 +119,11 @@ type CleanupSessionsQuery struct {
 	Project string `query:"project,omitempty" description:"Project id filter. When omitted, clean terminated sessions across all projects."`
 }
 
+// WorkspaceFileQuery is the query string accepted by GET /api/v1/sessions/{sessionId}/workspace/file.
+type WorkspaceFileQuery struct {
+	Path string `query:"path" description:"Session-worktree-relative file path."`
+}
+
 // SessionView is the session wire shape: the domain read model plus the
 // display-safe branch name and the session's attributed pull requests in the
 // curated SessionPRFacts shape. One session can own many PRs (e.g. a stack), so
@@ -161,6 +166,39 @@ type SpawnSessionRequest struct {
 // SessionResponse is the { session } body shared by session create/get.
 type SessionResponse struct {
 	Session SessionView `json:"session"`
+}
+
+// ListWorkspaceFilesResponse is the body of GET /api/v1/sessions/{sessionId}/workspace/files.
+type ListWorkspaceFilesResponse struct {
+	SessionID domain.SessionID       `json:"sessionId"`
+	Files     []WorkspaceFileSummary `json:"files"`
+	Truncated bool                   `json:"truncated"`
+}
+
+// WorkspaceFileSummary is one file row in the session workspace browser.
+type WorkspaceFileSummary struct {
+	Path      string                         `json:"path"`
+	Status    sessionsvc.WorkspaceFileStatus `json:"status" enum:"unmodified,modified,added,deleted,renamed"`
+	Additions int                            `json:"additions"`
+	Deletions int                            `json:"deletions"`
+	Size      int64                          `json:"size"`
+	Binary    bool                           `json:"binary"`
+}
+
+// WorkspaceFileResponse is the body of GET /api/v1/sessions/{sessionId}/workspace/file.
+type WorkspaceFileResponse struct {
+	SessionID        domain.SessionID               `json:"sessionId"`
+	Path             string                         `json:"path"`
+	Status           sessionsvc.WorkspaceFileStatus `json:"status" enum:"unmodified,modified,added,deleted,renamed"`
+	Additions        int                            `json:"additions"`
+	Deletions        int                            `json:"deletions"`
+	Size             int64                          `json:"size"`
+	Binary           bool                           `json:"binary"`
+	Deleted          bool                           `json:"deleted"`
+	Content          string                         `json:"content"`
+	ContentTruncated bool                           `json:"contentTruncated"`
+	Diff             string                         `json:"diff"`
+	DiffTruncated    bool                           `json:"diffTruncated"`
 }
 
 // SessionPreviewResponse is the body of GET /api/v1/sessions/{sessionId}/preview.

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -45,6 +45,8 @@ type SessionService interface {
 	Send(ctx context.Context, id domain.SessionID, message string) error
 	ListPRSummaries(ctx context.Context, id domain.SessionID) ([]sessionsvc.PRSummary, error)
 	ClaimPR(ctx context.Context, id domain.SessionID, ref string, opts sessionsvc.ClaimPROptions) (sessionsvc.ClaimPRResult, error)
+	ListWorkspaceFiles(ctx context.Context, id domain.SessionID) (sessionsvc.WorkspaceFiles, error)
+	GetWorkspaceFile(ctx context.Context, id domain.SessionID, path string) (sessionsvc.WorkspaceFileDetail, error)
 }
 
 // ActivityRecorder applies an agent activity-state signal to a session. It is
@@ -73,6 +75,8 @@ func (c *SessionsController) Register(r chi.Router) {
 	r.Post("/sessions/{sessionId}/preview", c.setPreview)
 	r.Delete("/sessions/{sessionId}/preview", c.clearPreview)
 	r.Get("/sessions/{sessionId}/preview/files/*", c.previewFile)
+	r.Get("/sessions/{sessionId}/workspace/files", c.listWorkspaceFiles)
+	r.Get("/sessions/{sessionId}/workspace/file", c.getWorkspaceFile)
 	r.Get("/sessions/{sessionId}/pr", c.listPRs)
 	r.Post("/sessions/{sessionId}/pr/claim", c.claimPR)
 	r.Patch("/sessions/{sessionId}", c.rename)
@@ -213,6 +217,37 @@ func (c *SessionsController) servePreviewMarkdown(w http.ResponseWriter, r *http
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
 	_, _ = w.Write(rendered) //nolint:gosec // G705: preview content is workspace-local and agent-trusted
+}
+
+func (c *SessionsController) listWorkspaceFiles(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "GET", "/api/v1/sessions/{sessionId}/workspace/files")
+		return
+	}
+	files, err := c.Svc.ListWorkspaceFiles(r.Context(), sessionID(r))
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, workspaceFilesResponse(files))
+}
+
+func (c *SessionsController) getWorkspaceFile(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "GET", "/api/v1/sessions/{sessionId}/workspace/file")
+		return
+	}
+	relPath := strings.TrimSpace(r.URL.Query().Get("path"))
+	if relPath == "" {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "WORKSPACE_PATH_REQUIRED", "path is required", nil)
+		return
+	}
+	file, err := c.Svc.GetWorkspaceFile(r.Context(), sessionID(r), relPath)
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, workspaceFileResponse(file))
 }
 
 // setPreview persists the browser preview URL the desktop app opens for a
@@ -742,6 +777,38 @@ func sessionPRSummaries(prs []sessionsvc.PRSummary) []SessionPRSummary {
 		out = append(out, NewSessionPRSummary(pr))
 	}
 	return out
+}
+
+func workspaceFilesResponse(files sessionsvc.WorkspaceFiles) ListWorkspaceFilesResponse {
+	out := make([]WorkspaceFileSummary, 0, len(files.Files))
+	for _, file := range files.Files {
+		out = append(out, WorkspaceFileSummary{
+			Path:      file.Path,
+			Status:    file.Status,
+			Additions: file.Additions,
+			Deletions: file.Deletions,
+			Size:      file.Size,
+			Binary:    file.Binary,
+		})
+	}
+	return ListWorkspaceFilesResponse{SessionID: files.SessionID, Files: out, Truncated: files.Truncated}
+}
+
+func workspaceFileResponse(file sessionsvc.WorkspaceFileDetail) WorkspaceFileResponse {
+	return WorkspaceFileResponse{
+		SessionID:        file.SessionID,
+		Path:             file.Path,
+		Status:           file.Status,
+		Additions:        file.Additions,
+		Deletions:        file.Deletions,
+		Size:             file.Size,
+		Binary:           file.Binary,
+		Deleted:          file.Deleted,
+		Content:          file.Content,
+		ContentTruncated: file.ContentTruncated,
+		Diff:             file.Diff,
+		DiffTruncated:    file.DiffTruncated,
+	}
 }
 
 func prState(pr domain.PRFacts) string {

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -28,9 +28,12 @@ type fakeSessionService struct {
 	cleanupProjects []domain.ProjectID
 	cleanupResult   []domain.SessionID
 	cleanupSkipped  []sessionsvc.CleanupSkipped
+	workspaceFiles  sessionsvc.WorkspaceFiles
+	workspaceFile   sessionsvc.WorkspaceFileDetail
 	spawnErr        error
 	claimErr        error
 	listPRErr       error
+	workspaceErr    error
 }
 
 func newFakeSessionService() *fakeSessionService {
@@ -214,6 +217,32 @@ func (f *fakeSessionService) ClaimPR(_ context.Context, id domain.SessionID, ref
 	}
 	prs, _ := f.ListPRs(context.Background(), id)
 	return sessionsvc.ClaimPRResult{PRs: prs, TakenOverFrom: []domain.SessionID{}, BranchChanged: true}, nil
+}
+
+func (f *fakeSessionService) ListWorkspaceFiles(_ context.Context, id domain.SessionID) (sessionsvc.WorkspaceFiles, error) {
+	if f.workspaceErr != nil {
+		return sessionsvc.WorkspaceFiles{}, f.workspaceErr
+	}
+	if _, ok := f.sessions[id]; !ok {
+		return sessionsvc.WorkspaceFiles{}, apierr.NotFound("SESSION_NOT_FOUND", "Unknown session")
+	}
+	if f.workspaceFiles.SessionID != "" {
+		return f.workspaceFiles, nil
+	}
+	return sessionsvc.WorkspaceFiles{SessionID: id}, nil
+}
+
+func (f *fakeSessionService) GetWorkspaceFile(_ context.Context, id domain.SessionID, path string) (sessionsvc.WorkspaceFileDetail, error) {
+	if f.workspaceErr != nil {
+		return sessionsvc.WorkspaceFileDetail{}, f.workspaceErr
+	}
+	if _, ok := f.sessions[id]; !ok {
+		return sessionsvc.WorkspaceFileDetail{}, apierr.NotFound("SESSION_NOT_FOUND", "Unknown session")
+	}
+	if f.workspaceFile.SessionID != "" {
+		return f.workspaceFile, nil
+	}
+	return sessionsvc.WorkspaceFileDetail{SessionID: id, Path: path}, nil
 }
 
 func newSessionTestServer(t *testing.T, svc *fakeSessionService) *httptest.Server {
@@ -653,6 +682,80 @@ func TestSessionsAPI_ClearPreviewNotFound(t *testing.T) {
 
 	body, status, _ := doRequest(t, srv, "DELETE", "/api/v1/sessions/missing-1/preview", "")
 	assertErrorCode(t, body, status, http.StatusNotFound, "SESSION_NOT_FOUND")
+}
+
+func TestSessionsAPI_ListWorkspaceFiles(t *testing.T) {
+	svc := newFakeSessionService()
+	svc.workspaceFiles = sessionsvc.WorkspaceFiles{
+		SessionID: "ao-1",
+		Files: []sessionsvc.WorkspaceFileSummary{
+			{Path: "README.md", Status: sessionsvc.WorkspaceFileModified, Additions: 2, Deletions: 1, Size: 48},
+			{Path: "notes.txt", Status: sessionsvc.WorkspaceFileAdded, Additions: 1, Size: 11},
+		},
+	}
+	srv := newSessionTestServer(t, svc)
+
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/sessions/ao-1/workspace/files", "")
+	assertJSON(t, headers)
+	if status != http.StatusOK {
+		t.Fatalf("GET workspace files = %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		SessionID string `json:"sessionId"`
+		Files     []struct {
+			Path      string `json:"path"`
+			Status    string `json:"status"`
+			Additions int    `json:"additions"`
+			Deletions int    `json:"deletions"`
+			Size      int64  `json:"size"`
+		} `json:"files"`
+	}
+	mustJSON(t, body, &got)
+	if got.SessionID != "ao-1" || len(got.Files) != 2 {
+		t.Fatalf("response = %#v", got)
+	}
+	if got.Files[0].Path != "README.md" || got.Files[0].Status != "modified" || got.Files[0].Additions != 2 || got.Files[0].Deletions != 1 {
+		t.Fatalf("first file = %#v", got.Files[0])
+	}
+}
+
+func TestSessionsAPI_GetWorkspaceFile(t *testing.T) {
+	svc := newFakeSessionService()
+	svc.workspaceFile = sessionsvc.WorkspaceFileDetail{
+		SessionID: "ao-1",
+		Path:      "README.md",
+		Status:    sessionsvc.WorkspaceFileModified,
+		Additions: 1,
+		Deletions: 1,
+		Size:      14,
+		Content:   "hello\nupdated\n",
+		Diff:      "@@ -1 +1 @@\n-hello\n+updated\n",
+	}
+	srv := newSessionTestServer(t, svc)
+
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/sessions/ao-1/workspace/file?path="+url.QueryEscape("README.md"), "")
+	assertJSON(t, headers)
+	if status != http.StatusOK {
+		t.Fatalf("GET workspace file = %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		SessionID string `json:"sessionId"`
+		Path      string `json:"path"`
+		Content   string `json:"content"`
+		Diff      string `json:"diff"`
+	}
+	mustJSON(t, body, &got)
+	if got.SessionID != "ao-1" || got.Path != "README.md" || got.Content == "" || got.Diff == "" {
+		t.Fatalf("response = %#v", got)
+	}
+}
+
+func TestSessionsAPI_GetWorkspaceFileRequiresPath(t *testing.T) {
+	srv := newSessionTestServer(t, newFakeSessionService())
+
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/sessions/ao-1/workspace/file", "")
+	assertJSON(t, headers)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "WORKSPACE_PATH_REQUIRED")
 }
 
 func TestSessionsAPI_SetPreviewEmptyURLNoEntry(t *testing.T) {

--- a/backend/internal/service/session/path_resolve_default.go
+++ b/backend/internal/service/session/path_resolve_default.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package session
+
+import "path/filepath"
+
+func resolvedFilesystemPath(path string) (string, error) {
+	return filepath.EvalSymlinks(path)
+}

--- a/backend/internal/service/session/path_resolve_windows.go
+++ b/backend/internal/service/session/path_resolve_windows.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package session
+
+import (
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func resolvedFilesystemPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	pathp, err := windows.UTF16PtrFromString(abs)
+	if err != nil {
+		return "", err
+	}
+	handle, err := windows.CreateFile(
+		pathp,
+		windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	size := uint32(256)
+	for {
+		buf := make([]uint16, size)
+		n, err := windows.GetFinalPathNameByHandle(handle, &buf[0], uint32(len(buf)), 0)
+		if err != nil {
+			return "", err
+		}
+		if n < uint32(len(buf)) {
+			return filepath.Clean(trimWindowsFinalPathPrefix(windows.UTF16ToString(buf[:n]))), nil
+		}
+		size = n + 1
+	}
+}
+
+func trimWindowsFinalPathPrefix(path string) string {
+	if strings.HasPrefix(path, `\\?\UNC\`) {
+		return `\\` + strings.TrimPrefix(path, `\\?\UNC\`)
+	}
+	return strings.TrimPrefix(path, `\\?\`)
+}

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -41,6 +44,41 @@ func newFakeStore() *fakeStore {
 		reviews:  map[string][]domain.PullRequestReview{},
 		threads:  map[string][]domain.PullRequestReviewThread{},
 		comments: map[string][]domain.PullRequestComment{},
+	}
+}
+
+func newWorkspaceRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "ao@example.com")
+	runGit(t, dir, "config", "user.name", "AO Tests")
+	writeWorkspaceFile(t, dir, ".gitignore", "node_modules/\n")
+	writeWorkspaceFile(t, dir, "README.md", "hello\n")
+	writeWorkspaceFile(t, dir, "src/app.go", "package main\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "initial")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git -C %s %s: %v\n%s", dir, strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+func writeWorkspaceFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }
 
@@ -185,6 +223,82 @@ func TestSessionSetPreviewUnknownSession(t *testing.T) {
 	st := newFakeStore()
 	if _, err := (&Service{store: st}).SetPreview(context.Background(), "ghost-1", "http://x"); err == nil {
 		t.Fatal("want error for unknown session")
+	}
+}
+
+func TestListWorkspaceFilesReturnsTrackedAndUntrackedStatus(t *testing.T) {
+	repo := newWorkspaceRepo(t)
+	writeWorkspaceFile(t, repo, "README.md", "goodbye\nupdated\n")
+	if err := os.Remove(filepath.Join(repo, "src", "app.go")); err != nil {
+		t.Fatal(err)
+	}
+	writeWorkspaceFile(t, repo, "notes.txt", "agent note\n")
+	writeWorkspaceFile(t, repo, "node_modules/cache.txt", "ignored\n")
+	st := newFakeStore()
+	st.sessions["ao-1"] = domain.SessionRecord{
+		ID:       "ao-1",
+		Metadata: domain.SessionMetadata{WorkspacePath: repo},
+		Activity: domain.Activity{State: domain.ActivityActive},
+	}
+
+	got, err := (&Service{store: st}).ListWorkspaceFiles(context.Background(), "ao-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPath := map[string]WorkspaceFileSummary{}
+	for _, file := range got.Files {
+		byPath[file.Path] = file
+	}
+	if got.SessionID != "ao-1" {
+		t.Fatalf("session id = %q, want ao-1", got.SessionID)
+	}
+	if byPath["README.md"].Status != WorkspaceFileModified {
+		t.Fatalf("README status = %q, want modified", byPath["README.md"].Status)
+	}
+	if byPath["src/app.go"].Status != WorkspaceFileDeleted {
+		t.Fatalf("src/app.go status = %q, want deleted", byPath["src/app.go"].Status)
+	}
+	if byPath["notes.txt"].Status != WorkspaceFileAdded {
+		t.Fatalf("notes.txt status = %q, want added", byPath["notes.txt"].Status)
+	}
+	if _, ok := byPath["node_modules/cache.txt"]; ok {
+		t.Fatal("ignored file was listed")
+	}
+	if byPath["README.md"].Additions == 0 || byPath["README.md"].Deletions == 0 {
+		t.Fatalf("README counts = +%d -%d, want non-zero diff counts", byPath["README.md"].Additions, byPath["README.md"].Deletions)
+	}
+}
+
+func TestGetWorkspaceFileReturnsContentAndDiff(t *testing.T) {
+	repo := newWorkspaceRepo(t)
+	writeWorkspaceFile(t, repo, "README.md", "goodbye\nupdated\n")
+	st := newFakeStore()
+	st.sessions["ao-1"] = domain.SessionRecord{ID: "ao-1", Metadata: domain.SessionMetadata{WorkspacePath: repo}}
+
+	got, err := (&Service{store: st}).GetWorkspaceFile(context.Background(), "ao-1", "README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != "README.md" {
+		t.Fatalf("path = %q, want README.md", got.Path)
+	}
+	if got.Content != "goodbye\nupdated\n" {
+		t.Fatalf("content = %q", got.Content)
+	}
+	if !strings.Contains(got.Diff, "-hello") || !strings.Contains(got.Diff, "+updated") {
+		t.Fatalf("diff did not include expected old/new lines:\n%s", got.Diff)
+	}
+}
+
+func TestGetWorkspaceFileRejectsTraversal(t *testing.T) {
+	repo := newWorkspaceRepo(t)
+	st := newFakeStore()
+	st.sessions["ao-1"] = domain.SessionRecord{ID: "ao-1", Metadata: domain.SessionMetadata{WorkspacePath: repo}}
+
+	_, err := (&Service{store: st}).GetWorkspaceFile(context.Background(), "ao-1", "../secrets.txt")
+	var e *apierr.Error
+	if !errors.As(err, &e) || e.Kind != apierr.KindInvalid || e.Code != "INVALID_WORKSPACE_PATH" {
+		t.Fatalf("err = %v, want bad request INVALID_WORKSPACE_PATH", err)
 	}
 }
 

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -79,6 +80,20 @@ func writeWorkspaceFile(t *testing.T, root, rel, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func linkWorkspaceDir(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err == nil {
+		return
+	} else if runtime.GOOS != "windows" {
+		t.Skipf("creating symlink: %v", err)
+	} else {
+		cmd := exec.Command("cmd", "/c", "mklink", "/J", link, target)
+		if out, junctionErr := cmd.CombinedOutput(); junctionErr != nil {
+			t.Skipf("creating symlink or junction: symlink: %v; junction: %v\n%s", err, junctionErr, out)
+		}
 	}
 }
 
@@ -296,6 +311,21 @@ func TestGetWorkspaceFileRejectsTraversal(t *testing.T) {
 	st.sessions["ao-1"] = domain.SessionRecord{ID: "ao-1", Metadata: domain.SessionMetadata{WorkspacePath: repo}}
 
 	_, err := (&Service{store: st}).GetWorkspaceFile(context.Background(), "ao-1", "../secrets.txt")
+	var e *apierr.Error
+	if !errors.As(err, &e) || e.Kind != apierr.KindInvalid || e.Code != "INVALID_WORKSPACE_PATH" {
+		t.Fatalf("err = %v, want bad request INVALID_WORKSPACE_PATH", err)
+	}
+}
+
+func TestGetWorkspaceFileRejectsIntermediateSymlinkEscape(t *testing.T) {
+	repo := newWorkspaceRepo(t)
+	outside := t.TempDir()
+	writeWorkspaceFile(t, outside, "secret.txt", "outside workspace\n")
+	linkWorkspaceDir(t, outside, filepath.Join(repo, "link"))
+	st := newFakeStore()
+	st.sessions["ao-1"] = domain.SessionRecord{ID: "ao-1", Metadata: domain.SessionMetadata{WorkspacePath: repo}}
+
+	_, err := (&Service{store: st}).GetWorkspaceFile(context.Background(), "ao-1", "link/secret.txt")
 	var e *apierr.Error
 	if !errors.As(err, &e) || e.Kind != apierr.KindInvalid || e.Code != "INVALID_WORKSPACE_PATH" {
 		t.Fatalf("err = %v, want bad request INVALID_WORKSPACE_PATH", err)

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -1,0 +1,497 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+)
+
+const (
+	maxWorkspaceFiles     = 5000
+	maxWorkspaceFileBytes = 256 * 1024
+	maxWorkspaceDiffBytes = 512 * 1024
+)
+
+// WorkspaceFileStatus describes a session-worktree file relative to HEAD.
+type WorkspaceFileStatus string
+
+const (
+	WorkspaceFileUnmodified WorkspaceFileStatus = "unmodified"
+	WorkspaceFileModified   WorkspaceFileStatus = "modified"
+	WorkspaceFileAdded      WorkspaceFileStatus = "added"
+	WorkspaceFileDeleted    WorkspaceFileStatus = "deleted"
+	WorkspaceFileRenamed    WorkspaceFileStatus = "renamed"
+)
+
+// WorkspaceFiles is the read model for the session workspace file browser.
+type WorkspaceFiles struct {
+	SessionID domain.SessionID
+	Files     []WorkspaceFileSummary
+	Truncated bool
+}
+
+// WorkspaceFileSummary is one file row in the session workspace browser.
+type WorkspaceFileSummary struct {
+	Path      string
+	Status    WorkspaceFileStatus
+	Additions int
+	Deletions int
+	Size      int64
+	Binary    bool
+}
+
+// WorkspaceFileDetail is the selected file's current content and diff.
+type WorkspaceFileDetail struct {
+	SessionID          domain.SessionID
+	Path               string
+	Status             WorkspaceFileStatus
+	Additions          int
+	Deletions          int
+	Size               int64
+	Binary             bool
+	Deleted            bool
+	Content            string
+	ContentTruncated   bool
+	Diff               string
+	DiffTruncated      bool
+	WorkspaceTruncated bool
+}
+
+// ListWorkspaceFiles returns all tracked and untracked, non-ignored files in a
+// session worktree, annotated with their current git status against HEAD.
+func (s *Service) ListWorkspaceFiles(ctx context.Context, id domain.SessionID) (WorkspaceFiles, error) {
+	rec, err := s.sessionWorkspaceRecord(ctx, id)
+	if err != nil {
+		return WorkspaceFiles{}, err
+	}
+	statuses, counts, err := workspaceChangeMaps(ctx, rec.Metadata.WorkspacePath)
+	if err != nil {
+		return WorkspaceFiles{}, err
+	}
+	paths, truncated, err := workspaceGitFiles(ctx, rec.Metadata.WorkspacePath)
+	if err != nil {
+		return WorkspaceFiles{}, err
+	}
+	files := make([]WorkspaceFileSummary, 0, len(paths))
+	for _, rel := range paths {
+		status := statuses[rel]
+		if status == "" {
+			status = WorkspaceFileUnmodified
+		}
+		additions, deletions := counts[rel][0], counts[rel][1]
+		size, binary := workspaceFileSizeAndBinary(rec.Metadata.WorkspacePath, rel, status)
+		files = append(files, WorkspaceFileSummary{
+			Path:      rel,
+			Status:    status,
+			Additions: additions,
+			Deletions: deletions,
+			Size:      size,
+			Binary:    binary,
+		})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return WorkspaceFiles{SessionID: id, Files: files, Truncated: truncated}, nil
+}
+
+// GetWorkspaceFile returns one session-worktree file's current text content and
+// the git diff for that path. Binary or deleted files omit content.
+func (s *Service) GetWorkspaceFile(ctx context.Context, id domain.SessionID, rawPath string) (WorkspaceFileDetail, error) {
+	rec, err := s.sessionWorkspaceRecord(ctx, id)
+	if err != nil {
+		return WorkspaceFileDetail{}, err
+	}
+	rel, err := cleanWorkspaceRelativePath(rawPath)
+	if err != nil {
+		return WorkspaceFileDetail{}, err
+	}
+	statuses, counts, err := workspaceChangeMaps(ctx, rec.Metadata.WorkspacePath)
+	if err != nil {
+		return WorkspaceFileDetail{}, err
+	}
+	status := statuses[rel]
+	if status == "" {
+		status = WorkspaceFileUnmodified
+	}
+	additions, deletions := counts[rel][0], counts[rel][1]
+	detail := WorkspaceFileDetail{
+		SessionID: id,
+		Path:      rel,
+		Status:    status,
+		Additions: additions,
+		Deletions: deletions,
+		Deleted:   status == WorkspaceFileDeleted,
+	}
+	if !detail.Deleted {
+		file, info, err := confinedWorkspaceFile(rec.Metadata.WorkspacePath, rel)
+		if err != nil {
+			return WorkspaceFileDetail{}, err
+		}
+		detail.Size = info.Size()
+		content, binary, truncated, err := readWorkspaceTextFile(file, maxWorkspaceFileBytes)
+		if err != nil {
+			return WorkspaceFileDetail{}, err
+		}
+		detail.Binary = binary
+		detail.ContentTruncated = truncated
+		if !binary {
+			detail.Content = content
+		}
+	}
+	diff, truncated, err := workspaceFileDiff(ctx, rec.Metadata.WorkspacePath, rel, status, detail.Content, detail.Binary)
+	if err != nil {
+		return WorkspaceFileDetail{}, err
+	}
+	detail.Diff = diff
+	detail.DiffTruncated = truncated
+	return detail, nil
+}
+
+func (s *Service) sessionWorkspaceRecord(ctx context.Context, id domain.SessionID) (domain.SessionRecord, error) {
+	rec, ok, err := s.store.GetSession(ctx, id)
+	if err != nil {
+		return domain.SessionRecord{}, fmt.Errorf("get %s: %w", id, err)
+	}
+	if !ok {
+		return domain.SessionRecord{}, apierr.NotFound("SESSION_NOT_FOUND", "Unknown session")
+	}
+	if strings.TrimSpace(rec.Metadata.WorkspacePath) == "" {
+		return domain.SessionRecord{}, apierr.NotFound("SESSION_WORKSPACE_NOT_FOUND", "Session workspace not found")
+	}
+	info, err := os.Stat(rec.Metadata.WorkspacePath)
+	if err != nil || !info.IsDir() {
+		return domain.SessionRecord{}, apierr.NotFound("SESSION_WORKSPACE_NOT_FOUND", "Session workspace not found")
+	}
+	return rec, nil
+}
+
+func workspaceGitFiles(ctx context.Context, root string) ([]string, bool, error) {
+	out, err := gitWorkspaceOutput(ctx, root, "ls-files", "-z", "-co", "--exclude-standard")
+	if err != nil {
+		return nil, false, err
+	}
+	parts := splitNUL(out)
+	paths := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	truncated := false
+	for _, part := range parts {
+		rel := filepath.ToSlash(part)
+		if rel == "" {
+			continue
+		}
+		if _, ok := seen[rel]; ok {
+			continue
+		}
+		seen[rel] = struct{}{}
+		if len(paths) >= maxWorkspaceFiles {
+			truncated = true
+			continue
+		}
+		paths = append(paths, rel)
+	}
+	return paths, truncated, nil
+}
+
+func workspaceChangeMaps(ctx context.Context, root string) (map[string]WorkspaceFileStatus, map[string][2]int, error) {
+	statuses, err := workspaceStatuses(ctx, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	counts, err := workspaceNumstat(ctx, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	for rel, status := range statuses {
+		if status != WorkspaceFileAdded {
+			continue
+		}
+		if _, ok := counts[rel]; ok {
+			continue
+		}
+		additions, ok := countUntrackedTextLines(root, rel)
+		if ok {
+			counts[rel] = [2]int{additions, 0}
+		}
+	}
+	return statuses, counts, nil
+}
+
+func workspaceStatuses(ctx context.Context, root string) (map[string]WorkspaceFileStatus, error) {
+	out, err := gitWorkspaceOutput(ctx, root, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+	if err != nil {
+		return nil, err
+	}
+	parts := splitNUL(out)
+	statuses := map[string]WorkspaceFileStatus{}
+	for i := 0; i < len(parts); i++ {
+		entry := parts[i]
+		if len(entry) < 4 {
+			continue
+		}
+		xy := entry[:2]
+		rel := filepath.ToSlash(entry[3:])
+		statuses[rel] = classifyWorkspaceStatus(xy)
+		if strings.ContainsAny(xy, "RC") && i+1 < len(parts) {
+			i++
+		}
+	}
+	return statuses, nil
+}
+
+func classifyWorkspaceStatus(xy string) WorkspaceFileStatus {
+	switch {
+	case xy == "??", strings.Contains(xy, "A"):
+		return WorkspaceFileAdded
+	case strings.ContainsAny(xy, "RC"):
+		return WorkspaceFileRenamed
+	case strings.Contains(xy, "D"):
+		return WorkspaceFileDeleted
+	case strings.ContainsAny(xy, "M"):
+		return WorkspaceFileModified
+	default:
+		return WorkspaceFileModified
+	}
+}
+
+func workspaceNumstat(ctx context.Context, root string) (map[string][2]int, error) {
+	out, err := gitWorkspaceOutput(ctx, root, "diff", "--numstat", "HEAD", "--")
+	if err != nil {
+		return nil, err
+	}
+	counts := map[string][2]int{}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 3 {
+			continue
+		}
+		additions, addOK := parseNumstatField(fields[0])
+		deletions, delOK := parseNumstatField(fields[1])
+		if !addOK || !delOK {
+			continue
+		}
+		counts[filepath.ToSlash(fields[2])] = [2]int{additions, deletions}
+	}
+	return counts, nil
+}
+
+func parseNumstatField(raw string) (int, bool) {
+	if raw == "-" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(raw)
+	return n, err == nil
+}
+
+func workspaceFileSizeAndBinary(root, rel string, status WorkspaceFileStatus) (int64, bool) {
+	if status == WorkspaceFileDeleted {
+		return 0, false
+	}
+	file, info, err := confinedWorkspaceFile(root, rel)
+	if err != nil {
+		return 0, false
+	}
+	_, binary, _, err := readWorkspaceTextFile(file, 8192)
+	if err != nil {
+		return info.Size(), false
+	}
+	return info.Size(), binary
+}
+
+func workspaceFileDiff(ctx context.Context, root, rel string, status WorkspaceFileStatus, content string, binary bool) (string, bool, error) {
+	if status == WorkspaceFileUnmodified {
+		return "", false, nil
+	}
+	if status == WorkspaceFileAdded && !gitTracked(ctx, root, rel) {
+		if binary {
+			return "", false, nil
+		}
+		diff := syntheticAddedFileDiff(rel, content)
+		truncatedDiff, truncated := truncateUTF8(diff, maxWorkspaceDiffBytes)
+		return truncatedDiff, truncated, nil
+	}
+	out, err := gitWorkspaceOutput(ctx, root, "diff", "--no-ext-diff", "--unified=80", "HEAD", "--", rel)
+	if err != nil {
+		return "", false, err
+	}
+	truncatedDiff, truncated := truncateUTF8(out, maxWorkspaceDiffBytes)
+	return truncatedDiff, truncated, nil
+}
+
+func gitTracked(ctx context.Context, root, rel string) bool {
+	_, err := gitWorkspaceOutput(ctx, root, "ls-files", "--error-unmatch", "--", rel)
+	return err == nil
+}
+
+func syntheticAddedFileDiff(rel, content string) string {
+	lines := strings.SplitAfter(content, "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		lines = nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "diff --git a/%s b/%s\n", rel, rel)
+	b.WriteString("new file mode 100644\n")
+	b.WriteString("--- /dev/null\n")
+	fmt.Fprintf(&b, "+++ b/%s\n", rel)
+	fmt.Fprintf(&b, "@@ -0,0 +1,%d @@\n", len(lines))
+	for _, line := range lines {
+		b.WriteByte('+')
+		b.WriteString(line)
+		if !strings.HasSuffix(line, "\n") {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func confinedWorkspaceFile(root, rel string) (string, os.FileInfo, error) {
+	clean, err := cleanWorkspaceRelativePath(rel)
+	if err != nil {
+		return "", nil, err
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return "", nil, apierr.NotFound("SESSION_WORKSPACE_NOT_FOUND", "Session workspace not found")
+	}
+	target := filepath.Join(rootAbs, filepath.FromSlash(clean))
+	targetAbs, err := filepath.Abs(target)
+	if err != nil || !pathWithin(rootAbs, targetAbs) {
+		return "", nil, apierr.Invalid("INVALID_WORKSPACE_PATH", "path escapes session workspace", nil)
+	}
+	info, err := os.Lstat(targetAbs)
+	if err != nil {
+		return "", nil, apierr.NotFound("WORKSPACE_FILE_NOT_FOUND", "Workspace file not found")
+	}
+	resolved := targetAbs
+	if info.Mode()&os.ModeSymlink != 0 {
+		resolved, err = filepath.EvalSymlinks(targetAbs)
+		if err != nil {
+			return "", nil, apierr.NotFound("WORKSPACE_FILE_NOT_FOUND", "Workspace file not found")
+		}
+		if !pathWithin(rootAbs, resolved) {
+			return "", nil, apierr.Invalid("INVALID_WORKSPACE_PATH", "path escapes session workspace", nil)
+		}
+		info, err = os.Stat(resolved)
+		if err != nil {
+			return "", nil, apierr.NotFound("WORKSPACE_FILE_NOT_FOUND", "Workspace file not found")
+		}
+	}
+	if info.IsDir() {
+		return "", nil, apierr.Invalid("WORKSPACE_PATH_IS_DIRECTORY", "Workspace path is a directory", nil)
+	}
+	return resolved, info, nil
+}
+
+func cleanWorkspaceRelativePath(raw string) (string, error) {
+	trimmed := strings.TrimSpace(strings.ReplaceAll(raw, "\\", "/"))
+	if trimmed == "" || path.IsAbs(trimmed) || filepath.IsAbs(raw) || filepath.VolumeName(raw) != "" {
+		return "", apierr.Invalid("INVALID_WORKSPACE_PATH", "workspace path must be relative", nil)
+	}
+	clean := path.Clean(trimmed)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", apierr.Invalid("INVALID_WORKSPACE_PATH", "path escapes session workspace", nil)
+	}
+	return clean, nil
+}
+
+func pathWithin(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	return err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func readWorkspaceTextFile(file string, limit int) (string, bool, bool, error) {
+	handle, err := os.Open(file)
+	if err != nil {
+		return "", false, false, apierr.NotFound("WORKSPACE_FILE_NOT_FOUND", "Workspace file not found")
+	}
+	defer handle.Close()
+	data, err := io.ReadAll(io.LimitReader(handle, int64(limit+1)))
+	if err != nil {
+		return "", false, false, err
+	}
+	truncated := len(data) > limit
+	if truncated {
+		data = data[:limit]
+	}
+	if isBinary(data) {
+		return "", true, truncated, nil
+	}
+	content := string(data)
+	if !utf8.ValidString(content) {
+		return "", true, truncated, nil
+	}
+	return content, false, truncated, nil
+}
+
+func isBinary(data []byte) bool {
+	return bytes.IndexByte(data, 0) >= 0 || !utf8.Valid(data)
+}
+
+func countUntrackedTextLines(root, rel string) (int, bool) {
+	file, _, err := confinedWorkspaceFile(root, rel)
+	if err != nil {
+		return 0, false
+	}
+	content, binary, _, err := readWorkspaceTextFile(file, maxWorkspaceFileBytes)
+	if err != nil || binary {
+		return 0, false
+	}
+	if content == "" {
+		return 0, true
+	}
+	return strings.Count(content, "\n") + btoi(!strings.HasSuffix(content, "\n")), true
+}
+
+func truncateUTF8(in string, limit int) (string, bool) {
+	if len(in) <= limit {
+		return in, false
+	}
+	end := 0
+	for i := range in {
+		if i > limit {
+			break
+		}
+		end = i
+	}
+	if end == 0 {
+		end = limit
+	}
+	return in[:end], true
+}
+
+func gitWorkspaceOutput(ctx context.Context, root string, args ...string) (string, error) {
+	cmd := aoprocess.CommandContext(ctx, "git", append([]string{"-C", root}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git -C %s %s: %w: %s", root, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func splitNUL(out string) []string {
+	raw := strings.TrimRight(out, "\x00")
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(raw, "\x00")
+}
+
+func btoi(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -474,9 +474,18 @@ func truncateUTF8(in string, limit int) (string, bool) {
 
 func gitWorkspaceOutput(ctx context.Context, root string, args ...string) (string, error) {
 	cmd := aoprocess.CommandContext(ctx, "git", append([]string{"-C", root}, args...)...)
-	out, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("git -C %s %s: %w: %s", root, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+		detail := strings.TrimSpace(stderr.String())
+		if stdout := strings.TrimSpace(string(out)); stdout != "" {
+			if detail != "" {
+				detail += ": "
+			}
+			detail += stdout
+		}
+		return "", fmt.Errorf("git -C %s %s: %w: %s", root, strings.Join(args, " "), err, detail)
 	}
 	return string(out), nil
 }

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -27,6 +27,7 @@ const (
 // WorkspaceFileStatus describes a session-worktree file relative to HEAD.
 type WorkspaceFileStatus string
 
+// Workspace file status values reported by the session workspace browser.
 const (
 	WorkspaceFileUnmodified WorkspaceFileStatus = "unmodified"
 	WorkspaceFileModified   WorkspaceFileStatus = "modified"
@@ -417,7 +418,7 @@ func readWorkspaceTextFile(file string, limit int) (string, bool, bool, error) {
 	if err != nil {
 		return "", false, false, apierr.NotFound("WORKSPACE_FILE_NOT_FOUND", "Workspace file not found")
 	}
-	defer handle.Close()
+	defer func() { _ = handle.Close() }()
 	data, err := io.ReadAll(io.LimitReader(handle, int64(limit+1)))
 	if err != nil {
 		return "", false, false, err

--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -367,28 +367,33 @@ func confinedWorkspaceFile(root, rel string) (string, os.FileInfo, error) {
 	if err != nil {
 		return "", nil, apierr.NotFound("SESSION_WORKSPACE_NOT_FOUND", "Session workspace not found")
 	}
-	target := filepath.Join(rootAbs, filepath.FromSlash(clean))
+	rootResolved, err := resolvedFilesystemPath(rootAbs)
+	if err != nil {
+		return "", nil, apierr.NotFound("SESSION_WORKSPACE_NOT_FOUND", "Session workspace not found")
+	}
+	rootInfo, err := os.Stat(rootResolved)
+	if err != nil || !rootInfo.IsDir() {
+		return "", nil, apierr.NotFound("SESSION_WORKSPACE_NOT_FOUND", "Session workspace not found")
+	}
+	target := filepath.Join(rootResolved, filepath.FromSlash(clean))
 	targetAbs, err := filepath.Abs(target)
-	if err != nil || !pathWithin(rootAbs, targetAbs) {
+	if err != nil || !pathWithin(rootResolved, targetAbs) {
 		return "", nil, apierr.Invalid("INVALID_WORKSPACE_PATH", "path escapes session workspace", nil)
 	}
-	info, err := os.Lstat(targetAbs)
-	if err != nil {
-		return "", nil, apierr.NotFound("WORKSPACE_FILE_NOT_FOUND", "Workspace file not found")
-	}
-	resolved := targetAbs
-	if info.Mode()&os.ModeSymlink != 0 {
-		resolved, err = filepath.EvalSymlinks(targetAbs)
+	resolved := rootResolved
+	for _, part := range strings.Split(clean, "/") {
+		resolved = filepath.Join(resolved, part)
+		resolved, err = resolvedFilesystemPath(resolved)
 		if err != nil {
 			return "", nil, apierr.NotFound("WORKSPACE_FILE_NOT_FOUND", "Workspace file not found")
 		}
-		if !pathWithin(rootAbs, resolved) {
+		if !pathWithin(rootResolved, resolved) {
 			return "", nil, apierr.Invalid("INVALID_WORKSPACE_PATH", "path escapes session workspace", nil)
 		}
-		info, err = os.Stat(resolved)
-		if err != nil {
-			return "", nil, apierr.NotFound("WORKSPACE_FILE_NOT_FOUND", "Workspace file not found")
-		}
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", nil, apierr.NotFound("WORKSPACE_FILE_NOT_FOUND", "Workspace file not found")
 	}
 	if info.IsDir() {
 		return "", nil, apierr.Invalid("WORKSPACE_PATH_IS_DIRECTORY", "Workspace path is a directory", nil)

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -624,6 +624,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sessions/{sessionId}/workspace/file": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read one session workspace file and its git diff */
+        get: operations["getSessionWorkspaceFile"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/sessions/{sessionId}/workspace/files": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List files in a session workspace with git change status */
+        get: operations["listSessionWorkspaceFiles"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/sessions/cleanup": {
         parameters: {
             query?: never;
@@ -783,6 +817,11 @@ export interface components {
         };
         ListSessionsResponse: {
             sessions: components["schemas"]["ControllersSessionView"][];
+        };
+        ListWorkspaceFilesResponse: {
+            files: components["schemas"]["WorkspaceFileSummary"][];
+            sessionId: string;
+            truncated: boolean;
         };
         MarkAllNotificationsReadResponse: {
             notifications: components["schemas"]["NotificationResponse"][];
@@ -1126,6 +1165,32 @@ export interface components {
         TriggerReviewResponse: {
             reviewerHandleId: string;
             reviews: components["schemas"]["PRReviewState"][];
+        };
+        WorkspaceFileResponse: {
+            additions: number;
+            binary: boolean;
+            content: string;
+            contentTruncated: boolean;
+            deleted: boolean;
+            deletions: number;
+            diff: string;
+            diffTruncated: boolean;
+            path: string;
+            sessionId: string;
+            /** Format: int64 */
+            size: number;
+            /** @enum {string} */
+            status: "unmodified" | "modified" | "added" | "deleted" | "renamed";
+        };
+        WorkspaceFileSummary: {
+            additions: number;
+            binary: boolean;
+            deletions: number;
+            path: string;
+            /** Format: int64 */
+            size: number;
+            /** @enum {string} */
+            status: "unmodified" | "modified" | "added" | "deleted" | "renamed";
         };
         WorkspaceRepo: {
             name: string;
@@ -3289,6 +3354,118 @@ export interface operations {
             };
             /** @description Internal Server Error */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    getSessionWorkspaceFile: {
+        parameters: {
+            query?: {
+                /** @description Session-worktree-relative file path. */
+                path?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Session identifier, e.g. project-1. */
+                sessionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceFileResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    listSessionWorkspaceFiles: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Session identifier, e.g. project-1. */
+                sessionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListWorkspaceFilesResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -128,4 +128,22 @@ describe("SessionFilesView", () => {
 		expect(codePane).toHaveClass("text-terminal-foreground");
 		expect(codePane).not.toHaveClass("text-terminal");
 	});
+
+	it("lets the caller toggle between rail and maximized layouts", async () => {
+		const onToggleMaximized = vi.fn();
+		renderWithQuery(<SessionFilesView onClose={vi.fn()} onToggleMaximized={onToggleMaximized} sessionId="sess-1" />);
+
+		await userEvent.click(await screen.findByRole("button", { name: "Maximize files" }));
+		expect(onToggleMaximized).toHaveBeenCalledWith(true);
+	});
+
+	it("shows a minimize action while maximized", async () => {
+		const onToggleMaximized = vi.fn();
+		renderWithQuery(
+			<SessionFilesView isMaximized onClose={vi.fn()} onToggleMaximized={onToggleMaximized} sessionId="sess-1" />,
+		);
+
+		await userEvent.click(await screen.findByRole("button", { name: "Minimize files" }));
+		expect(onToggleMaximized).toHaveBeenCalledWith(false);
+	});
 });

--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -1,0 +1,111 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionFilesView } from "./SessionFilesView";
+
+const { getMock } = vi.hoisted(() => ({ getMock: vi.fn() }));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: {
+		GET: getMock,
+	},
+	apiErrorMessage: (error: unknown, fallback = "Request failed") => {
+		if (error instanceof Error) return error.message;
+		if (typeof error === "object" && error !== null && "message" in error) {
+			return String((error as { message: unknown }).message);
+		}
+		return fallback;
+	},
+}));
+
+function renderWithQuery(children: ReactNode) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return render(<QueryClientProvider client={client}>{children}</QueryClientProvider>);
+}
+
+describe("SessionFilesView", () => {
+	beforeEach(() => {
+		getMock.mockReset();
+		getMock.mockImplementation(async (path: string, options?: unknown) => {
+			if (path === "/api/v1/sessions/{sessionId}/workspace/files") {
+				return {
+					data: {
+						sessionId: "sess-1",
+						truncated: false,
+						files: [
+							{
+								path: "src/App.tsx",
+								status: "modified",
+								additions: 2,
+								deletions: 1,
+								size: 120,
+								binary: false,
+							},
+							{
+								path: "README.md",
+								status: "unmodified",
+								additions: 0,
+								deletions: 0,
+								size: 80,
+								binary: false,
+							},
+						],
+					},
+				};
+			}
+			if (path === "/api/v1/sessions/{sessionId}/workspace/file") {
+				const query = options as { params?: { query?: { path?: string } } };
+				return {
+					data: {
+						sessionId: "sess-1",
+						path: query.params?.query?.path ?? "src/App.tsx",
+						status: "modified",
+						additions: 2,
+						deletions: 1,
+						size: 120,
+						binary: false,
+						deleted: false,
+						content: "const value = 1;\n",
+						contentTruncated: false,
+						diff: "@@\n-const value = 0;\n+const value = 1;\n",
+						diffTruncated: false,
+					},
+				};
+			}
+			return { data: undefined };
+		});
+	});
+
+	it("loads the workspace files and requests detail for the selected file", async () => {
+		renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
+
+		await screen.findByRole("button", { name: /src\/App\.tsx/ });
+		expect(screen.getByText("1 changed")).toBeInTheDocument();
+
+		await waitFor(() =>
+			expect(getMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/workspace/file", {
+				params: { path: { sessionId: "sess-1" }, query: { path: "src/App.tsx" } },
+			}),
+		);
+		expect(await screen.findByText("+const value = 1;")).toBeInTheDocument();
+	});
+
+	it("filters and opens a file from the list", async () => {
+		renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
+
+		await userEvent.type(await screen.findByPlaceholderText("Search files"), "readme");
+		expect(screen.queryByRole("button", { name: /src\/App\.tsx/ })).not.toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("button", { name: /README\.md/ }));
+
+		await waitFor(() =>
+			expect(getMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/workspace/file", {
+				params: { path: { sessionId: "sess-1" }, query: { path: "README.md" } },
+			}),
+		);
+	});
+});

--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -53,6 +53,14 @@ describe("SessionFilesView", () => {
 								size: 80,
 								binary: false,
 							},
+							{
+								path: "docs/guide.md",
+								status: "added",
+								additions: 3,
+								deletions: 0,
+								size: 90,
+								binary: false,
+							},
 						],
 					},
 				};
@@ -83,8 +91,10 @@ describe("SessionFilesView", () => {
 	it("loads the workspace files and requests detail for the selected file", async () => {
 		renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
 
-		await screen.findByRole("button", { name: /src\/App\.tsx/ });
-		expect(screen.getByText("1 changed")).toBeInTheDocument();
+		await screen.findByRole("button", { name: "Collapse src/App.tsx" });
+		expect(screen.getByRole("heading", { name: "Review" })).toBeInTheDocument();
+		expect(screen.getByText("2 files changed")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /README\.md/ })).not.toBeInTheDocument();
 
 		await waitFor(() =>
 			expect(getMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/workspace/file", {
@@ -94,28 +104,27 @@ describe("SessionFilesView", () => {
 		expect(await screen.findByText("+const value = 1;")).toBeInTheDocument();
 	});
 
-	it("filters and opens a file from the list", async () => {
+	it("filters and expands a changed file from the review list", async () => {
 		renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
 
-		await userEvent.type(await screen.findByPlaceholderText("Search files"), "readme");
+		await userEvent.type(await screen.findByPlaceholderText("Search changed files"), "guide");
 		expect(screen.queryByRole("button", { name: /src\/App\.tsx/ })).not.toBeInTheDocument();
 
-		await userEvent.click(screen.getByRole("button", { name: /README\.md/ }));
+		await userEvent.click(screen.getByRole("button", { name: "Expand docs/guide.md" }));
 
 		await waitFor(() =>
 			expect(getMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/workspace/file", {
-				params: { path: { sessionId: "sess-1" }, query: { path: "README.md" } },
+				params: { path: { sessionId: "sess-1" }, query: { path: "docs/guide.md" } },
 			}),
 		);
 	});
 
-	it("uses the terminal foreground color for normal file content", async () => {
+	it("uses the terminal foreground color for diff content", async () => {
 		renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
 
-		await screen.findByRole("button", { name: /src\/App\.tsx/ });
-		await userEvent.click(screen.getByRole("tab", { name: "File" }));
+		await screen.findByRole("button", { name: "Collapse src/App.tsx" });
 
-		const codePane = screen.getByText("const value = 1;").closest("pre");
+		const codePane = (await screen.findByText("+const value = 1;")).closest("pre");
 		expect(codePane).toHaveClass("text-terminal-foreground");
 		expect(codePane).not.toHaveClass("text-terminal");
 	});

--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -134,6 +134,20 @@ describe("SessionFilesView", () => {
 		expect(codePane).not.toHaveClass("text-terminal");
 	});
 
+	it("renders changed files as one integrated review list instead of boxed cards", async () => {
+		renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
+
+		const activeRowButton = await screen.findByRole("button", { name: "Collapse src/App.tsx" });
+		const list = screen.getByRole("list");
+		const row = activeRowButton.closest("article");
+
+		expect(list).toHaveClass("session-files-review-list");
+		expect(row).toHaveClass("session-files-review-row");
+		expect(row).not.toHaveClass("border");
+		expect(row).not.toHaveClass("bg-surface");
+		expect(row).not.toHaveClass("shadow-sm");
+	});
+
 	it("lets the caller toggle between rail and maximized layouts", async () => {
 		const onToggleMaximized = vi.fn();
 		renderWithQuery(<SessionFilesView onClose={vi.fn()} onToggleMaximized={onToggleMaximized} sessionId="sess-1" />);

--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -108,4 +108,15 @@ describe("SessionFilesView", () => {
 			}),
 		);
 	});
+
+	it("uses the terminal foreground color for normal file content", async () => {
+		renderWithQuery(<SessionFilesView onClose={vi.fn()} sessionId="sess-1" />);
+
+		await screen.findByRole("button", { name: /src\/App\.tsx/ });
+		await userEvent.click(screen.getByRole("tab", { name: "File" }));
+
+		const codePane = screen.getByText("const value = 1;").closest("pre");
+		expect(codePane).toHaveClass("text-terminal-foreground");
+		expect(codePane).not.toHaveClass("text-terminal");
+	});
 });

--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -95,6 +95,8 @@ describe("SessionFilesView", () => {
 		expect(screen.getByRole("heading", { name: "Review" })).toBeInTheDocument();
 		expect(screen.getByText("2 files changed")).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: /README\.md/ })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Diff layout" })).not.toBeInTheDocument();
+		expect(screen.queryByText("Stacked")).not.toBeInTheDocument();
 
 		await waitFor(() =>
 			expect(getMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/workspace/file", {

--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -95,6 +95,8 @@ describe("SessionFilesView", () => {
 		expect(screen.getByRole("heading", { name: "Review" })).toBeInTheDocument();
 		expect(screen.getByText("2 files changed")).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: /README\.md/ })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Download src/App.tsx" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Copy path for src/App.tsx" })).not.toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "Diff layout" })).not.toBeInTheDocument();
 		expect(screen.queryByText("Stacked")).not.toBeInTheDocument();
 
@@ -128,6 +130,7 @@ describe("SessionFilesView", () => {
 
 		const codePane = (await screen.findByText("+const value = 1;")).closest("pre");
 		expect(codePane).toHaveClass("text-terminal-foreground");
+		expect(codePane).toHaveClass("session-files-diff-scrollbar");
 		expect(codePane).not.toHaveClass("text-terminal");
 	});
 

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -188,10 +188,6 @@ export function SessionFilesView({
 							>
 								{expandedVisibleCount > 0 ? "Collapse all" : "Expand all"}
 							</Button>
-							<Button aria-label="Diff layout" disabled size="sm" type="button" variant="outline">
-								Stacked
-								<ChevronDown className="size-icon-sm" aria-hidden="true" />
-							</Button>
 						</div>
 					</div>
 					<ReviewFileList

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -223,9 +223,9 @@ function ReviewFileList({
 		return <PanelMessage>No changed files found.</PanelMessage>;
 	}
 	return (
-		<ul className="flex flex-col gap-3">
+		<ul className="session-files-review-list overflow-hidden border-y border-border/70">
 			{files.map((file) => (
-				<li key={file.path}>
+				<li className="border-b border-border/60 last:border-b-0" key={file.path}>
 					<ReviewFileCard
 						expanded={expandedPaths.has(file.path)}
 						file={file}
@@ -257,13 +257,16 @@ function ReviewFileCard({
 	});
 
 	return (
-		<article className="overflow-hidden rounded-md border border-border bg-surface shadow-sm">
-			<div className="flex min-h-14 items-center gap-3 px-4">
+		<article className="session-files-review-row overflow-hidden bg-transparent">
+			<div className="flex min-h-14 items-center">
 				<button
 					aria-controls={`workspace-diff-${file.path}`}
 					aria-expanded={expanded}
 					aria-label={`${expanded ? "Collapse" : "Expand"} ${file.path}`}
-					className="flex min-w-0 flex-1 items-center gap-3 py-3 text-left"
+					className={cn(
+						"flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left transition-colors",
+						expanded ? "bg-interactive-active/45" : "hover:bg-interactive-hover/50",
+					)}
 					onClick={onToggle}
 					type="button"
 				>
@@ -278,7 +281,7 @@ function ReviewFileCard({
 				</button>
 			</div>
 			{expanded ? (
-				<div id={`workspace-diff-${file.path}`} className="border-t border-border">
+				<div id={`workspace-diff-${file.path}`} className="border-t border-border/60 bg-background/40">
 					{detailQuery.isPending ? <PanelMessage>Loading diff...</PanelMessage> : null}
 					{!detailQuery.isPending && detailQuery.error ? (
 						<PanelMessage action={<RetryButton onClick={() => void detailQuery.refetch()} />}>

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -78,10 +78,7 @@ export function SessionFilesView({ sessionId, onClose }: SessionFilesViewProps) 
 
 	const normalizedFilter = filter.trim().toLowerCase();
 	const visibleFiles = useMemo(
-		() =>
-			normalizedFilter
-				? files.filter((file) => file.path.toLowerCase().includes(normalizedFilter))
-				: files,
+		() => (normalizedFilter ? files.filter((file) => file.path.toLowerCase().includes(normalizedFilter)) : files),
 		[files, normalizedFilter],
 	);
 	const changedCount = files.filter(isChanged).length;
@@ -172,7 +169,9 @@ function FileList({
 		return <PanelMessage>Loading files...</PanelMessage>;
 	}
 	if (error) {
-		return <PanelMessage action={<RetryButton onClick={onRetry} />}>{error.message || "Unable to load files."}</PanelMessage>;
+		return (
+			<PanelMessage action={<RetryButton onClick={onRetry} />}>{error.message || "Unable to load files."}</PanelMessage>
+		);
 	}
 	if (files.length === 0) {
 		return <PanelMessage>No files found.</PanelMessage>;
@@ -272,15 +271,7 @@ function DetailBody({ detail, mode }: { detail: WorkspaceFileDetail; mode: Detai
 	);
 }
 
-function CodePanel({
-	notice,
-	text,
-	variant,
-}: {
-	notice?: string;
-	text: string;
-	variant: "diff" | "file";
-}) {
+function CodePanel({ notice, text, variant }: { notice?: string; text: string; variant: "diff" | "file" }) {
 	const lines = text === "" ? [""] : text.replace(/\r\n/g, "\n").split("\n");
 	return (
 		<div className="flex h-full min-h-0 flex-col">

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -1,17 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-	ChevronDown,
-	ChevronRight,
-	Copy,
-	Download,
-	FileText,
-	Maximize2,
-	Minimize2,
-	RefreshCw,
-	Search,
-	X,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, FileText, Maximize2, Minimize2, RefreshCw, Search, X } from "lucide-react";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { cn } from "../lib/utils";
@@ -267,16 +256,6 @@ function ReviewFileCard({
 		queryFn: () => loadWorkspaceFile(sessionId, file.path),
 	});
 
-	const copyPath = () => {
-		void navigator.clipboard?.writeText(file.path);
-	};
-
-	const downloadFile = async () => {
-		const detail = detailQuery.data ?? (await detailQuery.refetch()).data;
-		if (!detail || detail.binary) return;
-		downloadTextFile(detail.path, detail.deleted ? detail.diff : detail.content || detail.diff);
-	};
-
 	return (
 		<article className="overflow-hidden rounded-md border border-border bg-surface shadow-sm">
 			<div className="flex min-h-14 items-center gap-3 px-4">
@@ -297,26 +276,6 @@ function ReviewFileCard({
 					<span className="min-w-0 flex-1 truncate font-mono text-sm font-semibold text-foreground">{file.path}</span>
 					<ChangeBadges additions={file.additions} deletions={file.deletions} />
 				</button>
-				<div className="flex shrink-0 items-center gap-1">
-					<Button
-						aria-label={`Download ${file.path}`}
-						onClick={downloadFile}
-						size="icon-sm"
-						type="button"
-						variant="ghost"
-					>
-						<Download className="size-icon-sm" aria-hidden="true" />
-					</Button>
-					<Button
-						aria-label={`Copy path for ${file.path}`}
-						onClick={copyPath}
-						size="icon-sm"
-						type="button"
-						variant="ghost"
-					>
-						<Copy className="size-icon-sm" aria-hidden="true" />
-					</Button>
-				</div>
 			</div>
 			{expanded ? (
 				<div id={`workspace-diff-${file.path}`} className="border-t border-border">
@@ -364,7 +323,7 @@ function CodePanel({ notice, text, variant }: { notice?: string; text: string; v
 			{notice ? (
 				<div className="shrink-0 border-b border-border bg-warning/10 px-4 py-2 text-xs text-warning">{notice}</div>
 			) : null}
-			<pre className="min-h-0 flex-1 overflow-auto bg-terminal py-3 font-mono text-xs leading-row text-terminal-foreground">
+			<pre className="session-files-diff-scrollbar min-h-0 flex-1 overflow-auto bg-terminal py-3 font-mono text-xs leading-row text-terminal-foreground">
 				{lines.map((line, index) => (
 					<div className={cn("min-w-max px-4", variant === "diff" && diffLineClass(line))} key={`${index}-${line}`}>
 						<span className="mr-4 inline-block w-8 select-none text-right text-passive">{index + 1}</span>
@@ -383,17 +342,6 @@ function ChangeBadges({ additions, deletions }: { additions: number; deletions: 
 			{deletions > 0 ? <span className="rounded bg-error/20 px-1.5 py-0.5 text-error">-{deletions}</span> : null}
 		</span>
 	);
-}
-
-function downloadTextFile(path: string, text: string) {
-	if (typeof document === "undefined") return;
-	const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
-	const url = URL.createObjectURL(blob);
-	const anchor = document.createElement("a");
-	anchor.href = url;
-	anchor.download = path.replace(/[\\/]/g, "__") || "workspace-file.txt";
-	anchor.click();
-	URL.revokeObjectURL(url);
 }
 
 function PanelMessage({ action, children }: { action?: ReactNode; children: ReactNode }) {

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -287,7 +287,7 @@ function CodePanel({
 			{notice ? (
 				<div className="shrink-0 border-b border-border bg-warning/10 px-4 py-2 text-xs text-warning">{notice}</div>
 			) : null}
-			<pre className="min-h-0 flex-1 overflow-auto bg-terminal py-3 font-mono text-xs leading-row text-terminal">
+			<pre className="min-h-0 flex-1 overflow-auto bg-terminal py-3 font-mono text-xs leading-row text-terminal-foreground">
 				{lines.map((line, index) => (
 					<div className={cn("min-w-max px-4", variant === "diff" && diffLineClass(line))} key={`${index}-${line}`}>
 						<span className="mr-4 inline-block w-8 select-none text-right text-passive">{index + 1}</span>

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -1,6 +1,17 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronDown, ChevronRight, Copy, Download, FileText, RefreshCw, Search, X } from "lucide-react";
+import {
+	ChevronDown,
+	ChevronRight,
+	Copy,
+	Download,
+	FileText,
+	Maximize2,
+	Minimize2,
+	RefreshCw,
+	Search,
+	X,
+} from "lucide-react";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { cn } from "../lib/utils";
@@ -14,6 +25,8 @@ type WorkspaceFileStatus = WorkspaceFileSummary["status"];
 type SessionFilesViewProps = {
 	sessionId: string;
 	onClose: () => void;
+	isMaximized?: boolean;
+	onToggleMaximized?: (next: boolean) => void;
 };
 
 const emptyFiles: WorkspaceFileSummary[] = [];
@@ -34,7 +47,12 @@ const statusTone: Record<WorkspaceFileStatus, string> = {
 	unmodified: "border-border bg-raised text-passive",
 };
 
-export function SessionFilesView({ sessionId, onClose }: SessionFilesViewProps) {
+export function SessionFilesView({
+	sessionId,
+	onClose,
+	isMaximized = false,
+	onToggleMaximized,
+}: SessionFilesViewProps) {
 	const queryClient = useQueryClient();
 	const [filter, setFilter] = useState("");
 	const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
@@ -136,6 +154,21 @@ export function SessionFilesView({ sessionId, onClose }: SessionFilesViewProps) 
 				>
 					<RefreshCw className={cn("size-icon-sm", filesQuery.isFetching && "animate-spin")} aria-hidden="true" />
 				</Button>
+				{onToggleMaximized ? (
+					<Button
+						aria-label={isMaximized ? "Minimize files" : "Maximize files"}
+						onClick={() => onToggleMaximized(!isMaximized)}
+						size="icon-sm"
+						type="button"
+						variant="ghost"
+					>
+						{isMaximized ? (
+							<Minimize2 className="size-icon-sm" aria-hidden="true" />
+						) : (
+							<Maximize2 className="size-icon-sm" aria-hidden="true" />
+						)}
+					</Button>
+				) : null}
 				<Button aria-label="Close files" onClick={onClose} size="icon-sm" type="button" variant="ghost">
 					<X className="size-icon-sm" aria-hidden="true" />
 				</Button>

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { FileText, RefreshCw, Search, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronRight, Copy, Download, FileText, RefreshCw, Search, X } from "lucide-react";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { cn } from "../lib/utils";
@@ -10,7 +10,6 @@ import { Input } from "./ui/input";
 type WorkspaceFileSummary = components["schemas"]["WorkspaceFileSummary"];
 type WorkspaceFileDetail = components["schemas"]["WorkspaceFileResponse"];
 type WorkspaceFileStatus = WorkspaceFileSummary["status"];
-type DetailMode = "diff" | "file";
 
 type SessionFilesViewProps = {
 	sessionId: string;
@@ -36,9 +35,10 @@ const statusTone: Record<WorkspaceFileStatus, string> = {
 };
 
 export function SessionFilesView({ sessionId, onClose }: SessionFilesViewProps) {
+	const queryClient = useQueryClient();
 	const [filter, setFilter] = useState("");
-	const [selectedPath, setSelectedPath] = useState<string | null>(null);
-	const [detailMode, setDetailMode] = useState<DetailMode>("diff");
+	const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set());
+	const initializedExpansionFor = useRef<string | null>(null);
 
 	const filesQuery = useQuery({
 		queryKey: ["session-workspace-files", sessionId],
@@ -52,40 +52,59 @@ export function SessionFilesView({ sessionId, onClose }: SessionFilesViewProps) 
 		},
 	});
 	const files = filesQuery.data?.files ?? emptyFiles;
+	const changedFiles = useMemo(() => files.filter(isChanged), [files]);
+
+	useEffect(() => {
+		initializedExpansionFor.current = null;
+		setExpandedPaths(new Set());
+		setFilter("");
+	}, [sessionId]);
 
 	useEffect(() => {
 		if (filesQuery.isPending) return;
-		setSelectedPath((current) => {
-			if (current && files.some((file) => file.path === current)) return current;
-			return files.find(isChanged)?.path ?? files[0]?.path ?? null;
-		});
-	}, [files, filesQuery.isPending]);
-
-	const detailQuery = useQuery({
-		queryKey: ["session-workspace-file", sessionId, selectedPath],
-		enabled: Boolean(selectedPath),
-		refetchInterval: 3500,
-		queryFn: async () => {
-			if (!selectedPath) throw new Error("file path is required");
-			const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/workspace/file", {
-				params: { path: { sessionId }, query: { path: selectedPath } },
-			});
-			if (error) throw new Error(apiErrorMessage(error, "Unable to load workspace file"));
-			if (!data) throw new Error("Workspace file response was empty");
-			return data;
-		},
-	});
+		if (initializedExpansionFor.current === sessionId) return;
+		initializedExpansionFor.current = sessionId;
+		setExpandedPaths(changedFiles[0] ? new Set([changedFiles[0].path]) : new Set());
+	}, [changedFiles, filesQuery.isPending, sessionId]);
 
 	const normalizedFilter = filter.trim().toLowerCase();
 	const visibleFiles = useMemo(
-		() => (normalizedFilter ? files.filter((file) => file.path.toLowerCase().includes(normalizedFilter)) : files),
-		[files, normalizedFilter],
+		() =>
+			normalizedFilter
+				? changedFiles.filter((file) => file.path.toLowerCase().includes(normalizedFilter))
+				: changedFiles,
+		[changedFiles, normalizedFilter],
 	);
-	const changedCount = files.filter(isChanged).length;
+	const changedCount = changedFiles.length;
+	const expandedVisibleCount = visibleFiles.filter((file) => expandedPaths.has(file.path)).length;
 
 	const refresh = () => {
 		void filesQuery.refetch();
-		if (selectedPath) void detailQuery.refetch();
+		void queryClient.invalidateQueries({ queryKey: ["session-workspace-file", sessionId] });
+	};
+
+	const toggleFile = (path: string) => {
+		setExpandedPaths((current) => {
+			const next = new Set(current);
+			if (next.has(path)) {
+				next.delete(path);
+			} else {
+				next.add(path);
+			}
+			return next;
+		});
+	};
+
+	const toggleVisibleFiles = () => {
+		setExpandedPaths((current) => {
+			const next = new Set(current);
+			if (expandedVisibleCount > 0) {
+				for (const file of visibleFiles) next.delete(file.path);
+				return next;
+			}
+			for (const file of visibleFiles) next.add(file.path);
+			return next;
+		});
 	};
 
 	return (
@@ -95,7 +114,7 @@ export function SessionFilesView({ sessionId, onClose }: SessionFilesViewProps) 
 					<FileText className="size-icon-md shrink-0 text-passive" aria-hidden="true" />
 					<h2 className="truncate text-md-sm font-semibold text-foreground">Files</h2>
 					<span className="shrink-0 font-mono text-caption text-passive">
-						{changedCount === 1 ? "1 changed" : `${changedCount} changed`}
+						{changedCount === 1 ? "1 file changed" : `${changedCount} files changed`}
 					</span>
 				</div>
 				<label className="relative ml-auto min-w-0 flex-1 max-w-[360px]">
@@ -103,67 +122,76 @@ export function SessionFilesView({ sessionId, onClose }: SessionFilesViewProps) 
 					<Input
 						className="h-8 pl-8 font-mono text-xs"
 						onChange={(event) => setFilter(event.target.value)}
-						placeholder="Search files"
+						placeholder="Search changed files"
 						value={filter}
 					/>
 				</label>
 				<Button
 					aria-label="Refresh files"
-					disabled={filesQuery.isFetching || detailQuery.isFetching}
+					disabled={filesQuery.isFetching}
 					onClick={refresh}
 					size="icon-sm"
 					type="button"
 					variant="ghost"
 				>
-					<RefreshCw
-						className={cn("size-icon-sm", (filesQuery.isFetching || detailQuery.isFetching) && "animate-spin")}
-						aria-hidden="true"
-					/>
+					<RefreshCw className={cn("size-icon-sm", filesQuery.isFetching && "animate-spin")} aria-hidden="true" />
 				</Button>
 				<Button aria-label="Close files" onClick={onClose} size="icon-sm" type="button" variant="ghost">
 					<X className="size-icon-sm" aria-hidden="true" />
 				</Button>
 			</header>
 
-			<div className="grid min-h-0 flex-1 grid-cols-[minmax(210px,32%)_minmax(0,1fr)]">
-				<aside className="min-h-0 border-r border-border bg-background">
-					<FileList
+			<div className="min-h-0 flex-1 overflow-auto bg-background">
+				<div className="mx-auto flex min-h-full w-full max-w-[1200px] flex-col px-6 py-5">
+					<div className="mb-4 flex shrink-0 items-center gap-3">
+						<h3 className="text-md-sm font-medium text-foreground">Review</h3>
+						<div className="ml-auto flex items-center gap-2">
+							<Button
+								disabled={visibleFiles.length === 0}
+								onClick={toggleVisibleFiles}
+								size="sm"
+								type="button"
+								variant="outline"
+							>
+								{expandedVisibleCount > 0 ? "Collapse all" : "Expand all"}
+							</Button>
+							<Button aria-label="Diff layout" disabled size="sm" type="button" variant="outline">
+								Stacked
+								<ChevronDown className="size-icon-sm" aria-hidden="true" />
+							</Button>
+						</div>
+					</div>
+					<ReviewFileList
 						error={filesQuery.error}
+						expandedPaths={expandedPaths}
 						files={visibleFiles}
 						isLoading={filesQuery.isPending}
 						onRetry={() => void filesQuery.refetch()}
-						onSelect={setSelectedPath}
-						selectedPath={selectedPath}
+						onToggle={toggleFile}
+						sessionId={sessionId}
 					/>
-				</aside>
-				<FileDetail
-					detail={detailQuery.data}
-					error={detailQuery.error}
-					isLoading={detailQuery.isPending && Boolean(selectedPath)}
-					mode={detailMode}
-					onModeChange={setDetailMode}
-					onRetry={() => void detailQuery.refetch()}
-					selectedPath={selectedPath}
-				/>
+				</div>
 			</div>
 		</section>
 	);
 }
 
-function FileList({
+function ReviewFileList({
 	error,
+	expandedPaths,
 	files,
 	isLoading,
 	onRetry,
-	onSelect,
-	selectedPath,
+	onToggle,
+	sessionId,
 }: {
 	error: Error | null;
+	expandedPaths: Set<string>;
 	files: WorkspaceFileSummary[];
 	isLoading: boolean;
 	onRetry: () => void;
-	onSelect: (path: string) => void;
-	selectedPath: string | null;
+	onToggle: (path: string) => void;
+	sessionId: string;
 }) {
 	if (isLoading) {
 		return <PanelMessage>Loading files...</PanelMessage>;
@@ -174,93 +202,122 @@ function FileList({
 		);
 	}
 	if (files.length === 0) {
-		return <PanelMessage>No files found.</PanelMessage>;
+		return <PanelMessage>No changed files found.</PanelMessage>;
 	}
 	return (
-		<ul className="h-full overflow-auto py-2">
+		<ul className="flex flex-col gap-3">
 			{files.map((file) => (
 				<li key={file.path}>
-					<button
-						className={cn(
-							"flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left text-xs transition-colors hover:bg-interactive-hover",
-							selectedPath === file.path && "bg-interactive-active text-foreground",
-						)}
-						onClick={() => onSelect(file.path)}
-						type="button"
-					>
-						<StatusMark status={file.status} />
-						<span className="min-w-0 flex-1 truncate font-mono text-foreground">{file.path}</span>
-						{isChanged(file) ? (
-							<span className="shrink-0 font-mono text-micro text-passive">
-								+{file.additions} -{file.deletions}
-							</span>
-						) : null}
-					</button>
+					<ReviewFileCard
+						expanded={expandedPaths.has(file.path)}
+						file={file}
+						onToggle={() => onToggle(file.path)}
+						sessionId={sessionId}
+					/>
 				</li>
 			))}
 		</ul>
 	);
 }
 
-function FileDetail({
-	detail,
-	error,
-	isLoading,
-	mode,
-	onModeChange,
-	onRetry,
-	selectedPath,
+function ReviewFileCard({
+	expanded,
+	file,
+	onToggle,
+	sessionId,
 }: {
-	detail?: WorkspaceFileDetail;
-	error: Error | null;
-	isLoading: boolean;
-	mode: DetailMode;
-	onModeChange: (mode: DetailMode) => void;
-	onRetry: () => void;
-	selectedPath: string | null;
+	expanded: boolean;
+	file: WorkspaceFileSummary;
+	onToggle: () => void;
+	sessionId: string;
 }) {
-	if (!selectedPath) {
-		return <PanelMessage>No file selected.</PanelMessage>;
-	}
+	const detailQuery = useQuery({
+		queryKey: ["session-workspace-file", sessionId, file.path],
+		enabled: expanded,
+		refetchInterval: expanded ? 3500 : false,
+		queryFn: () => loadWorkspaceFile(sessionId, file.path),
+	});
+
+	const copyPath = () => {
+		void navigator.clipboard?.writeText(file.path);
+	};
+
+	const downloadFile = async () => {
+		const detail = detailQuery.data ?? (await detailQuery.refetch()).data;
+		if (!detail || detail.binary) return;
+		downloadTextFile(detail.path, detail.deleted ? detail.diff : detail.content || detail.diff);
+	};
+
 	return (
-		<section className="flex min-h-0 flex-col bg-background" aria-label="File detail">
-			<div className="flex h-11 shrink-0 items-center gap-3 border-b border-border px-4">
-				<div className="min-w-0 flex-1 truncate font-mono text-xs font-semibold text-foreground">{selectedPath}</div>
-				<div className="inline-flex shrink-0 rounded-md bg-raised p-1" role="tablist" aria-label="File detail mode">
-					<ModeButton active={mode === "diff"} onClick={() => onModeChange("diff")}>
-						Diff
-					</ModeButton>
-					<ModeButton active={mode === "file"} onClick={() => onModeChange("file")}>
-						File
-					</ModeButton>
+		<article className="overflow-hidden rounded-md border border-border bg-surface shadow-sm">
+			<div className="flex min-h-14 items-center gap-3 px-4">
+				<button
+					aria-controls={`workspace-diff-${file.path}`}
+					aria-expanded={expanded}
+					aria-label={`${expanded ? "Collapse" : "Expand"} ${file.path}`}
+					className="flex min-w-0 flex-1 items-center gap-3 py-3 text-left"
+					onClick={onToggle}
+					type="button"
+				>
+					{expanded ? (
+						<ChevronDown className="size-icon-sm shrink-0 text-passive" aria-hidden="true" />
+					) : (
+						<ChevronRight className="size-icon-sm shrink-0 text-passive" aria-hidden="true" />
+					)}
+					<StatusMark status={file.status} />
+					<span className="min-w-0 flex-1 truncate font-mono text-sm font-semibold text-foreground">{file.path}</span>
+					<ChangeBadges additions={file.additions} deletions={file.deletions} />
+				</button>
+				<div className="flex shrink-0 items-center gap-1">
+					<Button
+						aria-label={`Download ${file.path}`}
+						onClick={downloadFile}
+						size="icon-sm"
+						type="button"
+						variant="ghost"
+					>
+						<Download className="size-icon-sm" aria-hidden="true" />
+					</Button>
+					<Button
+						aria-label={`Copy path for ${file.path}`}
+						onClick={copyPath}
+						size="icon-sm"
+						type="button"
+						variant="ghost"
+					>
+						<Copy className="size-icon-sm" aria-hidden="true" />
+					</Button>
 				</div>
 			</div>
-			<div className="min-h-0 flex-1">
-				{isLoading ? <PanelMessage>Loading file...</PanelMessage> : null}
-				{!isLoading && error ? (
-					<PanelMessage action={<RetryButton onClick={onRetry} />}>
-						{error.message || "Unable to load this file."}
-					</PanelMessage>
-				) : null}
-				{!isLoading && !error && detail ? <DetailBody detail={detail} mode={mode} /> : null}
-			</div>
-		</section>
+			{expanded ? (
+				<div id={`workspace-diff-${file.path}`} className="border-t border-border">
+					{detailQuery.isPending ? <PanelMessage>Loading diff...</PanelMessage> : null}
+					{!detailQuery.isPending && detailQuery.error ? (
+						<PanelMessage action={<RetryButton onClick={() => void detailQuery.refetch()} />}>
+							{detailQuery.error.message || "Unable to load this file."}
+						</PanelMessage>
+					) : null}
+					{!detailQuery.isPending && !detailQuery.error && detailQuery.data ? (
+						<ReviewDiffBody detail={detailQuery.data} />
+					) : null}
+				</div>
+			) : null}
+		</article>
 	);
 }
 
-function DetailBody({ detail, mode }: { detail: WorkspaceFileDetail; mode: DetailMode }) {
+async function loadWorkspaceFile(sessionId: string, path: string) {
+	const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/workspace/file", {
+		params: { path: { sessionId }, query: { path } },
+	});
+	if (error) throw new Error(apiErrorMessage(error, "Unable to load workspace file"));
+	if (!data) throw new Error("Workspace file response was empty");
+	return data;
+}
+
+function ReviewDiffBody({ detail }: { detail: WorkspaceFileDetail }) {
 	if (detail.binary) {
 		return <PanelMessage>Binary file preview is not available.</PanelMessage>;
-	}
-	if (mode === "file") {
-		if (detail.deleted) return <PanelMessage>File deleted in this session.</PanelMessage>;
-		return (
-			<CodePanel
-				notice={detail.contentTruncated ? "File preview truncated." : undefined}
-				text={detail.content}
-				variant="file"
-			/>
-		);
 	}
 	return (
 		<CodePanel
@@ -274,7 +331,7 @@ function DetailBody({ detail, mode }: { detail: WorkspaceFileDetail; mode: Detai
 function CodePanel({ notice, text, variant }: { notice?: string; text: string; variant: "diff" | "file" }) {
 	const lines = text === "" ? [""] : text.replace(/\r\n/g, "\n").split("\n");
 	return (
-		<div className="flex h-full min-h-0 flex-col">
+		<div className="flex min-h-[220px] max-h-[min(620px,calc(100vh-18rem))] flex-col">
 			{notice ? (
 				<div className="shrink-0 border-b border-border bg-warning/10 px-4 py-2 text-xs text-warning">{notice}</div>
 			) : null}
@@ -290,26 +347,29 @@ function CodePanel({ notice, text, variant }: { notice?: string; text: string; v
 	);
 }
 
-function ModeButton({ active, children, onClick }: { active: boolean; children: string; onClick: () => void }) {
+function ChangeBadges({ additions, deletions }: { additions: number; deletions: number }) {
 	return (
-		<button
-			aria-selected={active}
-			className={cn(
-				"rounded px-2.5 py-1 text-xs text-muted-foreground transition-colors",
-				active && "bg-background text-foreground",
-			)}
-			onClick={onClick}
-			role="tab"
-			type="button"
-		>
-			{children}
-		</button>
+		<span className="flex shrink-0 items-center gap-1 font-mono text-xs font-semibold">
+			{additions > 0 ? <span className="rounded bg-success/20 px-1.5 py-0.5 text-success">+{additions}</span> : null}
+			{deletions > 0 ? <span className="rounded bg-error/20 px-1.5 py-0.5 text-error">-{deletions}</span> : null}
+		</span>
 	);
+}
+
+function downloadTextFile(path: string, text: string) {
+	if (typeof document === "undefined") return;
+	const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+	const url = URL.createObjectURL(blob);
+	const anchor = document.createElement("a");
+	anchor.href = url;
+	anchor.download = path.replace(/[\\/]/g, "__") || "workspace-file.txt";
+	anchor.click();
+	URL.revokeObjectURL(url);
 }
 
 function PanelMessage({ action, children }: { action?: ReactNode; children: ReactNode }) {
 	return (
-		<div className="grid h-full min-h-0 place-items-center p-6 text-center text-xs text-muted-foreground">
+		<div className="grid min-h-[180px] place-items-center p-6 text-center text-xs text-muted-foreground">
 			<div className="flex max-w-sm flex-col items-center gap-3">
 				<p>{children}</p>
 				{action ?? null}

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -1,0 +1,362 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { FileText, RefreshCw, Search, X } from "lucide-react";
+import type { components } from "../../api/schema";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { cn } from "../lib/utils";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+
+type WorkspaceFileSummary = components["schemas"]["WorkspaceFileSummary"];
+type WorkspaceFileDetail = components["schemas"]["WorkspaceFileResponse"];
+type WorkspaceFileStatus = WorkspaceFileSummary["status"];
+type DetailMode = "diff" | "file";
+
+type SessionFilesViewProps = {
+	sessionId: string;
+	onClose: () => void;
+};
+
+const emptyFiles: WorkspaceFileSummary[] = [];
+
+const statusLabel: Record<WorkspaceFileStatus, string> = {
+	added: "A",
+	deleted: "D",
+	modified: "M",
+	renamed: "R",
+	unmodified: "",
+};
+
+const statusTone: Record<WorkspaceFileStatus, string> = {
+	added: "border-success/40 bg-success/10 text-success",
+	deleted: "border-error/40 bg-error/10 text-error",
+	modified: "border-warning/40 bg-warning/10 text-warning",
+	renamed: "border-accent/40 bg-accent-weak text-accent",
+	unmodified: "border-border bg-raised text-passive",
+};
+
+export function SessionFilesView({ sessionId, onClose }: SessionFilesViewProps) {
+	const [filter, setFilter] = useState("");
+	const [selectedPath, setSelectedPath] = useState<string | null>(null);
+	const [detailMode, setDetailMode] = useState<DetailMode>("diff");
+
+	const filesQuery = useQuery({
+		queryKey: ["session-workspace-files", sessionId],
+		refetchInterval: 3500,
+		queryFn: async () => {
+			const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/workspace/files", {
+				params: { path: { sessionId } },
+			});
+			if (error) throw new Error(apiErrorMessage(error, "Unable to load workspace files"));
+			return data ?? { sessionId, files: [], truncated: false };
+		},
+	});
+	const files = filesQuery.data?.files ?? emptyFiles;
+
+	useEffect(() => {
+		if (filesQuery.isPending) return;
+		setSelectedPath((current) => {
+			if (current && files.some((file) => file.path === current)) return current;
+			return files.find(isChanged)?.path ?? files[0]?.path ?? null;
+		});
+	}, [files, filesQuery.isPending]);
+
+	const detailQuery = useQuery({
+		queryKey: ["session-workspace-file", sessionId, selectedPath],
+		enabled: Boolean(selectedPath),
+		refetchInterval: 3500,
+		queryFn: async () => {
+			if (!selectedPath) throw new Error("file path is required");
+			const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/workspace/file", {
+				params: { path: { sessionId }, query: { path: selectedPath } },
+			});
+			if (error) throw new Error(apiErrorMessage(error, "Unable to load workspace file"));
+			if (!data) throw new Error("Workspace file response was empty");
+			return data;
+		},
+	});
+
+	const normalizedFilter = filter.trim().toLowerCase();
+	const visibleFiles = useMemo(
+		() =>
+			normalizedFilter
+				? files.filter((file) => file.path.toLowerCase().includes(normalizedFilter))
+				: files,
+		[files, normalizedFilter],
+	);
+	const changedCount = files.filter(isChanged).length;
+
+	const refresh = () => {
+		void filesQuery.refetch();
+		if (selectedPath) void detailQuery.refetch();
+	};
+
+	return (
+		<section className="flex h-full min-h-0 flex-col bg-background text-foreground" aria-label="Session files">
+			<header className="flex h-13 shrink-0 items-center gap-3 border-b border-border bg-surface px-4">
+				<div className="flex min-w-0 items-center gap-2">
+					<FileText className="size-icon-md shrink-0 text-passive" aria-hidden="true" />
+					<h2 className="truncate text-md-sm font-semibold text-foreground">Files</h2>
+					<span className="shrink-0 font-mono text-caption text-passive">
+						{changedCount === 1 ? "1 changed" : `${changedCount} changed`}
+					</span>
+				</div>
+				<label className="relative ml-auto min-w-0 flex-1 max-w-[360px]">
+					<Search className="pointer-events-none absolute left-2.5 top-1/2 size-icon-sm -translate-y-1/2 text-passive" />
+					<Input
+						className="h-8 pl-8 font-mono text-xs"
+						onChange={(event) => setFilter(event.target.value)}
+						placeholder="Search files"
+						value={filter}
+					/>
+				</label>
+				<Button
+					aria-label="Refresh files"
+					disabled={filesQuery.isFetching || detailQuery.isFetching}
+					onClick={refresh}
+					size="icon-sm"
+					type="button"
+					variant="ghost"
+				>
+					<RefreshCw
+						className={cn("size-icon-sm", (filesQuery.isFetching || detailQuery.isFetching) && "animate-spin")}
+						aria-hidden="true"
+					/>
+				</Button>
+				<Button aria-label="Close files" onClick={onClose} size="icon-sm" type="button" variant="ghost">
+					<X className="size-icon-sm" aria-hidden="true" />
+				</Button>
+			</header>
+
+			<div className="grid min-h-0 flex-1 grid-cols-[minmax(210px,32%)_minmax(0,1fr)]">
+				<aside className="min-h-0 border-r border-border bg-background">
+					<FileList
+						error={filesQuery.error}
+						files={visibleFiles}
+						isLoading={filesQuery.isPending}
+						onRetry={() => void filesQuery.refetch()}
+						onSelect={setSelectedPath}
+						selectedPath={selectedPath}
+					/>
+				</aside>
+				<FileDetail
+					detail={detailQuery.data}
+					error={detailQuery.error}
+					isLoading={detailQuery.isPending && Boolean(selectedPath)}
+					mode={detailMode}
+					onModeChange={setDetailMode}
+					onRetry={() => void detailQuery.refetch()}
+					selectedPath={selectedPath}
+				/>
+			</div>
+		</section>
+	);
+}
+
+function FileList({
+	error,
+	files,
+	isLoading,
+	onRetry,
+	onSelect,
+	selectedPath,
+}: {
+	error: Error | null;
+	files: WorkspaceFileSummary[];
+	isLoading: boolean;
+	onRetry: () => void;
+	onSelect: (path: string) => void;
+	selectedPath: string | null;
+}) {
+	if (isLoading) {
+		return <PanelMessage>Loading files...</PanelMessage>;
+	}
+	if (error) {
+		return <PanelMessage action={<RetryButton onClick={onRetry} />}>{error.message || "Unable to load files."}</PanelMessage>;
+	}
+	if (files.length === 0) {
+		return <PanelMessage>No files found.</PanelMessage>;
+	}
+	return (
+		<ul className="h-full overflow-auto py-2">
+			{files.map((file) => (
+				<li key={file.path}>
+					<button
+						className={cn(
+							"flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left text-xs transition-colors hover:bg-interactive-hover",
+							selectedPath === file.path && "bg-interactive-active text-foreground",
+						)}
+						onClick={() => onSelect(file.path)}
+						type="button"
+					>
+						<StatusMark status={file.status} />
+						<span className="min-w-0 flex-1 truncate font-mono text-foreground">{file.path}</span>
+						{isChanged(file) ? (
+							<span className="shrink-0 font-mono text-micro text-passive">
+								+{file.additions} -{file.deletions}
+							</span>
+						) : null}
+					</button>
+				</li>
+			))}
+		</ul>
+	);
+}
+
+function FileDetail({
+	detail,
+	error,
+	isLoading,
+	mode,
+	onModeChange,
+	onRetry,
+	selectedPath,
+}: {
+	detail?: WorkspaceFileDetail;
+	error: Error | null;
+	isLoading: boolean;
+	mode: DetailMode;
+	onModeChange: (mode: DetailMode) => void;
+	onRetry: () => void;
+	selectedPath: string | null;
+}) {
+	if (!selectedPath) {
+		return <PanelMessage>No file selected.</PanelMessage>;
+	}
+	return (
+		<section className="flex min-h-0 flex-col bg-background" aria-label="File detail">
+			<div className="flex h-11 shrink-0 items-center gap-3 border-b border-border px-4">
+				<div className="min-w-0 flex-1 truncate font-mono text-xs font-semibold text-foreground">{selectedPath}</div>
+				<div className="inline-flex shrink-0 rounded-md bg-raised p-1" role="tablist" aria-label="File detail mode">
+					<ModeButton active={mode === "diff"} onClick={() => onModeChange("diff")}>
+						Diff
+					</ModeButton>
+					<ModeButton active={mode === "file"} onClick={() => onModeChange("file")}>
+						File
+					</ModeButton>
+				</div>
+			</div>
+			<div className="min-h-0 flex-1">
+				{isLoading ? <PanelMessage>Loading file...</PanelMessage> : null}
+				{!isLoading && error ? (
+					<PanelMessage action={<RetryButton onClick={onRetry} />}>
+						{error.message || "Unable to load this file."}
+					</PanelMessage>
+				) : null}
+				{!isLoading && !error && detail ? <DetailBody detail={detail} mode={mode} /> : null}
+			</div>
+		</section>
+	);
+}
+
+function DetailBody({ detail, mode }: { detail: WorkspaceFileDetail; mode: DetailMode }) {
+	if (detail.binary) {
+		return <PanelMessage>Binary file preview is not available.</PanelMessage>;
+	}
+	if (mode === "file") {
+		if (detail.deleted) return <PanelMessage>File deleted in this session.</PanelMessage>;
+		return (
+			<CodePanel
+				notice={detail.contentTruncated ? "File preview truncated." : undefined}
+				text={detail.content}
+				variant="file"
+			/>
+		);
+	}
+	return (
+		<CodePanel
+			notice={detail.diffTruncated ? "Diff preview truncated." : undefined}
+			text={detail.diff || "No diff against HEAD."}
+			variant="diff"
+		/>
+	);
+}
+
+function CodePanel({
+	notice,
+	text,
+	variant,
+}: {
+	notice?: string;
+	text: string;
+	variant: "diff" | "file";
+}) {
+	const lines = text === "" ? [""] : text.replace(/\r\n/g, "\n").split("\n");
+	return (
+		<div className="flex h-full min-h-0 flex-col">
+			{notice ? (
+				<div className="shrink-0 border-b border-border bg-warning/10 px-4 py-2 text-xs text-warning">{notice}</div>
+			) : null}
+			<pre className="min-h-0 flex-1 overflow-auto bg-terminal py-3 font-mono text-xs leading-row text-terminal">
+				{lines.map((line, index) => (
+					<div className={cn("min-w-max px-4", variant === "diff" && diffLineClass(line))} key={`${index}-${line}`}>
+						<span className="mr-4 inline-block w-8 select-none text-right text-passive">{index + 1}</span>
+						<span>{line || " "}</span>
+					</div>
+				))}
+			</pre>
+		</div>
+	);
+}
+
+function ModeButton({ active, children, onClick }: { active: boolean; children: string; onClick: () => void }) {
+	return (
+		<button
+			aria-selected={active}
+			className={cn(
+				"rounded px-2.5 py-1 text-xs text-muted-foreground transition-colors",
+				active && "bg-background text-foreground",
+			)}
+			onClick={onClick}
+			role="tab"
+			type="button"
+		>
+			{children}
+		</button>
+	);
+}
+
+function PanelMessage({ action, children }: { action?: ReactNode; children: ReactNode }) {
+	return (
+		<div className="grid h-full min-h-0 place-items-center p-6 text-center text-xs text-muted-foreground">
+			<div className="flex max-w-sm flex-col items-center gap-3">
+				<p>{children}</p>
+				{action ?? null}
+			</div>
+		</div>
+	);
+}
+
+function RetryButton({ onClick }: { onClick: () => void }) {
+	return (
+		<Button onClick={onClick} size="sm" type="button" variant="outline">
+			Retry
+		</Button>
+	);
+}
+
+function StatusMark({ status }: { status: WorkspaceFileStatus }) {
+	const label = statusLabel[status];
+	return (
+		<span
+			className={cn(
+				"inline-flex size-5 shrink-0 items-center justify-center rounded border font-mono text-micro font-semibold",
+				statusTone[status],
+			)}
+			title={status}
+		>
+			{label}
+		</span>
+	);
+}
+
+function isChanged(file: WorkspaceFileSummary) {
+	return file.status !== "unmodified";
+}
+
+function diffLineClass(line: string) {
+	if (line.startsWith("+") && !line.startsWith("+++")) return "bg-success/10 text-success";
+	if (line.startsWith("-") && !line.startsWith("---")) return "bg-error/10 text-error";
+	if (line.startsWith("@@")) return "text-accent";
+	return "";
+}

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -139,13 +139,16 @@ describe("SessionInspector tabs", () => {
 		expect(summaryTab).not.toHaveClass("flex-1");
 	});
 
-	it("opens the expanded files panel from the Files tab", async () => {
+	it("renders the supplied files view when the Files tab opens", async () => {
 		const onOpenFiles = vi.fn();
-		renderWithQuery(<SessionInspector onOpenFiles={onOpenFiles} session={session([])} />);
+		renderWithQuery(
+			<SessionInspector filesView={<div>workspace file review</div>} onOpenFiles={onOpenFiles} session={session([])} />,
+		);
 
 		await userEvent.click(screen.getByRole("tab", { name: "Files" }));
 
 		expect(onOpenFiles).toHaveBeenCalledTimes(1);
+		expect(screen.getByText("workspace file review")).toBeInTheDocument();
 	});
 });
 

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -130,6 +130,25 @@ afterEach(() => {
 	vi.useRealTimers();
 });
 
+describe("SessionInspector tabs", () => {
+	it("sizes rail tabs to their labels instead of stretching across the inspector", () => {
+		renderWithQuery(<SessionInspector session={session([])} />);
+
+		const summaryTab = screen.getByRole("tab", { name: "Summary" });
+
+		expect(summaryTab).not.toHaveClass("flex-1");
+	});
+
+	it("opens the expanded files panel from the Files tab", async () => {
+		const onOpenFiles = vi.fn();
+		renderWithQuery(<SessionInspector onOpenFiles={onOpenFiles} session={session([])} />);
+
+		await userEvent.click(screen.getByRole("tab", { name: "Files" }));
+
+		expect(onOpenFiles).toHaveBeenCalledTimes(1);
+	});
+});
+
 describe("SessionInspector PR section", () => {
 	// Scope assertions to the PR section so the card order is explicit.
 	const prSection = (title: string) =>
@@ -377,10 +396,10 @@ describe("SessionInspector Activity section", () => {
 });
 
 describe("SessionInspector tabs", () => {
-	it("exposes Summary, Reviews, and Browser as the three inspector tabs", () => {
+	it("exposes Summary, Reviews, Browser, and Files as inspector tabs", () => {
 		renderWithQuery(<SessionInspector session={session([pr(1, "open")])} />);
 		const tabs = screen.getAllByRole("tab").map((el) => el.textContent?.trim());
-		expect(tabs).toEqual(["Summary", "Reviews", "Browser"]);
+		expect(tabs).toEqual(["Summary", "Reviews", "Browser", "Files"]);
 	});
 
 	it("shows the intake issue id in the summary overview when present", () => {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -122,6 +122,7 @@ export function SessionInspector({
 	isInspectorVisible = true,
 	onToggleBrowserPopOut,
 	onOpenFiles,
+	filesView,
 	browserView,
 	view: viewProp,
 	onViewChange,
@@ -133,6 +134,7 @@ export function SessionInspector({
 	isInspectorVisible?: boolean;
 	onToggleBrowserPopOut?: (next: boolean) => void;
 	onOpenFiles?: () => void;
+	filesView?: ReactNode;
 	browserView?: BrowserViewModel;
 	/** Controlled active tab. Omit to let the inspector own its own selection. */
 	view?: InspectorView;
@@ -186,6 +188,7 @@ export function SessionInspector({
 					view === "browser" &&
 						!browserPoppedOut &&
 						"p-0 overflow-hidden [&>[role=tabpanel]]:border-0 [&>[role=tabpanel]]:rounded-none",
+					view === "files" && "p-0 overflow-hidden [&>[role=tabpanel]]:h-full",
 				)}
 			>
 				{view === "summary" ? <SummaryView session={session} /> : null}
@@ -200,7 +203,7 @@ export function SessionInspector({
 						session={session}
 					/>
 				) : null}
-				{view === "files" ? <FilesView onOpenFiles={onOpenFiles} /> : null}
+				{view === "files" ? <FilesView filesView={filesView} onOpenFiles={onOpenFiles} /> : null}
 			</div>
 		</aside>
 	);
@@ -887,11 +890,18 @@ function BrowserView({
 	);
 }
 
-function FilesView({ onOpenFiles }: { onOpenFiles?: () => void }) {
+function FilesView({ filesView, onOpenFiles }: { filesView?: ReactNode; onOpenFiles?: () => void }) {
+	if (filesView) {
+		return (
+			<div className="h-full min-h-0" role="tabpanel">
+				{filesView}
+			</div>
+		);
+	}
 	return (
 		<div role="tabpanel">
 			<div className={cn(inspectorEmptyClass, "flex flex-col items-center gap-2 px-5 py-10 text-center")}>
-				<p className="text-md-sm text-muted-foreground">Files are open in the expanded workspace.</p>
+				<p className="text-md-sm text-muted-foreground">Files are not available for this session.</p>
 				<Button disabled={!onOpenFiles} onClick={() => onOpenFiles?.()} size="sm" type="button" variant="outline">
 					Open files
 				</Button>

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
-import { ArrowUpRight, GitPullRequest, Play, Shield, Terminal, X } from "lucide-react";
+import { ArrowUpRight, Files as FilesIcon, GitPullRequest, Play, Shield, Terminal, X } from "lucide-react";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
@@ -22,7 +22,7 @@ type PRReviewState = components["schemas"]["PRReviewState"];
 type ReviewsResponse = components["schemas"]["ListReviewsResponse"];
 type OpenReviewerTerminal = (target: { handleId: string; harness: string }) => void;
 
-export type InspectorView = "summary" | "reviews" | "browser";
+export type InspectorView = "summary" | "reviews" | "browser" | "files";
 
 const VIEWS: { id: InspectorView; label: string; icon: ReactNode }[] = [
 	{
@@ -58,6 +58,11 @@ const VIEWS: { id: InspectorView; label: string; icon: ReactNode }[] = [
 				<path d="M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18" />
 			</svg>
 		),
+	},
+	{
+		id: "files",
+		label: "Files",
+		icon: <FilesIcon aria-hidden="true" />,
 	},
 ];
 
@@ -116,6 +121,7 @@ export function SessionInspector({
 	browserAnnotationQueue,
 	isInspectorVisible = true,
 	onToggleBrowserPopOut,
+	onOpenFiles,
 	browserView,
 	view: viewProp,
 	onViewChange,
@@ -126,6 +132,7 @@ export function SessionInspector({
 	browserAnnotationQueue?: BrowserAnnotationQueueModel;
 	isInspectorVisible?: boolean;
 	onToggleBrowserPopOut?: (next: boolean) => void;
+	onOpenFiles?: () => void;
 	browserView?: BrowserViewModel;
 	/** Controlled active tab. Omit to let the inspector own its own selection. */
 	view?: InspectorView;
@@ -136,6 +143,7 @@ export function SessionInspector({
 	const setView = (next: InspectorView) => {
 		setInternalView(next);
 		onViewChange?.(next);
+		if (next === "files") onOpenFiles?.();
 	};
 
 	if (!session) {
@@ -158,7 +166,7 @@ export function SessionInspector({
 						role="tab"
 						aria-selected={view === entry.id}
 						className={cn(
-							"inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md p-1.5 text-sm-md font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
+							"inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md p-1.5 text-sm-md font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
 							view === entry.id && "bg-interactive-active text-foreground",
 						)}
 						onClick={() => setView(entry.id)}
@@ -192,6 +200,7 @@ export function SessionInspector({
 						session={session}
 					/>
 				) : null}
+				{view === "files" ? <FilesView onOpenFiles={onOpenFiles} /> : null}
 			</div>
 		</aside>
 	);
@@ -875,6 +884,19 @@ function BrowserView({
 			poppedOut={false}
 			session={session}
 		/>
+	);
+}
+
+function FilesView({ onOpenFiles }: { onOpenFiles?: () => void }) {
+	return (
+		<div role="tabpanel">
+			<div className={cn(inspectorEmptyClass, "flex flex-col items-center gap-2 px-5 py-10 text-center")}>
+				<p className="text-md-sm text-muted-foreground">Files are open in the expanded workspace.</p>
+				<Button disabled={!onOpenFiles} onClick={() => onOpenFiles?.()} size="sm" type="button" variant="outline">
+					Open files
+				</Button>
+			</div>
+		</div>
 	);
 }
 

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, Ref } from "react";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { SessionView } from "./SessionView";
 import { useUiStore } from "../stores/ui-store";
@@ -70,9 +70,15 @@ vi.mock("./BrowserPanel", () => ({
 	}),
 }));
 vi.mock("./SessionFilesView", () => ({
-	SessionFilesView: ({ onClose }: { onClose: () => void }) => (
-		<button type="button" onClick={onClose}>
-			files center
+	SessionFilesView: ({
+		isMaximized,
+		onToggleMaximized,
+	}: {
+		isMaximized?: boolean;
+		onToggleMaximized?: (next: boolean) => void;
+	}) => (
+		<button type="button" onClick={() => onToggleMaximized?.(!isMaximized)}>
+			{isMaximized ? "files center" : "files rail"}
 		</button>
 	),
 }));
@@ -99,10 +105,12 @@ vi.mock("../hooks/useBrowserView", () => ({
 }));
 vi.mock("./SessionInspector", () => ({
 	SessionInspector: ({
+		filesView,
 		onOpenFiles,
 		onToggleBrowserPopOut,
 		view,
 	}: {
+		filesView?: ReactNode;
 		onOpenFiles?: () => void;
 		onToggleBrowserPopOut?: () => void;
 		view?: string;
@@ -114,6 +122,7 @@ vi.mock("./SessionInspector", () => ({
 			<button type="button" onClick={onOpenFiles}>
 				open files
 			</button>
+			{view === "files" ? filesView : null}
 		</div>
 	),
 }));
@@ -347,16 +356,32 @@ describe("SessionView", () => {
 		expect(browserDestroy).not.toHaveBeenCalled();
 	});
 
-	it("opens the files view over the session workspace and closes it without unmounting the terminal", () => {
+	it("opens the files view in the inspector rail first", () => {
 		render(<SessionView sessionId="sess-1" />);
 
 		fireEvent.click(screen.getByRole("button", { name: "open files" }));
+
+		expect(
+			within(screen.getByTestId("panel-inspector")).getByRole("button", { name: "files rail" }),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "files center" })).not.toBeInTheDocument();
+		expect(screen.getByText("terminal center")).toBeInTheDocument();
+	});
+
+	it("lets the user maximize and minimize the files view explicitly", () => {
+		render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "open files" }));
+		fireEvent.click(within(screen.getByTestId("panel-inspector")).getByRole("button", { name: "files rail" }));
 
 		expect(screen.getByRole("button", { name: "files center" })).toBeInTheDocument();
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 
 		fireEvent.click(screen.getByRole("button", { name: "files center" }));
 		expect(screen.queryByRole("button", { name: "files center" })).not.toBeInTheDocument();
+		expect(
+			within(screen.getByTestId("panel-inspector")).getByRole("button", { name: "files rail" }),
+		).toBeInTheDocument();
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 	});
 

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -67,8 +67,8 @@ vi.mock("./BrowserPanel", () => ({
 		enqueue: vi.fn(),
 		failPicking: vi.fn(),
 		retryQueued: vi.fn(),
-		}),
-	}));
+	}),
+}));
 vi.mock("./SessionFilesView", () => ({
 	SessionFilesView: ({ onClose }: { onClose: () => void }) => (
 		<button type="button" onClick={onClose}>

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -67,7 +67,14 @@ vi.mock("./BrowserPanel", () => ({
 		enqueue: vi.fn(),
 		failPicking: vi.fn(),
 		retryQueued: vi.fn(),
-	}),
+		}),
+	}));
+vi.mock("./SessionFilesView", () => ({
+	SessionFilesView: ({ onClose }: { onClose: () => void }) => (
+		<button type="button" onClick={onClose}>
+			files center
+		</button>
+	),
 }));
 const browserDestroy = vi.hoisted(() => vi.fn());
 vi.mock("../hooks/useBrowserView", () => ({
@@ -91,10 +98,23 @@ vi.mock("../hooks/useBrowserView", () => ({
 	}),
 }));
 vi.mock("./SessionInspector", () => ({
-	SessionInspector: ({ onToggleBrowserPopOut, view }: { onToggleBrowserPopOut?: () => void; view?: string }) => (
-		<button type="button" data-view={view} onClick={onToggleBrowserPopOut}>
-			pop browser
-		</button>
+	SessionInspector: ({
+		onOpenFiles,
+		onToggleBrowserPopOut,
+		view,
+	}: {
+		onOpenFiles?: () => void;
+		onToggleBrowserPopOut?: () => void;
+		view?: string;
+	}) => (
+		<div>
+			<button type="button" data-view={view} onClick={onToggleBrowserPopOut}>
+				pop browser
+			</button>
+			<button type="button" onClick={onOpenFiles}>
+				open files
+			</button>
+		</div>
 	),
 }));
 vi.mock("../lib/shell-context", () => ({
@@ -325,6 +345,19 @@ describe("SessionView", () => {
 		expect(screen.queryByRole("button", { name: "browser center" })).not.toBeInTheDocument();
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 		expect(browserDestroy).not.toHaveBeenCalled();
+	});
+
+	it("opens the files view over the session workspace and closes it without unmounting the terminal", () => {
+		render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "open files" }));
+
+		expect(screen.getByRole("button", { name: "files center" })).toBeInTheDocument();
+		expect(screen.getByText("terminal center")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "files center" }));
+		expect(screen.queryByRole("button", { name: "files center" })).not.toBeInTheDocument();
+		expect(screen.getByText("terminal center")).toBeInTheDocument();
 	});
 
 	it("reveals an `ao preview` URL in the inspector Browser tab, not the center pane", () => {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
 import { BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { CenterPane } from "./CenterPane";
+import { SessionFilesView } from "./SessionFilesView";
 import { SessionInspector, type InspectorView } from "./SessionInspector";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "./ui/resizable";
 import { useUiStore } from "../stores/ui-store";
@@ -48,6 +49,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const inspectorSeparatorRef = useRef<HTMLDivElement | null>(null);
 	const [terminalTarget, setTerminalTarget] = useState<TerminalTarget>({ kind: "worker" });
 	const [browserPoppedOut, setBrowserPoppedOut] = useState(false);
+	const [filesPoppedOut, setFilesPoppedOut] = useState(false);
 	const [inspectorView, setInspectorView] = useState<InspectorView>("summary");
 
 	const session = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
@@ -73,9 +75,20 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	useEffect(() => {
 		setTerminalTarget({ kind: "worker" });
 		setBrowserPoppedOut(false);
+		setFilesPoppedOut(false);
 		setInspectorView("summary");
 		revealedPreviewRef.current = null;
 	}, [sessionId]);
+
+	const handleOpenFiles = useCallback(() => {
+		setBrowserPoppedOut(false);
+		setFilesPoppedOut(true);
+	}, []);
+
+	const handleToggleBrowserPopOut = useCallback((next: boolean) => {
+		if (next) setFilesPoppedOut(false);
+		setBrowserPoppedOut(next);
+	}, []);
 
 	// `ao preview` sets session.previewUrl (streamed over CDC); surface the result
 	// in the inspector rail's Browser tab (opening the rail if collapsed), not the
@@ -182,7 +195,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	}
 
 	return (
-		<div className="flex h-full min-h-0 flex-col bg-background text-foreground">
+		<div className="relative flex h-full min-h-0 flex-col bg-background text-foreground">
 			<ResizablePanelGroup className="session-split min-h-0 flex-1" id="session-workspace" orientation="horizontal">
 				{/* react-resizable-panels v4: bare numbers are PIXELS; percentages must
             be strings. Numeric sizes here once clamped the inspector to 45px. */}
@@ -220,10 +233,11 @@ export function SessionView({ sessionId }: SessionViewProps) {
 									browserAnnotationQueue={browserAnnotationQueue}
 									browserPoppedOut={browserPoppedOut}
 									isInspectorVisible={isInspectorOpen}
+									onOpenFiles={handleOpenFiles}
 									onOpenReviewerTerminal={({ handleId, harness }) =>
 										setTerminalTarget({ kind: "reviewer", handleId, harness })
 									}
-									onToggleBrowserPopOut={setBrowserPoppedOut}
+									onToggleBrowserPopOut={handleToggleBrowserPopOut}
 									onViewChange={setInspectorView}
 									view={inspectorView}
 									browserView={browserView}
@@ -234,6 +248,11 @@ export function SessionView({ sessionId }: SessionViewProps) {
 					</>
 				) : null}
 			</ResizablePanelGroup>
+			{filesPoppedOut && session ? (
+				<div className="absolute inset-0 z-30 bg-background">
+					<SessionFilesView onClose={() => setFilesPoppedOut(false)} sessionId={session.id} />
+				</div>
+			) : null}
 			{/* Maximized browser: a fixed overlay across the app workspace,
           portaled to <body> so it escapes the shell layout (covering the
           sidebar + topbar, not just the session area) and sits outside any
@@ -246,7 +265,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 								active
 								annotationQueue={browserAnnotationQueue}
 								browserView={browserView}
-								onTogglePopOut={setBrowserPoppedOut}
+								onTogglePopOut={handleToggleBrowserPopOut}
 								poppedOut
 								session={session}
 							/>

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -82,8 +82,20 @@ export function SessionView({ sessionId }: SessionViewProps) {
 
 	const handleOpenFiles = useCallback(() => {
 		setBrowserPoppedOut(false);
-		setFilesPoppedOut(true);
-	}, []);
+		setFilesPoppedOut(false);
+		setInspectorView("files");
+		if (!useUiStore.getState().isInspectorOpen) toggleInspector();
+	}, [toggleInspector]);
+
+	const handleToggleFilesPopOut = useCallback(
+		(next: boolean) => {
+			if (next) setBrowserPoppedOut(false);
+			setFilesPoppedOut(next);
+			setInspectorView("files");
+			if (!useUiStore.getState().isInspectorOpen) toggleInspector();
+		},
+		[toggleInspector],
+	);
 
 	const handleToggleBrowserPopOut = useCallback((next: boolean) => {
 		if (next) setFilesPoppedOut(false);
@@ -232,6 +244,15 @@ export function SessionView({ sessionId }: SessionViewProps) {
 								<SessionInspector
 									browserAnnotationQueue={browserAnnotationQueue}
 									browserPoppedOut={browserPoppedOut}
+									filesView={
+										session ? (
+											<SessionFilesView
+												onClose={() => setInspectorView("summary")}
+												onToggleMaximized={handleToggleFilesPopOut}
+												sessionId={session.id}
+											/>
+										) : null
+									}
 									isInspectorVisible={isInspectorOpen}
 									onOpenFiles={handleOpenFiles}
 									onOpenReviewerTerminal={({ handleId, harness }) =>
@@ -250,7 +271,15 @@ export function SessionView({ sessionId }: SessionViewProps) {
 			</ResizablePanelGroup>
 			{filesPoppedOut && session ? (
 				<div className="absolute inset-0 z-30 bg-background">
-					<SessionFilesView onClose={() => setFilesPoppedOut(false)} sessionId={session.id} />
+					<SessionFilesView
+						isMaximized
+						onClose={() => {
+							setFilesPoppedOut(false);
+							setInspectorView("summary");
+						}}
+						onToggleMaximized={handleToggleFilesPopOut}
+						sessionId={session.id}
+					/>
 				</div>
 			) : null}
 			{/* Maximized browser: a fixed overlay across the app workspace,

--- a/frontend/src/renderer/lib/api-client.test.ts
+++ b/frontend/src/renderer/lib/api-client.test.ts
@@ -189,6 +189,15 @@ describe("normalizeApiOperation", () => {
 		expect(normalizeApiOperation("POST", "/api/v1/sessions/cleanup")).toBe("POST /api/v1/sessions/cleanup");
 	});
 
+	it("keeps workspace file routes aligned with the generated API schema", () => {
+		expect(normalizeApiOperation("GET", "/api/v1/sessions/ao-42/workspace/files")).toBe(
+			"GET /api/v1/sessions/:id/workspace/files",
+		);
+		expect(normalizeApiOperation("GET", "/api/v1/sessions/ao-42/workspace/file")).toBe(
+			"GET /api/v1/sessions/:id/workspace/file",
+		);
+	});
+
 	it("normalizes ids for resources a collection heuristic would miss", () => {
 		expect(normalizeApiOperation("GET", "/api/v1/orchestrators/orch-abc")).toBe("GET /api/v1/orchestrators/:id");
 		expect(normalizeApiOperation("POST", "/api/v1/prs/pr-1/merge")).toBe("POST /api/v1/prs/:id/merge");

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -77,6 +77,8 @@ const ROUTE_TEMPLATES = [
 	"/api/v1/sessions/{sessionId}/reviews/trigger",
 	"/api/v1/sessions/{sessionId}/rollback",
 	"/api/v1/sessions/{sessionId}/send",
+	"/api/v1/sessions/{sessionId}/workspace/file",
+	"/api/v1/sessions/{sessionId}/workspace/files",
 	"/api/v1/sessions/cleanup",
 ] as const;
 

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -356,6 +356,36 @@ select {
 	height: 0;
 }
 
+.session-files-diff-scrollbar {
+	scrollbar-width: thin;
+	scrollbar-color: var(--color-scrollbar) transparent;
+}
+
+.session-files-diff-scrollbar::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+}
+
+.session-files-diff-scrollbar::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.session-files-diff-scrollbar::-webkit-scrollbar-thumb {
+	border: 2px solid transparent;
+	border-radius: var(--radius-full);
+	background: var(--color-scrollbar);
+	background-clip: content-box;
+}
+
+.session-files-diff-scrollbar::-webkit-scrollbar-thumb:hover {
+	background: var(--color-scrollbar-hover);
+	background-clip: content-box;
+}
+
+.session-files-diff-scrollbar::-webkit-scrollbar-corner {
+	background: transparent;
+}
+
 .terminal-pane-frame:fullscreen {
 	background: var(--color-bg-primary);
 }


### PR DESCRIPTION
## Summary
Adds a session workspace Files panel so users can browse files in a session repo and inspect file contents or diffs from the expanded right-side view.

## Changes
  - Adds backend APIs for listing workspace files and reading file content/diffs.
  - Adds the frontend Files panel with search, refresh, file/diff tabs, and status metadata.
  - Fixes Git output parsing so stderr warnings do not break file status detection.

## Testing
  - npm.cmd run test -- SessionInspector SessionView SessionFilesView api-client
  - npm.cmd run typecheck
  - go test ./internal/service/session ./internal/httpd/apispec/...
  - go test ./internal/httpd/controllers -run "TestSessionsAPI_(ListWorkspaceFiles|GetWorkspaceFile|GetWorkspaceFileRequiresPath)$"
