### PR TITLE
fix(workspace): recreate missing registered worktrees

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -593,6 +593,22 @@ func (w *Workspace) existingWorktree(ctx context.Context, repo, path string, cfg
 		return ports.WorkspaceInfo{}, false, err
 	}
 	if rec, ok := findWorktree(records, path); ok {
+		info, err := os.Stat(path)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return ports.WorkspaceInfo{}, false, fmt.Errorf("gitworktree: stat registered worktree %q: %w", path, err)
+			}
+			// A worktree registration can outlive its directory when an earlier
+			// daemon or a user removes the path. Do not hand that dead cwd to the
+			// runtime: prune it so Create proceeds to materialize a fresh checkout.
+			if err := w.pruneWorktrees(ctx, repo); err != nil {
+				return ports.WorkspaceInfo{}, false, fmt.Errorf("gitworktree: prune stale worktree %q: %w", path, err)
+			}
+			return ports.WorkspaceInfo{}, false, nil
+		}
+		if !info.IsDir() {
+			return ports.WorkspaceInfo{}, false, fmt.Errorf("gitworktree: registered worktree %q is not a directory", path)
+		}
 		branch := rec.Branch
 		if branch == "" {
 			branch = cfg.Branch

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -182,6 +182,9 @@ func TestCreateReusesRegisteredWorktreeAtExpectedPath(t *testing.T) {
 		t.Fatalf("new: %v", err)
 	}
 	path := filepath.Join(ws.managedRoot, "proj", "orchestrator", "proj-orchestrator")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("create registered worktree path: %v", err)
+	}
 	cfg := ports.WorkspaceConfig{
 		ProjectID:     "proj",
 		SessionID:     "proj-1",
@@ -208,6 +211,61 @@ func TestCreateReusesRegisteredWorktreeAtExpectedPath(t *testing.T) {
 	}
 	if info.Path != path || info.Branch != "ao/proj-orchestrator" {
 		t.Fatalf("info = %#v, want path %q branch ao/proj-orchestrator", info, path)
+	}
+}
+
+func TestCreatePrunesMissingRegisteredWorktreeBeforeRecreating(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	path := filepath.Join(ws.managedRoot, "proj", "orchestrator", "proj-orchestrator")
+	cfg := ports.WorkspaceConfig{
+		ProjectID:     "proj",
+		SessionID:     "proj-1",
+		Kind:          domain.KindOrchestrator,
+		SessionPrefix: "proj",
+		Branch:        "ao/proj-orchestrator",
+	}
+
+	stale := true
+	var calls []string
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		calls = append(calls, joined)
+		switch {
+		case strings.Contains(joined, "check-ref-format"):
+			return nil, nil
+		case strings.Contains(joined, "worktree list --porcelain"):
+			if stale {
+				return []byte("worktree " + path + "\nbranch refs/heads/ao/proj-orchestrator\n"), nil
+			}
+			return []byte("worktree " + repo + "\nbranch refs/heads/main\n"), nil
+		case strings.Contains(joined, "worktree prune"):
+			stale = false
+			return nil, nil
+		case strings.Contains(joined, "rev-parse --verify --quiet refs/heads/ao/proj-orchestrator"):
+			return nil, nil
+		case strings.Contains(joined, "worktree add "+path+" ao/proj-orchestrator"):
+			return nil, nil
+		default:
+			t.Fatalf("unexpected git invocation: %v", args)
+			return nil, nil
+		}
+	}
+
+	info, err := ws.Create(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if info.Path != path || info.Branch != cfg.Branch {
+		t.Fatalf("info = %#v, want path %q branch %q", info, path, cfg.Branch)
+	}
+	got := strings.Join(calls, "\n")
+	if !strings.Contains(got, "worktree prune") || !strings.Contains(got, "worktree add "+path+" "+cfg.Branch) {
+		t.Fatalf("Create did not prune and recreate missing worktree:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #2775

## Summary
- detect Git worktree registrations whose directories no longer exist
- prune the stale registration and materialize a fresh worktree before runtime launch
- cover both valid reuse and stale-registration recovery

## Tests
- cd backend && go test ./internal/adapters/workspace/gitworktree
- cd backend && go build ./... && go test -race ./...