### PR TITLE
fix(renderer): don't flash onboarding before projects load (#2514)

### DIFF
--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -21,6 +21,7 @@ vi.mock("../../lib/api-client", () => ({
 	apiClient: { GET: getMock, POST: vi.fn() },
 	apiErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "error"),
 	hasTrustedApiBaseUrl: () => true,
+	subscribeApiBaseUrl: () => () => {},
 }));
 
 vi.mock("../../lib/bridge", () => ({

--- a/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/pr-hydration.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../lib/api-client", () => ({
 	apiClient: { GET: getMock, POST: vi.fn() },
 	apiErrorMessage: (e: unknown) => (e instanceof Error ? e.message : "error"),
 	hasTrustedApiBaseUrl: () => true,
+	subscribeApiBaseUrl: () => () => {},
 }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -22,6 +22,10 @@ vi.mock("../lib/api-client", () => ({
 		}
 		return "Request failed";
 	},
+	// Gated off so useWorkspaceQuery reads only the seeded cache (setQueryData)
+	// instead of refetching over it — these tests drive settings, not discovery.
+	hasTrustedApiBaseUrl: () => false,
+	subscribeApiBaseUrl: () => () => {},
 }));
 
 import { ProjectSettingsForm } from "./ProjectSettingsForm";

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.test.tsx
@@ -1,16 +1,29 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
-const { getMock, hasTrustedApiBaseUrlMock } = vi.hoisted(() => ({
-	getMock: vi.fn(),
-	hasTrustedApiBaseUrlMock: vi.fn(() => true),
-}));
+const { getMock, hasTrustedApiBaseUrlMock, subscribeApiBaseUrlMock, emitApiBaseUrlChange } = vi.hoisted(() => {
+	const listeners = new Set<() => void>();
+	return {
+		getMock: vi.fn(),
+		hasTrustedApiBaseUrlMock: vi.fn(() => true),
+		subscribeApiBaseUrlMock: vi.fn((listener: () => void) => {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		}),
+		emitApiBaseUrlChange: () => {
+			for (const listener of listeners) listener();
+		},
+	};
+});
 
 vi.mock("../lib/api-client", () => ({
 	apiClient: { GET: getMock },
 	hasTrustedApiBaseUrl: hasTrustedApiBaseUrlMock,
+	subscribeApiBaseUrl: subscribeApiBaseUrlMock,
 }));
 
 import { useWorkspaceQuery } from "./useWorkspaceQuery";
@@ -38,14 +51,44 @@ beforeEach(() => {
 });
 
 describe("useWorkspaceQuery", () => {
-	it("returns an empty workspace list while the daemon base URL is untrusted", async () => {
+	it("stays pending and does not fetch while the daemon base URL is untrusted", async () => {
 		hasTrustedApiBaseUrlMock.mockReturnValue(false);
 
 		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
 
-		await waitFor(() => expect(result.current.isSuccess).toBe(true));
-		expect(result.current.data).toEqual([]);
+		// Gated off: the query never resolves to a *successful* empty list — doing
+		// so would flash the first-run onboarding over projects about to load
+		// (#2514) — and it never touches the API before the daemon is known.
+		await waitFor(() => expect(result.current.isPending).toBe(true));
+		expect(result.current.isSuccess).toBe(false);
+		expect(result.current.fetchStatus).toBe("idle");
+		expect(result.current.data).toBeUndefined();
 		expect(getMock).not.toHaveBeenCalled();
+	});
+
+	it("fetches once the base URL becomes trusted (no onboarding flash on cold start)", async () => {
+		hasTrustedApiBaseUrlMock.mockReturnValue(false);
+		respondWith({
+			projects: {
+				data: { projects: [{ id: "p1", name: "Repo", kind: "single_repo", path: "/tmp/p1" }] },
+				error: undefined,
+			},
+		});
+
+		const { result } = renderHook(() => useWorkspaceQuery(), { wrapper });
+
+		// Cold start: gated off, nothing fetched, no empty list to flash onboarding.
+		await waitFor(() => expect(result.current.isPending).toBe(true));
+		expect(getMock).not.toHaveBeenCalled();
+
+		// Daemon reports ready → base URL trusted → subscribers notified → refetch.
+		hasTrustedApiBaseUrlMock.mockReturnValue(true);
+		act(() => {
+			emitApiBaseUrlChange();
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data?.map((workspace) => workspace.id)).toEqual(["p1"]);
 	});
 
 	it("maps projects and their sessions, applying provider/status/title fallbacks", async () => {

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
+import { useSyncExternalStore } from "react";
 import type { components } from "../../api/schema";
-import { apiClient, hasTrustedApiBaseUrl } from "../lib/api-client";
+import { apiClient, hasTrustedApiBaseUrl, subscribeApiBaseUrl } from "../lib/api-client";
 import { mockWorkspaces } from "../lib/mock-data";
 import {
 	type PRState,
@@ -27,12 +28,25 @@ function toPullRequestFacts(pr: components["schemas"]["SessionPRFacts"]): PullRe
 export const workspaceQueryKey = ["workspaces"] as const;
 const usePreviewData = import.meta.env.VITE_NO_ELECTRON === "1";
 
+// Thrown when fetchWorkspaces runs before the daemon's API base URL is known.
+// The port is discovered at runtime (only once the daemon reports ready), so
+// before that there is no authoritative project list. Callers gate on
+// hasTrustedApiBaseUrl(); this exists so a missed gate fails as an error rather
+// than resolving to a *successful* empty list — which would flash the first-run
+// onboarding page over existing projects (#2514).
+export class ApiBaseUrlNotTrustedError extends Error {
+	constructor() {
+		super("workspace query ran before the daemon API base URL was trusted");
+		this.name = "ApiBaseUrlNotTrustedError";
+	}
+}
+
 async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 	if (usePreviewData) {
 		return mockWorkspaces;
 	}
 	if (!hasTrustedApiBaseUrl()) {
-		return [];
+		throw new ApiBaseUrlNotTrustedError();
 	}
 
 	const [{ data: projectsData, error: projectsError }, { data: sessionsData, error: sessionsError }] =
@@ -79,5 +93,12 @@ export const workspaceQueryOptions = {
 };
 
 export function useWorkspaceQuery() {
-	return useQuery(workspaceQueryOptions);
+	// Gate the query on a trusted API base URL, tracked reactively so it flips on
+	// the moment the daemon reports ready (setApiBaseUrl notifies subscribers).
+	// While untrusted the query stays *pending* (never a successful empty list),
+	// so SessionsBoard shows its loading shell instead of flashing onboarding
+	// over projects that are about to load (#2514). Preview mode has no daemon and
+	// serves mock data, so it is always enabled.
+	const trusted = useSyncExternalStore(subscribeApiBaseUrl, hasTrustedApiBaseUrl, hasTrustedApiBaseUrl);
+	return useQuery({ ...workspaceQueryOptions, enabled: usePreviewData || trusted });
 }

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -11,7 +11,7 @@ import { WindowTitlebar } from "../components/WindowTitlebar";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
 import { useDaemonStatus } from "../hooks/useDaemonStatus";
 import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
-import { apiClient, apiErrorCode, apiErrorMessage } from "../lib/api-client";
+import { apiClient, apiErrorCode, apiErrorMessage, hasTrustedApiBaseUrl } from "../lib/api-client";
 import { refreshDaemonStatus } from "../lib/daemon-status";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
 import { ShellProvider } from "../lib/shell-context";
@@ -28,6 +28,11 @@ export const Route = createFileRoute("/_shell")({
 	// nav target is warm before the click.
 	loader: async ({ context }) => {
 		await refreshDaemonStatus().catch(() => undefined);
+		// Only warm the cache once the daemon's API base URL is trusted. Prefetching
+		// before that runs fetchWorkspaces against an unknown daemon and would cache
+		// a bogus empty result, flashing onboarding over existing projects (#2514).
+		// The reactive `enabled` gate in useWorkspaceQuery refetches once ready.
+		if (!hasTrustedApiBaseUrl()) return undefined;
 		return context.queryClient.ensureQueryData(workspaceQueryOptions);
 	},
 	component: ShellLayout,


### PR DESCRIPTION
Fixes #2514.

## Problem

On cold start the Electron app briefly showed the first-run **onboarding page**, then replaced it with the real project list once daemon discovery settled.

Root cause: `fetchWorkspaces()` returned `[]` whenever the daemon's API base URL wasn't trusted yet (its port is discovered at runtime). React Query treated that `[]` as a **successful** empty result, so `SessionsBoard`'s `isSuccess && all.length === 0` rendered `BoardWelcome`. When the daemon later became ready, `_shell` invalidated the query and the real `/api/v1/projects` list replaced it — i.e. the onboarding page was a transient discovery placeholder, not an authoritative no-projects state.

## Fix

Represent "API base not trusted yet" as a **pending** query instead of a successful empty list:

- `fetchWorkspaces` throws `ApiBaseUrlNotTrustedError` instead of returning `[]` when the base URL is untrusted, so it can never resolve as an empty success.
- `useWorkspaceQuery` gates the query on a trusted base URL, tracked reactively via `subscribeApiBaseUrl` + `useSyncExternalStore`, so it flips the moment the daemon reports ready. While untrusted the query stays pending and the board shows its loading shell.
- The `_shell` loader skips the `ensureQueryData` prefetch until the base URL is trusted, so the loader can't cache a bogus empty result either.

No behavior change once the daemon is ready: a genuine empty project list still shows onboarding (real first run).

## Before / After

**What the evidence shows:** both screenshots were taken under the identical condition — the renderer running on the real fetch path with **no daemon**, so the API base URL is never trusted and the state stays stable (no timing race to catch). Only the fix differs between the two.

- **Before (`main`):** the untrusted `[]` resolves as a successful empty result → the first-run onboarding page is rendered (this is what would flash over real projects once they load).
- **After (this branch):** the query stays pending while the base URL is untrusted → the board loading shell is shown instead of onboarding.

| Before (`main`) — onboarding flashes | After (this branch) — loading shell |
| --- | --- |
| ![before](https://raw.githubusercontent.com/fireddd/agent-orchestrator/evidence/onboarding-flash-2514/.github/evidence/2514/pre-fix.png) | ![after](https://raw.githubusercontent.com/fireddd/agent-orchestrator/evidence/onboarding-flash-2514/.github/evidence/2514/post-fix.png) |

## Tests

- Rewrote the untrusted-path unit test to the new pending contract and added a cold-start regression test (untrusted → trusted → refetch) in `useWorkspaceQuery.test.tsx`.
- Added the new `subscribeApiBaseUrl` export to the mocks that drive the real hook.
- Full renderer suite green: **623 passed**; `tsc --noEmit` clean.

*Reproduction was by code inspection + a deterministic Playwright screenshot of the two states (renderer on the real fetch path with no daemon); not a live capture of the timing race.*
