### PR TITLE
fix: report project removal teardown blockers

### DIFF
--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
+
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
 
 	projectsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/project"
@@ -46,6 +48,19 @@ func (emptyGetManager) Get(context.Context, domain.ProjectID) (projectsvc.GetRes
 
 	return projectsvc.GetResult{}, nil
 
+}
+
+type removeBlockedManager struct{ projectsvc.Manager }
+
+func (removeBlockedManager) Remove(context.Context, domain.ProjectID) (projectsvc.RemoveResult, error) {
+	return projectsvc.RemoveResult{}, apierr.Conflict("PROJECT_REMOVE_BLOCKED", "Project has session workspaces that could not be removed", map[string]any{
+		"projectId": "proj",
+		"blockers": []map[string]any{{
+			"sessionId": "proj-1",
+			"phase":     "kill",
+			"reason":    "workspace has uncommitted changes",
+		}},
+	})
 }
 
 // TestProjectsAPI_GetEmptyResultIs500 locks the fix for the discriminated-union
@@ -342,6 +357,32 @@ func TestProjectsAPI_Delete(t *testing.T) {
 
 	}
 
+}
+
+func TestProjectsAPI_DeleteBlockedReturnsConflictDetails(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{
+		Projects: removeBlockedManager{},
+	}, httpd.ControlDeps{}))
+	t.Cleanup(srv.Close)
+
+	body, status, headers := doRequest(t, srv, "DELETE", "/api/v1/projects/proj", "")
+	assertJSON(t, headers)
+	assertErrorCode(t, body, status, http.StatusConflict, "PROJECT_REMOVE_BLOCKED")
+
+	var err errorBody
+	mustJSON(t, body, &err)
+	if err.Details["projectId"] != "proj" {
+		t.Fatalf("details projectId = %#v, want proj", err.Details["projectId"])
+	}
+	blockers, ok := err.Details["blockers"].([]any)
+	if !ok || len(blockers) != 1 {
+		t.Fatalf("details blockers = %#v, want one blocker", err.Details["blockers"])
+	}
+	blocker, ok := blockers[0].(map[string]any)
+	if !ok || blocker["sessionId"] != "proj-1" || blocker["reason"] != "workspace has uncommitted changes" {
+		t.Fatalf("blocker = %#v, want dirty session blocker", blockers[0])
+	}
 }
 
 // TestProjectsAPI_RejectsUnknownConfigKeys locks the strict-decoder gate on the

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
+	sessionsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/session"
 )
 
 // Manager is the controller-facing contract for the /api/v1/projects surface.
@@ -46,7 +47,7 @@ type Manager interface {
 // SessionTeardowner is the narrow session-service surface project removal
 // needs: stop live project sessions and reclaim managed terminal workspaces.
 type SessionTeardowner interface {
-	TeardownProject(ctx context.Context, project domain.ProjectID) error
+	TeardownProject(ctx context.Context, project domain.ProjectID) (sessionsvc.ProjectTeardownOutcome, error)
 }
 
 // Service implements project registration and lookup use-cases for controllers.
@@ -586,8 +587,12 @@ func (m *Service) Remove(ctx context.Context, id domain.ProjectID) (RemoveResult
 		return RemoveResult{}, apierr.NotFound("PROJECT_NOT_FOUND", "Unknown project")
 	}
 	if m.sessions != nil {
-		if err := m.sessions.TeardownProject(ctx, id); err != nil {
+		teardown, err := m.sessions.TeardownProject(ctx, id)
+		if err != nil {
 			return RemoveResult{}, err
+		}
+		if len(teardown.Blockers) > 0 {
+			return RemoveResult{}, projectRemoveBlocked(id, teardown)
 		}
 	}
 	ok, err = m.store.ArchiveProject(ctx, string(id), time.Now())
@@ -598,6 +603,15 @@ func (m *Service) Remove(ctx context.Context, id domain.ProjectID) (RemoveResult
 		return RemoveResult{}, apierr.NotFound("PROJECT_NOT_FOUND", "Unknown project")
 	}
 	return RemoveResult{ProjectID: id, RemovedStorageDir: false}, nil
+}
+
+func projectRemoveBlocked(id domain.ProjectID, teardown sessionsvc.ProjectTeardownOutcome) error {
+	return apierr.Conflict("PROJECT_REMOVE_BLOCKED", "Project has session workspaces that could not be removed", map[string]any{
+		"projectId": string(id),
+		"blockers":  teardown.Blockers,
+		"killed":    teardown.Killed,
+		"cleaned":   teardown.Cleaned,
+	})
 }
 
 func (m *Service) suggestID(ctx context.Context, base domain.ProjectID) domain.ProjectID {

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/service/project"
+	sessionsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/session"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
 
@@ -102,6 +103,7 @@ func wantCode(t *testing.T, err error, code string) {
 
 type fakeProjectTeardowner struct {
 	projects []domain.ProjectID
+	out      sessionsvc.ProjectTeardownOutcome
 	err      error
 }
 
@@ -115,9 +117,9 @@ func (s *captureSink) Emit(_ context.Context, ev ports.TelemetryEvent) {
 
 func (*captureSink) Close(context.Context) error { return nil }
 
-func (f *fakeProjectTeardowner) TeardownProject(_ context.Context, project domain.ProjectID) error {
+func (f *fakeProjectTeardowner) TeardownProject(_ context.Context, project domain.ProjectID) (sessionsvc.ProjectTeardownOutcome, error) {
 	f.projects = append(f.projects, project)
-	return f.err
+	return f.out, f.err
 }
 
 func TestManager_AddListGetRemove(t *testing.T) {
@@ -256,6 +258,48 @@ func TestManager_RemoveDoesNotArchiveWhenTeardownFails(t *testing.T) {
 	}
 	if got, err := m.Get(ctx, "ao"); err != nil || got.Project == nil || got.Project.ID != "ao" {
 		t.Fatalf("project after failed remove = %#v, %v; want still active", got, err)
+	}
+}
+
+func TestManager_RemoveReturnsConflictWhenTeardownBlocked(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	teardown := sessionsvc.ProjectTeardownOutcome{
+		Killed: []sessionsvc.ProjectTeardownKilled{{
+			SessionID:      "ao-1",
+			WorkspaceFreed: false,
+			Terminated:     false,
+		}},
+		Cleaned: []domain.SessionID{},
+		Blockers: []sessionsvc.ProjectTeardownBlocker{{
+			SessionID: "ao-1",
+			Phase:     "kill",
+			Reason:    "workspace has uncommitted changes",
+		}},
+	}
+	m := project.NewWithDeps(project.Deps{Store: store, Sessions: &fakeProjectTeardowner{out: teardown}})
+
+	if _, err := m.Add(ctx, project.AddInput{Path: gitRepo(t), ProjectID: ptr("ao")}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	_, err = m.Remove(ctx, "ao")
+	var api *apierr.Error
+	if !errors.As(err, &api) || api.Kind != apierr.KindConflict || api.Code != "PROJECT_REMOVE_BLOCKED" {
+		t.Fatalf("Remove err = %v, want PROJECT_REMOVE_BLOCKED conflict", err)
+	}
+	if api.Details["projectId"] != "ao" {
+		t.Fatalf("details projectId = %#v, want ao", api.Details["projectId"])
+	}
+	blockers, ok := api.Details["blockers"].([]sessionsvc.ProjectTeardownBlocker)
+	if !ok || len(blockers) != 1 || blockers[0].Reason != "workspace has uncommitted changes" {
+		t.Fatalf("details blockers = %#v, want dirty blocker", api.Details["blockers"])
+	}
+	if got, err := m.Get(ctx, "ao"); err != nil || got.Project == nil || got.Project.ID != "ao" {
+		t.Fatalf("project after blocked remove = %#v, %v; want still active", got, err)
 	}
 }
 

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -91,6 +91,30 @@ type RestoreOutcome struct {
 	Mode    RestoreModeView `json:"restoreMode"`
 }
 
+// ProjectTeardownOutcome reports the per-session effects of removing a project.
+// Blockers are safe, user-facing reasons that should stop project archival.
+type ProjectTeardownOutcome struct {
+	Killed   []ProjectTeardownKilled  `json:"killed"`
+	Cleaned  []domain.SessionID       `json:"cleaned"`
+	Blockers []ProjectTeardownBlocker `json:"blockers"`
+}
+
+// ProjectTeardownKilled is one live session that project teardown asked the
+// session manager to stop.
+type ProjectTeardownKilled struct {
+	SessionID      domain.SessionID `json:"sessionId"`
+	WorkspaceFreed bool             `json:"workspaceFreed"`
+	Terminated     bool             `json:"terminated"`
+}
+
+// ProjectTeardownBlocker is one session workspace that prevented project
+// removal from safely completing.
+type ProjectTeardownBlocker struct {
+	SessionID domain.SessionID `json:"sessionId"`
+	Phase     string           `json:"phase"`
+	Reason    string           `json:"reason"`
+}
+
 type scmProvider interface {
 	ParseRepository(remote string) (ports.SCMRepo, bool)
 	FetchPullRequests(ctx context.Context, refs []ports.SCMPRRef) ([]ports.SCMObservation, error)
@@ -500,23 +524,62 @@ func (s *Service) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 }
 
 // TeardownProject stops every live session in a project, then asks the session
-// manager to reclaim terminal workspaces. Dirty worktrees are preserved by Kill
-// and Cleanup; callers only see hard teardown failures.
-func (s *Service) TeardownProject(ctx context.Context, project domain.ProjectID) error {
+// manager to reclaim terminal workspaces. Dirty or otherwise unremoved
+// workspaces are returned as structured blockers so project removal can answer
+// with an actionable conflict instead of an opaque internal error.
+func (s *Service) TeardownProject(ctx context.Context, project domain.ProjectID) (ProjectTeardownOutcome, error) {
+	out := ProjectTeardownOutcome{
+		Killed:   []ProjectTeardownKilled{},
+		Cleaned:  []domain.SessionID{},
+		Blockers: []ProjectTeardownBlocker{},
+	}
 	recs, err := s.listRecords(ctx, project)
 	if err != nil {
-		return err
+		return out, err
 	}
 	for _, rec := range recs {
 		if rec.IsTerminated {
 			continue
 		}
-		if _, err := s.Kill(ctx, rec.ID); err != nil {
-			return err
+		freed, err := s.Kill(ctx, rec.ID)
+		if err != nil {
+			out.Blockers = append(out.Blockers, ProjectTeardownBlocker{
+				SessionID: rec.ID,
+				Phase:     "kill",
+				Reason:    "session teardown failed",
+			})
+			continue
+		}
+		terminated, err := s.sessionTerminated(ctx, rec.ID)
+		if err != nil {
+			return out, err
+		}
+		out.Killed = append(out.Killed, ProjectTeardownKilled{
+			SessionID:      rec.ID,
+			WorkspaceFreed: freed,
+			Terminated:     terminated,
+		})
+		if !terminated {
+			out.Blockers = append(out.Blockers, ProjectTeardownBlocker{
+				SessionID: rec.ID,
+				Phase:     "kill",
+				Reason:    "workspace has uncommitted changes",
+			})
 		}
 	}
-	_, err = s.Cleanup(ctx, project)
-	return err
+	cleanup, err := s.Cleanup(ctx, project)
+	if err != nil {
+		return out, err
+	}
+	out.Cleaned = append(out.Cleaned, cleanup.Cleaned...)
+	for _, skip := range cleanup.Skipped {
+		out.Blockers = append(out.Blockers, ProjectTeardownBlocker{
+			SessionID: skip.SessionID,
+			Phase:     "cleanup",
+			Reason:    skip.Reason,
+		})
+	}
+	return out, nil
 }
 
 // List returns sessions as enriched display models after applying API filters.
@@ -537,6 +600,14 @@ func (s *Service) List(ctx context.Context, filter ListFilter) ([]domain.Session
 		out = append(out, sess)
 	}
 	return out, nil
+}
+
+func (s *Service) sessionTerminated(ctx context.Context, id domain.SessionID) (bool, error) {
+	rec, ok, err := s.store.GetSession(ctx, id)
+	if err != nil {
+		return false, fmt.Errorf("teardown %s: reload session: %w", id, err)
+	}
+	return !ok || rec.IsTerminated, nil
 }
 
 func (s *Service) listRecords(ctx context.Context, project domain.ProjectID) ([]domain.SessionRecord, error) {

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -350,9 +350,11 @@ type fakeCommander struct {
 	sent            []domain.SessionID
 	cleanupProjects []domain.ProjectID
 	killErr         error
+	killResult      *bool
 	retireErr       error
 	sendErr         error
 	cleanupErr      error
+	cleanupResult   *sessionmanager.CleanupResult
 	spawnErr        error
 	spawnRecord     domain.SessionRecord
 	spawned         bool
@@ -385,6 +387,9 @@ func (f *fakeCommander) Kill(_ context.Context, id domain.SessionID) (bool, erro
 		return false, f.killErr
 	}
 	f.killed = append(f.killed, id)
+	if f.killResult != nil {
+		return *f.killResult, nil
+	}
 	return true, nil
 }
 func (f *fakeCommander) RetireForReplacement(_ context.Context, id domain.SessionID) error {
@@ -405,6 +410,9 @@ func (f *fakeCommander) Cleanup(_ context.Context, project domain.ProjectID) (se
 	f.cleanupProjects = append(f.cleanupProjects, project)
 	if f.cleanupErr != nil {
 		return sessionmanager.CleanupResult{}, f.cleanupErr
+	}
+	if f.cleanupResult != nil {
+		return *f.cleanupResult, nil
 	}
 	return sessionmanager.CleanupResult{
 		Cleaned: []domain.SessionID{"mer-1"},
@@ -439,7 +447,7 @@ func TestTeardownProjectKillsActiveSessionsThenCleansProject(t *testing.T) {
 	fc := &fakeCommander{}
 	svc := &Service{manager: fc, store: st}
 
-	if err := svc.TeardownProject(context.Background(), "mer"); err != nil {
+	if _, err := svc.TeardownProject(context.Background(), "mer"); err != nil {
 		t.Fatalf("TeardownProject: %v", err)
 	}
 	if len(fc.killed) != 1 || fc.killed[0] != "mer-1" {
@@ -450,19 +458,86 @@ func TestTeardownProjectKillsActiveSessionsThenCleansProject(t *testing.T) {
 	}
 }
 
-func TestTeardownProjectStopsOnKillError(t *testing.T) {
+func TestTeardownProjectReportsKillErrorBlockerAndContinues(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer"}
 	boom := errors.New("boom")
-	fc := &fakeCommander{killErr: boom}
+	fc := &fakeCommander{
+		killErr:       boom,
+		cleanupResult: &sessionmanager.CleanupResult{Cleaned: []domain.SessionID{}, Skipped: []sessionmanager.CleanupSkip{}},
+	}
 	svc := &Service{manager: fc, store: st}
 
-	err := svc.TeardownProject(context.Background(), "mer")
-	if !errors.Is(err, boom) {
-		t.Fatalf("TeardownProject err = %v, want boom", err)
+	out, err := svc.TeardownProject(context.Background(), "mer")
+	if err != nil {
+		t.Fatalf("TeardownProject err = %v, want nil", err)
 	}
-	if len(fc.cleanupProjects) != 0 {
-		t.Fatalf("cleanup projects = %#v, want none after kill failure", fc.cleanupProjects)
+	if len(out.Blockers) != 1 || out.Blockers[0].SessionID != "mer-1" || out.Blockers[0].Reason != "session teardown failed" {
+		t.Fatalf("blockers = %#v, want mer-1 session teardown failed", out.Blockers)
+	}
+	if len(fc.cleanupProjects) != 1 || fc.cleanupProjects[0] != "mer" {
+		t.Fatalf("cleanup projects = %#v, want cleanup to still aggregate terminal outcomes", fc.cleanupProjects)
+	}
+}
+
+func TestTeardownProjectReportsLiveDirtyWorktreeBlocker(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer"}
+	preserved := false
+	fc := &fakeCommander{
+		killResult:    &preserved,
+		cleanupResult: &sessionmanager.CleanupResult{Cleaned: []domain.SessionID{}, Skipped: []sessionmanager.CleanupSkip{}},
+	}
+	svc := &Service{manager: fc, store: st}
+
+	out, err := svc.TeardownProject(context.Background(), "mer")
+	if err != nil {
+		t.Fatalf("TeardownProject: %v", err)
+	}
+	if len(out.Killed) != 1 || out.Killed[0].SessionID != "mer-1" || out.Killed[0].WorkspaceFreed || out.Killed[0].Terminated {
+		t.Fatalf("killed = %#v, want preserved live session outcome", out.Killed)
+	}
+	if len(out.Blockers) != 1 || out.Blockers[0].Phase != "kill" || out.Blockers[0].Reason != "workspace has uncommitted changes" {
+		t.Fatalf("blockers = %#v, want dirty kill blocker", out.Blockers)
+	}
+}
+
+func TestTeardownProjectAllowsStalePrunableWorktreeCleanup(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", IsTerminated: true}
+	fc := &fakeCommander{cleanupResult: &sessionmanager.CleanupResult{
+		Cleaned: []domain.SessionID{"mer-1"},
+		Skipped: []sessionmanager.CleanupSkip{},
+	}}
+	svc := &Service{manager: fc, store: st}
+
+	out, err := svc.TeardownProject(context.Background(), "mer")
+	if err != nil {
+		t.Fatalf("TeardownProject: %v", err)
+	}
+	if len(out.Blockers) != 0 {
+		t.Fatalf("blockers = %#v, want none for pruned stale worktree", out.Blockers)
+	}
+	if len(out.Cleaned) != 1 || out.Cleaned[0] != "mer-1" {
+		t.Fatalf("cleaned = %#v, want mer-1", out.Cleaned)
+	}
+}
+
+func TestTeardownProjectReportsNonDirtyCleanupFailureBlocker(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", IsTerminated: true}
+	fc := &fakeCommander{cleanupResult: &sessionmanager.CleanupResult{
+		Cleaned: []domain.SessionID{},
+		Skipped: []sessionmanager.CleanupSkip{{SessionID: "mer-1", Reason: "workspace teardown failed"}},
+	}}
+	svc := &Service{manager: fc, store: st}
+
+	out, err := svc.TeardownProject(context.Background(), "mer")
+	if err != nil {
+		t.Fatalf("TeardownProject: %v", err)
+	}
+	if len(out.Blockers) != 1 || out.Blockers[0].SessionID != "mer-1" || out.Blockers[0].Phase != "cleanup" || out.Blockers[0].Reason != "workspace teardown failed" {
+		t.Fatalf("blockers = %#v, want cleanup teardown failure blocker", out.Blockers)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add structured project teardown outcomes for killed, cleaned, and blocked sessions
- return PROJECT_REMOVE_BLOCKED as a 409 when dirty or failed session workspace teardown prevents safe project deletion
- cover dirty live worktree, stale/prunable cleanup, non-dirty cleanup failure, project-service conflict handling, and HTTP conflict details

Fixes #2598

## Tests
- cd backend && go test ./internal/service/project ./internal/service/session ./internal/session_manager ./internal/httpd/controllers

## Risks
- Project deletion now blocks when teardown reports preserved or failed session workspaces; users must resolve the listed sessions before retrying.