### PR TITLE
fix: isolate preview content with CSP

### DIFF
--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -26,6 +26,8 @@ const (
 	maxPromptLen      = 4096
 	maxMessageLen     = 4096
 	maxDisplayNameLen = 20
+
+	previewContentSecurityPolicy = "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'; script-src 'none'; worker-src 'none'; connect-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https:; font-src 'self' data:; media-src 'self' data: blob: http: https:"
 )
 
 var errPreviewFileNotFound = errors.New("preview file not found")
@@ -189,6 +191,7 @@ func (c *SessionsController) previewFile(w http.ResponseWriter, r *http.Request)
 		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "PREVIEW_FILE_NOT_FOUND", "Preview file not found", nil)
 		return
 	}
+	setPreviewIsolationHeaders(w.Header())
 	if previewutil.IsMarkdownPath(file) {
 		c.servePreviewMarkdown(w, r, file)
 		return
@@ -212,7 +215,18 @@ func (c *SessionsController) servePreviewMarkdown(w http.ResponseWriter, r *http
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-	_, _ = w.Write(rendered) //nolint:gosec // G705: preview content is workspace-local and agent-trusted
+	_, _ = w.Write(rendered) //nolint:gosec // G705: preview CSP blocks script execution and daemon fetches.
+}
+
+func setPreviewIsolationHeaders(h http.Header) {
+	h.Set("Content-Security-Policy", previewContentSecurityPolicy)
+	h.Set("Cross-Origin-Opener-Policy", "same-origin")
+	h.Set("Cross-Origin-Resource-Policy", "same-origin")
+	// COEP would block otherwise valid external images unless those hosts opt
+	// into CORS/CORP; CSP script-src/connect-src closes the preview RCE vector.
+	h.Set("Origin-Agent-Cluster", "?1")
+	h.Set("Referrer-Policy", "no-referrer")
+	h.Set("X-Content-Type-Options", "nosniff")
 }
 
 // setPreview persists the browser preview URL the desktop app opens for a

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -224,6 +224,39 @@ func newSessionTestServer(t *testing.T, svc *fakeSessionService) *httptest.Serve
 	return srv
 }
 
+func assertPreviewIsolationHeaders(t *testing.T, headers http.Header) {
+	t.Helper()
+	csp := headers.Get("Content-Security-Policy")
+	for _, directive := range []string{
+		"default-src 'none'",
+		"script-src 'none'",
+		"connect-src 'none'",
+		"style-src 'self' 'unsafe-inline'",
+		"img-src 'self' data: blob: http: https:",
+		"object-src 'none'",
+		"frame-ancestors 'none'",
+		"form-action 'none'",
+	} {
+		if !strings.Contains(csp, directive) {
+			t.Fatalf("Content-Security-Policy = %q, want directive %q", csp, directive)
+		}
+	}
+	if strings.Contains(csp, "script-src 'unsafe-inline'") {
+		t.Fatalf("Content-Security-Policy allows inline scripts: %q", csp)
+	}
+	for name, want := range map[string]string{
+		"Cross-Origin-Opener-Policy":   "same-origin",
+		"Cross-Origin-Resource-Policy": "same-origin",
+		"Origin-Agent-Cluster":         "?1",
+		"Referrer-Policy":              "no-referrer",
+		"X-Content-Type-Options":       "nosniff",
+	} {
+		if got := headers.Get(name); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+}
+
 func TestSessionsRoutes_DefaultToStubsWithoutService(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	srv := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{}, httpd.ControlDeps{}))
@@ -379,9 +412,53 @@ func TestSessionsAPI_PreviewDiscoversAndServesStaticIndex(t *testing.T) {
 	if !strings.Contains(headers.Get("Content-Type"), "text/html") {
 		t.Fatalf("content type = %q, want text/html", headers.Get("Content-Type"))
 	}
+	assertPreviewIsolationHeaders(t, headers)
 	if !strings.Contains(string(body), "styles.css") {
 		t.Fatalf("preview body did not serve index: %s", body)
 	}
+}
+
+func TestSessionsAPI_PreviewMarkdownBlocksInjectedScriptVector(t *testing.T) {
+	svc := newFakeSessionService()
+	workspace := t.TempDir()
+	injected := `<script>
+fetch("/api/v1/projects/ao/config", { method: "PUT", body: JSON.stringify({ postCreate: ["touch /tmp/ao-rce"] }) });
+</script>`
+	if err := os.WriteFile(filepath.Join(workspace, "README.md"), []byte("# Report\n\n"+injected), 0o644); err != nil {
+		t.Fatalf("write markdown: %v", err)
+	}
+	s := svc.sessions["ao-1"]
+	s.Metadata = domain.SessionMetadata{WorkspacePath: workspace}
+	svc.sessions["ao-1"] = s
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "GET", "/api/v1/sessions/ao-1/preview", "")
+	if status != http.StatusOK {
+		t.Fatalf("preview = %d, want 200; body=%s", status, body)
+	}
+	var preview struct {
+		PreviewURL string `json:"previewUrl"`
+		Entry      string `json:"entry"`
+	}
+	mustJSON(t, body, &preview)
+	if preview.Entry != "README.md" {
+		t.Fatalf("preview entry = %q, want README.md", preview.Entry)
+	}
+	parsed, err := url.Parse(preview.PreviewURL)
+	if err != nil {
+		t.Fatalf("parse preview URL: %v", err)
+	}
+	body, status, headers := doRequest(t, srv, "GET", parsed.RequestURI(), "")
+	if status != http.StatusOK {
+		t.Fatalf("preview markdown = %d, want 200; body=%s", status, body)
+	}
+	if !strings.Contains(headers.Get("Content-Type"), "text/html") {
+		t.Fatalf("content type = %q, want text/html", headers.Get("Content-Type"))
+	}
+	if !strings.Contains(string(body), `fetch("/api/v1/projects/ao/config"`) {
+		t.Fatalf("test fixture did not render injected script; body=%s", body)
+	}
+	assertPreviewIsolationHeaders(t, headers)
 }
 
 func TestSessionsAPI_SetPreviewExplicitURLPersists(t *testing.T) {


### PR DESCRIPTION
## Summary
- add strict preview CSP headers that block scripts, workers, forms, objects, and daemon/API fetches while allowing preview styles and images
- add lightweight origin/resource isolation headers for preview file responses
- cover raw Markdown HTML injection with a regression test showing the injected config-write script is present but blocked by CSP

Fixes #2771

## Tests
- `cd backend && go test ./internal/httpd/controllers ./internal/httpd/... ./internal/preview/...`
- `cd backend && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs ./internal/httpd/controllers`
- `npm run lint` *(fails in existing `backend/internal/cli` spawn tests: expected project-context errors, got daemon HTTP 404; command stops before golangci-lint)*

## Notes
- COEP is intentionally omitted because it would break external image loads unless those hosts opt into CORS/CORP; `script-src` and `connect-src` are the controls that close this RCE path.