### PR TITLE
fix: rewrite preview asset URLs

### DIFF
--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -193,7 +193,35 @@ func (c *SessionsController) previewFile(w http.ResponseWriter, r *http.Request)
 		c.servePreviewMarkdown(w, r, file)
 		return
 	}
+	if previewutil.IsHTMLPath(file) {
+		c.servePreviewHTML(w, r, file)
+		return
+	}
+	if strings.EqualFold(filepath.Ext(file), ".css") {
+		c.servePreviewCSS(w, r, file)
+		return
+	}
 	http.ServeFile(w, r, file)
+}
+
+func (c *SessionsController) servePreviewHTML(w http.ResponseWriter, r *http.Request, file string) {
+	source, err := os.ReadFile(file)
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "PREVIEW_FILE_NOT_FOUND", "Preview file not found", nil)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write(previewutil.RewriteHTMLPreviewURLs(source, previewFileRootPath(r))) //nolint:gosec // G705: preview content is workspace-local and agent-trusted
+}
+
+func (c *SessionsController) servePreviewCSS(w http.ResponseWriter, r *http.Request, file string) {
+	source, err := os.ReadFile(file)
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "PREVIEW_FILE_NOT_FOUND", "Preview file not found", nil)
+		return
+	}
+	w.Header().Set("Content-Type", "text/css; charset=utf-8")
+	_, _ = w.Write(previewutil.RewriteCSSPreviewURLs(source, previewFileRootPath(r))) //nolint:gosec // G705: preview content is workspace-local and agent-trusted
 }
 
 // servePreviewMarkdown renders a workspace Markdown file to a self-contained
@@ -212,7 +240,7 @@ func (c *SessionsController) servePreviewMarkdown(w http.ResponseWriter, r *http
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-	_, _ = w.Write(rendered) //nolint:gosec // G705: preview content is workspace-local and agent-trusted
+	_, _ = w.Write(previewutil.RewriteHTMLPreviewURLs(rendered, previewFileRootPath(r))) //nolint:gosec // G705: preview content is workspace-local and agent-trusted
 }
 
 // setPreview persists the browser preview URL the desktop app opens for a
@@ -714,6 +742,14 @@ func confinedPreviewPath(workspacePath, assetPath string) (string, bool) {
 
 func previewFileURL(r *http.Request, id domain.SessionID, entry string) string {
 	return previewutil.FileURL("http://"+r.Host, id, entry)
+}
+
+func previewFileRootPath(r *http.Request) string {
+	const marker = "/preview/files/"
+	if i := strings.Index(r.URL.Path, marker); i >= 0 {
+		return r.URL.Path[:i+len(marker)]
+	}
+	return "/api/v1/sessions/" + url.PathEscape(string(sessionID(r))) + "/preview/files/"
 }
 
 func sessionView(s domain.Session) SessionView {

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -384,6 +384,95 @@ func TestSessionsAPI_PreviewDiscoversAndServesStaticIndex(t *testing.T) {
 	}
 }
 
+func TestSessionsAPI_PreviewFileRewritesRootAbsoluteHTMLAndCSSURLs(t *testing.T) {
+	svc := newFakeSessionService()
+	workspace := t.TempDir()
+	mustWritePreviewFile(t, workspace, "index.html", `<!doctype html>
+<html>
+<head>
+	<link rel="stylesheet" href="/style.css?v=55">
+	<link rel="stylesheet" href="relative.css">
+	<style>.hero { background-image: url("/img/hero.png"); }</style>
+</head>
+<body>
+	<img src="/img/avatar.jpg">
+	<img src="images/inline.png">
+	<img srcset="/img/avatar-small.jpg 1x, images/inline.png 2x">
+	<div style="background-image: url('/img/inline-bg.png')"></div>
+</body>
+</html>`)
+	mustWritePreviewFile(t, workspace, "style.css", `@import "/reset.css";
+body { background: url('/img/bg.png'); }
+.icon { background: url("icons/relative.svg"); }`)
+	mustWritePreviewFile(t, workspace, "relative.css", `body { color: red; }`)
+	mustWritePreviewFile(t, workspace, "reset.css", `* { box-sizing: border-box; }`)
+	mustWritePreviewFile(t, workspace, "img/avatar.jpg", "avatar")
+	mustWritePreviewFile(t, workspace, "img/avatar-small.jpg", "avatar-small")
+	mustWritePreviewFile(t, workspace, "img/hero.png", "hero")
+	mustWritePreviewFile(t, workspace, "img/inline-bg.png", "inline-bg")
+	mustWritePreviewFile(t, workspace, "img/bg.png", "bg")
+	mustWritePreviewFile(t, workspace, "images/inline.png", "inline")
+	mustWritePreviewFile(t, workspace, "icons/relative.svg", "<svg></svg>")
+	s := svc.sessions["ao-1"]
+	s.Metadata = domain.SessionMetadata{WorkspacePath: workspace}
+	svc.sessions["ao-1"] = s
+	srv := newSessionTestServer(t, svc)
+
+	const root = "/api/v1/sessions/ao-1/preview/files/"
+	body, status, headers := doRequest(t, srv, "GET", root+"index.html", "")
+	if status != http.StatusOK {
+		t.Fatalf("preview html = %d, want 200; body=%s", status, body)
+	}
+	if !strings.Contains(headers.Get("Content-Type"), "text/html") {
+		t.Fatalf("html content type = %q, want text/html", headers.Get("Content-Type"))
+	}
+	html := string(body)
+	for _, want := range []string{
+		`href="` + root + `style.css?v=55"`,
+		`href="relative.css"`,
+		`src="` + root + `img/avatar.jpg"`,
+		`src="images/inline.png"`,
+		`srcset="` + root + `img/avatar-small.jpg 1x, images/inline.png 2x"`,
+		`url("` + root + `img/hero.png")`,
+		`url('` + root + `img/inline-bg.png')`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("preview html missing %q:\n%s", want, body)
+		}
+	}
+
+	cssBody, cssStatus, cssHeaders := doRequest(t, srv, "GET", root+"style.css?v=55", "")
+	if cssStatus != http.StatusOK {
+		t.Fatalf("preview css = %d, want 200; body=%s", cssStatus, cssBody)
+	}
+	if !strings.Contains(cssHeaders.Get("Content-Type"), "text/css") {
+		t.Fatalf("css content type = %q, want text/css", cssHeaders.Get("Content-Type"))
+	}
+	css := string(cssBody)
+	for _, want := range []string{
+		`@import "` + root + `reset.css"`,
+		`url('` + root + `img/bg.png')`,
+		`url("icons/relative.svg")`,
+	} {
+		if !strings.Contains(css, want) {
+			t.Fatalf("preview css missing %q:\n%s", want, cssBody)
+		}
+	}
+
+	for _, asset := range []string{
+		root + "style.css?v=55",
+		root + "img/avatar.jpg",
+		root + "images/inline.png",
+		root + "img/bg.png",
+		root + "icons/relative.svg",
+	} {
+		_, assetStatus, _ := doRequest(t, srv, "GET", asset, "")
+		if assetStatus != http.StatusOK {
+			t.Fatalf("asset %s = %d, want 200", asset, assetStatus)
+		}
+	}
+}
+
 func TestSessionsAPI_SetPreviewExplicitURLPersists(t *testing.T) {
 	svc := newFakeSessionService()
 	srv := newSessionTestServer(t, svc)
@@ -671,6 +760,17 @@ func TestSessionsAPI_SetPreviewNotFound(t *testing.T) {
 
 	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/missing-1/preview", `{"url":"http://x"}`)
 	assertErrorCode(t, body, status, http.StatusNotFound, "SESSION_NOT_FOUND")
+}
+
+func mustWritePreviewFile(t *testing.T, root, rel, body string) {
+	t.Helper()
+	file := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(file), err)
+	}
+	if err := os.WriteFile(file, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
 }
 
 func TestSessionsAPI_SpawnBranchNotFetchedReturnsTypedError(t *testing.T) {

--- a/backend/internal/preview/entry.go
+++ b/backend/internal/preview/entry.go
@@ -132,6 +132,16 @@ func IsMarkdownPath(p string) bool {
 	return false
 }
 
+// IsHTMLPath reports whether p names an HTML file whose root-absolute asset
+// URLs should be rewritten for the preview/files route.
+func IsHTMLPath(p string) bool {
+	switch strings.ToLower(filepath.Ext(p)) {
+	case ".html", ".htm":
+		return true
+	}
+	return false
+}
+
 // ConfinedPath maps an asset path into workspacePath and rejects paths that
 // escape the workspace root.
 func ConfinedPath(workspacePath, assetPath string) (string, bool) {

--- a/backend/internal/preview/rewrite.go
+++ b/backend/internal/preview/rewrite.go
@@ -1,0 +1,151 @@
+package preview
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+)
+
+var (
+	htmlURLAttrRE         = regexp.MustCompile(`(?i)(\b(?:href|src|poster|action)\s*=\s*)(["'])([^"']*)(["'])`)
+	htmlSrcsetAttrRE      = regexp.MustCompile(`(?i)(\bsrcset\s*=\s*)(["'])([^"']*)(["'])`)
+	htmlStyleDoubleAttrRE = regexp.MustCompile(`(?i)(\bstyle\s*=\s*)"([^"]*)"`)
+	htmlStyleSingleAttrRE = regexp.MustCompile(`(?i)(\bstyle\s*=\s*)'([^']*)'`)
+	htmlStyleBlockRE      = regexp.MustCompile(`(?is)(<style\b[^>]*>)(.*?)(</style>)`)
+	cssURLRE              = regexp.MustCompile(`(?i)url\(\s*(?:"([^"]*)"|'([^']*)'|([^'")\s][^)]*?))\s*\)`)
+	cssImportRE           = regexp.MustCompile(`(?i)(@import\s+)(["'])([^"']*)(["'])`)
+)
+
+// RewriteHTMLPreviewURLs rewrites root-absolute asset URLs in workspace HTML
+// so pages served below /preview/files/ still resolve "/" against the preview
+// root. Ordinary relative and fully-qualified URLs are left for the browser to
+// resolve normally.
+func RewriteHTMLPreviewURLs(source []byte, previewRoot string) []byte {
+	root := normalizePreviewRoot(previewRoot)
+	if root == "" {
+		return source
+	}
+	out := replaceHTMLAttr(source, htmlStyleBlockRE, func(parts [][]byte) []byte {
+		var buf bytes.Buffer
+		buf.Write(parts[1])
+		buf.Write(RewriteCSSPreviewURLs(parts[2], root))
+		buf.Write(parts[3])
+		return buf.Bytes()
+	})
+	out = replaceHTMLAttr(out, htmlStyleDoubleAttrRE, func(parts [][]byte) []byte {
+		return joinQuotedAttr(parts[1], []byte(`"`), RewriteCSSPreviewURLs(parts[2], root), []byte(`"`))
+	})
+	out = replaceHTMLAttr(out, htmlStyleSingleAttrRE, func(parts [][]byte) []byte {
+		return joinQuotedAttr(parts[1], []byte(`'`), RewriteCSSPreviewURLs(parts[2], root), []byte(`'`))
+	})
+	out = replaceHTMLAttr(out, htmlSrcsetAttrRE, func(parts [][]byte) []byte {
+		return joinQuotedAttr(parts[1], parts[2], []byte(rewriteSrcset(string(parts[3]), root)), parts[4])
+	})
+	out = replaceHTMLAttr(out, htmlURLAttrRE, func(parts [][]byte) []byte {
+		value := string(parts[3])
+		if rewritten, ok := rewriteRootAbsolute(value, root); ok {
+			value = rewritten
+		}
+		return joinQuotedAttr(parts[1], parts[2], []byte(value), parts[4])
+	})
+	return out
+}
+
+// RewriteCSSPreviewURLs rewrites root-absolute url(...) and @import targets for
+// CSS served below /preview/files/. Relative URLs remain relative to the CSS
+// file, matching normal browser behavior.
+func RewriteCSSPreviewURLs(source []byte, previewRoot string) []byte {
+	root := normalizePreviewRoot(previewRoot)
+	if root == "" {
+		return source
+	}
+	out := replaceHTMLAttr(source, cssURLRE, func(parts [][]byte) []byte {
+		value, quote := cssURLValue(parts)
+		if rewritten, ok := rewriteRootAbsolute(value, root); ok {
+			value = rewritten
+		}
+		return []byte("url(" + quote + value + quote + ")")
+	})
+	out = replaceHTMLAttr(out, cssImportRE, func(parts [][]byte) []byte {
+		value := string(parts[3])
+		if rewritten, ok := rewriteRootAbsolute(value, root); ok {
+			value = rewritten
+		}
+		return joinQuotedAttr(parts[1], parts[2], []byte(value), parts[4])
+	})
+	return out
+}
+
+func replaceHTMLAttr(source []byte, re *regexp.Regexp, replace func(parts [][]byte) []byte) []byte {
+	return re.ReplaceAllFunc(source, func(match []byte) []byte {
+		parts := re.FindSubmatch(match)
+		if len(parts) == 0 {
+			return match
+		}
+		return replace(parts)
+	})
+}
+
+func joinQuotedAttr(prefix, openQuote, value, closeQuote []byte) []byte {
+	var buf bytes.Buffer
+	buf.Grow(len(prefix) + len(openQuote) + len(value) + len(closeQuote))
+	buf.Write(prefix)
+	buf.Write(openQuote)
+	buf.Write(value)
+	buf.Write(closeQuote)
+	return buf.Bytes()
+}
+
+func cssURLValue(parts [][]byte) (value, quote string) {
+	switch {
+	case len(parts) > 1 && parts[1] != nil:
+		return string(parts[1]), `"`
+	case len(parts) > 2 && parts[2] != nil:
+		return string(parts[2]), `'`
+	case len(parts) > 3 && parts[3] != nil:
+		return strings.TrimSpace(string(parts[3])), ""
+	default:
+		return "", ""
+	}
+}
+
+func rewriteSrcset(raw, previewRoot string) string {
+	candidates := strings.Split(raw, ",")
+	for i, candidate := range candidates {
+		leading := candidate[:len(candidate)-len(strings.TrimLeft(candidate, " \t\r\n"))]
+		trimmed := strings.TrimSpace(candidate)
+		if trimmed == "" {
+			continue
+		}
+		fields := strings.Fields(trimmed)
+		if len(fields) == 0 {
+			continue
+		}
+		if rewritten, ok := rewriteRootAbsolute(fields[0], previewRoot); ok {
+			fields[0] = rewritten
+			candidates[i] = leading + strings.Join(fields, " ")
+		}
+	}
+	return strings.Join(candidates, ",")
+}
+
+func rewriteRootAbsolute(raw, previewRoot string) (string, bool) {
+	if !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") || strings.HasPrefix(raw, previewRoot) {
+		return raw, false
+	}
+	return previewRoot + strings.TrimPrefix(raw, "/"), true
+}
+
+func normalizePreviewRoot(raw string) string {
+	root := strings.TrimSpace(raw)
+	if root == "" {
+		return ""
+	}
+	if !strings.HasPrefix(root, "/") {
+		root = "/" + root
+	}
+	if !strings.HasSuffix(root, "/") {
+		root += "/"
+	}
+	return root
+}


### PR DESCRIPTION
## Summary
- rewrite root-absolute asset references in preview-served HTML and CSS to stay under the session `/preview/files/` root
- preserve ordinary relative URLs so nested pages and stylesheets keep normal browser-relative resolution
- apply the same HTML rewrite to rendered Markdown previews

## Approach
I used targeted HTML/CSS URL rewriting instead of injecting `<base>` because `<base href=...>` does not fix root-absolute paths like `/style.css`; browsers still resolve those against the daemon origin root. Serving each preview at its own root-scoped origin would be closer to production, but it is a larger routing/listener change and would overlap more with the concurrent preview security-header work. This keeps the change scoped to URL/asset resolution in the existing preview file route.

## Tests
- `go test ./internal/httpd/controllers ./internal/preview`
- `go test ./internal/httpd/... ./internal/preview`
- `env -u AO_SESSION_ID -u AO_PROJECT_ID go test ./...` from `backend/`
- `env -u AO_SESSION_ID -u AO_PROJECT_ID go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --path-mode=abs` from `backend/`

Note: initial `go test ./...` inherited this worker session's `AO_SESSION_ID/AO_PROJECT_ID` and failed unrelated CLI spawn context tests; rerunning with those env vars unset passed. Initial `npm run lint` passed tests but golangci-lint read stale diagnostics from another deleted worktree; after `golangci-lint cache clean`, lint passed with 0 issues.

Closes #2779
Closes #2781