### PR TITLE
fix: size text badges as pills

### DIFF
--- a/frontend/src/renderer/components/ui/badge.test.tsx
+++ b/frontend/src/renderer/components/ui/badge.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Badge } from "./badge";
+
+describe("Badge", () => {
+	it("lets text badges size to their label instead of a fixed icon square", () => {
+		render(<Badge variant="success">Open</Badge>);
+
+		expect(screen.getByText("Open")).not.toHaveClass("size-icon-xl");
+	});
+});

--- a/frontend/src/renderer/components/ui/badge.tsx
+++ b/frontend/src/renderer/components/ui/badge.tsx
@@ -12,7 +12,7 @@ export function Badge({
 	return (
 		<span
 			className={cn(
-				"inline-flex size-icon-xl shrink-0 items-center gap-1 rounded-full border border-transparent px-2 font-mono text-micro font-medium",
+				"inline-flex h-[var(--size-icon-xl)] min-w-[var(--size-icon-xl)] shrink-0 items-center justify-center gap-1 rounded-full border border-transparent px-2 font-mono text-micro font-medium",
 				variant === "neutral" && "bg-raised text-muted-foreground",
 				variant === "outline" && "border-border text-foreground",
 				variant === "accent" && "border-accent-dim text-accent",


### PR DESCRIPTION
fixes the PR status badge so text labels like Open render as proper pills instead of being clipped by a fixed circular border
it also adds a regression test to ensure text badges are not sized as fixed icon squares.