### PR TITLE
fix(sessions): update Kill behavior to mark sessions as terminated wh…

### DIFF
--- a/backend/internal/adapters/agent/copilot/copilot_test.go
+++ b/backend/internal/adapters/agent/copilot/copilot_test.go
@@ -568,6 +568,47 @@ func TestGetAgentHooksInstallsSessionCopilotAgent(t *testing.T) {
 	}
 }
 
+func TestGetAgentHooksIgnoresSessionCopilotAgentInLinkedWorktreeCommonExclude(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "copilot"}
+	dir := t.TempDir()
+	commonGitDir := filepath.Join(dir, "repo", ".git")
+	worktreeGitDir := filepath.Join(commonGitDir, "worktrees", "sess-1")
+	workspace := filepath.Join(dir, "worktree")
+	if err := os.MkdirAll(worktreeGitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, ".git"), []byte("gitdir: "+worktreeGitDir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeGitDir, "commondir"), []byte("../..\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := ports.WorkspaceHookConfig{
+		DataDir:       t.TempDir(),
+		SessionID:     "sess-1",
+		SystemPrompt:  "orchestrator must spawn workers",
+		WorkspacePath: workspace,
+	}
+	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	exclude, err := os.ReadFile(filepath.Join(commonGitDir, "info", "exclude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(exclude), "/.github/agents/ao-sess-1.agent.md\n") {
+		t.Fatalf("common git exclude does not ignore custom agent:\n%s", exclude)
+	}
+	if _, err := os.Stat(filepath.Join(worktreeGitDir, "info", "exclude")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("worktree-local exclude exists or stat failed: %v", err)
+	}
+}
+
 func TestGetAgentHooksUpdatesManagedSessionCopilotAgent(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "copilot"}
 	workspace := t.TempDir()

--- a/backend/internal/adapters/agent/copilot/hooks.go
+++ b/backend/internal/adapters/agent/copilot/hooks.go
@@ -177,7 +177,7 @@ func copilotAgentProfile(agentName, sessionID, systemPrompt string) string {
 }
 
 func ignoreCopilotPath(workspacePath, pattern string) error {
-	gitDir, err := workspaceGitDir(workspacePath)
+	gitDir, err := workspaceGitCommonDir(workspacePath)
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ func ignoreCopilotPath(workspacePath, pattern string) error {
 	return nil
 }
 
-func workspaceGitDir(workspacePath string) (string, error) {
+func workspaceGitCommonDir(workspacePath string) (string, error) {
 	gitPath := filepath.Join(workspacePath, ".git")
 	info, err := os.Stat(gitPath)
 	if err != nil {
@@ -217,7 +217,7 @@ func workspaceGitDir(workspacePath string) (string, error) {
 		return "", fmt.Errorf("stat %s: %w", gitPath, err)
 	}
 	if info.IsDir() {
-		return gitPath, nil
+		return gitCommonDir(gitPath)
 	}
 	data, err := os.ReadFile(gitPath) //nolint:gosec // path built from caller-owned workspace dir
 	if err != nil {
@@ -233,9 +233,28 @@ func workspaceGitDir(workspacePath string) (string, error) {
 		return "", nil
 	}
 	if filepath.IsAbs(dir) {
-		return dir, nil
+		return gitCommonDir(dir)
 	}
-	return filepath.Clean(filepath.Join(workspacePath, dir)), nil
+	return gitCommonDir(filepath.Clean(filepath.Join(workspacePath, dir)))
+}
+
+func gitCommonDir(gitDir string) (string, error) {
+	commonPath := filepath.Join(gitDir, "commondir")
+	data, err := os.ReadFile(commonPath) //nolint:gosec // path derived from the workspace .git metadata
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return gitDir, nil
+		}
+		return "", fmt.Errorf("read %s: %w", commonPath, err)
+	}
+	dir := strings.TrimSpace(string(data))
+	if dir == "" {
+		return gitDir, nil
+	}
+	if filepath.IsAbs(dir) {
+		return filepath.Clean(dir), nil
+	}
+	return filepath.Clean(filepath.Join(gitDir, dir)), nil
 }
 
 // UninstallHooks removes AO's Copilot hooks from the workspace-local

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -602,7 +602,8 @@ func (m *Manager) RollbackSpawn(ctx context.Context, id domain.SessionID) (delet
 // Kill tears down the runtime and workspace, then records terminal intent with
 // the LCM. A workspace teardown refused by the worktree-remove safety
 // (uncommitted work) is never forced: Kill succeeds with freed=false,
-// signalling the workspace was preserved and the session is left retryable.
+// signalling the workspace was preserved for later inspection/cleanup while
+// the session itself is still marked terminated.
 //
 // A session whose runtime handle or workspace path is missing (e.g. spawn
 // failed partway, handle lost after a crash) is still terminated after the
@@ -638,6 +639,10 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 		cleaned, err := m.destroyWorkspaceProjectRows(ctx, workspaceProjectRows)
 		if err != nil {
 			if errors.Is(err, ports.ErrWorkspaceDirty) {
+				if err := m.lcm.MarkTerminated(ctx, id); err != nil {
+					return false, fmt.Errorf("kill %s: %w", id, err)
+				}
+				m.cleanupSystemPromptDir(id)
 				return false, nil
 			}
 			return false, fmt.Errorf("kill %s: workspace: %w", id, err)
@@ -649,6 +654,13 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	} else if ws.Path != "" {
 		if err := m.workspace.Destroy(ctx, ws); err != nil {
 			if errors.Is(err, ports.ErrWorkspaceDirty) {
+				if err := m.store.DeleteSessionWorktrees(ctx, id); err != nil {
+					m.logger.Warn("kill: delete restore marker failed", "sessionID", id, "error", err)
+				}
+				if err := m.lcm.MarkTerminated(ctx, id); err != nil {
+					return false, fmt.Errorf("kill %s: %w", id, err)
+				}
+				m.cleanupSystemPromptDir(id)
 				return false, nil
 			}
 			return false, fmt.Errorf("kill %s: workspace: %w", id, err)

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -1373,11 +1373,11 @@ func TestKill_TerminatesIncompleteHandle(t *testing.T) {
 	}
 }
 
-// TestKill_DirtyWorkspacePreservesAndRemainsRetryable: a workspace teardown
+// TestKill_DirtyWorkspacePreservesAndTerminates: a workspace teardown
 // refused because of uncommitted work must NOT force-remove the worktree. Kill
-// succeeds with freed=false and leaves the session non-terminal so a later retry
-// can complete cleanup.
-func TestKill_DirtyWorkspacePreservesAndRemainsRetryable(t *testing.T) {
+// succeeds with freed=false and still marks the session terminated; cleanup can
+// reclaim the preserved worktree after the user resolves the dirty state.
+func TestKill_DirtyWorkspacePreservesAndTerminates(t *testing.T) {
 	m, st, rt, ws := newManager()
 	st.sessions["mer-1"] = mkLive("mer-1")
 	ws.destroyErr = fmt.Errorf("gitworktree: refusing to remove: %w", ports.ErrWorkspaceDirty)
@@ -1391,8 +1391,8 @@ func TestKill_DirtyWorkspacePreservesAndRemainsRetryable(t *testing.T) {
 	if rt.destroyed != 1 {
 		t.Fatal("runtime should be destroyed")
 	}
-	if st.sessions["mer-1"].IsTerminated {
-		t.Fatal("session should remain active so cleanup can be retried")
+	if !st.sessions["mer-1"].IsTerminated {
+		t.Fatal("session should be terminated even when the workspace is preserved")
 	}
 }
 
@@ -1508,8 +1508,8 @@ func TestKill_WorkspaceProjectDirtyRowRefusesRemoval(t *testing.T) {
 	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("calls = %v, want %v", got, want)
 	}
-	if st.sessions["mer-1"].IsTerminated {
-		t.Fatal("session should remain active so dirty workspace cleanup can be retried")
+	if !st.sessions["mer-1"].IsTerminated {
+		t.Fatal("session should be terminated even when dirty workspace cleanup is deferred")
 	}
 }
 


### PR DESCRIPTION
Fixes AgentWrapper/agent-orchestrator#2792

  ## Summary

  - Fix Copilot hook setup for linked git worktrees by writing the generated agent-profile ignore rule to the common gitdir exclude.
  - Preserve dirty worktrees on session kill, but still mark the session terminated after the runtime has been torn down.
  - Add regression coverage for Copilot linked-worktree ignores and dirty-worktree kill behavior.

  ## Why

  Copilot sessions can create `.github/agents/ao-<session>.agent.md`. In linked worktrees, AO was writing the ignore rule to the per-worktree gitdir, but Git uses the common repo exclude, so the generated file still appeared as untracked.

  That made `git worktree remove` refuse cleanup. The kill path had already destroyed the runtime, then returned success before marking the session terminated, leaving the UI stuck at:

  `Terminal ended`
  `This terminal process ended, but the session is not marked terminated yet.`

  ## Test

  ```bash
  cd backend
  go test -count=1 ./internal/adapters/agent/copilot ./internal/session_manager
  go test ./internal/httpd/... ./internal/service/session/... ./internal/lifecycle/...
  go test ./...
