### PR TITLE
fix: capture grok session ids for restore

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -28,6 +28,7 @@ var Derivers = map[string]DeriveFunc{
 	// Adapters that parse hook payloads for finer-grained state keep their own
 	// deriver; the rest share the name-only StandardDeriveActivityState.
 	"claude-code": claudecode.DeriveActivityState,
+	"grok":        claudecode.DeriveActivityState,
 	"codex":       codex.DeriveActivityState,
 	"droid":       droid.DeriveActivityState,
 	"agy":         agy.DeriveActivityState,

--- a/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
@@ -18,7 +18,7 @@ func TestDeriverTokensAreKnownHarnesses(t *testing.T) {
 }
 
 func TestSupportsHarness(t *testing.T) {
-	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessOpenCode, domain.HarnessKimi} {
+	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessGrok, domain.HarnessOpenCode, domain.HarnessKimi} {
 		if !SupportsHarness(h) {
 			t.Errorf("SupportsHarness(%q) = false, want true", h)
 		}
@@ -29,5 +29,29 @@ func TestSupportsHarness(t *testing.T) {
 		if SupportsHarness(h) {
 			t.Errorf("SupportsHarness(%q) = true, want false", h)
 		}
+	}
+}
+
+func TestGrokDerivesClaudeCompatibleActivity(t *testing.T) {
+	tests := []struct {
+		name    string
+		event   string
+		payload string
+		want    domain.ActivityState
+	}{
+		{"permission request", "permission-request", `{}`, domain.ActivityBlocked},
+		{"idle notification", "notification", `{"notification_type":"idle_prompt"}`, domain.ActivityIdle},
+		{"session end", "session-end", `{}`, domain.ActivityExited},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := Derive("grok", tt.event, []byte(tt.payload))
+			if !ok {
+				t.Fatalf("Derive(grok, %q) ok=false, want true", tt.event)
+			}
+			if got != tt.want {
+				t.Fatalf("Derive(grok, %q) = %q, want %q", tt.event, got, tt.want)
+			}
+		})
 	}
 }

--- a/backend/internal/adapters/agent/grok/grok.go
+++ b/backend/internal/adapters/agent/grok/grok.go
@@ -1,9 +1,9 @@
 // Package grok implements the Grok Build (xAI) agent adapter.
 //
 // Grok Build is xAI's terminal coding agent (binary "grok"). It supports
-// Claude Code compatibility for hooks, skills, etc., so we reuse the claude
-// hook installation (which writes .claude/settings.local.json with AO
-// hook commands). Grok will pick them up via its compat layer.
+// Claude Code compatibility for hooks, skills, etc., so we write Claude-shaped
+// hooks into .claude/settings.local.json with Grok-specific AO hook commands.
+// Grok will pick them up via its compat layer.
 //
 // Launch uses a positional prompt for the initial task (in-command delivery).
 // AO's standing instructions are appended with `--rules` so Grok's built-in
@@ -12,21 +12,21 @@
 // (parity with Codex no-update).
 // Restore prefers the hook-captured native session id via `-r <id>`.
 //
-// SessionInfo and title/summary flow through the shared claude hook path
-// (when the hook handlers are extended to persist them).
+// SessionInfo and title/summary flow through the shared hook metadata path.
 package grok
 
 import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hooksjson"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -41,6 +41,39 @@ var grokBinarySpec = binaryutil.BinarySpec{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "grok.exe"}},
 		{Base: binaryutil.WinHome, Parts: []string{".grok", "bin", "grok.exe"}},
 	},
+}
+
+const (
+	grokClaudeSettingsDirName  = ".claude"
+	grokClaudeSettingsFileName = "settings.local.json"
+	grokHookCommandPrefix      = "ao hooks grok "
+	grokHookTimeout            = 30
+)
+
+var grokStartupMatcher = "startup"
+
+// grokManagedHooks is Claude Code's hook event shape with Grok-specific AO
+// hook commands. Grok reads this file through its Claude compatibility layer,
+// while `ao hooks grok` keeps activity and session metadata attributed to the
+// Grok harness.
+var grokManagedHooks = []hooksjson.HookSpec{
+	{Event: "SessionStart", Matcher: &grokStartupMatcher, Command: grokHookCommandPrefix + "session-start"},
+	{Event: "UserPromptSubmit", Command: grokHookCommandPrefix + "user-prompt-submit"},
+	{Event: "PreToolUse", Command: grokHookCommandPrefix + "pre-tool-use"},
+	{Event: "PostToolUse", Command: grokHookCommandPrefix + "post-tool-use"},
+	{Event: "PostToolUseFailure", Command: grokHookCommandPrefix + "post-tool-use-failure"},
+	{Event: "PermissionRequest", Command: grokHookCommandPrefix + "permission-request"},
+	{Event: "Stop", Command: grokHookCommandPrefix + "stop"},
+	{Event: "Notification", Command: grokHookCommandPrefix + "notification"},
+	{Event: "SessionEnd", Command: grokHookCommandPrefix + "session-end"},
+}
+
+var grokHooks = hooksjson.Manager{
+	Label:         "grok",
+	CommandPrefix: grokHookCommandPrefix,
+	Timeout:       grokHookTimeout,
+	Path:          grokClaudeSettingsPath,
+	Managed:       grokManagedHooks,
 }
 
 // Plugin is the Grok Build agent adapter.
@@ -100,50 +133,37 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	return cmd, nil
 }
 
-// GetAgentHooks reuses the Claude Code hook installer because Grok Build
-// has a full Claude Code compatibility layer.
+// GetAgentHooks installs Claude Code-shaped hooks because Grok Build has a
+// Claude Code compatibility layer.
 //
 // Official docs (https://docs.x.ai/build/features/skills-plugins-marketplaces#claude-code-compatibility:~:text=tasks%20in%20parallel.-,Claude%20Code%20compatibility,-Grok%20is%20fully):
 //
 //	"Grok is fully compatible with Claude Code with zero configuration needed.
 //	 Grok automatically reads Claude Code ... hooks ... alongside .grok/."
 //
-// This means Grok will pick up the .claude/settings.local.json (and the
-// AO hook commands we install there) in the worktree. The hook payloads for
-// SessionStart / UserPromptSubmit / Stop etc. are compatible, so we get
-// title/summary/agentSessionId + activity for free without a separate native
-// .grok/hooks/ implementation or code duplication.
+// This means Grok will pick up the .claude/settings.local.json in the
+// worktree. The hook payloads for SessionStart / UserPromptSubmit / Stop etc.
+// are compatible, and the installed commands use the Grok harness token so AO
+// persists Grok's native session id under the Grok session.
 func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	// Delegate; the installed commands will be "ao hooks claude-code <evt>"
-	// so the existing CLI hook dispatcher routes them to claude derive logic.
-	// This works because of Grok's documented zero-config Claude compat.
-	return (&claudecode.Plugin{}).GetAgentHooks(ctx, cfg)
+	return grokHooks.Install(ctx, cfg.WorkspacePath)
 }
 
 // UninstallHooks removes the Claude Code-compatible AO hooks Grok uses.
 func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return (&claudecode.Plugin{}).UninstallHooks(ctx, workspacePath)
+	return grokHooks.Uninstall(ctx, workspacePath)
 }
 
-// AreHooksInstalled reports whether the delegated Claude Code-compatible AO
+// AreHooksInstalled reports whether the Grok Claude Code-compatible AO
 // hooks are present for this Grok workspace.
 func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (bool, error) {
-	if err := ctx.Err(); err != nil {
-		return false, err
-	}
-	return (&claudecode.Plugin{}).AreHooksInstalled(ctx, workspacePath)
+	return grokHooks.AreInstalled(ctx, workspacePath)
 }
 
 // GetRestoreCommand resumes a prior grok session by its captured id, building
 // `grok --no-auto-update [--permission-mode <mode>] -r <agentSessionId>`
-// when we have a hook-captured native id. ok=false otherwise (fall back to fresh
-// launch in the manager).
+// when we have a hook-captured native id. ok=false otherwise, so the restore
+// manager falls back to a fresh launch with AO's saved system prompt.
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
@@ -172,10 +192,8 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	return cmd, true, nil
 }
 
-// SessionInfo reads hook-derived metadata. Since we delegate hook install to
-// claude hooks (via compat), the keys in the metadata map are the claude ones
-// ("title", "summary", "agentSessionId"). We surface them under the normalized
-// SessionInfo; grok-specific aliases are not needed.
+// SessionInfo reads hook-derived metadata under AO's normalized keys ("title",
+// "summary", "agentSessionId").
 func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (ports.SessionInfo, bool, error) {
 	if err := ctx.Err(); err != nil {
 		return ports.SessionInfo{}, false, err
@@ -203,6 +221,10 @@ func (p *Plugin) grokBinary(ctx context.Context) (string, error) {
 	}
 	p.resolvedBinary = binary
 	return binary, nil
+}
+
+func grokClaudeSettingsPath(workspacePath string) string {
+	return filepath.Join(workspacePath, grokClaudeSettingsDirName, grokClaudeSettingsFileName)
 }
 
 func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {

--- a/backend/internal/adapters/agent/grok/grok_test.go
+++ b/backend/internal/adapters/agent/grok/grok_test.go
@@ -2,6 +2,7 @@ package grok
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hooksjson"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -105,6 +107,22 @@ func TestGetLaunchCommandAcceptEdits(t *testing.T) {
 	assertNoPromptFlag(t, cmd)
 }
 
+func TestGetLaunchCommandAuto(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "grok"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Prompt:      "ship it",
+		Permissions: ports.PermissionModeAuto,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"grok", "--no-auto-update", "--permission-mode", "auto", "--", "ship it"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+	assertNoPromptFlag(t, cmd)
+}
+
 func TestGetLaunchCommandTerminatesFlagsBeforeLeadingDashPrompt(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "grok"}
 	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
@@ -190,16 +208,65 @@ func TestGetRestoreCommand(t *testing.T) {
 	}
 }
 
-func TestGetRestoreCommandNoID(t *testing.T) {
-	plugin := &Plugin{resolvedBinary: "grok"}
-	_, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
-		Session: ports.SessionRef{Metadata: map[string]string{}},
-	})
-	if err != nil {
-		t.Fatalf("err: %v", err)
+func TestGetRestoreCommandMapsPermissionModes(t *testing.T) {
+	tests := []struct {
+		name       string
+		permission ports.PermissionMode
+		want       []string
+	}{
+		{"accept edits", ports.PermissionModeAcceptEdits, []string{"grok", "--no-auto-update", "--permission-mode", "acceptEdits", "-r", "sess-abc123"}},
+		{"auto", ports.PermissionModeAuto, []string{"grok", "--no-auto-update", "--permission-mode", "auto", "-r", "sess-abc123"}},
+		{"bypass permissions", ports.PermissionModeBypassPermissions, []string{"grok", "--no-auto-update", "--permission-mode", "bypassPermissions", "-r", "sess-abc123"}},
 	}
-	if ok {
-		t.Fatal("ok=true with no agentSessionId, want false")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{resolvedBinary: "grok"}
+			cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+				Session: ports.SessionRef{
+					Metadata: map[string]string{
+						ports.MetadataKeyAgentSessionID: "sess-abc123",
+					},
+				},
+				Permissions: tt.permission,
+			})
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if !ok {
+				t.Fatal("ok=false, want true")
+			}
+			if !reflect.DeepEqual(cmd, tt.want) {
+				t.Fatalf("cmd = %#v, want %#v", cmd, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetRestoreCommandNoID(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  ports.SessionRef
+	}{
+		{"empty metadata", ports.SessionRef{Metadata: map[string]string{}}},
+		{"blank agent session metadata", ports.SessionRef{Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "   "}}},
+		{"ao session id only", ports.SessionRef{ID: "ao-7"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{resolvedBinary: "grok"}
+			cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+				Session: tt.ref,
+			})
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if ok {
+				t.Fatal("ok=true with no agentSessionId, want false")
+			}
+			if cmd != nil {
+				t.Fatalf("cmd = %#v, want nil", cmd)
+			}
+		})
 	}
 }
 
@@ -245,13 +312,18 @@ func TestSessionInfoFalseWhenNoHookMetadata(t *testing.T) {
 	}
 }
 
-func TestHookLifecycleDelegates(t *testing.T) {
-	// Claude tests cover the full merge behavior; here we assert Grok exposes
-	// the same delegated lifecycle so Grok-installed compat hooks can be
-	// detected and removed through the Grok adapter.
+func TestGetAgentHooksInstallsGrokCommandsInClaudeSettings(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "grok"}
 	ctx := context.Background()
 	ws := t.TempDir()
+	settingsPath := grokClaudeSettingsPath(ws)
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"my own stop hook","timeout":5},{"type":"command","command":"ao hooks claude-code stop","timeout":30}]}]},"permissions":{"defaultMode":"plan"}}`
+	if err := os.WriteFile(settingsPath, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg := ports.WorkspaceHookConfig{
 		WorkspacePath: ws,
 		SessionID:     "grok-test-1",
@@ -260,13 +332,108 @@ func TestHookLifecycleDelegates(t *testing.T) {
 	if err := plugin.GetAgentHooks(ctx, cfg); err != nil {
 		t.Fatalf("GetAgentHooks: %v", err)
 	}
+	if err := plugin.GetAgentHooks(ctx, cfg); err != nil {
+		t.Fatalf("second GetAgentHooks: %v", err)
+	}
 	if installed, err := plugin.AreHooksInstalled(ctx, ws); err != nil || !installed {
 		t.Fatalf("AreHooksInstalled after install = (%v, %v), want (true, nil)", installed, err)
 	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config struct {
+		Hooks       map[string][]hooksjson.MatcherGroup `json:"hooks"`
+		Permissions json.RawMessage                     `json:"permissions"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	if config.Hooks == nil {
+		t.Fatalf("hooks object missing: %s", data)
+	}
+	for _, spec := range grokManagedHooks {
+		if got := countGrokHookCommand(config.Hooks[spec.Event], spec.Command); got != 1 {
+			t.Fatalf("%s command %q count = %d, want 1", spec.Event, spec.Command, got)
+		}
+		claudeCommand := strings.Replace(spec.Command, "ao hooks grok ", "ao hooks claude-code ", 1)
+		if spec.Event != "Stop" && countGrokHookCommand(config.Hooks[spec.Event], claudeCommand) != 0 {
+			t.Fatalf("%s unexpectedly installed Claude command %q", spec.Event, claudeCommand)
+		}
+	}
+	if countGrokHookCommand(config.Hooks["Stop"], "my own stop hook") != 1 {
+		t.Fatalf("existing Stop hook not preserved: %#v", config.Hooks["Stop"])
+	}
+	if countGrokHookCommand(config.Hooks["Stop"], "ao hooks claude-code stop") != 1 {
+		t.Fatalf("existing Claude AO Stop hook not preserved: %#v", config.Hooks["Stop"])
+	}
+	if len(config.Permissions) == 0 {
+		t.Fatalf("unrelated settings clobbered: %s", data)
+	}
+	if m := grokMatcherForCommand(config.Hooks["SessionStart"], "ao hooks grok session-start"); m == nil || *m != "startup" {
+		t.Fatalf("SessionStart matcher = %v, want startup", m)
+	}
+	if m := grokMatcherForCommand(config.Hooks["UserPromptSubmit"], "ao hooks grok user-prompt-submit"); m != nil {
+		t.Fatalf("UserPromptSubmit matcher = %v, want none", m)
+	}
+	if m := grokMatcherForCommand(config.Hooks["Notification"], "ao hooks grok notification"); m != nil {
+		t.Fatalf("Notification matcher = %v, want none", m)
+	}
+
 	if err := plugin.UninstallHooks(ctx, ws); err != nil {
 		t.Fatalf("UninstallHooks: %v", err)
 	}
 	if installed, err := plugin.AreHooksInstalled(ctx, ws); err != nil || installed {
 		t.Fatalf("AreHooksInstalled after uninstall = (%v, %v), want (false, nil)", installed, err)
 	}
+
+	data, err = os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config = struct {
+		Hooks       map[string][]hooksjson.MatcherGroup `json:"hooks"`
+		Permissions json.RawMessage                     `json:"permissions"`
+	}{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	for _, spec := range grokManagedHooks {
+		if got := countGrokHookCommand(config.Hooks[spec.Event], spec.Command); got != 0 {
+			t.Fatalf("%s command %q count = %d after uninstall, want 0", spec.Event, spec.Command, got)
+		}
+	}
+	if countGrokHookCommand(config.Hooks["Stop"], "my own stop hook") != 1 {
+		t.Fatalf("user Stop hook not preserved after uninstall: %#v", config.Hooks["Stop"])
+	}
+	if countGrokHookCommand(config.Hooks["Stop"], "ao hooks claude-code stop") != 1 {
+		t.Fatalf("Claude AO Stop hook not preserved after uninstall: %#v", config.Hooks["Stop"])
+	}
+	if len(config.Permissions) == 0 {
+		t.Fatalf("unrelated settings clobbered after uninstall: %s", data)
+	}
+}
+
+func countGrokHookCommand(groups []hooksjson.MatcherGroup, command string) int {
+	count := 0
+	for _, group := range groups {
+		for _, hook := range group.Hooks {
+			if hook.Command == command {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func grokMatcherForCommand(groups []hooksjson.MatcherGroup, command string) *string {
+	for _, group := range groups {
+		for _, hook := range group.Hooks {
+			if hook.Command == command {
+				return group.Matcher
+			}
+		}
+	}
+	return nil
 }

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -372,6 +372,32 @@ func TestHooks_ClaudeCodeBlankSessionIDIsIgnored(t *testing.T) {
 	}
 }
 
+func TestHooks_GrokSessionStartReportsAgentSessionID(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"session_id":"grok-native-1"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "grok", "session-start")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capture.hits != 1 {
+		t.Fatalf("daemon calls = %d, want 1", capture.hits)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
+	}
+	want := setActivityAPIRequest{Event: "session-start", AgentSessionID: "grok-native-1"}
+	if req != want {
+		t.Fatalf("body = %+v, want %+v", req, want)
+	}
+}
+
 func TestHooks_RegisteredHarnessSessionStartReportsAgentSessionID(t *testing.T) {
 	for _, agent := range []string{"opencode", "qwen", "kimi", "kilocode"} {
 		t.Run(agent, func(t *testing.T) {


### PR DESCRIPTION
  ## Summary

  Fix Grok session restore by making AO capture Grok’s native session id through Grok-specific hook callbacks.

  Grok reads Claude Code-compatible hook config from `.claude/settings.local.json`, but AO previously installed those
  hooks as `ao hooks claude-code ...`. That meant Grok hook payloads were attributed to the Claude Code harness path
  instead of Grok’s own harness token. This change keeps the Claude-compatible hook file shape while routing callbacks
  through `ao hooks grok ...`.

  ## Changes

  - Install Grok-owned Claude-compatible hooks into `.claude/settings.local.json` with `ao hooks grok <event>` commands.
  - Preserve user hooks, unrelated settings, and existing Claude Code AO hooks when installing/uninstalling Grok hooks.
  - Register `grok` in `activitydispatch` using Claude-compatible activity derivation.
  - Capture Grok `session-start` payload `session_id` into AO `agentSessionId`.
  - Keep Grok restore behavior aligned with OpenCode-style fallback:
    - if `agentSessionId` exists, restore with `grok --no-auto-update ... --rules <systemPrompt> -r <agentSessionId>`
    - if `agentSessionId` is missing, return `ok=false` so the restore manager fresh-launches with AO’s saved system
    prompt
