### PR TITLE
fix(sessions): auto-update other clients when a session is renamed

### DIFF
--- a/backend/internal/storage/sqlite/migrations/0024_session_rename_cdc.sql
+++ b/backend/internal/storage/sqlite/migrations/0024_session_rename_cdc.sql
@@ -1,0 +1,50 @@
+-- +goose Up
+-- Recreate the sessions update CDC trigger so a display_name change also fans
+-- out a session_updated event. RenameSession (PATCH /sessions/{id}) writes only
+-- display_name + updated_at, but the prior trigger's WHEN clause watched
+-- activity_state/is_terminated/first_signal_at/preview_url/preview_revision and
+-- NOT display_name, so a rename wrote no change_log row and never reached the
+-- live SSE stream — the sidebar only picked up the new name on a full refetch.
+-- Migrations 0017/0019 extended this same trigger for preview fan-out; rename
+-- was left out. display_name is NOT NULL, so a plain <> comparison is complete.
+-- The payload gains displayName to match the previewUrl/previewRevision
+-- precedent (the renderer can read the new name straight from the event).
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+    OR OLD.display_name <> NEW.display_name
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END), 'previewUrl', NEW.preview_url, 'previewRevision', NEW.preview_revision, 'displayName', NEW.display_name),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS sessions_cdc_update;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE TRIGGER sessions_cdc_update
+AFTER UPDATE ON sessions
+WHEN OLD.activity_state <> NEW.activity_state
+    OR OLD.is_terminated <> NEW.is_terminated
+    OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
+    OR OLD.preview_url <> NEW.preview_url
+    OR OLD.preview_revision <> NEW.preview_revision
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.id, 'session_updated',
+        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END), 'previewUrl', NEW.preview_url, 'previewRevision', NEW.preview_revision),
+        NEW.updated_at);
+END;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/migrations/0024_session_rename_cdc.sql
+++ b/backend/internal/storage/sqlite/migrations/0024_session_rename_cdc.sql
@@ -1,18 +1,9 @@
 -- +goose Up
--- Recreate the sessions update CDC trigger so a display_name change also fans
--- out a session_updated event. RenameSession (PATCH /sessions/{id}) writes only
--- display_name + updated_at, but the prior trigger's WHEN clause watched
--- activity_state/is_terminated/first_signal_at/preview_url/preview_revision and
--- NOT display_name, so a rename wrote no change_log row and never reached the
--- live SSE stream — the sidebar only picked up the new name on a full refetch.
--- Migrations 0017/0019 extended this same trigger for preview fan-out; rename
--- was left out. display_name is NOT NULL, so a plain <> comparison is complete.
--- Only the WHEN guard changes: session_updated is an invalidation-only nudge
--- (every renderer consumer treats it as a signal to refetch the workspace, see
--- renderer/lib/event-transport.ts — no consumer reads fields off the payload),
--- so the new name is derived from durable state on refetch, not carried on the
--- event. The payload is left as-is to keep one invalidation-only contract for
--- session_updated across every emitter of it.
+-- Add display_name to the sessions_cdc_update WHEN guard so a rename fans out a
+-- session_updated event (previously it wrote no change_log row and never hit the
+-- SSE stream). display_name is NOT NULL, so a plain <> comparison is complete.
+-- Guard-only change: session_updated is an invalidation-only nudge (consumers
+-- refetch, see renderer/lib/event-transport.ts), so the payload stays as-is.
 -- +goose StatementBegin
 DROP TRIGGER IF EXISTS sessions_cdc_update;
 -- +goose StatementEnd

--- a/backend/internal/storage/sqlite/migrations/0024_session_rename_cdc.sql
+++ b/backend/internal/storage/sqlite/migrations/0024_session_rename_cdc.sql
@@ -7,8 +7,12 @@
 -- live SSE stream — the sidebar only picked up the new name on a full refetch.
 -- Migrations 0017/0019 extended this same trigger for preview fan-out; rename
 -- was left out. display_name is NOT NULL, so a plain <> comparison is complete.
--- The payload gains displayName to match the previewUrl/previewRevision
--- precedent (the renderer can read the new name straight from the event).
+-- Only the WHEN guard changes: session_updated is an invalidation-only nudge
+-- (every renderer consumer treats it as a signal to refetch the workspace, see
+-- renderer/lib/event-transport.ts — no consumer reads fields off the payload),
+-- so the new name is derived from durable state on refetch, not carried on the
+-- event. The payload is left as-is to keep one invalidation-only contract for
+-- session_updated across every emitter of it.
 -- +goose StatementBegin
 DROP TRIGGER IF EXISTS sessions_cdc_update;
 -- +goose StatementEnd
@@ -24,7 +28,7 @@ WHEN OLD.activity_state <> NEW.activity_state
 BEGIN
     INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
     VALUES (NEW.project_id, NEW.id, 'session_updated',
-        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END), 'previewUrl', NEW.preview_url, 'previewRevision', NEW.preview_revision, 'displayName', NEW.display_name),
+        json_object('id', NEW.id, 'activity', NEW.activity_state, 'isTerminated', json(CASE WHEN NEW.is_terminated THEN 'true' ELSE 'false' END), 'previewUrl', NEW.preview_url, 'previewRevision', NEW.preview_revision),
         NEW.updated_at);
 END;
 -- +goose StatementEnd

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -41,7 +41,9 @@ func (s *Store) UpdateSession(ctx context.Context, rec domain.SessionRecord) err
 }
 
 // RenameSession updates only the user-facing display name for an existing
-// session. It returns ok=false when the session id does not exist.
+// session. It returns ok=false when the session id does not exist. The
+// sessions_cdc_update trigger fans out a session_updated CDC event when the
+// display name actually changes.
 func (s *Store) RenameSession(ctx context.Context, id domain.SessionID, displayName string, updatedAt time.Time) (bool, error) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -726,7 +726,11 @@ func TestRenameSessionFiresCDCEvent(t *testing.T) {
 
 	// A rename must reach the live SSE stream: display_name is in the
 	// sessions_cdc_update WHEN guard, so the rename writes exactly one
-	// session_updated row carrying the new displayName.
+	// session_updated row. The event is an invalidation-only nudge (renderer
+	// consumers refetch the workspace and read the new name from durable
+	// state), so we assert the fan-out fired, not the payload contents — the
+	// payload carries the shared {id,activity,isTerminated,preview*} shape
+	// common to every session_updated emitter.
 	evs, err := s.EventsAfter(ctx, base, 100)
 	if err != nil {
 		t.Fatal(err)
@@ -744,8 +748,11 @@ func TestRenameSessionFiresCDCEvent(t *testing.T) {
 	if err := json.Unmarshal(payloads[0], &payload); err != nil {
 		t.Fatalf("session_updated payload JSON: %v", err)
 	}
-	if payload["displayName"] != "Fix flaky tests" {
-		t.Fatalf("payload displayName = %v, want %q", payload["displayName"], "Fix flaky tests")
+	if payload["id"] != string(r.ID) {
+		t.Fatalf("payload id = %v, want %q", payload["id"], r.ID)
+	}
+	if _, carried := payload["displayName"]; carried {
+		t.Fatalf("session_updated must stay invalidation-only; payload should not carry displayName: %v", payload)
 	}
 }
 

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -712,6 +712,43 @@ func TestSetSessionPreviewURLBumpsRevisionAndFiresCDCOnSameURL(t *testing.T) {
 	}
 }
 
+func TestRenameSessionFiresCDCEvent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	r, _ := s.CreateSession(ctx, sampleRecord("mer"))
+
+	base, _ := s.LatestSeq(ctx)
+	renamedAt := r.UpdatedAt.Add(time.Minute)
+	if ok, err := s.RenameSession(ctx, r.ID, "Fix flaky tests", renamedAt); err != nil || !ok {
+		t.Fatalf("rename: ok=%v err=%v", ok, err)
+	}
+
+	// A rename must reach the live SSE stream: display_name is in the
+	// sessions_cdc_update WHEN guard, so the rename writes exactly one
+	// session_updated row carrying the new displayName.
+	evs, err := s.EventsAfter(ctx, base, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payloads []json.RawMessage
+	for _, e := range evs {
+		if string(e.Type) == "session_updated" {
+			payloads = append(payloads, e.Payload)
+		}
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("session_updated events = %d, want 1 after rename", len(payloads))
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(payloads[0], &payload); err != nil {
+		t.Fatalf("session_updated payload JSON: %v", err)
+	}
+	if payload["displayName"] != "Fix flaky tests" {
+		t.Fatalf("payload displayName = %v, want %q", payload["displayName"], "Fix flaky tests")
+	}
+}
+
 func TestConcurrentSessionCreateAssignsUniqueNums(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Renaming a session did not emit a live update on the CDC/SSE event stream.
`RenameSession` updates only `display_name` (+ `updated_at`), but the
`sessions_cdc_update` trigger's `WHEN` guard did not include `display_name`,
so the update wrote no `change_log` row — and therefore no `session_updated`
event ever reached `GET /api/v1/events`.

## Root cause

The trigger (introduced in `0001`, later extended by `0017`/`0019`) fires only
when one of the watched columns changes:

```
WHEN OLD.activity_state    <> NEW.activity_state
  OR OLD.is_terminated     <> NEW.is_terminated
  OR (OLD.first_signal_at IS NULL AND NEW.first_signal_at IS NOT NULL)
  OR OLD.preview_url       <> NEW.preview_url
  OR OLD.preview_revision  <> NEW.preview_revision
```

`display_name` is not in that list. Migrations `0017` and `0019` added the
`preview_*` columns to this same trigger for exactly this fan-out reason;
rename was left out.

## Impact

The initiating desktop window happens to refetch on its own (the sidebar
invalidates its workspace query after a successful rename), which masks the
bug there. But any client relying on the CDC stream keeps showing the **old**
name until an unrelated event forces a refetch — e.g. a second desktop
window, the Connect Mobile client, or *every* connected client when the
rename comes from `ao session rename` (which does no client-side invalidation).

## Fix

New migration `0024_session_rename_cdc.sql` drops and recreates
`sessions_cdc_update` with `OR OLD.display_name <> NEW.display_name` added to
the `WHEN` guard. `display_name` is `NOT NULL`, so a plain `<>` comparison is
complete. Per the repo's hard rule I added a new migration rather than editing
a merged one; the `Down` reverts to the `0019` trigger.

The **only** change to the trigger is the `WHEN` guard — the payload is left at
the existing `{id, activity, isTerminated, previewUrl, previewRevision}` shape.
`session_updated` is an invalidation-only nudge: every renderer consumer
(`renderer/lib/event-transport.ts`) reacts to it by debouncing a
`["workspaces"]` refetch and reads no field off the payload, so the new name is
derived from durable state on refetch rather than carried on the event.

## Reproduction

1. Start the daemon and open an SSE reader against `GET /api/v1/events`
   (e.g. `curl -N http://127.0.0.1:3001/api/v1/events`).
2. Rename a session via the sidebar or `ao session rename <id> <name>`.
3. **Before:** no frame appears on the stream. **After:** a `session_updated`
   frame is delivered and connected clients refetch and show the new name.
