### PR TITLE
fix: don't drop queued nudges when the merge-conflict check errors

### DIFF
--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -18,6 +18,7 @@ type fakeStore struct {
 	prs        map[domain.SessionID][]domain.PullRequest
 	signatures map[string]string
 
+	listPRsErr        error
 	signatureWriteErr error
 	signatureWrites   int
 }
@@ -32,6 +33,9 @@ func (f *fakeStore) GetSession(_ context.Context, id domain.SessionID) (domain.S
 }
 
 func (f *fakeStore) ListPRsBySession(_ context.Context, id domain.SessionID) ([]domain.PullRequest, error) {
+	if f.listPRsErr != nil {
+		return nil, f.listPRsErr
+	}
 	return f.prs[id], nil
 }
 
@@ -409,6 +413,58 @@ func TestPRObservation_CIFailingAndReviewBothNudge(t *testing.T) {
 	}
 	if len(msg.msgs) != 2 {
 		t.Fatalf("re-observation should not re-nudge, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+}
+
+// A failed parent-stack lookup (the store read behind the merge-conflict
+// exemption) must not discard the CI/review nudges already queued for the same
+// PR. Only the merge-conflict nudge is skipped this cycle; CI and review still
+// send, the read error still surfaces so the observer logs and re-polls, and the
+// merge-conflict nudge fires once the read recovers.
+func TestPRObservation_MergeConflictReadErrorStillSendsCIAndReview(t *testing.T) {
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	st.listPRsErr = errors.New("transient store read failure")
+	o := ports.PRObservation{
+		Fetched:      true,
+		URL:          "pr1",
+		CI:           domain.CIFailing,
+		Checks:       []ports.PRCheckObservation{{Name: "build", CommitHash: "c1", Status: domain.PRCheckFailed, LogTail: "boom"}},
+		Review:       domain.ReviewChangesRequest,
+		Comments:     []ports.PRCommentObservation{{ID: "1", Author: "alice", Body: "fix this"}},
+		Mergeability: domain.MergeConflicting,
+	}
+	if err := m.ApplyPRObservation(ctx, "mer-1", o); err == nil {
+		t.Fatal("want the deferred parent-stack read error surfaced")
+	}
+	// CI and review still fired despite the merge-conflict lookup failing; the
+	// merge-conflict nudge itself is skipped this cycle.
+	if len(msg.msgs) != 2 {
+		t.Fatalf("want CI and review nudges sent, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+	if !strings.Contains(msg.msgs[0], "boom") {
+		t.Fatalf("first nudge should carry the CI failure, got %q", msg.msgs[0])
+	}
+	if !strings.Contains(msg.msgs[1], "fix this") {
+		t.Fatalf("second nudge should carry the review feedback, got %q", msg.msgs[1])
+	}
+	for _, sent := range msg.msgs {
+		if strings.Contains(sent, "merge conflicts") {
+			t.Fatalf("merge-conflict nudge must be skipped on read error, got %q", sent)
+		}
+	}
+
+	// Next poll, the read recovers: the merge-conflict nudge now fires while
+	// CI/review stay deduped (their signatures persisted before the error).
+	st.listPRsErr = nil
+	if err := m.ApplyPRObservation(ctx, "mer-1", o); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 3 {
+		t.Fatalf("want merge-conflict nudge on recovery with CI/review deduped, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+	if !strings.Contains(msg.msgs[2], "merge conflicts") {
+		t.Fatalf("third nudge should be the merge-conflict nudge, got %q", msg.msgs[2])
 	}
 }
 

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -203,6 +203,14 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 		}
 		nudges = append(nudges, pendingNudge{key: "review:" + o.URL, sig: sig, msg: msg, maxAttempts: reviewMaxNudge})
 	}
+	// Only the merge-conflict nudge needs a store read (the parent-stack check).
+	// A read error there must NOT discard the CI/review nudges already queued
+	// above — returning early here would re-introduce the "one condition
+	// suppresses the others" coupling this queue was built to remove. So on error
+	// we skip only the merge-conflict nudge (it self-heals on the next poll) and
+	// defer the error past the send loop, still surfacing it so the observer logs
+	// and re-polls.
+	var blockedCheckErr error
 	if o.Mergeability == domain.MergeConflicting {
 		// Only the bottom of a stack is eligible for the rebase nudge. A PR
 		// stacked on an open parent is expected to report conflicts against its
@@ -210,10 +218,10 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 		// agent to rebase it now would be noise. Mergeability UNKNOWN (the brief
 		// post-retarget recompute window) never reaches here.
 		blocked, err := m.prBlockedByOpenParent(ctx, id, o.URL)
-		if err != nil {
-			return err
-		}
-		if !blocked {
+		switch {
+		case err != nil:
+			blockedCheckErr = err
+		case !blocked:
 			msg := "There are merge conflicts on " + ident + ". Rebase onto the base branch and resolve them."
 			if o.URL != "" {
 				msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
@@ -227,7 +235,9 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			return err
 		}
 	}
-	return nil
+	// Surface a deferred parent-stack read error only after the independent
+	// CI/review nudges have been sent, so none of them are lost to it.
+	return blockedCheckErr
 }
 
 // ApplyReviewResult reacts to a completed AO-internal review pass after the


### PR DESCRIPTION
## Summary

A transient store read error while checking the merge-conflict exemption
discarded the CI and review nudges already queued for the same PR, so a poll
cycle that should have delivered "CI is failing" / "address review feedback"
delivered nothing.

## Root cause

`ApplyPRObservation` queues each independent nudge (CI, review, merge-conflict)
and sends them in one loop — deliberately, so no condition can suppress another.
But only the merge-conflict branch needs a store read (`prBlockedByOpenParent`
→ `ListPRsBySession`) to skip PRs stacked on an open parent, and on error it
returned early **before** the send loop, throwing away the CI/review nudges
already queued. That re-introduces the exact coupling the queue was built to
remove.

## Impact

Low and recovers on the next poll: when a PR simultaneously has failing CI (or
review feedback) and a merge conflict, a transient `ListPRsBySession` error
drops the CI/review nudge for that cycle. The next poll (~30s) redelivers it. No
wrong nudge is ever sent; a real one is just delayed one cycle.

## Fix

On a parent-stack read error, skip only the merge-conflict nudge (it recovers on
the next poll) and defer the error past the send loop, so the CI/review nudges
still go out and the error is still surfaced to the observer (which logs it and
re-polls). Sent nudges persist their own dedup signature, so the re-poll doesn't
double-nudge.
