### PR TITLE
fix(review): respawn the reviewer pane when the harness changes

### DIFF
--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -45,6 +45,7 @@ type LaunchSpec struct {
 // satisfies it.
 type reviewerRuntime interface {
 	Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error)
+	Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 	Interrupt(ctx context.Context, handle ports.RuntimeHandle) error
 	IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error)
 	SendMessage(ctx context.Context, handle ports.RuntimeHandle, message string) error
@@ -104,6 +105,15 @@ func (l *agentLauncher) Spawn(ctx context.Context, spec LaunchSpec) (string, err
 	cmd, err := reviewer.ReviewCommand(ctx, inv)
 	if err != nil {
 		return "", fmt.Errorf("reviewer command: %w", err)
+	}
+	// The reviewer handle is stable per worker, so a still-live pane from a
+	// previous pass would otherwise block `tmux new-session` (duplicate name) or,
+	// worse, keep serving under its old harness. Destroy any stale pane on this
+	// handle first so the reviewer always (re)launches under spec.Harness's
+	// sandbox/permissions/env — which are applied only here at Create, never by
+	// Notify. Destroy is idempotent when no pane exists (first spawn / dead pane).
+	if err := l.runtime.Destroy(ctx, ports.RuntimeHandle{ID: handleID}); err != nil {
+		return "", fmt.Errorf("reviewer replace stale pane: %w", err)
 	}
 	handle, err := l.runtime.Create(ctx, ports.RuntimeConfig{
 		SessionID:     domain.SessionID(handleID),

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -64,17 +64,28 @@ func (f fakeReviewerResolver) Reviewer(domain.ReviewerHarness) (ports.Reviewer, 
 }
 
 type fakeRuntime struct {
-	createCfg  ports.RuntimeConfig
-	sentMsg    string
-	sentTo     string
-	alive      bool
-	interrupt  string
-	interrupts int
+	createCfg     ports.RuntimeConfig
+	sentMsg       string
+	sentTo        string
+	alive         bool
+	interrupt     string
+	interrupts    int
+	destroyed     string
+	destroyBefore bool
+	created       bool
 }
 
 func (f *fakeRuntime) Create(_ context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
 	f.createCfg = cfg
+	f.created = true
 	return ports.RuntimeHandle{ID: string(cfg.SessionID)}, nil
+}
+func (f *fakeRuntime) Destroy(_ context.Context, handle ports.RuntimeHandle) error {
+	f.destroyed = handle.ID
+	if !f.created {
+		f.destroyBefore = true
+	}
+	return nil
 }
 func (f *fakeRuntime) IsAlive(_ context.Context, _ ports.RuntimeHandle) (bool, error) {
 	return f.alive, nil
@@ -118,6 +129,26 @@ func TestLauncherSpawnReturnsStableHandle(t *testing.T) {
 	}
 	if reviewer.gotInv.RunID != "run-1" || reviewer.gotInv.TargetSHA != "sha1" || reviewer.gotInv.ReviewerID != "review-mer-1" {
 		t.Fatalf("invocation = %+v", reviewer.gotInv)
+	}
+}
+
+// Spawn must replace any stale pane on the stable per-worker handle before
+// creating the new one — otherwise a reviewer-harness switch either collides
+// with the old pane's tmux session name or leaves it serving under the old
+// harness's sandbox/permissions/env (which are applied only at Create).
+func TestLauncherSpawnReplacesStalePane(t *testing.T) {
+	reviewer := &fakeReviewer{}
+	rt := &fakeRuntime{}
+	l := NewLauncher(fakeReviewerResolver{reviewer: reviewer, ok: true}, rt)
+
+	if _, err := l.Spawn(context.Background(), launchSpec()); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if rt.destroyed != "review-mer-1" {
+		t.Fatalf("stale pane not destroyed: destroyed=%q, want review-mer-1", rt.destroyed)
+	}
+	if !rt.destroyBefore {
+		t.Fatal("stale pane must be destroyed before the fresh pane is created")
 	}
 }
 

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -207,6 +207,14 @@ func (e *Engine) Trigger(ctx stdctx.Context, workerID domain.SessionID) (Trigger
 		return TriggerResult{}, err
 	}
 
+	// Harness the live reviewer pane was launched under, captured before the
+	// upsert below overwrites it. The reviewer handle is stable per worker, so a
+	// harness switch keeps the previous harness's process alive; reusing it (via
+	// Notify, which only sends prompt text) would silently run the review under
+	// the old harness's sandbox/permissions/env, since those apply only at Spawn.
+	// A changed (or unrecorded) harness therefore respawns instead of reusing.
+	prevHarness := reviewRow.Harness
+
 	now := e.clock()
 	reviewRow, err = e.upsertReview(ctx, worker, harness, reviewRow.ReviewerHandleID, now)
 	if err != nil {
@@ -266,7 +274,7 @@ func (e *Engine) Trigger(ctx stdctx.Context, workerID domain.SessionID) (Trigger
 
 	handleID := ""
 	queue := reviewQueue(created)
-	if hasReview && reviewRow.ReviewerHandleID != "" {
+	if hasReview && reviewRow.ReviewerHandleID != "" && prevHarness == harness {
 		alive, err := e.launcher.Alive(ctx, reviewRow.ReviewerHandleID)
 		if err != nil {
 			return TriggerResult{}, failRuns(0, err)

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -216,7 +216,19 @@ func (e *Engine) Trigger(ctx stdctx.Context, workerID domain.SessionID) (Trigger
 	prevHarness := reviewRow.Harness
 
 	now := e.clock()
-	reviewRow, err = e.upsertReview(ctx, worker, harness, reviewRow.ReviewerHandleID, now)
+	// This eager upsert only needs the review row to exist so the runs below can
+	// reference it; it must NOT advance the recorded harness past what the live
+	// pane actually runs. On a harness switch that creates no run, the
+	// len(created)==0 early return below reuses the old pane without respawning,
+	// so recording the new harness here would make the next trigger read it back
+	// as prevHarness, see prevHarness == harness, and Notify the stale old-harness
+	// pane. Preserve an existing row's harness; only the post-spawn upsert (after
+	// an actual Spawn/Notify) records the harness we launched under.
+	eagerHarness := harness
+	if hasReview {
+		eagerHarness = prevHarness
+	}
+	reviewRow, err = e.upsertReview(ctx, worker, eagerHarness, reviewRow.ReviewerHandleID, now)
 	if err != nil {
 		return TriggerResult{}, err
 	}

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -554,6 +554,74 @@ func TestTriggerRespawnsWhenReviewerHarnessChanged(t *testing.T) {
 	}
 }
 
+// A harness switch observed on a trigger that creates no run (the current
+// commit is already reviewed) must NOT advance the recorded harness. The live
+// pane keeps running under the previous harness, so recording the new harness
+// on this no-created path would make the next trigger read it back as
+// prevHarness, match the resolved harness, and reuse (Notify) the stale pane.
+func TestTriggerKeepsHarnessWhenNothingCreated(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerCodex, ReviewerHandleID: "review-mer-1"},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
+	}
+	// Live codex pane; the worker/project now resolves to claude-code.
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if res.Created || launcher.spawned || launcher.notified {
+		t.Fatalf("already-reviewed commit: expected no launch, got res=%+v launcher=%+v", res, launcher)
+	}
+	if store.review.Harness != domain.ReviewerCodex {
+		t.Fatalf("recorded harness = %q, want codex preserved (no respawn happened)", store.review.Harness)
+	}
+}
+
+// End-to-end of the blocker: a harness switch seen on a no-run trigger must not
+// defeat respawn on the next commit. Before the fix, the eager upsert recorded
+// the new harness on the no-created trigger, so the following commit saw
+// prevHarness == harness and reused (Notify) the stale old-harness pane.
+func TestTriggerRespawnsOnNextCommitAfterHarnessSwitchWithNoRun(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerCodex, ReviewerHandleID: "review-mer-1"},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
+			Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
+	}
+	// Trigger 1: current commit sha1 is already reviewed → no run created, while
+	// the worker now resolves to claude-code but the live pane is still codex.
+	l1 := &fakeLauncher{alive: true, handle: "review-mer-1"}
+	eng1 := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, l1)
+	if _, err := eng1.Trigger(context.Background(), "mer-1"); err != nil {
+		t.Fatalf("trigger 1: %v", err)
+	}
+	if l1.spawned || l1.notified {
+		t.Fatalf("trigger 1 (nothing new) should not launch: %+v", l1)
+	}
+
+	// Trigger 2: a new commit arrives → a run is created. The reviewer must
+	// respawn under claude-code, not Notify the stale codex pane.
+	l2 := &fakeLauncher{alive: true, handle: "review-mer-1"}
+	eng2 := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha2"), fakeProjects{}, l2)
+	res, err := eng2.Trigger(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("trigger 2: %v", err)
+	}
+	if !res.Created || !l2.spawned || l2.notified {
+		t.Fatalf("trigger 2 must respawn under the new harness, not reuse the stale pane: res=%+v launcher=%+v", res, l2)
+	}
+	if l2.gotSpec.Harness != domain.ReviewerClaudeCode {
+		t.Fatalf("respawn harness = %q, want claude-code", l2.gotSpec.Harness)
+	}
+}
+
 func TestTriggerLaunchFailureRecordsFailedRun(t *testing.T) {
 	store := &fakeStore{}
 	launcher := &fakeLauncher{spawnErr: fmt.Errorf("claude: %w", ports.ErrAgentBinaryNotFound)}

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -393,7 +393,7 @@ func TestTriggerFallsBackToExistingRunOnUniqueConflict(t *testing.T) {
 
 func TestTriggerIsIdempotentForSameCommit(t *testing.T) {
 	store := &fakeStore{
-		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1"},
 		runs: []domain.ReviewRun{{
 			ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
 			Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
@@ -419,7 +419,7 @@ func TestTriggerIsIdempotentForSameCommit(t *testing.T) {
 
 func TestTriggerReusesRunningRowWithNoVerdict(t *testing.T) {
 	store := &fakeStore{
-		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1"},
 		runs:   []domain.ReviewRun{{ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1", Status: domain.ReviewRunRunning}},
 	}
 	launcher := &fakeLauncher{alive: false, handle: "review-mer-2"}
@@ -442,7 +442,7 @@ func TestTriggerReusesRunningRowWithNoVerdict(t *testing.T) {
 
 func TestTriggerRetriesTerminalRowWithNoVerdict(t *testing.T) {
 	store := &fakeStore{
-		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1"},
 		runs: []domain.ReviewRun{{
 			ID: "run-empty-verdict", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
 			Status: domain.ReviewRunComplete, Verdict: domain.VerdictNone,
@@ -465,7 +465,7 @@ func TestTriggerRetriesTerminalRowWithNoVerdict(t *testing.T) {
 
 func TestTriggerNotifiesLiveReviewerOnNewCommit(t *testing.T) {
 	store := &fakeStore{
-		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1"},
 		runs:   []domain.ReviewRun{{ID: "run-0", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha0", Status: domain.ReviewRunComplete}},
 	}
 	launcher := &fakeLauncher{alive: true}
@@ -488,7 +488,7 @@ func TestTriggerNotifiesLiveReviewerOnNewCommit(t *testing.T) {
 
 func TestTriggerSupersedesOlderRunningRunOnNewCommit(t *testing.T) {
 	store := &fakeStore{
-		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1"},
 		runs:   []domain.ReviewRun{{ID: "run-old", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha0", Status: domain.ReviewRunRunning}},
 	}
 	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
@@ -511,7 +511,7 @@ func TestTriggerSupersedesOlderRunningRunOnNewCommit(t *testing.T) {
 
 func TestTriggerSpawnsWhenReviewerDead(t *testing.T) {
 	store := &fakeStore{
-		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1"},
 		runs:   []domain.ReviewRun{{ID: "run-0", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha0", Status: domain.ReviewRunComplete}},
 	}
 	launcher := &fakeLauncher{alive: false, handle: "review-mer-1"}
@@ -522,6 +522,35 @@ func TestTriggerSpawnsWhenReviewerDead(t *testing.T) {
 	}
 	if !launcher.spawned || launcher.notified {
 		t.Fatalf("expected spawn when reviewer dead: %+v", launcher)
+	}
+}
+
+// A live reviewer pane launched under a previous harness must be respawned under
+// the newly-resolved harness, not reused via Notify: the pane's sandbox/
+// permissions/env are fixed at Spawn, so reusing a codex pane to serve a
+// claude-code review (or vice versa) would run under the wrong profile.
+func TestTriggerRespawnsWhenReviewerHarnessChanged(t *testing.T) {
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerCodex, ReviewerHandleID: "review-mer-1"},
+		runs:   []domain.ReviewRun{{ID: "run-0", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha0", Status: domain.ReviewRunComplete}},
+	}
+	// Live pane exists (alive), but the worker/project now resolves to claude-code
+	// while the pane was launched under codex.
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if !launcher.spawned || launcher.notified {
+		t.Fatalf("expected respawn under the new harness, not reuse via notify: %+v", launcher)
+	}
+	if launcher.gotSpec.Harness != domain.ReviewerClaudeCode {
+		t.Fatalf("respawn harness = %q, want claude-code", launcher.gotSpec.Harness)
+	}
+	if res.Run.Harness != domain.ReviewerClaudeCode {
+		t.Fatalf("run harness = %q, want claude-code", res.Run.Harness)
 	}
 }
 
@@ -547,7 +576,7 @@ func TestTriggerLaunchFailureRecordsFailedRun(t *testing.T) {
 
 func TestTriggerRetriesAfterFailedRunForSameCommit(t *testing.T) {
 	store := &fakeStore{
-		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1"},
 		runs:   []domain.ReviewRun{{ID: "run-failed", ReviewID: "rev-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1", Status: domain.ReviewRunFailed}},
 	}
 	launcher := &fakeLauncher{handle: "review-mer-1"}
@@ -567,7 +596,7 @@ func TestTriggerRetriesAfterFailedRunForSameCommit(t *testing.T) {
 
 func TestTriggerRetriesAfterCancelledRunForSameCommit(t *testing.T) {
 	store := &fakeStore{
-		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1"},
 		runs:   []domain.ReviewRun{{ID: "run-cancelled", ReviewID: "rev-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1", Status: domain.ReviewRunCancelled}},
 	}
 	launcher := &fakeLauncher{handle: "review-mer-1"}
@@ -645,7 +674,7 @@ func TestTriggerAllowsTwoPRsWithSameHeadSHA(t *testing.T) {
 
 func TestTriggerSkipsApprovedAndRunningCurrentHead(t *testing.T) {
 	store := &fakeStore{
-		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1"},
 		runs: []domain.ReviewRun{
 			{ID: "approved", ReviewID: "rev-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1", Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved, CreatedAt: time.Unix(1, 0)},
 			{ID: "running", ReviewID: "rev-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/2", TargetSHA: "sha2", Status: domain.ReviewRunRunning, CreatedAt: time.Unix(2, 0)},
@@ -672,7 +701,7 @@ func TestTriggerSkipsApprovedAndRunningCurrentHead(t *testing.T) {
 
 func TestTriggerCreatesRunForChangesRequestedCurrentHead(t *testing.T) {
 	store := &fakeStore{
-		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1"},
 		runs: []domain.ReviewRun{{
 			ID: "changes", ReviewID: "rev-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1",
 			Status: domain.ReviewRunComplete, Verdict: domain.VerdictChangesRequested, CreatedAt: time.Unix(1, 0),
@@ -722,7 +751,7 @@ func TestTriggerRejectsBadWorkerState(t *testing.T) {
 
 func TestListReturnsHandleAndRuns(t *testing.T) {
 	store := &fakeStore{
-		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", Harness: domain.ReviewerClaudeCode, ReviewerHandleID: "review-mer-1"},
 		runs:   []domain.ReviewRun{{ID: "run-1", SessionID: "mer-1", PRURL: "https://github.com/o/r/pull/1", TargetSHA: "sha1"}},
 	}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, &fakeLauncher{})


### PR DESCRIPTION
## Summary

After switching a project's reviewer harness (e.g. claude-code → opencode), a
new review reused the still-live pane from the previous harness — so the review
ran under the **old** harness's sandbox/permissions/env while the DB recorded
the new harness.

## Root cause

The reviewer handle is stable per worker (`review-<workerID>`, independent of
harness), and `Trigger` reused any live pane keyed only on `Alive` — it never
compared the pane's harness to the freshly-resolved one. Reuse goes through
`Notify`, which only sends prompt text; sandbox/permissions/env are applied only
at `Spawn`. So a claude-code pane kept serving opencode-intended reviews.

## Impact

Security-relevant: if you switch to a stricter reviewer (e.g. opencode's
deny-all-bash profile), that stricter sandbox is silently not applied until the
old pane dies. Reviews run under the previous harness's looser profile.

## Fix

Gate pane reuse on the resolved harness matching the harness the live pane was
launched under; a changed (or unrecorded) harness respawns instead. Because the
handle is stable and `tmux new-session` collides on a live name, `Spawn` now
destroys any stale pane on that handle first (idempotent when absent), so the
switch actually replaces the process under the new harness's profile.
