### PR TITLE
fix(daemon): repair PATH with a tool floor at startup so headless daemons find tmux (#2812)

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -43,6 +43,13 @@ func Run() error {
 	// minimal PATH and otherwise can't see tmux / agent binaries installed under
 	// Homebrew or /usr/local, which makes the spawn gate fail spuriously with
 	// "tmux required on macOS/Linux but not in PATH" (#2812). No-op on Windows.
+	//
+	// TODO(#2812 follow-up): this floor is daemon-only. `ao doctor` runs in the
+	// CLI process (not the daemon), so its checkTmux still uses the un-floored
+	// exec.LookPath and can report a false "tmux: not found in PATH" on a headless
+	// box even though the daemon now spawns correctly. The follow-up fix is to call
+	// runtimeenv.EnsureFallbackPath() from the CLI entry (root PersistentPreRunE),
+	// not just change the doctor message.
 	runtimeenv.EnsureFallbackPath()
 
 	cfg, err := config.Load()

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/preview"
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
+	"github.com/aoagents/agent-orchestrator/backend/internal/runtimeenv"
 	agentsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/agent"
 	importsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/importer"
 	notificationsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/notification"
@@ -36,6 +37,14 @@ import (
 // Run starts the daemon and blocks until it exits. SIGINT/SIGTERM drive
 // graceful shutdown through the HTTP server and background workers.
 func Run() error {
+	// Repair the daemon's PATH with the standard macOS/Linux tool floor before
+	// anything does an exec.LookPath. A daemon started outside the Electron
+	// launcher (headless `ao start`, systemd, cron, a container) inherits a
+	// minimal PATH and otherwise can't see tmux / agent binaries installed under
+	// Homebrew or /usr/local, which makes the spawn gate fail spuriously with
+	// "tmux required on macOS/Linux but not in PATH" (#2812). No-op on Windows.
+	runtimeenv.EnsureFallbackPath()
+
 	cfg, err := config.Load()
 	if err != nil {
 		return err

--- a/backend/internal/runtimeenv/pathfloor.go
+++ b/backend/internal/runtimeenv/pathfloor.go
@@ -11,6 +11,13 @@
 // fail with "tmux required on macOS/Linux but not in PATH" even though tmux is
 // installed. This package ports the static floor to Go so the daemon repairs its
 // own PATH at startup. See AgentWrapper/agent-orchestrator#2812.
+//
+// Scope: this ports only the STATIC floor from shell-env.ts, not its login-shell
+// probe ($SHELL -ilc -> env). The floor covers the common Homebrew and
+// /usr/local case #2812 reports, but not custom prefixes the Electron probe
+// recovers (Nix ~/.nix-profile/bin, asdf/mise shims, or any non-standard dir), so
+// a non-Electron daemon remains less PATH-robust than the Electron-launched one
+// for those setups. Porting the login-shell probe is a possible future follow-up.
 package runtimeenv
 
 import (

--- a/backend/internal/runtimeenv/pathfloor.go
+++ b/backend/internal/runtimeenv/pathfloor.go
@@ -1,0 +1,69 @@
+// Package runtimeenv repairs the daemon process's environment so that a daemon
+// started outside the Electron launcher (headless `ao start`, systemd, cron, a
+// container, or any automation wrapper) can still resolve CLI tools installed
+// under Homebrew or /usr/local.
+//
+// The Electron launcher already does this for the daemons it spawns
+// (frontend/src/shared/shell-env.ts: a login-shell probe plus a static PATH
+// floor). But that logic lives only in the frontend, so a daemon launched any
+// other way inherits a minimal PATH and cannot see, e.g., tmux at
+// /opt/homebrew/bin — which makes the spawn gate (validateRuntimePrerequisites)
+// fail with "tmux required on macOS/Linux but not in PATH" even though tmux is
+// installed. This package ports the static floor to Go so the daemon repairs its
+// own PATH at startup. See AgentWrapper/agent-orchestrator#2812.
+package runtimeenv
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+// FallbackPathDirs mirrors FALLBACK_PATH_DIRS in frontend/src/shared/shell-env.ts:
+// the directories a working macOS/Linux box keeps CLI tools in. Kept in sync with
+// the frontend list so both launch paths resolve the same tools.
+var FallbackPathDirs = []string{
+	"/opt/homebrew/bin",
+	"/opt/homebrew/sbin",
+	"/usr/local/bin",
+	"/usr/bin",
+	"/bin",
+	"/usr/sbin",
+	"/sbin",
+}
+
+// WithFallbackPath appends any FallbackPathDirs not already present in path,
+// preserving the existing order/priority and de-duplicating. Existing entries
+// keep precedence (the user's own PATH wins); floor dirs are only appended, never
+// prepended. Empty segments are dropped.
+func WithFallbackPath(path string) string {
+	sep := string(os.PathListSeparator)
+	seen := make(map[string]bool)
+	out := make([]string, 0)
+	add := func(dir string) {
+		if dir == "" || seen[dir] {
+			return
+		}
+		seen[dir] = true
+		out = append(out, dir)
+	}
+	for _, dir := range strings.Split(path, sep) {
+		add(dir)
+	}
+	for _, dir := range FallbackPathDirs {
+		add(dir)
+	}
+	return strings.Join(out, sep)
+}
+
+// EnsureFallbackPath repairs the current process's PATH with the floor on
+// macOS/Linux. It is a no-op on Windows: the tmux prerequisite gate is
+// Windows-exempt and the floor dirs are POSIX paths. Call it once at daemon
+// startup, before any exec.LookPath (the tmux prereq gate and the agent-binary
+// preflight) runs, so every lookup sees the repaired PATH.
+func EnsureFallbackPath() {
+	if runtime.GOOS == "windows" {
+		return
+	}
+	_ = os.Setenv("PATH", WithFallbackPath(os.Getenv("PATH")))
+}

--- a/backend/internal/runtimeenv/pathfloor_test.go
+++ b/backend/internal/runtimeenv/pathfloor_test.go
@@ -1,0 +1,63 @@
+package runtimeenv
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func sep() string { return string(os.PathListSeparator) }
+
+func TestWithFallbackPathAppendsMissingFloorDirs(t *testing.T) {
+	// A minimal PATH (the classic headless/systemd case) must gain the floor so
+	// tmux at /opt/homebrew/bin becomes resolvable.
+	got := WithFallbackPath("/usr/bin" + sep() + "/bin")
+	for _, dir := range FallbackPathDirs {
+		if !strings.Contains(sep()+got+sep(), sep()+dir+sep()) {
+			t.Fatalf("result %q missing floor dir %q", got, dir)
+		}
+	}
+}
+
+func TestWithFallbackPathPreservesExistingOrderAndPrecedence(t *testing.T) {
+	// The user's own entries must stay first (keep precedence); floor dirs append.
+	got := WithFallbackPath("/my/tools" + sep() + "/usr/bin")
+	parts := strings.Split(got, sep())
+	if parts[0] != "/my/tools" || parts[1] != "/usr/bin" {
+		t.Fatalf("existing order not preserved: %v", parts)
+	}
+	if got != "/my/tools"+sep()+"/usr/bin"+sep()+strings.Join(dropDir(FallbackPathDirs, "/usr/bin"), sep()) {
+		t.Fatalf("unexpected composition: %q", got)
+	}
+}
+
+func TestWithFallbackPathDeduplicates(t *testing.T) {
+	got := WithFallbackPath("/opt/homebrew/bin" + sep() + "/opt/homebrew/bin" + sep() + "/usr/bin")
+	if strings.Count(sep()+got+sep(), sep()+"/opt/homebrew/bin"+sep()) != 1 {
+		t.Fatalf("expected /opt/homebrew/bin exactly once, got %q", got)
+	}
+}
+
+func TestWithFallbackPathEmptyYieldsFloorOnly(t *testing.T) {
+	if got := WithFallbackPath(""); got != strings.Join(FallbackPathDirs, sep()) {
+		t.Fatalf("empty PATH should yield the floor, got %q", got)
+	}
+}
+
+func TestWithFallbackPathDropsEmptySegments(t *testing.T) {
+	got := WithFallbackPath(sep() + "/usr/bin" + sep() + sep())
+	if strings.HasPrefix(got, sep()) || strings.Contains(got, sep()+sep()) {
+		t.Fatalf("empty segments not dropped: %q", got)
+	}
+}
+
+// dropDir returns dirs without the given entry (test helper for the precedence case).
+func dropDir(dirs []string, drop string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if d != drop {
+			out = append(out, d)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## What
Fixes #2812. A daemon started outside the Electron launcher (headless `ao start`, systemd, cron, container, automation) inherits a minimal `$PATH` and can't see `tmux` under `/opt/homebrew/bin` or `/usr/local/bin`, so **every spawn** fails the prereq gate with `tmux required on macOS/Linux but not in PATH` — even though tmux is installed.

## Root cause
`session_manager.validateRuntimePrerequisites` gates each spawn on `exec.LookPath("tmux")` against the daemon's own inherited PATH (`manager.go:2488` / prod wiring `manager.go:228`). The PATH floor + login-shell probe that fixes this exists **only in the Electron launcher** (`frontend/src/shared/shell-env.ts`), so it never reaches a non-Electron daemon.

## Fix
- New `internal/runtimeenv` package ports the static PATH floor (`FALLBACK_PATH_DIRS`) from `shell-env.ts` to Go.
- `daemon.Run()` calls `runtimeenv.EnsureFallbackPath()` once at startup, **before any `exec.LookPath`**, so the tmux prereq gate *and* the agent-binary preflight both see the floor.
- Existing PATH entries keep precedence (only appended, de-duped). No-op on Windows (the tmux gate is Windows-exempt; floor dirs are POSIX).

## Scope
This is the **core fix** (#1 in the issue). The two complementary items — enriching `ao doctor`'s tmux check to stat floor dirs, and making the spawn error actionable — are intentionally left as separate follow-up PRs so this stays focused and low-risk.

## Tests
`internal/runtimeenv/pathfloor_test.go`: appends missing floor dirs, preserves existing order/precedence, de-dupes, empty-PATH → floor only, drops empty segments. `go build` / `go vet` / `go test ./internal/runtimeenv/` all pass; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)