### PR TITLE
fix(sessions): reclaim the worktree on merge-triggered termination (#2811)

### DIFF
--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -111,6 +111,12 @@ func startSession(cfg config.Config, runtime runtimeselect.Runtime, store *sqlit
 		DataDir:   cfg.DataDir,
 		Logger:    log,
 	})
+	// Close the lifecycle↔teardown cycle: when an observed terminal fact (PR
+	// merged/closed, tracker issue done) terminates a session, lifecycle now
+	// reclaims its worktree through the manager instead of leaking it on disk
+	// (#2811). Set here, during single-threaded boot wiring, before any observer
+	// starts driving reactions.
+	lcm.SetTerminationReclaimer(mgr)
 	scmProvider, err := newGitHubSCMProvider(log)
 	if err != nil {
 		logSCMProviderDisabled(log, err)

--- a/backend/internal/integration/reclaim_worktree_test.go
+++ b/backend/internal/integration/reclaim_worktree_test.go
@@ -1,0 +1,217 @@
+package integration
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	prsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/pr"
+	sessionmanager "github.com/aoagents/agent-orchestrator/backend/internal/session_manager"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+// realWorktreeStack wires the production components that matter for #2811 over a
+// real SQLite store and a real git-worktree adapter: the PR service writes facts
+// and drives the lifecycle reducer, which (through the SetTerminationReclaimer
+// seam) calls the session manager to reclaim the worktree. Only the runtime and
+// agent are stubbed — everything the worktree teardown touches is real, so the
+// test proves a merged-PR fact actually deletes a worktree directory on disk.
+type realWorktreeStack struct {
+	store *sqlite.Store
+	mgr   *sessionmanager.Manager
+	prm   *prsvc.Manager
+	ws    *gitworktree.Workspace
+	repo  string
+}
+
+func newRealWorktreeStack(t *testing.T) *realWorktreeStack {
+	t.Helper()
+	ctx := context.Background()
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupWorktreeRepo(t, git, tmp)
+
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{
+		ID:           "mer",
+		Path:         repo,
+		RegisteredAt: time.Now(),
+		Config: domain.ProjectConfig{
+			Worker: domain.RoleOverride{Harness: domain.HarnessClaudeCode},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := gitworktree.New(gitworktree.Options{
+		Binary:       git,
+		ManagedRoot:  filepath.Join(tmp, "managed"),
+		RepoResolver: gitworktree.StaticRepoResolver{"mer": repo},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := &captureMessenger{}
+	lcm := lifecycle.New(store, msg)
+	rt := &stubRuntime{}
+	mgr := sessionmanager.New(sessionmanager.Deps{
+		Runtime:   rt,
+		Agents:    stubAgents{},
+		Workspace: ws,
+		Store:     store,
+		Messenger: msg,
+		Lifecycle: lcm,
+		LookPath:  func(string) (string, error) { return "/usr/bin/true", nil },
+	})
+	// The production wiring (daemon.startSession) closes this cycle; without it
+	// the reducer stays flag-only and the worktree would leak — the #2811 bug.
+	lcm.SetTerminationReclaimer(mgr)
+	prm := prsvc.New(prsvc.Deps{Writer: store, Lifecycle: lcm})
+
+	return &realWorktreeStack{store: store, mgr: mgr, prm: prm, ws: ws, repo: repo}
+}
+
+// seedSessionWithWorktree creates a live worker session row and materializes its
+// real worktree on disk, returning the row and the worktree path.
+func (st *realWorktreeStack) seedSessionWithWorktree(t *testing.T) (domain.SessionRecord, string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	rec, err := st.store.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: "mer",
+		Kind:      domain.KindWorker,
+		Harness:   domain.HarnessClaudeCode,
+		Activity:  domain.Activity{State: domain.ActivityActive, LastActivityAt: now},
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	info, err := st.ws.Create(ctx, ports.WorkspaceConfig{ProjectID: "mer", SessionID: rec.ID, Branch: "feature/one"})
+	if err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	if _, err := os.Stat(info.Path); err != nil {
+		t.Fatalf("worktree not on disk after create: %v", err)
+	}
+	rec.Metadata = domain.SessionMetadata{WorkspacePath: info.Path, Branch: info.Branch, RuntimeHandleID: "h1"}
+	if err := st.store.UpdateSession(ctx, rec); err != nil {
+		t.Fatalf("update session metadata: %v", err)
+	}
+	return rec, info.Path
+}
+
+// A merged PR observed for a session with no open PRs must terminate the session
+// AND physically reclaim its worktree from disk — the whole fix for #2811,
+// exercised through the real PR service, lifecycle reducer, session manager, and
+// git-worktree adapter.
+func TestMergeObservationReclaimsRealWorktree(t *testing.T) {
+	ctx := context.Background()
+	st := newRealWorktreeStack(t)
+	rec, wsPath := st.seedSessionWithWorktree(t)
+
+	if err := st.prm.ApplyObservation(ctx, rec.ID, ports.PRObservation{Fetched: true, URL: "pr1", Number: 1, Merged: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok, err := st.store.GetSession(ctx, rec.ID)
+	if err != nil || !ok {
+		t.Fatalf("get session: ok=%v err=%v", ok, err)
+	}
+	if !got.IsTerminated {
+		t.Fatalf("merged PR should terminate session, got %+v", got)
+	}
+	if _, err := os.Stat(wsPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("worktree should be reclaimed from disk, stat err = %v (want not-exist)", err)
+	}
+}
+
+// A worktree with uncommitted work is preserved, never force-removed (the
+// data-safety hard rule): the session still terminates on merge, but its
+// worktree survives on disk for the user to recover.
+func TestMergeObservationPreservesDirtyRealWorktree(t *testing.T) {
+	ctx := context.Background()
+	st := newRealWorktreeStack(t)
+	rec, wsPath := st.seedSessionWithWorktree(t)
+
+	// Dirty the worktree: any status-visible change makes `git worktree remove`
+	// refuse, which the reclaim maps to ErrWorkspaceDirty and preserves.
+	if err := os.WriteFile(filepath.Join(wsPath, "uncommitted.txt"), []byte("wip\n"), 0o644); err != nil {
+		t.Fatalf("dirty worktree: %v", err)
+	}
+
+	if err := st.prm.ApplyObservation(ctx, rec.ID, ports.PRObservation{Fetched: true, URL: "pr1", Number: 1, Merged: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok, err := st.store.GetSession(ctx, rec.ID)
+	if err != nil || !ok {
+		t.Fatalf("get session: ok=%v err=%v", ok, err)
+	}
+	if !got.IsTerminated {
+		t.Fatalf("merged PR should terminate session even when dirty, got %+v", got)
+	}
+	if _, err := os.Stat(wsPath); err != nil {
+		t.Fatalf("dirty worktree must be preserved, stat err = %v (want it to still exist)", err)
+	}
+}
+
+func requireGit(t *testing.T) string {
+	t.Helper()
+	git, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not found")
+	}
+	return git
+}
+
+// setupWorktreeRepo builds a bare origin plus a clone with a committed main
+// branch and a local git identity, the shape the gitworktree adapter expects to
+// add worktrees from. It mirrors the gitworktree package's own integration
+// setup, which lives in an unexported test helper there.
+func setupWorktreeRepo(t *testing.T, git, tmp string) string {
+	t.Helper()
+	origin := filepath.Join(tmp, "origin.git")
+	seed := filepath.Join(tmp, "seed")
+	repo := filepath.Join(tmp, "repo")
+	runGitIn(t, git, tmp, "init", "--bare", origin)
+	runGitIn(t, git, tmp, "init", seed)
+	runGitIn(t, git, seed, "config", "user.email", "ao@example.com")
+	runGitIn(t, git, seed, "config", "user.name", "Ao Agents")
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+	runGitIn(t, git, seed, "add", "README.md")
+	runGitIn(t, git, seed, "commit", "-m", "seed")
+	runGitIn(t, git, seed, "branch", "-M", "main")
+	runGitIn(t, git, seed, "remote", "add", "origin", origin)
+	runGitIn(t, git, seed, "push", "-u", "origin", "main")
+	runGitIn(t, git, tmp, "clone", origin, repo)
+	runGitIn(t, git, repo, "config", "user.email", "ao@example.com")
+	runGitIn(t, git, repo, "config", "user.name", "Ao Agents")
+	runGitIn(t, git, repo, "checkout", "main")
+	return repo
+}
+
+func runGitIn(t *testing.T, git, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(git, args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -36,6 +36,15 @@ type notificationSink interface {
 	Notify(ctx context.Context, intent ports.NotificationIntent) error
 }
 
+// terminationReclaimer releases the external resources (runtime, worktree) of a
+// session lifecycle has just marked terminated in reaction to an observed
+// terminal fact (PR merged/closed, tracker issue done). It is satisfied by the
+// session manager — the layer that owns teardown — so the reducer stays out of
+// runtime/workspace concerns and holds only this one narrow method.
+type terminationReclaimer interface {
+	ReclaimOnTerminate(ctx context.Context, id domain.SessionID) error
+}
+
 // Option customizes a Manager.
 type Option func(*Manager)
 
@@ -58,6 +67,13 @@ type Manager struct {
 	// nudges become no-ops but the reducer still runs.
 	guard         *sessionguard.Guard
 	notifications notificationSink
+	// reclaimer releases a session's external resources (runtime, worktree)
+	// after a fact-driven termination. It is satisfied by the session manager —
+	// the layer that owns teardown — and wired post-construction via
+	// SetTerminationReclaimer, because that manager is built over this same
+	// Manager. Nil leaves termination flag-only (the pre-#2811 behavior);
+	// guarded by mu since it is set after New.
+	reclaimer terminationReclaimer
 
 	mu        sync.Mutex
 	window    time.Duration
@@ -84,6 +100,17 @@ func New(store sessionStore, messenger ports.AgentMessenger, opts ...Option) *Ma
 		opt(m)
 	}
 	return m
+}
+
+// SetTerminationReclaimer wires the post-termination worktree reclaimer. The
+// session manager (the reclaimer) is built over this same Manager, so the
+// dependency can only be closed once both exist; the daemon calls this during
+// single-threaded boot wiring, before any observer drives a reaction. Guarded by
+// mu so a boot-time set can never race the reducer that reads it.
+func (m *Manager) SetTerminationReclaimer(r terminationReclaimer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reclaimer = r
 }
 
 func (m *Manager) mutate(ctx context.Context, id domain.SessionID, fn func(domain.SessionRecord, time.Time) (domain.SessionRecord, bool)) error {
@@ -464,15 +491,58 @@ func (m *Manager) MarkSpawned(ctx context.Context, id domain.SessionID, metadata
 
 // MarkTerminated marks a session terminated without tearing down external resources.
 func (m *Manager) MarkTerminated(ctx context.Context, id domain.SessionID) error {
-	return m.mutate(ctx, id, func(cur domain.SessionRecord, now time.Time) (domain.SessionRecord, bool) {
+	_, err := m.markTerminated(ctx, id)
+	return err
+}
+
+// markTerminated is MarkTerminated's core, additionally reporting whether it
+// flipped the row (changed=true) versus finding it already terminated
+// (changed=false). terminateWithReclaim uses this so the worktree reclaim runs
+// only on the actual termination transition, never on the idempotent repeat
+// observations a still-terminal PR or tracker issue keeps producing.
+func (m *Manager) markTerminated(ctx context.Context, id domain.SessionID) (bool, error) {
+	changed := false
+	err := m.mutate(ctx, id, func(cur domain.SessionRecord, now time.Time) (domain.SessionRecord, bool) {
 		if cur.IsTerminated {
 			return cur, false
 		}
 		cur.IsTerminated = true
 		cur.Activity = domain.Activity{State: domain.ActivityExited, LastActivityAt: now}
 		delete(m.flights, id) // runs under m.mu (mutate holds it)
+		changed = true
 		return cur, true
 	})
+	if err != nil {
+		return false, err
+	}
+	return changed, nil
+}
+
+// terminateWithReclaim marks a session terminated for an observed terminal fact
+// and then releases its worktree. Marking is authoritative — a store error fails
+// the reaction — while the worktree reclaim is best-effort: a dirty worktree is
+// preserved and any teardown error is logged, never surfaced, so a filesystem
+// hiccup can neither wedge the observation pipeline nor leave the row
+// un-terminated. Reclaim runs only when this call is the one that terminated the
+// session (and a reclaimer is wired), so repeat observations stay cheap no-ops.
+func (m *Manager) terminateWithReclaim(ctx context.Context, id domain.SessionID) error {
+	changed, err := m.markTerminated(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	m.mu.Lock()
+	reclaimer := m.reclaimer
+	m.mu.Unlock()
+	if reclaimer == nil {
+		return nil
+	}
+	if rErr := reclaimer.ReclaimOnTerminate(ctx, id); rErr != nil {
+		slog.Default().Warn("lifecycle: worktree reclaim after terminate failed", "session", id, "err", rErr)
+	}
+	return nil
 }
 
 // sameActivity reports whether two activity signals describe the same state.

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -154,7 +154,7 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			return err
 		}
 		if done {
-			return m.MarkTerminated(ctx, id)
+			return m.terminateWithReclaim(ctx, id)
 		}
 		return nil
 	}
@@ -482,9 +482,10 @@ func scmToPRObservation(o ports.SCMObservation) ports.PRObservation {
 // the read-side persistence path).
 //
 // Reactions today:
-//   - Issue terminal (state == done or cancelled) → MarkTerminated. The
-//     reducer is idempotent — repeat observations on an already-terminated
-//     session are no-ops because MarkTerminated skips when IsTerminated.
+//   - Issue terminal (state == done or cancelled) → terminate and reclaim the
+//     worktree. The reducer is idempotent — repeat observations on an
+//     already-terminated session are no-ops (the terminate skips when
+//     IsTerminated, and the reclaim runs only on the terminating transition).
 //   - Assignee changed → log only. No session-state reaction yet; the policy
 //     for "assignee changed away from AO" is reserved for the write-side work
 //     tracked by #40.
@@ -497,7 +498,7 @@ func (m *Manager) ApplyTrackerFacts(ctx context.Context, id domain.SessionID, o 
 		return nil
 	}
 	if isTerminalTrackerState(o.Issue.State) {
-		return m.MarkTerminated(ctx, id)
+		return m.terminateWithReclaim(ctx, id)
 	}
 	rec, ok, err := m.store.GetSession(ctx, id)
 	if err != nil || !ok {

--- a/backend/internal/lifecycle/reclaim_test.go
+++ b/backend/internal/lifecycle/reclaim_test.go
@@ -1,0 +1,147 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// fakeReclaimer records the sessions lifecycle asked to reclaim and can inject a
+// teardown error to prove it is swallowed.
+type fakeReclaimer struct {
+	ids []domain.SessionID
+	err error
+}
+
+func (f *fakeReclaimer) ReclaimOnTerminate(_ context.Context, id domain.SessionID) error {
+	f.ids = append(f.ids, id)
+	return f.err
+}
+
+// A merged PR that completes the session must both terminate it and reclaim its
+// worktree — the fix for #2811, where the reaction only flipped is_terminated
+// and left the worktree orphaned on disk.
+func TestPRObservation_MergeReclaimsWorktree(t *testing.T) {
+	m, st, _ := newManager()
+	rc := &fakeReclaimer{}
+	m.SetTerminationReclaimer(rc)
+	st.sessions["mer-1"] = working("mer-1")
+	st.prs["mer-1"] = []domain.PullRequest{{URL: "pr1", Merged: true}}
+
+	if err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Merged: true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions["mer-1"]; !got.IsTerminated {
+		t.Fatalf("merged PR should terminate session, got %+v", got)
+	}
+	if len(rc.ids) != 1 || rc.ids[0] != "mer-1" {
+		t.Fatalf("expected reclaim of mer-1, got %v", rc.ids)
+	}
+}
+
+// A tracker issue reaching a terminal state terminates the session and reclaims
+// its worktree, mirroring the merged-PR path.
+func TestApplyTrackerFacts_TerminalStateReclaimsWorktree(t *testing.T) {
+	m, st, _ := newManager()
+	rc := &fakeReclaimer{}
+	m.SetTerminationReclaimer(rc)
+	st.sessions["mer-1"] = working("mer-1")
+
+	o := ports.TrackerObservation{
+		Fetched: true,
+		Issue:   ports.TrackerIssueObservation{URL: "https://github.com/o/r/issues/1", State: domain.IssueDone},
+	}
+	if err := m.ApplyTrackerFacts(ctx, "mer-1", o); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions["mer-1"]; !got.IsTerminated {
+		t.Fatalf("terminal issue should terminate session, got %+v", got)
+	}
+	if len(rc.ids) != 1 || rc.ids[0] != "mer-1" {
+		t.Fatalf("expected reclaim of mer-1, got %v", rc.ids)
+	}
+}
+
+// A session that does not reach the completion bar (a merged PR with an open
+// sibling) must neither terminate nor reclaim: reclaiming a live session's
+// worktree would pull the worktree out from under an agent still at work.
+func TestPRObservation_OpenSiblingDoesNotReclaim(t *testing.T) {
+	m, st, _ := newManager()
+	rc := &fakeReclaimer{}
+	m.SetTerminationReclaimer(rc)
+	st.sessions["mer-1"] = working("mer-1")
+	st.prs["mer-1"] = []domain.PullRequest{
+		{URL: "pr1", Merged: true},
+		{URL: "pr2"},
+	}
+
+	if err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Merged: true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions["mer-1"]; got.IsTerminated {
+		t.Fatalf("session with an open sibling PR must stay alive, got %+v", got)
+	}
+	if len(rc.ids) != 0 {
+		t.Fatalf("a still-live session must not be reclaimed, got %v", rc.ids)
+	}
+}
+
+// Repeat terminal observations on an already-terminated session are cheap
+// no-ops: the reclaim fires only on the terminating transition, so a still-done
+// tracker issue polled every cycle does not re-attempt teardown (which would
+// spam warnings destroying an already-removed worktree).
+func TestTerminateWithReclaim_IdempotentRepeatDoesNotReclaim(t *testing.T) {
+	m, st, _ := newManager()
+	rc := &fakeReclaimer{}
+	m.SetTerminationReclaimer(rc)
+	rec := working("mer-1")
+	rec.IsTerminated = true
+	st.sessions["mer-1"] = rec
+	st.prs["mer-1"] = []domain.PullRequest{{URL: "pr1", Merged: true}}
+
+	if err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Merged: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(rc.ids) != 0 {
+		t.Fatalf("already-terminated session must not be reclaimed again, got %v", rc.ids)
+	}
+}
+
+// A best-effort reclaim failure (e.g. a transient filesystem error) is logged
+// and swallowed: the reaction still returns nil and the session stays
+// terminated, so a teardown hiccup can never wedge the observation pipeline.
+func TestTerminateWithReclaim_ReclaimErrorIsSwallowed(t *testing.T) {
+	m, st, _ := newManager()
+	rc := &fakeReclaimer{err: errors.New("boom")}
+	m.SetTerminationReclaimer(rc)
+	st.sessions["mer-1"] = working("mer-1")
+	st.prs["mer-1"] = []domain.PullRequest{{URL: "pr1", Merged: true}}
+
+	if err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Merged: true}); err != nil {
+		t.Fatalf("reclaim error must be swallowed, got %v", err)
+	}
+	if got := st.sessions["mer-1"]; !got.IsTerminated {
+		t.Fatalf("session should stay terminated despite reclaim error, got %+v", got)
+	}
+	if len(rc.ids) != 1 {
+		t.Fatalf("reclaim should have been attempted once, got %v", rc.ids)
+	}
+}
+
+// With no reclaimer wired, a merge still terminates the session (the pre-#2811
+// flag-only behavior) without panicking on the nil seam.
+func TestPRObservation_MergeWithoutReclaimerStillTerminates(t *testing.T) {
+	m, st, _ := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	st.prs["mer-1"] = []domain.PullRequest{{URL: "pr1", Merged: true}}
+
+	if err := m.ApplyPRObservation(ctx, "mer-1", ports.PRObservation{Fetched: true, URL: "pr1", Merged: true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions["mer-1"]; !got.IsTerminated {
+		t.Fatalf("merged PR should terminate session even without a reclaimer, got %+v", got)
+	}
+}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1720,42 +1720,92 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 		if !rec.IsTerminated {
 			continue
 		}
-		ws := workspaceInfo(rec)
-		if ws.Path == "" {
-			m.cleanupSystemPromptDir(rec.ID)
-			continue
+		cleaned, skipReason := m.reclaimTerminatedWorktree(ctx, rec)
+		switch {
+		case cleaned:
+			result.Cleaned = append(result.Cleaned, rec.ID)
+		case skipReason != "":
+			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: skipReason})
 		}
-		if h := runtimeHandle(rec.Metadata); h.ID != "" {
-			_ = m.runtime.Destroy(ctx, h) // best effort; usually already gone
-		}
-		if rows, ok, rowErr := m.workspaceProjectRows(ctx, rec); rowErr != nil {
-			m.logger.Warn("cleanup: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
-			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: "workspace teardown failed"})
-			continue
-		} else if ok {
-			if _, err := m.destroyWorkspaceProjectRows(ctx, rows); err != nil {
-				if !errors.Is(err, ports.ErrWorkspaceDirty) {
-					m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
-				}
-				result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(err)})
-				continue
-			}
-			m.cleanupAgentWorkspace(ctx, rec, ws.Path)
-		} else if err := m.workspace.Destroy(ctx, ws); err != nil {
-			if !errors.Is(err, ports.ErrWorkspaceDirty) {
-				// The public reason stays a fixed string (the raw error carries
-				// internal filesystem paths); the full cause lands here.
-				m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
-			}
-			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(err)})
-			continue
-		} else {
-			m.cleanupAgentWorkspace(ctx, rec, ws.Path)
-		}
-		m.cleanupSystemPromptDir(rec.ID)
-		result.Cleaned = append(result.Cleaned, rec.ID)
 	}
 	return result, nil
+}
+
+// reclaimTerminatedWorktree tears down one already-terminated session's runtime
+// and worktree, honoring the dirty-worktree guard (uncommitted work is never
+// force-removed). The caller must have confirmed rec.IsTerminated.
+//
+// Returns cleaned=true when the worktree was reclaimed; a non-empty skipReason
+// (with cleaned=false) when a present worktree was preserved (uncommitted work
+// or teardown failure); and cleaned=false, skipReason="" for a session that has
+// no worktree to reclaim (only its system-prompt dir is cleared). It does not
+// touch the session_worktrees restore markers: a terminated session's rows are
+// left "active" and so are inert for RestoreAll (only "removed"/legacy rows are
+// restorable), matching Cleanup's long-standing behavior.
+func (m *Manager) reclaimTerminatedWorktree(ctx context.Context, rec domain.SessionRecord) (cleaned bool, skipReason string) {
+	ws := workspaceInfo(rec)
+	if ws.Path == "" {
+		m.cleanupSystemPromptDir(rec.ID)
+		return false, ""
+	}
+	if h := runtimeHandle(rec.Metadata); h.ID != "" {
+		_ = m.runtime.Destroy(ctx, h) // best effort; usually already gone
+	}
+	if rows, ok, rowErr := m.workspaceProjectRows(ctx, rec); rowErr != nil {
+		m.logger.Warn("cleanup: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
+		return false, "workspace teardown failed"
+	} else if ok {
+		if _, err := m.destroyWorkspaceProjectRows(ctx, rows); err != nil {
+			if !errors.Is(err, ports.ErrWorkspaceDirty) {
+				m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
+			}
+			return false, cleanupSkipReason(err)
+		}
+		m.cleanupAgentWorkspace(ctx, rec, ws.Path)
+	} else if err := m.workspace.Destroy(ctx, ws); err != nil {
+		if !errors.Is(err, ports.ErrWorkspaceDirty) {
+			// The public reason stays a fixed string (the raw error carries
+			// internal filesystem paths); the full cause lands here.
+			m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
+		}
+		return false, cleanupSkipReason(err)
+	} else {
+		m.cleanupAgentWorkspace(ctx, rec, ws.Path)
+	}
+	m.cleanupSystemPromptDir(rec.ID)
+	return true, ""
+}
+
+// ReclaimOnTerminate releases the runtime and worktree of a session that
+// lifecycle has just marked terminated in reaction to an observed terminal fact
+// (a PR merged/closed, or a tracker issue reaching a done/cancelled state).
+// Before this, only the UI Kill button / POST /sessions/{id}/kill ran teardown,
+// while the fact-driven termination path flipped is_terminated and returned —
+// leaking a full worktree on disk for every merged-PR session (#2811).
+//
+// Unlike Kill it does not mark the session terminated (the caller already did);
+// unlike Cleanup it targets a single session by id. It is best-effort: a dirty
+// worktree is preserved (never forced), and an unknown or not-yet-terminated
+// session is a no-op so a caller ordering slip can never tear down a live
+// worktree.
+func (m *Manager) ReclaimOnTerminate(ctx context.Context, id domain.SessionID) error {
+	// Detach from the caller's context: this runs from the SCM/tracker observer
+	// loop, whose context is cancelled at daemon shutdown. A cancel landing
+	// mid-teardown would kill `git worktree remove`/prune between steps and leave
+	// the worktree half-removed or still registered — the very leak this reclaim
+	// exists to prevent — so once started it must run to completion (mirrors the
+	// detached spawn-rollback cleanup from #2731). Values are preserved; only
+	// cancellation/deadline are dropped.
+	ctx = context.WithoutCancel(ctx)
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return fmt.Errorf("reclaim %s: %w", id, err)
+	}
+	if !ok || !rec.IsTerminated {
+		return nil
+	}
+	m.reclaimTerminatedWorktree(ctx, rec)
+	return nil
 }
 
 // cleanupSkipReason renders a workspace teardown refusal as a short

--- a/backend/internal/session_manager/reclaim_test.go
+++ b/backend/internal/session_manager/reclaim_test.go
@@ -1,0 +1,68 @@
+package sessionmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// ReclaimOnTerminate is the teardown lifecycle runs after a merge/close/tracker
+// termination (#2811). It must destroy the runtime and worktree of a terminated
+// session — the reclaim that MarkTerminated deliberately skips.
+func TestReclaimOnTerminate_ReclaimsTerminatedWorktree(t *testing.T) {
+	m, st, rt, ws := newManager()
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+
+	if err := m.ReclaimOnTerminate(ctx, "mer-1"); err != nil {
+		t.Fatal(err)
+	}
+	if ws.destroyed != 1 {
+		t.Fatalf("worktree should be reclaimed, destroyed=%d", ws.destroyed)
+	}
+	if rt.destroyed != 1 || len(rt.destroyedIDs) != 1 || rt.destroyedIDs[0] != "h1" {
+		t.Fatalf("runtime handle should be destroyed, got %d %v", rt.destroyed, rt.destroyedIDs)
+	}
+}
+
+// A dirty worktree is preserved, never force-removed (the data-safety hard
+// rule). The reclaim is best-effort, so it swallows the refusal rather than
+// surfacing an error to the observation pipeline.
+func TestReclaimOnTerminate_PreservesDirtyWorktree(t *testing.T) {
+	m, st, _, ws := newManager()
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1"})
+	ws.destroyErr = fmt.Errorf("gitworktree: refusing to remove: %w", ports.ErrWorkspaceDirty)
+
+	if err := m.ReclaimOnTerminate(ctx, "mer-1"); err != nil {
+		t.Fatalf("dirty worktree refusal must be swallowed, got %v", err)
+	}
+}
+
+// A session that is not (yet) terminated must never be reclaimed: reclaiming a
+// live worktree would pull it out from under a working agent. This is the guard
+// against a caller-ordering slip.
+func TestReclaimOnTerminate_NoopWhenNotTerminated(t *testing.T) {
+	m, st, rt, ws := newManager()
+	st.sessions["mer-1"] = mkLive("mer-1")
+
+	if err := m.ReclaimOnTerminate(ctx, "mer-1"); err != nil {
+		t.Fatal(err)
+	}
+	if ws.destroyed != 0 || rt.destroyed != 0 {
+		t.Fatalf("live session must not be torn down, ws=%d rt=%d", ws.destroyed, rt.destroyed)
+	}
+}
+
+// An unknown session id is a benign no-op (e.g. a session deleted between the
+// terminate write and the reclaim call).
+func TestReclaimOnTerminate_NoopWhenUnknown(t *testing.T) {
+	m, _, rt, ws := newManager()
+
+	if err := m.ReclaimOnTerminate(ctx, "ghost"); err != nil {
+		t.Fatal(err)
+	}
+	if ws.destroyed != 0 || rt.destroyed != 0 {
+		t.Fatalf("unknown session must be a no-op, ws=%d rt=%d", ws.destroyed, rt.destroyed)
+	}
+}


### PR DESCRIPTION
Fixes #2811.

When a PR is merged (or closed, or a tracker issue reaches a terminal state), the lifecycle reaction terminates the session with `MarkTerminated` — which only sets `is_terminated` and tears down no external resources. The full teardown (runtime + worktree) lives on the Kill path (`POST /sessions/{id}/kill`), and that button is hidden the moment a session is terminated. So every merged-PR session leaves an orphaned worktree on disk that you can't reclaim from the UI. On an active project this piles up fast. The only recovery today is the project-scoped `ao session cleanup`, which isn't discoverable once the session drops out of the sidebar.

There's no automatic reclaim anywhere either: the reaper skips terminated sessions, and the boot-time Reconcile reap only kills a leaked runtime, never the worktree.

## What this does

Bridges the fact-driven termination to the teardown the session manager already owns, without dragging runtime/workspace deps into the lifecycle layer:

- `session_manager`: pull the per-session teardown out of `Cleanup`'s loop into `reclaimTerminatedWorktree` (no behavior change), and add `ReclaimOnTerminate(id)` — best-effort, skips dirty worktrees (never force-removed), no-ops for an unknown or still-live session. It runs the teardown under `context.WithoutCancel` so a daemon shutdown can't interrupt `git worktree remove` half-way (same reasoning as #2731).
- `lifecycle`: a narrow optional `terminationReclaimer` seam satisfied by the session manager, wired after construction via `SetTerminationReclaimer` (the lcm and session manager are built over each other, so it can't be a constructor option). `MarkTerminated` is split so the reclaim fires only on the actual termination transition — repeat observations on an already-terminal PR or issue stay no-ops. The merge/close and tracker-terminal reaction sites now reclaim; Kill's own `MarkTerminated` is untouched, so nothing double-tears-down.
- `daemon`: one line in `startSession` to wire it up.

The reclaim is best-effort throughout: a dirty worktree is preserved and a teardown error is logged, never surfaced, so a filesystem hiccup can't wedge the observation pipeline or leave the row un-terminated.

Backend-only, no API or SQLite regeneration.

## Tests

- lifecycle unit: merge and tracker-terminal reclaim; a merged PR with an open sibling does not reclaim; idempotent repeats don't re-tear-down; a reclaim error is swallowed; merge without a reclaimer wired still terminates.
- session_manager unit: `ReclaimOnTerminate` reclaims runtime + worktree, preserves a dirty worktree, and no-ops for a live or unknown session.
- integration (`internal/integration/reclaim_worktree_test.go`): over a real SQLite store and a real git-worktree adapter, a merged-PR observation driven through the real PR service physically removes the worktree directory from disk, and a dirty worktree is preserved.
- Existing `Cleanup` tests still pass over the extracted helper.

`go build`, `go vet`, `go test ./...`, `go test -race`, and golangci-lint all pass.

## Known boundary

A session already terminated by another path before its PR merges (e.g. the reaper marking it terminated on runtime death) hits the no-transition path and isn't reclaimed by the later merge; reaper-death sessions are also left alone since they may hold uncommitted work. Reclaiming those uniformly needs a boot-time or periodic reconcile pass, which I've left out to keep this change scoped to the merge path.
