### PR TITLE
fix(browser): remove redundant working label

### DIFF
--- a/frontend/src/renderer/components/BrowserPanel.test.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.test.tsx
@@ -219,7 +219,7 @@ describe("BrowserPanel", () => {
 		expect(hookState.setAnnotationMode).toHaveBeenCalledWith(true);
 	});
 
-	it("shows the working indicator only for active agent activity", () => {
+	it("keeps annotation mode available without duplicating agent status", () => {
 		hookState.navState = { ...hookState.navState, url: "http://localhost:5173/" };
 		const first = render(
 			<BrowserPanel
@@ -235,7 +235,7 @@ describe("BrowserPanel", () => {
 		);
 
 		expect(screen.getByRole("button", { name: /annotate/i })).toBeEnabled();
-		expect(screen.getByText("Agent working")).toBeInTheDocument();
+		expect(screen.queryByText("Agent working")).not.toBeInTheDocument();
 
 		first.unmount();
 		render(

--- a/frontend/src/renderer/components/BrowserPanel.tsx
+++ b/frontend/src/renderer/components/BrowserPanel.tsx
@@ -4,7 +4,6 @@ import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { useBrowserView, type BrowserViewModel } from "../hooks/useBrowserView";
 import { formatBrowserAnnotationMessage, type BrowserAnnotationSubmitPayload } from "../../shared/browser-annotations";
 import type { WorkspaceSession } from "../types/workspace";
-import { isAgentActivityWorking } from "../lib/session-presentation";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { cn } from "../lib/utils";
@@ -181,7 +180,6 @@ export function BrowserPanel({ session, active, poppedOut, onTogglePopOut }: Bro
 }
 
 export function BrowserPanelView({
-	session,
 	poppedOut,
 	onTogglePopOut,
 	browserView,
@@ -205,7 +203,6 @@ export function BrowserPanelView({
 	const { beginPicking, cancelPicking, enqueue, error, failPicking, queuedCount, retryQueued, status } =
 		annotationQueue;
 	const showStaticPreview = !window.ao?.browser && navState.url !== "";
-	const sessionBusy = isAgentActivityWorking(session.activity);
 	const canAnnotate = Boolean(window.ao?.browser && viewId && navState.url);
 	const canRetryAnnotation = status === "error" && queuedCount > 0;
 
@@ -339,8 +336,6 @@ export function BrowserPanelView({
 					>
 						{annotationStatusLabel}
 					</span>
-				) : sessionBusy ? (
-					<span className="browser-panel__annotation-status">Agent working</span>
 				) : null}
 				<div className="relative min-w-0 flex-1">
 					<Globe2


### PR DESCRIPTION
Removes the redundant Agent working annotation-toolbar fallback introduced by the browser annotations work. Annotation-specific statuses still render, and the annotate button remains enabled while the agent is active.\n\nVerification:\n- npm.cmd run test -- BrowserPanel.test.tsx\n- npm.cmd run typecheck