### PR TITLE
fix(lifecycle): wake orchestrator when a spawned worker goes idle

### DIFF
--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -20,6 +20,9 @@ import (
 type sessionStore interface {
 	GetSession(ctx context.Context, id domain.SessionID) (domain.SessionRecord, bool, error)
 	UpdateSession(ctx context.Context, rec domain.SessionRecord) error
+	// ListSessions returns every session in a project. The reducer reads it to
+	// find the project's active orchestrator when a worker goes idle.
+	ListSessions(ctx context.Context, project domain.ProjectID) ([]domain.SessionRecord, error)
 	// ListPRsBySession returns every PR row tracked for the session. The
 	// reducer reads it to apply the multi-PR completion rule (terminate only
 	// when no open PR remains and at least one merged) and to suppress
@@ -221,12 +224,70 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		}
 	}
 	waitingEvents := m.waitingInputEvents(next, prevState, prevAt, now)
+	workerWentIdle := crossedToIdle(prevState, next)
 	m.mu.Unlock()
 	for _, ev := range waitingEvents {
 		m.emitTelemetry(ctx, ev)
 	}
 	m.emitNotification(ctx, intent)
+	if workerWentIdle {
+		m.notifyOrchestratorWorkerIdle(ctx, next)
+	}
 	return nil
+}
+
+// crossedToIdle reports a worker finishing a turn: an active->idle transition on
+// a live worker session, which is AO's "this worker may be done" signal. Gating
+// on active (not merely non-idle) skips the spawn-time idle seed and
+// waiting_input->idle demotions.
+func crossedToIdle(prev domain.ActivityState, next domain.SessionRecord) bool {
+	return next.Kind == domain.KindWorker &&
+		prev == domain.ActivityActive &&
+		next.Activity.State == domain.ActivityIdle &&
+		!next.IsTerminated
+}
+
+// notifyOrchestratorWorkerIdle wakes the project's active orchestrator when one
+// of its workers goes idle, so it reports completion to the human instead of
+// waiting to be asked. Best-effort and non-fatal to the activity write: a
+// missing orchestrator, or a guard-suppressed paste (orchestrator blocked or
+// awaiting the user), is a silent no-op.
+func (m *Manager) notifyOrchestratorWorkerIdle(ctx context.Context, worker domain.SessionRecord) {
+	if m.guard == nil {
+		return
+	}
+	orchID, ok, err := m.activeOrchestrator(ctx, worker.ProjectID)
+	if err != nil {
+		slog.Default().Error("lifecycle: find orchestrator for idle worker", "worker", worker.ID, "err", err)
+		return
+	}
+	if !ok || orchID == worker.ID {
+		return
+	}
+	if _, err := m.guard.Nudge(ctx, orchID, workerIdleNudgeMessage(worker)); err != nil {
+		slog.Default().Error("lifecycle: nudge orchestrator on worker idle", "worker", worker.ID, "orchestrator", orchID, "err", err)
+	}
+}
+
+func (m *Manager) activeOrchestrator(ctx context.Context, project domain.ProjectID) (domain.SessionID, bool, error) {
+	recs, err := m.store.ListSessions(ctx, project)
+	if err != nil {
+		return "", false, err
+	}
+	for _, rec := range recs {
+		if rec.Kind == domain.KindOrchestrator && !rec.IsTerminated {
+			return rec.ID, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func workerIdleNudgeMessage(worker domain.SessionRecord) string {
+	label := string(worker.ID)
+	if name := strings.TrimSpace(domain.SanitizeControlChars(worker.DisplayName)); name != "" {
+		label = fmt.Sprintf("%s (%q)", worker.ID, name)
+	}
+	return fmt.Sprintf("[AO] Worker %s has gone idle and may be done. Inspect it with `ao session get %s`, then report its status and any PR to the human. If it needs more work, redirect it with `ao send`.", label, worker.ID)
 }
 
 // toolFlight tracks one session's in-flight tool executions and the pending

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -35,6 +35,16 @@ func (f *fakeStore) ListPRsBySession(_ context.Context, id domain.SessionID) ([]
 	return f.prs[id], nil
 }
 
+func (f *fakeStore) ListSessions(_ context.Context, project domain.ProjectID) ([]domain.SessionRecord, error) {
+	var out []domain.SessionRecord
+	for _, rec := range f.sessions {
+		if rec.ProjectID == project {
+			out = append(out, rec)
+		}
+	}
+	return out, nil
+}
+
 func (f *fakeStore) UpdateSession(_ context.Context, rec domain.SessionRecord) error {
 	f.sessions[rec.ID] = rec
 	return nil
@@ -1438,5 +1448,76 @@ func TestSCMObservation_ReadyToMergeSuppressedWhileWaitingInput(t *testing.T) {
 	}
 	if len(sink.intents) != 0 {
 		t.Fatalf("waiting-input session emitted ready notification: %+v", sink.intents)
+	}
+}
+
+func TestActivity_WorkerIdleNudgesOrchestrator(t *testing.T) {
+	m, st, msg := newManager()
+	now := time.Now()
+	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, DisplayName: "husky-setup", Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}, FirstSignalAt: now}
+
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle}); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("orchestrator nudges = %d, want 1", len(msg.msgs))
+	}
+	if !strings.Contains(msg.msgs[0], "mer-8") {
+		t.Fatalf("nudge missing worker id: %q", msg.msgs[0])
+	}
+}
+
+func TestActivity_WorkerIdleNoOrchestratorNoNudge(t *testing.T) {
+	m, st, msg := newManager()
+	now := time.Now()
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}, FirstSignalAt: now}
+
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle}); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 0 {
+		t.Fatalf("nudges = %d, want 0", len(msg.msgs))
+	}
+}
+
+func TestActivity_OrchestratorIdleDoesNotNudge(t *testing.T) {
+	m, st, msg := newManager()
+	now := time.Now()
+	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}, FirstSignalAt: now}
+
+	if err := m.ApplyActivitySignal(ctx, "mer-orch", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle}); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 0 {
+		t.Fatalf("orchestrator idle self-nudged: %d, want 0", len(msg.msgs))
+	}
+}
+
+func TestActivity_WorkerWaitingToIdleDoesNotNudge(t *testing.T) {
+	m, st, msg := newManager()
+	now := time.Now()
+	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}, FirstSignalAt: now}
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityWaitingInput, LastActivityAt: now}, FirstSignalAt: now}
+
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle}); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 0 {
+		t.Fatalf("waiting_input->idle nudged: %d, want 0", len(msg.msgs))
+	}
+}
+
+func TestActivity_WorkerIdleOrchestratorBlockedSuppressed(t *testing.T) {
+	m, st, msg := newManager()
+	now := time.Now()
+	st.sessions["mer-orch"] = domain.SessionRecord{ID: "mer-orch", ProjectID: "mer", Kind: domain.KindOrchestrator, Activity: domain.Activity{State: domain.ActivityBlocked, LastActivityAt: now}, FirstSignalAt: now}
+	st.sessions["mer-8"] = domain.SessionRecord{ID: "mer-8", ProjectID: "mer", Kind: domain.KindWorker, Activity: domain.Activity{State: domain.ActivityActive, LastActivityAt: now}, FirstSignalAt: now}
+
+	if err := m.ApplyActivitySignal(ctx, "mer-8", ports.ActivitySignal{Valid: true, State: domain.ActivityIdle}); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 0 {
+		t.Fatalf("nudged a blocked orchestrator: %d, want 0", len(msg.msgs))
 	}
 }


### PR DESCRIPTION
## Summary

Wakes the orchestrator when a spawned worker becomes idle, instead of leaving it silent until the user explicitly asks it to check.

**Closes:** AgentWrapper/agent-orchestrator#2820

## Problem

The orchestrator only discovered that a worker had finished after the user prompted it to poll. Since nothing reacted to a worker transitioning from **active → idle**, the orchestrator remained silent even after the worker completed its task, forcing the user to manually ask it to check for updates.

## Solution

Added a lifecycle hook in `ApplyActivitySignal` that detects when a live worker transitions from **active → idle**. When this occurs, it:

- Resolves the project's active orchestrator.
- Wakes it through the existing `sessionguard` mechanism.
- Prompts it to inspect the completed worker and report the results to the user.

The wake-up is **best-effort** and **non-blocking**:

- Failure to locate an orchestrator does not affect the activity update.
- If the orchestrator is blocked or waiting for user input, no wake-up occurs.
- Only an idle orchestrator is nudged, ensuring active user interactions are never interrupted.

To avoid unnecessary wake-ups, the trigger is gated on a true **active → idle** transition. This skips:

- The initial idle state assigned when a worker is spawned.
- `waiting_input → idle` transitions.

As a result, the orchestrator is notified only when a worker has genuinely completed its execution.

## Scope

- Applies to any worker within a project that has an active orchestrator.
- Uses the existing per-project orchestrator link already available in the worker's system prompt.
- Intentionally includes workers created through **"New Task"**, not just orchestrator-spawned workers. Restricting this behavior would require introducing a new `spawned_by` column and a database migration.
- Changes are confined to the lifecycle package.
- No API, DTO, or schema changes.

## Tests

Added test coverage for:

- Waking the orchestrator when a worker becomes idle.
- No-op behavior when no orchestrator exists.
- Preventing the orchestrator from waking itself on its own idle transition.
- Ignoring `waiting_input → idle` transitions.
- Leaving blocked orchestrators untouched.