### PR TITLE
fix(telemetry): cap CLI event volume and switch PostHog to anonymous …

### DIFF
--- a/backend/internal/adapters/telemetry/aggregate.go
+++ b/backend/internal/adapters/telemetry/aggregate.go
@@ -1,0 +1,141 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// PostHog bills per event ingested, regardless of what's in the payload. For
+// event names that are prone to bursts (a 5xx storm, a panic loop, a retry
+// hammering a bad command), per-occurrence rate limiting bounds the bill but
+// throws away everything past the cap - a storm of 10,000 errors and one of
+// 6 both show up as "5, then silence." AggregatingSink instead folds every
+// occurrence in a flush window into a single rollup event carrying a count,
+// so cost scales with flush windows (one event/minute per name, worst case),
+// not occurrences, and the true magnitude of a burst is still visible.
+//
+// Only event names named at construction are aggregated; everything else
+// passes straight through to next unchanged, so per-occurrence semantics and
+// RateLimitedSink's existing caps still apply to names this sink doesn't own.
+type AggregatingSink struct {
+	next       ports.EventSink
+	names      map[string]struct{}
+	flushEvery time.Duration
+
+	mu      sync.Mutex
+	buckets map[string]*aggBucket
+	closed  bool
+	done    chan struct{}
+}
+
+type aggBucket struct {
+	windowStart time.Time
+	count       int
+	sample      ports.TelemetryEvent
+}
+
+// NewAggregatingSink wraps next, folding occurrences of any event name in
+// names into one rollup event per flushEvery window. Event names not in
+// names are forwarded to next immediately, unaggregated. Starts a background
+// flush loop; call Close to stop it and flush anything buffered.
+func NewAggregatingSink(next ports.EventSink, names []string, flushEvery time.Duration) *AggregatingSink {
+	nameSet := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameSet[n] = struct{}{}
+	}
+	s := &AggregatingSink{
+		next:       next,
+		names:      nameSet,
+		flushEvery: flushEvery,
+		buckets:    make(map[string]*aggBucket),
+		done:       make(chan struct{}),
+	}
+	go s.flushLoop()
+	return s
+}
+
+// Emit forwards ev immediately if its name isn't aggregated; otherwise it is
+// folded into the current window's bucket for that name and only reaches
+// next as part of the next rollup.
+func (s *AggregatingSink) Emit(ctx context.Context, ev ports.TelemetryEvent) {
+	if _, ok := s.names[ev.Name]; !ok {
+		s.next.Emit(ctx, ev)
+		return
+	}
+
+	s.mu.Lock()
+	b, ok := s.buckets[ev.Name]
+	if !ok {
+		b = &aggBucket{windowStart: time.Now()}
+		s.buckets[ev.Name] = b
+	}
+	b.count++
+	b.sample = ev // last occurrence wins; only used for dims (level/source/ids), count/window carry the volume
+	s.mu.Unlock()
+}
+
+func (s *AggregatingSink) flushLoop() {
+	ticker := time.NewTicker(s.flushEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.flush(context.Background())
+		case <-s.done:
+			return
+		}
+	}
+}
+
+// flush emits one rollup event per non-empty bucket and clears the buckets.
+func (s *AggregatingSink) flush(ctx context.Context) {
+	s.mu.Lock()
+	buckets := s.buckets
+	s.buckets = make(map[string]*aggBucket)
+	s.mu.Unlock()
+
+	now := time.Now().UTC()
+	for name, b := range buckets {
+		payload := make(map[string]any, len(b.sample.Payload)+3)
+		for k, v := range b.sample.Payload {
+			payload[k] = v
+		}
+		payload["count"] = b.count
+		// Stringified (not time.Time): sanitizeRemoteValue's allowlist
+		// filter only understands JSON scalar types (string/bool/number), so
+		// a raw time.Time here would silently vanish before reaching
+		// PostHog even once the field name is allowlisted.
+		payload["window_start"] = b.windowStart.UTC().Format(time.RFC3339Nano)
+		payload["window_end"] = now.Format(time.RFC3339Nano)
+
+		s.next.Emit(ctx, ports.TelemetryEvent{
+			Name:       name,
+			Source:     b.sample.Source,
+			OccurredAt: now,
+			Level:      b.sample.Level,
+			ProjectID:  b.sample.ProjectID,
+			SessionID:  b.sample.SessionID,
+			RequestID:  b.sample.RequestID,
+			Payload:    payload,
+		})
+	}
+}
+
+// Close stops the flush loop, emits one final rollup for anything buffered
+// since the last tick, and closes the wrapped sink.
+func (s *AggregatingSink) Close(ctx context.Context) error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return s.next.Close(ctx)
+	}
+	s.closed = true
+	s.mu.Unlock()
+
+	close(s.done)
+	s.flush(ctx)
+	return s.next.Close(ctx)
+}

--- a/backend/internal/adapters/telemetry/aggregate.go
+++ b/backend/internal/adapters/telemetry/aggregate.go
@@ -8,14 +8,16 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
+// AggregatingSink folds every occurrence of a bursty event in a flush window
+// into a single rollup event carrying a count, so cost scales with flush
+// windows (one event/minute per name, worst case), not occurrences, and the
+// true magnitude of a burst is still visible.
+//
 // PostHog bills per event ingested, regardless of what's in the payload. For
 // event names that are prone to bursts (a 5xx storm, a panic loop, a retry
 // hammering a bad command), per-occurrence rate limiting bounds the bill but
 // throws away everything past the cap - a storm of 10,000 errors and one of
-// 6 both show up as "5, then silence." AggregatingSink instead folds every
-// occurrence in a flush window into a single rollup event carrying a count,
-// so cost scales with flush windows (one event/minute per name, worst case),
-// not occurrences, and the true magnitude of a burst is still visible.
+// 6 both show up as "5, then silence."
 //
 // Only event names named at construction are aggregated; everything else
 // passes straight through to next unchanged, so per-occurrence semantics and

--- a/backend/internal/adapters/telemetry/aggregate_test.go
+++ b/backend/internal/adapters/telemetry/aggregate_test.go
@@ -1,0 +1,154 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type syncRecordingSink struct {
+	mu     sync.Mutex
+	events []ports.TelemetryEvent
+	closed bool
+}
+
+func (s *syncRecordingSink) Emit(_ context.Context, ev ports.TelemetryEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, ev)
+}
+
+func (s *syncRecordingSink) Close(context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+func (s *syncRecordingSink) snapshot() []ports.TelemetryEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ports.TelemetryEvent, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+func TestAggregatingSinkPassesThroughUnaggregatedNamesImmediately(t *testing.T) {
+	rec := &syncRecordingSink{}
+	s := NewAggregatingSink(rec, []string{"ao.http.5xx"}, time.Hour)
+	defer s.Close(context.Background())
+
+	s.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.cli.invoked"})
+
+	events := rec.snapshot()
+	if len(events) != 1 || events[0].Name != "ao.cli.invoked" {
+		t.Fatalf("events = %#v, want one immediate ao.cli.invoked passthrough", events)
+	}
+}
+
+func TestAggregatingSinkFoldsBurstIntoOneRollupOnFlush(t *testing.T) {
+	rec := &syncRecordingSink{}
+	s := NewAggregatingSink(rec, []string{"ao.http.5xx"}, time.Hour)
+
+	for i := 0; i < 812; i++ {
+		s.Emit(context.Background(), ports.TelemetryEvent{
+			Name:    "ao.http.5xx",
+			Payload: map[string]any{"path": "/api/v1/whatever"},
+		})
+	}
+	if got := len(rec.snapshot()); got != 0 {
+		t.Fatalf("events before flush = %d, want 0 (buffered, not yet flushed)", got)
+	}
+
+	s.flush(context.Background())
+
+	events := rec.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events after flush = %d, want 1 rollup", len(events))
+	}
+	if events[0].Name != "ao.http.5xx" {
+		t.Fatalf("rollup name = %q, want ao.http.5xx", events[0].Name)
+	}
+	if count, _ := events[0].Payload["count"].(int); count != 812 {
+		t.Fatalf("rollup count = %#v, want 812", events[0].Payload["count"])
+	}
+	if events[0].Payload["path"] != "/api/v1/whatever" {
+		t.Fatalf("rollup payload lost sample dims: %#v", events[0].Payload)
+	}
+	windowStart, ok := events[0].Payload["window_start"].(string)
+	if !ok || windowStart == "" {
+		t.Fatalf("rollup payload window_start = %#v, want non-empty RFC3339 string", events[0].Payload["window_start"])
+	}
+	if _, err := time.Parse(time.RFC3339Nano, windowStart); err != nil {
+		t.Fatalf("window_start not RFC3339: %v", err)
+	}
+	windowEnd, ok := events[0].Payload["window_end"].(string)
+	if !ok || windowEnd == "" {
+		t.Fatalf("rollup payload window_end = %#v, want non-empty RFC3339 string", events[0].Payload["window_end"])
+	}
+	if _, err := time.Parse(time.RFC3339Nano, windowEnd); err != nil {
+		t.Fatalf("window_end not RFC3339: %v", err)
+	}
+}
+
+func TestAggregatingSinkTracksEventNamesIndependently(t *testing.T) {
+	rec := &syncRecordingSink{}
+	s := NewAggregatingSink(rec, []string{"ao.http.5xx", "ao.daemon.panic"}, time.Hour)
+
+	for i := 0; i < 3; i++ {
+		s.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.http.5xx"})
+	}
+	s.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.daemon.panic"})
+	s.flush(context.Background())
+
+	events := rec.snapshot()
+	counts := map[string]int{}
+	for _, ev := range events {
+		count, _ := ev.Payload["count"].(int)
+		counts[ev.Name] = count
+	}
+	if counts["ao.http.5xx"] != 3 {
+		t.Fatalf("ao.http.5xx rollup count = %d, want 3", counts["ao.http.5xx"])
+	}
+	if counts["ao.daemon.panic"] != 1 {
+		t.Fatalf("ao.daemon.panic rollup count = %d, want 1", counts["ao.daemon.panic"])
+	}
+}
+
+func TestAggregatingSinkClosesFlushesBufferedEvents(t *testing.T) {
+	rec := &syncRecordingSink{}
+	s := NewAggregatingSink(rec, []string{"ao.http.5xx"}, time.Hour)
+
+	s.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.http.5xx"})
+	if err := s.Close(context.Background()); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	events := rec.snapshot()
+	if len(events) != 1 || events[0].Payload["count"] != 1 {
+		t.Fatalf("events after Close = %#v, want one rollup with count 1", events)
+	}
+	if !rec.closed {
+		t.Fatal("wrapped sink was not closed")
+	}
+}
+
+func TestAggregatingSinkClosedTwiceDoesNotFlushAgain(t *testing.T) {
+	rec := &syncRecordingSink{}
+	s := NewAggregatingSink(rec, []string{"ao.http.5xx"}, time.Hour)
+
+	s.Emit(context.Background(), ports.TelemetryEvent{Name: "ao.http.5xx"})
+	if err := s.Close(context.Background()); err != nil {
+		t.Fatalf("first Close() error = %v", err)
+	}
+	if err := s.Close(context.Background()); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+
+	if got := len(rec.snapshot()); got != 1 {
+		t.Fatalf("events after double Close = %d, want 1 (no duplicate rollup)", got)
+	}
+}

--- a/backend/internal/adapters/telemetry/posthog.go
+++ b/backend/internal/adapters/telemetry/posthog.go
@@ -41,6 +41,13 @@ var remotePayloadAllowlist = map[string]map[string]struct{}{
 		"error_kind":   {},
 		"fingerprint":  {},
 		"operation":    {},
+		// Rolled up by AggregatingSink (adapters/telemetry/aggregate.go) into
+		// one event per minute; without these, a rollup's whole reason for
+		// existing - the true occurrence count of a burst - is silently
+		// stripped before it ever reaches PostHog.
+		"count":        {},
+		"window_start": {},
+		"window_end":   {},
 	},
 	"ao.daemon.panic": {
 		"component":         {},
@@ -50,6 +57,9 @@ var remotePayloadAllowlist = map[string]map[string]struct{}{
 		"path":              {},
 		"panic_kind":        {},
 		"stack_fingerprint": {},
+		"count":             {},
+		"window_start":      {},
+		"window_end":        {},
 	},
 	"ao.daemon.started": {
 		"agent": {},
@@ -66,6 +76,9 @@ var remotePayloadAllowlist = map[string]map[string]struct{}{
 		"path":          {},
 		"status":        {},
 		"status_family": {},
+		"count":         {},
+		"window_start":  {},
+		"window_end":    {},
 	},
 	"ao.onboarding.first_project_added": {
 		"has_git_remote": {},
@@ -217,6 +230,10 @@ func (s *PostHogSink) properties(ev ports.TelemetryEvent) map[string]any {
 	props := map[string]any{
 		"source": ev.Source,
 		"level":  string(ev.Level),
+		// The distinct ID is a random install ID with no person data behind it,
+		// so skip PostHog person-profile processing: identified events bill at
+		// several times the anonymous rate and the profiles would hold nothing.
+		"$process_person_profile": false,
 	}
 	if ev.RequestID != "" {
 		props["request_id"] = ev.RequestID

--- a/backend/internal/adapters/telemetry/posthog_test.go
+++ b/backend/internal/adapters/telemetry/posthog_test.go
@@ -63,6 +63,9 @@ func TestPostHogSinkCapturesEvent(t *testing.T) {
 		if props["project_id_hash"] == "" || props["session_id_hash"] == "" {
 			t.Fatalf("hashed ids missing from properties: %#v", props)
 		}
+		if props["$process_person_profile"] != false {
+			t.Fatalf("properties.$process_person_profile = %#v, want false", props["$process_person_profile"])
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("PostHog sink did not send request")
 	}

--- a/backend/internal/adapters/telemetry/ratelimit.go
+++ b/backend/internal/adapters/telemetry/ratelimit.go
@@ -1,0 +1,116 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// A per-minute cap alone doesn't bound the daily total: a loop that paces
+// itself just under the minute ceiling (e.g. one call every 3-4 seconds)
+// would sit under it forever and still rack up a large daily count. Two caps
+// close that: a burst ceiling for real signal in a short window, and a hard
+// daily ceiling that bounds worst case regardless of pacing. Both bound the
+// billed (remote) sink only; local storage keeps every occurrence.
+const (
+	// eventsPerNamePerMinute caps a short burst per event name. 5 is enough
+	// for genuine failure reporting (several real 5xx/panics while something
+	// is actually broken) without leaving room for a tight retry loop.
+	eventsPerNamePerMinute = 5
+	// eventsPerNamePerDay is the hard ceiling per event name regardless of
+	// how a runaway is paced. At anonymous PostHog rates this bounds a single
+	// looping event name to a few dollars a month at worst, not hundreds.
+	eventsPerNamePerDay = 200
+	// eventsPerNamePerDayAggregated applies to event names an upstream
+	// AggregatingSink has already folded into at most one rollup event per
+	// flush window (see aggregate.go) before they ever reach this limiter.
+	// The true occurrence count for the window is compressed into that one
+	// event's `count` field, so per-occurrence cost is already gone; this
+	// tier exists as a structural backstop (in case the aggregator itself
+	// misbehaves), not as the real limiting mechanism, so it can be much
+	// higher. 1500/day comfortably covers a name flushing every minute for a
+	// full day (1440) with headroom, at a cost of a few cents a month even
+	// in the worst case.
+	eventsPerNamePerDayAggregated = 1500
+)
+
+// RateLimitedSink wraps a sink and drops events past a per-event-name rate
+// ceiling. Intended to wrap only the remote (billed) sink; local storage
+// should see every event unfiltered.
+type RateLimitedSink struct {
+	next ports.EventSink
+
+	// aggregated marks event names that get the generous daily tier because
+	// an upstream AggregatingSink already compresses their occurrence count
+	// into one rollup per flush window.
+	aggregated map[string]struct{}
+
+	mu      sync.Mutex
+	minutes map[string]*rateWindow
+	days    map[string]*rateWindow
+}
+
+type rateWindow struct {
+	start time.Time
+	count int
+}
+
+// NewRateLimitedSink wraps next with the per-event-name rate ceiling.
+// aggregatedNames identifies event names that are pre-aggregated upstream
+// (see NewAggregatingSink) and should get the generous daily tier instead of
+// the standard one; pass nil if next has no aggregation in front of it.
+func NewRateLimitedSink(next ports.EventSink, aggregatedNames []string) *RateLimitedSink {
+	aggregated := make(map[string]struct{}, len(aggregatedNames))
+	for _, n := range aggregatedNames {
+		aggregated[n] = struct{}{}
+	}
+	return &RateLimitedSink{
+		next:       next,
+		aggregated: aggregated,
+		minutes:    make(map[string]*rateWindow),
+		days:       make(map[string]*rateWindow),
+	}
+}
+
+// Emit forwards ev to the wrapped sink unless its event name has exceeded
+// either ceiling, in which case it is silently dropped.
+func (s *RateLimitedSink) Emit(ctx context.Context, ev ports.TelemetryEvent) {
+	if !s.reserve(ev.Name, time.Now()) {
+		return
+	}
+	s.next.Emit(ctx, ev)
+}
+
+func (s *RateLimitedSink) reserve(name string, now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !reserveWindow(s.minutes, name, now, time.Minute, eventsPerNamePerMinute) {
+		return false
+	}
+	dayLimit := eventsPerNamePerDay
+	if _, ok := s.aggregated[name]; ok {
+		dayLimit = eventsPerNamePerDayAggregated
+	}
+	return reserveWindow(s.days, name, now, 24*time.Hour, dayLimit)
+}
+
+func reserveWindow(windows map[string]*rateWindow, name string, now time.Time, size time.Duration, limit int) bool {
+	w, ok := windows[name]
+	if !ok || now.Sub(w.start) >= size {
+		w = &rateWindow{start: now}
+		windows[name] = w
+	}
+	if w.count >= limit {
+		return false
+	}
+	w.count++
+	return true
+}
+
+// Close closes the wrapped sink.
+func (s *RateLimitedSink) Close(ctx context.Context) error {
+	return s.next.Close(ctx)
+}

--- a/backend/internal/adapters/telemetry/ratelimit_test.go
+++ b/backend/internal/adapters/telemetry/ratelimit_test.go
@@ -1,0 +1,147 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type recordingSink struct {
+	events []ports.TelemetryEvent
+}
+
+func (s *recordingSink) Emit(_ context.Context, ev ports.TelemetryEvent) {
+	s.events = append(s.events, ev)
+}
+
+func (s *recordingSink) Close(context.Context) error { return nil }
+
+func TestRateLimitedSinkCapsBurstPerMinute(t *testing.T) {
+	rec := &recordingSink{}
+	s := NewRateLimitedSink(rec, nil)
+	ctx := context.Background()
+	now := time.Now()
+
+	for i := 0; i < eventsPerNamePerMinute+10; i++ {
+		s.Emit(ctx, ports.TelemetryEvent{Name: "ao.http.5xx", OccurredAt: now})
+	}
+	if len(rec.events) != eventsPerNamePerMinute {
+		t.Fatalf("events forwarded = %d, want %d", len(rec.events), eventsPerNamePerMinute)
+	}
+}
+
+func TestRateLimitedSinkCapsTotalPerDayEvenWhenPacedUnderBurstLimit(t *testing.T) {
+	s := NewRateLimitedSink(&recordingSink{}, nil)
+	start := time.Now()
+
+	// One reservation per (simulated) minute never trips the burst cap, but
+	// the day cap must still bound the total once it's exhausted. Driving
+	// reserve() directly with synthetic timestamps, rather than Emit (which
+	// rate-limits by real wall-clock arrival time, not a caller-supplied
+	// event timestamp), is what actually simulates pacing here.
+	var forwarded int
+	for i := 0; i < eventsPerNamePerDay+10; i++ {
+		if s.reserve("ao.http.5xx", start) {
+			forwarded++
+		}
+		start = start.Add(time.Minute)
+	}
+	if forwarded != eventsPerNamePerDay {
+		t.Fatalf("events forwarded = %d, want %d", forwarded, eventsPerNamePerDay)
+	}
+}
+
+func TestRateLimitedSinkGivesAggregatedNamesTheGenerousDailyTier(t *testing.T) {
+	s := NewRateLimitedSink(&recordingSink{}, []string{"ao.http.5xx"})
+	start := time.Now()
+
+	// eventsPerNamePerDayAggregated (1500) exceeds the number of minutes in a
+	// day (1440), so pacing one reservation per minute would let the 24-hour
+	// window itself roll over and hand out a second, fresh budget before the
+	// cap is ever reached - that would test the window reset, not the cap.
+	// Pacing faster (30s) keeps the whole loop inside one 24-hour window so
+	// the cap is what actually gets exercised.
+	const step = 30 * time.Second
+	var forwarded int
+	for i := 0; i < eventsPerNamePerDayAggregated+10; i++ {
+		if s.reserve("ao.http.5xx", start) {
+			forwarded++
+		}
+		start = start.Add(step)
+	}
+	if forwarded != eventsPerNamePerDayAggregated {
+		t.Fatalf("events forwarded = %d, want %d (aggregated tier)", forwarded, eventsPerNamePerDayAggregated)
+	}
+}
+
+func TestRateLimitedSinkNonAggregatedNameKeepsStandardTierEvenWhenOthersAreAggregated(t *testing.T) {
+	s := NewRateLimitedSink(&recordingSink{}, []string{"ao.http.5xx"})
+	start := time.Now()
+
+	var forwarded int
+	for i := 0; i < eventsPerNamePerDay+10; i++ {
+		if s.reserve("ao.daemon.started", start) {
+			forwarded++
+		}
+		start = start.Add(time.Minute)
+	}
+	if forwarded != eventsPerNamePerDay {
+		t.Fatalf("events forwarded = %d, want %d (standard tier for a non-aggregated name)", forwarded, eventsPerNamePerDay)
+	}
+}
+
+func TestRateLimitedSinkTracksEventNamesIndependently(t *testing.T) {
+	rec := &recordingSink{}
+	s := NewRateLimitedSink(rec, nil)
+	ctx := context.Background()
+	now := time.Now()
+
+	for i := 0; i < eventsPerNamePerMinute; i++ {
+		s.Emit(ctx, ports.TelemetryEvent{Name: "ao.http.5xx", OccurredAt: now})
+	}
+	s.Emit(ctx, ports.TelemetryEvent{Name: "ao.daemon.panic", OccurredAt: now})
+
+	var panics int
+	for _, ev := range rec.events {
+		if ev.Name == "ao.daemon.panic" {
+			panics++
+		}
+	}
+	if panics != 1 {
+		t.Fatalf("ao.daemon.panic forwarded = %d, want 1 (independent window from ao.http.5xx)", panics)
+	}
+}
+
+func TestRateLimitedSinkBurstWindowResetsAfterOneMinute(t *testing.T) {
+	rec := &recordingSink{}
+	s := NewRateLimitedSink(rec, nil)
+	ctx := context.Background()
+	now := time.Now()
+
+	for i := 0; i < eventsPerNamePerMinute; i++ {
+		s.Emit(ctx, ports.TelemetryEvent{Name: "ao.http.5xx", OccurredAt: now})
+	}
+	if !s.reserve("ao.http.5xx", now.Add(61*time.Second)) {
+		t.Fatal("reserve should succeed once the one-minute burst window has elapsed")
+	}
+}
+
+func TestRateLimitedSinkDayWindowResetsAfter24Hours(t *testing.T) {
+	s := NewRateLimitedSink(&recordingSink{}, nil)
+	start := time.Now()
+
+	for i := 0; i < eventsPerNamePerDay; i++ {
+		if !s.reserve("ao.http.5xx", start) {
+			t.Fatalf("reserve unexpectedly failed at i=%d, before the daily ceiling should be reached", i)
+		}
+		start = start.Add(time.Minute)
+	}
+	if s.reserve("ao.http.5xx", start) {
+		t.Fatal("reserve should fail once the daily ceiling is exhausted within the same day")
+	}
+	if !s.reserve("ao.http.5xx", start.Add(24*time.Hour)) {
+		t.Fatal("reserve should succeed once the 24-hour day window has elapsed")
+	}
+}

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -208,6 +208,13 @@ type commandContext struct {
 
 func shouldEmitCLIInvocation(cmd *cobra.Command) bool {
 	switch strings.TrimSpace(cmd.CommandPath()) {
+	// "ao daemon"/"ao start" are supervisor-driven bootstrapping, and
+	// "ao completion"/"ao help" are shell setup and self-documentation, none
+	// of which reflect a human doing something with AO. "ao hooks" and
+	// "ao pty-host" ARE real usage signal (an agent session is doing
+	// something) even though a machine invokes them, so they are allowed
+	// through here; the per-command-path daily cap in httpd/router.go is what
+	// keeps their invocation frequency from reaching PostHog uncapped.
 	case "ao daemon", "ao start", "ao completion", "ao help":
 		return false
 	default:
@@ -236,12 +243,27 @@ func (c *commandContext) emitCLIUsageError(ctx context.Context, args []string, e
 }
 
 func usageErrorCommand(args []string) (string, string) {
+	// Only tokens that match registered subcommands may enter the reported
+	// path: anything past the deepest match is user data (session names,
+	// prompts, orchestrator names) and must never ride into telemetry.
+	current := NewRootCommand(Deps{})
 	tokens := []string{"ao"}
 	for _, arg := range args {
 		if strings.HasPrefix(arg, "-") {
 			break
 		}
+		var next *cobra.Command
+		for _, sub := range current.Commands() {
+			if sub.Name() == arg || sub.HasAlias(arg) {
+				next = sub
+				break
+			}
+		}
+		if next == nil {
+			break
+		}
 		tokens = append(tokens, arg)
+		current = next
 	}
 	commandPath := strings.Join(tokens, " ")
 	command := "ao"

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/aoagents/agent-orchestrator/backend/internal/daemonmeta"
 	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
 )
@@ -92,6 +94,53 @@ func TestVersionEmitsCLIInvocationBestEffort(t *testing.T) {
 		}
 	default:
 		t.Fatal("version did not emit CLI invocation")
+	}
+}
+
+func TestShouldEmitCLIInvocationSkipsOnlyNonUsageCommands(t *testing.T) {
+	byName := map[string]*cobra.Command{}
+	for _, cmd := range NewRootCommand(Deps{}).Commands() {
+		byName[cmd.Name()] = cmd
+	}
+	for name, want := range map[string]bool{
+		"daemon": false, // supervisor-driven bootstrapping, not human usage
+		"start":  false,
+		// "hooks" and "pty-host" ARE usage signal (an agent session doing
+		// something), even though a machine invokes them; the daily
+		// per-command cap in httpd/router.go, not this exclusion, is what
+		// keeps their invocation frequency off PostHog. Excluding them here
+		// would zero out ao.app.active on any day an install's only activity
+		// was agent work, undercounting DAU for headless/CLI-only installs.
+		"hooks":    true,
+		"pty-host": true,
+		"status":   true,
+		"spawn":    true,
+	} {
+		cmd, ok := byName[name]
+		if !ok {
+			t.Fatalf("command %q not registered", name)
+		}
+		if got := shouldEmitCLIInvocation(cmd); got != want {
+			t.Errorf("shouldEmitCLIInvocation(%s) = %v, want %v", cmd.CommandPath(), got, want)
+		}
+	}
+}
+
+func TestUsageErrorCommandDropsUserArgs(t *testing.T) {
+	for _, tc := range []struct {
+		args        []string
+		wantCommand string
+		wantPath    string
+	}{
+		{[]string{"send", "orchestrator-pack-5", "wake", "heartbeat.reconcile"}, "send", "ao send"},
+		{[]string{"status", "extra"}, "status", "ao status"},
+		{[]string{"not-a-command", "whatever"}, "ao", "ao"},
+		{[]string{"--bad-flag"}, "ao", "ao"},
+	} {
+		command, path := usageErrorCommand(tc.args)
+		if command != tc.wantCommand || path != tc.wantPath {
+			t.Errorf("usageErrorCommand(%v) = (%q, %q), want (%q, %q)", tc.args, command, path, tc.wantCommand, tc.wantPath)
+		}
 	}
 }
 

--- a/backend/internal/daemon/telemetry_wiring.go
+++ b/backend/internal/daemon/telemetry_wiring.go
@@ -2,12 +2,34 @@ package daemon
 
 import (
 	"log/slog"
+	"time"
 
 	telemetryadapter "github.com/aoagents/agent-orchestrator/backend/internal/adapters/telemetry"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
+
+// aggregatedEventNames are the event names prone to bursts (crash loops,
+// retry storms) that get folded into one rollup event per minute instead of
+// one PostHog event per occurrence, and correspondingly get the generous
+// daily rate-limit tier since their per-occurrence cost is already gone (see
+// RateLimitedSink's eventsPerNamePerDayAggregated). Must match the event
+// names as actually emitted (see httpd/router.go and httpd/recover.go /
+// httpd/log.go) exactly, including underscores - there is no compile-time
+// check tying this list to the emit sites.
+//
+// Deliberately does NOT include ao.cli.invoked or ao.app.active: those are
+// already deduped to at most once per command-path/day (ao.cli.invoked) or
+// once per day (ao.app.active) at the httpd layer before they ever reach a
+// sink, including for ao hooks/ao pty-host and high-frequency polling
+// commands like ao status/ao session ls - adding them here would double up
+// on dedup logic that already owns that job and gains nothing.
+var aggregatedEventNames = []string{
+	"ao.http.5xx",
+	"ao.daemon.panic",
+	"ao.cli.usage_errors",
+}
 
 func newTelemetrySink(cfg config.Config, store *sqlite.Store, log *slog.Logger) ports.EventSink {
 	if !cfg.Telemetry.Events {
@@ -22,5 +44,14 @@ func newTelemetrySink(cfg config.Config, store *sqlite.Store, log *slog.Logger) 
 		log.Warn("telemetry remote sink disabled", "remote", cfg.Telemetry.Remote, "error", err)
 		return local
 	}
-	return telemetryadapter.NewFanoutSink(local, remote)
+	// Both wrap only the billed remote sink; local storage keeps every event
+	// unaggregated and unfiltered for debugging regardless of PostHog volume.
+	// Aggregation sits in front: burst-prone event names get folded into one
+	// rollup per minute before they ever reach the rate limiter, which then
+	// applies the generous tier to those same names as a structural backstop
+	// rather than the primary cost control, and still does the real limiting
+	// job for every event name that isn't aggregated.
+	rateLimited := telemetryadapter.NewRateLimitedSink(remote, aggregatedEventNames)
+	aggregated := telemetryadapter.NewAggregatingSink(rateLimited, aggregatedEventNames, time.Minute)
+	return telemetryadapter.NewFanoutSink(local, aggregated)
 }

--- a/backend/internal/daemon/telemetry_wiring_test.go
+++ b/backend/internal/daemon/telemetry_wiring_test.go
@@ -1,11 +1,16 @@
 package daemon
 
 import (
+	"context"
+	"encoding/json"
 	"log/slog"
+	"net/http"
 	"testing"
+	"time"
 
 	telemetryadapter "github.com/aoagents/agent-orchestrator/backend/internal/adapters/telemetry"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
 
@@ -61,4 +66,83 @@ func TestNewTelemetrySink_FanoutIncludesPostHogWhenConfigured(t *testing.T) {
 		t.Fatalf("sink type = %T, want *telemetry.FanoutSink", sink)
 	}
 	t.Cleanup(func() { _ = fanout.Close(t.Context()) })
+}
+
+type wiringTestRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f wiringTestRoundTripper) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+// TestTelemetryWiringAggregatesUsageErrorsAndPreservesCountOnTheWire builds
+// the real aggregation -> rate-limit -> PostHog chain (the same shape
+// newTelemetrySink wires up), using the actual aggregatedEventNames list, and
+// asserts an event named exactly as httpd/router.go emits it
+// ("ao.cli.usage_errors") both gets folded into one rollup AND that the
+// rollup's count survives PostHog's remote payload allowlist onto the wire.
+// This is the test that would have caught two real bugs during review: an
+// aggregatedEventNames entry that didn't match the emitted event name
+// (silently skipping aggregation for that name), and count/window_start/
+// window_end being absent from the allowlist (silently stripped before
+// reaching PostHog even once aggregation ran correctly).
+func TestTelemetryWiringAggregatesUsageErrorsAndPreservesCountOnTheWire(t *testing.T) {
+	requests := make(chan map[string]any, 1)
+	remote, err := telemetryadapter.NewPostHogSink(t.TempDir(), "phc_test", "https://us.i.posthog.com",
+		wiringTestRoundTripper(func(req *http.Request) (*http.Response, error) {
+			defer req.Body.Close()
+			var body map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				return nil, err
+			}
+			requests <- body
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: http.NoBody}, nil
+		}), slog.Default())
+	if err != nil {
+		t.Fatalf("NewPostHogSink: %v", err)
+	}
+
+	rateLimited := telemetryadapter.NewRateLimitedSink(remote, aggregatedEventNames)
+	// flushEvery is intentionally long: the test controls flushing via
+	// Close(), not the background ticker, so it can't be flaky on timing.
+	aggregated := telemetryadapter.NewAggregatingSink(rateLimited, aggregatedEventNames, time.Hour)
+
+	for i := 0; i < 3; i++ {
+		aggregated.Emit(context.Background(), ports.TelemetryEvent{
+			Name:   "ao.cli.usage_errors",
+			Source: "cli",
+			Level:  ports.TelemetryLevelWarn,
+			Payload: map[string]any{
+				"component":  "cli",
+				"operation":  "command_parse",
+				"error_kind": "usage",
+			},
+		})
+	}
+	if err := aggregated.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	select {
+	case req := <-requests:
+		if got := req["event"]; got != "ao.cli.usage_errors" {
+			t.Fatalf("event = %#v, want ao.cli.usage_errors (aggregatedEventNames entry must match the real emit site)", got)
+		}
+		props, ok := req["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("properties type = %T, want map[string]any", req["properties"])
+		}
+		count, ok := props["count"].(float64) // JSON numbers decode as float64
+		if !ok || count != 3 {
+			t.Fatalf("properties.count = %#v, want 3 (rollup count must survive the PostHog allowlist)", props["count"])
+		}
+		if ws, ok := props["window_start"].(string); !ok || ws == "" {
+			t.Fatalf("properties.window_start = %#v, want a non-empty timestamp string", props["window_start"])
+		}
+		if we, ok := props["window_end"].(string); !ok || we == "" {
+			t.Fatalf("properties.window_end = %#v, want a non-empty timestamp string", props["window_end"])
+		}
+		if props["component"] != "cli" || props["operation"] != "command_parse" {
+			t.Fatalf("rollup lost sample dims: %#v", props)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("PostHog sink did not send the aggregated rollup")
+	}
 }

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -136,6 +137,43 @@ func mountTelemetry(r chi.Router, sink ports.EventSink) {
 	if sink == nil {
 		return
 	}
+	// CLI telemetry is capped to daily uniques: ao.app.active once per UTC day
+	// (matching the renderer heartbeat) and ao.cli.invoked once per command
+	// path per UTC day. Scripts and agent sessions invoke read-only commands
+	// (status, ls, get) in polling loops, so raw invocation counts measure
+	// automation, not usage; daily uniques keep the "which commands, how many
+	// users" signal without the firehose. In-memory state: a daemon restart may
+	// re-emit once that day, which dashboards dedupe by distinct ID anyway.
+	var (
+		cliTelemetryMu sync.Mutex
+		cliActiveDay   string
+		cliInvokedDay  string
+		cliInvokedSeen map[string]struct{}
+	)
+	reserveCLIActive := func(now time.Time) bool {
+		day := now.UTC().Format("2006-01-02")
+		cliTelemetryMu.Lock()
+		defer cliTelemetryMu.Unlock()
+		if cliActiveDay == day {
+			return false
+		}
+		cliActiveDay = day
+		return true
+	}
+	reserveCLIInvoked := func(now time.Time, commandPath string) bool {
+		day := now.UTC().Format("2006-01-02")
+		cliTelemetryMu.Lock()
+		defer cliTelemetryMu.Unlock()
+		if cliInvokedDay != day {
+			cliInvokedDay = day
+			cliInvokedSeen = make(map[string]struct{})
+		}
+		if _, seen := cliInvokedSeen[commandPath]; seen {
+			return false
+		}
+		cliInvokedSeen[commandPath] = struct{}{}
+		return true
+	}
 	r.Post("/internal/telemetry/cli-invoked", func(w http.ResponseWriter, req *http.Request) {
 		if !localControlRequest(req) {
 			envelope.WriteJSON(w, http.StatusForbidden, map[string]any{
@@ -157,29 +195,33 @@ func mountTelemetry(r chi.Router, sink ports.EventSink) {
 			return
 		}
 
-		sink.Emit(req.Context(), ports.TelemetryEvent{
-			Name:       "ao.cli.invoked",
-			Source:     "cli",
-			OccurredAt: time.Now().UTC(),
-			Level:      ports.TelemetryLevelInfo,
-			RequestID:  middleware.GetReqID(req.Context()),
-			Payload: map[string]any{
-				"command":      body.Command,
-				"command_path": body.CommandPath,
-			},
-		})
-		sink.Emit(req.Context(), ports.TelemetryEvent{
-			Name:       "ao.app.active",
-			Source:     "cli",
-			OccurredAt: time.Now().UTC(),
-			Level:      ports.TelemetryLevelInfo,
-			RequestID:  middleware.GetReqID(req.Context()),
-			Payload: map[string]any{
-				"channel":      "cli",
-				"command":      body.Command,
-				"command_path": body.CommandPath,
-			},
-		})
+		if now := time.Now(); reserveCLIInvoked(now, body.CommandPath) {
+			sink.Emit(req.Context(), ports.TelemetryEvent{
+				Name:       "ao.cli.invoked",
+				Source:     "cli",
+				OccurredAt: now.UTC(),
+				Level:      ports.TelemetryLevelInfo,
+				RequestID:  middleware.GetReqID(req.Context()),
+				Payload: map[string]any{
+					"command":      body.Command,
+					"command_path": body.CommandPath,
+				},
+			})
+		}
+		if now := time.Now(); reserveCLIActive(now) {
+			sink.Emit(req.Context(), ports.TelemetryEvent{
+				Name:       "ao.app.active",
+				Source:     "cli",
+				OccurredAt: now.UTC(),
+				Level:      ports.TelemetryLevelInfo,
+				RequestID:  middleware.GetReqID(req.Context()),
+				Payload: map[string]any{
+					"channel":      "cli",
+					"command":      body.Command,
+					"command_path": body.CommandPath,
+				},
+			})
+		}
 		w.WriteHeader(http.StatusAccepted)
 	})
 	r.Post("/internal/telemetry/cli-usage-error", func(w http.ResponseWriter, req *http.Request) {

--- a/backend/internal/httpd/telemetry_test.go
+++ b/backend/internal/httpd/telemetry_test.go
@@ -15,15 +15,20 @@ func TestCLIInvokedRouteEmitsTelemetry(t *testing.T) {
 	sink := &captureSink{}
 	r := NewRouterWithControl(config.Config{}, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
 
-	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/internal/telemetry/cli-invoked", strings.NewReader(`{"command":"status","commandPath":"ao status"}`))
-	req.Host = "127.0.0.1:3001"
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	r.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusAccepted {
-		t.Fatalf("status = %d, want 202", rec.Code)
+	postInvoked := func(command, commandPath string) {
+		t.Helper()
+		body := `{"command":"` + command + `","commandPath":"` + commandPath + `"}`
+		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/internal/telemetry/cli-invoked", strings.NewReader(body))
+		req.Host = "127.0.0.1:3001"
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202", rec.Code)
+		}
 	}
+
+	postInvoked("status", "ao status")
 	if len(sink.events) != 2 {
 		t.Fatalf("events = %d, want 2", len(sink.events))
 	}
@@ -38,6 +43,27 @@ func TestCLIInvokedRouteEmitsTelemetry(t *testing.T) {
 	}
 	if got := sink.events[1].Payload["channel"]; got != "cli" {
 		t.Fatalf("channel = %#v, want cli", got)
+	}
+
+	// Repeat invocations of the same command the same day are polling noise:
+	// both the per-command invocation event and the daily activity heartbeat
+	// stay silent.
+	postInvoked("status", "ao status")
+	if len(sink.events) != 2 {
+		t.Fatalf("events after repeat invocation = %d, want 2", len(sink.events))
+	}
+
+	// A different command the same day still reports its first invocation, but
+	// no additional heartbeat.
+	postInvoked("ls", "ao session ls")
+	if len(sink.events) != 3 {
+		t.Fatalf("events after new command = %d, want 3", len(sink.events))
+	}
+	if sink.events[2].Name != "ao.cli.invoked" {
+		t.Fatalf("third event name = %q, want ao.cli.invoked", sink.events[2].Name)
+	}
+	if got := sink.events[2].Payload["command_path"]; got != "ao session ls" {
+		t.Fatalf("command_path = %#v, want ao session ls", got)
 	}
 }
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -7,7 +7,8 @@ telemetry is enabled.
 
 ## What is collected
 
-- App activation events: `ao.app.active` from the renderer and CLI
+- App activation events: `ao.app.active` from the renderer and CLI, each capped
+  at once per UTC day per install
 - Renderer load and route views, grouped by coarse surface names
 - Project/task/session UI actions, with project identifiers SHA-256 hashed
 - Renderer exceptions, reduced to error name and coarse context
@@ -31,6 +32,44 @@ Before any renderer event or recording is transmitted:
 Daemon events use a remote payload allowlist before PostHog export. Project and
 session IDs are hashed, and raw location/IP fields are not accepted from AO
 payloads. Geographic reporting should use PostHog's GeoIP enrichment only.
+
+Three burst-prone daemon events — `ao.http.5xx`, `ao.daemon.panic`,
+`ao.cli.usage_errors` — are aggregated before export: every occurrence in a
+rolling one-minute window is folded into a single rollup event carrying
+`count`, `window_start`, and `window_end`, instead of exporting one PostHog
+event per occurrence. A storm of 10,000 errors and one of 6 both cost the same
+one event, and the true magnitude is still visible via `count` rather than
+being silently capped away. Only the most recent occurrence's other
+properties (path, fingerprint, etc.) are kept on the rollup — if a burst hits
+several different endpoints or fingerprints in the same window, the ones
+overwritten by later occurrences aren't visible on that rollup. Local SQLite
+storage is unaffected: it receives every raw occurrence, unaggregated, for
+full-fidelity debugging regardless of what PostHog sees.
+
+Everything reaching PostHog remotely is still bounded per event name: a
+5-per-minute burst cap plus a 200-per-day hard ceiling for ordinary events,
+or a 1,500-per-day ceiling for the three aggregated names above (since their
+per-occurrence cost is already collapsed by aggregation, the daily cap there
+is a structural backstop rather than the primary limit). The renderer applies
+the same 5-per-minute / 200-per-day shape to its own event and exception
+capture path, without the aggregation step.
+
+All events are sent as PostHog anonymous events (`$process_person_profile:
+false`; the renderer never calls `identify()`). The install ID still
+deduplicates unique-user counts, but no person profiles are created — person
+properties and person-property cohorts are intentionally unavailable.
+
+`ao.cli.invoked` is capped at once per command path per UTC day per daemon, so
+script- or agent-driven polling (`ao status`, `ao session ls`, `ao hooks`
+firing on every agent hook event, ...) reports as "this install used this
+command today" rather than one event per call. Only commands that never
+reflect activity — the supervisor-driven `ao daemon`/`ao start` and the
+self-documenting `ao completion`/`ao help` — are excluded outright. `ao hooks`
+and `ao pty-host` are deliberately NOT excluded: on a headless or CLI-only
+install, agent hook activity may be the only signal that install did anything
+that day, and excluding it would silently zero out `ao.app.active` (and DAU)
+for that install. The per-command daily cap, not exclusion, is what keeps
+their invocation frequency off PostHog.
 
 ## Install ID
 
@@ -70,7 +109,8 @@ country-level active-user maps. AO emits it from:
 
 - `channel=renderer` when the desktop app initializes and at most once per UTC
   day while the app stays open
-- `channel=cli` when the CLI reports a command invocation to the local daemon
+- `channel=cli` when the CLI reports a user-typed command invocation to the
+  local daemon, at most once per UTC day per daemon
 
 Recommended PostHog setup:
 

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildTelemetryContext,
+	reserveCapture,
 	reserveDailyActiveCapture,
 	routeSurface,
 	sanitizePostHogEvent,
@@ -247,6 +248,54 @@ describe("telemetry sanitizers", () => {
 		expect(
 			await sanitizeRendererProperties("ao.renderer.terminal_attach_failed", { reason: "something else" }),
 		).toEqual({});
+	});
+});
+
+describe("reserveCapture", () => {
+	it("allows up to 5 captures of a name within a minute", () => {
+		const start = 1_000_000;
+		for (let i = 0; i < 5; i += 1) {
+			expect(reserveCapture("ao.renderer.route_viewed", start + i)).toBe(true);
+		}
+		expect(reserveCapture("ao.renderer.route_viewed", start + 5)).toBe(false);
+	});
+
+	it("tracks each name in its own window", () => {
+		const start = 2_000_000;
+		for (let i = 0; i < 5; i += 1) {
+			reserveCapture("ao.renderer.route_viewed", start + i);
+		}
+		expect(reserveCapture("exception:TypeError", start)).toBe(true);
+	});
+
+	it("resets the burst window once a minute elapses", () => {
+		const start = 3_000_000;
+		for (let i = 0; i < 5; i += 1) {
+			reserveCapture("ao.renderer.loaded", start + i);
+		}
+		expect(reserveCapture("ao.renderer.loaded", start + 60_001)).toBe(true);
+	});
+
+	it("caps the daily total even when calls are paced under the burst limit", () => {
+		const name = "ao.renderer.paced_loop";
+		let start = 10_000_000;
+		let allowed = 0;
+		for (let i = 0; i < 210; i += 1) {
+			if (reserveCapture(name, start)) allowed += 1;
+			start += 60_000; // one call per simulated minute: never trips the burst cap
+		}
+		expect(allowed).toBe(200);
+	});
+
+	it("resets the daily ceiling after 24 hours", () => {
+		const name = "ao.renderer.daily_reset";
+		let start = 20_000_000;
+		for (let i = 0; i < 200; i += 1) {
+			expect(reserveCapture(name, start)).toBe(true);
+			start += 60_000;
+		}
+		expect(reserveCapture(name, start)).toBe(false);
+		expect(reserveCapture(name, start + 24 * 60 * 60_000)).toBe(true);
 	});
 });
 

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -17,6 +17,41 @@ let errorHandlersBound = false;
 let telemetryContext: TelemetryProperties = {};
 let fallbackDailyActiveDate = "";
 
+// Bounds how many captures of a single event (or exception) name reach
+// PostHog. Mirrors the daemon-side RateLimitedSink: a re-render loop or
+// repeatedly-thrown exception must not turn into an unbounded PostHog bill.
+// A per-minute cap alone doesn't bound the daily total — a loop paced just
+// under it would sit under the ceiling forever — so this pairs a small burst
+// allowance with a hard daily ceiling per name.
+const EVENTS_PER_NAME_PER_MINUTE = 5;
+const EVENTS_PER_NAME_PER_DAY = 200;
+const MINUTE_MS = 60_000;
+const DAY_MS = 24 * 60 * 60_000;
+const minuteWindows = new Map<string, { start: number; count: number }>();
+const dayWindows = new Map<string, { start: number; count: number }>();
+
+function reserveWindow(
+	windows: Map<string, { start: number; count: number }>,
+	name: string,
+	now: number,
+	size: number,
+	limit: number,
+): boolean {
+	const window = windows.get(name);
+	if (!window || now - window.start >= size) {
+		windows.set(name, { start: now, count: 1 });
+		return true;
+	}
+	if (window.count >= limit) return false;
+	window.count += 1;
+	return true;
+}
+
+export function reserveCapture(name: string, now = Date.now()): boolean {
+	if (!reserveWindow(minuteWindows, name, now, MINUTE_MS, EVENTS_PER_NAME_PER_MINUTE)) return false;
+	return reserveWindow(dayWindows, name, now, DAY_MS, EVENTS_PER_NAME_PER_DAY);
+}
+
 type TelemetryProperties = Record<string, unknown>;
 type DailyActiveStorage = Pick<Storage, "getItem" | "setItem">;
 type DailyActiveEventTarget = {
@@ -341,6 +376,14 @@ export async function initTelemetry(): Promise<boolean> {
 			capture_pageview: false,
 			capture_exceptions: false,
 			persistence: "localStorage",
+			// The distinct ID is a random install ID, never a person, so keep
+			// every event anonymous: identified events bill at several times the
+			// anonymous rate and the person profiles would hold nothing. The
+			// bootstrap distinct ID keeps renderer and daemon events deduplicated
+			// without an identify() call, which would flip the install to
+			// identified billing permanently.
+			person_profiles: "identified_only",
+			bootstrap: { distinctID: bootstrap.distinctId },
 			before_send: (event) => (event ? sanitizePostHogCaptureResult(event) : event),
 			session_recording: {
 				maskCapturedNetworkRequestFn: (request) => {
@@ -350,10 +393,6 @@ export async function initTelemetry(): Promise<boolean> {
 					return request;
 				},
 			},
-		});
-		posthog.identify(bootstrap.distinctId, {
-			...telemetryContext,
-			surface: "renderer",
 		});
 		posthog.register({
 			...telemetryContext,
@@ -386,12 +425,14 @@ export async function initTelemetry(): Promise<boolean> {
 }
 
 export async function captureRendererEvent(event: string, properties?: Record<string, unknown>): Promise<void> {
+	if (!reserveCapture(event)) return;
 	if (!(await initTelemetry())) return;
 	const safeProperties = withTelemetryContext(await sanitizeRendererProperties(event, properties));
 	posthog.capture(event, safeProperties);
 }
 
 export async function captureRendererException(error: unknown, properties?: Record<string, unknown>): Promise<void> {
+	if (!reserveCapture(`exception:${exceptionName(error)}`)) return;
 	if (!(await initTelemetry())) return;
 	const safeProperties = withTelemetryContext(await sanitizeRendererExceptionProperties(error, properties));
 	posthog.captureException(normalizeException(error), safeProperties);


### PR DESCRIPTION
CLI telemetry counted every invocation uncapped, and a few other events
(http errors, panics, generic renderer events) had no ceiling either.

This caps everything at the point it leaves the machine: CLI commands
report at most once per command per day (so polling loops become "used
today" instead of one event per call), events that need an actual count
(errors, crashes), and events bill as anonymous instead of identified since
our distinct id is just a random install id, not a person. Apart from that events like errors etc. are aggregated and have generous rate limits. 