### PR TITLE
fix: prevent desktop app from opening OS's browser for local pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ npm run typecheck
 npm run build
 ```
 
-When showing or demoing frontend changes, run `ao preview [url]` from inside the session so the change renders in the desktop browser panel (the inspector rail's Browser tab); do not just describe it.
+When showing or demoing frontend changes, run `ao preview [url]` from inside the session so the change renders in the desktop browser panel (the inspector rail's Browser tab); do not just describe it. Do not open local preview URLs with the OS browser, `open`/`xdg-open`, or headless browser tooling (Playwright, etc.) — only fall back to those if the user explicitly asks, or `ao preview` returns an error you report. `ao preview` only has a Browser tab to render into from a **worker** session; it has no effect from an orchestrator session.
 
 ## Where to look first
 

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -245,6 +245,13 @@ func (c *SessionsController) setPreview(w http.ResponseWriter, r *http.Request) 
 		envelope.WriteError(w, r, err)
 		return
 	}
+	// Orchestrator sessions have no inspector rail in the desktop app, so a
+	// preview write here would silently succeed with nothing visible for it.
+	// Reject loudly instead of storing a target no one can see.
+	if sess.Kind == domain.KindOrchestrator {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "PREVIEW_UNSUPPORTED_SESSION_KIND", "Orchestrator sessions have no browser preview panel; run ao preview from a worker session", nil)
+		return
+	}
 	// ponytail: no URL sanitization on preview target; agent-trusted for now
 	previewURL := strings.TrimSpace(in.URL)
 	if previewURL == "" {
@@ -285,6 +292,15 @@ func (c *SessionsController) setPreview(w http.ResponseWriter, r *http.Request) 
 func (c *SessionsController) clearPreview(w http.ResponseWriter, r *http.Request) {
 	if c.Svc == nil {
 		apispec.NotImplemented(w, r, "DELETE", "/api/v1/sessions/{sessionId}/preview")
+		return
+	}
+	sess, err := c.Svc.Get(r.Context(), sessionID(r))
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	if sess.Kind == domain.KindOrchestrator {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "PREVIEW_UNSUPPORTED_SESSION_KIND", "Orchestrator sessions have no browser preview panel; run ao preview from a worker session", nil)
 		return
 	}
 	updated, err := c.Svc.SetPreview(r.Context(), sessionID(r), "")

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -406,6 +406,35 @@ func TestSessionsAPI_SetPreviewExplicitURLPersists(t *testing.T) {
 	}
 }
 
+func TestSessionsAPI_SetPreviewRejectsOrchestratorSession(t *testing.T) {
+	svc := newFakeSessionService()
+	s := svc.sessions["ao-1"]
+	s.Kind = domain.KindOrchestrator
+	svc.sessions["ao-1"] = s
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/preview", `{"url":"http://localhost:5173/"}`)
+	assertErrorCode(t, body, status, http.StatusBadRequest, "PREVIEW_UNSUPPORTED_SESSION_KIND")
+	if got := svc.sessions["ao-1"].Metadata.PreviewURL; got != "" {
+		t.Fatalf("persisted previewUrl = %q, want no write on rejected orchestrator preview", got)
+	}
+}
+
+func TestSessionsAPI_ClearPreviewRejectsOrchestratorSession(t *testing.T) {
+	svc := newFakeSessionService()
+	s := svc.sessions["ao-1"]
+	s.Kind = domain.KindOrchestrator
+	s.Metadata = domain.SessionMetadata{PreviewURL: "http://localhost:5173/"}
+	svc.sessions["ao-1"] = s
+	srv := newSessionTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "DELETE", "/api/v1/sessions/ao-1/preview", "")
+	assertErrorCode(t, body, status, http.StatusBadRequest, "PREVIEW_UNSUPPORTED_SESSION_KIND")
+	if got := svc.sessions["ao-1"].Metadata.PreviewURL; got != "http://localhost:5173/" {
+		t.Fatalf("persisted previewUrl = %q, want unchanged on rejected orchestrator clear", got)
+	}
+}
+
 func TestSessionsAPI_SetPreviewEmptyURLAutodetectsIndex(t *testing.T) {
 	svc := newFakeSessionService()
 	workspace := t.TempDir()


### PR DESCRIPTION
## What

1. Enforce prompt for AGENTS.md to make sure it doesn't open OS's browser when encountering URLs.
2. Add a safety check for checking either if the session is orchestrator session or worker session 

## Why

Fixes #2809 .

To ensure that the local pages stay in Desktop app's preview pane, not opened in the OS's browser.

## How

Key implementation decisions, trade-offs, or areas reviewers should focus on.
Call out intentional omissions (especially vs older TypeScript behavior) when relevant.

## Testing

I add a test file to test out the changes. Here are the CLI to run these two functions (matched by Regex):

- _TestSessionsAPI_SetPreviewRejectsOrchestratorSession_
- _TestSessionsAPI_ClearPreviewRejectsOrchestratorSession_

```
cd backend
go test ./internal/httpd/controllers/sessions_test.go -run 'RejectsOrchestratorSession' -v
```

Result after testing (via Terminal):
```
$ AO_SESSION_ID=verify-proj-1 ao preview http://localhost:3002/landing   # orchestrator
Orchestrator sessions have no browser preview panel; run ao preview from a worker session (PREVIEW_UNSUPPORTED_SESSION_KIND) [request ...]
exit code: 1

$ AO_SESSION_ID=verify-proj-2 ao preview http://localhost:3002/landing   # worker
exit code: 0
```
Result after testing (via Desktop App):
<img width="1699" height="723" alt="image" src="https://github.com/user-attachments/assets/69ae9619-5130-48cb-b0ec-4a2766701aad" />



## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
