### PR TITLE
Fix detection of npm agent binaries from GUI path

### DIFF
--- a/backend/internal/adapters/agent/agy/agy.go
+++ b/backend/internal/adapters/agent/agy/agy.go
@@ -21,7 +21,8 @@ var agyBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"agy"},
 	WinNames:      []string{"agy.cmd", "agy.exe", "agy"},
 	UnixPaths:     []string{"/usr/local/bin/agy", "/opt/homebrew/bin/agy"},
-	UnixHomePaths: [][]string{{".local", "bin", "agy"}, {".cargo", "bin", "agy"}, {".npm", "bin", "agy"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("agy", []string{".cargo", "bin", "agy"}),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "agy.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "agy.exe"}},

--- a/backend/internal/adapters/agent/amp/amp.go
+++ b/backend/internal/adapters/agent/amp/amp.go
@@ -131,7 +131,8 @@ var ampBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"amp"},
 	WinNames:      []string{"amp.cmd", "amp.exe", "amp"},
 	UnixPaths:     []string{"/usr/local/bin/amp", "/opt/homebrew/bin/amp"},
-	UnixHomePaths: [][]string{{".local", "bin", "amp"}, {".npm", "bin", "amp"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("amp"),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "amp.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "amp.exe"}},

--- a/backend/internal/adapters/agent/auggie/auggie.go
+++ b/backend/internal/adapters/agent/auggie/auggie.go
@@ -143,7 +143,8 @@ var auggieBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"auggie"},
 	WinNames:      []string{"auggie.cmd", "auggie.exe", "auggie"},
 	UnixPaths:     []string{"/usr/local/bin/auggie", "/opt/homebrew/bin/auggie"},
-	UnixHomePaths: [][]string{{".local", "bin", "auggie"}, {".npm", "bin", "auggie"}, {".npm-global", "bin", "auggie"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("auggie"),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "auggie.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "auggie.exe"}},
@@ -151,8 +152,8 @@ var auggieBinarySpec = binaryutil.BinarySpec{
 }
 
 // ResolveAuggieBinary finds the `auggie` binary, searching PATH then common
-// install locations. It returns "auggie" as a last resort so callers get the
-// shell's normal command-not-found behavior if Auggie is absent.
+// install locations. It returns a wrapped ports.ErrAgentBinaryNotFound when
+// Auggie is absent.
 func ResolveAuggieBinary(ctx context.Context) (string, error) {
 	return binaryutil.ResolveBinary(ctx, auggieBinarySpec)
 }

--- a/backend/internal/adapters/agent/autohand/autohand.go
+++ b/backend/internal/adapters/agent/autohand/autohand.go
@@ -150,7 +150,8 @@ var autohandBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"autohand"},
 	WinNames:      []string{"autohand.cmd", "autohand.exe", "autohand"},
 	UnixPaths:     []string{"/usr/local/bin/autohand", "/opt/homebrew/bin/autohand"},
-	UnixHomePaths: [][]string{{".local", "bin", "autohand"}, {".npm", "bin", "autohand"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("autohand"),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "autohand.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "autohand.exe"}},

--- a/backend/internal/adapters/agent/binaryutil/binaryutil.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil.go
@@ -11,6 +11,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -46,6 +49,11 @@ type BinarySpec struct {
 	// before an npm shim wins when both are present, so it is spelled out here
 	// rather than assumed. Entries whose base env is unset are skipped.
 	WinPaths []WinPath
+
+	// NodeManaged adds Unix fallbacks for Node-version-manager global bins such
+	// as nvm, Volta, and fnm. Keep this explicit so non-Node adapters don't pick
+	// up unrelated same-named npm CLIs.
+	NodeManaged bool
 }
 
 // WinBase names the base directory a Windows candidate path is joined onto.
@@ -100,6 +108,13 @@ func ResolveBinary(ctx context.Context, spec BinarySpec) (string, error) {
 		candidates = append(candidates, spec.UnixPaths...)
 		if home, err := os.UserHomeDir(); err == nil {
 			candidates = append(candidates, joinAll(home, spec.UnixHomePaths)...)
+			if spec.NodeManaged {
+				nodeManagerCandidates, err := UnixNodeManagerBinCandidates(ctx, home, spec.Names...)
+				if err != nil {
+					return "", err
+				}
+				candidates = append(candidates, nodeManagerCandidates...)
+			}
 		}
 	}
 
@@ -131,4 +146,207 @@ func joinAll(base string, entries [][]string) []string {
 		out = append(out, filepath.Join(append([]string{base}, parts...)...))
 	}
 	return out
+}
+
+// NodeManagedUnixHomePaths returns the canonical Unix home fallback paths for
+// npm-distributed Node CLIs, followed by any adapter-specific extras.
+func NodeManagedUnixHomePaths(binary string, extras ...[]string) [][]string {
+	paths := make([][]string, 0, 3+len(extras))
+	paths = append(paths,
+		[]string{".npm-global", "bin", binary},
+		[]string{".npm", "bin", binary},
+		[]string{".local", "bin", binary},
+	)
+	paths = append(paths, extras...)
+	return paths
+}
+
+// UnixNodeManagerBinCandidates returns Node-version-manager global binary paths
+// under home. It covers the managers whose shims are commonly absent from GUI
+// launcher PATHs: Volta, nvm, and fnm.
+func UnixNodeManagerBinCandidates(ctx context.Context, home string, names ...string) ([]string, error) {
+	out := make([]string, 0, len(names)*3)
+	for _, name := range names {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		volta, err := unixVoltaBinCandidates(ctx, home, name)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, volta...)
+		nvm, err := unixNVMNodeBinCandidates(ctx, home, name)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, nvm...)
+		fnm, err := unixFNMNodeBinCandidates(ctx, home, name)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, fnm...)
+	}
+	return out, nil
+}
+
+func unixVoltaBinCandidates(ctx context.Context, home, name string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	voltaHome := os.Getenv("VOLTA_HOME")
+	if voltaHome == "" {
+		voltaHome = filepath.Join(home, ".volta")
+	}
+	candidate := filepath.Join(voltaHome, "bin", name)
+	if hookutil.FileExists(candidate) {
+		return []string{candidate}, nil
+	}
+	return nil, ctx.Err()
+}
+
+func unixNVMNodeBinCandidates(ctx context.Context, home, name string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	pattern := filepath.Join(home, ".nvm", "versions", "node", "*", "bin", name)
+	matches, err := sortedVersionedBinMatches(ctx, pattern)
+	if err != nil {
+		return nil, err
+	}
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if defaultVersion, err := readVersionAlias(ctx, filepath.Join(home, ".nvm", "alias", "default")); err != nil {
+		return nil, err
+	} else if defaultVersion != "" {
+		matches = preferVersion(matches, defaultVersion)
+	}
+	return matches, nil
+}
+
+func unixFNMNodeBinCandidates(ctx context.Context, home, name string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	fnmDir := os.Getenv("FNM_DIR")
+	if fnmDir == "" {
+		fnmDir = filepath.Join(home, ".local", "share", "fnm")
+	}
+	return sortedVersionedBinMatches(ctx, filepath.Join(fnmDir, "node-versions", "*", "installation", "bin", name))
+}
+
+func sortedVersionedBinMatches(ctx context.Context, pattern string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return nil, ctx.Err()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		return compareNodeVersions(versionDirName(matches[i]), versionDirName(matches[j])) > 0
+	})
+	return matches, nil
+}
+
+func versionDirName(path string) string {
+	dir := filepath.Dir(path)
+	if filepath.Base(dir) == "bin" {
+		dir = filepath.Dir(dir)
+	}
+	if filepath.Base(dir) == "installation" {
+		dir = filepath.Dir(dir)
+	}
+	return filepath.Base(dir)
+}
+
+func readVersionAlias(ctx context.Context, path string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", ctx.Err()
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return "", nil
+	}
+	return fields[0], nil
+}
+
+func preferVersion(paths []string, version string) []string {
+	version = normalizeNodeVersion(version)
+	if version == "" {
+		return paths
+	}
+	for i, path := range paths {
+		if normalizeNodeVersion(versionDirName(path)) != version {
+			continue
+		}
+		out := make([]string, 0, len(paths))
+		out = append(out, path)
+		out = append(out, paths[:i]...)
+		out = append(out, paths[i+1:]...)
+		return out
+	}
+	return paths
+}
+
+func compareNodeVersions(a, b string) int {
+	av := parseNodeVersion(a)
+	bv := parseNodeVersion(b)
+	for i := 0; i < 3; i++ {
+		if av.parts[i] > bv.parts[i] {
+			return 1
+		}
+		if av.parts[i] < bv.parts[i] {
+			return -1
+		}
+	}
+	if av.valid && !bv.valid {
+		return 1
+	}
+	if !av.valid && bv.valid {
+		return -1
+	}
+	return strings.Compare(a, b)
+}
+
+type nodeVersion struct {
+	parts [3]int
+	valid bool
+}
+
+func parseNodeVersion(version string) nodeVersion {
+	version = normalizeNodeVersion(version)
+	if version == "" {
+		return nodeVersion{}
+	}
+	fields := strings.Split(version, ".")
+	var parsed nodeVersion
+	for i := 0; i < len(fields) && i < 3; i++ {
+		n, err := strconv.Atoi(fields[i])
+		if err != nil {
+			return nodeVersion{}
+		}
+		parsed.parts[i] = n
+	}
+	parsed.valid = true
+	return parsed
+}
+
+func normalizeNodeVersion(version string) string {
+	version = strings.TrimSpace(version)
+	version = strings.TrimPrefix(version, "v")
+	return version
 }

--- a/backend/internal/adapters/agent/binaryutil/binaryutil.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil.go
@@ -83,9 +83,21 @@ func ResolveBinary(ctx context.Context, spec BinarySpec) (string, error) {
 	}
 
 	names := spec.Names
-	var candidates []string
 	if runtime.GOOS == "windows" {
 		names = spec.WinNames
+	}
+
+	for _, name := range names {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if path, err := exec.LookPath(name); err == nil && path != "" {
+			return path, nil
+		}
+	}
+
+	var candidates []string
+	if runtime.GOOS == "windows" {
 		home, _ := os.UserHomeDir()
 		appData := os.Getenv("APPDATA")
 		localAppData := os.Getenv("LOCALAPPDATA")
@@ -115,15 +127,6 @@ func ResolveBinary(ctx context.Context, spec BinarySpec) (string, error) {
 				}
 				candidates = append(candidates, nodeManagerCandidates...)
 			}
-		}
-	}
-
-	for _, name := range names {
-		if err := ctx.Err(); err != nil {
-			return "", err
-		}
-		if path, err := exec.LookPath(name); err == nil && path != "" {
-			return path, nil
 		}
 	}
 
@@ -233,9 +236,19 @@ func unixFNMNodeBinCandidates(ctx context.Context, home, name string) ([]string,
 	}
 	fnmDir := os.Getenv("FNM_DIR")
 	if fnmDir == "" {
-		fnmDir = filepath.Join(home, ".local", "share", "fnm")
+		fnmDir = defaultFNMDir(home, os.Getenv("XDG_DATA_HOME"), runtime.GOOS)
 	}
 	return sortedVersionedBinMatches(ctx, filepath.Join(fnmDir, "node-versions", "*", "installation", "bin", name))
+}
+
+func defaultFNMDir(home, xdgDataHome, goos string) string {
+	if xdgDataHome != "" {
+		return filepath.Join(xdgDataHome, "fnm")
+	}
+	if goos == "darwin" {
+		return filepath.Join(home, "Library", "Application Support", "fnm")
+	}
+	return filepath.Join(home, ".local", "share", "fnm")
 }
 
 func sortedVersionedBinMatches(ctx context.Context, pattern string) ([]string, error) {

--- a/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
@@ -31,6 +31,22 @@ func TestResolveBinaryPrefersPath(t *testing.T) {
 	}
 }
 
+func TestDefaultFNMDirDarwin(t *testing.T) {
+	home := filepath.Join(string(filepath.Separator), "Users", "tester")
+	want := filepath.Join(home, "Library", "Application Support", "fnm")
+	if got := defaultFNMDir(home, "", "darwin"); got != want {
+		t.Fatalf("defaultFNMDir() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultFNMDirPrefersXDGDataHome(t *testing.T) {
+	xdg := filepath.Join(string(filepath.Separator), "custom", "share")
+	want := filepath.Join(xdg, "fnm")
+	if got := defaultFNMDir("/home/tester", xdg, "linux"); got != want {
+		t.Fatalf("defaultFNMDir() = %q, want %q", got, want)
+	}
+}
+
 func TestResolveBinaryFallsBackToHomeCandidate(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix home candidate shape")

--- a/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
@@ -59,6 +59,238 @@ func TestResolveBinaryFallsBackToHomeCandidate(t *testing.T) {
 	}
 }
 
+func TestResolveBinaryFallsBackToNodeManagerCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix node-manager candidate shape")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir()) // empty of the binary
+	t.Setenv("VOLTA_HOME", "")
+	t.Setenv("FNM_DIR", "")
+	bin := filepath.Join(home, ".nvm", "versions", "node", "v22.23.1", "bin", "widget")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveBinary(context.Background(), BinarySpec{
+		Label:       "widget",
+		Names:       []string{"widget"},
+		NodeManaged: true,
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != bin {
+		t.Fatalf("got %q, want %q", got, bin)
+	}
+}
+
+func TestResolveBinarySkipsNodeManagerCandidatesUnlessExplicit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix node-manager candidate shape")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir()) // empty of the binary
+	t.Setenv("VOLTA_HOME", "")
+	t.Setenv("FNM_DIR", "")
+	bin := filepath.Join(home, ".nvm", "versions", "node", "v22.23.1", "bin", "widget")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ResolveBinary(context.Background(), BinarySpec{
+		Label: "widget",
+		Names: []string{"widget"},
+	})
+	if !errors.Is(err, ports.ErrAgentBinaryNotFound) {
+		t.Fatalf("want ErrAgentBinaryNotFound, got %v", err)
+	}
+}
+
+func TestResolveBinaryPrefersHomeCandidateOverNodeManagerCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix node-manager candidate shape")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir()) // empty of the binary
+	t.Setenv("VOLTA_HOME", "")
+	t.Setenv("FNM_DIR", "")
+	homeBin := filepath.Join(home, ".local", "bin", "widget")
+	nvmBin := filepath.Join(home, ".nvm", "versions", "node", "v22.23.1", "bin", "widget")
+	for _, bin := range []string{homeBin, nvmBin} {
+		if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := ResolveBinary(context.Background(), BinarySpec{
+		Label:         "widget",
+		Names:         []string{"widget"},
+		UnixHomePaths: [][]string{{".local", "bin", "widget"}},
+		NodeManaged:   true,
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != homeBin {
+		t.Fatalf("got %q, want %q", got, homeBin)
+	}
+}
+
+func TestUnixNodeManagerBinCandidatesSortsVersionsSemantically(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix node-manager candidate shape")
+	}
+	home := t.TempDir()
+	t.Setenv("VOLTA_HOME", filepath.Join(home, ".volta"))
+	t.Setenv("FNM_DIR", filepath.Join(home, ".local", "share", "fnm"))
+	for _, version := range []string{"v22.9.0", "v22.23.1", "v9.99.0"} {
+		bin := filepath.Join(home, ".nvm", "versions", "node", version, "bin", "widget")
+		if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := UnixNodeManagerBinCandidates(context.Background(), home, "widget")
+	if err != nil {
+		t.Fatalf("UnixNodeManagerBinCandidates: %v", err)
+	}
+	want := []string{
+		filepath.Join(home, ".nvm", "versions", "node", "v22.23.1", "bin", "widget"),
+		filepath.Join(home, ".nvm", "versions", "node", "v22.9.0", "bin", "widget"),
+		filepath.Join(home, ".nvm", "versions", "node", "v9.99.0", "bin", "widget"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d candidates, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestUnixNodeManagerBinCandidatesPreferNVMDefaultAlias(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix node-manager candidate shape")
+	}
+	home := t.TempDir()
+	t.Setenv("VOLTA_HOME", filepath.Join(home, ".volta"))
+	t.Setenv("FNM_DIR", filepath.Join(home, ".local", "share", "fnm"))
+	for _, version := range []string{"v22.23.1", "v20.11.1"} {
+		bin := filepath.Join(home, ".nvm", "versions", "node", version, "bin", "widget")
+		if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	alias := filepath.Join(home, ".nvm", "alias", "default")
+	if err := os.MkdirAll(filepath.Dir(alias), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(alias, []byte("v20.11.1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := UnixNodeManagerBinCandidates(context.Background(), home, "widget")
+	if err != nil {
+		t.Fatalf("UnixNodeManagerBinCandidates: %v", err)
+	}
+	want := filepath.Join(home, ".nvm", "versions", "node", "v20.11.1", "bin", "widget")
+	if len(got) == 0 || got[0] != want {
+		t.Fatalf("first candidate = %#v, want %q first", got, want)
+	}
+}
+
+func TestUnixNodeManagerBinCandidatesHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := UnixNodeManagerBinCandidates(ctx, t.TempDir(), "widget")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+}
+
+func TestResolveBinaryFallsBackToVoltaCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix node-manager candidate shape")
+	}
+	home := t.TempDir()
+	voltaHome := filepath.Join(home, "volta-home")
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("VOLTA_HOME", voltaHome)
+	t.Setenv("FNM_DIR", "")
+	bin := filepath.Join(voltaHome, "bin", "widget")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveBinary(context.Background(), BinarySpec{
+		Label:       "widget",
+		Names:       []string{"widget"},
+		NodeManaged: true,
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != bin {
+		t.Fatalf("got %q, want %q", got, bin)
+	}
+}
+
+func TestResolveBinaryFallsBackToFNMCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix node-manager candidate shape")
+	}
+	home := t.TempDir()
+	fnmDir := filepath.Join(home, "fnm")
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("VOLTA_HOME", filepath.Join(home, ".volta"))
+	t.Setenv("FNM_DIR", fnmDir)
+	bin := filepath.Join(fnmDir, "node-versions", "v22.23.1", "installation", "bin", "widget")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveBinary(context.Background(), BinarySpec{
+		Label:       "widget",
+		Names:       []string{"widget"},
+		NodeManaged: true,
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != bin {
+		t.Fatalf("got %q, want %q", got, bin)
+	}
+}
+
 func TestResolveBinaryNotFound(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	_, err := ResolveBinary(context.Background(), BinarySpec{

--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -461,7 +461,8 @@ var claudeBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"claude"},
 	WinNames:      []string{"claude.cmd", "claude.exe", "claude"},
 	UnixPaths:     []string{"/usr/local/bin/claude", "/opt/homebrew/bin/claude"},
-	UnixHomePaths: [][]string{{".local", "bin", "claude"}, {".npm", "bin", "claude"}, {".claude", "local", "claude"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("claude", []string{".claude", "local", "claude"}),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "claude.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "claude.exe"}},

--- a/backend/internal/adapters/agent/cline/cline.go
+++ b/backend/internal/adapters/agent/cline/cline.go
@@ -144,7 +144,8 @@ var clineBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"cline"},
 	WinNames:      []string{"cline.cmd", "cline.exe", "cline"},
 	UnixPaths:     []string{"/usr/local/bin/cline", "/opt/homebrew/bin/cline"},
-	UnixHomePaths: [][]string{{".npm-global", "bin", "cline"}, {".npm", "bin", "cline"}, {".local", "bin", "cline"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("cline"),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "cline.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "cline.exe"}},

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -13,13 +13,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -224,10 +224,16 @@ func ResolveCodexBinary(ctx context.Context) (string, error) {
 	}
 	if home, err := os.UserHomeDir(); err == nil {
 		candidates = append(candidates,
-			filepath.Join(home, ".cargo", "bin", "codex"),
+			filepath.Join(home, ".npm-global", "bin", "codex"),
 			filepath.Join(home, ".npm", "bin", "codex"),
+			filepath.Join(home, ".local", "bin", "codex"),
+			filepath.Join(home, ".cargo", "bin", "codex"),
 		)
-		candidates = append(candidates, nvmNodeBinCandidates(home, "codex")...)
+		nodeManagerCandidates, err := binaryutil.UnixNodeManagerBinCandidates(ctx, home, "codex")
+		if err != nil {
+			return "", err
+		}
+		candidates = append(candidates, nodeManagerCandidates...)
 	}
 
 	for _, candidate := range candidates {
@@ -242,14 +248,6 @@ func ResolveCodexBinary(ctx context.Context) (string, error) {
 	return "", fmt.Errorf("codex: %w", ports.ErrAgentBinaryNotFound)
 }
 
-func nvmNodeBinCandidates(home, binary string) []string {
-	matches, err := filepath.Glob(filepath.Join(home, ".nvm", "versions", "node", "*", "bin", binary))
-	if err != nil || len(matches) == 0 {
-		return nil
-	}
-	sort.Sort(sort.Reverse(sort.StringSlice(matches)))
-	return matches
-}
 func resolveNativeWindowsCodex(path string) string {
 	if runtime.GOOS != "windows" || !strings.EqualFold(filepath.Ext(path), ".cmd") {
 		return path

--- a/backend/internal/adapters/agent/continueagent/continueagent.go
+++ b/backend/internal/adapters/agent/continueagent/continueagent.go
@@ -41,7 +41,8 @@ var continueBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"cn"},
 	WinNames:      []string{"cn.cmd", "cn.exe", "cn"},
 	UnixPaths:     []string{"/usr/local/bin/cn", "/opt/homebrew/bin/cn"},
-	UnixHomePaths: [][]string{{".npm-global", "bin", "cn"}, {".local", "bin", "cn"}, {".npm", "bin", "cn"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("cn"),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "cn.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "cn.exe"}},
@@ -168,9 +169,8 @@ func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (por
 }
 
 // ResolveContinueBinary finds the `cn` binary (Continue CLI), searching PATH then
-// common npm/global install locations. It returns "cn" as a last resort so
-// callers get the shell's normal command-not-found behavior if Continue is
-// absent.
+// common npm/global install locations. It returns a wrapped
+// ports.ErrAgentBinaryNotFound when Continue is absent.
 func ResolveContinueBinary(ctx context.Context) (string, error) {
 	return binaryutil.ResolveBinary(ctx, continueBinarySpec)
 }

--- a/backend/internal/adapters/agent/copilot/copilot.go
+++ b/backend/internal/adapters/agent/copilot/copilot.go
@@ -31,11 +31,17 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
 const adapterID = "copilot"
+
+var copilotUnixPaths = []string{
+	"/usr/local/bin/copilot",
+	"/opt/homebrew/bin/copilot",
+}
 
 // Plugin is the GitHub Copilot CLI agent adapter. It is safe for concurrent use;
 // the binary path is resolved once and cached under binaryMu.
@@ -194,17 +200,20 @@ func ResolveCopilotBinary(ctx context.Context) (string, error) {
 		return path, nil
 	}
 
-	candidates := []string{
-		"/usr/local/bin/copilot",
-		"/opt/homebrew/bin/copilot",
-	}
+	candidates := append([]string(nil), copilotUnixPaths...)
 	if home, err := os.UserHomeDir(); err == nil {
 		candidates = append(candidates,
-			filepath.Join(home, ".copilot", "bin", "copilot"),
+			filepath.Join(home, ".npm-global", "bin", "copilot"),
 			filepath.Join(home, ".npm", "bin", "copilot"),
 			filepath.Join(home, ".local", "bin", "copilot"),
+			filepath.Join(home, ".copilot", "bin", "copilot"),
 			filepath.Join(home, "Library", "Application Support", "Code", "User", "globalStorage", "github.copilot-chat", "copilotCli", "copilot"),
 		)
+		nodeManagerCandidates, err := binaryutil.UnixNodeManagerBinCandidates(ctx, home, "copilot")
+		if err != nil {
+			return "", err
+		}
+		candidates = append(candidates, nodeManagerCandidates...)
 	}
 
 	for _, candidate := range candidates {

--- a/backend/internal/adapters/agent/copilot/copilot_test.go
+++ b/backend/internal/adapters/agent/copilot/copilot_test.go
@@ -241,6 +241,93 @@ func TestCopilotNativeBinaryForNpmLoader(t *testing.T) {
 	}
 }
 
+func TestResolveCopilotBinaryFallbacks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fallback candidate shape")
+	}
+	oldUnixPaths := copilotUnixPaths
+	copilotUnixPaths = nil
+	t.Cleanup(func() { copilotUnixPaths = oldUnixPaths })
+
+	tests := []struct {
+		name string
+		seed func(t *testing.T, home string) string
+	}{
+		{
+			name: "npm global",
+			seed: func(t *testing.T, home string) string {
+				return writeExecutable(t, filepath.Join(home, ".npm-global", "bin", "copilot"))
+			},
+		},
+		{
+			name: "nvm",
+			seed: func(t *testing.T, home string) string {
+				return writeExecutable(t, filepath.Join(home, ".nvm", "versions", "node", "v22.23.1", "bin", "copilot"))
+			},
+		},
+		{
+			name: "npm loader resolves to native",
+			seed: func(t *testing.T, home string) string {
+				packageDir := filepath.Join(home, ".npm-global", "lib", "node_modules", "@github", "copilot")
+				binDir := filepath.Join(home, ".npm-global", "bin")
+				if err := os.MkdirAll(filepath.Join(packageDir, "node_modules", ".bin"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(binDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				loader := filepath.Join(packageDir, "npm-loader.js")
+				if err := os.WriteFile(loader, []byte("#!/usr/bin/env node\n"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				native := writeExecutable(t, filepath.Join(packageDir, "node_modules", ".bin", "copilot-"+runtime.GOOS+"-"+runtime.GOARCH))
+				link := filepath.Join(binDir, "copilot")
+				if err := os.Symlink(loader, link); err != nil {
+					t.Fatal(err)
+				}
+				return native
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("PATH", t.TempDir())
+			t.Setenv("VOLTA_HOME", filepath.Join(home, ".volta"))
+			t.Setenv("FNM_DIR", "")
+			want := tt.seed(t, home)
+
+			got, err := ResolveCopilotBinary(context.Background())
+			if err != nil {
+				t.Fatalf("ResolveCopilotBinary: %v", err)
+			}
+			got, err = filepath.EvalSymlinks(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err = filepath.EvalSymlinks(want)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != want {
+				t.Fatalf("ResolveCopilotBinary = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func writeExecutable(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 func TestAuthStatusAuthorizedFromEnv(t *testing.T) {
 	clearCopilotAuthEnv(t)
 	t.Setenv("GH_TOKEN", "github_pat_test")

--- a/backend/internal/adapters/agent/crush/crush.go
+++ b/backend/internal/adapters/agent/crush/crush.go
@@ -155,7 +155,8 @@ var crushBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"crush"},
 	WinNames:      []string{"crush.cmd", "crush.exe", "crush"},
 	UnixPaths:     []string{"/usr/local/bin/crush", "/opt/homebrew/bin/crush"},
-	UnixHomePaths: [][]string{{".local", "bin", "crush"}, {".cargo", "bin", "crush"}, {".npm", "bin", "crush"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("crush", []string{".cargo", "bin", "crush"}),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "crush.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "crush.exe"}},

--- a/backend/internal/adapters/agent/devin/devin.go
+++ b/backend/internal/adapters/agent/devin/devin.go
@@ -40,7 +40,8 @@ var devinBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"devin"},
 	WinNames:      []string{"devin.cmd", "devin.exe", "devin"},
 	UnixPaths:     []string{"/usr/local/bin/devin", "/opt/homebrew/bin/devin"},
-	UnixHomePaths: [][]string{{".devin", "bin", "devin"}, {".local", "bin", "devin"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("devin", []string{".devin", "bin", "devin"}),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinHome, Parts: []string{".devin", "bin", "devin.exe"}},
 	},

--- a/backend/internal/adapters/agent/droid/droid.go
+++ b/backend/internal/adapters/agent/droid/droid.go
@@ -228,7 +228,8 @@ var droidBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"droid"},
 	WinNames:      []string{"droid.cmd", "droid.exe", "droid"},
 	UnixPaths:     []string{"/usr/local/bin/droid", "/opt/homebrew/bin/droid"},
-	UnixHomePaths: [][]string{{".local", "bin", "droid"}, {".factory", "bin", "droid"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("droid", []string{".factory", "bin", "droid"}),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "droid.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "droid.exe"}},

--- a/backend/internal/adapters/agent/goose/goose.go
+++ b/backend/internal/adapters/agent/goose/goose.go
@@ -230,7 +230,8 @@ var gooseBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"goose"},
 	WinNames:      []string{"goose.cmd", "goose.exe", "goose"},
 	UnixPaths:     []string{"/usr/local/bin/goose", "/opt/homebrew/bin/goose"},
-	UnixHomePaths: [][]string{{".local", "bin", "goose"}, {".cargo", "bin", "goose"}, {".npm", "bin", "goose"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("goose", []string{".cargo", "bin", "goose"}),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "goose.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "goose.exe"}},

--- a/backend/internal/adapters/agent/grok/grok.go
+++ b/backend/internal/adapters/agent/grok/grok.go
@@ -35,7 +35,8 @@ var grokBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"grok"},
 	WinNames:      []string{"grok.cmd", "grok.exe", "grok"},
 	UnixPaths:     []string{"/usr/local/bin/grok", "/opt/homebrew/bin/grok"},
-	UnixHomePaths: [][]string{{".grok", "bin", "grok"}, {".local", "bin", "grok"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("grok", []string{".grok", "bin", "grok"}),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "grok.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "grok.exe"}},

--- a/backend/internal/adapters/agent/kilocode/kilocode.go
+++ b/backend/internal/adapters/agent/kilocode/kilocode.go
@@ -268,7 +268,8 @@ var kilocodeBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"kilocode"},
 	WinNames:      []string{"kilocode.cmd", "kilocode.exe", "kilocode"},
 	UnixPaths:     []string{"/usr/local/bin/kilocode", "/opt/homebrew/bin/kilocode"},
-	UnixHomePaths: [][]string{{".npm-global", "bin", "kilocode"}, {".npm", "bin", "kilocode"}, {".local", "bin", "kilocode"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("kilocode"),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "kilocode.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "kilocode.exe"}},

--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -187,7 +187,8 @@ var kimiBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"kimi"},
 	WinNames:      []string{"kimi.cmd", "kimi.exe", "kimi"},
 	UnixPaths:     []string{"/usr/local/bin/kimi", "/opt/homebrew/bin/kimi"},
-	UnixHomePaths: [][]string{{".local", "bin", "kimi"}, {".cargo", "bin", "kimi"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("kimi", []string{".cargo", "bin", "kimi"}),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "kimi.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "kimi.exe"}},
@@ -196,9 +197,7 @@ var kimiBinarySpec = binaryutil.BinarySpec{
 }
 
 // ResolveKimiBinary finds the `kimi` binary, searching PATH then common install
-// locations (the uv tool/curl installer drops it in ~/.local/bin, plus Homebrew
-// and ~/.cargo/bin). It returns "kimi" as a last resort so callers get the
-// shell's normal command-not-found behavior if Kimi is absent.
+// locations (npm global dirs, ~/.local/bin, Homebrew, and ~/.cargo/bin).
 func ResolveKimiBinary(ctx context.Context) (string, error) {
 	return binaryutil.ResolveBinary(ctx, kimiBinarySpec)
 }

--- a/backend/internal/adapters/agent/kiro/kiro.go
+++ b/backend/internal/adapters/agent/kiro/kiro.go
@@ -162,7 +162,8 @@ var kiroBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"kiro-cli"},
 	WinNames:      []string{"kiro-cli.cmd", "kiro-cli.exe", "kiro-cli"},
 	UnixPaths:     []string{"/usr/local/bin/kiro-cli", "/opt/homebrew/bin/kiro-cli"},
-	UnixHomePaths: [][]string{{".kiro", "bin", "kiro-cli"}, {".local", "bin", "kiro-cli"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("kiro-cli", []string{".kiro", "bin", "kiro-cli"}),
+	NodeManaged:   true,
 	// The native Kiro installer location is probed before the npm shim, matching
 	// the pre-refactor order so a native install still wins when both are present.
 	WinPaths: []binaryutil.WinPath{

--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 
@@ -51,6 +52,11 @@ const (
 	// (same value), but GetRestoreCommand reads it directly, so the const stays.
 	opencodeAgentSessionIDMetadataKey = "agentSessionId"
 )
+
+var opencodeUnixPaths = []string{
+	"/usr/local/bin/opencode",
+	"/opt/homebrew/bin/opencode",
+}
 
 // Plugin is the opencode agent adapter. It is safe for concurrent use; the
 // binary path is resolved once and cached under binaryMu.
@@ -460,15 +466,19 @@ func ResolveOpenCodeBinary(ctx context.Context) (string, error) {
 		return path, nil
 	}
 
-	candidates := []string{
-		"/usr/local/bin/opencode",
-		"/opt/homebrew/bin/opencode",
-	}
+	candidates := append([]string(nil), opencodeUnixPaths...)
 	if home, err := os.UserHomeDir(); err == nil {
 		candidates = append(candidates,
-			filepath.Join(home, ".opencode", "bin", "opencode"),
+			filepath.Join(home, ".npm-global", "bin", "opencode"),
 			filepath.Join(home, ".npm", "bin", "opencode"),
+			filepath.Join(home, ".local", "bin", "opencode"),
+			filepath.Join(home, ".opencode", "bin", "opencode"),
 		)
+		nodeManagerCandidates, err := binaryutil.UnixNodeManagerBinCandidates(ctx, home, "opencode")
+		if err != nil {
+			return "", err
+		}
+		candidates = append(candidates, nodeManagerCandidates...)
 	}
 
 	for _, candidate := range candidates {

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -277,6 +278,62 @@ func TestResolveOpenCodeBinaryFallback(t *testing.T) {
 	if bin == "" {
 		t.Fatal("ResolveOpenCodeBinary returned empty path with no error")
 	}
+}
+
+func TestResolveOpenCodeBinaryFallbacks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fallback candidate shape")
+	}
+	oldUnixPaths := opencodeUnixPaths
+	opencodeUnixPaths = nil
+	t.Cleanup(func() { opencodeUnixPaths = oldUnixPaths })
+
+	tests := []struct {
+		name string
+		seed func(t *testing.T, home string) string
+	}{
+		{
+			name: "npm global",
+			seed: func(t *testing.T, home string) string {
+				return writeOpenCodeExecutable(t, filepath.Join(home, ".npm-global", "bin", "opencode"))
+			},
+		},
+		{
+			name: "nvm",
+			seed: func(t *testing.T, home string) string {
+				return writeOpenCodeExecutable(t, filepath.Join(home, ".nvm", "versions", "node", "v22.23.1", "bin", "opencode"))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("PATH", t.TempDir())
+			t.Setenv("VOLTA_HOME", filepath.Join(home, ".volta"))
+			t.Setenv("FNM_DIR", "")
+			want := tt.seed(t, home)
+
+			got, err := ResolveOpenCodeBinary(context.Background())
+			if err != nil {
+				t.Fatalf("ResolveOpenCodeBinary: %v", err)
+			}
+			if got != want {
+				t.Fatalf("ResolveOpenCodeBinary = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func writeOpenCodeExecutable(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func TestResolveOpenCodeBinaryContextCanceled(t *testing.T) {

--- a/backend/internal/adapters/agent/pi/pi.go
+++ b/backend/internal/adapters/agent/pi/pi.go
@@ -139,7 +139,8 @@ var piBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"pi"},
 	WinNames:      []string{"pi.cmd", "pi.exe", "pi"},
 	UnixPaths:     []string{"/usr/local/bin/pi", "/opt/homebrew/bin/pi"},
-	UnixHomePaths: [][]string{{".npm-global", "bin", "pi"}, {".local", "bin", "pi"}, {".pi", "bin", "pi"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("pi", []string{".pi", "bin", "pi"}),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "pi.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "pi.exe"}},
@@ -147,8 +148,7 @@ var piBinarySpec = binaryutil.BinarySpec{
 }
 
 // ResolvePiBinary finds the `pi` binary, searching PATH then common install
-// locations. It returns "pi" as a last resort so callers get the shell's normal
-// command-not-found behavior if Pi is absent.
+// locations. It returns a wrapped ports.ErrAgentBinaryNotFound when Pi is absent.
 func ResolvePiBinary(ctx context.Context) (string, error) {
 	return binaryutil.ResolveBinary(ctx, piBinarySpec)
 }

--- a/backend/internal/adapters/agent/qwen/qwen.go
+++ b/backend/internal/adapters/agent/qwen/qwen.go
@@ -183,7 +183,8 @@ var qwenBinarySpec = binaryutil.BinarySpec{
 	Names:         []string{"qwen"},
 	WinNames:      []string{"qwen.cmd", "qwen.exe", "qwen"},
 	UnixPaths:     []string{"/usr/local/bin/qwen", "/opt/homebrew/bin/qwen"},
-	UnixHomePaths: [][]string{{".npm-global", "bin", "qwen"}, {".npm", "bin", "qwen"}, {".local", "bin", "qwen"}},
+	UnixHomePaths: binaryutil.NodeManagedUnixHomePaths("qwen"),
+	NodeManaged:   true,
 	WinPaths: []binaryutil.WinPath{
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "qwen.cmd"}},
 		{Base: binaryutil.WinAppData, Parts: []string{"npm", "qwen.exe"}},

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -353,7 +353,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: %w", id, err)
 	}
-	augmentRuntimePATHForLaunchBinary(env, argv)
+	m.augmentRuntimePATHForLaunchBinary(ctx, env, argv)
 	handle, err := m.runtime.Create(ctx, ports.RuntimeConfig{
 		SessionID:     id,
 		WorkspacePath: ws.Path,
@@ -854,7 +854,7 @@ func (m *Manager) relaunchRestoredSession(ctx context.Context, rec domain.Sessio
 		m.cleanupSystemPromptDir(rec.ID)
 		return domain.SessionRecord{}, fmt.Errorf("restore %s: %w", rec.ID, err)
 	}
-	augmentRuntimePATHForLaunchBinary(env, argv)
+	m.augmentRuntimePATHForLaunchBinary(ctx, env, argv)
 	handle, err := m.runtime.Create(ctx, ports.RuntimeConfig{
 		SessionID:     rec.ID,
 		WorkspacePath: ws.Path,
@@ -2499,25 +2499,86 @@ func launchBinary(argv []string) (string, bool) {
 	return "", false
 }
 
-func augmentRuntimePATHForLaunchBinary(env map[string]string, argv []string) {
+func (m *Manager) augmentRuntimePATHForLaunchBinary(ctx context.Context, env map[string]string, argv []string) {
 	bin, ok := launchBinary(argv)
 	if !ok || !filepath.IsAbs(bin) {
 		return
 	}
-	dir := filepath.Dir(bin)
-	if dir == "." || dir == string(filepath.Separator) {
+	launchDir := filepath.Dir(bin)
+	if launchDir == "." || launchDir == string(filepath.Separator) {
 		return
 	}
-	path := env["PATH"]
-	if path == "" {
-		env["PATH"] = dir
-		return
+	dirs := []string{launchDir}
+	if nodeDir := m.nodeRuntimeDir(ctx); nodeDir != "" && nodeDir != launchDir {
+		dirs = append(dirs, nodeDir)
 	}
-	parts := strings.Split(path, string(os.PathListSeparator))
-	if len(parts) > 0 && parts[0] == dir {
-		return
+	var parts []string
+	if path := env["PATH"]; path != "" {
+		parts = strings.Split(path, string(os.PathListSeparator))
 	}
-	env["PATH"] = dir + string(os.PathListSeparator) + path
+	for i := len(dirs) - 1; i >= 0; i-- {
+		if !containsPathDir(parts, dirs[i]) {
+			parts = append([]string{dirs[i]}, parts...)
+		}
+	}
+	env["PATH"] = strings.Join(parts, string(os.PathListSeparator))
+}
+
+func containsPathDir(parts []string, dir string) bool {
+	for _, part := range parts {
+		if part == dir {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) nodeRuntimeDir(ctx context.Context) string {
+	if err := ctx.Err(); err != nil || runtime.GOOS == "windows" {
+		return ""
+	}
+	if node, err := m.lookPath("node"); err == nil && node != "" {
+		return filepath.Dir(node)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	fnmDir := os.Getenv("FNM_DIR")
+	if fnmDir == "" {
+		if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+			fnmDir = filepath.Join(xdg, "fnm")
+		} else if runtime.GOOS == "darwin" {
+			fnmDir = filepath.Join(home, "Library", "Application Support", "fnm")
+		} else {
+			fnmDir = filepath.Join(home, ".local", "share", "fnm")
+		}
+	}
+	voltaHome := os.Getenv("VOLTA_HOME")
+	if voltaHome == "" {
+		voltaHome = filepath.Join(home, ".volta")
+	}
+	candidates := []string{
+		filepath.Join(voltaHome, "bin", "node"),
+		"/opt/homebrew/bin/node",
+		"/usr/local/bin/node",
+	}
+	for _, pattern := range []string{
+		filepath.Join(home, ".nvm", "versions", "node", "*", "bin", "node"),
+		filepath.Join(fnmDir, "node-versions", "*", "installation", "bin", "node"),
+	} {
+		matches, _ := filepath.Glob(pattern)
+		candidates = append(candidates, matches...)
+	}
+	for _, candidate := range candidates {
+		if err := ctx.Err(); err != nil {
+			return ""
+		}
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+			return filepath.Dir(candidate)
+		}
+	}
+	return ""
 }
 
 func (m *Manager) validateRuntimePrerequisites() error {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -2509,8 +2511,10 @@ func (m *Manager) augmentRuntimePATHForLaunchBinary(ctx context.Context, env map
 		return
 	}
 	dirs := []string{launchDir}
-	if nodeDir := m.nodeRuntimeDir(ctx); nodeDir != "" && nodeDir != launchDir {
-		dirs = append(dirs, nodeDir)
+	if isNodeLaunchBinary(bin) {
+		if nodeDir := m.nodeRuntimeDir(ctx); nodeDir != "" && nodeDir != launchDir {
+			dirs = append(dirs, nodeDir)
+		}
 	}
 	var parts []string
 	if path := env["PATH"]; path != "" {
@@ -2522,6 +2526,34 @@ func (m *Manager) augmentRuntimePATHForLaunchBinary(ctx context.Context, env map
 		}
 	}
 	env["PATH"] = strings.Join(parts, string(os.PathListSeparator))
+}
+
+func isNodeLaunchBinary(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	const maxShebangBytes = 4096
+	buf := make([]byte, maxShebangBytes)
+	n, _ := f.Read(buf)
+	line := string(buf[:n])
+	if newline := strings.IndexByte(line, '\n'); newline >= 0 {
+		line = line[:newline]
+	}
+	if !strings.HasPrefix(line, "#!") {
+		return false
+	}
+	for _, field := range strings.Fields(strings.TrimPrefix(line, "#!")) {
+		if filepath.Base(field) == "node" {
+			return true
+		}
+	}
+	return false
 }
 
 func containsPathDir(parts []string, dir string) bool {
@@ -2558,18 +2590,20 @@ func (m *Manager) nodeRuntimeDir(ctx context.Context) string {
 	if voltaHome == "" {
 		voltaHome = filepath.Join(home, ".volta")
 	}
-	candidates := []string{
-		filepath.Join(voltaHome, "bin", "node"),
-		"/opt/homebrew/bin/node",
-		"/usr/local/bin/node",
+	var candidates []string
+	nvm := versionedNodeMatches(filepath.Join(home, ".nvm", "versions", "node", "*", "bin", "node"))
+	if data, err := os.ReadFile(filepath.Join(home, ".nvm", "alias", "default")); err == nil {
+		fields := strings.Fields(string(data))
+		if len(fields) > 0 {
+			nvm = preferNodeVersion(nvm, fields[0])
+		}
 	}
-	for _, pattern := range []string{
-		filepath.Join(home, ".nvm", "versions", "node", "*", "bin", "node"),
-		filepath.Join(fnmDir, "node-versions", "*", "installation", "bin", "node"),
-	} {
-		matches, _ := filepath.Glob(pattern)
-		candidates = append(candidates, matches...)
-	}
+	candidates = append(candidates, nvm...)
+	candidates = append(candidates, versionedNodeMatches(filepath.Join(fnmDir, "node-versions", "*", "installation", "bin", "node"))...)
+	// Prefer explicitly selected/versioned runtimes over manager and package-
+	// manager shims. A dormant ~/.volta installation must not override the NVM
+	// default or newest fnm runtime merely because the GUI omitted shell setup.
+	candidates = append(candidates, filepath.Join(voltaHome, "bin", "node"), "/opt/homebrew/bin/node", "/usr/local/bin/node")
 	for _, candidate := range candidates {
 		if err := ctx.Err(); err != nil {
 			return ""
@@ -2579,6 +2613,79 @@ func (m *Manager) nodeRuntimeDir(ctx context.Context) string {
 		}
 	}
 	return ""
+}
+
+func versionedNodeMatches(pattern string) []string {
+	matches, _ := filepath.Glob(pattern)
+	sort.SliceStable(matches, func(i, j int) bool {
+		return compareNodeVersion(nodeVersionFromPath(matches[i]), nodeVersionFromPath(matches[j])) > 0
+	})
+	return matches
+}
+
+func nodeVersionFromPath(path string) string {
+	dir := filepath.Dir(path)
+	if filepath.Base(dir) == "bin" {
+		dir = filepath.Dir(dir)
+	}
+	if filepath.Base(dir) == "installation" {
+		dir = filepath.Dir(dir)
+	}
+	return filepath.Base(dir)
+}
+
+func preferNodeVersion(paths []string, version string) []string {
+	version = normalizeNodeVersion(version)
+	for i, path := range paths {
+		if normalizeNodeVersion(nodeVersionFromPath(path)) == version {
+			out := make([]string, 0, len(paths))
+			out = append(out, path)
+			out = append(out, paths[:i]...)
+			out = append(out, paths[i+1:]...)
+			return out
+		}
+	}
+	return paths
+}
+
+func compareNodeVersion(a, b string) int {
+	av, aok := parseNodeVersion(a)
+	bv, bok := parseNodeVersion(b)
+	for i := range av {
+		if av[i] != bv[i] {
+			if av[i] > bv[i] {
+				return 1
+			}
+			return -1
+		}
+	}
+	if aok != bok {
+		if aok {
+			return 1
+		}
+		return -1
+	}
+	return strings.Compare(a, b)
+}
+
+func parseNodeVersion(version string) ([3]int, bool) {
+	var parsed [3]int
+	fields := strings.Split(normalizeNodeVersion(version), ".")
+	if len(fields) == 0 || fields[0] == "" {
+		return parsed, false
+	}
+	for i := 0; i < len(fields) && i < len(parsed); i++ {
+		n, err := strconv.Atoi(fields[i])
+		if err != nil {
+			return [3]int{}, false
+		}
+		parsed[i] = n
+	}
+	return parsed, true
+}
+
+func normalizeNodeVersion(version string) string {
+	return strings.TrimPrefix(strings.TrimSpace(version), "v")
 }
 
 func (m *Manager) validateRuntimePrerequisites() error {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -353,6 +353,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		m.rollbackSpawnSeedRow(ctx, id)
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: %w", id, err)
 	}
+	augmentRuntimePATHForLaunchBinary(env, argv)
 	handle, err := m.runtime.Create(ctx, ports.RuntimeConfig{
 		SessionID:     id,
 		WorkspacePath: ws.Path,
@@ -853,6 +854,7 @@ func (m *Manager) relaunchRestoredSession(ctx context.Context, rec domain.Sessio
 		m.cleanupSystemPromptDir(rec.ID)
 		return domain.SessionRecord{}, fmt.Errorf("restore %s: %w", rec.ID, err)
 	}
+	augmentRuntimePATHForLaunchBinary(env, argv)
 	handle, err := m.runtime.Create(ctx, ports.RuntimeConfig{
 		SessionID:     rec.ID,
 		WorkspacePath: ws.Path,
@@ -2495,6 +2497,27 @@ func launchBinary(argv []string) (string, bool) {
 		return arg, true
 	}
 	return "", false
+}
+
+func augmentRuntimePATHForLaunchBinary(env map[string]string, argv []string) {
+	bin, ok := launchBinary(argv)
+	if !ok || !filepath.IsAbs(bin) {
+		return
+	}
+	dir := filepath.Dir(bin)
+	if dir == "." || dir == string(filepath.Separator) {
+		return
+	}
+	path := env["PATH"]
+	if path == "" {
+		env["PATH"] = dir
+		return
+	}
+	parts := strings.Split(path, string(os.PathListSeparator))
+	if len(parts) > 0 && parts[0] == dir {
+		return
+	}
+	env["PATH"] = dir + string(os.PathListSeparator) + path
 }
 
 func (m *Manager) validateRuntimePrerequisites() error {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2537,7 +2537,7 @@ func isNodeLaunchBinary(path string) bool {
 	if err != nil {
 		return false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	const maxShebangBytes = 4096
 	buf := make([]byte, maxShebangBytes)
 	n, _ := f.Read(buf)
@@ -2590,7 +2590,6 @@ func (m *Manager) nodeRuntimeDir(ctx context.Context) string {
 	if voltaHome == "" {
 		voltaHome = filepath.Join(home, ".volta")
 	}
-	var candidates []string
 	nvm := versionedNodeMatches(filepath.Join(home, ".nvm", "versions", "node", "*", "bin", "node"))
 	if data, err := os.ReadFile(filepath.Join(home, ".nvm", "alias", "default")); err == nil {
 		fields := strings.Fields(string(data))
@@ -2598,8 +2597,10 @@ func (m *Manager) nodeRuntimeDir(ctx context.Context) string {
 			nvm = preferNodeVersion(nvm, fields[0])
 		}
 	}
+	fnmMatches := versionedNodeMatches(filepath.Join(fnmDir, "node-versions", "*", "installation", "bin", "node"))
+	candidates := make([]string, 0, len(nvm)+len(fnmMatches)+3)
 	candidates = append(candidates, nvm...)
-	candidates = append(candidates, versionedNodeMatches(filepath.Join(fnmDir, "node-versions", "*", "installation", "bin", "node"))...)
+	candidates = append(candidates, fnmMatches...)
 	// Prefer explicitly selected/versioned runtimes over manager and package-
 	// manager shims. A dormant ~/.volta installation must not override the NVM
 	// default or newest fnm runtime merely because the GUI omitted shell setup.
@@ -2637,13 +2638,14 @@ func nodeVersionFromPath(path string) string {
 func preferNodeVersion(paths []string, version string) []string {
 	version = normalizeNodeVersion(version)
 	for i, path := range paths {
-		if normalizeNodeVersion(nodeVersionFromPath(path)) == version {
-			out := make([]string, 0, len(paths))
-			out = append(out, path)
-			out = append(out, paths[:i]...)
-			out = append(out, paths[i+1:]...)
-			return out
+		if normalizeNodeVersion(nodeVersionFromPath(path)) != version {
+			continue
 		}
+		out := make([]string, 0, len(paths))
+		out = append(out, path)
+		out = append(out, paths[:i]...)
+		out = append(out, paths[i+1:]...)
+		return out
 	}
 	return paths
 }

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -3143,14 +3144,35 @@ func TestSpawn_ProjectPATHIsPinBase(t *testing.T) {
 
 func TestSpawnAndRestore_PrependsResolvedBinaryAndNodeDirsToRuntimePATH(t *testing.T) {
 	daemonExe := filepath.Join(t.TempDir(), "ao")
-	binDir := filepath.Join(t.TempDir(), ".npm-global", "bin")
-	nodeDir := filepath.Join(t.TempDir(), ".nvm", "versions", "node", "v22.23.1", "bin")
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".npm-global", "bin")
+	nodeDir := filepath.Join(home, ".nvm", "versions", "node", "v22.23.1", "bin")
 	agentBin := filepath.Join(binDir, "kimi")
+	for _, path := range []string{
+		agentBin,
+		filepath.Join(home, ".nvm", "versions", "node", "v18.20.0", "bin", "node"),
+		filepath.Join(nodeDir, "node"),
+		filepath.Join(home, ".volta", "bin", "node"),
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		contents := "#!/bin/sh\n"
+		if path == agentBin {
+			contents = "#!/usr/bin/env node\n"
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
 	want := strings.Join([]string{binDir, nodeDir, filepath.Dir(daemonExe), "/usr/bin"}, string(os.PathListSeparator))
 
 	for _, operation := range []string{"spawn", "restore"} {
 		t.Run(operation, func(t *testing.T) {
+			t.Setenv("HOME", home)
 			t.Setenv("PATH", "/usr/bin")
+			t.Setenv("VOLTA_HOME", filepath.Join(home, ".volta"))
+			t.Setenv("FNM_DIR", filepath.Join(home, ".fnm"))
 			st := newFakeStore()
 			st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
 			rt := &fakeRuntime{}
@@ -3160,7 +3182,7 @@ func TestSpawnAndRestore_PrependsResolvedBinaryAndNodeDirsToRuntimePATH(t *testi
 				Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
 				LookPath: func(name string) (string, error) {
 					if name == "node" {
-						return filepath.Join(nodeDir, "node"), nil
+						return "", exec.ErrNotFound
 					}
 					return agentBin, nil
 				},
@@ -3181,6 +3203,44 @@ func TestSpawnAndRestore_PrependsResolvedBinaryAndNodeDirsToRuntimePATH(t *testi
 				t.Fatalf("runtime env PATH = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestSpawn_DoesNotAddNodeRuntimeForNativeBinary(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	home := t.TempDir()
+	binDir := filepath.Join(home, "native", "bin")
+	agentBin := filepath.Join(binDir, "agent")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(agentBin, []byte("native executable"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	rt := &fakeRuntime{}
+	nodeLookups := 0
+	m := New(Deps{
+		Runtime: rt, Agents: singleAgent{agent: launchArgvAgent{argv: []string{agentBin}}}, Workspace: &fakeWorkspace{},
+		Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+		LookPath: func(name string) (string, error) {
+			if name == "node" {
+				nodeLookups++
+			}
+			return agentBin, nil
+		},
+		Executable: func() (string, error) { return "/ao/bin/ao", nil },
+	})
+	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if nodeLookups != 0 {
+		t.Fatalf("node LookPath calls = %d, want 0 for native binary", nodeLookups)
+	}
+	want := strings.Join([]string{binDir, "/ao/bin", "/usr/bin"}, string(os.PathListSeparator))
+	if got := rt.lastCfg.Env["PATH"]; got != want {
+		t.Fatalf("runtime env PATH = %q, want %q", got, want)
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -238,6 +238,10 @@ func (a launchArgvAgent) GetLaunchCommand(context.Context, ports.LaunchConfig) (
 	return a.argv, nil
 }
 
+func (a launchArgvAgent) GetRestoreCommand(context.Context, ports.RestoreConfig) ([]string, bool, error) {
+	return a.argv, true, nil
+}
+
 // fakeAgents resolves every harness to the same fakeAgent.
 type fakeAgents struct{}
 
@@ -3137,32 +3141,46 @@ func TestSpawn_ProjectPATHIsPinBase(t *testing.T) {
 	}
 }
 
-func TestSpawn_PrependsResolvedBinaryDirToRuntimePATH(t *testing.T) {
+func TestSpawnAndRestore_PrependsResolvedBinaryAndNodeDirsToRuntimePATH(t *testing.T) {
 	daemonExe := filepath.Join(t.TempDir(), "ao")
-	binDir := filepath.Join(t.TempDir(), ".nvm", "versions", "node", "v22.23.1", "bin")
+	binDir := filepath.Join(t.TempDir(), ".npm-global", "bin")
+	nodeDir := filepath.Join(t.TempDir(), ".nvm", "versions", "node", "v22.23.1", "bin")
 	agentBin := filepath.Join(binDir, "kimi")
-	st := newFakeStore()
-	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
-	rt := &fakeRuntime{}
-	agent := launchArgvAgent{argv: []string{agentBin}}
-	m := New(Deps{
-		Runtime:    rt,
-		Agents:     singleAgent{agent: agent},
-		Workspace:  &fakeWorkspace{path: "/ws/mer-1"},
-		Store:      st,
-		Messenger:  &fakeMessenger{},
-		Lifecycle:  &fakeLCM{store: st},
-		LookPath:   func(string) (string, error) { return agentBin, nil },
-		Executable: func() (string, error) { return daemonExe, nil },
-	})
-	t.Setenv("PATH", "/usr/bin")
+	want := strings.Join([]string{binDir, nodeDir, filepath.Dir(daemonExe), "/usr/bin"}, string(os.PathListSeparator))
 
-	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
-		t.Fatalf("Spawn: %v", err)
-	}
-	want := binDir + string(os.PathListSeparator) + filepath.Dir(daemonExe) + string(os.PathListSeparator) + "/usr/bin"
-	if got := rt.lastCfg.Env["PATH"]; got != want {
-		t.Fatalf("runtime env PATH = %q, want %q", got, want)
+	for _, operation := range []string{"spawn", "restore"} {
+		t.Run(operation, func(t *testing.T) {
+			t.Setenv("PATH", "/usr/bin")
+			st := newFakeStore()
+			st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+			rt := &fakeRuntime{}
+			agent := launchArgvAgent{argv: []string{agentBin}}
+			m := New(Deps{
+				Runtime: rt, Agents: singleAgent{agent: agent}, Workspace: &fakeWorkspace{path: "/ws/mer-1"},
+				Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+				LookPath: func(name string) (string, error) {
+					if name == "node" {
+						return filepath.Join(nodeDir, "node"), nil
+					}
+					return agentBin, nil
+				},
+				Executable: func() (string, error) { return daemonExe, nil },
+			})
+			if operation == "spawn" {
+				_, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker})
+				if err != nil {
+					t.Fatalf("Spawn: %v", err)
+				}
+			} else {
+				seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", AgentSessionID: "agent-x"})
+				if _, err := m.Restore(ctx, "mer-1"); err != nil {
+					t.Fatalf("Restore: %v", err)
+				}
+			}
+			if got := rt.lastCfg.Env["PATH"]; got != want {
+				t.Fatalf("runtime env PATH = %q, want %q", got, want)
+			}
+		})
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -3137,6 +3137,35 @@ func TestSpawn_ProjectPATHIsPinBase(t *testing.T) {
 	}
 }
 
+func TestSpawn_PrependsResolvedBinaryDirToRuntimePATH(t *testing.T) {
+	daemonExe := filepath.Join(t.TempDir(), "ao")
+	binDir := filepath.Join(t.TempDir(), ".nvm", "versions", "node", "v22.23.1", "bin")
+	agentBin := filepath.Join(binDir, "kimi")
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	rt := &fakeRuntime{}
+	agent := launchArgvAgent{argv: []string{agentBin}}
+	m := New(Deps{
+		Runtime:    rt,
+		Agents:     singleAgent{agent: agent},
+		Workspace:  &fakeWorkspace{path: "/ws/mer-1"},
+		Store:      st,
+		Messenger:  &fakeMessenger{},
+		Lifecycle:  &fakeLCM{store: st},
+		LookPath:   func(string) (string, error) { return agentBin, nil },
+		Executable: func() (string, error) { return daemonExe, nil },
+	})
+	t.Setenv("PATH", "/usr/bin")
+
+	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	want := binDir + string(os.PathListSeparator) + filepath.Dir(daemonExe) + string(os.PathListSeparator) + "/usr/bin"
+	if got := rt.lastCfg.Env["PATH"]; got != want {
+		t.Fatalf("runtime env PATH = %q, want %q", got, want)
+	}
+}
+
 func TestSpawn_KeepsExplicitBranch(t *testing.T) {
 	m, st, _, _ := newManager()
 	s, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, Branch: "feature/x"})


### PR DESCRIPTION
## Summary

Fix agent binary detection for npm-distributed adapters when AO is launched from Electron/GUI with a minimal `PATH`.

The daemon currently relies on `exec.LookPath` first, but GUI-launched Electron does not source shell rc files, so nvm/volta/fnm-managed npm global bins are often absent from `PATH`. This caused false "Needs install" results after refreshing agents, especially for adapters like Kimi, Grok, and Droid.

## Changes

- Add shared nvm fallback support in `binaryutil.ResolveBinary`
  - Probes `~/.nvm/versions/node/*/bin/<binary>` on Unix.
  - Keeps existing precedence: `PATH` first, configured absolute/home candidates next, nvm candidates last.
  - Sorts nvm matches in reverse lexicographic order for deterministic newest-looking selection.
- Normalize Unix npm fallback paths for npm-distributed `BinarySpec` adapters:
  - `~/.npm-global/bin/<binary>`
  - `~/.npm/bin/<binary>`
  - `~/.local/bin/<binary>`
  - adapter-specific fallback paths afterward.
- Patch custom npm-style resolvers:
  - `codex`: uses the shared nvm helper and now includes npm-global/local fallbacks.
  - `opencode`: adds npm-global, local, and nvm fallbacks.
  - `copilot`: adds npm-global and nvm fallbacks while preserving native-loader resolution.

## Why

Users installing agents globally through nvm-managed npm can end up with binaries only under paths like:

```bash
~/.nvm/versions/node/v22.23.1/bin/kimi
```

Those paths are usually available in an interactive shell, but not in the Electron daemon process. The selector then reports "Needs install" even though the agent is installed.

So if a user launched AO from the terminal, it might work because shell init added nvm to `PATH`. But if a user launched AO as the desktop app, it might fail because the Electron-launched daemon never saw the shell's nvm `PATH`.

What we changed:
- Keep `PATH` lookup first.
- Add shared fallback detection for nvm npm global binaries.
- Normalize npm fallback paths across npm-distributed adapters.
- This makes "Refresh agents" work even when AO is launched from the desktop app with a minimal environment.

## Testing

Ran:

```bash
cd backend
go test ./internal/adapters/agent/binaryutil ./internal/adapters/agent/copilot ./internal/adapters/agent/opencode
go test ./internal/adapters/agent/...
go test ./internal/service/agent/...
go test ./...
```

Also ran:

```bash
git diff --check
```

Fixes #2832