### PR TITLE
fix: remove duplicate sidebar header trigger

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -863,6 +863,12 @@ describe("Sidebar", () => {
 		expect(projectRow).toHaveClass("pr-sidebar-project-actions");
 	});
 
+	it("does not render a duplicate collapse trigger in the expanded header", () => {
+		renderSidebar();
+
+		expect(screen.queryByRole("button", { name: "Collapse sidebar" })).not.toBeInTheDocument();
+	});
+
 	it("snaps to the real collapsed rail when dragged past the resize collapse threshold", async () => {
 		renderSidebar();
 

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -262,8 +262,8 @@ export function Sidebar({
 							nightly
 						</span>
 					)}
-					</div>
-				</SidebarHeader>
+				</div>
+			</SidebarHeader>
 
 			<SidebarContent className="gap-0 pl-2.5 pr-1.75 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-1.5">
 				<SidebarGroup className="p-0">

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -262,20 +262,8 @@ export function Sidebar({
 							nightly
 						</span>
 					)}
-					{/* On macOS the toggle lives in the titlebar cluster instead. */}
-					{!isMac && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<SidebarTrigger
-									aria-label="Collapse sidebar"
-									className="sidebar-expanded-chrome size-icon-xl shrink-0 rounded-sm p-0 text-passive hover:bg-interactive-hover hover:text-foreground group-data-[collapsible=icon]:hidden [&_svg]:size-icon-lg"
-								/>
-							</TooltipTrigger>
-							<TooltipContent>Collapse sidebar · ⌘B</TooltipContent>
-						</Tooltip>
-					)}
-				</div>
-			</SidebarHeader>
+					</div>
+				</SidebarHeader>
 
 			<SidebarContent className="gap-0 pl-2.5 pr-1.75 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-1.5">
 				<SidebarGroup className="p-0">


### PR DESCRIPTION
  ## Summary
  - remove the duplicate expanded-state sidebar collapse button from the header
  - keep the collapsed sidebar expand trigger and edge rail behavior intact
  - add a regression test that the expanded header does not render the duplicate collapse trigger

  ## Tests
  - npm.cmd run test -- Sidebar.test.tsx
  - npm.cmd run typecheck