### PR TITLE
fix(dev): gate daemon isolation behind opt-in

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -47,6 +47,11 @@ import {
 	resolveDaemonFromPort,
 	resolveDaemonFromRunFile,
 } from "./shared/daemon-attach";
+import {
+	devDaemonPort,
+	isDevIsolationEnabled,
+	ISOLATED_DEV_STATE_SUBDIR,
+} from "./shared/dev-daemon-config";
 import { shouldReplacePortHolder } from "./shared/daemon-takeover";
 import { buildDaemonEnv, resolveShellEnv, type ShellRunner } from "./shared/shell-env";
 import { DEFAULT_POSTHOG_HOST, DEFAULT_POSTHOG_PROJECT_KEY } from "./shared/posthog-config";
@@ -137,13 +142,6 @@ const IMPORT_SCAN_SKIP_DIRS = new Set([
 ]);
 
 const isDev = !app.isPackaged;
-
-// Dev mode uses a separate port and state subdirectory so it never collides with
-// a concurrently running installed-app daemon. The subdir also isolates supervise.sock
-// on Unix (backend derives it as dir(RunFilePath)/supervise.sock) and the named pipe
-// on Windows (supervisorPipeFromRunFile derives it from the same dir basename).
-const DEV_DAEMON_PORT = 3002;
-const DEV_STATE_SUBDIR = "dev"; // ~/.ao/dev/
 
 // Height (px) of the custom Windows title bar. Must stay in sync with the Window
 // Controls Overlay height passed to BrowserWindow and the .window-titlebar height
@@ -384,7 +382,9 @@ const DAEMON_PROBE_TIMEOUT_MS = 2_000;
 
 function runFilePath(): string | null {
 	if (process.env.AO_RUN_FILE) return process.env.AO_RUN_FILE;
-	if (isDev) return path.join(os.homedir(), ".ao", DEV_STATE_SUBDIR, "running.json");
+	if (isDev && isDevIsolationEnabled(process.env)) {
+		return path.join(os.homedir(), ".ao", ISOLATED_DEV_STATE_SUBDIR, "running.json");
+	}
 	return defaultRunFilePath(process.platform, process.env, os.homedir());
 }
 
@@ -469,13 +469,15 @@ function daemonEnv(): NodeJS.ProcessEnv {
 	// supervisor on attach (headless `ao start` daemons get no AO_OWNER and stay
 	// unlinked, preserving their persistence across app quit).
 	const ownerTag = { AO_OWNER: "app" };
-	// In dev mode, inject isolation defaults so the dev daemon never collides with
-	// the installed app. User-set env vars take priority (checked first).
+	// Keep dev on the installed app's port and state by default. Explicit isolation
+	// provides a sandbox while user-set daemon paths and ports still take priority.
 	const devExtras: Record<string, string> = {};
-	if (isDev) {
-		if (!process.env.AO_PORT) devExtras.AO_PORT = String(DEV_DAEMON_PORT);
+	if (isDev && isDevIsolationEnabled(process.env)) {
+		if (!process.env.AO_PORT) devExtras.AO_PORT = String(devDaemonPort(process.env));
 		if (!process.env.AO_RUN_FILE) devExtras.AO_RUN_FILE = runFilePath() ?? "";
-		if (!process.env.AO_DATA_DIR) devExtras.AO_DATA_DIR = path.join(os.homedir(), ".ao", DEV_STATE_SUBDIR, "data");
+		if (!process.env.AO_DATA_DIR) {
+			devExtras.AO_DATA_DIR = path.join(os.homedir(), ".ao", ISOLATED_DEV_STATE_SUBDIR, "data");
+		}
 	}
 	// Windows keeps the old behavior exactly: no shell probe, no unix PATH floor.
 	if (process.platform === "win32") {
@@ -649,11 +651,10 @@ async function startDaemon(): Promise<DaemonStatus> {
 	return daemonStartPromise;
 }
 
-// The port this Electron instance expects the daemon to bind. In dev mode a
-// separate port isolates the dev daemon from the installed-app daemon.
-// AO_PORT always wins if set explicitly.
+// The port this Electron instance expects the daemon to bind. Dev shares the
+// installed-app default unless ISOLATE_DEV=true; AO_PORT always wins.
 function resolvedDaemonPort(): number {
-	return isDev && !process.env.AO_PORT ? DEV_DAEMON_PORT : expectedDaemonPort(process.env);
+	return isDev ? devDaemonPort(process.env) : expectedDaemonPort(process.env);
 }
 
 async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {

--- a/frontend/src/shared/dev-daemon-config.test.ts
+++ b/frontend/src/shared/dev-daemon-config.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { devDaemonPort, isDevIsolationEnabled } from "./dev-daemon-config";
+
+describe("dev daemon config", () => {
+	it("uses the shared daemon port by default", () => {
+		expect(isDevIsolationEnabled({})).toBe(false);
+		expect(devDaemonPort({})).toBe(3001);
+	});
+
+	it("uses the isolated port only when explicitly enabled", () => {
+		expect(isDevIsolationEnabled({ ISOLATE_DEV: "true" })).toBe(true);
+		expect(devDaemonPort({ ISOLATE_DEV: "true" })).toBe(3002);
+		expect(devDaemonPort({ ISOLATE_DEV: "false" })).toBe(3001);
+	});
+
+	it("honors AO_PORT in either mode", () => {
+		expect(devDaemonPort({ AO_PORT: "4100" })).toBe(4100);
+		expect(devDaemonPort({ ISOLATE_DEV: "true", AO_PORT: "4100" })).toBe(4100);
+	});
+});

--- a/frontend/src/shared/dev-daemon-config.ts
+++ b/frontend/src/shared/dev-daemon-config.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_DAEMON_PORT, expectedDaemonPort } from "./daemon-attach";
+
+export const ISOLATED_DEV_DAEMON_PORT = 3002;
+export const ISOLATED_DEV_STATE_SUBDIR = "dev";
+
+export function isDevIsolationEnabled(env: Record<string, string | undefined>): boolean {
+	return env.ISOLATE_DEV === "true";
+}
+
+export function devDaemonPort(env: Record<string, string | undefined>): number {
+	if (env.AO_PORT) return expectedDaemonPort(env);
+	return isDevIsolationEnabled(env) ? ISOLATED_DEV_DAEMON_PORT : DEFAULT_DAEMON_PORT;
+}

--- a/frontend/vite.renderer.config.ts
+++ b/frontend/vite.renderer.config.ts
@@ -7,7 +7,10 @@ import { fileURLToPath, URL } from "node:url";
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { devDaemonPort } from "./src/shared/dev-daemon-config";
 import { DEFAULT_POSTHOG_HOST } from "./src/shared/posthog-config";
+
+const DEV_API_TARGET = process.env.AO_DEV_API_TARGET ?? `http://127.0.0.1:${devDaemonPort(process.env)}`;
 
 const POSTHOG_ORIGIN = (() => {
 	const configured = process.env.VITE_AO_POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_HOST;
@@ -62,11 +65,11 @@ export default defineConfig({
 	server: {
 		proxy: {
 			"/api": {
-				target: process.env.AO_DEV_API_TARGET ?? "http://127.0.0.1:3001",
+				target: DEV_API_TARGET,
 				changeOrigin: false,
 			},
 			"/mux": {
-				target: process.env.AO_DEV_API_TARGET ?? "http://127.0.0.1:3001",
+				target: DEV_API_TARGET,
 				changeOrigin: false,
 				ws: true,
 			},


### PR DESCRIPTION
## What

Restore the shared daemon port and state directory for development builds by default.

- Development now uses port `3001` and the standard `~/.ao` state directory.
- Set `ISOLATE_DEV=true` to opt into port `3002` and `~/.ao/dev`.
- The Vite `/api` and `/mux` proxies now derive their target port from the same shared configuration as Electron.
- Explicit `AO_PORT`, `AO_RUN_FILE`, `AO_DATA_DIR`, and `AO_DEV_API_TARGET` overrides remain supported.

## Why

The previous development isolation behavior caused Electron and Vite to use different daemon ports. It also silently separated development data from the installed application's data.

Fixes #2845.

## How

Added a side-effect-free shared dev-daemon configuration module used by both Electron and Vite.

The shared resolver:

- Uses port `3001` by default.
- Uses port `3002` only when `ISOLATE_DEV=true`.
- Gives an explicit `AO_PORT` precedence in either mode.

Electron only switches the run file and data directory to `~/.ao/dev` when isolation is explicitly enabled.

Regression tests cover the default port, isolated port, and explicit port overrides.

## Testing

- `npm test -- src/shared/dev-daemon-config.test.ts` - 3 tests passed
- `npm run typecheck` - passed
- `npm test` - 66 test files and 712 tests passed
- `git diff --check` - passed
- Started the application with `ISOLATE_DEV=true` and confirmed that the Vite notifications proxy targets `127.0.0.1:3002`

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)