### PR TITLE
fix(review): destroy the reviewer pane on cancel instead of only interrupting

### DIFF
--- a/backend/internal/review/launcher.go
+++ b/backend/internal/review/launcher.go
@@ -30,6 +30,10 @@ type Launcher interface {
 	Alive(ctx context.Context, handleID string) (bool, error)
 	// Cancel interrupts a running reviewer pane while keeping the terminal alive.
 	Cancel(ctx context.Context, handleID string, harness domain.ReviewerHarness) error
+	// Teardown destroys a reviewer pane so a cancelled or ended reviewer does not
+	// leak a live pane. Idempotent: an empty handle or an already-gone pane is a
+	// no-op.
+	Teardown(ctx context.Context, handleID string) error
 }
 
 // LaunchSpec is the engine's request to (re)launch a reviewer for one pass.
@@ -258,4 +262,19 @@ func (l *agentLauncher) Cancel(ctx context.Context, handleID string, harness dom
 	default:
 		return fmt.Errorf("reviewer adapter %q returned unsupported cancel mode %q", harness, spec.Mode)
 	}
+}
+
+// Teardown destroys the reviewer pane for handleID. Unlike Cancel (which only
+// interrupts and keeps the pane alive), this removes the pane entirely so a
+// cancelled or ended reviewer does not leak a live pane + agent process. It is
+// idempotent: an empty handle is a no-op, and runtime.Destroy returns nil for an
+// already-gone pane.
+func (l *agentLauncher) Teardown(ctx context.Context, handleID string) error {
+	if handleID == "" {
+		return nil
+	}
+	if err := l.runtime.Destroy(ctx, ports.RuntimeHandle{ID: handleID}); err != nil {
+		return fmt.Errorf("teardown reviewer pane %q: %w", handleID, err)
+	}
+	return nil
 }

--- a/backend/internal/review/launcher_test.go
+++ b/backend/internal/review/launcher_test.go
@@ -270,6 +270,27 @@ func TestLauncherAlive(t *testing.T) {
 	}
 }
 
+func TestLauncherTeardownDestroysPane(t *testing.T) {
+	rt := &fakeRuntime{}
+	l := NewLauncher(fakeReviewerResolver{ok: true}, rt, t.TempDir())
+	if err := l.Teardown(context.Background(), "review-mer-1"); err != nil {
+		t.Fatalf("Teardown: %v", err)
+	}
+	if rt.destroyed != "review-mer-1" {
+		t.Fatalf("destroyed handle = %q, want review-mer-1", rt.destroyed)
+	}
+
+	// An empty handle is a no-op (nothing to destroy).
+	rtEmpty := &fakeRuntime{}
+	lEmpty := NewLauncher(fakeReviewerResolver{ok: true}, rtEmpty, t.TempDir())
+	if err := lEmpty.Teardown(context.Background(), ""); err != nil {
+		t.Fatalf("empty-handle Teardown: %v", err)
+	}
+	if rtEmpty.destroyed != "" {
+		t.Fatalf("empty handle should not Destroy, got %q", rtEmpty.destroyed)
+	}
+}
+
 func TestLauncherCancelUsesReviewerCancelMode(t *testing.T) {
 	reviewer := &fakeCancellableReviewer{interrupts: 2}
 	rt := &fakeRuntime{}

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -389,7 +389,8 @@ func (e *Engine) List(ctx stdctx.Context, workerID domain.SessionID) (SessionRev
 	return SessionReviews{ReviewerHandleID: handle, Runs: runs, Reviews: Plan(prs, runs)}, nil
 }
 
-// Cancel interrupts the live reviewer pane for a worker and marks running
+// Cancel stops the live reviewer for a worker: it interrupts the pane, tears it
+// down so a cancelled reviewer does not leak a live pane, and marks running
 // review runs as cancelled so they no longer block a fresh trigger.
 func (e *Engine) Cancel(ctx stdctx.Context, workerID domain.SessionID) (CancelResult, error) {
 	if workerID == "" {
@@ -415,6 +416,13 @@ func (e *Engine) Cancel(ctx stdctx.Context, workerID domain.SessionID) (CancelRe
 			return CancelResult{}, err
 		}
 	}
+	// Destroy the pane, not just interrupt it: a cancelled reviewer should not
+	// leave "review-"+workerID (and its agent process) running. Idempotent and
+	// serialised against a concurrent Trigger respawn via lockWorker inside
+	// TeardownReviewer.
+	if err := e.TeardownReviewer(ctx, workerID); err != nil {
+		return CancelResult{}, err
+	}
 	if _, err := e.store.CancelRunningReviewRunsBySession(ctx, workerID, "cancelled by user"); err != nil {
 		return CancelResult{}, err
 	}
@@ -435,6 +443,22 @@ func (e *Engine) Cancel(ctx stdctx.Context, workerID domain.SessionID) (CancelRe
 		return CancelResult{}, err
 	}
 	return CancelResult{ReviewerHandleID: review.ReviewerHandleID, Reviews: Plan(prs, runs), CancelledRuns: cancelled}, nil
+}
+
+// TeardownReviewer destroys a worker's reviewer pane so a cancelled or ended
+// reviewer does not leak a live pane. The reviewer pane ("review-"+workerID) is
+// stable per worker and reused across passes, so nothing else tears it down;
+// without this, an explicit cancel (or, wired later, a terminated worker) leaves
+// the pane and its agent process running. It is idempotent — no reviewer / an
+// already-gone pane is a no-op — and serialises against Trigger via lockWorker so
+// it cannot race a concurrent (re)spawn on the same deterministic handle.
+func (e *Engine) TeardownReviewer(ctx stdctx.Context, workerID domain.SessionID) error {
+	if workerID == "" {
+		return fmt.Errorf("%w: worker session id is required", ErrInvalid)
+	}
+	unlock := e.lockWorker(workerID)
+	defer unlock()
+	return e.launcher.Teardown(ctx, reviewerHandleID(workerID))
 }
 
 // reviewerHarness resolves which harness reviews the worker's PR: a configured

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -158,6 +158,9 @@ type fakeLauncher struct {
 	cancelled        bool
 	cancelErr        error
 	aliveErr         error
+	tornDown         bool
+	tornDownHandle   string
+	teardownErr      error
 	gotSpec          LaunchSpec
 	gotHandle        string
 	cancelledHandle  string
@@ -192,6 +195,11 @@ func (f *fakeLauncher) Cancel(_ context.Context, handleID string, harness domain
 	f.cancelledHandle = handleID
 	f.cancelledHarness = harness
 	return f.cancelErr
+}
+func (f *fakeLauncher) Teardown(_ context.Context, handleID string) error {
+	f.tornDown = true
+	f.tornDownHandle = handleID
+	return f.teardownErr
 }
 
 func liveWorker() domain.SessionRecord {
@@ -269,6 +277,11 @@ func TestCancelInterruptsReviewerAndCancelsRunningRuns(t *testing.T) {
 	if launcher.cancelledHarness != domain.ReviewerCodex {
 		t.Fatalf("cancel harness = %q, want codex", launcher.cancelledHarness)
 	}
+	// The pane is torn down, not merely interrupted — a cancelled reviewer must
+	// not leak a live pane.
+	if !launcher.tornDown || launcher.tornDownHandle != "review-mer-1" {
+		t.Fatalf("reviewer pane not torn down: tornDown=%v handle=%q", launcher.tornDown, launcher.tornDownHandle)
+	}
 	if len(res.CancelledRuns) != 1 || res.CancelledRuns[0].ID != "run-1" {
 		t.Fatalf("cancelled runs = %+v", res.CancelledRuns)
 	}
@@ -328,6 +341,33 @@ func TestCancelKeepsRunsRunningWhenReviewerCancelFailsAndHandleIsAlive(t *testin
 	}
 	if got := store.runs[0]; got.Status != domain.ReviewRunRunning {
 		t.Fatalf("run should remain running when reviewer is still alive: %+v", got)
+	}
+}
+
+func TestTeardownReviewerDestroysPaneIdempotently(t *testing.T) {
+	launcher := &fakeLauncher{}
+	eng := newEngineForTest(&fakeStore{}, fakeSessions{}, fakePRs{}, fakeProjects{}, launcher)
+
+	// Tears down the deterministic "review-"+workerID pane.
+	if err := eng.TeardownReviewer(context.Background(), "mer-1"); err != nil {
+		t.Fatalf("TeardownReviewer: %v", err)
+	}
+	if !launcher.tornDown || launcher.tornDownHandle != "review-mer-1" {
+		t.Fatalf("pane not torn down: tornDown=%v handle=%q", launcher.tornDown, launcher.tornDownHandle)
+	}
+
+	// Idempotent: a second teardown of an already-gone pane still succeeds.
+	launcher.tornDown = false
+	if err := eng.TeardownReviewer(context.Background(), "mer-1"); err != nil {
+		t.Fatalf("second TeardownReviewer: %v", err)
+	}
+	if !launcher.tornDown {
+		t.Fatal("second teardown should still reach the launcher")
+	}
+
+	// A missing worker id is rejected as invalid input.
+	if err := eng.TeardownReviewer(context.Background(), ""); !errors.Is(err, ErrInvalid) {
+		t.Fatalf("empty worker id err = %v, want ErrInvalid", err)
 	}
 }
 


### PR DESCRIPTION
The AO reviewer runs as a stable pane (`"review-"+workerID`) reused across
review passes. `Cancel` only *interrupted* that pane, so a cancelled reviewer
left a live pane + agent process running — a standing leak.

This adds a real teardown:
- `Launcher.Teardown(handleID)` destroys the pane via the runtime's `Destroy`
  (idempotent — empty / already-gone handle is a no-op).
- `Engine.TeardownReviewer(workerID)` destroys the deterministic
  `"review-"+workerID` pane under `lockWorker`, so it can't race a concurrent
  (re)spawn; idempotent.
- `Cancel` now calls it, so a cancelled reviewer's pane is destroyed rather
  than left interrupted-but-alive.

### Depends on
Stacked on #2800, which introduces the `reviewerRuntime.Destroy` seam this
reuses. Until #2800 merges this PR's diff also shows that commit — review the
`reviewer-teardown` commit.

### Tests
- launcher `Teardown` destroys the pane + no-ops on an empty handle
- `TeardownReviewer` tears down the deterministic handle, is idempotent, and
  rejects an empty worker id
- `Cancel` now tears the pane down (regression pin for the leak)

### Validation
`go build ./...`, `go test ./...`, `go test -race ./internal/review/...`,
`go vet ./...`, golangci-lint — all green.
