### PR TITLE
fix: restore Qwen sessions by native id

### DIFF
--- a/backend/internal/adapters/agent/hooksjson/hooksjson.go
+++ b/backend/internal/adapters/agent/hooksjson/hooksjson.go
@@ -65,10 +65,11 @@ type Manager struct {
 	Managed []HookSpec
 }
 
-// Install merges AO's managed hooks into the workspace's hooks file, preserving
-// user-defined hooks and unrelated settings, and is idempotent (a command
-// already present is not appended). It also writes a self-ignoring .gitignore
-// covering the hooks file so it does not block worktree teardown.
+// Install reconciles AO's managed hooks into the workspace's hooks file,
+// preserving user-defined hooks and unrelated settings. A managed command is
+// moved when its matcher changes and is never duplicated. It also writes a
+// self-ignoring .gitignore covering the hooks file so it does not block
+// worktree teardown.
 func (m Manager) Install(ctx context.Context, workspacePath string) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -89,10 +90,8 @@ func (m Manager) Install(ctx context.Context, workspacePath string) error {
 			return fmt.Errorf("%s.GetAgentHooks: %w", m.Label, err)
 		}
 		for _, spec := range specs {
-			if !commandExists(groups, spec.Command) {
-				entry := HookEntry{Type: "command", Command: spec.Command, Timeout: m.Timeout}
-				groups = addHook(groups, entry, spec.Matcher)
-			}
+			entry := HookEntry{Type: "command", Command: spec.Command, Timeout: m.Timeout}
+			groups = reconcileHook(groups, entry, spec.Matcher)
 		}
 		if err := marshalEvent(rawHooks, event, groups); err != nil {
 			return fmt.Errorf("%s.GetAgentHooks: %w", m.Label, err)
@@ -281,15 +280,25 @@ func marshalEvent(rawHooks map[string]json.RawMessage, event string, groups []Ma
 	return nil
 }
 
-func commandExists(groups []MatcherGroup, command string) bool {
+// reconcileHook removes every copy of one AO-owned command before adding the
+// current managed entry under its declared matcher. This lets adapter upgrades
+// change a matcher or timeout without leaving stale or duplicate commands,
+// while preserving every unrelated hook in the affected groups.
+func reconcileHook(groups []MatcherGroup, hook HookEntry, matcher *string) []MatcherGroup {
+	result := make([]MatcherGroup, 0, len(groups))
 	for _, group := range groups {
-		for _, hook := range group.Hooks {
-			if hook.Command == command {
-				return true
+		kept := make([]HookEntry, 0, len(group.Hooks))
+		for _, existing := range group.Hooks {
+			if existing.Command != hook.Command {
+				kept = append(kept, existing)
 			}
 		}
+		if len(kept) > 0 {
+			group.Hooks = kept
+			result = append(result, group)
+		}
 	}
-	return false
+	return addHook(result, hook, matcher)
 }
 
 // addHook appends hook to the group with a matching matcher, creating that group

--- a/backend/internal/adapters/agent/qwen/hooks.go
+++ b/backend/internal/adapters/agent/qwen/hooks.go
@@ -21,15 +21,15 @@ const (
 	qwenHookTimeout = 30000
 )
 
-// qwenStartupMatcher is referenced by pointer so SessionStart serializes with
-// its "startup" source matcher.
-var qwenStartupMatcher = "startup"
+// qwenSessionStartMatcher is referenced by pointer so SessionStart serializes
+// with the Qwen-documented startup and resume source matcher.
+var qwenSessionStartMatcher = "startup|resume"
 
 // qwenManagedHooks is the source of truth for the hooks AO installs:
-// SessionStart (under the "startup" source matcher), UserPromptSubmit,
+// SessionStart (under the startup/resume source matcher), UserPromptSubmit,
 // PermissionRequest, and Stop.
 var qwenManagedHooks = []hooksjson.HookSpec{
-	{Event: "SessionStart", Matcher: &qwenStartupMatcher, Command: qwenHookCommandPrefix + "session-start"},
+	{Event: "SessionStart", Matcher: &qwenSessionStartMatcher, Command: qwenHookCommandPrefix + "session-start"},
 	{Event: "UserPromptSubmit", Command: qwenHookCommandPrefix + "user-prompt-submit"},
 	{Event: "PermissionRequest", Command: qwenHookCommandPrefix + "permission-request"},
 	{Event: "Stop", Command: qwenHookCommandPrefix + "stop"},

--- a/backend/internal/adapters/agent/qwen/qwen.go
+++ b/backend/internal/adapters/agent/qwen/qwen.go
@@ -112,7 +112,7 @@ func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.Launch
 }
 
 // GetRestoreCommand rebuilds the argv that continues an existing Qwen Code
-// session: `qwen [--approval-mode <mode>] -r <agentSessionId>`. ok is false when
+// session: `qwen [--approval-mode <mode>] --resume <agentSessionId>`. ok is false when
 // the hook-derived native session id has not landed yet, so callers can fall
 // back to fresh launch behavior. Note: ports.RestoreConfig carries no Prompt.
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
@@ -139,7 +139,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if systemPrompt != "" {
 		cmd = append(cmd, "--append-system-prompt", systemPrompt)
 	}
-	cmd = append(cmd, "-r", agentSessionID)
+	cmd = append(cmd, "--resume", agentSessionID)
 	return cmd, true, nil
 }
 

--- a/backend/internal/adapters/agent/qwen/qwen_test.go
+++ b/backend/internal/adapters/agent/qwen/qwen_test.go
@@ -366,6 +366,41 @@ func assertSessionStartMatcher(t *testing.T, groups []hooksjson.MatcherGroup) {
 	t.Fatalf("session-start hook not found: %#v", groups)
 }
 
+func TestGetAgentHooksMigratesSessionStartMatcher(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "qwen"}
+	workspace := t.TempDir()
+	settingsDir := filepath.Join(workspace, ".qwen")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	existing := `{"hooks":{"SessionStart":[{"matcher":"startup","hooks":[{"type":"command","command":"ao hooks qwen session-start","timeout":30000},{"type":"command","command":"custom startup hook","timeout":3}]}]}}`
+	if err := os.WriteFile(settingsPath, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := plugin.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config qwenHookFile
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	groups := config.Hooks["SessionStart"]
+	assertSessionStartMatcher(t, groups)
+	if count := countQwenHookCommand(groups, qwenHookCommandPrefix+"session-start"); count != 1 {
+		t.Fatalf("session-start command count = %d, want 1 in %#v", count, groups)
+	}
+	if count := countQwenHookCommand(groups, "custom startup hook"); count != 1 {
+		t.Fatalf("custom startup hook count = %d, want 1 in %#v", count, groups)
+	}
+}
+
 func TestUninstallHooksRemovesQwenHooks(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "qwen"}
 	workspace := t.TempDir()

--- a/backend/internal/adapters/agent/qwen/qwen_test.go
+++ b/backend/internal/adapters/agent/qwen/qwen_test.go
@@ -347,17 +347,17 @@ func TestGetAgentHooksInstallsQwenHooks(t *testing.T) {
 	if countQwenHookCommand(config.Hooks["Stop"], "custom stop hook") != 1 {
 		t.Fatalf("existing Stop hook was not preserved: %#v", config.Hooks["Stop"])
 	}
-	// SessionStart lands under the "startup" matcher.
-	assertStartupMatcher(t, config.Hooks["SessionStart"])
+	// SessionStart lands under the startup/resume matcher.
+	assertSessionStartMatcher(t, config.Hooks["SessionStart"])
 }
 
-func assertStartupMatcher(t *testing.T, groups []hooksjson.MatcherGroup) {
+func assertSessionStartMatcher(t *testing.T, groups []hooksjson.MatcherGroup) {
 	t.Helper()
 	for _, group := range groups {
 		for _, hook := range group.Hooks {
 			if hook.Command == qwenHookCommandPrefix+"session-start" {
-				if group.Matcher == nil || *group.Matcher != "startup" {
-					t.Fatalf("session-start hook not under 'startup' matcher: %#v", group)
+				if group.Matcher == nil || *group.Matcher != "startup|resume" {
+					t.Fatalf("session-start hook not under startup/resume matcher: %#v", group)
 				}
 				return
 			}
@@ -435,7 +435,7 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 		"qwen",
 		"--approval-mode", "auto",
 		"--append-system-prompt", "restore instructions",
-		"-r", "sess-123",
+		"--resume", "sess-123",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
@@ -465,7 +465,7 @@ func TestGetRestoreCommandReadsSystemPromptFile(t *testing.T) {
 	want := []string{
 		"qwen",
 		"--append-system-prompt", "restore file instructions",
-		"-r", "sess-123",
+		"--resume", "sess-123",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
@@ -489,7 +489,7 @@ func TestGetRestoreCommandDefaultModeOmitsApprovalFlags(t *testing.T) {
 	}
 	want := []string{
 		"qwen",
-		"-r", "sess-123",
+		"--resume", "sess-123",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)


### PR DESCRIPTION
## Summary

Fix Qwen Code session restoration for both new and existing AO workspaces.

- register the Qwen `SessionStart` hook for both `startup` and `resume` sources
- reconcile existing AO-managed hooks so the old `startup` matcher migrates to `startup|resume` without duplicating commands or removing user hooks
- use the documented long-form `qwen --resume <session-id>` command

Qwen documents `--resume [sessionId]` with the session ID as its positional value. The previous `-r` flag was its short alias, so that argv change is cosmetic/clarifying; the functional fix is observing the `resume` hook source and migrating preserved workspace hook configurations.

AO already captures the native `session_id` from registered hooks and persists it as `AgentSessionID`.

## Testing

- `go test ./internal/adapters/agent/qwen`
- migration regression test preserves user hooks and leaves exactly one AO session-start hook under `startup|resume`
- `npm run lint`
- `git diff --check`

All checks pass.