### PR TITLE
fix: restore Goose sessions by native session id

### DIFF
--- a/backend/internal/adapters/agent/goose/goose.go
+++ b/backend/internal/adapters/agent/goose/goose.go
@@ -116,12 +116,15 @@ func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, _ ports.LaunchCo
 	return ports.PromptDeliveryAfterStart, nil
 }
 
-// GetRestoreCommand rebuilds the argv that continues an existing Goose session:
+// GetRestoreCommand rebuilds the argv that continues an existing interactive
+// Goose session:
 //
-//	[env GOOSE_MODE=<mode>] goose run --resume --session-id <agentSessionId>
+//	[env GOOSE_MODE=<mode>] goose session --resume --session-id <agentSessionId>
 //
 // ok is false when the hook-derived native session id has not landed yet, so
-// callers can fall back to fresh launch behavior.
+// callers can fall back to fresh launch behavior. Goose's session command does
+// not accept run's --system flag; the resumed transcript retains the original
+// session context, and AO must not replay the original task.
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
@@ -136,15 +139,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 
-	cmd = append(gooseModeEnvPrefix(cfg.Permissions), binary, "run")
-	systemPrompt, err := restoreSystemPromptText(cfg)
-	if err != nil {
-		return nil, false, err
-	}
-	if systemPrompt != "" {
-		cmd = append(cmd, "--system", systemPrompt)
-	}
-	cmd = append(cmd, "--resume", "--session-id", agentSessionID)
+	cmd = append(gooseModeEnvPrefix(cfg.Permissions), binary, "session", "--resume", "--session-id", agentSessionID)
 	return cmd, true, nil
 }
 
@@ -162,10 +157,6 @@ func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (por
 // flag takes inline text only (no file variant), so a system-prompt file is read
 // from disk only when inline instructions are unavailable.
 func systemPromptText(cfg ports.LaunchConfig) (string, error) {
-	return systemPromptTextFrom(cfg.SystemPrompt, cfg.SystemPromptFile)
-}
-
-func restoreSystemPromptText(cfg ports.RestoreConfig) (string, error) {
 	return systemPromptTextFrom(cfg.SystemPrompt, cfg.SystemPromptFile)
 }
 

--- a/backend/internal/adapters/agent/goose/goose.go
+++ b/backend/internal/adapters/agent/goose/goose.go
@@ -116,15 +116,15 @@ func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, _ ports.LaunchCo
 	return ports.PromptDeliveryAfterStart, nil
 }
 
-// GetRestoreCommand rebuilds the argv that continues an existing interactive
-// Goose session:
+// GetRestoreCommand rebuilds the argv that continues an existing Goose session:
 //
-//	[env GOOSE_MODE=<mode>] goose session --resume --session-id <agentSessionId>
+//	[env GOOSE_MODE=<mode>] goose run --system <text> --resume --session-id <agentSessionId>
 //
 // ok is false when the hook-derived native session id has not landed yet, so
-// callers can fall back to fresh launch behavior. Goose's session command does
-// not accept run's --system flag; the resumed transcript retains the original
-// session context, and AO must not replay the original task.
+// callers can fall back to fresh launch behavior. AO deliberately uses run
+// rather than session here: run supports --system alongside --resume, so the
+// current derived system instructions are reapplied without replaying the
+// original task or relying on Goose to persist invocation-level instructions.
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
@@ -139,7 +139,15 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 
-	cmd = append(gooseModeEnvPrefix(cfg.Permissions), binary, "session", "--resume", "--session-id", agentSessionID)
+	cmd = append(gooseModeEnvPrefix(cfg.Permissions), binary, "run")
+	systemPrompt, err := restoreSystemPromptText(cfg)
+	if err != nil {
+		return nil, false, err
+	}
+	if systemPrompt != "" {
+		cmd = append(cmd, "--system", systemPrompt)
+	}
+	cmd = append(cmd, "--resume", "--session-id", agentSessionID)
 	return cmd, true, nil
 }
 
@@ -157,6 +165,10 @@ func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (por
 // flag takes inline text only (no file variant), so a system-prompt file is read
 // from disk only when inline instructions are unavailable.
 func systemPromptText(cfg ports.LaunchConfig) (string, error) {
+	return systemPromptTextFrom(cfg.SystemPrompt, cfg.SystemPromptFile)
+}
+
+func restoreSystemPromptText(cfg ports.RestoreConfig) (string, error) {
 	return systemPromptTextFrom(cfg.SystemPrompt, cfg.SystemPromptFile)
 }
 

--- a/backend/internal/adapters/agent/goose/goose_test.go
+++ b/backend/internal/adapters/agent/goose/goose_test.go
@@ -366,10 +366,10 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 
 	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
 		Permissions:      ports.PermissionModeAuto,
-		SystemPrompt:     "restore inline wins",
-		SystemPromptFile: filepath.Join(t.TempDir(), "missing.md"),
+		SystemPrompt:     "must not be replayed",
+		SystemPromptFile: filepath.Join(t.TempDir(), "must-not-be-read.md"),
 		Session: ports.SessionRef{
-			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "thread-123"},
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "20260720_1"},
 		},
 	})
 	if err != nil {
@@ -380,10 +380,15 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 	}
 	want := []string{
 		"env", "GOOSE_MODE=auto",
-		"goose", "run", "--system", "restore inline wins", "--resume", "--session-id", "thread-123",
+		"goose", "session", "--resume", "--session-id", "20260720_1",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+	for _, forbidden := range []string{"run", "--system", "must not be replayed"} {
+		if contains(cmd, forbidden) {
+			t.Fatalf("restore command %#v unexpectedly contains %q", cmd, forbidden)
+		}
 	}
 }
 

--- a/backend/internal/adapters/agent/goose/goose_test.go
+++ b/backend/internal/adapters/agent/goose/goose_test.go
@@ -366,8 +366,8 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 
 	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
 		Permissions:      ports.PermissionModeAuto,
-		SystemPrompt:     "must not be replayed",
-		SystemPromptFile: filepath.Join(t.TempDir(), "must-not-be-read.md"),
+		SystemPrompt:     "restore inline wins",
+		SystemPromptFile: filepath.Join(t.TempDir(), "missing.md"),
 		Session: ports.SessionRef{
 			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "20260720_1"},
 		},
@@ -380,15 +380,13 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 	}
 	want := []string{
 		"env", "GOOSE_MODE=auto",
-		"goose", "session", "--resume", "--session-id", "20260720_1",
+		"goose", "run", "--system", "restore inline wins", "--resume", "--session-id", "20260720_1",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
 	}
-	for _, forbidden := range []string{"run", "--system", "must not be replayed"} {
-		if contains(cmd, forbidden) {
-			t.Fatalf("restore command %#v unexpectedly contains %q", cmd, forbidden)
-		}
+	if contains(cmd, "-t") || contains(cmd, "restore original task") {
+		t.Fatalf("restore command %#v unexpectedly replays the original task", cmd)
 	}
 }
 

--- a/backend/internal/adapters/agent/hooksjson/hooksjson.go
+++ b/backend/internal/adapters/agent/hooksjson/hooksjson.go
@@ -65,10 +65,11 @@ type Manager struct {
 	Managed []HookSpec
 }
 
-// Install merges AO's managed hooks into the workspace's hooks file, preserving
-// user-defined hooks and unrelated settings, and is idempotent (a command
-// already present is not appended). It also writes a self-ignoring .gitignore
-// covering the hooks file so it does not block worktree teardown.
+// Install reconciles AO's managed hooks into the workspace's hooks file,
+// preserving user-defined hooks and unrelated settings. A managed command is
+// moved when its matcher changes and is never duplicated. It also writes a
+// self-ignoring .gitignore covering the hooks file so it does not block
+// worktree teardown.
 func (m Manager) Install(ctx context.Context, workspacePath string) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -89,10 +90,8 @@ func (m Manager) Install(ctx context.Context, workspacePath string) error {
 			return fmt.Errorf("%s.GetAgentHooks: %w", m.Label, err)
 		}
 		for _, spec := range specs {
-			if !commandExists(groups, spec.Command) {
-				entry := HookEntry{Type: "command", Command: spec.Command, Timeout: m.Timeout}
-				groups = addHook(groups, entry, spec.Matcher)
-			}
+			entry := HookEntry{Type: "command", Command: spec.Command, Timeout: m.Timeout}
+			groups = reconcileHook(groups, entry, spec.Matcher)
 		}
 		if err := marshalEvent(rawHooks, event, groups); err != nil {
 			return fmt.Errorf("%s.GetAgentHooks: %w", m.Label, err)
@@ -281,15 +280,25 @@ func marshalEvent(rawHooks map[string]json.RawMessage, event string, groups []Ma
 	return nil
 }
 
-func commandExists(groups []MatcherGroup, command string) bool {
+// reconcileHook removes every copy of one AO-owned command before adding the
+// current managed entry under its declared matcher. This lets adapter upgrades
+// change a matcher or timeout without leaving stale or duplicate commands,
+// while preserving every unrelated hook in the affected groups.
+func reconcileHook(groups []MatcherGroup, hook HookEntry, matcher *string) []MatcherGroup {
+	result := make([]MatcherGroup, 0, len(groups))
 	for _, group := range groups {
-		for _, hook := range group.Hooks {
-			if hook.Command == command {
-				return true
+		kept := make([]HookEntry, 0, len(group.Hooks))
+		for _, existing := range group.Hooks {
+			if existing.Command != hook.Command {
+				kept = append(kept, existing)
 			}
 		}
+		if len(kept) > 0 {
+			group.Hooks = kept
+			result = append(result, group)
+		}
 	}
-	return false
+	return addHook(result, hook, matcher)
 }
 
 // addHook appends hook to the group with a matching matcher, creating that group

--- a/backend/internal/adapters/agent/hooksjson/hooksjson_test.go
+++ b/backend/internal/adapters/agent/hooksjson/hooksjson_test.go
@@ -1,0 +1,68 @@
+package hooksjson
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReconcileHookMovesCommandToDeclaredMatcher(t *testing.T) {
+	oldMatcher := "old"
+	newMatcher := "new"
+	managed := "ao hooks test session-start"
+	userOld := HookEntry{Type: "command", Command: "user old", Timeout: 3}
+	userNew := HookEntry{Type: "command", Command: "user new", Timeout: 4}
+	updated := HookEntry{Type: "command", Command: managed, Timeout: 30}
+	groups := []MatcherGroup{
+		{Matcher: &oldMatcher, Hooks: []HookEntry{{Type: "command", Command: managed, Timeout: 5}, userOld}},
+		{Matcher: &newMatcher, Hooks: []HookEntry{userNew}},
+	}
+
+	got := reconcileHook(groups, updated, &newMatcher)
+	want := []MatcherGroup{
+		{Matcher: &oldMatcher, Hooks: []HookEntry{userOld}},
+		{Matcher: &newMatcher, Hooks: []HookEntry{userNew, updated}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reconcileHook()\nwant: %#v\n got: %#v", want, got)
+	}
+}
+
+func TestReconcileHookDeduplicatesCommandAcrossGroups(t *testing.T) {
+	firstMatcher := "first"
+	targetMatcher := "target"
+	managed := "ao hooks test session-start"
+	user := HookEntry{Type: "command", Command: "user hook", Timeout: 7}
+	updated := HookEntry{Type: "command", Command: managed, Timeout: 30}
+	groups := []MatcherGroup{
+		{Hooks: []HookEntry{{Type: "command", Command: managed, Timeout: 1}}},
+		{Matcher: &firstMatcher, Hooks: []HookEntry{user, {Type: "command", Command: managed, Timeout: 2}}},
+		{Matcher: &targetMatcher, Hooks: []HookEntry{{Type: "command", Command: managed, Timeout: 3}}},
+	}
+
+	got := reconcileHook(groups, updated, &targetMatcher)
+	want := []MatcherGroup{
+		{Matcher: &firstMatcher, Hooks: []HookEntry{user}},
+		{Matcher: &targetMatcher, Hooks: []HookEntry{updated}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reconcileHook()\nwant: %#v\n got: %#v", want, got)
+	}
+}
+
+func TestReconcileHookDropsGroupsEmptiedByMove(t *testing.T) {
+	oldMatcher := "old"
+	newMatcher := "new"
+	managed := "ao hooks test session-start"
+	updated := HookEntry{Type: "command", Command: managed, Timeout: 30}
+	groups := []MatcherGroup{
+		{Matcher: &oldMatcher, Hooks: []HookEntry{{Type: "command", Command: managed, Timeout: 5}}},
+	}
+
+	got := reconcileHook(groups, updated, &newMatcher)
+	want := []MatcherGroup{
+		{Matcher: &newMatcher, Hooks: []HookEntry{updated}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reconcileHook()\nwant: %#v\n got: %#v", want, got)
+	}
+}

--- a/backend/internal/adapters/agent/qwen/hooks.go
+++ b/backend/internal/adapters/agent/qwen/hooks.go
@@ -21,15 +21,15 @@ const (
 	qwenHookTimeout = 30000
 )
 
-// qwenStartupMatcher is referenced by pointer so SessionStart serializes with
-// its "startup" source matcher.
-var qwenStartupMatcher = "startup"
+// qwenSessionStartMatcher is referenced by pointer so SessionStart serializes
+// with the Qwen-documented startup and resume source matcher.
+var qwenSessionStartMatcher = "startup|resume"
 
 // qwenManagedHooks is the source of truth for the hooks AO installs:
-// SessionStart (under the "startup" source matcher), UserPromptSubmit,
+// SessionStart (under the startup/resume source matcher), UserPromptSubmit,
 // PermissionRequest, and Stop.
 var qwenManagedHooks = []hooksjson.HookSpec{
-	{Event: "SessionStart", Matcher: &qwenStartupMatcher, Command: qwenHookCommandPrefix + "session-start"},
+	{Event: "SessionStart", Matcher: &qwenSessionStartMatcher, Command: qwenHookCommandPrefix + "session-start"},
 	{Event: "UserPromptSubmit", Command: qwenHookCommandPrefix + "user-prompt-submit"},
 	{Event: "PermissionRequest", Command: qwenHookCommandPrefix + "permission-request"},
 	{Event: "Stop", Command: qwenHookCommandPrefix + "stop"},

--- a/backend/internal/adapters/agent/qwen/qwen.go
+++ b/backend/internal/adapters/agent/qwen/qwen.go
@@ -112,7 +112,7 @@ func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.Launch
 }
 
 // GetRestoreCommand rebuilds the argv that continues an existing Qwen Code
-// session: `qwen [--approval-mode <mode>] -r <agentSessionId>`. ok is false when
+// session: `qwen [--approval-mode <mode>] --resume <agentSessionId>`. ok is false when
 // the hook-derived native session id has not landed yet, so callers can fall
 // back to fresh launch behavior. Note: ports.RestoreConfig carries no Prompt.
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
@@ -139,7 +139,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if systemPrompt != "" {
 		cmd = append(cmd, "--append-system-prompt", systemPrompt)
 	}
-	cmd = append(cmd, "-r", agentSessionID)
+	cmd = append(cmd, "--resume", agentSessionID)
 	return cmd, true, nil
 }
 

--- a/backend/internal/adapters/agent/qwen/qwen_test.go
+++ b/backend/internal/adapters/agent/qwen/qwen_test.go
@@ -366,6 +366,41 @@ func assertSessionStartMatcher(t *testing.T, groups []hooksjson.MatcherGroup) {
 	t.Fatalf("session-start hook not found: %#v", groups)
 }
 
+func TestGetAgentHooksMigratesSessionStartMatcher(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "qwen"}
+	workspace := t.TempDir()
+	settingsDir := filepath.Join(workspace, ".qwen")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	existing := `{"hooks":{"SessionStart":[{"matcher":"startup","hooks":[{"type":"command","command":"ao hooks qwen session-start","timeout":30000},{"type":"command","command":"custom startup hook","timeout":3}]}]}}`
+	if err := os.WriteFile(settingsPath, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := plugin.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config qwenHookFile
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	groups := config.Hooks["SessionStart"]
+	assertSessionStartMatcher(t, groups)
+	if count := countQwenHookCommand(groups, qwenHookCommandPrefix+"session-start"); count != 1 {
+		t.Fatalf("session-start command count = %d, want 1 in %#v", count, groups)
+	}
+	if count := countQwenHookCommand(groups, "custom startup hook"); count != 1 {
+		t.Fatalf("custom startup hook count = %d, want 1 in %#v", count, groups)
+	}
+}
+
 func TestUninstallHooksRemovesQwenHooks(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "qwen"}
 	workspace := t.TempDir()

--- a/backend/internal/adapters/agent/qwen/qwen_test.go
+++ b/backend/internal/adapters/agent/qwen/qwen_test.go
@@ -347,17 +347,17 @@ func TestGetAgentHooksInstallsQwenHooks(t *testing.T) {
 	if countQwenHookCommand(config.Hooks["Stop"], "custom stop hook") != 1 {
 		t.Fatalf("existing Stop hook was not preserved: %#v", config.Hooks["Stop"])
 	}
-	// SessionStart lands under the "startup" matcher.
-	assertStartupMatcher(t, config.Hooks["SessionStart"])
+	// SessionStart lands under the startup/resume matcher.
+	assertSessionStartMatcher(t, config.Hooks["SessionStart"])
 }
 
-func assertStartupMatcher(t *testing.T, groups []hooksjson.MatcherGroup) {
+func assertSessionStartMatcher(t *testing.T, groups []hooksjson.MatcherGroup) {
 	t.Helper()
 	for _, group := range groups {
 		for _, hook := range group.Hooks {
 			if hook.Command == qwenHookCommandPrefix+"session-start" {
-				if group.Matcher == nil || *group.Matcher != "startup" {
-					t.Fatalf("session-start hook not under 'startup' matcher: %#v", group)
+				if group.Matcher == nil || *group.Matcher != "startup|resume" {
+					t.Fatalf("session-start hook not under startup/resume matcher: %#v", group)
 				}
 				return
 			}
@@ -435,7 +435,7 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 		"qwen",
 		"--approval-mode", "auto",
 		"--append-system-prompt", "restore instructions",
-		"-r", "sess-123",
+		"--resume", "sess-123",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
@@ -465,7 +465,7 @@ func TestGetRestoreCommandReadsSystemPromptFile(t *testing.T) {
 	want := []string{
 		"qwen",
 		"--append-system-prompt", "restore file instructions",
-		"-r", "sess-123",
+		"--resume", "sess-123",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
@@ -489,7 +489,7 @@ func TestGetRestoreCommandDefaultModeOmitsApprovalFlags(t *testing.T) {
 	}
 	want := []string{
 		"qwen",
-		"-r", "sess-123",
+		"--resume", "sess-123",
 	}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -399,7 +399,7 @@ func TestHooks_GrokSessionStartReportsAgentSessionID(t *testing.T) {
 }
 
 func TestHooks_RegisteredHarnessSessionStartReportsAgentSessionID(t *testing.T) {
-	for _, agent := range []string{"opencode", "qwen", "kimi", "kilocode"} {
+	for _, agent := range []string{"opencode", "qwen", "kimi", "kilocode", "goose"} {
 		t.Run(agent, func(t *testing.T) {
 			t.Setenv("AO_SESSION_ID", "ao-7")
 			cfg := setConfigEnv(t)


### PR DESCRIPTION
## Summary

Fix Goose session restoration so AO resumes the original interactive Goose conversation using its persisted native session ID.

## Changes

- Restore Goose sessions with:
  `goose session --resume --session-id <agentSessionId>`
- Preserve the configured approval mode through `GOOSE_MODE`.
- Avoid replaying the original task when restoring a native session.
- Avoid passing `--system`, which is not supported by `goose session`.
- Add Goose session-start hook coverage for capturing `agentSessionId`.
- Add adapter tests using a realistic Goose session ID.

## Why

Goose automatically persists interactive sessions in its local SQLite database. AO already captures the native Goose session ID through lifecycle hooks and stores it as `agentSessionId`.

Using that ID allows a terminated AO session to resume the same Goose transcript instead of starting a new conversation or accidentally restoring the most recent unrelated Goose session.

## Restore flow

1. Goose emits a `SessionStart` hook containing its native session ID.
2. AO records that value in the session’s `agentSessionId` metadata.
3. When the AO session is restored, the Goose adapter runs:

   ```bash
   goose session --resume --session-id <agentSessionId>