### PR TITLE
feat(vibe): restore native sessions

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/vibe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
@@ -43,6 +44,7 @@ var Derivers = map[string]DeriveFunc{
 	"kiro":        activitystate.StandardDeriveActivityState,
 	"kilocode":    activitystate.StandardDeriveActivityState,
 	"autohand":    activitystate.StandardDeriveActivityState,
+	"vibe":        vibe.DeriveActivityState,
 }
 
 // Derive looks up the deriver for an agent token and applies it. ok=false when

--- a/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch_test.go
@@ -18,7 +18,7 @@ func TestDeriverTokensAreKnownHarnesses(t *testing.T) {
 }
 
 func TestSupportsHarness(t *testing.T) {
-	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessGrok, domain.HarnessOpenCode, domain.HarnessKimi} {
+	for _, h := range []domain.AgentHarness{domain.HarnessCodex, domain.HarnessClaudeCode, domain.HarnessGrok, domain.HarnessOpenCode, domain.HarnessKimi, domain.HarnessVibe} {
 		if !SupportsHarness(h) {
 			t.Errorf("SupportsHarness(%q) = false, want true", h)
 		}

--- a/backend/internal/adapters/agent/vibe/activity.go
+++ b/backend/internal/adapters/agent/vibe/activity.go
@@ -1,0 +1,19 @@
+package vibe
+
+import (
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// DeriveActivityState maps Vibe's available hook events conservatively. A
+// pre_tool callback happens before any permission prompt, so it is evidence of
+// work but not evidence that the agent is waiting for input.
+func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
+	switch event {
+	case "pre-tool", "post-tool":
+		return domain.ActivityActive, true
+	case "post-agent":
+		return domain.ActivityIdle, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/adapters/agent/vibe/activity_test.go
+++ b/backend/internal/adapters/agent/vibe/activity_test.go
@@ -1,0 +1,28 @@
+package vibe
+
+import (
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestDeriveActivityState(t *testing.T) {
+	tests := []struct {
+		event string
+		want  domain.ActivityState
+		ok    bool
+	}{
+		{"pre-tool", domain.ActivityActive, true},
+		{"post-tool", domain.ActivityActive, true},
+		{"post-agent", domain.ActivityIdle, true},
+		{"permission-request", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			got, ok := DeriveActivityState(tt.event, nil)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("DeriveActivityState(%q) = (%q, %v), want (%q, %v)", tt.event, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/agent/vibe/hooks.go
+++ b/backend/internal/adapters/agent/vibe/hooks.go
@@ -15,14 +15,15 @@ import (
 const (
 	vibeDirName       = ".vibe"
 	vibeHooksFileName = "hooks.toml"
-	vibeConfigName    = "config.toml"
 
 	vibeHooksSentinelStart = "# managed by agent-orchestrator: vibe hooks"
 	vibeHooksSentinelEnd   = "# /managed by agent-orchestrator: vibe hooks"
 )
 
-// GetAgentHooks installs Vibe callbacks that capture the native session id and
-// enables the interaction log that Vibe requires for --resume.
+// GetAgentHooks installs Vibe callbacks that capture the native session id.
+// Vibe enables interaction logging by default, which is required for
+// --resume. AO deliberately leaves the user-owned .vibe/config.toml untouched;
+// users who disable log_interactions also disable native session restore.
 func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -38,17 +39,13 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	if err := mergeVibeHooksFile(filepath.Join(dir, vibeHooksFileName)); err != nil {
 		return fmt.Errorf("vibe.GetAgentHooks: %w", err)
 	}
-	if err := enableVibeInteractionLogging(filepath.Join(dir, vibeConfigName)); err != nil {
-		return fmt.Errorf("vibe.GetAgentHooks: %w", err)
-	}
-	if err := hookutil.EnsureWorkspaceGitignore(dir, vibeHooksFileName, vibeConfigName); err != nil {
+	if err := hookutil.EnsureWorkspaceGitignore(dir, vibeHooksFileName); err != nil {
 		return fmt.Errorf("vibe.GetAgentHooks: gitignore: %w", err)
 	}
 	return nil
 }
 
-// UninstallHooks removes only AO's managed Vibe hook block. Interaction
-// logging remains enabled because the prior user value is not recoverable.
+// UninstallHooks removes only AO's managed Vibe hook block.
 func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -103,6 +100,9 @@ func mergeVibeHooksFile(path string) error {
 }
 
 func vibeHooksBlock() string {
+	// Vibe's hooks.toml contract uses [[hooks]] entries with name, type,
+	// optional match, command, and a floating-point timeout measured in seconds.
+	// Native event names use underscores; AO's hook CLI uses hyphenated tokens.
 	return vibeHooksSentinelStart + "\n\n" +
 		vibeHookEntry("ao-session-metadata", "post_agent", "", "ao hooks vibe post-agent") +
 		vibeHookEntry("ao-pre-tool", "pre_tool", "*", "ao hooks vibe pre-tool") +
@@ -151,35 +151,4 @@ func joinVibeTOML(prefix, block, suffix string) string {
 		b.WriteString(suffix)
 	}
 	return b.String()
-}
-
-func enableVibeInteractionLogging(path string) error {
-	data, err := os.ReadFile(path) //nolint:gosec // workspace-local adapter config
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("read %s: %w", path, err)
-	}
-	body := setVibeTopLevelLogging(string(data))
-	if err := hookutil.AtomicWriteFile(path, []byte(body), 0o600); err != nil {
-		return fmt.Errorf("write %s: %w", path, err)
-	}
-	return nil
-}
-
-func setVibeTopLevelLogging(existing string) string {
-	lines := strings.Split(existing, "\n")
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "[") {
-			break
-		}
-		if key, _, found := strings.Cut(trimmed, "="); found && strings.TrimSpace(key) == "log_interactions" {
-			lines[i] = "log_interactions = true"
-			return strings.TrimRight(strings.Join(lines, "\n"), "\n") + "\n"
-		}
-	}
-	base := strings.TrimRight(existing, "\n")
-	if base == "" {
-		return "log_interactions = true\n"
-	}
-	return "log_interactions = true\n\n" + base + "\n"
 }

--- a/backend/internal/adapters/agent/vibe/hooks.go
+++ b/backend/internal/adapters/agent/vibe/hooks.go
@@ -1,0 +1,185 @@
+package vibe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	vibeDirName       = ".vibe"
+	vibeHooksFileName = "hooks.toml"
+	vibeConfigName    = "config.toml"
+
+	vibeHooksSentinelStart = "# managed by agent-orchestrator: vibe hooks"
+	vibeHooksSentinelEnd   = "# /managed by agent-orchestrator: vibe hooks"
+)
+
+// GetAgentHooks installs Vibe callbacks that capture the native session id and
+// enables the interaction log that Vibe requires for --resume.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.WorkspacePath) == "" {
+		return errors.New("vibe.GetAgentHooks: WorkspacePath is required")
+	}
+
+	dir := filepath.Join(cfg.WorkspacePath, vibeDirName)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("vibe.GetAgentHooks: create config dir: %w", err)
+	}
+	if err := mergeVibeHooksFile(filepath.Join(dir, vibeHooksFileName)); err != nil {
+		return fmt.Errorf("vibe.GetAgentHooks: %w", err)
+	}
+	if err := enableVibeInteractionLogging(filepath.Join(dir, vibeConfigName)); err != nil {
+		return fmt.Errorf("vibe.GetAgentHooks: %w", err)
+	}
+	if err := hookutil.EnsureWorkspaceGitignore(dir, vibeHooksFileName, vibeConfigName); err != nil {
+		return fmt.Errorf("vibe.GetAgentHooks: gitignore: %w", err)
+	}
+	return nil
+}
+
+// UninstallHooks removes only AO's managed Vibe hook block. Interaction
+// logging remains enabled because the prior user value is not recoverable.
+func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(workspacePath) == "" {
+		return errors.New("vibe.UninstallHooks: workspacePath is required")
+	}
+	path := filepath.Join(workspacePath, vibeDirName, vibeHooksFileName)
+	data, err := os.ReadFile(path) //nolint:gosec // workspace-local adapter config
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("vibe.UninstallHooks: read %s: %w", path, err)
+	}
+	body := replaceVibeManagedBlock(string(data), "")
+	if err := hookutil.AtomicWriteFile(path, []byte(body), 0o600); err != nil {
+		return fmt.Errorf("vibe.UninstallHooks: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// AreHooksInstalled reports whether AO's managed Vibe hook block is present.
+func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(workspacePath) == "" {
+		return false, errors.New("vibe.AreHooksInstalled: workspacePath is required")
+	}
+	path := filepath.Join(workspacePath, vibeDirName, vibeHooksFileName)
+	data, err := os.ReadFile(path) //nolint:gosec // workspace-local adapter config
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("vibe.AreHooksInstalled: read %s: %w", path, err)
+	}
+	return strings.Contains(string(data), vibeHooksSentinelStart), nil
+}
+
+func mergeVibeHooksFile(path string) error {
+	data, err := os.ReadFile(path) //nolint:gosec // workspace-local adapter config
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	body := replaceVibeManagedBlock(string(data), vibeHooksBlock())
+	if err := hookutil.AtomicWriteFile(path, []byte(body), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func vibeHooksBlock() string {
+	return vibeHooksSentinelStart + "\n\n" +
+		vibeHookEntry("ao-session-metadata", "post_agent", "", "ao hooks vibe post-agent") +
+		vibeHookEntry("ao-pre-tool", "pre_tool", "*", "ao hooks vibe pre-tool") +
+		vibeHookEntry("ao-post-tool", "post_tool", "*", "ao hooks vibe post-tool") +
+		vibeHooksSentinelEnd + "\n"
+}
+
+func vibeHookEntry(name, hookType, match, command string) string {
+	var b strings.Builder
+	b.WriteString("[[hooks]]\n")
+	fmt.Fprintf(&b, "name = %q\n", name)
+	fmt.Fprintf(&b, "type = %q\n", hookType)
+	if match != "" {
+		fmt.Fprintf(&b, "match = %q\n", match)
+	}
+	fmt.Fprintf(&b, "command = %q\n", command)
+	b.WriteString("timeout = 30.0\n\n")
+	return b.String()
+}
+
+func replaceVibeManagedBlock(existing, block string) string {
+	start := strings.Index(existing, vibeHooksSentinelStart)
+	if start < 0 {
+		return joinVibeTOML(existing, block, "")
+	}
+	afterStart := existing[start+len(vibeHooksSentinelStart):]
+	endRel := strings.Index(afterStart, vibeHooksSentinelEnd)
+	if endRel < 0 {
+		return joinVibeTOML(existing[:start], block, "")
+	}
+	end := start + len(vibeHooksSentinelStart) + endRel + len(vibeHooksSentinelEnd)
+	return joinVibeTOML(existing[:start], block, existing[end:])
+}
+
+func joinVibeTOML(prefix, block, suffix string) string {
+	var b strings.Builder
+	prefix = strings.TrimRight(prefix, "\n")
+	if prefix != "" {
+		b.WriteString(prefix)
+		b.WriteString("\n\n")
+	}
+	b.WriteString(block)
+	suffix = strings.TrimLeft(suffix, "\n")
+	if suffix != "" {
+		b.WriteString("\n")
+		b.WriteString(suffix)
+	}
+	return b.String()
+}
+
+func enableVibeInteractionLogging(path string) error {
+	data, err := os.ReadFile(path) //nolint:gosec // workspace-local adapter config
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	body := setVibeTopLevelLogging(string(data))
+	if err := hookutil.AtomicWriteFile(path, []byte(body), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func setVibeTopLevelLogging(existing string) string {
+	lines := strings.Split(existing, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			break
+		}
+		if key, _, found := strings.Cut(trimmed, "="); found && strings.TrimSpace(key) == "log_interactions" {
+			lines[i] = "log_interactions = true"
+			return strings.TrimRight(strings.Join(lines, "\n"), "\n") + "\n"
+		}
+	}
+	base := strings.TrimRight(existing, "\n")
+	if base == "" {
+		return "log_interactions = true\n"
+	}
+	return "log_interactions = true\n\n" + base + "\n"
+}

--- a/backend/internal/adapters/agent/vibe/vibe.go
+++ b/backend/internal/adapters/agent/vibe/vibe.go
@@ -12,11 +12,10 @@
 // ("auto-approves all tool executions"). PermissionModeDefault emits no flag so
 // Vibe resolves its starting agent from the user's `default_agent` config.
 //
-// Vibe has no usable lifecycle-hook surface for AO activity: its only hook type
-// is an experimental, off-by-default POST_AGENT_TURN hook with no
-// session-start/user-prompt-submit/stop/permission-request taxonomy, and it is
-// not Claude-Code compatible. Hook installation and SessionInfo are therefore
-// intentionally no-ops (Tier C).
+// Vibe hooks receive the native session id on every callback. AO installs
+// workspace-local pre_tool, post_tool, and post_agent hooks to persist that id
+// for restore and to report conservative activity signals without mutating the
+// user's global Vibe configuration.
 //
 // Restore uses `--resume <session id>` (Vibe matches by partial/short id) when
 // a native session id is available in metadata.
@@ -146,6 +145,15 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	}
 	cmd = append(cmd, "--resume", agentSessionID)
 	return cmd, true, nil
+}
+
+// SessionInfo surfaces the native session id captured by AO's Vibe hooks.
+func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (ports.SessionInfo, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SessionInfo{}, false, err
+	}
+	info, ok := agentbase.StandardSessionInfo(session)
+	return info, ok, nil
 }
 
 // appendWorkdirFlag adds Vibe's explicit `--workdir` flag. Vibe validates its

--- a/backend/internal/adapters/agent/vibe/vibe_test.go
+++ b/backend/internal/adapters/agent/vibe/vibe_test.go
@@ -348,24 +348,122 @@ func TestGetRestoreCommandNoID(t *testing.T) {
 	}
 }
 
-func TestGetAgentHooksNoOp(t *testing.T) {
-	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: t.TempDir()}); err != nil {
-		t.Fatalf("GetAgentHooks err = %v, want nil", err)
+func TestGetAgentHooksInstallsManagedHooksAndLogging(t *testing.T) {
+	workspace := t.TempDir()
+	dir := filepath.Join(workspace, ".vibe")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	userHooks := "[[hooks]]\nname = \"user-hook\"\ntype = \"post_agent\"\ncommand = \"user-command\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "hooks.toml"), []byte(userHooks), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	userConfig := "log_interactions = false\nactive_model = \"custom-model\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(userConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Plugin{}
+	for range 2 {
+		if err := p.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+			t.Fatalf("GetAgentHooks: %v", err)
+		}
+	}
+
+	hooks, err := os.ReadFile(filepath.Join(dir, "hooks.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(hooks)
+	for _, want := range []string{"user-command", "ao hooks vibe post-agent", "ao hooks vibe pre-tool", "ao hooks vibe post-tool"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("hooks.toml missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Count(body, vibeHooksSentinelStart) != 1 || strings.Count(body, "ao hooks vibe post-agent") != 1 {
+		t.Fatalf("managed hooks duplicated:\n%s", body)
+	}
+
+	config, err := os.ReadFile(filepath.Join(dir, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(config); !strings.Contains(got, "log_interactions = true") || !strings.Contains(got, `active_model = "custom-model"`) {
+		t.Fatalf("config.toml = %q", got)
+	}
+	ignore, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"/hooks.toml\n", "/config.toml\n"} {
+		if !strings.Contains(string(ignore), want) {
+			t.Fatalf(".gitignore missing %q:\n%s", want, ignore)
+		}
 	}
 }
 
-func TestSessionInfoNoOp(t *testing.T) {
+func TestGetAgentHooksRequiresWorkspace(t *testing.T) {
+	err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{})
+	if err == nil || !strings.Contains(err.Error(), "WorkspacePath is required") {
+		t.Fatalf("GetAgentHooks error = %v", err)
+	}
+}
+
+func TestUninstallHooksPreservesUserHooks(t *testing.T) {
+	workspace := t.TempDir()
+	p := &Plugin{}
+	if err := p.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: workspace}); err != nil {
+		t.Fatal(err)
+	}
+	installed, err := p.AreHooksInstalled(context.Background(), workspace)
+	if err != nil || !installed {
+		t.Fatalf("AreHooksInstalled = (%v, %v), want (true, nil)", installed, err)
+	}
+	path := filepath.Join(workspace, ".vibe", "hooks.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withUserHook := "[[hooks]]\nname = \"user-hook\"\ntype = \"post_agent\"\ncommand = \"user-command\"\n\n" + string(data)
+	if err := os.WriteFile(path, []byte(withUserHook), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.UninstallHooks(context.Background(), workspace); err != nil {
+		t.Fatal(err)
+	}
+	installed, err = p.AreHooksInstalled(context.Background(), workspace)
+	if err != nil || installed {
+		t.Fatalf("AreHooksInstalled after uninstall = (%v, %v), want (false, nil)", installed, err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "user-command") || strings.Contains(string(got), "ao hooks vibe") {
+		t.Fatalf("hooks after uninstall:\n%s", got)
+	}
+}
+
+func TestSetVibeTopLevelLoggingLeavesNestedKeyAlone(t *testing.T) {
+	existing := "[provider]\nlog_interactions = false\n"
+	got := setVibeTopLevelLogging(existing)
+	if !strings.HasPrefix(got, "log_interactions = true\n\n") || !strings.Contains(got, "[provider]\nlog_interactions = false") {
+		t.Fatalf("setVibeTopLevelLogging() = %q", got)
+	}
+}
+
+func TestSessionInfoReadsHookMetadata(t *testing.T) {
 	info, ok, err := (&Plugin{}).SessionInfo(context.Background(), ports.SessionRef{
 		Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "abcd1234"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ok {
-		t.Fatalf("ok=true with info %#v, want no-op false", info)
+	if !ok {
+		t.Fatal("ok=false, want hook metadata")
 	}
-	if !reflect.DeepEqual(info, ports.SessionInfo{}) {
-		t.Fatalf("info = %#v, want zero", info)
+	if info.AgentSessionID != "abcd1234" {
+		t.Fatalf("AgentSessionID = %q", info.AgentSessionID)
 	}
 }
 

--- a/backend/internal/adapters/agent/vibe/vibe_test.go
+++ b/backend/internal/adapters/agent/vibe/vibe_test.go
@@ -348,7 +348,7 @@ func TestGetRestoreCommandNoID(t *testing.T) {
 	}
 }
 
-func TestGetAgentHooksInstallsManagedHooksAndLogging(t *testing.T) {
+func TestGetAgentHooksInstallsManagedHooksWithoutChangingConfig(t *testing.T) {
 	workspace := t.TempDir()
 	dir := filepath.Join(workspace, ".vibe")
 	if err := os.MkdirAll(dir, 0o750); err != nil {
@@ -375,7 +375,20 @@ func TestGetAgentHooksInstallsManagedHooksAndLogging(t *testing.T) {
 		t.Fatal(err)
 	}
 	body := string(hooks)
-	for _, want := range []string{"user-command", "ao hooks vibe post-agent", "ao hooks vibe pre-tool", "ao hooks vibe post-tool"} {
+	for _, want := range []string{
+		"user-command",
+		`name = "ao-session-metadata"`,
+		`type = "post_agent"`,
+		`name = "ao-pre-tool"`,
+		`type = "pre_tool"`,
+		`name = "ao-post-tool"`,
+		`type = "post_tool"`,
+		`match = "*"`,
+		`command = "ao hooks vibe post-agent"`,
+		`command = "ao hooks vibe pre-tool"`,
+		`command = "ao hooks vibe post-tool"`,
+		"timeout = 30.0",
+	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("hooks.toml missing %q:\n%s", want, body)
 		}
@@ -383,22 +396,28 @@ func TestGetAgentHooksInstallsManagedHooksAndLogging(t *testing.T) {
 	if strings.Count(body, vibeHooksSentinelStart) != 1 || strings.Count(body, "ao hooks vibe post-agent") != 1 {
 		t.Fatalf("managed hooks duplicated:\n%s", body)
 	}
+	if strings.Count(body, "timeout = 30.0") != 3 || strings.Count(body, `match = "*"`) != 2 {
+		t.Fatalf("unexpected Vibe hook schema:\n%s", body)
+	}
 
 	config, err := os.ReadFile(filepath.Join(dir, "config.toml"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := string(config); !strings.Contains(got, "log_interactions = true") || !strings.Contains(got, `active_model = "custom-model"`) {
-		t.Fatalf("config.toml = %q", got)
+	if got := string(config); got != userConfig {
+		t.Fatalf("config.toml changed\nwant: %q\n got: %q", userConfig, got)
 	}
 	ignore, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"/hooks.toml\n", "/config.toml\n"} {
+	for _, want := range []string{"/hooks.toml\n"} {
 		if !strings.Contains(string(ignore), want) {
 			t.Fatalf(".gitignore missing %q:\n%s", want, ignore)
 		}
+	}
+	if strings.Contains(string(ignore), "/config.toml\n") {
+		t.Fatalf(".gitignore unexpectedly claims user config:\n%s", ignore)
 	}
 }
 
@@ -441,14 +460,6 @@ func TestUninstallHooksPreservesUserHooks(t *testing.T) {
 	}
 	if !strings.Contains(string(got), "user-command") || strings.Contains(string(got), "ao hooks vibe") {
 		t.Fatalf("hooks after uninstall:\n%s", got)
-	}
-}
-
-func TestSetVibeTopLevelLoggingLeavesNestedKeyAlone(t *testing.T) {
-	existing := "[provider]\nlog_interactions = false\n"
-	got := setVibeTopLevelLogging(existing)
-	if !strings.HasPrefix(got, "log_interactions = true\n\n") || !strings.Contains(got, "[provider]\nlog_interactions = false") {
-		t.Fatalf("setVibeTopLevelLogging() = %q", got)
 	}
 }
 

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -428,6 +428,32 @@ func TestHooks_RegisteredHarnessSessionStartReportsAgentSessionID(t *testing.T) 
 	}
 }
 
+func TestHooks_VibePostAgentReportsSessionIDAndIdle(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "ao-7")
+	cfg := setConfigEnv(t)
+	srv, capture := activityServer(t, http.StatusOK, `{"ok":true}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		In:           strings.NewReader(`{"session_id":"vibe-native-1","hook_event_name":"post_agent"}`),
+		ProcessAlive: func(int) bool { return true },
+	}, "hooks", "vibe", "post-agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capture.hits != 1 {
+		t.Fatalf("daemon calls = %d, want 1", capture.hits)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
+	}
+	want := setActivityAPIRequest{State: "idle", Event: "post-agent", AgentSessionID: "vibe-native-1"}
+	if req != want {
+		t.Fatalf("body = %+v, want %+v", req, want)
+	}
+}
+
 func TestHooks_AgySessionStartReportsConversationID(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-7")
 	cfg := setConfigEnv(t)


### PR DESCRIPTION
## Summary

Add native session restore support for Mistral Vibe.

AO already generated `vibe --resume <session-id>` when a native session ID was available, but the Vibe adapter did not capture that ID. This change installs workspace-local Vibe hooks and persists the `session_id` through AO's existing activity and lifecycle pipeline.

## Changes

- Install managed Vibe hooks in `.vibe/hooks.toml`:
  - `pre_tool`
  - `post_tool`
  - `post_agent`
- Capture Vibe's native `session_id` from hook payloads.
- Persist the native ID as `agentSessionId`.
- Enable `log_interactions` in the workspace-local Vibe configuration, as required by Vibe session resume.
- Register Vibe with the activity dispatch pipeline.
- Map Vibe activity conservatively:
  - `pre-tool` and `post-tool` → `active`
  - `post-agent` → `idle`
- Surface captured metadata through `SessionInfo`.
- Preserve existing user hooks and unrelated TOML configuration.
- Add hook installation, activity mapping, metadata capture, and restore tests.

## Restore flow

1. AO launches Vibe in the managed worktree.
2. A Vibe hook reports the native `session_id`.
3. AO stores it in the existing session metadata.
4. `ao session restore <id>` relaunches Vibe with:

   ```text
   vibe --resume <native-session-id>