### PR TITLE
fix(preview): don't auto-preview Markdown docs for brand-new sessions

### DIFF
--- a/backend/internal/preview/entry.go
+++ b/backend/internal/preview/entry.go
@@ -51,6 +51,20 @@ type Entry struct {
 // previewable file (.html/.htm/.md/.markdown) anywhere in the workspace, so a
 // freshly generated report or document shows up automatically.
 func DiscoverEntry(workspacePath string) (Entry, bool) {
+	if entry, ok := DiscoverWebEntrypoint(workspacePath); ok {
+		return entry, true
+	}
+	return mostRecentPreviewable(workspacePath)
+}
+
+// DiscoverWebEntrypoint returns a conventional static-frontend entrypoint
+// (index.html or its public/dist/build variants) if one exists in the
+// workspace. Unlike DiscoverEntry it does NOT fall back to the most-recent
+// previewable document, so it is the right choice when auto-previewing a
+// brand-new session the user has never explicitly previewed: surfacing an
+// arbitrary repo README or generated report as the initial browser target is
+// noise, not the intended preview. See issue #2859.
+func DiscoverWebEntrypoint(workspacePath string) (Entry, bool) {
 	if strings.TrimSpace(workspacePath) == "" {
 		return Entry{}, false
 	}
@@ -59,7 +73,7 @@ func DiscoverEntry(workspacePath string) (Entry, bool) {
 			return entry, true
 		}
 	}
-	return mostRecentPreviewable(workspacePath)
+	return Entry{}, false
 }
 
 // mostRecentPreviewable walks the workspace and returns the newest previewable

--- a/backend/internal/preview/poller.go
+++ b/backend/internal/preview/poller.go
@@ -118,7 +118,20 @@ func (p *Poller) Poll(ctx context.Context) error {
 			entry, ok = EntryAtPath(sess.Metadata.WorkspacePath, storedEntry)
 		}
 		if !ok {
-			entry, ok = DiscoverEntry(sess.Metadata.WorkspacePath)
+			// A session the user has never explicitly previewed
+			// (workspaceOwned == false) is only auto-previewed when it has a
+			// real static-frontend entrypoint (index.html variants). The
+			// mostRecentPreviewable .md/.html fallback is intentionally NOT
+			// applied here, otherwise every new session in a Markdown-rich repo
+			// auto-opens its browser to an arbitrary repo doc. Once a session
+			// has been explicitly previewed (workspaceOwned == true), full
+			// DiscoverEntry — including the document fallback — keeps the
+			// preview fresh. See issue #2859.
+			if workspaceOwned {
+				entry, ok = DiscoverEntry(sess.Metadata.WorkspacePath)
+			} else {
+				entry, ok = DiscoverWebEntrypoint(sess.Metadata.WorkspacePath)
+			}
 		}
 		if !ok {
 			if workspaceOwned {

--- a/backend/internal/preview/poller_test.go
+++ b/backend/internal/preview/poller_test.go
@@ -244,6 +244,44 @@ func TestPollerRewritesStoredOriginToActualDaemonPortWithoutChangingEntry(t *tes
 	})
 }
 
+func TestPollerDoesNotAutoPreviewMarkdownOnlyNewSession(t *testing.T) {
+	// A brand-new session (never explicitly previewed) whose workspace contains
+	// only Markdown documents — no index.html — must NOT be auto-previewed.
+	// Surfacing an arbitrary repo README as the initial browser target is noise.
+	// See issue #2859.
+	workspace := t.TempDir()
+	writeFile(t, filepath.Join(workspace, "README.md"), "# project")
+	writeFile(t, filepath.Join(workspace, "docs", "setup.md"), "# setup")
+	svc := &fakePreviewSessions{sessions: []domain.SessionRecord{workerSession("ao-1", workspace, "")}}
+	poller := NewPoller(svc, svc, "http://127.0.0.1:3001", PollerConfig{Logger: discardLogger()})
+
+	if err := poller.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(svc.sets) != 0 {
+		t.Fatalf("sets = %#v, want no auto-preview for a Markdown-only new session", svc.sets)
+	}
+}
+
+func TestPollerKeepsMarkdownPreviewFreshOnceExplicitlySet(t *testing.T) {
+	// Once a session has been explicitly previewed against a workspace Markdown
+	// file (workspaceOwned), the poller must still keep that preview fresh — the
+	// document-fallback restriction only applies to never-previewed sessions.
+	workspace := t.TempDir()
+	writeFile(t, filepath.Join(workspace, "docs", "report.md"), "# report")
+	relative := "docs/report.md"
+	svc := &fakePreviewSessions{sessions: []domain.SessionRecord{workerSession("ao-1", workspace, relative)}}
+	poller := NewPoller(svc, svc, "http://127.0.0.1:3001", PollerConfig{Logger: discardLogger()})
+
+	if err := poller.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	assertSets(t, svc.sets, previewSet{
+		id:  "ao-1",
+		url: mustFileURL(t, "http://127.0.0.1:3001", "ao-1", relative),
+	})
+}
+
 func TestPollerSkipsNonWorkerSessions(t *testing.T) {
 	workspace := t.TempDir()
 	writeFile(t, filepath.Join(workspace, "index.html"), "<main>hello</main>")


### PR DESCRIPTION
Fixes #2859

## Summary

A new worker session's in-app browser was opening non-empty — navigated to an arbitrary repo Markdown/HTML file (e.g. `README.md`) instead of starting empty. Reported by @prateek: new sessions showed URLs like `…/sessions/safesplit-10/preview/files/website-setUp-for-links.md`.

**Root cause:** the preview poller (`backend/internal/preview/poller.go`) auto-discovers a workspace file on its very first 250 ms scan and sets `preview_url` for every active worker session. `DiscoverEntry`'s `mostRecentPreviewable` fallback (`entry.go`) returns the most-recently-modified `.md`/`.html` file anywhere in the workspace, so nearly every new session in a Markdown-rich repo matched and got auto-previewed — directly contradicting the expectation that a new session's browser starts empty.

## The fix

Restrict the **never-previewed** (`workspaceOwned == false`) auto-discovery path to real static-frontend entrypoints (`index.html` and its `public/`/`dist/`/`build/` variants). Drop the `.md`/`.html` `mostRecentPreviewable` fallback for that path only.

- New `DiscoverWebEntrypoint(workspacePath)` (`entry.go`) — entrypoint candidates only, no document fallback.
- `DiscoverEntry` is refactored to delegate to `DiscoverWebEntrypoint` first, then `mostRecentPreviewable` — **behavior-preserving** for its other callers (the explicit `ao preview` HTTP path at `sessions.go:733`, and the `entry_test.go` suite).
- In the poller, the fallback after `EntryAtPath` fails now branches on `workspaceOwned`: already-previewed sessions keep full `DiscoverEntry` (so their preview stays fresh as files change, including `.md`), while never-previewed sessions use `DiscoverWebEntrypoint`.

**Behavior after the fix:**
| Session state | Workspace has | Browser on creation |
| --- | --- | --- |
| New (never previewed) | only `.md` docs | **empty** (fixed) |
| New (never previewed) | `dist/index.html` | auto-previews the frontend (preserved) |
| Explicitly previewed (`ao preview X`) | `X` changed | refreshed (unchanged) |
| Explicitly previewed, file deleted | other `.md` | full re-discovery (unchanged) |

This is the "surgical alternative" noted in the issue rather than a blanket opt-in: it fixes both reported cases (`.md` repo docs) while preserving the poller's primary purpose of auto-surfacing built static frontends.

## Test

Two new tests in `poller_test.go`:
- `TestPollerDoesNotAutoPreviewMarkdownOnlyNewSession` — a brand-new session with only `README.md` + `docs/setup.md` gets **zero** preview sets (the bug).
- `TestPollerKeepsMarkdownPreviewFreshOnceExplicitlySet` — a session explicitly previewed against `docs/report.md` still gets its preview normalized/maintained (the restriction only affects never-previewed sessions).

All 17 existing poller/entry tests pass unchanged (the entrypoint-selection tests use real `index.html`/`dist`/`public`, which `DiscoverWebEntrypoint` still finds).

```
cd backend
go build ./...
go vet ./...
go test ./internal/preview/...     # 19/19 pass
go test ./...                      # full backend suite green
```
