### PR TITLE
feat(ci): add dispatchable unsigned desktop build-artifacts workflow

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -4,8 +4,9 @@ name: Desktop build artifacts
 # Dispatchable unsigned desktop build for an external release conductor.
 # Builds the Electron app for all four platforms at a pinned ref with a
 # caller-supplied version, uploads each installer as a short-lived run
-# artifact, and emits a digests.json artifact mapping each platform to the
-# SHA256 of its uploaded file. Creates no release and references no secrets.
+# artifact, and emits a digests.json artifact (a flat JSON object mapping
+# each artifact filename to its sha256 hex string) that the conductor reads
+# to verify hashes before signing. Creates no release, references no secrets.
 # macOS output is intentionally UNSIGNED: forge.config.ts only activates
 # osxSign/osxNotarize when the Apple env vars are present, and this workflow
 # never sets them (no macos-signing-setup). The conductor signs downstream.
@@ -31,14 +32,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # `artifact` is the pinned upload-artifact name the downstream release
+          # conductor consumes; the contained filenames keep the existing stable
+          # alias names so the cask/updater/landing stay compatible. Do not
+          # rename either without updating the conductor.
           - os: macos-latest
             platform: darwin-arm64
+            artifact: mac-arm64
           - os: macos-15-intel
             platform: darwin-x64
+            artifact: mac-x64
           - os: windows-latest
             platform: win32-x64
+            artifact: win
           - os: ubuntu-latest
             platform: linux-x64
+            artifact: linux
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -100,13 +109,15 @@ jobs:
           if [ -z "$src" ]; then echo "no build output found for $PLATFORM" >&2; exit 1; fi
           cp "$src" "dist-artifact/$name"
           hash="$(openssl dgst -sha256 "dist-artifact/$name" | awk '{print $NF}')"
-          jq -n --arg p "$PLATFORM" --arg f "$name" --arg h "$hash" \
-            '{($p): {file: $f, sha256: $h}}' > "dist-artifact/$PLATFORM.digest.json"
+          # Pinned digest contract: a flat filename -> sha256 hex map, merged
+          # into one digests.json by the digests job below.
+          jq -n --arg f "$name" --arg h "$hash" \
+            '{($f): $h}' > "dist-artifact/$PLATFORM.digest.json"
           echo "$PLATFORM: $name sha256=$hash" >> "$GITHUB_STEP_SUMMARY"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: agent-orchestrator-${{ matrix.platform }}
+          name: ${{ matrix.artifact }}
           path: frontend/dist-artifact/agent-orchestrator-${{ matrix.platform }}.*
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -11,12 +11,6 @@ name: Desktop build artifacts
 # never sets them (no macos-signing-setup). The conductor signs downstream.
 
 on:
-  # TEMPORARY: branch-scoped push trigger so GitHub registers this new
-  # workflow for dispatch (dispatch-only workflows are not registered until
-  # they reach the default branch). Removed in the next commit.
-  push:
-    branches:
-      - ao/agent-orchestrator-105/build-artifacts
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -11,6 +11,12 @@ name: Desktop build artifacts
 # never sets them (no macos-signing-setup). The conductor signs downstream.
 
 on:
+  # TEMPORARY: branch-scoped push trigger so GitHub registers this new
+  # workflow for dispatch (dispatch-only workflows are not registered until
+  # they reach the default branch). Removed in the next commit.
+  push:
+    branches:
+      - ao/agent-orchestrator-105/build-artifacts
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,141 @@
+# .github/workflows/build-artifacts.yml
+name: Desktop build artifacts
+
+# Dispatchable unsigned desktop build for an external release conductor.
+# Builds the Electron app for all four platforms at a pinned ref with a
+# caller-supplied version, uploads each installer as a short-lived run
+# artifact, and emits a digests.json artifact mapping each platform to the
+# SHA256 of its uploaded file. Creates no release and references no secrets.
+# macOS output is intentionally UNSIGNED: forge.config.ts only activates
+# osxSign/osxNotarize when the Apple env vars are present, and this workflow
+# never sets them (no macos-signing-setup). The conductor signs downstream.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref or SHA to build"
+        type: string
+        required: true
+      version:
+        description: "Version string to stamp into the app"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            platform: darwin-arm64
+          - os: macos-15-intel
+            platform: darwin-x64
+          - os: windows-latest
+            platform: win32-x64
+          - os: ubuntu-latest
+            platform: linux-x64
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      # The daemon is compiled by build-daemon.mjs during premake, so the Go
+      # toolchain must be present and pinned on every runner.
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - run: npm ci
+      # Same stamping mechanism as frontend-nightly.yml: rewrite package.json
+      # to the caller's version, dropping any +build metadata.
+      - name: Stamp version
+        shell: bash
+        env:
+          BUILD_VERSION: ${{ inputs.version }}
+        run: |
+          node -e "const v=process.env.BUILD_VERSION.split('+')[0]; const fs=require('fs'); const p=require('./package.json'); p.version=v; fs.writeFileSync('./package.json', JSON.stringify(p,null,'\t')+'\n');"
+      - name: Build (unsigned, no publish)
+        shell: bash
+        run: npm run make
+      - name: Collect artifact and compute digest
+        shell: bash
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          mkdir -p dist-artifact
+          case "$PLATFORM" in
+            darwin-*)
+              # maker-zip output: out/make/zip/darwin/<arch>/<name>-<version>.zip
+              src="$(find out/make/zip/darwin -name '*.zip' | head -n1)"
+              name="agent-orchestrator-$PLATFORM.zip"
+              ;;
+            win32-x64)
+              # NSIS (electron-builder) output: out/make/<productName> Setup <version>.exe
+              src="$(find out/make -maxdepth 1 -name '*Setup*.exe' | head -n1)"
+              name="agent-orchestrator-win32-x64.exe"
+              ;;
+            linux-x64)
+              # AppImage (electron-builder) output: out/make/<productName>-<version>.AppImage
+              src="$(find out/make -maxdepth 1 -name '*.AppImage' | head -n1)"
+              name="agent-orchestrator-linux-x64.AppImage"
+              ;;
+            *)
+              echo "unknown platform: $PLATFORM" >&2
+              exit 1
+              ;;
+          esac
+          if [ -z "$src" ]; then echo "no build output found for $PLATFORM" >&2; exit 1; fi
+          cp "$src" "dist-artifact/$name"
+          hash="$(openssl dgst -sha256 "dist-artifact/$name" | awk '{print $NF}')"
+          jq -n --arg p "$PLATFORM" --arg f "$name" --arg h "$hash" \
+            '{($p): {file: $f, sha256: $h}}' > "dist-artifact/$PLATFORM.digest.json"
+          echo "$PLATFORM: $name sha256=$hash" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-orchestrator-${{ matrix.platform }}
+          path: frontend/dist-artifact/agent-orchestrator-${{ matrix.platform }}.*
+          retention-days: 1
+          if-no-files-found: error
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.platform }}
+          path: frontend/dist-artifact/${{ matrix.platform }}.digest.json
+          retention-days: 1
+          if-no-files-found: error
+
+  # Merge the per-platform digest fragments into one digests.json artifact so
+  # a downstream consumer reads every expected hash from a single file.
+  digests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: digest-*
+          merge-multiple: true
+      - name: Merge digests
+        shell: bash
+        run: |
+          jq -s 'add' ./*.digest.json > digests.json
+          { echo '### Artifact digests'; echo '```json'; cat digests.json; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests
+          path: digests.json
+          retention-days: 1
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Adds `.github/workflows/build-artifacts.yml`, a `workflow_dispatch`-only workflow that lets an external release conductor drive a desktop build and consume the outputs as run artifacts:

- Inputs: `ref` (git ref/SHA to build, checked out via `actions/checkout` `ref:`) and `version` (stamped into `frontend/package.json` using the exact nightly stamping mechanism from `frontend-nightly.yml`).
- Platform matrix matching the existing release workflows: mac arm64 (`macos-latest`), mac x64 (`macos-15-intel`), windows (`windows-latest`), linux (`ubuntu-latest`).
- macOS builds are intentionally UNSIGNED: the workflow never invokes `macos-signing-setup` and sets no Apple env vars, and `forge.config.ts` only activates `osxSign`/`osxNotarize` when those vars are present. The conductor signs downstream.
- Pinned artifact contract (per the release conductor): upload-artifact names `mac-arm64`, `mac-x64`, `win`, `linux`, each containing the existing stable alias filename (`agent-orchestrator-darwin-arm64.zip`, `agent-orchestrator-darwin-x64.zip`, `agent-orchestrator-win32-x64.exe`, `agent-orchestrator-linux-x64.AppImage`), uploaded with `retention-days: 1`.
- A `digests` artifact contains `digests.json`, a flat JSON object mapping each of those four filenames to its sha256 hex string; the conductor reads it to verify hashes before signing. Digests are also echoed to the step summary.
- Creates no release and references no secrets; `permissions: contents: read` only.

Strictly additive: no existing workflow, signing, or release path is touched.

## Verification

- `actionlint` clean, `prettier --check` clean.
- Real `workflow_dispatch` verification run of the final contract (all four platforms green, artifacts `mac-arm64`/`mac-x64`/`win`/`linux` uploaded, flat `digests.json` emitted): https://github.com/AgentWrapper/agent-orchestrator/actions/runs/29832852780 (earlier pre-contract run: https://github.com/AgentWrapper/agent-orchestrator/actions/runs/29775090632)
- Note on branch history: GitHub does not register a dispatch-only workflow until it reaches the default branch, so two temp commits add and then remove a branch-scoped push trigger purely to register the workflow for the verification dispatch. The final tree is dispatch-only; happy to squash-merge.

Closes #2862

🤖 Generated with [Claude Code](https://claude.com/claude-code)