### PR TITLE
fix(feature-builds): strip doubled title prefix, add GitHub fetch timeout

### DIFF
--- a/frontend/src/main/feature-builds.test.ts
+++ b/frontend/src/main/feature-builds.test.ts
@@ -189,6 +189,40 @@ describe("listFeatureBuilds", () => {
 		expect(result[0].pr).toBe(2270);
 	});
 
+	it("strips the workflow's [feature] PR #N: title prefix so UI labels do not double-prefix", async () => {
+		const publishedAt = new Date(Date.now() - DAY_MS).toISOString();
+		stubFetch(
+			[
+				makeRelease({
+					tag_name: "v0.2.0-pr2270.202607061200",
+					name: "[feature] PR #2270: feat: per-PR installable builds",
+					published_at: publishedAt,
+				}),
+			],
+			{ 2270: { state: "open" } },
+		);
+		const result = await listFeatureBuilds();
+		expect(result).toHaveLength(1);
+		expect(result[0].title).toBe("feat: per-PR installable builds");
+	});
+
+	it("keeps a release title without the authored prefix unchanged", async () => {
+		const publishedAt = new Date(Date.now() - DAY_MS).toISOString();
+		stubFetch(
+			[
+				makeRelease({
+					tag_name: "v0.2.0-pr2270.202607061200",
+					name: "Feature build pr2270",
+					published_at: publishedAt,
+				}),
+			],
+			{ 2270: { state: "open" } },
+		);
+		const result = await listFeatureBuilds();
+		expect(result).toHaveLength(1);
+		expect(result[0].title).toBe("Feature build pr2270");
+	});
+
 	it("returns a FeatureBuild with the expected shape fields", async () => {
 		const publishedAt = new Date(Date.now() - DAY_MS).toISOString();
 		stubFetch(

--- a/frontend/src/main/feature-builds.ts
+++ b/frontend/src/main/feature-builds.ts
@@ -35,6 +35,13 @@ function resolveRepo(): { owner: string; repo: string } {
 // Marker embedded in feature-build release bodies by the CI workflow.
 const FEATURE_BUILD_MARKER = "<!-- ao-feature-build:";
 
+// The CI workflow titles feature releases "[feature] PR #<N>: <PR title>".
+// Strip that authored prefix so UI copy that composes its own "PR #<N>: <title>"
+// label does not render it twice.
+function stripReleaseTitlePrefix(name: string): string {
+	return name.replace(/^\[feature\]\s*PR #\d+:\s*/i, "");
+}
+
 // Feature builds older than this are dropped from the list, matching the
 // cleanup workflow's 7-day expiry sweep so the app and CI agree on liveness.
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -100,6 +107,10 @@ function parseMarker(body: string): MarkerPayload | null {
 	}
 }
 
+// Bounds every GitHub API call so a wedged connection cannot hang the
+// updates flow indefinitely for a user pinned to a feature build.
+const FETCH_TIMEOUT_MS = 10_000;
+
 async function fetchJson<T>(url: string): Promise<T> {
 	const res = await fetch(url, {
 		headers: {
@@ -107,6 +118,7 @@ async function fetchJson<T>(url: string): Promise<T> {
 			"X-GitHub-Api-Version": "2022-11-28",
 			"User-Agent": `ao-desktop/${app.getVersion()}`,
 		},
+		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 	});
 	if (!res.ok) throw new Error(`GitHub API ${res.status}: ${url}`);
 	return res.json() as Promise<T>;
@@ -157,7 +169,7 @@ async function collectFeatureBuilds(): Promise<FeatureBuild[]> {
 		if (!marker) continue;
 		candidates.push({
 			pr: marker.pr,
-			title: rel.name,
+			title: stripReleaseTitlePrefix(rel.name),
 			base: marker.base,
 			sha: marker.sha,
 			slug: marker.slug,


### PR DESCRIPTION
Two small fixes in the feature-releases code from #2459, both surfaced by an automated review pipeline run (the pipelines feature proposed in #2863 reviewing its own repo):

1. **Doubled title prefix.** The workflow titles releases `[feature] PR #<N>: <title>` and `listFeatureBuilds` passed `rel.name` through raw, so UI labels composing their own `PR #<N>: <title>` rendered the prefix twice (e.g. the pin-confirmation dialog). Now stripped at the parse layer so every consumer gets the bare PR title; titles without the authored prefix pass through unchanged.
2. **No fetch timeout.** `fetchJson` had no deadline, so a wedged connection could hang the updates flow indefinitely for a user pinned to a feature build. Every GitHub API call is now bounded with `AbortSignal.timeout(10s)`.

Tests: two new cases for the title stripping (authored prefix stripped, plain titles untouched); full feature-builds suite 27/27, tsc and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)