### PR TITLE
fix(preview): send CSP on preview responses to close RCE (#2771)

### DIFF
--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -183,6 +183,19 @@ func (c *SessionsController) preview(w http.ResponseWriter, r *http.Request) {
 	envelope.WriteJSON(w, http.StatusOK, res)
 }
 
+// previewMarkdownCSP hardens rendered-Markdown previews: no scripts and no
+// network access (a rendered document needs neither), while still allowing the
+// inline stylesheet and images/badges so the document renders normally. This
+// severs the "previewed file runs a script that calls the loopback API" chain
+// (issue #2771) for the Markdown path at zero cost to document rendering.
+const previewMarkdownCSP = "default-src 'none'; img-src * data:; style-src 'unsafe-inline'; font-src * data:; connect-src 'none'; base-uri 'none'; form-action 'none'"
+
+// previewFileCSP applies to raw workspace files served verbatim (including
+// .html, which cannot be sanitized). Scripts/styles/images still load so a
+// built static app renders, but connect-src 'none' blocks fetch/XHR/WebSocket
+// so page script cannot reach the loopback control API (issue #2771).
+const previewFileCSP = "connect-src 'none'; form-action 'none'"
+
 func (c *SessionsController) previewFile(w http.ResponseWriter, r *http.Request) {
 	if c.Svc == nil {
 		apispec.NotImplemented(w, r, "GET", "/api/v1/sessions/{sessionId}/preview/files/*")
@@ -270,6 +283,7 @@ func (c *SessionsController) serveWorkspacePreviewFile(w http.ResponseWriter, r 
 	}
 	defer func() { _ = file.Close() }()
 	if !previewutil.IsMarkdownPath(clean) {
+		w.Header().Set("Content-Security-Policy", previewFileCSP)
 		http.ServeContent(w, r, info.Name(), info.ModTime(), file)
 		return
 	}
@@ -284,9 +298,10 @@ func (c *SessionsController) serveWorkspacePreviewFile(w http.ResponseWriter, r 
 		envelope.WriteError(w, r, err)
 		return
 	}
+	w.Header().Set("Content-Security-Policy", previewMarkdownCSP)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if r.Method != http.MethodHead {
-		_, _ = w.Write(rendered) //nolint:gosec // G705: preview content is workspace-local and agent-trusted
+		_, _ = w.Write(rendered) //nolint:gosec // G705: raw-HTML passthrough is contained by the restrictive CSP set above (default-src 'none'; connect-src 'none'), so previewed content cannot reach the loopback API — see issue #2771
 	}
 }
 

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -464,6 +464,42 @@ func TestSessionsAPI_PreviewRejectsSessionIDTooLongForHostname(t *testing.T) {
 	assertErrorCode(t, body, status, http.StatusUnprocessableEntity, "PREVIEW_SESSION_ID_UNSUPPORTED")
 }
 
+func TestSessionsAPI_PreviewSendsCSP(t *testing.T) {
+	svc := newFakeSessionService()
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "README.md"),
+		[]byte("# Hi\n\n<script>fetch('/api/v1/projects')</script>"), 0o644); err != nil {
+		t.Fatalf("write md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "page.html"),
+		[]byte("<h1>hi</h1>"), 0o644); err != nil {
+		t.Fatalf("write html: %v", err)
+	}
+	s := svc.sessions["ao-1"]
+	s.Metadata = domain.SessionMetadata{WorkspacePath: workspace}
+	svc.sessions["ao-1"] = s
+	srv := newSessionTestServer(t, svc)
+
+	// Markdown path: strict CSP (no scripts, no network).
+	_, status, headers := doRequest(t, srv, "GET", "/api/v1/sessions/ao-1/preview/files/README.md", "")
+	if status != http.StatusOK {
+		t.Fatalf("md preview = %d, want 200", status)
+	}
+	if csp := headers.Get("Content-Security-Policy"); !strings.Contains(csp, "default-src 'none'") ||
+		!strings.Contains(csp, "connect-src 'none'") {
+		t.Fatalf("markdown CSP = %q, want default-src 'none' + connect-src 'none'", csp)
+	}
+
+	// Raw file path: connect-src 'none' cuts the API-reach vector.
+	_, status, headers = doRequest(t, srv, "GET", "/api/v1/sessions/ao-1/preview/files/page.html", "")
+	if status != http.StatusOK {
+		t.Fatalf("html preview = %d, want 200", status)
+	}
+	if csp := headers.Get("Content-Security-Policy"); !strings.Contains(csp, "connect-src 'none'") {
+		t.Fatalf("html CSP = %q, want connect-src 'none'", csp)
+	}
+}
+
 func TestSessionsAPI_SetPreviewExplicitURLPersists(t *testing.T) {
 	svc := newFakeSessionService()
 	srv := newSessionTestServer(t, svc)


### PR DESCRIPTION
<!-- Suggested title: fix(preview): set a Content-Security-Policy on preview responses to close the previewed-file → loopback-API RCE -->

## What

The browser-panel preview serves workspace Markdown and HTML as `text/html` with **no Content-Security-Policy**. On the legacy `/api/v1/sessions/{id}/preview/files/` route the preview document is same-origin with the daemon's control API (`http://127.0.0.1:<port>`), so a `<script>` in a previewed file can call that API directly — turning "open the Browser tab on a repository" into arbitrary command execution.

This PR sends a restrictive CSP on every preview response, differentiated by content type so existing functionality is preserved. The header is set in the single shared serving path (`serveWorkspacePreviewFile`), so it covers **both** the legacy route and the newer isolated `*.localhost` preview origin.

## Why

Fixes #2771.

### The vulnerability

Nothing more than a file landing in the workspace — for example a freshly cloned repository opened for inspection — is required to reach the daemon's privileged API. The chain:

| Step | Behavior | Location |
|---|---|---|
| 1 | The Markdown renderer passes raw HTML through unsanitized (`WithUnsafe()`) | `backend/internal/preview/markdown.go` |
| 2 | The preview is served as `text/html` with no CSP | `backend/internal/httpd/controllers/sessions.go` (`serveWorkspacePreviewFile`) |
| 3 | The newest `.md` in the workspace is auto-selected, so opening the preview is enough to load attacker-controlled content | `backend/internal/preview/entry.go` (`DiscoverEntry`) |
| 4 | The loopback listener is unauthenticated, so the config write is reachable same-origin over the legacy route | `backend/internal/httpd/controllers/projects.go` (`PUT /projects/{id}/config`) |
| 5 | `postCreate` reaches `sh -c` with `cmd.Dir` set to the workspace | `backend/internal/session_manager/manager.go` (`runPostCreate`) |

Concretely, script in a previewed file can `fetch()` `PUT /api/v1/projects/{id}/config` to set `postCreate`, which the session manager later executes via `sh -c`.

The preview loads through a top-level navigation (`frontend/src/main/browser-view-host.ts`, `webContents.loadURL(...)`), so an HTTP-response CSP header authoritatively governs the document and the browser blocks the `fetch`.

### Root cause

The comment in `markdown.go` — *"preview content is workspace-local and agent-trusted"* — conflates **being in the workspace** with **being authorized to execute**. Untrusted workspace content is served in a context that can reach a privileged API, with nothing instructing the browser to contain it.

## How

### The fix

Set a CSP header in `serveWorkspacePreviewFile`, the one function through which both the legacy `/preview/files/` route and the isolated preview origin serve content, with a policy chosen per content type. The load-bearing directive is **`connect-src 'none'`**: the exploit requires a scripted `fetch`/XHR to the API, and because the config endpoint is `PUT`+JSON a `<form>` cannot forge the request either.

Two policies are defined:

```go
// Rendered Markdown: a document needs neither scripts nor network, so lock both
// down while still allowing the inline stylesheet and images/badges.
const previewMarkdownCSP = "default-src 'none'; img-src * data:; style-src 'unsafe-inline'; font-src * data:; connect-src 'none'; base-uri 'none'; form-action 'none'"

// Raw files served verbatim (incl. .html, which cannot be sanitized): scripts/
// styles/images still load so a built static app renders, but connect-src 'none'
// blocks fetch/XHR/WebSocket so page script cannot reach the loopback API.
const previewFileCSP = "connect-src 'none'; form-action 'none'"
```

They are applied in the two branches of `serveWorkspacePreviewFile`:

```go
// raw / built-app files (the .html path that cannot be sanitized)
if !previewutil.IsMarkdownPath(clean) {
    w.Header().Set("Content-Security-Policy", previewFileCSP)
    http.ServeContent(w, r, info.Name(), info.ModTime(), file)
    return
}
// ... rendered Markdown ...
w.Header().Set("Content-Security-Policy", previewMarkdownCSP)
w.Header().Set("Content-Type", "text/html; charset=utf-8")
```

The pre-existing `//nolint:gosec` on the Markdown write is retained, but its justification is updated to cite the CSP rather than the "agent-trusted" assumption that no longer holds.

### Why CSP rather than the alternatives

- **Sanitizing the Markdown** (dropping `WithUnsafe()`) helps only the Markdown path and does nothing for raw `.html`, which is served verbatim. CSP covers both.
- **Validating `postCreate`** is not viable: running arbitrary shell is that field's intended behavior, so there is no "malicious value" to reject.

### Design notes and trade-offs

- **Two policies, not one.** The raw-file policy is intentionally weaker (no `default-src`; scripts still run) so a built static app renders. Containment there rests on `connect-src 'none'` + `form-action 'none'`: untrusted HTML may execute in-page but cannot reach the loopback API.
- **`img-src *`** (rather than `'self' data:`) preserves README badges and remote images. The trade-off is that a previewed file can still issue image `GET`s, an IP-leak channel — not the reported RCE, and tightenable later.
- **The isolated origin also receives `connect-src 'none'`.** Because the header lives in the shared serving path, it applies uniformly to the `*.localhost` origin as well. This is a deliberate defense-in-depth choice; if maintainers would prefer to let a built app fetch its own data on its isolated origin, the raw-file policy can be relaxed on that path specifically.

### Relationship to recent preview work

- **Isolated `*.localhost` preview origins (#2818)** already move preview off the API's origin. This change is complementary: the **legacy `/preview/files/` route is still same-origin** with the API and still needs the header, and on the isolated origin the CSP is defense-in-depth. Setting it in the shared serving path covers both with one change.
- The **workspace-confined `OpenWorkspaceFile` (OpenRoot)** path already blocks the in-workspace symlink escape, so that concern is **not** part of this PR.

### Compatibility

| Use case | Effect |
|---|---|
| Markdown docs / READMEs (incl. remote images & badges) | Unchanged (`img-src * data:`) |
| Rendered-document styling | Unchanged (`style-src 'unsafe-inline'`) |
| Built static app preview — rendering | Unchanged (scripts/styles/images still load) |
| Built app that fetches **its own data at runtime** in preview | Blocked by `connect-src 'none'` — the one behavioral change |
| Agent spawn / `postCreate` / dev-server preview | Unchanged |

### Follow-up (out of scope)

- A **repo-trust model** for the paths that inherently run repository code (agent spawn, `postCreate`) — the remaining defense-in-depth idea, separate from this fix.

### Related work

- #2818 — isolated `*.localhost` preview origins (this PR is complementary).
- #2581 — preview file / absolute-path confinement.
- #2449 — renderer-side `marked + DOMPurify` (separate from this daemon-side path).
- #307 / #1263 — original CSRF/origin hardening and loopback default.

## Testing

From `backend/`:

- `go build ./...` — compiles.
- `go test ./internal/httpd/controllers/` — passes, including the new `TestSessionsAPI_PreviewSendsCSP`, which asserts the CSP header on both the Markdown and raw-file preview responses (and fails without this change).
- `go vet ./internal/httpd/controllers/` — clean.
- `golangci-lint run` on the changed package — 0 issues.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
