### PR TITLE
fix: detach desktop app launched by ao start

### DIFF
--- a/backend/internal/cli/process.go
+++ b/backend/internal/cli/process.go
@@ -6,24 +6,53 @@ import (
 )
 
 type processStartConfig struct {
-	Path   string
-	Args   []string
-	Env    []string
-	Stdout *os.File
-	Stderr *os.File
+	Path         string
+	Args         []string
+	Env          []string
+	Stdin        *os.File
+	Stdout       *os.File
+	Stderr       *os.File
+	Detach       bool
+	DetachStdio  bool
+	ReleaseAfter bool
 }
 
 func startProcess(cfg processStartConfig) error {
 	cmd := exec.Command(cfg.Path, cfg.Args...)
 	cmd.Env = cfg.Env
+	cmd.Stdin = cfg.Stdin
 	cmd.Stdout = cfg.Stdout
 	cmd.Stderr = cfg.Stderr
-	// Detach the daemon into its own session/process group so a Ctrl-C in the
-	// terminal where `ao start` is waiting for readiness doesn't also SIGINT the
-	// freshly spawned daemon (it would otherwise share the launcher's group).
-	cmd.SysProcAttr = detachSysProcAttr()
+
+	var devNull *os.File
+	if cfg.DetachStdio && (cmd.Stdin == nil || cmd.Stdout == nil || cmd.Stderr == nil) {
+		var err error
+		devNull, err = os.OpenFile(os.DevNull, os.O_RDWR, 0)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = devNull.Close() }()
+		if cmd.Stdin == nil {
+			cmd.Stdin = devNull
+		}
+		if cmd.Stdout == nil {
+			cmd.Stdout = devNull
+		}
+		if cmd.Stderr == nil {
+			cmd.Stderr = devNull
+		}
+	}
+
+	if cfg.Detach {
+		// Detach long-running children into their own session/process group so
+		// they do not receive terminal signals sent to the launcher.
+		cmd.SysProcAttr = detachSysProcAttr()
+	}
 	if err := cmd.Start(); err != nil {
 		return err
+	}
+	if cfg.ReleaseAfter {
+		return cmd.Process.Release()
 	}
 	go func() { _ = cmd.Wait() }()
 	return nil

--- a/backend/internal/cli/process_unix_test.go
+++ b/backend/internal/cli/process_unix_test.go
@@ -1,0 +1,105 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	detachedProcessHelperEnv = "AO_TEST_DETACHED_PROCESS_HELPER"
+	detachedProcessScriptEnv = "AO_TEST_DETACHED_PROCESS_SCRIPT"
+	detachedProcessPIDEnv    = "AO_TEST_DETACHED_PROCESS_PID"
+)
+
+func TestStartProcessDetachedReleasedChildSurvivesLauncherExit(t *testing.T) {
+	if os.Getenv(detachedProcessHelperEnv) == "1" {
+		runDetachedProcessHelper()
+		return
+	}
+
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "child.pid")
+	scriptPath := filepath.Join(dir, "child.sh")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$$\" > \"$1\"\nsleep 30\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestStartProcessDetachedReleasedChildSurvivesLauncherExit$")
+	cmd.Env = append(os.Environ(),
+		detachedProcessHelperEnv+"=1",
+		detachedProcessScriptEnv+"="+scriptPath,
+		detachedProcessPIDEnv+"="+pidFile,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("detached process helper failed: %v\n%s", err, out)
+	}
+
+	pid := waitForPIDFile(t, pidFile)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("detached child is not alive after launcher exit: %v", err)
+	}
+
+	parentSID, err := unix.Getsid(os.Getpid())
+	if err != nil {
+		t.Fatalf("get parent sid: %v", err)
+	}
+	childSID, err := unix.Getsid(pid)
+	if err != nil {
+		t.Fatalf("get child sid: %v", err)
+	}
+	if childSID == parentSID {
+		t.Fatalf("detached child stayed in launcher session sid=%d", childSID)
+	}
+}
+
+func runDetachedProcessHelper() {
+	scriptPath := os.Getenv(detachedProcessScriptEnv)
+	pidFile := os.Getenv(detachedProcessPIDEnv)
+	if scriptPath == "" || pidFile == "" {
+		fmt.Fprintln(os.Stderr, "missing detached process helper env")
+		os.Exit(2)
+	}
+	if err := startProcess(processStartConfig{
+		Path:         "/bin/sh",
+		Args:         []string{scriptPath, pidFile},
+		Detach:       true,
+		DetachStdio:  true,
+		ReleaseAfter: true,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "start detached process: %v\n", err)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+func waitForPIDFile(t *testing.T, pidFile string) int {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidFile)
+		if err == nil {
+			pid, convErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if convErr != nil {
+				t.Fatalf("parse child pid: %v", convErr)
+			}
+			return pid
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for child pid file %s", pidFile)
+	return 0
+}

--- a/backend/internal/cli/start.go
+++ b/backend/internal/cli/start.go
@@ -563,15 +563,19 @@ func (c *commandContext) openApp(ctx context.Context, appPath string) (bool, err
 		return true, nil
 	case "windows", "linux":
 		// No `open`-style launcher on these platforms; exec the bundle directly,
-		// detached, so `ao start` does not block on the app. StartProcess uses
-		// cmd.Start() + a detached SysProcAttr (see process.go).
+		// detached, so `ao start` does not block on or supervise the app. The
+		// child gets its own session/process group, detached stdio, and is
+		// released so it survives after the CLI exits.
 		//
 		// ponytail: on some Linux hosts the AppImage may need --no-sandbox; not
 		// added here without evidence the bundled Electron requires it. If sandbox
 		// launch failures appear, append "--no-sandbox" as the follow-up.
 		err := c.deps.StartProcess(processStartConfig{
-			Path: appPath,
-			Args: []string{"--installed-via=npm-bootstrap"},
+			Path:         appPath,
+			Args:         []string{"--installed-via=npm-bootstrap"},
+			Detach:       true,
+			DetachStdio:  true,
+			ReleaseAfter: true,
 		})
 		if err != nil {
 			// Treat a launch failure as "not opened" so the caller prints the

--- a/backend/internal/cli/start_test.go
+++ b/backend/internal/cli/start_test.go
@@ -283,6 +283,15 @@ func TestOpenApp_DetachedSpawnOnWinLinux(t *testing.T) {
 	if !reflect.DeepEqual(gotCfg.Args, wantArgs) {
 		t.Fatalf("spawn args = %v, want %v", gotCfg.Args, wantArgs)
 	}
+	if !gotCfg.Detach {
+		t.Fatal("spawn should request a separate session/process group")
+	}
+	if !gotCfg.DetachStdio {
+		t.Fatal("spawn should detach stdio from the CLI")
+	}
+	if !gotCfg.ReleaseAfter {
+		t.Fatal("spawn should release the app process instead of waiting on it")
+	}
 }
 
 func TestOpenApp_SpawnFailureFallsBackToManual(t *testing.T) {


### PR DESCRIPTION
## Summary
- detach directly launched desktop app processes into their own session/process group
- connect detached stdio to the null device and release the process after start
- add Unix regression coverage proving the child survives launcher exit

Fixes #2778

## Tests
- `cd backend && env -u AO_SESSION_ID -u AO_PROJECT_ID go test ./internal/cli -run 'Test(OpenApp_DetachedSpawnOnWinLinux|OpenApp_ArgConstruction|OpenApp_SpawnFailureFallsBackToManual|StartProcessDetachedReleasedChildSurvivesLauncherExit)$'`