### PR TITLE
fix: wait for conpty host process exit

### DIFF
--- a/backend/internal/adapters/runtime/conpty/spawn_process.go
+++ b/backend/internal/adapters/runtime/conpty/spawn_process.go
@@ -1,0 +1,114 @@
+package conpty
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+// maxCapturedStderr bounds how much pty-host stderr we retain for diagnostics.
+const maxCapturedStderr = 8192
+
+// boundedBuffer is a thread-safe io.Writer that retains up to max bytes of what
+// is written and discards the rest. It always consumes its input, so it is a
+// safe stderr sink for the detached pty-host while still keeping a capped copy
+// of startup diagnostics.
+type boundedBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+	max int
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if room := b.max - len(b.buf); room > 0 {
+		if len(p) < room {
+			room = len(p)
+		}
+		b.buf = append(b.buf, p[:room]...)
+	}
+	return len(p), nil
+}
+
+func (b *boundedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.buf)
+}
+
+type managedHostProcess struct {
+	cmd    *exec.Cmd
+	stdout *os.File
+
+	closeStdoutOnce sync.Once
+	exitC           chan error
+}
+
+func startManagedHostProcess(cmd *exec.Cmd, stderr *boundedBuffer) (*managedHostProcess, error) {
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		_ = stdoutR.Close()
+		_ = stdoutW.Close()
+		return nil, err
+	}
+
+	cmd.Stdout = stdoutW
+	cmd.Stderr = stderrW
+
+	if err := cmd.Start(); err != nil {
+		_ = stdoutR.Close()
+		_ = stdoutW.Close()
+		_ = stderrR.Close()
+		_ = stderrW.Close()
+		return nil, err
+	}
+
+	// The child inherited the pipe writers. Close the parent's copies so the
+	// readers observe EOF when the child exits.
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
+
+	proc := &managedHostProcess{
+		cmd:    cmd,
+		stdout: stdoutR,
+		exitC:  make(chan error, 1),
+	}
+
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		defer func() { _ = stderrR.Close() }()
+		_, _ = io.Copy(stderr, stderrR)
+	}()
+
+	go func() {
+		err := cmd.Wait()
+		proc.closeStdout()
+		_ = stderrR.Close()
+		<-stderrDone
+		proc.exitC <- err
+		close(proc.exitC)
+	}()
+
+	return proc, nil
+}
+
+func (p *managedHostProcess) closeStdout() {
+	p.closeStdoutOnce.Do(func() {
+		_ = p.stdout.Close()
+	})
+}
+
+func (p *managedHostProcess) killAndWait() error {
+	if p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+	}
+	p.closeStdout()
+	return <-p.exitC
+}

--- a/backend/internal/adapters/runtime/conpty/spawn_test.go
+++ b/backend/internal/adapters/runtime/conpty/spawn_test.go
@@ -1,9 +1,95 @@
 package conpty
 
 import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 )
+
+func TestManagedHostProcessWaitsAndReleasesPipesAfterExit(t *testing.T) {
+	runManagedProcessHelperIfRequested()
+
+	beforeFDs, canCountFDs := countOpenFDs()
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestManagedHostProcessWaitsAndReleasesPipesAfterExit")
+	cmd.Env = append(os.Environ(), "AO_CONPTY_MANAGED_PROCESS_HELPER=exit")
+	stderr := &boundedBuffer{max: maxCapturedStderr}
+	proc, err := startManagedHostProcess(cmd, stderr)
+	if err != nil {
+		t.Fatalf("startManagedHostProcess: %v", err)
+	}
+
+	scanner := bufio.NewScanner(proc.stdout)
+	if !scanner.Scan() {
+		t.Fatalf("read READY line: %v", scanner.Err())
+	}
+	if got, want := strings.TrimSpace(scanner.Text()), "READY:123 456"; got != want {
+		t.Fatalf("READY line = %q, want %q", got, want)
+	}
+	proc.closeStdout()
+
+	select {
+	case err := <-proc.exitC:
+		if err != nil {
+			t.Fatalf("wait: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("managed process did not report exit")
+	}
+
+	if _, ok := <-proc.exitC; ok {
+		t.Fatal("exit channel still open after wait result")
+	}
+	if got := stderr.String(); !strings.Contains(got, "managed-helper-stderr") {
+		t.Fatalf("stderr = %q, want helper diagnostic", got)
+	}
+
+	if canCountFDs {
+		eventually(t, 2*time.Second, func() bool {
+			afterFDs, ok := countOpenFDs()
+			return ok && afterFDs <= beforeFDs
+		}, "pipe file descriptors were not released")
+	}
+}
+
+func TestManagedHostProcessKillAndWaitReleasesPipes(t *testing.T) {
+	runManagedProcessHelperIfRequested()
+
+	beforeFDs, canCountFDs := countOpenFDs()
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestManagedHostProcessKillAndWaitReleasesPipes")
+	cmd.Env = append(os.Environ(), "AO_CONPTY_MANAGED_PROCESS_HELPER=sleep")
+	stderr := &boundedBuffer{max: maxCapturedStderr}
+	proc, err := startManagedHostProcess(cmd, stderr)
+	if err != nil {
+		t.Fatalf("startManagedHostProcess: %v", err)
+	}
+
+	scanner := bufio.NewScanner(proc.stdout)
+	if !scanner.Scan() {
+		t.Fatalf("read READY line: %v", scanner.Err())
+	}
+	if got, want := strings.TrimSpace(scanner.Text()), "READY:123 456"; got != want {
+		t.Fatalf("READY line = %q, want %q", got, want)
+	}
+
+	_ = proc.killAndWait()
+	if _, ok := <-proc.exitC; ok {
+		t.Fatal("exit channel still open after killAndWait")
+	}
+
+	if canCountFDs {
+		eventually(t, 2*time.Second, func() bool {
+			afterFDs, ok := countOpenFDs()
+			return ok && afterFDs <= beforeFDs
+		}, "pipe file descriptors were not released after kill")
+	}
+}
 
 func TestStripEnvAssignments(t *testing.T) {
 	tests := []struct {
@@ -48,5 +134,42 @@ func TestStripEnvAssignments(t *testing.T) {
 				t.Errorf("rest = %#v, want %#v", gotRest, tt.wantRest)
 			}
 		})
+	}
+}
+
+func runManagedProcessHelperIfRequested() {
+	switch os.Getenv("AO_CONPTY_MANAGED_PROCESS_HELPER") {
+	case "exit":
+		fmt.Fprintln(os.Stdout, "READY:123 456")
+		fmt.Fprintln(os.Stderr, "managed-helper-stderr")
+		os.Exit(0)
+	case "sleep":
+		fmt.Fprintln(os.Stdout, "READY:123 456")
+		time.Sleep(30 * time.Second)
+		os.Exit(0)
+	}
+}
+
+func countOpenFDs() (int, bool) {
+	for _, dir := range []string{"/proc/self/fd", "/dev/fd"} {
+		entries, err := os.ReadDir(dir)
+		if err == nil {
+			return len(entries), true
+		}
+	}
+	return 0, false
+}
+
+func eventually(t *testing.T, timeout time.Duration, fn func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if fn() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal(msg)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/backend/internal/adapters/runtime/conpty/spawn_test.go
+++ b/backend/internal/adapters/runtime/conpty/spawn_test.go
@@ -2,6 +2,7 @@ package conpty
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -89,6 +90,40 @@ func TestManagedHostProcessKillAndWaitReleasesPipes(t *testing.T) {
 			return ok && afterFDs <= beforeFDs
 		}, "pipe file descriptors were not released after kill")
 	}
+}
+
+func TestManagedHostProcessSurvivesStartupContextCancellation(t *testing.T) {
+	runManagedProcessHelperIfRequested()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.Command(os.Args[0], "-test.run=TestManagedHostProcessSurvivesStartupContextCancellation")
+	cmd.Env = append(os.Environ(), "AO_CONPTY_MANAGED_PROCESS_HELPER=sleep")
+	stderr := &boundedBuffer{max: maxCapturedStderr}
+	proc, err := startManagedHostProcess(cmd, stderr)
+	if err != nil {
+		t.Fatalf("startManagedHostProcess: %v", err)
+	}
+
+	scanner := bufio.NewScanner(proc.stdout)
+	if !scanner.Scan() {
+		t.Fatalf("read READY line: %v", scanner.Err())
+	}
+	if got, want := strings.TrimSpace(scanner.Text()), "READY:123 456"; got != want {
+		t.Fatalf("READY line = %q, want %q", got, want)
+	}
+	proc.closeStdout()
+
+	cancel()
+	if ctx.Err() == nil {
+		t.Fatal("startup context was not canceled")
+	}
+	select {
+	case err := <-proc.exitC:
+		t.Fatalf("managed process exited after startup context cancellation: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	_ = proc.killAndWait()
 }
 
 func TestStripEnvAssignments(t *testing.T) {

--- a/backend/internal/adapters/runtime/conpty/spawn_windows.go
+++ b/backend/internal/adapters/runtime/conpty/spawn_windows.go
@@ -13,7 +13,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"golang.org/x/sys/windows"
@@ -24,43 +23,9 @@ var readyRE = regexp.MustCompile(`READY:(\d+) (\d+)`)
 
 const spawnReadyTimeout = 10 * time.Second
 
-// maxCapturedStderr bounds how much pty-host stderr we retain for diagnostics.
-const maxCapturedStderr = 8192
-
-// boundedBuffer is a thread-safe io.Writer that retains up to max bytes of what
-// is written and discards the rest. It always consumes its input (never blocks
-// or errors), so it is a safe stderr sink for the detached pty-host — matching
-// the previous io.Discard behavior while keeping a capped copy so a startup
-// failure (e.g. newConPTY) can be reported instead of only "exited without
-// printing READY".
-type boundedBuffer struct {
-	mu  sync.Mutex
-	buf []byte
-	max int
-}
-
-func (b *boundedBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if room := b.max - len(b.buf); room > 0 {
-		if len(p) < room {
-			room = len(p)
-		}
-		b.buf = append(b.buf, p[:room]...)
-	}
-	return len(p), nil
-}
-
-func (b *boundedBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return string(b.buf)
-}
-
 // defaultSpawnHost resolves the current executable, builds the pty-host argv,
 // and spawns it detached on Windows. It reads stdout for "READY:<pid> <port>"
-// with a 10s timeout, then unrefs (detaches) the child. Returns the loopback
-// address and the pty-host OS PID.
+// with a 10s timeout. Returns the loopback address and the pty-host OS PID.
 func defaultSpawnHost(ctx context.Context, sessionID, cwd string, argv []string, env map[string]string) (string, int, error) {
 	exe, err := os.Executable()
 	if err != nil {
@@ -99,17 +64,12 @@ func defaultSpawnHost(ctx context.Context, sessionID, cwd string, argv []string,
 		HideWindow:    true,
 	}
 
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return "", 0, fmt.Errorf("conpty spawn: stdout pipe: %w", err)
-	}
 	// Capture a bounded copy of the pty-host's stderr. It writes its startup
 	// diagnostics there (listen/newConPTY failures) before exiting without
 	// printing READY; retaining them lets us report the real cause below.
 	stderr := &boundedBuffer{max: maxCapturedStderr}
-	cmd.Stderr = stderr
-
-	if err := cmd.Start(); err != nil {
+	proc, err := startManagedHostProcess(cmd, stderr)
+	if err != nil {
 		return "", 0, fmt.Errorf("conpty spawn: start: %w", err)
 	}
 
@@ -121,7 +81,8 @@ func defaultSpawnHost(ctx context.Context, sessionID, cwd string, argv []string,
 	}, 1)
 
 	go func() {
-		scanner := bufio.NewScanner(stdout)
+		defer proc.closeStdout()
+		scanner := bufio.NewScanner(proc.stdout)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			m := readyRE.FindStringSubmatch(line)
@@ -153,19 +114,18 @@ func defaultSpawnHost(ctx context.Context, sessionID, cwd string, argv []string,
 	select {
 	case r := <-readyC:
 		if r.err != nil {
-			_ = cmd.Process.Kill()
+			_ = proc.killAndWait()
 			return "", 0, r.err
 		}
-		// Unref: detach stdout so the child is not blocked, then release reference
-		// so our process can exit while the child keeps running.
-		stdout.Close()
-		cmd.Process.Release() // nolint: errcheck - best-effort detach
+		// Detach stdout so the child is not blocked. The process handle remains
+		// owned by proc's waiter goroutine so cmd.Wait runs when pty-host exits.
+		proc.closeStdout()
 		return r.addr, cmd.Process.Pid, nil
 	case <-timer.C:
-		_ = cmd.Process.Kill()
+		_ = proc.killAndWait()
 		return "", 0, fmt.Errorf("conpty spawn: pty-host startup timeout (%s)", spawnReadyTimeout)
 	case <-ctx.Done():
-		_ = cmd.Process.Kill()
+		_ = proc.killAndWait()
 		return "", 0, ctx.Err()
 	}
 }

--- a/backend/internal/adapters/runtime/conpty/spawn_windows.go
+++ b/backend/internal/adapters/runtime/conpty/spawn_windows.go
@@ -51,7 +51,13 @@ func defaultSpawnHost(ctx context.Context, sessionID, cwd string, argv []string,
 	}
 	merged = append(merged, envAssignments...)
 
-	cmd := exec.CommandContext(ctx, exe, args...)
+	if err := ctx.Err(); err != nil {
+		return "", 0, err
+	}
+	// Do not bind the long-lived pty-host to ctx with exec.CommandContext. The
+	// caller's startup/request context is canceled after the spawn response is
+	// written; after READY, the host must keep running until the session exits.
+	cmd := exec.Command(exe, args...)
 	cmd.Dir = cwd
 	cmd.Env = merged
 


### PR DESCRIPTION
## Summary
- replace the conpty pty-host stderr custom writer path with parent-owned pipes
- keep a waiter goroutine so `cmd.Wait()` runs when the host exits
- close stdout deterministically on success, timeout, cancellation, and kill paths
- add lifecycle regression tests that prove wait completion and pipe FD cleanup

Fixes #2774

## Tests
- `cd backend && go test ./internal/adapters/runtime/conpty`
- `cd backend && GOOS=windows GOARCH=amd64 go test -c ./internal/adapters/runtime/conpty`