### PR TITLE
fix: add PATH floor to daemon binary resolution

### DIFF
--- a/backend/internal/adapters/agent/binaryutil/binaryutil.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil.go
@@ -1,7 +1,7 @@
-// Package binaryutil centralizes the "find an agent's CLI binary" search that
-// every adapter otherwise reimplements. Adapters differ only in the binary
-// name(s) and the well-known install locations to probe, so they describe those
-// with a BinarySpec and share the identical PATH-then-candidates iteration.
+// Package binaryutil centralizes the "find a CLI binary" search that adapters
+// otherwise reimplement. Callers differ only in the binary name(s) and the
+// well-known install locations to probe, so they describe those with a
+// BinarySpec and share the identical PATH-then-candidates iteration.
 package binaryutil
 
 import (
@@ -19,7 +19,17 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-// BinarySpec describes where one agent's CLI binary can live. ResolveBinary
+var unixPathFloorDirs = []string{
+	"/opt/homebrew/bin",
+	"/opt/homebrew/sbin",
+	"/usr/local/bin",
+	"/usr/bin",
+	"/bin",
+	"/usr/sbin",
+	"/sbin",
+}
+
+// BinarySpec describes where one CLI binary can live. ResolveBinary
 // searches PATH (via the platform's name list) first, then the platform's
 // candidate install paths in order, returning the first hit.
 //
@@ -39,6 +49,10 @@ type BinarySpec struct {
 
 	// UnixPaths are absolute candidate paths probed on non-Windows, in order.
 	UnixPaths []string
+	// UnixPathDirs are PATH-floor directories appended after the inherited PATH
+	// on non-Windows; each binary name is joined onto each directory in order.
+	// Nil uses AO's default Unix PATH floor; an empty non-nil slice disables it.
+	UnixPathDirs []string
 	// UnixHomePaths are candidate paths under the user's home dir on
 	// non-Windows; each entry is the components to join onto $HOME.
 	UnixHomePaths [][]string
@@ -70,6 +84,19 @@ const (
 type WinPath struct {
 	Base  WinBase
 	Parts []string
+}
+
+// UnixPathFloorDirs returns the fixed PATH floor AO applies for headless Unix
+// processes whose inherited PATH may omit Homebrew or /usr/local install roots.
+func UnixPathFloorDirs() []string {
+	return append([]string(nil), unixPathFloorDirs...)
+}
+
+// LookPath resolves file on the inherited PATH, then on AO's Unix PATH floor.
+// It mirrors exec.LookPath's signature for call sites that only need a PATH-like
+// lookup rather than a full BinarySpec.
+func LookPath(file string) (string, error) {
+	return lookPathInDirs(context.Background(), []string{file}, UnixPathFloorDirs())
 }
 
 // ResolveBinary returns the path to spec's binary, searching PATH then the
@@ -117,6 +144,11 @@ func ResolveBinary(ctx context.Context, spec BinarySpec) (string, error) {
 			candidates = append(candidates, filepath.Join(append([]string{base}, wp.Parts...)...))
 		}
 	} else {
+		pathDirs := spec.UnixPathDirs
+		if pathDirs == nil {
+			pathDirs = UnixPathFloorDirs()
+		}
+		candidates = append(candidates, unixPathDirCandidates(names, pathDirs)...)
 		candidates = append(candidates, spec.UnixPaths...)
 		if home, err := os.UserHomeDir(); err == nil {
 			candidates = append(candidates, joinAll(home, spec.UnixHomePaths)...)
@@ -362,4 +394,50 @@ func normalizeNodeVersion(version string) string {
 	version = strings.TrimSpace(version)
 	version = strings.TrimPrefix(version, "v")
 	return version
+}
+
+func lookPathInDirs(ctx context.Context, names, dirs []string) (string, error) {
+	var firstErr error
+	for _, name := range names {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		path, err := exec.LookPath(name)
+		if err == nil && path != "" {
+			return path, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if runtime.GOOS != "windows" {
+		for _, candidate := range unixPathDirCandidates(names, dirs) {
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+			if hookutil.FileExists(candidate) {
+				return candidate, nil
+			}
+		}
+	}
+	if firstErr != nil {
+		return "", firstErr
+	}
+	return "", exec.ErrNotFound
+}
+
+func unixPathDirCandidates(names, dirs []string) []string {
+	out := make([]string, 0, len(names)*len(dirs))
+	for _, name := range names {
+		if filepath.Base(name) != name {
+			continue
+		}
+		for _, dir := range dirs {
+			if dir == "" {
+				continue
+			}
+			out = append(out, filepath.Join(dir, name))
+		}
+	}
+	return out
 }

--- a/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
+++ b/backend/internal/adapters/agent/binaryutil/binaryutil_test.go
@@ -47,6 +47,86 @@ func TestDefaultFNMDirPrefersXDGDataHome(t *testing.T) {
 	}
 }
 
+func TestResolveBinaryFallsBackToUnixPathFloorDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix PATH floor does not apply on windows")
+	}
+	pathDir := t.TempDir()
+	floorDir := t.TempDir()
+	t.Setenv("PATH", pathDir)
+	oldFloor := unixPathFloorDirs
+	unixPathFloorDirs = []string{floorDir}
+	t.Cleanup(func() { unixPathFloorDirs = oldFloor })
+	bin := filepath.Join(floorDir, "widget")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveBinary(context.Background(), BinarySpec{
+		Label: "widget",
+		Names: []string{"widget"},
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != bin {
+		t.Fatalf("got %q, want %q", got, bin)
+	}
+}
+
+func TestResolveBinaryPrefersPathBeforeUnixPathFloorDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix PATH floor does not apply on windows")
+	}
+	pathDir := t.TempDir()
+	floorDir := t.TempDir()
+	t.Setenv("PATH", pathDir)
+	pathBin := filepath.Join(pathDir, "widget")
+	floorBin := filepath.Join(floorDir, "widget")
+	if err := os.WriteFile(pathBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(floorBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveBinary(context.Background(), BinarySpec{
+		Label:        "widget",
+		Names:        []string{"widget"},
+		UnixPathDirs: []string{floorDir},
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != pathBin {
+		t.Fatalf("got %q, want PATH binary %q", got, pathBin)
+	}
+}
+
+func TestLookPathUsesUnixPathFloor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix PATH floor does not apply on windows")
+	}
+	pathDir := t.TempDir()
+	floorDir := t.TempDir()
+	t.Setenv("PATH", pathDir)
+	oldFloor := unixPathFloorDirs
+	unixPathFloorDirs = []string{floorDir}
+	t.Cleanup(func() { unixPathFloorDirs = oldFloor })
+	bin := filepath.Join(floorDir, "widget")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LookPath("widget")
+	if err != nil {
+		t.Fatalf("LookPath: %v", err)
+	}
+	if got != bin {
+		t.Fatalf("got %q, want %q", got, bin)
+	}
+}
+
 func TestResolveBinaryFallsBackToHomeCandidate(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix home candidate shape")

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/ptyexec"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -45,11 +46,18 @@ const (
 var sessionIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 var getenv = os.Getenv
+var resolveTmuxBinary = func(ctx context.Context) (string, error) {
+	return binaryutil.ResolveBinary(ctx, binaryutil.BinarySpec{
+		Label:        "tmux",
+		Names:        []string{"tmux"},
+		UnixPathDirs: binaryutil.UnixPathFloorDirs(),
+	})
+}
 
 // Options configures a tmux Runtime. Every field has a sensible default (see
 // New), so the zero value is usable.
 type Options struct {
-	Binary     string        // default "tmux" (resolved via exec.LookPath)
+	Binary     string        // default "tmux" (resolved via binaryutil)
 	Shell      string        // default $SHELL else /bin/sh
 	Timeout    time.Duration // default 5s
 	ChunkSize  int           // default 16*1024
@@ -237,12 +245,12 @@ func stableRunDir() string {
 }
 
 // New builds a tmux Runtime, filling unset Options with defaults: binary "tmux"
-// (resolved via exec.LookPath), shell from $SHELL (else /bin/sh), and the
-// default timeout and output chunk size.
+// (resolved via binaryutil), shell from $SHELL (else /bin/sh), and the default
+// timeout and output chunk size.
 func New(opts Options) *Runtime {
 	binary := opts.Binary
 	if binary == "" {
-		if path, err := exec.LookPath("tmux"); err == nil {
+		if path, err := resolveTmuxBinary(context.Background()); err == nil {
 			binary = path
 		} else {
 			binary = "tmux"

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -160,6 +160,19 @@ func TestExecRunnerFallsBackWhenTempDirMissing(t *testing.T) {
 	}
 }
 
+func TestNewDefaultsToResolvedTmuxBinary(t *testing.T) {
+	oldResolve := resolveTmuxBinary
+	resolveTmuxBinary = func(context.Context) (string, error) {
+		return "/opt/homebrew/bin/tmux", nil
+	}
+	t.Cleanup(func() { resolveTmuxBinary = oldResolve })
+
+	r := New(Options{})
+	if got := r.binary; got != "/opt/homebrew/bin/tmux" {
+		t.Fatalf("binary = %q, want resolved tmux path", got)
+	}
+}
+
 // -- command builder tests --
 
 func TestCommandBuilders(t *testing.T) {

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -8,12 +8,12 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/daemon"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/processalive"
@@ -88,7 +88,7 @@ func DefaultDeps() Deps {
 		Executable:           os.Executable,
 		StartProcess:         startProcess,
 		ProcessAlive:         processalive.Alive,
-		LookPath:             exec.LookPath,
+		LookPath:             binaryutil.LookPath,
 		CommandOutput:        commandOutput,
 		CommandOutputInDir:   commandOutputInDir,
 		DoctorGitHubRESTBase: defaultDoctorGitHubRESTBase,

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
@@ -304,9 +305,8 @@ type Manager struct {
 	// deterministically prove that a post-stop transcript read failure falls
 	// back without advertising the provider path.
 	openTranscriptFile func(string) (*os.File, error)
-	// lookPath is exec.LookPath in production; tests substitute a stub so
-	// they don't need real binaries on PATH. Returns ports.ErrAgentBinaryNotFound
-	// when the binary is missing so the sentinel propagates through toAPIError.
+	// lookPath is binaryutil.LookPath in production; tests substitute a stub so
+	// they don't need real binaries on PATH.
 	lookPath func(string) (string, error)
 	// executable resolves the daemon's own binary (os.Executable in
 	// production); its directory is prepended to spawned sessions' PATH so the
@@ -544,9 +544,9 @@ type Deps struct {
 	// commands can open the same store.
 	DataDir string
 	Clock   func() time.Time
-	// LookPath overrides exec.LookPath for the pre-launch agent-binary check.
-	// Production wiring leaves this nil and the manager defaults to
-	// exec.LookPath; tests inject a stub so they need not seed real binaries.
+	// LookPath overrides binaryutil.LookPath for runtime prerequisite and
+	// pre-launch agent-binary checks. Production wiring leaves this nil; tests
+	// inject a stub so they need not seed real binaries.
 	LookPath func(string) (string, error)
 	// Executable overrides os.Executable for the session PATH pin (see
 	// hookPATH). Production wiring leaves this nil; tests inject a stub so they
@@ -613,7 +613,7 @@ func New(d Deps) *Manager {
 		m.clock = func() time.Time { return time.Now().UTC() }
 	}
 	if m.lookPath == nil {
-		m.lookPath = exec.LookPath
+		m.lookPath = binaryutil.LookPath
 	}
 	if m.executable == nil {
 		m.executable = os.Executable
@@ -3718,12 +3718,12 @@ func freshLaunchArgv(ctx context.Context, agent ports.Agent, id domain.SessionID
 }
 
 // validateAgentBinary checks that argv[0] resolves via the manager's
-// lookPath (exec.LookPath in prod) before any runtime work happens. Adapters
-// that can't resolve their binary now return ports.ErrAgentBinaryNotFound from
-// GetLaunchCommand directly; this guard is a defense-in-depth for adapters
-// that return an argv[0] like "claude" without verifying. Some adapters prefix
-// their command with `env KEY=value`; in that case validate the first real
-// executable after the environment assignments.
+// lookPath (binaryutil.LookPath in prod) before any runtime work happens.
+// Adapters that can't resolve their binary now return
+// ports.ErrAgentBinaryNotFound from GetLaunchCommand directly; this guard is a
+// defense-in-depth for adapters that return an argv[0] like "claude" without
+// verifying. Some adapters prefix their command with `env KEY=value`; in that
+// case validate the first real executable after the environment assignments.
 func (m *Manager) validateAgentBinary(argv []string) error {
 	if len(argv) == 0 {
 		return fmt.Errorf("agent: empty launch argv: %w", ports.ErrAgentBinaryNotFound)


### PR DESCRIPTION
## Summary
- add a shared Unix PATH floor in `binaryutil` for `/opt/homebrew/bin`, `/opt/homebrew/sbin`, `/usr/local/bin`, and system binary dirs
- use the shared resolver for daemon spawn-gate/default lookups, CLI doctor lookups, and the tmux runtime default binary
- extend resolver and tmux runtime tests for PATH-floor fallback behavior

Closes #2812

## Tests
- `env -u AO_SESSION_ID -u AO_PROJECT_ID go test ./...` from `backend/`
- `GOLANGCI_LINT_CACHE="$(mktemp -d)" env -u AO_SESSION_ID -u AO_PROJECT_ID npm run lint`

## Notes
- A first `npm run lint` attempt hit stale golangci cache entries from a deleted sibling worktree; rerunning with an isolated cache passed with 0 issues.