### PR TITLE
fix: stabilize daemon spawn working directories

### DIFF
--- a/backend/internal/adapters/runtime/conpty/host_main.go
+++ b/backend/internal/adapters/runtime/conpty/host_main.go
@@ -34,6 +34,10 @@ func RunHost(args []string, stdout io.Writer) int {
 	cwd := args[1]
 	shellCmd := args[2]
 	shellArgs := args[3:]
+	if err := os.Chdir(cwd); err != nil {
+		fmt.Fprintf(os.Stderr, "pty-host [%s]: chdir %s: %v\n", sessionID, cwd, err)
+		return 1
+	}
 
 	// Bind before creating the PTY so we can report READY atomically.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/backend/internal/adapters/runtime/conpty/host_main_test.go
+++ b/backend/internal/adapters/runtime/conpty/host_main_test.go
@@ -1,0 +1,15 @@
+package conpty
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunHostRejectsMissingWorkingDirectory(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	code := RunHost([]string{"sess-1", missing, "agent.exe"}, io.Discard)
+	if code != 1 {
+		t.Fatalf("RunHost code = %d, want 1", code)
+	}
+}

--- a/backend/internal/adapters/runtime/tmux/commands.go
+++ b/backend/internal/adapters/runtime/tmux/commands.go
@@ -44,6 +44,13 @@ func setWindowSizeLargestArgs(id string) []string {
 	return []string{"set-option", "-t", id, "window-size", "largest"}
 }
 
+// paneCurrentPathArgs prints tmux's cwd for the session's active pane. Create
+// uses this after new-session so a poisoned tmux server that ignores -c fails
+// loudly instead of silently starting the agent in the wrong directory.
+func paneCurrentPathArgs(id string) []string {
+	return []string{"display-message", "-p", "-t", id, "#{pane_current_path}"}
+}
+
 // killSessionArgs builds args for `tmux kill-session -t =<id>`. The `=` prefix
 // requests exact-name matching so a session "foo" does not accidentally match
 // "foobar" (tmux otherwise does unique-prefix matching).

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -203,6 +204,10 @@ func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.Ru
 	if _, err := r.run(ctx, args...); err != nil {
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: create session %s: %w", id, err)
 	}
+	if err := r.verifyPaneWorkingDirectory(ctx, id, cfg.WorkspacePath); err != nil {
+		_ = r.Destroy(context.Background(), ports.RuntimeHandle{ID: id})
+		return ports.RuntimeHandle{}, err
+	}
 
 	// Hide the status bar in the embedded terminal: it clutters the view and
 	// was not designed for the in-browser display context.
@@ -237,6 +242,18 @@ func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.Ru
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: session %s exited before ready", id)
 	}
 	return handle, nil
+}
+
+func (r *Runtime) verifyPaneWorkingDirectory(ctx context.Context, id, want string) error {
+	out, err := r.run(ctx, paneCurrentPathArgs(id)...)
+	if err != nil {
+		return fmt.Errorf("tmux runtime: verify working directory %s: %w", id, err)
+	}
+	got := strings.TrimSpace(string(out))
+	if sameDirectory(got, want) {
+		return nil
+	}
+	return fmt.Errorf("tmux runtime: session %s started in %q, want %q", id, got, want)
 }
 
 // Destroy kills the handle's tmux session and reaps the pane processes it
@@ -639,6 +656,9 @@ func buildLaunchCommand(cfg ports.RuntimeConfig) string {
 	}
 
 	var b strings.Builder
+	b.WriteString("cd ")
+	b.WriteString(shellQuote(cfg.WorkspacePath))
+	b.WriteString(" || exit; ")
 	for _, key := range sortedKeys(cfg.Env) {
 		if key == "PATH" {
 			continue
@@ -665,6 +685,27 @@ func buildLaunchCommand(cfg ports.RuntimeConfig) string {
 	// the process env if set, otherwise falls back to /bin/sh.
 	b.WriteString(`; exec "${SHELL:-/bin/sh}" -i`)
 	return b.String()
+}
+
+func sameDirectory(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	absA, errA := filepath.Abs(a)
+	if errA == nil {
+		a = absA
+	}
+	absB, errB := filepath.Abs(b)
+	if errB == nil {
+		b = absB
+	}
+	if realA, err := filepath.EvalSymlinks(a); err == nil {
+		a = realA
+	}
+	if realB, err := filepath.EvalSymlinks(b); err == nil {
+		b = realB
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
 }
 
 // -- error type --

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -98,6 +98,9 @@ func TestCommandBuilders(t *testing.T) {
 	if got, want := setWindowSizeLargestArgs("sess-1"), []string{"set-option", "-t", "sess-1", "window-size", "largest"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("setWindowSizeLargestArgs = %#v, want %#v", got, want)
 	}
+	if got, want := paneCurrentPathArgs("sess-1"), []string{"display-message", "-p", "-t", "sess-1", "#{pane_current_path}"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("paneCurrentPathArgs = %#v, want %#v", got, want)
+	}
 	if got, want := setMouseOnArgs("sess-1"), []string{"set-option", "-t", "sess-1", "mouse", "on"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("setMouseOnArgs = %#v, want %#v", got, want)
 	}
@@ -183,10 +186,10 @@ func TestCreateRejectsInvalidEnvKeys(t *testing.T) {
 // -- Create tests --
 
 func TestCreateIssuesNewSessionAndStatusOff(t *testing.T) {
-	// new-session, set-option status, set-option mouse, set-option window-size,
-	// has-session (exit 0 = alive)
+	// new-session, display-message cwd verification, set-option status,
+	// set-option mouse, set-option window-size, has-session (exit 0 = alive)
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{nil, nil, nil, nil, nil}
+	fr.outputs = [][]byte{nil, []byte("/tmp/ws\n"), nil, nil, nil, nil}
 
 	h, err := r.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     "sess-1",
@@ -200,10 +203,10 @@ func TestCreateIssuesNewSessionAndStatusOff(t *testing.T) {
 	if h.ID != "sess-1" {
 		t.Fatalf("handle ID = %q, want sess-1", h.ID)
 	}
-	// Expect 5 calls: new-session, set-option status, set-option mouse,
-	// set-option window-size, has-session.
-	if len(fr.calls) != 5 {
-		t.Fatalf("calls = %d, want 5", len(fr.calls))
+	// Expect 6 calls: new-session, display-message cwd verification,
+	// set-option status, set-option mouse, set-option window-size, has-session.
+	if len(fr.calls) != 6 {
+		t.Fatalf("calls = %d, want 6", len(fr.calls))
 	}
 
 	// Call 0: new-session
@@ -223,31 +226,36 @@ func TestCreateIssuesNewSessionAndStatusOff(t *testing.T) {
 		t.Fatalf("new-session args missing -x/-y: %v", fr.calls[0].args)
 	}
 
-	// Call 1: set-option status off (plain target, pane-targeting does not use =).
-	if got, want := fr.calls[1].args, setStatusOffArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	// Call 1: verify pane cwd.
+	if got, want := fr.calls[1].args, paneCurrentPathArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("call[1] = %#v, want %#v", got, want)
 	}
 
-	// Call 2: set-option mouse on (enables wheel-scroll of the pane).
-	if got, want := fr.calls[2].args, setMouseOnArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	// Call 2: set-option status off (plain target, pane-targeting does not use =).
+	if got, want := fr.calls[2].args, setStatusOffArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("call[2] = %#v, want %#v", got, want)
 	}
 
-	// Call 3: set-option window-size largest (multi-client sizing, see
-	// setWindowSizeLargestArgs).
-	if got, want := fr.calls[3].args, setWindowSizeLargestArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	// Call 3: set-option mouse on (enables wheel-scroll of the pane).
+	if got, want := fr.calls[3].args, setMouseOnArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("call[3] = %#v, want %#v", got, want)
 	}
 
-	// Call 4: has-session (IsAlive, uses exact-match target =sess-1).
-	if got, want := fr.calls[4].args, hasSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
+	// Call 4: set-option window-size largest (multi-client sizing, see
+	// setWindowSizeLargestArgs).
+	if got, want := fr.calls[4].args, setWindowSizeLargestArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("call[4] = %#v, want %#v", got, want)
+	}
+
+	// Call 5: has-session (IsAlive, uses exact-match target =sess-1).
+	if got, want := fr.calls[5].args, hasSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("call[5] = %#v, want %#v", got, want)
 	}
 }
 
 func TestCreateLaunchCommandContainsKeepAliveShell(t *testing.T) {
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{nil, nil, nil}
+	fr.outputs = [][]byte{nil, []byte("/tmp/ws\n"), nil, nil, nil, nil}
 
 	_, err := r.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     "sess-1",
@@ -262,6 +270,9 @@ func TestCreateLaunchCommandContainsKeepAliveShell(t *testing.T) {
 	launchCmd := args[len(args)-1]
 	if !strings.Contains(launchCmd, `exec "${SHELL:-/bin/sh}" -i`) {
 		t.Fatalf("launch command missing keep-alive shell: %q", launchCmd)
+	}
+	if !strings.HasPrefix(launchCmd, "cd '/tmp/ws' || exit; ") {
+		t.Fatalf("launch command missing cwd guard: %q", launchCmd)
 	}
 	if !strings.Contains(launchCmd, "'myagent'") {
 		t.Fatalf("launch command missing quoted argv: %q", launchCmd)
@@ -279,7 +290,7 @@ func TestCreateLaunchCommandExportsEnvVars(t *testing.T) {
 	defer func() { getenv = oldGetenv }()
 
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{nil, nil, nil}
+	fr.outputs = [][]byte{nil, []byte("/tmp/ws\n"), nil, nil, nil, nil}
 
 	_, err := r.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     "sess-1",
@@ -304,6 +315,29 @@ func TestCreateLaunchCommandExportsEnvVars(t *testing.T) {
 		if !strings.Contains(launchCmd, want) {
 			t.Fatalf("launch command missing %q in: %q", want, launchCmd)
 		}
+	}
+}
+
+func TestCreateDestroysAndReturnsErrorWhenPaneCWDDoesNotMatch(t *testing.T) {
+	r, fr := newTestRuntime(0)
+	fr.outputs = [][]byte{nil, []byte("/deleted/shipit\n")}
+
+	_, err := r.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     "sess-1",
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"myagent"},
+	})
+	if err == nil || !strings.Contains(err.Error(), `started in "/deleted/shipit", want "/tmp/ws"`) {
+		t.Fatalf("Create err = %v, want pane cwd mismatch", err)
+	}
+	hasKill := false
+	for _, c := range fr.calls {
+		if len(c.args) > 0 && c.args[0] == "kill-session" {
+			hasKill = true
+		}
+	}
+	if !hasKill {
+		t.Fatal("expected kill-session cleanup call when pane cwd verification fails")
 	}
 }
 
@@ -367,6 +401,9 @@ func (f *fakeRunnerSelectiveErr) Run(_ context.Context, env []string, name strin
 	f.calls = append(f.calls, runnerCall{env: append([]string(nil), env...), name: name, args: append([]string(nil), args...)})
 	if len(args) > 0 && args[0] == f.exitErrOn {
 		return f.errOutput, &exec.ExitError{}
+	}
+	if len(args) > 0 && args[0] == "display-message" {
+		return []byte("/tmp/ws\n"), nil
 	}
 	return nil, nil
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -309,7 +309,7 @@ func newAppRunID() string {
 // Electron supervisor share one handshake location.
 func resolveRunFilePath() (string, error) {
 	if p, ok := os.LookupEnv("AO_RUN_FILE"); ok && p != "" {
-		return p, nil
+		return absOverride("AO_RUN_FILE", p)
 	}
 	stateDir, err := defaultStateDir()
 	if err != nil {
@@ -323,7 +323,7 @@ func resolveRunFilePath() (string, error) {
 // directory as the run-file.
 func resolveDataDir() (string, error) {
 	if p, ok := os.LookupEnv("AO_DATA_DIR"); ok && p != "" {
-		return p, nil
+		return absOverride("AO_DATA_DIR", p)
 	}
 	stateDir, err := defaultStateDir()
 	if err != nil {
@@ -338,4 +338,18 @@ func defaultStateDir() (string, error) {
 		return "", fmt.Errorf("resolve state dir: %w", err)
 	}
 	return filepath.Join(homeDir, ".ao"), nil
+}
+
+// absOverride resolves an explicit AO_DATA_DIR/AO_RUN_FILE override to an
+// absolute path against the process's launch cwd. The daemon chdir's into its
+// data dir at startup (see stabilizeWorkingDirectory), so a relative override
+// left as-is would be re-resolved against the new cwd and double-nest state
+// (e.g. AO_DATA_DIR=data -> <cwd>/data/data). Absolutizing here keeps the path
+// stable regardless of the later chdir.
+func absOverride(name, p string) (string, error) {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s %q: %w", name, p, err)
+	}
+	return abs, nil
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -105,6 +105,10 @@ type Config struct {
 	AllowedOrigins []string
 	// Telemetry controls local/remote telemetry sinks.
 	Telemetry TelemetryConfig
+	// StartupWorkingDirectory is the daemon process cwd before startup
+	// normalizes it. The desktop uses this to identify dev daemons after the
+	// process cwd is moved to the stable data dir.
+	StartupWorkingDirectory string
 }
 
 // Addr returns the host:port the HTTP server binds. It uses net.JoinHostPort so

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -53,6 +53,35 @@ func TestLoadDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadAbsolutizesRelativeOverrides(t *testing.T) {
+	// A relative override must be resolved to absolute at Load time. The daemon
+	// chdir's into its data dir at startup, so a relative path left as-is would
+	// be re-resolved against the new cwd and double-nest state.
+	t.Setenv("AO_RUN_FILE", "rel-running.json")
+	t.Setenv("AO_DATA_DIR", "rel-data")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !filepath.IsAbs(cfg.RunFilePath) {
+		t.Errorf("RunFilePath = %q, want absolute", cfg.RunFilePath)
+	}
+	if !filepath.IsAbs(cfg.DataDir) {
+		t.Errorf("DataDir = %q, want absolute", cfg.DataDir)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(cwd, "rel-data"); cfg.DataDir != want {
+		t.Errorf("DataDir = %q, want %q", cfg.DataDir, want)
+	}
+	if want := filepath.Join(cwd, "rel-running.json"); cfg.RunFilePath != want {
+		t.Errorf("RunFilePath = %q, want %q", cfg.RunFilePath, want)
+	}
+}
+
 func TestLoadOverrides(t *testing.T) {
 	t.Setenv("AO_PORT", "4002")
 	t.Setenv("AO_REQUEST_TIMEOUT", "5s")

--- a/backend/internal/daemon/cwd_test.go
+++ b/backend/internal/daemon/cwd_test.go
@@ -1,0 +1,46 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStabilizeWorkingDirectoryChdirsToDataDir(t *testing.T) {
+	oldCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldCWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	dataDir := filepath.Join(t.TempDir(), "ao-data")
+	if err := stabilizeWorkingDirectory(dataDir); err != nil {
+		t.Fatalf("stabilizeWorkingDirectory: %v", err)
+	}
+	got, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got = cleanSymlinkedPath(t, got); got != cleanSymlinkedPath(t, dataDir) {
+		t.Fatalf("cwd = %q, want %q", got, dataDir)
+	}
+}
+
+func TestStabilizeWorkingDirectoryRequiresDataDir(t *testing.T) {
+	if err := stabilizeWorkingDirectory(""); err == nil {
+		t.Fatal("stabilizeWorkingDirectory empty dir: got nil, want error")
+	}
+}
+
+func cleanSymlinkedPath(t *testing.T, p string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -42,6 +42,12 @@ func Run() error {
 	if err != nil {
 		return err
 	}
+	if cwd, err := os.Getwd(); err == nil {
+		cfg.StartupWorkingDirectory = cwd
+	}
+	if err := stabilizeWorkingDirectory(cfg.DataDir); err != nil {
+		return err
+	}
 
 	log := newLogger()
 
@@ -309,4 +315,17 @@ func Run() error {
 // can capture it separately from any structured stdout protocol added later.
 func newLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func stabilizeWorkingDirectory(dataDir string) error {
+	if dataDir == "" {
+		return fmt.Errorf("daemon working directory: data dir is required")
+	}
+	if err := os.MkdirAll(dataDir, 0o750); err != nil {
+		return fmt.Errorf("daemon working directory: create %s: %w", dataDir, err)
+	}
+	if err := os.Chdir(dataDir); err != nil {
+		return fmt.Errorf("daemon working directory: chdir %s: %w", dataDir, err)
+	}
+	return nil
 }

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -62,7 +62,7 @@ func NewRouterWithControl(cfg config.Config, log *slog.Logger, termMgr *terminal
 	r.NotFound(notFoundJSON)
 	r.MethodNotAllowed(methodNotAllowedJSON)
 
-	mountHealth(r)
+	mountHealth(r, cfg)
 	mountTerminalMux(r, termMgr, log)
 	mountControl(r, control)
 	mountTelemetry(r, deps.Telemetry)
@@ -85,9 +85,13 @@ func previewOriginMiddleware(sessions *controllers.SessionsController) func(http
 
 // mountHealth registers the liveness and readiness probes the Electron
 // supervisor polls before letting the renderer connect.
-func mountHealth(r chi.Router) {
-	r.Get("/healthz", handleHealthz)
-	r.Get("/readyz", handleReadyz)
+func mountHealth(r chi.Router, cfg config.Config) {
+	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		envelope.WriteJSON(w, http.StatusOK, daemonProbePayload("ok", cfg))
+	})
+	r.Get("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		envelope.WriteJSON(w, http.StatusOK, daemonProbePayload("ready", cfg))
+	})
 }
 
 // mountControl registers the loopback daemon-control endpoints. /shutdown is
@@ -300,19 +304,10 @@ func localControlRequest(r *http.Request) bool {
 	return false
 }
 
-// handleHealthz is the liveness probe: it answers 200 as long as the process is
-// up and serving. It does no dependency checks by design.
-func handleHealthz(w http.ResponseWriter, _ *http.Request) {
-	envelope.WriteJSON(w, http.StatusOK, daemonProbePayload("ok"))
-}
-
-// handleReadyz is the readiness probe. Dependency initialization happens before
-// the server is constructed, so a listening daemon is ready to answer requests.
-func handleReadyz(w http.ResponseWriter, _ *http.Request) {
-	envelope.WriteJSON(w, http.StatusOK, daemonProbePayload("ready"))
-}
-
-func daemonProbePayload(status string) map[string]any {
+// daemonProbePayload is shared by /healthz and /readyz. Dependency
+// initialization happens before the server is constructed, so a listening
+// daemon is ready to answer requests.
+func daemonProbePayload(status string, cfg config.Config) map[string]any {
 	payload := map[string]any{
 		"status":  status,
 		"service": daemonmeta.ServiceName,
@@ -323,6 +318,9 @@ func daemonProbePayload(status string) map[string]any {
 	}
 	if cwd, err := os.Getwd(); err == nil && cwd != "" {
 		payload["workingDirectory"] = cwd
+	}
+	if cfg.StartupWorkingDirectory != "" {
+		payload["startupWorkingDirectory"] = cfg.StartupWorkingDirectory
 	}
 	return payload
 }

--- a/backend/internal/httpd/server_test.go
+++ b/backend/internal/httpd/server_test.go
@@ -42,7 +42,7 @@ func TestHealthProbes(t *testing.T) {
 }
 
 func TestHealthProbesIncludeDaemonIdentity(t *testing.T) {
-	router := newTestRouter(config.Config{}, discardLogger(), nil)
+	router := newTestRouter(config.Config{StartupWorkingDirectory: "/startup"}, discardLogger(), nil)
 	srv := httptest.NewServer(router)
 	defer srv.Close()
 
@@ -63,8 +63,9 @@ func TestHealthProbesIncludeDaemonIdentity(t *testing.T) {
 		}
 		defer resp.Body.Close()
 		var body struct {
-			ExecutablePath   string `json:"executablePath"`
-			WorkingDirectory string `json:"workingDirectory"`
+			ExecutablePath          string `json:"executablePath"`
+			WorkingDirectory        string `json:"workingDirectory"`
+			StartupWorkingDirectory string `json:"startupWorkingDirectory"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 			t.Fatalf("decode %s: %v", path, err)
@@ -74,6 +75,9 @@ func TestHealthProbesIncludeDaemonIdentity(t *testing.T) {
 		}
 		if body.WorkingDirectory != wantCWD {
 			t.Errorf("GET %s workingDirectory = %q, want %q", path, body.WorkingDirectory, wantCWD)
+		}
+		if body.StartupWorkingDirectory != "/startup" {
+			t.Errorf("GET %s startupWorkingDirectory = %q, want /startup", path, body.StartupWorkingDirectory)
 		}
 	}
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -541,12 +541,16 @@ async function readDaemonProbe(port: number, endpoint: "healthz" | "readyz"): Pr
 function daemonIdentityError(launch: DaemonLaunchSpec, probe: DaemonProbe): string | null {
 	if (launch.source === "dev") {
 		const cwdMatches = probe.workingDirectory ? samePath(probe.workingDirectory, launch.cwd) : false;
+		const startupCwdMatches = probe.startupWorkingDirectory
+			? samePath(probe.startupWorkingDirectory, launch.cwd)
+			: false;
 		const executableMatches = probe.executablePath ? pathInside(probe.executablePath, launch.cwd) : false;
-		if (!probe.workingDirectory && !probe.executablePath) {
+		if (!probe.workingDirectory && !probe.startupWorkingDirectory && !probe.executablePath) {
 			return "An older AO daemon is already running, but it does not report its checkout identity. Stop it and restart this app.";
 		}
-		if (!cwdMatches && !executableMatches) {
-			const actual = probe.workingDirectory ?? probe.executablePath ?? "an unknown location";
+		if (!cwdMatches && !startupCwdMatches && !executableMatches) {
+			const actual =
+				probe.startupWorkingDirectory ?? probe.workingDirectory ?? probe.executablePath ?? "an unknown location";
 			return `Another AO daemon is already running from ${actual}; expected this checkout at ${launch.cwd}. Stop the other daemon before using this checkout.`;
 		}
 		return null;
@@ -631,6 +635,7 @@ async function refreshDaemonStatus(): Promise<DaemonStatus> {
 		app.isPackaged,
 		process.resourcesPath,
 		app.getAppPath(),
+		os.homedir(),
 		process.platform,
 	);
 	if (!launch) return daemonStatus;
@@ -686,6 +691,7 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		app.isPackaged,
 		process.resourcesPath,
 		app.getAppPath(),
+		os.homedir(),
 		process.platform,
 	);
 	if (!launch) {
@@ -821,6 +827,9 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 	}
 
 	setDaemonStatus({ state: "starting" });
+	if (launch.source === "bundled") {
+		await mkdir(launch.cwd, { recursive: true, mode: 0o750 });
+	}
 
 	// Capture the spawned handle locally so the async lifecycle listeners act only
 	// on THIS process. Without this, a stale exit from an already-stopped daemon

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -828,7 +828,20 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 
 	setDaemonStatus({ state: "starting" });
 	if (launch.source === "bundled") {
-		await mkdir(launch.cwd, { recursive: true, mode: 0o750 });
+		try {
+			await mkdir(launch.cwd, { recursive: true, mode: 0o750 });
+		} catch (err) {
+			// A failure here (home unwritable, launch.cwd exists as a file) would
+			// otherwise reject out of startDaemonInner; boot calls this via
+			// `void startDaemon()`, so it would surface as an unhandled rejection
+			// and leave the UI stuck on "starting". Report it as a failure instead.
+			setDaemonStatus({
+				state: "error",
+				message: `Could not create the AO data directory at ${launch.cwd}: ${(err as Error).message}`,
+				code: "datadir_unwritable",
+			});
+			return daemonStatus;
+		}
 	}
 
 	// Capture the spawned handle locally so the async lifecycle listeners act only

--- a/frontend/src/shared/daemon-attach.test.ts
+++ b/frontend/src/shared/daemon-attach.test.ts
@@ -58,16 +58,25 @@ describe("parseDaemonProbe", () => {
 			pid: 4242,
 			executablePath: undefined,
 			workingDirectory: undefined,
+			startupWorkingDirectory: undefined,
 		});
 	});
 
 	it("accepts a well-formed readyz body and carries identity fields", () => {
-		expect(parseDaemonProbe("readyz", { ...readyBody, executablePath: "/bin/ao", workingDirectory: "/work" })).toEqual({
+		expect(
+			parseDaemonProbe("readyz", {
+				...readyBody,
+				executablePath: "/bin/ao",
+				workingDirectory: "/work/data",
+				startupWorkingDirectory: "/work",
+			}),
+		).toEqual({
 			status: "ready",
 			service: DAEMON_SERVICE_NAME,
 			pid: 4242,
 			executablePath: "/bin/ao",
-			workingDirectory: "/work",
+			workingDirectory: "/work/data",
+			startupWorkingDirectory: "/work",
 		});
 	});
 
@@ -97,6 +106,7 @@ describe("parseDaemonProbe", () => {
 		const probe = parseDaemonProbe("healthz", { ...healthBody, executablePath: 5, workingDirectory: {} });
 		expect(probe?.executablePath).toBeUndefined();
 		expect(probe?.workingDirectory).toBeUndefined();
+		expect(probe?.startupWorkingDirectory).toBeUndefined();
 	});
 });
 

--- a/frontend/src/shared/daemon-attach.ts
+++ b/frontend/src/shared/daemon-attach.ts
@@ -31,6 +31,7 @@ export type DaemonProbe = {
 	pid: number;
 	executablePath?: string;
 	workingDirectory?: string;
+	startupWorkingDirectory?: string;
 };
 
 /** A /healthz|/readyz probe of a loopback port; resolves null when nothing valid answers. */
@@ -63,6 +64,8 @@ export function parseDaemonProbe(endpoint: "healthz" | "readyz", body: unknown):
 		pid: candidate.pid,
 		executablePath: typeof candidate.executablePath === "string" ? candidate.executablePath : undefined,
 		workingDirectory: typeof candidate.workingDirectory === "string" ? candidate.workingDirectory : undefined,
+		startupWorkingDirectory:
+			typeof candidate.startupWorkingDirectory === "string" ? candidate.startupWorkingDirectory : undefined,
 	};
 }
 

--- a/frontend/src/shared/daemon-launch.test.ts
+++ b/frontend/src/shared/daemon-launch.test.ts
@@ -3,19 +3,19 @@ import { resolveDaemonLaunch } from "./daemon-launch";
 
 describe("resolveDaemonLaunch", () => {
 	it("uses AO_DAEMON_COMMAND when configured", () => {
-		expect(resolveDaemonLaunch({ AO_DAEMON_COMMAND: "/tmp/ao daemon" }, false, "/resources", "/app", "darwin")).toEqual(
-			{
-				command: "/tmp/ao daemon",
-				args: [],
-				cwd: "/app",
-				shell: true,
-				source: "configured",
-			},
-		);
+		expect(
+			resolveDaemonLaunch({ AO_DAEMON_COMMAND: "/tmp/ao daemon" }, false, "/resources", "/app", "/home/user", "darwin"),
+		).toEqual({
+			command: "/tmp/ao daemon",
+			args: [],
+			cwd: "/app",
+			shell: true,
+			source: "configured",
+		});
 	});
 
 	it("runs the backend daemon from source in dev without an explicit command", () => {
-		expect(resolveDaemonLaunch({}, false, "/resources", "/repo/frontend", "darwin")).toEqual({
+		expect(resolveDaemonLaunch({}, false, "/resources", "/repo/frontend", "/home/user", "darwin")).toEqual({
 			command: "go",
 			args: ["run", "./cmd/ao", "daemon"],
 			cwd: "/repo/frontend/../backend",
@@ -26,11 +26,18 @@ describe("resolveDaemonLaunch", () => {
 
 	it("uses the bundled daemon binary for packaged macOS/Linux builds", () => {
 		expect(
-			resolveDaemonLaunch({}, true, "/Applications/Agent Orchestrator.app/Contents/Resources", "/app", "darwin"),
+			resolveDaemonLaunch(
+				{},
+				true,
+				"/Applications/Agent Orchestrator.app/Contents/Resources",
+				"/app",
+				"/Users/alice",
+				"darwin",
+			),
 		).toEqual({
 			command: "/Applications/Agent Orchestrator.app/Contents/Resources/daemon/ao",
 			args: ["daemon"],
-			cwd: "/Applications/Agent Orchestrator.app/Contents/Resources",
+			cwd: "/Users/alice/.ao",
 			shell: false,
 			source: "bundled",
 		});
@@ -43,12 +50,13 @@ describe("resolveDaemonLaunch", () => {
 				true,
 				"C:\\Program Files\\AO\\resources",
 				"C:\\Program Files\\AO\\resources\\app.asar",
+				"C:\\Users\\alice",
 				"win32",
 			),
 		).toEqual({
 			command: "C:\\Program Files\\AO\\resources/daemon/ao.exe",
 			args: ["daemon"],
-			cwd: "C:\\Program Files\\AO\\resources",
+			cwd: "C:\\Users\\alice/.ao",
 			shell: false,
 			source: "bundled",
 		});

--- a/frontend/src/shared/daemon-launch.ts
+++ b/frontend/src/shared/daemon-launch.ts
@@ -19,6 +19,7 @@ export function resolveDaemonLaunch(
 	isPackaged: boolean,
 	resourcesPath: string,
 	appPath: string,
+	homeDir: string,
 	platform: NodeJS.Platform,
 ): DaemonLaunchSpec | null {
 	const configuredCommand = env.AO_DAEMON_COMMAND?.trim();
@@ -45,7 +46,7 @@ export function resolveDaemonLaunch(
 	return {
 		command: joinPath(resourcesPath, "daemon", bundledDaemonBinaryName(platform)),
 		args: ["daemon"],
-		cwd: resourcesPath,
+		cwd: joinPath(homeDir, ".ao"),
 		shell: false,
 		source: "bundled",
 	};

--- a/frontend/src/shared/daemon-status.ts
+++ b/frontend/src/shared/daemon-status.ts
@@ -12,7 +12,8 @@ export type DaemonFailureCode =
 	| "exited"
 	| "port_unconfirmed"
 	| "not_ready"
-	| "identity_mismatch";
+	| "identity_mismatch"
+	| "datadir_unwritable";
 
 export type DaemonStatus = {
 	state: "starting" | "ready" | "stopped" | "error";


### PR DESCRIPTION
## Summary

- launch packaged desktop daemons from a stable `~/.ao` cwd instead of the versioned app resources directory
- chdir the daemon to its configured data dir before runtimes can start long-lived helpers
- guard tmux launch commands with `cd <workspace> || exit`, verify the pane cwd after spawn, and fail with a clear mismatch instead of silently starting in a poisoned cwd
- validate the conpty host cwd before it starts serving and preserve the daemon startup cwd in probes for dev-daemon identity checks

Fixes #2780.
Addresses the root cause of #2775.

## Tests

- `go test ./internal/adapters/runtime/tmux ./internal/adapters/runtime/conpty ./internal/daemon ./internal/httpd`
- `env -u AO_PROJECT_ID -u AO_SESSION_ID go test ./...`
- `npm test -- --run src/shared/daemon-launch.test.ts src/shared/daemon-attach.test.ts`
- `npm run typecheck` (from `frontend/`)
- `env -u AO_PROJECT_ID -u AO_SESSION_ID npm run lint` after clearing stale golangci-lint cache

## Notes

- A plain `npm run lint` in this AO worker inherited `AO_PROJECT_ID`/`AO_SESSION_ID` and failed existing CLI spawn tests; rerunning with those vars unset matched CI isolation.
- The first golangci-lint attempt after that hit stale diagnostics from a deleted worktree cache; `golangci-lint cache clean` fixed the cache, and the rerun completed with `0 issues`.
