### PR TITLE
fix: deliver actionable bot review feedback

### DIFF
--- a/backend/internal/adapters/agent/fake/fake_test.go
+++ b/backend/internal/adapters/agent/fake/fake_test.go
@@ -216,6 +216,10 @@ func (s *lifecycleStore) GetSession(_ context.Context, id domain.SessionID) (dom
 	return r, ok, nil
 }
 
+func (s *lifecycleStore) GetProject(_ context.Context, _ string) (domain.ProjectRecord, bool, error) {
+	return domain.ProjectRecord{}, false, nil
+}
+
 func (s *lifecycleStore) UpdateSession(_ context.Context, rec domain.SessionRecord) error {
 	s.sessions[rec.ID] = rec
 	return nil

--- a/backend/internal/cli/project.go
+++ b/backend/internal/cli/project.go
@@ -93,22 +93,29 @@ type trackerIntakeConfig struct {
 	Assignee string `json:"assignee,omitempty"`
 }
 
+// botReviewFeedbackConfig mirrors domain.BotReviewFeedbackConfig.
+type botReviewFeedbackConfig struct {
+	AllowAuthors []string `json:"allowAuthors,omitempty"`
+	DenyAuthors  []string `json:"denyAuthors,omitempty"`
+}
+
 // projectConfig mirrors the daemon's typed domain.ProjectConfig for the CLI
 // client. The CLI sets common fields via flags and the whole object via
 // --config-json.
 type projectConfig struct {
-	DefaultBranch     string              `json:"defaultBranch,omitempty"`
-	SessionPrefix     string              `json:"sessionPrefix,omitempty"`
-	Env               map[string]string   `json:"env,omitempty"`
-	Symlinks          []string            `json:"symlinks,omitempty"`
-	PostCreate        []string            `json:"postCreate,omitempty"`
-	AgentRules        string              `json:"agentRules,omitempty"`
-	AgentRulesFile    string              `json:"agentRulesFile,omitempty"`
-	OrchestratorRules string              `json:"orchestratorRules,omitempty"`
-	AgentConfig       agentConfig         `json:"agentConfig,omitempty"`
-	Worker            roleOverride        `json:"worker,omitempty"`
-	Orchestrator      roleOverride        `json:"orchestrator,omitempty"`
-	TrackerIntake     trackerIntakeConfig `json:"trackerIntake,omitempty"`
+	DefaultBranch     string                  `json:"defaultBranch,omitempty"`
+	SessionPrefix     string                  `json:"sessionPrefix,omitempty"`
+	Env               map[string]string       `json:"env,omitempty"`
+	Symlinks          []string                `json:"symlinks,omitempty"`
+	PostCreate        []string                `json:"postCreate,omitempty"`
+	AgentRules        string                  `json:"agentRules,omitempty"`
+	AgentRulesFile    string                  `json:"agentRulesFile,omitempty"`
+	OrchestratorRules string                  `json:"orchestratorRules,omitempty"`
+	AgentConfig       agentConfig             `json:"agentConfig,omitempty"`
+	Worker            roleOverride            `json:"worker,omitempty"`
+	Orchestrator      roleOverride            `json:"orchestrator,omitempty"`
+	TrackerIntake     trackerIntakeConfig     `json:"trackerIntake,omitempty"`
+	BotReviewFeedback botReviewFeedbackConfig `json:"botReviewFeedback,omitempty"`
 }
 
 // setConfigRequest mirrors the daemon's SetConfigInput body for

--- a/backend/internal/domain/projectconfig.go
+++ b/backend/internal/domain/projectconfig.go
@@ -55,6 +55,19 @@ type ProjectConfig struct {
 	// read-only toward the tracker in v1: matching issues spawn sessions, but the
 	// tracker is not commented on or transitioned.
 	TrackerIntake TrackerIntakeConfig `json:"trackerIntake,omitempty"`
+
+	// BotReviewFeedback controls which bot-authored inline PR review comments
+	// are routed back to the owning agent. Empty lists allow any anchored bot
+	// review feedback; an allowlist narrows delivery, and the denylist wins.
+	BotReviewFeedback BotReviewFeedbackConfig `json:"botReviewFeedback,omitempty"`
+}
+
+// BotReviewFeedbackConfig controls bot-authored inline PR review feedback
+// delivery. Author names are provider logins such as "github-actions" or
+// "react-doctor[bot]"; matching is case-insensitive.
+type BotReviewFeedbackConfig struct {
+	AllowAuthors []string `json:"allowAuthors,omitempty"`
+	DenyAuthors  []string `json:"denyAuthors,omitempty"`
 }
 
 // ReviewerConfig names one reviewer agent by harness. The harness is drawn from
@@ -150,7 +163,56 @@ func (c ProjectConfig) Validate() error {
 	if err := c.TrackerIntake.Validate(); err != nil {
 		return err
 	}
+	if err := c.BotReviewFeedback.Validate(); err != nil {
+		return err
+	}
 	return nil
+}
+
+// AllowsAuthor reports whether bot-authored review feedback from author may be
+// delivered to the agent.
+func (c BotReviewFeedbackConfig) AllowsAuthor(author string) bool {
+	author = strings.TrimSpace(author)
+	if author == "" {
+		return false
+	}
+	if containsFold(c.DenyAuthors, author) {
+		return false
+	}
+	if len(c.AllowAuthors) > 0 {
+		return containsFold(c.AllowAuthors, author)
+	}
+	return true
+}
+
+// Validate rejects ambiguous author entries early when config is set.
+func (c BotReviewFeedbackConfig) Validate() error {
+	for i, author := range c.AllowAuthors {
+		if err := validateNoWhitespaceField(fmt.Sprintf("botReviewFeedback.allowAuthors[%d]", i), author); err != nil {
+			return err
+		}
+		if strings.TrimSpace(author) == "" {
+			return fmt.Errorf("botReviewFeedback.allowAuthors[%d]: must not be empty", i)
+		}
+	}
+	for i, author := range c.DenyAuthors {
+		if err := validateNoWhitespaceField(fmt.Sprintf("botReviewFeedback.denyAuthors[%d]", i), author); err != nil {
+			return err
+		}
+		if strings.TrimSpace(author) == "" {
+			return fmt.Errorf("botReviewFeedback.denyAuthors[%d]: must not be empty", i)
+		}
+	}
+	return nil
+}
+
+func containsFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), want) {
+			return true
+		}
+	}
+	return false
 }
 
 func validateNoWhitespaceField(name, value string) error {

--- a/backend/internal/domain/projectconfig_test.go
+++ b/backend/internal/domain/projectconfig_test.go
@@ -40,11 +40,38 @@ func TestProjectConfigValidate(t *testing.T) {
 		{"tracker intake unknown provider", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Provider: "linear", Assignee: "alice"}}, true},
 		{"tracker intake repo with whitespace", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Repo: " acme/demo", Assignee: "alice"}}, true},
 		{"tracker intake assignee with whitespace", ProjectConfig{TrackerIntake: TrackerIntakeConfig{Enabled: true, Assignee: " alice"}}, true},
+		{"good bot review feedback allowlist", ProjectConfig{BotReviewFeedback: BotReviewFeedbackConfig{AllowAuthors: []string{"github-actions"}}}, false},
+		{"good bot review feedback denylist", ProjectConfig{BotReviewFeedback: BotReviewFeedbackConfig{DenyAuthors: []string{"react-doctor[bot]"}}}, false},
+		{"bot review feedback allowlist whitespace", ProjectConfig{BotReviewFeedback: BotReviewFeedbackConfig{AllowAuthors: []string{" github-actions"}}}, true},
+		{"bot review feedback denylist empty", ProjectConfig{BotReviewFeedback: BotReviewFeedbackConfig{DenyAuthors: []string{""}}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := tt.cfg.Validate(); (err != nil) != tt.wantErr {
 				t.Fatalf("Validate() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBotReviewFeedbackConfigAllowsAuthor(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    BotReviewFeedbackConfig
+		author string
+		want   bool
+	}{
+		{"default allows concrete author", BotReviewFeedbackConfig{}, "github-actions", true},
+		{"default rejects empty author", BotReviewFeedbackConfig{}, "", false},
+		{"allowlist permits listed author", BotReviewFeedbackConfig{AllowAuthors: []string{"github-actions"}}, "GitHub-Actions", true},
+		{"allowlist rejects unlisted author", BotReviewFeedbackConfig{AllowAuthors: []string{"react-doctor[bot]"}}, "github-actions", false},
+		{"denylist rejects listed author", BotReviewFeedbackConfig{DenyAuthors: []string{"github-actions"}}, "github-actions", false},
+		{"denylist wins over allowlist", BotReviewFeedbackConfig{AllowAuthors: []string{"github-actions"}, DenyAuthors: []string{"github-actions"}}, "github-actions", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.AllowsAuthor(tt.author); got != tt.want {
+				t.Fatalf("AllowsAuthor(%q) = %v, want %v", tt.author, got, tt.want)
 			}
 		})
 	}

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2272,6 +2272,17 @@ components:
       - id
       - label
       type: object
+    BotReviewFeedbackConfig:
+      properties:
+        allowAuthors:
+          items:
+            type: string
+          type: array
+        denyAuthors:
+          items:
+            type: string
+          type: array
+      type: object
     CancelReviewResponse:
       properties:
         reviewerHandleId:
@@ -2931,6 +2942,8 @@ components:
           type: string
         agentRulesFile:
           type: string
+        botReviewFeedback:
+          $ref: '#/components/schemas/BotReviewFeedbackConfig'
         defaultBranch:
           type: string
         env:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -132,14 +132,15 @@ var schemaNames = map[string]string{
 	// httpd/envelope
 	"EnvelopeAPIError": "APIError",
 	// domain
-	"DomainProjectID":           "ProjectID",
-	"DomainSessionID":           "SessionID",
-	"DomainIssueID":             "IssueID",
-	"DomainSession":             "Session",
-	"DomainProjectConfig":       "ProjectConfig",
-	"DomainTrackerIntakeConfig": "TrackerIntakeConfig",
-	"DomainAgentConfig":         "AgentConfig",
-	"DomainRoleOverride":        "RoleOverride",
+	"DomainProjectID":               "ProjectID",
+	"DomainSessionID":               "SessionID",
+	"DomainIssueID":                 "IssueID",
+	"DomainSession":                 "Session",
+	"DomainProjectConfig":           "ProjectConfig",
+	"DomainBotReviewFeedbackConfig": "BotReviewFeedbackConfig",
+	"DomainTrackerIntakeConfig":     "TrackerIntakeConfig",
+	"DomainAgentConfig":             "AgentConfig",
+	"DomainRoleOverride":            "RoleOverride",
 	// httpd/controllers (wire envelopes)
 	"ControllersListProjectsResponse":             "ListProjectsResponse",
 	"ControllersProjectResponse":                  "ProjectResponse",

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -18,6 +18,7 @@ import (
 )
 
 type sessionStore interface {
+	GetProject(ctx context.Context, id string) (domain.ProjectRecord, bool, error)
 	GetSession(ctx context.Context, id domain.SessionID) (domain.SessionRecord, bool, error)
 	UpdateSession(ctx context.Context, rec domain.SessionRecord) error
 	// ListSessions returns every session in a project. The dispatcher reads it

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -15,6 +15,7 @@ var ctx = context.Background()
 
 type fakeStore struct {
 	sessions   map[domain.SessionID]domain.SessionRecord
+	projects   map[string]domain.ProjectRecord
 	prs        map[domain.SessionID][]domain.PullRequest
 	signatures map[string]string
 
@@ -24,7 +25,17 @@ type fakeStore struct {
 }
 
 func newFakeStore() *fakeStore {
-	return &fakeStore{sessions: map[domain.SessionID]domain.SessionRecord{}, prs: map[domain.SessionID][]domain.PullRequest{}, signatures: map[string]string{}}
+	return &fakeStore{
+		sessions:   map[domain.SessionID]domain.SessionRecord{},
+		projects:   map[string]domain.ProjectRecord{},
+		prs:        map[domain.SessionID][]domain.PullRequest{},
+		signatures: map[string]string{},
+	}
+}
+
+func (f *fakeStore) GetProject(_ context.Context, id string) (domain.ProjectRecord, bool, error) {
+	r, ok := f.projects[id]
+	return r, ok, nil
 }
 
 func (f *fakeStore) GetSession(_ context.Context, id domain.SessionID) (domain.SessionRecord, bool, error) {
@@ -854,6 +865,135 @@ func TestSCMObservationProjectsToExistingPRReactions(t *testing.T) {
 	}
 	if len(msg.msgs) != 1 || !strings.Contains(msg.msgs[0], "boom") {
 		t.Fatalf("want SCM CI nudge with log tail, got %v", msg.msgs)
+	}
+}
+
+func TestSCMObservation_AllowlistedBotReviewCommentsNudge(t *testing.T) {
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: domain.ProjectConfig{
+		BotReviewFeedback: domain.BotReviewFeedbackConfig{AllowAuthors: []string{"github-actions"}},
+	}}
+	o := reactDoctorSCMObservation()
+
+	if err := m.ApplySCMObservation(ctx, "mer-1", o); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("want one allowlisted bot review nudge, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+	got := msg.msgs[0]
+	for _, want := range []string{
+		"The following 2 unresolved review comment(s)",
+		"frontend/src/components/LandingHero.tsx:1218 (@github-actions):",
+		"memoize the video props",
+		"frontend/src/components/LandingInstall.tsx:171 (@github-actions):",
+		"avoid unstable hook deps",
+		"PR: https://github.com/AgentWrapper/agent-orchestrator/pull/2826",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("bot review nudge missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestSCMObservation_DenylistedBotReviewCommentsSuppressed(t *testing.T) {
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: domain.ProjectConfig{
+		BotReviewFeedback: domain.BotReviewFeedbackConfig{DenyAuthors: []string{"github-actions"}},
+	}}
+
+	if err := m.ApplySCMObservation(ctx, "mer-1", reactDoctorSCMObservation()); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 0 {
+		t.Fatalf("denylisted bot review feedback must be suppressed, got %v", msg.msgs)
+	}
+}
+
+func TestSCMObservation_BotReviewCommentsDedupOnRepeatedObservation(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = working("mer-1")
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: domain.ProjectConfig{
+		BotReviewFeedback: domain.BotReviewFeedbackConfig{AllowAuthors: []string{"github-actions"}},
+	}}
+	first := &fakeMessenger{}
+	m1 := New(st, first)
+	o := reactDoctorSCMObservation()
+
+	if err := m1.ApplySCMObservation(ctx, "mer-1", o); err != nil {
+		t.Fatalf("first ApplySCMObservation: %v", err)
+	}
+	if len(first.msgs) != 1 {
+		t.Fatalf("first observation should nudge once, got %d: %v", len(first.msgs), first.msgs)
+	}
+	if st.signatures[o.PR.URL] == "" {
+		t.Fatal("bot review nudge did not persist the semantic dedup payload")
+	}
+
+	second := &fakeMessenger{}
+	m2 := New(st, second)
+	if err := m2.ApplySCMObservation(ctx, "mer-1", o); err != nil {
+		t.Fatalf("second ApplySCMObservation: %v", err)
+	}
+	if len(second.msgs) != 0 {
+		t.Fatalf("repeated bot review observation should dedup after restart, got %d: %v", len(second.msgs), second.msgs)
+	}
+}
+
+func TestSCMObservation_ReactDoctorGreenCINudgesAgent(t *testing.T) {
+	m, st, msg := newManager()
+	st.sessions["mer-1"] = working("mer-1")
+	o := reactDoctorSCMObservation()
+
+	if err := m.ApplySCMObservation(ctx, "mer-1", o); err != nil {
+		t.Fatal(err)
+	}
+	if len(msg.msgs) != 1 {
+		t.Fatalf("green CI with actionable React Doctor comments should nudge once, got %d: %v", len(msg.msgs), msg.msgs)
+	}
+	got := msg.msgs[0]
+	if !strings.Contains(got, "memoize the video props") || !strings.Contains(got, "avoid unstable hook deps") {
+		t.Fatalf("React Doctor bot review feedback was not delivered:\n%s", got)
+	}
+}
+
+func reactDoctorSCMObservation() ports.SCMObservation {
+	return ports.SCMObservation{
+		Fetched: true,
+		PR: ports.SCMPRObservation{
+			URL:    "https://github.com/AgentWrapper/agent-orchestrator/pull/2826",
+			Number: 2826,
+			Title:  "frontend polish",
+		},
+		CI: ports.SCMCIObservation{Summary: string(domain.CIPassing), HeadSHA: "sha1"},
+		Review: ports.SCMReviewObservation{
+			Decision: string(domain.ReviewRequired),
+			Threads: []ports.SCMReviewThreadObservation{
+				{
+					ID:           "thread-hero",
+					Path:         "frontend/src/components/LandingHero.tsx",
+					Line:         1218,
+					IsBot:        true,
+					SemanticHash: "react-doctor-thread-hero-v1",
+					Comments: []ports.SCMReviewCommentObservation{{
+						ID: "comment-hero", Author: "github-actions", Body: "memoize the video props", URL: "https://github.com/AgentWrapper/agent-orchestrator/pull/2826#discussion_r1", IsBot: true,
+					}},
+				},
+				{
+					ID:           "thread-install",
+					Path:         "frontend/src/components/LandingInstall.tsx",
+					Line:         171,
+					IsBot:        true,
+					SemanticHash: "react-doctor-thread-install-v1",
+					Comments: []ports.SCMReviewCommentObservation{{
+						ID: "comment-install", Author: "github-actions", Body: "avoid unstable hook deps", URL: "https://github.com/AgentWrapper/agent-orchestrator/pull/2826#discussion_r2", IsBot: true,
+					}},
+				},
+			},
+		},
+		Mergeability: ports.SCMMergeabilityObservation{State: string(domain.MergeMergeable)},
 	}
 }
 

--- a/backend/internal/lifecycle/reactions.go
+++ b/backend/internal/lifecycle/reactions.go
@@ -15,7 +15,10 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/sessionguard"
 )
 
-const reviewMaxNudge = 3
+const (
+	reviewMaxNudge    = 3
+	botReviewMaxNudge = 2
+)
 
 // ReviewDeliveryOutcome reports what ApplyReviewResult did with a completed
 // AO-internal review pass.
@@ -195,8 +198,9 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			nudges = append(nudges, pendingNudge{key: "ci:" + o.URL, sig: ciFailureSignature(checks), msg: msg, maxAttempts: 0})
 		}
 	}
-	if o.Review == domain.ReviewChangesRequest || hasUnresolvedComments(o.Comments) {
-		comments := unresolvedReviewComments(o.Comments)
+	humanComments := unresolvedHumanReviewComments(o.Comments)
+	if o.Review == domain.ReviewChangesRequest || len(humanComments) > 0 {
+		comments := humanComments
 		msg := formatReviewCommentsMessage(comments)
 		if ident != "your PR" {
 			msg = strings.Replace(msg, "your PR", ident, 1)
@@ -209,6 +213,17 @@ func (m *Manager) ApplyPRObservation(ctx context.Context, id domain.SessionID, o
 			sig = string(o.Review)
 		}
 		nudges = append(nudges, pendingNudge{key: "review:" + o.URL, sig: sig, msg: msg, maxAttempts: reviewMaxNudge})
+	}
+	botComments := unresolvedBotReviewComments(o.Comments)
+	if len(botComments) > 0 {
+		msg := formatReviewCommentsMessage(botComments)
+		if ident != "your PR" {
+			msg = strings.Replace(msg, "your PR", ident, 1)
+		}
+		if o.URL != "" {
+			msg += "\nPR: " + domain.SanitizeControlChars(o.URL)
+		}
+		nudges = append(nudges, pendingNudge{key: "review-bot:" + o.URL, sig: botReviewCommentsSignature(botComments), msg: msg, maxAttempts: botReviewMaxNudge})
 	}
 	// Only the merge-conflict nudge needs a store read (the parent-stack check).
 	// A read error there must NOT discard the CI/review nudges already queued
@@ -353,10 +368,14 @@ func (m *Manager) ApplySCMObservation(ctx context.Context, id domain.SessionID, 
 	if !o.Fetched {
 		return nil
 	}
-	if err := m.ApplyPRObservation(ctx, id, scmToPRObservation(o)); err != nil {
+	cfg, err := m.projectConfigForSession(ctx, id)
+	if err != nil {
 		return err
 	}
-	intent, err := m.notificationIntentForCurrentSCM(ctx, id, o)
+	if err := m.ApplyPRObservation(ctx, id, scmToPRObservation(o, cfg)); err != nil {
+		return err
+	}
+	intent, err := m.notificationIntentForCurrentSCM(ctx, id, o, cfg)
 	if err != nil {
 		return err
 	}
@@ -364,7 +383,19 @@ func (m *Manager) ApplySCMObservation(ctx context.Context, id domain.SessionID, 
 	return nil
 }
 
-func (m *Manager) notificationIntentForCurrentSCM(ctx context.Context, id domain.SessionID, o ports.SCMObservation) (*ports.NotificationIntent, error) {
+func (m *Manager) projectConfigForSession(ctx context.Context, id domain.SessionID) (domain.ProjectConfig, error) {
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil || !ok || rec.ProjectID == "" {
+		return domain.ProjectConfig{}, err
+	}
+	project, ok, err := m.store.GetProject(ctx, string(rec.ProjectID))
+	if err != nil || !ok {
+		return domain.ProjectConfig{}, err
+	}
+	return project.Config, nil
+}
+
+func (m *Manager) notificationIntentForCurrentSCM(ctx context.Context, id domain.SessionID, o ports.SCMObservation, cfg domain.ProjectConfig) (*ports.NotificationIntent, error) {
 	// Serialize the session snapshot with activity transitions so ready-to-merge
 	// notifications do not race against a simultaneous waiting_input update.
 	m.mu.Lock()
@@ -376,10 +407,10 @@ func (m *Manager) notificationIntentForCurrentSCM(ctx context.Context, id domain
 	if !ok {
 		return nil, nil
 	}
-	return m.notificationIntentForSCM(rec, o), nil
+	return m.notificationIntentForSCM(rec, o, cfg), nil
 }
 
-func (m *Manager) notificationIntentForSCM(rec domain.SessionRecord, o ports.SCMObservation) *ports.NotificationIntent {
+func (m *Manager) notificationIntentForSCM(rec domain.SessionRecord, o ports.SCMObservation, cfg domain.ProjectConfig) *ports.NotificationIntent {
 	prURL := firstSCMNonEmpty(o.PR.URL, o.PR.HTMLURL)
 	base := ports.NotificationIntent{
 		SessionID:          rec.ID,
@@ -402,14 +433,14 @@ func (m *Manager) notificationIntentForSCM(rec domain.SessionRecord, o ports.SCM
 		base.Type = domain.NotificationPRClosedUnmerged
 		return &base
 	}
-	if rec.IsTerminated || rec.Activity.State.NeedsInput() || !scmObservationIsReadyToMerge(o) {
+	if rec.IsTerminated || rec.Activity.State.NeedsInput() || !scmObservationIsReadyToMerge(o, cfg) {
 		return nil
 	}
 	base.Type = domain.NotificationReadyToMerge
 	return &base
 }
 
-func scmObservationIsReadyToMerge(o ports.SCMObservation) bool {
+func scmObservationIsReadyToMerge(o ports.SCMObservation, cfg domain.ProjectConfig) bool {
 	if o.PR.Merged || o.PR.Closed || o.PR.Draft {
 		return false
 	}
@@ -421,19 +452,22 @@ func scmObservationIsReadyToMerge(o ports.SCMObservation) bool {
 	case domain.CIFailing, domain.CIPending, domain.CIUnknown:
 		return false
 	}
-	if domain.ReviewDecision(o.Review.Decision) == domain.ReviewChangesRequest || hasUnresolvedSCMComments(o.Review.Threads) {
+	if domain.ReviewDecision(o.Review.Decision) == domain.ReviewChangesRequest || hasUnresolvedSCMComments(o.Review.Threads, cfg) {
 		return false
 	}
 	return domain.Mergeability(o.Mergeability.State) == domain.MergeMergeable
 }
 
-func hasUnresolvedSCMComments(threads []ports.SCMReviewThreadObservation) bool {
+func hasUnresolvedSCMComments(threads []ports.SCMReviewThreadObservation, cfg domain.ProjectConfig) bool {
 	for _, th := range threads {
-		if th.Resolved || th.IsBot {
+		if th.Resolved {
 			continue
 		}
 		for _, c := range th.Comments {
-			if !c.IsBot {
+			if !c.IsBot && !th.IsBot {
+				return true
+			}
+			if botReviewCommentActionable(th, c, cfg) {
 				return true
 			}
 		}
@@ -441,7 +475,7 @@ func hasUnresolvedSCMComments(threads []ports.SCMReviewThreadObservation) bool {
 	return false
 }
 
-func scmToPRObservation(o ports.SCMObservation) ports.PRObservation {
+func scmToPRObservation(o ports.SCMObservation, cfg domain.ProjectConfig) ports.PRObservation {
 	pr := ports.PRObservation{
 		Fetched:      o.Fetched,
 		URL:          firstSCMNonEmpty(o.PR.URL, o.PR.HTMLURL),
@@ -484,26 +518,42 @@ func scmToPRObservation(o ports.SCMObservation) ports.PRObservation {
 		})
 	}
 	for _, th := range o.Review.Threads {
-		if th.Resolved || th.IsBot {
+		if th.Resolved {
 			continue
 		}
 		for _, c := range th.Comments {
-			if c.IsBot {
+			isBot := c.IsBot || th.IsBot
+			if isBot && !botReviewCommentActionable(th, c, cfg) {
 				continue
 			}
 			pr.Comments = append(pr.Comments, ports.PRCommentObservation{
-				ID:       c.ID,
-				ThreadID: th.ID,
-				Author:   c.Author,
-				File:     th.Path,
-				Line:     th.Line,
-				Body:     c.Body,
-				URL:      c.URL,
-				Resolved: th.Resolved,
+				ID:           c.ID,
+				ThreadID:     th.ID,
+				Author:       c.Author,
+				File:         th.Path,
+				Line:         th.Line,
+				Body:         c.Body,
+				URL:          c.URL,
+				Resolved:     th.Resolved,
+				IsBot:        isBot,
+				SemanticHash: th.SemanticHash,
 			})
 		}
 	}
 	return pr
+}
+
+func botReviewCommentActionable(th ports.SCMReviewThreadObservation, c ports.SCMReviewCommentObservation, cfg domain.ProjectConfig) bool {
+	if !c.IsBot && !th.IsBot {
+		return false
+	}
+	if strings.TrimSpace(th.Path) == "" || th.Line <= 0 {
+		return false
+	}
+	if strings.TrimSpace(c.Body) == "" {
+		return false
+	}
+	return cfg.BotReviewFeedback.AllowsAuthor(c.Author)
 }
 
 // ApplyTrackerFacts reacts to a fetched Tracker issue observation. It owns the
@@ -616,13 +666,26 @@ func prIdentity(o ports.PRObservation) string {
 	return id
 }
 
-func hasUnresolvedComments(comments []ports.PRCommentObservation) bool {
+func unresolvedHumanReviewComments(comments []ports.PRCommentObservation) []ports.PRCommentObservation {
+	unresolved := make([]ports.PRCommentObservation, 0, len(comments))
 	for _, c := range comments {
-		if !c.Resolved {
-			return true
+		if c.Resolved || c.IsBot {
+			continue
 		}
+		unresolved = append(unresolved, c)
 	}
-	return false
+	return unresolved
+}
+
+func unresolvedBotReviewComments(comments []ports.PRCommentObservation) []ports.PRCommentObservation {
+	unresolved := make([]ports.PRCommentObservation, 0, len(comments))
+	for _, c := range comments {
+		if c.Resolved || !c.IsBot {
+			continue
+		}
+		unresolved = append(unresolved, c)
+	}
+	return unresolved
 }
 
 func failedPRChecks(checks []ports.PRCheckObservation) []ports.PRCheckObservation {
@@ -679,17 +742,6 @@ func formatCIFailureMessage(checks []ports.PRCheckObservation) string {
 	return msg.String()
 }
 
-func unresolvedReviewComments(comments []ports.PRCommentObservation) []ports.PRCommentObservation {
-	unresolved := make([]ports.PRCommentObservation, 0, len(comments))
-	for _, c := range comments {
-		if c.Resolved {
-			continue
-		}
-		unresolved = append(unresolved, c)
-	}
-	return unresolved
-}
-
 func reviewCommentsSignature(comments []ports.PRCommentObservation) string {
 	parts := make([]string, 0, len(comments))
 	for _, c := range comments {
@@ -699,6 +751,28 @@ func reviewCommentsSignature(comments []ports.PRCommentObservation) string {
 			continue
 		}
 		parts = append(parts, threadID+"\x00"+id)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "\x01")
+}
+
+func botReviewCommentsSignature(comments []ports.PRCommentObservation) string {
+	parts := make([]string, 0, len(comments))
+	seen := map[string]bool{}
+	for _, c := range comments {
+		part := strings.TrimSpace(c.SemanticHash)
+		if part == "" {
+			id := strings.TrimSpace(c.ID)
+			threadID := strings.TrimSpace(c.ThreadID)
+			if id == "" && threadID == "" {
+				continue
+			}
+			part = threadID + "\x00" + id
+		}
+		if !seen[part] {
+			parts = append(parts, part)
+			seen[part] = true
+		}
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, "\x01")

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -1053,6 +1053,11 @@ func (o *Observer) needsReviewRefresh(key string, local domain.PullRequest, deci
 }
 
 func (o *Observer) prepareForPersistence(obs ports.SCMObservation, local domain.PullRequest, opts persistenceOptions, now time.Time) ports.SCMObservation {
+	for i := range obs.Review.Threads {
+		if obs.Review.Threads[i].SemanticHash == "" {
+			obs.Review.Threads[i].SemanticHash = threadSemanticHash(obs.Review.Threads[i])
+		}
+	}
 	metadataHash := metadataSemanticHash(obs)
 	if opts.preserveLocalMetadataHash {
 		metadataHash = local.MetadataHash
@@ -1168,7 +1173,11 @@ func domainFromObservation(sessionID domain.SessionID, obs ports.SCMObservation,
 	}
 	comments := make([]domain.PullRequestComment, 0, commentCount)
 	for _, th := range obs.Review.Threads {
-		threads = append(threads, domain.PullRequestReviewThread{ThreadID: th.ID, Path: th.Path, Line: th.Line, Resolved: th.Resolved, IsBot: th.IsBot, SemanticHash: threadSemanticHash(th), UpdatedAt: now})
+		semanticHash := th.SemanticHash
+		if semanticHash == "" {
+			semanticHash = threadSemanticHash(th)
+		}
+		threads = append(threads, domain.PullRequestReviewThread{ThreadID: th.ID, Path: th.Path, Line: th.Line, Resolved: th.Resolved, IsBot: th.IsBot, SemanticHash: semanticHash, UpdatedAt: now})
 		for _, c := range th.Comments {
 			comments = append(comments, domain.PullRequestComment{ThreadID: th.ID, ID: c.ID, Author: c.Author, File: th.Path, Line: th.Line, Body: c.Body, URL: c.URL, Resolved: th.Resolved, IsBot: c.IsBot || th.IsBot, CreatedAt: now})
 		}

--- a/backend/internal/ports/pr_observations.go
+++ b/backend/internal/ports/pr_observations.go
@@ -48,12 +48,14 @@ type PRCheckObservation struct {
 
 // PRCommentObservation is one review comment observed on the PR.
 type PRCommentObservation struct {
-	ID       string
-	ThreadID string
-	Author   string
-	File     string
-	Line     int
-	Body     string
-	URL      string
-	Resolved bool
+	ID           string
+	ThreadID     string
+	Author       string
+	File         string
+	Line         int
+	Body         string
+	URL          string
+	Resolved     bool
+	IsBot        bool
+	SemanticHash string
 }

--- a/backend/internal/ports/scm_observations.go
+++ b/backend/internal/ports/scm_observations.go
@@ -225,6 +225,10 @@ type SCMReviewThreadObservation struct {
 	Resolved bool
 	// IsBot is true when the thread's comments are all/primarily bot-authored.
 	IsBot bool
+	// SemanticHash is a stable hash of the provider thread payload. It is also
+	// stored in pr_review_threads.semantic_hash and can anchor dedup when bots
+	// edit an existing inline finding.
+	SemanticHash string
 	// Comments contains normalized comments in this review thread.
 	Comments []SCMReviewCommentObservation
 }

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -181,6 +181,7 @@ func TestProjectConfigRoundTrips(t *testing.T) {
 		OrchestratorRules: "Keep workers unblocked.",
 		AgentConfig:       domain.AgentConfig{Model: "claude-opus-4-5", Permissions: domain.PermissionModeAcceptEdits},
 		Worker:            domain.RoleOverride{Harness: domain.HarnessCodex},
+		BotReviewFeedback: domain.BotReviewFeedbackConfig{AllowAuthors: []string{"github-actions"}, DenyAuthors: []string{"noisy-bot[bot]"}},
 	}
 	if err := s.UpsertProject(ctx, domain.ProjectRecord{
 		ID: "cfg", Path: "/tmp/cfg", RegisteredAt: now, Config: cfg,

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -830,6 +830,10 @@ export interface components {
             id: string;
             label: string;
         };
+        BotReviewFeedbackConfig: {
+            allowAuthors?: string[];
+            denyAuthors?: string[];
+        };
         CancelReviewResponse: {
             reviewerHandleId: string;
             reviews: components["schemas"]["PRReviewState"][];
@@ -1075,6 +1079,7 @@ export interface components {
             agentConfig?: components["schemas"]["AgentConfig"];
             agentRules?: string;
             agentRulesFile?: string;
+            botReviewFeedback?: components["schemas"]["BotReviewFeedbackConfig"];
             defaultBranch?: string;
             env?: {
                 [key: string]: string;


### PR DESCRIPTION
## Summary
- add per-project `botReviewFeedback` allow/deny author policy for bot-authored inline PR review feedback
- deliver anchored bot review comments through a separate capped `review-bot` nudge path using thread semantic hashes for dedup
- keep ready-to-merge notifications blocked by actionable allowed bot feedback and regenerate OpenAPI/TS project config schema

Fixes #2827

## Tests
- `go test ./internal/domain ./internal/lifecycle ./internal/observe/scm ./internal/httpd/...`
- `go test ./internal/storage/sqlite/store -run TestProjectConfigRoundTrips -count=1`
- `env -u AO_PROJECT_ID -u AO_SESSION_ID go test ./...`
- `npm run frontend:typecheck`
- `env -u AO_PROJECT_ID -u AO_SESSION_ID npm run lint`

## Notes
- `AO_PROJECT_ID` and `AO_SESSION_ID` are unset for full backend/lint verification because this worker session exports them and they alter CLI spawn project-resolution tests.