### PR TITLE
fix(frontend): deep-link PR notifications to sessions

### DIFF
--- a/frontend/src/renderer/components/NotificationCenter.test.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.test.tsx
@@ -1,8 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NotificationCenter } from "./NotificationCenter";
 import type { NotificationDTO } from "../lib/notifications";
+
+const { navigateMock } = vi.hoisted(() => ({ navigateMock: vi.fn() }));
 
 const notifications: NotificationDTO[] = [
 	{
@@ -21,17 +24,41 @@ const notifications: NotificationDTO[] = [
 		id: "ntf_2",
 		sessionId: "sess-2",
 		projectId: "proj-1",
-		prUrl: "",
+		prUrl: "https://github.com/example/repo/pull/2",
 		type: "ready_to_merge",
-		title: "Ready to merge",
+		title: "Project PR ready to merge",
 		body: "",
 		status: "unread",
 		createdAt: "2026-06-16T11:00:00Z",
-		target: { kind: "session", sessionId: "sess-2" },
+		target: { kind: "pr", sessionId: "sess-2", prUrl: "https://github.com/example/repo/pull/2" },
+	},
+	{
+		id: "ntf_3",
+		sessionId: "sess-3",
+		projectId: "",
+		prUrl: "https://github.com/example/repo/pull/3",
+		type: "pr_merged",
+		title: "Unscoped PR merged",
+		body: "",
+		status: "unread",
+		createdAt: "2026-06-16T11:30:00Z",
+		target: { kind: "pr", sessionId: "sess-3", prUrl: "https://github.com/example/repo/pull/3" },
+	},
+	{
+		id: "ntf_4",
+		sessionId: "",
+		projectId: "",
+		prUrl: "https://github.com/example/repo/pull/4",
+		type: "pr_closed_unmerged",
+		title: "PR without a session",
+		body: "",
+		status: "unread",
+		createdAt: "2026-06-16T13:00:00Z",
+		target: { kind: "pr", sessionId: "", prUrl: "https://github.com/example/repo/pull/4" },
 	},
 ];
 
-vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => navigateMock }));
 
 vi.mock("../hooks/useNotificationsQuery", () => ({
 	useMarkAllNotificationsReadMutation: () => ({ isPending: false, mutateAsync: vi.fn() }),
@@ -53,13 +80,26 @@ function renderNotificationCenter() {
 	);
 }
 
+async function openNotification(title: string) {
+	const user = userEvent.setup();
+	await user.click(screen.getByRole("button", { name: "4 unread notifications" }));
+	const item = (await screen.findByText(title)).closest(".grid");
+	expect(item).not.toBeNull();
+	await user.click(within(item as HTMLElement).getByTitle("Open target"));
+}
+
 describe("NotificationCenter", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		navigateMock.mockReset();
+	});
+
 	it("renders a filled bell with a text-only yellow unread count", () => {
 		renderNotificationCenter();
 
-		const trigger = screen.getByRole("button", { name: "2 unread notifications" });
+		const trigger = screen.getByRole("button", { name: "4 unread notifications" });
 		const bell = trigger.querySelector("svg");
-		const count = screen.getByText("2");
+		const count = screen.getByText("4");
 
 		expect(bell).toHaveClass("fill-current");
 		expect(count).toHaveClass("text-caption");
@@ -67,5 +107,51 @@ describe("NotificationCenter", () => {
 		expect(count).not.toHaveClass("bg-warning");
 		expect(count).not.toHaveClass("rounded-full");
 		expect(count).not.toHaveClass("text-background");
+	});
+
+	it("opens a PR and navigates to its project-scoped session", async () => {
+		const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+		renderNotificationCenter();
+
+		await openNotification("Project PR ready to merge");
+
+		expect(openSpy).toHaveBeenCalledWith("https://github.com/example/repo/pull/2", "_blank", "noopener,noreferrer");
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/sessions/$sessionId",
+			params: { projectId: "proj-1", sessionId: "sess-2" },
+		});
+	});
+
+	it("opens a PR and navigates to its unscoped session", async () => {
+		const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+		renderNotificationCenter();
+
+		await openNotification("Unscoped PR merged");
+
+		expect(openSpy).toHaveBeenCalledWith("https://github.com/example/repo/pull/3", "_blank", "noopener,noreferrer");
+		expect(navigateMock).toHaveBeenCalledWith({ to: "/sessions/$sessionId", params: { sessionId: "sess-3" } });
+	});
+
+	it("keeps session notification navigation unchanged", async () => {
+		const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+		renderNotificationCenter();
+
+		await openNotification("Needs input");
+
+		expect(openSpy).not.toHaveBeenCalled();
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/sessions/$sessionId",
+			params: { projectId: "proj-1", sessionId: "sess-1" },
+		});
+	});
+
+	it("opens a PR without navigating when its session ID is missing", async () => {
+		const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+		renderNotificationCenter();
+
+		await openNotification("PR without a session");
+
+		expect(openSpy).toHaveBeenCalledWith("https://github.com/example/repo/pull/4", "_blank", "noopener,noreferrer");
+		expect(navigateMock).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -33,7 +33,6 @@ function useNotificationTargetNavigation() {
 			if (target.kind === "pr" && target.prUrl) {
 				void captureRendererEvent("ao.renderer.notification_opened", { target: "pr" });
 				window.open(target.prUrl, "_blank", "noopener,noreferrer");
-				return;
 			}
 			const sessionId = target.sessionId || notification.sessionId;
 			if (!sessionId) return;


### PR DESCRIPTION
## Summary

Fixes #2726 (AO-09, P1). PR-type notifications only opened the external GitHub PR link and never navigated into the owning AO session — the in-app navigation path was unreachable because the PR branch returned early.

This removes the early `return` after `window.open(...)` in `NotificationCenter`, so clicking a PR notification now:
- opens the external GitHub PR link (unchanged), **and**
- also navigates to the owning AO session when a session id is present.

Backend already carries session context for PR notifications (`service/notification/service.go`, `httpd/controllers/notifications.go` set `Kind: "pr"` with `SessionID`), so no backend change is required.

Ports the fix merged on the fork PR xuelongmu/agent-orchestrator#196.

## Changes
- `frontend/src/renderer/components/NotificationCenter.tsx` — drop the early return in the PR-target branch.
- `frontend/src/renderer/components/NotificationCenter.test.tsx` — regression tests:
  - project-scoped PR → navigates to scoped session route
  - unscoped PR → navigates to unscoped session route
  - session-kind notifications unchanged
  - PR without session id → opens PR link, no in-app nav

## Notes / follow-ups
- `ao.renderer.notification_opened` now emits twice for a PR click (`target: "pr"` then `target: "session"`). Flagging in case dashboards assume one event per click — can adjust telemetry in a follow-up if intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)