### PR TITLE
fix(landing): emit docs routes with trailing slashes

### DIFF
--- a/frontend/src/landing/app/not-found.tsx
+++ b/frontend/src/landing/app/not-found.tsx
@@ -12,7 +12,7 @@ export default function NotFound() {
 			</p>
 			<div className="flex gap-4 text-sm underline underline-offset-4">
 				<Link href="/">Home</Link>
-				<Link href="/docs">Docs</Link>
+				<Link href="/docs/">Docs</Link>
 			</div>
 		</main>
 	);

--- a/frontend/src/landing/components/LandingFooter.tsx
+++ b/frontend/src/landing/components/LandingFooter.tsx
@@ -7,17 +7,17 @@ const columns = [
 		links: [
 			{ label: "Features", href: "#features" },
 			{ label: "Agents", href: "#agents" },
-			{ label: "Install", href: "/docs/installation" },
-			{ label: "CLI", href: "/docs/cli" },
+			{ label: "Install", href: "/docs/installation/" },
+			{ label: "CLI", href: "/docs/cli/" },
 		],
 	},
 	{
 		title: "Docs",
 		links: [
-			{ label: "Overview", href: "/docs" },
-			{ label: "Architecture", href: "/docs/architecture" },
-			{ label: "Plugins", href: "/docs/plugins" },
-			{ label: "Changelog", href: "/docs/changelog" },
+			{ label: "Overview", href: "/docs/" },
+			{ label: "Architecture", href: "/docs/architecture/" },
+			{ label: "Plugins", href: "/docs/plugins/" },
+			{ label: "Changelog", href: "/docs/changelog/" },
 		],
 	},
 	{

--- a/frontend/src/landing/components/LandingNav.tsx
+++ b/frontend/src/landing/components/LandingNav.tsx
@@ -80,7 +80,7 @@ const socials = [
 const navLinks = [
 	{ label: "Demo", href: "#see-it" },
 	{ label: "Features", href: "#features" },
-	{ label: "Docs", href: "/docs" },
+	{ label: "Docs", href: "/docs/" },
 ];
 
 export function LandingNav() {

--- a/frontend/src/landing/components/docs/DocsMissingPage.tsx
+++ b/frontend/src/landing/components/docs/DocsMissingPage.tsx
@@ -28,7 +28,7 @@ export function DocsMissingPage() {
 									search in the sidebar to find where it landed.
 								</p>
 								<div className="docs-missing-actions">
-									<Link href="/docs" className="docs-missing-primary">
+									<Link href="/docs/" className="docs-missing-primary">
 										Browse docs
 									</Link>
 									<Link href="/" className="docs-missing-secondary">

--- a/frontend/src/landing/next.config.mjs
+++ b/frontend/src/landing/next.config.mjs
@@ -6,6 +6,9 @@ const nextConfig = {
 	// and every route (including /api/search via staticGET) is emitted at build.
 	output: "export",
 	images: { unoptimized: true },
+	// Emit /docs/index.html and /docs/*/index.html so static hosts/CDNs do not
+	// have to choose between a sibling docs.html file and the docs/ directory.
+	trailingSlash: true,
 };
 
 const withMDX = createMDX();


### PR DESCRIPTION
## Summary
- emit the landing/docs static export with `trailingSlash: true` so docs pages are written as `/docs/.../index.html`
- update landing/footer and fallback docs links to canonical trailing-slash URLs

## Root cause
The deployed static artifact previously emitted both `docs.html` and a `docs/` directory for nested docs pages. GitHub Pages can serve that shape, but the public Cloudflare path for `aoagents.dev` still self-redirects on `/docs*`, reproducing #2817. Directory index output avoids that ambiguous routing shape on static hosts/CDNs.

Fixes #2817

## Validation
- `cd frontend/src/landing && npm run build`
- confirmed exported files include `out/docs/index.html`, `out/docs/architecture/index.html`, `out/docs/plugins/index.html`, and `out/docs/changelog/index.html`
- local static server: `/docs`, `/docs/architecture`, `/docs/plugins`, and `/docs/changelog` each redirect once to the slash URL and return `200` with the expected title
