### PR TITLE
fix(landing): shorten orchestrator CTA label

### DIFF
--- a/frontend/src/landing/components/LandingHero.tsx
+++ b/frontend/src/landing/components/LandingHero.tsx
@@ -595,11 +595,11 @@ function HeroDashboardMockup() {
 									</button>
 									<button
 										type="button"
-										onClick={() => showTerminal(`Spawn orchestrator · ${activeProjectLabel}`)}
+										onClick={() => showTerminal(`Orchestrator · ${activeProjectLabel}`)}
 										className="hero-pressable inline-flex h-[34px] items-center gap-1.5 rounded-[7px] bg-[color:var(--accent)] px-[15px] text-[13px] font-semibold leading-none text-[#11140c] hover:brightness-110"
 									>
 										<NetworkIcon className="h-3.5 w-3.5" />
-										Spawn Orchestrator
+										Orchestrator
 									</button>
 								</div>
 							</div>


### PR DESCRIPTION
## Summary
- rename the live-preview top-right CTA from `Spawn Orchestrator` to `Orchestrator`
- update the mock terminal title opened by that CTA to use the same wording

## Validation
- `cd frontend/src/landing && npm run build`
- `npx --yes prettier@3 --check frontend/src/landing/components/LandingHero.tsx`
- `git diff --check`
- confirmed generated landing output no longer contains `Spawn Orchestrator`
