### PR TITLE
feat(mobile): terminal scroll-to-top, tab scroll-to-top, and open new session on spawn

### DIFF
--- a/packages/mobile/app/(tabs)/index.tsx
+++ b/packages/mobile/app/(tabs)/index.tsx
@@ -9,6 +9,7 @@ import { ProjectSwitcher } from "../../lib/ProjectSwitcher";
 import { SessionCard } from "../../lib/SessionCard";
 import { useApp, useVisibleSessions } from "../../lib/store";
 import { attentionMeta, theme } from "../../lib/theme";
+import { useTabScrollToTop } from "../../lib/useTabScrollToTop";
 import { Button, ConnectionPill, EmptyState, ScreenHeader, SectionHeader } from "../../lib/ui";
 
 type Section = { key: string; label: string; color: string; order: number; data: DashboardSession[] };
@@ -38,6 +39,8 @@ export default function FleetScreen() {
 	const { configured, loading, error, connection, config, refresh } = useApp();
 	const sessions = useVisibleSessions();
 	const [refreshing, setRefreshing] = useState(false);
+
+	const listRef = useTabScrollToTop<SectionList<DashboardSession>>();
 
 	const sections = useMemo(() => groupByAttention(sessions), [sessions]);
 
@@ -94,6 +97,7 @@ export default function FleetScreen() {
 				</View>
 			) : (
 				<SectionList
+					ref={listRef}
 					sections={sections}
 					keyExtractor={(item) => `${item.projectId}:${item.id}`}
 					contentContainerStyle={{ paddingBottom: 120 }}

--- a/packages/mobile/app/(tabs)/orchestrator.tsx
+++ b/packages/mobile/app/(tabs)/orchestrator.tsx
@@ -7,6 +7,7 @@ import { attentionOf, type DashboardSession, type OrchestratorLink } from "../..
 import { haptics } from "../../lib/haptics";
 import { useApp } from "../../lib/store";
 import { attentionMeta, statusVisual, theme, type AttentionLevel, type StatusVisual } from "../../lib/theme";
+import { useTabScrollToTop } from "../../lib/useTabScrollToTop";
 import { Button, ConnectionPill, Dot, EmptyState, ScreenHeader } from "../../lib/ui";
 
 const ZONE_ORDER: AttentionLevel[] = ["merge", "respond", "review", "pending", "working", "done"];
@@ -15,6 +16,8 @@ export default function OrchestratorScreen() {
 	const insets = useSafeAreaInsets();
 	const { configured, connection, projects, sessions, orchestrators, refresh } = useApp();
 	const [refreshing, setRefreshing] = useState(false);
+
+	const scrollRef = useTabScrollToTop<ScrollView>();
 
 	// Always show every project's orchestrator here - no per-project filtering.
 	const visibleProjects = projects;
@@ -45,6 +48,7 @@ export default function OrchestratorScreen() {
 			/>
 
 			<ScrollView
+				ref={scrollRef}
 				contentContainerStyle={{ paddingBottom: 110, paddingTop: 4 }}
 				refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.blue} />}
 			>

--- a/packages/mobile/app/(tabs)/prs.tsx
+++ b/packages/mobile/app/(tabs)/prs.tsx
@@ -7,6 +7,7 @@ import { haptics } from "../../lib/haptics";
 import { ProjectSwitcher } from "../../lib/ProjectSwitcher";
 import { useApp, usePRs } from "../../lib/store";
 import { ciVisual, theme } from "../../lib/theme";
+import { useTabScrollToTop } from "../../lib/useTabScrollToTop";
 import { Button, Chip, ConnectionPill, EmptyState, Pill, ScreenHeader } from "../../lib/ui";
 
 type Filter = "open" | "merged" | "all";
@@ -18,6 +19,8 @@ export default function PRsScreen() {
 	const prs = usePRs();
 	const [filter, setFilter] = useState<Filter>("open");
 	const [refreshing, setRefreshing] = useState(false);
+
+	const scrollRef = useTabScrollToTop<ScrollView>();
 
 	const filtered = useMemo(() => {
 		return prs.filter(({ pr }) => {
@@ -68,6 +71,7 @@ export default function PRsScreen() {
 			</View>
 
 			<ScrollView
+				ref={scrollRef}
 				contentContainerStyle={{ paddingBottom: 110, paddingTop: 4 }}
 				refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.blue} />}
 			>

--- a/packages/mobile/app/(tabs)/settings.tsx
+++ b/packages/mobile/app/(tabs)/settings.tsx
@@ -22,12 +22,15 @@ import { haptics } from "../../lib/haptics";
 import { getPushStatus, openNotificationSettings, type PushStatus, registerForPush } from "../../lib/push";
 import { useApp } from "../../lib/store";
 import { theme } from "../../lib/theme";
+import { useTabScrollToTop } from "../../lib/useTabScrollToTop";
 import { Button, ConnectionPill, ScreenHeader } from "../../lib/ui";
 
 export default function SettingsScreen() {
 	const insets = useSafeAreaInsets();
 	const router = useRouter();
 	const { reloadConfig, projects, connection, setActiveProject } = useApp();
+
+	const scrollRef = useTabScrollToTop<ScrollView>();
 
 	// Tapping a project scopes the Kanban board to it and jumps to that tab.
 	const openProject = (id: string) => {
@@ -138,6 +141,7 @@ export default function SettingsScreen() {
 			<View style={{ height: insets.top }} />
 			<ScreenHeader title="Settings" right={<ConnectionPill status={connection} />} />
 			<ScrollView
+				ref={scrollRef}
 				style={styles.screen}
 				contentContainerStyle={{ padding: 16, paddingBottom: 120 }}
 				keyboardShouldPersistTaps="handled"

--- a/packages/mobile/app/session/[id].tsx
+++ b/packages/mobile/app/session/[id].tsx
@@ -255,6 +255,10 @@ const TERMINAL_ENHANCE_JS = `
   }
 
   document.addEventListener('touchstart', function (e) {
+    // Taps on the scroll-to-top button are handled by the button itself; don't
+    // let this capture-phase listener consume them as a terminal tap/long-press.
+    var _tt = e.target;
+    if (_tt && _tt.closest && _tt.closest('#ao-scrolltop')) return;
     if (e.touches && e.touches.length >= 2) {
       // Second finger down -> pinch. Cancel any pending tap/long-press/scroll.
       clearLP(); mode = 'pinch';
@@ -376,6 +380,82 @@ const TERMINAL_ENHANCE_JS = `
     }
     mode = 'idle';
   }, { capture: true, passive: true });
+
+  // ---- Scroll-to-top button ------------------------------------------------
+  // A floating button that scrolls back to the oldest output. It lives in the
+  // terminal DOM (not RN) because the WebView package exposes no inject hook.
+  // Two regimes, mirroring the drag handler above:
+  //  • normal buffer  -> xterm owns the scrollback; scrollToTop() is a true jump,
+  //    and viewportY tells us whether there's anything above (hide at the top).
+  //  • alt buffer / mouse-tracking (Claude Code, Codex, aider, vim, less, ...) ->
+  //    the APP owns its scrollback, so scrollToTop() can't reach it. Send the same
+  //    wheel notches a drag produces. We can't query the app's scroll position, so
+  //    the button always shows there and the jump is a generous burst.
+  (function scrollTopBtn() {
+    var btn = document.createElement('div');
+    btn.id = 'ao-scrolltop';
+    btn.setAttribute('aria-label', 'Scroll to top');
+    btn.innerHTML = '↑'; // up arrow
+    var s = btn.style;
+    s.position = 'fixed'; s.right = '12px'; s.bottom = '12px';
+    s.width = '36px'; s.height = '36px'; s.lineHeight = '36px';
+    s.textAlign = 'center'; s.borderRadius = '18px';
+    s.background = 'rgba(20,28,40,0.72)'; s.color = '#dbe4f0';
+    s.fontSize = '18px'; s.fontWeight = '600';
+    s.border = '1px solid rgba(120,140,170,0.35)';
+    s.boxShadow = '0 2px 8px rgba(0,0,0,0.4)';
+    s.webkitBackdropFilter = 'blur(6px)'; s.backdropFilter = 'blur(6px)';
+    s.zIndex = '2147483647'; s.display = 'none'; s.cursor = 'pointer';
+    s.pointerEvents = 'auto'; s.userSelect = 'none'; s.webkitUserSelect = 'none';
+    (document.getElementById('terminal') || document.body).appendChild(btn);
+
+    function atTop() {
+      try { var b = term().buffer.active; return !b || b.viewportY <= 0; }
+      catch (_) { return true; }
+    }
+    function update() {
+      // When the app drives scrolling we can't read its position, so always offer
+      // the button; otherwise hide it once xterm's viewport is at the top.
+      var show = appDrivesScroll() ? true : !atTop();
+      btn.style.display = show ? 'block' : 'none';
+    }
+    // Walk the app's scrollback up with the same wheel notches a drag produces,
+    // chunked across frames so a few hundred events don't block the renderer.
+    var TOP_BURST = 400, BURST_CHUNK = 25;
+    function burstUp() {
+      var el = document.querySelector('.xterm');
+      var r = el ? el.getBoundingClientRect() : null;
+      var cx = r ? r.left + r.width / 2 : 0;
+      var cy = r ? r.top + r.height / 2 : 0;
+      var left = TOP_BURST;
+      (function step() {
+        for (var i = 0; i < BURST_CHUNK && left > 0; i++, left--) wheelTick(true, cx, cy);
+        if (left > 0) requestAnimationFrame(step);
+      })();
+    }
+    // Tap -> back to the oldest output. Swallow the event so nothing else reacts.
+    function go(e) {
+      if (e.stopPropagation) e.stopPropagation();
+      if (e.cancelable && e.preventDefault) e.preventDefault();
+      if (appDrivesScroll()) burstUp();
+      else { try { term().scrollToTop(); } catch (_) {} }
+      update();
+    }
+    btn.addEventListener('touchstart', go, { capture: true });
+    btn.addEventListener('click', go, { capture: true });
+
+    // Re-evaluate on xterm scroll and buffer switches; poll as a cheap fallback
+    // for transitions those miss (our drag handler moves the viewport directly).
+    (function wire() {
+      var T = term();
+      if (T && T.onScroll) {
+        T.onScroll(update);
+        try { if (T.buffer && T.buffer.onBufferChange) T.buffer.onBufferChange(update); } catch (_) {}
+        update();
+      } else { setTimeout(wire, 200); }
+    })();
+    setInterval(update, 500);
+  })();
 
   // Disable the WebView's hidden textarea so it can NEVER show a keyboard or
   // steal first-responder from the RN input. RN handles all keyboard I/O.

--- a/packages/mobile/app/spawn.tsx
+++ b/packages/mobile/app/spawn.tsx
@@ -2,6 +2,7 @@ import { Feather } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
 import {
+	InteractionManager,
 	KeyboardAvoidingView,
 	Modal,
 	Platform,
@@ -112,9 +113,22 @@ export default function SpawnModal() {
 		setBusy(true);
 		setError(null);
 		try {
-			await spawn(prompt.trim() || undefined, projectId, harness || undefined);
+			const session = await spawn(prompt.trim() || undefined, projectId, harness || undefined);
 			haptics.success();
+			// Dismiss the modal first, then open the freshly spawned session's terminal
+			// once the dismiss transition has settled. Firing both navigations in the
+			// same tick overlaps their animations (the modal retracts while the session
+			// is already sliding in); runAfterInteractions waits for the modal's
+			// transition to finish so the two happen back-to-back, not on top of each
+			// other. The session screen shows its own "connecting" state while the
+			// terminal attaches, so landing on it before the PTY is ready is expected.
 			router.back();
+			InteractionManager.runAfterInteractions(() => {
+				router.push({
+					pathname: "/session/[id]",
+					params: { id: session.id, projectId: session.projectId },
+				});
+			});
 		} catch (e) {
 			haptics.error();
 			setError(e instanceof Error ? e.message : "Failed to spawn agent.");

--- a/packages/mobile/lib/store.tsx
+++ b/packages/mobile/lib/store.tsx
@@ -41,7 +41,7 @@ type AppState = {
 	reloadConfig: () => Promise<void>;
 	refresh: () => Promise<void>;
 	setActiveProject: (id: string) => void;
-	spawn: (prompt?: string, projectId?: string, harness?: string) => Promise<void>;
+	spawn: (prompt?: string, projectId?: string, harness?: string) => Promise<DashboardSession>;
 	launchConductor: (projectId: string, clean?: boolean) => Promise<OrchestratorLink>;
 	merge: (pr: DashboardPR) => Promise<void>;
 	kill: (id: string) => Promise<void>;
@@ -178,8 +178,9 @@ export function AppProvider({ children }: { children: ReactNode }) {
 			const c = cfgRef.current;
 			const proj = projectId ?? targetProject();
 			if (!c || !proj) throw new Error("Pick a project first");
-			await spawnSession(c, { projectId: proj, prompt, harness });
+			const session = await spawnSession(c, { projectId: proj, prompt, harness });
 			await fetchAll();
+			return session;
 		},
 		[targetProject, fetchAll],
 	);

--- a/packages/mobile/lib/useTabScrollToTop.ts
+++ b/packages/mobile/lib/useTabScrollToTop.ts
@@ -1,0 +1,27 @@
+import { useScrollToTop } from "@react-navigation/native";
+import { type RefObject, useRef } from "react";
+
+// The ref shape @react-navigation/native accepts (ScrollView, FlatList,
+// SectionList, ...). The package doesn't export it, so derive it from the hook.
+type ScrollableRef = Parameters<typeof useScrollToTop>[0];
+
+/**
+ * Ref for a tab screen's scroll container, wired so that tapping the
+ * already-active tab scrolls it back to the top - the standard iOS tab-bar
+ * gesture. Pressing a *different* tab just switches, as usual.
+ *
+ * Attach the returned ref to the screen's scroll container:
+ *
+ *     const scrollRef = useTabScrollToTop<ScrollView>();
+ *     <ScrollView ref={scrollRef} ... />
+ *
+ * This is also the single place we import `@react-navigation/native`, which
+ * reaches us transitively through expo-router rather than as a declared
+ * dependency - keeping that coupling in one file.
+ */
+export function useTabScrollToTop<T>(): RefObject<T | null> {
+	const ref = useRef<T>(null);
+	// Callers always pass a scrollable; the generic keeps the JSX ref precise.
+	useScrollToTop(ref as ScrollableRef);
+	return ref;
+}


### PR DESCRIPTION
Three small mobile UX changes, one per commit.

## Scroll-to-top button in the session terminal

A floating button at the bottom-right of the terminal scrolls back to the oldest output.

It lives in the terminal DOM rather than in React Native, because `@fressh/react-native-xtermjs-webview` exposes only a narrow handle (`write / clear / focus / resize / fit`) and keeps its WebView ref private — there is no way to inject JS from RN. So the button is created inside the existing `TERMINAL_ENHANCE_JS`.

It follows the same split the drag handler already uses (`appDrivesScroll()`):

- **Normal buffer** — xterm owns the scrollback, so `scrollToTop()` is a true jump, and `viewportY` tells us when to hide the button at the top.
- **Alt buffer / mouse-tracking** (Claude Code, Codex, aider, vim, less) — the *app* owns its scrollback, so `scrollToTop()` cannot reach it. Instead we send the same wheel notches a drag produces, through the existing `wheelTick()`. This keeps the behavior harness-agnostic rather than encoding scroll bytes per harness. The burst is chunked across animation frames so it doesn't block the renderer, and the button is always visible here since there is no way to query the app's scroll position.

The document-level touch listeners run in the capture phase, so they now ignore touches that originate on the button — otherwise a tap would be consumed as a terminal tap or long-press.

## Tap the active tab to scroll it to top

Tapping the already-focused tab scrolls its list to the top (the standard iOS tab-bar gesture). Pressing a *different* tab still just switches.

This wraps React Navigation's `useScrollToTop` in a small shared hook so each screen needs one line plus the ref binding. The hook is also the single place we import `@react-navigation/native` — it reaches us transitively through `expo-router` rather than as a declared dependency, so keeping that coupling in one file makes it cheap to change later.

Applies to all four tabs: Kanban, PRs, Orchestrator, Settings.

## Open the new worker session after spawning

Spawning from the modal previously left you on the list, having to hunt for the session you just created. Now the modal dismisses and navigates to the new session's terminal.

`spawn()` returns the created session so the caller knows where to go. The navigation waits on `runAfterInteractions` — firing both in the same tick overlaps the animations, with the modal retracting while the session is already sliding in.

## Testing

`npm run typecheck` passes in `packages/mobile`.

The terminal button was verified by hand on device against a live Claude Code session. The tab gesture and the spawn redirect have not been exercised on device yet.