### PR TITLE
feat(web): image paste/drop/attach in the New Task brief (#2722)

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/exclude_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/exclude_test.go
@@ -1,0 +1,89 @@
+package gitworktree
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestAddExcludeWritesAndIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	// A managed worktree path must exist and resolve inside the managed root.
+	wtPath := filepath.Join(ws.managedRoot, "proj", "worker", "proj-1")
+	if err := os.MkdirAll(wtPath, 0o750); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	// The per-worktree git dir is resolved via `git rev-parse --git-dir`; stub it.
+	gitDir := filepath.Join(root, "gitdir")
+	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if strings.Contains(strings.Join(args, " "), "rev-parse --git-dir") {
+			return []byte(gitDir + "\n"), nil
+		}
+		t.Fatalf("unexpected git invocation: %v", args)
+		return nil, nil
+	}
+
+	info := ports.WorkspaceInfo{Path: wtPath, SessionID: "proj-1", ProjectID: "proj"}
+	pattern := "/.ao/attachments/"
+	if err := ws.AddExclude(context.Background(), info, pattern); err != nil {
+		t.Fatalf("AddExclude: %v", err)
+	}
+
+	excludePath := filepath.Join(gitDir, "info", "exclude")
+	data, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	if !strings.Contains(string(data), pattern) {
+		t.Errorf("exclude missing pattern: %q", data)
+	}
+
+	// Calling again must not duplicate the entry.
+	if err := ws.AddExclude(context.Background(), info, pattern); err != nil {
+		t.Fatalf("AddExclude (repeat): %v", err)
+	}
+	data, err = os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	if got := strings.Count(string(data), pattern); got != 1 {
+		t.Errorf("pattern written %d times, want 1: %q", got, data)
+	}
+}
+
+func TestAddExcludeRejectsUnmanagedPath(t *testing.T) {
+	root := t.TempDir()
+	repo := t.TempDir()
+	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	info := ports.WorkspaceInfo{Path: "/etc", SessionID: "proj-1"}
+	if err := ws.AddExclude(context.Background(), info, "/x/"); err == nil {
+		t.Fatal("expected AddExclude to reject a path outside the managed root")
+	}
+}
+
+func TestAddExcludeNoPatternsIsNoop(t *testing.T) {
+	ws, err := New(Options{ManagedRoot: t.TempDir(), RepoResolver: StaticRepoResolver{"proj": t.TempDir()}})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ws.run = func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		t.Fatal("run must not be called when there are no patterns")
+		return nil, nil
+	}
+	if err := ws.AddExclude(context.Background(), ports.WorkspaceInfo{Path: "/whatever"}); err != nil {
+		t.Fatalf("AddExclude with no patterns: %v", err)
+	}
+}

--- a/backend/internal/adapters/workspace/gitworktree/exclude_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/exclude_test.go
@@ -3,6 +3,7 @@ package gitworktree
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,49 +11,67 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-func TestAddExcludeWritesAndIsIdempotent(t *testing.T) {
-	root := t.TempDir()
-	repo := t.TempDir()
-	ws, err := New(Options{ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
+// TestAddExcludeTakesEffectInLinkedWorktree exercises AddExclude against a REAL
+// linked worktree (the only kind this adapter creates). git reads info/exclude
+// from $GIT_COMMON_DIR, not $GIT_DIR, and in a linked worktree those differ, so a
+// resolution via `--git-dir` writes the exclude where git never looks and the
+// pattern is a silent no-op. This test asserts the exclude actually takes effect:
+// after AddExclude, a file matching the pattern must NOT surface as an untracked
+// change. It fails against a `--git-dir` resolution and passes with
+// `--git-common-dir`.
+func TestAddExcludeTakesEffectInLinkedWorktree(t *testing.T) {
+	git := requireGit(t)
+	tmp := t.TempDir()
+	repo := setupOriginClone(t, git, tmp)
+	root := filepath.Join(tmp, "managed")
+	ws, err := New(Options{Binary: git, ManagedRoot: root, RepoResolver: StaticRepoResolver{"proj": repo}})
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
+	ctx := context.Background()
 
-	// A managed worktree path must exist and resolve inside the managed root.
-	wtPath := filepath.Join(ws.managedRoot, "proj", "worker", "proj-1")
-	if err := os.MkdirAll(wtPath, 0o750); err != nil {
-		t.Fatalf("mkdir worktree: %v", err)
-	}
-	// The per-worktree git dir is resolved via `git rev-parse --git-dir`; stub it.
-	gitDir := filepath.Join(root, "gitdir")
-	ws.run = func(_ context.Context, _ string, args ...string) ([]byte, error) {
-		if strings.Contains(strings.Join(args, " "), "rev-parse --git-dir") {
-			return []byte(gitDir + "\n"), nil
-		}
-		t.Fatalf("unexpected git invocation: %v", args)
-		return nil, nil
+	// Create a real linked worktree under the managed root.
+	info, err := ws.Create(ctx, ports.WorkspaceConfig{ProjectID: "proj", SessionID: "sess", Branch: "feature/exclude"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
 	}
 
-	info := ports.WorkspaceInfo{Path: wtPath, SessionID: "proj-1", ProjectID: "proj"}
 	pattern := "/.ao/attachments/"
-	if err := ws.AddExclude(context.Background(), info, pattern); err != nil {
+	if err := ws.AddExclude(ctx, info, pattern); err != nil {
 		t.Fatalf("AddExclude: %v", err)
 	}
 
-	excludePath := filepath.Join(gitDir, "info", "exclude")
-	data, err := os.ReadFile(excludePath)
-	if err != nil {
-		t.Fatalf("read exclude: %v", err)
+	// Drop a file that matches the excluded pattern into the worktree.
+	attachDir := filepath.Join(info.Path, ".ao", "attachments")
+	if err := os.MkdirAll(attachDir, 0o750); err != nil {
+		t.Fatalf("mkdir attachments: %v", err)
 	}
-	if !strings.Contains(string(data), pattern) {
-		t.Errorf("exclude missing pattern: %q", data)
+	if err := os.WriteFile(filepath.Join(attachDir, "pasted.png"), []byte("not really a png"), 0o644); err != nil {
+		t.Fatalf("write attachment: %v", err)
 	}
 
-	// Calling again must not duplicate the entry.
-	if err := ws.AddExclude(context.Background(), info, pattern); err != nil {
+	// If the exclude took effect, git sees no untracked changes in the worktree.
+	out, err := exec.Command(git, "-C", info.Path, "status", "--porcelain").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git status: %v\n%s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "" {
+		t.Fatalf("exclude did not take effect; git status --porcelain not empty:\n%s", out)
+	}
+
+	// Idempotent: a second call must not duplicate the entry in the exclude file.
+	if err := ws.AddExclude(ctx, info, pattern); err != nil {
 		t.Fatalf("AddExclude (repeat): %v", err)
 	}
-	data, err = os.ReadFile(excludePath)
+	commonDir, err := exec.Command(git, "-C", info.Path, "rev-parse", "--git-common-dir").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse --git-common-dir: %v", err)
+	}
+	excludePath := filepath.Join(strings.TrimSpace(string(commonDir)), "info", "exclude")
+	if !filepath.IsAbs(excludePath) {
+		excludePath = filepath.Join(info.Path, excludePath)
+	}
+	data, err := os.ReadFile(excludePath)
 	if err != nil {
 		t.Fatalf("read exclude: %v", err)
 	}

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -530,6 +530,57 @@ func (w *Workspace) ApplyPreserved(ctx context.Context, info ports.WorkspaceInfo
 	return nil
 }
 
+// AddExclude appends git ignore patterns to the worktree's local info/exclude so
+// daemon-generated files never surface as untracked changes. The git dir is
+// resolved via rev-parse (a linked worktree's .git is a file pointing elsewhere,
+// so info/exclude does not live at <worktree>/.git/info). Idempotent: patterns
+// already present are skipped.
+func (w *Workspace) AddExclude(ctx context.Context, info ports.WorkspaceInfo, patterns ...string) error {
+	if len(patterns) == 0 {
+		return nil
+	}
+	path, err := w.validateManagedPath(info.Path)
+	if err != nil {
+		return err
+	}
+	out, err := w.run(ctx, w.binary, "-C", path, "rev-parse", "--git-dir")
+	if err != nil {
+		return fmt.Errorf("gitworktree: AddExclude resolve git dir: %w", err)
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(path, gitDir)
+	}
+	infoDir := filepath.Join(gitDir, "info")
+	if err := os.MkdirAll(infoDir, 0o750); err != nil {
+		return fmt.Errorf("gitworktree: AddExclude create info dir: %w", err)
+	}
+	excludePath := filepath.Join(infoDir, "exclude")
+	existing, _ := os.ReadFile(excludePath)
+	var toAdd []string
+	for _, p := range patterns {
+		if !strings.Contains(string(existing), p) {
+			toAdd = append(toAdd, p)
+		}
+	}
+	if len(toAdd) == 0 {
+		return nil
+	}
+	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("gitworktree: AddExclude open exclude: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	prefix := ""
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		prefix = "\n"
+	}
+	if _, err := f.WriteString(prefix + strings.Join(toAdd, "\n") + "\n"); err != nil {
+		return fmt.Errorf("gitworktree: AddExclude write exclude: %w", err)
+	}
+	return nil
+}
+
 // runCherryPickNoCommit runs "git -C <worktree> cherry-pick --no-commit <sha>"
 // and captures combined output so any conflict details are available in the
 // returned commandError. Exit code detection happens in the caller.

--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -531,10 +531,13 @@ func (w *Workspace) ApplyPreserved(ctx context.Context, info ports.WorkspaceInfo
 }
 
 // AddExclude appends git ignore patterns to the worktree's local info/exclude so
-// daemon-generated files never surface as untracked changes. The git dir is
-// resolved via rev-parse (a linked worktree's .git is a file pointing elsewhere,
-// so info/exclude does not live at <worktree>/.git/info). Idempotent: patterns
-// already present are skipped.
+// daemon-generated files never surface as untracked changes. The exclude file is
+// resolved via `git rev-parse --git-common-dir`, not `--git-dir`: git reads
+// info/exclude from $GIT_COMMON_DIR, and this adapter only ever creates linked
+// worktrees, where --git-dir points into .git/worktrees/<name> (per-worktree)
+// while --git-common-dir points at the shared main .git. Writing under --git-dir
+// would land info/exclude in a directory git never consults, making the exclude a
+// no-op. Idempotent: patterns already present are skipped.
 func (w *Workspace) AddExclude(ctx context.Context, info ports.WorkspaceInfo, patterns ...string) error {
 	if len(patterns) == 0 {
 		return nil
@@ -543,9 +546,9 @@ func (w *Workspace) AddExclude(ctx context.Context, info ports.WorkspaceInfo, pa
 	if err != nil {
 		return err
 	}
-	out, err := w.run(ctx, w.binary, "-C", path, "rev-parse", "--git-dir")
+	out, err := w.run(ctx, w.binary, "-C", path, "rev-parse", "--git-common-dir")
 	if err != nil {
-		return fmt.Errorf("gitworktree: AddExclude resolve git dir: %w", err)
+		return fmt.Errorf("gitworktree: AddExclude resolve git common dir: %w", err)
 	}
 	gitDir := strings.TrimSpace(string(out))
 	if !filepath.IsAbs(gitDir) {

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2067,6 +2067,15 @@ components:
       - status
       - prs
       type: object
+    ControllersSpawnAttachmentInput:
+      properties:
+        data:
+          type: string
+        mimeType:
+          type: string
+      required:
+      - data
+      type: object
     DegradedProject:
       properties:
         id:
@@ -3075,6 +3084,10 @@ components:
       type: object
     SpawnSessionRequest:
       properties:
+        attachments:
+          items:
+            $ref: '#/components/schemas/ControllersSpawnAttachmentInput'
+          type: array
         branch:
           type: string
         displayName:

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -161,6 +161,20 @@ type SpawnSessionRequest struct {
 	// `ao spawn --name` always sets it; other clients (e.g. the desktop new-task
 	// dialog) may omit it and fall back to the session id in the read model.
 	DisplayName string `json:"displayName,omitempty" maxLength:"20"`
+	// Attachments are images pasted or dropped into the task brief. Each carries
+	// its bytes as standard base64 (no data: URL prefix). The daemon writes them
+	// into the session worktree and appends path references to the prompt.
+	Attachments []SpawnAttachmentInput `json:"attachments,omitempty"`
+}
+
+// SpawnAttachmentInput is one image attached to a spawn request.
+type SpawnAttachmentInput struct {
+	// MimeType is the browser-reported content type (e.g. "image/png"). Used to
+	// derive the on-disk file extension; only image/* types are accepted.
+	MimeType string `json:"mimeType,omitempty"`
+	// Data is the raw image bytes, standard base64-encoded, without any
+	// "data:...;base64," prefix.
+	Data string `json:"data"`
 }
 
 // SessionResponse is the { session } body shared by session create/get.

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"io"
 	"net/http"
@@ -27,7 +28,26 @@ const (
 	maxPromptLen      = 4096
 	maxMessageLen     = 4096
 	maxDisplayNameLen = 20
+
+	// Attachment limits guard the daemon against oversized spawn bodies. Images
+	// are pasted/dropped into the task brief and inlined as base64 in the JSON
+	// body, so the caps are deliberately conservative.
+	maxAttachments      = 8
+	maxAttachmentBytes  = 10 << 20 // 10 MiB per image, decoded
+	maxAttachmentsBytes = 25 << 20 // 25 MiB total, decoded
 )
+
+// attachmentExtByMime maps the accepted image MIME types to the file extension
+// used when the image is written into the worktree.
+var attachmentExtByMime = map[string]string{
+	"image/png":     ".png",
+	"image/jpeg":    ".jpg",
+	"image/jpg":     ".jpg",
+	"image/gif":     ".gif",
+	"image/webp":    ".webp",
+	"image/svg+xml": ".svg",
+	"image/bmp":     ".bmp",
+}
 
 var errPreviewFileNotFound = errors.New("preview file not found")
 
@@ -139,12 +159,60 @@ func (c *SessionsController) spawn(w http.ResponseWriter, r *http.Request) {
 	if in.Kind == "" {
 		in.Kind = domain.KindWorker
 	}
-	sess, err := c.Svc.Spawn(r.Context(), ports.SpawnConfig{ProjectID: in.ProjectID, IssueID: in.IssueID, Kind: in.Kind, Harness: in.Harness, Branch: in.Branch, Prompt: in.Prompt, DisplayName: displayName})
+	attachments, attachErr := decodeSpawnAttachments(in.Attachments)
+	if attachErr != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", attachErr.code, attachErr.message, nil)
+		return
+	}
+	sess, err := c.Svc.Spawn(r.Context(), ports.SpawnConfig{ProjectID: in.ProjectID, IssueID: in.IssueID, Kind: in.Kind, Harness: in.Harness, Branch: in.Branch, Prompt: in.Prompt, DisplayName: displayName, Attachments: attachments})
 	if err != nil {
 		envelope.WriteError(w, r, err)
 		return
 	}
 	envelope.WriteJSON(w, http.StatusCreated, SessionResponse{Session: sessionView(sess)})
+}
+
+// spawnAttachmentError carries a client-facing API error code + message for a
+// rejected attachment payload.
+type spawnAttachmentError struct {
+	code    string
+	message string
+}
+
+// decodeSpawnAttachments validates and base64-decodes the inline image
+// attachments from a spawn request, enforcing count, per-image, and total size
+// caps. It returns a nil slice when there are no attachments.
+func decodeSpawnAttachments(in []SpawnAttachmentInput) ([]ports.SpawnAttachment, *spawnAttachmentError) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	if len(in) > maxAttachments {
+		return nil, &spawnAttachmentError{"TOO_MANY_ATTACHMENTS", "too many attachments"}
+	}
+	out := make([]ports.SpawnAttachment, 0, len(in))
+	total := 0
+	for _, a := range in {
+		ext, ok := attachmentExtByMime[strings.ToLower(strings.TrimSpace(a.MimeType))]
+		if !ok {
+			return nil, &spawnAttachmentError{"UNSUPPORTED_ATTACHMENT_TYPE", "unsupported attachment type"}
+		}
+		data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(a.Data))
+		if err != nil {
+			return nil, &spawnAttachmentError{"INVALID_ATTACHMENT_DATA", "attachment data is not valid base64"}
+		}
+		if len(data) == 0 {
+			return nil, &spawnAttachmentError{"INVALID_ATTACHMENT_DATA", "attachment is empty"}
+		}
+		if len(data) > maxAttachmentBytes {
+			return nil, &spawnAttachmentError{"ATTACHMENT_TOO_LARGE", "attachment is too large"}
+		}
+		total += len(data)
+		if total > maxAttachmentsBytes {
+			return nil, &spawnAttachmentError{"ATTACHMENTS_TOO_LARGE", "attachments are too large"}
+		}
+		out = append(out, ports.SpawnAttachment{Ext: ext, Data: data})
+	}
+	return out, nil
 }
 
 func (c *SessionsController) get(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -35,18 +35,26 @@ const (
 	maxAttachments      = 8
 	maxAttachmentBytes  = 10 << 20 // 10 MiB per image, decoded
 	maxAttachmentsBytes = 25 << 20 // 25 MiB total, decoded
+	// maxSpawnBodyBytes bounds the raw request body before it is decoded. The
+	// per-attachment and total caps above only apply after the whole body is
+	// materialized, so without this an oversized body (base64 inflates the
+	// decoded total by ~4/3) would allocate in full first. Derived from the
+	// decoded total plus headroom for the prompt and JSON envelope.
+	maxSpawnBodyBytes = maxAttachmentsBytes*4/3 + (2 << 20)
 )
 
 // attachmentExtByMime maps the accepted image MIME types to the file extension
-// used when the image is written into the worktree.
+// used when the image is written into the worktree. Raster formats only: the
+// agent is told to open the file for visual context, so active-content formats
+// (notably image/svg+xml, which is XML that can carry scripts/external entities)
+// are intentionally excluded.
 var attachmentExtByMime = map[string]string{
-	"image/png":     ".png",
-	"image/jpeg":    ".jpg",
-	"image/jpg":     ".jpg",
-	"image/gif":     ".gif",
-	"image/webp":    ".webp",
-	"image/svg+xml": ".svg",
-	"image/bmp":     ".bmp",
+	"image/png":  ".png",
+	"image/jpeg": ".jpg",
+	"image/jpg":  ".jpg",
+	"image/gif":  ".gif",
+	"image/webp": ".webp",
+	"image/bmp":  ".bmp",
 }
 
 var errPreviewFileNotFound = errors.New("preview file not found")
@@ -134,6 +142,11 @@ func (c *SessionsController) spawn(w http.ResponseWriter, r *http.Request) {
 		apispec.NotImplemented(w, r, "POST", "/api/v1/sessions")
 		return
 	}
+	// Bound the body before decoding: this route is served on the LAN listener
+	// (AO Mobile), not just loopback, and the attachment caps only run after the
+	// whole body is decoded. MaxBytesReader stops the read past the limit so an
+	// oversized base64 payload can't allocate in full first.
+	r.Body = http.MaxBytesReader(w, r.Body, maxSpawnBodyBytes)
 	var in SpawnSessionRequest
 	if err := decodeJSON(r, &in); err != nil {
 		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)

--- a/backend/internal/httpd/controllers/sessions_attachments_test.go
+++ b/backend/internal/httpd/controllers/sessions_attachments_test.go
@@ -52,6 +52,14 @@ func TestDecodeSpawnAttachments(t *testing.T) {
 		}
 	})
 
+	// SVG is XML that can carry active content; the raster-only allowlist rejects it.
+	t.Run("rejects svg", func(t *testing.T) {
+		_, err := decodeSpawnAttachments([]SpawnAttachmentInput{{MimeType: "image/svg+xml", Data: b64([]byte("<svg/>"))}})
+		if err == nil || err.code != "UNSUPPORTED_ATTACHMENT_TYPE" {
+			t.Fatalf("want UNSUPPORTED_ATTACHMENT_TYPE got %v", err)
+		}
+	})
+
 	t.Run("rejects invalid base64", func(t *testing.T) {
 		_, err := decodeSpawnAttachments([]SpawnAttachmentInput{{MimeType: "image/png", Data: "!!!not base64!!!"}})
 		if err == nil || err.code != "INVALID_ATTACHMENT_DATA" {

--- a/backend/internal/httpd/controllers/sessions_attachments_test.go
+++ b/backend/internal/httpd/controllers/sessions_attachments_test.go
@@ -1,0 +1,101 @@
+package controllers
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func b64(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
+
+func TestDecodeSpawnAttachments(t *testing.T) {
+	t.Run("nil when empty", func(t *testing.T) {
+		out, err := decodeSpawnAttachments(nil)
+		if err != nil || out != nil {
+			t.Fatalf("want nil,nil got %v,%v", out, err)
+		}
+	})
+
+	t.Run("decodes and maps extension", func(t *testing.T) {
+		out, err := decodeSpawnAttachments([]SpawnAttachmentInput{
+			{MimeType: "image/png", Data: b64([]byte("pngbytes"))},
+			{MimeType: "IMAGE/JPEG", Data: b64([]byte("jpgbytes"))},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %+v", err)
+		}
+		if len(out) != 2 {
+			t.Fatalf("want 2 attachments got %d", len(out))
+		}
+		if out[0].Ext != ".png" || string(out[0].Data) != "pngbytes" {
+			t.Errorf("attachment 0 = %q %q", out[0].Ext, out[0].Data)
+		}
+		if out[1].Ext != ".jpg" {
+			t.Errorf("case-insensitive mime not mapped: %q", out[1].Ext)
+		}
+	})
+
+	t.Run("rejects too many", func(t *testing.T) {
+		in := make([]SpawnAttachmentInput, maxAttachments+1)
+		for i := range in {
+			in[i] = SpawnAttachmentInput{MimeType: "image/png", Data: b64([]byte("x"))}
+		}
+		_, err := decodeSpawnAttachments(in)
+		if err == nil || err.code != "TOO_MANY_ATTACHMENTS" {
+			t.Fatalf("want TOO_MANY_ATTACHMENTS got %v", err)
+		}
+	})
+
+	t.Run("rejects unsupported type", func(t *testing.T) {
+		_, err := decodeSpawnAttachments([]SpawnAttachmentInput{{MimeType: "application/pdf", Data: b64([]byte("x"))}})
+		if err == nil || err.code != "UNSUPPORTED_ATTACHMENT_TYPE" {
+			t.Fatalf("want UNSUPPORTED_ATTACHMENT_TYPE got %v", err)
+		}
+	})
+
+	t.Run("rejects invalid base64", func(t *testing.T) {
+		_, err := decodeSpawnAttachments([]SpawnAttachmentInput{{MimeType: "image/png", Data: "!!!not base64!!!"}})
+		if err == nil || err.code != "INVALID_ATTACHMENT_DATA" {
+			t.Fatalf("want INVALID_ATTACHMENT_DATA got %v", err)
+		}
+	})
+
+	t.Run("rejects empty payload", func(t *testing.T) {
+		_, err := decodeSpawnAttachments([]SpawnAttachmentInput{{MimeType: "image/png", Data: ""}})
+		if err == nil || err.code != "INVALID_ATTACHMENT_DATA" {
+			t.Fatalf("want INVALID_ATTACHMENT_DATA got %v", err)
+		}
+	})
+
+	t.Run("rejects oversized single attachment", func(t *testing.T) {
+		big := b64(make([]byte, maxAttachmentBytes+1))
+		_, err := decodeSpawnAttachments([]SpawnAttachmentInput{{MimeType: "image/png", Data: big}})
+		if err == nil || err.code != "ATTACHMENT_TOO_LARGE" {
+			t.Fatalf("want ATTACHMENT_TOO_LARGE got %v", err)
+		}
+	})
+
+	t.Run("rejects oversized total", func(t *testing.T) {
+		half := b64(make([]byte, maxAttachmentBytes))
+		in := []SpawnAttachmentInput{
+			{MimeType: "image/png", Data: half},
+			{MimeType: "image/png", Data: half},
+			{MimeType: "image/png", Data: half},
+		}
+		_, err := decodeSpawnAttachments(in)
+		if err == nil || err.code != "ATTACHMENTS_TOO_LARGE" {
+			t.Fatalf("want ATTACHMENTS_TOO_LARGE got %v", err)
+		}
+	})
+}
+
+func TestDecodeSpawnAttachmentsTrimsWhitespace(t *testing.T) {
+	out, err := decodeSpawnAttachments([]SpawnAttachmentInput{
+		{MimeType: "  image/png  ", Data: "  " + b64([]byte("hi")) + "  "},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	if len(out) != 1 || string(out[0].Data) != "hi" {
+		t.Fatalf("whitespace not trimmed: %+v", out)
+	}
+}

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -407,12 +407,16 @@ func TestSessionsAPI_SpawnRejectsOversizedBody(t *testing.T) {
 
 	// A body past the ~35 MiB maxSpawnBodyBytes cap is rejected while decoding
 	// (MaxBytesReader), before the attachment size caps and without materializing
-	// the whole body. 40 MiB comfortably exceeds the cap.
-	oversized := `{"projectId":"ao","prompt":"` + strings.Repeat("a", 40<<20) + `"}`
+	// the whole body. The oversized bytes live in an *attachment* payload (not the
+	// prompt, which has its own much smaller PROMPT_TOO_LONG cap), so this pins the
+	// body cap specifically: MaxBytesReader makes the read/decode fail with
+	// INVALID_JSON. If that line were removed the body would decode fully and be
+	// rejected later with an attachment-specific code (ATTACHMENT_TOO_LARGE),
+	// failing this test. 40 MiB of base64 comfortably exceeds the ~35 MiB cap.
+	oversized := `{"projectId":"ao","attachments":[{"mimeType":"image/png","data":"` +
+		strings.Repeat("A", 40<<20) + `"}]}`
 	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions", oversized)
-	if status != http.StatusBadRequest {
-		t.Fatalf("oversized spawn body = %d, want 400; body=%s", status, body)
-	}
+	assertErrorCode(t, body, status, http.StatusBadRequest, "INVALID_JSON")
 }
 
 func TestSessionsAPI_PreviewDiscoversAndServesStaticIndex(t *testing.T) {

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -401,6 +401,20 @@ func TestSessionsAPI_ListSpawnGetAndActions(t *testing.T) {
 	}
 }
 
+func TestSessionsAPI_SpawnRejectsOversizedBody(t *testing.T) {
+	svc := newFakeSessionService()
+	srv := newSessionTestServer(t, svc)
+
+	// A body past the ~35 MiB maxSpawnBodyBytes cap is rejected while decoding
+	// (MaxBytesReader), before the attachment size caps and without materializing
+	// the whole body. 40 MiB comfortably exceeds the cap.
+	oversized := `{"projectId":"ao","prompt":"` + strings.Repeat("a", 40<<20) + `"}`
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions", oversized)
+	if status != http.StatusBadRequest {
+		t.Fatalf("oversized spawn body = %d, want 400; body=%s", status, body)
+	}
+}
+
 func TestSessionsAPI_PreviewDiscoversAndServesStaticIndex(t *testing.T) {
 	svc := newFakeSessionService()
 	workspace := t.TempDir()

--- a/backend/internal/integration/lifecycle_sqlite_test.go
+++ b/backend/internal/integration/lifecycle_sqlite_test.go
@@ -103,6 +103,10 @@ func (s *stubWorkspace) ApplyPreserved(_ context.Context, _ ports.WorkspaceInfo,
 	return nil
 }
 
+func (s *stubWorkspace) AddExclude(_ context.Context, _ ports.WorkspaceInfo, _ ...string) error {
+	return nil
+}
+
 type captureMessenger struct{ msgs []string }
 
 func (c *captureMessenger) Send(_ context.Context, _ domain.SessionID, msg string) error {

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -142,6 +142,12 @@ type Workspace interface {
 	// tree, and ErrPreservedConflict (wrapped) is returned. The ref must never
 	// be deleted on a failed or conflicted apply.
 	ApplyPreserved(ctx context.Context, info WorkspaceInfo, ref string) error
+	// AddExclude appends the given git ignore patterns to the worktree's local
+	// info/exclude so daemon-generated files (e.g. pasted task attachments) never
+	// surface as untracked changes or get committed. Idempotent: patterns already
+	// present are skipped. Owning this here keeps git/process execution inside the
+	// workspace adapter rather than leaking into callers.
+	AddExclude(ctx context.Context, info WorkspaceInfo, patterns ...string) error
 }
 
 // WorkspaceProject is an optional extension for projects composed from a

--- a/backend/internal/ports/session.go
+++ b/backend/internal/ports/session.go
@@ -25,4 +25,18 @@ type SpawnConfig struct {
 	// DisplayName is the user-facing sidebar label. Empty falls back to the
 	// session id in the read model (e.g. orchestrator sessions).
 	DisplayName string
+	// Attachments are images pasted or dropped into the task brief. They are
+	// written into the session worktree and referenced by path in the prompt so
+	// the agent can read them (CLI agents receive the prompt as text and cannot
+	// consume inline binary data).
+	Attachments []SpawnAttachment
+}
+
+// SpawnAttachment is a single image attached to a spawn request. Data holds the
+// already-decoded bytes; the manager derives the on-disk filename.
+type SpawnAttachment struct {
+	// Ext is the file extension (including the leading dot, e.g. ".png")
+	// inferred from the attachment's declared MIME type, or empty when unknown.
+	Ext  string
+	Data []byte
 }

--- a/backend/internal/session_manager/attachments_test.go
+++ b/backend/internal/session_manager/attachments_test.go
@@ -1,0 +1,67 @@
+package sessionmanager
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestWriteSpawnAttachments(t *testing.T) {
+	dir := t.TempDir()
+	refs, err := writeSpawnAttachments(dir, []ports.SpawnAttachment{
+		{Ext: ".png", Data: []byte("first")},
+		{Ext: ".jpg", Data: []byte("second")},
+		{Ext: "", Data: []byte("third")},
+	})
+	if err != nil {
+		t.Fatalf("writeSpawnAttachments: %v", err)
+	}
+
+	want := []string{".ao/attachments/image-1.png", ".ao/attachments/image-2.jpg", ".ao/attachments/image-3.bin"}
+	if len(refs) != len(want) {
+		t.Fatalf("refs = %v, want %v", refs, want)
+	}
+	for i, ref := range refs {
+		if ref != want[i] {
+			t.Errorf("ref[%d] = %q, want %q", i, ref, want[i])
+		}
+		got, readErr := os.ReadFile(filepath.Join(dir, filepath.FromSlash(ref)))
+		if readErr != nil {
+			t.Fatalf("read %s: %v", ref, readErr)
+		}
+		if len(got) == 0 {
+			t.Errorf("attachment %s is empty on disk", ref)
+		}
+	}
+}
+
+func TestAppendAttachmentReferences(t *testing.T) {
+	t.Run("appends after a brief", func(t *testing.T) {
+		got := appendAttachmentReferences("Fix the button", []string{".ao/attachments/image-1.png"})
+		if !strings.HasPrefix(got, "Fix the button\n\n") {
+			t.Errorf("brief not preserved: %q", got)
+		}
+		if !strings.Contains(got, "- .ao/attachments/image-1.png") {
+			t.Errorf("missing reference: %q", got)
+		}
+	})
+
+	t.Run("handles empty brief", func(t *testing.T) {
+		got := appendAttachmentReferences("", []string{".ao/attachments/image-1.png"})
+		if strings.HasPrefix(got, "\n") {
+			t.Errorf("leading blank line for empty brief: %q", got)
+		}
+		if !strings.Contains(got, "Attached images") {
+			t.Errorf("missing header: %q", got)
+		}
+	})
+
+	t.Run("no refs returns prompt unchanged", func(t *testing.T) {
+		if got := appendAttachmentReferences("brief", nil); got != "brief" {
+			t.Errorf("got %q, want %q", got, "brief")
+		}
+	})
+}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -334,6 +334,11 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 			m.rollbackSpawnSeedRow(ctx, id)
 			return domain.SessionRecord{}, fmt.Errorf("spawn %s: attachments: %w", id, err)
 		}
+		// Keep the attachments dir out of git status. Best-effort: the images are
+		// already written and usable, so an exclude failure must not fail the spawn.
+		if err := m.workspace.AddExclude(ctx, ws, "/"+attachmentsDir+"/"); err != nil {
+			m.logger.Warn("spawn: exclude attachments dir", "sessionID", id, "error", err)
+		}
 		prompt = appendAttachmentReferences(prompt, refs)
 	}
 
@@ -1921,45 +1926,7 @@ func writeSpawnAttachments(workspacePath string, attachments []ports.SpawnAttach
 		// Worktree-relative reference, always forward-slashed for the prompt.
 		refs = append(refs, attachmentsDir+"/"+name)
 	}
-	excludeAttachmentsDir(workspacePath)
 	return refs, nil
-}
-
-// excludeAttachmentsDir adds the attachments directory to the worktree's local
-// git excludes so pasted images do not show up as untracked changes. Best
-// effort: a failure here is non-fatal since the attachment is already written.
-func excludeAttachmentsDir(workspacePath string) {
-	// In a linked worktree, .git is a file pointing at the real gitdir; use
-	// `git rev-parse` to resolve the per-worktree git dir rather than assuming
-	// a .git directory.
-	out, err := exec.Command("git", "-C", workspacePath, "rev-parse", "--git-dir").Output()
-	if err != nil {
-		return
-	}
-	gitDir := strings.TrimSpace(string(out))
-	if !filepath.IsAbs(gitDir) {
-		gitDir = filepath.Join(workspacePath, gitDir)
-	}
-	infoDir := filepath.Join(gitDir, "info")
-	if err := os.MkdirAll(infoDir, 0o750); err != nil {
-		return
-	}
-	excludePath := filepath.Join(infoDir, "exclude")
-	existing, _ := os.ReadFile(excludePath)
-	entry := "/" + attachmentsDir + "/"
-	if strings.Contains(string(existing), entry) {
-		return
-	}
-	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
-		return
-	}
-	defer func() { _ = f.Close() }()
-	prefix := ""
-	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
-		prefix = "\n"
-	}
-	_, _ = f.WriteString(prefix + entry + "\n")
 }
 
 // appendAttachmentReferences appends a block listing the attached image paths so

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -322,6 +322,21 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, fmt.Errorf("spawn %s: provision: %w", id, err)
 	}
 
+	// CLI agents receive the prompt as text and cannot consume inline binary
+	// data, so any pasted/dropped images are written into the worktree and
+	// referenced by path in the prompt. Done after provisioning (so the worktree
+	// exists) and before the launch command is built (so the references reach
+	// the agent).
+	if len(cfg.Attachments) > 0 {
+		refs, err := writeSpawnAttachments(ws.Path, cfg.Attachments)
+		if err != nil {
+			_ = m.workspace.Destroy(ctx, ws)
+			m.rollbackSpawnSeedRow(ctx, id)
+			return domain.SessionRecord{}, fmt.Errorf("spawn %s: attachments: %w", id, err)
+		}
+		prompt = appendAttachmentReferences(prompt, refs)
+	}
+
 	agent, ok := m.agents.Agent(cfg.Harness)
 	if !ok {
 		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
@@ -1878,6 +1893,92 @@ func promptProjectContext(projectID domain.ProjectID, project domain.ProjectReco
 		DefaultBranch: cfg.DefaultBranch,
 		Path:          project.Path,
 	}
+}
+
+// attachmentsDir is the worktree-relative directory where spawn image
+// attachments are written.
+const attachmentsDir = ".ao/attachments"
+
+// writeSpawnAttachments writes each attachment into the worktree under
+// attachmentsDir as image-1<ext>, image-2<ext>, ... and returns the
+// worktree-relative paths in order. The files are excluded from git via the
+// worktree's info/exclude so they do not dirty the working tree.
+func writeSpawnAttachments(workspacePath string, attachments []ports.SpawnAttachment) ([]string, error) {
+	dir := filepath.Join(workspacePath, filepath.FromSlash(attachmentsDir))
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("create attachments dir: %w", err)
+	}
+	refs := make([]string, 0, len(attachments))
+	for i, a := range attachments {
+		ext := a.Ext
+		if ext == "" {
+			ext = ".bin"
+		}
+		name := fmt.Sprintf("image-%d%s", i+1, ext)
+		if err := os.WriteFile(filepath.Join(dir, name), a.Data, 0o600); err != nil {
+			return nil, fmt.Errorf("write attachment %d: %w", i+1, err)
+		}
+		// Worktree-relative reference, always forward-slashed for the prompt.
+		refs = append(refs, attachmentsDir+"/"+name)
+	}
+	excludeAttachmentsDir(workspacePath)
+	return refs, nil
+}
+
+// excludeAttachmentsDir adds the attachments directory to the worktree's local
+// git excludes so pasted images do not show up as untracked changes. Best
+// effort: a failure here is non-fatal since the attachment is already written.
+func excludeAttachmentsDir(workspacePath string) {
+	// In a linked worktree, .git is a file pointing at the real gitdir; use
+	// `git rev-parse` to resolve the per-worktree git dir rather than assuming
+	// a .git directory.
+	out, err := exec.Command("git", "-C", workspacePath, "rev-parse", "--git-dir").Output()
+	if err != nil {
+		return
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(workspacePath, gitDir)
+	}
+	infoDir := filepath.Join(gitDir, "info")
+	if err := os.MkdirAll(infoDir, 0o750); err != nil {
+		return
+	}
+	excludePath := filepath.Join(infoDir, "exclude")
+	existing, _ := os.ReadFile(excludePath)
+	entry := "/" + attachmentsDir + "/"
+	if strings.Contains(string(existing), entry) {
+		return
+	}
+	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	prefix := ""
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		prefix = "\n"
+	}
+	_, _ = f.WriteString(prefix + entry + "\n")
+}
+
+// appendAttachmentReferences appends a block listing the attached image paths so
+// the agent knows to read them. Placed after the human's brief.
+func appendAttachmentReferences(prompt string, refs []string) string {
+	if len(refs) == 0 {
+		return prompt
+	}
+	var b strings.Builder
+	b.WriteString(prompt)
+	if strings.TrimSpace(prompt) != "" {
+		b.WriteString("\n\n")
+	}
+	b.WriteString("Attached images (read these files in the workspace for visual context):")
+	for _, ref := range refs {
+		b.WriteString("\n- ")
+		b.WriteString(ref)
+	}
+	return b.String()
 }
 
 // buildSpawnTexts returns the user-facing prompt and the system prompt to

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -390,6 +390,10 @@ type fakeWorkspace struct {
 	forceDestroyErr error
 	// stashCalls counts StashUncommitted invocations.
 	stashCalls int
+	// excludePatterns records patterns passed to AddExclude; addExcludeErr, when
+	// set, is returned so best-effort handling can be exercised.
+	excludePatterns []string
+	addExcludeErr   error
 	// calls records the sequence of workspace method calls for ordering assertions.
 	calls []string
 	// sharedLog, when non-nil, receives entries alongside calls so ordering
@@ -508,6 +512,12 @@ func (w *fakeWorkspace) ApplyPreserved(_ context.Context, info ports.WorkspaceIn
 	}
 	w.calls = append(w.calls, entry)
 	return w.applyErr
+}
+
+func (w *fakeWorkspace) AddExclude(_ context.Context, info ports.WorkspaceInfo, patterns ...string) error {
+	w.calls = append(w.calls, "AddExclude:"+string(info.SessionID))
+	w.excludePatterns = append(w.excludePatterns, patterns...)
+	return w.addExcludeErr
 }
 
 type loggingDestroyWorkspace struct {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -788,6 +788,10 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
+        ControllersSpawnAttachmentInput: {
+            data: string;
+            mimeType?: string;
+        };
         DegradedProject: {
             id: string;
             kind: string;
@@ -1182,6 +1186,7 @@ export interface components {
             orchestrator: components["schemas"]["OrchestratorResponse"];
         };
         SpawnSessionRequest: {
+            attachments?: components["schemas"]["ControllersSpawnAttachmentInput"][];
             branch?: string;
             displayName?: string;
             /** @enum {string} */

--- a/frontend/src/renderer/components/NewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NewTaskDialog } from "./NewTaskDialog";
@@ -148,6 +148,57 @@ describe("NewTaskDialog", () => {
 
 		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
 		expect(spawnBody().harness).toBe("kiro");
+	});
+
+	it("attaches a pasted image as a numbered chip and sends it in the spawn body", async () => {
+		renderDialog();
+		const user = userEvent.setup();
+		await waitForAgentCatalog();
+
+		const brief = screen.getByLabelText("Brief");
+		const png = new File([new Uint8Array([137, 80, 78, 71])], "shot.png", { type: "image/png" });
+		fireEvent.paste(brief, { clipboardData: { files: [png], items: [] } });
+
+		expect(await screen.findByText("Image 1")).toBeInTheDocument();
+
+		await user.type(screen.getByLabelText("Title"), "T");
+		await user.type(brief, "B");
+		await user.click(screen.getByRole("button", { name: "Start task" }));
+
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+		const attachments = spawnBody().attachments as Array<{ mimeType: string; data: string }>;
+		expect(attachments).toHaveLength(1);
+		expect(attachments[0].mimeType).toBe("image/png");
+		expect(attachments[0].data.length).toBeGreaterThan(0);
+	});
+
+	it("removes an attached image and renumbers the remaining chips", async () => {
+		renderDialog();
+		const user = userEvent.setup();
+		await waitForAgentCatalog();
+
+		const brief = screen.getByLabelText("Brief");
+		const a = new File([new Uint8Array([1, 2, 3])], "a.png", { type: "image/png" });
+		const b = new File([new Uint8Array([4, 5, 6])], "b.png", { type: "image/png" });
+		fireEvent.paste(brief, { clipboardData: { files: [a, b], items: [] } });
+
+		expect(await screen.findByText("Image 1")).toBeInTheDocument();
+		expect(screen.getByText("Image 2")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Remove image 1" }));
+
+		await waitFor(() => expect(screen.queryByText("Image 2")).not.toBeInTheDocument());
+		expect(screen.getByText("Image 1")).toBeInTheDocument();
+	});
+
+	it("ignores a paste that carries no image", async () => {
+		renderDialog();
+		await waitForAgentCatalog();
+
+		const brief = screen.getByLabelText("Brief");
+		fireEvent.paste(brief, { clipboardData: { files: [], items: [] } });
+
+		expect(screen.queryByText("Image 1")).not.toBeInTheDocument();
 	});
 
 	it("requires both title and brief", async () => {

--- a/frontend/src/renderer/components/NewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.test.tsx
@@ -201,6 +201,22 @@ describe("NewTaskDialog", () => {
 		expect(screen.queryByText("Image 1")).not.toBeInTheDocument();
 	});
 
+	it("caps attachments at 8 and shows an inline error instead of a late submit rejection", async () => {
+		renderDialog();
+		await waitForAgentCatalog();
+
+		const brief = screen.getByLabelText("Brief");
+		const files = Array.from(
+			{ length: 10 },
+			(_, i) => new File([new Uint8Array([i + 1])], `shot-${i}.png`, { type: "image/png" }),
+		);
+		fireEvent.paste(brief, { clipboardData: { files, items: [] } });
+
+		expect(await screen.findByText("Image 8")).toBeInTheDocument();
+		expect(screen.queryByText("Image 9")).not.toBeInTheDocument();
+		expect(screen.getByText(/up to 8 images/i)).toBeInTheDocument();
+	});
+
 	it("requires both title and brief", async () => {
 		renderDialog();
 		const user = userEvent.setup();

--- a/frontend/src/renderer/components/NewTaskDialog.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.tsx
@@ -38,7 +38,14 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 	const [error, setError] = useState<string | undefined>();
 	const [isDragging, setIsDragging] = useState(false);
 	const fileInputRef = useRef<HTMLInputElement>(null);
-	const { attachments, addFiles, remove: removeAttachment, clear: clearAttachments, toPayload } = useImageAttachments();
+	const {
+		attachments,
+		error: attachmentError,
+		addFiles,
+		remove: removeAttachment,
+		clear: clearAttachments,
+		toPayload,
+	} = useImageAttachments();
 
 	const projectQuery = useQuery({
 		queryKey: ["project", projectId],
@@ -252,6 +259,7 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 									event.target.value = "";
 								}}
 							/>
+							{attachmentError && <p className="text-caption text-destructive">{attachmentError}</p>}
 						</div>
 
 						<div className="grid gap-3 sm:grid-cols-[1fr_1fr]">

--- a/frontend/src/renderer/components/NewTaskDialog.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.tsx
@@ -1,7 +1,7 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2, X } from "lucide-react";
-import { type FormEvent, useEffect, useId, useState } from "react";
+import { ImagePlus, Loader2, X } from "lucide-react";
+import { type ClipboardEvent, type DragEvent, type FormEvent, useEffect, useId, useRef, useState } from "react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
@@ -11,6 +11,8 @@ import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { captureRendererEvent } from "../lib/telemetry";
 import type { AgentProvider } from "../types/workspace";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
+import { useImageAttachments } from "../hooks/useImageAttachments";
+import { cn } from "../lib/utils";
 
 type Project = components["schemas"]["Project"];
 
@@ -34,6 +36,9 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 	const [agentTouched, setAgentTouched] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [error, setError] = useState<string | undefined>();
+	const [isDragging, setIsDragging] = useState(false);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const { attachments, addFiles, remove: removeAttachment, clear: clearAttachments, toPayload } = useImageAttachments();
 
 	const projectQuery = useQuery({
 		queryKey: ["project", projectId],
@@ -67,8 +72,10 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 			setAgentTouched(false);
 			setError(undefined);
 			setIsSubmitting(false);
+			setIsDragging(false);
+			clearAttachments();
 		}
-	}, [open]);
+	}, [open, clearAttachments]);
 
 	useEffect(() => {
 		if (open && !agentTouched) {
@@ -100,6 +107,7 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 					issueId: cleanTitle,
 					prompt: cleanPrompt,
 					branch: cleanBranch || undefined,
+					attachments: attachments.length > 0 ? toPayload() : undefined,
 				},
 			});
 			if (apiError) throw new Error(apiErrorMessage(apiError, "Unable to start task"));
@@ -113,6 +121,29 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 			setError(err instanceof Error ? err.message : "Unable to start task");
 		} finally {
 			setIsSubmitting(false);
+		}
+	};
+
+	const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
+		const files = Array.from(event.clipboardData?.files ?? []).filter((file) => file.type.startsWith("image/"));
+		if (files.length === 0) return;
+		// An image is on the clipboard: attach it instead of pasting a file path
+		// or nothing into the textarea.
+		event.preventDefault();
+		void addFiles(files);
+	};
+
+	const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+		event.preventDefault();
+		setIsDragging(false);
+		const files = Array.from(event.dataTransfer?.files ?? []).filter((file) => file.type.startsWith("image/"));
+		if (files.length > 0) void addFiles(files);
+	};
+
+	const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+		if (Array.from(event.dataTransfer?.items ?? []).some((item) => item.kind === "file")) {
+			event.preventDefault();
+			setIsDragging(true);
 		}
 	};
 
@@ -154,15 +185,72 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 						</div>
 
 						<div className="space-y-1.5">
-							<label className="text-xs font-medium text-muted-foreground" htmlFor={promptId}>
-								Brief
-							</label>
-							<textarea
-								id={promptId}
-								className="min-h-textarea-min w-full resize-y rounded-md border border-border bg-transparent px-3 py-2 text-control leading-relaxed text-foreground outline-none transition placeholder:text-passive focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-weak"
-								placeholder="Describe the change, constraints, and expected verification."
-								value={prompt}
-								onChange={(event) => setPrompt(event.target.value)}
+							<div className="flex items-center justify-between">
+								<label className="text-xs font-medium text-muted-foreground" htmlFor={promptId}>
+									Brief
+								</label>
+								<button
+									type="button"
+									className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+									onClick={() => fileInputRef.current?.click()}
+								>
+									<ImagePlus className="size-icon-sm" aria-hidden="true" />
+									Add image
+								</button>
+							</div>
+							<div
+								className={cn(
+									"rounded-md border border-border transition",
+									isDragging && "border-accent ring-2 ring-accent-weak",
+								)}
+								onDrop={handleDrop}
+								onDragOver={handleDragOver}
+								onDragLeave={() => setIsDragging(false)}
+							>
+								<textarea
+									id={promptId}
+									className="min-h-textarea-min w-full resize-y rounded-md bg-transparent px-3 py-2 text-control leading-relaxed text-foreground outline-none transition placeholder:text-passive focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-weak"
+									placeholder="Describe the change, constraints, and expected verification. Paste or drop images to attach them."
+									value={prompt}
+									onChange={(event) => setPrompt(event.target.value)}
+									onPaste={handlePaste}
+								/>
+								{attachments.length > 0 && (
+									<ul className="grid max-h-40 grid-cols-2 gap-2 overflow-y-auto border-t border-border p-2 sm:grid-cols-3">
+										{attachments.map((attachment, index) => (
+											<li
+												key={attachment.id}
+												className="flex items-center gap-2 rounded-md border border-border bg-surface p-1 text-xs text-foreground"
+											>
+												<img
+													src={attachment.dataUrl}
+													alt={`Image ${index + 1}`}
+													className="size-7 shrink-0 rounded object-cover"
+												/>
+												<span className="min-w-0 flex-1 truncate font-medium">Image {index + 1}</span>
+												<button
+													type="button"
+													className="grid size-5 shrink-0 place-items-center rounded text-muted-foreground transition hover:bg-border hover:text-foreground"
+													aria-label={`Remove image ${index + 1}`}
+													onClick={() => removeAttachment(attachment.id)}
+												>
+													<X className="size-icon-sm" aria-hidden="true" />
+												</button>
+											</li>
+										))}
+									</ul>
+								)}
+							</div>
+							<input
+								ref={fileInputRef}
+								type="file"
+								accept="image/*"
+								multiple
+								className="hidden"
+								onChange={(event) => {
+									if (event.target.files) void addFiles(event.target.files);
+									event.target.value = "";
+								}}
 							/>
 						</div>
 

--- a/frontend/src/renderer/hooks/useImageAttachments.test.ts
+++ b/frontend/src/renderer/hooks/useImageAttachments.test.ts
@@ -1,0 +1,55 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { describe, expect, it } from "vitest";
+
+import { MAX_ATTACHMENTS, useImageAttachments } from "./useImageAttachments";
+
+const pngFile = (name: string, bytes = 8, type = "image/png") =>
+	new File([new Uint8Array(bytes).fill(1)], name, { type });
+
+describe("useImageAttachments", () => {
+	it("retains images from two overlapping addFiles calls", async () => {
+		// Regression probe for the cap-accounting-from-a-stale-snapshot bug: two
+		// addFiles calls fired back-to-back (fast double paste, or paste-then-drop)
+		// must both survive. With a closure snapshot the second call overwrote the
+		// first and silently dropped an image.
+		const { result } = renderHook(() => useImageAttachments());
+
+		await act(async () => {
+			const first = result.current.addFiles([pngFile("a.png")]);
+			const second = result.current.addFiles([pngFile("b.png")]);
+			await Promise.all([first, second]);
+		});
+
+		expect(result.current.attachments).toHaveLength(2);
+		expect(result.current.error).toBeNull();
+	});
+
+	it("stages a supported image", async () => {
+		const { result } = renderHook(() => useImageAttachments());
+		await act(async () => {
+			await result.current.addFiles([pngFile("a.png")]);
+		});
+		expect(result.current.attachments).toHaveLength(1);
+		expect(result.current.attachments[0]?.mimeType).toBe("image/png");
+		expect(result.current.error).toBeNull();
+	});
+
+	it("rejects unsupported image types (e.g. SVG) with inline feedback", async () => {
+		const { result } = renderHook(() => useImageAttachments());
+		await act(async () => {
+			await result.current.addFiles([pngFile("vector.svg", 8, "image/svg+xml")]);
+		});
+		expect(result.current.attachments).toHaveLength(0);
+		expect(result.current.error).toMatch(/supported/i);
+	});
+
+	it("enforces the count cap against current state", async () => {
+		const { result } = renderHook(() => useImageAttachments());
+		await act(async () => {
+			await result.current.addFiles(Array.from({ length: MAX_ATTACHMENTS + 2 }, (_, i) => pngFile(`img-${i}.png`)));
+		});
+		expect(result.current.attachments).toHaveLength(MAX_ATTACHMENTS);
+		expect(result.current.error).toMatch(/up to/i);
+	});
+});

--- a/frontend/src/renderer/hooks/useImageAttachments.ts
+++ b/frontend/src/renderer/hooks/useImageAttachments.ts
@@ -1,0 +1,75 @@
+import { useCallback, useState } from "react";
+
+/** A single image staged for a task/orchestrator brief. */
+export type ImageAttachment = {
+	/** Stable id for list keys and removal. */
+	id: string;
+	/** Browser-reported MIME type (e.g. "image/png"). */
+	mimeType: string;
+	/** data: URL used to render the thumbnail preview. */
+	dataUrl: string;
+	/** Base64 payload without the "data:...;base64," prefix, for upload. */
+	data: string;
+};
+
+/** Attachment payload shape accepted by the spawn API. */
+export type ImageAttachmentPayload = {
+	mimeType: string;
+	data: string;
+};
+
+const isImageType = (type: string) => type.startsWith("image/");
+
+const readImageFile = (file: File): Promise<ImageAttachment> =>
+	new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onerror = () => reject(reader.error ?? new Error("Failed to read image"));
+		reader.onload = () => {
+			const dataUrl = typeof reader.result === "string" ? reader.result : "";
+			const comma = dataUrl.indexOf(",");
+			if (!dataUrl || comma < 0) {
+				reject(new Error("Unreadable image data"));
+				return;
+			}
+			resolve({
+				id:
+					typeof crypto !== "undefined" && "randomUUID" in crypto
+						? crypto.randomUUID()
+						: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+				mimeType: file.type || "image/png",
+				dataUrl,
+				data: dataUrl.slice(comma + 1),
+			});
+		};
+		reader.readAsDataURL(file);
+	});
+
+/**
+ * useImageAttachments stages images pasted, dropped, or picked into a brief and
+ * exposes them as upload-ready payloads. Non-image inputs are ignored so a
+ * caller can wire `addFiles` straight to a paste/drop event's file list.
+ */
+export function useImageAttachments() {
+	const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+
+	const addFiles = useCallback(async (files: Iterable<File>) => {
+		const images = Array.from(files).filter((file) => isImageType(file.type));
+		if (images.length === 0) return;
+		const read = await Promise.all(images.map((file) => readImageFile(file).catch(() => null)));
+		const next = read.filter((a): a is ImageAttachment => a !== null);
+		if (next.length > 0) setAttachments((prev) => [...prev, ...next]);
+	}, []);
+
+	const remove = useCallback((id: string) => {
+		setAttachments((prev) => prev.filter((a) => a.id !== id));
+	}, []);
+
+	const clear = useCallback(() => setAttachments([]), []);
+
+	const toPayload = useCallback(
+		(): ImageAttachmentPayload[] => attachments.map(({ mimeType, data }) => ({ mimeType, data })),
+		[attachments],
+	);
+
+	return { attachments, addFiles, remove, clear, toPayload };
+}

--- a/frontend/src/renderer/hooks/useImageAttachments.ts
+++ b/frontend/src/renderer/hooks/useImageAttachments.ts
@@ -30,7 +30,15 @@ export type ImageAttachmentPayload = {
 	data: string;
 };
 
-const isImageType = (type: string) => type.startsWith("image/");
+// Client-side mirror of the backend raster-only allowlist
+// (backend/internal/httpd/controllers/sessions.go attachmentExtByMime). The
+// browser's accept="image/*" and File.type would otherwise stage active-content
+// formats like image/svg+xml, turning an SVG paste into a late post-submit
+// rejection. Keeping the allowlist here surfaces unsupported types with the same
+// inline feedback as the size/count caps.
+const SUPPORTED_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp", "image/bmp"]);
+
+const isImageType = (type: string) => SUPPORTED_IMAGE_TYPES.has(type.toLowerCase().trim());
 
 const readImageFile = (file: File): Promise<ImageAttachment> =>
 	new Promise((resolve, reject) => {
@@ -68,31 +76,46 @@ export function useImageAttachments() {
 	const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
 	const [error, setError] = useState<string | null>(null);
 
-	const addFiles = useCallback(
-		async (files: Iterable<File>) => {
-			const images = Array.from(files).filter((file) => isImageType(file.type));
-			if (images.length === 0) return;
+	const addFiles = useCallback(async (files: Iterable<File>) => {
+		// Only image/* inputs are considered; truly non-image content (e.g. a text
+		// paste) is silently ignored so a caller can wire addFiles straight to a
+		// paste/drop event's file list.
+		const images = Array.from(files).filter((file) => file.type.toLowerCase().startsWith("image/"));
+		if (images.length === 0) return;
 
-			const errors = new Set<string>();
-			// Reject oversized files before the (async) read.
-			const readable = images.filter((file) => {
-				if (file.size > MAX_ATTACHMENT_BYTES) {
-					errors.add(`Each image must be under ${mb(MAX_ATTACHMENT_BYTES)} MB.`);
-					return false;
-				}
-				return true;
-			});
-
-			const results = await Promise.all(readable.map((file) => readImageFile(file).catch(() => null)));
-			const fresh = results.filter((a): a is ImageAttachment => a !== null);
-			if (fresh.length < results.length) {
-				errors.add("Some images couldn't be read and were skipped.");
+		const errors = new Set<string>();
+		// Reject unsupported image types (e.g. image/svg+xml) up front, mirroring
+		// the backend raster-only allowlist so an SVG paste is rejected inline
+		// rather than after submit.
+		const supported = images.filter((file) => {
+			if (!isImageType(file.type)) {
+				errors.add("Only PNG, JPEG, GIF, WebP, and BMP images are supported.");
+				return false;
 			}
+			return true;
+		});
+		// Reject oversized files before the (async) read.
+		const readable = supported.filter((file) => {
+			if (file.size > MAX_ATTACHMENT_BYTES) {
+				errors.add(`Each image must be under ${mb(MAX_ATTACHMENT_BYTES)} MB.`);
+				return false;
+			}
+			return true;
+		});
 
-			// Apply count/total-size caps against the current set. (Paste/drop is a
-			// sequential user action, so reading current state from the closure is
-			// safe; deps include `attachments` to keep it current.)
-			const accepted = [...attachments];
+		const results = await Promise.all(readable.map((file) => readImageFile(file).catch(() => null)));
+		const fresh = results.filter((a): a is ImageAttachment => a !== null);
+		if (fresh.length < results.length) {
+			errors.add("Some images couldn't be read and were skipped.");
+		}
+
+		// Apply count/total-size caps inside the functional updater so they are
+		// computed against the CURRENT state, not a stale closure snapshot. Two
+		// overlapping addFiles calls (fast double paste, or paste-then-drop) would
+		// otherwise both read the same pre-update snapshot and the second would
+		// overwrite the first, silently dropping images.
+		setAttachments((prev) => {
+			const accepted = [...prev];
 			let total = accepted.reduce((sum, a) => sum + a.bytes, 0);
 			for (const a of fresh) {
 				if (accepted.length >= MAX_ATTACHMENTS) {
@@ -106,12 +129,10 @@ export function useImageAttachments() {
 				accepted.push(a);
 				total += a.bytes;
 			}
-
-			if (accepted.length !== attachments.length) setAttachments(accepted);
-			setError(errors.size > 0 ? Array.from(errors).join(" ") : null);
-		},
-		[attachments],
-	);
+			return accepted.length === prev.length ? prev : accepted;
+		});
+		setError(errors.size > 0 ? Array.from(errors).join(" ") : null);
+	}, []);
 
 	const remove = useCallback((id: string) => {
 		setAttachments((prev) => prev.filter((a) => a.id !== id));

--- a/frontend/src/renderer/hooks/useImageAttachments.ts
+++ b/frontend/src/renderer/hooks/useImageAttachments.ts
@@ -1,11 +1,23 @@
 import { useCallback, useState } from "react";
 
+// Client-side mirror of the backend spawn caps in
+// backend/internal/httpd/controllers/sessions.go (maxAttachments /
+// maxAttachmentBytes / maxAttachmentsBytes). Enforced here too so the user gets
+// inline feedback at paste/drop time instead of a late rejection after submit.
+export const MAX_ATTACHMENTS = 8;
+export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+export const MAX_ATTACHMENTS_BYTES = 25 * 1024 * 1024;
+
+const mb = (bytes: number) => Math.round(bytes / (1024 * 1024));
+
 /** A single image staged for a task/orchestrator brief. */
 export type ImageAttachment = {
 	/** Stable id for list keys and removal. */
 	id: string;
 	/** Browser-reported MIME type (e.g. "image/png"). */
 	mimeType: string;
+	/** Decoded byte size (from File.size), used to enforce the total-size cap. */
+	bytes: number;
 	/** data: URL used to render the thumbnail preview. */
 	dataUrl: string;
 	/** Base64 payload without the "data:...;base64," prefix, for upload. */
@@ -37,6 +49,7 @@ const readImageFile = (file: File): Promise<ImageAttachment> =>
 						? crypto.randomUUID()
 						: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
 				mimeType: file.type || "image/png",
+				bytes: file.size,
 				dataUrl,
 				data: dataUrl.slice(comma + 1),
 			});
@@ -47,29 +60,73 @@ const readImageFile = (file: File): Promise<ImageAttachment> =>
 /**
  * useImageAttachments stages images pasted, dropped, or picked into a brief and
  * exposes them as upload-ready payloads. Non-image inputs are ignored so a
- * caller can wire `addFiles` straight to a paste/drop event's file list.
+ * caller can wire `addFiles` straight to a paste/drop event's file list. Count
+ * and size caps (mirroring the backend) are enforced here, and rejections /
+ * unreadable files surface through `error` for inline feedback.
  */
 export function useImageAttachments() {
 	const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+	const [error, setError] = useState<string | null>(null);
 
-	const addFiles = useCallback(async (files: Iterable<File>) => {
-		const images = Array.from(files).filter((file) => isImageType(file.type));
-		if (images.length === 0) return;
-		const read = await Promise.all(images.map((file) => readImageFile(file).catch(() => null)));
-		const next = read.filter((a): a is ImageAttachment => a !== null);
-		if (next.length > 0) setAttachments((prev) => [...prev, ...next]);
-	}, []);
+	const addFiles = useCallback(
+		async (files: Iterable<File>) => {
+			const images = Array.from(files).filter((file) => isImageType(file.type));
+			if (images.length === 0) return;
+
+			const errors = new Set<string>();
+			// Reject oversized files before the (async) read.
+			const readable = images.filter((file) => {
+				if (file.size > MAX_ATTACHMENT_BYTES) {
+					errors.add(`Each image must be under ${mb(MAX_ATTACHMENT_BYTES)} MB.`);
+					return false;
+				}
+				return true;
+			});
+
+			const results = await Promise.all(readable.map((file) => readImageFile(file).catch(() => null)));
+			const fresh = results.filter((a): a is ImageAttachment => a !== null);
+			if (fresh.length < results.length) {
+				errors.add("Some images couldn't be read and were skipped.");
+			}
+
+			// Apply count/total-size caps against the current set. (Paste/drop is a
+			// sequential user action, so reading current state from the closure is
+			// safe; deps include `attachments` to keep it current.)
+			const accepted = [...attachments];
+			let total = accepted.reduce((sum, a) => sum + a.bytes, 0);
+			for (const a of fresh) {
+				if (accepted.length >= MAX_ATTACHMENTS) {
+					errors.add(`You can attach up to ${MAX_ATTACHMENTS} images.`);
+					break;
+				}
+				if (total + a.bytes > MAX_ATTACHMENTS_BYTES) {
+					errors.add(`Attachments must total under ${mb(MAX_ATTACHMENTS_BYTES)} MB.`);
+					break;
+				}
+				accepted.push(a);
+				total += a.bytes;
+			}
+
+			if (accepted.length !== attachments.length) setAttachments(accepted);
+			setError(errors.size > 0 ? Array.from(errors).join(" ") : null);
+		},
+		[attachments],
+	);
 
 	const remove = useCallback((id: string) => {
 		setAttachments((prev) => prev.filter((a) => a.id !== id));
+		setError(null);
 	}, []);
 
-	const clear = useCallback(() => setAttachments([]), []);
+	const clear = useCallback(() => {
+		setAttachments([]);
+		setError(null);
+	}, []);
 
 	const toPayload = useCallback(
 		(): ImageAttachmentPayload[] => attachments.map(({ mimeType, data }) => ({ mimeType, data })),
 		[attachments],
 	);
 
-	return { attachments, addFiles, remove, clear, toPayload };
+	return { attachments, error, addFiles, remove, clear, toPayload };
 }


### PR DESCRIPTION
## What

Adds image attachment support to the **New Task "Brief"** composer, addressing the P1 finding in #2722 (part of the UX-audit epic #2728). Previously the Brief was a plain `<textarea>` with no way to paste, drop, or attach an image.

## Screenshots

Empty composer — note the **Add image** affordance and the paste/drop hint:

![New Task composer](https://raw.githubusercontent.com/AgentWrapper/agent-orchestrator/ao/ao-5/pr-assets/docs/pr-2907/composer-empty.png)

Pasted/attached images render as a tidy, aligned grid of numbered **Image N** chips with thumbnails and per-item remove:

![Composer with image chips](https://raw.githubusercontent.com/AgentWrapper/agent-orchestrator/ao/ao-5/pr-assets/docs/pr-2907/composer-grid.png)

The chip area is **height-capped and scrolls**, so many attachments never stretch the dialog past the viewport:

![Many images, scrollable](https://raw.githubusercontent.com/AgentWrapper/agent-orchestrator/ao/ao-5/pr-assets/docs/pr-2907/composer-scroll.png)

## Changes

**Frontend**
- New reusable `useImageAttachments` hook (paste / drop / file-picker → staged base64 payloads).
- `NewTaskDialog`: **Cmd+V paste**, drag-and-drop, and an **"Add image"** picker on the Brief. Attachments render as numbered **"Image 1", "Image 2"** chips (uniform grid, thumbnails, per-item remove); state clears when the dialog closes. The chip list is capped and scrollable.

**Backend**
- `SpawnSessionRequest` accepts optional inline base64 image attachments, validated for count (≤8), per-image size (≤10 MiB), total size (≤25 MiB), and image MIME type.
- On spawn, images are written into the session worktree under `.ao/attachments/` (added to the worktree's git excludes so they don't dirty the tree) and their paths appended to the prompt — CLI agents receive the prompt as text and can then read the files for visual context.
- Regenerated `openapi.yaml` + TS `schema.ts`.

## How to test

- `pnpm --prefix frontend test` (or `npx vitest run src/renderer/components/NewTaskDialog.test.tsx`) — covers paste → numbered chip → spawn body, removal/renumber, non-image paste ignored.
- `go test ./internal/httpd/controllers/ ./internal/session_manager/` — covers attachment decode/validation, worktree writing, and prompt augmentation.
- Manually: open New Task, Cmd+V a screenshot into the Brief → "Image 1" chip appears; start the task → the agent's worktree contains `.ao/attachments/image-1.png` and the prompt references it.

## Notes / follow-ups
- **Orchestrator brief:** the "new orchestrator" flow is a one-click spawn with **no brief input** today (orchestrators are promptless by design), so there is nothing to paste into there yet. The `useImageAttachments` hook was built to be reusable if we add an orchestrator brief later.
- Screenshots were captured by driving the real Electron app via Playwright; they are hosted on the `ao/ao-5/pr-assets` branch and are **not** part of this PR's diff.

Refs #2722

🤖 Generated with [Claude Code](https://claude.com/claude-code)