### PR TITLE
fix: persist Devin session IDs for restore

### DIFF
--- a/backend/internal/adapters/agent/devin/devin.go
+++ b/backend/internal/adapters/agent/devin/devin.go
@@ -17,7 +17,8 @@
 // BypassPermissions maps to `dangerous`.
 //
 // Restore prefers a native session id from AO session metadata via `-r <id>`
-// when one is available.
+// when one is available. Devin's SessionStart payload omits that id, so AO's
+// hook receiver discovers it from `devin list --format json` and persists it.
 package devin
 
 import (

--- a/backend/internal/cli/hooks.go
+++ b/backend/internal/cli/hooks.go
@@ -32,6 +32,10 @@ const (
 	// the cap truncates it first, so a persistently failing hook cannot grow
 	// the file without bound.
 	maxHooksLogBytes = 1 << 20
+	// devinSessionLookupTimeout keeps Devin's SessionStart hook comfortably
+	// inside the adapter's 30-second native hook timeout. Devin does not include
+	// its conversation id in the hook payload, so AO asks the local CLI registry.
+	devinSessionLookupTimeout = 5 * time.Second
 )
 
 // setActivityAPIRequest mirrors the daemon's SetActivityRequest body for
@@ -153,6 +157,9 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 	if activitydispatch.SupportsHarness(domain.AgentHarness(agent)) {
 		agentSessionID = hookAgentSessionID(payload)
 	}
+	if agent == "devin" && event == "session-start" && agentSessionID == "" {
+		agentSessionID = c.devinSessionID(ctx, sessionID)
+	}
 	if !hasActivity && agentSessionID == "" {
 		// Unknown agent, or an event carrying neither activity nor resumable
 		// session metadata: report nothing.
@@ -176,6 +183,42 @@ func (c *commandContext) runHook(ctx context.Context, agent, event string) error
 		c.reportHookFailure(agent, event, sessionID, err)
 	}
 	return nil
+}
+
+// devinSessionID reads the newest conversation id for the hook's current
+// working directory. Unlike the other Claude-compatible agents, Devin's real
+// SessionStart payload contains only hook_event_name and source; its resumable
+// id is exposed by `devin list --format json` instead. The hook process inherits
+// the agent worktree as its cwd, and `devin list` scopes results to that cwd.
+func (c *commandContext) devinSessionID(ctx context.Context, aoSessionID string) string {
+	lookupCtx, cancel := context.WithTimeout(ctx, devinSessionLookupTimeout)
+	defer cancel()
+	out, err := c.deps.CommandOutput(lookupCtx, "devin", "list", "--format", "json")
+	if err != nil {
+		c.reportHookFailure("devin", "session-start", aoSessionID, fmt.Errorf("resolve native session id: %w", err))
+		return ""
+	}
+	var sessions []struct {
+		ID             string `json:"id"`
+		LastActivityAt int64  `json:"last_activity_at"`
+	}
+	if err := json.Unmarshal(out, &sessions); err != nil {
+		c.reportHookFailure("devin", "session-start", aoSessionID, fmt.Errorf("parse native session list: %w", err))
+		return ""
+	}
+	var newestID string
+	var newestActivity int64
+	for _, session := range sessions {
+		id := strings.TrimSpace(session.ID)
+		if id == "" || len(id) > maxActivityMetaLen {
+			continue
+		}
+		if newestID == "" || session.LastActivityAt > newestActivity {
+			newestID = id
+			newestActivity = session.LastActivityAt
+		}
+	}
+	return newestID
 }
 
 func shouldEmitSessionStartContext(agent, event string) bool {

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -490,7 +490,7 @@ func TestHooks_CopilotSessionStartReportsSessionID(t *testing.T) {
 	}
 }
 
-func TestHooks_DevinSessionStartInjectsSystemPromptContext(t *testing.T) {
+func TestHooks_DevinSessionStartReportsSessionIDAndInjectsSystemPromptContext(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", "ao-7")
 	cfg := setConfigEnv(t)
 	promptDir := filepath.Join(cfg.dataDir, "prompts", "ao-7")
@@ -504,7 +504,7 @@ func TestHooks_DevinSessionStartInjectsSystemPromptContext(t *testing.T) {
 	writeRunFileFor(t, cfg, srv)
 
 	out, _, err := executeCLI(t, Deps{
-		In:           strings.NewReader(`{"source":"startup"}`),
+		In:           strings.NewReader(`{"source":"startup","session_id":"devin-native-1"}`),
 		ProcessAlive: func(int) bool { return true },
 	}, "hooks", "devin", "session-start")
 	if err != nil {
@@ -525,8 +525,16 @@ func TestHooks_DevinSessionStartInjectsSystemPromptContext(t *testing.T) {
 	if got.HookSpecificOutput.AdditionalContext != "follow AO standing instructions" {
 		t.Fatalf("additionalContext = %q", got.HookSpecificOutput.AdditionalContext)
 	}
-	if got := capturedState(t, capture); got != "active" {
-		t.Errorf("state = %q, want active", got)
+	if capture.hits != 1 {
+		t.Fatalf("daemon calls = %d, want 1", capture.hits)
+	}
+	var req setActivityAPIRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
+	}
+	want := setActivityAPIRequest{State: "active", Event: "session-start", AgentSessionID: "devin-native-1"}
+	if req != want {
+		t.Fatalf("body = %+v, want %+v", req, want)
 	}
 }
 

--- a/backend/internal/cli/hooks_test.go
+++ b/backend/internal/cli/hooks_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -504,8 +506,17 @@ func TestHooks_DevinSessionStartReportsSessionIDAndInjectsSystemPromptContext(t 
 	writeRunFileFor(t, cfg, srv)
 
 	out, _, err := executeCLI(t, Deps{
-		In:           strings.NewReader(`{"source":"startup","session_id":"devin-native-1"}`),
+		In:           strings.NewReader(`{"hook_event_name":"SessionStart","source":"startup"}`),
 		ProcessAlive: func(int) bool { return true },
+		CommandOutput: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if name != "devin" || !reflect.DeepEqual(args, []string{"list", "--format", "json"}) {
+				t.Fatalf("command = %q %q", name, args)
+			}
+			return []byte(`[
+				{"id":"older-session","last_activity_at":100},
+				{"id":"devin-native-1","last_activity_at":200}
+			]`), nil
+		},
 	}, "hooks", "devin", "session-start")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2483,13 +2483,14 @@ func TestRestore_OpenCodeWithoutAgentSessionIDFallsBackToSavedPrompt(t *testing.
 	}
 }
 
-func TestRestore_AgyAndCopilotWithoutAgentSessionIDFallBackToSavedPrompt(t *testing.T) {
+func TestRestore_AgyCopilotAndDevinWithoutAgentSessionIDFallBackToSavedPrompt(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		harness domain.AgentHarness
 	}{
 		{name: "agy", harness: domain.HarnessAgy},
 		{name: "copilot", harness: domain.HarnessCopilot},
+		{name: "devin", harness: domain.HarnessDevin},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			st := newFakeStore()
@@ -2531,13 +2532,14 @@ func TestRestore_AgyAndCopilotWithoutAgentSessionIDFallBackToSavedPrompt(t *test
 	}
 }
 
-func TestRestore_AgyAndCopilotWithAgentSessionIDUseNativeResume(t *testing.T) {
+func TestRestore_AgyCopilotAndDevinWithAgentSessionIDUseNativeResume(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		harness domain.AgentHarness
 	}{
 		{name: "agy", harness: domain.HarnessAgy},
 		{name: "copilot", harness: domain.HarnessCopilot},
+		{name: "devin", harness: domain.HarnessDevin},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			st := newFakeStore()
@@ -2583,13 +2585,14 @@ func TestRestore_AgyAndCopilotWithAgentSessionIDUseNativeResume(t *testing.T) {
 	}
 }
 
-func TestRestore_AgyAndCopilotPromptlessWorkersWithoutAgentSessionIDNotResumable(t *testing.T) {
+func TestRestore_AgyCopilotAndDevinPromptlessWorkersWithoutAgentSessionIDNotResumable(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		harness domain.AgentHarness
 	}{
 		{name: "agy", harness: domain.HarnessAgy},
 		{name: "copilot", harness: domain.HarnessCopilot},
+		{name: "devin", harness: domain.HarnessDevin},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			st := newFakeStore()


### PR DESCRIPTION
## Summary
- capture Devin native session IDs from `devin list --format json` because real SessionStart payloads omit the ID
- persist the newest worktree-scoped Devin session ID through AO activity metadata
- restore terminated Devin sessions natively with `devin -r <id>`
- retain saved-prompt fallback and promptless non-resumable behavior

## Root cause
A live Devin for Terminal probe emitted `{"hook_event_name":"SessionStart","source":"startup"}`. AO expected `session_id` in that payload, so it never persisted a native resume handle and could not select native restore.

## Verification
- live isolated Devin hook-payload probe
- `go test ./internal/cli ./internal/adapters/agent/devin ./internal/session_manager ./internal/lifecycle ./internal/httpd/controllers`
- full `go test ./...` passes the changed and related packages; the existing Kilocode interactive-shell auth test times out independently and also fails in isolation