### PR TITLE
fix: restore Aider chat sessions

### DIFF
--- a/backend/internal/adapters/agent/aider/aider.go
+++ b/backend/internal/adapters/agent/aider/aider.go
@@ -1,15 +1,15 @@
 // Package aider implements the Aider agent adapter: launching interactive Aider
 // worker sessions.
 //
-// Aider is a Tier C adapter: it has no lifecycle hook surface, no native
-// session id, and no resume-by-id mechanism, so hook installation, restore, and
-// SessionInfo are intentionally no-ops. The permission mapping is lossy because
-// Aider lacks a graduated approval ladder or sandbox (see the comments on
-// appendApprovalFlags).
+// Aider has no lifecycle hook surface or native session id. AO restores its
+// conversation through Aider's session-scoped chat history file instead.
+// SessionInfo remains a no-op. The permission mapping is lossy because Aider
+// lacks a graduated approval ladder or sandbox (see appendApprovalFlags).
 package aider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -76,12 +76,67 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	cmd = []string{binary}
 	appendApprovalFlags(&cmd, cfg.Permissions)
 	cmd = append(cmd, "--no-check-update", "--no-stream", "--no-pretty")
+	if historyFile, err := prepareChatHistoryFile(cfg.DataDir, cfg.SessionID); err != nil {
+		return nil, err
+	} else if historyFile != "" {
+		cmd = append(cmd, "--chat-history-file", historyFile)
+	}
 	if cfg.SystemPromptFile != "" {
 		cmd = append(cmd, "--read", cfg.SystemPromptFile)
 	}
 	// aider has no inline system-prompt mechanism. A cfg.SystemPrompt with no
 	// file is intentionally dropped here rather than written to disk.
 	return cmd, nil
+}
+
+// GetRestoreCommand continues an Aider conversation from the transcript AO
+// assigned on first launch. Aider has no resume id; --restore-chat-history
+// reconstructs its message history from this file. A missing transcript is not
+// an error and lets the session manager fall back to replaying the saved task.
+func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) ([]string, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	historyFile := chatHistoryFile(cfg.DataDir, cfg.Session.ID)
+	if historyFile == "" {
+		return nil, false, nil
+	}
+	if _, err := os.Stat(historyFile); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("aider: stat chat history: %w", err)
+	}
+
+	binary, err := p.aiderBinary(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	cmd := []string{binary}
+	appendApprovalFlags(&cmd, cfg.Permissions)
+	cmd = append(cmd, "--no-check-update", "--no-stream", "--no-pretty", "--chat-history-file", historyFile, "--restore-chat-history")
+	if cfg.SystemPromptFile != "" {
+		cmd = append(cmd, "--read", cfg.SystemPromptFile)
+	}
+	return cmd, true, nil
+}
+
+func chatHistoryFile(dataDir, sessionID string) string {
+	if dataDir == "" || sessionID == "" {
+		return ""
+	}
+	return filepath.Join(dataDir, "sessions", sessionID, "aider.chat.history.md")
+}
+
+func prepareChatHistoryFile(dataDir, sessionID string) (string, error) {
+	path := chatHistoryFile(dataDir, sessionID)
+	if path == "" {
+		return "", nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("aider: prepare chat history directory: %w", err)
+	}
+	return path, nil
 }
 
 // GetPromptDeliveryStrategy reports that AO should inject prompted Aider tasks

--- a/backend/internal/adapters/agent/aider/aider_test.go
+++ b/backend/internal/adapters/agent/aider/aider_test.go
@@ -3,6 +3,8 @@ package aider
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -105,6 +107,23 @@ func TestGetLaunchCommandAlwaysAppendsStableOutputFlags(t *testing.T) {
 		if !found {
 			t.Fatalf("cmd = %#v missing stable output flag %q", cmd, want)
 		}
+	}
+}
+
+func TestGetLaunchCommandAssignsSessionChatHistory(t *testing.T) {
+	dataDir := t.TempDir()
+	p := &Plugin{resolvedBinary: "aider"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{DataDir: dataDir, SessionID: "session-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	historyFile := filepath.Join(dataDir, "sessions", "session-1", "aider.chat.history.md")
+	want := []string{"aider", "--no-check-update", "--no-stream", "--no-pretty", "--chat-history-file", historyFile}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+	if info, err := os.Stat(filepath.Dir(historyFile)); err != nil || !info.IsDir() {
+		t.Fatalf("history directory was not prepared: info=%v err=%v", info, err)
 	}
 }
 
@@ -221,22 +240,41 @@ func TestGetLaunchCommandInlineSystemPromptIsDropped(t *testing.T) {
 	}
 }
 
-func TestGetRestoreCommandAlwaysFalse(t *testing.T) {
-	p := &Plugin{}
+func TestGetRestoreCommandRestoresSessionChatHistory(t *testing.T) {
+	dataDir := t.TempDir()
+	historyFile, err := prepareChatHistoryFile(dataDir, "session-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyFile, []byte("# aider chat history\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p := &Plugin{resolvedBinary: "aider"}
 	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
-		Session: ports.SessionRef{
-			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "abc123"},
-		},
+		DataDir:     dataDir,
+		Session:     ports.SessionRef{ID: "session-1"},
 		Permissions: ports.PermissionModeBypassPermissions,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ok {
-		t.Fatalf("ok=true, want false (aider has no resume-by-id)")
+	if !ok {
+		t.Fatal("ok=false, want true")
 	}
-	if cmd != nil {
-		t.Fatalf("cmd = %#v, want nil", cmd)
+	want := []string{"aider", "--yes-always", "--no-check-update", "--no-stream", "--no-pretty", "--chat-history-file", historyFile, "--restore-chat-history"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandFallsBackWhenHistoryIsMissing(t *testing.T) {
+	p := &Plugin{resolvedBinary: "aider"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{DataDir: t.TempDir(), Session: ports.SessionRef{ID: "session-1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || cmd != nil {
+		t.Fatalf("cmd=%#v ok=%v, want nil false", cmd, ok)
 	}
 }
 

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -214,6 +214,7 @@ type WorkspaceHookConfig struct {
 // RestoreConfig carries inputs needed to continue an existing native agent session.
 type RestoreConfig struct {
 	Config      AgentConfig
+	DataDir     string
 	Kind        domain.SessionKind
 	Permissions PermissionMode
 	Session     SessionRef

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2443,7 +2443,7 @@ func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, wo
 		WorkspacePath: workspacePath,
 		Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: meta.AgentSessionID},
 	}
-	cmd, ok, err := agent.GetRestoreCommand(ctx, ports.RestoreConfig{Session: ref, Kind: kind, SystemPrompt: systemPrompt, SystemPromptFile: systemPromptFile, Config: agentConfig, Permissions: agentConfig.Permissions})
+	cmd, ok, err := agent.GetRestoreCommand(ctx, ports.RestoreConfig{Session: ref, Kind: kind, SystemPrompt: systemPrompt, SystemPromptFile: systemPromptFile, Config: agentConfig, DataDir: dataDir, Permissions: agentConfig.Permissions})
 	if err != nil {
 		return nil, "", "", fmt.Errorf("restore command: %w", err)
 	}


### PR DESCRIPTION
## Summary
- persist Aider chat history in AO-owned per-session storage
- restore existing conversations with Aider's documented `--restore-chat-history` support
- fall back to replaying the saved task when no transcript exists

## Testing
- `go test ./internal/adapters/agent/aider ./internal/session_manager`
- full backend suite was also run; one unrelated Kilocode timeout passed on isolated retry