### PR TITLE
fix(desktop): sync embedded preview BrowserView with app theme

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,6 +5,7 @@ import {
 	dialog,
 	ipcMain,
 	Menu,
+	nativeTheme,
 	net,
 	nativeImage,
 	Notification as ElectronNotification,
@@ -1056,6 +1057,16 @@ ipcMain.handle("window:setOverlay", (_event, overlay: { color: string; symbolCol
 		mainWindow.setTitleBarOverlay({ ...overlay, height: TITLEBAR_HEIGHT });
 	} catch {
 		// Window has no overlay on this platform; ignore.
+	}
+});
+
+// Drive Electron's nativeTheme from the app's theme preference so embedded
+// preview WebContentsViews (which follow prefers-color-scheme) flip in step with
+// the shell. The three preference values map 1:1 onto themeSource; "system" keeps
+// both the preview and the shell's own matchMedia following the OS.
+ipcMain.handle("theme:set", (_event, preference: "light" | "dark" | "system") => {
+	if (preference === "light" || preference === "dark" || preference === "system") {
+		nativeTheme.themeSource = preference;
 	}
 });
 

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -78,8 +78,7 @@ const api = {
 		// Propagate the app's theme preference to Electron's nativeTheme so embedded
 		// WebContentsView previews (which follow prefers-color-scheme) stay in sync
 		// with the shell. "system" lets both follow the OS.
-		set: (preference: "light" | "dark" | "system") =>
-			ipcRenderer.invoke("theme:set", preference) as Promise<void>,
+		set: (preference: "light" | "dark" | "system") => ipcRenderer.invoke("theme:set", preference) as Promise<void>,
 	},
 	menu: {
 		action: (action: string) => ipcRenderer.invoke("menu:action", action) as Promise<void>,

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -74,6 +74,13 @@ const api = {
 		setOverlay: (overlay: { color: string; symbolColor: string }) =>
 			ipcRenderer.invoke("window:setOverlay", overlay) as Promise<void>,
 	},
+	theme: {
+		// Propagate the app's theme preference to Electron's nativeTheme so embedded
+		// WebContentsView previews (which follow prefers-color-scheme) stay in sync
+		// with the shell. "system" lets both follow the OS.
+		set: (preference: "light" | "dark" | "system") =>
+			ipcRenderer.invoke("theme:set", preference) as Promise<void>,
+	},
 	menu: {
 		action: (action: string) => ipcRenderer.invoke("menu:action", action) as Promise<void>,
 		notifyShellFocus: () => ipcRenderer.send("shell:focus"),

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -20,6 +20,9 @@ export const aoBridge: AoBridge =
 		window: {
 			setOverlay: async () => undefined,
 		},
+		theme: {
+			set: async () => undefined,
+		},
 		menu: {
 			action: async () => undefined,
 			notifyShellFocus: () => undefined,

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -271,6 +271,14 @@ function ShellLayout() {
 		applyDocumentTheme(resolvedTheme);
 	}, [resolvedTheme]);
 
+	// Keep Electron's nativeTheme in step with the shell so the embedded preview
+	// WebContentsView (which follows prefers-color-scheme) flips at the same time.
+	// Send the preference, not the resolved theme, so "system" keeps both surfaces
+	// following the OS instead of freezing matchMedia to a forced value.
+	useEffect(() => {
+		void aoBridge.theme?.set(themePreference);
+	}, [themePreference]);
+
 	useEffect(() => {
 		if (daemonStatus.state !== "ready" || !daemonStatus.port) return;
 		if (agentCatalogPortRef.current === daemonStatus.port) return;

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -69,6 +69,9 @@ if (typeof window !== "undefined") {
 		window: {
 			setOverlay: async () => undefined,
 		},
+		theme: {
+			set: async () => undefined,
+		},
 		menu: {
 			action: async () => undefined,
 			notifyShellFocus: () => undefined,


### PR DESCRIPTION
Closes (#2906)

## Summary

Toggling the app theme (Light ↔ Dark) left the embedded Orchestrator/Agent preview on its previous appearance. The React shell repainted immediately, but the preview `WebContentsView` stayed on the old theme until a later Chromium repaint or navigation, creating a visible desync.

The preview was never connected to the app's theme system. It received no theme updates, referenced no `nativeTheme`, and only fell back to the OS `prefers-color-scheme`.

This change drives Electron's `nativeTheme.themeSource` from the shell's theme preference so the preview updates at the same time as the rest of the UI.

## Approach

The preview renders arbitrary web content (AO preview targets), so `nativeTheme.themeSource` is the correct integration point. Since it changes what `prefers-color-scheme` reports to every `WebContents` in the app, any target that respects `prefers-color-scheme` switches themes immediately, with no reload or per-page injection.

The renderer sends the **theme preference** (`light` / `dark` / `system`), not the resolved theme, because these values map 1:1 to `themeSource`.

This distinction is important for `system`: forcing `themeSource` to `light` or `dark` while the app is set to System would freeze the shell's own `matchMedia`, breaking the existing follow-OS behavior. Sending `system` preserves OS-driven updates for both the preview and the shell.

This is the same class of issue as the terminal theme sync bug (#1283), but for the preview `BrowserView`.

## Changes

- `preload.ts` — expose `theme.set(preference)` on the bridge → `theme:set` IPC.
- `main.ts` — `theme:set` handler sets `nativeTheme.themeSource` (validated to `light` / `dark` / `system`).
- `_shell.tsx` — effect keyed on `themePreference` calls `aoBridge.theme.set(...)` alongside the existing `applyDocumentTheme`.
- `bridge.ts` / `test/setup.ts` — add a no-op `theme.set` for browser-preview and test modes.

**32 insertions, 0 deletions.** No UI, markup, or style changes.

## Testing

- `tsc --noEmit` passes cleanly.
- Packaged the app and launched a real Electron build under Playwright.
- Drove the actual **Settings → Theme** control.
- Verified that a single store update per selection kept both the shell and preview synchronized.

| Pick | Shell `data-theme` | `nativeTheme.themeSource` |
|------|--------------------|---------------------------|
| Light | `light` | `light` |
| Dark | `dark` | `dark` |
| System | `light` (OS) | `system` |
| Light | `light` | `light` |

## Notes

If a preview target ignores `prefers-color-scheme` and implements its own theme toggle, this approach (like any `nativeTheme`-based solution) will not override it. That behavior is outside the scope of the reported OS-fallback issue.

---

cc @Vaibhaav-Tiwari 