### PR TITLE
fix(opencode): forward role-specific model config on launch and restore

### DIFF
--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -88,6 +88,22 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys opencode understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `opencode --model`, in provider/model form.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new interactive opencode session.
 // Shape:
 //
@@ -111,6 +127,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	cmd = envPrefix
 	cmd = append(cmd, binary)
 	appendPermissionFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 	if agentName != "" {
 		cmd = append(cmd, "--agent", agentName)
 	}
@@ -147,6 +164,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	cmd = envPrefix
 	cmd = append(cmd, binary)
 	appendPermissionFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 	if agentName != "" {
 		cmd = append(cmd, "--agent", agentName)
 	}
@@ -355,6 +373,15 @@ func opencodeDBCount(ctx context.Context, db *sql.DB, query string) (int, error)
 func appendPermissionFlags(cmd *[]string, permissions ports.PermissionMode) {
 	if ports.NormalizePermissionMode(permissions) == ports.PermissionModeBypassPermissions {
 		*cmd = append(*cmd, "--dangerously-skip-permissions")
+	}
+}
+
+// appendModelFlag forwards the configured role model to opencode. The CLI flag
+// takes precedence over the config file, so a configured worker no longer falls
+// back to opencode's global default.
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
 	}
 }
 

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -459,15 +459,76 @@ func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	plugin := &Plugin{}
 
 	spec, err := plugin.GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("unexpected config fields: %#v", spec.Fields)
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `opencode --model`, in provider/model form.",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
+	}
+}
+
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "opencode"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "  anthropic/claude-4.5-sonnet  "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"opencode", "--model", "anthropic/claude-4.5-sonnet"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("launch cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "opencode"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(cmd, "--model") {
+		t.Fatalf("command %#v contains --model for a blank model", cmd)
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "opencode"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "anthropic/claude-4.5-sonnet"},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{opencodeAgentSessionIDMetadataKey: "ses_abc123"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	want := []string{
+		"opencode",
+		"--model", "anthropic/claude-4.5-sonnet",
+		"--session", "ses_abc123",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
 	}
 }
 


### PR DESCRIPTION
## What

Forward the configured role model to the `opencode` CLI on both launch and restore, and advertise the `model` config field.

## Why

Fixes #2891.

`GetLaunchCommand` and `GetRestoreCommand` built their argv without reading `cfg.Config.Model`, so a worker or orchestrator configured with a specific model silently started on opencode's global default. The adapter also inherited the empty `agentbase.Base.GetConfigSpec`, so it never advertised a `model` field.

## How

Mirrors the Codex fix in #2869:

- `appendModelFlag` appends `--model <trimmed model>` when `strings.TrimSpace(cfg.Config.Model) != ""`, called from both `GetLaunchCommand` and `GetRestoreCommand`.
- `GetConfigSpec` override advertising `model` as `ports.ConfigFieldString`.

The flag is appended right after the permission flags so it sits with the other `append*Flags` output, ahead of `--agent` and the trailing `--prompt` / `--session` argument pairs. opencode gives the CLI flag the highest precedence, above the config file, so this wins over a user's `model` config value as intended.

Model values stay in opencode's `provider/model` form; the adapter passes the string through untouched apart from trimming.

## Testing

```
go test ./internal/adapters/agent/opencode/    ok
gofmt -l / go vet                              clean
go build ./...                                 clean
```

Three new tests, proven to fail on `main` before the fix:

```
--- FAIL: TestGetConfigSpecReportsModelField
         got: []ports.ConfigField(nil)
--- FAIL: TestGetLaunchCommandAppendsConfiguredModel
        want: []string{"opencode", "--model", "anthropic/claude-4.5-sonnet"}
         got: []string{"opencode"}
--- FAIL: TestGetRestoreCommandAppendsConfiguredModel
        want: []string{"opencode", "--model", "anthropic/claude-4.5-sonnet", "--session", "ses_abc123"}
         got: []string{"opencode", "--session", "ses_abc123"}
```

`TestGetLaunchCommandOmitsBlankConfiguredModel` passes both before and after, so it pins the blank/whitespace case rather than restating the fix.

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for user-visible behavior
- [x] Relevant CI checks pass for the area touched
