### PR TITLE
fix(aider): forward role-specific model config on launch

### DIFF
--- a/backend/internal/adapters/agent/aider/aider.go
+++ b/backend/internal/adapters/agent/aider/aider.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
@@ -54,6 +55,22 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Aider understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `aider --model`.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start an interactive Aider session:
 //
 //	aider [permission flags] --no-check-update --no-stream --no-pretty [--read <context file>]
@@ -75,6 +92,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd = []string{binary}
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 	cmd = append(cmd, "--no-check-update", "--no-stream", "--no-pretty")
 	if cfg.SystemPromptFile != "" {
 		cmd = append(cmd, "--read", cfg.SystemPromptFile)
@@ -92,6 +110,14 @@ func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, _ ports.LaunchCo
 		return "", err
 	}
 	return ports.PromptDeliveryAfterStart, nil
+}
+
+// appendModelFlag forwards the configured role model to Aider. Without it a
+// configured worker silently falls back to Aider's own default model.
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
+	}
 }
 
 // normalizePermissionMode collapses an empty mode onto PermissionModeDefault so

--- a/backend/internal/adapters/agent/aider/aider_test.go
+++ b/backend/internal/adapters/agent/aider/aider_test.go
@@ -29,13 +29,50 @@ func TestManifest(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecEmpty(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `aider --model`.",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
+	}
+}
+
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	p := &Plugin{resolvedBinary: "aider"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "  openai/gpt-5.4  "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"aider", "--model", "openai/gpt-5.4", "--no-check-update", "--no-stream", "--no-pretty"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	p := &Plugin{resolvedBinary: "aider"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"aider", "--no-check-update", "--no-stream", "--no-pretty"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
 	}
 }
 


### PR DESCRIPTION
## What

Forward the configured role model to the `aider` CLI on launch, and advertise the `model` config field.

## Why

Fixes #2887.

`GetLaunchCommand` built its argv without reading `cfg.Config.Model`, so a worker configured with a specific model silently started on Aider's own default. The adapter also inherited the empty `agentbase.Base.GetConfigSpec`, so it never advertised a `model` field.

## How

Mirrors the Codex fix in #2869:

- `appendModelFlag` appends `--model <trimmed model>` when `strings.TrimSpace(cfg.Config.Model) != ""`, called from `GetLaunchCommand`.
- `GetConfigSpec` override advertising `model` as `ports.ConfigFieldString`.

The flag is appended after the approval flags and before the fixed `--no-check-update --no-stream --no-pretty` block, keeping the existing argv shape otherwise unchanged.

Intentional omission: Aider is a Tier C adapter with no `GetRestoreCommand`, so unlike #2869 there is no restore call site to update. This matches the harness note on #2887.

## Testing

```
go test ./internal/adapters/agent/aider/    ok
gofmt -l / go vet                           clean
go build ./...                              clean
```

Two new tests, proven to fail on `main` before the fix:

```
--- FAIL: TestGetConfigSpecReportsModelField
         got: []ports.ConfigField(nil)
--- FAIL: TestGetLaunchCommandAppendsConfiguredModel
        want: []string{"aider", "--model", "openai/gpt-5.4", "--no-check-update", "--no-stream", "--no-pretty"}
         got: []string{"aider", "--no-check-update", "--no-stream", "--no-pretty"}
```

`TestGetLaunchCommandOmitsBlankConfiguredModel` asserts the exact unchanged argv for a whitespace-only model, so it also guards against the flag being added with an empty value.

The existing `TestGetConfigSpecEmpty` is replaced by `TestGetConfigSpecReportsModelField`, since the spec is no longer empty.

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for user-visible behavior
- [x] Relevant CI checks pass for the area touched
