### PR TITLE
feat(settings): add app links and LAN/Tailscale setup steps to Connect Mobile

### DIFF
--- a/frontend/src/renderer/components/ConnectMobileModal.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.tsx
@@ -4,6 +4,8 @@ import { Check, Copy, Info, Loader2, X } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { cn } from "../lib/utils";
+import { ConnectMobileGetApp } from "./settings/ConnectMobileGetApp";
+import { ConnectMobileSetup } from "./settings/ConnectMobileSetup";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Switch } from "./ui/switch";
 
@@ -149,13 +151,17 @@ export function ConnectMobileModal({ open, onOpenChange }: ConnectMobileModalPro
 						<X className="size-5" aria-hidden="true" />
 					</button>
 				</DialogClose>
-				<div className="flex flex-col px-(--size-settings-mobile-dialog-pad-x) pb-6 pt-8">
+				{/* The get-app QR and setup steps can push this past a short window,
+				    so the body scrolls rather than clipping under the screen edges. */}
+				<div className="scrollbar-none flex max-h-[80vh] flex-col overflow-y-auto px-(--size-settings-mobile-dialog-pad-x) pb-6 pt-8">
 					<DialogHeader className="items-center gap-1.5 text-center">
 						<DialogTitle className="settings-dialog-title text-center">Connect Mobile</DialogTitle>
 						<DialogDescription className="max-w-(--size-settings-mobile-desc) text-center text-control font-normal leading-4 text-settings-muted">
 							Pair the Agent Orchestrator mobile app with this desktop over your LAN.
 						</DialogDescription>
 					</DialogHeader>
+
+					<ConnectMobileGetApp />
 
 					{query.isLoading ? (
 						<p className="mt-6 text-center text-xs text-settings-muted">Checking status…</p>
@@ -211,7 +217,11 @@ export function ConnectMobileModal({ open, onOpenChange }: ConnectMobileModalPro
 											enabled ? "opacity-100" : "opacity-0",
 										)}
 									>
-										<div className="flex w-(--size-settings-mobile-qr) flex-col items-center">
+										{/* Steps sit above the QR so the LAN/Tailscale choice is on screen
+										    the moment the bridge turns on, with no scrolling. */}
+										<ConnectMobileSetup port={status.port} enabled={enabled} />
+
+										<div className="mt-6 flex w-(--size-settings-mobile-qr) flex-col items-center">
 											<div className="rounded-(--radius-settings-dialog-lg) bg-white p-2 shadow-[var(--shadow-settings-qr)]">
 												<QRCodeSVG
 													value={pairingPayload(status.host, status.port, status.password)}

--- a/frontend/src/renderer/components/settings/ConnectMobileGetApp.test.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileGetApp.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, expect, test, vi } from "vitest";
+import { ConnectMobileGetApp, TESTFLIGHT_URL } from "./ConnectMobileGetApp";
+
+const { openExternal } = vi.hoisted(() => ({ openExternal: vi.fn() }));
+
+vi.mock("../../lib/bridge", () => ({
+	aoBridge: { app: { openExternal } },
+}));
+
+beforeEach(() => {
+	openExternal.mockReset();
+	openExternal.mockResolvedValue(undefined);
+});
+
+test("TestFlight button opens the join link through the app bridge", async () => {
+	render(<ConnectMobileGetApp />);
+	await userEvent.click(screen.getByRole("button", { name: "Join the TestFlight beta" }));
+	expect(openExternal).toHaveBeenCalledWith("https://testflight.apple.com/join/t4U3fu2H");
+	expect(TESTFLIGHT_URL).toBe("https://testflight.apple.com/join/t4U3fu2H");
+});
+
+test("Android is listed as not yet available", () => {
+	render(<ConnectMobileGetApp />);
+	expect(screen.getByText("Android")).toBeInTheDocument();
+	expect(screen.getByText("Coming soon")).toBeInTheDocument();
+});
+
+// The join link is useless without Apple's TestFlight app, and "TestFlight beta"
+// alone reads like a build channel rather than a prerequisite — say so plainly.
+test("iOS row names TestFlight as a prerequisite install", () => {
+	render(<ConnectMobileGetApp />);
+	expect(screen.getByText(/Install Apple's TestFlight app first/i)).toBeInTheDocument();
+});
+
+test("QR code stays collapsed until the disclosure is toggled", async () => {
+	render(<ConnectMobileGetApp />);
+	const toggle = screen.getByRole("button", { name: "Show TestFlight QR code" });
+	expect(toggle).toHaveAttribute("aria-expanded", "false");
+	expect(screen.getByTestId("testflight-qr")).toHaveAttribute("aria-hidden", "true");
+
+	await userEvent.click(toggle);
+
+	expect(screen.getByRole("button", { name: "Hide TestFlight QR code" })).toHaveAttribute("aria-expanded", "true");
+	expect(screen.getByTestId("testflight-qr")).toHaveAttribute("aria-hidden", "false");
+});

--- a/frontend/src/renderer/components/settings/ConnectMobileGetApp.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileGetApp.tsx
@@ -1,0 +1,94 @@
+import { QrCode } from "lucide-react";
+import { useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { aoBridge } from "../../lib/bridge";
+import { cn } from "../../lib/utils";
+
+/** TestFlight beta for the Agent Orchestrator iOS app. */
+export const TESTFLIGHT_URL = "https://testflight.apple.com/join/t4U3fu2H";
+
+/** Deliberately smaller than the pairing QR so it never competes with it. */
+const TESTFLIGHT_QR_SIZE = 140;
+
+// ConnectMobileGetApp is step zero of pairing: the pairing QR below it is
+// meaningless until the app is installed. It sits outside the modal's
+// enable-collapse because installing the app has nothing to do with whether
+// the LAN bridge is running. The QR (of the TestFlight URL itself) hides
+// behind a disclosure so the widened modal keeps its height.
+export function ConnectMobileGetApp() {
+	const [showQR, setShowQR] = useState(false);
+
+	return (
+		<div className="mt-6 flex flex-col rounded-(--radius-settings-dialog-lg) border border-[var(--color-border-settings-input)] bg-[var(--color-bg-settings-input)] px-3.5 py-3">
+			<span className="text-subtitle leading-(--leading-settings-mobile-title) text-settings-label">Get the app</span>
+
+			{/* iOS — items-center so the action cluster sits on the row's optical centre. */}
+			<div className="mt-2.5 flex items-center justify-between gap-3">
+				<div className="flex min-w-0 flex-col">
+					<span className="text-sm leading-5 text-settings-label">iOS</span>
+					<span className="text-caption leading-(--leading-settings-mobile-hint) text-settings-muted">
+						Install Apple's TestFlight app first, then join the beta
+					</span>
+				</div>
+				<div className="flex shrink-0 items-center gap-1.5">
+					<button
+						type="button"
+						aria-label="Join the TestFlight beta"
+						onClick={() => void aoBridge.app.openExternal(TESTFLIGHT_URL)}
+						className="inline-flex h-7 shrink-0 items-center justify-center rounded-lg border border-[var(--color-border-settings-input)] bg-settings-row px-3 text-caption text-settings-label transition-opacity hover:opacity-90"
+					>
+						Join beta
+					</button>
+					<button
+						type="button"
+						aria-label={showQR ? "Hide TestFlight QR code" : "Show TestFlight QR code"}
+						aria-expanded={showQR}
+						onClick={() => setShowQR((v) => !v)}
+						className={cn(
+							"inline-flex size-7 items-center justify-center rounded-lg transition-colors hover:bg-settings-row",
+							showQR ? "bg-settings-row text-settings-title" : "text-settings-muted",
+						)}
+					>
+						<QrCode className="size-4" aria-hidden="true" />
+					</button>
+				</div>
+			</div>
+
+			<div
+				data-testid="testflight-qr"
+				className={cn(
+					"grid transition-[grid-template-rows] duration-300 ease-out",
+					showQR ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+				)}
+				aria-hidden={!showQR}
+			>
+				<div className="overflow-hidden">
+					<div
+						className={cn(
+							"flex flex-col items-center pt-3 transition-opacity duration-300 ease-out",
+							showQR ? "opacity-100" : "opacity-0",
+						)}
+					>
+						<div className="rounded-xl bg-white p-2 shadow-[var(--shadow-settings-qr)]">
+							<QRCodeSVG value={TESTFLIGHT_URL} size={TESTFLIGHT_QR_SIZE} className="block" />
+						</div>
+						<p className="mt-2 text-caption text-settings-muted">Install TestFlight, then scan to join the beta</p>
+					</div>
+				</div>
+			</div>
+
+			{/* Android — no build to hand out yet, so this row is informational only. */}
+			<div className="mt-3 flex items-center justify-between gap-3 border-t border-[var(--color-border-settings-input)] pt-3">
+				<div className="flex min-w-0 flex-col">
+					<span className="text-sm leading-5 text-settings-label">Android</span>
+					<span className="text-caption leading-(--leading-settings-mobile-hint) text-settings-muted">
+						Play Store beta
+					</span>
+				</div>
+				<span className="inline-flex h-7 shrink-0 items-center rounded-lg bg-settings-row px-3 text-caption text-settings-muted">
+					Coming soon
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/renderer/components/settings/ConnectMobileSetup.test.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileSetup.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { expect, test } from "vitest";
+import { ConnectMobileSetup } from "./ConnectMobileSetup";
+
+test("LAN steps show by default", () => {
+	render(<ConnectMobileSetup port={3011} enabled={true} />);
+	expect(screen.getByText(/same Wi-Fi as this computer/i)).toBeInTheDocument();
+	expect(screen.queryByText(/tailscale ip -4/i)).not.toBeInTheDocument();
+});
+
+test("Tailscale tab explains manual entry and echoes the live port", async () => {
+	render(<ConnectMobileSetup port={3011} enabled={true} />);
+	await userEvent.click(screen.getByRole("tab", { name: "Tailscale" }));
+	expect(screen.getByText(/tailscale ip -4/i)).toBeInTheDocument();
+	expect(
+		screen.getByText((_, el) => el?.textContent?.includes("port 3011") ?? false, { selector: "li" }),
+	).toBeInTheDocument();
+});
+
+test("tabs leave the tab order while the bridge is disabled", () => {
+	render(<ConnectMobileSetup port={3011} enabled={false} />);
+	expect(screen.getByRole("tab", { name: "LAN" })).toHaveAttribute("tabindex", "-1");
+});

--- a/frontend/src/renderer/components/settings/ConnectMobileSetup.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileSetup.tsx
@@ -1,0 +1,56 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+
+interface ConnectMobileSetupProps {
+	/** Live bridge port, echoed in the Tailscale manual-entry step. */
+	port: number;
+	/**
+	 * False while the bridge is off; the steps are then collapsed, so their
+	 * tabs must leave the tab order (same pattern as the pairing block).
+	 */
+	enabled: boolean;
+}
+
+const stepListClass =
+	"list-decimal space-y-1.5 pl-4 text-caption leading-(--leading-settings-mobile-hint) text-settings-muted";
+
+const triggerClass = "text-settings-muted data-[state=active]:bg-settings-row data-[state=active]:text-settings-title";
+
+// ConnectMobileSetup tells the user what to do with the pairing QR above it.
+// The LAN tab is the happy path (scan and go). The Tailscale tab is manual
+// entry on purpose: the pairing QR can only ever carry the LAN address,
+// because AutopickLANIP skips utun* interfaces and rejects Tailscale's
+// 100.64.0.0/10 CGNAT range as non-private (backend/internal/mobilebridge/netiface.go).
+export function ConnectMobileSetup({ port, enabled }: ConnectMobileSetupProps) {
+	// Margin-free on purpose: the modal owns the spacing around this block.
+	return (
+		<Tabs defaultValue="lan" className="flex w-full flex-col items-center">
+			<TabsList className="bg-[var(--color-bg-settings-input)]">
+				<TabsTrigger value="lan" tabIndex={enabled ? 0 : -1} className={triggerClass}>
+					LAN
+				</TabsTrigger>
+				<TabsTrigger value="tailscale" tabIndex={enabled ? 0 : -1} className={triggerClass}>
+					Tailscale
+				</TabsTrigger>
+			</TabsList>
+
+			<TabsContent value="lan" className="mt-3 w-full px-(--size-settings-mobile-details-pad-x)">
+				<ol className={stepListClass}>
+					<li>Put your phone on the same Wi-Fi as this computer.</li>
+					<li>Open Agent Orchestrator on your phone and tap Scan.</li>
+					<li>Scan the code below — address and password fill in automatically.</li>
+				</ol>
+			</TabsContent>
+
+			<TabsContent value="tailscale" className="mt-3 w-full px-(--size-settings-mobile-details-pad-x)">
+				<ol className={stepListClass}>
+					<li>Install Tailscale here and on your phone, signed into the same account.</li>
+					<li>
+						Run <span className="tracking-settings-mono text-settings-label">tailscale ip -4</span> here to get your
+						100.x address.
+					</li>
+					<li>In the app's Settings, enter that address, port {port}, and the password below. Leave Use TLS off.</li>
+				</ol>
+			</TabsContent>
+		</Tabs>
+	);
+}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -645,6 +645,17 @@ select {
 	height: 0;
 }
 
+/* Scrollable region that must not show a scrollbar — the wheel/trackpad still
+   scrolls, but no track is painted and none reserves width. */
+.scrollbar-none {
+	scrollbar-width: none;
+}
+
+.scrollbar-none::-webkit-scrollbar {
+	width: 0;
+	height: 0;
+}
+
 .session-files-diff-scrollbar {
 	scrollbar-width: thin;
 	scrollbar-color: var(--color-scrollbar) transparent;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -303,12 +303,12 @@
 	--color-text-agents-sheet-label: #d1d5db;
 	--radius-agents-sheet: var(--radius-center-panel);
 	/* Settings layout sizes (Figma) */
-	--size-settings-mobile-dialog: 336px;
-	--size-settings-mobile-dialog-pad-x: 17px;
-	--size-settings-mobile-desc: 306px;
+	--size-settings-mobile-dialog: 550px;
+	--size-settings-mobile-dialog-pad-x: 24px;
+	--size-settings-mobile-desc: 420px;
 	--size-settings-mobile-qr: 220px;
 	--size-settings-mobile-qr-code: 204px;
-	--size-settings-mobile-warning: 290px;
+	--size-settings-mobile-warning: 400px;
 	--size-settings-mobile-label: 55px;
 	--size-settings-mobile-regen-width: 179px;
 	--size-settings-mobile-switch-w: 42px;


### PR DESCRIPTION
## Problem

The Connect Mobile modal shows a pairing QR, but:

1. **It never says where to get the app.** The QR is meaningless until Agent Orchestrator is installed on the phone.
2. **Tailscale is invisible.** The LAN listener binds all interfaces, so Tailscale already works — but only if the user types the `100.x` host into the mobile app's Settings by hand (`packages/mobile/app/(tabs)/settings.tsx:151`). The pairing QR structurally cannot carry it: `mobilebridge.AutopickLANIP()` skips `utun*` interfaces and accepts only RFC1918 addresses, and Tailscale's `100.64.0.0/10` is CGNAT, not private (`backend/internal/mobilebridge/netiface.go:12,48`). Nothing in the desktop UI said so.

## Changes

Frontend only — no backend, API-schema, or dependency changes.

- **`ConnectMobileGetApp`** — a "Get the app" card above the Enable toggle, outside the enable-collapse since installing the app is independent of whether the bridge runs. iOS row links to the TestFlight beta via `aoBridge.app.openExternal` (no `<a href>`), with a collapsible QR of the join URL so you can install from the phone without typing. Android row is an informational "coming soon" chip.
- **`ConnectMobileSetup`** — `LAN` / `Tailscale` tabs with per-transport steps, placed above the pairing QR so the choice is visible without scrolling. Tailscale steps are manual-entry on purpose, for the reason above.
- **Modal** — widened 336px → 500px, body scrolls past `80vh` with the scrollbar hidden via a new `.scrollbar-none` utility (following the existing `.xterm-viewport` pattern).

Both new components are pure and presentational; `ConnectMobileModal` keeps sole ownership of bridge state.

## Testing

- 6 new unit tests across the two components; 574 renderer tests pass.
- Verified in the Electron app and via Playwright screenshots in dark mode, in both tabs and with the QR expanded/collapsed.

## Notes

- The width bump is a deliberate deviation from the agent-orchestrator dialog width DESIGN.md pins — happy to revert it if you'd rather keep them uniform.
