### PR TITLE
fix(push): don't offer Register before pairing, and report the real failure

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  typecheck:
+  check:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -35,3 +35,6 @@ jobs:
 
       - name: Typecheck
         run: npm run typecheck
+
+      - name: Unit tests
+        run: npm test

--- a/packages/mobile/app/(tabs)/settings.tsx
+++ b/packages/mobile/app/(tabs)/settings.tsx
@@ -19,7 +19,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { pingServer } from "../../lib/api";
 import { DEFAULT_CONFIG, loadConfig, saveConfig, type ServerConfig } from "../../lib/config";
 import { haptics } from "../../lib/haptics";
-import { getPushStatus, openNotificationSettings, type PushStatus, registerForPush } from "../../lib/push";
+import { getPushStatus, openNotificationSettings, registerForPush } from "../../lib/push";
+import { describePush, describeRegisterFailure, type PushStatus } from "../../lib/pushStatus";
 import { useApp } from "../../lib/store";
 import { theme } from "../../lib/theme";
 import { Button, ConnectionPill, ScreenHeader } from "../../lib/ui";
@@ -274,35 +275,6 @@ export default function SettingsScreen() {
 	);
 }
 
-// Describes the current push state as a label/hint and the single action that
-// moves it forward, so the section renders one clear next step.
-function describePush(
-	status: PushStatus | null,
-	hasConfig: boolean,
-): { label: string; hint: string; action: string | null } {
-	if (!status) return { label: "Checking…", hint: "", action: null };
-	if (!status.supported) {
-		return { label: "Not available", hint: "Push notifications need a physical device.", action: null };
-	}
-	if (status.granted && status.registered) {
-		return { label: "On", hint: "You'll be alerted when an agent needs you or a PR is ready.", action: null };
-	}
-	if (status.granted && !status.registered) {
-		return {
-			label: "Permission granted",
-			hint: hasConfig
-				? "This device isn't registered yet. Tap to register with your server."
-				: "Connect to a server first, then this device registers automatically.",
-			action: hasConfig ? "Register" : null,
-		};
-	}
-	if (!status.granted && status.canAskAgain) {
-		return { label: "Off", hint: "Turn on alerts for agents that need input and PR updates.", action: "Enable" };
-	}
-	// Permanently denied — only system settings can flip it back on.
-	return { label: "Blocked", hint: "Notifications are turned off for AO in system settings.", action: "Open settings" };
-}
-
 // Settings section that surfaces push-notification status and the one action to
 // advance it: request permission, register, or (after a permanent denial) open
 // the OS settings. Closes the "denied on first try, no way back" gap.
@@ -322,30 +294,26 @@ function NotificationsSection() {
 	useFocusEffect(useCallback(() => refresh(), [refresh]));
 	useEffect(() => refresh(), [connection, refresh]);
 
-	const { label, hint, action } = describePush(status, !!config);
+	// Pass the config itself — describePush decides whether a server actually
+	// exists (non-empty host). Passing a caller-computed boolean is what shipped
+	// a Register button to unpaired testers.
+	const { label, hint, action, actionLabel } = describePush(status, config);
 
 	async function onAction() {
-		if (!status) return;
+		if (!status || !action) return;
 		setBusy(true);
 		try {
-			if (!status.granted && !status.canAskAgain) {
+			if (action === "open-settings") {
 				await openNotificationSettings();
 			} else if (config) {
 				// Requests permission if needed, then registers with the daemon.
-				// A null result means the build couldn't mint a token (most often an
-				// iOS local build with no APNs entitlement) — say so instead of a
-				// silent no-op.
-				const token = await registerForPush(config);
-				if (token) {
+				const result = await registerForPush(config);
+				if (result.ok) {
 					haptics.success();
 				} else {
 					haptics.error();
-					Alert.alert(
-						"Couldn't enable push on this build",
-						Platform.OS === "ios"
-							? "A local iOS build has no push entitlement, so it can't receive notifications. Install an EAS build (with an APNs key) to test push on iOS."
-							: "Couldn't register a push token. Check that notifications are allowed and that you're connected to your server.",
-					);
+					const { title, message } = describeRegisterFailure(result.reason, Platform.OS);
+					Alert.alert(title, message);
 				}
 			}
 		} finally {
@@ -362,7 +330,9 @@ function NotificationsSection() {
 					<Text style={styles.toggleLabel}>{label}</Text>
 					{hint ? <Text style={styles.toggleHint}>{hint}</Text> : null}
 				</View>
-				{action ? <Button title={action} variant="ghost" loading={busy} onPress={onAction} /> : null}
+				{action && actionLabel ? (
+					<Button title={actionLabel} variant="ghost" loading={busy} onPress={onAction} />
+				) : null}
 			</View>
 		</>
 	);

--- a/packages/mobile/lib/push.ts
+++ b/packages/mobile/lib/push.ts
@@ -9,6 +9,9 @@ import * as SecureStore from "expo-secure-store";
 import { Linking, Platform } from "react-native";
 import { registerPushDevice, unregisterPushDevice } from "./api";
 import type { ServerConfig } from "./config";
+import type { PushRegisterResult, PushStatus } from "./pushStatus";
+
+export type { PushRegisterResult, PushStatus } from "./pushStatus";
 
 // The last successful registration: the Expo token AND the daemon it was
 // registered with (host/port/TLS/password). Persisting the daemon — not just the
@@ -135,12 +138,14 @@ function easProjectId(): string | undefined {
 }
 
 // Request permission (once), acquire the Expo push token, and register it with
-// the daemon. Returns the token on success or null when unavailable (simulator,
-// permission denied, or no EAS projectId). Idempotent: the daemon upserts by
-// token, so this is also the foreground-refresh path (D7).
-export async function registerForPush(cfg: ServerConfig): Promise<string | null> {
+// the daemon. Returns the token on success, or a typed reason on failure so the
+// UI can say something accurate — notably distinguishing "this build can't mint a
+// token" from "the server wasn't reachable", which are very different problems.
+// Idempotent: the daemon upserts by token, so this is also the foreground-refresh
+// path (D7).
+export async function registerForPush(cfg: ServerConfig): Promise<PushRegisterResult> {
 	// Remote push tokens are only issued on physical devices.
-	if (!Device.isDevice) return null;
+	if (!Device.isDevice) return { ok: false, reason: "unsupported" };
 
 	// Ensure the Android channel exists BEFORE the permission prompt and before
 	// any notification could arrive, so a notification is never mis-filed onto an
@@ -152,14 +157,14 @@ export async function registerForPush(cfg: ServerConfig): Promise<string | null>
 	if (status !== "granted" && current.canAskAgain) {
 		status = (await Notifications.requestPermissionsAsync()).status;
 	}
-	if (status !== "granted") return null;
+	if (status !== "granted") return { ok: false, reason: "denied" };
 
 	const projectId = easProjectId();
 	if (!projectId) {
 		// Without a projectId Expo can't mint a token — this is an EAS setup gap,
 		// not a runtime error. Warn and no-op so the app still works without push.
 		console.warn("[push] no EAS projectId (run `eas init`); skipping push registration");
-		return null;
+		return { ok: false, reason: "no-project-id" };
 	}
 
 	// Retry any unregisters we still owe from a previous failure.
@@ -179,38 +184,39 @@ export async function registerForPush(cfg: ServerConfig): Promise<string | null>
 		}
 	}
 
-	// Acquiring the token can throw when the build lacks push support — most
-	// commonly on iOS with no APNs `aps-environment` entitlement (a local dev
-	// build not provisioned for push), or on a simulator. Treat that as "push
-	// unavailable on this build" and no-op rather than crashing the app.
+	// Step 1 — mint the token. This throws when the build itself can't do push:
+	// most commonly an iOS build with no APNs `aps-environment` entitlement, or a
+	// simulator. Kept in its own try so it is never confused with a server error.
+	let token: string;
 	try {
-		const { data: token } = await Notifications.getExpoPushTokenAsync({ projectId });
+		token = (await Notifications.getExpoPushTokenAsync({ projectId })).data;
+	} catch (e) {
+		console.warn("[push] could not obtain an Expo push token (build not provisioned for push?)", e);
+		return { ok: false, reason: "token-failed" };
+	}
+
+	// Step 2 — hand the token to the daemon. A failure here means the server was
+	// unreachable (not paired, offline, wrong host) — the build is fine.
+	try {
 		await registerPushDevice(cfg, {
 			token,
 			platform: Platform.OS,
 			deviceName: Device.deviceName ?? undefined,
 		});
-		await saveRegistration({
-			token,
-			host: cfg.host,
-			httpPort: cfg.httpPort,
-			secure: !!cfg.secure,
-			password: cfg.password,
-		});
-		return token;
 	} catch (e) {
-		console.warn("[push] could not obtain/register an Expo push token (build not provisioned for push?)", e);
-		return null;
+		console.warn("[push] could not register the token with the daemon (server unreachable?)", e);
+		return { ok: false, reason: "server-unreachable" };
 	}
-}
 
-// Current push state, for the Settings Notifications section.
-export type PushStatus = {
-	supported: boolean; // remote push only works on a physical device
-	granted: boolean; // OS notification permission granted
-	canAskAgain: boolean; // false once the user permanently denied (must use system settings)
-	registered: boolean; // we hold a token registered with a daemon
-};
+	await saveRegistration({
+		token,
+		host: cfg.host,
+		httpPort: cfg.httpPort,
+		secure: !!cfg.secure,
+		password: cfg.password,
+	});
+	return { ok: true, token };
+}
 
 // Reads the live permission + registration state without prompting.
 export async function getPushStatus(): Promise<PushStatus> {

--- a/packages/mobile/lib/pushStatus.test.ts
+++ b/packages/mobile/lib/pushStatus.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { describePush, describeRegisterFailure, hasServer, type PushStatus } from "./pushStatus";
+
+const status = (over: Partial<PushStatus> = {}): PushStatus => ({
+	supported: true,
+	granted: true,
+	canAskAgain: true,
+	registered: false,
+	...over,
+});
+
+describe("describePush", () => {
+	it("shows a neutral placeholder before status loads", () => {
+		const d = describePush(null, { host: "192.168.1.5" });
+		expect(d.action).toBeNull();
+		expect(d.label).toBe("Checking…");
+	});
+
+	it("offers nothing on a simulator", () => {
+		const d = describePush(status({ supported: false }), { host: "192.168.1.5" });
+		expect(d.action).toBeNull();
+		expect(d.label).toBe("Not available");
+	});
+
+	it("reports On with no action once granted and registered", () => {
+		const d = describePush(status({ registered: true }), { host: "192.168.1.5" });
+		expect(d.action).toBeNull();
+		expect(d.label).toBe("On");
+	});
+
+	// Regression: an unpaired app still has a default config with an empty host.
+	// Offering Register there always fails, which is what shipped to testers.
+	it("does NOT offer Register when the config exists but has no host (unpaired)", () => {
+		// This is the exact shape an unpaired app holds: a real config object with
+		// an empty host. Passing `!!config` here (truthy!) is what shipped a
+		// broken Register button to TestFlight users.
+		const d = describePush(status({ granted: true, registered: false }), { host: "" });
+		expect(d.action).toBeNull();
+		expect(d.actionLabel).toBeNull();
+		expect(d.hint).toMatch(/connect to your ao server first/i);
+	});
+
+	it("offers Register once a server host is set", () => {
+		const d = describePush(status({ granted: true, registered: false }), { host: "192.168.1.5" });
+		expect(d.action).toBe("register");
+		expect(d.actionLabel).toBe("Register");
+	});
+
+	it("offers Enable when permission has not been asked yet", () => {
+		const d = describePush(status({ granted: false, canAskAgain: true }), { host: "192.168.1.5" });
+		expect(d.action).toBe("enable");
+	});
+
+	it("offers Open settings after a permanent denial", () => {
+		const d = describePush(status({ granted: false, canAskAgain: false }), { host: "192.168.1.5" });
+		expect(d.action).toBe("open-settings");
+	});
+});
+
+describe("hasServer", () => {
+	it("treats a missing, empty, or whitespace host as no server", () => {
+		expect(hasServer(null)).toBe(false);
+		expect(hasServer(undefined)).toBe(false);
+		expect(hasServer({})).toBe(false);
+		expect(hasServer({ host: "" })).toBe(false);
+		expect(hasServer({ host: "   " })).toBe(false);
+	});
+
+	it("treats a real host as a server", () => {
+		expect(hasServer({ host: "192.168.1.5" })).toBe(true);
+	});
+});
+
+describe("describeRegisterFailure", () => {
+	// Regression: a TestFlight user whose server was simply unreachable was told
+	// their build "has no push entitlement", which was false and alarming.
+	it("blames the server, not the build, when the daemon is unreachable", () => {
+		const { title, message } = describeRegisterFailure("server-unreachable", "ios");
+		expect(title).toMatch(/couldn't reach your ao server/i);
+		expect(`${title} ${message}`).not.toMatch(/entitlement/i);
+	});
+
+	it("explains the missing entitlement only when the token itself failed on iOS", () => {
+		const { message } = describeRegisterFailure("token-failed", "ios");
+		expect(message).toMatch(/entitlement/i);
+		expect(message).toMatch(/testflight/i);
+	});
+
+	it("does not mention iOS entitlements on Android", () => {
+		const { message } = describeRegisterFailure("token-failed", "android");
+		expect(message).not.toMatch(/entitlement/i);
+	});
+
+	it("points at system settings when permission was denied", () => {
+		const { message } = describeRegisterFailure("denied", "ios");
+		expect(message).toMatch(/system settings/i);
+	});
+
+	it("covers the remaining reasons with a usable message", () => {
+		for (const reason of ["no-project-id", "unsupported"] as const) {
+			const { title, message } = describeRegisterFailure(reason, "ios");
+			expect(title.length).toBeGreaterThan(0);
+			expect(message.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/packages/mobile/lib/pushStatus.ts
+++ b/packages/mobile/lib/pushStatus.ts
@@ -1,0 +1,148 @@
+// Pure decision logic for the push-notification UI. Deliberately free of React
+// Native / Expo imports so it can be unit-tested directly, and so the rules that
+// decide "what can the user do next" live in one place instead of inside a screen.
+
+/** Live permission + registration state of push on this device. */
+export type PushStatus = {
+	supported: boolean; // remote push only works on a physical device
+	granted: boolean; // OS notification permission granted
+	canAskAgain: boolean; // false once permanently denied (must use system settings)
+	registered: boolean; // we hold a token registered with a daemon
+};
+
+/** The single action offered to move push forward, if any. */
+export type PushAction = "enable" | "register" | "open-settings";
+
+export type PushDescription = {
+	label: string;
+	hint: string;
+	action: PushAction | null;
+	actionLabel: string | null;
+};
+
+/** Just enough of the server config to know whether there's a server to talk to. */
+export type ServerTarget = { host?: string } | null | undefined;
+
+/**
+ * Is there actually a server to register with? An unpaired app still holds a
+ * default config object with an empty host, so presence of the object means
+ * nothing — only a non-empty host does.
+ */
+export function hasServer(server: ServerTarget): boolean {
+	return !!server?.host?.trim();
+}
+
+/**
+ * Describes push state as a label/hint plus the one action that advances it.
+ *
+ * Takes the server config itself rather than a caller-computed boolean: passing
+ * `!!config` (always true, even unpaired) was the original bug, so the "is there
+ * a server" rule lives here where it is tested, not at each call site.
+ */
+export function describePush(status: PushStatus | null, server: ServerTarget): PushDescription {
+	const configured = hasServer(server);
+	if (!status) {
+		return { label: "Checking…", hint: "", action: null, actionLabel: null };
+	}
+	if (!status.supported) {
+		return {
+			label: "Not available",
+			hint: "Push notifications need a physical device.",
+			action: null,
+			actionLabel: null,
+		};
+	}
+	if (status.granted && status.registered) {
+		return {
+			label: "On",
+			hint: "You'll be alerted when an agent needs you or a PR is ready.",
+			action: null,
+			actionLabel: null,
+		};
+	}
+	if (status.granted && !status.registered) {
+		// Only offer Register when there's actually a server configured.
+		return configured
+			? {
+					label: "Permission granted",
+					hint: "This device isn't registered yet. Tap to register with your server.",
+					action: "register",
+					actionLabel: "Register",
+				}
+			: {
+					label: "Permission granted",
+					hint: "Connect to your AO server first — this device registers automatically once connected.",
+					action: null,
+					actionLabel: null,
+				};
+	}
+	if (!status.granted && status.canAskAgain) {
+		return {
+			label: "Off",
+			hint: "Turn on alerts for agents that need input and PR updates.",
+			action: "enable",
+			actionLabel: "Enable",
+		};
+	}
+	// Permanently denied — only system settings can flip it back on.
+	return {
+		label: "Blocked",
+		hint: "Notifications are turned off for AO in system settings.",
+		action: "open-settings",
+		actionLabel: "Open settings",
+	};
+}
+
+/** Why a registration attempt did not produce a usable token. */
+export type PushRegisterFailure =
+	| "unsupported" // simulator / not a physical device
+	| "denied" // permission not granted
+	| "no-project-id" // EAS projectId missing from app config
+	| "token-failed" // the OS/Expo refused to mint a token (e.g. no APNs entitlement)
+	| "server-unreachable"; // token fine, but the daemon couldn't be reached
+
+export type PushRegisterResult = { ok: true; token: string } | { ok: false; reason: PushRegisterFailure };
+
+/**
+ * Human-facing title/message for a failed registration. Kept separate from the
+ * network code so the wording is testable — and so we never again tell a user on
+ * a proper store build that their build "has no push entitlement" when the real
+ * problem was simply that their server wasn't reachable.
+ */
+export function describeRegisterFailure(
+	reason: PushRegisterFailure,
+	platform: "ios" | "android" | string,
+): { title: string; message: string } {
+	switch (reason) {
+		case "server-unreachable":
+			return {
+				title: "Couldn't reach your AO server",
+				message:
+					"Your device is set up for notifications, but we couldn't reach your server to register it. " +
+					"Check that AO is running and your phone is on the same network, then try again.",
+			};
+		case "token-failed":
+			return {
+				title: "This build can't receive push notifications",
+				message:
+					platform === "ios"
+						? "This iOS build has no push entitlement. Install a build distributed through TestFlight to receive notifications."
+						: "The device couldn't provide a push token for this build.",
+			};
+		case "denied":
+			return {
+				title: "Notifications are turned off",
+				message: "Allow notifications for AO in your system settings, then try again.",
+			};
+		case "no-project-id":
+			return {
+				title: "Push isn't configured in this build",
+				message: "This build is missing its EAS project ID, so it can't register for notifications.",
+			};
+		case "unsupported":
+			return {
+				title: "Not available on this device",
+				message: "Push notifications only work on a physical device, not a simulator.",
+			};
+	}
+}

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -32,7 +32,8 @@
       "devDependencies": {
         "@types/react": "~19.1.10",
         "patch-package": "^8.0.1",
-        "typescript": "~5.9.2"
+        "typescript": "~5.9.2",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -1607,6 +1608,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@expo/cli": {
       "version": "54.0.25",
       "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.25.tgz",
@@ -2465,6 +2500,35 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -3422,6 +3486,288 @@
         "nanoid": "^3.3.11"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -3444,6 +3790,24 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -3486,6 +3850,31 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -3587,6 +3976,119 @@
       },
       "peerDependencies": {
         "@urql/core": "^5.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -3796,6 +4298,16 @@
         "object-is": "^1.1.5",
         "object.assign": "^4.1.4",
         "util": "^0.12.5"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async-limiter": {
@@ -4320,6 +4832,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4875,6 +5397,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -4927,6 +5456,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -4943,6 +5482,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/expo": {
@@ -6874,6 +7423,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -7413,9 +7972,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7563,6 +8122,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {
@@ -7880,6 +8453,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8654,6 +9234,40 @@
         "node": "*"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -8897,6 +9511,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -9032,6 +9653,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -9064,6 +9692,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-buffers": {
       "version": "2.2.0",
@@ -9362,6 +9997,23 @@
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -9376,6 +10028,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -9713,6 +10375,203 @@
         "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
+      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vlq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
@@ -9806,6 +10665,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wonka": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -10,7 +10,8 @@
 		"ios": "expo run:ios",
 		"typecheck": "tsc --noEmit",
 		"build": "npm run typecheck",
-		"postinstall": "patch-package"
+		"postinstall": "patch-package",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@expo/vector-icons": "^15.0.3",
@@ -36,6 +37,7 @@
 	"devDependencies": {
 		"@types/react": "~19.1.10",
 		"patch-package": "^8.0.1",
-		"typescript": "~5.9.2"
+		"typescript": "~5.9.2",
+		"vitest": "^4.1.10"
 	}
 }


### PR DESCRIPTION
## Fix misleading push registration UX

A TestFlight tester who hadn't yet connected to an AO server saw a **Register** button in Settings → Notifications and, on tapping it, an alert saying their build **"has no push entitlement"**. Both were wrong — the build was fine; they simply had no server to register with.

### Two bugs

**1. Register was offered before pairing.** The action was gated on `!!config`, which is truthy even when unpaired (the default config has an empty `host`). Every fresh install got a button that could only fail.

**2. The error message described the wrong failure.** `registerForPush` wrapped both steps in one `try`:
```
getExpoPushTokenAsync()  ← succeeded (TestFlight build has the entitlement)
registerPushDevice(cfg)  ← failed (server unreachable)
```
Both funnelled into one `catch`, which reported the hardcoded "no entitlement" text.

### Changes

- **`describePush` now takes the config object** and derives "is there a server" from a non-empty host, so the rule lives in one tested place rather than at each call site — the mis-wiring is no longer expressible.
- **`registerForPush` returns a typed result** (`token-failed` vs `server-unreachable` vs `denied` vs …), and the two steps are in separate `try` blocks. The UI now says *"Couldn't reach your AO server"* when that's the actual problem.
- **Extracted the decision logic to `lib/pushStatus.ts`** (no React Native imports) so it is unit-testable.
- **Added vitest coverage** (14 tests) and wired the mobile workflow to run the suite alongside typecheck.

### Verification

- `tsc --noEmit` and the full suite pass; `npm ci` is in sync with the lockfile.
- **Mutation-checked the regression tests:** reintroducing the original `!!config` behaviour makes exactly the two guarding tests fail, and restoring the fix makes all 14 pass — so the tests genuinely cover the reported bug rather than just describing current behaviour.
- Lockfile diff is limited to the vitest additions (880 insertions, 0 removed packages).
