### PR TITLE
fix(session_manager): repair broken Go CI on main (m.Restore -> RestoreWithMode)

### DIFF
--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -3241,7 +3241,7 @@ func TestSpawnAndRestore_PrependsResolvedBinaryAndNodeDirsToRuntimePATH(t *testi
 				}
 			} else {
 				seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "b", AgentSessionID: "agent-x"})
-				if _, err := m.Restore(ctx, "mer-1"); err != nil {
+				if _, err := m.RestoreWithMode(ctx, "mer-1"); err != nil {
 					t.Fatalf("Restore: %v", err)
 				}
 			}


### PR DESCRIPTION
## Problem

`main` is red on the **Go** job (both `golangci-lint` typecheck and `go vet ./...`):

```
internal/session_manager/manager_test.go:3244:20: m.Restore undefined
(type *Manager has no field or method Restore)
```

This broke at commit `08c9b770e` (#2838) and remained broken through `f94acd2b3` (#2601).

## Root cause — semantic merge conflict

Two PRs that each passed in isolation but break when combined:

- **#2790** renamed `Manager.Restore(...)` → `Manager.RestoreWithMode(...)` and updated its own call sites (green).
- **#2838** was branched before that rename landed and added a new test, `TestSpawnAndRestore_PrependsResolvedBinaryAndNodeDirsToRuntimePATH`, that still calls the old `m.Restore(...)`. On #2838's stale base the method still existed, so it compiled → PR green.

The textual merge is clean (new function, different location), so nothing conflicted. But post-merge `main` has `RestoreWithMode` **and** a test calling the removed `m.Restore` → typecheck fails. #2601 landed one minute later on top of the broken tree and inherited the failure.

Neither PR's CI ever compiled both changes together because branches aren't required to be up to date with `main` before merging.

## Fix

One-line change: `m.Restore(ctx, "mer-1")` → `m.RestoreWithMode(ctx, "mer-1")`. The test already discards the first return value with `_`, and `RestoreWithMode` returns `(RestoreResult, error)`, so it's a drop-in.

Verified locally: `go vet ./internal/session_manager/` exits clean.

## Follow-up (not in this PR)

Enable **"Require branches to be up to date before merging"** (or a merge queue) on `main` to prevent this class of semantic conflict.