### PR TITLE
fix(board): make idle-first work lane clearer

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
@@ -91,7 +91,6 @@ describe("SessionsBoard", () => {
 
 		renderBoard("p1");
 
-		fireEvent.click(screen.getByRole("button", { name: /idle sessions/i }));
 		const idleCard = screen.getByText("brand-font-pipeline").closest('[role="button"]') as HTMLElement;
 		expect(within(idleCard).getByText("Idle")).toBeInTheDocument();
 	});
@@ -147,7 +146,6 @@ describe("SessionsBoard", () => {
 		});
 
 		renderBoard("p1");
-		fireEvent.click(screen.getByRole("button", { name: /idle sessions/i }));
 
 		const idleCard = screen.getByText("idle-card-task").closest('[role="button"]') as HTMLElement;
 		const noSignalCard = screen.getByText("no-signal-card-task").closest('[role="button"]') as HTMLElement;
@@ -158,7 +156,7 @@ describe("SessionsBoard", () => {
 		expect(within(draftCard).getByText("Draft PR").closest("span")).toHaveClass("text-accent");
 	});
 
-	it("collapses idle sessions into a nested Working-column stack", () => {
+	it("renders an idle-first work lane with a separate lower working section", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				{
@@ -210,26 +208,28 @@ describe("SessionsBoard", () => {
 
 		renderBoard("p1");
 
-		expect(screen.getByText("active-task")).toBeInTheDocument();
-		expect(screen.queryByText("idle-no-pr-task")).not.toBeInTheDocument();
-		expect(screen.queryByText("idle-with-pr-task")).not.toBeInTheDocument();
+		const workLane = screen.getByRole("region", { name: "Idle / Working sessions" });
 
-		const idleStackToggle = screen.getByRole("button", { name: /idle sessions/i });
-		expect(idleStackToggle).toHaveAttribute("aria-expanded", "false");
-		expect(within(idleStackToggle).getByText("2")).toBeInTheDocument();
-
-		fireEvent.click(idleStackToggle);
-
-		expect(screen.getByRole("button", { name: /idle sessions/i })).toHaveAttribute("aria-expanded", "true");
-		expect(screen.getByText("active-task")).toBeInTheDocument();
+		expect(within(workLane).getByText("Idle / Working")).toBeInTheDocument();
+		expect(within(workLane).getByLabelText("2 idle sessions")).toHaveTextContent("2");
+		expect(within(workLane).getByLabelText("1 working sessions")).toHaveTextContent("1");
+		expect(screen.queryByRole("button", { name: /idle sessions/i })).not.toBeInTheDocument();
+		expect(within(workLane).getByText("active-task")).toBeInTheDocument();
 		const idleCard = screen.getByText("idle-no-pr-task").closest('[role="button"]') as HTMLElement;
-		expect(screen.getByText("idle-with-pr-task")).toBeInTheDocument();
-		const badge = within(idleCard).getByText("Working").closest("span");
-		expect(badge).toHaveClass("text-working");
-		expect(badge).not.toHaveClass("text-passive");
+		expect(within(workLane).getByText("idle-with-pr-task")).toBeInTheDocument();
+
+		const workingRegion = within(workLane).getByRole("region", { name: "Working sessions" });
+		expect(workingRegion).toHaveClass("rounded-t-(--radius-panel)", "border-t", "flex-[2]");
+		expect(workingRegion).not.toHaveClass("mx-2.75", "border");
+		expect(within(workingRegion).getByText("active-task")).toBeInTheDocument();
+		expect(within(workingRegion).queryByText("idle-no-pr-task")).not.toBeInTheDocument();
+
+		const badge = within(idleCard).getByText("Idle").closest("span");
+		expect(badge).toHaveClass("text-passive");
+		expect(badge).not.toHaveClass("text-working");
 	});
 
-	it("toggles idle contents without hiding active cards or remounting the toggle", () => {
+	it("omits the lower working section when no active working sessions exist", () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [
 				{
@@ -237,18 +237,6 @@ describe("SessionsBoard", () => {
 					name: "radic",
 					path: "/tmp/radic",
 					sessions: [
-						{
-							id: "s0",
-							workspaceId: "p1",
-							workspaceName: "radic",
-							title: "active-task",
-							provider: "claude-code",
-							branch: "ao/radic-4",
-							status: "working",
-							activity: { state: "active", lastActivityAt: "2026-01-01T00:00:00Z" },
-							updatedAt: "2026-01-01T00:00:00Z",
-							prs: [],
-						},
 						{
 							id: "s1",
 							workspaceId: "p1",
@@ -269,30 +257,15 @@ describe("SessionsBoard", () => {
 
 		renderBoard("p1");
 
-		expect(screen.getByText("active-task")).toBeInTheDocument();
-		expect(screen.queryByText("idle-task")).not.toBeInTheDocument();
+		const workLane = screen.getByRole("region", { name: "Idle / Working sessions" });
 
-		const idleToggle = screen.getByRole("button", { name: /idle sessions/i });
-		expect(idleToggle).toHaveAttribute("aria-expanded", "false");
-		expect(idleToggle.parentElement).toHaveClass("transition-[opacity,transform]");
-		expect(idleToggle.parentElement).not.toHaveClass("transition-[flex-grow,opacity,transform]");
-		expect(idleToggle.parentElement).toHaveClass("motion-reduce:transition-none");
-		expect(idleToggle.querySelector("svg")).toHaveClass("motion-reduce:transition-none");
-		fireEvent.click(idleToggle);
-
-		expect(screen.getByRole("button", { name: /idle sessions/i })).toBe(idleToggle);
-		expect(idleToggle).toHaveAttribute("aria-expanded", "true");
-		expect(screen.getByText("active-task")).toBeInTheDocument();
-		expect(screen.getByText("idle-task")).toBeInTheDocument();
-
-		fireEvent.click(idleToggle);
-
-		expect(screen.getByText("active-task")).toBeInTheDocument();
-		expect(screen.queryByText("idle-task")).not.toBeInTheDocument();
-		expect(idleToggle).toHaveAttribute("aria-expanded", "false");
+		expect(within(workLane).getByText("idle-task")).toBeInTheDocument();
+		expect(within(workLane).getByLabelText("1 idle sessions")).toHaveTextContent("1");
+		expect(within(workLane).getByLabelText("0 working sessions")).toHaveTextContent("0");
+		expect(within(workLane).queryByRole("region", { name: "Working sessions" })).not.toBeInTheDocument();
 	});
 
-	it("resets the idle stack when navigating between project boards", () => {
+	it("keeps idle sessions visible when navigating between project boards", () => {
 		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 		workspaceQueryMock.mockReturnValue({
 			data: [
@@ -363,8 +336,9 @@ describe("SessionsBoard", () => {
 		});
 		const view = renderBoardWithClient(queryClient, "p1");
 
-		fireEvent.click(screen.getByRole("button", { name: /idle sessions/i }));
-		expect(screen.getByText("p1 idle")).toBeInTheDocument();
+		const p1Lane = screen.getByRole("region", { name: "Idle / Working sessions" });
+		expect(within(p1Lane).getByText("p1 idle")).toBeInTheDocument();
+		expect(within(p1Lane).getByText("p1 active")).toBeInTheDocument();
 
 		view.rerender(
 			<QueryClientProvider client={queryClient}>
@@ -372,9 +346,10 @@ describe("SessionsBoard", () => {
 			</QueryClientProvider>,
 		);
 
-		expect(screen.getByText("p2 active")).toBeInTheDocument();
-		expect(screen.queryByText("p2 idle")).not.toBeInTheDocument();
-		expect(screen.getByRole("button", { name: /idle sessions/i })).toHaveAttribute("aria-expanded", "false");
+		const p2Lane = screen.getByRole("region", { name: "Idle / Working sessions" });
+		expect(screen.queryByText("p1 idle")).not.toBeInTheDocument();
+		expect(within(p2Lane).getByText("p2 idle")).toBeInTheDocument();
+		expect(within(p2Lane).getByRole("region", { name: "Working sessions" })).toHaveTextContent("p2 active");
 	});
 
 	it("shows a restore action for terminated sessions in expanded Done / Terminated", async () => {

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -267,7 +267,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 					/>
 				) : (
 					<div className="grid h-full grid-cols-4 gap-2">
-						{COLUMNS.map((col) => (
+						{COLUMNS.map((col) =>
 							col.zone === "working" ? (
 								<WorkLaneColumn
 									key={`${projectId ?? "all"}:${col.zone}`}
@@ -282,8 +282,8 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 									sessions={byZone.get(col.zone) ?? []}
 									onOpen={openSession}
 								/>
-							)
-						))}
+							),
+						)}
 					</div>
 				)}
 			</div>
@@ -445,12 +445,7 @@ function WorkLaneColumn({
 					</div>
 				) : null}
 				{showWorking ? (
-					<WorkingSessionsSection
-						col={col}
-						sessions={workingSessions}
-						onOpen={onOpen}
-						standalone={!showIdle}
-					/>
+					<WorkingSessionsSection col={col} sessions={workingSessions} onOpen={onOpen} standalone={!showIdle} />
 				) : null}
 			</div>
 		</section>
@@ -488,9 +483,7 @@ function WorkingSessionsSection({
 					}}
 					aria-hidden="true"
 				/>
-				<span className={cn("text-caption font-semibold uppercase tracking-wide-md", col.titleClassName)}>
-					Working
-				</span>
+				<span className={cn("text-caption font-semibold uppercase tracking-wide-md", col.titleClassName)}>Working</span>
 				<span className="ml-auto font-mono text-caption leading-none text-passive">{sessions.length}</span>
 			</div>
 			<div className="min-h-0 flex-1 overflow-y-auto px-2.75 pb-3">

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { AlertTriangle, ChevronRight, Plus, RotateCw } from "lucide-react";
+import { AlertTriangle, Plus, RotateCw } from "lucide-react";
 import {
 	type WorkspaceSession,
 	canonicalTrackerIssueId,
@@ -13,8 +13,8 @@ import {
 	attentionZone,
 	boardAttentionZoneOrder,
 	getAttentionZoneViewForZone,
-	getSessionStatusView,
-	isSessionInIdleStack,
+	getSessionCardStatusView,
+	isSessionEffectivelyIdle,
 	type AttentionZone,
 	type AttentionZoneView,
 } from "../lib/session-presentation";
@@ -268,12 +268,21 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				) : (
 					<div className="grid h-full grid-cols-4 gap-2">
 						{COLUMNS.map((col) => (
-							<ZoneColumn
-								key={`${projectId ?? "all"}:${col.zone}`}
-								col={col}
-								sessions={byZone.get(col.zone) ?? []}
-								onOpen={openSession}
-							/>
+							col.zone === "working" ? (
+								<WorkLaneColumn
+									key={`${projectId ?? "all"}:${col.zone}`}
+									col={col}
+									sessions={byZone.get(col.zone) ?? []}
+									onOpen={openSession}
+								/>
+							) : (
+								<ZoneColumn
+									key={`${projectId ?? "all"}:${col.zone}`}
+									col={col}
+									sessions={byZone.get(col.zone) ?? []}
+									onOpen={openSession}
+								/>
+							)
 						))}
 					</div>
 				)}
@@ -347,12 +356,9 @@ function ZoneColumn({
 	sessions: WorkspaceSession[];
 	onOpen: (s: WorkspaceSession) => void;
 }) {
-	const isWorkingColumn = col.zone === "working";
-	const [idleExpanded, setIdleExpanded] = useState(false);
-	const activeSessions = isWorkingColumn ? sessions.filter((session) => !isSessionInIdleStack(session)) : sessions;
-	const idleSessions = isWorkingColumn ? sessions.filter(isSessionInIdleStack) : [];
 	return (
 		<section
+			aria-label={`${col.label} sessions`}
 			className="flex min-w-0 flex-col overflow-hidden rounded-panel"
 			style={{
 				background: `linear-gradient(180deg, ${col.glow}, transparent var(--size-kanban-glow)), var(--color-overlay-subtle)`,
@@ -373,69 +379,127 @@ function ZoneColumn({
 			</div>
 			<div className="min-h-0 flex-1 overflow-y-auto px-2.75 pb-3">
 				<div className="flex min-h-full flex-col gap-2.5">
-					{activeSessions.map((session) => (
+					{sessions.map((session) => (
 						<SessionCard key={session.id} session={session} onOpen={() => onOpen(session)} />
 					))}
-					{idleSessions.length > 0 ? (
-						<IdleSessionsStack
-							expanded={idleExpanded}
-							sessions={idleSessions}
-							onOpen={onOpen}
-							onToggle={() => setIdleExpanded((value) => !value)}
-						/>
-					) : null}
 				</div>
 			</div>
 		</section>
 	);
 }
 
-function IdleSessionsStack({
-	expanded,
+function WorkLaneColumn({
+	col,
 	sessions,
 	onOpen,
-	onToggle,
 }: {
-	expanded: boolean;
+	col: Column;
 	sessions: WorkspaceSession[];
 	onOpen: (s: WorkspaceSession) => void;
-	onToggle: () => void;
+}) {
+	const idleSessions = sessions.filter(isSessionEffectivelyIdle);
+	const workingSessions = sessions.filter((session) => !isSessionEffectivelyIdle(session));
+	const showIdle = idleSessions.length > 0;
+	const showWorking = workingSessions.length > 0;
+	return (
+		<section
+			aria-label="Idle / Working sessions"
+			className="flex min-w-0 flex-col overflow-hidden rounded-panel"
+			style={{
+				background:
+					"linear-gradient(180deg, color-mix(in srgb, var(--color-text-muted) 6%, transparent), transparent var(--size-kanban-glow)), var(--color-overlay-subtle)",
+			}}
+		>
+			<div className="flex shrink-0 items-center gap-2.25 px-3.75 pb-2.75 pt-3.5">
+				<span className="size-dot-sm rounded-full bg-passive" aria-hidden="true" />
+				<span className="text-caption font-semibold uppercase tracking-wide-md text-muted-foreground">
+					Idle / Working
+				</span>
+				<div className="ml-auto flex shrink-0 items-center gap-2 font-mono text-caption leading-none text-passive">
+					<span aria-label={`${idleSessions.length} idle sessions`} className="inline-flex items-center gap-1">
+						<span className="h-1.5 w-1.5 rounded-full bg-passive" aria-hidden="true" />
+						{idleSessions.length}
+					</span>
+					<span aria-hidden="true">/</span>
+					<span aria-label={`${workingSessions.length} working sessions`} className="inline-flex items-center gap-1">
+						<span
+							className="h-1.5 w-1.5 rounded-full"
+							style={{
+								background: col.dot,
+								boxShadow: col.dotGlow ? `0 0 7px color-mix(in srgb, ${col.dot} 60%, transparent)` : undefined,
+							}}
+							aria-hidden="true"
+						/>
+						{workingSessions.length}
+					</span>
+				</div>
+			</div>
+			<div className="min-h-0 flex flex-1 flex-col">
+				{showIdle ? (
+					<div className={cn("min-h-0 overflow-y-auto px-2.75", showWorking ? "flex-[3] pb-3" : "flex-1 pb-3")}>
+						<div className="flex min-h-full flex-col gap-2.5">
+							{idleSessions.map((session) => (
+								<SessionCard key={session.id} session={session} onOpen={() => onOpen(session)} />
+							))}
+						</div>
+					</div>
+				) : null}
+				{showWorking ? (
+					<WorkingSessionsSection
+						col={col}
+						sessions={workingSessions}
+						onOpen={onOpen}
+						standalone={!showIdle}
+					/>
+				) : null}
+			</div>
+		</section>
+	);
+}
+
+function WorkingSessionsSection({
+	col,
+	sessions,
+	onOpen,
+	standalone,
+}: {
+	col: Column;
+	sessions: WorkspaceSession[];
+	onOpen: (s: WorkspaceSession) => void;
+	standalone: boolean;
 }) {
 	return (
 		<div
+			aria-label="Working sessions"
+			role="region"
 			className={cn(
-				"mt-auto overflow-hidden rounded-panel border border-border bg-surface/70 transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none",
-				expanded ? "opacity-100" : "opacity-95 hover:opacity-100",
+				"min-h-0 overflow-hidden",
+				standalone
+					? "flex flex-1 flex-col bg-surface/35"
+					: "flex flex-[2] flex-col rounded-t-(--radius-panel) border-t border-border bg-surface/35",
 			)}
 		>
-			<button
-				aria-expanded={expanded}
-				aria-label={`Idle sessions (${sessions.length})`}
-				className={cn(
-					"flex min-h-row-md w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:text-foreground",
-					expanded ? "text-foreground" : "text-passive",
-				)}
-				onClick={onToggle}
-				type="button"
-			>
-				<ChevronRight
-					className={cn(
-						"size-icon-2xs shrink-0 transition-transform duration-normal motion-reduce:transition-none",
-						expanded && "rotate-90",
-					)}
+			<div className="flex shrink-0 items-center gap-2.25 px-3.75 pb-2.5 pt-3">
+				<span
+					className="size-dot-sm rounded-full"
+					style={{
+						background: col.dot,
+						boxShadow: col.dotGlow ? `0 0 7px color-mix(in srgb, ${col.dot} 60%, transparent)` : undefined,
+					}}
 					aria-hidden="true"
 				/>
-				<span className="size-dot-sm shrink-0 rounded-full bg-passive" aria-hidden="true" />
-				<span className="font-mono text-2xs font-semibold uppercase tracking-wide-md">Idle</span>
-				<span className="ml-auto shrink-0 font-mono text-caption leading-none text-passive">{sessions.length}</span>
-			</button>
-			{expanded ? (
-				<div className="flex max-h-[min(45vh,28rem)] flex-col gap-2.5 overflow-y-auto border-t border-border p-2.5 animate-in fade-in-0 slide-in-from-top-1 duration-200 motion-reduce:animate-none">
+				<span className={cn("text-caption font-semibold uppercase tracking-wide-md", col.titleClassName)}>
+					Working
+				</span>
+				<span className="ml-auto font-mono text-caption leading-none text-passive">{sessions.length}</span>
+			</div>
+			<div className="min-h-0 flex-1 overflow-y-auto px-2.75 pb-3">
+				<div className="flex min-h-full flex-col gap-2.5">
 					{sessions.map((session) => (
 						<SessionCard key={session.id} session={session} onOpen={() => onOpen(session)} />
 					))}
 				</div>
-			) : null}
+			</div>
 		</div>
 	);
 }
@@ -457,7 +521,7 @@ function SessionCard({
 	isRestoring?: boolean;
 	isRestoreDisabled?: boolean;
 }) {
-	const badge = getSessionStatusView(session.status);
+	const badge = getSessionCardStatusView(session);
 	const issueId = canonicalTrackerIssueId(session.issueId);
 	const branch = session.branch || "";
 	const showBranch = branch !== "" && !sameLabel(branch, session.title) && !sameLabel(branch, session.id);

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -809,7 +809,7 @@ describe("Sidebar", () => {
 		}
 	});
 
-	it("renders sidebar dots from attention zones without activity overrides", () => {
+	it("renders idle sidebar dots quietly while preserving attention colors", () => {
 		renderSidebar({
 			workspaces: [
 				{
@@ -836,7 +836,7 @@ describe("Sidebar", () => {
 		});
 
 		const idleDot = screen.getByLabelText("Open idle task").querySelector('span[aria-hidden="true"]');
-		expect(idleDot).toHaveClass("bg-working");
+		expect(idleDot).toHaveClass("bg-passive");
 		expect(idleDot).not.toHaveClass("animate-status-pulse");
 
 		const workingDot = screen.getByLabelText("Open working task").querySelector('span[aria-hidden="true"]');
@@ -875,7 +875,7 @@ describe("Sidebar", () => {
 		});
 
 		const idleDot = screen.getByLabelText("Open idle activity task").querySelector('span[aria-hidden="true"]');
-		expect(idleDot).toHaveClass("bg-working");
+		expect(idleDot).toHaveClass("bg-passive");
 		expect(idleDot).not.toHaveClass("animate-status-pulse");
 
 		const idleDraftDot = screen.getByLabelText("Open idle draft task").querySelector('span[aria-hidden="true"]');

--- a/frontend/src/renderer/lib/session-presentation.test.ts
+++ b/frontend/src/renderer/lib/session-presentation.test.ts
@@ -3,11 +3,12 @@ import {
 	attentionZone,
 	getAgentActivityView,
 	getAttentionZoneView,
+	getSessionCardStatusView,
 	getSessionDotView,
 	getSessionStatusView,
 	getSessionTimelinePillView,
 	isAgentActivityWorking,
-	isSessionInIdleStack,
+	isSessionEffectivelyIdle,
 } from "./session-presentation";
 import type { WorkspaceSession } from "../types/workspace";
 
@@ -82,6 +83,25 @@ describe("session presentation", () => {
 		expect(getSessionStatusView("review_pending").className).toBe("text-accent");
 	});
 
+	it("uses the idle card badge for working sessions whose activity is idle", () => {
+		expect(
+			getSessionCardStatusView(
+				sessionWith({
+					status: "working",
+					activity: { state: "idle", lastActivityAt: "" },
+				}),
+			),
+		).toMatchObject({ label: "Idle", className: "text-passive" });
+		expect(
+			getSessionCardStatusView(
+				sessionWith({
+					status: "working",
+					activity: { state: "active", lastActivityAt: "" },
+				}),
+			),
+		).toMatchObject({ label: "Working", className: "text-working" });
+	});
+
 	it.each([
 		["approved", "merge", "Ready to merge"],
 		["mergeable", "merge", "Ready to merge"],
@@ -102,7 +122,7 @@ describe("session presentation", () => {
 		expect(getAttentionZoneView(status)).toMatchObject({ zone, label });
 	});
 
-	it("uses attention zones only for sidebar dot color and motion", () => {
+	it("renders idle session dots quietly while preserving attention colors", () => {
 		const activeWorkingDotClass = getSessionDotView(
 			sessionWith({
 				status: "working",
@@ -110,6 +130,12 @@ describe("session presentation", () => {
 			}),
 		).className;
 		const idleDotClass = getSessionDotView(sessionWith({ status: "idle" })).className;
+		const idleActivityDotClass = getSessionDotView(
+			sessionWith({
+				status: "working",
+				activity: { state: "idle", lastActivityAt: "" },
+			}),
+		).className;
 		const activeUnknownDotClass = getSessionDotView(
 			sessionWith({
 				status: "unknown",
@@ -125,8 +151,10 @@ describe("session presentation", () => {
 
 		expect(activeWorkingDotClass).toContain("bg-working");
 		expect(activeWorkingDotClass).not.toContain("animate-status-pulse");
-		expect(idleDotClass).toContain("bg-working");
+		expect(idleDotClass).toContain("bg-passive");
 		expect(idleDotClass).not.toContain("animate-status-pulse");
+		expect(idleActivityDotClass).toContain("bg-passive");
+		expect(idleActivityDotClass).not.toContain("animate-status-pulse");
 		expect(activeUnknownDotClass).toContain("bg-warning");
 		expect(activeUnknownDotClass).not.toContain("animate-status-pulse");
 		expect(idleDraftDotClass).toContain("bg-accent-dim");
@@ -143,10 +171,10 @@ describe("session presentation", () => {
 		});
 	});
 
-	it("separates idle sessions inside the Working board column", () => {
-		expect(isSessionInIdleStack(sessionWith({ status: "idle" }))).toBe(true);
+	it("classifies idle sessions for the board work lane", () => {
+		expect(isSessionEffectivelyIdle(sessionWith({ status: "idle" }))).toBe(true);
 		expect(
-			isSessionInIdleStack(
+			isSessionEffectivelyIdle(
 				sessionWith({
 					status: "idle",
 					activity: { state: "active", lastActivityAt: "" },
@@ -155,7 +183,7 @@ describe("session presentation", () => {
 			),
 		).toBe(true);
 		expect(
-			isSessionInIdleStack(
+			isSessionEffectivelyIdle(
 				sessionWith({
 					status: "working",
 					activity: { state: "idle", lastActivityAt: "" },
@@ -164,14 +192,14 @@ describe("session presentation", () => {
 			),
 		).toBe(true);
 		expect(
-			isSessionInIdleStack(
+			isSessionEffectivelyIdle(
 				sessionWith({
 					status: "working",
 					activity: { state: "active", lastActivityAt: "" },
 				}),
 			),
 		).toBe(false);
-		expect(isSessionInIdleStack(sessionWith({ status: "working" }))).toBe(false);
+		expect(isSessionEffectivelyIdle(sessionWith({ status: "working" }))).toBe(false);
 	});
 
 	it.each([

--- a/frontend/src/renderer/lib/session-presentation.ts
+++ b/frontend/src/renderer/lib/session-presentation.ts
@@ -51,6 +51,11 @@ export function getSessionStatusView(status: SessionStatus): SessionStatusView {
 	return sessionStatusViews[status] ?? sessionStatusViews.unknown;
 }
 
+export function getSessionCardStatusView(session: Pick<WorkspaceSession, "status" | "activity">): SessionStatusView {
+	if (isSessionEffectivelyIdle(session)) return sessionStatusViews.idle;
+	return getSessionStatusView(session.status);
+}
+
 export type AttentionZone = "merge" | "action" | "pending" | "working" | "done";
 
 export type AttentionZoneView = {
@@ -156,7 +161,8 @@ export function getAttentionZoneViewForZone(zone: AttentionZone): AttentionZoneV
 	return attentionZoneViews[zone];
 }
 
-export function getSessionDotView(session: Pick<WorkspaceSession, "status">): { className: string } {
+export function getSessionDotView(session: Pick<WorkspaceSession, "status" | "activity">): { className: string } {
+	if (isSessionEffectivelyIdle(session)) return { className: attentionZoneViews.done.dotClassName };
 	return { className: getAttentionZoneView(session.status).dotClassName };
 }
 
@@ -178,6 +184,10 @@ export function getSessionTimelinePillView(status: SessionTimelinePillStatus): S
 	return sessionTimelinePillViews[status];
 }
 
-export function isSessionInIdleStack(session: Pick<WorkspaceSession, "status" | "activity">): boolean {
+export function isSessionEffectivelyIdle(session: Pick<WorkspaceSession, "status" | "activity">): boolean {
 	return session.status === "idle" || (session.status === "working" && session.activity?.state === "idle");
+}
+
+export function isSessionInIdleStack(session: Pick<WorkspaceSession, "status" | "activity">): boolean {
+	return isSessionEffectivelyIdle(session);
 }


### PR DESCRIPTION
## Summary

This updates the sessions board's first lane so idle work is treated as the primary attention surface while active work remains visible as a separate lower region.

## What changed

- Replaced the old collapsed idle stack inside the Working column with an `Idle / Working` lane.
- Idle sessions now render visibly at the top of the first lane instead of behind an expand/collapse control.
- Active working sessions render in a lower `Working` region only when at least one active working session exists.
- When both idle and working sessions exist, the lane uses roughly a 60/40 vertical split so the Working region starts higher but still shares the parent lane's side boundaries.
- The Working separator now uses a rounded top edge rather than an inset card, avoiding the visual impression that Working is nested inside Idle.
- Session cards and sidebar dots now use a shared “effectively idle” classification so `status: working` with `activity.state: idle` displays as idle/passive.
- PR/review/CI attention colors are preserved for non-working statuses even if their underlying activity is idle.

## Why

The previous UI made idle sessions look secondary by hiding them in a collapsed stack inside the Working column. That was backwards for the dashboard workflow: idle sessions usually need more user attention than actively working sessions. The sidebar also had an inconsistent visual bug where activity-idle worker sessions could still inherit the working-colored dot.

## User impact

- Idle sessions are more discoverable on the Kanban board.
- Active Working sessions remain visible, but as a lower companion area rather than the dominant first-column state.
- The first lane header shows both idle and working counts with matching status dots.
- Sidebar dots and card badges now agree with the board's idle classification.

## Validation

- `cd frontend && npm run test -- src/renderer/components/SessionsBoard.test.tsx`
- `npm run frontend:typecheck`
- `cd frontend && npm run test`
- Manual Playwright visual checks at 1920x1080 for:
  - both idle and working sessions
  - only idle sessions
  - only working sessions

## Screenshots

A follow-up PR comment includes the generated screenshot references. The screenshots were kept out of the commit because they are generated review artifacts, not source assets.
