### PR TITLE
fix(cursor): pass role-specific model config to launch commands

### DIFF
--- a/backend/internal/adapters/agent/agentbase/agentbase.go
+++ b/backend/internal/adapters/agent/agentbase/agentbase.go
@@ -7,6 +7,7 @@ package agentbase
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -50,6 +51,24 @@ func (Base) SessionInfo(ctx context.Context, _ ports.SessionRef) (ports.SessionI
 		return ports.SessionInfo{}, false, err
 	}
 	return ports.SessionInfo{}, false, nil
+}
+
+// AppendModelFlag appends `--model <model>` to cmd when the configured model is
+// non-blank, trimming surrounding whitespace; it is a no-op otherwise.
+func AppendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
+	}
+}
+
+// ModelConfigField returns the standard user-facing `model` config field, using
+// description to name the concrete CLI flag it maps to.
+func ModelConfigField(description string) ports.ConfigField {
+	return ports.ConfigField{
+		Key:         "model",
+		Type:        ports.ConfigFieldString,
+		Description: description,
+	}
 }
 
 // StandardSessionInfo returns the normalized session metadata (native session

--- a/backend/internal/adapters/agent/agentbase/agentbase_test.go
+++ b/backend/internal/adapters/agent/agentbase/agentbase_test.go
@@ -1,0 +1,43 @@
+package agentbase
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestAppendModelFlagAppendsTrimmedModel(t *testing.T) {
+	cmd := []string{"agent", "--force"}
+	AppendModelFlag(&cmd, ports.AgentConfig{Model: "  gpt-5  "})
+
+	want := []string{"agent", "--force", "--model", "gpt-5"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestAppendModelFlagNoOpForBlankModel(t *testing.T) {
+	for _, model := range []string{"", " \t "} {
+		cmd := []string{"agent"}
+		AppendModelFlag(&cmd, ports.AgentConfig{Model: model})
+
+		want := []string{"agent"}
+		if !reflect.DeepEqual(cmd, want) {
+			t.Fatalf("model %q: cmd\nwant: %#v\n got: %#v", model, want, cmd)
+		}
+	}
+}
+
+func TestModelConfigField(t *testing.T) {
+	got := ModelConfigField("Model override passed to `x --model`.")
+
+	want := ports.ConfigField{
+		Key:         "model",
+		Type:        ports.ConfigFieldString,
+		Description: "Model override passed to `x --model`.",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("field\nwant: %#v\n got: %#v", want, got)
+	}
+}

--- a/backend/internal/adapters/agent/cursor/cursor.go
+++ b/backend/internal/adapters/agent/cursor/cursor.go
@@ -69,6 +69,18 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Cursor understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			agentbase.ModelConfigField("Model override passed to `cursor-agent --model`."),
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new interactive Cursor CLI
 // session:
 //
@@ -88,6 +100,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd = []string{binary}
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	agentbase.AppendModelFlag(&cmd, cfg.Config)
 
 	// Prompt is positional and must be last. The `--` sentinel ends option
 	// parsing so a leading "-" in the prompt is not read as a flag.
@@ -120,9 +133,10 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 
-	cmd = make([]string, 0, 6)
+	cmd = make([]string, 0, 8)
 	cmd = append(cmd, binary)
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	agentbase.AppendModelFlag(&cmd, cfg.Config)
 	cmd = append(cmd, "--resume", agentSessionID)
 	return cmd, true, nil
 }

--- a/backend/internal/adapters/agent/cursor/cursor_test.go
+++ b/backend/internal/adapters/agent/cursor/cursor_test.go
@@ -124,15 +124,75 @@ func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	plugin := &Plugin{}
 
 	spec, err := plugin.GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("unexpected config fields: %#v", spec.Fields)
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `cursor-agent --model`.",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
+	}
+}
+
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cursor-agent"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "  gpt-5  "},
+		Prompt: "fix this",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"cursor-agent", "--model", "gpt-5", "--", "fix this"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cursor-agent"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+		Prompt: "fix this",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"cursor-agent", "--", "fix this"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cursor-agent"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "  gpt-5  "},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "chat-123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	want := []string{"cursor-agent", "--model", "gpt-5", "--resume", "chat-123"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("restore cmd = %#v, want %#v", cmd, want)
 	}
 }
 


### PR DESCRIPTION
Fixes #2883

## Summary

The Cursor adapter never forwarded the resolved `ports.AgentConfig.Model` to `cursor-agent`, so a worker/orchestrator configured with a specific model silently fell back to `cursor-agent`'s global default. This wires the resolved model through to both the fresh-launch and restore commands, and advertises the `model` config field.

## Depends on #3025

Built on the shared `agentbase` model helpers (`AppendModelFlag`, `ModelConfigField`) from base PR #3025 — this PR only *uses* them, it does not introduce them. Until #3025 merges, this PR's diff also shows the base commit; after #3025 lands I'll rebase so the diff is Cursor-only. Independent of the Devin PR #2927 — both branch from the shared base, so neither carries the other.

## Cursor specifics

- `agentbase.AppendModelFlag` appends `--model` **before** the `--` end-of-options sentinel in `GetLaunchCommand`, so it is not swallowed as part of the positional prompt.
- `GetRestoreCommand` forwards the model on the resume path too.
- `GetConfigSpec` advertises `model` (`ports.ConfigFieldString`) via `agentbase.ModelConfigField`.

CLI mechanism: `cursor-agent` supports a launch-time `--model` override (Cursor CLI docs).

## Tests

`cursor_test.go` asserts exact argv with `reflect.DeepEqual`: launch places `--model` before `--` (`cursor-agent --model gpt-5 -- <prompt>`) and trims whitespace, blank model omits the flag, restore appends it on the resume path, and `GetConfigSpec` reports the `model` field.

```
cd backend && go test ./internal/adapters/agent/cursor
```

`go build ./...`, `go vet`, and `gofmt` are clean.
