### PR TITLE
fix(devin): pass role-specific model config to launch commands

### DIFF
--- a/backend/internal/adapters/agent/agentbase/agentbase.go
+++ b/backend/internal/adapters/agent/agentbase/agentbase.go
@@ -7,6 +7,7 @@ package agentbase
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -50,6 +51,24 @@ func (Base) SessionInfo(ctx context.Context, _ ports.SessionRef) (ports.SessionI
 		return ports.SessionInfo{}, false, err
 	}
 	return ports.SessionInfo{}, false, nil
+}
+
+// AppendModelFlag appends `--model <model>` to cmd when the configured model is
+// non-blank, trimming surrounding whitespace; it is a no-op otherwise.
+func AppendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
+	}
+}
+
+// ModelConfigField returns the standard user-facing `model` config field, using
+// description to name the concrete CLI flag it maps to.
+func ModelConfigField(description string) ports.ConfigField {
+	return ports.ConfigField{
+		Key:         "model",
+		Type:        ports.ConfigFieldString,
+		Description: description,
+	}
 }
 
 // StandardSessionInfo returns the normalized session metadata (native session

--- a/backend/internal/adapters/agent/agentbase/agentbase_test.go
+++ b/backend/internal/adapters/agent/agentbase/agentbase_test.go
@@ -1,0 +1,43 @@
+package agentbase
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestAppendModelFlagAppendsTrimmedModel(t *testing.T) {
+	cmd := []string{"agent", "--force"}
+	AppendModelFlag(&cmd, ports.AgentConfig{Model: "  gpt-5  "})
+
+	want := []string{"agent", "--force", "--model", "gpt-5"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestAppendModelFlagNoOpForBlankModel(t *testing.T) {
+	for _, model := range []string{"", " \t "} {
+		cmd := []string{"agent"}
+		AppendModelFlag(&cmd, ports.AgentConfig{Model: model})
+
+		want := []string{"agent"}
+		if !reflect.DeepEqual(cmd, want) {
+			t.Fatalf("model %q: cmd\nwant: %#v\n got: %#v", model, want, cmd)
+		}
+	}
+}
+
+func TestModelConfigField(t *testing.T) {
+	got := ModelConfigField("Model override passed to `x --model`.")
+
+	want := ports.ConfigField{
+		Key:         "model",
+		Type:        ports.ConfigFieldString,
+		Description: "Model override passed to `x --model`.",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("field\nwant: %#v\n got: %#v", want, got)
+	}
+}

--- a/backend/internal/adapters/agent/devin/devin.go
+++ b/backend/internal/adapters/agent/devin/devin.go
@@ -75,7 +75,19 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
-// GetLaunchCommand builds `devin [--permission-mode <mode>] [-- <prompt>]`.
+// GetConfigSpec reports the per-project agent config keys Devin understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			agentbase.ModelConfigField("Model override passed to `devin --model`."),
+		},
+	}, nil
+}
+
+// GetLaunchCommand builds `devin [--permission-mode <mode>] [--model <model>] [-- <prompt>]`.
 //
 // The `-- <prompt>` form starts an interactive session. Do not use `-p`, which
 // is Devin's non-interactive print mode.
@@ -87,6 +99,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd = []string{binary}
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	agentbase.AppendModelFlag(&cmd, cfg.Config)
 	if prompt := strings.TrimSpace(cfg.Prompt); prompt != "" {
 		cmd = append(cmd, "--", prompt)
 	}
@@ -150,9 +163,10 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 
-	cmd = make([]string, 0, 5)
+	cmd = make([]string, 0, 7)
 	cmd = append(cmd, binary)
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	agentbase.AppendModelFlag(&cmd, cfg.Config)
 	cmd = append(cmd, "-r", agentSessionID)
 	return cmd, true, nil
 }

--- a/backend/internal/adapters/agent/devin/devin_test.go
+++ b/backend/internal/adapters/agent/devin/devin_test.go
@@ -33,13 +33,20 @@ func TestManifest(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecEmpty(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `devin --model`.",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
 	}
 }
 
@@ -278,6 +285,36 @@ func TestGetLaunchCommandAuto(t *testing.T) {
 	}
 }
 
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "devin"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "  opus  "},
+		Prompt: "fix it",
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"devin", "--model", "opus", "--", "fix it"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "devin"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+		Prompt: "fix it",
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"devin", "--", "fix it"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
 func TestGetLaunchCommandNoPrompt(t *testing.T) {
 	plugin := &Plugin{resolvedBinary: "devin"}
 	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{})
@@ -315,6 +352,28 @@ func TestGetRestoreCommand(t *testing.T) {
 		t.Fatal("ok=false, want true")
 	}
 	want := []string{"devin", "--permission-mode", "dangerous", "-r", "sess-abc123"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "devin"}
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "  opus  "},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{
+				ports.MetadataKeyAgentSessionID: "sess-abc123",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+	want := []string{"devin", "--model", "opus", "-r", "sess-abc123"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}


### PR DESCRIPTION
## Summary

The Devin adapter never forwarded the resolved `ports.AgentConfig.Model` to the `devin` CLI, so a worker/orchestrator configured with a specific model silently fell back to Devin's default (the Adaptive router). This wires the resolved model through to both fresh-launch and restore commands, and advertises the `model` config field.

## Depends on #3025

Built on the shared `agentbase` model helpers (`AppendModelFlag`, `ModelConfigField`) from base PR #3025. Until #3025 merges, this PR's diff also shows the base commit; after #3025 lands I'll rebase so the diff is Devin-only. Independent of the Cursor PR #2926 — this branch is cut from the shared base, not from a peer adapter, so neither carries the other.

## Changes (Devin-specific)

- `GetConfigSpec` advertises `model` (`ports.ConfigFieldString`).
- `agentbase.AppendModelFlag` called in `GetLaunchCommand` (before the `--` prompt sentinel, so it isn't swallowed) and in `GetRestoreCommand`.
- Blank model omits `--model`, preserving Devin's Adaptive router default.

CLI mechanism: `devin --model <model> -- ...` (Devin CLI docs).

## Tests

`devin_test.go` asserts exact argv with `reflect.DeepEqual`: launch places `--model` in `devin --model opus -- <prompt>` and trims whitespace, blank model omits the flag, restore appends it on the `-r` resume path, and `GetConfigSpec` reports the `model` field.

```
cd backend && go test ./internal/adapters/agent/devin
```

`go build ./...`, `go vet`, and `gofmt` are clean.

Fixes #2884
