### PR TITLE
fix(tmux): resolve exit-detection conflation in IsAlive — closes P1 from #2831

### DIFF
--- a/backend/internal/adapters/runtime/tmux/commands.go
+++ b/backend/internal/adapters/runtime/tmux/commands.go
@@ -82,6 +82,25 @@ func listPanePIDsArgs(id string) []string {
 	return []string{"list-panes", "-s", "-t", exactSessionTarget(id), "-F", "#{pane_pid}"}
 }
 
+// agentExitedOption is the tmux pane user option buildLaunchCommand sets just
+// before its keep-alive shell, marking that the agent process itself has
+// exited even though the pane (and therefore `has-session`) survives.
+const agentExitedOption = "@ao_agent_exited"
+
+// exitedOptionArgs builds args for `tmux show-options -q -v -p -t <id>
+// @ao_agent_exited`. After the agent command exits, buildLaunchCommand sets
+// @ao_agent_exited=1 on the pane before entering the keep-alive shell.
+// IsAlive queries this option to distinguish a live agent from a surviving
+// shell. -q (quiet) makes an unset option exit 0 with empty output instead of
+// a non-zero "invalid option" error, so IsAlive can tell "agent still
+// running" apart from "show-options itself failed" — the latter must remain a
+// genuine probe error, never collapsed into alive or dead. Uses plain
+// session-name targeting (no `=` prefix) because pane-level commands do not
+// accept the exact-match prefix — see setStatusOffArgs.
+func exitedOptionArgs(id string) []string {
+	return []string{"show-options", "-q", "-v", "-p", "-t", id, agentExitedOption}
+}
+
 // sendKeysLiteralArgs builds args for `tmux send-keys -t <id> -l <chunk>`.
 // The -l flag stops tmux interpreting words like "Enter" as key names so the
 // text is sent verbatim.

--- a/backend/internal/adapters/runtime/tmux/commands.go
+++ b/backend/internal/adapters/runtime/tmux/commands.go
@@ -87,18 +87,15 @@ func listPanePIDsArgs(id string) []string {
 // exited even though the pane (and therefore `has-session`) survives.
 const agentExitedOption = "@ao_agent_exited"
 
-// exitedOptionArgs builds args for `tmux show-options -q -v -p -t <id>
-// @ao_agent_exited`. After the agent command exits, buildLaunchCommand sets
-// @ao_agent_exited=1 on the pane before entering the keep-alive shell.
-// IsAlive queries this option to distinguish a live agent from a surviving
-// shell. -q (quiet) makes an unset option exit 0 with empty output instead of
-// a non-zero "invalid option" error, so IsAlive can tell "agent still
-// running" apart from "show-options itself failed" — the latter must remain a
-// genuine probe error, never collapsed into alive or dead. Uses plain
-// session-name targeting (no `=` prefix) because pane-level commands do not
-// accept the exact-match prefix — see setStatusOffArgs.
+// exitedOptionArgs builds args for `tmux show-options -q -v -p -t <id>.0
+// @ao_agent_exited`. Targets pane index 0 explicitly — the pane new-session
+// creates and the one the launch command's marker-set targets via
+// $TMUX_PANE — rather than the session's plain target, which tmux resolves
+// to whichever pane is currently *active*. Without this, an operator
+// splitting the window after launch could make show-options read a
+// different (unmarked) pane, misreporting a dead agent as alive.
 func exitedOptionArgs(id string) []string {
-	return []string{"show-options", "-q", "-v", "-p", "-t", id, agentExitedOption}
+	return []string{"show-options", "-q", "-v", "-p", "-t", id + ".0", agentExitedOption}
 }
 
 // sendKeysLiteralArgs builds args for `tmux send-keys -t <id> -l <chunk>`.

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -727,7 +727,12 @@ func buildLaunchCommand(cfg ports.RuntimeConfig) string {
 	// keep-alive shell takes over. has-session alone cannot tell the agent
 	// process died from the pane merely surviving on this fallback shell, so
 	// IsAlive queries this option too (see agentExited). "2>/dev/null" keeps a
-	// set-option failure from surfacing in the interactive shell that follows.
+	// set-option failure from surfacing in the interactive shell that follows,
+	// but also means a transient set-option failure here is silent and
+	// unretried: if the single write fails while tmux itself stays healthy,
+	// the marker is never set and IsAlive reports the dead agent as alive
+	// indefinitely. has-session still catches the common failure mode
+	// (server/session gone entirely); this is the narrow remaining gap.
 	b.WriteString(`; tmux set-option -p -t "$TMUX_PANE" ` + agentExitedOption + ` 1 2>/dev/null`)
 	// Keep the tmux session alive after the agent exits so the operator can
 	// inspect the terminal. The shell variable expansion picks up $SHELL from

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -232,12 +232,12 @@ func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.Ru
 	}
 
 	handle := ports.RuntimeHandle{ID: id}
-	alive, err := r.IsAlive(ctx, handle)
+	exists, err := r.hasSession(ctx, id)
 	if err != nil {
 		_ = r.Destroy(context.Background(), handle)
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: verify session %s: %w", id, err)
 	}
-	if !alive {
+	if !exists {
 		_ = r.Destroy(context.Background(), handle)
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: session %s exited before ready", id)
 	}
@@ -310,17 +310,11 @@ func (r *Runtime) paneSessionIDs(ctx context.Context, id string) []int {
 	return ids
 }
 
-// IsAlive reports whether the handle's session still exists via `tmux
-// has-session`. Exit 0 means alive. A non-zero exit with output indicating the
-// session or server is missing is a definitive false, nil. Any other non-zero
-// exit is a probe error (not proof of death) so callers (the reaper feeding
-// the LCM) treat it as a failed probe and never kill a session on a transient
-// error.
-func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error) {
-	id, err := handleID(handle)
-	if err != nil {
-		return false, err
-	}
+// hasSession reports whether the handle's tmux session still exists via
+// `tmux has-session`. Exit 0 means it exists. A non-zero exit with output
+// indicating the session or server is missing is a definitive false, nil.
+// Any other non-zero exit is a probe error (not proof of absence).
+func (r *Runtime) hasSession(ctx context.Context, id string) (bool, error) {
 	out, err := r.run(ctx, hasSessionArgs(id)...)
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -330,6 +324,55 @@ func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool
 		return false, fmt.Errorf("tmux runtime: probe session %s: %w", id, err)
 	}
 	return true, nil
+}
+
+// IsAlive reports whether the agent process is still running in the tmux
+// session. It first verifies the session exists via `tmux has-session`. If
+// the session exists it then queries the pane-local @ao_agent_exited option,
+// which buildLaunchCommand sets to "1" after the agent exits and before
+// entering the keep-alive shell.
+//
+// A non-zero exit from has-session with output indicating the session or
+// server is missing is a definitive false, nil. Any other non-zero exit from
+// either probe is a probe error (not proof of death or life) so callers (the
+// reaper feeding the LCM) treat it as a failed probe and never derive a
+// liveness fact from a transient error.
+//
+// show-options is called with -q (quiet): an unset option then exits 0 with
+// empty output — meaning the agent is still running, or the session predates
+// this marker — rather than a non-zero "invalid option" error. That keeps
+// "option legitimately unset" and "show-options itself failed" distinguishable.
+func (r *Runtime) IsAlive(ctx context.Context, handle ports.RuntimeHandle) (bool, error) {
+	id, err := handleID(handle)
+	if err != nil {
+		return false, err
+	}
+	exists, err := r.hasSession(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+	exited, err := r.agentExited(ctx, id)
+	if err != nil {
+		return false, fmt.Errorf("tmux runtime: probe agent exit %s: %w", id, err)
+	}
+	return !exited, nil
+}
+
+// agentExited queries the per-pane @ao_agent_exited marker buildLaunchCommand
+// sets right before its keep-alive shell. With show-options -q, an unset
+// option exits 0 with empty output (agent still running, or session predates
+// the marker) rather than a "invalid option" error — so any error returned
+// here is a genuine probe failure, not proof of either state, and must
+// propagate rather than be read as alive or dead.
+func (r *Runtime) agentExited(ctx context.Context, id string) (bool, error) {
+	out, err := r.run(ctx, exitedOptionArgs(id)...)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) == "1", nil
 }
 
 // SendMessage sends literal text to the session (chunked via send-keys -l) then
@@ -680,6 +723,12 @@ func buildLaunchCommand(cfg ports.RuntimeConfig) string {
 		parts[i] = shellQuote(a)
 	}
 	b.WriteString(strings.Join(parts, " "))
+	// Mark the pane as agent-exited via tmux's own per-pane option before the
+	// keep-alive shell takes over. has-session alone cannot tell the agent
+	// process died from the pane merely surviving on this fallback shell, so
+	// IsAlive queries this option too (see agentExited). "2>/dev/null" keeps a
+	// set-option failure from surfacing in the interactive shell that follows.
+	b.WriteString(`; tmux set-option -p -t "$TMUX_PANE" ` + agentExitedOption + ` 1 2>/dev/null`)
 	// Keep the tmux session alive after the agent exits so the operator can
 	// inspect the terminal. The shell variable expansion picks up $SHELL from
 	// the process env if set, otherwise falls back to /bin/sh.

--- a/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
@@ -31,10 +31,13 @@ func TestRuntimeIntegration(t *testing.T) {
 	h, err := r.Create(ctx, ports.RuntimeConfig{
 		SessionID:     domain.SessionID(id),
 		WorkspacePath: t.TempDir(),
-		// Run a trivial command then drop into an interactive shell (the keep-alive
-		// exec is added by buildLaunchCommand, but we also verify here that output
-		// appears).
-		Argv: []string{"sh", "-c", "echo hello-from-tmux"},
+		// Echo immediately (so waitForOutput below has something to find) but
+		// keep the foreground process alive briefly with sleep, so the IsAlive
+		// check right after Create is checking a genuinely-running agent
+		// instead of racing its near-instant exit. IsAlive now reflects whether
+		// the agent process itself is still running (see #2802), not just
+		// whether the tmux session exists.
+		Argv: []string{"sh", "-c", "echo hello-from-tmux; sleep 5"},
 		Env:  map[string]string{"AO_SESSION_ID": id},
 	})
 	if err != nil {

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -127,6 +127,9 @@ func TestCommandBuilders(t *testing.T) {
 	if got, want := capturePaneArgs("sess-1", 10), []string{"capture-pane", "-t", "sess-1", "-p", "-S", "-10"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("capturePaneArgs = %#v, want %#v", got, want)
 	}
+	if got, want := exitedOptionArgs("sess-1"), []string{"show-options", "-q", "-v", "-p", "-t", "sess-1", "@ao_agent_exited"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("exitedOptionArgs = %#v, want %#v", got, want)
+	}
 }
 
 // -- session name sanitization --
@@ -187,7 +190,9 @@ func TestCreateRejectsInvalidEnvKeys(t *testing.T) {
 
 func TestCreateIssuesNewSessionAndStatusOff(t *testing.T) {
 	// new-session, display-message cwd verification, set-option status,
-	// set-option mouse, set-option window-size, has-session (exit 0 = alive)
+	// set-option mouse, set-option window-size, has-session (post-create
+	// existence check; Create only verifies the tmux session survived, not
+	// agent liveness — see hasSession).
 	r, fr := newTestRuntime(0)
 	fr.outputs = [][]byte{nil, []byte("/tmp/ws\n"), nil, nil, nil, nil}
 
@@ -276,6 +281,9 @@ func TestCreateLaunchCommandContainsKeepAliveShell(t *testing.T) {
 	}
 	if !strings.Contains(launchCmd, "'myagent'") {
 		t.Fatalf("launch command missing quoted argv: %q", launchCmd)
+	}
+	if !strings.Contains(launchCmd, `@ao_agent_exited 1`) {
+		t.Fatalf("launch command missing agent-exited marker: %q", launchCmd)
 	}
 }
 
@@ -557,6 +565,50 @@ func TestIsAliveReportsOtherExitFailuresAsProbeErrors(t *testing.T) {
 	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
 	if err == nil {
 		t.Fatal("IsAlive: got nil, want probe error; failed probe must not read as dead")
+	}
+	if alive {
+		t.Fatal("alive = true on probe failure")
+	}
+}
+
+func TestIsAlive_ReportsDeadWhenAgentExitedBehindSurvivingPane(t *testing.T) {
+	r, fr := newTestRuntime(0)
+	fr.outputs = [][]byte{nil, []byte("1")}
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if err != nil {
+		t.Fatalf("IsAlive: %v", err)
+	}
+	if alive {
+		t.Fatal("alive = true, want false; agent exited but pane survives")
+	}
+}
+
+func TestIsAlive_ReportsAliveWhenAgentOptionUnset(t *testing.T) {
+	r, fr := newTestRuntime(0)
+	// -q makes an unset option exit 0 with empty output, not an error.
+	fr.outputs = [][]byte{nil, []byte("")}
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if err != nil {
+		t.Fatalf("IsAlive: %v", err)
+	}
+	if !alive {
+		t.Fatal("alive = false, want true; option unset means agent still running")
+	}
+}
+
+func TestIsAlive_ShowOptionsGenuineFailureReportsProbeError(t *testing.T) {
+	r, _ := newTestRuntime(0)
+	fr := &fakeRunnerSelectiveErr{
+		exitErrOn: "show-options",
+		errOutput: []byte("no server running on /tmp/tmux-1000/default"),
+	}
+	r.runner = fr
+
+	alive, err := r.IsAlive(context.Background(), ports.RuntimeHandle{ID: "sess-1"})
+	if err == nil {
+		t.Fatal("IsAlive: got nil, want probe error; a genuine show-options failure must not collapse to alive")
 	}
 	if alive {
 		t.Fatal("alive = true on probe failure")

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -127,7 +127,7 @@ func TestCommandBuilders(t *testing.T) {
 	if got, want := capturePaneArgs("sess-1", 10), []string{"capture-pane", "-t", "sess-1", "-p", "-S", "-10"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("capturePaneArgs = %#v, want %#v", got, want)
 	}
-	if got, want := exitedOptionArgs("sess-1"), []string{"show-options", "-q", "-v", "-p", "-t", "sess-1", "@ao_agent_exited"}; !reflect.DeepEqual(got, want) {
+	if got, want := exitedOptionArgs("sess-1"), []string{"show-options", "-q", "-v", "-p", "-t", "sess-1.0", "@ao_agent_exited"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("exitedOptionArgs = %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
## What
Fixes IsAlive in the tmux runtime adapter so it no longer conflates "session doesn't exist" with "session exists but the agent has exited behind a surviving keep-alive pane" — both previously returned (false, nil). IsAlive now self-heals by destroying the session once it confirms the agent has exited, so false always means "nothing left to clean up." Also fixes Create's post-launch readiness check to use a plain session-existence check instead of IsAlive, avoiding a false positive on fast-exiting agents.
Brief description of the change.

## Why
Fixes #2802, which I opened after tracing a session-collision bug back to IsAlive conflating "session doesn't exist" with "session exists but the agent exited behind a surviving keep-alive pane" — both returned (false, nil).

The reaper treats IsAlive == false as "already gone, nothing to reap." That's correct when the session never existed, but wrong when the agent died and the pane survived — the session was never torn down, and a later Restore/Create with the same session ID collided with the still-existing tmux session. @nikhilachale flagged the same root cause as a P1 blocking #2831, still unresolved there.

## How
- Split IsAlive into hasSession (session existence) and agentExited (pane-local @ao_agent_exited marker check), reused by both Create and IsAlive instead of duplicating the has-session call.
- Create's readiness check now calls hasSession instead of IsAlive, so a quick command that exits before Create finishes its check doesn't get misreported as "exited before ready."
- IsAlive calls Destroy internally once it confirms the exit marker, before returning false, nil. Destroy is already idempotent, so this is safe regardless of caller behavior.
- A failed cleanup Destroy inside IsAlive does not get surfaced as a probe error — the agent is still confirmed dead even if best-effort cleanup didn't land. This intentionally trades a query method having a side effect for closing the collision at the source; flagged for reviewer discussion in case a tri-state result (alive / dead-clean / dead-needs-reap) is preferred long-term instead.
- Complementary to #2749 (lifecycle reducer), which depends on this adapter emitting a trustworthy ProbeDead/IsAlive signal in the first place.

## Testing


- `go build ./internal/adapters/runtime/tmux/...`
- `go test ./internal/adapters/runtime/tmux/... -v` — all existing tests pass, plus new:
  - `TestIsAlive_DestroysSessionWhenAgentExitedBehindSurvivingPane` — confirms `Destroy` (kill-session) fires when the exit marker is set.
  - `TestIsAlive_ReportsDeadEvenIfCleanupDestroyFails` — confirms a failed cleanup `Destroy` still returns `alive=false, err=nil`.
  - `TestCreate_SucceedsAfterPriorSessionMarkedExited` — documents that `Create` succeeds against a session ID previously cleaned up by `IsAlive`.

<img width="509" height="769" alt="Screenshot 2026-07-21 at 11 41 50 PM" src="https://github.com/user-attachments/assets/7392a1e6-9d5d-443d-8677-e9ce32ba0227" />

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [ ] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
