### PR TITLE
fix(kiro): advertise model config via GetConfigSpec

### DIFF
--- a/backend/internal/adapters/agent/kiro/kiro.go
+++ b/backend/internal/adapters/agent/kiro/kiro.go
@@ -60,6 +60,26 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Kiro understands:
+// a model override. Kiro already forwards agentConfig.Model into its
+// workspace-local custom agent config (see setKiroAgentDefaults in
+// hooks.go); this declares that support so it is discoverable/validated
+// through the config-spec surface, matching claude-code and codex.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override written into Kiro's workspace-local agent config.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new Kiro session:
 // `kiro-cli chat [--agent ao] --agent ao [trust flags] [-- <prompt>]`.
 //

--- a/backend/internal/adapters/agent/kiro/kiro_test.go
+++ b/backend/internal/adapters/agent/kiro/kiro_test.go
@@ -337,18 +337,6 @@ func TestPromptReadinessHints(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
-	plugin := &Plugin{}
-
-	spec, err := plugin.GetConfigSpec(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("unexpected config fields: %#v", spec.Fields)
-	}
-}
-
 func TestAuthStatusUsesKiroWhoami(t *testing.T) {
 	restore := stubKiroAuthRunner(t, func(_ context.Context, name string, arg ...string) ([]byte, error) {
 		if name != "kiro-cli" {
@@ -371,6 +359,42 @@ func TestAuthStatusUsesKiroWhoami(t *testing.T) {
 	}
 }
 
+func TestGetConfigSpecReportsModelField(t *testing.T) {
+	p := New()
+
+	spec, err := p.GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatalf("GetConfigSpec: %v", err)
+	}
+
+	var found bool
+	for _, f := range spec.Fields {
+		if f.Key != "model" {
+			continue
+		}
+		found = true
+		if f.Type != ports.ConfigFieldString {
+			t.Errorf("model field Type = %v, want %v", f.Type, ports.ConfigFieldString)
+		}
+		if f.Description == "" {
+			t.Error("model field Description is empty")
+		}
+	}
+	if !found {
+		t.Fatal("GetConfigSpec did not report a \"model\" field")
+	}
+}
+
+func TestGetConfigSpecHonorsContextCancellation(t *testing.T) {
+	p := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := p.GetConfigSpec(ctx)
+	if err == nil {
+		t.Fatal("GetConfigSpec with canceled context: want error, got nil")
+	}
+}
 func TestAuthStatusUnauthorizedFromKiroWhoami(t *testing.T) {
 	restore := stubKiroAuthRunner(t, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
 		return []byte("Not logged in\n"), nil


### PR DESCRIPTION
## What

Adds a GetConfigSpec override to the Kiro agent adapter so it advertises the model config field it already honors. Kiro was already forwarding agentConfig.Model into its workspace-local custom agent config, but it never declared that support through the config-spec surface,  this brings it in line with claude-code and codex.

## Why
Fixes #2903.

agentConfig.model is resolved and forwarded to every adapter, and adapters that honor it are expected to also advertise it via GetConfigSpec ,  Claude does this, and Codex's fix (#2869) added the same. Kiro's runtime behavior was already correct (verified by TestGetAgentHooksWritesConfiguredModel and related tests), but it inherited the empty agentbase.Base.GetConfigSpec, so the model field it consumes was never discoverable or validated through the config-spec surface — inconsistent with the other model-aware adapters.

## How

- Added a GetConfigSpec override in kiro.go, mirroring the pattern in claude-code/claude-code.go (a single model field of type ports.ConfigFieldString). Kiro doesn't have a permissions-style enum config like Claude's, so only model is reported.
- Removed the now-outdated TestGetConfigSpecHasNoCustomFieldsYet test, which asserted len(spec.Fields) == 0 — that assumption no longer holds once the model field is reported, so it was replaced rather than kept alongside the new tests.
- Added TestGetConfigSpecReportsModelField (asserts the model field is present with the correct type and a non-empty description) and TestGetConfigSpecHonorsContextCancellation (matches the ctx-cancellation pattern used elsewhere in this file, e.g. TestGetLaunchCommandCtxCancelled).
- No changes to GetLaunchCommand, hooks, or any runtime behavior — this is purely a declarative/config-spec change, as scoped in the issue.
## Testing

cd backend
go build ./internal/adapters/agent/kiro/...
go test ./internal/adapters/agent/kiro/... -v

All existing tests pass, plus the two new ones:

- TestGetConfigSpecReportsModelField — confirms GetConfigSpec reports a model field of type ports.ConfigFieldString with a non-empty description.
- TestGetConfigSpecHonorsContextCancellation — confirms GetConfigSpec returns an error on a canceled context.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [ ] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [ ] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
