### PR TITLE
fix: show project loading state during startup

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -85,12 +85,14 @@ function renderSidebar({
 	onCreateProject = vi.fn().mockResolvedValue(undefined) as CreateProjectHandler,
 	onInitializeProject = vi.fn().mockResolvedValue(undefined) as InitializeProjectHandler,
 	onRemoveProject = vi.fn().mockResolvedValue(undefined) as RemoveProjectHandler,
+	isLoadingProjects = false,
 	seedAgents = true,
 	workspaces = [workspace],
 }: {
 	onCreateProject?: CreateProjectHandler;
 	onInitializeProject?: InitializeProjectHandler;
 	onRemoveProject?: RemoveProjectHandler;
+	isLoadingProjects?: boolean;
 	seedAgents?: boolean;
 	workspaces?: WorkspaceSummary[];
 } = {}) {
@@ -117,6 +119,7 @@ function renderSidebar({
 		<QueryClientProvider client={queryClient}>
 			<SidebarProvider>
 				<Sidebar
+					isLoadingProjects={isLoadingProjects}
 					onCreateProject={onCreateProject}
 					onInitializeProject={onInitializeProject}
 					onRemoveProject={onRemoveProject}
@@ -203,6 +206,14 @@ afterEach(() => {
 });
 
 describe("Sidebar", () => {
+	it("shows project loading state instead of claiming the project list is empty", () => {
+		renderSidebar({ isLoadingProjects: true, workspaces: [] });
+
+		expect(screen.getByText("Loading projects…")).toBeVisible();
+		expect(screen.getByText("Restoring your existing projects and sessions.")).toBeVisible();
+		expect(screen.queryByText("No projects yet.")).not.toBeInTheDocument();
+	});
+
 	it("shows a ConfirmDialog and calls onRemoveProject when confirmed", async () => {
 		const user = userEvent.setup();
 		const onRemoveProject = renderSidebar();

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -77,6 +77,7 @@ type SidebarProps = {
 	underTopbar?: boolean;
 	/** Chrome height to clear when underTopbar is set. Defaults to the 56px shell toolbar. */
 	topbarOffset?: "toolbar" | "titlebar";
+	isLoadingProjects: boolean;
 	workspaceError?: string;
 	workspaces: WorkspaceSummary[];
 	onCreateProject: (input: CreateProjectInput) => Promise<void>;
@@ -118,6 +119,7 @@ export function Sidebar({
 	hideEdgeBorder = false,
 	underTopbar = true,
 	topbarOffset = "toolbar",
+	isLoadingProjects,
 	workspaceError,
 	workspaces,
 	onCreateProject,
@@ -280,6 +282,14 @@ export function Sidebar({
 							<div className="sidebar-expanded-chrome px-2 py-3 group-data-[collapsible=icon]:hidden">
 								<p className="text-xs text-foreground">Could not load projects.</p>
 								<p className="mt-1 text-caption text-passive">{workspaceError}</p>
+							</div>
+						) : isLoadingProjects ? (
+							<div
+								aria-live="polite"
+								className="sidebar-expanded-chrome px-2 py-3 group-data-[collapsible=icon]:hidden"
+							>
+								<p className="text-xs text-foreground">Loading projects…</p>
+								<p className="mt-1 text-caption text-passive">Restoring your existing projects and sessions.</p>
 							</div>
 						) : workspaces.length === 0 ? null : (
 							<SidebarMenu className="gap-0 group-data-[collapsible=icon]:gap-1">

--- a/frontend/src/renderer/hooks/useDaemonStatus.ts
+++ b/frontend/src/renderer/hooks/useDaemonStatus.ts
@@ -9,7 +9,11 @@ const STATUS_REFRESH_MS = 2_000;
 const READY_STATUS_REFRESH_MS = 10_000;
 
 export function useDaemonStatus(queryClient: QueryClient = defaultQueryClient) {
-	const [status, setStatus] = useState<DaemonStatus>({ state: "stopped" });
+	// The first IPC status read is asynchronous. Treat that handshake as startup
+	// rather than briefly claiming the daemon is stopped; the shell uses this
+	// state to keep persisted projects behind a loading treatment until it knows
+	// whether the daemon is ready.
+	const [status, setStatus] = useState<DaemonStatus>({ state: "starting" });
 	const statusRef = useRef(status);
 
 	useEffect(() => {
@@ -34,7 +38,12 @@ export function useDaemonStatus(queryClient: QueryClient = defaultQueryClient) {
 				})
 				.catch(() => {
 					// IPC unavailable (browser preview, broken preload): stay on the
-					// last known status and keep the recovery loop alive.
+					// last known status and keep the recovery loop alive. The initial
+					// synthetic startup state is not a known daemon status, so settle it
+					// to stopped instead of leaving the project loader running forever.
+					if (active && requestVersion === statusVersion && statusRef.current.state === "starting") {
+						applyStatus({ state: "stopped" });
+					}
 				})
 				.finally(() => {
 					if (!active || requestVersion !== statusVersion) return;

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -80,6 +80,8 @@ function ShellLayout() {
 	const workspaceQuery = useWorkspaceQuery();
 	const workspaces = workspaceQuery.data ?? [];
 	const daemonStatus = useDaemonStatus(queryClient);
+	const [isLoadingProjects, setIsLoadingProjects] = useState(true);
+	const workspaceLoadPortRef = useRef<number | undefined>(undefined);
 	const agentCatalogPortRef = useRef<number | undefined>(undefined);
 	const { themePreference, resolvedTheme, isSidebarOpen, toggleSidebar } = useUiStore();
 	const syncSystemTheme = useUiStore((state) => state.syncSystemTheme);
@@ -273,13 +275,30 @@ function ShellLayout() {
 	}, [resolvedTheme]);
 
 	useEffect(() => {
-		if (daemonStatus.state !== "ready" || !daemonStatus.port) return;
-		if (agentCatalogPortRef.current === daemonStatus.port) return;
+		if (daemonStatus.state !== "ready" || !daemonStatus.port) {
+			workspaceLoadPortRef.current = undefined;
+			if (daemonStatus.state !== "starting") setIsLoadingProjects(false);
+			return;
+		}
+		if (agentCatalogPortRef.current === daemonStatus.port && workspaceLoadPortRef.current === daemonStatus.port) {
+			return;
+		}
 
 		agentCatalogPortRef.current = daemonStatus.port;
 		void queryClient.invalidateQueries({ queryKey: agentsQueryKey });
 		void queryClient.fetchQuery({ ...agentsQueryOptions, queryFn: refreshAgents });
-		void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+
+		workspaceLoadPortRef.current = daemonStatus.port;
+		setIsLoadingProjects(true);
+		let active = true;
+		void Promise.resolve(queryClient.invalidateQueries({ queryKey: workspaceQueryKey }))
+			.catch(() => undefined)
+			.finally(() => {
+				if (active && workspaceLoadPortRef.current === daemonStatus.port) setIsLoadingProjects(false);
+			});
+		return () => {
+			active = false;
+		};
 	}, [daemonStatus.port, daemonStatus.state, queryClient]);
 
 	// Follow OS appearance while the user keeps Theme on System — updates
@@ -343,6 +362,17 @@ function ShellLayout() {
             the chrome the frameless window drops. Renders null on macOS/Linux. */}
 				<WindowTitlebar />
 				{!hideShellTopbar ? <ShellTopbar /> : null}
+				{isLoadingProjects ? (
+					<div
+						aria-label="Loading projects"
+						className="relative z-20 h-0 shrink-0"
+						role="progressbar"
+					>
+						<div className="absolute inset-x-0 top-0 h-0.5 overflow-hidden bg-accent-weak">
+							<div className="h-full w-2/5 animate-project-loading bg-accent motion-reduce:w-full motion-reduce:animate-pulse" />
+						</div>
+					</div>
+				) : null}
 				{/* Controlled by the ui-store so TitlebarNav / Topbar toggles (which
             call the store directly) stay in sync. --sidebar-width chains to
             the drag-resizable --ao-sidebar-w set on :root by useResizable. */}
@@ -364,6 +394,7 @@ function ShellLayout() {
             routes when the shell topbar is visible. */}
 					<Sidebar
 						hideEdgeBorder={isWelcomeBoard}
+						isLoadingProjects={isLoadingProjects}
 						underTopbar={isMac || isWindows || (!hideShellTopbar && (isLinux ? isSessionRoute : true))}
 						topbarOffset={isWindows && hideShellTopbar ? "titlebar" : "toolbar"}
 						onCreateProject={createProject}
@@ -374,7 +405,16 @@ function ShellLayout() {
 					/>
 					<main className="flex min-w-0 flex-1 flex-col overflow-x-hidden">
 						<div className="min-h-0 flex-1 overflow-x-hidden">
-							<Outlet />
+							{isLoadingProjects ? (
+								<div className="flex h-full items-center justify-center px-6 text-center" aria-live="polite">
+									<div>
+										<p className="text-sm font-medium text-foreground">Loading your projects…</p>
+										<p className="mt-1 text-xs text-passive">Checking existing projects and sessions.</p>
+									</div>
+								</div>
+							) : (
+								<Outlet />
+							)}
 						</div>
 					</main>
 					{/* When ShellTopbar is hidden on the welcome board, keep a macOS

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -227,6 +227,7 @@
 	--color-interactive-active: var(--bridge-interactive-active);
 
 	--animate-status-pulse: status-pulse 1.8s ease-in-out infinite;
+	--animate-project-loading: project-loading 1.1s ease-in-out infinite;
 	--animate-overlay-in: overlay-in 150ms ease-out;
 	--animate-modal-in: modal-in 150ms ease-out;
 }
@@ -686,6 +687,15 @@ select {
 	}
 	50% {
 		opacity: 0.35;
+	}
+}
+
+@keyframes project-loading {
+	from {
+		transform: translateX(-100%);
+	}
+	to {
+		transform: translateX(250%);
 	}
 }
 

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -6,6 +6,7 @@ import type { WorkspaceSummary } from "../types/workspace";
 
 const shellMocks = vi.hoisted(() => {
 	const state = {
+		daemonStatus: { state: "stopped" } as { state: "starting" | "ready" | "stopped" | "error"; port?: number },
 		newSessionListener: undefined as (() => void) | undefined,
 		keyboardShortcutsListener: undefined as (() => void) | undefined,
 		routeParams: {} as { projectId?: string; sessionId?: string },
@@ -38,7 +39,7 @@ vi.mock("@tanstack/react-query", () => ({
 vi.mock("@tanstack/react-router", async (importOriginal) => ({
 	...(await importOriginal<typeof import("@tanstack/react-router")>()),
 	createFileRoute: () => (options: unknown) => ({ options }),
-	Outlet: () => null,
+	Outlet: () => <div data-testid="shell-outlet" />,
 	useMatchRoute: () => () => false,
 	useNavigate: () => shellMocks.navigate,
 	useParams: () => shellMocks.state.routeParams,
@@ -60,7 +61,7 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 }));
 
 vi.mock("../hooks/useDaemonStatus", () => ({
-	useDaemonStatus: () => ({ state: "stopped" }),
+	useDaemonStatus: () => shellMocks.state.daemonStatus,
 }));
 
 vi.mock("../hooks/useAgentsQuery", () => ({
@@ -141,9 +142,21 @@ beforeEach(() => {
 	shellMocks.onKeyboardShortcutsHelp.mockClear();
 	shellMocks.state.newSessionListener = undefined;
 	shellMocks.state.keyboardShortcutsListener = undefined;
+	shellMocks.state.daemonStatus = { state: "stopped" };
 	shellMocks.state.routeParams = {};
 	shellMocks.state.workspaces = workspaces;
 	useUiStore.setState({ createProjectNonce: 0, newTaskRequest: null });
+});
+
+describe("shell project loading state", () => {
+	it("keeps the route content hidden behind an accessible loading bar while the daemon starts", async () => {
+		shellMocks.state.daemonStatus = { state: "starting" };
+		await renderShell();
+
+		expect(screen.getByRole("progressbar", { name: "Loading projects" })).toBeVisible();
+		expect(screen.getByText("Loading your projects…")).toBeVisible();
+		expect(screen.queryByTestId("shell-outlet")).not.toBeInTheDocument();
+	});
 });
 
 describe("shell keyboard-shortcuts help subscription", () => {


### PR DESCRIPTION
## Summary

- show an indeterminate loading bar while the desktop app restores projects from the daemon
- replace the false-empty sidebar and board states with reassuring loading copy
- hold routed project/session content until the first daemon-backed workspace fetch completes
- cover startup, IPC failure, accessibility, and false-empty behavior with renderer tests

## Why

During startup, the renderer can query workspaces before the daemon URL is trusted. That query intentionally returns an empty list, which made existing projects briefly appear to be gone. The shell now treats the daemon handshake and first real workspace fetch as one loading phase; genuine first-run empty states only render after that phase completes.

Closes #2935

## Validation

- `npm.cmd run typecheck` — passed
- `npx.cmd vite build --config vite.renderer.config.ts` — passed
- `npm.cmd test -- --run src/renderer/components/Sidebar.test.tsx src/renderer/hooks/useDaemonStatus.test.tsx src/renderer/test/shell-new-session-shortcut.test.tsx` — 48 passed
- Full renderer suite — 868 passed; 4 unrelated `supervisor-link.test.ts` failures because Windows denied temporary Unix-socket paths with `EACCES`
