### PR TITLE
fix: polish Updates settings layout and feature build picker

### DIFF
--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -152,6 +152,15 @@ describe("GlobalSettingsForm", () => {
 		expect(screen.queryByText(/Nightly builds are cut every day/i)).not.toBeInTheDocument();
 	});
 
+	it("hides the nightly warning when Feature Releases is selected", async () => {
+		getUpdate.mockResolvedValue({ enabled: true, channel: "nightly", nightlyAck: true, feature: null });
+		renderForm();
+		expect(await screen.findByText(/Nightly builds are cut every day/i)).toBeInTheDocument();
+		await userEvent.click(screen.getByLabelText("Updates channel"));
+		await userEvent.click(await screen.findByRole("menuitem", { name: "Feature Releases" }));
+		expect(screen.queryByText(/Nightly builds are cut every day/i)).not.toBeInTheDocument();
+	});
+
 	it("shows the current app version", async () => {
 		renderForm();
 		expect(await screen.findByText(/Current version - v1\.4\.0/)).toBeInTheDocument();

--- a/frontend/src/renderer/components/settings/SettingsOptionMenu.tsx
+++ b/frontend/src/renderer/components/settings/SettingsOptionMenu.tsx
@@ -36,12 +36,12 @@ export function SettingsOptionMenu<T extends string>({
 				<button
 					type="button"
 					className={cn(
-						"settings-option-trigger hover:text-settings-label focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-[state=open]:outline-none data-[state=open]:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
+						"settings-option-trigger max-w-full min-w-0 hover:text-settings-label focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-[state=open]:outline-none data-[state=open]:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
 						triggerClassName,
 					)}
 					aria-label={ariaLabel}
 				>
-					<span className="truncate">{selected?.label ?? placeholder}</span>
+					<span className="min-w-0 truncate">{selected?.label ?? placeholder}</span>
 					<ChevronDown className="size-icon-sm shrink-0 opacity-70" aria-hidden="true" />
 				</button>
 			</DropdownMenuTrigger>
@@ -51,7 +51,7 @@ export function SettingsOptionMenu<T extends string>({
 						key={option.value}
 						onSelect={() => onChange(option.value)}
 						className={cn(
-							"settings-menu-item cursor-default outline-none",
+							"settings-menu-item min-w-0 cursor-default outline-none",
 							"focus:border-settings-menu focus:bg-settings-menu-selected focus:text-settings-label",
 							"data-highlighted:border-settings-menu data-highlighted:bg-settings-menu-selected data-highlighted:text-settings-label",
 							option.value === value && "border-settings-menu bg-settings-menu-selected",

--- a/frontend/src/renderer/components/settings/SettingsRow.tsx
+++ b/frontend/src/renderer/components/settings/SettingsRow.tsx
@@ -4,9 +4,9 @@ import { cn } from "../../lib/utils";
 
 function SettingsRowLabel({ icon: Icon, label }: { icon?: LucideIcon; label: string }) {
 	return (
-		<div className="flex min-w-0 flex-1 items-center gap-(--size-settings-row-icon-gap)">
+		<div className="flex shrink-0 items-center gap-(--size-settings-row-icon-gap)">
 			{Icon ? <Icon className="size-icon-lg shrink-0 text-settings-muted" aria-hidden="true" /> : null}
-			<span className="text-sm leading-5 text-settings-label">{label}</span>
+			<span className="whitespace-nowrap text-sm leading-5 text-settings-label">{label}</span>
 		</div>
 	);
 }
@@ -26,7 +26,7 @@ export function SettingsRow({
 	return (
 		<div className={cn("settings-row-bar", className)}>
 			<SettingsRowLabel icon={icon} label={label} />
-			<div className="flex shrink-0 items-center justify-end">{children}</div>
+			<div className="flex min-w-0 flex-1 items-center justify-end">{children}</div>
 		</div>
 	);
 }

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -8,7 +8,6 @@ import type { UpdateChannel, UpdateSettings, UpdateState, UpdateStatus } from ".
 import { ConfirmDialog } from "../ConfirmDialog";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { Skeleton } from "../ui/skeleton";
 import { SettingsOptionMenu } from "./SettingsOptionMenu";
 import { SettingsRow } from "./SettingsRow";
 import { SettingsSection } from "./SettingsSection";
@@ -252,19 +251,9 @@ function FeatureBuildsSelect({
 		queryFn: () => aoBridge.featureBuilds.list(),
 	});
 
-	if (buildsQuery.isLoading) {
-		return (
-			<SettingsRow icon={GitPullRequest} label="Feature build">
-				<div className="flex w-48 flex-col gap-1">
-					<Skeleton className="h-control-form w-full" />
-				</div>
-			</SettingsRow>
-		);
-	}
-
 	const builds = buildsQuery.data ?? [];
 
-	if (builds.length === 0) {
+	if (!buildsQuery.isLoading && builds.length === 0) {
 		return (
 			<div className="px-1 text-xs text-settings-muted">
 				<span className="sr-only">Feature build</span>
@@ -285,6 +274,7 @@ function FeatureBuildsSelect({
 				value={currentPr === null ? "__none__" : currentPr.toString()}
 				placeholder="Select a feature build..."
 				options={options}
+				disabled={buildsQuery.isLoading}
 				onChange={(nextPr) => {
 					const pr = Number(nextPr);
 					const build = builds.find((b) => b.pr === pr);
@@ -307,7 +297,9 @@ function FeatureBuildsSelect({
 							</span>
 							<div className="flex min-w-0 items-center gap-1.5">
 								<span className="min-w-0 truncate font-mono text-caption text-passive">{build.buildId}</span>
-								<Badge variant={isStale ? "warning" : "neutral"}>{ageLabel}</Badge>
+								<Badge variant={isStale ? "warning" : "neutral"} className="h-3.5 px-1 text-[9px] leading-none">
+									{ageLabel}
+								</Badge>
 							</div>
 						</div>
 					);

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -1,7 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
-import { AlertTriangle, Check, HardDriveDownload, History, Loader2, RefreshCw } from "lucide-react";
+import { AlertTriangle, Check, GitPullRequest, HardDriveDownload, History, Loader2, RefreshCw } from "lucide-react";
 import { aoBridge } from "../../lib/bridge";
+import { formatTimeCompact } from "../../lib/format-time";
 import { useUpdateStatus } from "../../hooks/useUpdateStatus";
 import type { UpdateChannel, UpdateSettings, UpdateState, UpdateStatus } from "../../../main/update-settings";
 import { ConfirmDialog } from "../ConfirmDialog";
@@ -35,17 +36,6 @@ let updateRequestSequence = 0;
 function nextUpdateRequestId(): string {
 	updateRequestSequence += 1;
 	return `feature-update-${updateRequestSequence}`;
-}
-
-function relativeAge(iso: string): string {
-	const diffMs = Date.now() - new Date(iso).getTime();
-	const mins = Math.floor(diffMs / 60000);
-	if (mins < 1) return "just now";
-	if (mins < 60) return `${mins}m ago`;
-	const hours = Math.floor(mins / 60);
-	if (hours < 24) return `${hours}h ago`;
-	const days = Math.floor(hours / 24);
-	return `${days}d ago`;
 }
 
 export function UpdatesSection() {
@@ -215,7 +205,7 @@ export function UpdatesSection() {
 					<FeatureBuildsSelect currentPr={form.feature?.pr ?? null} onPin={handlePinBuild} />
 				)}
 
-				{form.channel === "nightly" && form.feature === null && form.enabled && (
+				{primaryValue === "nightly" && form.enabled && (
 					<p className="flex items-center gap-2 px-1 text-xs leading-row text-warning">
 						<AlertTriangle className="size-icon-sm shrink-0" aria-hidden="true" />
 						<span>
@@ -264,7 +254,7 @@ function FeatureBuildsSelect({
 
 	if (buildsQuery.isLoading) {
 		return (
-			<SettingsRow label="Feature build">
+			<SettingsRow icon={GitPullRequest} label="Feature build">
 				<div className="flex w-48 flex-col gap-1">
 					<Skeleton className="h-control-form w-full" />
 				</div>
@@ -285,11 +275,11 @@ function FeatureBuildsSelect({
 
 	const options = builds.map((build) => ({
 		value: build.pr.toString(),
-		label: `PR #${build.pr}: ${build.title}`,
+		label: `PR #${build.pr}`,
 	}));
 
 	return (
-		<SettingsRow label="Feature build">
+		<SettingsRow icon={GitPullRequest} label="Feature build">
 			<SettingsOptionMenu
 				aria-label="Feature build"
 				value={currentPr === null ? "__none__" : currentPr.toString()}
@@ -308,15 +298,15 @@ function FeatureBuildsSelect({
 
 					const ageMs = Date.now() - new Date(build.publishedAt).getTime();
 					const isStale = ageMs > STALE_THRESHOLD_MS;
-					const ageLabel = relativeAge(build.publishedAt);
+					const ageLabel = formatTimeCompact(build.publishedAt);
 
 					return (
-						<div className="flex min-w-0 flex-col gap-0.5">
-							<span>
+						<div className="flex w-full min-w-0 flex-col gap-0.5">
+							<span className="line-clamp-2 break-words">
 								PR #{build.pr}: {build.title}
 							</span>
-							<div className="flex items-center gap-1.5">
-								<span className="font-mono text-caption text-passive">{build.buildId}</span>
+							<div className="flex min-w-0 items-center gap-1.5">
+								<span className="min-w-0 truncate font-mono text-caption text-passive">{build.buildId}</span>
 								<Badge variant={isStale ? "warning" : "neutral"}>{ageLabel}</Badge>
 							</div>
 						</div>

--- a/frontend/src/renderer/components/ui/badge.tsx
+++ b/frontend/src/renderer/components/ui/badge.tsx
@@ -12,7 +12,7 @@ export function Badge({
 	return (
 		<span
 			className={cn(
-				"inline-flex size-icon-xl shrink-0 items-center gap-1 rounded-full border border-transparent px-2 font-mono text-micro font-medium",
+				"inline-flex h-icon-xl shrink-0 items-center gap-1 whitespace-nowrap rounded-full border border-transparent px-2 font-mono text-micro font-medium",
 				variant === "neutral" && "bg-raised text-muted-foreground",
 				variant === "outline" && "border-border text-foreground",
 				variant === "accent" && "border-accent-dim text-accent",

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -408,6 +408,7 @@ button.settings-row-bar {
 	display: flex;
 	min-width: 11rem;
 	width: max-content;
+	max-width: min(18rem, calc(100vw - 2rem));
 	flex-direction: column;
 	border-radius: var(--radius-settings-panel);
 	border: 1px solid var(--color-border-settings-menu);


### PR DESCRIPTION
## Summary
- Hide the nightly instability warning when Updates channel is Feature Releases (was still showing when home channel was nightly)
- Fix Badge sizing so relative-age labels like `4h ago` render as pills, not stacked circles
- Cap feature-build menu width, clamp long PR titles, and keep the Feature build row label/trigger from overlapping
- Reuse `formatTimeCompact` instead of a local relative-age helper; add a regression test for the nightly warning

## Test plan
- [ ] Enable Automatic Updates → Nightly → confirm warning shows
- [ ] Switch to Feature Releases → confirm warning disappears and Feature build row appears with icon
- [ ] Open Feature build menu with a long PR title → menu width matches other settings menus; title clamps; `4h ago` is a single-line pill
- [ ] Select a feature build → row stays normal height; trigger shows compact `PR #<n>`; label does not wrap/overlap
- [ ] Switch back to Stable/Nightly → picker hides; nightly warning only on Nightly
- [ ] `npx vitest run src/renderer/components/GlobalSettingsForm.test.tsx`

## Before
<img width="897" height="701" alt="image" src="https://github.com/user-attachments/assets/88ec6ab5-2148-491a-ab2e-f5a6b8d0b40b" />
<img width="963" height="720" alt="image" src="https://github.com/user-attachments/assets/f3b6ad5a-d163-4139-ba80-a9af0ec3c58c" />
<img width="1011" height="790" alt="image" src="https://github.com/user-attachments/assets/93f659e6-3734-430c-b490-4b7d1e51731f" />
<img width="1040" height="819" alt="image" src="https://github.com/user-attachments/assets/de7f3a0f-ef93-405b-8d60-6e4f02f8e169" />



## After
<img width="946" height="743" alt="image" src="https://github.com/user-attachments/assets/3a7c2dde-ae65-4620-8478-b48a0c214ca6" />
<img width="789" height="729" alt="image" src="https://github.com/user-attachments/assets/b377c8d4-568f-4c60-a515-14c59aad58a8" />
<img width="820" height="733" alt="image" src="https://github.com/user-attachments/assets/008a8032-b6ec-4375-813a-6fe3be4ffd78" />
