### PR TITLE
feat(shortcuts): new terminal on Ctrl+Shift+` / Ctrl+` (Claude/Codex/VS Code parity)

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -24,19 +24,11 @@ import {
 	setUpdateSettings,
 	type UpdateCheckOptions,
 } from "./main/auto-updater";
-import {
-	readUpdateSettings,
-	writeUpdateSettings,
-	type UpdateSettings,
-	type UpdateStatus,
-} from "./main/update-settings";
-import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
-import { listFeatureBuilds, getActiveFeatureBuild } from "./main/feature-builds";
 import { readUpdateSettings, type UpdateSettings, type UpdateStatus } from "./main/update-settings";
 import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { closeSync, existsSync, openSync } from "node:fs";
+import { listFeatureBuilds, getActiveFeatureBuild } from "./main/feature-builds";
 import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -486,7 +478,6 @@ function daemonEnv(): NodeJS.ProcessEnv {
 	// standalone shell terminals survive; a later app launch gets a new id, which
 	// is how the daemon recognises the previous run's shells as orphans and
 	// destroys them (see internal/service/shellterm).
-	const ownerTag = { AO_OWNER: "app", AO_APP_RUN_ID: appRunId };
 	// AO_OWNER is the daemon's durable spawn-mode record: the daemon writes it
 	// into running.json and the attach path reads it to decide the supervisor
 	// link from the daemon's own state (not this Electron process's env, which
@@ -494,7 +485,7 @@ function daemonEnv(): NodeJS.ProcessEnv {
 	// re-linked, survives app quit); a normal app-owned daemon is "app";
 	// headless `ao start` sets none (stays unlinked, persistent by default).
 	const AO_OWNER = keepDaemonAlive(process.env) ? "persistent" : "app";
-	const ownerTag = { AO_OWNER };
+	const ownerTag = { AO_OWNER, AO_APP_RUN_ID: appRunId };
 	// In dev mode, inject isolation defaults so the dev daemon never collides with
 	// the installed app. User-set env vars take priority (checked first).
 	const devExtras: Record<string, string> = {};

--- a/frontend/src/main/app-shortcuts.ts
+++ b/frontend/src/main/app-shortcuts.ts
@@ -12,6 +12,7 @@ import {
 // locally so tests can supply a plain fake while WebContents still satisfies it.
 type BeforeInput = {
 	key: string;
+	code?: string;
 	control: boolean;
 	meta: boolean;
 	shift: boolean;
@@ -53,6 +54,7 @@ export function attachAppShortcuts(
 		const channel = appShortcutChannel(
 			{
 				key: input.key,
+				code: input.code,
 				ctrl: input.control,
 				meta: input.meta,
 				shift: input.shift,

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { useCloseShellTerminal, useShellTerminals } from "../hooks/useShellTerminals";
 import { useShell } from "../lib/shell-context";
 import { cn } from "../lib/utils";
-import { useUiStore } from "../stores/ui-store";
+import { useResolvedTheme, useUiStore } from "../stores/ui-store";
 import { TerminalPane } from "./TerminalPane";
 
 // The standalone terminals screen: shells with no agent session behind them,
@@ -15,7 +15,7 @@ import { TerminalPane } from "./TerminalPane";
 // beside that session's pane; this screen is where they live otherwise.
 export function ShellTerminalsView() {
 	const { daemonStatus } = useShell();
-	const { theme } = useUiStore();
+	const theme = useResolvedTheme();
 	const shellTerminals = useShellTerminals().data ?? [];
 	const closeShellTerminal = useCloseShellTerminal();
 	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -178,12 +178,13 @@ export function ShellTopbar() {
 
 			<div className="flex shrink-0 items-center gap-1.5">
 				{/* Standalone shell, independent of any agent session — the same action
-				    Ctrl+` fires, routed through the store so the two cannot drift. */}
+				    Ctrl+Shift+` (and Ctrl+`) fires, routed through the store so the two
+				    cannot drift. Identical chord on every platform. */}
 				<TopbarButton
 					aria-label="New terminal"
 					onClick={requestNewShellTerminal}
 					style={noDragStyle}
-					title="New terminal (Ctrl+`)"
+					title="New terminal (Ctrl+Shift+`)"
 					variant="icon"
 				>
 					<SquareTerminal className="size-icon-md" aria-hidden="true" />

--- a/frontend/src/shared/shortcuts.test.ts
+++ b/frontend/src/shared/shortcuts.test.ts
@@ -43,31 +43,38 @@ describe("matchesNewSessionShortcut", () => {
 });
 
 describe("matchesNewShellTerminalShortcut", () => {
-	it("matches Ctrl+` on both platforms", () => {
+	// VS Code / Cursor / Codex bindings — identical on every platform.
+	it("matches Ctrl+Shift+` (Create New Terminal) on both platforms", () => {
+		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, shift: true }), false)).toBe(true);
+		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, shift: true }), true)).toBe(true);
+	});
+
+	it("also matches plain Ctrl+` (toggle) on both platforms", () => {
 		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true }), false)).toBe(true);
 		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true }), true)).toBe(true);
 	});
 
 	// Layouts that need a modifier for the backtick report the physical key.
 	it("matches the Backquote key name", () => {
-		expect(matchesNewShellTerminalShortcut(chord({ key: "Backquote", ctrl: true }), false)).toBe(true);
+		expect(matchesNewShellTerminalShortcut(chord({ key: "Backquote", ctrl: true, shift: true }), false)).toBe(true);
 	});
 
-	// ⌘` is the macOS "cycle windows" binding and must stay with the OS.
+	// The binding uses Ctrl on every platform, never ⌘ — ⌘` is the macOS
+	// "cycle windows" binding and must stay with the OS.
 	it("does not match Command+backtick on macOS", () => {
 		expect(matchesNewShellTerminalShortcut(chord({ key: "`", meta: true }), true)).toBe(false);
+		expect(matchesNewShellTerminalShortcut(chord({ key: "`", meta: true, shift: true }), true)).toBe(false);
 	});
 
-	it("requires Ctrl and rejects extra modifiers", () => {
+	it("requires Ctrl and rejects Alt / Meta", () => {
 		expect(matchesNewShellTerminalShortcut(chord({ key: "`" }), false)).toBe(false);
-		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, shift: true }), false)).toBe(false);
 		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, alt: true }), false)).toBe(false);
 		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, meta: true }), false)).toBe(false);
 	});
 
 	it("ignores other keys", () => {
 		expect(matchesNewShellTerminalShortcut(chord({ key: "1", ctrl: true }), false)).toBe(false);
-		expect(matchesNewShellTerminalShortcut(chord({ key: "~", ctrl: true }), false)).toBe(false);
+		expect(matchesNewShellTerminalShortcut(chord({ key: "t", ctrl: true, shift: true }), false)).toBe(false);
 	});
 });
 

--- a/frontend/src/shared/shortcuts.test.ts
+++ b/frontend/src/shared/shortcuts.test.ts
@@ -43,38 +43,53 @@ describe("matchesNewSessionShortcut", () => {
 });
 
 describe("matchesNewShellTerminalShortcut", () => {
-	// VS Code / Cursor / Codex bindings — identical on every platform.
-	it("matches Ctrl+Shift+` (Create New Terminal) on both platforms", () => {
-		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, shift: true }), false)).toBe(true);
-		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, shift: true }), true)).toBe(true);
+	// VS Code / Cursor / Codex "Create New Terminal", identical on every platform.
+	// Matched on the physical `code`: Shift shifts the character (US delivers key
+	// "~" for Ctrl+Shift+`), so the runtime chord carries code "Backquote".
+	it("matches Ctrl+Shift+` even though the character arrives shifted", () => {
+		expect(
+			matchesNewShellTerminalShortcut(chord({ code: "Backquote", key: "~", ctrl: true, shift: true }), false),
+		).toBe(true);
+		expect(matchesNewShellTerminalShortcut(chord({ code: "Backquote", key: "~", ctrl: true, shift: true }), true)).toBe(
+			true,
+		);
 	});
 
 	it("also matches plain Ctrl+` (toggle) on both platforms", () => {
-		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true }), false)).toBe(true);
-		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true }), true)).toBe(true);
+		expect(matchesNewShellTerminalShortcut(chord({ code: "Backquote", key: "`", ctrl: true }), false)).toBe(true);
+		expect(matchesNewShellTerminalShortcut(chord({ code: "Backquote", key: "`", ctrl: true }), true)).toBe(true);
 	});
 
-	// Layouts that need a modifier for the backtick report the physical key.
-	it("matches the Backquote key name", () => {
-		expect(matchesNewShellTerminalShortcut(chord({ key: "Backquote", ctrl: true, shift: true }), false)).toBe(true);
+	// Chords supplied without a code fall back to the key spelling.
+	it("falls back to the key spelling when no code is present", () => {
+		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true }), false)).toBe(true);
+		expect(matchesNewShellTerminalShortcut(chord({ key: "Backquote", ctrl: true }), false)).toBe(true);
 	});
 
 	// The binding uses Ctrl on every platform, never ⌘ — ⌘` is the macOS
 	// "cycle windows" binding and must stay with the OS.
 	it("does not match Command+backtick on macOS", () => {
-		expect(matchesNewShellTerminalShortcut(chord({ key: "`", meta: true }), true)).toBe(false);
-		expect(matchesNewShellTerminalShortcut(chord({ key: "`", meta: true, shift: true }), true)).toBe(false);
+		expect(matchesNewShellTerminalShortcut(chord({ code: "Backquote", key: "`", meta: true }), true)).toBe(false);
+		expect(matchesNewShellTerminalShortcut(chord({ code: "Backquote", key: "~", meta: true, shift: true }), true)).toBe(
+			false,
+		);
 	});
 
 	it("requires Ctrl and rejects Alt / Meta", () => {
-		expect(matchesNewShellTerminalShortcut(chord({ key: "`" }), false)).toBe(false);
-		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, alt: true }), false)).toBe(false);
-		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, meta: true }), false)).toBe(false);
+		expect(matchesNewShellTerminalShortcut(chord({ code: "Backquote", key: "`" }), false)).toBe(false);
+		expect(matchesNewShellTerminalShortcut(chord({ code: "Backquote", key: "`", ctrl: true, alt: true }), false)).toBe(
+			false,
+		);
+		expect(matchesNewShellTerminalShortcut(chord({ code: "Backquote", key: "`", ctrl: true, meta: true }), false)).toBe(
+			false,
+		);
 	});
 
 	it("ignores other keys", () => {
-		expect(matchesNewShellTerminalShortcut(chord({ key: "1", ctrl: true }), false)).toBe(false);
-		expect(matchesNewShellTerminalShortcut(chord({ key: "t", ctrl: true, shift: true }), false)).toBe(false);
+		expect(matchesNewShellTerminalShortcut(chord({ code: "Digit1", key: "1", ctrl: true }), false)).toBe(false);
+		expect(matchesNewShellTerminalShortcut(chord({ code: "KeyT", key: "t", ctrl: true, shift: true }), false)).toBe(
+			false,
+		);
 	});
 });
 

--- a/frontend/src/shared/shortcuts.ts
+++ b/frontend/src/shared/shortcuts.ts
@@ -4,6 +4,10 @@
 
 export type ShortcutChord = {
 	key: string;
+	// Physical key (KeyboardEvent.code / Electron input.code), independent of
+	// layout and modifiers. Needed for chords whose character shifts — e.g.
+	// Ctrl+Shift+` reports key "~" on a US layout but code "Backquote".
+	code?: string;
 	ctrl: boolean;
 	meta: boolean;
 	shift: boolean;
@@ -11,12 +15,7 @@ export type ShortcutChord = {
 };
 
 export type AppShortcutId =
-	| "new-session"
-	| "new-shell-terminal"
-	| "keyboard-shortcuts"
-	| "toggle-sidebar"
-	| "open-project"
-	| "toggle-inspector";
+	"new-session" | "new-shell-terminal" | "keyboard-shortcuts" | "toggle-sidebar" | "open-project" | "toggle-inspector";
 
 export type ShortcutCategory = "General" | "Navigation" | "Session";
 
@@ -114,10 +113,13 @@ export function matchesNewSessionShortcut(chord: ShortcutChord, isMac: boolean):
 // The tradeoff is deliberate and matches VS Code: no shell or TUI in a pane can
 // receive Ctrl+` / Ctrl+Shift+` while AO owns them. Almost nothing binds them.
 export function matchesNewShellTerminalShortcut(chord: ShortcutChord, _isMac: boolean): boolean {
-	// Keyboards that need a modifier for the backtick can report the physical
-	// key instead of the character, so accept either spelling. Shift is optional
-	// (Ctrl+` and Ctrl+Shift+` both open a terminal); ⌘/Alt must not be held.
-	if (chord.key !== "`" && chord.key !== "Backquote") return false;
+	// Match on the physical `code` (Backquote), not the character: with Shift
+	// held the character is layout-shifted — US Ctrl+Shift+` reports key "~", not
+	// "`" — so keying off `key` would miss the advertised Ctrl+Shift+` chord.
+	// Fall back to the `key` spelling for chords supplied without a code. Shift is
+	// optional (Ctrl+` and Ctrl+Shift+` both open a terminal); ⌘/Alt must not hold.
+	const isBackquote = chord.code === "Backquote" || chord.key === "`" || chord.key === "Backquote";
+	if (!isBackquote) return false;
 	return chord.ctrl && !chord.meta && !chord.alt;
 }
 

--- a/frontend/src/shared/shortcuts.ts
+++ b/frontend/src/shared/shortcuts.ts
@@ -45,8 +45,8 @@ export const APP_SHORTCUTS: readonly ShortcutDefinition[] = [
 		id: "new-shell-terminal",
 		label: "New terminal",
 		category: "General",
-		mac: ["Ctrl", "`"],
-		windowsLinux: ["Ctrl", "`"],
+		mac: ["⌃", "⇧", "`"],
+		windowsLinux: ["Ctrl", "Shift", "`"],
 	},
 	{
 		id: "keyboard-shortcuts",
@@ -103,19 +103,22 @@ export function matchesNewSessionShortcut(chord: ShortcutChord, isMac: boolean):
 		: chord.ctrl && chord.shift && !chord.alt && !chord.meta;
 }
 
-// New standalone terminal: Ctrl+` on every platform, matching VS Code and most
-// IDEs. Ctrl (not ⌘) on macOS too — that is the conventional binding there, and
-// ⌘` is already taken by the OS for cycling an app's windows.
+// New standalone terminal, bound to the backtick chords VS Code / Cursor /
+// Codex use for the integrated terminal — identical on macOS, Windows, and
+// Linux (Ctrl, never ⌘, so there is nothing platform-specific to learn):
 //
-// Like the other app shortcuts this is handled in the main process, so it fires
-// even while focus is inside xterm. The tradeoff is deliberate: no shell or TUI
-// running in a pane can receive Ctrl+` while AO owns it. Almost nothing binds
-// that chord, and VS Code makes the same trade.
+//   • Ctrl+Shift+` — "Create New Terminal" (the primary, advertised binding).
+//   • Ctrl+`       — VS Code's toggle/focus chord; also opens one here.
+//
+// Handled in the main process so they fire even while focus is inside xterm.
+// The tradeoff is deliberate and matches VS Code: no shell or TUI in a pane can
+// receive Ctrl+` / Ctrl+Shift+` while AO owns them. Almost nothing binds them.
 export function matchesNewShellTerminalShortcut(chord: ShortcutChord, _isMac: boolean): boolean {
 	// Keyboards that need a modifier for the backtick can report the physical
-	// key instead of the character, so accept either spelling.
+	// key instead of the character, so accept either spelling. Shift is optional
+	// (Ctrl+` and Ctrl+Shift+` both open a terminal); ⌘/Alt must not be held.
 	if (chord.key !== "`" && chord.key !== "Backquote") return false;
-	return chord.ctrl && !chord.meta && !chord.alt && !chord.shift;
+	return chord.ctrl && !chord.meta && !chord.alt;
 }
 
 // Keyboard shortcut help: ⌘/ on macOS, Ctrl+/ on Windows/Linux. This is also


### PR DESCRIPTION
## Summary

The **Create New Terminal** keyboard chord for AO's standalone terminals, **stacked on #2861**. Base is `stack/2861-shortcuts-base` (a snapshot of #2861's head), so the diff here is only my changes. **Retarget to `main` once #2861 merges.**

Now scoped to **one atomic thing** — the new-terminal chord. (The Shift+Enter brief/terminal newline that used to be bundled here moved to its own main-targeted PR, **#2955**.)

## What changed
- **New terminal → `Ctrl+Shift+`` (and `Ctrl+`)** — the VS Code / Cursor / Codex "Create New Terminal" chord, identical on macOS, Windows and Linux (Ctrl, never ⌘). Shift is optional (both `Ctrl+`` and `Ctrl+Shift+`` open one); ⌘/Alt must not be held. Routed through #2861's `matchesNewShellTerminalShortcut` + main-process handler; catalog entry + topbar tooltip updated to match.
- Files: `shared/shortcuts.ts`, `shared/shortcuts.test.ts`, `components/ShellTopbar.tsx`.

## Build unblock (`fix(build)`)
#2861's snapshot base didn't compile due to a botched main-merge; two files are fixed here so this stack builds (`main.ts` import/ownerTag collapse; `ShellTerminalsView.tsx` `useResolvedTheme()`). **This belongs in #2861** — drop it on rebase once #2861 fixes its own branch.

## Relationship to the other shortcut PRs
- **#2861** — standalone terminal base (prerequisite).
- **#2955** — Enter/Shift+Enter in the New Task brief (independent, already on `main`).
- **#2954** — settings / session-nav / focus-terminal shortcuts (on `main`).
- **No key collisions** across all four. Both this and #2954 edit `shared/shortcuts.ts`; whichever merges second does a small union merge (and reconcile #2954's removal of the `context` field with the `new-shell-terminal` entry).

## Test
- `npx vitest run src/shared/shortcuts.test.ts` — 15/15 pass. Prettier clean on changed files.

Ready for review. Merge order: #2861 → this (retargeted to main). Refs #2828.