### PR TITLE
fix(session): show working status when agent is active, even with an open PR

### DIFF
--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -193,7 +193,7 @@ func (f *fakeStore) GetProject(_ context.Context, id string) (domain.ProjectReco
 
 func TestSessionListDerivesStatusFromPRFacts(t *testing.T) {
 	st := newFakeStore()
-	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Activity: domain.Activity{State: domain.ActivityActive}}
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Activity: domain.Activity{State: domain.ActivityIdle}}
 	st.pr["mer-1"] = domain.PRFacts{URL: "pr1", CI: domain.CIFailing}
 
 	list, err := (&Service{store: st}).List(context.Background(), ListFilter{ProjectID: "mer"})

--- a/backend/internal/service/session/status.go
+++ b/backend/internal/service/session/status.go
@@ -35,6 +35,13 @@ func deriveStatus(rec domain.SessionRecord, prs []domain.PRFacts, now time.Time,
 	if rec.Activity.State.NeedsInput() {
 		return domain.StatusNeedsInput
 	}
+	// An actively working agent takes precedence over the PR lifecycle:
+	// a session fixing CI or addressing reviews is "working", not "in review".
+	// Without this, the sidebar dot and kanban badge are locked to a PR-derived
+	// color whenever a PR exists, hiding real-time activity from those surfaces.
+	if rec.Activity.State == domain.ActivityActive {
+		return domain.StatusWorking
+	}
 
 	open := openPRs(prs)
 	if len(open) > 0 {
@@ -42,10 +49,6 @@ func deriveStatus(rec domain.SessionRecord, prs []domain.PRFacts, now time.Time,
 	}
 	if anyMerged(prs) {
 		return domain.StatusMerged
-	}
-
-	if rec.Activity.State == domain.ActivityActive {
-		return domain.StatusWorking
 	}
 
 	// No hook callback has ever arrived for this spawn/restore even though the

--- a/backend/internal/service/session/status_test.go
+++ b/backend/internal/service/session/status_test.go
@@ -51,6 +51,13 @@ func TestServiceDerivesStatusFromSessionFactsAndPR(t *testing.T) {
 		{"review-pending", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{Review: domain.ReviewRequired}), false, domain.StatusReviewPending},
 		{"pr-open", statusRec(domain.ActivityIdle, false), statusPR(domain.PRFacts{}), false, domain.StatusPROpen},
 		{"working", statusRec(domain.ActivityActive, false), nil, false, domain.StatusWorking},
+		// An actively working agent takes precedence over any PR lifecycle
+		// status — the sidebar dot and kanban badge must reflect real-time
+		// activity even when a PR is open. Without this, those surfaces are
+		// locked to a PR-derived color and can't show "working".
+		{"active-pr-open-wins", statusRec(domain.ActivityActive, false), statusPR(domain.PRFacts{}), false, domain.StatusWorking},
+		{"active-ci-failed-wins", statusRec(domain.ActivityActive, false), statusPR(domain.PRFacts{CI: domain.CIFailing}), false, domain.StatusWorking},
+		{"active-review-pending-wins", statusRec(domain.ActivityActive, false), statusPR(domain.PRFacts{Review: domain.ReviewRequired}), false, domain.StatusWorking},
 		{"idle", statusRec(domain.ActivityIdle, false), nil, false, domain.StatusIdle},
 
 		// A live session whose hook-capable agent never signaled is no_signal


### PR DESCRIPTION
Fixes #2944

## Summary

`deriveStatus()` checked for open PRs **before** checking agent activity, so any session with an open PR had its status locked to a PR-derived value (`review_pending`, `ci_failed`, etc.) regardless of whether the agent was actively working. This made the sidebar dot and kanban badge permanently blue for sessions that had raised a PR — users could no longer tell if the agent was working or idle from those surfaces.

**The fix:** move the `ActivityActive` check before the PR aggregation, matching the existing precedence that `NeedsInput()` already enjoys. When the agent goes idle, the status falls back to the PR lifecycle as before.

### Changes
- `backend/internal/service/session/status.go` — moved `ActivityActive` check (lines 47-49) above the `openPRs()` check (lines 39-42), with explanatory comment
- `backend/internal/service/session/status_test.go` — 3 new test cases: `active-pr-open-wins`, `active-ci-failed-wins`, `active-review-pending-wins`
- `backend/internal/service/session/service_test.go` — updated `TestSessionListDerivesStatusFromPRFacts` to use `ActivityIdle` (its intent is to verify PR-derived CI status derivation, which only applies when the agent is idle)

## Test

```bash
cd backend && go build ./... && go test ./...
```

All 40+ packages pass, including the 3 new status derivation cases.
