### PR TITLE
fix: size badge text as pills

### DIFF
--- a/frontend/src/renderer/components/ui/badge.test.tsx
+++ b/frontend/src/renderer/components/ui/badge.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Badge } from "./badge";
+
+describe("Badge", () => {
+	it("sizes text badges as content-width pills instead of fixed icon squares", () => {
+		render(
+			<Badge variant="success" className="h-5 px-1.5 text-micro font-medium">
+				open
+			</Badge>,
+		);
+
+		const badge = screen.getByText("open");
+
+		expect(badge).not.toHaveClass("size-icon-xl");
+		expect(badge).not.toHaveClass("h-icon-xl");
+		expect(badge.className).not.toMatch(/\b(?:w|min-w)-/);
+		expect(badge).toHaveClass("inline-flex", "whitespace-nowrap", "rounded-full", "h-5", "px-1.5");
+	});
+
+	it("lets compact call sites override badge height without reintroducing fixed width", () => {
+		render(
+			<Badge variant="neutral" className="h-3.5 px-1 text-[9px] leading-none">
+				2d ago
+			</Badge>,
+		);
+
+		const badge = screen.getByText("2d ago");
+
+		expect(badge).toHaveClass("h-3.5", "px-1", "text-[9px]", "leading-none");
+		expect(badge.className).not.toMatch(/\b(?:size|h|w|min-w)-icon-xl\b/);
+	});
+});

--- a/frontend/src/renderer/components/ui/badge.tsx
+++ b/frontend/src/renderer/components/ui/badge.tsx
@@ -12,7 +12,7 @@ export function Badge({
 	return (
 		<span
 			className={cn(
-				"inline-flex h-icon-xl shrink-0 items-center gap-1 whitespace-nowrap rounded-full border border-transparent px-2 font-mono text-micro font-medium",
+				"inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full border border-transparent px-2 font-mono text-micro font-medium",
 				variant === "neutral" && "bg-raised text-muted-foreground",
 				variant === "outline" && "border-border text-foreground",
 				variant === "accent" && "border-accent-dim text-accent",


### PR DESCRIPTION
## Summary
- remove the remaining icon-sized height utility from the shared Badge base so text badges are content-sized pills
- add Badge component regression tests covering the PR state chip and compact settings badge class patterns

Fixes #2942

## Verification
- `npx -p node@22.13.1 node node_modules/vitest/vitest.mjs run --config vite.renderer.config.ts src/renderer/components/ui/badge.test.tsx src/renderer/components/SessionInspector.test.tsx src/renderer/components/PRSummaryDisplay.test.tsx`
- `npx -p node@22.13.1 node node_modules/typescript/bin/tsc --noEmit`
- Tailwind merge check: fixed base + PR state classes produce no `size-icon-xl`, while the old buggy base keeps `size-icon-xl` with `tailwind-merge@3.6.0`
- Visual harness via Vite + AO preview at `http://127.0.0.1:5174/badge-harness.html`; Chrome geometry confirmed all state badges are pill-shaped and text does not overflow (`open` 47.72x20 for 33.72px text, `draft` 56.16x20 for 42.16px text, `merged`/`closed` 64.58x20 for 50.58px text)