### PR TITLE
fix: reduce telemetry event volume

### DIFF
--- a/backend/internal/adapters/telemetry/posthog.go
+++ b/backend/internal/adapters/telemetry/posthog.go
@@ -26,11 +26,13 @@ const postHogBufferSize = 128
 
 var remotePayloadAllowlist = map[string]map[string]struct{}{
 	"ao.app.active": {
+		"actor_type":   {},
 		"channel":      {},
 		"command":      {},
 		"command_path": {},
 	},
 	"ao.cli.invoked": {
+		"actor_type":   {},
 		"command":      {},
 		"command_path": {},
 	},

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -212,13 +212,11 @@ type commandContext struct {
 func shouldEmitCLIInvocation(cmd *cobra.Command) bool {
 	switch strings.TrimSpace(cmd.CommandPath()) {
 	// "ao daemon"/"ao start" are supervisor-driven bootstrapping, and
-	// "ao completion"/"ao help" are shell setup and self-documentation, none
-	// of which reflect a human doing something with AO. "ao hooks" and
-	// "ao pty-host" ARE real usage signal (an agent session is doing
-	// something) even though a machine invokes them, so they are allowed
-	// through here; the per-command-path daily cap in httpd/router.go is what
-	// keeps their invocation frequency from reaching PostHog uncapped.
-	case "ao daemon", "ao start", "ao completion", "ao help", "ao agent-process", "ao agent-process supervise":
+	// "ao completion"/"ao help" are shell setup and self-documentation.
+	// "ao pty-host" and "ao agent-process" are internal runtime processes.
+	// None reflect user activity. "ao hooks" is agent activity and is still
+	// reported, but the daemon keeps it out of ao.app.active/DAU.
+	case "ao daemon", "ao start", "ao completion", "ao help", "ao pty-host", "ao agent-process", "ao agent-process supervise":
 		return false
 	default:
 		return true
@@ -231,7 +229,18 @@ func (c *commandContext) emitCLIInvoked(ctx context.Context, cmd *cobra.Command)
 	_ = c.postLoopbackJSON(reqCtx, "/internal/telemetry/cli-invoked", map[string]string{
 		"command":     cmd.Name(),
 		"commandPath": cmd.CommandPath(),
+		"actorType":   cliInvocationActorType(cmd),
 	})
+}
+
+func cliInvocationActorType(cmd *cobra.Command) string {
+	if strings.TrimSpace(cmd.CommandPath()) == "ao hooks" {
+		return "agent"
+	}
+	if sessionIDPattern.MatchString(strings.TrimSpace(os.Getenv("AO_SESSION_ID"))) {
+		return "agent"
+	}
+	return "user"
 }
 
 func (c *commandContext) emitCLIUsageError(ctx context.Context, args []string, err error) {

--- a/backend/internal/cli/root_test.go
+++ b/backend/internal/cli/root_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -69,8 +70,9 @@ func TestCommandsRejectUnexpectedArgs(t *testing.T) {
 }
 
 func TestVersionEmitsCLIInvocationBestEffort(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "")
 	cfg := setConfigEnv(t)
-	called := make(chan string, 1)
+	called := make(chan map[string]string, 1)
 	if err := runfile.Write(cfg.runFile, runfile.Info{PID: os.Getpid(), Port: 3001, StartedAt: time.Unix(100, 0).UTC()}); err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +80,12 @@ func TestVersionEmitsCLIInvocationBestEffort(t *testing.T) {
 	if _, _, err := executeCLI(t, Deps{
 		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			if req.URL.Path == "/internal/telemetry/cli-invoked" {
-				called <- req.URL.Path
+				defer req.Body.Close()
+				var body map[string]string
+				if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+					t.Fatalf("decode telemetry body: %v", err)
+				}
+				called <- body
 				return jsonResponse(http.StatusAccepted, ""), nil
 			}
 			return jsonResponse(http.StatusNotFound, ""), nil
@@ -88,9 +95,9 @@ func TestVersionEmitsCLIInvocationBestEffort(t *testing.T) {
 		t.Fatal(err)
 	}
 	select {
-	case path := <-called:
-		if path != "/internal/telemetry/cli-invoked" {
-			t.Fatalf("telemetry path = %q, want /internal/telemetry/cli-invoked", path)
+	case body := <-called:
+		if body["actorType"] != "user" {
+			t.Fatalf("telemetry actorType = %q, want user", body["actorType"])
 		}
 	default:
 		t.Fatal("version did not emit CLI invocation")
@@ -105,14 +112,10 @@ func TestShouldEmitCLIInvocationSkipsOnlyNonUsageCommands(t *testing.T) {
 	for name, want := range map[string]bool{
 		"daemon": false, // supervisor-driven bootstrapping, not human usage
 		"start":  false,
-		// "hooks" and "pty-host" ARE usage signal (an agent session doing
-		// something), even though a machine invokes them; the daily
-		// per-command cap in httpd/router.go, not this exclusion, is what
-		// keeps their invocation frequency off PostHog. Excluding them here
-		// would zero out ao.app.active on any day an install's only activity
-		// was agent work, undercounting DAU for headless/CLI-only installs.
+		// hooks is agent activity; pty-host is only an internal Windows runtime
+		// process and should not count as CLI usage.
 		"hooks":    true,
-		"pty-host": true,
+		"pty-host": false,
 		"status":   true,
 		"spawn":    true,
 	} {
@@ -123,6 +126,26 @@ func TestShouldEmitCLIInvocationSkipsOnlyNonUsageCommands(t *testing.T) {
 		if got := shouldEmitCLIInvocation(cmd); got != want {
 			t.Errorf("shouldEmitCLIInvocation(%s) = %v, want %v", cmd.CommandPath(), got, want)
 		}
+	}
+}
+
+func TestCLIInvocationActorType(t *testing.T) {
+	t.Setenv("AO_SESSION_ID", "")
+	byName := map[string]*cobra.Command{}
+	for _, cmd := range NewRootCommand(Deps{}).Commands() {
+		byName[cmd.Name()] = cmd
+	}
+
+	if got := cliInvocationActorType(byName["hooks"]); got != "agent" {
+		t.Fatalf("hooks actor = %q, want agent", got)
+	}
+	if got := cliInvocationActorType(byName["status"]); got != "user" {
+		t.Fatalf("status actor without session env = %q, want user", got)
+	}
+
+	t.Setenv("AO_SESSION_ID", "ao-session-1")
+	if got := cliInvocationActorType(byName["status"]); got != "agent" {
+		t.Fatalf("status actor with session env = %q, want agent", got)
 	}
 }
 

--- a/backend/internal/httpd/cli_telemetry_reservoir.go
+++ b/backend/internal/httpd/cli_telemetry_reservoir.go
@@ -1,0 +1,138 @@
+package httpd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const cliTelemetryStateFile = "telemetry_cli_daily.json"
+
+type cliTelemetryReservoir struct {
+	mu sync.Mutex
+
+	path        string
+	activeDay   string
+	invokedDay  string
+	invokedSeen map[string]struct{}
+}
+
+type cliTelemetryState struct {
+	ActiveDay   string   `json:"active_day"`
+	InvokedDay  string   `json:"invoked_day"`
+	InvokedSeen []string `json:"invoked_seen"`
+}
+
+func newCLITelemetryReservoir(dataDir string) *cliTelemetryReservoir {
+	r := &cliTelemetryReservoir{
+		invokedSeen: make(map[string]struct{}),
+	}
+	if dataDir != "" {
+		r.path = filepath.Join(dataDir, cliTelemetryStateFile)
+		r.load()
+	}
+	return r
+}
+
+func (r *cliTelemetryReservoir) reserveActive(now time.Time) bool {
+	day := telemetryUTCDate(now)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.activeDay == day {
+		return false
+	}
+	r.activeDay = day
+	_ = r.saveLocked()
+	return true
+}
+
+func (r *cliTelemetryReservoir) reserveInvoked(now time.Time, commandPath string) bool {
+	day := telemetryUTCDate(now)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.invokedDay != day {
+		r.invokedDay = day
+		r.invokedSeen = make(map[string]struct{})
+	}
+	if _, seen := r.invokedSeen[commandPath]; seen {
+		return false
+	}
+	r.invokedSeen[commandPath] = struct{}{}
+	_ = r.saveLocked()
+	return true
+}
+
+func telemetryUTCDate(now time.Time) string {
+	return now.UTC().Format("2006-01-02")
+}
+
+func (r *cliTelemetryReservoir) load() {
+	if r.path == "" {
+		return
+	}
+	b, err := os.ReadFile(r.path)
+	if err != nil {
+		return
+	}
+	var st cliTelemetryState
+	if err := json.Unmarshal(b, &st); err != nil {
+		return
+	}
+	r.activeDay = st.ActiveDay
+	r.invokedDay = st.InvokedDay
+	r.invokedSeen = make(map[string]struct{}, len(st.InvokedSeen))
+	for _, commandPath := range st.InvokedSeen {
+		if commandPath != "" {
+			r.invokedSeen[commandPath] = struct{}{}
+		}
+	}
+}
+
+func (r *cliTelemetryReservoir) saveLocked() error {
+	if r.path == "" {
+		return nil
+	}
+	seen := make([]string, 0, len(r.invokedSeen))
+	for commandPath := range r.invokedSeen {
+		seen = append(seen, commandPath)
+	}
+	body, err := json.Marshal(cliTelemetryState{
+		ActiveDay:   r.activeDay,
+		InvokedDay:  r.invokedDay,
+		InvokedSeen: seen,
+	})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(r.path), 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(r.path), ".telemetry-cli-*.json")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, r.path); err != nil {
+		if removeErr := os.Remove(r.path); removeErr != nil && !os.IsNotExist(removeErr) {
+			return err
+		}
+		return os.Rename(tmpName, r.path)
+	}
+	return nil
+}

--- a/backend/internal/httpd/cli_telemetry_reservoir.go
+++ b/backend/internal/httpd/cli_telemetry_reservoir.go
@@ -49,8 +49,9 @@ func (r *cliTelemetryReservoir) reserveActive(now time.Time) bool {
 	return true
 }
 
-func (r *cliTelemetryReservoir) reserveInvoked(now time.Time, commandPath string) bool {
+func (r *cliTelemetryReservoir) reserveInvoked(now time.Time, actorType, commandPath string) bool {
 	day := telemetryUTCDate(now)
+	key := cliInvokedReservationKey(actorType, commandPath)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -58,16 +59,20 @@ func (r *cliTelemetryReservoir) reserveInvoked(now time.Time, commandPath string
 		r.invokedDay = day
 		r.invokedSeen = make(map[string]struct{})
 	}
-	if _, seen := r.invokedSeen[commandPath]; seen {
+	if _, seen := r.invokedSeen[key]; seen {
 		return false
 	}
-	r.invokedSeen[commandPath] = struct{}{}
+	r.invokedSeen[key] = struct{}{}
 	_ = r.saveLocked()
 	return true
 }
 
 func telemetryUTCDate(now time.Time) string {
 	return now.UTC().Format("2006-01-02")
+}
+
+func cliInvokedReservationKey(actorType, commandPath string) string {
+	return actorType + "\t" + commandPath
 }
 
 func (r *cliTelemetryReservoir) load() {

--- a/backend/internal/httpd/cli_telemetry_reservoir.go
+++ b/backend/internal/httpd/cli_telemetry_reservoir.go
@@ -15,18 +15,21 @@ type cliTelemetryReservoir struct {
 
 	path        string
 	activeDay   string
+	activeSlots map[int]struct{}
 	invokedDay  string
 	invokedSeen map[string]struct{}
 }
 
 type cliTelemetryState struct {
 	ActiveDay   string   `json:"active_day"`
+	ActiveSlots []int    `json:"active_slots"`
 	InvokedDay  string   `json:"invoked_day"`
 	InvokedSeen []string `json:"invoked_seen"`
 }
 
 func newCLITelemetryReservoir(dataDir string) *cliTelemetryReservoir {
 	r := &cliTelemetryReservoir{
+		activeSlots: make(map[int]struct{}),
 		invokedSeen: make(map[string]struct{}),
 	}
 	if dataDir != "" {
@@ -38,13 +41,18 @@ func newCLITelemetryReservoir(dataDir string) *cliTelemetryReservoir {
 
 func (r *cliTelemetryReservoir) reserveActive(now time.Time) bool {
 	day := telemetryUTCDate(now)
+	slot := activeCaptureSlot(now)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.activeDay == day {
+	if r.activeDay != day {
+		r.activeDay = day
+		r.activeSlots = make(map[int]struct{})
+	}
+	if _, seen := r.activeSlots[slot]; seen {
 		return false
 	}
-	r.activeDay = day
+	r.activeSlots[slot] = struct{}{}
 	_ = r.saveLocked()
 	return true
 }
@@ -71,6 +79,10 @@ func telemetryUTCDate(now time.Time) string {
 	return now.UTC().Format("2006-01-02")
 }
 
+func activeCaptureSlot(now time.Time) int {
+	return now.UTC().Hour() / 6
+}
+
 func cliInvokedReservationKey(actorType, commandPath string) string {
 	return actorType + "\t" + commandPath
 }
@@ -88,6 +100,15 @@ func (r *cliTelemetryReservoir) load() {
 		return
 	}
 	r.activeDay = st.ActiveDay
+	r.activeSlots = make(map[int]struct{}, len(st.ActiveSlots))
+	for _, slot := range st.ActiveSlots {
+		if slot >= 0 && slot < 4 {
+			r.activeSlots[slot] = struct{}{}
+		}
+	}
+	if r.activeDay != "" && len(r.activeSlots) == 0 {
+		r.activeSlots[0] = struct{}{}
+	}
 	r.invokedDay = st.InvokedDay
 	r.invokedSeen = make(map[string]struct{}, len(st.InvokedSeen))
 	for _, commandPath := range st.InvokedSeen {
@@ -101,12 +122,17 @@ func (r *cliTelemetryReservoir) saveLocked() error {
 	if r.path == "" {
 		return nil
 	}
+	activeSlots := make([]int, 0, len(r.activeSlots))
+	for slot := range r.activeSlots {
+		activeSlots = append(activeSlots, slot)
+	}
 	seen := make([]string, 0, len(r.invokedSeen))
 	for commandPath := range r.invokedSeen {
 		seen = append(seen, commandPath)
 	}
 	body, err := json.Marshal(cliTelemetryState{
 		ActiveDay:   r.activeDay,
+		ActiveSlots: activeSlots,
 		InvokedDay:  r.invokedDay,
 		InvokedSeen: seen,
 	})

--- a/backend/internal/httpd/cli_telemetry_reservoir_test.go
+++ b/backend/internal/httpd/cli_telemetry_reservoir_test.go
@@ -13,7 +13,7 @@ func TestCLITelemetryReservoirPersistsDailyReservations(t *testing.T) {
 	if !first.reserveActive(now) {
 		t.Fatal("first active reservation = false, want true")
 	}
-	if !first.reserveInvoked(now, "ao status") {
+	if !first.reserveInvoked(now, "user", "ao status") {
 		t.Fatal("first invoked reservation = false, want true")
 	}
 
@@ -21,10 +21,13 @@ func TestCLITelemetryReservoirPersistsDailyReservations(t *testing.T) {
 	if second.reserveActive(now) {
 		t.Fatal("active reservation after reload = true, want false")
 	}
-	if second.reserveInvoked(now, "ao status") {
+	if second.reserveInvoked(now, "user", "ao status") {
 		t.Fatal("invoked reservation after reload = true, want false")
 	}
-	if !second.reserveInvoked(now, "ao session ls") {
+	if !second.reserveInvoked(now, "agent", "ao status") {
+		t.Fatal("same command with different actor after reload = false, want true")
+	}
+	if !second.reserveInvoked(now, "user", "ao session ls") {
 		t.Fatal("new command reservation after reload = false, want true")
 	}
 }
@@ -35,13 +38,13 @@ func TestCLITelemetryReservoirResetsOnNewUTCDay(t *testing.T) {
 	secondDay := time.Date(2026, 7, 21, 0, 1, 0, 0, time.UTC)
 
 	r := newCLITelemetryReservoir(dir)
-	if !r.reserveActive(firstDay) || !r.reserveInvoked(firstDay, "ao status") {
+	if !r.reserveActive(firstDay) || !r.reserveInvoked(firstDay, "user", "ao status") {
 		t.Fatal("initial reservations failed")
 	}
 	if !r.reserveActive(secondDay) {
 		t.Fatal("active reservation on new UTC day = false, want true")
 	}
-	if !r.reserveInvoked(secondDay, "ao status") {
+	if !r.reserveInvoked(secondDay, "user", "ao status") {
 		t.Fatal("invoked reservation on new UTC day = false, want true")
 	}
 }

--- a/backend/internal/httpd/cli_telemetry_reservoir_test.go
+++ b/backend/internal/httpd/cli_telemetry_reservoir_test.go
@@ -19,7 +19,7 @@ func TestCLITelemetryReservoirPersistsDailyReservations(t *testing.T) {
 
 	second := newCLITelemetryReservoir(dir)
 	if second.reserveActive(now) {
-		t.Fatal("active reservation after reload = true, want false")
+		t.Fatal("active reservation in same slot after reload = true, want false")
 	}
 	if second.reserveInvoked(now, "user", "ao status") {
 		t.Fatal("invoked reservation after reload = true, want false")
@@ -46,5 +46,29 @@ func TestCLITelemetryReservoirResetsOnNewUTCDay(t *testing.T) {
 	}
 	if !r.reserveInvoked(secondDay, "user", "ao status") {
 		t.Fatal("invoked reservation on new UTC day = false, want true")
+	}
+}
+
+func TestCLITelemetryReservoirActiveReservationsUseSixHourSlots(t *testing.T) {
+	dir := t.TempDir()
+	r := newCLITelemetryReservoir(dir)
+
+	if !r.reserveActive(time.Date(2026, 7, 20, 0, 1, 0, 0, time.UTC)) {
+		t.Fatal("slot 0 reservation = false, want true")
+	}
+	if r.reserveActive(time.Date(2026, 7, 20, 5, 59, 0, 0, time.UTC)) {
+		t.Fatal("duplicate slot 0 reservation = true, want false")
+	}
+	if !r.reserveActive(time.Date(2026, 7, 20, 6, 0, 0, 0, time.UTC)) {
+		t.Fatal("slot 1 reservation = false, want true")
+	}
+	if !r.reserveActive(time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)) {
+		t.Fatal("slot 2 reservation = false, want true")
+	}
+	if !r.reserveActive(time.Date(2026, 7, 20, 18, 0, 0, 0, time.UTC)) {
+		t.Fatal("slot 3 reservation = false, want true")
+	}
+	if r.reserveActive(time.Date(2026, 7, 20, 23, 59, 0, 0, time.UTC)) {
+		t.Fatal("duplicate slot 3 reservation = true, want false")
 	}
 }

--- a/backend/internal/httpd/cli_telemetry_reservoir_test.go
+++ b/backend/internal/httpd/cli_telemetry_reservoir_test.go
@@ -1,0 +1,47 @@
+package httpd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCLITelemetryReservoirPersistsDailyReservations(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+
+	first := newCLITelemetryReservoir(dir)
+	if !first.reserveActive(now) {
+		t.Fatal("first active reservation = false, want true")
+	}
+	if !first.reserveInvoked(now, "ao status") {
+		t.Fatal("first invoked reservation = false, want true")
+	}
+
+	second := newCLITelemetryReservoir(dir)
+	if second.reserveActive(now) {
+		t.Fatal("active reservation after reload = true, want false")
+	}
+	if second.reserveInvoked(now, "ao status") {
+		t.Fatal("invoked reservation after reload = true, want false")
+	}
+	if !second.reserveInvoked(now, "ao session ls") {
+		t.Fatal("new command reservation after reload = false, want true")
+	}
+}
+
+func TestCLITelemetryReservoirResetsOnNewUTCDay(t *testing.T) {
+	dir := t.TempDir()
+	firstDay := time.Date(2026, 7, 20, 23, 59, 0, 0, time.UTC)
+	secondDay := time.Date(2026, 7, 21, 0, 1, 0, 0, time.UTC)
+
+	r := newCLITelemetryReservoir(dir)
+	if !r.reserveActive(firstDay) || !r.reserveInvoked(firstDay, "ao status") {
+		t.Fatal("initial reservations failed")
+	}
+	if !r.reserveActive(secondDay) {
+		t.Fatal("active reservation on new UTC day = false, want true")
+	}
+	if !r.reserveInvoked(secondDay, "ao status") {
+		t.Fatal("invoked reservation on new UTC day = false, want true")
+	}
+}

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -189,7 +189,7 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 			return
 		}
 
-		if now := time.Now(); cliTelemetry.reserveInvoked(now, body.CommandPath) {
+		if now := time.Now(); cliTelemetry.reserveInvoked(now, actorType, body.CommandPath) {
 			sink.Emit(req.Context(), ports.TelemetryEvent{
 				Name:       "ao.cli.invoked",
 				Source:     "cli",

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -154,14 +154,14 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 	if sink == nil {
 		return
 	}
-	// CLI telemetry is capped to daily uniques: ao.app.active once per UTC day
-	// (matching the renderer heartbeat) and ao.cli.invoked once per command
-	// path per UTC day. Scripts and agent sessions invoke read-only commands
-	// (status, ls, get) in polling loops, so raw invocation counts measure
-	// automation, not usage; daily uniques keep the "which commands, how many
-	// users" signal without the firehose. The reservation state is persisted
-	// under DataDir so daemon restarts cannot turn polling loops back into raw
-	// event volume.
+	// CLI telemetry is capped to bounded uniques: ao.app.active once per UTC
+	// six-hour slot for user-context CLI activity (matching the renderer
+	// heartbeat) and ao.cli.invoked once per actor type + command path per UTC
+	// day. Scripts and agent sessions invoke read-only commands (status, ls,
+	// get) in polling loops, so raw invocation counts measure automation, not
+	// usage; bounded uniques keep the "which commands, how many users" signal
+	// without the firehose. The reservation state is persisted under DataDir so
+	// daemon restarts cannot turn polling loops back into raw event volume.
 	cliTelemetry := newCLITelemetryReservoir(cfg.DataDir)
 	r.Post("/internal/telemetry/cli-invoked", func(w http.ResponseWriter, req *http.Request) {
 		if !localControlRequest(req) {

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -141,6 +141,7 @@ func mountMobile(r chi.Router, c *controllers.MobileController) {
 type cliInvokedRequest struct {
 	Command     string `json:"command"`
 	CommandPath string `json:"commandPath"`
+	ActorType   string `json:"actorType"`
 }
 
 type cliUsageErrorRequest struct {
@@ -182,6 +183,11 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 			envelope.WriteAPIError(w, req, http.StatusBadRequest, "bad_request", "COMMAND_PATH_REQUIRED", "commandPath is required", nil)
 			return
 		}
+		actorType := cliActorType(body.ActorType, body.CommandPath)
+		if actorType == "system" {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
 
 		if now := time.Now(); cliTelemetry.reserveInvoked(now, body.CommandPath) {
 			sink.Emit(req.Context(), ports.TelemetryEvent{
@@ -193,22 +199,26 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 				Payload: map[string]any{
 					"command":      body.Command,
 					"command_path": body.CommandPath,
+					"actor_type":   actorType,
 				},
 			})
 		}
-		if now := time.Now(); cliTelemetry.reserveActive(now) {
-			sink.Emit(req.Context(), ports.TelemetryEvent{
-				Name:       "ao.app.active",
-				Source:     "cli",
-				OccurredAt: now.UTC(),
-				Level:      ports.TelemetryLevelInfo,
-				RequestID:  middleware.GetReqID(req.Context()),
-				Payload: map[string]any{
-					"channel":      "cli",
-					"command":      body.Command,
-					"command_path": body.CommandPath,
-				},
-			})
+		if actorType == "user" {
+			if now := time.Now(); cliTelemetry.reserveActive(now) {
+				sink.Emit(req.Context(), ports.TelemetryEvent{
+					Name:       "ao.app.active",
+					Source:     "cli",
+					OccurredAt: now.UTC(),
+					Level:      ports.TelemetryLevelInfo,
+					RequestID:  middleware.GetReqID(req.Context()),
+					Payload: map[string]any{
+						"channel":      "cli",
+						"command":      body.Command,
+						"command_path": body.CommandPath,
+						"actor_type":   actorType,
+					},
+				})
+			}
 		}
 		w.WriteHeader(http.StatusAccepted)
 	})
@@ -250,6 +260,23 @@ func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 		})
 		w.WriteHeader(http.StatusAccepted)
 	})
+}
+
+func cliActorType(actorType, commandPath string) string {
+	switch actorType {
+	case "agent", "user":
+		return actorType
+	case "system":
+		return "system"
+	}
+	switch commandPath {
+	case "ao hooks":
+		return "agent"
+	case "ao daemon", "ao start", "ao completion", "ao help", "ao pty-host":
+		return "system"
+	default:
+		return "user"
+	}
 }
 
 // localControlRequest reports whether a control request is a trusted local

--- a/backend/internal/httpd/router.go
+++ b/backend/internal/httpd/router.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -65,7 +64,7 @@ func NewRouterWithControl(cfg config.Config, log *slog.Logger, termMgr *terminal
 	mountHealth(r, cfg)
 	mountTerminalMux(r, termMgr, log)
 	mountControl(r, control)
-	mountTelemetry(r, deps.Telemetry)
+	mountTelemetry(r, cfg, deps.Telemetry)
 	mountMobile(r, deps.Mobile)
 	api.Register(r)
 
@@ -150,7 +149,7 @@ type cliUsageErrorRequest struct {
 	Error       string `json:"error"`
 }
 
-func mountTelemetry(r chi.Router, sink ports.EventSink) {
+func mountTelemetry(r chi.Router, cfg config.Config, sink ports.EventSink) {
 	if sink == nil {
 		return
 	}
@@ -159,38 +158,10 @@ func mountTelemetry(r chi.Router, sink ports.EventSink) {
 	// path per UTC day. Scripts and agent sessions invoke read-only commands
 	// (status, ls, get) in polling loops, so raw invocation counts measure
 	// automation, not usage; daily uniques keep the "which commands, how many
-	// users" signal without the firehose. In-memory state: a daemon restart may
-	// re-emit once that day, which dashboards dedupe by distinct ID anyway.
-	var (
-		cliTelemetryMu sync.Mutex
-		cliActiveDay   string
-		cliInvokedDay  string
-		cliInvokedSeen map[string]struct{}
-	)
-	reserveCLIActive := func(now time.Time) bool {
-		day := now.UTC().Format("2006-01-02")
-		cliTelemetryMu.Lock()
-		defer cliTelemetryMu.Unlock()
-		if cliActiveDay == day {
-			return false
-		}
-		cliActiveDay = day
-		return true
-	}
-	reserveCLIInvoked := func(now time.Time, commandPath string) bool {
-		day := now.UTC().Format("2006-01-02")
-		cliTelemetryMu.Lock()
-		defer cliTelemetryMu.Unlock()
-		if cliInvokedDay != day {
-			cliInvokedDay = day
-			cliInvokedSeen = make(map[string]struct{})
-		}
-		if _, seen := cliInvokedSeen[commandPath]; seen {
-			return false
-		}
-		cliInvokedSeen[commandPath] = struct{}{}
-		return true
-	}
+	// users" signal without the firehose. The reservation state is persisted
+	// under DataDir so daemon restarts cannot turn polling loops back into raw
+	// event volume.
+	cliTelemetry := newCLITelemetryReservoir(cfg.DataDir)
 	r.Post("/internal/telemetry/cli-invoked", func(w http.ResponseWriter, req *http.Request) {
 		if !localControlRequest(req) {
 			envelope.WriteJSON(w, http.StatusForbidden, map[string]any{
@@ -212,7 +183,7 @@ func mountTelemetry(r chi.Router, sink ports.EventSink) {
 			return
 		}
 
-		if now := time.Now(); reserveCLIInvoked(now, body.CommandPath) {
+		if now := time.Now(); cliTelemetry.reserveInvoked(now, body.CommandPath) {
 			sink.Emit(req.Context(), ports.TelemetryEvent{
 				Name:       "ao.cli.invoked",
 				Source:     "cli",
@@ -225,7 +196,7 @@ func mountTelemetry(r chi.Router, sink ports.EventSink) {
 				},
 			})
 		}
-		if now := time.Now(); reserveCLIActive(now) {
+		if now := time.Now(); cliTelemetry.reserveActive(now) {
 			sink.Emit(req.Context(), ports.TelemetryEvent{
 				Name:       "ao.app.active",
 				Source:     "cli",

--- a/backend/internal/httpd/telemetry_test.go
+++ b/backend/internal/httpd/telemetry_test.go
@@ -114,6 +114,40 @@ func TestCLIInvokedRouteSeparatesAgentAndSystemInvocationsFromActiveUsers(t *tes
 	}
 }
 
+func TestCLIInvokedRouteDedupeIncludesActorType(t *testing.T) {
+	sink := &captureSink{}
+	r := NewRouterWithControl(config.Config{DataDir: t.TempDir()}, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
+
+	postInvoked := func(body string) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/internal/telemetry/cli-invoked", strings.NewReader(body))
+		req.Host = "127.0.0.1:3001"
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202", rec.Code)
+		}
+	}
+
+	postInvoked(`{"command":"ls","commandPath":"ao session ls","actorType":"agent"}`)
+	postInvoked(`{"command":"ls","commandPath":"ao session ls","actorType":"agent"}`)
+	if len(sink.events) != 1 {
+		t.Fatalf("events after repeated agent command = %d, want 1", len(sink.events))
+	}
+
+	postInvoked(`{"command":"ls","commandPath":"ao session ls","actorType":"user"}`)
+	if len(sink.events) != 3 {
+		t.Fatalf("events after same user command = %d, want 3", len(sink.events))
+	}
+	if sink.events[1].Name != "ao.cli.invoked" || sink.events[1].Payload["actor_type"] != "user" {
+		t.Fatalf("second emitted event = %#v, want user ao.cli.invoked", sink.events[1])
+	}
+	if sink.events[2].Name != "ao.app.active" {
+		t.Fatalf("third emitted event = %#v, want ao.app.active", sink.events[2])
+	}
+}
+
 func TestCLIInvokedRouteRequiresLoopback(t *testing.T) {
 	sink := &captureSink{}
 	r := NewRouterWithControl(config.Config{DataDir: t.TempDir()}, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})

--- a/backend/internal/httpd/telemetry_test.go
+++ b/backend/internal/httpd/telemetry_test.go
@@ -38,6 +38,9 @@ func TestCLIInvokedRouteEmitsTelemetry(t *testing.T) {
 	if got := sink.events[0].Payload["command_path"]; got != "ao status" {
 		t.Fatalf("command_path = %#v, want ao status", got)
 	}
+	if got := sink.events[0].Payload["actor_type"]; got != "user" {
+		t.Fatalf("actor_type = %#v, want user", got)
+	}
 	if sink.events[1].Name != "ao.app.active" {
 		t.Fatalf("second event name = %q, want ao.app.active", sink.events[1].Name)
 	}
@@ -64,6 +67,50 @@ func TestCLIInvokedRouteEmitsTelemetry(t *testing.T) {
 	}
 	if got := sink.events[2].Payload["command_path"]; got != "ao session ls" {
 		t.Fatalf("command_path = %#v, want ao session ls", got)
+	}
+}
+
+func TestCLIInvokedRouteSeparatesAgentAndSystemInvocationsFromActiveUsers(t *testing.T) {
+	sink := &captureSink{}
+	r := NewRouterWithControl(config.Config{DataDir: t.TempDir()}, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
+
+	postInvoked := func(body string) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/internal/telemetry/cli-invoked", strings.NewReader(body))
+		req.Host = "127.0.0.1:3001"
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202", rec.Code)
+		}
+	}
+
+	// Older CLIs do not send actorType, so the daemon infers ao hooks as agent
+	// activity and keeps it out of ao.app.active.
+	postInvoked(`{"command":"hooks","commandPath":"ao hooks"}`)
+	if len(sink.events) != 1 {
+		t.Fatalf("events after hooks = %d, want 1", len(sink.events))
+	}
+	if sink.events[0].Name != "ao.cli.invoked" || sink.events[0].Payload["actor_type"] != "agent" {
+		t.Fatalf("hooks event = %#v, want agent ao.cli.invoked", sink.events[0])
+	}
+
+	// Newer CLIs mark any command run inside an AO-managed agent session as
+	// agent-context, even if it is not the hooks subcommand.
+	postInvoked(`{"command":"ls","commandPath":"ao session ls","actorType":"agent"}`)
+	if len(sink.events) != 2 {
+		t.Fatalf("events after agent session ls = %d, want 2", len(sink.events))
+	}
+	if sink.events[1].Payload["actor_type"] != "agent" {
+		t.Fatalf("agent session ls actor_type = %#v, want agent", sink.events[1].Payload["actor_type"])
+	}
+
+	// Internal runtime hosts are system background processes and should not
+	// emit CLI usage or active-user telemetry at all.
+	postInvoked(`{"command":"pty-host","commandPath":"ao pty-host"}`)
+	if len(sink.events) != 2 {
+		t.Fatalf("events after pty-host = %d, want 2", len(sink.events))
 	}
 }
 

--- a/backend/internal/httpd/telemetry_test.go
+++ b/backend/internal/httpd/telemetry_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCLIInvokedRouteEmitsTelemetry(t *testing.T) {
 	sink := &captureSink{}
-	r := NewRouterWithControl(config.Config{}, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
+	r := NewRouterWithControl(config.Config{DataDir: t.TempDir()}, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
 
 	postInvoked := func(command, commandPath string) {
 		t.Helper()
@@ -69,7 +69,7 @@ func TestCLIInvokedRouteEmitsTelemetry(t *testing.T) {
 
 func TestCLIInvokedRouteRequiresLoopback(t *testing.T) {
 	sink := &captureSink{}
-	r := NewRouterWithControl(config.Config{}, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
+	r := NewRouterWithControl(config.Config{DataDir: t.TempDir()}, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
 
 	req := httptest.NewRequest(http.MethodPost, "http://evil.example/internal/telemetry/cli-invoked", strings.NewReader(`{"command":"status","commandPath":"ao status"}`))
 	req.Host = "evil.example"
@@ -87,7 +87,7 @@ func TestCLIInvokedRouteRequiresLoopback(t *testing.T) {
 func TestCLIUsageErrorRouteEmitsTelemetry(t *testing.T) {
 	sink := &captureSink{}
 	r := chi.NewRouter()
-	mountTelemetry(r, sink)
+	mountTelemetry(r, config.Config{DataDir: t.TempDir()}, sink)
 
 	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/internal/telemetry/cli-usage-error", strings.NewReader(`{"command":"status","commandPath":"ao status","error":"too many args"}`))
 	rec := httptest.NewRecorder()
@@ -117,6 +117,45 @@ func TestCLIUsageErrorRouteEmitsTelemetry(t *testing.T) {
 	}
 	if _, ok := payload["error"]; ok {
 		t.Fatalf("payload leaked raw error text: %#v", payload)
+	}
+}
+
+func TestCLIInvokedRoutePersistsDailyReservationsAcrossRouterRestart(t *testing.T) {
+	dataDir := t.TempDir()
+	sink := &captureSink{}
+	cfg := config.Config{DataDir: dataDir}
+
+	postInvoked := func(r http.Handler, command, commandPath string) {
+		t.Helper()
+		body := `{"command":"` + command + `","commandPath":"` + commandPath + `"}`
+		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/internal/telemetry/cli-invoked", strings.NewReader(body))
+		req.Host = "127.0.0.1:3001"
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202", rec.Code)
+		}
+	}
+
+	r1 := NewRouterWithControl(cfg, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
+	postInvoked(r1, "status", "ao status")
+	if len(sink.events) != 2 {
+		t.Fatalf("events after first invocation = %d, want 2", len(sink.events))
+	}
+
+	r2 := NewRouterWithControl(cfg, discardLogger(), nil, APIDeps{Telemetry: sink}, ControlDeps{})
+	postInvoked(r2, "status", "ao status")
+	if len(sink.events) != 2 {
+		t.Fatalf("events after router restart repeat = %d, want 2", len(sink.events))
+	}
+
+	postInvoked(r2, "ls", "ao session ls")
+	if len(sink.events) != 3 {
+		t.Fatalf("events after router restart new command = %d, want 3", len(sink.events))
+	}
+	if sink.events[2].Name != "ao.cli.invoked" {
+		t.Fatalf("third event name = %q, want ao.cli.invoked", sink.events[2].Name)
 	}
 }
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -59,10 +59,10 @@ false`; the renderer never calls `identify()`). The install ID still
 deduplicates unique-user counts, but no person profiles are created — person
 properties and person-property cohorts are intentionally unavailable.
 
-`ao.cli.invoked` is capped at once per command path per UTC day per install, so
-script- or agent-driven polling (`ao status`, `ao session ls`, `ao hooks`
-firing on every agent hook event, ...) reports as "this install used this
-command today" rather than one event per call. Commands that never reflect
+`ao.cli.invoked` is capped at once per actor type and command path per UTC day
+per install, so script- or agent-driven polling (`ao status`, `ao session ls`,
+`ao hooks` firing on every agent hook event, ...) reports as "this install used
+this command today" rather than one event per call. Commands that never reflect
 product activity — the supervisor-driven `ao daemon`/`ao start`, the
 self-documenting `ao completion`/`ao help`, and the internal Windows
 `ao pty-host` runtime host — are excluded outright.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -7,8 +7,8 @@ telemetry is enabled.
 
 ## What is collected
 
-- App activation events: `ao.app.active` from the renderer and CLI, each capped
-  at once per UTC day per install
+- App activation events: `ao.app.active` from the renderer and user-context
+  CLI, each capped at once per UTC day per install
 - Renderer load and daily route-surface usage, grouped by coarse surface names
 - Project/task/session UI actions, with project identifiers SHA-256 hashed
 - Renderer exceptions, reduced to error name and coarse context
@@ -62,20 +62,65 @@ properties and person-property cohorts are intentionally unavailable.
 `ao.cli.invoked` is capped at once per command path per UTC day per install, so
 script- or agent-driven polling (`ao status`, `ao session ls`, `ao hooks`
 firing on every agent hook event, ...) reports as "this install used this
-command today" rather than one event per call. Only commands that never
-reflect activity — the supervisor-driven `ao daemon`/`ao start` and the
-self-documenting `ao completion`/`ao help` — are excluded outright. `ao hooks`
-and `ao pty-host` are deliberately NOT excluded: on a headless or CLI-only
-install, agent hook activity may be the only signal that install did anything
-that day, and excluding it would silently zero out `ao.app.active` (and DAU)
-for that install. The per-command daily cap, not exclusion, is what keeps
-their invocation frequency off PostHog. The CLI reservation state is persisted
-under the AO data dir so a daemon restart does not re-emit every polling
-command for the same day.
+command today" rather than one event per call. Commands that never reflect
+product activity — the supervisor-driven `ao daemon`/`ao start`, the
+self-documenting `ao completion`/`ao help`, and the internal Windows
+`ao pty-host` runtime host — are excluded outright.
+
+CLI invocations are classified by actor:
+
+- `actor_type=user`: a user-context CLI command. These can refresh CLI-channel
+  `ao.app.active`.
+- `actor_type=agent`: `ao hooks` and commands run inside an AO-managed agent
+  session (`AO_SESSION_ID` is set). These are useful agent-activity signal but
+  do not refresh `ao.app.active`, because agents can keep running after the
+  human has stopped actively using AO.
+- `actor_type=system`: supervisor/runtime background processes. These are not
+  sent as CLI usage.
+
+The per-command daily cap keeps invocation frequency off PostHog, and the CLI
+reservation state is persisted under the AO data dir so a daemon restart does
+not re-emit every polling command for the same day.
 
 `ao.renderer.route_viewed` is capped at once per coarse surface per UTC day per
 renderer install. This preserves surface adoption and retention signal while
 dropping repeated navigation churn inside the same surface.
+
+## Product Metrics Model
+
+AO currently has a stable install ID, not a signed-in account user ID. That
+means today's DAU/MAU can accurately represent active installs, but not unique
+people across multiple machines. True user-level new/churn/journey metrics
+require an explicit stable user identity from a login, license, or workspace
+account system. That identity should be sent as a first-party AO user ID (or a
+one-way hash of it) only when the user has authenticated or explicitly enabled
+account-level telemetry; it should not be inferred from machine fingerprints,
+paths, git remotes, emails in repo config, or other local data.
+
+The minimum signals for accurate usage analytics are:
+
+- `ao.app.active`: one event per UTC day per install/account when a human uses
+  the desktop app or runs a user-context CLI command. This powers DAU, WAU, MAU,
+  retention, and churn.
+- `ao.projects.created` and `ao.onboarding.first_project_added`: activation
+  funnel from install to first project.
+- `ao.session.spawned`, `ao.session.spawn_failed`, and
+  `ao.onboarding.first_session_spawned`: activation funnel from project to
+  first running agent, plus spawn reliability.
+- `ao.cli.invoked` with `actor_type=user|agent`: command adoption by actor,
+  capped by command/install/day. Agent-context command usage is product signal,
+  but should be analyzed separately from active-user counts.
+- `ao.session.waiting_input_entered/exited`: whether agents are making progress
+  or waiting on the human, with dwell time.
+- Renderer and daemon error/crash events: reliability and support signal.
+
+Signals that should not drive active-user metrics:
+
+- Internal runtime hosts such as `ao pty-host`.
+- Supervisor startup/control commands such as `ao daemon` and `ao start`.
+- Agent hook callbacks and other CLI commands run with `AO_SESSION_ID`, except
+  as separate agent-activity or command-adoption metrics.
+- Raw polling frequency for read-only state commands.
 
 ## Volume Investigation: 2026-07-21
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -56,9 +56,14 @@ the same 5-per-minute / 200-per-day shape to its own event and exception
 capture path, without the aggregation step.
 
 All events are sent as PostHog anonymous events (`$process_person_profile:
-false`; the renderer never calls `identify()`). The install ID still
-deduplicates unique-user counts, but no person profiles are created — person
-properties and person-property cohorts are intentionally unavailable.
+false`; the renderer never calls `identify()`). The renderer keeps PostHog SDK
+persistence in memory, disables person profiles, and explicitly bootstraps the
+AO install ID as anonymous. This prevents legacy PostHog state from restoring
+an identified user or replacing the stable AO device ID after an upgrade. The
+install ID still deduplicates unique-user counts, but no person profiles are
+created — person properties and person-property cohorts are intentionally
+unavailable. AO's heartbeat and route reservations continue to use their own
+sanitized `localStorage` keys independently of PostHog SDK persistence.
 
 `ao.cli.invoked` is capped at once per actor type and command path per UTC day
 per install, so script- or agent-driven polling (`ao status`, `ao session ls`,
@@ -103,7 +108,9 @@ The minimum signals for accurate usage analytics are:
 - `ao.app.active`: up to one event per six-hour UTC slot per install/account
   when a human uses the desktop app or runs a user-context CLI command. This
   powers DAU, WAU, MAU, retention, and churn while keeping arbitrary rolling
-  windows from undercounting long-running usage.
+  windows from undercounting long-running usage. Renderer active events are
+  sent immediately; a slot is released for retry when the SDK rejects or
+  throws while capturing the event.
 - `ao.projects.created` and `ao.onboarding.first_project_added`: activation
   funnel from install to first project.
 - `ao.session.spawned`, `ao.session.spawn_failed`, and
@@ -194,7 +201,8 @@ On first run, a random install identifier is generated and stored at
 `~/.ao/data/telemetry_install_id` (or `$AO_DATA_DIR/telemetry_install_id`). The
 renderer and daemon both use this ID as the PostHog distinct ID so activity is
 deduplicated across app launches and CLI invocations. It is not linked to any
-personal account.
+personal account. In the renderer it is also the PostHog device ID, and the SDK
+is explicitly kept in anonymous mode.
 
 ## Configuration
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -82,33 +82,33 @@ dropping repeated navigation churn inside the same surface.
 Read-only HogQL queries against PostHog project `475752` over the trailing
 30-day window found 3,203,364 total events. The dominant event names were:
 
-| Event | Count | Installs | Events/install |
-| --- | ---: | ---: | ---: |
-| `ao.cli.invoked` | 1,508,888 | 870 | 1,734.35 |
-| `ao.app.active` | 1,411,807 | 1,434 | 984.52 |
-| `ao.renderer.route_viewed` | 114,940 | 1,388 | 82.81 |
-| `ao.renderer.api_error` | 18,634 | 662 | 28.15 |
-| `ao.session.waiting_input_entered` | 17,583 | 377 | 46.64 |
-| `$exception` | 16,563 | 681 | 24.32 |
-| `ao.cli.usage_errors` | 15,349 | 215 | 71.39 |
-| `ao.session.waiting_input_exited` | 15,343 | 339 | 45.26 |
-| `$set` | 13,211 | 1,137 | 11.62 |
-| `ao.session.spawned` | 11,439 | 887 | 12.90 |
+| Event                              |     Count | Installs | Events/install |
+| ---------------------------------- | --------: | -------: | -------------: |
+| `ao.cli.invoked`                   | 1,508,888 |      870 |       1,734.35 |
+| `ao.app.active`                    | 1,411,807 |    1,434 |         984.52 |
+| `ao.renderer.route_viewed`         |   114,940 |    1,388 |          82.81 |
+| `ao.renderer.api_error`            |    18,634 |      662 |          28.15 |
+| `ao.session.waiting_input_entered` |    17,583 |      377 |          46.64 |
+| `$exception`                       |    16,563 |      681 |          24.32 |
+| `ao.cli.usage_errors`              |    15,349 |      215 |          71.39 |
+| `ao.session.waiting_input_exited`  |    15,343 |      339 |          45.26 |
+| `$set`                             |    13,211 |    1,137 |          11.62 |
+| `ao.session.spawned`               |    11,439 |      887 |          12.90 |
 
 The top two events were almost entirely CLI-sourced and moved together:
 `ao.cli.invoked` had 1,508,888 events and CLI-channel `ao.app.active` had
 1,403,170 events. The largest command paths were polling/hook paths:
 
-| Command path | `ao.cli.invoked` count | Install-days | Projected events saved by persistent daily cap |
-| --- | ---: | ---: | ---: |
-| `ao hooks` | 589,338 | 1,624 | 587,714 |
-| `ao session ls` | 270,977 | 764 | 270,213 |
-| `ao orchestrator ls` | 236,877 | 177 | 236,700 |
-| `ao status` | 220,436 | 524 | 219,912 |
-| `ao session get` | 75,946 | 603 | 75,343 |
-| `ao project ls` | 40,435 | 462 | 39,973 |
-| `ao project get` | 31,048 | 356 | 30,692 |
-| `ao send` | 19,104 | 536 | 18,568 |
+| Command path         | `ao.cli.invoked` count | Install-days | Projected events saved by persistent daily cap |
+| -------------------- | ---------------------: | -----------: | ---------------------------------------------: |
+| `ao hooks`           |                589,338 |        1,624 |                                        587,714 |
+| `ao session ls`      |                270,977 |          764 |                                        270,213 |
+| `ao orchestrator ls` |                236,877 |          177 |                                        236,700 |
+| `ao status`          |                220,436 |          524 |                                        219,912 |
+| `ao session get`     |                 75,946 |          603 |                                         75,343 |
+| `ao project ls`      |                 40,435 |          462 |                                         39,973 |
+| `ao project get`     |                 31,048 |          356 |                                         30,692 |
+| `ao send`            |                 19,104 |          536 |                                         18,568 |
 
 Using `ao.session.spawned` as the AO-session denominator, the 30-day window had
 11,439 spawned sessions, 131.91 `ao.cli.invoked` events per spawned session,

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -9,7 +9,7 @@ telemetry is enabled.
 
 - App activation events: `ao.app.active` from the renderer and CLI, each capped
   at once per UTC day per install
-- Renderer load and route views, grouped by coarse surface names
+- Renderer load and daily route-surface usage, grouped by coarse surface names
 - Project/task/session UI actions, with project identifiers SHA-256 hashed
 - Renderer exceptions, reduced to error name and coarse context
 - Daemon operational events: CLI invocation, session spawn/failure, waiting-input
@@ -59,7 +59,7 @@ false`; the renderer never calls `identify()`). The install ID still
 deduplicates unique-user counts, but no person profiles are created — person
 properties and person-property cohorts are intentionally unavailable.
 
-`ao.cli.invoked` is capped at once per command path per UTC day per daemon, so
+`ao.cli.invoked` is capped at once per command path per UTC day per install, so
 script- or agent-driven polling (`ao status`, `ao session ls`, `ao hooks`
 firing on every agent hook event, ...) reports as "this install used this
 command today" rather than one event per call. Only commands that never
@@ -69,7 +69,76 @@ and `ao pty-host` are deliberately NOT excluded: on a headless or CLI-only
 install, agent hook activity may be the only signal that install did anything
 that day, and excluding it would silently zero out `ao.app.active` (and DAU)
 for that install. The per-command daily cap, not exclusion, is what keeps
-their invocation frequency off PostHog.
+their invocation frequency off PostHog. The CLI reservation state is persisted
+under the AO data dir so a daemon restart does not re-emit every polling
+command for the same day.
+
+`ao.renderer.route_viewed` is capped at once per coarse surface per UTC day per
+renderer install. This preserves surface adoption and retention signal while
+dropping repeated navigation churn inside the same surface.
+
+## Volume Investigation: 2026-07-21
+
+Read-only HogQL queries against PostHog project `475752` over the trailing
+30-day window found 3,203,364 total events. The dominant event names were:
+
+| Event | Count | Installs | Events/install |
+| --- | ---: | ---: | ---: |
+| `ao.cli.invoked` | 1,508,888 | 870 | 1,734.35 |
+| `ao.app.active` | 1,411,807 | 1,434 | 984.52 |
+| `ao.renderer.route_viewed` | 114,940 | 1,388 | 82.81 |
+| `ao.renderer.api_error` | 18,634 | 662 | 28.15 |
+| `ao.session.waiting_input_entered` | 17,583 | 377 | 46.64 |
+| `$exception` | 16,563 | 681 | 24.32 |
+| `ao.cli.usage_errors` | 15,349 | 215 | 71.39 |
+| `ao.session.waiting_input_exited` | 15,343 | 339 | 45.26 |
+| `$set` | 13,211 | 1,137 | 11.62 |
+| `ao.session.spawned` | 11,439 | 887 | 12.90 |
+
+The top two events were almost entirely CLI-sourced and moved together:
+`ao.cli.invoked` had 1,508,888 events and CLI-channel `ao.app.active` had
+1,403,170 events. The largest command paths were polling/hook paths:
+
+| Command path | `ao.cli.invoked` count | Install-days | Projected events saved by persistent daily cap |
+| --- | ---: | ---: | ---: |
+| `ao hooks` | 589,338 | 1,624 | 587,714 |
+| `ao session ls` | 270,977 | 764 | 270,213 |
+| `ao orchestrator ls` | 236,877 | 177 | 236,700 |
+| `ao status` | 220,436 | 524 | 219,912 |
+| `ao session get` | 75,946 | 603 | 75,343 |
+| `ao project ls` | 40,435 | 462 | 39,973 |
+| `ao project get` | 31,048 | 356 | 30,692 |
+| `ao send` | 19,104 | 536 | 18,568 |
+
+Using `ao.session.spawned` as the AO-session denominator, the 30-day window had
+11,439 spawned sessions, 131.91 `ao.cli.invoked` events per spawned session,
+and 10.05 `ao.renderer.route_viewed` events per spawned session. Looking only
+at renderer/PostHog browser sessions, there were 211,532 renderer SDK events
+across 6,988 PostHog sessions, or 30.27 events per PostHog session. Route
+views were the largest renderer contributor at 17.67 events per PostHog
+session.
+
+Projected 30-day reduction from the implemented changes, using the observed
+install-day cardinalities:
+
+- Persisting the CLI command daily cap: `ao.cli.invoked` drops from 1,508,888
+  to about 8,416 events, saving about 1,500,472 events.
+- Persisting the CLI active daily cap: CLI-channel `ao.app.active` drops from
+  1,403,170 to about 1,877 events, saving about 1,401,293 events.
+- Daily renderer route-surface capping: `ao.renderer.route_viewed` drops from
+  114,940 to about 8,483 events, saving about 106,457 events.
+
+Total projected event-volume savings from those three changes are roughly
+3.0M events per trailing 30 days before adoption effects.
+
+Anonymous-vs-identified check: all events had a `person_id` in HogQL, but the
+event-level profile-processing property showed renderer exceptions as the
+remaining identified-risk path: 16,534 of 16,563 `$exception` events carried
+`$process_person_profile=true`, while only 29 carried `false`. Renderer
+captures now force `$process_person_profile=false` on the event properties, and
+Web Vitals capture is disabled because the 7,017 `$web_vitals` events in the
+window were diagnostic noise rather than activation, feature usage, or
+crash/error signal.
 
 ## Install ID
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -8,7 +8,8 @@ telemetry is enabled.
 ## What is collected
 
 - App activation events: `ao.app.active` from the renderer and user-context
-  CLI, each capped at once per UTC day per install
+  CLI, each capped to one event per six-hour UTC slot, or four per day per
+  install/channel
 - Renderer load and daily route-surface usage, grouped by coarse surface names
 - Project/task/session UI actions, with project identifiers SHA-256 hashed
 - Renderer exceptions, reduced to error name and coarse context
@@ -99,9 +100,10 @@ paths, git remotes, emails in repo config, or other local data.
 
 The minimum signals for accurate usage analytics are:
 
-- `ao.app.active`: one event per UTC day per install/account when a human uses
-  the desktop app or runs a user-context CLI command. This powers DAU, WAU, MAU,
-  retention, and churn.
+- `ao.app.active`: up to one event per six-hour UTC slot per install/account
+  when a human uses the desktop app or runs a user-context CLI command. This
+  powers DAU, WAU, MAU, retention, and churn while keeping arbitrary rolling
+  windows from undercounting long-running usage.
 - `ao.projects.created` and `ao.onboarding.first_project_added`: activation
   funnel from install to first project.
 - `ao.session.spawned`, `ao.session.spawn_failed`, and
@@ -168,12 +170,13 @@ install-day cardinalities:
 
 - Persisting the CLI command daily cap: `ao.cli.invoked` drops from 1,508,888
   to about 8,416 events, saving about 1,500,472 events.
-- Persisting the CLI active daily cap: CLI-channel `ao.app.active` drops from
-  1,403,170 to about 1,877 events, saving about 1,401,293 events.
+- Persisting the CLI active six-hour slot cap: CLI-channel `ao.app.active`
+  drops from 1,403,170 to at most about 7,508 events, saving at least about
+  1,395,662 events.
 - Daily renderer route-surface capping: `ao.renderer.route_viewed` drops from
   114,940 to about 8,483 events, saving about 106,457 events.
 
-Total projected event-volume savings from those three changes are roughly
+Total projected event-volume savings from those three changes are still roughly
 3.0M events per trailing 30 days before adoption effects.
 
 Anonymous-vs-identified check: all events had a `person_id` in HogQL, but the
@@ -222,9 +225,9 @@ Use `ao.app.active` as the active-user event for DAU, weekly retention, and
 country-level active-user maps. AO emits it from:
 
 - `channel=renderer` when the desktop app initializes and at most once per UTC
-  day while the app stays open
+  six-hour slot while the app stays open
 - `channel=cli` when the CLI reports a user-typed command invocation to the
-  local daemon, at most once per UTC day per daemon
+  local daemon, at most once per UTC six-hour slot per install
 
 Recommended PostHog setup:
 

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -59,7 +59,8 @@ describe("telemetry sanitizers", () => {
 			});
 		} finally {
 			const queue = client._requestQueue as unknown as
-				{ _queue: unknown[]; _clearFlushTimeout: () => void } | undefined;
+				| { _queue: unknown[]; _clearFlushTimeout: () => void }
+				| undefined;
 			if (queue) {
 				queue._queue.length = 0;
 				queue._clearFlushTimeout();

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -320,15 +320,19 @@ describe("reserveCapture", () => {
 });
 
 describe("daily active heartbeat", () => {
-	it("reserves one active capture per UTC date", () => {
+	it("reserves one active capture per six-hour UTC slot", () => {
 		const storage = memoryStorage();
 
-		expect(reserveDailyActiveCapture(storage, new Date("2026-07-12T23:59:00.000Z"))).toBe(true);
+		expect(reserveDailyActiveCapture(storage, new Date("2026-07-12T00:05:00.000Z"))).toBe(true);
+		expect(reserveDailyActiveCapture(storage, new Date("2026-07-12T05:59:59.000Z"))).toBe(false);
+		expect(reserveDailyActiveCapture(storage, new Date("2026-07-12T06:00:00.000Z"))).toBe(true);
+		expect(reserveDailyActiveCapture(storage, new Date("2026-07-12T12:00:00.000Z"))).toBe(true);
+		expect(reserveDailyActiveCapture(storage, new Date("2026-07-12T18:00:00.000Z"))).toBe(true);
 		expect(reserveDailyActiveCapture(storage, new Date("2026-07-12T23:59:59.000Z"))).toBe(false);
 		expect(reserveDailyActiveCapture(storage, new Date("2026-07-13T00:00:00.000Z"))).toBe(true);
 	});
 
-	it("emits at startup and then only after a later UTC date is observed on user activity", () => {
+	it("emits at startup and then only after a later UTC slot is observed on user activity", () => {
 		const storage = memoryStorage();
 		const captured: string[] = [];
 		let now = new Date("2026-07-12T08:00:00.000Z");
@@ -347,9 +351,9 @@ describe("daily active heartbeat", () => {
 			document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
 			expect(captured).toHaveLength(1);
 
-			now = new Date("2026-07-13T09:00:00.000Z");
+			now = new Date("2026-07-12T12:00:00.000Z");
 			window.dispatchEvent(new Event("focus"));
-			expect(captured).toEqual(["2026-07-12T08:00:00.000Z", "2026-07-13T09:00:00.000Z"]);
+			expect(captured).toEqual(["2026-07-12T08:00:00.000Z", "2026-07-12T12:00:00.000Z"]);
 		} finally {
 			stop();
 		}

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -39,7 +39,7 @@ describe("telemetry sanitizers", () => {
 	});
 
 	it("forces renderer events to stay anonymous in PostHog", () => {
-		expect(withTelemetryContext({ "$process_person_profile": true })).toMatchObject({
+		expect(withTelemetryContext({ $process_person_profile: true })).toMatchObject({
 			$process_person_profile: false,
 		});
 	});

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -59,8 +59,7 @@ describe("telemetry sanitizers", () => {
 			});
 		} finally {
 			const queue = client._requestQueue as unknown as
-				| { _queue: unknown[]; _clearFlushTimeout: () => void }
-				| undefined;
+				{ _queue: unknown[]; _clearFlushTimeout: () => void } | undefined;
 			if (queue) {
 				queue._queue.length = 0;
 				queue._clearFlushTimeout();

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { PostHog } from "posthog-js/dist/module.full.no-external";
 import {
+	buildPostHogConfig,
 	buildTelemetryContext,
 	reserveCapture,
 	reserveDailyActiveCapture,
@@ -25,6 +27,46 @@ function memoryStorage(initial: Record<string, string> = {}) {
 }
 
 describe("telemetry sanitizers", () => {
+	it("isolates anonymous AO installation identity from persisted PostHog person state", () => {
+		const config = buildPostHogConfig("ins_stable-install-id");
+
+		expect(config.persistence).toBe("memory");
+		expect(config.person_profiles).toBe("never");
+		expect(config.capture_performance).toBe(false);
+		expect(config.bootstrap).toEqual({
+			distinctID: "ins_stable-install-id",
+			isIdentifiedID: false,
+		});
+	});
+
+	it("emits the stable AO installation id without creating a person profile", () => {
+		const client = new PostHog();
+		client.init("phc_test", {
+			...buildPostHogConfig("ins_stable-install-id"),
+			advanced_disable_decide: true,
+			advanced_disable_flags: true,
+			disable_session_recording: true,
+			disable_surveys: true,
+		});
+		try {
+			const captured = client.capture("ao.app.active", { channel: "renderer" });
+
+			expect(captured?.properties).toMatchObject({
+				distinct_id: "ins_stable-install-id",
+				$device_id: "ins_stable-install-id",
+				$is_identified: false,
+				$process_person_profile: false,
+			});
+		} finally {
+			const queue = client._requestQueue as unknown as
+				{ _queue: unknown[]; _clearFlushTimeout: () => void } | undefined;
+			if (queue) {
+				queue._queue.length = 0;
+				queue._clearFlushTimeout();
+			}
+		}
+	});
+
 	it("builds stable AO version context for PostHog events", () => {
 		expect(buildTelemetryContext(" 1.2.3-nightly.20260707 ", "linux")).toMatchObject({
 			app_version: "1.2.3-nightly.20260707",
@@ -340,7 +382,9 @@ describe("daily active heartbeat", () => {
 		const stop = startDailyActiveHeartbeat({
 			storage,
 			now: () => now,
-			capture: () => captured.push(now.toISOString()),
+			capture: () => {
+				captured.push(now.toISOString());
+			},
 			window,
 			document,
 		});
@@ -354,6 +398,32 @@ describe("daily active heartbeat", () => {
 			now = new Date("2026-07-12T12:00:00.000Z");
 			window.dispatchEvent(new Event("focus"));
 			expect(captured).toEqual(["2026-07-12T08:00:00.000Z", "2026-07-12T12:00:00.000Z"]);
+		} finally {
+			stop();
+		}
+	});
+
+	it("retries the same six-hour UTC slot when PostHog rejects the first capture", async () => {
+		const storage = memoryStorage();
+		let attempts = 0;
+		const slotTime = new Date("2026-07-23T08:00:00.000Z");
+		const stop = startDailyActiveHeartbeat({
+			storage,
+			now: () => slotTime,
+			capture: () => {
+				attempts += 1;
+				return attempts > 1;
+			},
+			window,
+			document,
+		});
+		try {
+			await Promise.resolve();
+			window.dispatchEvent(new Event("focus"));
+			await Promise.resolve();
+
+			expect(attempts).toBe(2);
+			expect(reserveDailyActiveCapture(storage, new Date("2026-07-23T09:00:00.000Z"))).toBe(false);
 		} finally {
 			stop();
 		}

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -3,12 +3,14 @@ import {
 	buildTelemetryContext,
 	reserveCapture,
 	reserveDailyActiveCapture,
+	reserveRouteViewCapture,
 	routeSurface,
 	sanitizePostHogEvent,
 	sanitizeReplayRequestName,
 	sanitizeRendererExceptionProperties,
 	sanitizeRendererProperties,
 	startDailyActiveHeartbeat,
+	withTelemetryContext,
 } from "./telemetry";
 import { ORCHESTRATOR_SPAWN_SOURCES } from "./orchestrator-spawn-sources";
 
@@ -33,6 +35,12 @@ describe("telemetry sanitizers", () => {
 			app_version: "unknown",
 			ao_version: "unknown",
 			platform: "darwin",
+		});
+	});
+
+	it("forces renderer events to stay anonymous in PostHog", () => {
+		expect(withTelemetryContext({ "$process_person_profile": true })).toMatchObject({
+			$process_person_profile: false,
 		});
 	});
 
@@ -345,5 +353,16 @@ describe("daily active heartbeat", () => {
 		} finally {
 			stop();
 		}
+	});
+});
+
+describe("route view reservation", () => {
+	it("reserves one capture per surface per UTC date", () => {
+		const storage = memoryStorage();
+
+		expect(reserveRouteViewCapture(storage, "session_detail", new Date("2026-07-12T08:00:00.000Z"))).toBe(true);
+		expect(reserveRouteViewCapture(storage, "session_detail", new Date("2026-07-12T09:00:00.000Z"))).toBe(false);
+		expect(reserveRouteViewCapture(storage, "project_board", new Date("2026-07-12T09:00:00.000Z"))).toBe(true);
+		expect(reserveRouteViewCapture(storage, "session_detail", new Date("2026-07-13T00:00:00.000Z"))).toBe(true);
 	});
 });

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -9,7 +9,7 @@ const POSTHOG_HOST = import.meta.env.VITE_AO_POSTHOG_HOST?.trim() || DEFAULT_POS
 const RELEASE_TAG = "2026-01-30";
 const REDACTED_LOCAL_URL = "[redacted-local-url]";
 const REDACTED_LOCAL_PATH = "[redacted-local-path]";
-const DAILY_ACTIVE_STORAGE_KEY = "ao.telemetry.lastActiveDate";
+const ACTIVE_STORAGE_KEY = "ao.telemetry.activeSlotsByDate";
 const ROUTE_VIEW_STORAGE_KEY = "ao.telemetry.routeViewsByDate";
 const EMBEDDED_LOCAL_URL_PATTERN =
 	/(?:\bfile:\/\/\/\S+|\bapp:\/\/renderer\/\S+|\bhttps?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?\S*)/gi;
@@ -17,7 +17,8 @@ const EMBEDDED_LOCAL_URL_PATTERN =
 let initPromise: Promise<boolean> | null = null;
 let errorHandlersBound = false;
 let telemetryContext: TelemetryProperties = {};
-let fallbackDailyActiveDate = "";
+let fallbackActiveDate = "";
+let fallbackActiveSlots = new Set<number>();
 let fallbackRouteViewDate = "";
 let fallbackRouteViewSurfaces = new Set<string>();
 
@@ -87,20 +88,36 @@ export function withTelemetryContext(properties: TelemetryProperties): Telemetry
 
 export function reserveDailyActiveCapture(storage?: DailyActiveStorage, now = new Date()): boolean {
 	const utcDate = now.toISOString().slice(0, 10);
-	if (!storage) {
-		if (fallbackDailyActiveDate === utcDate) return false;
-		fallbackDailyActiveDate = utcDate;
+	const slot = activeCaptureSlot(now);
+	const reserveFallback = () => {
+		if (fallbackActiveDate !== utcDate) {
+			fallbackActiveDate = utcDate;
+			fallbackActiveSlots = new Set<number>();
+		}
+		if (fallbackActiveSlots.has(slot)) return false;
+		fallbackActiveSlots.add(slot);
 		return true;
-	}
+	};
+
+	if (!storage) return reserveFallback();
 	try {
-		if (storage.getItem(DAILY_ACTIVE_STORAGE_KEY) === utcDate) return false;
-		storage.setItem(DAILY_ACTIVE_STORAGE_KEY, utcDate);
+		const raw = storage.getItem(ACTIVE_STORAGE_KEY);
+		const parsed = raw ? (JSON.parse(raw) as { date?: unknown; slots?: unknown }) : {};
+		const slots =
+			parsed.date === utcDate && Array.isArray(parsed.slots)
+				? parsed.slots.filter((value): value is number => Number.isInteger(value) && value >= 0 && value < 4)
+				: [];
+		if (slots.includes(slot)) return false;
+		slots.push(slot);
+		storage.setItem(ACTIVE_STORAGE_KEY, JSON.stringify({ date: utcDate, slots }));
 		return true;
 	} catch {
-		if (fallbackDailyActiveDate === utcDate) return false;
-		fallbackDailyActiveDate = utcDate;
-		return true;
+		return reserveFallback();
 	}
+}
+
+function activeCaptureSlot(now: Date): number {
+	return Math.floor(now.getUTCHours() / 6);
 }
 
 export function reserveRouteViewCapture(

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -10,6 +10,7 @@ const RELEASE_TAG = "2026-01-30";
 const REDACTED_LOCAL_URL = "[redacted-local-url]";
 const REDACTED_LOCAL_PATH = "[redacted-local-path]";
 const DAILY_ACTIVE_STORAGE_KEY = "ao.telemetry.lastActiveDate";
+const ROUTE_VIEW_STORAGE_KEY = "ao.telemetry.routeViewsByDate";
 const EMBEDDED_LOCAL_URL_PATTERN =
 	/(?:\bfile:\/\/\/\S+|\bapp:\/\/renderer\/\S+|\bhttps?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?\S*)/gi;
 
@@ -17,6 +18,8 @@ let initPromise: Promise<boolean> | null = null;
 let errorHandlersBound = false;
 let telemetryContext: TelemetryProperties = {};
 let fallbackDailyActiveDate = "";
+let fallbackRouteViewDate = "";
+let fallbackRouteViewSurfaces = new Set<string>();
 
 // Bounds how many captures of a single event (or exception) name reach
 // PostHog. Mirrors the daemon-side RateLimitedSink: a re-render loop or
@@ -78,8 +81,8 @@ export function buildTelemetryContext(appVersion: string, platform: string): Tel
 	};
 }
 
-function withTelemetryContext(properties: TelemetryProperties): TelemetryProperties {
-	return { ...telemetryContext, ...properties };
+export function withTelemetryContext(properties: TelemetryProperties): TelemetryProperties {
+	return { ...telemetryContext, ...properties, $process_person_profile: false };
 }
 
 export function reserveDailyActiveCapture(storage?: DailyActiveStorage, now = new Date()): boolean {
@@ -97,6 +100,48 @@ export function reserveDailyActiveCapture(storage?: DailyActiveStorage, now = ne
 		if (fallbackDailyActiveDate === utcDate) return false;
 		fallbackDailyActiveDate = utcDate;
 		return true;
+	}
+}
+
+export function reserveRouteViewCapture(
+	storage: DailyActiveStorage | undefined,
+	surface: string,
+	now = new Date(),
+): boolean {
+	const normalizedSurface = surface.trim() || "unknown";
+	const utcDate = now.toISOString().slice(0, 10);
+	const reserveFallback = () => {
+		if (fallbackRouteViewDate !== utcDate) {
+			fallbackRouteViewDate = utcDate;
+			fallbackRouteViewSurfaces = new Set<string>();
+		}
+		if (fallbackRouteViewSurfaces.has(normalizedSurface)) return false;
+		fallbackRouteViewSurfaces.add(normalizedSurface);
+		return true;
+	};
+
+	if (!storage) return reserveFallback();
+	try {
+		const raw = storage.getItem(ROUTE_VIEW_STORAGE_KEY);
+		const parsed = raw ? (JSON.parse(raw) as { date?: unknown; surfaces?: unknown }) : {};
+		const surfaces =
+			parsed.date === utcDate && Array.isArray(parsed.surfaces)
+				? parsed.surfaces.filter((value): value is string => typeof value === "string")
+				: [];
+		if (surfaces.includes(normalizedSurface)) return false;
+		surfaces.push(normalizedSurface);
+		storage.setItem(ROUTE_VIEW_STORAGE_KEY, JSON.stringify({ date: utcDate, surfaces }));
+		return true;
+	} catch {
+		return reserveFallback();
+	}
+}
+
+function telemetryStorage(): DailyActiveStorage | undefined {
+	try {
+		return window.localStorage;
+	} catch {
+		return undefined;
 	}
 }
 
@@ -369,6 +414,7 @@ export async function initTelemetry(): Promise<boolean> {
 			autocapture: false,
 			capture_pageview: false,
 			capture_exceptions: false,
+			capture_performance: false,
 			persistence: "localStorage",
 			// The distinct ID is a random install ID, never a person, so keep
 			// every event anonymous: identified events bill at several times the
@@ -393,14 +439,8 @@ export async function initTelemetry(): Promise<boolean> {
 			surface: "renderer",
 		});
 		bindErrorHandlers();
-		let storage: DailyActiveStorage | undefined;
-		try {
-			storage = window.localStorage;
-		} catch {
-			storage = undefined;
-		}
 		startDailyActiveHeartbeat({
-			storage,
+			storage: telemetryStorage(),
 			window,
 			document,
 			capture: () => {
@@ -419,9 +459,15 @@ export async function initTelemetry(): Promise<boolean> {
 }
 
 export async function captureRendererEvent(event: string, properties?: Record<string, unknown>): Promise<void> {
-	if (!reserveCapture(event)) return;
+	const sanitizedProperties = await sanitizeRendererProperties(event, properties);
+	if (event === "ao.renderer.route_viewed") {
+		const surface = typeof sanitizedProperties.surface === "string" ? sanitizedProperties.surface : "other";
+		if (!reserveRouteViewCapture(telemetryStorage(), surface)) return;
+	} else if (!reserveCapture(event)) {
+		return;
+	}
 	if (!(await initTelemetry())) return;
-	const safeProperties = withTelemetryContext(await sanitizeRendererProperties(event, properties));
+	const safeProperties = withTelemetryContext(sanitizedProperties);
 	posthog.capture(event, safeProperties);
 }
 

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -67,7 +67,7 @@ type DailyActiveEventTarget = {
 export type DailyActiveHeartbeatOptions = {
 	storage?: DailyActiveStorage;
 	now?: () => Date;
-	capture: () => void;
+	capture: () => boolean | void | Promise<boolean | void>;
 	window: DailyActiveEventTarget;
 	document: DailyActiveEventTarget & Pick<Document, "visibilityState">;
 };
@@ -113,6 +113,25 @@ export function reserveDailyActiveCapture(storage?: DailyActiveStorage, now = ne
 		return true;
 	} catch {
 		return reserveFallback();
+	}
+}
+
+function releaseDailyActiveCapture(storage?: DailyActiveStorage, now = new Date()): void {
+	const utcDate = now.toISOString().slice(0, 10);
+	const slot = activeCaptureSlot(now);
+	if (fallbackActiveDate === utcDate) fallbackActiveSlots.delete(slot);
+	if (!storage) return;
+
+	try {
+		const raw = storage.getItem(ACTIVE_STORAGE_KEY);
+		const parsed = raw ? (JSON.parse(raw) as { date?: unknown; slots?: unknown }) : {};
+		if (parsed.date !== utcDate || !Array.isArray(parsed.slots)) return;
+		const slots = parsed.slots.filter(
+			(value): value is number => Number.isInteger(value) && value >= 0 && value < 4 && value !== slot,
+		);
+		storage.setItem(ACTIVE_STORAGE_KEY, JSON.stringify({ date: utcDate, slots }));
+	} catch {
+		// The fallback reservation was already released above.
 	}
 }
 
@@ -170,9 +189,22 @@ export function startDailyActiveHeartbeat({
 	document,
 }: DailyActiveHeartbeatOptions): () => void {
 	const maybeCapture = () => {
-		if (reserveDailyActiveCapture(storage, now())) {
-			capture();
+		const captureTime = now();
+		if (!reserveDailyActiveCapture(storage, captureTime)) return;
+
+		let result: boolean | void | Promise<boolean | void>;
+		try {
+			result = capture();
+		} catch {
+			releaseDailyActiveCapture(storage, captureTime);
+			return;
 		}
+		void Promise.resolve(result).then(
+			(captured) => {
+				if (captured === false) releaseDailyActiveCapture(storage, captureTime);
+			},
+			() => releaseDailyActiveCapture(storage, captureTime),
+		);
 	};
 	const onVisibilityChange = () => {
 		if (document.visibilityState === "visible") {
@@ -418,6 +450,38 @@ function bindErrorHandlers() {
 	});
 }
 
+type PostHogInitOptions = NonNullable<Parameters<typeof posthog.init>[1]>;
+
+export function buildPostHogConfig(distinctId: string): PostHogInitOptions {
+	return {
+		api_host: POSTHOG_HOST,
+		defaults: RELEASE_TAG,
+		autocapture: false,
+		capture_pageview: false,
+		capture_exceptions: false,
+		capture_performance: false,
+		// AO owns the stable random installation ID. Memory-only SDK
+		// persistence prevents legacy identified state from replacing it after
+		// an upgrade; the AO-owned heartbeat and route reservations continue to
+		// use window.localStorage independently.
+		persistence: "memory",
+		person_profiles: "never",
+		bootstrap: {
+			distinctID: distinctId,
+			isIdentifiedID: false,
+		},
+		before_send: (event) => (event ? sanitizePostHogCaptureResult(event) : event),
+		session_recording: {
+			maskCapturedNetworkRequestFn: (request) => {
+				if (request.name) {
+					request.name = sanitizeReplayRequestName(request.name);
+				}
+				return request;
+			},
+		},
+	};
+}
+
 export async function initTelemetry(): Promise<boolean> {
 	if (initPromise) return initPromise;
 	initPromise = (async () => {
@@ -425,32 +489,7 @@ export async function initTelemetry(): Promise<boolean> {
 		const bootstrap = await aoBridge.telemetry.getBootstrap();
 		if (!bootstrap) return false;
 		telemetryContext = buildTelemetryContext(bootstrap.appVersion, bootstrap.platform);
-		posthog.init(POSTHOG_KEY, {
-			api_host: POSTHOG_HOST,
-			defaults: RELEASE_TAG,
-			autocapture: false,
-			capture_pageview: false,
-			capture_exceptions: false,
-			capture_performance: false,
-			persistence: "localStorage",
-			// The distinct ID is a random install ID, never a person, so keep
-			// every event anonymous: identified events bill at several times the
-			// anonymous rate and the person profiles would hold nothing. The
-			// bootstrap distinct ID keeps renderer and daemon events deduplicated
-			// without an identify() call, which would flip the install to
-			// identified billing permanently.
-			person_profiles: "identified_only",
-			bootstrap: { distinctID: bootstrap.distinctId },
-			before_send: (event) => (event ? sanitizePostHogCaptureResult(event) : event),
-			session_recording: {
-				maskCapturedNetworkRequestFn: (request) => {
-					if (request.name) {
-						request.name = sanitizeReplayRequestName(request.name);
-					}
-					return request;
-				},
-			},
-		});
+		posthog.init(POSTHOG_KEY, buildPostHogConfig(bootstrap.distinctId));
 		posthog.register({
 			...telemetryContext,
 			surface: "renderer",
@@ -460,14 +499,14 @@ export async function initTelemetry(): Promise<boolean> {
 			storage: telemetryStorage(),
 			window,
 			document,
-			capture: () => {
-				void (async () => {
+			capture: async () =>
+				Boolean(
 					posthog.capture(
 						"ao.app.active",
 						withTelemetryContext(await sanitizeRendererProperties("ao.app.active", { channel: "renderer" })),
-					);
-				})();
-			},
+						{ send_instantly: true },
+					),
+				),
 		});
 		posthog.capture("ao.renderer.loaded", withTelemetryContext(await sanitizeRendererProperties("ao.renderer.loaded")));
 		return true;


### PR DESCRIPTION
## Summary

Reduces PostHog event volume and separates actual user activity from agent/system background activity:

- persists CLI telemetry reservations under `DataDir` so daemon restarts cannot re-emit every polling command or active heartbeat slot for the same install/day
- classifies CLI invocations as `actor_type=user|agent|system`
- keeps `ao hooks` and commands run with `AO_SESSION_ID` as agent activity, but prevents them from refreshing `ao.app.active` / DAU
- excludes internal system CLI processes such as `ao pty-host`
- changes `ao.app.active` to a bounded heartbeat: at most once per six-hour UTC slot, or four times per day per install/channel
- caps renderer `ao.renderer.route_viewed` to once per coarse surface per UTC day per renderer install
- forces renderer PostHog captures to include `$process_person_profile: false`, including exceptions, and disables Web Vitals capture
- documents the read-only PostHog investigation, product metrics model, top event counts, ratios, and projected savings in `docs/telemetry.md`

## Product metrics model

Current AO telemetry has a stable install ID, not a signed-in account user ID. That means today's DAU/MAU can accurately represent active installs, but not unique people across multiple machines. True user-level new/churn/journey metrics require an explicit stable user identity from a login, license, or workspace account system. That identity should be sent as a first-party AO user ID or one-way hash only after auth/consent; it should not be inferred from machine fingerprints, local paths, git remotes, or repo config.

Active-user events should come from human/product activity only:

- renderer heartbeat when a human uses the desktop app
- user-context CLI commands

`ao.app.active` remains the active-user event for DAU/WAU/MAU. It is now emitted at most once per six-hour UTC slot, so unique-user aggregation stays bounded while arbitrary rolling windows are less likely to undercount someone who is active later in the same UTC day.

These should not drive DAU/MAU:

- `ao hooks` agent callbacks
- CLI commands run inside AO-managed agent sessions (`AO_SESSION_ID` set)
- internal runtime/supervisor commands such as `ao pty-host`, `ao daemon`, `ao start`
- raw polling frequency for read-only state commands

Agent CLI activity remains useful, but as command/agent-activity signal, not active-user signal.

## PostHog investigation: trailing 30 days as of 2026-07-21

Read-only HogQL against project `475752` found 3,203,364 total events. Top events:

| Event | Count | Installs | Events/install |
| --- | ---: | ---: | ---: |
| `ao.cli.invoked` | 1,508,888 | 870 | 1,734.35 |
| `ao.app.active` | 1,411,807 | 1,434 | 984.52 |
| `ao.renderer.route_viewed` | 114,940 | 1,388 | 82.81 |
| `ao.renderer.api_error` | 18,634 | 662 | 28.15 |
| `ao.session.waiting_input_entered` | 17,583 | 377 | 46.64 |
| `$exception` | 16,563 | 681 | 24.32 |
| `ao.cli.usage_errors` | 15,349 | 215 | 71.39 |
| `ao.session.waiting_input_exited` | 15,343 | 339 | 45.26 |
| `$set` | 13,211 | 1,137 | 11.62 |
| `ao.session.spawned` | 11,439 | 887 | 12.90 |

The runaway path is CLI polling/hook traffic. The daemon was not invoking the CLI; external processes invoked `ao`, then the CLI posted telemetry to the daemon. `ao.cli.invoked` and CLI-channel `ao.app.active` moved almost one-for-one because agent/polling invocations were allowed to refresh active-user telemetry.

Biggest command paths:

| Command path | Count | Install-days | Projected saved by persistent daily cap |
| --- | ---: | ---: | ---: |
| `ao hooks` | 589,338 | 1,624 | 587,714 |
| `ao session ls` | 270,977 | 764 | 270,213 |
| `ao orchestrator ls` | 236,877 | 177 | 236,700 |
| `ao status` | 220,436 | 524 | 219,912 |
| `ao session get` | 75,946 | 603 | 75,343 |
| `ao project ls` | 40,435 | 462 | 39,973 |
| `ao project get` | 31,048 | 356 | 30,692 |
| `ao send` | 19,104 | 536 | 18,568 |

Ratios:

- 11,439 `ao.session.spawned` events in the window
- 131.91 `ao.cli.invoked` events per spawned AO session
- 10.05 `ao.renderer.route_viewed` events per spawned AO session
- renderer SDK events: 211,532 events / 6,988 PostHog sessions = 30.27 events/session
- renderer route views: 17.67 events/PostHog session, the largest renderer contributor

Anonymous/identified check:

- all HogQL rows had a `person_id`, so that column is not useful for billing split here
- event-level `$process_person_profile` showed the actionable issue: 16,534 of 16,563 `$exception` events had `$process_person_profile=true`; only 29 had `false`
- renderer events now force `$process_person_profile=false` so exceptions do not undo the anonymous-mode work from #2829

## Ranked reduction plan

1. Persist CLI daily caps across daemon restarts: saves about 2.90M events/30 days while preserving daily command adoption signal.
2. Separate actor types: keep agent command usage, but prevent agent/system automation from inflating DAU/MAU.
3. Use a bounded six-hour active heartbeat: keeps `ao.app.active` useful for arbitrary rolling windows while capping each install/channel to four active events per UTC day.
4. Daily-dedupe renderer route views by coarse surface: saves about 106k events/30 days, preserves surface adoption/retention signal.
5. Force anonymous renderer capture properties, especially exceptions: reduces identified-cost risk without dropping crash signal.
6. Disable Web Vitals capture: removes about 7k diagnostic events/30 days that are not used for activation, feature usage, or crash/error decisions.
7. Leave API errors, session spawn/failure, waiting-input transitions, and user action events intact for product/reliability decisions; existing rate limits still bound storms.

Projected direct volume savings from the CLI command cap, CLI active slot cap, and route-view cap: still about 3.0M events per trailing 30 days before release/adoption effects. The CLI active projection changes from about 1,877 events under a once-daily cap to at most about 7,508 events under the four-slot cap, still saving at least about 1,395,662 CLI-channel `ao.app.active` events over the measured window.

## Validation

- `cd backend && go test ./internal/httpd ./internal/adapters/telemetry`
- `cd backend && go test ./internal/httpd/...`
- `cd backend && go test ./internal/httpd ./internal/adapters/telemetry ./internal/cli -run 'TestCLI|TestShouldEmit|TestVersionEmits|TestRootCommands|TestUsageError'`
- `cd frontend && npm test -- --run src/renderer/lib/telemetry.test.ts`
- `cd frontend && npm run typecheck`
- `./frontend/node_modules/.bin/prettier --check docs/telemetry.md frontend/src/renderer/lib/telemetry.ts frontend/src/renderer/lib/telemetry.test.ts`
- `git diff --check`

Known unrelated local failure:

- `cd backend && go test ./internal/httpd ./internal/adapters/telemetry ./internal/cli` fails in existing `internal/cli` spawn tests with `daemon returned HTTP 404` in `TestSpawnCommand_MissingProjectContext`, `TestSpawnResolvesProjectFromAOSessionID`, `TestSpawnAOSessionIDFailureRequiresProject`, and `TestSpawnResolvesProjectFromCWD`. The changed `httpd`, telemetry adapter, focused CLI telemetry/root tests, and renderer telemetry tests pass.
