### PR TITLE
feat: add terminal context menu

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { XtermTerminal } from "./XtermTerminal";
 
@@ -12,6 +12,9 @@ const state = vi.hoisted(() => ({
 		modes: { bracketedPasteMode: boolean; mouseTrackingMode: string };
 		buffer: { active: { type: string } };
 		scrollLines: ReturnType<typeof vi.fn>;
+		clear: ReturnType<typeof vi.fn>;
+		focus: ReturnType<typeof vi.fn>;
+		selectAll: ReturnType<typeof vi.fn>;
 		dataListeners: Set<(data: string) => void>;
 		keyListeners: Set<(event: { key: string }) => void>;
 		selectionListeners: Set<() => void>;
@@ -36,6 +39,9 @@ vi.mock("@xterm/xterm", () => ({
 		modes = { bracketedPasteMode: false, mouseTrackingMode: "vt200" };
 		buffer = { active: { type: "normal" } };
 		scrollLines = vi.fn();
+		clear = vi.fn();
+		focus = vi.fn();
+		selectAll = vi.fn();
 		dataListeners = new Set<(data: string) => void>();
 		keyListeners = new Set<(event: { key: string }) => void>();
 		selectionListeners = new Set<() => void>();
@@ -196,6 +202,62 @@ describe("XtermTerminal", () => {
 
 		expect(event.defaultPrevented).toBe(true);
 		expect(window.ao!.clipboard.writeText).toHaveBeenCalledWith("focused copied selection");
+	});
+
+	it("opens a themed context menu on right-click and disables Copy without a selection", async () => {
+		const { container } = render(<XtermTerminal theme="dark" />);
+		const host = container.firstElementChild!;
+
+		expect(fireEvent.contextMenu(host, { clientX: 120, clientY: 88 })).toBe(false);
+
+		expect(await screen.findByText("Paste")).toBeInTheDocument();
+		expect(screen.getByText("Copy")).toHaveAttribute("data-disabled");
+		const trigger = container.querySelector("button[aria-hidden='true']") as HTMLButtonElement;
+		expect(trigger.style.left).toBe("120px");
+		expect(trigger.style.top).toBe("88px");
+	});
+
+	it("runs context menu copy, select all, and clear against the xterm instance", async () => {
+		const { container } = render(<XtermTerminal theme="dark" />);
+		const host = container.firstElementChild!;
+		state.lastTerminal!.selection = "menu copy";
+
+		fireEvent.contextMenu(host);
+		fireEvent.click(await screen.findByText("Copy"));
+		await waitFor(() => expect(window.ao!.clipboard.writeText).toHaveBeenCalledWith("menu copy"));
+		expect(state.lastTerminal!.focus).toHaveBeenCalled();
+
+		fireEvent.contextMenu(host);
+		fireEvent.click(await screen.findByText("Select All"));
+		expect(state.lastTerminal!.selectAll).toHaveBeenCalled();
+
+		fireEvent.contextMenu(host);
+		fireEvent.click(await screen.findByText("Clear"));
+		expect(state.lastTerminal!.clear).toHaveBeenCalled();
+	});
+
+	it("pastes from the context menu through the terminal paste path", async () => {
+		const onInput = vi.fn();
+		window.ao!.clipboard.readText = vi.fn().mockResolvedValue("menu\npaste");
+		const { container } = render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		fireEvent.contextMenu(container.firstElementChild!);
+		fireEvent.click(await screen.findByText("Paste"));
+
+		await waitFor(() => expect(onInput).toHaveBeenCalledWith("menu\rpaste", "paste"));
+		expect(window.ao!.clipboard.readText).toHaveBeenCalledTimes(1);
+	});
+
+	it("honors bracketed paste mode from the context menu", async () => {
+		const onInput = vi.fn();
+		window.ao!.clipboard.readText = vi.fn().mockResolvedValue("bracketed\npaste");
+		const { container } = render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+		state.lastTerminal!.modes.bracketedPasteMode = true;
+
+		fireEvent.contextMenu(container.firstElementChild!);
+		fireEvent.click(await screen.findByText("Paste"));
+
+		await waitFor(() => expect(onInput).toHaveBeenCalledWith("\x1b[200~bracketed\rpaste\x1b[201~", "paste"));
 	});
 
 	it("auto-copies new selections and retries explicit copy if the auto-copy failed", async () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -241,10 +241,13 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		setContextMenu((current) => ({ ...current, open }));
 	}, []);
 
-	const runContextMenuAction = useCallback((action: TerminalContextMenuAction) => {
-		contextMenuActionsRef.current?.[action]();
-		setContextMenuOpen(false);
-	}, [setContextMenuOpen]);
+	const runContextMenuAction = useCallback(
+		(action: TerminalContextMenuAction) => {
+			contextMenuActionsRef.current?.[action]();
+			setContextMenuOpen(false);
+		},
+		[setContextMenuOpen],
+	);
 
 	useEffect(() => {
 		callbacksRef.current = props;

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -19,7 +19,7 @@
 //    itself only fires onResize when the grid actually changed, so repeated
 //    fits don't spam the PTY.
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { CanvasAddon } from "@xterm/addon-canvas";
 import { FitAddon } from "@xterm/addon-fit";
@@ -32,6 +32,13 @@ import { aoBridge } from "../lib/bridge";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
 import { buildTerminalThemes } from "../lib/terminal-themes";
 import type { Theme } from "../stores/ui-store";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
 
 export type XtermTerminalProps = {
 	ariaLabel?: string;
@@ -170,6 +177,17 @@ type XtermInternal = Terminal & {
 	};
 };
 
+type TerminalContextMenuState = {
+	canCopy: boolean;
+	open: boolean;
+	x: number;
+	y: number;
+};
+
+type TerminalContextMenuAction = "copy" | "paste" | "selectAll" | "clear";
+
+type TerminalContextMenuActions = Record<TerminalContextMenuAction, () => void>;
+
 // For mouse-tracking panes we synthesize SGR mouse-wheel reports and write them
 // to the pane; tmux (with `mouse on`, set by the runtime adapter) acts on them
 // and scrolls its scrollback via copy-mode. Left to itself xterm would convert
@@ -207,10 +225,26 @@ export function XtermTerminal(props: XtermTerminalProps) {
 	const hostRef = useRef<HTMLDivElement | null>(null);
 	const termRef = useRef<Terminal | null>(null);
 	const fitRef = useRef<(() => void) | null>(null);
+	const contextMenuActionsRef = useRef<TerminalContextMenuActions | null>(null);
+	const [contextMenu, setContextMenu] = useState<TerminalContextMenuState>({
+		canCopy: false,
+		open: false,
+		x: 0,
+		y: 0,
+	});
 	// Latest callbacks in a ref so the mount effect stays dependency-free — we
 	// never tear down and recreate the terminal because a handler identity
 	// changed between renders.
 	const callbacksRef = useRef(props);
+
+	const setContextMenuOpen = useCallback((open: boolean) => {
+		setContextMenu((current) => ({ ...current, open }));
+	}, []);
+
+	const runContextMenuAction = useCallback((action: TerminalContextMenuAction) => {
+		contextMenuActionsRef.current?.[action]();
+		setContextMenuOpen(false);
+	}, [setContextMenuOpen]);
 
 	useEffect(() => {
 		callbacksRef.current = props;
@@ -351,6 +385,42 @@ export function XtermTerminal(props: XtermTerminalProps) {
 					console.warn("Unable to paste terminal clipboard text", error);
 				});
 		};
+		const focusTerminal = () => {
+			try {
+				term.focus();
+			} catch {
+				// Terminal is being torn down or its hidden textarea is unavailable.
+			}
+		};
+		contextMenuActionsRef.current = {
+			clear: () => {
+				term.clear();
+				focusTerminal();
+			},
+			copy: () => {
+				copySelection();
+				focusTerminal();
+			},
+			paste: () => {
+				pasteFromClipboard();
+				focusTerminal();
+			},
+			selectAll: () => {
+				term.selectAll();
+				focusTerminal();
+			},
+		};
+		const openContextMenu = (event: MouseEvent) => {
+			event.preventDefault();
+			event.stopPropagation();
+			setContextMenu({
+				canCopy: term.hasSelection(),
+				open: true,
+				x: event.clientX,
+				y: event.clientY,
+			});
+		};
+		host.addEventListener("contextmenu", openContextMenu);
 		term.attachCustomKeyEventHandler((event) => {
 			// xterm invokes this same handler on keydown, keyup, AND keypress (see
 			// Terminal.ts _keyDown/_keyUp/_keyPress). Only keydown should trigger our
@@ -623,10 +693,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			host.removeEventListener("copy", copyInput);
 			window.removeEventListener("keydown", copyShortcut, true);
 			selectionChange.dispose();
+			host.removeEventListener("contextmenu", openContextMenu);
 			host.removeEventListener("paste", pasteInput, true);
 			host.removeEventListener("compositionend", compositionInput, true);
 			host.removeEventListener("dragover", dragOverInput);
 			host.removeEventListener("drop", dropInput);
+			contextMenuActionsRef.current = null;
 			clearSuppressNativePaste();
 			keyInput.dispose();
 			userInputListeners.clear();
@@ -640,11 +712,48 @@ export function XtermTerminal(props: XtermTerminalProps) {
 	}, []);
 
 	return (
-		<div
-			ref={hostRef}
-			aria-label={props.ariaLabel}
-			className={props.className}
-			style={{ height: "100%", overflow: "hidden", width: "100%" }}
-		/>
+		<>
+			<div
+				ref={hostRef}
+				aria-label={props.ariaLabel}
+				className={props.className}
+				style={{ height: "100%", overflow: "hidden", width: "100%" }}
+			/>
+			<DropdownMenu modal={false} open={contextMenu.open} onOpenChange={setContextMenuOpen}>
+				<DropdownMenuTrigger asChild>
+					<button
+						type="button"
+						aria-hidden="true"
+						tabIndex={-1}
+						style={{
+							border: 0,
+							height: 0,
+							left: contextMenu.x,
+							opacity: 0,
+							padding: 0,
+							pointerEvents: "none",
+							position: "fixed",
+							top: contextMenu.y,
+							width: 0,
+						}}
+					/>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent
+					align="start"
+					className="min-w-36"
+					onCloseAutoFocus={(event) => event.preventDefault()}
+					side="right"
+					sideOffset={2}
+				>
+					<DropdownMenuItem disabled={!contextMenu.canCopy} onSelect={() => runContextMenuAction("copy")}>
+						Copy
+					</DropdownMenuItem>
+					<DropdownMenuItem onSelect={() => runContextMenuAction("paste")}>Paste</DropdownMenuItem>
+					<DropdownMenuItem onSelect={() => runContextMenuAction("selectAll")}>Select All</DropdownMenuItem>
+					<DropdownMenuSeparator />
+					<DropdownMenuItem onSelect={() => runContextMenuAction("clear")}>Clear</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</>
 	);
 }


### PR DESCRIPTION
## Summary
- Add a right-click terminal context menu with Copy, Paste, Select All, and Clear.
- Reuse the renderer shadcn/Radix dropdown primitive instead of an Electron-native menu so the menu follows the existing app theme/tokens and stays beside the xterm selection/paste logic.
- Route Paste through the existing terminal paste helper so newline normalization and bracketed paste behavior match keyboard paste, without touching the Ctrl+V suppression path from #2586.

Closes #2874

## Tests
- `npx -y node@22.12.0 node_modules/vitest/vitest.mjs run --config vite.renderer.config.ts XtermTerminal.test.tsx` (from `frontend/`)
- `npm --prefix frontend run typecheck`
- Live Electron check: launched the real Electron app against the running AO daemon, opened `agent-orchestrator-37`, right-clicked the live xterm terminal, verified menu items Copy/Paste/Select All/Clear, Copy disabled with no selection, and Escape dismisses the menu.

## Notes
- Local Node is 22.11.0, while the current Vite/Vitest dependency set requires 22.12.0+, so the focused Vitest run used a temporary Node 22.12.0 binary.
- The live check avoided invoking Paste in the active agent terminal; paste semantics are covered by unit tests, including bracketed paste.
