### PR TITLE
fix(cline): forward role-specific model config to the Cline CLI

### DIFF
--- a/backend/internal/adapters/agent/cline/cline.go
+++ b/backend/internal/adapters/agent/cline/cline.go
@@ -53,6 +53,22 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Cline understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `cline --model`.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new interactive Cline session.
 // Prompted worker tasks are injected after startup; passing them in argv makes
 // Cline's startup parser reject short prompts such as "hi" as unknown commands.
@@ -64,6 +80,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd = []string{binary}
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 
 	if cfg.SystemPrompt != "" {
 		cmd = append(cmd, "-s", cfg.SystemPrompt)
@@ -122,6 +139,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	cmd = make([]string, 0, 8)
 	cmd = append(cmd, binary)
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 	if cfg.SystemPrompt != "" {
 		cmd = append(cmd, "-s", cfg.SystemPrompt)
 	}
@@ -173,6 +191,12 @@ func (p *Plugin) clineBinary(ctx context.Context) (string, error) {
 	}
 	p.resolvedBinary = binary
 	return binary, nil
+}
+
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
+	}
 }
 
 func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {

--- a/backend/internal/adapters/agent/cline/cline_test.go
+++ b/backend/internal/adapters/agent/cline/cline_test.go
@@ -139,15 +139,73 @@ func TestPromptReadinessHints(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	plugin := &Plugin{}
 
 	spec, err := plugin.GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("unexpected config fields: %#v", spec.Fields)
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `cline --model`.",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
+	}
+}
+
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cline"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "  claude-sonnet-5  "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsSubsequence(cmd, []string{"--model", "claude-sonnet-5"}) {
+		t.Fatalf("command %#v missing trimmed --model flag", cmd)
+	}
+	if containsSubsequence(cmd, []string{"--model", "  claude-sonnet-5  "}) {
+		t.Fatalf("command %#v used untrimmed model", cmd)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cline"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(cmd, "--model") {
+		t.Fatalf("command %#v contains --model for blank model", cmd)
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cline"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "  claude-sonnet-5  "},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "session-123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if !containsSubsequence(cmd, []string{"--model", "claude-sonnet-5"}) {
+		t.Fatalf("restore command %#v missing trimmed --model flag", cmd)
 	}
 }
 


### PR DESCRIPTION
## Summary

The Cline adapter's `GetLaunchCommand` and `GetRestoreCommand` never read `cfg.Config.Model`, so a project's per-role `agentConfig.model` was silently dropped and Cline workers/orchestrators always launched on Cline's own global default model instead of the configured one.

This mirrors the pattern already applied to the Codex adapter (#2869): append a trimmed `--model` flag to both the launch and restore argv when a model is configured, and advertise the field via `GetConfigSpec` so it shows up in project config UI/validation.

Fixes #2894

## Changes

- `backend/internal/adapters/agent/cline/cline.go`: add `appendModelFlag` helper, call it from `GetLaunchCommand` and `GetRestoreCommand`, and override `GetConfigSpec` to advertise the `model` field (previously inherited the empty default from `agentbase.Base`).
- `backend/internal/adapters/agent/cline/cline_test.go`: replace the now-stale `TestGetConfigSpecHasNoCustomFieldsYet` with `TestGetConfigSpecReportsModelField`, and add regression tests for: trimmed model appended on launch, blank model omitted on launch, and trimmed model appended on restore.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./internal/adapters/agent/cline/...` passes
- [x] `go test ./internal/adapters/agent/cline/...` — all new/updated tests pass (pre-existing unrelated failures on this Windows dev box: OAuth-fixture auth-status tests and an executable-bit hooks test, both failing identically on `main` before this change, due to local environment/filesystem permission quirks, not this change)
