### PR TITLE
feat(new-task): Enter starts task, Shift+Enter inserts newline (Claude/Codex parity)

### DIFF
--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,0 +1,1 @@
+/Users/psudokit/.ao/data/worktrees/ao/ao-5/frontend/node_modules

--- a/frontend/src/renderer/components/NewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.test.tsx
@@ -246,6 +246,28 @@ describe("NewTaskDialog", () => {
 		expect(spawnBody().prompt).toContain("\n");
 	});
 
+	it("does not submit on Alt+Enter or Shift+Enter but does on plain Enter in the brief", async () => {
+		renderDialog();
+		const user = userEvent.setup();
+		await waitForAgentCatalog();
+
+		await user.type(screen.getByLabelText("Title"), "Fix fallback renderer");
+		const brief = screen.getByLabelText("Brief");
+		await user.type(brief, "Line");
+
+		// Alt+Enter must NOT submit — Alt is excluded so it can't submit by accident.
+		await user.keyboard("{Alt>}{Enter}{/Alt}");
+		expect(postMock).not.toHaveBeenCalled();
+
+		// Shift+Enter must NOT submit — it inserts a newline.
+		await user.keyboard("{Shift>}{Enter}{/Shift}");
+		expect(postMock).not.toHaveBeenCalled();
+
+		// Plain Enter submits the task.
+		await user.keyboard("{Enter}");
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+	});
+
 	it.each([
 		{
 			code: "AGENT_BINARY_NOT_FOUND",

--- a/frontend/src/renderer/components/NewTaskDialog.test.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.test.tsx
@@ -227,6 +227,25 @@ describe("NewTaskDialog", () => {
 		expect(postMock).not.toHaveBeenCalled();
 	});
 
+	it("submits on Enter and inserts a newline on Shift+Enter in the brief", async () => {
+		renderDialog();
+		const user = userEvent.setup();
+		await waitForAgentCatalog();
+
+		await user.type(screen.getByLabelText("Title"), "Fix fallback renderer");
+		const brief = screen.getByLabelText("Brief");
+		await user.type(brief, "First line");
+		// Shift+Enter must NOT submit — it adds a newline.
+		await user.keyboard("{Shift>}{Enter}{/Shift}");
+		await user.type(brief, "Second line");
+		expect(postMock).not.toHaveBeenCalled();
+
+		// Plain Enter submits the task.
+		await user.keyboard("{Enter}");
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+		expect(spawnBody().prompt).toContain("\n");
+	});
+
 	it.each([
 		{
 			code: "AGENT_BINARY_NOT_FOUND",

--- a/frontend/src/renderer/components/NewTaskDialog.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.tsx
@@ -223,9 +223,11 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 									onPaste={handlePaste}
 									onKeyDown={(event) => {
 										// Chat-style, matching Claude Code / Codex: Enter starts the task,
-										// Shift+Enter inserts a newline. Guard against IME composition so
+										// Shift+Enter inserts a newline. Alt+Enter is excluded so it can't
+										// submit by accident; Cmd+Enter is intentionally left submitting as a
+										// common chat-send affordance. Guard against IME composition so
 										// committing a CJK candidate with Enter doesn't submit.
-										if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+										if (event.key === "Enter" && !event.shiftKey && !event.altKey && !event.nativeEvent.isComposing) {
 											event.preventDefault();
 											event.currentTarget.form?.requestSubmit();
 										}

--- a/frontend/src/renderer/components/NewTaskDialog.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.tsx
@@ -221,6 +221,15 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 									value={prompt}
 									onChange={(event) => setPrompt(event.target.value)}
 									onPaste={handlePaste}
+									onKeyDown={(event) => {
+										// Chat-style, matching Claude Code / Codex: Enter starts the task,
+										// Shift+Enter inserts a newline. Guard against IME composition so
+										// committing a CJK candidate with Enter doesn't submit.
+										if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+											event.preventDefault();
+											event.currentTarget.form?.requestSubmit();
+										}
+									}}
 								/>
 								{attachments.length > 0 && (
 									<ul className="grid max-h-40 grid-cols-2 gap-2 overflow-y-auto border-t border-border p-2 sm:grid-cols-3">
@@ -260,6 +269,7 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 								}}
 							/>
 							{attachmentError && <p className="text-caption text-destructive">{attachmentError}</p>}
+							<p className="text-caption text-muted-foreground">Enter to start · Shift+Enter for a new line</p>
 						</div>
 
 						<div className="grid gap-3 sm:grid-cols-[1fr_1fr]">

--- a/frontend/src/renderer/components/NewTaskDialog.tsx
+++ b/frontend/src/renderer/components/NewTaskDialog.tsx
@@ -222,11 +222,12 @@ export function NewTaskDialog({ open, projectId, onCreated, onOpenChange }: NewT
 									onChange={(event) => setPrompt(event.target.value)}
 									onPaste={handlePaste}
 									onKeyDown={(event) => {
-										// Chat-style, matching Claude Code / Codex: Enter starts the task,
-										// Shift+Enter inserts a newline. Alt+Enter is excluded so it can't
-										// submit by accident; Cmd+Enter is intentionally left submitting as a
-										// common chat-send affordance. Guard against IME composition so
-										// committing a CJK candidate with Enter doesn't submit.
+										// Chat-style, matching Claude Code / Codex. Submit affordances:
+										// plain Enter, and Cmd+Enter / Ctrl+Enter (common chat-send combos)
+										// which pass this guard because we only exclude Shift and Alt.
+										// Do NOT submit: Shift+Enter and Alt+Enter — both insert a newline
+										// (Alt is excluded so it can't submit by accident). Guard against IME
+										// composition so committing a CJK candidate with Enter doesn't submit.
 										if (event.key === "Enter" && !event.shiftKey && !event.altKey && !event.nativeEvent.isComposing) {
 											event.preventDefault();
 											event.currentTarget.form?.requestSubmit();

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -555,6 +555,73 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenCalledTimes(1);
 	});
 
+	it("sends the meta-return escape sequence for Shift+Enter and consumes the event", () => {
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		const event = {
+			type: "keydown",
+			key: "Enter",
+			metaKey: false,
+			ctrlKey: false,
+			shiftKey: true,
+			altKey: false,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		} as unknown as KeyboardEvent;
+		const allowed = state.lastTerminal!.keyHandler!(event);
+
+		expect(allowed).toBe(false);
+		expect(event.preventDefault).toHaveBeenCalled();
+		expect(event.stopPropagation).toHaveBeenCalled();
+		expect(onInput).toHaveBeenCalledTimes(1);
+		expect(onInput).toHaveBeenCalledWith("\x1b\r", "keyboard");
+	});
+
+	it("does not re-send the meta-return sequence on the keyup that follows Shift+Enter", () => {
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		const keyDown = {
+			type: "keydown",
+			key: "Enter",
+			metaKey: false,
+			ctrlKey: false,
+			shiftKey: true,
+			altKey: false,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		} as unknown as KeyboardEvent;
+		expect(state.lastTerminal!.keyHandler!(keyDown)).toBe(false);
+		expect(onInput).toHaveBeenCalledTimes(1);
+
+		const keyUp = { ...keyDown, type: "keyup" } as unknown as KeyboardEvent;
+		expect(state.lastTerminal!.keyHandler!(keyUp)).toBe(true);
+		expect(onInput).toHaveBeenCalledTimes(1);
+	});
+
+	it("leaves plain Enter as normal terminal input rather than intercepting it", () => {
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		const event = {
+			type: "keydown",
+			key: "Enter",
+			metaKey: false,
+			ctrlKey: false,
+			shiftKey: false,
+			altKey: false,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		} as unknown as KeyboardEvent;
+		const allowed = state.lastTerminal!.keyHandler!(event);
+
+		expect(allowed).toBe(true);
+		expect(event.preventDefault).not.toHaveBeenCalled();
+		expect(event.stopPropagation).not.toHaveBeenCalled();
+		expect(onInput).not.toHaveBeenCalled();
+	});
+
 	it("forwards keyboard input from explicit key events", () => {
 		const onInput = vi.fn();
 		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -437,6 +437,15 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// agent can't distinguish them; emit the meta-return (ESC+CR) that
 			// readline/Ink-based TUIs interpret as "insert a newline" rather than
 			// "submit". Plain Enter still falls through to xterm's default CR.
+			//
+			// SCOPE: this meta-return is applied to every pane intentionally for now.
+			// It is correct for agent TUIs but untested and unintended for plain login
+			// shells, where ESC+CR is not a "newline" affordance. The correct fix is to
+			// scope it by pane kind — TerminalPane already branches on
+			// `terminalTarget?.kind === "shell"` at the XtermTerminal call site — once
+			// this branch is rebased onto main, which brings that discriminator (and
+			// ShellTerminalsView) that does not yet exist here. Until then the behavior
+			// is left unchanged and the emitted bytes are identical for all panes.
 			if (event.key === "Enter" && event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey) {
 				consumeTerminalShortcut(event);
 				emitUserInput("\x1b\r", "keyboard");

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -432,6 +432,16 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			// paste, double word-delete, etc). keyup/keypress fall through to
 			// xterm's own default handling for that event type.
 			if (event.type === "keyup" || event.type === "keypress") return true;
+			// Shift+Enter → newline without submitting, matching Claude Code / Codex.
+			// A terminal normally sends the same CR for Enter and Shift+Enter, so the
+			// agent can't distinguish them; emit the meta-return (ESC+CR) that
+			// readline/Ink-based TUIs interpret as "insert a newline" rather than
+			// "submit". Plain Enter still falls through to xterm's default CR.
+			if (event.key === "Enter" && event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey) {
+				consumeTerminalShortcut(event);
+				emitUserInput("\x1b\r", "keyboard");
+				return false;
+			}
 			if (isTerminalCopyShortcut(event)) {
 				if (copySelection()) {
 					consumeTerminalShortcut(event);


### PR DESCRIPTION
## Summary

Chat-style submit in the **New Task brief**, matching Claude Code / Codex:
- **Enter** starts the task (guarded against IME composition so committing a CJK candidate doesn't submit).
- **Shift+Enter** inserts a newline.

In the **live agent terminal**, Shift+Enter emits the meta-return (`ESC`+`CR`) that readline / Ink-based TUIs interpret as "insert a newline" rather than "submit"; plain Enter still sends a normal CR.

## Why this is its own PR

This was originally bundled in #2940 (terminal-shortcut PR, stacked on #2861). It is **independent of the standalone-terminal feature (#2861) and of any shortcut chord**, so it should ship to `main` on its own rather than being blocked behind that stack. #2940 now carries only the `Ctrl+Shift+\`` new-terminal chord.

## Changes
- `NewTaskDialog.tsx` — `onKeyDown`: Enter → `requestSubmit()` (IME-guarded); Shift+Enter falls through as a newline. The guard excludes Shift and Alt, so **Alt+Enter no longer submits** (it inserts a newline), while plain Enter and Cmd/Ctrl+Enter intentionally submit as chat-send affordances. This intent is now documented in the comment. Added a one-line hint.
- `XtermTerminal.tsx` — Shift+Enter → `ESC`+`CR` in the terminal key handler. This meta-return is applied to every pane intentionally for now; a code comment documents that it is untested/unintended for plain login shells and should be scoped by pane kind (`terminalTarget?.kind === "shell"`) once this branch is rebased onto `main`, which brings that discriminator.
- `NewTaskDialog.test.tsx` — covers Enter submits / Shift+Enter adds a newline, plus a new test that **Alt+Enter and Shift+Enter do not submit while plain Enter does** (mutation-verified: removing `!event.altKey` fails it).
- `XtermTerminal.test.tsx` — covers that Shift+Enter emits the `ESC`+`CR` meta-return and consumes the event, and does not re-send it on the following keyup.

## Test
- `npx vitest run --config vite.renderer.config.ts src/renderer/components/NewTaskDialog.test.tsx src/renderer/components/XtermTerminal.test.tsx` — all pass.
- `npx tsc --noEmit` clean; Prettier clean on changed files.

Part of the shortcuts/terminal work: #2861 (terminal base), #2940 (new-terminal chord), #2954 (more shortcuts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)