### PR TITLE
fix(goose): forward role-specific model config to the Goose CLI

### DIFF
--- a/backend/internal/adapters/agent/goose/goose.go
+++ b/backend/internal/adapters/agent/goose/goose.go
@@ -73,6 +73,22 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Goose understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `goose run --model`.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new interactive Goose session:
 //
 //	[env GOOSE_MODE=<mode>] goose run [--system <text>] -t "" --interactive
@@ -100,6 +116,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	if systemPrompt != "" {
 		cmd = append(cmd, "--system", systemPrompt)
 	}
+	appendModelFlag(&cmd, cfg.Config)
 
 	cmd = append(cmd, "-t", "", "--interactive")
 
@@ -147,6 +164,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if systemPrompt != "" {
 		cmd = append(cmd, "--system", systemPrompt)
 	}
+	appendModelFlag(&cmd, cfg.Config)
 	cmd = append(cmd, "--resume", "--session-id", agentSessionID)
 	return cmd, true, nil
 }
@@ -187,6 +205,16 @@ func systemPromptTextFrom(inline, file string) (string, error) {
 		return text, nil
 	}
 	return "", nil
+}
+
+// appendModelFlag appends a trimmed --model flag when a model override is
+// configured. Goose pairs a model with a --provider; a bare --model overrides
+// the model within the configured provider, which matches AO's single-string
+// agentConfig.model contract.
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
+	}
 }
 
 // gooseModeEnvPrefix renders mode as an `env GOOSE_MODE=<mode>` argv prefix, or

--- a/backend/internal/adapters/agent/goose/goose_test.go
+++ b/backend/internal/adapters/agent/goose/goose_test.go
@@ -156,15 +156,73 @@ func TestGetPromptDeliveryStrategyIsAfterStart(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	plugin := &Plugin{}
 
 	spec, err := plugin.GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("unexpected config fields: %#v", spec.Fields)
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `goose run --model`.",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
+	}
+}
+
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "goose"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "  claude-4-sonnet  "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsSubsequence(cmd, []string{"--model", "claude-4-sonnet"}) {
+		t.Fatalf("command %#v missing trimmed --model flag", cmd)
+	}
+	if containsSubsequence(cmd, []string{"--model", "  claude-4-sonnet  "}) {
+		t.Fatalf("command %#v used untrimmed model", cmd)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "goose"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(cmd, "--model") {
+		t.Fatalf("command %#v contains --model for blank model", cmd)
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "goose"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "  claude-4-sonnet  "},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "20260720_1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if !containsSubsequence(cmd, []string{"--model", "claude-4-sonnet"}) {
+		t.Fatalf("restore command %#v missing trimmed --model flag", cmd)
 	}
 }
 


### PR DESCRIPTION
## Summary

The Goose adapter's `GetLaunchCommand` and `GetRestoreCommand` never read `cfg.Config.Model`, so a project's per-role `agentConfig.model` was silently dropped and Goose workers/orchestrators always launched on Goose's own global/default model instead of the configured one.

This mirrors the pattern already applied to the Codex (#2869) and Cline (#2894, #2953) adapters: append a trimmed `--model` flag to both the launch and restore argv (alongside the existing `--system` flag) when a model is configured, and advertise the field via `GetConfigSpec` so it shows up in project config UI/validation.

Fixes #2885

## Changes

- `backend/internal/adapters/agent/goose/goose.go`: add an `appendModelFlag` helper, call it from `GetLaunchCommand` and `GetRestoreCommand` (right after `--system`, before the trailing `-t "" --interactive` / `--resume --session-id` args), and override `GetConfigSpec` to advertise the `model` field (previously inherited the empty default from `agentbase.Base`).
- `backend/internal/adapters/agent/goose/goose_test.go`: replace the now-stale `TestGetConfigSpecHasNoCustomFieldsYet` with `TestGetConfigSpecReportsModelField`, and add regression tests for: trimmed model appended on launch, blank model omitted on launch, and trimmed model appended on restore.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./internal/adapters/agent/goose/...` passes
- [x] `go test ./internal/adapters/agent/goose/...` — all new/updated tests pass (pre-existing unrelated failures on this Windows dev box: `TestAuthStatusAuthorizedFromGooseConfig` / `TestAuthStatusUnauthorizedFromGooseConfig`, both failing identically on `main` before this change due to a local `HOME`/config-path environment quirk, not this change)
