### PR TITLE
fix(kimi): seed OAuth-backed config into AO-managed home

### DIFF
--- a/backend/internal/adapters/agent/kimi/auth.go
+++ b/backend/internal/adapters/agent/kimi/auth.go
@@ -43,33 +43,58 @@ func kimiLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 			return ports.AgentAuthStatusAuthorized, true, nil
 		}
 	}
-	home, ok := kimiCodeHome()
-	if !ok {
-		return ports.AgentAuthStatusUnknown, false, nil
+	var fallbackStatus ports.AgentAuthStatus
+	var fallbackOK bool
+	for _, home := range kimiUserHomes() {
+		configStatus, configOK, err := kimiConfigAuthStatus(filepath.Join(home, "config.toml"))
+		if err != nil || configStatus == ports.AgentAuthStatusAuthorized {
+			return configStatus, configOK, err
+		}
+		credentialsStatus, credentialsOK, err := kimiCredentialsAuthStatus(kimiCredentialsPath(home))
+		if err != nil || credentialsStatus == ports.AgentAuthStatusAuthorized {
+			return credentialsStatus, credentialsOK, err
+		}
+		if !fallbackOK {
+			if credentialsOK {
+				fallbackStatus, fallbackOK = credentialsStatus, true
+			} else if configOK {
+				fallbackStatus, fallbackOK = configStatus, true
+			}
+		}
 	}
-	configStatus, configOK, err := kimiConfigAuthStatus(filepath.Join(home, "config.toml"))
-	if err != nil || configStatus == ports.AgentAuthStatusAuthorized {
-		return configStatus, configOK, err
-	}
-	credentialsStatus, credentialsOK, err := kimiCredentialsAuthStatus(kimiCredentialsPath(home))
-	if err != nil || credentialsOK {
-		return credentialsStatus, credentialsOK, err
-	}
-	if configOK {
-		return configStatus, configOK, nil
+	if fallbackOK {
+		return fallbackStatus, true, nil
 	}
 	return ports.AgentAuthStatusUnknown, false, nil
 }
 
-func kimiCodeHome() (string, bool) {
-	if home := strings.TrimSpace(os.Getenv(kimiCodeHomeEnv)); home != "" {
-		return home, true
+// kimiUserHomes returns explicitly configured Kimi homes, or the current and
+// legacy default homes when neither environment override is set.
+func kimiUserHomes() []string {
+	homes := make([]string, 0, 4)
+	add := func(home string) {
+		home = strings.TrimSpace(home)
+		if home == "" {
+			return
+		}
+		for _, existing := range homes {
+			if sameKimiConfigPath(existing, home) {
+				return
+			}
+		}
+		homes = append(homes, home)
 	}
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return "", false
+
+	add(os.Getenv(kimiShareDirEnv))
+	add(os.Getenv(kimiCodeHomeEnv))
+	if len(homes) > 0 {
+		return homes
 	}
-	return filepath.Join(home, ".kimi-code"), true
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		add(filepath.Join(home, ".kimi"))
+		add(filepath.Join(home, ".kimi-code"))
+	}
+	return homes
 }
 
 // kimiCredentialsPath returns the device-code OAuth credential file inside a

--- a/backend/internal/adapters/agent/kimi/auth.go
+++ b/backend/internal/adapters/agent/kimi/auth.go
@@ -51,7 +51,7 @@ func kimiLocalAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 	if err != nil || configStatus == ports.AgentAuthStatusAuthorized {
 		return configStatus, configOK, err
 	}
-	credentialsStatus, credentialsOK, err := kimiCredentialsAuthStatus(filepath.Join(home, "credentials", "kimi-code.json"))
+	credentialsStatus, credentialsOK, err := kimiCredentialsAuthStatus(kimiCredentialsPath(home))
 	if err != nil || credentialsOK {
 		return credentialsStatus, credentialsOK, err
 	}
@@ -70,6 +70,13 @@ func kimiCodeHome() (string, bool) {
 		return "", false
 	}
 	return filepath.Join(home, ".kimi-code"), true
+}
+
+// kimiCredentialsPath returns the device-code OAuth credential file inside a
+// Kimi Code home. OAuth-authenticated profiles keep their tokens here and leave
+// every config.toml api_key empty.
+func kimiCredentialsPath(home string) string {
+	return filepath.Join(home, "credentials", "kimi-code.json")
 }
 
 var kimiAPIKeyLineRE = regexp.MustCompile(`(?m)^\s*api_key\s*=\s*("([^"]*)"|'([^']*)'|([^\s#]+))`)

--- a/backend/internal/adapters/agent/kimi/auth_test.go
+++ b/backend/internal/adapters/agent/kimi/auth_test.go
@@ -42,6 +42,50 @@ base_url = "https://api.z.ai/api/coding/paas/v4"
 	}
 }
 
+func TestKimiLocalAuthStatusUsesKimiShareDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(kimiShareDirEnv, home)
+	t.Setenv(kimiCodeHomeEnv, "")
+	credentialsDir := filepath.Join(home, "credentials")
+	if err := os.MkdirAll(credentialsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(credentialsDir, "kimi-code.json"), []byte(`{"access_token":"token"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, ok, err := kimiLocalAuthStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || status != ports.AgentAuthStatusAuthorized {
+		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestKimiUserHomesIncludesCurrentAndLegacyDefaults(t *testing.T) {
+	t.Setenv(kimiShareDirEnv, "")
+	t.Setenv(kimiCodeHomeEnv, "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	homes := kimiUserHomes()
+	for _, want := range []string{filepath.Join(home, ".kimi"), filepath.Join(home, ".kimi-code")} {
+		found := false
+		for _, got := range homes {
+			if sameKimiConfigPath(got, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("kimiUserHomes() = %#v, missing %q", homes, want)
+		}
+	}
+}
+
 func TestKimiLocalAuthStatusUsesKimiCredentials(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KIMI_CODE_HOME", home)

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -73,7 +73,7 @@ func kimiInstructionsPath(workspacePath string) string {
 }
 
 func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
-	home, ok := kimiCodeHomeFromEnv(cfg.Env)
+	home, ok := kimiManagedHomeFromEnv(cfg.Env)
 	if !ok {
 		return errors.New("kimi: AO-managed Kimi Code home is unavailable")
 	}
@@ -81,7 +81,7 @@ func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
 		return err
 	}
 	path := filepath.Join(home, "config.toml")
-	data, err := os.ReadFile(path) //nolint:gosec // path is the AO-managed Kimi config under KIMI_CODE_HOME.
+	data, err := os.ReadFile(path) //nolint:gosec // path is the AO-managed Kimi config under KIMI_SHARE_DIR/KIMI_CODE_HOME.
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
@@ -101,44 +101,45 @@ func installKimiConfigHooks(cfg ports.WorkspaceHookConfig) error {
 }
 
 func seedKimiCredentials(targetHome string) error {
-	sourceHome, ok := kimiCodeHome()
-	if !ok {
-		return nil
-	}
-	sourcePath := kimiCredentialsPath(sourceHome)
 	targetPath := kimiCredentialsPath(targetHome)
-	if sameKimiConfigPath(sourcePath, targetPath) {
-		return nil
-	}
 	if _, err := os.Stat(targetPath); err == nil {
 		return nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("stat target Kimi credentials %s: %w", targetPath, err)
 	}
-	status, ok, err := kimiCredentialsAuthStatus(sourcePath)
-	if err != nil {
-		return fmt.Errorf("read source Kimi credentials %s: %w", sourcePath, err)
-	}
-	if !ok || status != ports.AgentAuthStatusAuthorized {
+	for _, sourceHome := range kimiUserHomes() {
+		sourcePath := kimiCredentialsPath(sourceHome)
+		if sameKimiConfigPath(sourcePath, targetPath) {
+			continue
+		}
+		status, ok, err := kimiCredentialsAuthStatus(sourcePath)
+		if err != nil {
+			return fmt.Errorf("read source Kimi credentials %s: %w", sourcePath, err)
+		}
+		if !ok || status != ports.AgentAuthStatusAuthorized {
+			continue
+		}
+		data, err := os.ReadFile(sourcePath) //nolint:gosec // user Kimi credentials copied into AO's isolated Kimi home.
+		if err != nil {
+			return fmt.Errorf("read source Kimi credentials %s: %w", sourcePath, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
+			return fmt.Errorf("create target Kimi credentials dir: %w", err)
+		}
+		if err := hookutil.AtomicWriteFile(targetPath, data, 0o600); err != nil {
+			return fmt.Errorf("write target Kimi credentials %s: %w", targetPath, err)
+		}
 		return nil
-	}
-	data, err := os.ReadFile(sourcePath) //nolint:gosec // user Kimi credentials copied into AO's isolated Kimi home.
-	if err != nil {
-		return fmt.Errorf("read source Kimi credentials %s: %w", sourcePath, err)
-	}
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
-		return fmt.Errorf("create target Kimi credentials dir: %w", err)
-	}
-	if err := hookutil.AtomicWriteFile(targetPath, data, 0o600); err != nil {
-		return fmt.Errorf("write target Kimi credentials %s: %w", targetPath, err)
 	}
 	return nil
 }
 
-func kimiCodeHomeFromEnv(env map[string]string) (string, bool) {
+func kimiManagedHomeFromEnv(env map[string]string) (string, bool) {
 	if env != nil {
-		if home := strings.TrimSpace(env[kimiCodeHomeEnv]); home != "" {
-			return home, true
+		for _, name := range []string{kimiShareDirEnv, kimiCodeHomeEnv} {
+			if home := strings.TrimSpace(env[name]); home != "" {
+				return home, true
+			}
 		}
 	}
 	return "", false
@@ -151,36 +152,35 @@ func kimiSeedConfig(targetPath string, existing []byte) ([]byte, bool, error) {
 	if !kimiConfigCanSeed(existing) {
 		return nil, false, nil
 	}
-	sourceHome, ok := kimiCodeHome()
-	if !ok {
-		return nil, false, nil
-	}
-	sourcePath := filepath.Join(sourceHome, "config.toml")
-	if sameKimiConfigPath(sourcePath, targetPath) {
-		return nil, false, nil
-	}
-	source, err := os.ReadFile(sourcePath) //nolint:gosec // user/process Kimi config used only as a seed for AO-managed home.
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, false, nil
-	}
-	if err != nil {
-		return nil, false, fmt.Errorf("read source Kimi config %s: %w", sourcePath, err)
-	}
-	if !kimiConfigHasAPIKey(source) {
-		// Device-code logins intentionally leave every api_key empty and keep the
-		// tokens in credentials/kimi-code.json instead. Seeding the whole source
-		// profile is what makes the isolated home usable: it carries
-		// default_model, the provider/OAuth mapping, model aliases, services, and
-		// permissions, which a credential file alone cannot supply.
-		authorized, err := kimiSourceOAuthAuthorized(sourceHome)
+	for _, sourceHome := range kimiUserHomes() {
+		sourcePath := filepath.Join(sourceHome, "config.toml")
+		if sameKimiConfigPath(sourcePath, targetPath) {
+			continue
+		}
+		source, err := os.ReadFile(sourcePath) //nolint:gosec // user/process Kimi config used only as a seed for AO-managed home.
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
 		if err != nil {
-			return nil, false, err
+			return nil, false, fmt.Errorf("read source Kimi config %s: %w", sourcePath, err)
 		}
-		if !authorized {
-			return nil, false, nil
+		if !kimiConfigHasAPIKey(source) {
+			// Device-code logins intentionally leave every api_key empty and keep the
+			// tokens in credentials/kimi-code.json instead. Seeding the whole source
+			// profile is what makes the isolated home usable: it carries
+			// default_model, the provider/OAuth mapping, model aliases, services, and
+			// permissions, which a credential file alone cannot supply.
+			authorized, err := kimiSourceOAuthAuthorized(sourceHome)
+			if err != nil {
+				return nil, false, err
+			}
+			if !authorized {
+				continue
+			}
 		}
+		return source, true, nil
 	}
-	return source, true, nil
+	return nil, false, nil
 }
 
 // kimiSourceOAuthAuthorized reports whether the user's Kimi profile holds a

--- a/backend/internal/adapters/agent/kimi/hooks.go
+++ b/backend/internal/adapters/agent/kimi/hooks.go
@@ -105,8 +105,8 @@ func seedKimiCredentials(targetHome string) error {
 	if !ok {
 		return nil
 	}
-	sourcePath := filepath.Join(sourceHome, "credentials", "kimi-code.json")
-	targetPath := filepath.Join(targetHome, "credentials", "kimi-code.json")
+	sourcePath := kimiCredentialsPath(sourceHome)
+	targetPath := kimiCredentialsPath(targetHome)
 	if sameKimiConfigPath(sourcePath, targetPath) {
 		return nil
 	}
@@ -167,9 +167,32 @@ func kimiSeedConfig(targetPath string, existing []byte) ([]byte, bool, error) {
 		return nil, false, fmt.Errorf("read source Kimi config %s: %w", sourcePath, err)
 	}
 	if !kimiConfigHasAPIKey(source) {
-		return nil, false, nil
+		// Device-code logins intentionally leave every api_key empty and keep the
+		// tokens in credentials/kimi-code.json instead. Seeding the whole source
+		// profile is what makes the isolated home usable: it carries
+		// default_model, the provider/OAuth mapping, model aliases, services, and
+		// permissions, which a credential file alone cannot supply.
+		authorized, err := kimiSourceOAuthAuthorized(sourceHome)
+		if err != nil {
+			return nil, false, err
+		}
+		if !authorized {
+			return nil, false, nil
+		}
 	}
 	return source, true, nil
+}
+
+// kimiSourceOAuthAuthorized reports whether the user's Kimi profile holds a
+// usable device-code login. An empty or token-less credential file means the
+// profile cannot drive a session, so AO must not seed it.
+func kimiSourceOAuthAuthorized(sourceHome string) (bool, error) {
+	path := kimiCredentialsPath(sourceHome)
+	status, ok, err := kimiCredentialsAuthStatus(path)
+	if err != nil {
+		return false, fmt.Errorf("read source Kimi credentials %s: %w", path, err)
+	}
+	return ok && status == ports.AgentAuthStatusAuthorized, nil
 }
 
 func kimiConfigCanSeed(existing []byte) bool {

--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -232,7 +232,8 @@ var kimiBinarySpec = binaryutil.BinarySpec{
 }
 
 // ResolveKimiBinary finds the `kimi` binary, searching PATH then common install
-// locations (npm global dirs, ~/.local/bin, Homebrew, and ~/.cargo/bin).
+// locations (npm global dirs, the official ~/.kimi-code/bin install script
+// target, ~/.local/bin, Homebrew, and ~/.cargo/bin).
 func ResolveKimiBinary(ctx context.Context) (string, error) {
 	return binaryutil.ResolveBinary(ctx, kimiBinarySpec)
 }

--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	adapterID       = "kimi"
+	kimiShareDirEnv = "KIMI_SHARE_DIR"
 	kimiCodeHomeEnv = "KIMI_CODE_HOME"
 	kimiDataDirName = "kimi"
 )
@@ -61,7 +62,9 @@ func (p *Plugin) AugmentRuntimeEnv(env map[string]string, dataDir string) {
 	if strings.TrimSpace(dataDir) == "" {
 		return
 	}
-	env[kimiCodeHomeEnv] = kimiCodeHomeDir(dataDir)
+	home := kimiCodeHomeDir(dataDir)
+	env[kimiShareDirEnv] = home
+	env[kimiCodeHomeEnv] = home
 }
 
 // Manifest returns the adapter's static self-description.

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -480,6 +480,209 @@ func TestGetAgentHooksPreservesExistingAOManagedCredentials(t *testing.T) {
 	}
 }
 
+// kimiOAuthUserConfig mirrors a profile authenticated through Kimi's device-code
+// flow: every api_key is empty and the login lives in credentials/kimi-code.json.
+const kimiOAuthUserConfig = `default_model = "kimi-code/kimi-for-coding"
+
+[providers."managed:kimi-code"]
+type = "kimi"
+api_key = ""
+
+[providers."managed:kimi-code".oauth]
+storage = "file"
+key = "oauth/kimi-code"
+
+[models."kimi-code/kimi-for-coding"]
+provider = "managed:kimi-code"
+name = "K3"
+`
+
+func writeKimiOAuthProfile(t *testing.T, home, config, credentials string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if credentials == "" {
+		return
+	}
+	path := filepath.Join(home, "credentials", "kimi-code.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(credentials), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetAgentHooksSeedsAOManagedConfigFromOAuthUserKimiHome(t *testing.T) {
+	workspace := t.TempDir()
+	userHome := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, userHome)
+	userCredentials := `{"access_token":"user-access","refresh_token":"user-refresh"}`
+	writeKimiOAuthProfile(t, userHome, kimiOAuthUserConfig, userCredentials)
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(aoHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read AO config: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`default_model = "kimi-code/kimi-for-coding"`,
+		`[providers."managed:kimi-code"]`,
+		`[providers."managed:kimi-code".oauth]`,
+		`[models."kimi-code/kimi-for-coding"]`,
+		`command = "ao hooks kimi session-start"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("AO config missing %q:\n%s", want, text)
+		}
+	}
+	if got := strings.Count(text, kimiHooksSentinelStart); got != 1 {
+		t.Fatalf("managed hook block count = %d, want 1:\n%s", got, text)
+	}
+
+	credentials, err := os.ReadFile(filepath.Join(aoHome, "credentials", "kimi-code.json"))
+	if err != nil {
+		t.Fatalf("read AO credentials: %v", err)
+	}
+	if string(credentials) != userCredentials {
+		t.Fatalf("AO credentials = %s, want %s", credentials, userCredentials)
+	}
+
+	sourceConfig, err := os.ReadFile(filepath.Join(userHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read source config: %v", err)
+	}
+	if string(sourceConfig) != kimiOAuthUserConfig {
+		t.Fatalf("source config mutated:\n%s", sourceConfig)
+	}
+	sourceCredentials, err := os.ReadFile(filepath.Join(userHome, "credentials", "kimi-code.json"))
+	if err != nil {
+		t.Fatalf("read source credentials: %v", err)
+	}
+	if string(sourceCredentials) != userCredentials {
+		t.Fatalf("source credentials mutated: %s", sourceCredentials)
+	}
+}
+
+func TestGetAgentHooksReseedsHookOnlyAOManagedConfigFromOAuthUserKimiHome(t *testing.T) {
+	workspace := t.TempDir()
+	userHome := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, userHome)
+	writeKimiOAuthProfile(t, userHome, kimiOAuthUserConfig, `{"refresh_token":"user-refresh"}`)
+	if err := os.WriteFile(filepath.Join(aoHome, "config.toml"), []byte(kimiHooksConfigBlock()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(aoHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read AO config: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`default_model = "kimi-code/kimi-for-coding"`,
+		`[models."kimi-code/kimi-for-coding"]`,
+		`command = "ao hooks kimi session-start"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("AO config missing %q:\n%s", want, text)
+		}
+	}
+	if got := strings.Count(text, kimiHooksSentinelStart); got != 1 {
+		t.Fatalf("managed hook block count = %d, want 1:\n%s", got, text)
+	}
+}
+
+func TestGetAgentHooksSkipsSeedingOAuthConfigWithoutUsableCredentials(t *testing.T) {
+	for name, credentials := range map[string]string{
+		"missing":     "",
+		"emptyTokens": `{"access_token":"","refresh_token":"","expires_at":123}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			workspace := t.TempDir()
+			userHome := t.TempDir()
+			aoHome := t.TempDir()
+			t.Setenv(kimiCodeHomeEnv, userHome)
+			writeKimiOAuthProfile(t, userHome, kimiOAuthUserConfig, credentials)
+
+			if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+				WorkspacePath: workspace,
+				Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+			}); err != nil {
+				t.Fatalf("GetAgentHooks err = %v", err)
+			}
+
+			data, err := os.ReadFile(filepath.Join(aoHome, "config.toml"))
+			if err != nil {
+				t.Fatalf("read AO config: %v", err)
+			}
+			text := string(data)
+			if strings.Contains(text, "default_model") {
+				t.Fatalf("seeded an unusable Kimi profile:\n%s", text)
+			}
+			if !strings.Contains(text, `command = "ao hooks kimi session-start"`) {
+				t.Fatalf("AO config missing managed hooks:\n%s", text)
+			}
+			if _, err := os.Stat(filepath.Join(aoHome, "credentials", "kimi-code.json")); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("AO credentials stat err = %v, want not exist", err)
+			}
+		})
+	}
+}
+
+func TestGetAgentHooksPreservesExistingAOManagedConfigWithOAuthSource(t *testing.T) {
+	workspace := t.TempDir()
+	userHome := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiCodeHomeEnv, userHome)
+	writeKimiOAuthProfile(t, userHome, kimiOAuthUserConfig, `{"access_token":"user-access"}`)
+	existing := `default_model = "ao-managed/model"` + "\n"
+	if err := os.WriteFile(filepath.Join(aoHome, "config.toml"), []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiCodeHomeEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(aoHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read AO config: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `default_model = "ao-managed/model"`) {
+		t.Fatalf("existing AO config was replaced:\n%s", text)
+	}
+	if strings.Contains(text, `[providers."managed:kimi-code"]`) {
+		t.Fatalf("source config seeded over existing AO config:\n%s", text)
+	}
+	if got := strings.Count(text, kimiHooksSentinelStart); got != 1 {
+		t.Fatalf("managed hook block count = %d, want 1:\n%s", got, text)
+	}
+	if !strings.Contains(text, `command = "ao hooks kimi session-start"`) {
+		t.Fatalf("AO config missing managed hooks:\n%s", text)
+	}
+}
+
 func TestGetAgentHooksReseedsAOManagedConfigWithoutAuth(t *testing.T) {
 	workspace := t.TempDir()
 	userHome := t.TempDir()

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -573,6 +573,50 @@ func TestGetAgentHooksSeedsAOManagedConfigFromOAuthUserKimiHome(t *testing.T) {
 	}
 }
 
+func TestGetAgentHooksSeedsAOManagedConfigFromOAuthKimiShareDir(t *testing.T) {
+	workspace := t.TempDir()
+	userShareDir := t.TempDir()
+	aoHome := t.TempDir()
+	t.Setenv(kimiShareDirEnv, userShareDir)
+	t.Setenv(kimiCodeHomeEnv, "")
+	userCredentials := `{"access_token":"current-access","refresh_token":"current-refresh"}`
+	writeKimiOAuthProfile(t, userShareDir, kimiOAuthUserConfig, userCredentials)
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Env:           map[string]string{kimiShareDirEnv: aoHome},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(aoHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read AO config: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`default_model = "kimi-code/kimi-for-coding"`,
+		`[providers."managed:kimi-code".oauth]`,
+		`[models."kimi-code/kimi-for-coding"]`,
+		`command = "ao hooks kimi session-start"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("AO config missing %q:\n%s", want, text)
+		}
+	}
+	if got := strings.Count(text, kimiHooksSentinelStart); got != 1 {
+		t.Fatalf("managed hook block count = %d, want 1:\n%s", got, text)
+	}
+
+	credentials, err := os.ReadFile(kimiCredentialsPath(aoHome))
+	if err != nil {
+		t.Fatalf("read AO credentials: %v", err)
+	}
+	if string(credentials) != userCredentials {
+		t.Fatalf("AO credentials = %s, want %s", credentials, userCredentials)
+	}
+}
+
 func TestGetAgentHooksReseedsHookOnlyAOManagedConfigFromOAuthUserKimiHome(t *testing.T) {
 	workspace := t.TempDir()
 	userHome := t.TempDir()
@@ -759,13 +803,18 @@ func TestGetAgentHooksRewritesManagedKimiConfigBlock(t *testing.T) {
 }
 
 func TestAugmentRuntimeEnvUsesAODataDir(t *testing.T) {
-	env := map[string]string{kimiCodeHomeEnv: "/outside-ao"}
+	env := map[string]string{
+		kimiShareDirEnv: "/outside-current",
+		kimiCodeHomeEnv: "/outside-legacy",
+	}
 	dataDir := filepath.Join(t.TempDir(), "ao")
 
 	(&Plugin{}).AugmentRuntimeEnv(env, dataDir)
 
-	if got, want := env[kimiCodeHomeEnv], kimiCodeHomeDir(dataDir); got != want {
-		t.Fatalf("%s = %q, want %q", kimiCodeHomeEnv, got, want)
+	for _, name := range []string{kimiShareDirEnv, kimiCodeHomeEnv} {
+		if got, want := env[name], kimiCodeHomeDir(dataDir); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Seed the user's **full native Kimi config** into AO's isolated Kimi home when the profile is authenticated through Kimi's device-code OAuth flow, not only when it carries a literal API key.

The follow-up now supports both Kimi storage generations:

- current `KIMI_SHARE_DIR` / `~/.kimi`
- legacy `KIMI_CODE_HOME` / `~/.kimi-code`

AO sets both environment variables to the same directory under `AO_DATA_DIR`, so current and legacy Kimi binaries use the same isolated, hook-enabled profile.

> **Rebased 2026-08-20.** This branch originally also added `~/.kimi-code/bin/kimi` binary discovery and OAuth credential auth-detection. Both landed on `main` independently (#3648 and follow-ups), so the rebase kept only the config-seeding gap they left open. The 2026-08-23 follow-up adds the current official Kimi share-directory layout requested in review and was verified against the current `main` merge result.

## Why

AO isolates Kimi state under its own data directory. `seedKimiCredentials` already copied OAuth credentials there, but `kimiSeedConfig` refused to seed `config.toml` unless `kimiConfigHasAPIKey(source)` was true.

A device-code login **intentionally leaves every `api_key` empty** — the tokens live in `credentials/kimi-code.json`. The managed home therefore received a valid credential and only AO's hook entries: no `default_model`, provider/OAuth mapping, model tables, services, or permissions.

Kimi then starts with `Model: not set`, rejects AO's injected task with `Error: LLM not set`, never creates a native session, and surfaces as `no_signal` after the grace period even though the advisory auth probe reports the agent `authorized`.

Current Kimi releases also store runtime data under `KIMI_SHARE_DIR` (default `~/.kimi`) rather than the legacy `KIMI_CODE_HOME` location. Supporting only the legacy layout would leave modern installs unable to seed or consume AO's isolated config.

Full RCA with an A/B reproduction against `63b5ffb`: https://github.com/Untrivial-ai/agent-orchestrator/pull/2960#issuecomment-5354802534

## How

- Discover explicitly configured `KIMI_SHARE_DIR` and `KIMI_CODE_HOME` locations; when neither is set, check `~/.kimi` first and then `~/.kimi-code`.
- Probe config and OAuth credentials across those current and legacy locations.
- Treat a source profile as seedable when it is authorized by either a non-empty `api_key` or a usable `credentials/kimi-code.json`.
- Copy the whole source config, then merge exactly one AO hook block as before.
- Set both Kimi home variables to AO's isolated Kimi directory at launch.

Seeding the whole file — rather than cherry-picking `default_model`/provider fields — is deliberate: selective TOML merging drops the linked OAuth storage, aliases, services, and permission settings that make the profile internally consistent. Full first-use seeding is already the established behavior for API-key profiles.

Deliberately unchanged:

- AO's Kimi-home isolation stays; AO never writes to the user's native profile.
- An AO config with any non-hook content is preserved; only the managed hook block is merged/updated.
- An existing AO-managed credential is never overwritten by the native one.
- A source profile with a missing or token-less credential is **not** seeded unless it has a usable API key.

## Testing

Passing locally:

- `cd backend && go test -race ./internal/adapters/agent/kimi`
- current-`main` merge result: `go test ./internal/adapters/agent/registry ./internal/session_manager`
- current-`main` merge result: `go build ./...`
- focused reruns: `go test -race ./internal/adapters/agent/kilocode ./internal/adapters/agent/opencode`
- `go vet ./internal/adapters/agent/kimi`

`go test -race ./internal/adapters/...` and `go test ./...` each otherwise completed but hit the same unrelated 3-second auth-probe deadline flakes in `kilocode` and `opencode`; both packages passed immediately when rerun together in isolation. The focused Kimi race suite stayed green.

Coverage now includes:

- OAuth seeding from the current `KIMI_SHARE_DIR` layout, including config, credentials, and one managed hook block.
- Auth discovery from `KIMI_SHARE_DIR` and default discovery of both `~/.kimi` and `~/.kimi-code`.
- Both runtime home variables pinned to AO's isolated directory.
- Legacy OAuth config seeding, hook-only reseeding, unusable-credential rejection, existing-config preservation, credential non-overwrite, and source immutability.

## Checklist

- [x] Existing PR updated in place; no duplicate PR
- [x] Current and legacy Kimi storage layouts supported
- [x] One focused adapter change
- [x] Review feedback addressed
- [x] Focused Kimi race tests and current-main backend verification run
