### PR TITLE
fix: keep migration popup across first-run scratch redirect (follow-up to #2952)

### DIFF
--- a/backend/internal/adapters/workspace/router/router.go
+++ b/backend/internal/adapters/workspace/router/router.go
@@ -141,7 +141,12 @@ func (w *Workspace) adapterForProject(ctx context.Context, projectID domain.Proj
 		if err != nil {
 			return nil, fmt.Errorf("workspace router: project %q: %w", projectID, err)
 		}
-		if ok && project.Kind.WithDefault() == domain.ProjectKindScratch {
+		if !ok {
+			// Fail closed: a missing project must not fall through to the git
+			// adapter (that could mis-handle a scratch session path).
+			return nil, fmt.Errorf("workspace router: project %q not found", projectID)
+		}
+		if project.Kind.WithDefault() == domain.ProjectKindScratch {
 			if w.scratch == nil {
 				return nil, errors.New("workspace router: scratch workspace is not configured")
 			}

--- a/backend/internal/adapters/workspace/router/router_test.go
+++ b/backend/internal/adapters/workspace/router/router_test.go
@@ -200,3 +200,29 @@ func TestRouterPreservesWorkspaceProjectDelegation(t *testing.T) {
 		t.Fatalf("scratch create calls = %d, want 0", scratch.createCalls)
 	}
 }
+
+func TestRouterFailsClosedWhenProjectMissing(t *testing.T) {
+	git := &recordingWorkspace{}
+	scratch := &recordingWorkspace{}
+	r := workspacerouter.New(workspacerouter.Deps{
+		Git:      git,
+		Scratch:  scratch,
+		Projects: projectStore{projects: map[string]domain.ProjectRecord{}},
+	})
+
+	_, err := r.Create(context.Background(), ports.WorkspaceConfig{ProjectID: "missing", SessionID: "s-1", Kind: domain.KindWorker})
+	if err == nil {
+		t.Fatal("Create missing project: want error, got nil")
+	}
+	if git.createCalls != 0 || scratch.createCalls != 0 {
+		t.Fatalf("create calls git/scratch = %d/%d, want 0/0 (must not fall back to git)", git.createCalls, scratch.createCalls)
+	}
+
+	err = r.Destroy(context.Background(), ports.WorkspaceInfo{ProjectID: "missing", SessionID: "s-1", Path: "/tmp/missing"})
+	if err == nil {
+		t.Fatal("Destroy missing project: want error, got nil")
+	}
+	if git.destroyCalls != 0 || scratch.destroyCalls != 0 {
+		t.Fatalf("destroy calls git/scratch = %d/%d, want 0/0", git.destroyCalls, scratch.destroyCalls)
+	}
+}

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -172,6 +172,15 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 	m.addMu.Lock()
 	defer m.addMu.Unlock()
 
+	// "scratch" is reserved for the built-in first-run project. Refuse reuse
+	// (including after archive) so a git project cannot demote that id.
+	if isReservedScratchProjectID(id) {
+		return Project{}, apierr.Conflict("SCRATCH_PROJECT_ID_RESERVED", `Project id "scratch" is reserved for the built-in Scratch project`, map[string]any{
+			"existingProjectId":  reservedScratchProjectID,
+			"suggestedProjectId": string(m.suggestID(ctx, domain.ProjectID("scratch-repo"))),
+		})
+	}
+
 	projectCountBefore, err := m.activeProjectCount(ctx)
 	if err != nil {
 		return Project{}, apierr.Internal("PROJECT_LOAD_FAILED", "Failed to load project")
@@ -864,6 +873,14 @@ func defaultProjectID(path string) domain.ProjectID {
 }
 
 var projectIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+// reservedScratchProjectID is the built-in first-run Scratch project id. Users
+// cannot register a different project under this id via project add.
+const reservedScratchProjectID = "scratch"
+
+func isReservedScratchProjectID(id domain.ProjectID) bool {
+	return strings.EqualFold(string(id), reservedScratchProjectID)
+}
 
 func validateProjectID(id domain.ProjectID) error {
 	raw := string(id)

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -873,6 +873,44 @@ func TestManager_AddValidationAndConflicts(t *testing.T) {
 	wantCode(t, err, "ID_ALREADY_REGISTERED")
 }
 
+func TestManager_AddRejectsReservedScratchProjectID(t *testing.T) {
+	ctx := context.Background()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	m := project.NewWithDeps(project.Deps{Store: store, DefaultHarness: domain.HarnessCodex})
+
+	// Active built-in Scratch must not be replaceable via project add.
+	if _, err := m.EnsureDefaultScratchProject(ctx, filepath.Join(t.TempDir(), "scratch", "default")); err != nil {
+		t.Fatalf("EnsureDefaultScratchProject: %v", err)
+	}
+	_, err = m.Add(ctx, project.AddInput{Path: gitRepo(t), ProjectID: ptr("scratch")})
+	wantCode(t, err, "SCRATCH_PROJECT_ID_RESERVED")
+
+	// Archived Scratch still reserves the id so a git project cannot demote it.
+	if ok, archErr := store.ArchiveProject(ctx, "scratch", time.Now().UTC()); archErr != nil || !ok {
+		t.Fatalf("archive scratch: ok=%v err=%v", ok, archErr)
+	}
+	_, err = m.Add(ctx, project.AddInput{Path: gitRepo(t), ProjectID: ptr("scratch")})
+	wantCode(t, err, "SCRATCH_PROJECT_ID_RESERVED")
+
+	// Path basename "scratch" also resolves to the reserved id.
+	dir := filepath.Join(t.TempDir(), "scratch")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if out, initErr := exec.Command("git", "init", "-b", "main", dir).CombinedOutput(); initErr != nil {
+		t.Fatalf("git init: %v (%s)", initErr, out)
+	}
+	if out, commitErr := exec.Command("git", "-C", dir, "commit", "--allow-empty", "-m", "init").CombinedOutput(); commitErr != nil {
+		t.Fatalf("git commit: %v (%s)", commitErr, out)
+	}
+	_, err = m.Add(ctx, project.AddInput{Path: dir})
+	wantCode(t, err, "SCRATCH_PROJECT_ID_RESERVED")
+}
+
 // gitRepoWithOrigin creates a real git repo with an `origin` remote pointing
 // at `originURL`. Used to assert project.Add captures the origin at add time.
 func gitRepoWithOrigin(t *testing.T, originURL string) string {

--- a/frontend/src/renderer/__tests__/_shell-index-redirect.test.tsx
+++ b/frontend/src/renderer/__tests__/_shell-index-redirect.test.tsx
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { act, render, waitFor } from "@testing-library/react";
 import { type ComponentType } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -22,10 +25,11 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 	}),
 }));
 
-vi.mock("../components/MigrationPopup", () => ({ MigrationPopup: () => null }));
 vi.mock("../components/SessionsBoard", () => ({ SessionsBoard: () => <div data-testid="sessions-board" /> }));
 
 import { Route } from "../routes/_shell.index";
+
+const routesDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "../routes");
 
 async function renderIndex() {
 	const Component = Route.options.component as ComponentType;
@@ -72,5 +76,16 @@ describe("shell index route", () => {
 		await renderIndex();
 
 		expect(routeMocks.navigate).not.toHaveBeenCalled();
+	});
+
+	it("keeps MigrationPopup on the shell layout so first-run redirect cannot unmount it", () => {
+		// The index replace-navigates sole-scratch users to /projects/scratch.
+		// MigrationPopup must live on the parent shell, not this child route.
+		const indexSource = readFileSync(path.join(routesDir, "_shell.index.tsx"), "utf8");
+		const shellSource = readFileSync(path.join(routesDir, "_shell.tsx"), "utf8");
+		expect(indexSource).not.toMatch(/from ["'][^"']*MigrationPopup["']/);
+		expect(indexSource).not.toMatch(/<MigrationPopup\b/);
+		expect(shellSource).toMatch(/from ["'][^"']*MigrationPopup["']/);
+		expect(shellSource).toMatch(/<MigrationPopup\s*\/>/);
 	});
 });

--- a/frontend/src/renderer/lib/command-palette.ts
+++ b/frontend/src/renderer/lib/command-palette.ts
@@ -73,7 +73,7 @@ function sessionCommand(
 		group,
 		title: session.title,
 		subtitle: workspace.name,
-		keywords: [workspace.name, session.branch, session.issueId ?? ""],
+		keywords: [workspace.name, session.branch ?? "", session.issueId ?? ""],
 		action: {
 			kind: "navigate",
 			target: {
@@ -141,7 +141,12 @@ export function buildCommands(ctx: CommandPaletteContext): CommandItem[] {
 		});
 	}
 
-	if (currentSession && currentSession.kind !== "orchestrator" && !isSyntheticBranch(currentSession)) {
+	if (
+		currentSession &&
+		currentSession.kind !== "orchestrator" &&
+		currentSession.branch &&
+		!isSyntheticBranch(currentSession)
+	) {
 		items.push({
 			id: "current-copy-branch",
 			group: "current",
@@ -200,7 +205,7 @@ export function buildCommands(ctx: CommandPaletteContext): CommandItem[] {
 						String(pr.number),
 						pr.url,
 						session.title,
-						session.branch,
+						session.branch ?? "",
 						workspace.name,
 						pr.state,
 					],

--- a/frontend/src/renderer/routes/_shell.index.tsx
+++ b/frontend/src/renderer/routes/_shell.index.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
-import { MigrationPopup } from "../components/MigrationPopup";
 import { SessionsBoard } from "../components/SessionsBoard";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 
@@ -8,6 +7,8 @@ export const Route = createFileRoute("/_shell/")({
 	component: ShellIndex,
 });
 
+// MigrationPopup lives on the parent shell layout so the first-run scratch
+// redirect below does not unmount the legacy-import offer.
 function ShellIndex() {
 	const navigate = useNavigate();
 	const workspaceQuery = useWorkspaceQuery();
@@ -25,10 +26,5 @@ function ShellIndex() {
 		});
 	}, [navigate, workspaceQuery.data, workspaceQuery.isSuccess]);
 
-	return (
-		<>
-			<MigrationPopup />
-			<SessionsBoard />
-		</>
-	);
+	return <SessionsBoard />;
 }

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -7,6 +7,7 @@ import { DaemonFailureBanner } from "../components/DaemonFailureBanner";
 import { NotificationRuntime } from "../components/NotificationCenter";
 import { GlobalNewTaskDialog } from "../components/GlobalNewTaskDialog";
 import { KeyboardShortcutsDialog } from "../components/KeyboardShortcutsDialog";
+import { MigrationPopup } from "../components/MigrationPopup";
 import { ShellTopbar } from "../components/ShellTopbar";
 import { OrchestratorReplacementDialog } from "../components/OrchestratorReplacementDialog";
 import { Sidebar } from "../components/Sidebar";
@@ -516,6 +517,9 @@ function ShellLayout() {
 					projectId={replacementErrorProjectId}
 					workspaces={workspaces}
 				/>
+				{/* Mounted on the shell (not the index board) so the first-run
+				    scratch redirect to /projects/scratch cannot unmount it. */}
+				<MigrationPopup />
 				<CommandPalette />
 			</div>
 		</ShellProvider>


### PR DESCRIPTION
## Summary
Follow-up / re-host of [#2952](https://github.com/AgentWrapper/agent-orchestrator/pull/2952) with review bugs fixed.

Original head is `Vaibhaav-Tiwari:feat/first-run-scratch-project` (cross-repo); this account cannot push there.

### Fixes (`e9d29f16`)
1. **Migration popup survives first-run redirect** — mount on shell routes so sole-scratch redirect to `/projects/scratch` no longer unmounts the offer.
2. Reserve project id `scratch` against reuse after archive.
3. Workspace router fail-closed when project is missing (no silent git fallback).

## Test plan
- [ ] First-run with only scratch still shows migration popup
- [ ] Cannot re-add project id `scratch` as single_repo after archive
- [ ] go test project + workspace router; frontend typecheck + shell index tests