### PR TITLE
fix(auggie): pass configured model to launch commands

### DIFF
--- a/backend/internal/adapters/agent/auggie/auggie.go
+++ b/backend/internal/adapters/agent/auggie/auggie.go
@@ -78,6 +78,22 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Auggie understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `auggie --model`.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new headless Auggie session:
 //
 //	auggie --print [--rules <f>] [-- <prompt>]
@@ -99,6 +115,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	if cfg.SystemPromptFile != "" {
 		cmd = append(cmd, "--rules", cfg.SystemPromptFile)
 	}
+	appendModelFlag(&cmd, cfg.Config)
 	if cfg.Prompt != "" {
 		cmd = append(cmd, "--", cfg.Prompt)
 	}
@@ -129,8 +146,15 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if cfg.SystemPromptFile != "" {
 		cmd = append(cmd, "--rules", cfg.SystemPromptFile)
 	}
+	appendModelFlag(&cmd, cfg.Config)
 	cmd = append(cmd, "--resume", agentSessionID)
 	return cmd, true, nil
+}
+
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
+	}
 }
 
 // Auggie has no single blanket auto-approve/bypass flag; unattended tool/file

--- a/backend/internal/adapters/agent/auggie/auggie.go
+++ b/backend/internal/adapters/agent/auggie/auggie.go
@@ -151,6 +151,9 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	return cmd, true, nil
 }
 
+// appendModelFlag treats the configured model as opaque: it trims and forwards
+// non-empty values for Auggie to validate. Invalid models intentionally surface
+// Auggie's error; AO does not silently retry with Auggie's default model.
 func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
 	if model := strings.TrimSpace(cfg.Model); model != "" {
 		*cmd = append(*cmd, "--model", model)

--- a/backend/internal/adapters/agent/auggie/auggie_test.go
+++ b/backend/internal/adapters/agent/auggie/auggie_test.go
@@ -29,13 +29,20 @@ func TestManifest(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecEmpty(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `auggie --model`.",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
 	}
 }
 
@@ -62,6 +69,37 @@ func TestGetLaunchCommandWithPrompt(t *testing.T) {
 	want := []string{"auggie", "--print", "--", "-add a health check"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	p := &Plugin{resolvedBinary: "auggie"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "  claude-sonnet-4  "},
+		Prompt: "fix this",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"auggie", "--print", "--model", "claude-sonnet-4", "--", "fix this"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	p := &Plugin{resolvedBinary: "auggie"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"auggie", "--print"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
 }
 
@@ -150,6 +188,27 @@ func TestGetRestoreCommand(t *testing.T) {
 	}
 
 	want := []string{"auggie", "--print", "--rules", "/tmp/system.md", "--resume", "sess-abc123"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	p := &Plugin{resolvedBinary: "auggie"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "  claude-sonnet-4  "},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "sess-abc123"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+
+	want := []string{"auggie", "--print", "--model", "claude-sonnet-4", "--resume", "sess-abc123"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}


### PR DESCRIPTION
## What changed

- pass the configured model to Auggie using `--model`
- support the model for both new and restored sessions
- ignore blank model values
- advertise model support through `GetConfigSpec`
- add tests for the new behavior

Previously, AO received the configured model but did not pass it to Auggie, so Auggie used its default model instead.

Fixes #2888

## Tests

- `go test -race ./internal/adapters/agent/auggie`
- `go test ./...`
- `go build ./...`
- `go vet ./...`

@nikhilachale, could you please review this PR?
