### PR TITLE
Fix/daemon failure errors

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
 	},
 	"scripts": {
 		"build:daemon": "node ./scripts/build-daemon.mjs",
+		"predev": "npm run build:daemon",
 		"dev": "electron-forge start",
 		"dev:web": "VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts",
 		"prepackage": "npm run build:daemon",

--- a/frontend/scripts/build-daemon.mjs
+++ b/frontend/scripts/build-daemon.mjs
@@ -9,6 +9,32 @@ const repoRoot = resolve(frontendRoot, "..");
 const backendRoot = join(repoRoot, "backend");
 const outDir = join(frontendRoot, "daemon");
 const outPath = join(outDir, process.platform === "win32" ? "ao.exe" : "ao");
+const minimumGoVersion = [1, 25, 7];
+
+function parseGoVersion(value) {
+	const match = /go(\d+)\.(\d+)(?:\.(\d+))?/.exec(value);
+	if (!match) return null;
+	return [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)];
+}
+
+function meetsMinimumVersion(actual, minimum) {
+	for (let index = 0; index < minimum.length; index += 1) {
+		if (actual[index] !== minimum[index]) return actual[index] > minimum[index];
+	}
+	return true;
+}
+
+const versionResult = spawnSync("go", ["version"], { encoding: "utf8" });
+if (versionResult.error) {
+	console.error(`Go ${minimumGoVersion.join(".")}+ is required, but Go could not be started: ${versionResult.error.message}`);
+	process.exit(1);
+}
+const actualGoVersion = parseGoVersion(versionResult.stdout);
+if (versionResult.status !== 0 || !actualGoVersion || !meetsMinimumVersion(actualGoVersion, minimumGoVersion)) {
+	const found = actualGoVersion ? actualGoVersion.join(".") : versionResult.stdout.trim() || "unknown";
+	console.error(`Go ${minimumGoVersion.join(".")}+ required, found ${found} — upgrade at https://go.dev/dl/`);
+	process.exit(1);
+}
 
 rmSync(outDir, { recursive: true, force: true });
 mkdirSync(outDir, { recursive: true });

--- a/frontend/scripts/build-daemon.mjs
+++ b/frontend/scripts/build-daemon.mjs
@@ -26,7 +26,9 @@ function meetsMinimumVersion(actual, minimum) {
 
 const versionResult = spawnSync("go", ["version"], { encoding: "utf8" });
 if (versionResult.error) {
-	console.error(`Go ${minimumGoVersion.join(".")}+ is required, but Go could not be started: ${versionResult.error.message}`);
+	console.error(
+		`Go ${minimumGoVersion.join(".")}+ is required, but Go could not be started: ${versionResult.error.message}`,
+	);
 	process.exit(1);
 }
 const actualGoVersion = parseGoVersion(versionResult.stdout);

--- a/frontend/scripts/build-daemon.mjs
+++ b/frontend/scripts/build-daemon.mjs
@@ -2,6 +2,7 @@ import { rmSync, mkdirSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { meetsMinimumVersion, minimumGoVersion, parseGoVersion } from "./go-version.mjs";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const frontendRoot = resolve(scriptsDir, "..");
@@ -9,20 +10,6 @@ const repoRoot = resolve(frontendRoot, "..");
 const backendRoot = join(repoRoot, "backend");
 const outDir = join(frontendRoot, "daemon");
 const outPath = join(outDir, process.platform === "win32" ? "ao.exe" : "ao");
-const minimumGoVersion = [1, 25, 7];
-
-function parseGoVersion(value) {
-	const match = /go(\d+)\.(\d+)(?:\.(\d+))?/.exec(value);
-	if (!match) return null;
-	return [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)];
-}
-
-function meetsMinimumVersion(actual, minimum) {
-	for (let index = 0; index < minimum.length; index += 1) {
-		if (actual[index] !== minimum[index]) return actual[index] > minimum[index];
-	}
-	return true;
-}
 
 const versionResult = spawnSync("go", ["version"], { encoding: "utf8" });
 if (versionResult.error) {

--- a/frontend/scripts/build-daemon.mjs
+++ b/frontend/scripts/build-daemon.mjs
@@ -1,8 +1,8 @@
-import { rmSync, mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
-import { meetsMinimumVersion, minimumGoVersion, parseGoVersion } from "./go-version.mjs";
+import { meetsMinimumVersion, parseGoVersion, parseMinimumGoVersion } from "./go-version.mjs";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const frontendRoot = resolve(scriptsDir, "..");
@@ -10,6 +10,12 @@ const repoRoot = resolve(frontendRoot, "..");
 const backendRoot = join(repoRoot, "backend");
 const outDir = join(frontendRoot, "daemon");
 const outPath = join(outDir, process.platform === "win32" ? "ao.exe" : "ao");
+const minimumGoVersion = parseMinimumGoVersion(readFileSync(join(backendRoot, "go.mod"), "utf8"));
+
+if (!minimumGoVersion) {
+	console.error("Could not determine the required Go version from backend/go.mod.");
+	process.exit(1);
+}
 
 const versionResult = spawnSync("go", ["version"], { encoding: "utf8" });
 if (versionResult.error) {

--- a/frontend/scripts/go-version.mjs
+++ b/frontend/scripts/go-version.mjs
@@ -1,5 +1,3 @@
-export const minimumGoVersion = [1, 25, 7];
-
 // Prerelease toolchains are deliberately rejected: this build requires the
 // stable Go release declared in backend/go.mod or a later stable release.
 export function parseGoVersion(value) {
@@ -8,7 +6,13 @@ export function parseGoVersion(value) {
 	return [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)];
 }
 
-export function meetsMinimumVersion(actual, minimum = minimumGoVersion) {
+export function parseMinimumGoVersion(goMod) {
+	const match = /^go\s+(\d+)\.(\d+)(?:\.(\d+))?\s*$/m.exec(goMod);
+	if (!match) return null;
+	return [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)];
+}
+
+export function meetsMinimumVersion(actual, minimum) {
 	for (let index = 0; index < minimum.length; index += 1) {
 		if (actual[index] !== minimum[index]) return actual[index] > minimum[index];
 	}

--- a/frontend/scripts/go-version.mjs
+++ b/frontend/scripts/go-version.mjs
@@ -1,0 +1,16 @@
+export const minimumGoVersion = [1, 25, 7];
+
+// Prerelease toolchains are deliberately rejected: this build requires the
+// stable Go release declared in backend/go.mod or a later stable release.
+export function parseGoVersion(value) {
+	const match = /\bgo(\d+)\.(\d+)(?:\.(\d+))?(?![\w.])/.exec(value);
+	if (!match) return null;
+	return [Number(match[1]), Number(match[2]), Number(match[3] ?? 0)];
+}
+
+export function meetsMinimumVersion(actual, minimum = minimumGoVersion) {
+	for (let index = 0; index < minimum.length; index += 1) {
+		if (actual[index] !== minimum[index]) return actual[index] > minimum[index];
+	}
+	return true;
+}

--- a/frontend/scripts/go-version.test.mjs
+++ b/frontend/scripts/go-version.test.mjs
@@ -1,0 +1,31 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { meetsMinimumVersion, minimumGoVersion, parseGoVersion } from "./go-version.mjs";
+
+describe("parseGoVersion", () => {
+	it("parses stable Go versions and defaults a missing patch to zero", () => {
+		expect(parseGoVersion("go version go1.25.7 darwin/arm64")).toEqual([1, 25, 7]);
+		expect(parseGoVersion("go version go1.26 linux/amd64")).toEqual([1, 26, 0]);
+	});
+
+	it("rejects unparseable and prerelease Go versions", () => {
+		expect(parseGoVersion("not Go")).toBeNull();
+		expect(parseGoVersion("go version go1.25rc1 darwin/arm64")).toBeNull();
+		expect(parseGoVersion("go version go1.25.7rc1 darwin/arm64")).toBeNull();
+	});
+});
+
+describe("meetsMinimumVersion", () => {
+	it.each([
+		{ version: [1, 25, 6], expected: false },
+		{ version: [1, 25, 7], expected: true },
+		{ version: [1, 26, 0], expected: true },
+		{ version: [2, 0, 0], expected: true },
+	])("returns $expected for $version", ({ version, expected }) => {
+		expect(meetsMinimumVersion(version)).toBe(expected);
+	});
+
+	it("accepts an explicit minimum version", () => {
+		expect(meetsMinimumVersion([1, 25, 7], minimumGoVersion)).toBe(true);
+	});
+});

--- a/frontend/scripts/go-version.test.mjs
+++ b/frontend/scripts/go-version.test.mjs
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { meetsMinimumVersion, minimumGoVersion, parseGoVersion } from "./go-version.mjs";
+import { meetsMinimumVersion, parseGoVersion, parseMinimumGoVersion } from "./go-version.mjs";
 
 describe("parseGoVersion", () => {
 	it("parses stable Go versions and defaults a missing patch to zero", () => {
@@ -15,17 +15,31 @@ describe("parseGoVersion", () => {
 	});
 });
 
+describe("parseMinimumGoVersion", () => {
+	it("reads the stable Go requirement from go.mod", () => {
+		expect(parseMinimumGoVersion("module example.com/project\n\ngo 1.25.7\n")).toEqual([1, 25, 7]);
+		expect(parseMinimumGoVersion("go 1.26\n")).toEqual([1, 26, 0]);
+	});
+
+	it("rejects a missing or prerelease Go directive", () => {
+		expect(parseMinimumGoVersion("module example.com/project\n")).toBeNull();
+		expect(parseMinimumGoVersion("go 1.25rc1\n")).toBeNull();
+	});
+});
+
 describe("meetsMinimumVersion", () => {
+	const minimum = [1, 25, 7];
+
 	it.each([
 		{ version: [1, 25, 6], expected: false },
 		{ version: [1, 25, 7], expected: true },
 		{ version: [1, 26, 0], expected: true },
 		{ version: [2, 0, 0], expected: true },
 	])("returns $expected for $version", ({ version, expected }) => {
-		expect(meetsMinimumVersion(version)).toBe(expected);
+		expect(meetsMinimumVersion(version, minimum)).toBe(expected);
 	});
 
 	it("accepts an explicit minimum version", () => {
-		expect(meetsMinimumVersion([1, 25, 7], minimumGoVersion)).toBe(true);
+		expect(meetsMinimumVersion([1, 25, 7], minimum)).toBe(true);
 	});
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -984,7 +984,12 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		if (daemonProcess !== child) return;
 		daemonProcess = null;
 		if (daemonStoppingProcess === child) daemonStoppingProcess = null;
-		setDaemonStatus({ state: "error", message: error.message, details: daemonOutput.trim() || undefined, code: "spawn_failed" });
+		setDaemonStatus({
+			state: "error",
+			message: error.message,
+			details: daemonOutput.trim() || undefined,
+			code: "spawn_failed",
+		});
 	});
 
 	child.once("exit", (code, signal) => {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -96,6 +96,7 @@ let daemonStoppingProcess: ChildProcess | null = null;
 let daemonStartPromise: Promise<DaemonStatus> | null = null;
 let daemonStartEpoch = 0;
 let daemonStatus: DaemonStatus = { state: "stopped" };
+let daemonOutput = "";
 let browserViewHost: BrowserViewHost | null = null;
 // Held for the app lifetime. Dropping it (on any exit) triggers daemon self-stop.
 let supervisorLink: SupervisorLinkHandle | null = null;
@@ -233,6 +234,12 @@ function applyRuntimeAppIcon(): void {
 function setDaemonStatus(nextStatus: DaemonStatus): void {
 	daemonStatus = nextStatus;
 	mainWindow?.webContents.send("daemon:status", daemonStatus);
+}
+
+const MAX_DAEMON_OUTPUT_CHARS = 12_000;
+
+function appendDaemonOutput(text: string): void {
+	daemonOutput = (daemonOutput + text).slice(-MAX_DAEMON_OUTPUT_CHARS);
 }
 
 // Role-based menu installed on Windows where the native menu bar is hidden. The
@@ -807,6 +814,7 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		return daemonStatus;
 	}
 
+	daemonOutput = "";
 	setDaemonStatus({ state: "starting" });
 
 	// Capture the spawned handle locally so the async lifecycle listeners act only
@@ -929,12 +937,14 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 
 		child.stdout?.on("data", (chunk: Buffer) => {
 			const text = chunk.toString("utf8");
+			appendDaemonOutput(text);
 			console.log(text.trimEnd());
 			scanStdout(text);
 		});
 
 		child.stderr?.on("data", (chunk: Buffer) => {
 			const text = chunk.toString("utf8");
+			appendDaemonOutput(text);
 			console.error(text.trimEnd());
 			scanStderr(text);
 		});
@@ -974,7 +984,7 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		if (daemonProcess !== child) return;
 		daemonProcess = null;
 		if (daemonStoppingProcess === child) daemonStoppingProcess = null;
-		setDaemonStatus({ state: "error", message: error.message, code: "spawn_failed" });
+		setDaemonStatus({ state: "error", message: error.message, details: daemonOutput.trim() || undefined, code: "spawn_failed" });
 	});
 
 	child.once("exit", (code, signal) => {
@@ -994,6 +1004,7 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		setDaemonStatus({
 			state: "stopped",
 			message: signal ? `Daemon exited with ${signal}` : `Daemon exited with code ${code ?? "unknown"}`,
+			details: daemonOutput.trim() || undefined,
 			code: "exited",
 			exitCode: code,
 			signal,

--- a/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { DaemonFailureBanner } from "./DaemonFailureBanner";
 
@@ -7,17 +7,19 @@ describe("DaemonFailureBanner", () => {
 		render(
 			<DaemonFailureBanner
 				status={{
-					state: "error",
+					state: "stopped",
 					code: "exited",
 					message: "AO daemon exited with code 1",
+					details: "go: go.mod requires go >= 1.25.7",
 				}}
 			/>,
 		);
 
 		expect(screen.getByRole("alert")).toHaveTextContent("AO daemon failed to start");
 		expect(screen.getByRole("alert")).toHaveTextContent("AO daemon exited with code 1");
-		expect(screen.getByRole("alert")).toHaveTextContent("Check the terminal where you ran npm run dev");
 		expect(screen.getByText("exited")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Show details" }));
+		expect(screen.getByText("go: go.mod requires go >= 1.25.7")).toBeInTheDocument();
 	});
 
 	it("renders nothing while the daemon is not in an error state", () => {

--- a/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DaemonFailureBanner } from "./DaemonFailureBanner";
+
+describe("DaemonFailureBanner", () => {
+	it("shows the daemon failure message, code, and actionable hint", () => {
+		render(
+			<DaemonFailureBanner
+				status={{
+					state: "error",
+					code: "exited",
+					message: "AO daemon exited with code 1",
+				}}
+			/>,
+		);
+
+		expect(screen.getByRole("alert")).toHaveTextContent("AO daemon failed to start");
+		expect(screen.getByRole("alert")).toHaveTextContent("AO daemon exited with code 1");
+		expect(screen.getByRole("alert")).toHaveTextContent("Check the terminal where you ran npm run dev");
+		expect(screen.getByText("exited")).toBeInTheDocument();
+	});
+
+	it("renders nothing while the daemon is not in an error state", () => {
+		const { container } = render(<DaemonFailureBanner status={{ state: "starting" }} />);
+
+		expect(container).toBeEmptyDOMElement();
+	});
+});

--- a/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
@@ -24,21 +24,6 @@ describe("DaemonFailureBanner", () => {
 		expect(screen.getByText("go: go.mod requires go >= 1.25.7")).toBeInTheDocument();
 	});
 
-	it.each([
-		{ code: "not_ready" as const, title: "AO daemon is not ready yet" },
-		{ code: "port_unconfirmed" as const, title: "AO daemon is not ready yet" },
-		{ code: "not_configured" as const, title: "AO daemon is not configured" },
-		{ code: "daemon_unreachable" as const, title: "AO daemon is unreachable" },
-		{ code: "identity_mismatch" as const, title: "AO daemon identity check failed" },
-		{ code: "binary_missing" as const, title: "AO daemon binary is missing" },
-		{ code: "spawn_failed" as const, title: "AO daemon failed to start" },
-		{ code: "exited" as const, title: "AO daemon failed to start" },
-	])("uses a status-appropriate heading for $code", ({ code, title }) => {
-		render(<DaemonFailureBanner status={{ state: "error", code }} />);
-
-		expect(screen.getByRole("alert")).toHaveTextContent(title);
-	});
-
 	it("resets copy feedback when failure details change", async () => {
 		const { rerender } = render(
 			<DaemonFailureBanner status={{ state: "stopped", code: "exited", details: "first failure" }} />,

--- a/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.test.tsx
@@ -1,8 +1,10 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { DaemonFailureBanner } from "./DaemonFailureBanner";
 
 describe("DaemonFailureBanner", () => {
+	afterEach(() => vi.useRealTimers());
+
 	it("shows the daemon failure message, code, and actionable hint", () => {
 		render(
 			<DaemonFailureBanner
@@ -20,6 +22,50 @@ describe("DaemonFailureBanner", () => {
 		expect(screen.getByText("exited")).toBeInTheDocument();
 		fireEvent.click(screen.getByRole("button", { name: "Show details" }));
 		expect(screen.getByText("go: go.mod requires go >= 1.25.7")).toBeInTheDocument();
+	});
+
+	it.each([
+		{ code: "not_ready" as const, title: "AO daemon is not ready yet" },
+		{ code: "port_unconfirmed" as const, title: "AO daemon is not ready yet" },
+		{ code: "not_configured" as const, title: "AO daemon is not configured" },
+		{ code: "daemon_unreachable" as const, title: "AO daemon is unreachable" },
+		{ code: "identity_mismatch" as const, title: "AO daemon identity check failed" },
+		{ code: "binary_missing" as const, title: "AO daemon binary is missing" },
+		{ code: "spawn_failed" as const, title: "AO daemon failed to start" },
+		{ code: "exited" as const, title: "AO daemon failed to start" },
+	])("uses a status-appropriate heading for $code", ({ code, title }) => {
+		render(<DaemonFailureBanner status={{ state: "error", code }} />);
+
+		expect(screen.getByRole("alert")).toHaveTextContent(title);
+	});
+
+	it("resets copy feedback when failure details change", async () => {
+		const { rerender } = render(
+			<DaemonFailureBanner status={{ state: "stopped", code: "exited", details: "first failure" }} />,
+		);
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: "Copy details" }));
+		});
+		expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+
+		rerender(<DaemonFailureBanner status={{ state: "stopped", code: "exited", details: "second failure" }} />);
+
+		expect(screen.getByRole("button", { name: "Copy details" })).toBeInTheDocument();
+	});
+
+	it("resets copy feedback after two seconds", async () => {
+		vi.useFakeTimers();
+		render(<DaemonFailureBanner status={{ state: "stopped", code: "exited", details: "failure" }} />);
+
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: "Copy details" }));
+		});
+		expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+
+		act(() => vi.advanceTimersByTime(2_000));
+
+		expect(screen.getByRole("button", { name: "Copy details" })).toBeInTheDocument();
 	});
 
 	it("renders nothing while the daemon is not in an error state", () => {

--- a/frontend/src/renderer/components/DaemonFailureBanner.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.tsx
@@ -1,10 +1,29 @@
 import { AlertTriangle } from "lucide-react";
+import { useState } from "react";
 import type { DaemonStatus } from "../../shared/daemon-status";
 import { daemonFailureHint, daemonFailureMessage } from "../lib/daemon-failure";
+import { aoBridge } from "../lib/bridge";
 
 export function DaemonFailureBanner({ status }: { status: DaemonStatus }) {
-	if (status.state !== "error") return null;
+	if (!status.code || status.state === "ready") return null;
+	return <DaemonFailureContent status={status} />;
+}
 
+function DaemonFailureContent({ status }: { status: DaemonStatus }) {
+	const [detailsOpen, setDetailsOpen] = useState(false);
+	const [copied, setCopied] = useState(false);
+	const details = status.details?.trim();
+	const hint = daemonFailureHint(status);
+	const copyDetails = async () => {
+		const lines = [
+			"AO daemon startup failure",
+			`Code: ${status.code ?? "unknown"}`,
+			`Message: ${daemonFailureMessage(status)}`,
+			details ? `\nDetails:\n${details}` : "",
+		];
+		await aoBridge.clipboard.writeText(lines.filter(Boolean).join("\n"));
+		setCopied(true);
+	};
 	return (
 		<section
 			aria-live="assertive"
@@ -15,7 +34,32 @@ export function DaemonFailureBanner({ status }: { status: DaemonStatus }) {
 			<div className="min-w-0 flex-1">
 				<p className="font-medium text-foreground">AO daemon failed to start</p>
 				<p className="mt-0.5 break-words text-muted-foreground">{daemonFailureMessage(status)}</p>
-				<p className="mt-1 text-muted-foreground">{daemonFailureHint(status)}</p>
+				{hint ? <p className="mt-1 text-muted-foreground">{hint}</p> : null}
+				{details ? (
+					<div className="mt-2">
+						<div className="flex items-center gap-3">
+							<button
+								type="button"
+								className="text-xs text-foreground underline-offset-2 hover:underline"
+								onClick={() => setDetailsOpen((open) => !open)}
+							>
+								{detailsOpen ? "Hide details" : "Show details"}
+							</button>
+							<button
+								type="button"
+								className="text-xs text-foreground underline-offset-2 hover:underline"
+								onClick={() => void copyDetails()}
+							>
+								{copied ? "Copied" : "Copy details"}
+							</button>
+						</div>
+						{detailsOpen ? (
+							<pre className="mt-2 max-h-40 overflow-auto rounded border border-border bg-background/60 p-2 font-mono text-[11px] leading-relaxed text-muted-foreground">
+								{details}
+							</pre>
+						) : null}
+					</div>
+				) : null}
 			</div>
 			{status.code ? (
 				<code className="shrink-0 rounded bg-background/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">

--- a/frontend/src/renderer/components/DaemonFailureBanner.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.tsx
@@ -1,0 +1,27 @@
+import { AlertTriangle } from "lucide-react";
+import type { DaemonStatus } from "../../shared/daemon-status";
+import { daemonFailureHint, daemonFailureMessage } from "../lib/daemon-failure";
+
+export function DaemonFailureBanner({ status }: { status: DaemonStatus }) {
+	if (status.state !== "error") return null;
+
+	return (
+		<section
+			aria-live="assertive"
+			className="flex shrink-0 items-start gap-3 border-b border-error/30 bg-error/10 px-4.5 py-2.5 text-xs"
+			role="alert"
+		>
+			<AlertTriangle className="mt-0.5 size-icon-base shrink-0 text-error" aria-hidden="true" />
+			<div className="min-w-0 flex-1">
+				<p className="font-medium text-foreground">AO daemon failed to start</p>
+				<p className="mt-0.5 break-words text-muted-foreground">{daemonFailureMessage(status)}</p>
+				<p className="mt-1 text-muted-foreground">{daemonFailureHint(status)}</p>
+			</div>
+			{status.code ? (
+				<code className="shrink-0 rounded bg-background/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+					{status.code}
+				</code>
+			) : null}
+		</section>
+	);
+}

--- a/frontend/src/renderer/components/DaemonFailureBanner.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.tsx
@@ -1,7 +1,7 @@
 import { AlertTriangle } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { DaemonStatus } from "../../shared/daemon-status";
-import { daemonFailureHint, daemonFailureMessage } from "../lib/daemon-failure";
+import { daemonFailureHint, daemonFailureMessage, daemonFailureTitle } from "../lib/daemon-failure";
 import { aoBridge } from "../lib/bridge";
 
 export function DaemonFailureBanner({ status }: { status: DaemonStatus }) {
@@ -12,17 +12,30 @@ export function DaemonFailureBanner({ status }: { status: DaemonStatus }) {
 function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 	const [detailsOpen, setDetailsOpen] = useState(false);
 	const [copied, setCopied] = useState(false);
+	const copiedTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const details = status.details?.trim();
 	const hint = daemonFailureHint(status);
+	const title = daemonFailureTitle(status);
+	useEffect(() => {
+		setCopied(false);
+		return () => {
+			if (copiedTimeout.current !== null) clearTimeout(copiedTimeout.current);
+		};
+	}, [details]);
 	const copyDetails = async () => {
 		const lines = [
-			"AO daemon startup failure",
+			title,
 			`Code: ${status.code ?? "unknown"}`,
 			`Message: ${daemonFailureMessage(status)}`,
 			details ? `\nDetails:\n${details}` : "",
 		];
 		await aoBridge.clipboard.writeText(lines.filter(Boolean).join("\n"));
 		setCopied(true);
+		if (copiedTimeout.current !== null) clearTimeout(copiedTimeout.current);
+		copiedTimeout.current = setTimeout(() => {
+			setCopied(false);
+			copiedTimeout.current = null;
+		}, 2_000);
 	};
 	return (
 		<section
@@ -32,7 +45,7 @@ function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 		>
 			<AlertTriangle className="mt-0.5 size-icon-base shrink-0 text-error" aria-hidden="true" />
 			<div className="min-w-0 flex-1">
-				<p className="font-medium text-foreground">AO daemon failed to start</p>
+				<p className="font-medium text-foreground">{title}</p>
 				<p className="mt-0.5 break-words text-muted-foreground">{daemonFailureMessage(status)}</p>
 				{hint ? <p className="mt-1 text-muted-foreground">{hint}</p> : null}
 				{details ? (

--- a/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
+++ b/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
@@ -3,7 +3,7 @@ import { act } from "react";
 import type { QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getStatusMock, onStatusMock, removeStatusMock, connectMock, stopTransportMock, setApiBaseUrlMock } = vi.hoisted(
+const { getStatusMock, onStatusMock, removeStatusMock, connectMock, stopTransportMock, setApiBaseUrlMock, setApiDaemonStatusMock } = vi.hoisted(
 	() => ({
 		getStatusMock: vi.fn(),
 		onStatusMock: vi.fn(),
@@ -11,6 +11,7 @@ const { getStatusMock, onStatusMock, removeStatusMock, connectMock, stopTranspor
 		connectMock: vi.fn(),
 		stopTransportMock: vi.fn(),
 		setApiBaseUrlMock: vi.fn(),
+		setApiDaemonStatusMock: vi.fn(),
 	}),
 );
 
@@ -24,6 +25,7 @@ vi.mock("../lib/event-transport", () => ({
 
 vi.mock("../lib/api-client", () => ({
 	setApiBaseUrl: setApiBaseUrlMock,
+	setApiDaemonStatus: setApiDaemonStatusMock,
 }));
 
 import { useDaemonStatus } from "./useDaemonStatus";
@@ -42,6 +44,7 @@ beforeEach(() => {
 	connectMock.mockReset().mockReturnValue(stopTransportMock);
 	stopTransportMock.mockReset();
 	setApiBaseUrlMock.mockReset();
+	setApiDaemonStatusMock.mockReset();
 });
 
 afterEach(() => {

--- a/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
+++ b/frontend/src/renderer/hooks/useDaemonStatus.test.tsx
@@ -3,17 +3,23 @@ import { act } from "react";
 import type { QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getStatusMock, onStatusMock, removeStatusMock, connectMock, stopTransportMock, setApiBaseUrlMock, setApiDaemonStatusMock } = vi.hoisted(
-	() => ({
-		getStatusMock: vi.fn(),
-		onStatusMock: vi.fn(),
-		removeStatusMock: vi.fn(),
-		connectMock: vi.fn(),
-		stopTransportMock: vi.fn(),
-		setApiBaseUrlMock: vi.fn(),
-		setApiDaemonStatusMock: vi.fn(),
-	}),
-);
+const {
+	getStatusMock,
+	onStatusMock,
+	removeStatusMock,
+	connectMock,
+	stopTransportMock,
+	setApiBaseUrlMock,
+	setApiDaemonStatusMock,
+} = vi.hoisted(() => ({
+	getStatusMock: vi.fn(),
+	onStatusMock: vi.fn(),
+	removeStatusMock: vi.fn(),
+	connectMock: vi.fn(),
+	stopTransportMock: vi.fn(),
+	setApiBaseUrlMock: vi.fn(),
+	setApiDaemonStatusMock: vi.fn(),
+}));
 
 vi.mock("../lib/bridge", () => ({
 	aoBridge: { daemon: { getStatus: getStatusMock, onStatus: onStatusMock } },

--- a/frontend/src/renderer/lib/api-client.test.ts
+++ b/frontend/src/renderer/lib/api-client.test.ts
@@ -5,6 +5,7 @@ import {
 	getApiBaseUrl,
 	hasTrustedApiBaseUrl,
 	normalizeApiOperation,
+	setApiDaemonStatus,
 	setApiBaseUrl,
 	subscribeApiBaseUrl,
 } from "./api-client";
@@ -20,6 +21,7 @@ describe("apiClient runtime base URL", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		setApiBaseUrl("http://127.0.0.1:3001");
+		setApiDaemonStatus({ state: "stopped" });
 	});
 
 	it("rewrites requests to the current runtime daemon port", async () => {
@@ -128,6 +130,19 @@ describe("apiClient runtime base URL", () => {
 		expect(hasTrustedApiBaseUrl()).toBe(false);
 		expect(fetchSpy).not.toHaveBeenCalled();
 	});
+
+	it("returns the current daemon startup failure when the base URL is untrusted", async () => {
+		setApiBaseUrl(null);
+		setApiDaemonStatus({
+			state: "error",
+			code: "exited",
+			message: "AO daemon exited with code 1",
+		});
+
+		const { error } = await apiClient.GET("/api/v1/projects");
+
+		expect(error).toEqual({ code: "exited", message: "AO daemon exited with code 1" });
+	});
 });
 
 describe("subscribeApiBaseUrl", () => {
@@ -218,6 +233,7 @@ describe("api error telemetry", () => {
 		vi.useRealTimers();
 		vi.restoreAllMocks();
 		setApiBaseUrl("http://127.0.0.1:3001");
+		setApiDaemonStatus({ state: "stopped" });
 	});
 
 	it("reports http_5xx with a normalized operation", async () => {

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -1,5 +1,7 @@
 import createClient from "openapi-fetch";
 import type { paths } from "../../api/schema";
+import type { DaemonStatus } from "../../shared/daemon-status";
+import { daemonFailureMessage } from "./daemon-failure";
 import { captureRendererEvent } from "./telemetry";
 
 function devApiBaseUrl(): string {
@@ -10,6 +12,7 @@ const explicitApiBaseUrl = import.meta.env.VITE_AO_API_BASE_URL;
 const initialApiBaseUrl = explicitApiBaseUrl ?? (import.meta.env.DEV ? devApiBaseUrl() : "http://127.0.0.1:3001");
 
 let runtimeApiBaseUrl: string | null = explicitApiBaseUrl ?? null;
+let daemonStatus: DaemonStatus = { state: "stopped" };
 
 const baseUrlListeners = new Set<() => void>();
 
@@ -38,6 +41,13 @@ export function setApiBaseUrl(nextBaseUrl: string | null): void {
 	if (normalized === runtimeApiBaseUrl) return;
 	runtimeApiBaseUrl = normalized;
 	baseUrlListeners.forEach((listener) => listener());
+}
+
+// The renderer records every supervisor status here so API requests made while
+// no daemon URL is trusted can return the actual startup failure, not a generic
+// availability message.
+export function setApiDaemonStatus(nextStatus: DaemonStatus): void {
+	daemonStatus = nextStatus;
 }
 
 // Route templates from the generated OpenAPI schema (frontend/src/api/schema.ts).
@@ -164,7 +174,7 @@ async function runtimeFetch(input: Request): Promise<Response> {
 	const baseUrl = runtimeApiBaseUrl;
 	if (baseUrl === null) {
 		reportApiError(operation, "daemon_unavailable", 503);
-		return new Response(JSON.stringify({ message: "AO daemon is not ready." }), {
+		return new Response(JSON.stringify({ message: daemonFailureMessage(daemonStatus), code: daemonStatus.code }), {
 			status: 503,
 			headers: { "Content-Type": "application/json" },
 		});

--- a/frontend/src/renderer/lib/daemon-failure.test.ts
+++ b/frontend/src/renderer/lib/daemon-failure.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { daemonFailureTitle } from "./daemon-failure";
+
+describe("daemonFailureTitle", () => {
+	it.each([
+		{ code: "not_ready" as const, title: "AO daemon is not ready yet" },
+		{ code: "port_unconfirmed" as const, title: "AO daemon is not ready yet" },
+		{ code: "not_configured" as const, title: "AO daemon is not configured" },
+		{ code: "daemon_unreachable" as const, title: "AO daemon is unreachable" },
+		{ code: "identity_mismatch" as const, title: "AO daemon identity check failed" },
+		{ code: "binary_missing" as const, title: "AO daemon binary is missing" },
+		{ code: "spawn_failed" as const, title: "AO daemon failed to start" },
+		{ code: "exited" as const, title: "AO daemon failed to start" },
+	])("returns $title for $code", ({ code, title }) => {
+		expect(daemonFailureTitle({ state: "error", code })).toBe(title);
+	});
+});

--- a/frontend/src/renderer/lib/daemon-failure.ts
+++ b/frontend/src/renderer/lib/daemon-failure.ts
@@ -6,6 +6,26 @@ export function daemonFailureMessage(status: DaemonStatus): string {
 	return "AO daemon is not ready.";
 }
 
+export function daemonFailureTitle(status: DaemonStatus): string {
+	switch (status.code) {
+		case "not_ready":
+		case "port_unconfirmed":
+			return "AO daemon is not ready yet";
+		case "not_configured":
+			return "AO daemon is not configured";
+		case "daemon_unreachable":
+			return "AO daemon is unreachable";
+		case "identity_mismatch":
+			return "AO daemon identity check failed";
+		case "binary_missing":
+			return "AO daemon binary is missing";
+		case "spawn_failed":
+		case "exited":
+		default:
+			return "AO daemon failed to start";
+	}
+}
+
 export function daemonFailureHint(status: DaemonStatus): string {
 	switch (status.code) {
 		case "binary_missing":

--- a/frontend/src/renderer/lib/daemon-failure.ts
+++ b/frontend/src/renderer/lib/daemon-failure.ts
@@ -11,11 +11,10 @@ export function daemonFailureHint(status: DaemonStatus): string {
 		case "binary_missing":
 			return "Run npm run build:daemon to rebuild the daemon.";
 		case "spawn_failed":
-			return "Check the terminal where you ran npm run dev for the underlying OS error.";
 		case "exited":
-			return "Check the terminal where you ran npm run dev for build or startup errors.";
+			return "";
 		case "not_ready":
-			return "The daemon has not passed its readiness check yet. Check the development terminal for details.";
+			return "The daemon has not passed its readiness check yet. Open details below for more information.";
 		case "not_configured":
 			return "Set AO_DAEMON_COMMAND or run the desktop app from a source checkout.";
 		case "daemon_unreachable":

--- a/frontend/src/renderer/lib/daemon-failure.ts
+++ b/frontend/src/renderer/lib/daemon-failure.ts
@@ -1,0 +1,27 @@
+import type { DaemonStatus } from "../../shared/daemon-status";
+
+export function daemonFailureMessage(status: DaemonStatus): string {
+	if (status.message) return status.message;
+	if (status.state === "starting") return "AO daemon is starting.";
+	return "AO daemon is not ready.";
+}
+
+export function daemonFailureHint(status: DaemonStatus): string {
+	switch (status.code) {
+		case "binary_missing":
+			return "Run npm run build:daemon to rebuild the daemon.";
+		case "spawn_failed":
+			return "Check the terminal where you ran npm run dev for the underlying OS error.";
+		case "exited":
+			return "Check the terminal where you ran npm run dev for build or startup errors.";
+		case "not_ready":
+			return "The daemon has not passed its readiness check yet. Check the development terminal for details.";
+		case "not_configured":
+			return "Set AO_DAEMON_COMMAND or run the desktop app from a source checkout.";
+		case "daemon_unreachable":
+		case "identity_mismatch":
+			return "Stop the conflicting daemon, then restart the desktop app.";
+		default:
+			return "Check the terminal where you ran npm run dev for details.";
+	}
+}

--- a/frontend/src/renderer/lib/daemon-status.ts
+++ b/frontend/src/renderer/lib/daemon-status.ts
@@ -1,9 +1,10 @@
 import { aoBridge } from "./bridge";
-import { setApiBaseUrl } from "./api-client";
+import { setApiBaseUrl, setApiDaemonStatus } from "./api-client";
 
 export type DaemonStatus = Awaited<ReturnType<typeof aoBridge.daemon.getStatus>>;
 
 export function applyDaemonStatus(nextStatus: DaemonStatus): void {
+	setApiDaemonStatus(nextStatus);
 	if (nextStatus.state === "ready" && nextStatus.port) {
 		setApiBaseUrl(`http://127.0.0.1:${nextStatus.port}`);
 	} else {

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { CommandPalette } from "../components/CommandPalette";
 import { CenterPanelShell } from "../components/CenterPanelShell";
+import { DaemonFailureBanner } from "../components/DaemonFailureBanner";
 import { NotificationRuntime } from "../components/NotificationCenter";
 import { GlobalNewTaskDialog } from "../components/GlobalNewTaskDialog";
 import { KeyboardShortcutsDialog } from "../components/KeyboardShortcutsDialog";
@@ -366,6 +367,7 @@ function ShellLayout() {
 						workspaces={workspaces}
 					/>
 					<main className="flex min-w-0 flex-1 flex-col overflow-x-hidden">
+						<DaemonFailureBanner status={daemonStatus} />
 						<div className="min-h-0 flex-1 overflow-x-hidden">
 							{/* Board/session routes render inside the same inset box the welcome board and settings paint for themselves, so every screen sits within the app's outer boundary. */}
 							{hideShellTopbar ? (

--- a/frontend/src/shared/daemon-status.ts
+++ b/frontend/src/shared/daemon-status.ts
@@ -21,6 +21,9 @@ export type DaemonStatus = {
 	executablePath?: string;
 	workingDirectory?: string;
 	message?: string;
+	// Recent daemon stdout/stderr retained by the Electron supervisor for local
+	// troubleshooting. It is never sent to telemetry.
+	details?: string;
 	code?: DaemonFailureCode;
 	exitCode?: number | null;
 	signal?: string | null;


### PR DESCRIPTION
Fixes #2958: daemon startup failures no longer collapse into the generic “AO daemon is not ready” message.
• Surfaces the supervisor’s real failure message/code in API errors and shows a persistent in-app failure banner.
• Captures recent daemon stdout/stderr locally so users can expand and copy the actual diagnostic details.
• Adds a Go 1.25.7+ preflight before npm run dev, preventing Electron from opening when the local Go version is unsupported.
<img width="1164" height="403" alt="image" src="https://github.com/user-attachments/assets/63499c9f-39c7-4ac5-9f9b-a791c0b4da73" />
