### PR TITLE
fix: add terminal refresh button

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -1,13 +1,18 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession } from "../types/workspace";
 import { CenterPane } from "./CenterPane";
 
 // The terminal body pulls in xterm/SSE machinery irrelevant to the header under test.
-vi.mock("./TerminalPane", () => ({ TerminalPane: () => <div>terminal body</div> }));
+vi.mock("./TerminalPane", () => ({
+	TerminalPane: ({ refreshToken }: { refreshToken?: number }) => (
+		<div data-refresh-token={String(refreshToken ?? 0)}>terminal body</div>
+	),
+}));
 
 const worker = {
 	id: "sess-1",
+	terminalHandleId: "handle-1",
 	workspaceId: "proj-1",
 	workspaceName: "my-app",
 	title: "do the thing",
@@ -126,5 +131,13 @@ describe("CenterPane toolbar session label", () => {
 		scrollBy.mockClear();
 		fireEvent.wheel(scrollRegion, { deltaY: 80, ctrlKey: true });
 		expect(scrollBy).not.toHaveBeenCalled();
+	});
+
+	it("refreshes the terminal from the toolbar", () => {
+		render(<CenterPane session={worker} theme="dark" daemonReady />);
+
+		expect(screen.getByText("terminal body")).toHaveAttribute("data-refresh-token", "0");
+		fireEvent.click(screen.getByRole("button", { name: "Refresh terminal" }));
+		return waitFor(() => expect(screen.getByText("terminal body")).toHaveAttribute("data-refresh-token", "1"));
 	});
 });

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, Maximize2, Minimize2, Shield, Terminal as TerminalIcon, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Maximize2, Minimize2, RefreshCw, Shield, Terminal as TerminalIcon, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type WheelEvent } from "react";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
 import { useTruncatedText } from "../hooks/useTruncatedText";
@@ -63,6 +63,7 @@ export function CenterPane({
 	const [isFullscreen, setIsFullscreen] = useState(false);
 	const tabOverflowWatch = `${session?.id ?? ""}|${shellTerminals.map((terminal) => terminal.handleId).join("|")}`;
 	const tabsOverflow = useOverflowScroll<HTMLDivElement>(tabOverflowWatch);
+	const [refreshToken, setRefreshToken] = useState(0);
 	const target = terminalTarget ?? { kind: "worker" };
 
 	useEffect(() => {
@@ -211,6 +212,7 @@ export function CenterPane({
 				<TerminalPane
 					daemonReady={daemonReady}
 					fontSize={fontSize}
+					refreshToken={refreshToken}
 					session={session}
 					terminalTarget={target}
 					theme={theme}
@@ -240,6 +242,16 @@ export function CenterPane({
 						type="button"
 					>
 						+
+					</button>
+					<button
+						aria-label="Refresh terminal"
+						className="ml-1.5 inline-flex size-control-sm items-center justify-center rounded-sm bg-transparent text-control leading-none transition-[background,color,opacity] duration-fast hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50 disabled:cursor-default disabled:opacity-35 disabled:hover:bg-transparent disabled:hover:text-passive"
+						disabled={!daemonReady || !session?.terminalHandleId || session?.status === "terminated"}
+						onClick={() => setRefreshToken((current) => current + 1)}
+						title="Refresh terminal"
+						type="button"
+					>
+						<RefreshCw aria-hidden="true" className="size-icon-md" />
 					</button>
 					<button
 						aria-label={isFullscreen ? "Exit terminal fullscreen" : "Open terminal fullscreen"}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -19,9 +19,10 @@ type TerminalPaneProps = {
 	daemonReady: boolean;
 	terminalTarget?: TerminalTarget;
 	fontSize: number;
+	refreshToken?: number;
 };
 
-export function TerminalPane({ session, theme, daemonReady, terminalTarget, fontSize }: TerminalPaneProps) {
+export function TerminalPane({ session, theme, daemonReady, terminalTarget, fontSize, refreshToken = 0 }: TerminalPaneProps) {
 	const terminalKey =
 		terminalTarget?.kind === "reviewer" || terminalTarget?.kind === "shell"
 			? terminalTarget.handleId
@@ -85,6 +86,7 @@ export function TerminalPane({ session, theme, daemonReady, terminalTarget, font
 			theme={theme}
 			daemonReady={daemonReady}
 			fontSize={fontSize}
+			refreshToken={refreshToken}
 			terminalTarget={terminalTarget}
 		/>
 	);
@@ -220,7 +222,7 @@ function bannerText(state: TerminalSessionState, error?: string): string | undef
 	return undefined;
 }
 
-function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSize }: TerminalPaneProps) {
+function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSize, refreshToken = 0 }: TerminalPaneProps) {
 	const attachSession =
 		session && terminalTarget?.kind === "reviewer"
 			? { ...session, terminalHandleId: terminalTarget.handleId }
@@ -259,7 +261,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 		},
 		[session?.id],
 	);
-	const { attach, state, error, replaySettled } = useTerminalSession(attachSession, {
+	const { attach, refresh, state, error, replaySettled } = useTerminalSession(attachSession, {
 		daemonReady,
 		shellTerminalHandleId,
 		onOutput: watchLinks ? handleOutput : undefined,
@@ -267,6 +269,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 	const handleId = shellTerminalHandleId ?? attachSession?.terminalHandleId;
 	const provider = terminalTarget?.kind === "reviewer" ? terminalTarget.harness : session?.provider;
 	const hadAttachmentRef = useRef(false);
+	const previousRefreshTokenRef = useRef(refreshToken);
 	const isSessionActive = session ? sessionIsActive(session) : false;
 	// A standalone shell is never restorable: there is no session row to restore.
 	const canRestoreSession =
@@ -352,6 +355,12 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 		hadAttachmentRef.current = true;
 		return attach(terminal);
 	}, [terminal, handleId, attach, attachSession?.id]);
+
+	useEffect(() => {
+		if (previousRefreshTokenRef.current === refreshToken) return;
+		previousRefreshTokenRef.current = refreshToken;
+		refresh();
+	}, [refresh, refreshToken]);
 
 	if (initFailed) {
 		return (

--- a/frontend/src/renderer/hooks/useTerminalSession.test.tsx
+++ b/frontend/src/renderer/hooks/useTerminalSession.test.tsx
@@ -634,6 +634,21 @@ describe("useTerminalSession", () => {
 		expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: workspaceQueryKey });
 	});
 
+	it("refreshes an attached terminal with a fresh mux and clears the stale screen", () => {
+		const { view, terminal, muxes } = setup();
+		act(() => muxes[0].emitOpened("handle-1"));
+
+		act(() => view.result.current.refresh());
+
+		expect(view.result.current.state).toBe("connecting");
+		expect(muxes).toHaveLength(2);
+		expect(muxes[0].disposed).toBe(true);
+		expect(terminal.clears).toBe(1);
+		expect(muxes[1].opens).toEqual([["handle-1", 80, 24]]);
+		act(() => muxes[1].emitOpened("handle-1"));
+		expect(view.result.current.state).toBe("attached");
+	});
+
 	it("reconnects when a merged terminated session is restored with the same terminal handle", () => {
 		const muxes: FakeMux[] = [];
 		const createMux = () => {

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -591,6 +591,16 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 	]);
 	connectRef.current = connect;
 
+	const refresh = useCallback(() => {
+		const r = runtime.current;
+		if (!r.terminal || !r.handle || r.detached) return;
+		r.attempts = 0;
+		setError(undefined);
+		transition(optionsRef.current.daemonReady ? "connecting" : "reattaching");
+		if (!optionsRef.current.daemonReady) return;
+		connect();
+	}, [connect, transition]);
+
 	/**
 	 * Bind a terminal to the current session's PTY. Call once the terminal is
 	 * opened (and fitted); returns the detach function for effect cleanup.
@@ -692,5 +702,5 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 		[teardownMux],
 	);
 
-	return { attach, state, error, replaySettled };
+	return { attach, refresh, state, error, replaySettled };
 }


### PR DESCRIPTION
Summary:
- Add a refresh button to the terminal toolbar.
- Refresh safely tears down and recreates the terminal mux.
- Tests cover the UI trigger and reconnect lifecycle.

Tests:
- npm --prefix frontend run test -- src/renderer/components/TerminalPane.test.tsx src/renderer/components/CenterPane.test.tsx src/renderer/hooks/useTerminalSession.test.tsx
- npm --prefix frontend run typecheck
