### PR TITLE
fix: hide macOS shell topbar and mount actions in-panel

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -32,8 +32,10 @@ sections below — where they conflict, **agent-orchestrator wins**. Do not re-f
 - The one carried-over divergence still holds: the **accent is refined blue**, and
   the **terminal keeps its own palette**. Everything else tracks agent-orchestrator.
 - **Approved divergence (2026-06-10):** on macOS, a titlebar cluster (sidebar toggle +
-  back/forward history arrows, `TitlebarNav`) sits beside the traffic lights,
-  VS Code-style — the web reference has no window chrome, so no analogue exists.
+  back/forward history arrows, `TitlebarNav`) lives in the sidebar header below the
+  traffic lights — the web reference has no window chrome, so no analogue exists.
+  The toggle is pinned in the icon-rail column so it stays put during expand/collapse;
+  arrows hide when the sidebar is collapsed.
 - **Approved divergence (2026-06-10):** the session inspector rail is fully
   collapsible, built on the shadcn resizable primitive (`pnpm dlx shadcn add
 resizable`, react-resizable-panels v4 `collapsible` panel + imperative API,
@@ -41,12 +43,11 @@ resizable`, react-resizable-panels v4 `collapsible` panel + imperative API,
   content keeps a stable min-width (yyork-style, no mid-animation reflow). Toggled
   by a `PanelRight` icon button in the session topbar and ⌘⇧B; open state + split
   width persist. The AO reference keeps the rail always visible.
-- **Approved divergence (2026-06-12):** the shell topbar spans the full window
-  width and the sidebar is pinned below it (`top-14`), so the sidebar's right
-  border stops at the header instead of cutting through the macOS traffic-light
-  strip (user-requested). The AO reference keeps a full-height sidebar with the
-  header beside it. On macOS the header always pads past the lights + TitlebarNav
-  cluster (`.is-under-titlebar-nav`, 180px).
+- **Approved divergence (2026-06-12):** on Win/Linux the shell topbar spans the
+  window and the sidebar hangs below it so the sidebar border stops at the header.
+  On macOS the shell topbar is hidden (in-panel actions) and the sidebar is
+  full-height; traffic-light clearance uses `--size-traffic-light-clearance` for
+  both the sidebar header pad and the window-drag strip.
 
 ## Product Context
 

--- a/frontend/e2e/titlebar-brand.spec.ts
+++ b/frontend/e2e/titlebar-brand.spec.ts
@@ -1,12 +1,10 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
 // Regression guard for #366 (macOS): the sidebar's "Agent Orchestrator" brand
-// must never sit under the fixed TitlebarNav cluster, and the wordmark must stay
-// readable. The original bug was board routes (`/` and `/projects/:id`) having no
-// topbar, so the sidebar stayed at top-0 and the brand landed in the cluster's
-// 56px lane. It is now fixed structurally — the shell renders the topbar on every
-// route, so the sidebar always hangs below the titlebar band — and these tests
-// lock that invariant in: if a topbar-less route is ever reintroduced, they fail.
+// must never sit under the TitlebarNav cluster, and the wordmark must stay
+// readable. TitlebarNav now lives in the sidebar header below the traffic
+// lights (in-flow), so the brand is the next row — these tests lock that the
+// two boxes never overlap and the wordmark is not clipped.
 //
 // macOS-only: TitlebarNav (and the bug) gate on navigator.userAgent looking like
 // a Mac, read once at module load. Force a Mac UA so this is deterministic
@@ -71,7 +69,7 @@ test("brand stays put and readable when navigating board → session", async ({ 
 	expect(boardBrandBox).not.toBeNull();
 
 	await page.getByRole("button", { name: "Open Split terminal mux responsibilities" }).click();
-	await expect(page.locator(".dashboard-app-header")).toBeVisible();
+	await expect(page.getByRole("button", { name: "Open Kanban" })).toBeVisible();
 
 	const sessionBrandBox = await brand(page).boundingBox();
 	expect(sessionBrandBox).not.toBeNull();

--- a/frontend/src/renderer/components/CenterPanelShell.tsx
+++ b/frontend/src/renderer/components/CenterPanelShell.tsx
@@ -1,33 +1,22 @@
 import type { ReactNode } from "react";
 
-/** Visual variants for inset center panels (app routes, welcome board, settings, …). */
-export type CenterPanelVariant = "app" | "welcome" | "settings";
-
-const variantClass: Record<CenterPanelVariant, string> = {
-	app: "center-panel-app",
-	welcome: "center-panel-welcome",
-	settings: "center-panel-settings",
-};
-
 /**
  * Shared inset center panel: sidebar-colored outer frame with a bordered inner
- * surface. Used by the shell's app routes (kanban board, session views), the
- * welcome board, and the settings page. Chrome lives in `styles.css`
- * (`center-panel-*` utilities).
+ * surface. Used by the shell's app routes (kanban / session), the welcome board,
+ * and settings. Chrome lives in `styles.css` (`center-panel-shell` +
+ * `center-panel-surface`).
  */
 export function CenterPanelShell({
-	variant,
 	className,
 	children,
 }: {
-	variant: CenterPanelVariant;
-	/** Extra classes on the outer frame (e.g. the macOS top inset). */
+	/** Extra classes on the outer frame. */
 	className?: string;
 	children: ReactNode;
 }) {
 	return (
 		<div className={className ? `center-panel-shell ${className}` : "center-panel-shell"}>
-			<div className={variantClass[variant]}>{children}</div>
+			<div className="center-panel-surface">{children}</div>
 		</div>
 	);
 }

--- a/frontend/src/renderer/components/CenterPanelShell.tsx
+++ b/frontend/src/renderer/components/CenterPanelShell.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { cn } from "../lib/utils";
 
 /**
  * Shared inset center panel: sidebar-colored outer frame with a bordered inner
@@ -15,7 +16,7 @@ export function CenterPanelShell({
 	children: ReactNode;
 }) {
 	return (
-		<div className={className ? `center-panel-shell ${className}` : "center-panel-shell"}>
+		<div className={cn("center-panel-shell", className)}>
 			<div className="center-panel-surface">{children}</div>
 		</div>
 	);

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -54,7 +54,9 @@ const { workspaces, workspaceQueryState, panels } = vi.hoisted(() => {
 });
 
 // The terminal and inspector body pull in xterm/SSE machinery irrelevant to
-// the split under test. (The topbar is shell-owned — see ShellTopbar.)
+// the split under test. (ShellTopbar is shell-owned on Win/Linux; when the
+// platform hides the shell topbar, SessionView mounts it in-panel.)
+vi.mock("./ShellTopbar", () => ({ ShellTopbar: () => null }));
 vi.mock("./CenterPane", () => ({ CenterPane: () => <div>terminal center</div> }));
 vi.mock("./BrowserPanel", () => ({
 	BrowserPanelView: ({

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -5,17 +5,20 @@ import { BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { CenterPane } from "./CenterPane";
 import { SessionFilesView } from "./SessionFilesView";
 import { SessionInspector } from "./SessionInspector";
+import { ShellTopbar } from "./ShellTopbar";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "./ui/resizable";
 import { useResolvedTheme, useUiStore, type InspectorView } from "../stores/ui-store";
 import { useShell } from "../lib/shell-context";
 import { useBrowserView } from "../hooks/useBrowserView";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
+import { hidesShellTopbar } from "../lib/platform";
 import { isOrchestratorSession } from "../types/workspace";
 import type { TerminalTarget } from "../types/terminal";
 
 const INSPECTOR_MIN_PERCENT = 22;
 const INSPECTOR_MAX_PERCENT = 45;
 const inspectorSplitStorageKey = "ao.inspector.split";
+const shellTopbarHiddenByPlatform = hidesShellTopbar();
 
 function initialSplitPercent(): number {
 	const raw = typeof window === "undefined" ? null : window.localStorage?.getItem(inspectorSplitStorageKey);
@@ -35,10 +38,12 @@ type SessionViewProps = {
 	sessionId: string;
 };
 
-// The session detail screen: terminal + git rail, under the shell-owned
-// ShellTopbar. Rendered by both the project-scoped and cross-project session
-// routes. TerminalPane owns the terminal lifetime and remounts by terminal
-// handle so each session gets a clean xterm/mux binding.
+// The session detail screen: terminal + git rail. On Win/Linux the shell owns
+// ShellTopbar above this view; when the platform hides the shell topbar
+// (macOS), the same topbar mounts here so the outer panel stays full-height.
+// Rendered by both the project-scoped and cross-project session routes.
+// TerminalPane owns the terminal lifetime and remounts by terminal handle so
+// each session gets a clean xterm/mux binding.
 //
 // The split is shadcn's resizable (react-resizable-panels v4) with a fully
 // collapsible inspector: the panel is `collapsible` and driven to 0% via the
@@ -241,6 +246,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 
 	return (
 		<div className="relative flex h-full min-h-0 flex-col bg-background text-foreground" data-testid="session-detail">
+			{shellTopbarHiddenByPlatform ? <ShellTopbar /> : null}
 			<ResizablePanelGroup className="session-split min-h-0 flex-1" id="session-workspace" orientation="horizontal">
 				{/* react-resizable-panels v4: bare numbers are PIXELS; percentages must
             be strings. Numeric sizes here once clamped the inspector to 45px. */}

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -4,11 +4,12 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 
-const { navigateMock, notificationShowMock, postMock, workspaceQueryMock } = vi.hoisted(() => ({
+const { navigateMock, notificationShowMock, postMock, workspaceQueryMock, boardActionsInPanelMock } = vi.hoisted(() => ({
 	navigateMock: vi.fn(),
 	notificationShowMock: vi.fn(),
 	postMock: vi.fn(),
 	workspaceQueryMock: vi.fn(),
+	boardActionsInPanelMock: vi.fn(() => false),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -33,6 +34,15 @@ vi.mock("../lib/bridge", () => ({
 	},
 }));
 
+vi.mock("../lib/platform", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/platform")>();
+	return {
+		...actual,
+		usesBoardActionsInPanel: () => boardActionsInPanelMock(),
+		isLinuxPlatform: () => false,
+	};
+});
+
 import { SessionsBoard } from "./SessionsBoard";
 
 function renderBoard(projectId?: string) {
@@ -54,6 +64,7 @@ beforeEach(() => {
 	notificationShowMock.mockReset().mockResolvedValue(undefined);
 	postMock.mockReset().mockResolvedValue({ data: {} });
 	workspaceQueryMock.mockReset().mockReturnValue({ data: [], isError: false });
+	boardActionsInPanelMock.mockReset().mockReturnValue(false);
 });
 
 describe("SessionsBoard", () => {
@@ -61,6 +72,60 @@ describe("SessionsBoard", () => {
 		renderBoard();
 
 		expect(screen.queryByText(/reload agents/i)).not.toBeInTheDocument();
+	});
+
+	it("shows the project name in the in-panel board chrome when actions live in the panel", () => {
+		boardActionsInPanelMock.mockReturnValue(true);
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					id: "p1",
+					name: "solkit-ui",
+					path: "/tmp/solkit-ui",
+					sessions: [
+						{
+							id: "s1",
+							workspaceId: "p1",
+							workspaceName: "solkit-ui",
+							title: "test",
+							provider: "codex",
+							branch: "ao/dev/solkit-ui-5/root",
+							status: "running",
+							activity: { state: "working", lastActivityAt: "2026-01-01T00:00:00Z" },
+							updatedAt: "2026-01-01T00:00:00Z",
+							prs: [],
+						},
+					],
+				},
+			],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+
+		expect(screen.getByText("solkit-ui")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "New task" })).toBeInTheDocument();
+	});
+
+	it("shows the Board crumb on the root board when actions live in the panel", () => {
+		boardActionsInPanelMock.mockReturnValue(true);
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					id: "p1",
+					name: "solkit-ui",
+					path: "/tmp/solkit-ui",
+					sessions: [],
+				},
+			],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard();
+
+		expect(screen.getByText("Board")).toBeInTheDocument();
 	});
 
 	it("labels an idle session as Idle, not Working", () => {

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -4,13 +4,15 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 
-const { navigateMock, notificationShowMock, postMock, workspaceQueryMock, boardActionsInPanelMock } = vi.hoisted(() => ({
-	navigateMock: vi.fn(),
-	notificationShowMock: vi.fn(),
-	postMock: vi.fn(),
-	workspaceQueryMock: vi.fn(),
-	boardActionsInPanelMock: vi.fn(() => false),
-}));
+const { navigateMock, notificationShowMock, postMock, workspaceQueryMock, boardActionsInPanelMock } = vi.hoisted(
+	() => ({
+		navigateMock: vi.fn(),
+		notificationShowMock: vi.fn(),
+		postMock: vi.fn(),
+		workspaceQueryMock: vi.fn(),
+		boardActionsInPanelMock: vi.fn(() => false),
+	}),
+);
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => navigateMock,

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -24,17 +24,15 @@ import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery
 import { NotificationCenter } from "./NotificationCenter";
 import { BoardWelcome, ProjectBoardEmpty } from "./BoardEmptyStates";
 import { OrchestratorIcon } from "./icons";
-import { TopbarButton, TopbarKillError } from "./TopbarButton";
+import { TopbarButton, TopbarKillError, topbarProjectLabelClass } from "./TopbarButton";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
 import { prBrowserUrl, sessionPRDisplaySummaries } from "../lib/pr-display";
 import { cn } from "../lib/utils";
-import { isLinuxPlatform, usesBoardActionsInFramedTopbar } from "../lib/platform";
+import { isLinuxPlatform, isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
 import { useUiStore } from "../stores/ui-store";
 import { RestoreUnavailableDialog } from "./RestoreUnavailableDialog";
 
-const isLinux = isLinuxPlatform();
-const boardActionsInFramedTopbar = usesBoardActionsInFramedTopbar();
 type SessionsBoardProps = {
 	/** When set, the board shows only this project's sessions. */
 	projectId?: string;
@@ -44,14 +42,24 @@ type SessionsBoardProps = {
 type Column = AttentionZoneView;
 const COLUMNS: Column[] = boardAttentionZoneOrder.map((zone) => getAttentionZoneViewForZone(zone));
 
+const isMac = isMacPlatform();
+const dragStyle = isMac ? ({ WebkitAppRegion: "drag" } as React.CSSProperties) : undefined;
+const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
+
 export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const restoreSessionById = useRestoreSession();
 	const workspaceQuery = useWorkspaceQuery();
+	// Evaluated at render so platform mocks in tests can flip the in-panel chrome.
+	const boardActionsInPanel = usesBoardActionsInPanel();
+	/** Bell lives in the board action row when the shell topbar does not host it. */
+	const boardOwnsNotificationCenter = isLinuxPlatform() || boardActionsInPanel;
 	const all = workspaceQuery.data ?? [];
 	const workspaces = projectId ? all.filter((w) => w.id === projectId) : all;
 	const workspace = projectId ? workspaces[0] : undefined;
+	// Same crumb as ShellTopbar: project name in scope, else root-board "Board".
+	const boardLabel = workspace?.name ?? (projectId ? "" : "Board");
 	const sessions = workspaces.flatMap((w) => workerSessions(w.sessions));
 	const orchestrator = projectId ? newestActiveOrchestrator(workspaces[0]?.sessions ?? []) : undefined;
 	const [isSpawning, setIsSpawning] = useState(false);
@@ -193,7 +201,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 
 	const actions = projectId ? (
 		<>
-			{isLinux ? <NotificationCenter /> : null}
+			{boardOwnsNotificationCenter ? <NotificationCenter style={noDragStyle} /> : null}
 			{visibleSpawnError && !showProjectEmpty && (
 				<TopbarKillError className="max-w-content-max truncate" title={visibleSpawnError}>
 					{visibleSpawnError}
@@ -203,6 +211,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				aria-label="New task"
 				disabled={isProjectRestarting}
 				onClick={() => projectId && requestNewTask(projectId)}
+				style={noDragStyle}
 				variant="accent"
 			>
 				<Plus className="size-icon-md" aria-hidden="true" />
@@ -212,6 +221,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				aria-label={orchestrator ? "Orchestrator" : "Spawn Orchestrator"}
 				disabled={isSpawning || isProjectRestarting}
 				onClick={() => void openOrchestrator()}
+				style={noDragStyle}
 				variant="primary"
 			>
 				<OrchestratorIcon className="size-icon-md" aria-hidden="true" />
@@ -224,19 +234,27 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 							: "Spawn Orchestrator"}
 			</TopbarButton>
 		</>
-	) : isLinux ? (
-		<NotificationCenter />
+	) : boardOwnsNotificationCenter ? (
+		<NotificationCenter style={noDragStyle} />
 	) : undefined;
 
 	return (
 		<div className="flex h-full min-h-0 flex-col bg-background text-foreground" data-testid="board">
-			{/* The first-launch welcome carries its own orientation; a "Board"
-			    header above it would describe a board that isn't rendered
-			    (review feedback on #2432). The shell topbar crumb already
-			    names the board/project, so only the actions row stays here —
-			    and on inset-topbar platforms even that moves into the framed topbar. */}
-			{!showWelcome && actions && !boardActionsInFramedTopbar ? (
-				<div className="flex items-center justify-end gap-2 px-4.5 pt-4">{actions}</div>
+			{/* macOS: shell topbar is hidden on board routes, so the project/"Board"
+			    crumb + New task / Orchestrator / bell live in this in-panel row.
+			    Win/Linux keep the crumb and actions in the framed ShellTopbar.
+			    Welcome skips the row — a dangling "Board" above the import
+			    chooser was review feedback on #2432. */}
+			{!showWelcome && boardActionsInPanel && (boardLabel || actions) ? (
+				<div className="flex h-toolbar shrink-0 items-center gap-2 px-4.5" style={dragStyle}>
+					{boardLabel ? <span className={topbarProjectLabelClass}>{boardLabel}</span> : null}
+					<div className="min-w-0 flex-1" />
+					{actions ? (
+						<div className="flex shrink-0 items-center gap-2" style={noDragStyle}>
+							{actions}
+						</div>
+					) : null}
+				</div>
 			) : null}
 
 			<div className={cn("min-h-0 flex-1 overflow-hidden", showWelcome ? "p-0" : "p-4.5")}>
@@ -368,10 +386,10 @@ function ZoneColumn({
 						boxShadow: col.dotGlow ? `0 0 7px color-mix(in srgb, ${col.dot} 60%, transparent)` : undefined,
 					}}
 				/>
-				<span className={cn("text-caption font-semibold uppercase tracking-wide-md", col.titleClassName)}>
+				<span className={cn("text-control font-semibold uppercase tracking-wide-md", col.titleClassName)}>
 					{col.label}
 				</span>
-				<span className="ml-auto font-mono text-caption leading-none text-passive">{sessions.length}</span>
+				<span className="ml-auto font-mono text-sm leading-none text-passive">{sessions.length}</span>
 			</div>
 			<div className="min-h-0 flex-1 overflow-y-auto px-2.75 pb-3">
 				<div className="flex min-h-full flex-col gap-2.5">

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -201,7 +201,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 
 	const actions = projectId ? (
 		<>
-			{boardOwnsNotificationCenter ? <NotificationCenter style={noDragStyle} /> : null}
+			{boardOwnsNotificationCenter ? <NotificationCenter /> : null}
 			{visibleSpawnError && !showProjectEmpty && (
 				<TopbarKillError className="max-w-content-max truncate" title={visibleSpawnError}>
 					{visibleSpawnError}
@@ -211,7 +211,6 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				aria-label="New task"
 				disabled={isProjectRestarting}
 				onClick={() => projectId && requestNewTask(projectId)}
-				style={noDragStyle}
 				variant="accent"
 			>
 				<Plus className="size-icon-md" aria-hidden="true" />
@@ -221,7 +220,6 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				aria-label={orchestrator ? "Orchestrator" : "Spawn Orchestrator"}
 				disabled={isSpawning || isProjectRestarting}
 				onClick={() => void openOrchestrator()}
-				style={noDragStyle}
 				variant="primary"
 			>
 				<OrchestratorIcon className="size-icon-md" aria-hidden="true" />
@@ -235,7 +233,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 			</TopbarButton>
 		</>
 	) : boardOwnsNotificationCenter ? (
-		<NotificationCenter style={noDragStyle} />
+		<NotificationCenter />
 	) : undefined;
 
 	return (

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -21,7 +21,7 @@ import {
 	isLinuxPlatform,
 	isMacPlatform,
 	isWindowsPlatform,
-	usesBoardActionsInFramedTopbar,
+	usesBoardActionsInPanel,
 	usesFramedAppTopbar,
 } from "../lib/platform";
 import { StatusPill } from "./StatusPill";
@@ -36,23 +36,22 @@ import {
 const isMac = isMacPlatform();
 const isLinux = isLinuxPlatform();
 const isWindows = isWindowsPlatform();
-const boardActionsInFramedTopbar = usesBoardActionsInFramedTopbar();
+const boardActionsInPanel = usesBoardActionsInPanel();
 const topbarNeedsTitlebarOffset = isMac && !usesFramedAppTopbar();
 const dragStyle = isMac ? ({ WebkitAppRegion: "drag" } as React.CSSProperties) : undefined;
 const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
 
-// The one app topbar (.dashboard-app-header), rendered by the shell layout
-// across the full window width — above both the sidebar and the route outlet —
-// so the crumb and actions sit at identical offsets on every screen and the
-// macOS traffic lights + TitlebarNav cluster live in its left inset
-// (.is-under-titlebar-nav pads past them). The
-// variant is derived from the route, not props: a sessionId in the URL swaps
-// the lead to the session identity (orchestrator crumb + mode badge, or worker
-// branch + status pill) and the actions to board/orchestrator + inspector
-// controls (orchestrators open the Kanban board; workers open their orchestrator);
-// otherwise it's the dashboard crumb plus the Orchestrator launcher when a
-// project is in scope. Merges the old DashboardTopbar/Topbar pair —
-// agent-orchestrator keeps those as two components aligned only by CSS.
+// The one app topbar (.dashboard-app-header). On Win/Linux the shell mounts it
+// inside the framed center panel; when the platform hides the shell topbar
+// (macOS), SessionView mounts the same component in-panel so Kill / Orchestrator
+// / inspector stay available. The variant is derived from the route, not props:
+// a sessionId in the URL swaps the lead to the session identity (orchestrator
+// crumb + mode badge, or worker branch + status pill) and the actions to
+// board/orchestrator + inspector controls (orchestrators open the Kanban board;
+// workers open their orchestrator); otherwise it's the dashboard crumb plus the
+// Orchestrator launcher when a project is in scope. Merges the old
+// DashboardTopbar/Topbar pair — agent-orchestrator keeps those as two components
+// aligned only by CSS.
 export function ShellTopbar() {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
@@ -163,8 +162,8 @@ export function ShellTopbar() {
 						</div>
 						{session ? <SessionStatusPill session={session} /> : null}
 					</div>
-				) : (isProjectBoardRoute && !boardActionsInFramedTopbar) ||
-				  (isMac && isRootBoardRoute && !boardActionsInFramedTopbar) ? null : (
+				) : (isProjectBoardRoute && boardActionsInPanel) ||
+				  (isMac && isRootBoardRoute && boardActionsInPanel) ? null : (
 					<div className="inline-flex min-w-0 items-center gap-1.5">
 						<span className={topbarProjectLabelClass}>{projectLabel}</span>
 					</div>
@@ -175,8 +174,8 @@ export function ShellTopbar() {
 
 			<div className="flex shrink-0 items-center gap-1.5">
 				{/* Native-titlebar platforms keep the bell leading the actions row; the custom titlebar pins it to the far edge. */}
-				{!boardActionsInFramedTopbar && !isLinux && !isWindows ? <NotificationCenter style={noDragStyle} /> : null}
-				{boardActionsInFramedTopbar && isProjectBoardRoute ? (
+				{boardActionsInPanel && !isLinux && !isWindows ? <NotificationCenter style={noDragStyle} /> : null}
+				{!boardActionsInPanel && isProjectBoardRoute ? (
 					<>
 						{boardSpawnError ? (
 							<TopbarKillError className="max-w-content-max truncate" title={boardSpawnError}>
@@ -281,7 +280,7 @@ export function ShellTopbar() {
 					</>
 				) : null}
 				{/* Custom-titlebar platforms pin the bell to the far right. */}
-				{boardActionsInFramedTopbar ? <NotificationCenter style={noDragStyle} /> : null}
+				{!boardActionsInPanel ? <NotificationCenter style={noDragStyle} /> : null}
 			</div>
 		</header>
 	);

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -15,21 +15,18 @@ import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
 import { useUiStore } from "../stores/ui-store";
 import { OrchestratorIcon } from "./icons";
-import { cn } from "../lib/utils";
 import { getAgentActivityView } from "../lib/session-presentation";
 import {
 	isLinuxPlatform,
 	isMacPlatform,
 	isWindowsPlatform,
 	usesBoardActionsInPanel,
-	usesFramedAppTopbar,
 } from "../lib/platform";
 import { StatusPill } from "./StatusPill";
 import {
 	TopbarButton,
 	TopbarKillError,
 	topbarHeaderClass,
-	topbarHeaderMacClass,
 	topbarProjectLabelClass,
 } from "./TopbarButton";
 
@@ -37,7 +34,6 @@ const isMac = isMacPlatform();
 const isLinux = isLinuxPlatform();
 const isWindows = isWindowsPlatform();
 const boardActionsInPanel = usesBoardActionsInPanel();
-const topbarNeedsTitlebarOffset = isMac && !usesFramedAppTopbar();
 const dragStyle = isMac ? ({ WebkitAppRegion: "drag" } as React.CSSProperties) : undefined;
 const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
 
@@ -139,7 +135,7 @@ export function ShellTopbar() {
 	};
 
 	return (
-		<header className={cn(topbarHeaderClass, topbarNeedsTitlebarOffset && topbarHeaderMacClass)} style={dragStyle}>
+		<header className={topbarHeaderClass} style={dragStyle}>
 			<div className="flex min-w-0 items-center gap-3">
 				{isSessionRoute && isOrchestrator ? (
 					<div className="inline-flex min-w-0 items-center gap-2">

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -16,19 +16,9 @@ import { addRendererExceptionStep, captureRendererEvent, captureRendererExceptio
 import { useUiStore } from "../stores/ui-store";
 import { OrchestratorIcon } from "./icons";
 import { getAgentActivityView } from "../lib/session-presentation";
-import {
-	isLinuxPlatform,
-	isMacPlatform,
-	isWindowsPlatform,
-	usesBoardActionsInPanel,
-} from "../lib/platform";
+import { isLinuxPlatform, isMacPlatform, isWindowsPlatform, usesBoardActionsInPanel } from "../lib/platform";
 import { StatusPill } from "./StatusPill";
-import {
-	TopbarButton,
-	TopbarKillError,
-	topbarHeaderClass,
-	topbarProjectLabelClass,
-} from "./TopbarButton";
+import { TopbarButton, TopbarKillError, topbarHeaderClass, topbarProjectLabelClass } from "./TopbarButton";
 
 const isMac = isMacPlatform();
 const isLinux = isLinuxPlatform();

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -225,38 +225,24 @@ export function Sidebar({
 				)}
 			>
 				{isMac ? <TitlebarNav historyLocked={historyLocked} /> : null}
-				{/* Brand: logo is pinned in the same 48px icon-rail column as the
-				    toggle so it does not resize or reflow during the width
-				    animation. Wordmark fades in beside it when expanded. */}
+				{/* Brand: logo stays in the --size-sidebar-icon column at a fixed
+				    size so it does not resize or reflow during the width animation.
+				    Wordmark fades in beside it when expanded. */}
 				<div
 					className={cn(
-						"flex shrink-0 items-center pb-4.5",
-						isMac ? "group-data-[collapsible=icon]:pb-2" : "gap-2.5 px-2 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-1 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:pb-2",
+						"flex shrink-0 items-center pb-4.5 group-data-[collapsible=icon]:pb-2",
+						!isMac &&
+							"group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:gap-1",
 					)}
 				>
-					<div
-						className={cn(
-							isMac && "flex w-(--size-sidebar-icon) shrink-0 items-center justify-center",
-						)}
-					>
+					<div className="flex w-(--size-sidebar-icon) shrink-0 items-center justify-center">
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<button
 									aria-label="Orchestrator board"
 									className={cn(
-										"grid shrink-0 place-items-center rounded-lg",
-										isMac
-											? cn(
-													"size-control-board",
-													selection.isHome ? "bg-interactive-active" : "hover:bg-interactive-hover",
-												)
-											: cn(
-													"h-5.5 w-5.5",
-													"group-data-[collapsible=icon]:size-control-board",
-													selection.isHome
-														? "group-data-[collapsible=icon]:bg-interactive-active"
-														: "group-data-[collapsible=icon]:hover:bg-interactive-hover",
-												),
+										"grid size-control-board shrink-0 place-items-center rounded-lg",
+										selection.isHome ? "bg-interactive-active" : "hover:bg-interactive-hover",
 									)}
 									onClick={selection.goHome}
 									type="button"

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -50,19 +50,14 @@ import { useUiStore } from "../stores/ui-store";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { CreateProjectFlow, type CreateProjectInput } from "./CreateProjectFlow";
 import { ResizeHandle } from "./ResizeHandle";
+import { TitlebarNav } from "./TitlebarNav";
+import { isMacPlatform, isWindowsPlatform } from "../lib/platform";
 
-// The macOS hiddenInset traffic lights and the fixed TitlebarNav overlay live
-// in the full-width topbar's left inset (_shell renders the bar above the
-// sidebar row); the sidebar itself starts below the 56px header, so its border
-// never crosses the titlebar strip.
-const isMac = typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
-const isWindows =
-	typeof navigator !== "undefined" &&
-	/win/i.test(
-		(navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform ??
-			navigator.platform ??
-			"",
-	);
+// On macOS the sidebar is full-height: traffic lights sit over its top chrome,
+// and TitlebarNav (toggle + history) stacks in this header directly below them.
+// Win/Linux still hang the sidebar under their shell titlebar/toolbar.
+const isMac = isMacPlatform();
+const isWindows = isWindowsPlatform();
 const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
 
 // Shared styling for the per-project hover action buttons (dashboard,
@@ -85,6 +80,8 @@ type SidebarProps = {
 	underTopbar?: boolean;
 	/** Chrome height to clear when underTopbar is set. Defaults to the 56px shell toolbar. */
 	topbarOffset?: "toolbar" | "titlebar";
+	/** Lock back/forward in TitlebarNav (empty welcome board). */
+	historyLocked?: boolean;
 	workspaceError?: string;
 	workspaces: WorkspaceSummary[];
 	onCreateProject: (input: CreateProjectInput) => Promise<void>;
@@ -126,6 +123,7 @@ export function Sidebar({
 	hideEdgeBorder = false,
 	underTopbar = true,
 	topbarOffset = "toolbar",
+	historyLocked = false,
 	workspaceError,
 	workspaces,
 	onCreateProject,
@@ -215,31 +213,62 @@ export function Sidebar({
 					: "top-0 h-svh!",
 			)}
 		>
-			<SidebarHeader className="gap-0 p-0 pl-2.5 pr-1.75 pt-2.5 group-data-[collapsible=icon]:px-1.5 group-data-[collapsible=icon]:pt-2">
-				{/* Brand (project-sidebar__brand); in the icon rail it becomes the old
-            36px board button wrapping the 22px accent mark. */}
-				<div className="flex shrink-0 items-center gap-2.5 px-2 pb-4.5 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-1 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:pb-2">
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<button
-								aria-label="Orchestrator board"
-								className={cn(
-									"grid h-5.5 w-5.5 shrink-0 place-items-center",
-									"group-data-[collapsible=icon]:size-control-board group-data-[collapsible=icon]:rounded-lg",
-									selection.isHome
-										? "group-data-[collapsible=icon]:bg-interactive-active"
-										: "group-data-[collapsible=icon]:hover:bg-interactive-hover",
-								)}
-								onClick={selection.goHome}
-								type="button"
-							>
-								<img src={aoLogo} alt="" aria-hidden="true" className="h-5.5 w-5.5 rounded-md object-cover" />
-							</button>
-						</TooltipTrigger>
-						<TooltipContent side="right" hidden={state !== "collapsed"}>
-							Orchestrator board
-						</TooltipContent>
-					</Tooltip>
+			{/* macOS: pt clears the traffic lights + drag strip (shared
+			    --size-traffic-light-clearance); header padding stays constant
+			    across expand/collapse so the pinned toggle/logo column does
+			    not shift. */}
+			<SidebarHeader
+				className={cn(
+					"gap-0 p-0",
+					isMac ? "pt-traffic-light-clearance" : "pt-2.5 pl-2.5 pr-1.75",
+					!isMac && "group-data-[collapsible=icon]:px-1.5 group-data-[collapsible=icon]:pt-2",
+				)}
+			>
+				{isMac ? <TitlebarNav historyLocked={historyLocked} /> : null}
+				{/* Brand: logo is pinned in the same 48px icon-rail column as the
+				    toggle so it does not resize or reflow during the width
+				    animation. Wordmark fades in beside it when expanded. */}
+				<div
+					className={cn(
+						"flex shrink-0 items-center pb-4.5",
+						isMac ? "group-data-[collapsible=icon]:pb-2" : "gap-2.5 px-2 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-1 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:pb-2",
+					)}
+				>
+					<div
+						className={cn(
+							isMac && "flex w-(--size-sidebar-icon) shrink-0 items-center justify-center",
+						)}
+					>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									aria-label="Orchestrator board"
+									className={cn(
+										"grid shrink-0 place-items-center rounded-lg",
+										isMac
+											? cn(
+													"size-control-board",
+													selection.isHome ? "bg-interactive-active" : "hover:bg-interactive-hover",
+												)
+											: cn(
+													"h-5.5 w-5.5",
+													"group-data-[collapsible=icon]:size-control-board",
+													selection.isHome
+														? "group-data-[collapsible=icon]:bg-interactive-active"
+														: "group-data-[collapsible=icon]:hover:bg-interactive-hover",
+												),
+									)}
+									onClick={selection.goHome}
+									type="button"
+								>
+									<img src={aoLogo} alt="" aria-hidden="true" className="h-5.5 w-5.5 rounded-md object-cover" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="right" hidden={state !== "collapsed"}>
+								Orchestrator board
+							</TooltipContent>
+						</Tooltip>
+					</div>
 					<span className="sidebar-expanded-chrome min-w-0 flex-1 truncate text-sm font-bold tracking-tight-lg text-foreground group-data-[collapsible=icon]:hidden">
 						Agent Orchestrator
 					</span>
@@ -248,9 +277,6 @@ export function Sidebar({
 							nightly
 						</span>
 					)}
-					{/* On macOS the toggle lives in the TitlebarNav cluster, on Windows in
-					    the WindowTitlebar — only Linux keeps the in-header trigger.
-					    SidebarTrigger already toggles open/closed. */}
 					{!isMac && !isWindows && (
 						<Tooltip>
 							<TooltipTrigger asChild>

--- a/frontend/src/renderer/components/TitlebarNav.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.tsx
@@ -105,7 +105,6 @@ function TitlebarButton({
 			className="grid size-control-md place-items-center rounded-md text-passive transition-colors hover:bg-interactive-hover hover:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent disabled:hover:text-passive"
 			disabled={disabled}
 			onClick={onClick}
-			style={noDragStyle}
 			tabIndex={tabIndex}
 			title={title}
 			type="button"

--- a/frontend/src/renderer/components/TitlebarNav.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.tsx
@@ -1,18 +1,16 @@
 import { useCanGoBack, useRouter } from "@tanstack/react-router";
 import { ArrowLeft, ArrowRight, PanelLeft } from "lucide-react";
 import { useEffect, useState } from "react";
+import { isMacPlatform } from "../lib/platform";
 import { useUiStore } from "../stores/ui-store";
 
-const isMac = typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
+const isMac = isMacPlatform();
 const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
 
-// macOS-only titlebar cluster (sidebar toggle + history arrows) pinned beside
-// the traffic lights, VS Code-style. Approved divergence from the web
-// reference, which has no window chrome (DESIGN.md banner, 2026-06-10).
-// Rendered once by the shell as a fixed overlay (.titlebar-nav in styles.css)
-// over the full-width topbar's left inset, so the buttons occupy the exact
-// same spot whether the sidebar is expanded or collapsed; the topbar starts
-// its content past the cluster (.is-under-titlebar-nav).
+// macOS-only sidebar chrome cluster (sidebar toggle + history arrows). Lives
+// in the Sidebar header below the traffic lights. The toggle is pinned in the
+// icon-rail column so it never moves during expand/collapse; history arrows
+// sit absolutely to its right and only fade in when expanded.
 // The installed router has no useCanGoForward, and deriving one as
 // `__TSR_index < history.length - 1` (the upstream hook's approach) is wrong
 // here: window.history.length also counts entries the router never created —
@@ -44,34 +42,43 @@ export function TitlebarNav({ historyLocked = false }: { historyLocked?: boolean
 
 	if (!isMac) return null;
 
+	const historyInactive = !isSidebarOpen;
+
 	return (
-		<div
-			className="fixed top-0 left-titlebar-cluster-left z-titlebar flex h-toolbar items-center gap-1"
-			style={noDragStyle}
-		>
-			<TitlebarButton
-				label={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
-				onClick={toggleSidebar}
-				title={`${isSidebarOpen ? "Collapse" : "Expand"} sidebar · ⌘B`}
-			>
-				<PanelLeft className="size-icon-lg" aria-hidden="true" />
-			</TitlebarButton>
-			<TitlebarButton
-				disabled={historyLocked || !canGoBack}
-				label="Go back"
-				onClick={() => router.history.back()}
-				title="Go back"
-			>
-				<ArrowLeft className="size-icon-lg" aria-hidden="true" />
-			</TitlebarButton>
-			<TitlebarButton
-				disabled={historyLocked || !canGoForward}
-				label="Go forward"
-				onClick={() => router.history.forward()}
-				title="Go forward"
-			>
-				<ArrowRight className="size-icon-lg" aria-hidden="true" />
-			</TitlebarButton>
+		<div className="titlebar-nav" style={noDragStyle}>
+			{/* Fixed-width slot matches --size-sidebar-icon so the toggle stays
+			    put while the sidebar width animates. */}
+			<div className="titlebar-nav__toggle-slot">
+				<TitlebarButton
+					label={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
+					onClick={toggleSidebar}
+					title={`${isSidebarOpen ? "Collapse" : "Expand"} sidebar · ⌘B`}
+				>
+					<PanelLeft className="size-icon-lg" aria-hidden="true" />
+				</TitlebarButton>
+			</div>
+			{/* Absolute: never takes layout space, so showing/hiding arrows
+			    cannot shift the toggle. Fades with expanded chrome. */}
+			<div className="titlebar-nav__history sidebar-expanded-chrome" aria-hidden={historyInactive}>
+				<TitlebarButton
+					disabled={historyInactive || historyLocked || !canGoBack}
+					label="Go back"
+					onClick={() => router.history.back()}
+					tabIndex={historyInactive ? -1 : undefined}
+					title="Go back"
+				>
+					<ArrowLeft className="size-icon-lg" aria-hidden="true" />
+				</TitlebarButton>
+				<TitlebarButton
+					disabled={historyInactive || historyLocked || !canGoForward}
+					label="Go forward"
+					onClick={() => router.history.forward()}
+					tabIndex={historyInactive ? -1 : undefined}
+					title="Go forward"
+				>
+					<ArrowRight className="size-icon-lg" aria-hidden="true" />
+				</TitlebarButton>
+			</div>
 		</div>
 	);
 }
@@ -80,12 +87,14 @@ function TitlebarButton({
 	label,
 	title,
 	disabled,
+	tabIndex,
 	onClick,
 	children,
 }: {
 	label: string;
 	title: string;
 	disabled?: boolean;
+	tabIndex?: number;
 	onClick: () => void;
 	children: React.ReactNode;
 }) {
@@ -97,6 +106,7 @@ function TitlebarButton({
 			disabled={disabled}
 			onClick={onClick}
 			style={noDragStyle}
+			tabIndex={tabIndex}
 			title={title}
 			type="button"
 		>

--- a/frontend/src/renderer/components/TopbarButton.tsx
+++ b/frontend/src/renderer/components/TopbarButton.tsx
@@ -38,7 +38,5 @@ export function TopbarKillError({ className, ...props }: React.HTMLAttributes<HT
 export const topbarHeaderClass =
 	"flex h-toolbar shrink-0 items-center gap-3 border-b border-border bg-background px-4 z-chrome";
 
-export const topbarHeaderMacClass = "pl-titlebar-content-offset";
-
 export const topbarProjectLabelClass =
 	"text-brand font-semibold tracking-tight leading-none text-foreground whitespace-nowrap";

--- a/frontend/src/renderer/components/WelcomePanel.tsx
+++ b/frontend/src/renderer/components/WelcomePanel.tsx
@@ -3,5 +3,5 @@ import { CenterPanelShell } from "./CenterPanelShell";
 
 /** Inset frame for the first-launch welcome board (import chooser). */
 export function WelcomePanel({ children }: { children: ReactNode }) {
-	return <CenterPanelShell variant="welcome">{children}</CenterPanelShell>;
+	return <CenterPanelShell>{children}</CenterPanelShell>;
 }

--- a/frontend/src/renderer/components/settings/SettingsPageShell.tsx
+++ b/frontend/src/renderer/components/settings/SettingsPageShell.tsx
@@ -3,5 +3,5 @@ import { CenterPanelShell } from "../CenterPanelShell";
 
 /** Outer settings frame — sidebar chrome with the settings inset panel. */
 export function SettingsPageShell({ children }: { children: ReactNode }) {
-	return <CenterPanelShell variant="settings">{children}</CenterPanelShell>;
+	return <CenterPanelShell>{children}</CenterPanelShell>;
 }

--- a/frontend/src/renderer/lib/platform.test.ts
+++ b/frontend/src/renderer/lib/platform.test.ts
@@ -3,8 +3,9 @@ import {
 	isLinuxPlatform,
 	isMacPlatform,
 	isWindowsPlatform,
-	usesBoardActionsInFramedTopbar,
 	usesFramedAppTopbar,
+	hidesShellTopbar,
+	usesBoardActionsInPanel,
 } from "./platform";
 
 const originalPlatform = Object.getOwnPropertyDescriptor(window.navigator, "platform");
@@ -41,22 +42,24 @@ afterEach(() => {
 });
 
 describe("renderer platform behavior", () => {
-	it("uses the framed app topbar on macOS while leaving OS chrome native", () => {
+	it("hides the shell topbar on macOS and keeps board actions in the panel", () => {
 		spoofPlatform("MacIntel", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
 
 		expect(isMacPlatform()).toBe(true);
 		expect(isWindowsPlatform()).toBe(false);
 		expect(usesFramedAppTopbar()).toBe(true);
-		expect(usesBoardActionsInFramedTopbar()).toBe(true);
+		expect(hidesShellTopbar()).toBe(true);
+		expect(usesBoardActionsInPanel()).toBe(true);
 	});
 
-	it("keeps Windows-specific board controls in the inset panel topbar", () => {
+	it("keeps Windows board controls in the inset panel topbar", () => {
 		spoofPlatform("Win32");
 
 		expect(isWindowsPlatform()).toBe(true);
 		expect(isMacPlatform()).toBe(false);
 		expect(usesFramedAppTopbar()).toBe(true);
-		expect(usesBoardActionsInFramedTopbar()).toBe(true);
+		expect(hidesShellTopbar()).toBe(false);
+		expect(usesBoardActionsInPanel()).toBe(false);
 	});
 
 	it("uses the framed app topbar on Linux", () => {
@@ -65,6 +68,7 @@ describe("renderer platform behavior", () => {
 		expect(isLinuxPlatform()).toBe(true);
 		expect(isWindowsPlatform()).toBe(false);
 		expect(usesFramedAppTopbar()).toBe(true);
-		expect(usesBoardActionsInFramedTopbar()).toBe(true);
+		expect(hidesShellTopbar()).toBe(false);
+		expect(usesBoardActionsInPanel()).toBe(false);
 	});
 });

--- a/frontend/src/renderer/lib/platform.ts
+++ b/frontend/src/renderer/lib/platform.ts
@@ -30,9 +30,18 @@ export function usesFramedAppTopbar(): boolean {
 	return true;
 }
 
-export function usesBoardActionsInFramedTopbar(): boolean {
-	// Paired with usesFramedAppTopbar so board actions can move back out of the
-	// framed header independently if a platform-specific shell regression turns
-	// up during desktop validation.
-	return true;
+/**
+ * macOS: shell does not mount ShellTopbar (full-height inset panel + drag
+ * strip). SessionView mounts the same topbar in-panel for session actions.
+ */
+export function hidesShellTopbar(): boolean {
+	return isMacPlatform();
+}
+
+/**
+ * Board New task / Orchestrator / bell render in the board body instead of the
+ * framed shell topbar (macOS). Win/Linux keep those controls in the topbar.
+ */
+export function usesBoardActionsInPanel(): boolean {
+	return hidesShellTopbar();
 }

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -10,7 +10,6 @@ import { ShellTopbar } from "../components/ShellTopbar";
 import { OrchestratorReplacementDialog } from "../components/OrchestratorReplacementDialog";
 import { Sidebar } from "../components/Sidebar";
 import { SidebarProvider } from "../components/ui/sidebar";
-import { TitlebarNav } from "../components/TitlebarNav";
 import { WindowTitlebar } from "../components/WindowTitlebar";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
 import { useDaemonStatus } from "../hooks/useDaemonStatus";
@@ -23,7 +22,13 @@ import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
 import { captureOrchestratorReplacementFailure } from "../lib/orchestrator-replacement-telemetry";
 import { applyDocumentTheme } from "../lib/theme";
 import { aoBridge } from "../lib/bridge";
-import { isLinuxPlatform, isMacPlatform, isWindowsPlatform, usesFramedAppTopbar } from "../lib/platform";
+import {
+	isLinuxPlatform,
+	isMacPlatform,
+	isWindowsPlatform,
+	usesFramedAppTopbar,
+	hidesShellTopbar,
+} from "../lib/platform";
 import { useUiStore } from "../stores/ui-store";
 import type { WorkspaceSummary } from "../types/workspace";
 import type { components } from "../../api/schema";
@@ -61,6 +66,7 @@ const isMac = isMacPlatform();
 const isWindows = isWindowsPlatform();
 const isLinux = isLinuxPlatform();
 const framedAppTopbar = usesFramedAppTopbar();
+const shellTopbarHiddenByPlatform = hidesShellTopbar();
 
 // Persistent app shell: the Sidebar + shared state survive route changes; only
 // the <Outlet> content (board / session / settings / …) swaps. Lifted out of
@@ -96,7 +102,11 @@ function ShellLayout() {
 	const isSettingsRoute =
 		Boolean(matchRoute({ to: "/settings", fuzzy: true })) ||
 		Boolean(matchRoute({ to: "/projects/$projectId/settings", fuzzy: true }));
-	const hideShellTopbar = isWelcomeBoard || isSettingsRoute;
+	// Welcome/settings always self-frame. Platforms that hide the shell-owned
+	// topbar (macOS) use the same full-height inset; session actions mount
+	// inside SessionView.
+	const selfFramedCenterPanel = isWelcomeBoard || isSettingsRoute;
+	const hideShellTopbar = selfFramedCenterPanel || shellTopbarHiddenByPlatform;
 	const setProjectRestarting = useUiStore((state) => state.setProjectRestarting);
 	const orchestratorReplacementErrors = useUiStore((state) => state.orchestratorReplacementErrors);
 	const setOrchestratorReplacementError = useUiStore((state) => state.setOrchestratorReplacementError);
@@ -325,12 +335,9 @@ function ShellLayout() {
 			<NotificationRuntime />
 			<GlobalNewTaskDialog />
 			<KeyboardShortcutsDialog open={isKeyboardShortcutsOpen} onOpenChange={setIsKeyboardShortcutsOpen} />
-			{/* The topbar spans the full window width above the sidebar row (the
-          macOS traffic lights + TitlebarNav cluster sit in its left inset),
-          and the sidebar hangs below it — so the sidebar border stops at the
-          header instead of cutting through the titlebar strip. The bar lives
-          in the layout, not the screens, so the crumb and actions never shift
-          when the outlet content swaps. */}
+			{/* Shell chrome: Win/Linux hang the sidebar under a topbar. macOS uses a
+          full-height sidebar with TitlebarNav under the traffic lights. The bar
+          lives in the layout so crumb/actions never shift when the outlet swaps. */}
 			<div className="flex h-screen min-h-0 flex-col bg-sidebar text-foreground">
 				{/* Windows-only custom title bar (sidebar toggle + File/Edit/View/…
             menu); paints the chrome the frameless window drops. Renders null on
@@ -352,11 +359,14 @@ function ShellLayout() {
 						} as CSSProperties
 					}
 				>
-					{/* Hang the fixed sidebar below shell chrome. macOS keeps room for the traffic-light/titlebar controls; Windows clears only its custom titlebar because the app topbar is inside the framed panel. When the topbar lives inside the framed panel (framedAppTopbar), Linux reserves no offset — otherwise the sidebar would clear a full-width topbar that isn't there. */}
+					{/* Hang the fixed sidebar below shell chrome on Win/Linux. macOS
+              keeps a full-height sidebar so TitlebarNav can sit under the
+              traffic lights inside the sidebar header (no center-panel pad). */}
 					<Sidebar
 						hideEdgeBorder={isWelcomeBoard}
+						historyLocked={isWelcomeBoard}
 						underTopbar={
-							isMac || isWindows || (!framedAppTopbar && !hideShellTopbar && (isLinux ? isSessionRoute : true))
+							isWindows || (!framedAppTopbar && !hideShellTopbar && (isLinux ? isSessionRoute : true))
 						}
 						topbarOffset={isWindows ? "titlebar" : "toolbar"}
 						onCreateProject={createProject}
@@ -369,44 +379,40 @@ function ShellLayout() {
 						<div className="min-h-0 flex-1 overflow-x-hidden">
 							{/* Board/session routes render inside the same inset box the welcome board and settings paint for themselves, so every screen sits within the app's outer boundary. */}
 							{hideShellTopbar ? (
-								<Outlet />
+								selfFramedCenterPanel ? (
+									<Outlet />
+								) : (
+									// Platform hides shell topbar: full-height panel; session mounts actions in-panel.
+									<CenterPanelShell>
+										<Outlet />
+									</CenterPanelShell>
+								)
 							) : framedAppTopbar ? (
-								<CenterPanelShell className={isMac ? "center-panel-shell--mac" : undefined} variant="app">
+								<CenterPanelShell>
 									<ShellTopbar />
 									<div className="flex min-h-0 flex-1 flex-col">
 										<Outlet />
 									</div>
 								</CenterPanelShell>
 							) : (
-								<CenterPanelShell variant="app">
+								<CenterPanelShell>
 									<Outlet />
 								</CenterPanelShell>
 							)}
 						</div>
 					</main>
-					{/* When ShellTopbar is hidden on the welcome board, keep a macOS
-              window-drag strip in the same 56px band — otherwise only
-              TitlebarNav's no-drag buttons remain and the top chrome can't
-              move the window. Invisible/fixed so the start-page layout is
-              unchanged. */}
-					{isWelcomeBoard && isMac ? (
+					{/* When ShellTopbar is hidden, keep a macOS window-drag strip over
+              the traffic-light band only (same --size-traffic-light-clearance
+              as the Sidebar header pad). TitlebarNav sits in the sidebar below
+              that band, so a taller strip would cover the toggle/arrows and
+              swallow clicks. Width matches the sidebar. */}
+					{hideShellTopbar && isMac ? (
 						<div
 							aria-hidden="true"
-							className="fixed inset-x-0 top-0 z-chrome h-toolbar"
+							className="fixed top-0 left-0 z-chrome h-traffic-light-clearance w-(--ao-sidebar-w,var(--size-sidebar-default))"
 							style={{ WebkitAppRegion: "drag" } as CSSProperties}
 						/>
 					) : null}
-					{/* Fixed macOS titlebar cluster beside the traffic lights — rendered
-              once here so the toggle/history buttons never move when the
-              sidebar collapses or expands. History arrows stay visible but
-              locked on the empty start page. MUST come after the drag strip
-              (ShellTopbar or the welcome substitute) in the DOM: Electron
-              builds the window-drag region in document order (drag rects add,
-              no-drag rects subtract), so the cluster's no-drag holes only
-              survive if they're processed after the drag strips they overlap.
-              Rendered first, real clicks get swallowed by window-drag even
-              though DOM hit-testing looks correct. */}
-					<TitlebarNav historyLocked={isWelcomeBoard} />
 				</SidebarProvider>
 				<OrchestratorReplacementDialog
 					error={replacementErrorProjectId ? orchestratorReplacementErrors[replacementErrorProjectId] : undefined}

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -365,9 +365,7 @@ function ShellLayout() {
 					<Sidebar
 						hideEdgeBorder={isWelcomeBoard}
 						historyLocked={isWelcomeBoard}
-						underTopbar={
-							isWindows || (!framedAppTopbar && !hideShellTopbar && (isLinux ? isSessionRoute : true))
-						}
+						underTopbar={isWindows || (!framedAppTopbar && !hideShellTopbar && (isLinux ? isSessionRoute : true))}
 						topbarOffset={isWindows ? "titlebar" : "toolbar"}
 						onCreateProject={createProject}
 						onInitializeProject={initializeProjectRepository}

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -103,10 +103,8 @@
 	--color-terminal: var(--color-bg-terminal);
 	--color-terminal-dim: var(--color-text-terminal-dim);
 	--color-scrim: var(--bridge-scrim);
-	--color-welcome-panel: var(--color-bg-welcome-panel);
 
 	/* Settings page (Figma) */
-	--color-settings-panel: var(--color-bg-settings-panel);
 	--color-settings-row: var(--color-bg-settings-row);
 	--color-settings-menu-selected: var(--color-bg-settings-menu-selected);
 	--color-settings-title: var(--color-text-settings-title);
@@ -164,8 +162,8 @@
 
 	/* Layout — toolbar offset for fixed sidebar below topbar */
 	--spacing-toolbar: var(--size-toolbar);
+	--spacing-traffic-light-clearance: var(--size-traffic-light-clearance);
 	--spacing-titlebar-content-offset: var(--size-titlebar-content-offset);
-	--spacing-titlebar-cluster-left: var(--size-titlebar-cluster-left);
 	--spacing-control-xs: var(--size-control-xs);
 	--spacing-control-sm: var(--size-control-sm);
 	--spacing-control-form: var(--size-control-form);
@@ -337,36 +335,7 @@
 	padding-left: 0;
 }
 
-/* macOS: drop the framed panel below the traffic-light/TitlebarNav band
- * (56px toolbar height) so its top edge lines up with the sidebar brand and
- * the pinned toggle/history cluster no longer overlaps the panel's topbar. */
-.center-panel-shell--mac {
-	padding-top: var(--size-toolbar);
-}
-
-@utility center-panel-welcome {
-	display: flex;
-	min-height: 0;
-	flex: 1 1 0%;
-	flex-direction: column;
-	overflow: hidden;
-	border-radius: var(--radius-welcome-panel);
-	border: 1px solid var(--color-border-welcome-panel);
-	background-color: var(--color-bg-welcome-panel);
-}
-
-@utility center-panel-settings {
-	display: flex;
-	min-height: 0;
-	flex: 1 1 0%;
-	flex-direction: column;
-	overflow: hidden;
-	border-radius: var(--radius-settings-panel);
-	border: 1px solid var(--color-border-settings);
-	background-color: var(--color-bg-settings-panel);
-}
-
-@utility center-panel-app {
+@utility center-panel-surface {
 	display: flex;
 	min-height: 0;
 	flex: 1 1 0%;
@@ -978,27 +947,34 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 }
 
 /* ── macOS titlebar cluster (TitlebarNav) ─────────────────────────────────
- * Fixed beside the traffic lights so the toggle/history buttons occupy the
- * exact same spot in both sidebar states. The 56px strip matches the
- * .dashboard-app-header height so the buttons share the topbar's center line
- * (y 28) with the project crumb / bell; the lights match via
- * trafficLightPosition y:20 in main.ts. Lights span x=14–66; the cluster
- * starts a 13px group gap after them (the .dashboard-app-header gap), so
- * the toggle reads as its own group rather than a fourth light. */
+ * In-flow inside the Sidebar header, below the traffic lights. The toggle is
+ * pinned in a --size-sidebar-icon column so its screen position never changes
+ * during the width animation; history arrows are absolute to the right and
+ * fade with .sidebar-expanded-chrome. */
 .titlebar-nav {
-	position: fixed;
-	top: 0;
-	left: 79px;
-	z-index: 20;
+	position: relative;
 	display: flex;
-	height: 56px;
+	height: var(--size-control-md);
+	flex-shrink: 0;
 	align-items: center;
-	gap: 2px;
+	margin-bottom: var(--space-2);
 }
 
-.titlebar-nav__btn {
-	width: 28px;
-	height: 28px;
+.titlebar-nav__toggle-slot {
+	display: flex;
+	width: var(--size-sidebar-icon);
+	flex-shrink: 0;
+	align-items: center;
+	justify-content: center;
+}
+
+.titlebar-nav__history {
+	position: absolute;
+	top: 0;
+	left: var(--size-sidebar-icon);
+	display: flex;
+	align-items: center;
+	gap: var(--space-1);
 }
 
 /* Windows custom title bar (WindowTitlebar): the app paints the sidebar toggle
@@ -1073,13 +1049,6 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 
 .window-titlebar__menu {
 	min-width: 200px;
-}
-
-/* macOS: the full-width header starts its content past the lights + fixed
- * cluster: cluster right edge 79 + 3×28 + 2×2 = 167px, + the header's 13px
- * group gap = 180px. */
-.dashboard-app-header.is-under-titlebar-nav {
-	padding-left: 180px;
 }
 
 .topbar-project-pills-group {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -163,7 +163,6 @@
 	/* Layout — toolbar offset for fixed sidebar below topbar */
 	--spacing-toolbar: var(--size-toolbar);
 	--spacing-traffic-light-clearance: var(--size-traffic-light-clearance);
-	--spacing-titlebar-content-offset: var(--size-titlebar-content-offset);
 	--spacing-control-xs: var(--size-control-xs);
 	--spacing-control-sm: var(--size-control-sm);
 	--spacing-control-form: var(--size-control-form);

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -207,7 +207,6 @@
 	/* Clears macOS traffic lights (y:20 discs) before in-sidebar TitlebarNav;
 	   keep Sidebar header padding and the shell drag strip on this same token. */
 	--size-traffic-light-clearance: 36px;
-	--size-titlebar-content-offset: 180px;
 	--size-resize-handle: 7px;
 	--size-resize-handle-offset: 3px;
 	--size-kanban-glow: 130px;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -87,7 +87,7 @@
 	--font-size-sm: 12px; /* secondary chrome / Tailwind text-xs */
 	--font-size-md-sm: 12.5px; /* kv rows, PR summaries */
 	--font-size-base: 13px; /* dense controls (board buttons) */
-	--font-size-brand: 14.5px; /* titlebar project name */
+	--font-size-brand: 16px; /* titlebar / board project name */
 	--font-size-md: 14px; /* body / Tailwind text-sm */
 	--font-size-subtitle: 15px; /* dialog titles, stat values */
 	--font-size-heading-sm: 17px; /* empty-state headings */
@@ -204,7 +204,9 @@
 	--size-sidebar-icon: 48px;
 	--size-sidebar-default: 240px;
 	--size-sidebar-mobile: 288px;
-	--size-titlebar-cluster-left: 79px;
+	/* Clears macOS traffic lights (y:20 discs) before in-sidebar TitlebarNav;
+	   keep Sidebar header padding and the shell drag strip on this same token. */
+	--size-traffic-light-clearance: 36px;
 	--size-titlebar-content-offset: 180px;
 	--size-resize-handle: 7px;
 	--size-resize-handle-offset: 3px;
@@ -232,12 +234,11 @@
 	--size-textarea-min: 112px;
 	--size-sidebar-project-actions: 84px;
 
-	/* Shared inset-panel geometry (welcome board + settings page) */
+	/* Shared inset-panel geometry */
 	--size-center-panel-inset: 14px;
 	--radius-center-panel: 17px;
 
-	/* Welcome board inset panel */
-	--color-bg-welcome-panel: rgb(18 18 19);
+	/* Welcome / import radius alias (CreateProjectFlow rounded-welcome-panel) */
 	--color-border-welcome-panel: #212121;
 	--radius-welcome-panel: var(--radius-center-panel);
 
@@ -257,7 +258,6 @@
 	--size-import-mode-card-min-sm: 292px;
 
 	/* Settings page (Figma) */
-	--color-bg-settings-panel: #101013;
 	--color-bg-settings-row: #18181c;
 	--color-bg-settings-menu: #212121;
 	--color-bg-settings-menu-selected: rgb(66 66 66 / 0.78);
@@ -453,8 +453,7 @@
 	--elevation-lg: 0 16px 48px rgb(20 30 50 / 0.16);
 	--elevation-xl: 0 1px 0 rgb(0 0 0 / 0.03), 0 20px 50px rgb(20 30 50 / 0.14);
 
-	/* Welcome board inset panel */
-	--color-bg-welcome-panel: #ffffff;
+	/* Welcome / import radius alias */
 	--color-border-welcome-panel: #d4d4d6;
 
 	/* Import mode picker — light surfaces */
@@ -474,7 +473,6 @@
 	--color-text-agents-sheet-description: #666666;
 	--color-text-agents-sheet-label: #374151;
 
-	--color-bg-settings-panel: #ffffff;
 	--color-bg-settings-row: #f3f3f4;
 	--color-bg-settings-menu: #f3f3f4;
 	--color-bg-settings-menu-selected: rgb(0 0 0 / 0.08);


### PR DESCRIPTION
## Summary
- On macOS, hide the shell-owned `ShellTopbar` and use a full-height inset center panel; board/session actions mount in-panel instead.
- Move `TitlebarNav` into the sidebar header under the traffic lights (toggle stays in the icon-rail column on collapse; history arrows hide), with a macOS window-drag strip when the shell topbar is absent.
- Keep Win/Linux on the framed full-width topbar + sidebar-under-header layout; simplify `CenterPanelShell`, drop the unused titlebar content-offset token, and keep the sidebar brand logo at a fixed size during expand/collapse. Update `DESIGN.md` for the platform split.

## Test plan
- [ ] macOS: board route — no shell topbar; crumb + New task / Orchestrator / bell render inside the inset panel
- [ ] macOS: session route — session actions appear in-panel; panel stays full-height under the titlebar band
- [ ] macOS: sidebar expand/collapse — toggle stays put; history arrows only when expanded; brand logo does not resize/reflow; traffic lights clear sidebar chrome
- [ ] macOS: welcome + settings — self-framed panels still work; window still draggable via the top drag strip
- [ ] Windows/Linux: framed `ShellTopbar` still owns board/session chrome; sidebar still hangs below the topbar
- [ ] `cd frontend && npm test -- platform.test SessionsBoard.test SessionView.test` and titlebar-brand e2e still pass

## Before
<img width="1166" height="741" alt="image" src="https://github.com/user-attachments/assets/f70d09ca-962f-4c27-b934-dd8fe8a68e45" />


## After
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/595e2d5c-d8a6-4e6c-83d3-0a5d6135b97e" />
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/74f41dda-ca58-4c2a-ab44-65e1d0914e6d" />
<img width="1470" height="949" alt="image" src="https://github.com/user-attachments/assets/050b69be-4ee3-4e38-959a-5f70a8c4f30f" />
<img width="141" height="556" alt="image" src="https://github.com/user-attachments/assets/9f2a4a89-2a0c-4fef-bd46-b0ec3c28b8dc" />
