### PR TITLE
fix(browser): park native preview synchronously so overlays never flash on top (#2949)

### DIFF
--- a/frontend/src/renderer/hooks/useBrowserView.test.tsx
+++ b/frontend/src/renderer/hooks/useBrowserView.test.tsx
@@ -356,6 +356,114 @@ describe("useBrowserView", () => {
 		);
 	});
 
+	it("parks the native view synchronously when an overlay opens, without waiting for a frame", async () => {
+		// Regression for the notifications-over-browser overlay race: parking used to
+		// be deferred to requestAnimationFrame, leaving a ~16ms window where the live
+		// native view painted over the just-opened dropdown. Under fake timers the
+		// parked bounds must land from the MutationObserver microtask alone, before
+		// any rAF/timer is advanced.
+		vi.useFakeTimers();
+		try {
+			const bridge = setupBridge();
+			const slot = createSlot();
+			const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+			await act(async () => {
+				await Promise.resolve();
+			});
+			act(() =>
+				bridge.emit({
+					viewId: "42:sess-1",
+					url: "http://localhost:3000/",
+					title: "",
+					canGoBack: false,
+					canGoForward: false,
+					isLoading: false,
+				}),
+			);
+			act(() => result.current.slotRef(slot));
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
+
+			bridge.setBounds.mockClear();
+			const menu = document.createElement("div");
+			menu.setAttribute("role", "menu");
+			menu.setAttribute("data-state", "open");
+			// Flush only the observer microtask — deliberately do NOT advance timers,
+			// so a parked call here proves the park is synchronous, not rAF-deferred.
+			await act(async () => {
+				document.body.appendChild(menu);
+				await Promise.resolve();
+			});
+			expect(bridge.setBounds).toHaveBeenCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 12, y: 34, width: 320, height: 240 },
+				visible: true,
+				parked: true,
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("re-parks when a reused portal flips data-state in place under rapid toggling", async () => {
+		// Radix reuses its portal node and flips data-state="open"↔"closed" without
+		// adding/removing a body child. A childList-only observer misses this, so the
+		// view stays un-parked while the dropdown is open. The hardened observer must
+		// catch the in-place attribute flip and re-park.
+		const bridge = setupBridge();
+		const slot = createSlot();
+		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));
+
+		await waitFor(() => expect(bridge.ensure).toHaveBeenCalledWith("sess-1"));
+		act(() =>
+			bridge.emit({
+				viewId: "42:sess-1",
+				url: "http://localhost:3000/",
+				title: "",
+				canGoBack: false,
+				canGoForward: false,
+				isLoading: false,
+			}),
+		);
+		act(() => result.current.slotRef(slot));
+
+		// The portal node is present the whole time; only its data-state flips.
+		const portal = document.createElement("div");
+		portal.setAttribute("role", "menu");
+		portal.setAttribute("data-state", "closed");
+		await act(async () => {
+			document.body.appendChild(portal);
+			await Promise.resolve();
+		});
+
+		await act(async () => {
+			portal.setAttribute("data-state", "open");
+			await Promise.resolve();
+		});
+		await waitFor(() =>
+			expect(bridge.setBounds).toHaveBeenLastCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 12, y: 34, width: 320, height: 240 },
+				visible: true,
+				parked: true,
+			}),
+		);
+
+		bridge.setBounds.mockClear();
+		await act(async () => {
+			portal.setAttribute("data-state", "closed");
+			await Promise.resolve();
+		});
+		await waitFor(() =>
+			expect(bridge.setBounds).toHaveBeenLastCalledWith({
+				viewId: "42:sess-1",
+				rect: { x: 12, y: 34, width: 320, height: 240 },
+				visible: true,
+			}),
+		);
+	});
+
 	it("updates nav state only for the current view", async () => {
 		const bridge = setupBridge();
 		const { result } = renderHook(() => useBrowserView({ sessionId: "sess-1", active: true, poppedOut: false }));

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -137,6 +137,16 @@ export function useBrowserView({
 	}, []);
 
 	const measureAndSend = useCallback(() => {
+		// measureAndSend runs both from the scheduleMeasure() rAF callback and as a
+		// direct synchronous call (parking on overlay open, the settle timer). A
+		// direct call may land while a scheduled frame is still queued, so cancel
+		// that live handle rather than blindly nulling it — otherwise the
+		// scheduleMeasure() dedupe guard and cancelScheduledMeasure() cleanup would
+		// both trust a frameRef that no longer reflects the pending frame.
+		if (frameRef.current !== null) {
+			if (window.cancelAnimationFrame) window.cancelAnimationFrame(frameRef.current);
+			window.clearTimeout(frameRef.current);
+		}
 		frameRef.current = null;
 		const id = viewIdRef.current;
 		const node = slotNodeRef.current;
@@ -357,8 +367,10 @@ export function useBrowserView({
 		// adding/removing a body child, so a `childList`-only observer misses the
 		// open/close transition under rapid toggling and `modalOpenRef` desyncs.
 		// Watch subtree attribute flips on `data-state` too so the transition is
-		// always observed. `update()` early-returns when the open state is unchanged,
-		// so the extra callbacks are cheap.
+		// always observed. This widens the firing rate a lot — `data-state` is used
+		// across Radix (tooltips, accordions, selects, switches, …), so `update()`
+		// now runs a document-wide querySelector on activity anywhere in the app
+		// before it can bail. Cheap enough in practice, but not free.
 		observer.observe(document.body, {
 			childList: true,
 			subtree: true,

--- a/frontend/src/renderer/hooks/useBrowserView.ts
+++ b/frontend/src/renderer/hooks/useBrowserView.ts
@@ -330,7 +330,13 @@ export function useBrowserView({
 				const id = viewIdRef.current;
 				if (id && activeRef.current && hasUrlRef.current) {
 					runMirror(id);
-					scheduleMeasure();
+					// Park the native view synchronously, in the same tick the overlay
+					// opened. `modalOpenRef` is already true, so measureAndSend() emits
+					// the `parked: true` bounds now instead of a frame later — deferring
+					// to rAF leaves a ~16ms window where the live view paints over the
+					// freshly-opened dropdown, which stacks into a stuck overlay under
+					// rapid toggling. rAF still refines geometry on later resize/scroll.
+					measureAndSend();
 				} else {
 					sendHiddenBounds();
 				}
@@ -347,14 +353,25 @@ export function useBrowserView({
 		};
 		update();
 		const observer = new MutationObserver(update);
-		observer.observe(document.body, { childList: true });
+		// Radix reuses its portal node and flips `data-state` in place rather than
+		// adding/removing a body child, so a `childList`-only observer misses the
+		// open/close transition under rapid toggling and `modalOpenRef` desyncs.
+		// Watch subtree attribute flips on `data-state` too so the transition is
+		// always observed. `update()` early-returns when the open state is unchanged,
+		// so the extra callbacks are cheap.
+		observer.observe(document.body, {
+			childList: true,
+			subtree: true,
+			attributes: true,
+			attributeFilter: ["data-state"],
+		});
 		return () => {
 			observer.disconnect();
 			clearMirrorTimer();
 			mirrorTokenRef.current += 1;
 			stopMirrorStream();
 		};
-	}, [hasNativeBrowser, runMirror, scheduleMeasure, scheduleSettleMeasure, sendHiddenBounds, stopMirrorStream]);
+	}, [hasNativeBrowser, measureAndSend, runMirror, scheduleSettleMeasure, sendHiddenBounds, stopMirrorStream]);
 
 	useEffect(() => {
 		const handle = () => scheduleMeasure();


### PR DESCRIPTION
## Problem

Rapidly clicking the notifications bell while a browser preview is active makes the native `WebContentsView` render on top of the open dropdown instead of parking behind it (#2949).

This isn't a z-index issue. The preview is a native Electron `WebContentsView`, a window-level overlay Chromium composites above the entire DOM. No DOM z-index can place a React dropdown above it. Dropdowns and modals stay visible only via the "park" machinery in `useBrowserView.ts`, which moves the native view off-screen while an overlay is open.

Two gaps defeated that mechanism under rapid toggling:

1. **One-frame flash (primary).** Parking was deferred to `requestAnimationFrame`. The overlay opens in frame **N**, but the view only parks in **N+1**, creating a ~16 ms window where the live view paints over the newly opened dropdown. A slow click makes the flash nearly imperceptible, while rapid clicks stack the flashes into a persistent overlay.

2. **Observer desync (secondary).** The `MutationObserver` watched `document.body` with `{ childList: true }` only. Radix reuses its portal node and flips `data-state="open"` ↔ `"closed"` in place without modifying direct body children. Under rapid open/close, those transitions were never observed, causing `modalOpenRef` to desynchronize from reality.

### Before fix — the bug

The browser preview panel paints over the open **Notifications** dropdown (reporter's original repro):

<img width="565" height="657" alt="notif-browser-overlay" src="https://github.com/user-attachments/assets/75604cb3-0060-42c8-9b1c-1c79593d9ee2" />

---

## Fix

- Park synchronously inside the observer callback, in the same tick the overlay opens (after `modalOpenRef` is updated), instead of deferring to `requestAnimationFrame`.
- Keep `requestAnimationFrame` only for later geometry refinement during resize and scroll.
- Harden the observer to:

```ts
{
  childList: true,
  subtree: true,
  attributes: true,
  attributeFilter: ["data-state"],
}
```

This ensures in-place `data-state` transitions and nested portal updates are always detected.

The callback exits early when the open state has not changed, so the additional observer callbacks remain inexpensive.

Because the same machinery protects every modal, dialog, and dropdown in the application, this hardens the entire overlay system rather than only the notifications dropdown.

---

## After fix

Verified in the packaged Electron app with an active native browser preview. Even after rapidly toggling the notifications bell (the original reproduction), the dropdown consistently renders above the parked `WebContentsView`.

| Before clicking the bell | After clicking the bell |
| ------------------------- | ----------------------- |
| <img width="960" height="540" alt="os-10-before-closed" src="https://github.com/user-attachments/assets/c384e8d8-2437-4072-ad75-0ef824ee87f5" /> | <img width="960" height="540" alt="os-09-after-open" src="https://github.com/user-attachments/assets/fce25b41-288c-4b28-8546-8f868cb76394" /> |
| Native preview ("6. Objection answers") fills the Browser panel. | Notifications dropdown renders cleanly on top of the parked preview. |

---

## Tests

Two regression tests were added to `useBrowserView.test.tsx`:

- Verifies parking occurs synchronously from the observer microtask without advancing a frame, proving the view is parked immediately.
- Verifies the view re-parks and restores correctly when a reused portal flips `data-state` in place, covering the previous `childList`-only observer gap.

**Results:**

- ✅ All 16 tests pass.
- ✅ `prettier --check` passes cleanly.

Closes #2949.