### PR TITLE
fix(kimi):forward role-specific model config on launch and restore

### DIFF
--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -77,6 +77,22 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Kimi understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `kimi --model`.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new Kimi session:
 //
 //	kimi [--auto|-y]                            (interactive)
@@ -94,6 +110,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd = []string{binary}
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 	return cmd, nil
 }
 
@@ -145,7 +162,9 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if err != nil {
 		return nil, false, err
 	}
-	cmd = []string{binary, "--session", agentSessionID}
+	cmd = []string{binary}
+	appendModelFlag(&cmd, cfg.Config)
+	cmd = append(cmd, "--session", agentSessionID)
 	return cmd, true, nil
 }
 
@@ -167,6 +186,12 @@ func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
 		*cmd = append(*cmd, "--auto")
 	case ports.PermissionModeBypassPermissions:
 		*cmd = append(*cmd, "-y")
+	}
+}
+
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
 	}
 }
 

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -32,13 +32,22 @@ func TestManifest(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecEmpty(t *testing.T) {
-	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
+func TestGetConfigSpecReportsModelField(t *testing.T) {
+	plugin := &Plugin{}
+
+	spec, err := plugin.GetConfigSpec(context.Background())
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		t.Fatal(err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `kimi --model`.",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
 	}
 }
 
@@ -122,6 +131,38 @@ func TestGetLaunchCommandIgnoresSystemPrompt(t *testing.T) {
 	}
 }
 
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kimi"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "  claude-sonnet-5  "},
+		Prompt: "fix this",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsSubsequence(cmd, []string{"--model", "claude-sonnet-5"}) {
+		t.Fatalf("command %#v missing trimmed --model flag", cmd)
+	}
+	if containsSubsequence(cmd, []string{"--model", "  claude-sonnet-5  "}) {
+		t.Fatalf("command %#v used untrimmed model", cmd)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kimi"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(cmd, "--model") {
+		t.Fatalf("command %#v contains --model for blank model", cmd)
+	}
+}
+
 // Kimi docs: `--yolo` and `--auto` cannot be used together with `--continue`
 // or `--session` — resumed sessions inherit the approval settings of the
 // original session — so the restore path must not emit approval flags
@@ -189,6 +230,26 @@ func TestGetRestoreCommandNoID(t *testing.T) {
 				t.Fatalf("cmd = %#v, want nil", cmd)
 			}
 		})
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kimi"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "  claude-sonnet-5  "},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "01HZABC"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if !containsSubsequence(cmd, []string{"--model", "claude-sonnet-5"}) {
+		t.Fatalf("restore command %#v missing trimmed --model flag", cmd)
 	}
 }
 
@@ -588,4 +649,37 @@ func TestContextCancellation(t *testing.T) {
 	if _, err := ResolveKimiBinary(ctx); !errors.Is(err, context.Canceled) {
 		t.Fatalf("ResolveKimiBinary err = %v, want context.Canceled", err)
 	}
+}
+
+func contains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSubsequence(values []string, needle []string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+
+	for start := range values {
+		if start+len(needle) > len(values) {
+			return false
+		}
+		ok := true
+		for offset, want := range needle {
+			if values[start+offset] != want {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
## What

Forward the configured role model to the `kimi` CLI on both launch and restore, and advertise the `model` config field.

## Why

Fixes #2890.

`GetLaunchCommand` and `GetRestoreCommand` built their argv without reading `cfg.Config.Model`, so a worker or orchestrator configured with a specific model silently started on Kimi's global default. The adapter also inherited the empty `agentbase.Base.GetConfigSpec`, so it never advertised a `model` field.

## How

Mirrors the Codex fix in #2869:

- `appendModelFlag` appends `--model <trimmed model>` when `strings.TrimSpace(cfg.Config.Model) != ""`, called from both `GetLaunchCommand` and `GetRestoreCommand`.
- `GetConfigSpec` override advertising `model` as `ports.ConfigFieldString`.

The flag is appended right after the permission flags so it sits with the other `append*Flags` output, ahead of `--session` on the restore path. Kimi gives the CLI flag the highest precedence, so this wins over a user's config file value as intended.

Model values stay in Kimi's `provider/model` form; the adapter passes the string through untouched apart from trimming.

## Testing

```
cd backend && go build ./... && go test -v ./internal/adapters/agent/kimi/...
```

Three new tests, proven to fail on `main` before the fix:

```
--- PASS: TestGetLaunchCommandAppendsConfiguredModel (0.00s)
--- PASS: TestGetLaunchCommandOmitsBlankConfiguredModel (0.00s)
--- PASS: TestGetRestoreCommandAppendsConfiguredModel (0.00s)
--- PASS: TestGetConfigSpecReportsModelField (0.00s)
```

`TestGetLaunchCommandOmitsBlankConfiguredModel` passes both before and after, so it pins the blank/whitespace case rather than restating the fix.

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added for user-visible behavior
- [x] Relevant CI checks pass for the area touched
