### PR TITLE
fix: make frontend web dev script cross-platform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,30 @@ Non-trivial work? Comment on the issue or ping Discord first. Get a thumbs-up, t
 
 Need the product/run overview first? Start with [README.md](README.md) and [docs/architecture.md](docs/architecture.md).
 
+### Run from source
+
+The desktop app lives in `frontend/`. For renderer-only UI work, run the web
+preview from the source checkout:
+
+```bash
+cd frontend
+npm install
+npm run dev:web
+```
+
+`dev:web` sets `VITE_NO_ELECTRON=1` through a Node launcher so it works on
+macOS, Linux, and Windows. On Windows, if PowerShell blocks `npm.ps1` with a
+script execution policy error, use the command shim directly:
+
+```powershell
+cd frontend
+npm.cmd install
+npm.cmd run dev:web
+```
+
+The command prints a local Vite URL, usually `http://127.0.0.1:5173/`. Use
+`npm run dev` from `frontend/` when you need the full Electron desktop shell.
+
 ### Bugs and features
 
 Use the GitHub issue forms (**Bug report** / **Feature request**) so reports stay reproducible.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,30 @@ Download the latest desktop build for your platform:
 
 After installing, open Agent Orchestrator and point it at the repository you want AO to manage. The desktop app runs the daemon for you, so no CLI is required. Installed desktop builds check for updates on launch and periodically while the app is running. See the [installation guide](https://ao-agents.com/docs/installation) for agent CLI setup and troubleshooting.
 
+### Run From Source
+
+For frontend development, install dependencies in `frontend/` and start the
+renderer web preview:
+
+```bash
+cd frontend
+npm install
+npm run dev:web
+```
+
+`dev:web` is cross-platform and starts Vite with `VITE_NO_ELECTRON=1`, so the
+same command works on macOS, Linux, and Windows. If Windows PowerShell blocks
+the `npm.ps1` shim with a script execution policy error, call npm through
+`npm.cmd` instead:
+
+```powershell
+cd frontend
+npm.cmd install
+npm.cmd run dev:web
+```
+
+Use `npm run dev` from `frontend/` when you need the full Electron desktop app.
+
 <details>
 <summary>Install via npm (legacy CLI, no longer recommended)</summary>
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
 	"scripts": {
 		"build:daemon": "node ./scripts/build-daemon.mjs",
 		"dev": "electron-forge start",
-		"dev:web": "VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts",
+		"dev:web": "node ./scripts/dev-web.mjs",
 		"prepackage": "npm run build:daemon",
 		"package": "electron-forge package",
 		"premake": "npm run build:daemon",

--- a/frontend/scripts/dev-web.mjs
+++ b/frontend/scripts/dev-web.mjs
@@ -1,0 +1,29 @@
+import { spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const viteBin = resolve(scriptDir, "../node_modules/vite/bin/vite.js");
+const args = [viteBin, "--config", "vite.renderer.config.ts", ...process.argv.slice(2)];
+
+const child = spawn(process.execPath, args, {
+	env: {
+		...process.env,
+		VITE_NO_ELECTRON: "1",
+	},
+	stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+	if (signal) {
+		process.kill(process.pid, signal);
+		return;
+	}
+
+	process.exit(code ?? 1);
+});
+
+child.on("error", (error) => {
+	console.error(error);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- replace the POSIX-only `VITE_NO_ELECTRON=1 vite ...` `dev:web` script with a small Node launcher
- keep `VITE_NO_ELECTRON=1` behavior while allowing extra Vite arguments to pass through
- document frontend source-development commands and the Windows `npm.cmd` workaround

## Why

Windows PowerShell/cmd do not support `VAR=value command` syntax, so `npm run dev:web` fails for Windows contributors before Vite can start. The launcher sets the environment through Node instead of depending on shell-specific syntax.

Fixes # 2981

## Validation

- `npm.cmd run dev:web -- --host 127.0.0.1 --port 5185 --strictPort` reached Vite ready state on Windows
- `npm.cmd run typecheck`