### PR TITLE
fix(tmux): run tmux CLI from stable cwd and verify pane starts in workspace

### DIFF
--- a/backend/internal/adapters/runtime/tmux/commands.go
+++ b/backend/internal/adapters/runtime/tmux/commands.go
@@ -75,6 +75,15 @@ func listPanePIDsArgs(id string) []string {
 	return []string{"list-panes", "-s", "-t", exactSessionTarget(id), "-F", "#{pane_pid}"}
 }
 
+// displayPaneCwdArgs builds args for `tmux display-message -p -t <id>
+// #{pane_current_path}`, printing the pane's current working directory so
+// Create can verify the pane really started in the workspace and not in the
+// server-cwd fallback tmux uses when `new-session -c` cannot be resolved.
+// Pane-targeting, so no `=` prefix (see setStatusOffArgs).
+func displayPaneCwdArgs(id string) []string {
+	return []string{"display-message", "-p", "-t", id, "#{pane_current_path}"}
+}
+
 // sendKeysLiteralArgs builds args for `tmux send-keys -t <id> -l <chunk>`.
 // The -l flag stops tmux interpreting words like "Enter" as key names so the
 // text is sent verbatim.

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -128,8 +129,17 @@ func sessionsHaveProcesses(ctx context.Context, pids []int) bool {
 
 type execRunner struct{}
 
+// Run executes the tmux CLI from a stable directory rather than the daemon's
+// own cwd. The first tmux CLI call after boot auto-starts the persistent tmux
+// server, which inherits this process's cwd and keeps it for its lifetime.
+// The daemon can be started from inside the packaged app bundle (or a
+// Squirrel/ShipIt staging dir) that the next auto-update swaps or deletes;
+// tmux then silently falls back to that doomed server cwd whenever
+// `new-session -c <dir>` cannot be resolved at spawn time, stranding panes in
+// a deleted directory (issue #2775). os.TempDir() outlives app updates.
 func (execRunner) Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = os.TempDir()
 	cmd.Env = append(append([]string(nil), os.Environ()...), env...)
 	return cmd.CombinedOutput()
 }
@@ -182,7 +192,8 @@ func New(opts Options) *Runtime {
 }
 
 // Create starts a new tmux session in the workspace, running the agent's
-// launch command with a keep-alive shell, and returns a handle to it.
+// launch command with a keep-alive shell, verifies the pane really started in
+// the workspace (see verifyPaneCwd), and returns a handle to it.
 func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
 	id, err := tmuxSessionName(cfg.SessionID)
 	if err != nil {
@@ -236,7 +247,43 @@ func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.Ru
 		_ = r.Destroy(context.Background(), handle)
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: session %s exited before ready", id)
 	}
+	if err := r.verifyPaneCwd(ctx, id, cfg.WorkspacePath); err != nil {
+		_ = r.Destroy(context.Background(), handle)
+		return ports.RuntimeHandle{}, err
+	}
 	return handle, nil
+}
+
+// verifyPaneCwd checks that the new pane actually started in the requested
+// workspace. When `new-session -c <dir>` cannot resolve dir at spawn time,
+// tmux does not error: it silently falls back to the SERVER's cwd, and the
+// agent later dies with a context-free ENOENT (plus shell-init getcwd errors)
+// far from the real cause. Catch it here with an error naming both paths.
+func (r *Runtime) verifyPaneCwd(ctx context.Context, id, workspace string) error {
+	out, err := r.run(ctx, displayPaneCwdArgs(id)...)
+	if err != nil {
+		return fmt.Errorf("tmux runtime: verify pane cwd %s: %w", id, err)
+	}
+	paneCwd := strings.TrimSpace(string(out))
+	if samePath(paneCwd, workspace) {
+		return nil
+	}
+	return fmt.Errorf("tmux runtime: session %s pane started in %q instead of the workspace %q; tmux silently falls back to its server's cwd when the requested directory cannot be resolved, so the workspace is likely missing or the tmux server is pinned to a deleted directory (kill the tmux server and retry)", id, paneCwd, workspace)
+}
+
+// samePath reports whether two paths refer to the same directory, resolving
+// symlinks so macOS's /var vs /private/var aliasing does not read as a
+// mismatch. A path that cannot be resolved (e.g. already deleted) falls back
+// to its cleaned literal form.
+func samePath(a, b string) bool {
+	return resolvePath(a) == resolvePath(b)
+}
+
+func resolvePath(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return filepath.Clean(p)
 }
 
 // Destroy kills the handle's tmux session and reaps the pane processes it

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -3,7 +3,9 @@ package tmux
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -112,6 +114,10 @@ func TestCommandBuilders(t *testing.T) {
 	if got, want := listPanePIDsArgs("sess-1"), []string{"list-panes", "-s", "-t", "=sess-1", "-F", "#{pane_pid}"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("listPanePIDsArgs = %#v, want %#v", got, want)
 	}
+	// display-message prints the pane cwd for Create's post-spawn verification.
+	if got, want := displayPaneCwdArgs("sess-1"), []string{"display-message", "-p", "-t", "sess-1", "#{pane_current_path}"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("displayPaneCwdArgs = %#v, want %#v", got, want)
+	}
 	if got, want := sendKeysLiteralArgs("sess-1", "hello"), []string{"send-keys", "-t", "sess-1", "-l", "hello"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("sendKeysLiteralArgs = %#v, want %#v", got, want)
 	}
@@ -184,9 +190,9 @@ func TestCreateRejectsInvalidEnvKeys(t *testing.T) {
 
 func TestCreateIssuesNewSessionAndStatusOff(t *testing.T) {
 	// new-session, set-option status, set-option mouse, set-option window-size,
-	// has-session (exit 0 = alive)
+	// has-session (exit 0 = alive), display-message (pane cwd matches workspace)
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{nil, nil, nil, nil, nil}
+	fr.outputs = [][]byte{nil, nil, nil, nil, nil, []byte("/tmp/ws\n")}
 
 	h, err := r.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     "sess-1",
@@ -200,10 +206,10 @@ func TestCreateIssuesNewSessionAndStatusOff(t *testing.T) {
 	if h.ID != "sess-1" {
 		t.Fatalf("handle ID = %q, want sess-1", h.ID)
 	}
-	// Expect 5 calls: new-session, set-option status, set-option mouse,
-	// set-option window-size, has-session.
-	if len(fr.calls) != 5 {
-		t.Fatalf("calls = %d, want 5", len(fr.calls))
+	// Expect 6 calls: new-session, set-option status, set-option mouse,
+	// set-option window-size, has-session, display-message.
+	if len(fr.calls) != 6 {
+		t.Fatalf("calls = %d, want 6", len(fr.calls))
 	}
 
 	// Call 0: new-session
@@ -243,11 +249,16 @@ func TestCreateIssuesNewSessionAndStatusOff(t *testing.T) {
 	if got, want := fr.calls[4].args, hasSessionArgs("sess-1"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("call[4] = %#v, want %#v", got, want)
 	}
+
+	// Call 5: display-message (pane cwd verification, see verifyPaneCwd).
+	if got, want := fr.calls[5].args, displayPaneCwdArgs("sess-1"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("call[5] = %#v, want %#v", got, want)
+	}
 }
 
 func TestCreateLaunchCommandContainsKeepAliveShell(t *testing.T) {
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{nil, nil, nil}
+	fr.outputs = [][]byte{nil, nil, nil, nil, nil, []byte("/tmp/ws\n")}
 
 	_, err := r.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     "sess-1",
@@ -279,7 +290,7 @@ func TestCreateLaunchCommandExportsEnvVars(t *testing.T) {
 	defer func() { getenv = oldGetenv }()
 
 	r, fr := newTestRuntime(0)
-	fr.outputs = [][]byte{nil, nil, nil}
+	fr.outputs = [][]byte{nil, nil, nil, nil, nil, []byte("/tmp/ws\n")}
 
 	_, err := r.Create(context.Background(), ports.RuntimeConfig{
 		SessionID:     "sess-1",
@@ -349,6 +360,79 @@ func TestCreateDestroysAndReturnsErrorWhenNotAlive(t *testing.T) {
 	}
 	if !hasKill {
 		t.Fatal("expected kill-session cleanup call when session not alive")
+	}
+}
+
+// TestCreateFailsLoudlyWhenPaneCwdMismatches pins the poisoned-cwd guard:
+// when `new-session -c <dir>` cannot resolve the workspace, tmux silently
+// starts the pane in the SERVER's cwd instead of erroring, and the agent later
+// dies with a context-free ENOENT. Create must catch the mismatch, name both
+// paths in the error, and clean up the session.
+func TestCreateFailsLoudlyWhenPaneCwdMismatches(t *testing.T) {
+	r, fr := newTestRuntime(0)
+	// Setup and liveness succeed; display-message reports a pane cwd that is
+	// not the requested workspace (the tmux server-cwd fallback).
+	fr.outputs = [][]byte{nil, nil, nil, nil, nil, []byte("/somewhere/else\n")}
+
+	_, err := r.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     "sess-1",
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"myagent"},
+	})
+	if err == nil {
+		t.Fatal("Create: got nil, want error when pane cwd is not the workspace")
+	}
+	// The error must be actionable: it names the pane's actual cwd and the
+	// requested workspace so the operator can see the fallback happened.
+	if !strings.Contains(err.Error(), "/somewhere/else") || !strings.Contains(err.Error(), "/tmp/ws") {
+		t.Fatalf("Create err = %v, want both the pane cwd and the workspace path", err)
+	}
+	// Verify Destroy was called (kill-session) so the misplaced session is not
+	// left running.
+	hasKill := false
+	for _, c := range fr.calls {
+		if len(c.args) > 0 && c.args[0] == "kill-session" {
+			hasKill = true
+		}
+	}
+	if !hasKill {
+		t.Fatal("expected kill-session cleanup call when pane cwd mismatches")
+	}
+}
+
+// samePath must treat symlink aliases of the same directory as equal (macOS
+// reports pane_current_path under /private/var while workspaces are addressed
+// as /var/...), and must fall back to a literal compare for paths that no
+// longer resolve.
+func TestSamePathResolvesSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(dir, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if !samePath(dir, link) {
+		t.Fatalf("samePath(%q, %q) = false, want true via symlink resolution", dir, link)
+	}
+	if !samePath("/does/not/exist/ws", "/does/not/exist/ws/") {
+		t.Fatal("samePath literal fallback should clean and match unresolvable paths")
+	}
+	if samePath("/does/not/exist/a", "/does/not/exist/b") {
+		t.Fatal("samePath = true for distinct unresolvable paths")
+	}
+}
+
+// TestExecRunnerRunsFromStableDir pins the poisoned-cwd fix at the source: the
+// tmux CLI (and therefore the auto-started tmux server, which inherits its
+// cwd) must run from a stable directory that outlives app updates, not from
+// the daemon's own cwd (which can be a deleted ShipIt staging dir, issue
+// #2775).
+func TestExecRunnerRunsFromStableDir(t *testing.T) {
+	out, err := execRunner{}.Run(context.Background(), nil, "pwd")
+	if err != nil {
+		t.Fatalf("execRunner.Run(pwd): %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); !samePath(got, os.TempDir()) {
+		t.Fatalf("execRunner cwd = %q, want os.TempDir() %q", got, os.TempDir())
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the tmux poisoned-cwd bug that strands worker panes in deleted ShipIt directories (root-caused live by inode matching; related: #2775).

**Root cause.** `execRunner.Run` called `exec.CommandContext` without setting `cmd.Dir`, so every tmux CLI invocation inherited the daemon's own cwd. The first tmux call after boot auto-starts the persistent tmux server, permanently pinning the server's cwd to whatever the daemon had. After a Squirrel/ShipIt auto-update that can be a staging dir that gets deleted (observed: `/var/folders/.../ShipIt.zThlb2VO/...app/Contents/Resources`; even the healthy case is the app bundle Resources dir, which ShipIt swaps every update). tmux has a silent fallback: when `new-session -c <dir>` cannot be resolved at spawn time, the pane starts in the server's cwd instead of erroring. A session hit that fallback and its agent died with a context-free `ENOENT: Bun could not find a file` plus shell-init getcwd errors.

Reproduced on a scratch tmux socket: `tmux new-session -d -c <deleted-dir>` exits 0 and the pane silently starts elsewhere; `display-message -p '#{pane_current_path}'` exposes the mismatch.

## Changes

- `execRunner.Run` now sets `cmd.Dir = os.TempDir()`, so the auto-started tmux server is never pinned to a path an app update can delete. (`tmux.New` is constructed config-free in `runtimeselect`, so the temp dir is the clean stable choice over plumbing the data dir through.)
- `Create` now verifies the pane's `#{pane_current_path}` matches `cfg.WorkspacePath` after the liveness check, resolving symlinks so macOS `/var` vs `/private/var` compares equal. On mismatch it destroys the session and fails with an error naming both paths and pointing at the server-cwd fallback, replacing today's silent fallback plus downstream raw ENOENT.
- New `displayPaneCwdArgs` builder in `commands.go`, following the existing arg-builder pattern.

## Tests

- New: `TestCreateFailsLoudlyWhenPaneCwdMismatches` (fake runner reports a pane cwd that is not the workspace; asserts loud error naming both paths + kill-session cleanup), `TestSamePathResolvesSymlinks`, `TestExecRunnerRunsFromStableDir`.
- Updated `TestCommandBuilders` and the existing `Create` tests for the new sixth call.
- Ran: `gofmt` (clean), `go vet`, `go build ./...`, `go test ./internal/adapters/runtime/tmux/` (42 pass, including the real-tmux integration tests, which now exercise the verification through macOS `/var` aliasing end to end).
- Full `go test ./...`: 4 pre-existing `internal/cli` spawn-test failures reproduce identically on clean `upstream/main` on this machine (live AO daemon state interferes); unrelated to this change.

## Risks / follow-ups

- The verification only runs at `Create`. `IsAlive` and `SendMessage` deliberately do not probe pane cwd in this PR (kept minimal per scope); a follow-up could add a cwd probe to the reaper path to catch a server whose panes were poisoned before this fix shipped.
- `Create` now fails where it previously "succeeded" with a doomed pane. That is the intended behavior change: a loud, actionable error instead of a stranded agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)