### PR TITLE
fix(kimi): forward role-specific model config to launch (restore deferred pending CLI verification)

### DIFF
--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -150,6 +150,9 @@ func (p *Plugin) PromptReadinessHints(ctx context.Context, _ ports.LaunchConfig)
 // approval settings of the original session -- so cfg.Permissions is
 // intentionally ignored here.
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
+	// Deliberately does not forward cfg.Config.Model: --model + --session
+	// composition is unverified against a real kimi install (see #2890 and
+	// appendModelFlag). Pinned by TestGetRestoreCommandDoesNotForwardModelOverride.
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
 	}

--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -77,6 +77,22 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Kimi understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `kimi --model`.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new Kimi session:
 //
 //	kimi [--auto|-y]                            (interactive)
@@ -94,6 +110,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd = []string{binary}
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 	return cmd, nil
 }
 
@@ -167,6 +184,21 @@ func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
 		*cmd = append(*cmd, "--auto")
 	case ports.PermissionModeBypassPermissions:
 		*cmd = append(*cmd, "-y")
+	}
+}
+
+// appendModelFlag appends `--model <model>` when a role-specific model
+// override is configured. A blank/whitespace-only value means no override was
+// configured, so the flag is omitted and Kimi's own default model applies.
+//
+// Restore-path note: this is intentionally NOT called from
+// GetRestoreCommand. Kimi's docs do not confirm --model composes with
+// --session the way it does on the launch path (see issue #2890); wiring it
+// blind risks silently breaking session resume. Left as a fast-follow pending
+// verification against a real kimi install.
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
 	}
 }
 

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -32,13 +32,84 @@ func TestManifest(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecEmpty(t *testing.T) {
+func TestGetConfigSpecAdvertisesModelField(t *testing.T) {
 	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	if len(spec.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(spec.Fields))
+	}
+	if spec.Fields[0].Key != "model" || spec.Fields[0].Type != ports.ConfigFieldString {
+		t.Fatalf("field = %#v, want model/string", spec.Fields[0])
+	}
+}
+
+func TestGetLaunchCommandAppendsModelFlagWhenConfigured(t *testing.T) {
+	p := &Plugin{resolvedBinary: "kimi"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "k2.5"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"kimi", "--model", "k2.5"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandOmitsModelFlagWhenBlank(t *testing.T) {
+	p := &Plugin{resolvedBinary: "kimi"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "   "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"kimi"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandModelFlagComposesWithApprovalFlags(t *testing.T) {
+	p := &Plugin{resolvedBinary: "kimi"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Permissions: ports.PermissionModeBypassPermissions,
+		Config:      ports.AgentConfig{Model: "k2.5"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"kimi", "-y", "--model", "k2.5"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+// Mirrors the issue #2890 harness note: --model + --session composition is
+// unverified against a real kimi install, so appendModelFlag is intentionally
+// not wired into GetRestoreCommand. This test locks that decision in so a
+// future "just mirror Copilot/Codex" edit doesn't silently forward the model
+// override on restore without re-verifying first.
+func TestGetRestoreCommandDoesNotForwardModelOverride(t *testing.T) {
+	p := &Plugin{resolvedBinary: "kimi"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "01HZABC"},
+		},
+		Config: ports.AgentConfig{Model: "k2.5"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+	want := []string{"kimi", "--session", "01HZABC"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v (model override must not be forwarded on restore)", cmd, want)
 	}
 }
 


### PR DESCRIPTION
## What

Adds `appendModelFlag` to the Kimi adapter, called from `GetLaunchCommand`, so a configured
`agentConfig.model` is forwarded as `--model <model>` to the `kimi` CLI. Also adds a GetConfigSpec override advertising the model field, matching claude-code and codex (#2869). (kiro #2932 handles model config through a hooks file rather than a CLI flag, so it isn't precedent for this approach; copilot's equivalent fix, #2975, is still open and not yet merged.)

Unlike the Copilot fix, this does **not** wire `appendModelFlag` into `GetRestoreCommand`.
Kimi's docs don't confirm `--model` composes with `--session` on resume, so forwarding it
there is left as a documented fast-follow rather than guessed at.


## Why

Fixes #2890. A Kimi worker/orchestrator configured with a specific model silently fell back
to `kimi`'s global default because the adapter never read `cfg.Config.Model` — same
root-cause pattern as #2769 (Codex), #2895 (Copilot), and #2897 (Vibe) in this audit series.


## How

- Mirrors #2869's `appendModelFlag` pattern: appends `--model` only when
  `strings.TrimSpace(cfg.Config.Model)` is non-blank, so an unconfigured launch is
  byte-for-byte unchanged.
- `GetRestoreCommand` is intentionally left unchanged. A doc comment on `appendModelFlag`
  and an inline comment on `GetRestoreCommand` both point back to this decision, and a
  dedicated regression test (`TestGetRestoreCommandDoesNotForwardModelOverride`) locks it in
  so a future "just mirror Copilot/Codex" edit doesn't silently wire it without verifying
  `kimi --model X --session Y` against a real install first.
- Replaced the now-outdated `TestGetConfigSpecEmpty` (asserted zero fields) with
  `TestGetConfigSpecAdvertisesModelField`, since that assumption no longer holds once
  `model` is declared.


## Testing

Full package run, all passing (35 tests, no regressions):

- `TestGetConfigSpecAdvertisesModelField`
- `TestGetLaunchCommandAppendsModelFlagWhenConfigured`
- `TestGetLaunchCommandOmitsModelFlagWhenBlank`
- `TestGetLaunchCommandModelFlagComposesWithApprovalFlags`
- `TestGetRestoreCommandDoesNotForwardModelOverride`

## Open follow-up

Verify `--model` + `--session` composition against a real `kimi` install, then wire
`appendModelFlag` into `GetRestoreCommand` in a follow-up PR (tracked against #2890).

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows AGENTS.md conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)

