### PR TITLE
fix(web): show Restore button for merged sessions in done strip

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -618,7 +618,7 @@ describe("SessionsBoard", () => {
 		expect(screen.queryByText("Session can no longer be restored")).not.toBeInTheDocument();
 	});
 
-	it("opens a merged Done session from the card body without showing restore", async () => {
+	it("shows restore button for a merged Done session and can invoke it", async () => {
 		workspaceQueryMock.mockReturnValue({
 			data: [workspaceWithSessions([terminatedSession({ id: "s-merged", title: "merged worker", status: "merged" })])],
 			isError: false,
@@ -629,7 +629,7 @@ describe("SessionsBoard", () => {
 
 		await userEvent.click(screen.getByRole("button", { name: /done \/ terminated/i }));
 
-		expect(screen.queryByRole("button", { name: "Restore merged worker" })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Restore merged worker" })).toBeInTheDocument();
 
 		await userEvent.click(screen.getByText("merged worker"));
 

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -312,7 +312,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 									key={s.id}
 									session={s}
 									onOpen={() => openSession(s)}
-									restoreAction={s.status === "terminated" ? (event) => void restoreDoneSession(event, s) : undefined}
+									restoreAction={s.status === "terminated" || s.status === "merged" ? (event) => void restoreDoneSession(event, s) : undefined}
 									restoreError={restoreErrors[s.id]}
 									isRestoring={restoringSessionId === s.id}
 									isRestoreDisabled={restoringSessionId !== undefined}

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -243,7 +243,9 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 	const hadAttachmentRef = useRef(false);
 	// A standalone shell is never restorable: there is no session row to restore.
 	const canRestoreSession =
-		terminalTarget?.kind !== "reviewer" && terminalTarget?.kind !== "shell" && session?.status === "terminated";
+		terminalTarget?.kind !== "reviewer" &&
+		terminalTarget?.kind !== "shell" &&
+		(session?.status === "terminated" || session?.status === "merged");
 
 	const handleReady = useCallback((handle: AttachableTerminal) => {
 		setTerminal(handle);


### PR DESCRIPTION
## Summary

Sessions with `status === "merged"` now show a Restore button in both the Kanban done strip and the terminal-ended banner, on par with `terminated` sessions.

## Changes

- **`SessionsBoard.tsx`** — extended `restoreAction` guard from `status === "terminated"` to also include `status === "merged"`
- **`TerminalPane.tsx`** — extended `canRestoreSession` guard the same way
- **`SessionsBoard.test.tsx`** — flipped the existing test that previously asserted the Restore button was absent for merged sessions; it now asserts the button is present and invokable

## Testing

- `npm run frontend:typecheck` ✓
- `npx vitest run src/renderer/components/SessionsBoard.test.tsx` — 17/17 pass ✓

Closes #1907