### PR TITLE
fix(cli): remove tmux attach hint from ao spawn output

### DIFF
--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -8,15 +8,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/tmux"
 )
 
 // maxDisplayNameLen caps the sidebar label set by `--name`. Mirrored by the
@@ -137,17 +134,7 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 			if _, err := fmt.Fprintf(out, "spawned session %s (%s)%s\n", res.Session.ID, res.Session.Status, claimLabel); err != nil {
 				return err
 			}
-			// Print a copy-pasteable attach hint for the selected runtime.
-			// On Darwin/Linux: tmux attach-session using the sanitised session name.
-			// On Windows: ConPTY has no user-facing attach CLI; use the AO dashboard.
-			var attach string
-			if runtime.GOOS != "windows" {
-				attach = fmt.Sprintf("tmux attach -t %s", tmux.SessionName(res.Session.ID))
-			} else {
-				attach = "Attach from the AO dashboard (ConPTY sessions have no CLI attach command)"
-			}
-			_, err = fmt.Fprintf(out, "attach with: %s\n", attach)
-			return err
+			return nil
 		},
 	}
 	f := cmd.Flags()


### PR DESCRIPTION
## Summary

Removes the `attach with: tmux attach -t <session>` line from `ao spawn` output. tmux is an internal implementation detail; users interact with sessions through the AO dashboard, and direct tmux attachment bypasses AO's lifecycle management.

After this change, `ao spawn` prints only the confirmation line:
```
spawned session <id> (<status>)
```

## Changes

- **`backend/internal/cli/spawn.go`** — deleted the attach hint block (~14 lines) and removed the now-unused `runtime` and `tmux` imports

## Testing

- `go build ./...` ✓
- `go vet ./internal/cli/...` ✓
- `go test ./internal/cli/...` ✓ (all spawn tests pass including the existing output assertion)

Closes #2658