### PR TITLE
fix: sanitize project IDs derived from folder names with dots/special chars

### DIFF
--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -739,8 +739,11 @@ func defaultProjectID(path string) domain.ProjectID {
 	id := strings.ToLower(filepath.Base(path))
 	id = strings.TrimSpace(id)
 	id = strings.ReplaceAll(id, " ", "-")
+	id = nonAlphanumeric.ReplaceAllString(id, "-")
 	return domain.ProjectID(id)
 }
+
+var nonAlphanumeric = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
 
 var projectIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 


### PR DESCRIPTION
When running `ao start` in a folder whose name contains dots (e.g. `llama.cpp`), the auto-derived project ID produces a session ID like `llama.cpp-1` that fails the session ID pattern `[a-zA-Z0-9_-]+`.

This sanitizes the project ID at derivation time  replacing any character outside `[a-zA-Z0-9_-]` with a hyphen  so `llama.cpp` becomes `llama-cpp` and sessions are valid.

Closes #1877