### PR TITLE
fix(autohand): forward role-specific model config to the Autohand CLI

### DIFF
--- a/backend/internal/adapters/agent/autohand/autohand.go
+++ b/backend/internal/adapters/agent/autohand/autohand.go
@@ -52,12 +52,29 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Autohand understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `autohand --model`.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new Autohand command-mode session,
-// scoping the run to the workspace, applying the approval-mode flags and optional
-// system-prompt override, and passing the initial prompt as a positional argument
-// after `--` so a prompt beginning with "-" is not read as a flag.
+// scoping the run to the workspace, applying the approval-mode flags, an
+// optional model override, and optional system-prompt override, and passing
+// the initial prompt as a positional argument after `--` so a prompt beginning
+// with "-" is not read as a flag.
 //
-//	autohand [--path <workspace>] [<approval flags>] [--sys-prompt <value>] [-- <prompt>]
+//	autohand [--path <workspace>] [<approval flags>] [--model <value>] [--sys-prompt <value>] [-- <prompt>]
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	binary, err := p.autohandBinary(ctx)
 	if err != nil {
@@ -67,6 +84,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	cmd = []string{binary}
 	appendWorkspaceFlag(&cmd, cfg.WorkspacePath)
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 
 	// Autohand's --sys-prompt accepts either an inline string or a file path,
 	// auto-detected by the CLI; prefer inline instructions when AO has them.
@@ -84,11 +102,11 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 }
 
 // GetRestoreCommand rebuilds the argv that continues an existing Autohand
-// session: `autohand resume [--path <workspace>] <sessionId>`. ok is false when
-// the hook-derived native session id has not landed yet, so callers can fall
-// back to fresh launch behavior. Autohand's resume sub-command only accepts the
-// workspace path and session id, so approval and system-prompt flags are not
-// re-applied here.
+// session: `autohand resume [--path <workspace>] [--model <value>] <sessionId>`.
+// ok is false when the hook-derived native session id has not landed yet, so
+// callers can fall back to fresh launch behavior. Autohand's resume
+// sub-command only accepts the workspace path, model, and session id, so
+// approval and system-prompt flags are not re-applied here.
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
@@ -103,9 +121,10 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 
-	cmd = make([]string, 0, 5)
+	cmd = make([]string, 0, 7)
 	cmd = append(cmd, binary, "resume")
 	appendWorkspaceFlag(&cmd, cfg.Session.WorkspacePath)
+	appendModelFlag(&cmd, cfg.Config)
 	cmd = append(cmd, agentSessionID)
 	return cmd, true, nil
 }
@@ -124,6 +143,14 @@ func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (por
 func appendWorkspaceFlag(cmd *[]string, workspacePath string) {
 	if strings.TrimSpace(workspacePath) != "" {
 		*cmd = append(*cmd, "--path", workspacePath)
+	}
+}
+
+// appendModelFlag appends a trimmed --model flag when a model override is
+// configured. Accepted on both the launch and resume argv.
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
 	}
 }
 

--- a/backend/internal/adapters/agent/autohand/autohand_test.go
+++ b/backend/internal/adapters/agent/autohand/autohand_test.go
@@ -137,15 +137,76 @@ func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	plugin := &Plugin{}
 
 	spec, err := plugin.GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("unexpected config fields: %#v", spec.Fields)
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `autohand --model`.",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
+	}
+}
+
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "  anthropic/claude-sonnet-4-20250514  "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(cmd, "--model") {
+		t.Fatalf("command %#v missing --model flag", cmd)
+	}
+	want := []string{"autohand", "--model", "anthropic/claude-sonnet-4-20250514"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(cmd, "--model") {
+		t.Fatalf("command %#v contains --model for blank model", cmd)
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "  anthropic/claude-sonnet-4-20250514  "},
+		Session: ports.SessionRef{
+			WorkspacePath: "/work/space",
+			Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: "sess-123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	want := []string{"autohand", "resume", "--path", "/work/space", "--model", "anthropic/claude-sonnet-4-20250514", "sess-123"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
 	}
 }
 


### PR DESCRIPTION
## Summary

The Autohand adapter's `GetLaunchCommand` and `GetRestoreCommand` never read `cfg.Config.Model`, so a project's per-role `agentConfig.model` was silently dropped and Autohand workers/orchestrators always launched on Autohand's own global default model instead of the configured one.

This mirrors the pattern already applied to the Codex (#2869), Cline (#2894, #2953), and Goose (#2885, #2956) adapters: append a trimmed `--model` flag when a model is configured, and advertise the field via `GetConfigSpec` so it shows up in project config UI/validation.

Fixes #2889

## Changes

- `backend/internal/adapters/agent/autohand/autohand.go`: add an `appendModelFlag` helper, call it from `GetLaunchCommand` and `GetRestoreCommand`, and override `GetConfigSpec` to advertise the `model` field (previously inherited the empty default from `agentbase.Base`). `--model` is accepted on both the main invocation and the `resume` subcommand, so both argv builders forward it, and the stale doc comment claiming resume "only accepts workspace path and session id" is updated accordingly.
- `backend/internal/adapters/agent/autohand/autohand_test.go`: replace the now-stale `TestGetConfigSpecHasNoCustomFieldsYet` with `TestGetConfigSpecReportsModelField`, and add regression tests for: trimmed model appended on launch, blank model omitted on launch, and trimmed model appended on restore.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./internal/adapters/agent/autohand/...` passes
- [x] `go test ./internal/adapters/agent/autohand/...` — all tests pass (no pre-existing failures in this package)
