### PR TITLE
fix(shortcuts): new terminal on Ctrl+Shift+` (match physical code)

### DIFF
--- a/frontend/src/main/app-shortcuts.ts
+++ b/frontend/src/main/app-shortcuts.ts
@@ -12,6 +12,10 @@ import {
 // locally so tests can supply a plain fake while WebContents still satisfies it.
 type BeforeInput = {
 	key: string;
+	// Physical key (layout-independent), needed for chords whose character
+	// shifts, e.g. Ctrl+Shift+` reports key "~" but code "Backquote". Optional so
+	// test doubles need not supply it; Electron always does at runtime.
+	code?: string;
 	control: boolean;
 	meta: boolean;
 	shift: boolean;
@@ -53,6 +57,7 @@ export function attachAppShortcuts(
 		const channel = appShortcutChannel(
 			{
 				key: input.key,
+				code: input.code,
 				ctrl: input.control,
 				meta: input.meta,
 				shift: input.shift,

--- a/frontend/src/main/new-session-shortcut.test.ts
+++ b/frontend/src/main/new-session-shortcut.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
-import { KEYBOARD_SHORTCUTS_HELP_CHANNEL, NEW_SESSION_SHORTCUT_CHANNEL } from "../shared/shortcuts";
+import {
+	KEYBOARD_SHORTCUTS_HELP_CHANNEL,
+	NEW_SESSION_SHORTCUT_CHANNEL,
+	NEW_SHELL_TERMINAL_SHORTCUT_CHANNEL,
+} from "../shared/shortcuts";
 import { attachAppShortcuts } from "./app-shortcuts";
 
 type InputEvent = {
 	key: string;
+	// Physical key (Electron input.code), needed for chords whose character is
+	// layout-shifted, e.g. Ctrl+Shift+` reports key "~" but code "Backquote".
+	code?: string;
 	control: boolean;
 	meta: boolean;
 	shift: boolean;
@@ -95,6 +102,19 @@ describe("attachAppShortcuts", () => {
 		source.emit({ key: "N", control: true, shift: true, isAutoRepeat: true });
 
 		expect(target.send).toHaveBeenCalledTimes(1);
+	});
+
+	it("forwards the new-shell-terminal chord using the physical code Ctrl+Shift+` reports", () => {
+		const source = fakeSource();
+		const target = fakeTarget();
+		attachAppShortcuts(source, false, target);
+
+		// Real Electron values for Ctrl+Shift+` on a US layout: Shift shifts the
+		// character to "~", so only the physical code "Backquote" identifies the
+		// chord. This pins app-shortcuts forwarding `code` into the matcher.
+		source.emit({ key: "~", code: "Backquote", control: true, shift: true, type: "keyDown" });
+
+		expect(target.send).toHaveBeenCalledWith(NEW_SHELL_TERMINAL_SHORTCUT_CHANNEL);
 	});
 
 	it("forwards keyboard-shortcut help on each platform", () => {

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -185,13 +185,13 @@ export function ShellTopbar() {
 
 			<div className="flex shrink-0 items-center gap-1.5">
 				{/* Standalone shell, independent of any agent session — the same action
-				    Ctrl+` fires, routed through the store so the two cannot drift. Leads
-				    the actions row so it stays visible on every route. */}
+				    Ctrl+Shift+` fires, routed through the store so the two cannot drift.
+				    Leads the actions row so it stays visible on every route. */}
 				<TopbarButton
 					aria-label="New terminal"
 					onClick={requestNewShellTerminal}
 					style={noDragStyle}
-					title="New terminal (Ctrl+`)"
+					title="New terminal (Ctrl+Shift+`)"
 					variant="icon"
 				>
 					<SquareTerminal className="size-icon-md" aria-hidden="true" />

--- a/frontend/src/shared/shortcuts.test.ts
+++ b/frontend/src/shared/shortcuts.test.ts
@@ -58,9 +58,22 @@ describe("matchesNewShellTerminalShortcut", () => {
 		expect(matchesNewShellTerminalShortcut(chord({ key: "`", meta: true }), true)).toBe(false);
 	});
 
-	it("requires Ctrl and rejects extra modifiers", () => {
+	// Shift is optional: Ctrl+Shift+` is the advertised "Create New Terminal" chord.
+	it("matches Ctrl+Shift+` on both platforms", () => {
+		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, shift: true }), false)).toBe(true);
+		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, shift: true }), true)).toBe(true);
+	});
+
+	// With Shift held the character shifts (US "~"), but the physical code is
+	// stable — matching on code is what makes Ctrl+Shift+` actually fire.
+	it("matches on the physical Backquote code even when the character is shifted", () => {
+		expect(
+			matchesNewShellTerminalShortcut(chord({ key: "~", code: "Backquote", ctrl: true, shift: true }), false),
+		).toBe(true);
+	});
+
+	it("requires Ctrl and rejects ⌘/Alt", () => {
 		expect(matchesNewShellTerminalShortcut(chord({ key: "`" }), false)).toBe(false);
-		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, shift: true }), false)).toBe(false);
 		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, alt: true }), false)).toBe(false);
 		expect(matchesNewShellTerminalShortcut(chord({ key: "`", ctrl: true, meta: true }), false)).toBe(false);
 	});

--- a/frontend/src/shared/shortcuts.ts
+++ b/frontend/src/shared/shortcuts.ts
@@ -4,6 +4,10 @@
 
 export type ShortcutChord = {
 	key: string;
+	// Physical key (KeyboardEvent.code / Electron input.code), independent of
+	// layout and modifiers. Needed for chords whose character shifts — e.g.
+	// Ctrl+Shift+` reports key "~" on a US layout but code "Backquote".
+	code?: string;
 	ctrl: boolean;
 	meta: boolean;
 	shift: boolean;
@@ -40,8 +44,8 @@ export const APP_SHORTCUTS: readonly ShortcutDefinition[] = [
 		id: "new-shell-terminal",
 		label: "New terminal",
 		category: "General",
-		mac: ["Ctrl", "`"],
-		windowsLinux: ["Ctrl", "`"],
+		mac: ["Ctrl", "Shift", "`"],
+		windowsLinux: ["Ctrl", "Shift", "`"],
 	},
 	{
 		id: "keyboard-shortcuts",
@@ -98,19 +102,25 @@ export function matchesNewSessionShortcut(chord: ShortcutChord, isMac: boolean):
 		: chord.ctrl && chord.shift && !chord.alt && !chord.meta;
 }
 
-// New standalone terminal: Ctrl+` on every platform, matching VS Code and most
-// IDEs. Ctrl (not ⌘) on macOS too — that is the conventional binding there, and
-// ⌘` is already taken by the OS for cycling an app's windows.
+// New standalone terminal, bound to the backtick chords VS Code / Cursor /
+// Codex use for the integrated terminal — Ctrl (never ⌘) on every platform, so
+// there is nothing platform-specific to learn (⌘` is taken by the OS on macOS):
 //
-// Like the other app shortcuts this is handled in the main process, so it fires
-// even while focus is inside xterm. The tradeoff is deliberate: no shell or TUI
-// running in a pane can receive Ctrl+` while AO owns it. Almost nothing binds
-// that chord, and VS Code makes the same trade.
+//   • Ctrl+Shift+` — "Create New Terminal" (the primary, advertised binding).
+//   • Ctrl+`       — VS Code's toggle/focus chord; also opens one here.
+//
+// Handled in the main process so it fires even while focus is inside xterm; the
+// tradeoff (no pane shell can receive these chords while AO owns them) matches
+// VS Code.
 export function matchesNewShellTerminalShortcut(chord: ShortcutChord, _isMac: boolean): boolean {
-	// Keyboards that need a modifier for the backtick can report the physical
-	// key instead of the character, so accept either spelling.
-	if (chord.key !== "`" && chord.key !== "Backquote") return false;
-	return chord.ctrl && !chord.meta && !chord.alt && !chord.shift;
+	// Match on the physical `code` (Backquote), not the character: with Shift
+	// held the character is layout-shifted — US Ctrl+Shift+` reports key "~", not
+	// "`" — so keying off `key` would miss the advertised Ctrl+Shift+` chord. Fall
+	// back to the `key` spelling for chords supplied without a code. Shift is
+	// optional (Ctrl+` and Ctrl+Shift+` both open a terminal); ⌘/Alt must not hold.
+	const isBackquote = chord.code === "Backquote" || chord.key === "`" || chord.key === "Backquote";
+	if (!isBackquote) return false;
+	return chord.ctrl && !chord.meta && !chord.alt;
 }
 
 // Keyboard shortcut help: ⌘/ on macOS, Ctrl+/ on Windows/Linux. This is also


### PR DESCRIPTION
## Summary

`main` currently binds the standalone **New terminal** shortcut (landed with #2861) to **`Ctrl+`` only**, matched on the character `key`. That misses the advertised **`Ctrl+Shift+`** chord: with Shift held, the backtick key reports **`~`** on a US layout, not `` ` `` — so `key`-based matching never fires.

This binds it to the physical **`code` (`Backquote`)** and makes **Shift optional**, so both `Ctrl+`` and `Ctrl+Shift+`` open a terminal — matching VS Code / Cursor / Codex.

### Why a new PR
The same fix was in **#2940**, but that PR merged into the intermediate `stack/2861-shortcuts-base` branch, **not `main`**, so it never reached the shipping app. This ports it directly on top of what #2861 landed.

## Changes
- `shared/shortcuts.ts` — `matchesNewShellTerminalShortcut` matches `code === "Backquote"` (falls back to the `key` spelling), Shift optional; `ShortcutChord` gains an optional `code`; catalog label → `Ctrl Shift `` .
- `main/app-shortcuts.ts` — pass `input.code` through from `before-input-event`.
- `renderer/components/ShellTopbar.tsx` — tooltip now reads `New terminal (Ctrl+Shift+`)`.
- `shared/shortcuts.test.ts` — cover `Ctrl+Shift+`` and the shifted-character/physical-code case; drop the now-invalid "Shift rejected" assertion.

## Test
- `npx vitest run src/shared/shortcuts.test.ts src/main/new-session-shortcut.test.ts` — 22/22 pass.
- Prettier clean on changed files.

Refs #2828, #2861, #2940.

🤖 Generated with [Claude Code](https://claude.com/claude-code)