### PR TITLE
fix(frontend): make dev:web cross-platform using cross-env

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -58,6 +58,7 @@
 				"@types/semver": "^7.7.1",
 				"@vitejs/plugin-react": "^6.0.2",
 				"app-builder-lib": "^26.15.3",
+				"cross-env": "^10.1.0",
 				"electron": "^33.0.0",
 				"jsdom": "^29.1.1",
 				"openapi-typescript": "^7.13.0",
@@ -2757,6 +2758,13 @@
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
+		},
+		"node_modules/@epic-web/invariant": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+			"integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@exodus/bytes": {
 			"version": "1.15.1",
@@ -8415,6 +8423,24 @@
 			"integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/cross-env": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+			"integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@epic-web/invariant": "^1.0.0",
+				"cross-spawn": "^7.0.6"
+			},
+			"bin": {
+				"cross-env": "dist/bin/cross-env.js",
+				"cross-env-shell": "dist/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=20"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
 	"scripts": {
 		"build:daemon": "node ./scripts/build-daemon.mjs",
 		"dev": "electron-forge start",
-		"dev:web": "VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts",
+		"dev:web": "cross-env VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts",
 		"prepackage": "npm run build:daemon",
 		"package": "electron-forge package",
 		"premake": "npm run build:daemon",
@@ -47,6 +47,7 @@
 		"@types/semver": "^7.7.1",
 		"@vitejs/plugin-react": "^6.0.2",
 		"app-builder-lib": "^26.15.3",
+		"cross-env": "^10.1.0",
 		"electron": "^33.0.0",
 		"jsdom": "^29.1.1",
 		"openapi-typescript": "^7.13.0",


### PR DESCRIPTION
## Summary

`npm run dev:web` uses inline Unix env assignment (`VITE_NO_ELECTRON=1 vite ...`), which fails on Windows (PowerShell/cmd). This blocks Windows contributors from running the web preview.

## Changes

- Added `cross-env` as a dev dependency (`^10.1.0`)
- Updated `dev:web` script to prefix with `cross-env`:
  ```json
  "dev:web": "cross-env VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts"
  ```

`cross-env` is the standard solution for this — it normalises env var setting across shells with no behaviour change on macOS/Linux.

## Verification

- `npm run typecheck` ✓
- `cross-env` is a zero-dependency, widely-used package (hundreds of millions of weekly downloads)

Closes #2981