### PR TITLE
fix: harden anonymous renderer activity delivery

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -56,9 +56,14 @@ the same 5-per-minute / 200-per-day shape to its own event and exception
 capture path, without the aggregation step.
 
 All events are sent as PostHog anonymous events (`$process_person_profile:
-false`; the renderer never calls `identify()`). The install ID still
-deduplicates unique-user counts, but no person profiles are created — person
-properties and person-property cohorts are intentionally unavailable.
+false`; the renderer never calls `identify()`). The renderer keeps PostHog SDK
+persistence in memory, disables person profiles, and explicitly bootstraps the
+AO install ID as anonymous. This prevents legacy PostHog state from restoring
+an identified user or replacing the stable AO device ID after an upgrade. The
+install ID still deduplicates unique-user counts, but no person profiles are
+created — person properties and person-property cohorts are intentionally
+unavailable. AO's heartbeat and route reservations continue to use their own
+sanitized `localStorage` keys independently of PostHog SDK persistence.
 
 `ao.cli.invoked` is capped at once per actor type and command path per UTC day
 per install, so script- or agent-driven polling (`ao status`, `ao session ls`,
@@ -103,7 +108,9 @@ The minimum signals for accurate usage analytics are:
 - `ao.app.active`: up to one event per six-hour UTC slot per install/account
   when a human uses the desktop app or runs a user-context CLI command. This
   powers DAU, WAU, MAU, retention, and churn while keeping arbitrary rolling
-  windows from undercounting long-running usage.
+  windows from undercounting long-running usage. Renderer active events are
+  sent immediately; a slot is released for retry when the SDK rejects or
+  throws while capturing the event.
 - `ao.projects.created` and `ao.onboarding.first_project_added`: activation
   funnel from install to first project.
 - `ao.session.spawned`, `ao.session.spawn_failed`, and
@@ -194,7 +201,8 @@ On first run, a random install identifier is generated and stored at
 `~/.ao/data/telemetry_install_id` (or `$AO_DATA_DIR/telemetry_install_id`). The
 renderer and daemon both use this ID as the PostHog distinct ID so activity is
 deduplicated across app launches and CLI invocations. It is not linked to any
-personal account.
+personal account. In the renderer it is also the PostHog device ID, and the SDK
+is explicitly kept in anonymous mode.
 
 ## Configuration
 

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -59,8 +59,7 @@ describe("telemetry sanitizers", () => {
 			});
 		} finally {
 			const queue = client._requestQueue as unknown as
-				| { _queue: unknown[]; _clearFlushTimeout: () => void }
-				| undefined;
+				{ _queue: unknown[]; _clearFlushTimeout: () => void } | undefined;
 			if (queue) {
 				queue._queue.length = 0;
 				queue._clearFlushTimeout();

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { PostHog } from "posthog-js/dist/module.full.no-external";
 import {
+	buildPostHogConfig,
 	buildTelemetryContext,
 	reserveCapture,
 	reserveDailyActiveCapture,
@@ -25,6 +27,47 @@ function memoryStorage(initial: Record<string, string> = {}) {
 }
 
 describe("telemetry sanitizers", () => {
+	it("isolates anonymous AO installation identity from persisted PostHog person state", () => {
+		const config = buildPostHogConfig("ins_stable-install-id");
+
+		expect(config.persistence).toBe("memory");
+		expect(config.person_profiles).toBe("never");
+		expect(config.capture_performance).toBe(false);
+		expect(config.bootstrap).toEqual({
+			distinctID: "ins_stable-install-id",
+			isIdentifiedID: false,
+		});
+	});
+
+	it("emits the stable AO installation id without creating a person profile", () => {
+		const client = new PostHog();
+		client.init("phc_test", {
+			...buildPostHogConfig("ins_stable-install-id"),
+			advanced_disable_decide: true,
+			advanced_disable_flags: true,
+			disable_session_recording: true,
+			disable_surveys: true,
+		});
+		try {
+			const captured = client.capture("ao.app.active", { channel: "renderer" });
+
+			expect(captured?.properties).toMatchObject({
+				distinct_id: "ins_stable-install-id",
+				$device_id: "ins_stable-install-id",
+				$is_identified: false,
+				$process_person_profile: false,
+			});
+		} finally {
+			const queue = client._requestQueue as unknown as
+				| { _queue: unknown[]; _clearFlushTimeout: () => void }
+				| undefined;
+			if (queue) {
+				queue._queue.length = 0;
+				queue._clearFlushTimeout();
+			}
+		}
+	});
+
 	it("builds stable AO version context for PostHog events", () => {
 		expect(buildTelemetryContext(" 1.2.3-nightly.20260707 ", "linux")).toMatchObject({
 			app_version: "1.2.3-nightly.20260707",
@@ -329,7 +372,9 @@ describe("daily active heartbeat", () => {
 		const stop = startDailyActiveHeartbeat({
 			storage,
 			now: () => now,
-			capture: () => captured.push(now.toISOString()),
+			capture: () => {
+				captured.push(now.toISOString());
+			},
 			window,
 			document,
 		});
@@ -343,6 +388,32 @@ describe("daily active heartbeat", () => {
 			now = new Date("2026-07-12T12:00:00.000Z");
 			window.dispatchEvent(new Event("focus"));
 			expect(captured).toEqual(["2026-07-12T08:00:00.000Z", "2026-07-12T12:00:00.000Z"]);
+		} finally {
+			stop();
+		}
+	});
+
+	it("retries the same six-hour UTC slot when PostHog rejects the first capture", async () => {
+		const storage = memoryStorage();
+		let attempts = 0;
+		const slotTime = new Date("2026-07-23T08:00:00.000Z");
+		const stop = startDailyActiveHeartbeat({
+			storage,
+			now: () => slotTime,
+			capture: () => {
+				attempts += 1;
+				return attempts > 1;
+			},
+			window,
+			document,
+		});
+		try {
+			await Promise.resolve();
+			window.dispatchEvent(new Event("focus"));
+			await Promise.resolve();
+
+			expect(attempts).toBe(2);
+			expect(reserveDailyActiveCapture(storage, new Date("2026-07-23T09:00:00.000Z"))).toBe(false);
 		} finally {
 			stop();
 		}

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -67,7 +67,7 @@ type DailyActiveEventTarget = {
 export type DailyActiveHeartbeatOptions = {
 	storage?: DailyActiveStorage;
 	now?: () => Date;
-	capture: () => void;
+	capture: () => boolean | void | Promise<boolean | void>;
 	window: DailyActiveEventTarget;
 	document: DailyActiveEventTarget & Pick<Document, "visibilityState">;
 };
@@ -113,6 +113,25 @@ export function reserveDailyActiveCapture(storage?: DailyActiveStorage, now = ne
 		return true;
 	} catch {
 		return reserveFallback();
+	}
+}
+
+function releaseDailyActiveCapture(storage?: DailyActiveStorage, now = new Date()): void {
+	const utcDate = now.toISOString().slice(0, 10);
+	const slot = activeCaptureSlot(now);
+	if (fallbackActiveDate === utcDate) fallbackActiveSlots.delete(slot);
+	if (!storage) return;
+
+	try {
+		const raw = storage.getItem(ACTIVE_STORAGE_KEY);
+		const parsed = raw ? (JSON.parse(raw) as { date?: unknown; slots?: unknown }) : {};
+		if (parsed.date !== utcDate || !Array.isArray(parsed.slots)) return;
+		const slots = parsed.slots.filter(
+			(value): value is number => Number.isInteger(value) && value >= 0 && value < 4 && value !== slot,
+		);
+		storage.setItem(ACTIVE_STORAGE_KEY, JSON.stringify({ date: utcDate, slots }));
+	} catch {
+		// The fallback reservation was already released above.
 	}
 }
 
@@ -170,9 +189,22 @@ export function startDailyActiveHeartbeat({
 	document,
 }: DailyActiveHeartbeatOptions): () => void {
 	const maybeCapture = () => {
-		if (reserveDailyActiveCapture(storage, now())) {
-			capture();
+		const captureTime = now();
+		if (!reserveDailyActiveCapture(storage, captureTime)) return;
+
+		let result: boolean | void | Promise<boolean | void>;
+		try {
+			result = capture();
+		} catch {
+			releaseDailyActiveCapture(storage, captureTime);
+			return;
 		}
+		void Promise.resolve(result).then(
+			(captured) => {
+				if (captured === false) releaseDailyActiveCapture(storage, captureTime);
+			},
+			() => releaseDailyActiveCapture(storage, captureTime),
+		);
 	};
 	const onVisibilityChange = () => {
 		if (document.visibilityState === "visible") {
@@ -414,6 +446,38 @@ function bindErrorHandlers() {
 	});
 }
 
+type PostHogInitOptions = NonNullable<Parameters<typeof posthog.init>[1]>;
+
+export function buildPostHogConfig(distinctId: string): PostHogInitOptions {
+	return {
+		api_host: POSTHOG_HOST,
+		defaults: RELEASE_TAG,
+		autocapture: false,
+		capture_pageview: false,
+		capture_exceptions: false,
+		capture_performance: false,
+		// AO owns the stable random installation ID. Memory-only SDK
+		// persistence prevents legacy identified state from replacing it after
+		// an upgrade; the AO-owned heartbeat and route reservations continue to
+		// use window.localStorage independently.
+		persistence: "memory",
+		person_profiles: "never",
+		bootstrap: {
+			distinctID: distinctId,
+			isIdentifiedID: false,
+		},
+		before_send: (event) => (event ? sanitizePostHogCaptureResult(event) : event),
+		session_recording: {
+			maskCapturedNetworkRequestFn: (request) => {
+				if (request.name) {
+					request.name = sanitizeReplayRequestName(request.name);
+				}
+				return request;
+			},
+		},
+	};
+}
+
 export async function initTelemetry(): Promise<boolean> {
 	if (initPromise) return initPromise;
 	initPromise = (async () => {
@@ -421,32 +485,7 @@ export async function initTelemetry(): Promise<boolean> {
 		const bootstrap = await aoBridge.telemetry.getBootstrap();
 		if (!bootstrap) return false;
 		telemetryContext = buildTelemetryContext(bootstrap.appVersion, bootstrap.platform);
-		posthog.init(POSTHOG_KEY, {
-			api_host: POSTHOG_HOST,
-			defaults: RELEASE_TAG,
-			autocapture: false,
-			capture_pageview: false,
-			capture_exceptions: false,
-			capture_performance: false,
-			persistence: "localStorage",
-			// The distinct ID is a random install ID, never a person, so keep
-			// every event anonymous: identified events bill at several times the
-			// anonymous rate and the person profiles would hold nothing. The
-			// bootstrap distinct ID keeps renderer and daemon events deduplicated
-			// without an identify() call, which would flip the install to
-			// identified billing permanently.
-			person_profiles: "identified_only",
-			bootstrap: { distinctID: bootstrap.distinctId },
-			before_send: (event) => (event ? sanitizePostHogCaptureResult(event) : event),
-			session_recording: {
-				maskCapturedNetworkRequestFn: (request) => {
-					if (request.name) {
-						request.name = sanitizeReplayRequestName(request.name);
-					}
-					return request;
-				},
-			},
-		});
+		posthog.init(POSTHOG_KEY, buildPostHogConfig(bootstrap.distinctId));
 		posthog.register({
 			...telemetryContext,
 			surface: "renderer",
@@ -456,14 +495,14 @@ export async function initTelemetry(): Promise<boolean> {
 			storage: telemetryStorage(),
 			window,
 			document,
-			capture: () => {
-				void (async () => {
+			capture: async () =>
+				Boolean(
 					posthog.capture(
 						"ao.app.active",
 						withTelemetryContext(await sanitizeRendererProperties("ao.app.active", { channel: "renderer" })),
-					);
-				})();
-			},
+						{ send_instantly: true },
+					),
+				),
 		});
 		posthog.capture("ao.renderer.loaded", withTelemetryContext(await sanitizeRendererProperties("ao.renderer.loaded")));
 		return true;


### PR DESCRIPTION
## Summary

- isolate renderer PostHog SDK identity from legacy persisted identified state
- keep the stable anonymous AO installation ID as both `distinct_id` and `$device_id`, with person profiles disabled
- retry a rejected six-hour active slot and send accepted `ao.app.active` captures immediately
- document the identity and delivery guarantees

## Why

This PR is stacked on #2947.

Read-only PostHog verification found renderer exception events where `distinct_id` remained the AO `ins_...` installation ID, but `$device_id` was a generated SDK UUID, `$is_identified` was `true`, and person processing was enabled. #2947 already adds the four six-hour activity slots, route deduplication, CLI actor filtering, performance-capture disablement, and per-event `$process_person_profile: false`.

This follow-up covers the missing renderer safeguards without replacing that work:

- PostHog SDK persistence is memory-only, so legacy browser state cannot restore an identified identity
- `person_profiles: "never"` and anonymous bootstrap make the intended identity mode explicit
- the AO installation ID remains stable for DAU/MAU deduplication
- a slot reservation is released when capture returns false, throws, or rejects, allowing a later focus/visibility event to retry
- accepted active events use `send_instantly: true`

## Validation

- `npm test -- --run src/renderer/lib/telemetry.test.ts` — 27 passed
- `npx vitest run --config vite.renderer.config.ts --exclude "src/main/supervisor-link.test.ts"` — 71 files / 875 tests passed
- `npm run typecheck` — passed
- `npx vite build --config vite.renderer.config.ts` — passed
- `npx prettier --check ../docs/telemetry.md src/renderer/lib/telemetry.ts src/renderer/lib/telemetry.test.ts` — passed
- `git diff --cached --check` — passed

The Windows-only supervisor socket test is excluded from the broad local run because Unix-domain socket creation fails with `EACCES` in this Windows environment.

Depends on #2947. Retarget this PR to `main` after #2947 merges.




## In simple terms: why I raised this PR

I raised this PR because our PostHog data could count the same anonymous AO installation with the wrong identity and could miss an active-use event when sending failed. That makes DAU and MAU less trustworthy.

This change keeps each installation anonymous but consistently recognizable, retries failed activity events, and makes our active-user numbers more accurate without collecting personal information.
