### PR TITLE
fix(frontend): surface real daemon failure reason instead of generic "AO daemon is not ready"

### DIFF
--- a/frontend/scripts/build-daemon.mjs
+++ b/frontend/scripts/build-daemon.mjs
@@ -1,7 +1,8 @@
+import { readFileSync } from "node:fs";
 import { rmSync, mkdirSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { spawnSync } from "node:child_process";
+import { spawnSync, execSync } from "node:child_process";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const frontendRoot = resolve(scriptsDir, "..");
@@ -9,6 +10,34 @@ const repoRoot = resolve(frontendRoot, "..");
 const backendRoot = join(repoRoot, "backend");
 const outDir = join(frontendRoot, "daemon");
 const outPath = join(outDir, process.platform === "win32" ? "ao.exe" : "ao");
+
+// Go version preflight: read required version from go.mod and check against installed Go.
+const goMod = readFileSync(join(backendRoot, "go.mod"), "utf-8");
+const requiredGo = goMod.match(/^go\s+(\S+)/m)?.[1];
+if (!requiredGo) {
+	console.error("Could not parse Go version from go.mod");
+	process.exit(1);
+}
+const installedGo = String(execSync("go version", { encoding: "utf-8" })).match(/go(\d+\.\d+(?:\.\d+)?)/)?.[1];
+if (!installedGo) {
+	console.error("Could not detect installed Go version — is Go installed?");
+	process.exit(1);
+}
+// Simple semver comparison: split each into [major, minor, patch], compare left to right.
+const cmp = (a, b) => {
+	const pa = a.split(".").map(Number);
+	const pb = b.split(".").map(Number);
+	for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+		const va = pa[i] ?? 0;
+		const vb = pb[i] ?? 0;
+		if (va !== vb) return va - vb;
+	}
+	return 0;
+};
+if (cmp(installedGo, requiredGo) < 0) {
+	console.error(`Go ${requiredGo}+ required, found ${installedGo} — upgrade at https://go.dev/dl/`);
+	process.exit(1);
+}
 
 rmSync(outDir, { recursive: true, force: true });
 mkdirSync(outDir, { recursive: true });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -936,6 +936,12 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 	// One scanner per stream: each keeps its own partial-line buffer.
 	// Skipped under AO_KEEP_DAEMON: stdio is redirected to a log file (no pipes
 	// to scan), so port discovery falls back to the running.json handshake below.
+	//
+	// lastStderrLine feeds the exit-status message below: an exit code alone
+	// ("Daemon exited with code 1") tells the user nothing actionable, but the
+	// daemon's last stderr line usually names the actual cause (bind error,
+	// panic, etc).
+	let lastStderrLine: string | undefined;
 	if (!keep) {
 		const scanStdout = createListenPortScanner(reportBoundPort);
 		const scanStderr = createListenPortScanner(reportBoundPort);
@@ -950,6 +956,8 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 			const text = chunk.toString("utf8");
 			console.error(text.trimEnd());
 			scanStderr(text);
+			const lines = text.split("\n").map((line) => line.trim()).filter(Boolean);
+			if (lines.length > 0) lastStderrLine = lines[lines.length - 1];
 		});
 	}
 
@@ -990,7 +998,11 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		setDaemonStatus({ state: "error", message: error.message, code: "spawn_failed" });
 	});
 
-	child.once("exit", (code, signal) => {
+	// "close", not "exit": "exit" only means the process terminated — the
+	// stdio pipes can still have unread data in flight, so lastStderrLine may
+	// not be set yet. "close" is guaranteed to fire after the stdio streams
+	// have ended, so the daemon's last stderr line is available below.
+	child.once("close", (code, signal) => {
 		stopDiscovery();
 		if (daemonProcess !== child) return;
 		daemonProcess = null;
@@ -1004,9 +1016,15 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 			setDaemonStatus({ state: "stopped" });
 			return;
 		}
+		// Prefer the daemon's own stderr line: it names the actual cause (bind
+		// error, panic, etc). The exit code/signal are already captured as
+		// structured fields below, so fall back to spelling them out in the
+		// message only when we have nothing more specific to say.
+		const message =
+			lastStderrLine ?? (signal ? `Daemon exited with ${signal}` : `Daemon exited with code ${code ?? "unknown"}`);
 		setDaemonStatus({
 			state: "stopped",
-			message: signal ? `Daemon exited with ${signal}` : `Daemon exited with code ${code ?? "unknown"}`,
+			message,
 			code: "exited",
 			exitCode: code,
 			signal,

--- a/frontend/src/renderer/lib/api-client.test.ts
+++ b/frontend/src/renderer/lib/api-client.test.ts
@@ -123,7 +123,7 @@ describe("apiClient runtime base URL", () => {
 
 		const { error } = await apiClient.GET("/api/v1/projects");
 
-		expect(error).toEqual({ message: "AO daemon is not ready." });
+		expect(error).toEqual({ message: "AO daemon is not ready: unknown error" });
 		expect(getApiBaseUrl()).toBe("");
 		expect(hasTrustedApiBaseUrl()).toBe(false);
 		expect(fetchSpy).not.toHaveBeenCalled();

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -2,7 +2,6 @@ import createClient from "openapi-fetch";
 import type { paths } from "../../api/schema";
 import { captureRendererEvent } from "./telemetry";
 import { getLastDaemonMessage } from "../lib/daemon-status";
-import { getLastDaemonMessage } from "../lib/daemon-status";
 
 function devApiBaseUrl(): string {
 	return typeof window === "undefined" ? "http://127.0.0.1:3001" : window.location.origin;

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -1,11 +1,11 @@
 import createClient from "openapi-fetch";
 import type { paths } from "../../api/schema";
 import { captureRendererEvent } from "./telemetry";
+import { getLastDaemonMessage } from "../lib/daemon-status";
 
 function devApiBaseUrl(): string {
 	return typeof window === "undefined" ? "http://127.0.0.1:3001" : window.location.origin;
 }
-
 const explicitApiBaseUrl = import.meta.env.VITE_AO_API_BASE_URL;
 const initialApiBaseUrl = explicitApiBaseUrl ?? (import.meta.env.DEV ? devApiBaseUrl() : "http://127.0.0.1:3001");
 
@@ -162,9 +162,10 @@ function reportApiError(operation: string, category: ApiErrorCategory, status?: 
 async function runtimeFetch(input: Request): Promise<Response> {
 	const operation = normalizeApiOperation(input.method, new URL(input.url).pathname);
 	const baseUrl = runtimeApiBaseUrl;
+	const msg = getLastDaemonMessage() ?? "AO Daemon is not ready."
 	if (baseUrl === null) {
 		reportApiError(operation, "daemon_unavailable", 503);
-		return new Response(JSON.stringify({ message: "AO daemon is not ready." }), {
+		return new Response(JSON.stringify({ message: `AO daemon is not ready: ${msg}.` }), {
 			status: 503,
 			headers: { "Content-Type": "application/json" },
 		});

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -2,6 +2,7 @@ import createClient from "openapi-fetch";
 import type { paths } from "../../api/schema";
 import { captureRendererEvent } from "./telemetry";
 import { getLastDaemonMessage } from "../lib/daemon-status";
+import { getLastDaemonMessage } from "../lib/daemon-status";
 
 function devApiBaseUrl(): string {
 	return typeof window === "undefined" ? "http://127.0.0.1:3001" : window.location.origin;
@@ -162,10 +163,10 @@ function reportApiError(operation: string, category: ApiErrorCategory, status?: 
 async function runtimeFetch(input: Request): Promise<Response> {
 	const operation = normalizeApiOperation(input.method, new URL(input.url).pathname);
 	const baseUrl = runtimeApiBaseUrl;
-	const msg = getLastDaemonMessage() ?? "AO Daemon is not ready."
+	const msg = getLastDaemonMessage() ?? "unknown error"
 	if (baseUrl === null) {
 		reportApiError(operation, "daemon_unavailable", 503);
-		return new Response(JSON.stringify({ message: `AO daemon is not ready: ${msg}.` }), {
+		return new Response(JSON.stringify({ message: `AO daemon is not ready: ${msg}` }), {
 			status: 503,
 			headers: { "Content-Type": "application/json" },
 		});

--- a/frontend/src/renderer/lib/daemon-status.ts
+++ b/frontend/src/renderer/lib/daemon-status.ts
@@ -3,7 +3,10 @@ import { setApiBaseUrl } from "./api-client";
 
 export type DaemonStatus = Awaited<ReturnType<typeof aoBridge.daemon.getStatus>>;
 
+let lastDaemonMessage: string | undefined;
+
 export function applyDaemonStatus(nextStatus: DaemonStatus): void {
+	lastDaemonMessage = nextStatus.message;
 	if (nextStatus.state === "ready" && nextStatus.port) {
 		setApiBaseUrl(`http://127.0.0.1:${nextStatus.port}`);
 	} else {
@@ -19,4 +22,8 @@ export async function refreshDaemonStatus(): Promise<DaemonStatus> {
 
 export function readDaemonStatus(): Promise<DaemonStatus> {
 	return aoBridge.daemon.getStatus();
+}
+
+export function getLastDaemonMessage(): string | undefined {
+	return lastDaemonMessage;
 }

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import { AlertTriangle } from "lucide-react";
 import { CommandPalette } from "../components/CommandPalette";
 import { CenterPanelShell } from "../components/CenterPanelShell";
 import { NotificationRuntime } from "../components/NotificationCenter";
@@ -382,6 +383,13 @@ function ShellLayout() {
           in the layout, not the screens, so the crumb and actions never shift
           when the outlet content swaps. */}
 			<div className="flex h-screen min-h-0 flex-col bg-sidebar text-foreground">
+				{daemonStatus.state === "error" ? (
+					<div className="flex items-center gap-2 border-b border-error/20 bg-error/8 px-4 py-2 text-xs text-error">
+						<AlertTriangle className="size-3.5 shrink-0" aria-hidden="true" />
+						<span>{daemonStatus.message ?? "AO daemon encountered an error."}</span>
+						<span className="ml-auto text-muted-foreground">Check the terminal where you ran <code className="rounded bg-muted px-1 font-mono">npm run dev</code></span>
+					</div>
+				) : null}
 				{/* Windows-only custom title bar (sidebar toggle + File/Edit/View/…
             menu); paints the chrome the frameless window drops. Renders null on
             macOS/Linux. */}


### PR DESCRIPTION
## What

Surfaces the daemon's actual failure reason across the UI instead of the generic "AO daemon is not ready." message:

- `api-client.ts`'s 503 fallback now includes the last known daemon status message instead of a hardcoded string.
- The Electron main process now tracks the daemon's last stderr line and prefers it over a bare exit code when the process dies (e.g. `listen tcp :3001: bind: address already in use` instead of `Daemon exited with code 1`).
- A persistent error banner in the shell surfaces `daemonStatus.message` when `state === "error"`, with a hint to check the terminal running `npm run dev`.
- `build-daemon.mjs` now checks the installed Go version against `go.mod`'s requirement before building, and fails fast with an upgrade link instead of letting a compile failure cascade into an opaque daemon crash.

## Why

Fixes #2958 
Fixes #2959
(It seems AO bot opened up 2 issues at the same time based on my report on Discord. cc @somewherelostt 
https://discord.com/channels/1476302178913357958/1529382371156033656)

Every API failure showed the same opaque "AO daemon is not ready." regardless of cause — missing binary, spawn error, crash, or (as in the reported case) an outdated Go toolchain failing to compile the daemon. Diagnosing any of this required digging into the terminal or source, with no actionable signal in the app itself.

## How

- `daemon-status.ts` now caches the last `DaemonStatus.message` so `api-client.ts` can read it when building the 503 fallback response.
- In `main.ts`, the daemon's stderr is scanned for its last non-empty line while the process runs. The exit handler was switched from Node's `"exit"` event to `"close"`: `"exit"` fires as soon as the process terminates and can race ahead of the final stderr `data` event, so `"close"` (guaranteed to fire only after stdio streams end) is used to reliably read that last line. The exit code/signal are still tracked as structured fields (`exitCode`, `signal`) on `DaemonStatus`; the stderr line, when available, replaces the generic exit-code text in the human-readable `message` rather than duplicating both.
- The Go preflight in `build-daemon.mjs` does a simple parsed-integer semver comparison (major.minor.patch) between `go.mod`'s `go` directive and `go version`'s output — no new dependency.

## Testing

- `npm run typecheck` (frontend)
- `npx vitest run --config vite.renderer.config.ts` — full renderer suite, including `api-client.test.ts` (updated assertion) and `daemon-attach.test.ts`
- I try to downgrade my Go to 1.18, and the error message pops up, following with the banner.

Before Changes:
<img width="413" height="287" alt="Screenshot from 2026-07-21 15-57-47" src="https://github.com/user-attachments/assets/c56de1a3-acb3-464b-9975-085c23f4db0f" />

After Changes:
<img width="468" height="455" alt="Screenshot from 2026-07-23 10-35-38" src="https://github.com/user-attachments/assets/04712170-413f-47d7-a95d-2a036d31de68" />

## Checklist

- [x] Branched from `main`
- [x] One focused change; links the related issue
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense — see Testing note above
- [x] Relevant CI checks pass for the area touched (frontend)


