### PR TITLE
fix(ui): fix the disable-report-problem to submit

### DIFF
--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,1 +1,0 @@
-/Users/psudokit/.ao/data/worktrees/ao/ao-5/frontend/node_modules

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -280,6 +280,7 @@ describe("GlobalSettingsForm", () => {
 		await user.click(await screen.findByRole("button", { name: "Report a problem" }));
 		expect(await screen.findByRole("dialog", { name: "Report a problem" })).toBeInTheDocument();
 		await user.type(screen.getByLabelText("Title"), "Need help with setup");
+		await user.type(screen.getByLabelText("What happened?"), "The setup flow stalls after the first prompt.");
 
 		await user.click(screen.getByRole("radio", { name: "Discord" }));
 		expect(screen.getByRole("button", { name: /copy & open discord/i })).toBeInTheDocument();
@@ -288,6 +289,8 @@ describe("GlobalSettingsForm", () => {
 		await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
 		expect(writeText.mock.calls[0][0]).toContain("**AO feedback**");
 		expect(screen.getByText("Discord draft copied.")).toBeInTheDocument();
+		expect(screen.getByLabelText("Title")).toHaveValue("");
+		expect(screen.getByLabelText("What happened?")).toHaveValue("");
 
 		await user.click(screen.getByRole("radio", { name: "Email" }));
 		expect(screen.getByRole("button", { name: /copy & open email/i })).toBeInTheDocument();
@@ -295,6 +298,7 @@ describe("GlobalSettingsForm", () => {
 		expect(screen.queryByText("Discord draft copied.")).not.toBeInTheDocument();
 		expect(screen.getByRole("button", { name: /copy & open email/i })).toBeDisabled();
 		await user.type(screen.getByLabelText("Title"), "Need help with setup");
+		await user.type(screen.getByLabelText("What happened?"), "The setup flow stalls after the first prompt.");
 		await user.click(screen.getByRole("button", { name: /copy & open email/i }));
 
 		await waitFor(() => expect(writeText).toHaveBeenCalledTimes(2));

--- a/frontend/src/renderer/components/settings/ReportProblemDialog.test.tsx
+++ b/frontend/src/renderer/components/settings/ReportProblemDialog.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ReportProblemDialog } from "./ReportProblemDialog";
+
+describe("ReportProblemDialog", () => {
+	it("disables primary action when fields are empty, and enables only when both summary and details contain text", () => {
+		render(
+			<ReportProblemDialog
+				open={true}
+				onOpenChange={vi.fn()}
+			/>
+		);
+
+		// Exact placeholders & labels from DOM
+		const summaryInput = screen.getByPlaceholderText(/brief title/i);
+		const detailsInput = screen.getByPlaceholderText(/share what happened/i);
+		const submitButton = screen.getByRole("button", { name: /copy & create github issue/i });
+
+		// 1. Both empty -> Disabled
+		expect(submitButton).toBeDisabled();
+
+		// 2. Only summary filled -> Disabled
+		fireEvent.change(summaryInput, { target: { value: "Test Summary" } });
+		expect(submitButton).toBeDisabled();
+
+		// Clear summary and fill only details -> Disabled
+		fireEvent.change(summaryInput, { target: { value: "" } });
+		fireEvent.change(detailsInput, { target: { value: "Test Details" } });
+		expect(submitButton).toBeDisabled();
+
+		// 3. Both filled -> Enabled
+		fireEvent.change(summaryInput, { target: { value: "Test Summary" } });
+		expect(submitButton).toBeEnabled();
+	});
+});

--- a/frontend/src/renderer/components/settings/ReportProblemDialog.test.tsx
+++ b/frontend/src/renderer/components/settings/ReportProblemDialog.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ReportProblemDialog } from "./ReportProblemDialog";
 
 describe("ReportProblemDialog", () => {
-	it("disables primary action when fields are empty, and enables only when both summary and details contain text", async () => {
+	it("disables primary action when fields are empty or whitespace-only, and enables when both summary and details contain non-whitespace text", async () => {
 		await act(async () => {
 			render(<ReportProblemDialog open={true} onOpenChange={vi.fn()} />);
 			await Promise.resolve();
@@ -22,11 +22,16 @@ describe("ReportProblemDialog", () => {
 		fireEvent.change(summaryInput, { target: { value: "Test Summary" } });
 		expect(submitButton).toBeDisabled();
 
-		fireEvent.change(summaryInput, { target: { value: "" } });
+		fireEvent.change(summaryInput, { target: { value: "   " } });
 		fireEvent.change(detailsInput, { target: { value: "Test Details" } });
 		expect(submitButton).toBeDisabled();
 
 		fireEvent.change(summaryInput, { target: { value: "Test Summary" } });
+		fireEvent.change(detailsInput, { target: { value: "   " } });
+		expect(submitButton).toBeDisabled();
+
+		fireEvent.change(summaryInput, { target: { value: "Test Summary" } });
+		fireEvent.change(detailsInput, { target: { value: "Test Details" } });
 		expect(submitButton).toBeEnabled();
 	});
 });

--- a/frontend/src/renderer/components/settings/ReportProblemDialog.test.tsx
+++ b/frontend/src/renderer/components/settings/ReportProblemDialog.test.tsx
@@ -1,37 +1,31 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ReportProblemDialog } from "./ReportProblemDialog";
 
 describe("ReportProblemDialog", () => {
-	it("disables primary action when fields are empty, and enables only when both summary and details contain text", () => {
-		render(
-			<ReportProblemDialog
-				open={true}
-				onOpenChange={vi.fn()}
-			/>
-		);
+	it("disables primary action when fields are empty, and enables only when both summary and details contain text", async () => {
+		await act(async () => {
+			render(<ReportProblemDialog open={true} onOpenChange={vi.fn()} />);
+			await Promise.resolve();
+		});
 
-		// Exact placeholders & labels from DOM
 		const summaryInput = screen.getByPlaceholderText(/brief title/i);
 		const detailsInput = screen.getByPlaceholderText(/share what happened/i);
 		const submitButton = screen.getByRole("button", { name: /copy & create github issue/i });
 
-		// 1. Both empty -> Disabled
 		expect(submitButton).toBeDisabled();
 
-		// 2. Only summary filled -> Disabled
 		fireEvent.change(summaryInput, { target: { value: "Test Summary" } });
 		expect(submitButton).toBeDisabled();
 
-		// Clear summary and fill only details -> Disabled
 		fireEvent.change(summaryInput, { target: { value: "" } });
 		fireEvent.change(detailsInput, { target: { value: "Test Details" } });
 		expect(submitButton).toBeDisabled();
 
-		// 3. Both filled -> Enabled
 		fireEvent.change(summaryInput, { target: { value: "Test Summary" } });
 		expect(submitButton).toBeEnabled();
 	});

--- a/frontend/src/renderer/components/settings/ReportProblemDialog.tsx
+++ b/frontend/src/renderer/components/settings/ReportProblemDialog.tsx
@@ -231,7 +231,7 @@ export function ReportProblemDialog({ open, onOpenChange }: ReportProblemDialogP
 					<button
 						type="button"
 						className="settings-footer-button border-transparent bg-settings-accent text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-						disabled={!canCopy}
+						disabled={!canSubmit}
 						onClick={() => void copyDraft()}
 					>
 						{destination.action}

--- a/frontend/src/renderer/components/settings/ReportProblemDialog.tsx
+++ b/frontend/src/renderer/components/settings/ReportProblemDialog.tsx
@@ -98,7 +98,7 @@ export function ReportProblemDialog({ open, onOpenChange }: ReportProblemDialogP
 	const input = { summary, details };
 	const draft = formatReportProblemDraft(input, diagnostics, selectedOutput);
 	const destination = DESTINATIONS.find((option) => option.value === selectedOutput) ?? DESTINATIONS[0];
-	const canCopy = summary.trim().length > 0;
+	const canSubmit = summary.trim().length > 0 && details.trim().length > 0;
 
 	const clearStatus = () => {
 		setCopiedOutput(null);
@@ -106,7 +106,7 @@ export function ReportProblemDialog({ open, onOpenChange }: ReportProblemDialogP
 	};
 
 	const copyDraft = async () => {
-		if (!canCopy) return;
+		if (!canSubmit) return;
 		setCopyError(null);
 		const output = selectedOutput;
 		try {
@@ -230,7 +230,7 @@ export function ReportProblemDialog({ open, onOpenChange }: ReportProblemDialogP
 					</DialogClose>
 					<button
 						type="button"
-						className="settings-footer-button border-transparent bg-settings-accent text-white disabled:cursor-not-allowed disabled:opacity-50"
+						className="settings-footer-button border-transparent bg-settings-accent text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
 						disabled={!canCopy}
 						onClick={() => void copyDraft()}
 					>

--- a/frontend/src/renderer/components/settings/ReportProblemDialog.tsx
+++ b/frontend/src/renderer/components/settings/ReportProblemDialog.tsx
@@ -59,10 +59,10 @@ const DESTINATIONS: {
 	action: string;
 	icon: (props: DestinationIconProps) => ReactNode;
 }[] = [
-	{ value: "github", label: "GitHub", action: "Copy & Create GitHub Issue", icon: GithubIcon },
-	{ value: "discord", label: "Discord", action: "Copy & Open Discord", icon: DiscordIcon },
-	{ value: "email", label: "Email", action: "Copy & Open Email", icon: EmailIcon },
-];
+		{ value: "github", label: "GitHub", action: "Copy & Create GitHub Issue", icon: GithubIcon },
+		{ value: "discord", label: "Discord", action: "Copy & Open Discord", icon: DiscordIcon },
+		{ value: "email", label: "Email", action: "Copy & Open Email", icon: EmailIcon },
+	];
 
 export function ReportProblemDialog({ open, onOpenChange }: ReportProblemDialogProps) {
 	const titleId = useId();
@@ -232,7 +232,10 @@ export function ReportProblemDialog({ open, onOpenChange }: ReportProblemDialogP
 						type="button"
 						className="settings-footer-button border-transparent bg-settings-accent text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
 						disabled={!canSubmit}
-						onClick={() => void copyDraft()}
+						onClick={() => {
+							if (!canSubmit) return;
+							void copyDraft()
+						}}
 					>
 						{destination.action}
 					</button>


### PR DESCRIPTION
## What
Fixed the **disable-report-problem to submit** dialog submit button behavior in the settings UI so that users cannot submit empty problem reports.

## Why
Fixes #2938

## How
- Added validation check `summary.trim().length > 0 && details.trim().length > 0` to determine `canSubmit`.
- Updated the primary action button to be disabled (`disabled={!canSubmit}`) when required fields are empty.
- Added a guard clause in the submit handler (`if (!canSubmit) return;`) to prevent accidental or forced form submission.

## Testing
- Verified locally in the renderer settings dialog that the Submit button remains disabled until both summary and details inputs contain text.
- Ran `npx tsc -p frontend/tsconfig.json --noEmit` and confirmed zero TypeScript errors.

## Checklist
- [x] Branched from `main`
- [x] One focused change; links the related issue (#2938)
- [x] Follows PR hygiene and coding conventions
- [x] Relevant CI checks/typechecks pass locally
