### PR TITLE
fix(conpty): launch batch-file agents from paths with spaces on Windows

### DIFF
--- a/backend/internal/adapters/runtime/conpty/host_conpty_windows.go
+++ b/backend/internal/adapters/runtime/conpty/host_conpty_windows.go
@@ -5,9 +5,14 @@ package conpty
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"sync"
+	"syscall"
 
 	gopty "github.com/aymanbagabas/go-pty"
+	"golang.org/x/sys/windows"
 )
 
 // conptyConn is the real ptyConn implementation backed by go-pty's ConPty
@@ -43,7 +48,7 @@ func newConPTY(cwd, shellCmd string, shellArgs []string) (ptyConn, error) {
 		return nil, fmt.Errorf("conpty: initial resize: %w", err)
 	}
 
-	cmd := cp.Command(shellCmd, shellArgs...)
+	cmd := conptyCommand(cp, shellCmd, shellArgs)
 	cmd.Dir = cwd
 	// Inherit parent env so PATH, HOME, etc. are available.
 	cmd.Env = os.Environ()
@@ -61,6 +66,54 @@ func newConPTY(cwd, shellCmd string, shellArgs []string) (ptyConn, error) {
 
 	go c.wait()
 	return c, nil
+}
+
+// conptyCommand builds the go-pty Cmd that runs shellCmd on the ConPTY.
+//
+// Non-batch executables run directly. Batch files (.cmd/.bat) are routed
+// through `cmd.exe /S /c "<command line>"` instead: CreateProcess executes
+// batch files via cmd.exe, and when the batch path contains spaces (e.g. an
+// npm global shim such as C:\Program Files\nodejs\claude.cmd) the program name
+// is split at the first space, failing with "'C:\Program' is not recognized".
+// Using cmd.exe (resolved via %ComSpec%, which has no spaces) as the
+// application name and passing the full command line verbatim through
+// SysProcAttr.CmdLine keeps the batch path intact. The /S switch makes cmd.exe
+// strip exactly the outer quote pair and run the inner command literally,
+// preserving the per-argument quoting windows.ComposeCommandLine applies.
+func conptyCommand(cp gopty.ConPty, shellCmd string, shellArgs []string) *gopty.Cmd {
+	if !isBatchFile(shellCmd) {
+		return cp.Command(shellCmd, shellArgs...)
+	}
+	inner := windows.ComposeCommandLine(append([]string{shellCmd}, shellArgs...))
+	cmd := cp.Command(comspecPath())
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CmdLine: `/S /c "` + inner + `"`,
+	}
+	return cmd
+}
+
+// isBatchFile reports whether path has a .cmd or .bat extension, ignoring case.
+func isBatchFile(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".cmd", ".bat":
+		return true
+	default:
+		return false
+	}
+}
+
+// comspecPath returns the absolute path to cmd.exe, preferring %ComSpec% and
+// falling back to a PATH lookup. A full path is required: go-pty resolves a
+// bare command name relative to the working directory, which would not find
+// cmd.exe there.
+func comspecPath() string {
+	if comspec := os.Getenv("ComSpec"); comspec != "" {
+		return comspec
+	}
+	if path, err := exec.LookPath("cmd.exe"); err == nil {
+		return path
+	}
+	return "cmd.exe"
 }
 
 func (c *conptyConn) wait() {

--- a/backend/internal/adapters/runtime/conpty/host_conpty_windows_test.go
+++ b/backend/internal/adapters/runtime/conpty/host_conpty_windows_test.go
@@ -1,0 +1,108 @@
+//go:build windows
+
+package conpty
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestIsBatchFile(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{`C:\Program Files\nodejs\claude.cmd`, true},
+		{`C:\Program Files\nodejs\qwen.CMD`, true},
+		{`C:\tools\run.bat`, true},
+		{`C:\tools\run.Bat`, true},
+		{`C:\Program Files\nodejs\claude.exe`, false},
+		{`C:\tools\qwen`, false},
+		{`claude`, false},
+		{``, false},
+	}
+	for _, tt := range tests {
+		if got := isBatchFile(tt.path); got != tt.want {
+			t.Errorf("isBatchFile(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+// TestNewConPTY_BatchFileWithSpaceInPath reproduces the Windows launch failure
+// for an agent CLI installed under a path containing spaces (e.g. an npm global
+// shim at C:\Program Files\nodejs\claude.cmd). CreateProcess runs .cmd files
+// through cmd.exe, and the unquoted program name was split at the first space,
+// failing with "'C:\Program' is not recognized". The batch file lives in a
+// directory whose name contains a space and must start and receive its
+// arguments (including one with a space) intact.
+func TestNewConPTY_BatchFileWithSpaceInPath(t *testing.T) {
+	// A directory WITH a space in its name mirrors "C:\Program Files\...".
+	dir := filepath.Join(t.TempDir(), "Program Files")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	batch := filepath.Join(dir, "echoer.cmd")
+	// %~N strips the surrounding quotes cmd.exe adds, so the echoed line shows
+	// the arguments exactly as the child received them.
+	script := "@echo off\r\necho MARKER:%~1:%~2\r\n"
+	if err := os.WriteFile(batch, []byte(script), 0o755); err != nil {
+		t.Fatalf("write batch: %v", err)
+	}
+
+	conn, err := newConPTY(dir, batch, []string{"hello world", "second"})
+	if err != nil {
+		t.Fatalf("newConPTY: %v", err)
+	}
+	defer conn.Close()
+
+	// Accumulate PTY output in the background. ConPTY's Read does not surface
+	// EOF when the child exits (the pseudo-console pipe stays open), so exit is
+	// observed via Done(), not a Read error.
+	var mu sync.Mutex
+	var acc []byte
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := conn.Read(buf)
+			if n > 0 {
+				mu.Lock()
+				acc = append(acc, buf[:n]...)
+				mu.Unlock()
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	// Wait for the batch to exit.
+	select {
+	case <-conn.Done():
+	case <-time.After(15 * time.Second):
+		mu.Lock()
+		got := string(acc)
+		mu.Unlock()
+		t.Fatalf("timeout waiting for batch to exit; output so far: %q", got)
+	}
+
+	// Poll briefly for the marker to land (output may trail Done by a moment).
+	deadline := time.After(3 * time.Second)
+	for {
+		mu.Lock()
+		got := string(acc)
+		mu.Unlock()
+		if strings.Contains(got, "MARKER:hello world:second") {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("batch output missing intact marker; got %q", got)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}


### PR DESCRIPTION
## Problem

On Windows, starting an agent whose CLI is installed under a path containing
spaces (for example an npm global shim at `C:\Program Files\nodejs\claude.cmd`)
failed immediately with:

```
'C:\Program' 不是内部或外部命令，也不是可运行的程序
('C:\Program' is not recognized as an internal or external command)
```

`CreateProcess` runs `.cmd`/`.bat` files through `cmd.exe`. go-pty passed the
batch path as `lpApplicationName`, and when that path contained a space the
program name was split at the first space, so `cmd.exe` tried to run
`C:\Program`.

## Fix

In `newConPTY` (`backend/internal/adapters/runtime/conpty/host_conpty_windows.go`),
batch files are now routed through `cmd.exe /S /c "<command line>"`:

- `cmd.exe` (resolved via `%ComSpec%`, which has no spaces) is used as the
  application name instead of the batch file.
- The full command line is set verbatim via `SysProcAttr.CmdLine`, built with
  `windows.ComposeCommandLine` so every argument is quoted. The `/S` switch
  makes `cmd.exe` strip exactly the outer quote pair and run the inner command
  literally, so that quoting survives.

Non-batch executables keep the existing direct-launch path, so there is no
behavior change for `.exe` agents.

## Testing

Added `backend/internal/adapters/runtime/conpty/host_conpty_windows_test.go`:

- `TestNewConPTY_BatchFileWithSpaceInPath` starts a real `.cmd` located under a
  space-containing directory via `newConPTY` and asserts its arguments
  (including one with a space) arrive intact. Bypassing the fix makes this test
  reproduce the exact original `'C:\Program' is not recognized` error, so it
  guards the regression.
- `TestIsBatchFile` covers the `.cmd`/`.bat` extension detection.

Verified on Windows 11:

```
go test ./internal/adapters/runtime/conpty/   # all pass
```

## Notes / omissions

- The change is scoped to the Windows ConPTY host used for agent launch. The
  Unix tmux runtime already shell-quotes every argv word, so it is unaffected.
- `go test -race` was not run locally because the Windows Go toolchain used here
  has no cgo/C compiler; CI should cover the race pass.
