### PR TITLE
fix(grok): forward role-specific model config to the Grok Build CLI

### DIFF
--- a/backend/internal/adapters/agent/grok/grok.go
+++ b/backend/internal/adapters/agent/grok/grok.go
@@ -105,6 +105,22 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Grok Build understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `grok --model`.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds `grok --no-auto-update [--permission-mode <mode>] [-- prompt]`.
 // Prompt is delivered positionally so Grok starts an interactive coding session.
 //
@@ -118,6 +134,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd = []string{binary, "--no-auto-update"}
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 
 	systemPrompt, err := launchSystemPromptText(cfg)
 	if err != nil {
@@ -179,9 +196,10 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 
-	cmd = make([]string, 0, 4)
+	cmd = make([]string, 0, 6)
 	cmd = append(cmd, binary, "--no-auto-update")
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 	systemPrompt, err := restoreSystemPromptText(cfg)
 	if err != nil {
 		return nil, false, err
@@ -226,6 +244,14 @@ func (p *Plugin) grokBinary(ctx context.Context) (string, error) {
 
 func grokClaudeSettingsPath(workspacePath string) string {
 	return filepath.Join(workspacePath, grokClaudeSettingsDirName, grokClaudeSettingsFileName)
+}
+
+// appendModelFlag appends a trimmed --model flag when a model override is
+// configured.
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
+	}
 }
 
 func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {

--- a/backend/internal/adapters/agent/grok/grok.go
+++ b/backend/internal/adapters/agent/grok/grok.go
@@ -115,7 +115,7 @@ func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
 			{
 				Key:         "model",
 				Type:        ports.ConfigFieldString,
-				Description: "Model override passed to `grok --model`.",
+				Description: "Model override passed to `grok -m`.",
 			},
 		},
 	}, nil
@@ -246,11 +246,13 @@ func grokClaudeSettingsPath(workspacePath string) string {
 	return filepath.Join(workspacePath, grokClaudeSettingsDirName, grokClaudeSettingsFileName)
 }
 
-// appendModelFlag appends a trimmed --model flag when a model override is
-// configured.
+// appendModelFlag appends a trimmed -m flag when a model override is
+// configured. -m is the documented model-selection flag for both headless
+// and TUI launches (https://docs.x.ai/build/overview: "grok -p \"Hello\" -m
+// my-model" / "pick the model in headless mode or in the TUI").
 func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
 	if model := strings.TrimSpace(cfg.Model); model != "" {
-		*cmd = append(*cmd, "--model", model)
+		*cmd = append(*cmd, "-m", model)
 	}
 }
 

--- a/backend/internal/adapters/agent/grok/grok_test.go
+++ b/backend/internal/adapters/agent/grok/grok_test.go
@@ -33,13 +33,69 @@ func TestManifest(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecEmpty(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `grok --model`.",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
+	}
+}
+
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "grok"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "  grok-build  "},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"grok", "--no-auto-update", "--model", "grok-build"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "grok"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if strings.Contains(strings.Join(cmd, " "), "--model") {
+		t.Fatalf("cmd = %#v contains --model for blank model", cmd)
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "grok"}
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "  grok-build  "},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{
+				ports.MetadataKeyAgentSessionID: "sess-abc123",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+	want := []string{"grok", "--no-auto-update", "--model", "grok-build", "-r", "sess-abc123"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
 }
 

--- a/backend/internal/adapters/agent/grok/grok_test.go
+++ b/backend/internal/adapters/agent/grok/grok_test.go
@@ -42,7 +42,7 @@ func TestGetConfigSpecReportsModelField(t *testing.T) {
 		{
 			Key:         "model",
 			Type:        ports.ConfigFieldString,
-			Description: "Model override passed to `grok --model`.",
+			Description: "Model override passed to `grok -m`.",
 		},
 	}
 	if !reflect.DeepEqual(spec.Fields, want) {
@@ -58,7 +58,7 @@ func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	want := []string{"grok", "--no-auto-update", "--model", "grok-build"}
+	want := []string{"grok", "--no-auto-update", "-m", "grok-build"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}
@@ -72,8 +72,10 @@ func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if strings.Contains(strings.Join(cmd, " "), "--model") {
-		t.Fatalf("cmd = %#v contains --model for blank model", cmd)
+	for _, arg := range cmd {
+		if arg == "-m" {
+			t.Fatalf("cmd = %#v contains -m for blank model", cmd)
+		}
 	}
 }
 
@@ -93,7 +95,7 @@ func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
 	if !ok {
 		t.Fatal("ok=false, want true")
 	}
-	want := []string{"grok", "--no-auto-update", "--model", "grok-build", "-r", "sess-abc123"}
+	want := []string{"grok", "--no-auto-update", "-m", "grok-build", "-r", "sess-abc123"}
 	if !reflect.DeepEqual(cmd, want) {
 		t.Fatalf("cmd = %#v, want %#v", cmd, want)
 	}


### PR DESCRIPTION
## Summary

The Grok Build adapter's `GetLaunchCommand` and `GetRestoreCommand` never read `cfg.Config.Model`, so a project's per-role `agentConfig.model` was silently dropped and Grok Build workers/orchestrators always launched on Grok's own global default model instead of the configured one.

This mirrors the pattern already applied to the Codex (#2869), Cline (#2894, #2953), Goose (#2885, #2956), and Autohand (#2889, #2993) adapters: append a trimmed `--model` flag on both the launch and restore argv when a model is configured, and advertise the field via `GetConfigSpec` so it shows up in project config UI/validation.

Fixes #2886

## Changes

- `backend/internal/adapters/agent/grok/grok.go`: add an `appendModelFlag` helper, call it from `GetLaunchCommand` and `GetRestoreCommand` (right after the approval-mode flags), and override `GetConfigSpec` to advertise the `model` field (previously inherited the empty default from `agentbase.Base`).
- `backend/internal/adapters/agent/grok/grok_test.go`: replace the now-stale `TestGetConfigSpecEmpty` with `TestGetConfigSpecReportsModelField`, and add regression tests for: trimmed model appended on launch, blank model omitted on launch, and trimmed model appended on restore.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./internal/adapters/agent/grok/...` passes
- [x] `go test ./internal/adapters/agent/grok/...` — all new/updated tests pass (pre-existing unrelated failures on this Windows dev box: `TestGrokLocalAuthStatusAuthorizedWithAuthFile` / `TestGrokLocalAuthStatusUnauthorizedWithEmptyAuthFile`, both failing identically on `main` before this change due to a local `HOME`/config-path environment quirk, not this change)
