### PR TITLE
`fix(windows): route background agent auth checks through aoprocess to suppress console window flashes`

### DIFF
--- a/backend/internal/adapters/agent/authprobe/authprobe.go
+++ b/backend/internal/adapters/agent/authprobe/authprobe.go
@@ -2,10 +2,10 @@ package authprobe
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 	"time"
 
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -21,7 +21,7 @@ var DefaultCommands = [][]string{
 // CmdRunner runs the command and returns the combined stdout/stderr.
 // It is exposed as a package variable to allow mocking in tests.
 var CmdRunner = func(ctx context.Context, name string, arg ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, arg...).CombinedOutput()
+	return aoprocess.CommandContext(ctx, name, arg...).CombinedOutput()
 }
 
 // CLIStatus runs bounded local CLI probes and classifies their output.

--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -33,6 +32,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -289,7 +289,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	out, err := exec.CommandContext(probeCtx, binary, "auth", "status").CombinedOutput()
+	out, err := aoprocess.CommandContext(probeCtx, binary, "auth", "status").CombinedOutput()
 	if probeCtx.Err() != nil {
 		return ports.AgentAuthStatusUnknown, probeCtx.Err()
 	}

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -177,7 +178,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	out, err := exec.CommandContext(probeCtx, binary, "login", "status").CombinedOutput()
+	out, err := aoprocess.CommandContext(probeCtx, binary, "login", "status").CombinedOutput()
 	if probeCtx.Err() != nil {
 		return ports.AgentAuthStatusUnknown, probeCtx.Err()
 	}

--- a/backend/internal/adapters/agent/copilot/auth.go
+++ b/backend/internal/adapters/agent/copilot/auth.go
@@ -3,11 +3,11 @@ package copilot
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -121,7 +121,7 @@ func copilotGHAuthStatus(ctx context.Context) (ports.AgentAuthStatus, bool, erro
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	out, err := exec.CommandContext(probeCtx, "gh", "auth", "token").CombinedOutput()
+	out, err := aoprocess.CommandContext(probeCtx, "gh", "auth", "token").CombinedOutput()
 	if probeCtx.Err() != nil {
 		return ports.AgentAuthStatusUnknown, false, probeCtx.Err()
 	}

--- a/backend/internal/adapters/agent/kilocode/auth.go
+++ b/backend/internal/adapters/agent/kilocode/auth.go
@@ -5,12 +5,12 @@ import (
 	"database/sql"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 
 	_ "modernc.org/sqlite" // register sqlite driver for KiloCode auth database probes
@@ -32,7 +32,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(probeCtx, binary, "auth", "list").CombinedOutput()
+	out, err := aoprocess.CommandContext(probeCtx, binary, "auth", "list").CombinedOutput()
 	if probeCtx.Err() != nil {
 		return ports.AgentAuthStatusUnknown, probeCtx.Err()
 	}

--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 
 	_ "modernc.org/sqlite" // register sqlite driver for opencode session metadata probes
@@ -180,7 +181,7 @@ func (p *Plugin) AuthStatus(ctx context.Context) (ports.AgentAuthStatus, error) 
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	out, err := exec.CommandContext(probeCtx, binary, "auth", "list").CombinedOutput()
+	out, err := aoprocess.CommandContext(probeCtx, binary, "auth", "list").CombinedOutput()
 	if probeCtx.Err() != nil {
 		return ports.AgentAuthStatusUnknown, probeCtx.Err()
 	}


### PR DESCRIPTION
# Description
This PR addresses a Windows-specific user experience issue where brief command prompt window flashes would appear on the user's desktop whenever the local daemon ran background status/auth probes for registered agent CLIs.
### Root Cause
Several agent adapters (specifically `authprobe.go`, `claudecode.go`, `codex.go`, `copilot/auth.go`, `kilocode/auth.go`, and `opencode.go`) were calling the standard Go library `exec.CommandContext(...)` directly to probe status. On Windows, executing shell commands from a background/GUI application (like the AO daemon or the Electron wrapper) without specifying console window creation flags forces Windows to draw and temporarily flash a console window.
### Solution
We swapped direct standard library `exec.CommandContext(...)` usage for the project's native `aoprocess.CommandContext(...)` helper (from `backend/internal/process`). The `aoprocess` package properly configures Windows execution flags (`windows.CREATE_NO_WINDOW` and `HideWindow: true`) to ensure all background child processes run completely invisibly.
## Changes
The following files were updated to import `aoprocess` and call `aoprocess.CommandContext(...)` for background probes:
- `backend/internal/adapters/agent/authprobe/authprobe.go`
- `backend/internal/adapters/agent/claudecode/claudecode.go`
- `backend/internal/adapters/agent/codex/codex.go`
- `backend/internal/adapters/agent/copilot/auth.go`
- `backend/internal/adapters/agent/kilocode/auth.go`
- `backend/internal/adapters/agent/opencode/opencode.go`
## Verification
<img width="1104" height="292" alt="Screenshot 2026-07-23 134010" src="https://github.com/user-attachments/assets/3a5500a9-d77b-41be-b369-1ffe23f509ff" />

