### PR TITLE
fix(session): drop phantom trailing blank line from synthetic new-file diffs

### DIFF
--- a/backend/internal/service/session/workspace_files.go
+++ b/backend/internal/service/session/workspace_files.go
@@ -519,8 +519,12 @@ func gitTracked(ctx context.Context, root, rel string) bool {
 
 func syntheticAddedFileDiff(rel, content string) string {
 	lines := strings.SplitAfter(content, "\n")
-	if len(lines) == 1 && lines[0] == "" {
-		lines = nil
+	// SplitAfter appends an empty trailing element whenever content ends in
+	// "\n" (including the empty-content case, where it yields [""]) — drop it
+	// so the hunk's line count matches the file's actual line count instead of
+	// counting one phantom blank line past the final newline.
+	if n := len(lines); n > 0 && lines[n-1] == "" {
+		lines = lines[:n-1]
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "diff --git a/%s b/%s\n", rel, rel)

--- a/backend/internal/service/session/workspace_files_test.go
+++ b/backend/internal/service/session/workspace_files_test.go
@@ -1,0 +1,87 @@
+package session
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestSyntheticAddedFileDiffMatchesActualLineCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantLines []string
+	}{
+		{
+			name:      "trailing newline",
+			content:   "hello\nworld\n",
+			wantLines: []string{"+hello", "+world"},
+		},
+		{
+			name:      "no trailing newline",
+			content:   "hello\nworld",
+			wantLines: []string{"+hello", "+world"},
+		},
+		{
+			name:      "single line with trailing newline",
+			content:   "hello\n",
+			wantLines: []string{"+hello"},
+		},
+		{
+			name:      "empty content",
+			content:   "",
+			wantLines: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diff := syntheticAddedFileDiff("new.txt", tt.content)
+
+			gotLines := addedLinesFrom(diff)
+			if !equalStrings(gotLines, tt.wantLines) {
+				t.Fatalf("added lines = %#v, want %#v\ndiff:\n%s", gotLines, tt.wantLines, diff)
+			}
+
+			wantHeader := "@@ -0,0 +1," + strconv.Itoa(len(tt.wantLines)) + " @@"
+			if !strings.Contains(diff, wantHeader) {
+				t.Fatalf("diff missing hunk header %q:\n%s", wantHeader, diff)
+			}
+
+			// The hunk's declared count must equal the number of "+" lines
+			// actually emitted, and both must equal the file's real line
+			// count (textLineCount), which is what the changed-files list
+			// displays. A mismatch here is the exact bug #2923 reported.
+			if got, want := len(gotLines), textLineCount(tt.content); got != want {
+				t.Fatalf("diff added-line count = %d, textLineCount = %d, want equal", got, want)
+			}
+		})
+	}
+}
+
+// addedLinesFrom extracts the "+..." content lines from a synthetic diff,
+// skipping the "+++ b/<path>" file-header line.
+func addedLinesFrom(diff string) []string {
+	var added []string
+	for _, line := range strings.Split(diff, "\n") {
+		if strings.HasPrefix(line, "+++ ") {
+			continue
+		}
+		if strings.HasPrefix(line, "+") {
+			added = append(added, line)
+		}
+	}
+	return added
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

The synthetic diff generated for a newly-added, untracked text file had an off-by-one: for any file whose content ends in a newline (i.e. almost every file), the hunk header claimed one line too many and a phantom empty `+` line was appended.

Root cause: `syntheticAddedFileDiff` (`backend/internal/service/session/workspace_files.go`) splits content with `strings.SplitAfter(content, "
")`, which always appends an empty trailing element whenever the string ends with the separator. For `"hello
world
"` this yields `["hello
", "world
", ""]` — 3 elements instead of 2. The existing guard (`if len(lines) == 1 && lines[0] == ""`) only handled the fully-empty-content special case, so it never caught this general one. Meanwhile the changed-files list's line count (`textLineCount`) correctly counts 2, so the two counts shown in the UI for the same file disagreed.

Fixes #2923

## Fix

Drop the trailing empty split segment unconditionally (`if lines[len(lines)-1] == "": lines = lines[:len(lines)-1]`) instead of only in the singleton-empty-string special case. This correctly handles: content ending in `
` (the reported bug), content not ending in `
` (unaffected, already correct), and empty content (still yields zero lines, same as before).

## Test plan

- [x] Added `backend/internal/service/session/workspace_files_test.go` with `TestSyntheticAddedFileDiffMatchesActualLineCount`, covering: trailing newline, no trailing newline, single line with trailing newline, and empty content. Each case asserts the hunk header count, the actual emitted `+` line count, and that both match `textLineCount` (the same count the changed-files list uses) — the exact invariant the issue reported as broken.
- [x] Verified the new test fails against the pre-fix code, reproducing the exact phantom `+` line from the issue report, and passes after the fix.
- [x] `go build ./...` passes
- [x] `go vet ./internal/service/session/...` passes
- [x] `go test ./internal/service/session/...` — full package suite passes
