### PR TITLE
feat(review): show previous head verdict as secondary context

### DIFF
--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2622,6 +2622,8 @@ components:
           type: integer
         prUrl:
           type: string
+        previousRun:
+          $ref: '#/components/schemas/ReviewRun'
         status:
           enum:
           - needs_review

--- a/backend/internal/review/planner.go
+++ b/backend/internal/review/planner.go
@@ -24,12 +24,13 @@ const (
 
 // PRReviewState is one PR-scoped review decision for a worker session.
 type PRReviewState struct {
-	PRURL     string            `json:"prUrl"`
-	PRNumber  int               `json:"prNumber"`
-	Title     string            `json:"title"`
-	TargetSHA string            `json:"targetSha"`
-	Status    StateStatus       `json:"status" enum:"needs_review,running,up_to_date,changes_requested,ineligible"`
-	LatestRun *domain.ReviewRun `json:"latestRun,omitempty"`
+	PRURL       string            `json:"prUrl"`
+	PRNumber    int               `json:"prNumber"`
+	Title       string            `json:"title"`
+	TargetSHA   string            `json:"targetSha"`
+	Status      StateStatus       `json:"status" enum:"needs_review,running,up_to_date,changes_requested,ineligible"`
+	LatestRun   *domain.ReviewRun `json:"latestRun,omitempty"`
+	PreviousRun *domain.ReviewRun `json:"previousRun,omitempty"`
 }
 
 // Plan computes per-PR review work from the currently observed PRs and existing
@@ -45,6 +46,9 @@ func Plan(prs []domain.PullRequest, runs []domain.ReviewRun) []PRReviewState {
 			Title:     pr.Title,
 			TargetSHA: pr.HeadSHA,
 			Status:    ReviewStateNeedsReview,
+		}
+		if run, ok := latestCompletedRunForOtherSHA(runs, review.PRURL, review.TargetSHA); ok {
+			review.PreviousRun = &run
 		}
 		if pr.URL == "" || pr.HeadSHA == "" || pr.Draft || pr.Merged || pr.Closed {
 			review.Status = ReviewStateIneligible
@@ -78,6 +82,30 @@ func Plan(prs []domain.PullRequest, runs []domain.ReviewRun) []PRReviewState {
 		return reviews[i].PRURL < reviews[j].PRURL
 	})
 	return reviews
+}
+
+func latestCompletedRunForOtherSHA(runs []domain.ReviewRun, prURL, targetSHA string) (domain.ReviewRun, bool) {
+	if prURL == "" || targetSHA == "" {
+		return domain.ReviewRun{}, false
+	}
+	var latest domain.ReviewRun
+	found := false
+	for _, run := range runs {
+		if run.PRURL != prURL || run.TargetSHA == "" || run.TargetSHA == targetSHA {
+			continue
+		}
+		if run.Status != domain.ReviewRunComplete && run.Status != domain.ReviewRunDelivered {
+			continue
+		}
+		if run.Verdict != domain.VerdictApproved && run.Verdict != domain.VerdictChangesRequested {
+			continue
+		}
+		if !found || run.CreatedAt.After(latest.CreatedAt) {
+			latest = run
+			found = true
+		}
+	}
+	return latest, found
 }
 
 func latestRunsByPRAndSHA(runs []domain.ReviewRun) map[string]domain.ReviewRun {

--- a/backend/internal/review/planner_test.go
+++ b/backend/internal/review/planner_test.go
@@ -48,6 +48,67 @@ func TestPlanStatuses(t *testing.T) {
 	}
 }
 
+func TestPlanPreservesPreviousVerdictWithoutChangingCurrentHeadState(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	tests := []struct {
+		name       string
+		currentRun *domain.ReviewRun
+		wantStatus StateStatus
+	}{
+		{name: "new head needs review", wantStatus: ReviewStateNeedsReview},
+		{
+			name: "new head running",
+			currentRun: &domain.ReviewRun{
+				ID: "run-current", PRURL: "pr1", TargetSHA: "sha2", Status: domain.ReviewRunRunning, CreatedAt: now.Add(time.Second),
+			},
+			wantStatus: ReviewStateRunning,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runs := []domain.ReviewRun{{
+				ID: "run-previous", PRURL: "pr1", TargetSHA: "sha1", Status: domain.ReviewRunDelivered,
+				Verdict: domain.VerdictChangesRequested, CreatedAt: now,
+			}}
+			if tt.currentRun != nil {
+				runs = append(runs, *tt.currentRun)
+			}
+
+			got := Plan([]domain.PullRequest{planPR("pr1", 1, "sha2")}, runs)
+			if got[0].Status != tt.wantStatus {
+				t.Fatalf("status = %s, want %s", got[0].Status, tt.wantStatus)
+			}
+			if got[0].PreviousRun == nil || got[0].PreviousRun.ID != "run-previous" {
+				t.Fatalf("previous run = %+v, want run-previous", got[0].PreviousRun)
+			}
+			if tt.currentRun == nil {
+				if got[0].LatestRun != nil {
+					t.Fatalf("latest run = %+v, want nil for unreviewed current head", got[0].LatestRun)
+				}
+			} else if got[0].LatestRun == nil || got[0].LatestRun.ID != tt.currentRun.ID {
+				t.Fatalf("latest run = %+v, want current-head run %q", got[0].LatestRun, tt.currentRun.ID)
+			}
+		})
+	}
+}
+
+func TestPlanPreviousRunChoosesNewestQualifyingDifferentHead(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	got := Plan([]domain.PullRequest{planPR("pr1", 1, "sha-current")}, []domain.ReviewRun{
+		{ID: "older", PRURL: "pr1", TargetSHA: "sha-old", Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved, CreatedAt: now},
+		{ID: "newest-other", PRURL: "pr1", TargetSHA: "sha-newer", Status: domain.ReviewRunDelivered, Verdict: domain.VerdictChangesRequested, CreatedAt: now.Add(time.Second)},
+		{ID: "failed-other", PRURL: "pr1", TargetSHA: "sha-failed", Status: domain.ReviewRunFailed, Verdict: domain.VerdictApproved, CreatedAt: now.Add(2 * time.Second)},
+		{ID: "current", PRURL: "pr1", TargetSHA: "sha-current", Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved, CreatedAt: now.Add(3 * time.Second)},
+	})
+
+	if got[0].PreviousRun == nil || got[0].PreviousRun.ID != "newest-other" {
+		t.Fatalf("previous run = %+v, want newest qualifying different-head run", got[0].PreviousRun)
+	}
+	if got[0].LatestRun == nil || got[0].LatestRun.ID != "current" || got[0].Status != ReviewStateUpToDate {
+		t.Fatalf("current-head state = %+v, want current approved run", got[0])
+	}
+}
+
 func planPR(url string, n int, sha string) domain.PullRequest {
 	return domain.PullRequest{URL: url, Number: n, HeadSHA: sha}
 }

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -998,6 +998,7 @@ export interface components {
             latestRun?: components["schemas"]["ReviewRun"];
             prNumber: number;
             prUrl: string;
+            previousRun?: components["schemas"]["ReviewRun"];
             /** @enum {string} */
             status: "needs_review" | "running" | "up_to_date" | "changes_requested" | "ineligible";
             targetSha: string;

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -496,6 +496,63 @@ describe("SessionInspector reviews tab", () => {
 		expect(screen.queryByRole("button", { name: "Re-run" })).not.toBeInTheDocument();
 	});
 
+	it.each([
+		["needs_review", "changes_requested", "Changes requested", "Not run", "Run review"],
+		["running", "approved", "Approved", "Reviewing...", "Cancel review"],
+	] as const)(
+		"shows the previous verdict while the current head is %s without changing its current status",
+		async (status, previousVerdict, previousLabel, currentLabel, actionLabel) => {
+			const current = {
+				...reviewState(3, status, "sha-current"),
+				previousRun: {
+					...approvedReview,
+					id: "run-previous",
+					status: "delivered",
+					verdict: previousVerdict,
+					targetSha: "sha-previous",
+				},
+			};
+			if (status === "running") {
+				current.latestRun = {
+					...approvedReview,
+					id: "run-current",
+					status: "running",
+					verdict: "",
+					targetSha: "sha-current",
+				};
+			}
+			mockCommonGets([], "reviewer-pane", [current]);
+
+			renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
+			await openReviewsTab();
+
+			const previous = await screen.findByText(`Previous: ${previousLabel}`);
+			expect(within(previous.parentElement as HTMLElement).getByText(currentLabel)).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: actionLabel })).toBeInTheDocument();
+		},
+	);
+
+	it("hides the previous verdict after the current head review completes", async () => {
+		const current = {
+			...reviewState(3, "up_to_date", "sha-current"),
+			previousRun: {
+				...approvedReview,
+				id: "run-previous",
+				status: "delivered",
+				verdict: "changes_requested",
+				targetSha: "sha-previous",
+			},
+		};
+		mockCommonGets([], "reviewer-pane", [current]);
+
+		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
+		await openReviewsTab();
+
+		expect(await screen.findAllByText("Approved")).not.toHaveLength(0);
+		expect(screen.queryByText(/Previous:/)).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Re-run review" })).toBeInTheDocument();
+	});
+
 	it("shows a no-needed-reviews notice instead of opening the terminal when the backend reuses runs", async () => {
 		mockCommonGets([approvedReview], "reviewer-pane", [reviewState(3, "up_to_date")]);
 		postMock.mockResolvedValue({

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -740,6 +740,7 @@ function ReviewPanel({
 
 function ReviewStateRow({ reviewState }: { reviewState: PRReviewState }) {
 	const verdict = reviewVerdict(reviewState);
+	const previousVerdict = previousReviewVerdict(reviewState);
 	const title = reviewState.title?.trim() || `PR #${reviewState.prNumber}`;
 	return (
 		<div
@@ -763,9 +764,14 @@ function ReviewStateRow({ reviewState }: { reviewState: PRReviewState }) {
 					<span className="col-start-1 font-mono text-caption text-passive">#{reviewState.prNumber}</span>
 				</div>
 			</div>
-			<span className={cn("whitespace-nowrap text-caption font-semibold", reviewerVerdictTone[verdict.tone])}>
-				{verdict.label}
-			</span>
+			<div className="flex flex-col items-end gap-1 whitespace-nowrap">
+				<span className={cn("text-caption font-semibold", reviewerVerdictTone[verdict.tone])}>{verdict.label}</span>
+				{previousVerdict ? (
+					<span className={cn("text-2xs font-medium", reviewerVerdictTone[previousVerdict.tone])}>
+						Previous: {previousVerdict.label}
+					</span>
+				) : null}
+			</div>
 		</div>
 	);
 }
@@ -815,6 +821,21 @@ function reviewVerdict(reviewState: PRReviewState): {
 			return { label: "Not run", tone: "neutral" };
 	}
 	return { label: "Not run", tone: "neutral" };
+}
+
+function previousReviewVerdict(reviewState: PRReviewState): {
+	label: string;
+	tone: "success" | "danger";
+} | null {
+	if (reviewState.status !== "needs_review" && reviewState.status !== "running") return null;
+	switch (reviewState.previousRun?.verdict) {
+		case "approved":
+			return { label: "Approved", tone: "success" };
+		case "changes_requested":
+			return { label: "Changes requested", tone: "danger" };
+		default:
+			return null;
+	}
 }
 
 function reviewSessionRunAction(reviewStates: PRReviewState[], isTriggering: boolean): string {


### PR DESCRIPTION
## Summary

Closes item 2 of #2433 (relates to #2300): the reviews panel now shows the last decisive verdict from a **previously reviewed commit** while the current PR head is still awaiting or undergoing review.

- Backend attaches the newest completed/delivered run with a decisive verdict (approved / changes requested) for a **different** SHA as `PreviousRun` on each `PRReviewState`.
- The reviews row renders it as a small `Previous: <verdict>` line under the current verdict, and **only** while the current head is `needs_review` or `running`. It never changes the current head's status, gating, or approval, and it disappears once the current head has its own verdict.

Ported from xuelongmu's fork PR #207 (approach unchanged), which was self-contained against upstream with no fork-only plumbing.

## Out of scope

#2300 also asks to auto-restart the reviewer on a new head. That behavior lives in separate fork work and is intentionally left for a follow-up PR so this stays a focused display-only change.

## Tests

- `cd backend && go build ./internal/review/... && go test ./internal/review/ -count=1` (2 new planner cases)
- gofmt + `go vet ./internal/review/` clean
- API regenerated from Go source (`npm run api:spec`) — `openapi.yaml` matches, no drift
- `cd frontend && npx vitest run --config vite.renderer.config.ts src/renderer/components/SessionInspector.test.tsx` — 35/35 (3 new)
- `cd frontend && npx tsc --noEmit` clean
