### PR TITLE
feat(storage): persist provider PR review body

### DIFF
--- a/backend/internal/domain/pr.go
+++ b/backend/internal/domain/pr.go
@@ -113,6 +113,7 @@ type PullRequestReview struct {
 	Author      string
 	State       ReviewDecision
 	URL         string
+	Body        string
 	IsBot       bool
 	SubmittedAt time.Time
 }

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -109,6 +109,7 @@ type PRReview struct {
 	URL         string
 	IsBot       int64
 	SubmittedAt time.Time
+	Body        string
 }
 
 type PRReviewThread struct {

--- a/backend/internal/storage/sqlite/gen/pr_reviews.sql.go
+++ b/backend/internal/storage/sqlite/gen/pr_reviews.sql.go
@@ -20,7 +20,7 @@ func (q *Queries) DeletePRReviews(ctx context.Context, prUrl string) error {
 }
 
 const listPRReviews = `-- name: ListPRReviews :many
-SELECT pr_url, review_id, author, state, url, is_bot, submitted_at
+SELECT pr_url, review_id, author, state, url, is_bot, submitted_at, body
 FROM pr_reviews WHERE pr_url = ? ORDER BY submitted_at, review_id
 `
 
@@ -41,6 +41,7 @@ func (q *Queries) ListPRReviews(ctx context.Context, prUrl string) ([]PRReview, 
 			&i.URL,
 			&i.IsBot,
 			&i.SubmittedAt,
+			&i.Body,
 		); err != nil {
 			return nil, err
 		}
@@ -56,14 +57,15 @@ func (q *Queries) ListPRReviews(ctx context.Context, prUrl string) ([]PRReview, 
 }
 
 const upsertPRReview = `-- name: UpsertPRReview :exec
-INSERT INTO pr_reviews (pr_url, review_id, author, state, url, is_bot, submitted_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO pr_reviews (pr_url, review_id, author, state, url, is_bot, submitted_at, body)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (pr_url, review_id) DO UPDATE SET
     author = excluded.author,
     state = excluded.state,
     url = excluded.url,
     is_bot = excluded.is_bot,
-    submitted_at = excluded.submitted_at
+    submitted_at = excluded.submitted_at,
+    body = excluded.body
 `
 
 type UpsertPRReviewParams struct {
@@ -74,6 +76,7 @@ type UpsertPRReviewParams struct {
 	URL         string
 	IsBot       int64
 	SubmittedAt time.Time
+	Body        string
 }
 
 func (q *Queries) UpsertPRReview(ctx context.Context, arg UpsertPRReviewParams) error {
@@ -85,6 +88,7 @@ func (q *Queries) UpsertPRReview(ctx context.Context, arg UpsertPRReviewParams) 
 		arg.URL,
 		arg.IsBot,
 		arg.SubmittedAt,
+		arg.Body,
 	)
 	return err
 }

--- a/backend/internal/storage/sqlite/migrations/0029_pr_reviews_body.sql
+++ b/backend/internal/storage/sqlite/migrations/0029_pr_reviews_body.sql
@@ -1,0 +1,14 @@
+-- Summary: persist the provider review body so the reviews UI can show a
+-- summary alongside each PR review verdict. Defaulting to '' keeps existing
+-- rows valid without backfill; older rows simply have no stored summary until
+-- the next SCM observation refreshes them.
+
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE pr_reviews ADD COLUMN body TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE pr_reviews DROP COLUMN body;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/pr_reviews.sql
+++ b/backend/internal/storage/sqlite/queries/pr_reviews.sql
@@ -1,16 +1,17 @@
 -- name: UpsertPRReview :exec
-INSERT INTO pr_reviews (pr_url, review_id, author, state, url, is_bot, submitted_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO pr_reviews (pr_url, review_id, author, state, url, is_bot, submitted_at, body)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (pr_url, review_id) DO UPDATE SET
     author = excluded.author,
     state = excluded.state,
     url = excluded.url,
     is_bot = excluded.is_bot,
-    submitted_at = excluded.submitted_at;
+    submitted_at = excluded.submitted_at,
+    body = excluded.body;
 
 -- name: DeletePRReviews :exec
 DELETE FROM pr_reviews WHERE pr_url = ?;
 
 -- name: ListPRReviews :many
-SELECT pr_url, review_id, author, state, url, is_bot, submitted_at
+SELECT pr_url, review_id, author, state, url, is_bot, submitted_at, body
 FROM pr_reviews WHERE pr_url = ? ORDER BY submitted_at, review_id;

--- a/backend/internal/storage/sqlite/store/pr_store.go
+++ b/backend/internal/storage/sqlite/store/pr_store.go
@@ -517,6 +517,7 @@ func genReviewParams(prURL string, review domain.PullRequestReview) gen.UpsertPR
 		URL:         review.URL,
 		IsBot:       boolInt(review.IsBot),
 		SubmittedAt: review.SubmittedAt,
+		Body:        review.Body,
 	}
 }
 
@@ -526,6 +527,7 @@ func reviewFromGen(review gen.PRReview) domain.PullRequestReview {
 		Author:      review.Author,
 		State:       domain.ReviewDecision(review.State),
 		URL:         review.URL,
+		Body:        review.Body,
 		IsBot:       review.IsBot != 0,
 		SubmittedAt: review.SubmittedAt,
 	}

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -507,7 +507,7 @@ func TestWriteSCMObservationPersistsMetadataChecksReviewsAndComments(t *testing.
 		UpdatedAt: now, ObservedAt: now, CIObservedAt: now, ReviewObservedAt: now,
 	}
 	checks := []domain.PullRequestCheck{{Name: "build", CommitHash: "h1", Status: domain.PRCheckFailed, Conclusion: "failure", URL: "ci", Details: "99", LogTail: "boom", CreatedAt: now}}
-	reviews := []domain.PullRequestReview{{ID: "review-1", Author: "reviewer", State: domain.ReviewChangesRequest, URL: "https://github.com/o/r/pull/1#pullrequestreview-1", SubmittedAt: now}}
+	reviews := []domain.PullRequestReview{{ID: "review-1", Author: "reviewer", State: domain.ReviewChangesRequest, URL: "https://github.com/o/r/pull/1#pullrequestreview-1", Body: "please fix the nil check", SubmittedAt: now}}
 	threads := []domain.PullRequestReviewThread{{ThreadID: "t1", Path: "main.go", Line: 7, SemanticHash: "th", UpdatedAt: now}}
 	comments := []domain.PullRequestComment{{ThreadID: "t1", ID: "c1", Author: "reviewer", File: "main.go", Line: 7, Body: "fix", URL: "comment", CreatedAt: now}}
 
@@ -530,12 +530,46 @@ func TestWriteSCMObservationPersistsMetadataChecksReviewsAndComments(t *testing.
 		t.Fatalf("threads not persisted: %+v", gotThreads)
 	}
 	gotReviews, _ := s.ListPRReviews(ctx, pr.URL)
-	if len(gotReviews) != 1 || gotReviews[0].ID != "review-1" || gotReviews[0].URL != "https://github.com/o/r/pull/1#pullrequestreview-1" {
+	if len(gotReviews) != 1 || gotReviews[0].ID != "review-1" || gotReviews[0].URL != "https://github.com/o/r/pull/1#pullrequestreview-1" || gotReviews[0].Body != "please fix the nil check" {
 		t.Fatalf("reviews not persisted: %+v", gotReviews)
 	}
 	gotComments, _ := s.ListPRComments(ctx, pr.URL)
 	if len(gotComments) != 1 || gotComments[0].ThreadID != "t1" || gotComments[0].URL != "comment" {
 		t.Fatalf("comments not persisted: %+v", gotComments)
+	}
+}
+
+func TestUpsertPRReviewUpdatesBody(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	seedProject(t, s, "mer")
+	r, _ := s.CreateSession(ctx, sampleRecord("mer"))
+	now := time.Now().UTC().Truncate(time.Second)
+
+	pr := domain.PullRequest{
+		URL: "https://github.com/o/r/pull/9", SessionID: r.ID, Number: 9,
+		Provider: "github", Host: "github.com", Repo: "o/r",
+		SourceBranch: "feat/body", TargetBranch: "main", HeadSHA: "h1",
+		Title: "review body", UpdatedAt: now, ObservedAt: now,
+	}
+	review := domain.PullRequestReview{ID: "review-1", Author: "reviewer", State: domain.ReviewChangesRequest, URL: "https://github.com/o/r/pull/9#pullrequestreview-1", Body: "first pass", SubmittedAt: now}
+
+	if err := s.WriteSCMObservation(ctx, pr, nil, []domain.PullRequestReview{review}, nil, nil, ports.ReviewWriteReplace); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := s.ListPRReviews(ctx, pr.URL); len(got) != 1 || got[0].Body != "first pass" {
+		t.Fatalf("initial body not persisted: %+v", got)
+	}
+
+	// A re-observation of the same review id must overwrite the stored body.
+	review.State = domain.ReviewApproved
+	review.Body = "resolved, approving"
+	if err := s.WriteSCMObservation(ctx, pr, nil, []domain.PullRequestReview{review}, nil, nil, ports.ReviewWriteReplace); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.ListPRReviews(ctx, pr.URL)
+	if len(got) != 1 || got[0].Body != "resolved, approving" || got[0].State != domain.ReviewApproved {
+		t.Fatalf("body/state not updated on upsert: %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Storage groundwork for the reviews-tab revamp tracked in #2433: persist the **body** (summary text) of each provider PR review so a later change can show it alongside the verdict.

- Migration **0029** adds `body TEXT NOT NULL DEFAULT ''` to `pr_reviews`. No backfill needed — existing rows stay valid and pick up a body on the next SCM observation.
- `UpsertPRReview` / `ListPRReviews` carry `body`; the upsert overwrites it on re-observation.
- `domain.PullRequestReview` gains `Body`, mapped through `genReviewParams` / `reviewFromGen`.
- `gen/*` regenerated via `npm run sqlc`.

This is intentionally storage-only. Fetching the body from the GitHub SCM GraphQL and exposing it through the session PR API are separate follow-up PRs, so this stays small and reviewable.

## Migration number

Uses **0029** (main is at 0028 after #2952). Heads up: open PR #2980 currently sits on 0026–0028 with different names and will need to renumber before it merges — if it lands first and takes 0029, this needs a quick rename before merge.

## Tests

- `cd backend && go build ./... && go vet ./internal/storage/... ./internal/domain/...` clean
- `go test ./internal/storage/sqlite/store/ -count=1` — includes an extended `WriteSCMObservation` assertion for `body` and a new `TestUpsertPRReviewUpdatesBody` covering the upsert-overwrite path
- gofmt clean
