### PR TITLE
feat(scm): fetch provider PR review body from GitHub

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -557,7 +557,7 @@ func buildReviewThreadsQuery(ref ports.SCMPRRef, beforeCursor string, includeRev
 	}
 	reviewSelection := ""
 	if includeReviews {
-		reviewSelection = fmt.Sprintf(" reviewSummaries: reviews(last:%d, states:[APPROVED,CHANGES_REQUESTED]){ nodes{ id state url submittedAt author{ login __typename } } }", githubReviewSummaryLimit)
+		reviewSelection = fmt.Sprintf(" reviewSummaries: reviews(last:%d, states:[APPROVED,CHANGES_REQUESTED]){ nodes{ id state url submittedAt body author{ login __typename } } }", githubReviewSummaryLimit)
 	}
 	return fmt.Sprintf(`query{
 repo: repository(owner:%s,name:%s){ pullRequest(number:%d){ reviewDecision%s reviewThreads(last:%d, before:%s){ nodes{
@@ -574,6 +574,7 @@ func scmReviewSummaryFromGraphQL(review map[string]any) ports.SCMReviewSummaryOb
 		Author:      str(author["login"]),
 		State:       string(reviewStateFromGraphQL(review["state"])),
 		URL:         str(review["url"]),
+		Body:        str(review["body"]),
 		IsBot:       isBotAuthor(author),
 		SubmittedAt: parseGitHubTime(str(review["submittedAt"])),
 	}

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -1375,6 +1375,9 @@ func TestFetchReviewThreadsUsesLatestWindowWithoutFallbackWhenOldestResolved(t *
 		if !strings.Contains(string(body), "reviews(last:20, states:[APPROVED,CHANGES_REQUESTED])") {
 			t.Fatalf("review query should fetch decisive review summaries, body=%s", body)
 		}
+		if !strings.Contains(string(body), "submittedAt body author") {
+			t.Fatalf("review query should request the review body, body=%s", body)
+		}
 		if !strings.Contains(string(body), "comments(first:5)") {
 			t.Fatalf("review query should cap comments per thread, body=%s", body)
 		}
@@ -1387,6 +1390,7 @@ func TestFetchReviewThreadsUsesLatestWindowWithoutFallbackWhenOldestResolved(t *
 					"state":       "CHANGES_REQUESTED",
 					"url":         "https://github.com/o/r/pull/1#pullrequestreview-1",
 					"submittedAt": "2026-06-15T00:00:00Z",
+					"body":        "please address the failing test",
 					"author":      map[string]any{"login": "alice", "__typename": "User"},
 				}}},
 				"reviewThreads": map[string]any{
@@ -1412,7 +1416,7 @@ func TestFetchReviewThreadsUsesLatestWindowWithoutFallbackWhenOldestResolved(t *
 	if len(review.Threads) != 1 || review.Threads[0].ID != "latest-resolved" {
 		t.Fatalf("threads = %#v", review.Threads)
 	}
-	if len(review.Reviews) != 1 || review.Reviews[0].Author != "alice" || review.Reviews[0].URL != "https://github.com/o/r/pull/1#pullrequestreview-1" {
+	if len(review.Reviews) != 1 || review.Reviews[0].Author != "alice" || review.Reviews[0].URL != "https://github.com/o/r/pull/1#pullrequestreview-1" || review.Reviews[0].Body != "please address the failing test" {
 		t.Fatalf("reviews = %#v", review.Reviews)
 	}
 	if len(review.Threads[0].Comments) != 1 || review.Threads[0].Comments[0].URL != "https://github.com/o/r/pull/1#discussion_r1" {

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -1136,6 +1136,7 @@ func domainFromObservation(sessionID domain.SessionID, obs ports.SCMObservation,
 			Author:      review.Author,
 			State:       domain.ReviewDecision(firstNonEmpty(review.State, string(domain.ReviewNone))),
 			URL:         review.URL,
+			Body:        review.Body,
 			IsBot:       review.IsBot,
 			SubmittedAt: firstTime(review.SubmittedAt, now),
 		})

--- a/backend/internal/ports/scm_observations.go
+++ b/backend/internal/ports/scm_observations.go
@@ -204,6 +204,9 @@ type SCMReviewSummaryObservation struct {
 	State string
 	// URL is a provider link to the submitted review summary.
 	URL string
+	// Body is the reviewer's submitted summary text, empty when the provider
+	// review carried no body.
+	Body string
 	// IsBot is true when the provider identifies the reviewer as a bot.
 	IsBot bool
 	// SubmittedAt is the provider's review submission timestamp.

--- a/backend/internal/service/session/claim_pr.go
+++ b/backend/internal/service/session/claim_pr.go
@@ -243,6 +243,7 @@ func claimRowsFromSCM(sessionID domain.SessionID, obs ports.SCMObservation, now 
 			Author:      review.Author,
 			State:       domain.ReviewDecision(firstNonEmpty(review.State, string(domain.ReviewNone))),
 			URL:         review.URL,
+			Body:        review.Body,
 			IsBot:       review.IsBot,
 			SubmittedAt: submittedAt,
 		})


### PR DESCRIPTION
## Summary

Step 2 of the reviews-tab revamp (#2433): actually populate the `pr_reviews.body` column added in #3009 by fetching the review summary text from GitHub.

- `ports.SCMReviewSummaryObservation` gains `Body`.
- The GitHub review-summary GraphQL node now requests `body`, mapped in `scmReviewSummaryFromGraphQL`.
- `Body` flows through `domainFromObservation` (the observer refresh path) and `claimRowsFromSCM` (the session claim path), so both persistence entry points carry it into the domain review rows written by the store.

Bounds are unchanged: still only the decisive submitted reviews (`APPROVED` / `CHANGES_REQUESTED`), capped by `githubReviewSummaryLimit` (20).

## Stacked on #3009

> ⚠️ Based on `feat/persist-pr-review-body` (#3009), not `main` — it needs the `domain.PullRequestReview.Body` field and the store column from that PR. Merge #3009 first, then this retargets to `main` cleanly. Review just the top commit here.

Exposing the body through the session PR API / DTO / openapi is the next PR.

## Tests

- `cd backend && go build ./... && go vet ./internal/adapters/scm/github/ ./internal/observe/scm/ ./internal/service/session/ ./internal/ports/` clean
- `go test ./internal/adapters/scm/github/ ./internal/observe/scm/ ./internal/service/session/ -count=1` — provider test now asserts the query requests `body` and maps it through `FetchReviewThreads`
- gofmt clean
