### PR TITLE
feat(api): expose provider PR review summaries on the session PR API

### DIFF
--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2148,31 +2148,6 @@ components:
       - sessionId
       - reason
       type: object
-    ControllersSessionPRReviewEntry:
-      properties:
-        body:
-          type: string
-        isBot:
-          type: boolean
-        reviewUrl:
-          type: string
-        reviewerId:
-          type: string
-        submittedAt:
-          format: date-time
-          type: string
-        verdict:
-          enum:
-          - none
-          - approved
-          - changes_requested
-          - review_required
-          type: string
-      required:
-      - reviewerId
-      - verdict
-      - submittedAt
-      type: object
     ControllersSessionView:
       properties:
         activity:
@@ -3142,6 +3117,31 @@ components:
         url:
           type: string
       type: object
+    SessionPRReviewEntry:
+      properties:
+        body:
+          type: string
+        isBot:
+          type: boolean
+        reviewUrl:
+          type: string
+        reviewerId:
+          type: string
+        submittedAt:
+          format: date-time
+          type: string
+        verdict:
+          enum:
+          - none
+          - approved
+          - changes_requested
+          - review_required
+          type: string
+      required:
+      - reviewerId
+      - verdict
+      - submittedAt
+      type: object
     SessionPRReviewSummary:
       properties:
         decision:
@@ -3155,7 +3155,7 @@ components:
           type: boolean
         reviews:
           items:
-            $ref: '#/components/schemas/ControllersSessionPRReviewEntry'
+            $ref: '#/components/schemas/SessionPRReviewEntry'
           type: array
         unresolvedBy:
           items:

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2148,6 +2148,31 @@ components:
       - sessionId
       - reason
       type: object
+    ControllersSessionPRReviewEntry:
+      properties:
+        body:
+          type: string
+        isBot:
+          type: boolean
+        reviewUrl:
+          type: string
+        reviewerId:
+          type: string
+        submittedAt:
+          format: date-time
+          type: string
+        verdict:
+          enum:
+          - none
+          - approved
+          - changes_requested
+          - review_required
+          type: string
+      required:
+      - reviewerId
+      - verdict
+      - submittedAt
+      type: object
     ControllersSessionView:
       properties:
         activity:
@@ -3128,6 +3153,10 @@ components:
           type: string
         hasUnresolvedHumanComments:
           type: boolean
+        reviews:
+          items:
+            $ref: '#/components/schemas/ControllersSessionPRReviewEntry'
+          type: array
         unresolvedBy:
           items:
             $ref: '#/components/schemas/SessionPRUnresolvedReviewer'

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -173,6 +173,7 @@ var schemaNames = map[string]string{
 	"ControllersSessionPRCISummary":               "SessionPRCISummary",
 	"ControllersSessionPRFailingCheck":            "SessionPRFailingCheck",
 	"ControllersSessionPRReviewSummary":           "SessionPRReviewSummary",
+	"ControllersSessionPRReviewEntry":             "SessionPRReviewEntry",
 	"ControllersSessionPRUnresolvedReviewer":      "SessionPRUnresolvedReviewer",
 	"ControllersSessionPRReviewCommentLink":       "SessionPRReviewCommentLink",
 	"ControllersSessionPRMergeabilitySummary":     "SessionPRMergeabilitySummary",

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -352,6 +352,18 @@ type SessionPRReviewSummary struct {
 	Decision                   domain.ReviewDecision         `json:"decision" enum:"none,approved,changes_requested,review_required"`
 	HasUnresolvedHumanComments bool                          `json:"hasUnresolvedHumanComments"`
 	UnresolvedBy               []SessionPRUnresolvedReviewer `json:"unresolvedBy"`
+	Reviews                    []SessionPRReviewEntry        `json:"reviews,omitempty"`
+}
+
+// SessionPRReviewEntry is one submitted provider review summary: a reviewer's
+// decisive verdict and the summary body they submitted with it.
+type SessionPRReviewEntry struct {
+	ReviewerID  string                `json:"reviewerId"`
+	Verdict     domain.ReviewDecision `json:"verdict" enum:"none,approved,changes_requested,review_required"`
+	Body        string                `json:"body,omitempty"`
+	ReviewURL   string                `json:"reviewUrl,omitempty"`
+	SubmittedAt time.Time             `json:"submittedAt"`
+	IsBot       bool                  `json:"isBot,omitempty"`
 }
 
 // SessionPRUnresolvedReviewer groups unresolved human comments by reviewer.
@@ -434,7 +446,18 @@ func newSessionPRReviewSummary(in sessionsvc.PRReviewSummary) SessionPRReviewSum
 		}
 		reviewers = append(reviewers, SessionPRUnresolvedReviewer{ReviewerID: reviewer.ReviewerID, Count: reviewer.Count, Links: links, ReviewURL: reviewer.ReviewURL, IsBot: reviewer.IsBot})
 	}
-	return SessionPRReviewSummary{Decision: in.Decision, HasUnresolvedHumanComments: in.HasUnresolvedHumanComments, UnresolvedBy: reviewers}
+	entries := make([]SessionPRReviewEntry, 0, len(in.Reviews))
+	for _, review := range in.Reviews {
+		entries = append(entries, SessionPRReviewEntry{
+			ReviewerID:  review.Reviewer,
+			Verdict:     review.Verdict,
+			Body:        review.Body,
+			ReviewURL:   review.URL,
+			SubmittedAt: review.SubmittedAt,
+			IsBot:       review.IsBot,
+		})
+	}
+	return SessionPRReviewSummary{Decision: in.Decision, HasUnresolvedHumanComments: in.HasUnresolvedHumanComments, UnresolvedBy: reviewers, Reviews: entries}
 }
 
 func newSessionPRMergeabilitySummary(in sessionsvc.PRMergeabilitySummary) SessionPRMergeabilitySummary {

--- a/backend/internal/httpd/controllers/dto_test.go
+++ b/backend/internal/httpd/controllers/dto_test.go
@@ -1,0 +1,52 @@
+package controllers_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
+	sessionsvc "github.com/aoagents/agent-orchestrator/backend/internal/service/session"
+)
+
+func TestNewSessionPRSummaryMapsProviderReviewEntries(t *testing.T) {
+	submitted := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	in := sessionsvc.PRSummary{
+		URL: "https://github.com/o/r/pull/7",
+		Review: sessionsvc.PRReviewSummary{
+			Decision: domain.ReviewChangesRequest,
+			Reviews: []sessionsvc.PRReviewEntry{{
+				Reviewer:    "alice",
+				Verdict:     domain.ReviewApproved,
+				Body:        "looks good to me",
+				URL:         "https://github.com/o/r/pull/7#pullrequestreview-1",
+				SubmittedAt: submitted,
+				IsBot:       true,
+			}},
+		},
+	}
+
+	got := controllers.NewSessionPRSummary(in)
+	if len(got.Review.Reviews) != 1 {
+		t.Fatalf("review entries = %+v, want 1", got.Review.Reviews)
+	}
+	entry := got.Review.Reviews[0]
+	if entry.ReviewerID != "alice" {
+		t.Fatalf("reviewerId = %q, want alice", entry.ReviewerID)
+	}
+	if entry.Verdict != domain.ReviewApproved {
+		t.Fatalf("verdict = %q, want approved", entry.Verdict)
+	}
+	if entry.Body != "looks good to me" {
+		t.Fatalf("body = %q", entry.Body)
+	}
+	if entry.ReviewURL != "https://github.com/o/r/pull/7#pullrequestreview-1" {
+		t.Fatalf("reviewUrl = %q", entry.ReviewURL)
+	}
+	if !entry.SubmittedAt.Equal(submitted) {
+		t.Fatalf("submittedAt = %v, want %v", entry.SubmittedAt, submitted)
+	}
+	if !entry.IsBot {
+		t.Fatalf("isBot = false, want true")
+	}
+}

--- a/backend/internal/service/session/pr_summary.go
+++ b/backend/internal/service/session/pr_summary.go
@@ -225,7 +225,11 @@ func summarizeReview(pr domain.PullRequest, comments []domain.PullRequestComment
 		reviewURLByAuthor[reviewer] = review.URL
 		isBot[reviewer] = review.IsBot
 	}
-	for reviewer, review := range latestReviews {
+	// Reviews carries every reviewer's latest decisive verdict (approved and
+	// changes_requested alike), not just the changes-requested subset used for
+	// the unresolved-comment grouping above, so an approved review's summary
+	// body is surfaced too.
+	for reviewer, review := range latestDecisiveReviews(reviews) {
 		out.Reviews = append(out.Reviews, PRReviewEntry{
 			Reviewer:    reviewer,
 			Verdict:     reviewOrNone(review.State),
@@ -255,7 +259,9 @@ func summarizeReview(pr domain.PullRequest, comments []domain.PullRequestComment
 	return out
 }
 
-func latestChangesRequestedReviews(reviews []domain.PullRequestReview) map[string]domain.PullRequestReview {
+// latestDecisiveReviews returns each reviewer's most recent decisive review —
+// the latest one whose verdict is approved or changes_requested.
+func latestDecisiveReviews(reviews []domain.PullRequestReview) map[string]domain.PullRequestReview {
 	latestByReviewer := map[string]domain.PullRequestReview{}
 	for _, review := range reviews {
 		if review.State != domain.ReviewChangesRequest && review.State != domain.ReviewApproved {
@@ -270,8 +276,15 @@ func latestChangesRequestedReviews(reviews []domain.PullRequestReview) map[strin
 			latestByReviewer[reviewer] = review
 		}
 	}
+	return latestByReviewer
+}
+
+// latestChangesRequestedReviews narrows latestDecisiveReviews to reviewers whose
+// latest decisive verdict is changes_requested — used to attach a review link to
+// the unresolved-comment grouping.
+func latestChangesRequestedReviews(reviews []domain.PullRequestReview) map[string]domain.PullRequestReview {
 	out := map[string]domain.PullRequestReview{}
-	for reviewer, review := range latestByReviewer {
+	for reviewer, review := range latestDecisiveReviews(reviews) {
 		if review.State == domain.ReviewChangesRequest {
 			out[reviewer] = review
 		}

--- a/backend/internal/service/session/pr_summary.go
+++ b/backend/internal/service/session/pr_summary.go
@@ -55,6 +55,22 @@ type PRReviewSummary struct {
 	Decision                   domain.ReviewDecision
 	HasUnresolvedHumanComments bool
 	UnresolvedBy               []PRUnresolvedReviewer
+	// Reviews is the latest decisive submitted review per reviewer, carrying
+	// the reviewer's summary body so the UI can show a verdict with context.
+	// Inline review comment bodies are deliberately not included here; they
+	// stay folded into UnresolvedBy counts and links.
+	Reviews []PRReviewEntry
+}
+
+// PRReviewEntry is one submitted provider review summary: a reviewer's decisive
+// verdict and the body they submitted with it.
+type PRReviewEntry struct {
+	Reviewer    string
+	Verdict     domain.ReviewDecision
+	Body        string
+	URL         string
+	SubmittedAt time.Time
+	IsBot       bool
 }
 
 // PRUnresolvedReviewer groups unresolved human comments by reviewer.
@@ -200,14 +216,26 @@ func summarizeReview(pr domain.PullRequest, comments []domain.PullRequestComment
 			Line: c.Line,
 		})
 	}
+	latestReviews := latestChangesRequestedReviews(reviews)
 	reviewURLByAuthor := map[string]string{}
-	for reviewer, review := range latestChangesRequestedReviews(reviews) {
+	for reviewer, review := range latestReviews {
 		if _, ok := byReviewer[reviewer]; !ok {
 			order = append(order, reviewer)
 		}
 		reviewURLByAuthor[reviewer] = review.URL
 		isBot[reviewer] = review.IsBot
 	}
+	for reviewer, review := range latestReviews {
+		out.Reviews = append(out.Reviews, PRReviewEntry{
+			Reviewer:    reviewer,
+			Verdict:     reviewOrNone(review.State),
+			Body:        review.Body,
+			URL:         review.URL,
+			SubmittedAt: review.SubmittedAt,
+			IsBot:       review.IsBot,
+		})
+	}
+	sort.Slice(out.Reviews, func(i, j int) bool { return out.Reviews[i].Reviewer < out.Reviews[j].Reviewer })
 	sort.Strings(order)
 	for _, reviewer := range order {
 		out.UnresolvedBy = append(out.UnresolvedBy, PRUnresolvedReviewer{

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -1354,6 +1354,32 @@ func TestListPRSummariesExposesReviewSummariesButKeepsRawLogsAndCommentBodiesPri
 	}
 }
 
+func TestSummarizeReviewSurfacesApprovedAndChangesRequestedSummaries(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	reviews := []domain.PullRequestReview{
+		// alice's approved review supersedes her earlier changes_requested one.
+		{ID: "a-old", Author: "alice", State: domain.ReviewChangesRequest, Body: "old note", URL: "url-a-old", SubmittedAt: now.Add(-time.Hour)},
+		{ID: "a-new", Author: "alice", State: domain.ReviewApproved, Body: "looks good now", URL: "url-a-new", SubmittedAt: now},
+		{ID: "b", Author: "bob", State: domain.ReviewChangesRequest, Body: "please fix", URL: "url-b", SubmittedAt: now},
+	}
+
+	got := summarizeReview(domain.PullRequest{URL: "u", Review: domain.ReviewChangesRequest}, nil, reviews)
+
+	byReviewer := map[string]PRReviewEntry{}
+	for _, entry := range got.Reviews {
+		byReviewer[entry.Reviewer] = entry
+	}
+	if len(got.Reviews) != 2 {
+		t.Fatalf("review summaries = %+v, want alice + bob", got.Reviews)
+	}
+	if a := byReviewer["alice"]; a.Verdict != domain.ReviewApproved || a.Body != "looks good now" || a.URL != "url-a-new" {
+		t.Fatalf("alice entry = %+v, want latest approved with its body", a)
+	}
+	if b := byReviewer["bob"]; b.Verdict != domain.ReviewChangesRequest || b.Body != "please fix" {
+		t.Fatalf("bob entry = %+v, want changes_requested with its body", b)
+	}
+}
+
 func TestListPRSummariesSuppressesFailingChecksUnlessCIFailing(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker}

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -1272,7 +1272,7 @@ func TestListPRsOrdersActiveBeforeClosedThenUpdatedDesc(t *testing.T) {
 	}
 }
 
-func TestListPRSummariesOmitsRawLogsAndReviewBodies(t *testing.T) {
+func TestListPRSummariesExposesReviewSummariesButKeepsRawLogsAndCommentBodiesPrivate(t *testing.T) {
 	st := newFakeStore()
 	now := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", Kind: domain.KindWorker}
@@ -1303,7 +1303,7 @@ func TestListPRSummariesOmitsRawLogsAndReviewBodies(t *testing.T) {
 		{Name: "lint", Status: domain.PRCheckPassed, Conclusion: "success", URL: "https://github.com/acme/repo/actions/runs/2"},
 	}
 	stList.reviews[prURL] = []domain.PullRequestReview{
-		{ID: "review-1", Author: "reviewer-a", State: domain.ReviewChangesRequest, URL: "https://github.com/acme/repo/pull/7#pullrequestreview-1", SubmittedAt: now.Add(-30 * time.Second)},
+		{ID: "review-1", Author: "reviewer-a", State: domain.ReviewChangesRequest, URL: "https://github.com/acme/repo/pull/7#pullrequestreview-1", Body: "summary: please fix the failing unit test", SubmittedAt: now.Add(-30 * time.Second)},
 	}
 	stList.comments[prURL] = []domain.PullRequestComment{
 		{Author: "reviewer-a", File: "main.go", Line: 12, Body: "raw body must stay private", URL: "https://github.com/acme/repo/pull/7#discussion_r1"},
@@ -1335,6 +1335,22 @@ func TestListPRSummariesOmitsRawLogsAndReviewBodies(t *testing.T) {
 	}
 	if pr.Mergeability.State != domain.MergeConflicting || len(pr.Mergeability.ConflictFiles) != 0 || !containsString(pr.Mergeability.Reasons, "conflicts") {
 		t.Fatalf("mergeability = %+v", pr.Mergeability)
+	}
+	if len(pr.Review.Reviews) != 1 {
+		t.Fatalf("review summaries = %+v", pr.Review.Reviews)
+	}
+	if entry := pr.Review.Reviews[0]; entry.Reviewer != "reviewer-a" || entry.Verdict != domain.ReviewChangesRequest ||
+		entry.Body != "summary: please fix the failing unit test" ||
+		entry.URL != "https://github.com/acme/repo/pull/7#pullrequestreview-1" {
+		t.Fatalf("review summary entry = %+v", entry)
+	}
+	// The review summary body is surfaced, but inline comment bodies and CI log
+	// tails must never leak into the PR summary.
+	blob := fmt.Sprintf("%+v", got)
+	for _, secret := range []string{"raw body must stay private", "another raw body", "bot body", "panic: secret"} {
+		if strings.Contains(blob, secret) {
+			t.Fatalf("summary leaked private text %q", secret)
+		}
 	}
 }
 

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -818,6 +818,16 @@ export interface components {
             reason: string;
             sessionId: string;
         };
+        ControllersSessionPRReviewEntry: {
+            body?: string;
+            isBot?: boolean;
+            reviewUrl?: string;
+            reviewerId: string;
+            /** Format: date-time */
+            submittedAt: string;
+            /** @enum {string} */
+            verdict: "none" | "approved" | "changes_requested" | "review_required";
+        };
         ControllersSessionView: {
             activity: components["schemas"]["DomainActivity"];
             branch?: string;
@@ -1190,6 +1200,7 @@ export interface components {
             /** @enum {string} */
             decision: "none" | "approved" | "changes_requested" | "review_required";
             hasUnresolvedHumanComments: boolean;
+            reviews?: components["schemas"]["ControllersSessionPRReviewEntry"][];
             unresolvedBy: components["schemas"]["SessionPRUnresolvedReviewer"][];
         };
         SessionPRSummary: {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -818,16 +818,6 @@ export interface components {
             reason: string;
             sessionId: string;
         };
-        ControllersSessionPRReviewEntry: {
-            body?: string;
-            isBot?: boolean;
-            reviewUrl?: string;
-            reviewerId: string;
-            /** Format: date-time */
-            submittedAt: string;
-            /** @enum {string} */
-            verdict: "none" | "approved" | "changes_requested" | "review_required";
-        };
         ControllersSessionView: {
             activity: components["schemas"]["DomainActivity"];
             branch?: string;
@@ -1196,11 +1186,21 @@ export interface components {
             line?: number;
             url?: string;
         };
+        SessionPRReviewEntry: {
+            body?: string;
+            isBot?: boolean;
+            reviewUrl?: string;
+            reviewerId: string;
+            /** Format: date-time */
+            submittedAt: string;
+            /** @enum {string} */
+            verdict: "none" | "approved" | "changes_requested" | "review_required";
+        };
         SessionPRReviewSummary: {
             /** @enum {string} */
             decision: "none" | "approved" | "changes_requested" | "review_required";
             hasUnresolvedHumanComments: boolean;
-            reviews?: components["schemas"]["ControllersSessionPRReviewEntry"][];
+            reviews?: components["schemas"]["SessionPRReviewEntry"][];
             unresolvedBy: components["schemas"]["SessionPRUnresolvedReviewer"][];
         };
         SessionPRSummary: {


### PR DESCRIPTION
## Summary

Step 3 of the reviews-tab revamp (#2433): expose each reviewer's submitted review summary (verdict + body) through the session PR API, so the frontend can render a verdict with its summary text.

- `sessionsvc.PRReviewSummary` gains `Reviews []PRReviewEntry`. `summarizeReview` populates it from the latest decisive (`approved` / `changes_requested`) review per reviewer, sorted by reviewer for deterministic output.
- Controller DTO gains `SessionPRReviewEntry` (reviewerId, verdict, body, reviewUrl, submittedAt, isBot) and a `reviews` field on `SessionPRReviewSummary`.
- `openapi.yaml` + `schema.ts` regenerated.

Combines the plan's "add API shape" and "populate summarizeReview" steps, since a plumbed-but-unpopulated field isn't a reviewable unit on its own.

## Privacy

Inline review **comment** bodies stay private — they remain folded into `unresolvedBy` counts and links, never surfaced as raw text. Only the top-level review **summary** body is exposed. The renamed test `TestListPRSummariesExposesReviewSummariesButKeepsRawLogsAndCommentBodiesPrivate` asserts both: the review summary is surfaced, and comment bodies + CI log tails never leak into the summary.

## `reviews` is optional

Added with `omitempty`, so `reviews?` is optional in the generated schema. This keeps the field backward-compatible for existing clients and avoids forcing unrelated fixture churn onto this PR; the step-5 UI will consume it with a `?? []` default.

## Stacked on #3010 → #3009

> ⚠️ Based on `feat/scm-fetch-pr-review-body` (#3010), which is based on `feat/persist-pr-review-body` (#3009). Merge #3009 → #3010 → this, in order. Review only the top commit.

## Tests

- `cd backend && go build ./... && go vet ./internal/service/session/ ./internal/httpd/controllers/` clean
- `go test ./internal/service/session/ ./internal/httpd/controllers/ ./internal/httpd/apispec/...` pass
- `npm run api:spec` + `openapi-typescript` regen — schema.ts change is purely additive
- `cd frontend && npx tsc --noEmit` clean (frontend diff is generated schema.ts only)
- gofmt clean
