### PR TITLE
docs: add telemetry guide to docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Start with [architecture.md](architecture.md) for the current backend model and
 | [cli/README.md](cli/README.md)                         | CLI commands and daemon control surface.                                                                              |
 | [STATUS.md](STATUS.md)                                 | What is shipped on `main` today and what is still in flight.                                                          |
 | [stack.md](stack.md)                                   | Accepted library/runtime choices, pending stack decisions, and dependencies explicitly avoided for V1.                |
+| [telemetry.md](telemetry.md)                           | Telemetry collection, privacy safeguards, configuration, and PostHog dashboard guidance.                             |
 
 ## Mental model
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Start with [architecture.md](architecture.md) for the current backend model and
 | [cli/README.md](cli/README.md)                         | CLI commands and daemon control surface.                                                                              |
 | [STATUS.md](STATUS.md)                                 | What is shipped on `main` today and what is still in flight.                                                          |
 | [stack.md](stack.md)                                   | Accepted library/runtime choices, pending stack decisions, and dependencies explicitly avoided for V1.                |
-| [telemetry.md](telemetry.md)                           | Telemetry collection, privacy safeguards, configuration, and PostHog dashboard guidance.                             |
+| [telemetry.md](telemetry.md)                           | Telemetry collection, privacy safeguards, configuration, and PostHog dashboard guidance.                              |
 
 ## Mental model
 


### PR DESCRIPTION
## Summary

- add the existing telemetry guide to the documentation index
- make privacy safeguards and telemetry configuration easier to discover
- intentionally keep this as a small documentation example with no code or generated-file changes

## Validation

- confirmed `docs/telemetry.md` exists at the linked relative path
- `git diff --check`

## Notes

This is a small, harmless documentation-only example PR against `main`.