### PR TITLE
fix(tracker-intake): keep issue claimed while a terminated worker's PR is in flight

### DIFF
--- a/backend/internal/observe/trackerintake/observer.go
+++ b/backend/internal/observe/trackerintake/observer.go
@@ -35,6 +35,10 @@ const (
 type Store interface {
 	ListProjects(ctx context.Context) ([]domain.ProjectRecord, error)
 	ListAllSessions(ctx context.Context) ([]domain.SessionRecord, error)
+	// ListPRFactsForSession returns the PRs attributed to a session. Intake uses
+	// it to tell whether a terminated session already left a PR before freeing
+	// its issue for re-spawn (see claimIssuesWithInFlightPR).
+	ListPRFactsForSession(ctx context.Context, id domain.SessionID) ([]domain.PRFacts, error)
 }
 
 // Spawner is the session creation surface used by intake.
@@ -142,6 +146,7 @@ func (o *Observer) Poll(ctx context.Context) error {
 		return err
 	}
 	seen := seenIssueIDs(sessions)
+	o.claimIssuesWithInFlightPR(ctx, sessions, seen)
 	for _, project := range enabledProjects {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -249,6 +254,52 @@ func seenIssueIDs(sessions []domain.SessionRecord) map[domain.IssueID]bool {
 		}
 	}
 	return seen
+}
+
+// claimIssuesWithInFlightPR augments seen with issues whose only session is
+// terminated but that still left an open or merged PR. Without this, excluding
+// terminated sessions from the seen set (#2777) lets intake spawn a duplicate
+// worker — and a second PR — on top of a PR that is already open, e.g. after a
+// worker opened a PR and was then killed or crashed while its issue stayed open
+// (#2921).
+//
+// A terminated session with no PR, or only a closed and unmerged PR, does not
+// claim its issue: that is the genuinely-dead-worker case #2777 exists to
+// re-spawn, and a rejected attempt should be retried fresh.
+//
+// Only terminated sessions whose issue is not already claimed by a live session
+// are queried, so a healthy project (one live session per issue) issues no PR
+// lookups at all.
+func (o *Observer) claimIssuesWithInFlightPR(ctx context.Context, sessions []domain.SessionRecord, seen map[domain.IssueID]bool) {
+	for _, sess := range sessions {
+		if sess.IssueID == "" || !sess.IsTerminated || seen[sess.IssueID] {
+			continue
+		}
+		prs, err := o.store.ListPRFactsForSession(ctx, sess.ID)
+		if err != nil {
+			// Fail safe toward "claimed": a duplicate worker opens a real,
+			// duplicate PR, which is worse than deferring a re-spawn until a
+			// later tick reads cleanly. A genuinely dead worker's issue is not
+			// lost — only delayed while the read keeps failing.
+			o.logger.Warn("tracker intake: PR lookup for terminated session failed; treating issue as claimed to avoid a duplicate spawn", "session", sess.ID, "issue", sess.IssueID, "err", err)
+			seen[sess.IssueID] = true
+			continue
+		}
+		if anyOpenOrMerged(prs) {
+			seen[sess.IssueID] = true
+		}
+	}
+}
+
+// anyOpenOrMerged reports whether any PR is still open (not merged, not closed)
+// or was merged. A closed, unmerged PR (rejected/abandoned) does not count.
+func anyOpenOrMerged(prs []domain.PRFacts) bool {
+	for _, pr := range prs {
+		if pr.Merged || !pr.Closed {
+			return true
+		}
+	}
+	return false
 }
 
 // CanonicalIssueID stores tracker issue ids in sessions.issue_id with the

--- a/backend/internal/observe/trackerintake/observer_test.go
+++ b/backend/internal/observe/trackerintake/observer_test.go
@@ -340,6 +340,11 @@ type fakeStore struct {
 	projects    []domain.ProjectRecord
 	sessions    []domain.SessionRecord
 	sessionsErr error
+	// prsBySession is the PR facts each session owns. Empty/absent means the
+	// session never produced a PR.
+	prsBySession map[domain.SessionID][]domain.PRFacts
+	// prsErr, when set for a session id, makes ListPRFactsForSession fail for it.
+	prsErr map[domain.SessionID]error
 }
 
 func (f *fakeStore) ListProjects(context.Context) ([]domain.ProjectRecord, error) {
@@ -348,6 +353,13 @@ func (f *fakeStore) ListProjects(context.Context) ([]domain.ProjectRecord, error
 
 func (f *fakeStore) ListAllSessions(context.Context) ([]domain.SessionRecord, error) {
 	return append([]domain.SessionRecord(nil), f.sessions...), f.sessionsErr
+}
+
+func (f *fakeStore) ListPRFactsForSession(_ context.Context, id domain.SessionID) ([]domain.PRFacts, error) {
+	if err := f.prsErr[id]; err != nil {
+		return nil, err
+	}
+	return append([]domain.PRFacts(nil), f.prsBySession[id]...), nil
 }
 
 type fakeTracker struct {

--- a/backend/internal/observe/trackerintake/respawn_pr_claim_test.go
+++ b/backend/internal/observe/trackerintake/respawn_pr_claim_test.go
@@ -1,0 +1,129 @@
+package trackerintake
+
+// Regression tests for #2921: after #2777 excluded terminated sessions from the
+// seen set, intake would spawn a duplicate worker (and a duplicate PR) for an
+// open issue whose worker was terminated after opening a PR. A terminated
+// session that left an open or merged PR now keeps its issue claimed, while a
+// terminated session that produced no PR (or only a closed, unmerged one) still
+// frees its issue for re-spawn (#2746).
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func intakeProject() domain.ProjectRecord {
+	return domain.ProjectRecord{
+		ID:            "demo",
+		RepoOriginURL: "https://github.com/acme/demo.git",
+		Config:        domain.ProjectConfig{TrackerIntake: domain.TrackerIntakeConfig{Enabled: true, Assignee: "alice"}},
+	}
+}
+
+func openIssue12() *fakeTracker {
+	return &fakeTracker{issues: []domain.Issue{{
+		ID:        domain.TrackerID{Provider: domain.TrackerProviderGitHub, Native: "acme/demo#12"},
+		Title:     "Implement feature X",
+		State:     domain.IssueOpen,
+		Assignees: []string{"alice"},
+	}}}
+}
+
+// terminatedSessionForIssue12 stands in for a worker that opened its PR and was
+// then killed or crashed: the session row (and its PR rows) persist with
+// IsTerminated=true.
+func terminatedSessionForIssue12() domain.SessionRecord {
+	return domain.SessionRecord{ID: "demo-1", ProjectID: "demo", IssueID: "github:acme/demo#12", IsTerminated: true}
+}
+
+func TestPollDoesNotRespawnIssueWithOpenPRFromTerminatedSession(t *testing.T) {
+	store := &fakeStore{
+		projects: []domain.ProjectRecord{intakeProject()},
+		sessions: []domain.SessionRecord{terminatedSessionForIssue12()},
+		prsBySession: map[domain.SessionID][]domain.PRFacts{
+			"demo-1": {{Number: 100, Merged: false, Closed: false}}, // PR #100 still open
+		},
+	}
+	spawner := &fakeSpawner{}
+
+	if err := New(singleResolver(openIssue12()), store, spawner, Config{Logger: discardLogger()}).Poll(context.Background()); err != nil {
+		t.Fatalf("Poll() error = %v", err)
+	}
+	if len(spawner.calls) != 0 {
+		t.Fatalf("spawn calls = %+v, want 0: an open PR from the terminated worker must not be duplicated (#2921)", spawner.calls)
+	}
+}
+
+func TestPollDoesNotRespawnIssueWithMergedPRFromTerminatedSession(t *testing.T) {
+	store := &fakeStore{
+		projects: []domain.ProjectRecord{intakeProject()},
+		sessions: []domain.SessionRecord{terminatedSessionForIssue12()},
+		prsBySession: map[domain.SessionID][]domain.PRFacts{
+			"demo-1": {{Number: 100, Merged: true, Closed: true}}, // merged (GitHub marks a merged PR closed)
+		},
+	}
+	spawner := &fakeSpawner{}
+
+	if err := New(singleResolver(openIssue12()), store, spawner, Config{Logger: discardLogger()}).Poll(context.Background()); err != nil {
+		t.Fatalf("Poll() error = %v", err)
+	}
+	if len(spawner.calls) != 0 {
+		t.Fatalf("spawn calls = %+v, want 0: a merged PR means the work was done; do not redo it", spawner.calls)
+	}
+}
+
+func TestPollRespawnsIssueWhenTerminatedSessionPRClosedUnmerged(t *testing.T) {
+	store := &fakeStore{
+		projects: []domain.ProjectRecord{intakeProject()},
+		sessions: []domain.SessionRecord{terminatedSessionForIssue12()},
+		prsBySession: map[domain.SessionID][]domain.PRFacts{
+			"demo-1": {{Number: 100, Merged: false, Closed: true}}, // rejected / abandoned
+		},
+	}
+	spawner := &fakeSpawner{}
+
+	if err := New(singleResolver(openIssue12()), store, spawner, Config{Logger: discardLogger()}).Poll(context.Background()); err != nil {
+		t.Fatalf("Poll() error = %v", err)
+	}
+	if len(spawner.calls) != 1 || spawner.calls[0].IssueID != "github:acme/demo#12" {
+		t.Fatalf("spawn calls = %+v, want one respawn: a closed, unmerged PR should be retried fresh", spawner.calls)
+	}
+}
+
+func TestPollTreatsIssueClaimedWhenPRLookupFails(t *testing.T) {
+	store := &fakeStore{
+		projects: []domain.ProjectRecord{intakeProject()},
+		sessions: []domain.SessionRecord{terminatedSessionForIssue12()},
+		prsErr:   map[domain.SessionID]error{"demo-1": errors.New("db unavailable")},
+	}
+	spawner := &fakeSpawner{}
+
+	if err := New(singleResolver(openIssue12()), store, spawner, Config{Logger: discardLogger()}).Poll(context.Background()); err != nil {
+		t.Fatalf("Poll() error = %v", err)
+	}
+	if len(spawner.calls) != 0 {
+		t.Fatalf("spawn calls = %+v, want 0: a PR-lookup failure must fail safe and not spawn a possible duplicate", spawner.calls)
+	}
+}
+
+// A live session claims its issue outright and its PRs are never queried — a
+// healthy project (one live worker per issue) triggers no PR lookups.
+func TestPollLiveSessionClaimsWithoutPRLookup(t *testing.T) {
+	store := &fakeStore{
+		projects: []domain.ProjectRecord{intakeProject()},
+		sessions: []domain.SessionRecord{{ID: "demo-1", ProjectID: "demo", IssueID: "github:acme/demo#12"}},
+		// prsErr would blow up if the live session were queried; it must not be.
+		prsErr: map[domain.SessionID]error{"demo-1": errors.New("PRs must not be queried for a live session")},
+	}
+	spawner := &fakeSpawner{}
+
+	if err := New(singleResolver(openIssue12()), store, spawner, Config{Logger: discardLogger()}).Poll(context.Background()); err != nil {
+		t.Fatalf("Poll() error = %v", err)
+	}
+	if len(spawner.calls) != 0 {
+		t.Fatalf("spawn calls = %+v, want 0: a live session already claims the issue", spawner.calls)
+	}
+}


### PR DESCRIPTION
## Problem

#2777 fixed #2746 by excluding terminated sessions from intake's `seen` set, so a genuinely dead worker no longer blocks re-spawn. But that opened a new window (#2921):

- Intake dedups **only on live sessions** (`seenIssueIDs`) and has **no PR awareness** — its `Store` interface never exposed PR facts.
- `Manager.Spawn` has **no issue-level dedup**.
- A `Fixes #N` PR closes issue `#N` only on **merge**, not on open.

So when a worker opens a PR and is then **killed or crashes** while its issue is still open (PR unmerged), the terminated session drops out of `seen`, and the next 1-minute tick spawns a **duplicate worker — and a second PR — for the same issue**. The simplest trigger needs no crash: an operator killing a worker that already opened a PR.

## Fix

Intake now also treats an issue as **claimed** when a terminated session for it left an **open or merged** PR, using the existing per-session PR store (`ListPRFactsForSession`). A terminated session keeps its `pr` rows because kill/terminate only sets `is_terminated=1` — it does not delete the `sessions` row (that persistence is the same basis as #2746), and `pr.session_id` cascades only on row delete.

```go
seen := seenIssueIDs(sessions)               // live sessions claim outright
o.claimIssuesWithInFlightPR(ctx, sessions, seen) // + terminated sessions with an open/merged PR
```

Behavior:
- **Open or merged PR** on the terminated session → issue stays claimed, no duplicate spawn.
- **No PR**, or **only a closed-unmerged (rejected) PR** → issue is freed for re-spawn, preserving #2746 and allowing a fresh retry.
- **PR-lookup error** → fails safe toward *claimed*, so a transient read cannot cause a duplicate PR.
- Only terminated sessions whose issue is **not already claimed by a live session** are queried, so a healthy project (one live worker per issue) issues **no PR lookups**.

No schema/query/codegen change — reuses `ListPRFactsForSession` and adds one method to intake's local `Store` interface (satisfied by the production `*sqlite.Store`).

## Tests

Added to the `trackerintake` package:
- `TestPollDoesNotRespawnIssueWithOpenPRFromTerminatedSession` — the #2921 case.
- `TestPollDoesNotRespawnIssueWithMergedPRFromTerminatedSession` — merged work isn't redone.
- `TestPollRespawnsIssueWhenTerminatedSessionPRClosedUnmerged` — rejected attempt retried.
- `TestPollTreatsIssueClaimedWhenPRLookupFails` — fail-safe.
- `TestPollLiveSessionClaimsWithoutPRLookup` — live session claims with no PR query.

All existing tests (including #2777's) pass unchanged; full package + `go build ./...` + `go vet` clean.

## Scope

Only touches `trackerintake`'s dedup logic and its tests. Does not change the SQL layer, session lifecycle, or `Spawn`. Distinct from #2745 (reaper cannot terminate stuck sessions).

Fixes #2921

🤖 Generated with [Claude Code](https://claude.com/claude-code)