### PR TITLE
Fix/daemon failure toast

### DIFF
--- a/frontend/src/renderer/components/DaemonFailureBanner.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.tsx
@@ -40,44 +40,44 @@ function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 	return (
 		<section
 			aria-live="assertive"
-			className="flex shrink-0 items-start gap-3 border-b border-error/30 bg-error/10 px-4.5 py-2.5 text-xs"
+			className="pointer-events-auto fixed top-3 right-3 z-overlay flex w-[min(22rem,calc(100vw-1.5rem))] flex-col rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-modal)] px-3.5 py-3 text-xs shadow-[var(--shadow-import-modal)]"
 			role="alert"
 		>
-			<AlertTriangle className="mt-0.5 size-icon-base shrink-0 text-error" aria-hidden="true" />
-			<div className="min-w-0 flex-1">
-				<p className="font-medium text-foreground">{title}</p>
-				<p className="mt-0.5 break-words text-muted-foreground">{daemonFailureMessage(status)}</p>
-				{hint ? <p className="mt-1 text-muted-foreground">{hint}</p> : null}
-				{details ? (
-					<div className="mt-2">
-						<div className="flex items-center gap-3">
+			<div className="flex items-start gap-3">
+				<AlertTriangle className="mt-0.5 size-icon-base shrink-0 text-error" aria-hidden="true" />
+				<div className="min-w-0 flex-1">
+					<p className="font-medium text-(--color-text-import-title)">{title}</p>
+					<p className="mt-0.5 wrap-break-word text-[var(--color-text-import-muted)]">{daemonFailureMessage(status)}</p>
+					{hint ? <p className="mt-1 text-[var(--color-text-import-muted)]">{hint}</p> : null}
+					{details ? (
+						<div className="mt-2 flex items-center gap-3">
 							<button
 								type="button"
-								className="text-xs text-foreground underline-offset-2 hover:underline"
+								className="text-xs text-[var(--color-text-import-title)] underline-offset-2 hover:underline"
 								onClick={() => setDetailsOpen((open) => !open)}
 							>
 								{detailsOpen ? "Hide details" : "Show details"}
 							</button>
 							<button
 								type="button"
-								className="text-xs text-foreground underline-offset-2 hover:underline"
+								className="text-xs text-[var(--color-text-import-title)] underline-offset-2 hover:underline"
 								onClick={() => void copyDetails()}
 							>
 								{copied ? "Copied" : "Copy details"}
 							</button>
 						</div>
-						{detailsOpen ? (
-							<pre className="mt-2 max-h-40 overflow-auto rounded border border-border bg-background/60 p-2 font-mono text-[11px] leading-relaxed text-muted-foreground">
-								{details}
-							</pre>
-						) : null}
-					</div>
+					) : null}
+				</div>
+				{status.code ? (
+					<code className="shrink-0 rounded-md bg-(--color-bg-import-chip) px-1.5 py-0.5 font-mono text-micro text-[var(--color-text-import-muted)]">
+						{status.code}
+					</code>
 				) : null}
 			</div>
-			{status.code ? (
-				<code className="shrink-0 rounded bg-background/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-					{status.code}
-				</code>
+			{details && detailsOpen ? (
+				<pre className="mt-2 max-h-40 w-full overflow-auto rounded-md border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] px-1.5 py-1 font-mono text-caption leading-relaxed text-[var(--color-text-import-muted)]">
+					{details}
+				</pre>
 			) : null}
 		</section>
 	);

--- a/frontend/src/renderer/components/DaemonFailureBanner.tsx
+++ b/frontend/src/renderer/components/DaemonFailureBanner.tsx
@@ -40,7 +40,7 @@ function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 	return (
 		<section
 			aria-live="assertive"
-			className="pointer-events-auto fixed top-3 right-3 z-overlay flex w-[min(22rem,calc(100vw-1.5rem))] flex-col rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-modal)] px-3.5 py-3 text-xs shadow-[var(--shadow-import-modal)]"
+			className="pointer-events-auto fixed top-3 right-3 z-overlay flex w-daemon-failure-toast flex-col rounded-welcome-panel border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-modal)] px-3.5 py-3 text-xs shadow-[var(--shadow-import-modal)]"
 			role="alert"
 		>
 			<div className="flex items-start gap-3">
@@ -75,7 +75,7 @@ function DaemonFailureContent({ status }: { status: DaemonStatus }) {
 				) : null}
 			</div>
 			{details && detailsOpen ? (
-				<pre className="mt-2 max-h-40 w-full overflow-auto rounded-md border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] px-1.5 py-1 font-mono text-caption leading-relaxed text-[var(--color-text-import-muted)]">
+				<pre className="mt-2 max-h-daemon-failure-details-max w-full overflow-auto rounded-md border border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-card)] px-1.5 py-1 font-mono text-caption leading-relaxed text-[var(--color-text-import-muted)]">
 					{details}
 				</pre>
 			) : null}

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -468,7 +468,6 @@ function ShellLayout() {
 						workspaces={workspaces}
 					/>
 					<main className="flex min-w-0 flex-1 flex-col overflow-x-hidden">
-						<DaemonFailureBanner status={daemonStatus} />
 						<div className="min-h-0 flex-1 overflow-x-hidden">
 							{/* Board/session routes render inside the same inset box the welcome board and settings paint for themselves, so every screen sits within the app's outer boundary. */}
 							{hideShellTopbar ? (
@@ -494,6 +493,7 @@ function ShellLayout() {
 							)}
 						</div>
 					</main>
+					<DaemonFailureBanner status={daemonStatus} />
 					{/* When ShellTopbar is hidden, keep a macOS window-drag strip over
               the traffic-light band only (same --size-traffic-light-clearance
               as the Sidebar header pad). TitlebarNav sits in the sidebar below

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -185,6 +185,7 @@
 	--spacing-notification-max-height: var(--size-notification-max-height);
 	--spacing-select-menu-max: var(--size-select-menu-max);
 	--spacing-notification-icon: var(--size-notification-icon);
+	--spacing-daemon-failure-details-max: var(--size-daemon-failure-details-max);
 	--spacing-font-size-label: var(--size-font-size-label);
 	--spacing-pr-table-actions: var(--size-pr-table-actions);
 	--spacing-pr-col-number: var(--size-pr-col-number);
@@ -237,6 +238,10 @@
 	background-color: var(--color-scrim);
 	-webkit-backdrop-filter: blur(var(--blur-overlay));
 	backdrop-filter: blur(var(--blur-overlay));
+}
+
+@utility w-daemon-failure-toast {
+	width: min(var(--size-daemon-failure-toast), calc(100vw - var(--space-6)));
 }
 
 @utility w-dialog-md {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -215,6 +215,9 @@
 	--size-notification-max-height: 420px;
 	--size-select-menu-max: 320px; /* agent/select dropdown scroll cap (was max-h-80) */
 	--size-notification-icon: 26px;
+	/* DaemonFailureBanner floating toast (was w-[min(22rem,…)] / max-h-40). */
+	--size-daemon-failure-toast: 22rem;
+	--size-daemon-failure-details-max: 10rem;
 	--size-font-size-label: 44px;
 	--size-inspector-status-chip-max: 58%;
 	--size-board-empty: 460px;


### PR DESCRIPTION
## Summary
- Relocate `DaemonFailureBanner` out of `<main>` so it overlays the shell instead of consuming layout height.
- Restyle it as a fixed top-right panel using import-modal surface/border/text tokens (rounded panel + shadow).
- Keep show/copy details behavior; details expand below the toast body.

## Test plan
- [ ] Force a daemon failure (e.g. bad daemon binary / exit) and confirm the toast appears top-right without shifting the board/import layout.
- [ ] Confirm title, message, status code chip, Show/Hide details, and Copy details still work.
- [ ] Confirm the toast stays visible over sidebar + main content and doesn’t block critical chrome unduly.
- [ ] Spot-check light/dark if import-modal tokens differ by theme.

## Before
<img width="1424" height="338" alt="image" src="https://github.com/user-attachments/assets/33bf1e7d-f9e3-44b6-a8ec-8e7260ef4ee7" />

## After
<img width="1414" height="368" alt="image" src="https://github.com/user-attachments/assets/ddf112b2-2085-4c05-9445-be0075e55671" />
<img width="1418" height="286" alt="image" src="https://github.com/user-attachments/assets/95bef33f-7b5f-4971-b126-5aee64ba6319" />
