### PR TITLE
fix: center project illustration in import mode picker

### DIFF
--- a/frontend/src/renderer/components/CreateProjectFlow.tsx
+++ b/frontend/src/renderer/components/CreateProjectFlow.tsx
@@ -359,10 +359,13 @@ function ProjectModeButton({
 		>
 			<span className="flex w-full flex-col items-start">
 				<span
-					className={cn("flex w-full justify-center", isWorkspace ? "h-[178px] items-start" : "h-[120px] items-center")}
+					className={cn(
+						"flex h-(--size-import-mode-illustration) w-full justify-center",
+						isWorkspace ? "items-start" : "items-center",
+					)}
 				>
 					{isWorkspace ? (
-						<span className="flex h-[178px] w-full max-w-[240px] flex-col items-start gap-3 rounded-lg border border-dashed border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-illustration)] p-4">
+						<span className="flex h-(--size-import-mode-illustration) w-full max-w-[240px] flex-col items-start gap-3 rounded-lg border border-dashed border-[var(--color-border-import-modal)] bg-[var(--color-bg-import-illustration)] p-4">
 							<span className="flex items-center gap-2 text-[14px] leading-5 text-[var(--color-text-import-muted)]">
 								<Folder className="size-[14px] shrink-0" aria-hidden="true" />
 								my-workspace/

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -258,6 +258,7 @@
 	--size-import-folder-dialog: 640px;
 	--size-import-mode-card-min: 252px;
 	--size-import-mode-card-min-sm: 292px;
+	--size-import-mode-illustration: 178px;
 
 	/* Settings page (Figma) */
 	--color-bg-settings-row: #18181c;


### PR DESCRIPTION
## Summary
- Center the `web-app · main` chip in the Project import card by giving both cards the same illustration height
- Replace hardcoded `178px` with `--size-import-mode-illustration` in `tokens.css`

## Test plan
- [ ] Open New Project / Import modal
- [ ] Confirm Workspace and Project cards share the same illustration area height
- [ ] Confirm the Project chip is centered horizontally and vertically above the title
- [ ] Confirm Workspace dashed illustration layout is unchanged

## Before
<img width="1114" height="614" alt="image" src="https://github.com/user-attachments/assets/7e60ee2f-42d3-44ec-bcdc-e73869d88087" />

## After
<img width="1248" height="698" alt="image" src="https://github.com/user-attachments/assets/90659e3d-adcf-4e0f-ba94-6b287b3d1e8c" />
