### PR TITLE
feat(agentbase): add shared model-forwarding helpers

### DIFF
--- a/backend/internal/adapters/agent/agentbase/agentbase.go
+++ b/backend/internal/adapters/agent/agentbase/agentbase.go
@@ -7,6 +7,7 @@ package agentbase
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -50,6 +51,24 @@ func (Base) SessionInfo(ctx context.Context, _ ports.SessionRef) (ports.SessionI
 		return ports.SessionInfo{}, false, err
 	}
 	return ports.SessionInfo{}, false, nil
+}
+
+// AppendModelFlag appends `--model <model>` to cmd when the configured model is
+// non-blank, trimming surrounding whitespace; it is a no-op otherwise.
+func AppendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
+	}
+}
+
+// ModelConfigField returns the standard user-facing `model` config field, using
+// description to name the concrete CLI flag it maps to.
+func ModelConfigField(description string) ports.ConfigField {
+	return ports.ConfigField{
+		Key:         "model",
+		Type:        ports.ConfigFieldString,
+		Description: description,
+	}
 }
 
 // StandardSessionInfo returns the normalized session metadata (native session

--- a/backend/internal/adapters/agent/agentbase/agentbase_test.go
+++ b/backend/internal/adapters/agent/agentbase/agentbase_test.go
@@ -1,0 +1,43 @@
+package agentbase
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestAppendModelFlagAppendsTrimmedModel(t *testing.T) {
+	cmd := []string{"agent", "--force"}
+	AppendModelFlag(&cmd, ports.AgentConfig{Model: "  gpt-5  "})
+
+	want := []string{"agent", "--force", "--model", "gpt-5"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestAppendModelFlagNoOpForBlankModel(t *testing.T) {
+	for _, model := range []string{"", " \t "} {
+		cmd := []string{"agent"}
+		AppendModelFlag(&cmd, ports.AgentConfig{Model: model})
+
+		want := []string{"agent"}
+		if !reflect.DeepEqual(cmd, want) {
+			t.Fatalf("model %q: cmd\nwant: %#v\n got: %#v", model, want, cmd)
+		}
+	}
+}
+
+func TestModelConfigField(t *testing.T) {
+	got := ModelConfigField("Model override passed to `x --model`.")
+
+	want := ports.ConfigField{
+		Key:         "model",
+		Type:        ports.ConfigFieldString,
+		Description: "Model override passed to `x --model`.",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("field\nwant: %#v\n got: %#v", want, got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds two reusable helpers to `agentbase` so adapters whose CLI accepts a launch-time `--model` override can forward the resolved `ports.AgentConfig.Model` through one tested implementation, instead of each adapter re-implementing the same trim-and-append plus a hand-written config-field literal:

- `AppendModelFlag(cmd, cfg)` — appends `--model <trimmed>` when the configured model is non-blank; no-op otherwise.
- `ModelConfigField(description)` — the standard user-facing `model` config field.

## Context

AO stores a per-role model in `agentConfig.model`; `session_manager.effectiveAgentConfig` resolves it and forwards it to every adapter as `cfg.Config.Model`, but each adapter must opt in to passing it to its CLI. A family of ~15 adapters currently drops it. This is the shared base those adapter fixes build on.

The opt-in stays per-adapter by design: `agentbase` never forces the field on embedders, so adapters whose CLI spells the override differently (a config-file key, a `-m`-only alias) are unaffected. Adapters just call the helpers where they apply.

## Tests

New `agentbase_test.go` covers `AppendModelFlag` (trimmed append / blank no-op) and `ModelConfigField`.

```
cd backend && go test ./internal/adapters/agent/agentbase
```

`go build ./...`, `go vet`, and `gofmt` are clean.

## Follow-ups

The per-adapter fixes rebase onto this base as independent, single-adapter PRs (Cursor #2926, Devin #2927).