### PR TITLE
fix(workspace): prune stale registered worktrees on reuse

### DIFF
--- a/backend/internal/adapters/workspace/gitworktree/workspace.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace.go
@@ -647,6 +647,19 @@ func (w *Workspace) existingWorktree(ctx context.Context, repo, path string, cfg
 		return ports.WorkspaceInfo{}, false, err
 	}
 	if rec, ok := findWorktree(records, path); ok {
+		// Git can still list a worktree after the directory was deleted (stale
+		// registration). Reusing that path leaves tmux new-session -c falling
+		// back to the server cwd and agents stranded in the wrong directory.
+		nonEmpty, existsErr := pathExistsNonEmpty(path)
+		if existsErr != nil {
+			return ports.WorkspaceInfo{}, false, existsErr
+		}
+		if !nonEmpty {
+			if pruneErr := w.pruneWorktrees(ctx, repo); pruneErr != nil {
+				return ports.WorkspaceInfo{}, false, fmt.Errorf("gitworktree: prune stale worktree %q: %w", path, pruneErr)
+			}
+			return ports.WorkspaceInfo{}, false, nil
+		}
 		branch := rec.Branch
 		if branch == "" {
 			branch = cfg.Branch

--- a/backend/internal/adapters/workspace/gitworktree/workspace_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/workspace_test.go
@@ -182,6 +182,14 @@ func TestCreateReusesRegisteredWorktreeAtExpectedPath(t *testing.T) {
 		t.Fatalf("new: %v", err)
 	}
 	path := filepath.Join(ws.managedRoot, "proj", "orchestrator", "proj-orchestrator")
+	// Directory must exist on disk: registered-but-missing paths are treated as
+	// stale and pruned (would otherwise strand tmux panes in the server cwd).
+	if err := os.MkdirAll(path, 0o750); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(path, ".keep"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed worktree: %v", err)
+	}
 	cfg := ports.WorkspaceConfig{
 		ProjectID:     "proj",
 		SessionID:     "proj-1",


### PR DESCRIPTION
## Problem
Git can still list a worktree after its directory was deleted (stale registration). `existingWorktree` treated that path as reusable, so Create returned a missing path. Downstream `tmux new-session -c` then fell back to the tmux server cwd and stranded agents in the wrong directory.

## Solution
In `existingWorktree`, if a registered path is missing or empty:
1. prune worktrees for the repo
2. treat the registration as absent (`ok=false`) so Create re-adds a real worktree

## Tests
- `go test ./internal/adapters/workspace/gitworktree/ -count=1`
- `TestCreateReusesRegisteredWorktreeAtExpectedPath` now seeds the directory on disk (registered-but-missing paths are no longer reused).

## Notes
- Backend-only product fix extracted from local desktop WIP (`local/zh-ui-sync`). **Independent of any Chinese UI branch** — no i18n or frontend changes.
- Does not include the staged migration renumber (0025 → 0029); that is owned by #3014.
- CI may stay red on main if migrate panics on the duplicate 0025 until #3014 merges; this PR does not depend on that renumber.

## Independence
Can merge independently of the tmux stable-cwd and httpd forced-shutdown fixes.