### PR TITLE
fix(httpd): treat forced shutdown as a successful stop

### DIFF
--- a/backend/internal/httpd/server.go
+++ b/backend/internal/httpd/server.go
@@ -131,10 +131,16 @@ func (s *Server) Run(ctx context.Context) error {
 	defer cancel()
 
 	if err := s.http.Shutdown(shutdownCtx); err != nil {
-		// The deadline elapsed with connections still open; force them closed.
+		// The deadline elapsed with connections still open (long-lived SSE
+		// streams routinely outlive ShutdownTimeout). Force them closed.
+		// This is still a successful intentional stop: returning an error here
+		// makes the daemon process exit 1, which Electron reports as
+		// "daemon start failed" (code: exited) even though the user/app asked
+		// to stop.
 		s.log.Warn("graceful shutdown timed out, forcing close", "err", err)
 		_ = s.http.Close()
-		return fmt.Errorf("graceful shutdown exceeded %s: %w", s.cfg.ShutdownTimeout, err)
+		s.log.Info("daemon stopped after forced close")
+		return <-serveErr
 	}
 
 	s.log.Info("daemon stopped cleanly")


### PR DESCRIPTION
## Problem
When graceful `http.Server.Shutdown` times out (common with long-lived SSE streams), the daemon forced `Close()` and then **returned an error**. That made the process exit 1. Electron surfaced intentional stop/restart as **"daemon start failed" (code: exited)** even though the user/app asked to stop.

## Solution
After shutdown timeout + forced close, log and return `<-serveErr` (normally nil after `ErrServerClosed`) instead of wrapping the timeout as a failure. Forced close is still an intentional, successful stop.

## Tests
- `go test ./internal/httpd/ -count=1`
- Existing lifecycle / `POST /shutdown` tests still expect a nil `Run` error on intentional stop.

## Notes
- Backend-only product fix extracted from local desktop WIP (`local/zh-ui-sync`). **Independent of any Chinese UI branch** — no i18n or frontend changes.
- Does not include the staged migration renumber (0025 → 0029); that is owned by #3014.
- CI may stay red on main if migrate panics on the duplicate 0025 until #3014 merges; this PR does not depend on that renumber.

## Independence
Can merge independently of the tmux and workspace product fixes.