### PR TITLE
feat(renderer): pin orchestrator row in sidebar session tree

### DIFF
--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -12,15 +12,10 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { NotificationCenter } from "./NotificationCenter";
-import {
-	findProjectOrchestrator,
-	isOrchestratorSession,
-	sessionIsActive,
-	type WorkspaceSession,
-} from "../types/workspace";
+import { isOrchestratorSession, sessionIsActive, type WorkspaceSession } from "../types/workspace";
 import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
+import { useOpenOrchestrator } from "../hooks/useOpenOrchestrator";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
-import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { addRendererExceptionStep, captureRendererEvent, captureRendererException } from "../lib/telemetry";
 import { useUiStore } from "../stores/ui-store";
 import { OrchestratorIcon } from "./icons";
@@ -49,7 +44,6 @@ const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperti
 // aligned only by CSS.
 export function ShellTopbar() {
 	const navigate = useNavigate();
-	const queryClient = useQueryClient();
 	const params = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
 	const currentSessionId = params.sessionId;
 	const isInspectorOpen = useUiStore((state) =>
@@ -59,7 +53,6 @@ export function ShellTopbar() {
 	const restartingProjectIds = useUiStore((state) => state.restartingProjectIds);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
 	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);
-	const [isSpawning, setIsSpawning] = useState(false);
 	// Board-scope spawn failures surface where the board actions render.
 	const [boardSpawnError, setBoardSpawnError] = useState<string | null>(null);
 	const all = useWorkspaceQuery().data ?? [];
@@ -79,8 +72,12 @@ export function ShellTopbar() {
 	const isRootBoardRoute = !isSessionRoute && !isProjectBoardRoute;
 	const project = projectId ? all.find((workspace) => workspace.id === projectId) : undefined;
 	const projectLabel = project?.name ?? session?.workspaceName ?? (projectId ? "" : "Board");
-	const orchestrator = projectId ? findProjectOrchestrator(all, projectId) : undefined;
 	const isProjectRestarting = projectId ? restartingProjectIds.has(projectId) : false;
+	const { orchestrator, openOrchestrator, isSpawning } = useOpenOrchestrator(
+		projectId ?? "",
+		project?.sessions ?? [],
+		"topbar",
+	);
 
 	const openBoard = () =>
 		projectId ? void navigate({ to: "/projects/$projectId", params: { projectId } }) : void navigate({ to: "/" });
@@ -95,7 +92,7 @@ export function ShellTopbar() {
 		toggleInspector(currentSessionId);
 	};
 
-	const openOrchestrator = async () => {
+	const handleOpenOrchestrator = async () => {
 		if (!projectId) return;
 		setBoardSpawnError(null);
 		void addRendererExceptionStep("Orchestrator open requested", {
@@ -105,21 +102,8 @@ export function ShellTopbar() {
 			project_id: projectId,
 		});
 		void captureRendererEvent("ao.renderer.orchestrator_open_requested", { project_id: projectId });
-		if (orchestrator) {
-			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId, sessionId: orchestrator.id },
-			});
-			return;
-		}
-		setIsSpawning(true);
 		try {
-			const sessionId = await spawnOrchestrator(projectId, "topbar");
-			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-			void navigate({
-				to: "/projects/$projectId/sessions/$sessionId",
-				params: { projectId, sessionId },
-			});
+			await openOrchestrator();
 		} catch (error) {
 			void captureRendererException(error, {
 				source: "orchestrator-open",
@@ -127,10 +111,7 @@ export function ShellTopbar() {
 				surface: isSessionRoute ? "session_detail" : "project_board",
 				project_id: projectId,
 			});
-			console.error("Failed to spawn orchestrator:", error);
 			setBoardSpawnError(error instanceof Error ? error.message : "Could not spawn orchestrator");
-		} finally {
-			setIsSpawning(false);
 		}
 	};
 
@@ -205,7 +186,7 @@ export function ShellTopbar() {
 						<TopbarButton
 							aria-label={orchestrator ? "Orchestrator" : "Spawn Orchestrator"}
 							disabled={isSpawning || isProjectRestarting}
-							onClick={() => void openOrchestrator()}
+							onClick={() => void handleOpenOrchestrator()}
 							style={noDragStyle}
 							variant="primary"
 						>
@@ -262,7 +243,7 @@ export function ShellTopbar() {
 							<TopbarButton
 								aria-label="Open orchestrator"
 								disabled={isSpawning || isProjectRestarting}
-								onClick={() => void openOrchestrator()}
+								onClick={() => void handleOpenOrchestrator()}
 								style={noDragStyle}
 								variant="primary"
 							>

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -8,22 +8,26 @@ import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { agentsQueryKey } from "../hooks/useAgentsQuery";
 import { useUiStore } from "../stores/ui-store";
 
-const { getMock, navigateMock, mockParams, renameSessionMock, updateStatusMock } = vi.hoisted(() => ({
-	getMock: vi.fn(),
-	navigateMock: vi.fn(),
-	mockParams: { projectId: undefined as string | undefined },
-	renameSessionMock: vi.fn().mockResolvedValue(undefined),
-	updateStatusMock: vi.fn(),
-}));
+const { getMock, navigateMock, mockParams, renameSessionMock, spawnOrchestratorMock, updateStatusMock } = vi.hoisted(
+	() => ({
+		getMock: vi.fn(),
+		navigateMock: vi.fn(),
+		mockParams: { projectId: undefined as string | undefined, sessionId: undefined as string | undefined },
+		renameSessionMock: vi.fn().mockResolvedValue(undefined),
+		spawnOrchestratorMock: vi.fn(),
+		updateStatusMock: vi.fn(),
+	}),
+);
 
 vi.mock("../lib/rename-session", () => ({ renameSession: renameSessionMock }));
+vi.mock("../lib/spawn-orchestrator", () => ({ spawnOrchestrator: spawnOrchestratorMock }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@tanstack/react-router")>();
 	return {
 		...actual,
 		useNavigate: () => navigateMock,
-		useParams: () => ({}),
+		useParams: () => mockParams,
 		useRouterState: ({ select }: { select: (state: { location: { pathname: string } }) => unknown }) =>
 			select({ location: { pathname: "/" } }),
 	};
@@ -65,6 +69,19 @@ const session: WorkspaceSession = {
 	provider: "claude-code",
 	kind: "worker",
 	branch: "session/proj-1-1",
+	status: "working",
+	updatedAt: "2026-06-30T00:00:00Z",
+	prs: [],
+};
+
+const orchestrator: WorkspaceSession = {
+	id: "proj-1-orch",
+	workspaceId: "proj-1",
+	workspaceName: "Project One",
+	title: "orchestrator",
+	provider: "claude-code",
+	kind: "orchestrator",
+	branch: "main",
 	status: "working",
 	updatedAt: "2026-06-30T00:00:00Z",
 	prs: [],
@@ -194,8 +211,10 @@ beforeEach(() => {
 	});
 	navigateMock.mockReset();
 	renameSessionMock.mockReset().mockResolvedValue(undefined);
+	spawnOrchestratorMock.mockReset();
 	updateStatusMock.mockReset().mockResolvedValue({ state: "idle" });
 	mockParams.projectId = undefined;
+	mockParams.sessionId = undefined;
 });
 
 afterEach(() => {
@@ -907,5 +926,72 @@ describe("Sidebar", () => {
 			expect(button).toHaveClass("text-working", "bg-working/12");
 		}
 		expect(screen.getByText("v9.9.9 ready")).toBeInTheDocument();
+	});
+
+	it("pins an orchestrator row at the top of the project's session group", () => {
+		renderSidebar({
+			workspaces: [{ ...workspace, sessions: [orchestrator, session] }],
+		});
+
+		const orchestratorRow = screen.getByLabelText("Open Orchestrator");
+		const workerRow = screen.getByLabelText("Open fix login");
+		expect(orchestratorRow).toBeInTheDocument();
+		expect(workerRow).toBeInTheDocument();
+		expect(workerRow.compareDocumentPosition(orchestratorRow) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+	});
+
+	it("navigates to the live orchestrator session when the pinned row is clicked", async () => {
+		const user = userEvent.setup();
+		renderSidebar({
+			workspaces: [{ ...workspace, sessions: [orchestrator, session] }],
+		});
+
+		await user.click(screen.getByLabelText("Open Orchestrator"));
+
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/sessions/$sessionId",
+			params: { projectId: "proj-1", sessionId: "proj-1-orch" },
+		});
+	});
+
+	it("spawns an orchestrator and navigates to it when the pinned row is clicked and none exists", async () => {
+		const user = userEvent.setup();
+		spawnOrchestratorMock.mockResolvedValue("proj-1-orch-spawned");
+		renderSidebar({ workspaces: [{ ...workspace, sessions: [] }] });
+
+		await user.click(screen.getByLabelText("Spawn Orchestrator"));
+
+		await waitFor(() => expect(spawnOrchestratorMock).toHaveBeenCalledWith("proj-1", "sidebar"));
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/sessions/$sessionId",
+			params: { projectId: "proj-1", sessionId: "proj-1-orch-spawned" },
+		});
+	});
+
+	it("shows the orchestrator's live status dot from its attention zone", () => {
+		renderSidebar({
+			workspaces: [
+				{
+					...workspace,
+					sessions: [{ ...orchestrator, status: "needs_input" }, session],
+				},
+			],
+		});
+
+		const dot = screen.getByLabelText("Open Orchestrator").querySelector('span[aria-hidden="true"]');
+		expect(dot).toHaveClass("bg-warning");
+		expect(dot).not.toHaveClass("bg-working");
+	});
+
+	it("marks the orchestrator row as active when its session is selected", () => {
+		mockParams.projectId = "proj-1";
+		mockParams.sessionId = "proj-1-orch";
+		renderSidebar({
+			workspaces: [{ ...workspace, sessions: [orchestrator, session] }],
+		});
+
+		const row = screen.getByLabelText("Open Orchestrator");
+		expect(row).toHaveAttribute("aria-current", "page");
+		expect(row).toHaveClass("before:bg-accent");
 	});
 });

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -4,7 +4,6 @@ import { ChevronRight, LayoutDashboard, MoreVertical, Pencil, Plus, RefreshCw, S
 import { useEffect, useRef, useState } from "react";
 import type { UpdateStatus } from "../../main/update-settings";
 import {
-	newestActiveOrchestrator,
 	sessionIsActive,
 	type WorkspaceSession,
 	type WorkspaceSummary,
@@ -13,7 +12,7 @@ import {
 import { getSessionDotView } from "../lib/session-presentation";
 import { aoBridge } from "../lib/bridge";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
-import { spawnOrchestrator } from "../lib/spawn-orchestrator";
+import { useOpenOrchestrator } from "../hooks/useOpenOrchestrator";
 import { renameSession } from "../lib/rename-session";
 import { useResizable } from "../hooks/useResizable";
 import { useShellMaybe } from "../lib/shell-context";
@@ -396,11 +395,9 @@ function ProjectItem({
 	onRemoveProject: (projectId: string) => Promise<void>;
 }) {
 	const projectActive = selection.activeProjectId === workspace.id && !selection.activeSessionId;
-	const queryClient = useQueryClient();
 	const [removeError, setRemoveError] = useState<string | null>(null);
 	const [isRemoving, setIsRemoving] = useState(false);
 	const [confirmOpen, setConfirmOpen] = useState(false);
-	const [isSpawning, setIsSpawning] = useState(false);
 	const restartingProjectIds = useUiStore((state) => state.restartingProjectIds);
 	const isProjectRestarting = restartingProjectIds.has(workspace.id);
 	const requestNewTask = useUiStore((state) => state.requestNewTask);
@@ -408,28 +405,12 @@ function ProjectItem({
 	// reachable through the board's Done / Terminated bar (SessionsBoard).
 	const sessions = workerSessions(workspace.sessions).filter(sessionIsActive);
 	// The project's live orchestrator (if any) backs the hover Orchestrator
-	// button: navigate to it when present, otherwise spawn one first.
-	const orchestrator = newestActiveOrchestrator(workspace.sessions);
-
-	// Mirrors ShellTopbar's launcher: attach to the running orchestrator, or
-	// spawn one via the daemon and follow it once the workspace refetches.
-	const openOrchestrator = async () => {
-		if (isProjectRestarting) return;
-		if (orchestrator) {
-			selection.goSession(workspace.id, orchestrator.id);
-			return;
-		}
-		setIsSpawning(true);
-		try {
-			const sessionId = await spawnOrchestrator(workspace.id, "sidebar");
-			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-			selection.goSession(workspace.id, sessionId);
-		} catch (err) {
-			console.error("Failed to spawn orchestrator:", err);
-		} finally {
-			setIsSpawning(false);
-		}
-	};
+	// button and the pinned orchestrator row in the session tree.
+	const { orchestrator, openOrchestrator, isSpawning } = useOpenOrchestrator(
+		workspace.id,
+		workspace.sessions,
+		"sidebar",
+	);
 
 	const onProjectClick = () => {
 		if (!expanded) {
@@ -570,8 +551,14 @@ function ProjectItem({
 			</div>
 			{/* project-sidebar__sessions: indented under the project parent so worker
           sessions read as children without adding a persistent guide rail. */}
-			{expanded && sessions.length > 0 && (
+			{expanded && (
 				<SidebarMenuSub className="sidebar-expanded-chrome mx-0 ml-4.5 translate-x-0 gap-0 border-l-0 px-0 py-1 pl-2.5">
+					<OrchestratorRow
+						orchestrator={orchestrator}
+						active={Boolean(orchestrator) && selection.activeSessionId === orchestrator?.id}
+						disabled={isSpawning || isProjectRestarting}
+						onOpen={() => void openOrchestrator()}
+					/>
 					{sessions.map((session) => (
 						<SessionRow
 							key={session.id}
@@ -706,6 +693,51 @@ function SessionRow({ session, active, onOpen }: { session: WorkspaceSession; ac
 				type="button"
 			>
 				<Pencil aria-hidden="true" />
+			</button>
+		</SidebarMenuSubItem>
+	);
+}
+
+// Pinned orchestrator row at the top of a project's session group. Shows the
+// same live status dot as worker rows and navigates to the orchestrator session,
+// spawning one first when none is running.
+function OrchestratorRow({
+	orchestrator,
+	active,
+	disabled,
+	onOpen,
+}: {
+	orchestrator?: WorkspaceSession;
+	active: boolean;
+	disabled?: boolean;
+	onOpen: () => void;
+}) {
+	return (
+		<SidebarMenuSubItem>
+			<button
+				aria-current={active ? "page" : undefined}
+				aria-label={orchestrator ? "Open Orchestrator" : "Spawn Orchestrator"}
+				className={cn(
+					"relative flex h-auto w-full items-center gap-2.25 rounded-sm py-1.25 pl-2.5 pr-1.5 text-left outline-hidden transition-[color]",
+					"before:absolute before:top-1.5 before:bottom-1.5 before:left-0 before:w-px before:rounded-full before:bg-transparent",
+					"hover:text-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+					"disabled:pointer-events-none disabled:opacity-50",
+					active && "text-foreground before:bg-accent",
+				)}
+				disabled={disabled}
+				onClick={onOpen}
+				type="button"
+			>
+				{orchestrator ? (
+					<SessionDot session={orchestrator} />
+				) : (
+					<span aria-hidden="true" className="mt-px h-1.5 w-1.5 shrink-0 rounded-full bg-passive" />
+				)}
+				<span className="min-w-0 flex-1">
+					<span className={cn("block truncate text-xs", active ? "text-foreground" : "text-muted-foreground")}>
+						Orchestrator
+					</span>
+				</span>
 			</button>
 		</SidebarMenuSubItem>
 	);

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -3,12 +3,7 @@ import { useNavigate, useParams, useRouterState } from "@tanstack/react-router";
 import { ChevronRight, LayoutDashboard, MoreVertical, Pencil, Plus, RefreshCw, Settings, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { UpdateStatus } from "../../main/update-settings";
-import {
-	sessionIsActive,
-	type WorkspaceSession,
-	type WorkspaceSummary,
-	workerSessions,
-} from "../types/workspace";
+import { sessionIsActive, type WorkspaceSession, type WorkspaceSummary, workerSessions } from "../types/workspace";
 import { getSessionDotView } from "../lib/session-presentation";
 import { aoBridge } from "../lib/bridge";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";

--- a/frontend/src/renderer/hooks/useOpenOrchestrator.ts
+++ b/frontend/src/renderer/hooks/useOpenOrchestrator.ts
@@ -13,11 +13,7 @@ import { workspaceQueryKey } from "./useWorkspaceQuery";
  * (`newestActiveOrchestrator`), which fixes the lexicographic-targeting bug
  * reported in #1362.
  */
-export function useOpenOrchestrator(
-	projectId: string,
-	sessions: WorkspaceSession[],
-	source: OrchestratorSpawnSource,
-) {
+export function useOpenOrchestrator(projectId: string, sessions: WorkspaceSession[], source: OrchestratorSpawnSource) {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const [isSpawning, setIsSpawning] = useState(false);

--- a/frontend/src/renderer/hooks/useOpenOrchestrator.ts
+++ b/frontend/src/renderer/hooks/useOpenOrchestrator.ts
@@ -1,0 +1,56 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { spawnOrchestrator, type OrchestratorSpawnSource } from "../lib/spawn-orchestrator";
+import { newestActiveOrchestrator, type WorkspaceSession } from "../types/workspace";
+import { workspaceQueryKey } from "./useWorkspaceQuery";
+
+/**
+ * Shared navigation helper for opening a project's orchestrator session.
+ *
+ * Both the topbar and the sidebar route through this hook so they agree on
+ * which orchestrator to open. The live orchestrator is chosen by recency
+ * (`newestActiveOrchestrator`), which fixes the lexicographic-targeting bug
+ * reported in #1362.
+ */
+export function useOpenOrchestrator(
+	projectId: string,
+	sessions: WorkspaceSession[],
+	source: OrchestratorSpawnSource,
+) {
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+	const [isSpawning, setIsSpawning] = useState(false);
+
+	const orchestrator = newestActiveOrchestrator(sessions);
+
+	const openOrchestrator = async () => {
+		if (isSpawning) return;
+
+		if (orchestrator) {
+			void navigate({
+				to: "/projects/$projectId/sessions/$sessionId",
+				params: { projectId, sessionId: orchestrator.id },
+			});
+			return;
+		}
+
+		setIsSpawning(true);
+		try {
+			const sessionId = await spawnOrchestrator(projectId, source);
+			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+			void navigate({
+				to: "/projects/$projectId/sessions/$sessionId",
+				params: { projectId, sessionId },
+			});
+		} catch (err) {
+			console.error("Failed to spawn orchestrator:", err);
+			// Rethrow so surfaces that render spawn failures (e.g. board topbar) can show them.
+			throw err;
+		} finally {
+			setIsSpawning(false);
+		}
+	};
+
+	return { orchestrator, openOrchestrator, isSpawning };
+}


### PR DESCRIPTION
Closes #2804

**Supersedes #2810** (same change, rebased onto current `main` after merge conflicts). The original PR branch lives on `AgentWrapper/agent-orchestrator` and this worker could not force-push there (`Permission denied to AllBeingsFuture`), so the rebased tip is on `AllBeingsFuture:ao/agent-orchestrator-24/sidebar-orchestrator-row`.

## What
- Adds a pinned "Orchestrator" row at the top of every expanded project session group in the Electron sidebar.
- The row shows the same live status dot as worker sessions and navigates to the orchestrator session on click.
- If no live orchestrator exists, clicking the row spawns one and then navigates.

## Shared helper / targeting fix
- Extracts `useOpenOrchestrator` so both the topbar "Orchestrator" button and the new sidebar row route through the same recency-based picker (`newestActiveOrchestrator`).
- This fixes the lexicographic-targeting issue described in #1362.
- Parent tracking from #1211 (`parentOrchestratorId`) is not available in the Go rewrite domain yet, so this change does not attempt that backend fix.

## Rebase conflict resolution (`ShellTopbar.tsx`)
Main had grown past the PR base (new shell-terminal control, board spawn error UI, "Board" root crumb, richer open-orchestrator telemetry). Resolution kept those main behaviors and still routed open/spawn through `useOpenOrchestrator`. The hook rethrows spawn failures so the board topbar can surface `boardSpawnError`.

## Tests
- `cd frontend && npm test -- --run src/renderer/components/Sidebar.test.tsx` ✅ (38 tests)
- Component tests for the pinned row: presence/order, navigation, spawn fallback, status dot, and active selection.

## Visual verification
`ao preview` is for previewing URLs in the desktop browser panel, not the app chrome, so it is not applicable for this sidebar UI change.