### PR TITLE
feat(settings): add Developer Mode section gating Feature Releases

### DIFF
--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -259,7 +259,10 @@ no environment gate (no secrets needed for deletion).
 
 ### How users consume feature releases
 
-Users install and track a feature build from **Settings > Updates**:
+Feature Releases is gated behind **Developer Mode** (off by default). Enable it first
+under **Settings > Developer Mode**; the **Feature Releases** channel option only
+appears while Developer Mode is on. Users then install and track a feature build from
+**Settings > Updates**:
 
 1. Change the primary channel to **Feature Releases**. A second dropdown appears
    showing currently live feature builds, each labeled `PR #N: <title>` with its

--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -122,6 +122,7 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 				updateSettings: {
 					get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 					set: async () => undefined,
+					clearFeature: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 				},
 				updates: {
 					getStatus: async () => ({ state: "idle" }),
@@ -466,6 +467,7 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 				updateSettings: {
 					get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 					set: async () => undefined,
+					clearFeature: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 				},
 				updates: {
 					getStatus: async () => ({ state: "idle" }),

--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -122,11 +122,11 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 				updateSettings: {
 					get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 					set: async () => undefined,
-					clearFeature: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 				},
 				updates: {
 					getStatus: async () => ({ state: "idle" }),
 					check: async () => undefined,
+					returnHome: async () => undefined,
 					download: async () => undefined,
 					install: async () => undefined,
 					onStatus: unsubscribe,
@@ -467,11 +467,11 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 				updateSettings: {
 					get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 					set: async () => undefined,
-					clearFeature: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 				},
 				updates: {
 					getStatus: async () => ({ state: "idle" }),
 					check: async () => undefined,
+					returnHome: async () => undefined,
 					download: async () => undefined,
 					install: async () => undefined,
 					onStatus: unsubscribe,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -26,7 +26,12 @@ import {
 	type UpdateCheckOptions,
 } from "./main/auto-updater";
 import { listFeatureBuilds, getActiveFeatureBuild } from "./main/feature-builds";
-import { readUpdateSettings, updateUpdateSettings, type UpdateSettings, type UpdateStatus } from "./main/update-settings";
+import {
+	readUpdateSettings,
+	updateUpdateSettings,
+	type UpdateSettings,
+	type UpdateStatus,
+} from "./main/update-settings";
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { closeSync, existsSync, openSync } from "node:fs";

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -23,15 +23,11 @@ import {
 	quitAndInstallUpdate,
 	getUpdateStatus,
 	setUpdateSettings,
+	returnToHome,
 	type UpdateCheckOptions,
 } from "./main/auto-updater";
 import { listFeatureBuilds, getActiveFeatureBuild } from "./main/feature-builds";
-import {
-	readUpdateSettings,
-	updateUpdateSettings,
-	type UpdateSettings,
-	type UpdateStatus,
-} from "./main/update-settings";
+import { readUpdateSettings, type UpdateSettings, type UpdateStatus } from "./main/update-settings";
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { closeSync, existsSync, openSync } from "node:fs";
@@ -1393,16 +1389,6 @@ ipcMain.handle("updateSettings:set", async (_event, settings: UpdateSettings) =>
 	if (!runFile) return;
 	await setUpdateSettings(path.dirname(runFile), settings);
 });
-// Atomically clear only the feature pin against persisted state, preserving the
-// user's home channel/enabled prefs, so Return-home never depends on renderer form
-// hydration. Returns the resulting settings for the renderer to sync.
-ipcMain.handle("updateSettings:clearFeature", async (): Promise<UpdateSettings> => {
-	const runFile = runFilePath();
-	if (!runFile) return { enabled: false, channel: "latest", nightlyAck: false, feature: null };
-	return updateUpdateSettings(path.dirname(runFile), (current) =>
-		current.feature ? { ...current, feature: null } : current,
-	);
-});
 
 ipcMain.handle("featureBuilds:list", () => listFeatureBuilds());
 ipcMain.handle("featureBuilds:getActive", () => getActiveFeatureBuild());
@@ -1412,6 +1398,11 @@ ipcMain.handle("updates:check", async (_event, options?: UpdateCheckOptions) => 
 	const runFile = runFilePath();
 	if (!runFile) return;
 	await checkForUpdatesNow(path.dirname(runFile), options);
+});
+ipcMain.handle("updates:returnHome", async (_event, requestId?: string) => {
+	const runFile = runFilePath();
+	if (!runFile) return;
+	await returnToHome(path.dirname(runFile), requestId);
 });
 ipcMain.handle("updates:download", async (_event, requestId?: string) => {
 	await downloadUpdateNow(requestId);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -26,7 +26,7 @@ import {
 	type UpdateCheckOptions,
 } from "./main/auto-updater";
 import { listFeatureBuilds, getActiveFeatureBuild } from "./main/feature-builds";
-import { readUpdateSettings, type UpdateSettings, type UpdateStatus } from "./main/update-settings";
+import { readUpdateSettings, updateUpdateSettings, type UpdateSettings, type UpdateStatus } from "./main/update-settings";
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { closeSync, existsSync, openSync } from "node:fs";
@@ -1387,6 +1387,16 @@ ipcMain.handle("updateSettings:set", async (_event, settings: UpdateSettings) =>
 	const runFile = runFilePath();
 	if (!runFile) return;
 	await setUpdateSettings(path.dirname(runFile), settings);
+});
+// Atomically clear only the feature pin against persisted state, preserving the
+// user's home channel/enabled prefs, so Return-home never depends on renderer form
+// hydration. Returns the resulting settings for the renderer to sync.
+ipcMain.handle("updateSettings:clearFeature", async (): Promise<UpdateSettings> => {
+	const runFile = runFilePath();
+	if (!runFile) return { enabled: false, channel: "latest", nightlyAck: false, feature: null };
+	return updateUpdateSettings(path.dirname(runFile), (current) =>
+		current.feature ? { ...current, feature: null } : current,
+	);
 });
 
 ipcMain.handle("featureBuilds:list", () => listFeatureBuilds());

--- a/frontend/src/main/auto-updater.test.ts
+++ b/frontend/src/main/auto-updater.test.ts
@@ -13,6 +13,7 @@ type UpdaterEventHandler = (...args: any[]) => void;
 
 type ImportOptions = {
 	reconcileFeaturePin?: (settings: UpdateSettings) => Promise<{ settings: UpdateSettings; cleared: boolean }>;
+	isPackaged?: boolean;
 };
 
 type AutoUpdaterMock = {
@@ -66,7 +67,7 @@ async function importAutoUpdater(
 	vi.doMock("electron-updater", () => ({ autoUpdater }));
 	vi.doMock("electron", () => ({
 		app: {
-			isPackaged: true,
+			isPackaged: options.isPackaged ?? true,
 			getVersion: () => "1.0.0",
 		},
 		BrowserWindow,
@@ -812,5 +813,64 @@ describe("startAutoUpdates", () => {
 		await module.startAutoUpdates(stateDir);
 
 		expect(unref).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("returnToHome", () => {
+	const stateDir = "/tmp/ao-state";
+
+	it("clears only the feature pin, preserves home channel/prefs, and checks", async () => {
+		const { module, autoUpdater, updateUpdateSettings } = await importAutoUpdater({
+			enabled: true,
+			channel: "nightly",
+			nightlyAck: true,
+			feature: { pr: 2270 },
+		});
+
+		await module.returnToHome(stateDir, "req-1");
+
+		// The pin is cleared via a single read-modify-write; applying that updater
+		// preserves every field except feature.
+		expect(updateUpdateSettings).toHaveBeenCalledTimes(1);
+		const clear = updateUpdateSettings.mock.calls[0]?.[1] as (c: UpdateSettings) => UpdateSettings;
+		expect(clear({ enabled: true, channel: "nightly", nightlyAck: true, feature: { pr: 2270 } })).toEqual({
+			enabled: true,
+			channel: "nightly",
+			nightlyAck: true,
+			feature: null,
+		});
+		// The feed resolves the home channel (not the pr<N> feed) and a check runs.
+		expect(autoUpdater.channel).toBe("nightly");
+		expect(autoUpdater.allowPrerelease).toBe(true);
+		expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+	});
+
+	it("checks the home channel even when nothing is pinned", async () => {
+		const { module, autoUpdater, updateUpdateSettings } = await importAutoUpdater({
+			enabled: true,
+			channel: "latest",
+			nightlyAck: false,
+			feature: null,
+		});
+
+		await module.returnToHome(stateDir);
+
+		const clear = updateUpdateSettings.mock.calls[0]?.[1] as (c: UpdateSettings) => UpdateSettings;
+		const current: UpdateSettings = { enabled: true, channel: "latest", nightlyAck: false, feature: null };
+		expect(clear(current)).toBe(current); // no pin -> unchanged
+		expect(autoUpdater.channel).toBe("latest");
+		expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+	});
+
+	it("reports unsupported in dev (unpackaged) without touching settings", async () => {
+		const { module, autoUpdater, updateUpdateSettings } = await importAutoUpdater(
+			{ enabled: true, channel: "latest", nightlyAck: false, feature: { pr: 2270 } },
+			{ isPackaged: false },
+		);
+
+		await module.returnToHome(stateDir, "req-2");
+
+		expect(updateUpdateSettings).not.toHaveBeenCalled();
+		expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/main/auto-updater.ts
+++ b/frontend/src/main/auto-updater.ts
@@ -80,7 +80,7 @@ let escalationTimer: ReturnType<typeof setInterval> | undefined;
 let escalationStateDir: string | undefined;
 const AUTOMATIC_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 let automaticUpdateTimer: ReturnType<typeof setInterval> | undefined;
-type UpdaterOperation = "automatic-check" | "manual-check" | "manual-download" | "settings-write";
+type UpdaterOperation = "automatic-check" | "manual-check" | "manual-download" | "settings-write" | "return-home";
 let activeUpdaterOperation: UpdaterOperation | undefined;
 let activeUpdaterRequestId: string | undefined;
 let automaticCheckPreviousStatus: { status: UpdateStatus; independentRevision: number } | undefined;
@@ -483,6 +483,49 @@ export async function checkForUpdatesNow(stateDir: string, options: UpdateCheckO
 			state: "error",
 			message: (err as Error)?.message ?? "Update check failed",
 			requestId: options.requestId,
+		});
+	}
+}
+
+// returnToHome clears any pinned feature build and resolves the home channel in a
+// SINGLE updater-serialized operation. Clearing and checking must share one
+// operation on updaterOperationQueue: a separate clear (on the settings queue)
+// could interleave with a queued settings-write or an in-flight check and see the
+// stale pin restored, leaving the app on the pr<N> feed. The pin is cleared against
+// persisted state, so this never depends on renderer form hydration.
+export async function returnToHome(stateDir: string, requestId?: string): Promise<void> {
+	escalationStateDir = stateDir;
+	wireUpdaterEvents();
+	if (!app.isPackaged) {
+		broadcast({
+			state: "unsupported",
+			message: "Updates are only available in the installed app.",
+			requestId,
+		});
+		return;
+	}
+	try {
+		await runSerializedUpdaterOperation(
+			"return-home",
+			async () => {
+				const cleared = await updateUpdateSettings(stateDir, (current) =>
+					current.feature ? { ...current, feature: null } : current,
+				);
+				const settings = await reconcileAndPersist(stateDir, cleared);
+				reconcileAutomaticUpdateSchedule(stateDir, settings.enabled);
+				configureFeed(settings);
+				autoUpdater.autoDownload = false;
+				autoUpdater.autoInstallOnAppQuit = true;
+				broadcastUpdaterStatus({ state: "checking" });
+				await autoUpdater.checkForUpdates();
+			},
+			requestId,
+		);
+	} catch (err) {
+		broadcast({
+			state: "error",
+			message: (err as Error)?.message ?? "Return failed",
+			requestId,
 		});
 	}
 }

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -198,11 +198,11 @@ const api = {
 	updateSettings: {
 		get: () => ipcRenderer.invoke("updateSettings:get") as Promise<UpdateSettings>,
 		set: (settings: UpdateSettings) => ipcRenderer.invoke("updateSettings:set", settings) as Promise<void>,
-		clearFeature: () => ipcRenderer.invoke("updateSettings:clearFeature") as Promise<UpdateSettings>,
 	},
 	updates: {
 		getStatus: () => ipcRenderer.invoke("updates:getStatus") as Promise<UpdateStatus>,
 		check: (options?: UpdateCheckOptions) => ipcRenderer.invoke("updates:check", options) as Promise<void>,
+		returnHome: (requestId?: string) => ipcRenderer.invoke("updates:returnHome", requestId) as Promise<void>,
 		download: (requestId?: string) => ipcRenderer.invoke("updates:download", requestId) as Promise<void>,
 		install: () => ipcRenderer.invoke("updates:install") as Promise<void>,
 		onStatus: (listener: (status: UpdateStatus) => void) => {

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -198,6 +198,7 @@ const api = {
 	updateSettings: {
 		get: () => ipcRenderer.invoke("updateSettings:get") as Promise<UpdateSettings>,
 		set: (settings: UpdateSettings) => ipcRenderer.invoke("updateSettings:set", settings) as Promise<void>,
+		clearFeature: () => ipcRenderer.invoke("updateSettings:clearFeature") as Promise<UpdateSettings>,
 	},
 	updates: {
 		getStatus: () => ipcRenderer.invoke("updates:getStatus") as Promise<UpdateStatus>,

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -8,6 +8,7 @@ import { useUiStore } from "../stores/ui-store";
 const {
 	getUpdate,
 	setUpdate,
+	clearFeature,
 	updGetStatus,
 	updCheck,
 	updDownload,
@@ -23,6 +24,7 @@ const {
 } = vi.hoisted(() => ({
 	getUpdate: vi.fn(),
 	setUpdate: vi.fn(),
+	clearFeature: vi.fn(),
 	updGetStatus: vi.fn(),
 	updCheck: vi.fn(),
 	updDownload: vi.fn(),
@@ -50,7 +52,7 @@ vi.mock("../lib/bridge", () => ({
 		app: { getVersion, openExternal },
 		clipboard: { writeText },
 		daemon: { getStatus: getDaemonStatus },
-		updateSettings: { get: getUpdate, set: setUpdate },
+		updateSettings: { get: getUpdate, set: setUpdate, clearFeature },
 		updates: {
 			getStatus: updGetStatus,
 			check: updCheck,
@@ -76,6 +78,7 @@ beforeEach(() => {
 	for (const m of [
 		getUpdate,
 		setUpdate,
+		clearFeature,
 		updGetStatus,
 		updCheck,
 		updDownload,
@@ -93,6 +96,7 @@ beforeEach(() => {
 	}
 	getUpdate.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false, feature: null });
 	setUpdate.mockResolvedValue(undefined);
+	clearFeature.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false, feature: null });
 	updGetStatus.mockResolvedValue({ state: "idle" });
 	updCheck.mockResolvedValue(undefined);
 	updDownload.mockResolvedValue(undefined);
@@ -392,17 +396,25 @@ describe("GlobalSettingsForm", () => {
 		renderForm();
 		// The concealed pin is announced even though the channel option/picker are hidden.
 		expect(await screen.findByText("PR #2270 is pinned but not yet installed.")).toBeInTheDocument();
+		// The Feature Releases channel option and its build picker stay hidden.
+		expect(screen.queryByLabelText("Feature build")).not.toBeInTheDocument();
 		await userEvent.click(screen.getByLabelText("Updates channel"));
 		expect(screen.queryByRole("menuitem", { name: "Feature Releases" })).not.toBeInTheDocument();
 		await userEvent.keyboard("{Escape}");
-		// Return clears the pin so the main-process updater stops tracking the feature feed.
+		// Return clears the pin atomically against main-process state, then checks home.
 		await userEvent.click(screen.getByRole("button", { name: "Return to Stable" }));
-		await waitFor(() =>
-			expect(updCheck).toHaveBeenCalledWith({
-				settings: expect.objectContaining({ feature: null }),
-				requestId: expect.any(String),
-			}),
-		);
+		await waitFor(() => expect(clearFeature).toHaveBeenCalled());
+		expect(updCheck).toHaveBeenCalledWith({ requestId: expect.any(String) });
+	});
+
+	it("keeps Updates unchanged with Developer Mode on for a pinned-but-not-running build", async () => {
+		// With Developer Mode on the visible picker shows the pin, so no extra banner.
+		useUiStore.getState().setDeveloperMode(true);
+		getUpdate.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false, feature: { pr: 2270 } });
+		featGetActive.mockResolvedValue(null);
+		renderForm();
+		expect(await screen.findByLabelText("Feature build")).toBeInTheDocument();
+		expect(screen.queryByText("PR #2270 is pinned but not yet installed.")).not.toBeInTheDocument();
 	});
 
 	it("reveals the feature-build picker when Feature Releases is selected", async () => {
@@ -469,6 +481,7 @@ describe("GlobalSettingsForm", () => {
 
 	it("returns to Stable, then auto-progresses check -> download -> install", async () => {
 		getUpdate.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false, feature: { pr: 2270 } });
+		clearFeature.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false, feature: null });
 		featGetActive.mockResolvedValue({ pr: 2270 });
 		let emit: (s: { state: string; version?: string; requestId?: string }) => void = () => undefined;
 		updOnStatus.mockImplementation((cb: (s: unknown) => void) => {
@@ -480,12 +493,8 @@ describe("GlobalSettingsForm", () => {
 		const returnBtn = await screen.findByRole("button", { name: "Return to Stable" });
 		await userEvent.click(returnBtn);
 
-		await waitFor(() =>
-			expect(updCheck).toHaveBeenCalledWith({
-				settings: expect.objectContaining({ feature: null }),
-				requestId: expect.any(String),
-			}),
-		);
+		await waitFor(() => expect(clearFeature).toHaveBeenCalled());
+		await waitFor(() => expect(updCheck).toHaveBeenCalledWith({ requestId: expect.any(String) }));
 		const requestId = updCheck.mock.calls[0]?.[0]?.requestId as string;
 
 		act(() => emit({ state: "available", version: "1.3.0", requestId }));

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -363,6 +363,48 @@ describe("GlobalSettingsForm", () => {
 		expect(await screen.findByRole("menuitem", { name: "Feature Releases" })).toBeInTheDocument();
 	});
 
+	it("persists Developer Mode to localStorage and defaults off", async () => {
+		expect(useUiStore.getState().developerMode).toBe(false);
+		renderForm();
+		const toggle = await screen.findByRole("switch", { name: "Developer Mode" });
+		expect(toggle).toHaveAttribute("aria-checked", "false");
+		await userEvent.click(toggle);
+		expect(useUiStore.getState().developerMode).toBe(true);
+		expect(window.localStorage.getItem("ao.developerMode")).toBe("true");
+	});
+
+	it("hides the feature-build picker when Developer Mode is turned off after selecting it", async () => {
+		useUiStore.getState().setDeveloperMode(true);
+		renderForm();
+		await screen.findByText("Updates");
+		await userEvent.click(screen.getByLabelText("Updates channel"));
+		await userEvent.click(await screen.findByRole("menuitem", { name: "Feature Releases" }));
+		expect(await screen.findByText("No live feature releases.")).toBeInTheDocument();
+		// Toggling Developer Mode off must drop the transient picker (primaryValue guard).
+		await userEvent.click(screen.getByRole("switch", { name: "Developer Mode" }));
+		await waitFor(() => expect(screen.queryByText("No live feature releases.")).not.toBeInTheDocument());
+	});
+
+	it("surfaces a Return action for a persisted feature pin even when Developer Mode is off", async () => {
+		// A pin persists in settings but is not yet running; Developer Mode is off (default).
+		getUpdate.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false, feature: { pr: 2270 } });
+		featGetActive.mockResolvedValue(null);
+		renderForm();
+		// The concealed pin is announced even though the channel option/picker are hidden.
+		expect(await screen.findByText("PR #2270 is pinned but not yet installed.")).toBeInTheDocument();
+		await userEvent.click(screen.getByLabelText("Updates channel"));
+		expect(screen.queryByRole("menuitem", { name: "Feature Releases" })).not.toBeInTheDocument();
+		await userEvent.keyboard("{Escape}");
+		// Return clears the pin so the main-process updater stops tracking the feature feed.
+		await userEvent.click(screen.getByRole("button", { name: "Return to Stable" }));
+		await waitFor(() =>
+			expect(updCheck).toHaveBeenCalledWith({
+				settings: expect.objectContaining({ feature: null }),
+				requestId: expect.any(String),
+			}),
+		);
+	});
+
 	it("reveals the feature-build picker when Feature Releases is selected", async () => {
 		useUiStore.getState().setDeveloperMode(true);
 		renderForm();

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -3,6 +3,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GlobalSettingsForm } from "./GlobalSettingsForm";
+import { useUiStore } from "../stores/ui-store";
 
 const {
 	getUpdate,
@@ -103,6 +104,8 @@ beforeEach(() => {
 	openExternal.mockResolvedValue(undefined);
 	featListBuilds.mockResolvedValue([]);
 	featGetActive.mockResolvedValue(null);
+	// Feature Releases lives behind Developer Mode; reset to the default (off).
+	useUiStore.getState().setDeveloperMode(false);
 });
 
 describe("GlobalSettingsForm", () => {
@@ -112,6 +115,7 @@ describe("GlobalSettingsForm", () => {
 		expect(screen.getByRole("heading", { name: "Settings" })).toBeInTheDocument();
 		expect(screen.getByText("General")).toBeInTheDocument();
 		expect(screen.getByText("Updates")).toBeInTheDocument();
+		expect(screen.getByRole("switch", { name: "Developer Mode" })).toBeInTheDocument();
 		expect(screen.getByText("Get help")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Report a problem" })).toBeInTheDocument();
 	});
@@ -174,6 +178,7 @@ describe("GlobalSettingsForm", () => {
 	});
 
 	it("hides the nightly warning when Feature Releases is selected", async () => {
+		useUiStore.getState().setDeveloperMode(true);
 		getUpdate.mockResolvedValue({ enabled: true, channel: "nightly", nightlyAck: true, feature: null });
 		renderForm();
 		expect(await screen.findByText(/Nightly builds are cut every day/i)).toBeInTheDocument();
@@ -342,7 +347,24 @@ describe("GlobalSettingsForm", () => {
 		expect(screen.queryByLabelText("Report preview")).not.toBeInTheDocument();
 	});
 
+	it("hides the Feature Releases channel option when Developer Mode is off", async () => {
+		renderForm();
+		await screen.findByText("Updates");
+		await userEvent.click(screen.getByLabelText("Updates channel"));
+		expect(await screen.findByRole("menuitem", { name: "Stable (Latest)" })).toBeInTheDocument();
+		expect(screen.queryByRole("menuitem", { name: "Feature Releases" })).not.toBeInTheDocument();
+	});
+
+	it("reveals the Feature Releases channel option when Developer Mode is turned on", async () => {
+		renderForm();
+		await screen.findByText("Updates");
+		await userEvent.click(screen.getByRole("switch", { name: "Developer Mode" }));
+		await userEvent.click(screen.getByLabelText("Updates channel"));
+		expect(await screen.findByRole("menuitem", { name: "Feature Releases" })).toBeInTheDocument();
+	});
+
 	it("reveals the feature-build picker when Feature Releases is selected", async () => {
+		useUiStore.getState().setDeveloperMode(true);
 		renderForm();
 		await screen.findByText("Updates");
 		// The picker must be reachable from a clean state (no pin seeded).
@@ -354,6 +376,7 @@ describe("GlobalSettingsForm", () => {
 	});
 
 	it("pins a feature build after confirming and ignores unowned updater events", async () => {
+		useUiStore.getState().setDeveloperMode(true);
 		featListBuilds.mockResolvedValue([
 			{
 				pr: 2270,

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -8,9 +8,9 @@ import { useUiStore } from "../stores/ui-store";
 const {
 	getUpdate,
 	setUpdate,
-	clearFeature,
 	updGetStatus,
 	updCheck,
+	updReturnHome,
 	updDownload,
 	updInstall,
 	updOnStatus,
@@ -24,8 +24,8 @@ const {
 } = vi.hoisted(() => ({
 	getUpdate: vi.fn(),
 	setUpdate: vi.fn(),
-	clearFeature: vi.fn(),
 	updGetStatus: vi.fn(),
+	updReturnHome: vi.fn(),
 	updCheck: vi.fn(),
 	updDownload: vi.fn(),
 	updInstall: vi.fn(),
@@ -52,10 +52,11 @@ vi.mock("../lib/bridge", () => ({
 		app: { getVersion, openExternal },
 		clipboard: { writeText },
 		daemon: { getStatus: getDaemonStatus },
-		updateSettings: { get: getUpdate, set: setUpdate, clearFeature },
+		updateSettings: { get: getUpdate, set: setUpdate },
 		updates: {
 			getStatus: updGetStatus,
 			check: updCheck,
+			returnHome: updReturnHome,
 			download: updDownload,
 			install: updInstall,
 			onStatus: updOnStatus,
@@ -78,9 +79,9 @@ beforeEach(() => {
 	for (const m of [
 		getUpdate,
 		setUpdate,
-		clearFeature,
 		updGetStatus,
 		updCheck,
+		updReturnHome,
 		updDownload,
 		updInstall,
 		updOnStatus,
@@ -96,9 +97,9 @@ beforeEach(() => {
 	}
 	getUpdate.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false, feature: null });
 	setUpdate.mockResolvedValue(undefined);
-	clearFeature.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false, feature: null });
 	updGetStatus.mockResolvedValue({ state: "idle" });
 	updCheck.mockResolvedValue(undefined);
+	updReturnHome.mockResolvedValue(undefined);
 	updDownload.mockResolvedValue(undefined);
 	updInstall.mockResolvedValue(undefined);
 	updOnStatus.mockReturnValue(() => undefined);
@@ -401,10 +402,10 @@ describe("GlobalSettingsForm", () => {
 		await userEvent.click(screen.getByLabelText("Updates channel"));
 		expect(screen.queryByRole("menuitem", { name: "Feature Releases" })).not.toBeInTheDocument();
 		await userEvent.keyboard("{Escape}");
-		// Return clears the pin atomically against main-process state, then checks home.
+		// Return delegates to the single updater-serialized returnHome operation.
 		await userEvent.click(screen.getByRole("button", { name: "Return to Stable" }));
-		await waitFor(() => expect(clearFeature).toHaveBeenCalled());
-		expect(updCheck).toHaveBeenCalledWith({ requestId: expect.any(String) });
+		await waitFor(() => expect(updReturnHome).toHaveBeenCalledWith(expect.any(String)));
+		expect(updCheck).not.toHaveBeenCalled();
 	});
 
 	it("keeps Updates unchanged with Developer Mode on for a pinned-but-not-running build", async () => {
@@ -481,7 +482,6 @@ describe("GlobalSettingsForm", () => {
 
 	it("returns to Stable, then auto-progresses check -> download -> install", async () => {
 		getUpdate.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false, feature: { pr: 2270 } });
-		clearFeature.mockResolvedValue({ enabled: true, channel: "latest", nightlyAck: false, feature: null });
 		featGetActive.mockResolvedValue({ pr: 2270 });
 		let emit: (s: { state: string; version?: string; requestId?: string }) => void = () => undefined;
 		updOnStatus.mockImplementation((cb: (s: unknown) => void) => {
@@ -493,9 +493,8 @@ describe("GlobalSettingsForm", () => {
 		const returnBtn = await screen.findByRole("button", { name: "Return to Stable" });
 		await userEvent.click(returnBtn);
 
-		await waitFor(() => expect(clearFeature).toHaveBeenCalled());
-		await waitFor(() => expect(updCheck).toHaveBeenCalledWith({ requestId: expect.any(String) }));
-		const requestId = updCheck.mock.calls[0]?.[0]?.requestId as string;
+		await waitFor(() => expect(updReturnHome).toHaveBeenCalledWith(expect.any(String)));
+		const requestId = updReturnHome.mock.calls[0]?.[0] as string;
 
 		act(() => emit({ state: "available", version: "1.3.0", requestId }));
 		await waitFor(() => expect(updDownload).toHaveBeenCalledWith(requestId));

--- a/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.test.tsx
@@ -397,6 +397,13 @@ describe("GlobalSettingsForm", () => {
 		renderForm();
 		// The concealed pin is announced even though the channel option/picker are hidden.
 		expect(await screen.findByText("PR #2270 is pinned but not yet installed.")).toBeInTheDocument();
+		// The fall-home copy must be truthful: automatic updates keep tracking the pin,
+		// they do NOT silently return the user home on the next check.
+		expect(
+			screen.getByText(
+				/Automatic updates, if enabled, keep tracking PR #2270 until you return home or the build retires\./i,
+			),
+		).toBeInTheDocument();
 		// The Feature Releases channel option and its build picker stay hidden.
 		expect(screen.queryByLabelText("Feature build")).not.toBeInTheDocument();
 		await userEvent.click(screen.getByLabelText("Updates channel"));

--- a/frontend/src/renderer/components/GlobalSettingsForm.tsx
+++ b/frontend/src/renderer/components/GlobalSettingsForm.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { Mail } from "lucide-react";
 import { ConnectMobileModal } from "./ConnectMobileModal";
+import { DeveloperModeSection } from "./settings/DeveloperModeSection";
 import { GeneralSettingsSection } from "./settings/GeneralSettingsSection";
 import { ReportProblemDialog } from "./settings/ReportProblemDialog";
 import { SettingsLinkRow } from "./settings/SettingsRow";
@@ -21,6 +22,7 @@ export function GlobalSettingsForm() {
 				<SettingsPanel onClose={() => navigate({ to: "/" })}>
 					<GeneralSettingsSection onConnectMobile={() => setMobileOpen(true)} />
 					<UpdatesSection />
+					<DeveloperModeSection />
 					<SettingsSection title="Get help">
 						<SettingsLinkRow icon={Mail} label="Report a problem" onClick={() => setReportProblemOpen(true)} />
 					</SettingsSection>

--- a/frontend/src/renderer/components/settings/DeveloperModeSection.tsx
+++ b/frontend/src/renderer/components/settings/DeveloperModeSection.tsx
@@ -1,0 +1,20 @@
+import { Wrench } from "lucide-react";
+import { useUiStore } from "../../stores/ui-store";
+import { Switch } from "../ui/switch";
+import { SettingsRow } from "./SettingsRow";
+import { SettingsSection } from "./SettingsSection";
+
+// Single opt-in toggle that reveals developer-only surfaces (currently the
+// Feature Releases update channel). Persisted via the ui-store, defaults off.
+export function DeveloperModeSection() {
+	const developerMode = useUiStore((state) => state.developerMode);
+	const setDeveloperMode = useUiStore((state) => state.setDeveloperMode);
+
+	return (
+		<SettingsSection title="Developer Mode" sectionId="developer-mode">
+			<SettingsRow icon={Wrench} label="Developer Mode">
+				<Switch aria-label="Developer Mode" checked={developerMode} onCheckedChange={setDeveloperMode} />
+			</SettingsRow>
+		</SettingsSection>
+	);
+}

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Check, GitPullRequest, HardDriveDownload, History, Loade
 import { aoBridge } from "../../lib/bridge";
 import { formatTimeCompact } from "../../lib/format-time";
 import { useUpdateStatus } from "../../hooks/useUpdateStatus";
+import { useUiStore } from "../../stores/ui-store";
 import type { UpdateChannel, UpdateSettings, UpdateState, UpdateStatus } from "../../../main/update-settings";
 import { ConfirmDialog } from "../ConfirmDialog";
 import { Badge } from "../ui/badge";
@@ -26,6 +27,9 @@ const CHANNEL_OPTIONS: { value: PrimaryValue; label: string }[] = [
 	{ value: "nightly", label: "Nightly (Pre-release)" },
 	{ value: "feature", label: "Feature Releases" },
 ];
+
+// Feature Releases is developer-only; hide it entirely unless Developer Mode is on.
+const STABLE_CHANNEL_OPTIONS = CHANNEL_OPTIONS.filter((option) => option.value !== "feature");
 
 const DEFAULT_SETTINGS: UpdateSettings = { enabled: false, channel: "latest", nightlyAck: false, feature: null };
 
@@ -52,6 +56,8 @@ export function UpdatesSection() {
 	// but has not pinned a build yet (form.feature is still null).
 	const [showFeature, setShowFeature] = useState(false);
 	const [pendingPin, setPendingPin] = useState<{ pr: number; title: string } | null>(null);
+
+	const developerMode = useUiStore((state) => state.developerMode);
 
 	const status = useUpdateStatus();
 	// Set only for the owned pin/home transition request, so unrelated hourly
@@ -93,7 +99,9 @@ export function UpdatesSection() {
 		},
 	});
 
-	const primaryValue: PrimaryValue = form.feature != null || showFeature ? "feature" : form.channel;
+	// With Developer Mode off the "feature" value has no matching option, so fall
+	// back to the home channel to keep the dropdown showing a valid selection.
+	const primaryValue: PrimaryValue = developerMode && (form.feature != null || showFeature) ? "feature" : form.channel;
 
 	const setEnabled = (enabled: boolean) => {
 		const next = { ...formRef.current, enabled };
@@ -194,7 +202,7 @@ export function UpdatesSection() {
 					<SettingsOptionMenu
 						aria-label="Updates channel"
 						value={primaryValue}
-						options={CHANNEL_OPTIONS}
+						options={developerMode ? CHANNEL_OPTIONS : STABLE_CHANNEL_OPTIONS}
 						onChange={handlePrimaryChannel}
 						disabled={!form.enabled || save.isPending}
 					/>

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -144,23 +144,27 @@ export function UpdatesSection() {
 			void queryClient.invalidateQueries({ queryKey: updateSettingsQueryKey });
 		} catch {
 			if (autoProgressRef.current === requestId) autoProgressRef.current = null;
+			// The optimistic form update may now disagree with disk; re-sync to truth.
+			void queryClient.invalidateQueries({ queryKey: updateSettingsQueryKey });
 		}
 	};
 
 	const handleReturnToHome = async () => {
 		setShowFeature(false);
+		// Optimistic; the main process clears the pin against persisted state.
+		setForm({ ...formRef.current, feature: null });
 		const requestId = nextUpdateRequestId();
 		autoProgressRef.current = requestId;
 		handledStatusRef.current = null;
 		try {
-			// Clear the pin atomically against persisted main-process state (preserves
-			// the home channel) so Return works regardless of renderer form hydration.
-			const next = await aoBridge.updateSettings.clearFeature();
-			setForm(next);
-			await aoBridge.updates.check({ requestId });
+			// Single updater-serialized op: clears the pin and checks the home channel
+			// atomically, so a concurrent settings-write cannot restore the pin.
+			await aoBridge.updates.returnHome(requestId);
 			void queryClient.invalidateQueries({ queryKey: updateSettingsQueryKey });
 		} catch {
 			if (autoProgressRef.current === requestId) autoProgressRef.current = null;
+			// The optimistic form update may now disagree with disk; re-sync to truth.
+			void queryClient.invalidateQueries({ queryKey: updateSettingsQueryKey });
 		}
 	};
 

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -29,7 +29,7 @@ const CHANNEL_OPTIONS: { value: PrimaryValue; label: string }[] = [
 ];
 
 // Feature Releases is developer-only; hide it entirely unless Developer Mode is on.
-const STABLE_CHANNEL_OPTIONS = CHANNEL_OPTIONS.filter((option) => option.value !== "feature");
+const NON_FEATURE_CHANNEL_OPTIONS = CHANNEL_OPTIONS.filter((option) => option.value !== "feature");
 
 const DEFAULT_SETTINGS: UpdateSettings = { enabled: false, channel: "latest", nightlyAck: false, feature: null };
 
@@ -167,18 +167,30 @@ export function UpdatesSection() {
 		queryFn: () => aoBridge.featureBuilds.getActive(),
 	});
 	const activeBuild = activeQuery.data ?? null;
+	// Show the escape hatch whenever a feature build is running OR merely pinned in
+	// persisted settings. A pin stays effective in the main-process updater even
+	// when Developer Mode is off and hides the picker, so it must never be silent.
+	const pinnedPr = activeBuild?.pr ?? form.feature?.pr ?? null;
 
 	return (
 		<>
 			<SettingsSection title="Updates" sectionId="updates">
-				{activeBuild && (
+				{pinnedPr != null && (
 					<div className="flex flex-col gap-2">
 						<div className="settings-row-bar h-auto min-h-(--size-settings-row) flex-wrap gap-2">
-							<Badge variant="accent">PR #{activeBuild.pr}</Badge>
+							<Badge variant="accent">PR #{pinnedPr}</Badge>
 							<span className="min-w-0 flex-1 text-sm leading-5 text-settings-label">
-								You are on PR #{activeBuild.pr}'s build.
+								{activeBuild
+									? `You are on PR #${pinnedPr}'s build.`
+									: `PR #${pinnedPr} is pinned but not yet installed.`}
 							</span>
-							<Button type="button" variant="outline" size="sm" onClick={() => void handleReturnToHome()}>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								disabled={!query.isSuccess}
+								onClick={() => void handleReturnToHome()}
+							>
 								Return to {form.channel === "nightly" ? "Nightly" : "Stable"}
 							</Button>
 						</div>
@@ -202,7 +214,7 @@ export function UpdatesSection() {
 					<SettingsOptionMenu
 						aria-label="Updates channel"
 						value={primaryValue}
-						options={developerMode ? CHANNEL_OPTIONS : STABLE_CHANNEL_OPTIONS}
+						options={developerMode ? CHANNEL_OPTIONS : NON_FEATURE_CHANNEL_OPTIONS}
 						onChange={handlePrimaryChannel}
 						disabled={!form.enabled || save.isPending}
 					/>

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -149,13 +149,15 @@ export function UpdatesSection() {
 
 	const handleReturnToHome = async () => {
 		setShowFeature(false);
-		const next = { ...formRef.current, feature: null };
-		setForm(next);
 		const requestId = nextUpdateRequestId();
 		autoProgressRef.current = requestId;
 		handledStatusRef.current = null;
 		try {
-			await aoBridge.updates.check({ settings: next, requestId });
+			// Clear the pin atomically against persisted main-process state (preserves
+			// the home channel) so Return works regardless of renderer form hydration.
+			const next = await aoBridge.updateSettings.clearFeature();
+			setForm(next);
+			await aoBridge.updates.check({ requestId });
 			void queryClient.invalidateQueries({ queryKey: updateSettingsQueryKey });
 		} catch {
 			if (autoProgressRef.current === requestId) autoProgressRef.current = null;
@@ -167,30 +169,26 @@ export function UpdatesSection() {
 		queryFn: () => aoBridge.featureBuilds.getActive(),
 	});
 	const activeBuild = activeQuery.data ?? null;
-	// Show the escape hatch whenever a feature build is running OR merely pinned in
-	// persisted settings. A pin stays effective in the main-process updater even
-	// when Developer Mode is off and hides the picker, so it must never be silent.
-	const pinnedPr = activeBuild?.pr ?? form.feature?.pr ?? null;
+	// Show the escape hatch whenever a feature build is running. When Developer Mode
+	// is off, also surface a merely-pinned build: the pin stays effective in the
+	// main-process updater while the picker is hidden, so it must never be silent.
+	// With Developer Mode on the visible picker already shows the pin, so Updates
+	// behaves exactly as before (banner only for a running build).
+	const featurePr = activeBuild?.pr ?? (developerMode ? null : (form.feature?.pr ?? null));
 
 	return (
 		<>
 			<SettingsSection title="Updates" sectionId="updates">
-				{pinnedPr != null && (
+				{featurePr != null && (
 					<div className="flex flex-col gap-2">
 						<div className="settings-row-bar h-auto min-h-(--size-settings-row) flex-wrap gap-2">
-							<Badge variant="accent">PR #{pinnedPr}</Badge>
+							<Badge variant="accent">PR #{featurePr}</Badge>
 							<span className="min-w-0 flex-1 text-sm leading-5 text-settings-label">
 								{activeBuild
-									? `You are on PR #${pinnedPr}'s build.`
-									: `PR #${pinnedPr} is pinned but not yet installed.`}
+									? `You are on PR #${featurePr}'s build.`
+									: `PR #${featurePr} is pinned but not yet installed.`}
 							</span>
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								disabled={!query.isSuccess}
-								onClick={() => void handleReturnToHome()}
-							>
+							<Button type="button" variant="outline" size="sm" onClick={() => void handleReturnToHome()}>
 								Return to {form.channel === "nightly" ? "Nightly" : "Stable"}
 							</Button>
 						</div>

--- a/frontend/src/renderer/components/settings/UpdatesSection.tsx
+++ b/frontend/src/renderer/components/settings/UpdatesSection.tsx
@@ -197,7 +197,7 @@ export function UpdatesSection() {
 							</Button>
 						</div>
 						<p className="px-1 text-xs text-settings-muted">
-							Automatic updates, if enabled, will return you to your home channel on the next check.
+							Automatic updates, if enabled, keep tracking PR #{featurePr} until you return home or the build retires.
 						</p>
 					</div>
 				)}

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -129,11 +129,11 @@ export const aoBridge: AoBridge =
 		updateSettings: {
 			get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 			set: async () => undefined,
-			clearFeature: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 		},
 		updates: {
 			getStatus: async () => ({ state: "idle" }),
 			check: async () => undefined,
+			returnHome: async () => undefined,
 			download: async () => undefined,
 			install: async () => undefined,
 			onStatus: () => () => undefined,

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -129,6 +129,7 @@ export const aoBridge: AoBridge =
 		updateSettings: {
 			get: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 			set: async () => undefined,
+			clearFeature: async () => ({ enabled: false, channel: "latest", nightlyAck: false, feature: null }),
 		},
 		updates: {
 			getStatus: async () => ({ state: "idle" }),

--- a/frontend/src/renderer/stores/ui-store.test.ts
+++ b/frontend/src/renderer/stores/ui-store.test.ts
@@ -19,7 +19,7 @@ describe("ui-store developerMode persistence", () => {
 		expect(useUiStore.getState().developerMode).toBe(true);
 	});
 
-	it("treats any non-\"true\" stored value as off", async () => {
+	it('treats any non-"true" stored value as off', async () => {
 		window.localStorage.setItem("ao.developerMode", "1");
 		const { useUiStore } = await import("./ui-store");
 		expect(useUiStore.getState().developerMode).toBe(false);

--- a/frontend/src/renderer/stores/ui-store.test.ts
+++ b/frontend/src/renderer/stores/ui-store.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// developerMode initializes from localStorage at module load, so each case resets
+// modules and re-imports to exercise the real initialization path.
+describe("ui-store developerMode persistence", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+		vi.resetModules();
+	});
+
+	it("defaults to off when nothing is stored", async () => {
+		const { useUiStore } = await import("./ui-store");
+		expect(useUiStore.getState().developerMode).toBe(false);
+	});
+
+	it("restores an enabled flag from stored ao.developerMode=true", async () => {
+		window.localStorage.setItem("ao.developerMode", "true");
+		const { useUiStore } = await import("./ui-store");
+		expect(useUiStore.getState().developerMode).toBe(true);
+	});
+
+	it("treats any non-\"true\" stored value as off", async () => {
+		window.localStorage.setItem("ao.developerMode", "1");
+		const { useUiStore } = await import("./ui-store");
+		expect(useUiStore.getState().developerMode).toBe(false);
+	});
+
+	it("setDeveloperMode writes localStorage and updates state", async () => {
+		const { useUiStore } = await import("./ui-store");
+		useUiStore.getState().setDeveloperMode(true);
+		expect(useUiStore.getState().developerMode).toBe(true);
+		expect(window.localStorage.getItem("ao.developerMode")).toBe("true");
+		useUiStore.getState().setDeveloperMode(false);
+		expect(useUiStore.getState().developerMode).toBe(false);
+		expect(window.localStorage.getItem("ao.developerMode")).toBe("false");
+	});
+});

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -33,6 +33,8 @@ type UiState = {
 	themePreference: ThemePreference;
 	/** Resolved light/dark for React consumers; may track OS while preference is system. */
 	resolvedTheme: Theme;
+	/** When true, developer-only surfaces (e.g. Feature Releases) are revealed. Default off. */
+	developerMode: boolean;
 	restartingProjectIds: ReadonlySet<string>;
 	orchestratorReplacementErrors: Record<string, string>;
 	orchestratorStartupErrors: Record<string, string>;
@@ -56,6 +58,7 @@ type UiState = {
 	activeShellTerminalHandleId: string | null;
 	setWorkbenchTab: (tab: WorkbenchTab) => void;
 	setThemePreference: (theme: ThemePreference) => void;
+	setDeveloperMode: (enabled: boolean) => void;
 	/** Refresh resolvedTheme from OS without writing light/dark to storage. */
 	syncSystemTheme: () => void;
 	toggleSidebar: () => void;
@@ -74,6 +77,7 @@ type UiState = {
 };
 
 const sidebarStorageKey = "ao.sidebar.open";
+const developerModeStorageKey = "ao.developerMode";
 
 function getLocalStorage() {
 	if (typeof window === "undefined" || !window.localStorage) return null;
@@ -82,6 +86,10 @@ function getLocalStorage() {
 
 function initialSidebarOpen() {
 	return getLocalStorage()?.getItem(sidebarStorageKey) !== "false";
+}
+
+function initialDeveloperMode() {
+	return getLocalStorage()?.getItem(developerModeStorageKey) === "true";
 }
 
 function inspectorState(sessions: Record<string, InspectorSessionState>, sessionId: string): InspectorSessionState {
@@ -97,6 +105,7 @@ export const useUiStore = create<UiState>((set) => ({
 	isCommandPaletteOpen: false,
 	themePreference: initialThemePreference,
 	resolvedTheme: resolveTheme(initialThemePreference),
+	developerMode: initialDeveloperMode(),
 	restartingProjectIds: new Set<string>(),
 	orchestratorReplacementErrors: {},
 	orchestratorStartupErrors: {},
@@ -108,6 +117,10 @@ export const useUiStore = create<UiState>((set) => ({
 	setThemePreference: (themePreference) => {
 		getLocalStorage()?.setItem(themeStorageKey, themePreference);
 		set({ themePreference, resolvedTheme: resolveTheme(themePreference) });
+	},
+	setDeveloperMode: (developerMode) => {
+		getLocalStorage()?.setItem(developerModeStorageKey, String(developerMode));
+		set({ developerMode });
 	},
 	syncSystemTheme: () =>
 		set((state) => {

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -175,6 +175,7 @@ if (typeof window !== "undefined") {
 		updates: {
 			getStatus: async () => ({ state: "idle" }),
 			check: async () => undefined,
+			returnHome: async () => undefined,
 			download: async () => undefined,
 			install: async () => undefined,
 			onStatus: () => () => undefined,


### PR DESCRIPTION
## Summary

Adds a **Developer Mode** section to the global app Settings and gates the **Feature Releases** update channel behind it.

- New `Developer Mode` section in Global Settings: a single Switch toggle, default **off**, persisted via the existing `ui-store` + `localStorage` pattern (same one the Theme/sidebar preferences use; `localStorage` resolves under `~/.ao/electron`, respecting the `~/.ao`-only state rule).
- When Developer Mode is **off**, the `Feature Releases` option is removed entirely from the Updates channel dropdown and the feature-build picker is hidden (hidden, not disabled). When **on**, Updates behaves exactly as before.
- The Updates "you are on PR #N's build" banner is intentionally left outside the gate, so a user who pinned a build and later turns Developer Mode off still has a "Return to Stable/Nightly" escape hatch.

### Note on scope
The pre-existing "Feature Releases" surface is the `feature` channel option inside `UpdatesSection` (plus its `FeatureBuildsSelect` picker). There is no separate top-level Feature Releases page in `main`, so this gates that entry point. Feature Releases itself is unchanged.

## Changes
- `stores/ui-store.ts` — add `developerMode` state + `setDeveloperMode`, initialized from and persisted to `localStorage`.
- `settings/DeveloperModeSection.tsx` — new section with a single shadcn `Switch`.
- `GlobalSettingsForm.tsx` — render the new section.
- `settings/UpdatesSection.tsx` — hide the `feature` channel option / picker unless Developer Mode is on.

## Tests
- `npx vitest run GlobalSettingsForm.test.tsx` — 21 passing, including two new gating tests (option hidden when off, revealed when toggled on) plus a section-render assertion.
- Renderer production build (`vite build`) passes.
- Verified in-app via `ao preview` on `/settings`.

## Known risks / follow-ups
- Purely a UI gate; the main-process auto-updater is untouched.
- Pre-existing `tsc` errors in `src/renderer/lib/command-palette.ts` are unrelated (that file is byte-identical to `main`).