### PR TITLE
fix(orchestrator): open most recently active session, not newest-created

### DIFF
--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -376,12 +376,20 @@ func newestSession(sessions []domain.Session) domain.Session {
 	return newest
 }
 
+// sessionNewer ranks orchestrators for ensure/reuse: prefer the one that has
+// been used most recently (activity), not merely the most recently created.
+// CreatedAt-first ranking made POST /orchestrators (clean=false) and the UI
+// "Open Orchestrator" control attach to a brand-new empty session when an
+// older still-live orchestrator held the conversation history.
 func sessionNewer(a, b domain.SessionRecord) bool {
-	if !a.CreatedAt.Equal(b.CreatedAt) {
-		return a.CreatedAt.After(b.CreatedAt)
+	if !a.Activity.LastActivityAt.Equal(b.Activity.LastActivityAt) {
+		return a.Activity.LastActivityAt.After(b.Activity.LastActivityAt)
 	}
 	if !a.UpdatedAt.Equal(b.UpdatedAt) {
 		return a.UpdatedAt.After(b.UpdatedAt)
+	}
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.After(b.CreatedAt)
 	}
 	return string(a.ID) > string(b.ID)
 }

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -1094,6 +1094,51 @@ func TestSpawnOrchestratorNoCleanReturnsExistingWhenActiveExists(t *testing.T) {
 	}
 }
 
+// TestSpawnOrchestratorNoCleanReturnsMostRecentlyActiveAmongDuplicates locks
+// ensure/reuse ranking: when more than one live orchestrator exists, return the
+// one with the most recent agent activity — not the most recently created empty
+// replacement. CreatedAt-first ranking is what made "Open Orchestrator" land on
+// a cold session while history stayed on an older still-live orchestrator.
+func TestSpawnOrchestratorNoCleanReturnsMostRecentlyActiveAmongDuplicates(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer"}
+	olderActive := time.Date(2026, 1, 3, 12, 0, 0, 0, time.UTC)
+	newerCreated := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
+	st.sessions["mer-3"] = domain.SessionRecord{
+		ID:        "mer-3",
+		ProjectID: "mer",
+		Kind:      domain.KindOrchestrator,
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+		Activity:  domain.Activity{State: domain.ActivityActive, LastActivityAt: olderActive},
+	}
+	st.sessions["mer-4"] = domain.SessionRecord{
+		ID:        "mer-4",
+		ProjectID: "mer",
+		Kind:      domain.KindOrchestrator,
+		CreatedAt: newerCreated,
+		UpdatedAt: newerCreated,
+		Activity:  domain.Activity{State: domain.ActivityIdle, LastActivityAt: newerCreated},
+	}
+
+	fc := &fakeCommander{}
+	svc := &Service{manager: fc, store: st}
+
+	got, err := svc.SpawnOrchestrator(context.Background(), "mer", false)
+	if err != nil {
+		t.Fatalf("SpawnOrchestrator: %v", err)
+	}
+	if got.ID != "mer-3" {
+		t.Fatalf("returned id = %q, want most recently active orchestrator mer-3", got.ID)
+	}
+	if fc.spawned {
+		t.Fatal("manager.Spawn must NOT be called when an active orchestrator already exists")
+	}
+	if len(st.sessions) != 2 {
+		t.Fatalf("session count = %d, want 2 (no extra spawn)", len(st.sessions))
+	}
+}
+
 // TestSpawnOrchestratorNoCleanSpawnsWhenNoneExists: clean=false spawns a new
 // orchestrator when no active one exists for the project.
 func TestSpawnOrchestratorNoCleanSpawnsWhenNoneExists(t *testing.T) {

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -209,6 +209,30 @@ describe("findProjectOrchestrator", () => {
 		expect(newestActiveOrchestrator([oldUpdate, newUpdate])).toBe(newUpdate);
 		expect(newestActiveOrchestrator([newUpdate, sameTimesHigherID])).toBe(sameTimesHigherID);
 	});
+
+	it("prefers the most recently active orchestrator over a newer empty spawn", () => {
+		// Regression: when two live orchestrators overlap, ranking by createdAt
+		// alone sent Open Orchestrator to the brand-new empty session while the
+		// conversation history still lived on the older, actively used one.
+		const withHistory = sessionWith({
+			id: "skills-3",
+			kind: "orchestrator",
+			status: "working",
+			createdAt: "2026-01-01T00:00:00Z",
+			updatedAt: "2026-01-01T12:00:00Z",
+			activity: { state: "active", lastActivityAt: "2026-01-03T12:00:00Z" },
+		});
+		const emptyNewer = sessionWith({
+			id: "skills-4",
+			kind: "orchestrator",
+			status: "idle",
+			createdAt: "2026-01-03T00:00:00Z",
+			updatedAt: "2026-01-03T00:00:00Z",
+			activity: { state: "idle", lastActivityAt: "2026-01-03T00:00:00Z" },
+		});
+		expect(newestActiveOrchestrator([emptyNewer, withHistory])).toBe(withHistory);
+		expect(findProjectOrchestrator([workspaceWith([emptyNewer, withHistory])], "skills")).toBe(withHistory);
+	});
 });
 
 describe("sessionNeedsAttention", () => {
@@ -260,7 +284,7 @@ describe("orchestratorHealth", () => {
 		).toEqual({
 			state: "duplicates",
 			message:
-				"Multiple orchestrators are active. The newest one is used; stale ones will be cleaned up on daemon reconcile.",
+				"Multiple orchestrators are active. The most recently active one is used; stale ones will be cleaned up on daemon reconcile.",
 		});
 
 		expect(

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -261,6 +261,16 @@ export function findProjectOrchestrator(
 	return newestActiveOrchestrator(workspace?.sessions ?? []);
 }
 
+/**
+ * The project's most recently active live orchestrator.
+ *
+ * When multiple orchestrators are still non-terminated (overlap during
+ * replacement, accidental duplicates), prefer the one the user was actually
+ * talking to — most recent agent activity, then updatedAt — over the
+ * most-recently-created row. Ranking by createdAt alone sent "Open
+ * Orchestrator" to a brand-new empty session while history lived on an older
+ * still-live orchestrator (#1362 / empty-history-on-click reports).
+ */
 export function newestActiveOrchestrator(sessions: WorkspaceSession[]): WorkspaceSession | undefined {
 	const active = sessions.filter((session) => isOrchestratorSession(session) && sessionIsActive(session));
 	return active.reduce<WorkspaceSession | undefined>(
@@ -270,12 +280,17 @@ export function newestActiveOrchestrator(sessions: WorkspaceSession[]): Workspac
 }
 
 function sessionNewer(a: WorkspaceSession, b: WorkspaceSession): boolean {
-	const aCreated = timestamp(a.createdAt);
-	const bCreated = timestamp(b.createdAt);
-	if (aCreated !== bCreated) return aCreated > bCreated;
+	// Prefer the orchestrator that has been used most recently (live agent
+	// activity), not merely the one that was spawned last.
+	const aActivity = timestamp(a.activity?.lastActivityAt);
+	const bActivity = timestamp(b.activity?.lastActivityAt);
+	if (aActivity !== bActivity) return aActivity > bActivity;
 	const aUpdated = timestamp(a.updatedAt);
 	const bUpdated = timestamp(b.updatedAt);
 	if (aUpdated !== bUpdated) return aUpdated > bUpdated;
+	const aCreated = timestamp(a.createdAt);
+	const bCreated = timestamp(b.createdAt);
+	if (aCreated !== bCreated) return aCreated > bCreated;
 	return a.id > b.id;
 }
 
@@ -355,7 +370,7 @@ export function orchestratorHealth(workspace: WorkspaceSummary, restarting = fal
 		return {
 			state: "duplicates",
 			message:
-				"Multiple orchestrators are active. The newest one is used; stale ones will be cleaned up on daemon reconcile.",
+				"Multiple orchestrators are active. The most recently active one is used; stale ones will be cleaned up on daemon reconcile.",
 		};
 	}
 	const orchestrator = newestActiveOrchestrator(workspace.sessions);


### PR DESCRIPTION
## Problem

Clicking **Orchestrator** (sidebar / topbar / board / command palette) sometimes opened an **empty conversation** as if history had been wiped. History was still on another live orchestrator session; the UI/daemon had attached to a different, newer empty one.

## Root cause

When more than one non-terminated orchestrator existed for a project (overlap during replacement, accidental duplicates, etc.), both the frontend picker (`newestActiveOrchestrator`) and the daemon ensure path (`SpawnOrchestrator` clean=false → `newestSession`) ranked by **createdAt first**.

That preferred a brand-new empty spawn over an older still-active orchestrator that held the real conversation — matching the “wrong session / empty history on open” report and the recency intent of #1362 (most recently **used/active**, not lex-smallest or newest-created).

## Fix

Rank live orchestrators by:

1. `activity.lastActivityAt` (most recently used)
2. `updatedAt`
3. `createdAt`
4. session id

Applied in both:

- `frontend/.../workspace.ts` (`newestActiveOrchestrator` — all open entry points already use this)
- `backend/.../service/session/service.go` (`sessionNewer` — ensure/reuse when clean=false)

## What was deliberately not changed

| Path | Behavior preserved |
|------|-------------------|
| `SpawnOrchestrator(clean=false)` with **one** active orchestrator | Still returns that session; no spawn |
| `SpawnOrchestrator(clean=true)` / restart / settings / restore-dialog | Still retires then spawns |
| Kill / terminate / multi-project isolation / worker spawn / review | Untouched |
| #3032 sidebar pinned Orchestrator row | **Not** duplicated; that remains a separate UX PR |
| #2501 false terminate + silent replace | **Not** fixed here (lifecycle); residual risk noted below |

## Tests

- Frontend: `cd frontend && npm test -- --run src/renderer/types/workspace.test.ts` — prefers recently-active over newer empty spawn
- Backend: `cd backend && go test ./internal/service/session/ -count=1` — ensure returns most recently active among duplicates; existing clean=false/true tests still pass

## Residual risks / follow-ups

- **#2501**: if the reaper falsely marks the live orchestrator terminated, ensure still spawns a cold session. Consecutive-probe work is in #2587; unlinked respawn notification is still open.
- Parent-orchestrator linkage (#1211) is still absent in the Go domain; when multiple lives exist we pick by activity recency, not worker parent.

Closes nothing automatically; addresses the open-path half of the “click Orchestrator clears history” report and improves #1362 targeting.