### PR TITLE
feat(cli): add PR and review action commands

### DIFF
--- a/backend/internal/cli/pr.go
+++ b/backend/internal/cli/pr.go
@@ -39,7 +39,7 @@ func newPRMergeCommand(ctx *commandContext) *cobra.Command {
 	return &cobra.Command{
 		Use:   "merge <pr-number>",
 		Short: "Merge a pull request",
-		Args:  exactPRArgs(1),
+		Args:  usageArgs(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prNumber, err := normalizePRNumber(args[0])
 			if err != nil {
@@ -49,7 +49,11 @@ func newPRMergeCommand(ctx *commandContext) *cobra.Command {
 			if err := ctx.postJSON(cmd.Context(), "prs/"+url.PathEscape(prNumber)+"/merge", struct{}{}, &res); err != nil {
 				return err
 			}
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "merged PR #%d using %s\n", res.PRNumber, res.Method)
+			if method := strings.TrimSpace(res.Method); method != "" {
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "merged PR #%d using %s\n", res.PRNumber, method)
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "merged PR #%d\n", res.PRNumber)
 			return err
 		},
 	}
@@ -59,7 +63,7 @@ func newPRResolveCommentsCommand(ctx *commandContext) *cobra.Command {
 	return &cobra.Command{
 		Use:   "resolve-comments <pr-number> [comment-id...]",
 		Short: "Resolve review threads on a pull request",
-		Args:  exactPRArgsAtLeast(1),
+		Args:  usageArgs(cobra.MinimumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prNumber, err := normalizePRNumber(args[0])
 			if err != nil {
@@ -95,22 +99,4 @@ func normalizePRNumber(raw string) (string, error) {
 		return "", usageError{errors.New("PR number must be a positive integer")}
 	}
 	return strconv.Itoa(n), nil
-}
-
-func exactPRArgs(n int) cobra.PositionalArgs {
-	return func(cmd *cobra.Command, args []string) error {
-		if err := cobra.ExactArgs(n)(cmd, args); err != nil {
-			return usageError{err}
-		}
-		return nil
-	}
-}
-
-func exactPRArgsAtLeast(n int) cobra.PositionalArgs {
-	return func(cmd *cobra.Command, args []string) error {
-		if err := cobra.MinimumNArgs(n)(cmd, args); err != nil {
-			return usageError{err}
-		}
-		return nil
-	}
 }

--- a/backend/internal/cli/pr.go
+++ b/backend/internal/cli/pr.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type mergePRResponse struct {
+	OK       bool   `json:"ok"`
+	PRNumber int    `json:"prNumber"`
+	Method   string `json:"method"`
+}
+
+type resolveCommentsRequest struct {
+	CommentIDs []string `json:"commentIds,omitempty"`
+}
+
+type resolveCommentsResponse struct {
+	OK       bool `json:"ok"`
+	Resolved int  `json:"resolved"`
+}
+
+func newPRCommand(ctx *commandContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pr",
+		Short: "Manage pull requests",
+	}
+	cmd.AddCommand(newPRMergeCommand(ctx))
+	cmd.AddCommand(newPRResolveCommentsCommand(ctx))
+	return cmd
+}
+
+func newPRMergeCommand(ctx *commandContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "merge <pr-number>",
+		Short: "Merge a pull request",
+		Args:  exactPRArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			prNumber, err := normalizePRNumber(args[0])
+			if err != nil {
+				return err
+			}
+			var res mergePRResponse
+			if err := ctx.postJSON(cmd.Context(), "prs/"+url.PathEscape(prNumber)+"/merge", struct{}{}, &res); err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "merged PR #%d using %s\n", res.PRNumber, res.Method)
+			return err
+		},
+	}
+}
+
+func newPRResolveCommentsCommand(ctx *commandContext) *cobra.Command {
+	return &cobra.Command{
+		Use:   "resolve-comments <pr-number> [comment-id...]",
+		Short: "Resolve review threads on a pull request",
+		Args:  exactPRArgsAtLeast(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			prNumber, err := normalizePRNumber(args[0])
+			if err != nil {
+				return err
+			}
+			commentIDs := make([]string, 0, len(args)-1)
+			for _, id := range args[1:] {
+				id = strings.TrimSpace(id)
+				if id == "" {
+					return usageError{errors.New("comment id must not be blank")}
+				}
+				commentIDs = append(commentIDs, id)
+			}
+			var res resolveCommentsResponse
+			if err := ctx.postJSON(
+				cmd.Context(),
+				"prs/"+url.PathEscape(prNumber)+"/resolve-comments",
+				resolveCommentsRequest{CommentIDs: commentIDs},
+				&res,
+			); err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "resolved %d review thread(s) on PR #%s\n", res.Resolved, prNumber)
+			return err
+		},
+	}
+}
+
+func normalizePRNumber(raw string) (string, error) {
+	raw = strings.TrimPrefix(strings.TrimSpace(raw), "#")
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return "", usageError{errors.New("PR number must be a positive integer")}
+	}
+	return strconv.Itoa(n), nil
+}
+
+func exactPRArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := cobra.ExactArgs(n)(cmd, args); err != nil {
+			return usageError{err}
+		}
+		return nil
+	}
+}
+
+func exactPRArgsAtLeast(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := cobra.MinimumNArgs(n)(cmd, args); err != nil {
+			return usageError{err}
+		}
+		return nil
+	}
+}

--- a/backend/internal/cli/pr_test.go
+++ b/backend/internal/cli/pr_test.go
@@ -27,6 +27,20 @@ func TestPRMergePostsToDaemon(t *testing.T) {
 	}
 }
 
+func TestPRMergeOmitsMissingMethodFromOutput(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := reviewServer(t, http.StatusOK, `{"ok":true,"prNumber":42}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "pr", "merge", "42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if out != "merged PR #42\n" {
+		t.Fatalf("stdout = %q, want %q", out, "merged PR #42\n")
+	}
+}
+
 func TestPRMergeRejectsInvalidNumber(t *testing.T) {
 	setConfigEnv(t)
 

--- a/backend/internal/cli/pr_test.go
+++ b/backend/internal/cli/pr_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestPRMergePostsToDaemon(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := reviewServer(t, http.StatusOK, `{"ok":true,"prNumber":42,"method":"squash"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "pr", "merge", "#42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodPost || capture.path != "/api/v1/prs/42/merge" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+	if strings.TrimSpace(capture.body) != "{}" {
+		t.Fatalf("body = %q, want {}", capture.body)
+	}
+	if !strings.Contains(out, "merged PR #42 using squash") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestPRMergeRejectsInvalidNumber(t *testing.T) {
+	setConfigEnv(t)
+
+	for _, number := range []string{"0", "-1", "abc", "#"} {
+		t.Run(number, func(t *testing.T) {
+			_, _, err := executeCLI(t, aliveDeps(), "pr", "merge", number)
+			if got := ExitCode(err); got != 2 {
+				t.Fatalf("exit code = %d, want 2; err=%v", got, err)
+			}
+		})
+	}
+}
+
+func TestPRMergeRequiresExactlyOneArgument(t *testing.T) {
+	setConfigEnv(t)
+
+	for _, args := range [][]string{
+		{"pr", "merge"},
+		{"pr", "merge", "42", "43"},
+	} {
+		_, _, err := executeCLI(t, aliveDeps(), args...)
+		if got := ExitCode(err); got != 2 {
+			t.Fatalf("args = %v, exit code = %d, want 2; err=%v", args, got, err)
+		}
+	}
+}
+
+func TestPRMergeSurfacesDaemonError(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := reviewServer(t, http.StatusConflict, `{"message":"PR is not mergeable","code":"PR_NOT_MERGEABLE","requestId":"req-1"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, aliveDeps(), "pr", "merge", "42")
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1; err=%v", got, err)
+	}
+	for _, want := range []string{"PR is not mergeable", "PR_NOT_MERGEABLE", "req-1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err = %q, want %q", err, want)
+		}
+	}
+}
+
+func TestPRResolveCommentsPostsIDs(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := reviewServer(t, http.StatusOK, `{"ok":true,"resolved":2}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "pr", "resolve-comments", "42", "thread-1", "thread-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodPost || capture.path != "/api/v1/prs/42/resolve-comments" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+	var req resolveCommentsRequest
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(req.CommentIDs) != 2 || req.CommentIDs[0] != "thread-1" || req.CommentIDs[1] != "thread-2" {
+		t.Fatalf("comment ids = %v", req.CommentIDs)
+	}
+	if !strings.Contains(out, "resolved 2 review thread(s) on PR #42") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestPRResolveCommentsAllowsNoIDs(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := reviewServer(t, http.StatusOK, `{"ok":true,"resolved":3}`)
+	writeRunFileFor(t, cfg, srv)
+
+	if _, errOut, err := executeCLI(t, aliveDeps(), "pr", "resolve-comments", "42"); err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if strings.TrimSpace(capture.body) != "{}" {
+		t.Fatalf("body = %q, want {}", capture.body)
+	}
+}
+
+func TestPRResolveCommentsRequiresPRNumber(t *testing.T) {
+	setConfigEnv(t)
+
+	_, _, err := executeCLI(t, aliveDeps(), "pr", "resolve-comments")
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2; err=%v", got, err)
+	}
+}

--- a/backend/internal/cli/review.go
+++ b/backend/internal/cli/review.go
@@ -112,7 +112,7 @@ func newReviewListCommand(ctx *commandContext) *cobra.Command {
 		Use:     "ls <worker-session-id>",
 		Aliases: []string{"list"},
 		Short:   "List reviews for a worker session",
-		Args:    exactReviewArgs(1),
+		Args:    usageArgs(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			session := strings.TrimSpace(args[0])
 			if session == "" {
@@ -313,15 +313,6 @@ func writeReviewList(cmd *cobra.Command, session string, res listReviewsResponse
 		}
 	}
 	return tw.Flush()
-}
-
-func exactReviewArgs(n int) cobra.PositionalArgs {
-	return func(cmd *cobra.Command, args []string) error {
-		if err := cobra.ExactArgs(n)(cmd, args); err != nil {
-			return usageError{err}
-		}
-		return nil
-	}
 }
 
 func readReviewItems(cmd *cobra.Command, path string) ([]submitReviewItem, error) {

--- a/backend/internal/cli/review.go
+++ b/backend/internal/cli/review.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -17,6 +18,7 @@ import (
 // reviewRun mirrors the daemon's domain.ReviewRun for the CLI client.
 type reviewRun struct {
 	ID             string     `json:"id"`
+	ReviewID       string     `json:"reviewId"`
 	SessionID      string     `json:"sessionId"`
 	BatchID        string     `json:"batchId"`
 	Harness        string     `json:"harness"`
@@ -28,6 +30,21 @@ type reviewRun struct {
 	GithubReviewID string     `json:"githubReviewId"`
 	CreatedAt      time.Time  `json:"createdAt"`
 	DeliveredAt    *time.Time `json:"deliveredAt,omitempty"`
+}
+
+type reviewState struct {
+	PRURL       string     `json:"prUrl"`
+	PRNumber    int        `json:"prNumber"`
+	Title       string     `json:"title"`
+	TargetSHA   string     `json:"targetSha"`
+	Status      string     `json:"status"`
+	LatestRun   *reviewRun `json:"latestRun,omitempty"`
+	PreviousRun *reviewRun `json:"previousRun,omitempty"`
+}
+
+type listReviewsResponse struct {
+	ReviewerHandleID string        `json:"reviewerHandleId"`
+	Reviews          []reviewState `json:"reviews"`
 }
 
 // triggerReviewResponse mirrors controllers.TriggerReviewResponse. Only the
@@ -73,14 +90,46 @@ type reviewSessionOptions struct {
 	session string
 }
 
+type reviewListOptions struct {
+	json bool
+}
+
 func newReviewCommand(ctx *commandContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "review",
 		Short: "Manage AO code reviews of a worker's PR",
 	}
+	cmd.AddCommand(newReviewListCommand(ctx))
 	cmd.AddCommand(newReviewSubmitCommand(ctx))
-	cmd.AddCommand(newReviewStopCommand(ctx))
-	cmd.AddCommand(newReviewRestartCommand(ctx))
+	cmd.AddCommand(newReviewCancelCommand(ctx))
+	cmd.AddCommand(newReviewTriggerCommand(ctx))
+	return cmd
+}
+
+func newReviewListCommand(ctx *commandContext) *cobra.Command {
+	var opts reviewListOptions
+	cmd := &cobra.Command{
+		Use:     "ls <worker-session-id>",
+		Aliases: []string{"list"},
+		Short:   "List reviews for a worker session",
+		Args:    exactReviewArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			session := strings.TrimSpace(args[0])
+			if session == "" {
+				return usageError{errors.New("worker session id must not be blank")}
+			}
+			var res listReviewsResponse
+			path := "sessions/" + url.PathEscape(session) + "/reviews"
+			if err := ctx.getJSON(cmd.Context(), path, &res); err != nil {
+				return err
+			}
+			if opts.json {
+				return writeJSON(cmd.OutOrStdout(), res)
+			}
+			return writeReviewList(cmd, session, res)
+		},
+	}
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Output reviews as JSON")
 	return cmd
 }
 
@@ -174,12 +223,13 @@ func (c *commandContext) submitReviewBatch(cmd *cobra.Command, session string, o
 	return err
 }
 
-func newReviewStopCommand(ctx *commandContext) *cobra.Command {
+func newReviewCancelCommand(ctx *commandContext) *cobra.Command {
 	var opts reviewSessionOptions
 	cmd := &cobra.Command{
-		Use:   "stop [worker-session-id]",
-		Short: "Cancel any running review for a worker's PR",
-		Args:  atMostOneArg,
+		Use:     "cancel [worker-session-id]",
+		Aliases: []string{"stop"},
+		Short:   "Cancel any running review for a worker's PR",
+		Args:    atMostOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ctx.stopReview(cmd, args, opts)
 		},
@@ -188,12 +238,13 @@ func newReviewStopCommand(ctx *commandContext) *cobra.Command {
 	return cmd
 }
 
-func newReviewRestartCommand(ctx *commandContext) *cobra.Command {
+func newReviewTriggerCommand(ctx *commandContext) *cobra.Command {
 	var opts reviewSessionOptions
 	cmd := &cobra.Command{
-		Use:   "restart [worker-session-id]",
-		Short: "Trigger a new review pass for a worker's PR",
-		Args:  atMostOneArg,
+		Use:     "trigger [worker-session-id]",
+		Aliases: []string{"execute", "restart"},
+		Short:   "Trigger a new review pass for a worker's PR",
+		Args:    atMostOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return ctx.restartReview(cmd, args, opts)
 		},
@@ -239,6 +290,38 @@ func (c *commandContext) restartReview(cmd *cobra.Command, args []string, opts r
 	}
 	_, err := fmt.Fprintf(cmd.OutOrStdout(), msg, session)
 	return err
+}
+
+func writeReviewList(cmd *cobra.Command, session string, res listReviewsResponse) error {
+	out := cmd.OutOrStdout()
+	if len(res.Reviews) == 0 {
+		_, err := fmt.Fprintf(out, "No reviews found for %s.\n", session)
+		return err
+	}
+
+	tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "PR\tSTATUS\tVERDICT\tTITLE"); err != nil {
+		return err
+	}
+	for _, review := range res.Reviews {
+		verdict := "-"
+		if review.LatestRun != nil && review.LatestRun.Verdict != "" {
+			verdict = review.LatestRun.Verdict
+		}
+		if _, err := fmt.Fprintf(tw, "#%d\t%s\t%s\t%s\n", review.PRNumber, review.Status, verdict, review.Title); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func exactReviewArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := cobra.ExactArgs(n)(cmd, args); err != nil {
+			return usageError{err}
+		}
+		return nil
+	}
 }
 
 func readReviewItems(cmd *cobra.Command, path string) ([]submitReviewItem, error) {

--- a/backend/internal/cli/review_test.go
+++ b/backend/internal/cli/review_test.go
@@ -295,3 +295,133 @@ func TestReviewRestartMissingSessionIsUsageError(t *testing.T) {
 		t.Fatalf("exit code = %d, want 2 (usage); err=%v", got, err)
 	}
 }
+
+func TestReviewListGetsReviews(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, capture := reviewServer(t, http.StatusOK, `{
+		"reviewerHandleId":"handle-1",
+		"reviews":[{
+			"prUrl":"https://github.com/example/repo/pull/42",
+			"prNumber":42,
+			"title":"Fix session resume",
+			"targetSha":"abc123",
+			"status":"changes_requested",
+			"latestRun":{"id":"run-1","reviewId":"review-1","verdict":"changes_requested"}
+		}]
+	}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "review", "ls", "mer-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if capture.method != http.MethodGet || capture.path != "/api/v1/sessions/mer-1/reviews" {
+		t.Fatalf("request = %s %s", capture.method, capture.path)
+	}
+	for _, want := range []string{"PR", "STATUS", "VERDICT", "TITLE", "#42", "changes_requested", "Fix session resume"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want %q", out, want)
+		}
+	}
+}
+
+func TestReviewListJSONPreservesResponse(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := reviewServer(t, http.StatusOK, `{
+		"reviewerHandleId":"handle-1",
+		"reviews":[{
+			"prUrl":"https://github.com/example/repo/pull/42",
+			"prNumber":42,
+			"title":"Fix session resume",
+			"targetSha":"abc123",
+			"status":"running",
+			"latestRun":{"id":"run-1","reviewId":"review-1","status":"running"}
+		}]
+	}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "review", "ls", "mer-1", "--json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	var res listReviewsResponse
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if res.ReviewerHandleID != "handle-1" || len(res.Reviews) != 1 {
+		t.Fatalf("response = %+v", res)
+	}
+	if res.Reviews[0].LatestRun == nil || res.Reviews[0].LatestRun.ReviewID != "review-1" {
+		t.Fatalf("latest run = %+v", res.Reviews[0].LatestRun)
+	}
+}
+
+func TestReviewListEmpty(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := reviewServer(t, http.StatusOK, `{"reviewerHandleId":"","reviews":[]}`)
+	writeRunFileFor(t, cfg, srv)
+
+	out, errOut, err := executeCLI(t, aliveDeps(), "review", "list", "mer-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if !strings.Contains(out, "No reviews found for mer-1.") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestReviewListRequiresExactlyOneArgument(t *testing.T) {
+	setConfigEnv(t)
+
+	for _, args := range [][]string{
+		{"review", "ls"},
+		{"review", "ls", "mer-1", "mer-2"},
+	} {
+		_, _, err := executeCLI(t, aliveDeps(), args...)
+		if got := ExitCode(err); got != 2 {
+			t.Fatalf("args = %v, exit code = %d, want 2; err=%v", args, got, err)
+		}
+	}
+}
+
+func TestReviewListSurfacesDaemonError(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := reviewServer(t, http.StatusNotFound, `{"message":"session not found","code":"SESSION_NOT_FOUND","requestId":"req-2"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, aliveDeps(), "review", "ls", "missing")
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1; err=%v", got, err)
+	}
+	for _, want := range []string{"session not found", "SESSION_NOT_FOUND", "req-2"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err = %q, want %q", err, want)
+		}
+	}
+}
+
+func TestReviewActionCommandNames(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		path string
+	}{
+		{name: "cancel", cmd: "cancel", path: "/api/v1/sessions/mer-1/reviews/cancel"},
+		{name: "trigger", cmd: "trigger", path: "/api/v1/sessions/mer-1/reviews/trigger"},
+		{name: "execute alias", cmd: "execute", path: "/api/v1/sessions/mer-1/reviews/trigger"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setConfigEnv(t)
+			srv, capture := reviewServer(t, http.StatusOK, `{}`)
+			writeRunFileFor(t, cfg, srv)
+
+			if _, errOut, err := executeCLI(t, aliveDeps(), "review", tt.cmd, "mer-1"); err != nil {
+				t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+			}
+			if capture.method != http.MethodPost || capture.path != tt.path {
+				t.Fatalf("request = %s %s", capture.method, capture.path)
+			}
+		})
+	}
+}

--- a/backend/internal/cli/review_test.go
+++ b/backend/internal/cli/review_test.go
@@ -335,7 +335,8 @@ func TestReviewListJSONPreservesResponse(t *testing.T) {
 			"title":"Fix session resume",
 			"targetSha":"abc123",
 			"status":"running",
-			"latestRun":{"id":"run-1","reviewId":"review-1","status":"running"}
+			"latestRun":{"id":"run-1","reviewId":"review-1","status":"running"},
+			"previousRun":{"id":"run-0","reviewId":"review-1","status":"completed","verdict":"approved"}
 		}]
 	}`)
 	writeRunFileFor(t, cfg, srv)
@@ -353,6 +354,9 @@ func TestReviewListJSONPreservesResponse(t *testing.T) {
 	}
 	if res.Reviews[0].LatestRun == nil || res.Reviews[0].LatestRun.ReviewID != "review-1" {
 		t.Fatalf("latest run = %+v", res.Reviews[0].LatestRun)
+	}
+	if res.Reviews[0].PreviousRun == nil || res.Reviews[0].PreviousRun.ID != "run-0" {
+		t.Fatalf("previous run = %+v", res.Reviews[0].PreviousRun)
 	}
 }
 

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -196,6 +196,7 @@ func NewRootCommand(deps Deps) *cobra.Command {
 	root.AddCommand(newProjectCommand(ctx))
 	root.AddCommand(newSessionCommand(ctx))
 	root.AddCommand(newOrchestratorCommand(ctx))
+	root.AddCommand(newPRCommand(ctx))
 	root.AddCommand(newReviewCommand(ctx))
 	root.AddCommand(newCompletionCommand())
 	root.AddCommand(newVersionCommand())

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -275,6 +275,15 @@ func usageErrorCommand(args []string) (string, string) {
 	return command, commandPath
 }
 
+func usageArgs(validate cobra.PositionalArgs) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := validate(cmd, args); err != nil {
+			return usageError{err}
+		}
+		return nil
+	}
+}
+
 func noArgs(cmd *cobra.Command, args []string) error {
 	if err := cobra.ExactArgs(0)(cmd, args); err != nil {
 		return usageError{err}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -92,5 +92,6 @@ surface (`npm run sqlc`, `npm run api`).
   ([#110](https://github.com/aoagents/agent-orchestrator/issues/110)) and in
   `ao session get` ([#111](https://github.com/aoagents/agent-orchestrator/issues/111))
   is still open.
+
 Tracking milestone:
 [`rewrite`](https://github.com/aoagents/agent-orchestrator/milestone/1).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -92,8 +92,5 @@ surface (`npm run sqlc`, `npm run api`).
   ([#110](https://github.com/aoagents/agent-orchestrator/issues/110)) and in
   `ao session get` ([#111](https://github.com/aoagents/agent-orchestrator/issues/111))
   is still open.
-- **CLI parity for PR/review actions**: merge, resolve-comments, and review are
-  HTTP-only (frontend-driven); there are no `ao pr` / `ao review` commands.
-
 Tracking milestone:
 [`rewrite`](https://github.com/aoagents/agent-orchestrator/milestone/1).

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -82,9 +82,10 @@ opens that URL verbatim (`file://`, `http`, `https`).
 
 `go run .` in `backend/` remains a compatibility wrapper around the daemon.
 
-PR and review actions (merge, resolve-comments, review execute/send) are
-HTTP-only today and driven by the frontend; there are no `ao pr` / `ao review`
-commands yet.
+PR actions are available through `ao pr merge` and
+`ao pr resolve-comments`. Review actions are available through `ao review ls`,
+`ao review trigger` (also `execute` and `restart`), `ao review cancel` (also
+`stop`), and `ao review submit`.
 
 ## Configuration
 


### PR DESCRIPTION
Closes #2988

Adds the missing thin CLI commands for PR and review actions:

- `ao pr merge <pr-number>`
- `ao pr resolve-comments <pr-number> [comment-id...]`
- `ao review ls <worker-session-id>` with table and JSON output
- `ao review trigger`, with `execute` and `restart` aliases
- `ao review cancel`, with the existing `stop` alias

The CLI keeps mirrored DTOs locally and calls the existing daemon routes. The PR commands intentionally stay within that thin-client scope: current daemon behavior is preserved when the PR action service is unavailable, and no SCM business logic is added here.

Also updates the CLI docs and removes the completed parity item from the status page.

Checks:

- `go test -p 1 ./...`
- `go test -race ./internal/cli/...`
- `golangci-lint run ./...` — 0 issues
- `go build ./...`
- `go vet ./...`
- frontend Vitest — 973 tests passed
- frontend e2e typecheck
- renderer smoke — 20 tests passed

Ready for review @Pulkit7070 @codebanditssss
