### PR TITLE
fix(kilocode): forward role-specific model config on launch

### DIFF
--- a/backend/internal/adapters/agent/kilocode/kilocode.go
+++ b/backend/internal/adapters/agent/kilocode/kilocode.go
@@ -69,6 +69,22 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Kilo Code understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override written to the AO-generated Kilo agent (agent.<name>.model); format provider/model-id (e.g. anthropic/claude-haiku-4-20250514).",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new interactive Kilo Code session.
 // Shape:
 //
@@ -86,7 +102,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 		return nil, err
 	}
 
-	envPrefix, agentName, err := kilocodeConfigEnvPrefix(cfg.Permissions, cfg.SystemPrompt, cfg.SystemPromptFile, cfg.SessionID)
+	envPrefix, agentName, err := kilocodeConfigEnvPrefix(cfg.Permissions, cfg.SystemPrompt, cfg.SystemPromptFile, cfg.SessionID, cfg.Config.Model)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +137,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 
-	envPrefix, agentName, err := kilocodeConfigEnvPrefix(cfg.Permissions, cfg.SystemPrompt, cfg.SystemPromptFile, cfg.Session.ID)
+	envPrefix, agentName, err := kilocodeConfigEnvPrefix(cfg.Permissions, cfg.SystemPrompt, cfg.SystemPromptFile, cfg.Session.ID, cfg.Config.Model)
 	if err != nil {
 		return nil, false, err
 	}
@@ -185,6 +201,7 @@ type kilocodeInlineConfig struct {
 
 type kilocodeAgentSettings struct {
 	Prompt string `json:"prompt,omitempty"`
+	Model  string `json:"model,omitempty"`
 }
 
 // kilocodeConfigEnvPrefix renders permission and system-prompt config as an
@@ -197,17 +214,22 @@ type kilocodeAgentSettings struct {
 // runtime shell-quotes every element, and a quoted token is run as a command
 // rather than read as an assignment — hence the explicit `env` wrapper.
 // POSIX-only, which matches the tmux runtime.
-func kilocodeConfigEnvPrefix(mode ports.PermissionMode, inlinePrompt, promptFile, sessionID string) ([]string, string, error) {
+func kilocodeConfigEnvPrefix(mode ports.PermissionMode, inlinePrompt, promptFile, sessionID, model string) ([]string, string, error) {
 	config := kilocodeInlineConfig{Permission: kilocodePermissionConfig(mode)}
 	agentName := ""
 	systemPrompt, err := kilocodeSystemPromptText(inlinePrompt, promptFile)
 	if err != nil {
 		return nil, "", err
 	}
-	if systemPrompt != "" {
+	model = strings.TrimSpace(model)
+	// A non-default permission mode rides on the permission map alone, but a
+	// system prompt or a role-specific model must be carried on AO's generated
+	// agent (selected with --agent): Kilo Code reads the per-agent model from
+	// agent.<name>.model, and its interactive TUI has no reliable --model flag.
+	if systemPrompt != "" || model != "" {
 		agentName = kilocodeAOAgentName(sessionID)
 		config.Agent = map[string]kilocodeAgentSettings{
-			agentName: {Prompt: systemPrompt},
+			agentName: {Prompt: systemPrompt, Model: model},
 		}
 	}
 	if len(config.Permission) == 0 && len(config.Agent) == 0 {

--- a/backend/internal/adapters/agent/kilocode/kilocode_test.go
+++ b/backend/internal/adapters/agent/kilocode/kilocode_test.go
@@ -119,6 +119,77 @@ func TestGetLaunchCommandMapsPermissionModes(t *testing.T) {
 	}
 }
 
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Permissions:  ports.PermissionModeBypassPermissions,
+		SystemPrompt: "follow AO rules",
+		SessionID:    "sess-1",
+		// Surrounding whitespace must be trimmed before it reaches the config.
+		Config: ports.AgentConfig{Model: "  anthropic/claude-haiku-4-20250514  "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The role model rides on the AO-generated agent (agent.<name>.model),
+	// alongside the injected system prompt, selected with --agent.
+	want := []string{
+		"env", `KILO_CONFIG_CONTENT={"permission":{"*":"allow"},"agent":{"ao-sess-1":{"prompt":"follow AO rules","model":"anthropic/claude-haiku-4-20250514"}}}`,
+		"kilocode",
+		"--agent", "ao-sess-1",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+	if strings.Contains(strings.Join(cmd, " "), "  anthropic/claude-haiku-4-20250514  ") {
+		t.Fatalf("command %#v used untrimmed model", cmd)
+	}
+}
+
+// TestGetLaunchCommandAppendsModelWithoutSystemPrompt is the issue's repro: a
+// role config with a model but no system prompt. The model must still create and
+// select an AO agent, otherwise --agent is never passed and the model is dropped.
+func TestGetLaunchCommandAppendsModelWithoutSystemPrompt(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SessionID: "sess-1",
+		Config:    ports.AgentConfig{Model: "anthropic/claude-haiku-4-20250514"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"env", `KILO_CONFIG_CONTENT={"agent":{"ao-sess-1":{"model":"anthropic/claude-haiku-4-20250514"}}}`,
+		"kilocode",
+		"--agent", "ao-sess-1",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SessionID: "sess-1",
+		Config:    ports.AgentConfig{Model: " \t "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A blank model must not fabricate an agent, an --agent flag, or an env prefix.
+	want := []string{"kilocode"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
 func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
 	plugin := &Plugin{}
 
@@ -131,15 +202,22 @@ func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	plugin := &Plugin{}
 
 	spec, err := plugin.GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("unexpected config fields: %#v", spec.Fields)
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override written to the AO-generated Kilo agent (agent.<name>.model); format provider/model-id (e.g. anthropic/claude-haiku-4-20250514).",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
 	}
 }
 
@@ -364,6 +442,34 @@ func TestGetRestoreCommandReappliesSystemPromptAgent(t *testing.T) {
 	}
 	want := []string{
 		"env", `KILO_CONFIG_CONTENT={"agent":{"ao-sess-1":{"prompt":"restore AO rules"}}}`,
+		"kilocode",
+		"--agent", "ao-sess-1",
+		"--session", "ses_abc123",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{
+			ID:       "sess-1",
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "ses_abc123"},
+		},
+		Config: ports.AgentConfig{Model: "anthropic/claude-haiku-4-20250514"},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	// Resume re-injects the role model on the AO agent, mirroring launch.
+	want := []string{
+		"env", `KILO_CONFIG_CONTENT={"agent":{"ao-sess-1":{"model":"anthropic/claude-haiku-4-20250514"}}}`,
 		"kilocode",
 		"--agent", "ao-sess-1",
 		"--session", "ses_abc123",


### PR DESCRIPTION

Closes #2896.

## Problem
AO forwards a per-role model (`agentConfig.model`) into every adapter as `cfg.Config.Model`, but each adapter must opt in to passing it to its CLI. The Kilo Code adapter never read `cfg.Config`, so a configured worker/orchestrator model was silently dropped and the session fell back to Kilo Code's global default.

## Fix
Kilo Code has no reliable `--model` flag for the interactive TUI AO launches (`--model` exists only on `kilo run`). It reads a per-agent model from its injected `KILO_CONFIG_CONTENT` config at `agent.<name>.model` (precedence: session override > per-agent config > global > auto). AO already injects that config and selects a generated agent with `--agent`, so the model is carried there:

- Add a `Model` field to `kilocodeAgentSettings`.
- Create and select the AO agent whenever a system prompt **or** a model is present. Previously the agent entry was created only for a system prompt, so a model-only role never received `--agent` and the model was dropped — this is the reported repro.
- Forward `cfg.Config.Model` (trimmed) from both `GetLaunchCommand` and `GetRestoreCommand`.
- Override `GetConfigSpec` to advertise the `model` key.

Mirrors the Codex fix (#2869), adapted to Kilo Code's config-injection mechanism instead of a CLI flag.

## Tests
- Model forwarded on launch (with a system prompt) and on restore.
- Model-only / no-prompt launch still creates and selects the AO agent (the repro).
- Blank/whitespace model omitted (no agent, no `--agent`, no env prefix).
- Config-spec test updated to assert the `model` field.

`go test ./...` and golangci-lint pass. End-to-end confirmation that Kilo Code applies the model requires the `kilocode` binary and is a manual step.