### PR TITLE
fix(scm): re-land review-body fetch/mapping on main (recover stranded #3010)

### DIFF
--- a/backend/internal/adapters/scm/github/observer_provider.go
+++ b/backend/internal/adapters/scm/github/observer_provider.go
@@ -557,7 +557,7 @@ func buildReviewThreadsQuery(ref ports.SCMPRRef, beforeCursor string, includeRev
 	}
 	reviewSelection := ""
 	if includeReviews {
-		reviewSelection = fmt.Sprintf(" reviewSummaries: reviews(last:%d, states:[APPROVED,CHANGES_REQUESTED]){ nodes{ id state url submittedAt author{ login __typename } } }", githubReviewSummaryLimit)
+		reviewSelection = fmt.Sprintf(" reviewSummaries: reviews(last:%d, states:[APPROVED,CHANGES_REQUESTED]){ nodes{ id state url submittedAt body author{ login __typename } } }", githubReviewSummaryLimit)
 	}
 	return fmt.Sprintf(`query{
 repo: repository(owner:%s,name:%s){ pullRequest(number:%d){ reviewDecision%s reviewThreads(last:%d, before:%s){ nodes{
@@ -574,6 +574,7 @@ func scmReviewSummaryFromGraphQL(review map[string]any) ports.SCMReviewSummaryOb
 		Author:      str(author["login"]),
 		State:       string(reviewStateFromGraphQL(review["state"])),
 		URL:         str(review["url"]),
+		Body:        str(review["body"]),
 		IsBot:       isBotAuthor(author),
 		SubmittedAt: parseGitHubTime(str(review["submittedAt"])),
 	}

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -1375,6 +1375,9 @@ func TestFetchReviewThreadsUsesLatestWindowWithoutFallbackWhenOldestResolved(t *
 		if !strings.Contains(string(body), "reviews(last:20, states:[APPROVED,CHANGES_REQUESTED])") {
 			t.Fatalf("review query should fetch decisive review summaries, body=%s", body)
 		}
+		if !strings.Contains(string(body), "submittedAt body author") {
+			t.Fatalf("review query should request the review body, body=%s", body)
+		}
 		if !strings.Contains(string(body), "comments(first:5)") {
 			t.Fatalf("review query should cap comments per thread, body=%s", body)
 		}
@@ -1387,6 +1390,7 @@ func TestFetchReviewThreadsUsesLatestWindowWithoutFallbackWhenOldestResolved(t *
 					"state":       "CHANGES_REQUESTED",
 					"url":         "https://github.com/o/r/pull/1#pullrequestreview-1",
 					"submittedAt": "2026-06-15T00:00:00Z",
+					"body":        "please address the failing test",
 					"author":      map[string]any{"login": "alice", "__typename": "User"},
 				}}},
 				"reviewThreads": map[string]any{
@@ -1412,7 +1416,7 @@ func TestFetchReviewThreadsUsesLatestWindowWithoutFallbackWhenOldestResolved(t *
 	if len(review.Threads) != 1 || review.Threads[0].ID != "latest-resolved" {
 		t.Fatalf("threads = %#v", review.Threads)
 	}
-	if len(review.Reviews) != 1 || review.Reviews[0].Author != "alice" || review.Reviews[0].URL != "https://github.com/o/r/pull/1#pullrequestreview-1" {
+	if len(review.Reviews) != 1 || review.Reviews[0].Author != "alice" || review.Reviews[0].URL != "https://github.com/o/r/pull/1#pullrequestreview-1" || review.Reviews[0].Body != "please address the failing test" {
 		t.Fatalf("reviews = %#v", review.Reviews)
 	}
 	if len(review.Threads[0].Comments) != 1 || review.Threads[0].Comments[0].URL != "https://github.com/o/r/pull/1#discussion_r1" {

--- a/backend/internal/observe/scm/observer.go
+++ b/backend/internal/observe/scm/observer.go
@@ -1136,6 +1136,7 @@ func domainFromObservation(sessionID domain.SessionID, obs ports.SCMObservation,
 			Author:      review.Author,
 			State:       domain.ReviewDecision(firstNonEmpty(review.State, string(domain.ReviewNone))),
 			URL:         review.URL,
+			Body:        review.Body,
 			IsBot:       review.IsBot,
 			SubmittedAt: firstTime(review.SubmittedAt, now),
 		})

--- a/backend/internal/ports/scm_observations.go
+++ b/backend/internal/ports/scm_observations.go
@@ -204,6 +204,9 @@ type SCMReviewSummaryObservation struct {
 	State string
 	// URL is a provider link to the submitted review summary.
 	URL string
+	// Body is the reviewer's submitted summary text, empty when the provider
+	// review carried no body.
+	Body string
 	// IsBot is true when the provider identifies the reviewer as a bot.
 	IsBot bool
 	// SubmittedAt is the provider's review submission timestamp.

--- a/backend/internal/service/session/claim_pr.go
+++ b/backend/internal/service/session/claim_pr.go
@@ -243,6 +243,7 @@ func claimRowsFromSCM(sessionID domain.SessionID, obs ports.SCMObservation, now 
 			Author:      review.Author,
 			State:       domain.ReviewDecision(firstNonEmpty(review.State, string(domain.ReviewNone))),
 			URL:         review.URL,
+			Body:        review.Body,
 			IsBot:       review.IsBot,
 			SubmittedAt: submittedAt,
 		})


### PR DESCRIPTION
## Summary

Re-lands #3010's provider review-body fetch/mapping onto `main`. Addresses the [P1] on #3046: like #3011, **#3010 (`3da9fff85`) was merged into its stacked base (`feat/persist-pr-review-body`), not `main`** — confirmed `3da9fff85` is not an ancestor of `main`, and `SCMReviewSummaryObservation` has no `Body` field there.

So even after #3046, the pipeline was broken end to end: the API copies `review.Body` into the response, but nothing populated it — real GitHub refreshes persisted `Body == ""` and `omitempty` dropped it from the response. Reviewer/verdict showed, the summary body did not. #3046's tests injected `Body` above the missing fetch layer, so they didn't catch it (fair call by the reviewer).

This cherry-picks `3da9fff85` (the five-file fetch/mapping commit, including its provider test):

- request `body` in the GitHub review-summary GraphQL and map it in `scmReviewSummaryFromGraphQL`
- add `Body` to `ports.SCMReviewSummaryObservation`
- carry `Body` through `domainFromObservation` (observer) and `claimRowsFromSCM` (session claim)

With this + #3009 (persist) + #3046 (expose) all on `main`, the review-summary body flows end to end for the first time.

## Verification

- `3da9fff85` cherry-picked cleanly onto current `main` (no conflicts)
- `cd backend && go build ./...` clean; gofmt clean
- `go test ./internal/adapters/scm/github/ ./internal/observe/scm/ ./internal/service/session/` pass — the github provider test asserts the query requests `body` and maps it through, which is exactly the check the injected-Body #3046 tests lacked
