### PR TITLE
feat(frontend): add board copy actions

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -4,15 +4,21 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 
-const { navigateMock, notificationShowMock, postMock, workspaceQueryMock, boardActionsInPanelMock } = vi.hoisted(
-	() => ({
-		navigateMock: vi.fn(),
-		notificationShowMock: vi.fn(),
-		postMock: vi.fn(),
-		workspaceQueryMock: vi.fn(),
-		boardActionsInPanelMock: vi.fn(() => false),
-	}),
-);
+const {
+	clipboardWriteTextMock,
+	navigateMock,
+	notificationShowMock,
+	postMock,
+	workspaceQueryMock,
+	boardActionsInPanelMock,
+} = vi.hoisted(() => ({
+	clipboardWriteTextMock: vi.fn(),
+	navigateMock: vi.fn(),
+	notificationShowMock: vi.fn(),
+	postMock: vi.fn(),
+	workspaceQueryMock: vi.fn(),
+	boardActionsInPanelMock: vi.fn(() => false),
+}));
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => navigateMock,
@@ -30,6 +36,9 @@ vi.mock("../lib/api-client", () => ({
 
 vi.mock("../lib/bridge", () => ({
 	aoBridge: {
+		clipboard: {
+			writeText: (...args: unknown[]) => clipboardWriteTextMock(...args),
+		},
 		notifications: {
 			show: (...args: unknown[]) => notificationShowMock(...args),
 		},
@@ -62,6 +71,7 @@ function renderBoardWithClient(queryClient: QueryClient, projectId?: string) {
 }
 
 beforeEach(() => {
+	clipboardWriteTextMock.mockReset().mockResolvedValue(undefined);
 	navigateMock.mockReset();
 	notificationShowMock.mockReset().mockResolvedValue(undefined);
 	postMock.mockReset().mockResolvedValue({ data: {} });
@@ -161,6 +171,49 @@ describe("SessionsBoard", () => {
 		fireEvent.click(screen.getByRole("button", { name: /idle sessions/i }));
 		const idleCard = screen.getByText("brand-font-pipeline").closest('[role="button"]') as HTMLElement;
 		expect(within(idleCard).getByText("Idle")).toBeInTheDocument();
+	});
+
+	it("copies visible branch names and PR URLs without opening the session", async () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					id: "p1",
+					name: "radic",
+					path: "/tmp/radic",
+					sessions: [
+						{
+							id: "s1",
+							workspaceId: "p1",
+							workspaceName: "radic",
+							title: "clipboard support",
+							provider: "claude-code",
+							branch: "feat/copy-actions",
+							status: "working",
+							activity: { state: "active", lastActivityAt: "2026-01-01T00:00:00Z" },
+							updatedAt: "2026-01-01T00:00:00Z",
+							prs: [{ number: 45, url: "https://github.com/acme/radic/pull/45", state: "open" }],
+						},
+					],
+				},
+			],
+			isError: false,
+			isSuccess: true,
+		});
+
+		renderBoard("p1");
+
+		await userEvent.click(screen.getByRole("button", { name: "Copy branch feat/copy-actions" }));
+		expect(clipboardWriteTextMock).toHaveBeenLastCalledWith("feat/copy-actions");
+		expect(screen.getByRole("button", { name: "Copied branch feat/copy-actions" })).toBeInTheDocument();
+		expect(navigateMock).not.toHaveBeenCalled();
+
+		await userEvent.click(screen.getByRole("button", { name: "Copy PR #45 URL" }));
+		expect(clipboardWriteTextMock).toHaveBeenLastCalledWith("https://github.com/acme/radic/pull/45");
+		expect(screen.getByRole("button", { name: "Copied PR #45 URL" })).toBeInTheDocument();
+		expect(navigateMock).not.toHaveBeenCalled();
+		await waitFor(() => expect(screen.getByRole("button", { name: "Copy PR #45 URL" })).toBeInTheDocument(), {
+			timeout: 2_000,
+		});
 	});
 
 	it("uses distinct card badge tones for idle, no signal, and draft PR sessions", () => {

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -191,7 +191,10 @@ describe("SessionsBoard", () => {
 							status: "working",
 							activity: { state: "active", lastActivityAt: "2026-01-01T00:00:00Z" },
 							updatedAt: "2026-01-01T00:00:00Z",
-							prs: [{ number: 45, url: "https://github.com/acme/radic/pull/45", state: "open" }],
+							prs: [
+								{ number: 45, url: "https://github.com/acme/radic/pull/45", state: "open" },
+								{ number: 46, url: "https://github.com/acme/radic/pull/46", state: "open" },
+							],
 						},
 					],
 				},
@@ -211,6 +214,8 @@ describe("SessionsBoard", () => {
 		expect(clipboardWriteTextMock).toHaveBeenLastCalledWith("https://github.com/acme/radic/pull/45");
 		expect(screen.getByRole("button", { name: "Copied PR #45 URL" })).toBeInTheDocument();
 		expect(navigateMock).not.toHaveBeenCalled();
+		const firstPRCopyButton = screen.getByRole("button", { name: "Copied PR #45 URL" });
+		expect(firstPRCopyButton.parentElement?.nextSibling?.textContent).toBe(",");
 		await waitFor(() => expect(screen.getByRole("button", { name: "Copy PR #45 URL" })).toBeInTheDocument(), {
 			timeout: 2_000,
 		});

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -591,20 +591,22 @@ function BoardPRGroup({ group, linksInteractive = true }: { group: BoardPRGroup;
 		>
 			<span>PR</span>
 			{group.prs.map((pr, index) => (
-				<span className="inline-flex items-center gap-0.5" key={pr.number}>
-					{linksInteractive ? (
-						<a
-							className="text-passive underline-offset-2 transition-colors hover:text-foreground hover:underline"
-							href={prBrowserUrl(pr)}
-							rel="noreferrer"
-							target="_blank"
-						>
-							#{pr.number}
-						</a>
-					) : (
-						<span>#{pr.number}</span>
-					)}
-					<CopyActionButton label={`PR #${pr.number} URL`} value={prBrowserUrl(pr)} />
+				<span className="inline-flex items-center" key={pr.number}>
+					<span className="inline-flex items-center gap-0.5">
+						{linksInteractive ? (
+							<a
+								className="text-passive underline-offset-2 transition-colors hover:text-foreground hover:underline"
+								href={prBrowserUrl(pr)}
+								rel="noreferrer"
+								target="_blank"
+							>
+								#{pr.number}
+							</a>
+						) : (
+							<span>#{pr.number}</span>
+						)}
+						<CopyActionButton label={`PR #${pr.number} URL`} value={prBrowserUrl(pr)} />
+					</span>
 					{index < group.prs.length - 1 ? "," : null}
 				</span>
 			))}

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { AlertTriangle, ChevronRight, Plus, RotateCw } from "lucide-react";
+import { AlertTriangle, Check, ChevronRight, Copy, Plus, RotateCw } from "lucide-react";
 import {
 	type WorkspaceSession,
 	canonicalTrackerIssueId,
@@ -28,6 +28,7 @@ import { TopbarButton, TopbarKillError, topbarProjectLabelClass } from "./Topbar
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
 import { prBrowserUrl, sessionPRDisplaySummaries } from "../lib/pr-display";
+import { aoBridge } from "../lib/bridge";
 import { cn } from "../lib/utils";
 import { isLinuxPlatform, isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
 import { useUiStore } from "../stores/ui-store";
@@ -531,8 +532,16 @@ function SessionCard({
 				>
 					{session.title}
 				</div>
-				{showBranch && <div className="px-3.25 pb-2.5 font-mono text-2xs text-passive">{branch}</div>}
 			</div>
+			{showBranch && (
+				<div
+					className="flex min-w-0 items-center gap-1 px-3.25 pb-2.5 font-mono text-2xs text-passive"
+					onClick={interactive ? onOpen : undefined}
+				>
+					<span className="truncate">{branch}</span>
+					<CopyActionButton label={`branch ${branch}`} value={branch} />
+				</div>
+			)}
 			{restoreError && (
 				<div className="border-t border-border px-3.25 py-1.5 text-2xs text-destructive">{restoreError}</div>
 			)}
@@ -582,7 +591,7 @@ function BoardPRGroup({ group, linksInteractive = true }: { group: BoardPRGroup;
 		>
 			<span>PR</span>
 			{group.prs.map((pr, index) => (
-				<span key={pr.number}>
+				<span className="inline-flex items-center gap-0.5" key={pr.number}>
 					{linksInteractive ? (
 						<a
 							className="text-passive underline-offset-2 transition-colors hover:text-foreground hover:underline"
@@ -595,11 +604,53 @@ function BoardPRGroup({ group, linksInteractive = true }: { group: BoardPRGroup;
 					) : (
 						<span>#{pr.number}</span>
 					)}
+					<CopyActionButton label={`PR #${pr.number} URL`} value={prBrowserUrl(pr)} />
 					{index < group.prs.length - 1 ? "," : null}
 				</span>
 			))}
 			<span className={cn("font-medium", group.status.className)}>{group.status.label}</span>
 		</span>
+	);
+}
+
+function CopyActionButton({ label, value }: { label: string; value: string }) {
+	const [copied, setCopied] = useState(false);
+	const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	useEffect(
+		() => () => {
+			if (copiedTimeoutRef.current !== null) clearTimeout(copiedTimeoutRef.current);
+		},
+		[],
+	);
+	const buttonLabel = copied ? `Copied ${label}` : `Copy ${label}`;
+	const copyValue = async (event: MouseEvent<HTMLButtonElement>) => {
+		event.stopPropagation();
+		try {
+			await aoBridge.clipboard.writeText(value);
+		} catch {
+			return;
+		}
+		setCopied(true);
+		if (copiedTimeoutRef.current !== null) clearTimeout(copiedTimeoutRef.current);
+		copiedTimeoutRef.current = setTimeout(() => {
+			setCopied(false);
+			copiedTimeoutRef.current = null;
+		}, 1_500);
+	};
+	return (
+		<button
+			aria-label={buttonLabel}
+			className="inline-flex size-4 shrink-0 items-center justify-center rounded-sm text-passive transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+			onClick={(event) => void copyValue(event)}
+			title={buttonLabel}
+			type="button"
+		>
+			{copied ? (
+				<Check className="size-icon-2xs text-success" aria-hidden="true" />
+			) : (
+				<Copy className="size-icon-2xs" aria-hidden="true" />
+			)}
+		</button>
 	);
 }
 


### PR DESCRIPTION
Closes #3045

## What changed

- added copy buttons beside visible branch names and each PR link on board cards
- kept copy clicks from opening the session card
- added accessible labels and a brief copied/check state
- added coverage for copied values, click isolation, and state reset

## Testing

- `npm test` — 978 tests passed
- `npm run typecheck`
- Prettier check on both changed files
- `CI=true npm run test:e2e:renderer` — 20 tests passed
- manually verified branch and PR copying in the Electron app with the built-in mock data
