### PR TITLE
feat(frontend): surface terminal-resource cleanup recovery on the board (#2811)

### DIFF
--- a/backend/internal/cli/dto_drift_e2e_test.go
+++ b/backend/internal/cli/dto_drift_e2e_test.go
@@ -96,6 +96,10 @@ func (f *fakeSessionService) Cleanup(context.Context, domain.ProjectID) (session
 	return sessionsvc.CleanupOutcome{}, nil
 }
 
+func (f *fakeSessionService) CleanupSession(context.Context, domain.SessionID) (domain.SessionCleanupRecord, error) {
+	return domain.SessionCleanupRecord{}, nil
+}
+
 func (f *fakeSessionService) Rename(context.Context, domain.SessionID, string) error {
 	return nil
 }

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
 	"github.com/aoagents/agent-orchestrator/backend/internal/mobilebridge"
 	"github.com/aoagents/agent-orchestrator/backend/internal/notify"
+	"github.com/aoagents/agent-orchestrator/backend/internal/observe/reconciler"
 	usagepipeline "github.com/aoagents/agent-orchestrator/backend/internal/observe/usage"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	"github.com/aoagents/agent-orchestrator/backend/internal/preview"
@@ -424,9 +425,10 @@ func Run() error {
 	}
 
 	// Reconcile sessions on boot: adopt crash-surviving runtimes, capture and
-	// terminate dead ones, reap leaked tmux, then restore shutdown-saved
-	// sessions. Best-effort: a failure is logged but never blocks boot. Placed
-	// before srv.Run so sessions are consistent before the server serves.
+	// terminate dead ones, then restore shutdown-saved sessions. Run to
+	// completion (synchronous, as before) so restore-pending sessions are settled
+	// before the terminal-resource reconciler starts and before the server
+	// serves. Best-effort: a failure is logged but never blocks boot.
 	if reconcileErr := sessMgr.Reconcile(ctx); reconcileErr != nil {
 		log.Error("reconcile sessions on boot failed", "err", reconcileErr)
 	}
@@ -436,6 +438,16 @@ func Run() error {
 	if usagePipeline != nil {
 		usageDone = usagePipeline.Start(ctx)
 	}
+
+	// Start the terminal-resource reconciler AFTER Reconcile/RestoreAll has
+	// settled: it subscribes to the CDC session_updated wake, then drains the
+	// sessions-driven candidate backlog (the pre-existing leaked worktrees #2811
+	// is about) onto its async worker, and retries capped-backoff pending
+	// cleanups on a sweep. Subscribing before its own boot snapshot closes the
+	// boot-window race; draining is async so a large backlog never delays serving.
+	// Its done-channel joins lcStack.Stop so it unsubscribes before cdcPipe.Stop.
+	termReconciler := reconciler.New(sessMgr, store, cdcPipe.Broadcaster, reconciler.Config{Logger: log})
+	lcStack.reconcilerDone = termReconciler.Start(ctx)
 
 	// ponytail: 5s tolerates a brief frontend restart; tune if dev hot-reload trips it.
 	const supervisorGrace = 5 * time.Second

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -47,6 +47,11 @@ type lifecycleStack struct {
 	activityDone  <-chan struct{}
 	scmDone       <-chan struct{}
 	trackerDone   <-chan struct{}
+	// reconcilerDone is the terminal-resource reconciler's drain channel. Assigned
+	// after boot Reconcile completes (daemon.go); nil until then, so Stop must
+	// nil-guard it. It is drained BEFORE the CDC pipe stops so the reconciler
+	// unsubscribes before a late Publish could send on its closed queue.
+	reconcilerDone <-chan struct{}
 }
 
 // startLifecycle constructs the Lifecycle Manager over the store and starts the
@@ -109,6 +114,11 @@ func (l *lifecycleStack) Stop() {
 	if l.trackerDone != nil {
 		<-l.trackerDone
 	}
+	// Drained before the CDC pipe stops (daemon shutdown order) so the reconciler
+	// unsubscribes before a late Publish could send on its closed queue.
+	if l.reconcilerDone != nil {
+		<-l.reconcilerDone
+	}
 }
 
 // sessionLifecycle is the narrow surface of sessionmanager.Manager used for
@@ -134,6 +144,10 @@ type sessionLifecycle interface {
 	// SetReviewerTerminator late-binds worker lifecycle teardown to the review
 	// service, which is built alongside the controller-facing service below.
 	SetReviewerTerminator(terminator sessionmanager.ReviewerTerminator)
+	// FinalizeTerminalSession is the terminal-resource reconciler's per-session
+	// unit of work (release a terminated session's runtime + workspace). Exposed
+	// here so the daemon can hand the manager to the reconciler runner.
+	FinalizeTerminalSession(ctx context.Context, id domain.SessionID) error
 }
 
 // startSession builds the controller-facing session service: a session manager

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -641,6 +641,10 @@ func (f *fakeSessionLifecycle) SetTerminalInputGate(sessionmanager.TerminalInput
 
 func (f *fakeSessionLifecycle) SetReviewerTerminator(sessionmanager.ReviewerTerminator) {}
 
+func (f *fakeSessionLifecycle) FinalizeTerminalSession(_ context.Context, _ domain.SessionID) error {
+	return nil
+}
+
 // TestWiring_SessionLifecycleInterfaceInvokedByDaemon asserts the
 // sessionLifecycle interface is satisfied by *sessionmanager.Manager (compile
 // check) and that Reconcile and RestoreAll dispatch correctly through the

--- a/backend/internal/domain/session.go
+++ b/backend/internal/domain/session.go
@@ -110,4 +110,8 @@ type Session struct {
 	// They feed status derivation and are surfaced on the API read model. Not
 	// serialized here: the HTTP boundary maps them to the curated wire shape.
 	PRs []PRFacts `json:"-"`
+	// Cleanup holds the terminal-resource cleanup facts for a terminated session,
+	// nil when none exist yet (a live session, or one not yet finalized). Joined
+	// at read time; the HTTP boundary maps it to the curated wire shape.
+	Cleanup *SessionCleanupRecord `json:"-"`
 }

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -1642,6 +1642,45 @@ paths:
       summary: Write images into a running session's worktree and return their paths
       tags:
       - sessions
+  /api/v1/sessions/{sessionId}/cleanup:
+    post:
+      operationId: cleanupSession
+      parameters:
+      - description: Session identifier, e.g. project-1.
+        in: path
+        name: sessionId
+        required: true
+        schema:
+          description: Session identifier, e.g. project-1.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CleanupSessionResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Conflict
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+      summary: Reclaim a single terminated session's runtime + workspace resources
+      tags:
+      - sessions
   /api/v1/sessions/{sessionId}/conversation:
     get:
       operationId: getSessionConversation
@@ -4433,6 +4472,21 @@ components:
       - branchChanged
       - takenOverFrom
       type: object
+    CleanupSessionResponse:
+      properties:
+        cleanup:
+          $ref: '#/components/schemas/SessionCleanupView'
+        isTerminated:
+          type: boolean
+        ok:
+          type: boolean
+        sessionId:
+          type: string
+      required:
+      - ok
+      - sessionId
+      - isTerminated
+      type: object
     CleanupSessionsResponse:
       properties:
         cleaned:
@@ -4495,6 +4549,8 @@ components:
           $ref: '#/components/schemas/DomainActivity'
         branch:
           type: string
+        cleanup:
+          $ref: '#/components/schemas/SessionCleanupView'
         createdAt:
           format: date-time
           type: string
@@ -6250,6 +6306,28 @@ components:
       - ok
       - sessionId
       - message
+      type: object
+    SessionCleanupView:
+      properties:
+        attemptCount:
+          format: int64
+          type: integer
+        failureCode:
+          type: string
+        nextAttemptAt:
+          format: date-time
+          type:
+          - "null"
+          - string
+        runtimeReleasedAt:
+          format: date-time
+          type:
+          - "null"
+          - string
+        workspaceDisposition:
+          type: string
+      required:
+      - workspaceDisposition
       type: object
     SessionInterfaceTransition:
       properties:

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -6325,6 +6325,12 @@ components:
           - "null"
           - string
         workspaceDisposition:
+          enum:
+          - pending
+          - removed
+          - preserved_dirty
+          - failed
+          - not_applicable
           type: string
       required:
       - workspaceDisposition

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -230,6 +230,8 @@ var schemaNames = map[string]string{
 	"ControllersWorkspaceFileSummary":                     "WorkspaceFileSummary",
 	"ControllersWorkspaceFileResponse":                    "WorkspaceFileResponse",
 	"ControllersKillSessionResponse":                      "KillSessionResponse",
+	"ControllersCleanupSessionResponse":                   "CleanupSessionResponse",
+	"ControllersSessionCleanupView":                       "SessionCleanupView",
 	"ControllersRollbackSessionResponse":                  "RollbackSessionResponse",
 	"ControllersSendSessionMessageRequest":                "SendSessionMessageRequest",
 	"ControllersSendSessionMessageResponse":               "SendSessionMessageResponse",
@@ -1514,6 +1516,17 @@ func sessionOperations() []operation {
 			pathParams: []any{controllers.SessionIDParam{}},
 			resps: []respUnit{
 				{http.StatusOK, controllers.KillSessionResponse{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusConflict, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+			},
+		},
+		{
+			method: http.MethodPost, path: "/api/v1/sessions/{sessionId}/cleanup", id: "cleanupSession", tag: "sessions",
+			summary:    "Reclaim a single terminated session's runtime + workspace resources",
+			pathParams: []any{controllers.SessionIDParam{}},
+			resps: []respUnit{
+				{http.StatusOK, controllers.CleanupSessionResponse{}},
 				{http.StatusNotFound, envelope.APIError{}},
 				{http.StatusConflict, envelope.APIError{}},
 				{http.StatusInternalServerError, envelope.APIError{}},

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -145,6 +145,31 @@ type SessionView struct {
 	// Metadata.
 	PreviewRevision int64            `json:"previewRevision,omitempty"`
 	PRs             []SessionPRFacts `json:"prs"`
+	// Cleanup is the terminal-resource cleanup state for a terminated session
+	// (runtime + workspace release progress). Omitted for a live session or one
+	// with no facts row yet. Derived at read time — no display status is stored.
+	Cleanup *SessionCleanupView `json:"cleanup,omitempty"`
+}
+
+// SessionCleanupView is the read-model view of a terminated session's
+// terminal-resource cleanup facts. Every field is a durable fact, never a
+// derived display status: the client renders cleanup state (cleaning up /
+// worktree kept — uncommitted changes / cleanup failed / done) from
+// workspaceDisposition.
+type SessionCleanupView struct {
+	// WorkspaceDisposition is the rollup: pending, removed, preserved_dirty,
+	// failed, or not_applicable.
+	WorkspaceDisposition string `json:"workspaceDisposition"`
+	// RuntimeReleasedAt is when the runtime handle was genuinely released; omitted
+	// when the runtime has not been confirmed released.
+	RuntimeReleasedAt *time.Time `json:"runtimeReleasedAt,omitempty"`
+	// AttemptCount is how many teardown attempts have run so far.
+	AttemptCount int64 `json:"attemptCount,omitempty"`
+	// NextAttemptAt is when the next capped-backoff retry is due; omitted when
+	// none is scheduled (a terminal disposition, or preserved-dirty pause).
+	NextAttemptAt *time.Time `json:"nextAttemptAt,omitempty"`
+	// FailureCode is a machine code for the last teardown failure; omitted when none.
+	FailureCode string `json:"failureCode,omitempty"`
 }
 
 // ListSessionsResponse is the body of GET /api/v1/sessions.
@@ -431,6 +456,17 @@ type KillSessionResponse struct {
 	OK        bool             `json:"ok"`
 	SessionID domain.SessionID `json:"sessionId"`
 	Freed     bool             `json:"freed,omitempty"`
+}
+
+// CleanupSessionResponse is the body of POST /api/v1/sessions/{sessionId}/cleanup:
+// the resulting cleanup facts after reclaiming one terminated session's runtime +
+// workspace. isTerminated is always true here (the endpoint 409s for a live
+// session); it is surfaced for parity with the session read model.
+type CleanupSessionResponse struct {
+	OK           bool                `json:"ok"`
+	SessionID    domain.SessionID    `json:"sessionId"`
+	IsTerminated bool                `json:"isTerminated"`
+	Cleanup      *SessionCleanupView `json:"cleanup,omitempty"`
 }
 
 // RollbackSessionResponse is the body of POST /api/v1/sessions/{sessionId}/rollback.

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -159,7 +159,7 @@ type SessionView struct {
 type SessionCleanupView struct {
 	// WorkspaceDisposition is the rollup: pending, removed, preserved_dirty,
 	// failed, or not_applicable.
-	WorkspaceDisposition string `json:"workspaceDisposition"`
+	WorkspaceDisposition domain.WorkspaceDisposition `json:"workspaceDisposition" enum:"pending,removed,preserved_dirty,failed,not_applicable"`
 	// RuntimeReleasedAt is when the runtime handle was genuinely released; omitted
 	// when the runtime has not been confirmed released.
 	RuntimeReleasedAt *time.Time `json:"runtimeReleasedAt,omitempty"`

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -70,6 +70,7 @@ type SessionService interface {
 	Kill(ctx context.Context, id domain.SessionID) (bool, error)
 	RollbackSpawn(ctx context.Context, id domain.SessionID) (sessionsvc.RollbackOutcome, error)
 	Cleanup(ctx context.Context, project domain.ProjectID) (sessionsvc.CleanupOutcome, error)
+	CleanupSession(ctx context.Context, id domain.SessionID) (domain.SessionCleanupRecord, error)
 	Rename(ctx context.Context, id domain.SessionID, displayName string) error
 	SetPreview(ctx context.Context, id domain.SessionID, previewURL string) (domain.Session, error)
 	SetTerminateOnPRMerge(ctx context.Context, id domain.SessionID, terminate bool) (domain.Session, error)
@@ -153,6 +154,7 @@ func (c *SessionsController) Register(r chi.Router) {
 	r.Post("/sessions/{sessionId}/interface-transition", c.startInterfaceTransition)
 	r.Delete("/sessions/{sessionId}/interface-transition", c.cancelInterfaceTransition)
 	r.Post("/sessions/{sessionId}/kill", c.kill)
+	r.Post("/sessions/{sessionId}/cleanup", c.cleanupSession)
 	r.Post("/sessions/{sessionId}/rollback", c.rollback)
 	r.Post("/sessions/{sessionId}/send", c.send)
 	r.Post("/sessions/{sessionId}/activity", c.activity)
@@ -1004,6 +1006,28 @@ func (c *SessionsController) rollback(w http.ResponseWriter, r *http.Request) {
 	envelope.WriteJSON(w, http.StatusOK, RollbackSessionResponse{OK: true, SessionID: sessionID(r), Deleted: out.Deleted, Killed: out.Killed})
 }
 
+// cleanupSession reclaims a single terminated session's runtime + workspace
+// (the per-session counterpart to the bulk /sessions/cleanup). It returns 409
+// for a still-live session and, for a preserved-dirty or failed one, re-attempts
+// the release — the user-triggered retry the UI offers.
+func (c *SessionsController) cleanupSession(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "POST", "/api/v1/sessions/{sessionId}/cleanup")
+		return
+	}
+	facts, err := c.Svc.CleanupSession(r.Context(), sessionID(r))
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, CleanupSessionResponse{
+		OK:           true,
+		SessionID:    sessionID(r),
+		IsTerminated: true, // CleanupSession 409s a live session, so we only reach here for a terminal one.
+		Cleanup:      cleanupFactsView(&facts),
+	})
+}
+
 func (c *SessionsController) cleanup(w http.ResponseWriter, r *http.Request) {
 	if c.Svc == nil {
 		apispec.NotImplemented(w, r, "POST", "/api/v1/sessions/cleanup")
@@ -1416,7 +1440,30 @@ func sessionView(s domain.Session) SessionView {
 		PreviewURL:      s.Metadata.PreviewURL,
 		PreviewRevision: s.Metadata.PreviewRevision,
 		PRs:             sessionPRFacts(s.PRs),
+		Cleanup:         cleanupFactsView(s.Cleanup),
 	}
+}
+
+// cleanupFactsView maps the domain cleanup record to its wire view, dropping the
+// internal generation counter and rendering zero timestamps as omitted.
+func cleanupFactsView(rec *domain.SessionCleanupRecord) *SessionCleanupView {
+	if rec == nil {
+		return nil
+	}
+	v := &SessionCleanupView{
+		WorkspaceDisposition: string(rec.WorkspaceDisposition),
+		AttemptCount:         rec.AttemptCount,
+		FailureCode:          rec.FailureCode,
+	}
+	if !rec.RuntimeReleasedAt.IsZero() {
+		t := rec.RuntimeReleasedAt
+		v.RuntimeReleasedAt = &t
+	}
+	if !rec.NextAttemptAt.IsZero() {
+		t := rec.NextAttemptAt
+		v.NextAttemptAt = &t
+	}
+	return v
 }
 
 func sessionViews(sessions []domain.Session) []SessionView {

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -1451,7 +1451,7 @@ func cleanupFactsView(rec *domain.SessionCleanupRecord) *SessionCleanupView {
 		return nil
 	}
 	v := &SessionCleanupView{
-		WorkspaceDisposition: string(rec.WorkspaceDisposition),
+		WorkspaceDisposition: rec.WorkspaceDisposition,
 		AttemptCount:         rec.AttemptCount,
 		FailureCode:          rec.FailureCode,
 	}

--- a/backend/internal/httpd/controllers/sessions_test.go
+++ b/backend/internal/httpd/controllers/sessions_test.go
@@ -29,24 +29,27 @@ import (
 )
 
 type fakeSessionService struct {
-	sessions         map[domain.SessionID]domain.Session
-	sent             string
-	delegationInput  sessionsvc.DelegateTaskInput
-	delegationErr    error
-	cleanupProjects  []domain.ProjectID
-	cleanupResult    []domain.SessionID
-	cleanupSkipped   []sessionsvc.CleanupSkipped
-	workspaceFiles   sessionsvc.WorkspaceFiles
-	workspaceFile    sessionsvc.WorkspaceFileDetail
-	workspacePaths   []string
-	spawnErr         error
-	orchestratorMode domain.SessionMode
-	claimErr         error
-	listPRErr        error
-	workspaceErr     error
-	staged           []ports.SpawnAttachment
-	stagedPaths      []string
-	stageErr         error
+	sessions          map[domain.SessionID]domain.Session
+	sent              string
+	delegationInput   sessionsvc.DelegateTaskInput
+	delegationErr     error
+	cleanupProjects   []domain.ProjectID
+	cleanupResult     []domain.SessionID
+	cleanupSkipped    []sessionsvc.CleanupSkipped
+	cleanedSessions   []domain.SessionID
+	cleanupSessionRec domain.SessionCleanupRecord
+	cleanupSessionErr error
+	workspaceFiles    sessionsvc.WorkspaceFiles
+	workspaceFile     sessionsvc.WorkspaceFileDetail
+	workspacePaths    []string
+	spawnErr          error
+	orchestratorMode  domain.SessionMode
+	claimErr          error
+	listPRErr         error
+	workspaceErr      error
+	staged            []ports.SpawnAttachment
+	stagedPaths       []string
+	stageErr          error
 }
 
 type fakeManagedPreviewServer struct {
@@ -262,6 +265,14 @@ func (f *fakeSessionService) Cleanup(_ context.Context, project domain.ProjectID
 	return sessionsvc.CleanupOutcome{Cleaned: cleaned, Skipped: f.cleanupSkipped}, nil
 }
 
+func (f *fakeSessionService) CleanupSession(_ context.Context, id domain.SessionID) (domain.SessionCleanupRecord, error) {
+	if f.cleanupSessionErr != nil {
+		return domain.SessionCleanupRecord{}, f.cleanupSessionErr
+	}
+	f.cleanedSessions = append(f.cleanedSessions, id)
+	return f.cleanupSessionRec, nil
+}
+
 func (f *fakeSessionService) Rename(_ context.Context, id domain.SessionID, displayName string) error {
 	s, ok := f.sessions[id]
 	if !ok {
@@ -456,6 +467,50 @@ func doPreviewOriginMethod(t *testing.T, srv *httptest.Server, method, previewUR
 		t.Fatalf("read preview response: %v", err)
 	}
 	return body, resp.StatusCode, resp.Header
+}
+
+func TestCleanupSessionEndpoint(t *testing.T) {
+	// Happy path: 200 with the resulting cleanup facts.
+	svc := newFakeSessionService()
+	svc.cleanupSessionRec = domain.SessionCleanupRecord{SessionID: "ao-1", WorkspaceDisposition: domain.DispositionPreservedDirty, AttemptCount: 1}
+	srv := newSessionTestServer(t, svc)
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/sessions/ao-1/cleanup", "")
+	if status != http.StatusOK {
+		t.Fatalf("cleanup = %d, want 200; body=%s", status, body)
+	}
+	var resp struct {
+		OK           bool             `json:"ok"`
+		SessionID    domain.SessionID `json:"sessionId"`
+		IsTerminated bool             `json:"isTerminated"`
+		Cleanup      *struct {
+			WorkspaceDisposition string `json:"workspaceDisposition"`
+			AttemptCount         int64  `json:"attemptCount"`
+		} `json:"cleanup"`
+	}
+	mustJSON(t, body, &resp)
+	if !resp.OK || resp.SessionID != "ao-1" || !resp.IsTerminated {
+		t.Fatalf("resp = %+v", resp)
+	}
+	if resp.Cleanup == nil || resp.Cleanup.WorkspaceDisposition != "preserved_dirty" || resp.Cleanup.AttemptCount != 1 {
+		t.Fatalf("cleanup = %+v, want preserved_dirty/attempt 1", resp.Cleanup)
+	}
+	if len(svc.cleanedSessions) != 1 || svc.cleanedSessions[0] != "ao-1" {
+		t.Fatalf("cleaned = %v, want [ao-1]", svc.cleanedSessions)
+	}
+
+	// Daemon-error envelope: a still-live session surfaces the service's 409.
+	svc2 := newFakeSessionService()
+	svc2.cleanupSessionErr = apierr.Conflict("SESSION_NOT_TERMINAL", "Session is still live", nil)
+	srv2 := newSessionTestServer(t, svc2)
+	body, status, _ = doRequest(t, srv2, "POST", "/api/v1/sessions/ao-1/cleanup", "")
+	assertErrorCode(t, body, status, http.StatusConflict, "SESSION_NOT_TERMINAL")
+
+	// Nil service: the route stays registered and returns a 501.
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv3 := httptest.NewServer(httpd.NewRouterWithControl(config.Config{}, log, nil, httpd.APIDeps{}, httpd.ControlDeps{}))
+	t.Cleanup(srv3.Close)
+	body, status, _ = doRequest(t, srv3, "POST", "/api/v1/sessions/ao-1/cleanup", "")
+	assertErrorCode(t, body, status, http.StatusNotImplemented, "NOT_IMPLEMENTED")
 }
 
 func TestSessionsRoutes_DefaultToStubsWithoutService(t *testing.T) {

--- a/backend/internal/integration/lifecycle_sqlite_test.go
+++ b/backend/internal/integration/lifecycle_sqlite_test.go
@@ -261,7 +261,7 @@ func TestRestoreRoundTripPreservesMetadata(t *testing.T) {
 //     is_terminated=true, runtime.Create count stays 0.
 //   - Session B: is_terminated=1 but its runtime is still ALIVE (leaked teardown)
 //     => Reconcile must call Destroy on its handle.
-func TestReconcile_TerminatesDeadLiveSessionAndReapsLeakedTmux(t *testing.T) {
+func TestReconcile_TerminatesDeadLiveSession_FinalizerReapsLeakedRuntime(t *testing.T) {
 	ctx := context.Background()
 	st := newStack(t)
 
@@ -342,9 +342,22 @@ func TestReconcile_TerminatesDeadLiveSessionAndReapsLeakedTmux(t *testing.T) {
 		t.Fatalf("want 0 runtime Creates (promptless worker must not relaunch), got %d", st.rt.created)
 	}
 
-	// Session B's leaked runtime must have been destroyed.
+	// Reconcile no longer reaps a terminated session's leaked runtime: the old
+	// reconcileReap pass was deleted because it is a strict subset of the
+	// terminal-resource reconciler's runtime-first release. So session B's leaked
+	// runtime is still alive right after Reconcile.
+	if st.rt.wasDestroyed("hdl-B") {
+		t.Fatalf("session B: Reconcile must NOT reap the leaked runtime (that is now the finalizer's job); destroyed handles: %v", st.rt.destroyedHandles)
+	}
+
+	// FinalizeTerminalSession (the reconciler's per-session unit of work, driven at
+	// boot by the sessions-driven candidate scan) now owns reclaiming the leaked
+	// runtime — runtime-first, so hdl-B is destroyed before any workspace teardown.
+	if err := st.mgr.FinalizeTerminalSession(ctx, recB.ID); err != nil {
+		t.Fatalf("FinalizeTerminalSession(B): %v", err)
+	}
 	if !st.rt.wasDestroyed("hdl-B") {
-		t.Fatalf("session B: want Destroy called for handle hdl-B; destroyed handles: %v", st.rt.destroyedHandles)
+		t.Fatalf("session B: want the finalizer to Destroy leaked handle hdl-B; destroyed handles: %v", st.rt.destroyedHandles)
 	}
 }
 

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -755,6 +755,14 @@ func (m *Manager) MarkSpawned(ctx context.Context, id domain.SessionID, metadata
 		}
 		now := m.clock()
 		rec.IsTerminated = false
+		// Bump the cleanup generation in the same UPDATE that un-terminates the
+		// session. The terminal-resource reconciler stamps each cleanup-facts row
+		// with the generation it observed; comparing that against this authoritative
+		// counter is what stops a finalize begun under an earlier terminal episode
+		// from satisfying a later Restore→Terminate cycle. Keeping the bump inline
+		// here (rather than in a shared UpdateSession) keeps it atomic-with the
+		// un-terminate and ensures only spawn/restore advances it.
+		rec.CleanupGeneration++
 		rec.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}
 		// Each spawn/restore must re-prove its hook pipeline: clear the receipt so
 		// a relaunch with broken hooks degrades to no_signal instead of inheriting

--- a/backend/internal/observe/reconciler/reconciler.go
+++ b/backend/internal/observe/reconciler/reconciler.go
@@ -1,0 +1,256 @@
+// Package reconciler drives the terminal-resource reconciler: a state-driven,
+// idempotent loop that converges every terminated session's runtime + workspace
+// toward safe release. It is the mirror image of observe/reaper — the reaper
+// skips terminated sessions, the reconciler processes ONLY them.
+//
+// The durable invariant it maintains: is_terminated=true means the session no
+// longer wants runtime resources, so the daemon must release them (or record why
+// it can't: a dirty worktree, a transient failure being retried, or an exhausted
+// failure). Terminal state is the durable intent; it does not promise cleanup
+// already succeeded.
+//
+// Three drivers feed one async worker:
+//   - Live wake: a CDC session_updated subscription enqueues a session the moment
+//     its is_terminated flips true (the immediate first attempt).
+//   - Boot scan: a sessions-driven candidate scan at start drains the pre-existing
+//     leaked backlog (terminated sessions with no facts row).
+//   - Periodic sweep: the same candidate scan on a ticker retries capped-backoff
+//     pending cleanups whose next_attempt_at is due.
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// Default tunables.
+const (
+	// DefaultSweepInterval is how often the periodic candidate scan runs to pick
+	// up capped-backoff retries and any session missed by a dropped live wake.
+	DefaultSweepInterval = 30 * time.Second
+	// DefaultQueueSize bounds the enqueue channel. A live wake that finds it full
+	// is dropped (the scan is the durable backstop), so this only needs to absorb
+	// bursts, not the whole backlog.
+	DefaultQueueSize = 256
+	// DefaultAttemptTimeout bounds one finalize attempt. It runs on a detached
+	// context so a slow `git worktree remove` is not interrupted by daemon
+	// shutdown, yet cannot hang forever.
+	DefaultAttemptTimeout = 2 * time.Minute
+	// DefaultShutdownGrace is how long Stop waits for an in-flight attempt to
+	// finish before returning. Independent of AttemptTimeout so a generous
+	// per-attempt bound can't stall daemon exit.
+	DefaultShutdownGrace = 5 * time.Second
+)
+
+// finalizer releases one terminated session's resources. Implemented by
+// *sessionmanager.Manager.FinalizeTerminalSession.
+type finalizer interface {
+	FinalizeTerminalSession(ctx context.Context, id domain.SessionID) error
+}
+
+// candidateSource is the sessions-driven candidate scan. Implemented by the
+// sqlite store's ListTerminalCleanupCandidates.
+type candidateSource interface {
+	ListTerminalCleanupCandidates(ctx context.Context, now time.Time) ([]domain.SessionID, error)
+}
+
+// subscriber is the CDC broadcaster surface used for the live wake. Implemented
+// by *cdc.Broadcaster.
+type subscriber interface {
+	Subscribe(fn func(cdc.Event)) (unsubscribe func())
+}
+
+// Config holds the reconciler's tunables; the zero value is filled with defaults.
+type Config struct {
+	SweepInterval  time.Duration
+	QueueSize      int
+	AttemptTimeout time.Duration
+	ShutdownGrace  time.Duration
+	Clock          func() time.Time
+	Logger         *slog.Logger
+}
+
+// Reconciler runs the terminal-resource reconciliation loop.
+type Reconciler struct {
+	finalizer  finalizer
+	candidates candidateSource
+	events     subscriber
+
+	queue chan domain.SessionID
+	unsub func()
+	// attemptBase is the detached base context for finalize attempts: it survives
+	// parent (daemon) cancellation so a git op isn't interrupted the instant
+	// shutdown begins, but is force-cancelled after the shutdown grace so an
+	// in-flight attempt can't keep writing to a store the daemon is about to close.
+	attemptBase   context.Context
+	attemptCancel context.CancelFunc
+
+	sweep          time.Duration
+	attemptTimeout time.Duration
+	grace          time.Duration
+	clock          func() time.Time
+	logger         *slog.Logger
+}
+
+// New builds a Reconciler, defaulting any unset Config field.
+func New(f finalizer, candidates candidateSource, events subscriber, cfg Config) *Reconciler {
+	r := &Reconciler{
+		finalizer:      f,
+		candidates:     candidates,
+		events:         events,
+		sweep:          cfg.SweepInterval,
+		attemptTimeout: cfg.AttemptTimeout,
+		grace:          cfg.ShutdownGrace,
+		clock:          cfg.Clock,
+		logger:         cfg.Logger,
+	}
+	if r.sweep <= 0 {
+		r.sweep = DefaultSweepInterval
+	}
+	if r.attemptTimeout <= 0 {
+		r.attemptTimeout = DefaultAttemptTimeout
+	}
+	if r.grace <= 0 {
+		r.grace = DefaultShutdownGrace
+	}
+	if r.clock == nil {
+		r.clock = time.Now
+	}
+	if r.logger == nil {
+		r.logger = slog.Default()
+	}
+	qs := cfg.QueueSize
+	if qs <= 0 {
+		qs = DefaultQueueSize
+	}
+	r.queue = make(chan domain.SessionID, qs)
+	return r
+}
+
+// Start registers the live-wake subscription, then launches the run loop and
+// returns a done-channel closed once the loop has drained on ctx cancellation.
+// Subscribing here — BEFORE run takes the boot-scan snapshot — closes the boot
+// window: a restore-then-exit session can't slip between the snapshot and the
+// live wake (an overlap is harmless because finalize is idempotent).
+func (r *Reconciler) Start(ctx context.Context) <-chan struct{} {
+	r.unsub = r.events.Subscribe(r.onEvent)
+	// Detached from ctx on purpose (see field doc); cancelled by run after the
+	// shutdown grace, and always released via defer in run.
+	r.attemptBase, r.attemptCancel = context.WithCancel(context.Background()) //nolint:gosec // G118: detached attempt context is intentional
+	done := make(chan struct{})
+	go r.run(ctx, done)
+	return done
+}
+
+func (r *Reconciler) run(ctx context.Context, done chan<- struct{}) {
+	defer close(done)
+	// Always release the detached base so it can't leak past shutdown.
+	defer r.attemptCancel()
+
+	workerDone := make(chan struct{})
+	go r.worker(workerDone)
+
+	// Boot scan: drain the backlog onto the worker (idempotent with any live wake
+	// that also fires for the same session).
+	r.scan(ctx)
+
+	t := time.NewTicker(r.sweep)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			// Stop new live wakes BEFORE closing the queue, else a late Publish
+			// would send on a closed channel and panic. Unsubscribe blocks until any
+			// in-flight Publish callback returns, so no onEvent can race the close.
+			r.unsub()
+			close(r.queue)
+			// Wait a short bounded grace for the worker to finish cleanly. If it
+			// doesn't (a slow git op on the detached context), force-cancel the
+			// attempt base and JOIN the worker before returning: this both bounds
+			// shutdown (we don't wait the full per-attempt timeout) AND guarantees
+			// the worker has stopped touching the store before the daemon closes it,
+			// closing the write-after-close window.
+			select {
+			case <-workerDone:
+			case <-time.After(r.grace):
+				r.logger.Warn("reconciler: shutdown grace elapsed, cancelling in-flight cleanup")
+				r.attemptCancel()
+				<-workerDone
+			}
+			return
+		case <-t.C:
+			r.scan(ctx)
+		}
+	}
+}
+
+// worker drains the queue, finalizing one session at a time. Serial processing
+// keeps concurrent finalizes off the same session (the manager also holds a
+// per-session lock) and bounds resource use during a large boot drain.
+func (r *Reconciler) worker(done chan<- struct{}) {
+	defer close(done)
+	for id := range r.queue {
+		// A fresh bounded context per attempt, derived from the detached
+		// attemptBase: it survives daemon-shutdown cancellation (so a git op isn't
+		// interrupted mid-write) yet cannot hang forever, and run force-cancels
+		// attemptBase after the shutdown grace so this can't outlive store.Close.
+		attemptCtx, cancel := context.WithTimeout(r.attemptBase, r.attemptTimeout)
+		if err := r.finalizer.FinalizeTerminalSession(attemptCtx, id); err != nil {
+			r.logger.Error("reconciler: finalize failed", "sessionID", id, "err", err)
+		}
+		cancel()
+	}
+}
+
+// scan enqueues every current cleanup candidate. It blocks on a full queue
+// (draining as the worker makes room) but unblocks promptly on ctx cancellation,
+// so a large backlog neither drops work nor stalls shutdown.
+func (r *Reconciler) scan(ctx context.Context) {
+	ids, err := r.candidates.ListTerminalCleanupCandidates(ctx, r.clock())
+	if err != nil {
+		r.logger.Error("reconciler: candidate scan failed", "err", err)
+		return
+	}
+	for _, id := range ids {
+		select {
+		case r.queue <- id:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// onEvent is the live-wake callback. It runs inline on the CDC poller goroutine
+// under the broadcaster's RLock, so it MUST NOT block: it does a non-blocking
+// send and drops on a full queue (the scan is the backstop). It filters on the
+// payload's isTerminated so it only wakes on a genuine terminal transition and
+// never does a DB read on the hot path. Facts-trigger events carry {id} only (no
+// isTerminated), so they are ignored here and serve purely as the frontend
+// refetch nudge — which is also why a failed/pending retry write can't self-wake
+// the reconciler and hot-loop.
+func (r *Reconciler) onEvent(e cdc.Event) {
+	if e.Type != cdc.EventSessionUpdated {
+		return
+	}
+	var p struct {
+		ID           string `json:"id"`
+		IsTerminated bool   `json:"isTerminated"`
+	}
+	if err := json.Unmarshal(e.Payload, &p); err != nil {
+		return
+	}
+	if p.ID == "" || !p.IsTerminated {
+		return
+	}
+	select {
+	case r.queue <- domain.SessionID(p.ID):
+	default:
+		// Never block the broadcaster (it stalls SSE + terminal fanout too).
+		r.logger.Warn("reconciler: enqueue full, dropping live wake; scan will retry", "sessionID", p.ID)
+	}
+}

--- a/backend/internal/observe/reconciler/reconciler_test.go
+++ b/backend/internal/observe/reconciler/reconciler_test.go
@@ -1,0 +1,189 @@
+package reconciler_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/observe/reconciler"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+// --- fakes ---
+
+type fakeFinalizer struct {
+	called chan domain.SessionID
+}
+
+func (f *fakeFinalizer) FinalizeTerminalSession(_ context.Context, id domain.SessionID) error {
+	f.called <- id
+	return nil
+}
+
+type fakeCandidates struct {
+	mu  sync.Mutex
+	ids []domain.SessionID
+}
+
+func (f *fakeCandidates) ListTerminalCleanupCandidates(_ context.Context, _ time.Time) ([]domain.SessionID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]domain.SessionID, len(f.ids))
+	copy(out, f.ids)
+	return out, nil
+}
+
+type fakeBroadcaster struct {
+	mu sync.Mutex
+	fn func(cdc.Event)
+}
+
+func (b *fakeBroadcaster) Subscribe(fn func(cdc.Event)) func() {
+	b.mu.Lock()
+	b.fn = fn
+	b.mu.Unlock()
+	return func() { b.mu.Lock(); b.fn = nil; b.mu.Unlock() }
+}
+
+func (b *fakeBroadcaster) publish(e cdc.Event) {
+	b.mu.Lock()
+	fn := b.fn
+	b.mu.Unlock()
+	if fn != nil {
+		fn(e)
+	}
+}
+
+func sessionUpdated(id string, terminated bool) cdc.Event {
+	payload, _ := json.Marshal(map[string]any{"id": id, "isTerminated": terminated})
+	return cdc.Event{Type: cdc.EventSessionUpdated, SessionID: id, Payload: payload}
+}
+
+func awaitCall(t *testing.T, ch chan domain.SessionID, want domain.SessionID) {
+	t.Helper()
+	select {
+	case got := <-ch:
+		if got != want {
+			t.Fatalf("finalize called for %q, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for finalize(%q)", want)
+	}
+}
+
+func expectNoCall(t *testing.T, ch chan domain.SessionID) {
+	t.Helper()
+	select {
+	case got := <-ch:
+		t.Fatalf("unexpected finalize for %q", got)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// --- unit tests (fakes) ---
+
+func TestLiveWake_EnqueuesTerminatedSession(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fin := &fakeFinalizer{called: make(chan domain.SessionID, 4)}
+	bcast := &fakeBroadcaster{}
+	r := reconciler.New(fin, &fakeCandidates{}, bcast, reconciler.Config{})
+	done := r.Start(ctx)
+
+	bcast.publish(sessionUpdated("mer-1", true))
+	awaitCall(t, fin.called, "mer-1")
+
+	cancel()
+	<-done
+}
+
+func TestLiveWake_IgnoresNonTerminalAndFactsOnlyEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fin := &fakeFinalizer{called: make(chan domain.SessionID, 4)}
+	bcast := &fakeBroadcaster{}
+	r := reconciler.New(fin, &fakeCandidates{}, bcast, reconciler.Config{})
+	done := r.Start(ctx)
+
+	// A live (non-terminal) session_updated must not wake the reconciler.
+	bcast.publish(sessionUpdated("mer-1", false))
+	// A facts-trigger event carries {id} only (no isTerminated): it is the
+	// frontend refetch nudge and must NOT self-wake the reconciler (critique #14).
+	bcast.publish(cdc.Event{Type: cdc.EventSessionUpdated, SessionID: "mer-2", Payload: json.RawMessage(`{"id":"mer-2"}`)})
+	expectNoCall(t, fin.called)
+
+	cancel()
+	<-done
+}
+
+func TestBootScan_EnqueuesBacklogCandidates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fin := &fakeFinalizer{called: make(chan domain.SessionID, 4)}
+	cands := &fakeCandidates{ids: []domain.SessionID{"mer-9"}}
+	r := reconciler.New(fin, cands, &fakeBroadcaster{}, reconciler.Config{})
+	done := r.Start(ctx)
+
+	awaitCall(t, fin.called, "mer-9")
+
+	cancel()
+	<-done
+}
+
+// --- wake-path e2e (real store + real CDC poller/broadcaster + reconciler) ---
+
+// TestWakePath_E2E drives convergence through the REAL session_updated CDC chain
+// (store trigger → change_log → poller → broadcaster → reconciler subscription →
+// finalizer), which unit-testing the finalizer in isolation cannot cover
+// (critique #6).
+func TestWakePath_E2E(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if err := store.UpsertProject(ctx, domain.ProjectRecord{ID: "mer", Path: "/tmp/mer", RegisteredAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	rec, err := store.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: "mer", Kind: domain.KindWorker, Harness: domain.HarnessClaudeCode,
+		Activity:  domain.Activity{State: domain.ActivityActive, LastActivityAt: time.Now().UTC()},
+		CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// Real CDC pipe seeked to head, so only the future is_terminated flip is seen.
+	bcast := cdc.NewBroadcaster()
+	poller := cdc.NewPoller(store, bcast, cdc.PollerConfig{})
+	if err := poller.SeekToHead(ctx); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+	pollerDone := poller.Start(ctx)
+
+	fin := &fakeFinalizer{called: make(chan domain.SessionID, 4)}
+	r := reconciler.New(fin, store, bcast, reconciler.Config{})
+	reconcilerDone := r.Start(ctx)
+
+	// Flip is_terminated: the sessions_cdc_update trigger fans out a
+	// session_updated event carrying isTerminated=true.
+	rec.IsTerminated = true
+	if err := store.UpdateSession(ctx, rec); err != nil {
+		t.Fatalf("mark terminated: %v", err)
+	}
+
+	awaitCall(t, fin.called, rec.ID)
+
+	cancel()
+	<-reconcilerDone
+	<-pollerDone
+}

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -37,6 +37,9 @@ type Store interface {
 	ListPRReviewThreads(ctx context.Context, prURL string) ([]domain.PullRequestReviewThread, error)
 	ListPRComments(ctx context.Context, prURL string) ([]domain.PullRequestComment, error)
 	GetProject(ctx context.Context, id string) (domain.ProjectRecord, bool, error)
+	// GetSessionCleanupFacts joins the terminal-resource cleanup facts onto the
+	// session read model; ok=false when the session has no facts row yet.
+	GetSessionCleanupFacts(ctx context.Context, id domain.SessionID) (domain.SessionCleanupRecord, bool, error)
 }
 
 // ListFilter captures API-facing session list query filters.
@@ -58,6 +61,7 @@ type commander interface {
 	WaitForMessageDeliveryReady(ctx context.Context, id domain.SessionID) error
 	Send(ctx context.Context, id domain.SessionID, message string) error
 	Cleanup(ctx context.Context, project domain.ProjectID) (sessionmanager.CleanupResult, error)
+	CleanupSession(ctx context.Context, id domain.SessionID) (domain.SessionCleanupRecord, error)
 	RollbackSpawn(ctx context.Context, id domain.SessionID) (deleted, killed bool, err error)
 	StageAttachments(ctx context.Context, id domain.SessionID, attachments []ports.SpawnAttachment) ([]string, error)
 }
@@ -598,6 +602,18 @@ func (s *Service) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	return freed, toAPIError(err)
 }
 
+// CleanupSession reclaims a single terminated session's runtime + workspace and
+// returns its resulting cleanup facts. It is the per-session counterpart to bulk
+// Cleanup: a 404 for an unknown session, a 409 for a still-live one, and (for a
+// preserved_dirty/failed session) a user-triggered retry of the release.
+func (s *Service) CleanupSession(ctx context.Context, id domain.SessionID) (domain.SessionCleanupRecord, error) {
+	facts, err := s.manager.CleanupSession(ctx, id)
+	if err != nil {
+		return domain.SessionCleanupRecord{}, toAPIError(err)
+	}
+	return facts, nil
+}
+
 // RollbackSpawn deletes a seed-state session row, or falls back to a Kill if
 // the session has spawn output. Used by the CLI to undo a `spawn --claim-pr`
 // when the claim step fails, avoiding the orphan terminated row that a plain
@@ -838,6 +854,8 @@ func toAPIError(err error) error {
 			"The session is already using the requested interface", nil)
 	case errors.Is(err, sessionmanager.ErrInterfaceTransitionNotFound):
 		return apierr.NotFound("INTERFACE_TRANSITION_NOT_FOUND", "No active interface switch exists")
+	case errors.Is(err, sessionmanager.ErrNotTerminal):
+		return apierr.Conflict("SESSION_NOT_TERMINAL", "Session is still live; only a terminated session can be cleaned up", nil)
 	case errors.Is(err, sessionmanager.ErrAwaitingDecision):
 		return apierr.Conflict("SESSION_AWAITING_DECISION",
 			"Session is paused on a permission decision; answer it in the session terminal first", nil)
@@ -887,13 +905,23 @@ func (s *Service) toSession(ctx context.Context, rec domain.SessionRecord) (doma
 		return domain.Session{}, fmt.Errorf("pr facts %s: %w", rec.ID, err)
 	}
 	prs = deduplicatePRFacts(prs)
-	return domain.Session{
+	sess := domain.Session{
 		SessionRecord:    rec,
 		Status:           deriveStatus(rec, prs, s.now(), s.harnessSignals(rec.Harness)),
 		SCMStatus:        deriveSCMStatus(prs),
 		TerminalHandleID: rec.Metadata.RuntimeHandleID,
 		PRs:              prs,
-	}, nil
+	}
+	// Join terminal-resource cleanup facts so the UI can render a terminated
+	// session's release progress (pending / preserved_dirty / failed / removed).
+	// Derived at read time — no display status is stored.
+	if facts, ok, err := s.store.GetSessionCleanupFacts(ctx, rec.ID); err != nil {
+		return domain.Session{}, fmt.Errorf("cleanup facts %s: %w", rec.ID, err)
+	} else if ok {
+		f := facts
+		sess.Cleanup = &f
+	}
+	return sess, nil
 }
 
 // now tolerates a zero-value Service (tests construct the struct literally

--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -914,12 +914,17 @@ func (s *Service) toSession(ctx context.Context, rec domain.SessionRecord) (doma
 	}
 	// Join terminal-resource cleanup facts so the UI can render a terminated
 	// session's release progress (pending / preserved_dirty / failed / removed).
+	// Only the current terminal episode's facts qualify: a live session (Restore
+	// un-terminated it) or a stale generation (a second termination since these
+	// facts were written) must not leak the prior episode's disposition.
 	// Derived at read time — no display status is stored.
-	if facts, ok, err := s.store.GetSessionCleanupFacts(ctx, rec.ID); err != nil {
-		return domain.Session{}, fmt.Errorf("cleanup facts %s: %w", rec.ID, err)
-	} else if ok {
-		f := facts
-		sess.Cleanup = &f
+	if rec.IsTerminated {
+		if facts, ok, err := s.store.GetSessionCleanupFacts(ctx, rec.ID); err != nil {
+			return domain.Session{}, fmt.Errorf("cleanup facts %s: %w", rec.ID, err)
+		} else if ok && facts.SessionGeneration == rec.CleanupGeneration {
+			f := facts
+			sess.Cleanup = &f
+		}
 	}
 	return sess, nil
 }

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -1255,6 +1255,39 @@ func TestReadModelSurfacesCleanupFacts(t *testing.T) {
 	}
 }
 
+// TestReadModelHidesCleanupFactsForLiveOrStaleGeneration: a facts row from a
+// prior terminal episode must not leak onto a live (Restore un-terminated) or
+// newly re-terminated session — the read model only surfaces facts stamped
+// with the session's current CleanupGeneration, matching the write-side guard
+// finalizeOne and FinalizeTerminalSession already enforce.
+func TestReadModelHidesCleanupFactsForLiveOrStaleGeneration(t *testing.T) {
+	st := newFakeStore()
+	// Restored: no longer terminated, but the prior episode's facts row lingers.
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", IsTerminated: false, CleanupGeneration: 1}
+	st.cleanup["mer-1"] = domain.SessionCleanupRecord{SessionID: "mer-1", SessionGeneration: 0, WorkspaceDisposition: domain.DispositionRemoved}
+	// Re-terminated (generation bumped) before the reconciler wrote fresh facts
+	// for the new episode: the stale generation-0 row must not surface either.
+	st.sessions["mer-2"] = domain.SessionRecord{ID: "mer-2", ProjectID: "mer", IsTerminated: true, CleanupGeneration: 1}
+	st.cleanup["mer-2"] = domain.SessionCleanupRecord{SessionID: "mer-2", SessionGeneration: 0, WorkspaceDisposition: domain.DispositionRemoved}
+	svc := NewWithDeps(Deps{Store: st})
+
+	restored, err := svc.Get(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("Get mer-1: %v", err)
+	}
+	if restored.Cleanup != nil {
+		t.Fatalf("mer-1 (restored, live) cleanup = %+v, want nil", restored.Cleanup)
+	}
+
+	staleGen, err := svc.Get(context.Background(), "mer-2")
+	if err != nil {
+		t.Fatalf("Get mer-2: %v", err)
+	}
+	if staleGen.Cleanup != nil {
+		t.Fatalf("mer-2 (stale generation) cleanup = %+v, want nil", staleGen.Cleanup)
+	}
+}
+
 func TestTeardownProjectKillsActiveSessionsThenCleansProject(t *testing.T) {
 	st := newFakeStore()
 	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer"}

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -36,6 +36,7 @@ type fakeStore struct {
 	reviews   map[string][]domain.PullRequestReview
 	threads   map[string][]domain.PullRequestReviewThread
 	comments  map[string][]domain.PullRequestComment
+	cleanup   map[domain.SessionID]domain.SessionCleanupRecord
 	num       int
 }
 
@@ -50,7 +51,13 @@ func newFakeStore() *fakeStore {
 		reviews:   map[string][]domain.PullRequestReview{},
 		threads:   map[string][]domain.PullRequestReviewThread{},
 		comments:  map[string][]domain.PullRequestComment{},
+		cleanup:   map[domain.SessionID]domain.SessionCleanupRecord{},
 	}
+}
+
+func (f *fakeStore) GetSessionCleanupFacts(_ context.Context, id domain.SessionID) (domain.SessionCleanupRecord, bool, error) {
+	rec, ok := f.cleanup[id]
+	return rec, ok, nil
 }
 
 func newWorkspaceRepo(t *testing.T) string {
@@ -1070,28 +1077,31 @@ func TestSessionRenameMissingSessionReturnsNotFound(t *testing.T) {
 // fakeCommander records Kill/Spawn calls so a test can assert the
 // clean-orchestrator ordering without wiring a real session engine.
 type fakeCommander struct {
-	killed          []domain.SessionID
-	retired         []domain.SessionID
-	resumed         []domain.SessionID
-	ready           []domain.SessionID
-	sent            []domain.SessionID
-	sentMessages    []string
-	cleanupProjects []domain.ProjectID
-	killErr         error
-	retireErr       error
-	sendErr         error
-	sendFunc        func(domain.SessionID, string) error
-	cleanupErr      error
-	spawnErr        error
-	spawnRecord     domain.SessionRecord
-	spawnFunc       func(ports.SpawnConfig) domain.SessionRecord
-	spawnCalls      int
-	spawned         bool
-	spawnedCfg      ports.SpawnConfig
-	killsAtSpawn    int
-	restoreErr      error
-	restoreResult   sessionmanager.RestoreResult
-	readyErr        error
+	killed            []domain.SessionID
+	retired           []domain.SessionID
+	resumed           []domain.SessionID
+	ready             []domain.SessionID
+	sent              []domain.SessionID
+	sentMessages      []string
+	cleanupProjects   []domain.ProjectID
+	cleanedSessions   []domain.SessionID
+	cleanupSessionRec domain.SessionCleanupRecord
+	cleanupSessionErr error
+	killErr           error
+	retireErr         error
+	sendErr           error
+	sendFunc          func(domain.SessionID, string) error
+	cleanupErr        error
+	spawnErr          error
+	spawnRecord       domain.SessionRecord
+	spawnFunc         func(ports.SpawnConfig) domain.SessionRecord
+	spawnCalls        int
+	spawned           bool
+	spawnedCfg        ports.SpawnConfig
+	killsAtSpawn      int
+	restoreErr        error
+	restoreResult     sessionmanager.RestoreResult
+	readyErr          error
 }
 
 func (f *fakeCommander) Spawn(_ context.Context, cfg ports.SpawnConfig) (domain.SessionRecord, int, int, error) {
@@ -1162,6 +1172,13 @@ func (f *fakeCommander) Cleanup(_ context.Context, project domain.ProjectID) (se
 		Skipped: []sessionmanager.CleanupSkip{{SessionID: "mer-2", Reason: "workspace has uncommitted changes"}},
 	}, nil
 }
+func (f *fakeCommander) CleanupSession(_ context.Context, id domain.SessionID) (domain.SessionCleanupRecord, error) {
+	if f.cleanupSessionErr != nil {
+		return domain.SessionCleanupRecord{}, f.cleanupSessionErr
+	}
+	f.cleanedSessions = append(f.cleanedSessions, id)
+	return f.cleanupSessionRec, nil
+}
 func (f *fakeCommander) RollbackSpawn(context.Context, domain.SessionID) (bool, bool, error) {
 	return false, false, nil
 }
@@ -1187,6 +1204,54 @@ func TestCleanupMapsManagerResult(t *testing.T) {
 	}
 	if len(out.Skipped) != 1 || out.Skipped[0].SessionID != "mer-2" || out.Skipped[0].Reason != "workspace has uncommitted changes" {
 		t.Fatalf("skipped = %#v", out.Skipped)
+	}
+}
+
+// TestCleanupSessionMapsNotTerminalToConflict: the per-session cleanup API maps
+// the manager's ErrNotTerminal sentinel to a 409 apierr (a live session cannot
+// be cleaned up).
+func TestCleanupSessionMapsNotTerminalToConflict(t *testing.T) {
+	svc := &Service{manager: &fakeCommander{cleanupSessionErr: sessionmanager.ErrNotTerminal}}
+	_, err := svc.CleanupSession(context.Background(), "mer-1")
+	var e *apierr.Error
+	if !errors.As(err, &e) || e.Kind != apierr.KindConflict || e.Code != "SESSION_NOT_TERMINAL" {
+		t.Fatalf("err = %v, want SESSION_NOT_TERMINAL conflict", err)
+	}
+}
+
+func TestCleanupSessionReturnsFacts(t *testing.T) {
+	svc := &Service{manager: &fakeCommander{cleanupSessionRec: domain.SessionCleanupRecord{SessionID: "mer-1", WorkspaceDisposition: domain.DispositionPreservedDirty}}}
+	facts, err := svc.CleanupSession(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("CleanupSession: %v", err)
+	}
+	if facts.WorkspaceDisposition != domain.DispositionPreservedDirty {
+		t.Fatalf("disposition = %q, want preserved_dirty", facts.WorkspaceDisposition)
+	}
+}
+
+// TestReadModelSurfacesCleanupFacts: the session read model joins cleanup facts
+// for a terminated session and omits them for one with no facts row.
+func TestReadModelSurfacesCleanupFacts(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", IsTerminated: true}
+	st.sessions["mer-2"] = domain.SessionRecord{ID: "mer-2", ProjectID: "mer", IsTerminated: true}
+	st.cleanup["mer-1"] = domain.SessionCleanupRecord{SessionID: "mer-1", WorkspaceDisposition: domain.DispositionPreservedDirty, AttemptCount: 1}
+	svc := NewWithDeps(Deps{Store: st})
+
+	withFacts, err := svc.Get(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("Get mer-1: %v", err)
+	}
+	if withFacts.Cleanup == nil || withFacts.Cleanup.WorkspaceDisposition != domain.DispositionPreservedDirty {
+		t.Fatalf("mer-1 cleanup facts = %+v, want preserved_dirty", withFacts.Cleanup)
+	}
+	noFacts, err := svc.Get(context.Background(), "mer-2")
+	if err != nil {
+		t.Fatalf("Get mer-2: %v", err)
+	}
+	if noFacts.Cleanup != nil {
+		t.Fatalf("mer-2 cleanup = %+v, want nil (no facts row)", noFacts.Cleanup)
 	}
 }
 

--- a/backend/internal/session_manager/finalize.go
+++ b/backend/internal/session_manager/finalize.go
@@ -1,0 +1,381 @@
+package sessionmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Retry bounds for a transient teardown failure. The backoff caps the interval;
+// a capped attempt COUNT is also enforced so a permanently-failing teardown
+// (locked file, corrupt worktree registration) transitions to a terminal
+// `failed` disposition instead of retrying forever with no end state.
+const maxCleanupAttempts = 5
+
+const (
+	cleanupBackoffBase = 30 * time.Second
+	cleanupBackoffCap  = 15 * time.Minute
+)
+
+// Machine failure codes recorded on session_cleanup_facts.failure_code.
+const (
+	failRuntimeDestroy      = "runtime_destroy"
+	failWorkspaceRows       = "workspace_rows"
+	failWorkspaceDestroy    = "workspace_destroy"
+	failReviewerTerminator  = "reviewer_terminator"
+	failProjectUnresolvable = "project_unresolvable"
+	failTeardown            = "teardown"
+)
+
+// cleanupResult is the structured outcome of a single terminal-resource release
+// attempt. It records durable facts only — the derived display status is never
+// stored (hard rule). A "" disposition means the attempt aborted before it could
+// classify the workspace (the accompanying error carries why).
+type cleanupResult struct {
+	// disposition is the session-level rollup: removed / preserved_dirty /
+	// not_applicable, or pending when a transient failure needs a retry.
+	disposition domain.WorkspaceDisposition
+	// runtimeReleased is true only on a genuine runtime release (not a no-op skip
+	// on an empty/unrouted handle).
+	runtimeReleased bool
+	// workspaceProject is true for a multi-repo workspace-project session.
+	workspaceProject bool
+	// failureCode is a machine code for the last failure; "" when none.
+	failureCode string
+}
+
+// releaseTerminalResources is the shared, idempotent release core that Kill,
+// bulk Cleanup, and the reconciler's FinalizeTerminalSession all funnel through.
+// Ordering is runtime-first: if the runtime cannot be destroyed the workspace is
+// left untouched and the error is returned, so a worktree is never removed out
+// from under a live process. Workspace teardown continues past a dirty child so
+// one dirty worktree cannot strand its clean siblings. It returns a structured
+// result plus a hard error for the two fail-closed cases (runtime destroy failed;
+// non-dirty workspace teardown failed) — the caller decides whether to surface
+// that (Kill) or fold it into a retry fact (the finalizer / Cleanup).
+func (m *Manager) releaseTerminalResources(ctx context.Context, rec domain.SessionRecord) (cleanupResult, error) {
+	var res cleanupResult
+
+	m.stopPreviewBestEffort(ctx, rec.ID)
+	m.destroyBrowserBestEffort(ctx, rec.ID)
+
+	// Exactly one controller exists, so exactly one gets torn down. A chat
+	// session has no runtime handle; its controller owns an app-server child
+	// process, and closing it also settles any turn left in flight so a later
+	// read does not show work that is no longer running.
+	if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat {
+		m.stopChatBestEffort(ctx, rec.ID)
+		res.runtimeReleased = true
+	} else if handle := runtimeHandle(rec.Metadata); handle.ID != "" {
+		if err := m.runtime.Destroy(ctx, handle); err != nil {
+			res.failureCode = failRuntimeDestroy
+			return res, fmt.Errorf("runtime: %w", err)
+		}
+		res.runtimeReleased = true
+	}
+	// handle.ID == "": an unrouted / legacy-backlog row. Destroy returns nil for
+	// an empty handle too, so treating that as proof of release would silently
+	// leave a live-but-unrouted runtime leaked. We do NOT claim release
+	// (runtimeReleased stays false) and still proceed to workspace cleanup;
+	// actively reconstructing the adapter's deterministic session name to probe
+	// such a runtime is a cross-adapter seam left as follow-up (ties to #1458).
+
+	if err := m.terminateReviewer(ctx, rec.ID, "cancelled by worker session termination"); err != nil {
+		res.failureCode = failReviewerTerminator
+		return res, fmt.Errorf("reviewer: %w", err)
+	}
+
+	rows, workspaceProject, err := m.workspaceProjectRows(ctx, rec)
+	if err != nil {
+		// Fail closed on unresolved historical rows (mirrors Kill): a workspace
+		// whose repo layout can't be reconciled must not be torn down. An archived
+		// or unregistered project gets a distinct code so the UI can tell the user
+		// to remove the worktree manually.
+		res.failureCode = failWorkspaceRows
+		if errors.Is(err, ErrProjectNotResolvable) {
+			res.failureCode = failProjectUnresolvable
+		}
+		return res, fmt.Errorf("workspace rows: %w", err)
+	}
+	res.workspaceProject = workspaceProject
+	ws := workspaceInfo(rec)
+	if !workspaceProject && ws.Path == "" {
+		// No workspace to release (no-worktree / spawn-failed / orchestrator).
+		res.disposition = domain.DispositionNotApplicable
+		m.cleanupSystemPromptDir(rec.ID)
+		return res, nil
+	}
+
+	// Gate shut any shell terminal scoped to this session BEFORE the worktree
+	// goes away: an open shell whose cwd is that directory can otherwise survive
+	// the removal (and on Windows can even block it — an open handle on a
+	// directory refuses deletion), or a concurrent Open could land a new one in
+	// the same race window. A shell that cannot be confirmed closed stops the
+	// release here — same shape as a dirty-workspace refusal — rather than
+	// letting the worktree disappear out from under it.
+	if ws.Path != "" {
+		release, err := m.beginShellTerminalTeardown(ctx, rec.ID)
+		if err != nil {
+			res.disposition = domain.DispositionPreservedDirty
+			m.deleteRestoreMarker(ctx, rec.ID)
+			m.cleanupSystemPromptDir(rec.ID)
+			return res, nil
+		}
+		if release != nil {
+			defer release()
+		}
+	}
+
+	if workspaceProject {
+		out := m.releaseWorkspaceProjectRows(ctx, rows)
+		if out.dirty == 0 && out.firstErr != nil {
+			// Purely non-dirty failure(s): surface so Kill fails closed and the
+			// finalizer/Cleanup schedule a retry. The failed rows are already
+			// marked retry_remove.
+			res.failureCode = workspaceFailureCode(out.firstErr)
+			return res, fmt.Errorf("workspace: %w", out.firstErr)
+		}
+		if out.removed > 0 {
+			m.cleanupAgentWorkspace(ctx, rec, rec.Metadata.WorkspacePath)
+		}
+		if out.dirty > 0 {
+			res.disposition = domain.DispositionPreservedDirty
+		} else {
+			res.disposition = domain.DispositionRemoved
+		}
+		m.cleanupSystemPromptDir(rec.ID)
+		return res, nil
+	}
+
+	// Single worktree.
+	if err := m.workspace.Destroy(ctx, ws); err != nil {
+		if errors.Is(err, ports.ErrWorkspaceDirty) {
+			res.disposition = domain.DispositionPreservedDirty
+			// Drop the restore marker so RestoreAll can't relaunch a terminated
+			// session over the preserved worktree; the worktree is left on disk.
+			m.deleteRestoreMarker(ctx, rec.ID)
+			m.cleanupSystemPromptDir(rec.ID)
+			return res, nil
+		}
+		res.failureCode = workspaceFailureCode(err)
+		return res, fmt.Errorf("workspace: %w", err)
+	}
+	res.disposition = domain.DispositionRemoved
+	m.cleanupAgentWorkspace(ctx, rec, ws.Path)
+	m.deleteRestoreMarker(ctx, rec.ID)
+	m.cleanupSystemPromptDir(rec.ID)
+	return res, nil
+}
+
+// workspaceFailureCode classifies a non-dirty workspace teardown error: an
+// archived/unregistered project (its repo no longer resolves) gets a distinct
+// code so the UI can tell the user to remove the worktree by hand; everything
+// else is a generic teardown failure.
+func workspaceFailureCode(err error) string {
+	if errors.Is(err, ErrProjectNotResolvable) {
+		return failProjectUnresolvable
+	}
+	return failWorkspaceDestroy
+}
+
+// isTerminalDisposition reports whether a stored disposition is settled for the
+// current generation — i.e. auto-retry is done and a finalize can no-op. Pending
+// is the only non-terminal state (it is still auto-retrying).
+func isTerminalDisposition(d domain.WorkspaceDisposition) bool {
+	switch d {
+	case domain.DispositionRemoved, domain.DispositionPreservedDirty,
+		domain.DispositionFailed, domain.DispositionNotApplicable:
+		return true
+	default:
+		return false
+	}
+}
+
+// wpOutcome tallies a workspace-project teardown that continues past dirty
+// children (#16). Per-repo state lives in session_worktrees.state; the
+// facts-table disposition is only the rollup.
+type wpOutcome struct {
+	removed  int
+	dirty    int
+	failed   int
+	firstErr error // first non-dirty teardown error, for the failure code
+}
+
+// releaseWorkspaceProjectRows removes a workspace project's worktrees child-first
+// but, unlike the old abort-on-first-dirty destroyWorkspaceProjectRows, continues
+// past a dirty child: clean children are removed (state → unavailable), dirty
+// children are preserved untouched, and non-dirty failures are marked
+// retry_remove. This stops one dirty worktree from permanently stranding its
+// clean siblings.
+func (m *Manager) releaseWorkspaceProjectRows(ctx context.Context, rows []ports.WorkspaceRepoInfo) wpOutcome {
+	var out wpOutcome
+	for i := len(rows) - 1; i >= 0; i-- {
+		if rows[i].Path == "" {
+			continue
+		}
+		info := workspaceInfoFromRepoInfo(rows[i])
+		if err := m.workspace.Destroy(ctx, info); err != nil {
+			if errors.Is(err, ports.ErrWorkspaceDirty) {
+				// Preserve the dirty child as-is (never force); its row stays
+				// non-restorable spawn state, so RestoreAll won't resurrect it.
+				out.dirty++
+				continue
+			}
+			if stateErr := m.upsertWorkspaceProjectRowState(ctx, rows[i], "retry_remove"); stateErr != nil && out.firstErr == nil {
+				out.firstErr = stateErr
+			}
+			if out.firstErr == nil {
+				out.firstErr = err
+			}
+			out.failed++
+			continue
+		}
+		if err := m.upsertWorkspaceProjectRowState(ctx, rows[i], "unavailable"); err != nil && out.firstErr == nil {
+			out.firstErr = err
+		}
+		out.removed++
+	}
+	return out
+}
+
+// deleteRestoreMarker best-effort clears a session's shutdown-restore markers.
+func (m *Manager) deleteRestoreMarker(ctx context.Context, id domain.SessionID) {
+	if err := m.store.DeleteSessionWorktrees(ctx, id); err != nil {
+		m.logger.Warn("finalize: delete restore marker failed", "sessionID", id, "error", err)
+	}
+}
+
+// cleanupBackoff returns the capped-exponential retry interval for the given
+// (1-based) attempt number.
+func cleanupBackoff(attempt int64) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := cleanupBackoffBase
+	for i := int64(1); i < attempt; i++ {
+		d *= 2
+		if d >= cleanupBackoffCap {
+			return cleanupBackoffCap
+		}
+	}
+	return d
+}
+
+// persistCleanupFacts writes the durable teardown facts for a terminal session,
+// stamped with the cleanup generation the release ran under. Retry bookkeeping
+// (attempt count, next_attempt_at) is only carried forward within the same
+// generation episode: a Restore→Terminate cycle that advanced the counter starts
+// a fresh episode. A pending (transient-failure) result schedules a capped
+// backoff retry, or transitions to a terminal `failed` disposition once the
+// attempt cap is reached.
+func (m *Manager) persistCleanupFacts(ctx context.Context, rec domain.SessionRecord, generation int64, res cleanupResult) error {
+	now := m.clock()
+	prior, hadPrior, err := m.store.GetSessionCleanupFacts(ctx, rec.ID)
+	if err != nil {
+		return err
+	}
+	sameEpisode := hadPrior && prior.SessionGeneration == generation
+
+	facts := domain.SessionCleanupRecord{
+		SessionID:         rec.ID,
+		SessionGeneration: generation,
+		FailureCode:       res.failureCode,
+		LastAttemptAt:     now,
+	}
+	switch {
+	case res.runtimeReleased:
+		facts.RuntimeReleasedAt = now
+	case sameEpisode && !prior.RuntimeReleasedAt.IsZero():
+		// Once genuinely released this episode, the stamp survives later retries.
+		facts.RuntimeReleasedAt = prior.RuntimeReleasedAt
+	}
+
+	priorAttempts := int64(0)
+	if sameEpisode {
+		priorAttempts = prior.AttemptCount
+	}
+	attempts := priorAttempts + 1
+	facts.AttemptCount = attempts
+
+	if res.disposition == domain.DispositionPending {
+		if attempts >= maxCleanupAttempts {
+			// Exhausted: stop auto-retry. Only a user-triggered retry (PR 3 API)
+			// clears this, distinct from a still-auto-retrying pending state.
+			facts.WorkspaceDisposition = domain.DispositionFailed
+		} else {
+			facts.WorkspaceDisposition = domain.DispositionPending
+			facts.NextAttemptAt = now.Add(cleanupBackoff(attempts))
+		}
+	} else {
+		facts.WorkspaceDisposition = res.disposition
+	}
+	return m.store.UpsertSessionCleanupFacts(ctx, facts)
+}
+
+// FinalizeTerminalSession converges a terminated session's runtime + workspace
+// toward safe release. It is idempotent and safe to call repeatedly: it is the
+// reconciler's per-session unit of work and the primitive the per-session
+// cleanup API (PR 3) delegates to. It never marks a session terminated — that
+// durable intent is written by Kill / the lifecycle reactions — and it never
+// releases a restore-pending session (RestoreAll owns those).
+func (m *Manager) FinalizeTerminalSession(ctx context.Context, id domain.SessionID) error {
+	unlock := m.sessionLocks.lock(id)
+	defer unlock()
+
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return fmt.Errorf("finalize %s: %w", id, err)
+	}
+	if !ok || !rec.IsTerminated {
+		// Gone or no longer terminal (a Restore un-terminated it): nothing to do.
+		return nil
+	}
+
+	// A restorable session_worktrees row means the session is shutdown-saved and
+	// owned by RestoreAll; releasing under it would race a restore. Merge/kill
+	// terminated sessions keep their spawn-time rows in state "active" (not
+	// restorable), so those remain finalize-eligible.
+	rows, err := m.store.ListSessionWorktrees(ctx, id)
+	if err != nil {
+		return fmt.Errorf("finalize %s: %w", id, err)
+	}
+	if len(restorableWorktreeRows(rows)) > 0 {
+		return nil
+	}
+
+	generation := rec.CleanupGeneration
+
+	// Idempotent no-op if already finalized for this generation episode. Shared
+	// with finalizeOne (bulk Cleanup) so both entry points skip a re-release.
+	if facts, ok, err := m.store.GetSessionCleanupFacts(ctx, id); err != nil {
+		return fmt.Errorf("finalize %s: %w", id, err)
+	} else if ok && facts.SessionGeneration == generation && isTerminalDisposition(facts.WorkspaceDisposition) {
+		return nil
+	}
+
+	res, releaseErr := m.releaseTerminalResources(ctx, rec)
+	if releaseErr != nil {
+		// A terminated session's teardown failure is not surfaced to the caller;
+		// it becomes a retry fact the periodic sweep re-attempts.
+		m.logger.Warn("finalize: release failed; scheduling retry", "sessionID", id, "error", releaseErr)
+		res.disposition = domain.DispositionPending
+		if res.failureCode == "" {
+			res.failureCode = failTeardown
+		}
+	}
+
+	// Generation guard: if a Restore→Terminate cycle advanced the counter while we
+	// released, this result is stale and must not satisfy the newer episode.
+	cur, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return fmt.Errorf("finalize %s: %w", id, err)
+	}
+	if !ok || !cur.IsTerminated || cur.CleanupGeneration != generation {
+		return nil
+	}
+	return m.persistCleanupFacts(ctx, rec, generation, res)
+}

--- a/backend/internal/session_manager/finalize.go
+++ b/backend/internal/session_manager/finalize.go
@@ -24,6 +24,7 @@ const (
 // Machine failure codes recorded on session_cleanup_facts.failure_code.
 const (
 	failRuntimeDestroy      = "runtime_destroy"
+	failRuntimeUnresolved   = "runtime_unresolved"
 	failWorkspaceRows       = "workspace_rows"
 	failWorkspaceDestroy    = "workspace_destroy"
 	failReviewerTerminator  = "reviewer_terminator"
@@ -59,6 +60,7 @@ type cleanupResult struct {
 // that (Kill) or fold it into a retry fact (the finalizer / Cleanup).
 func (m *Manager) releaseTerminalResources(ctx context.Context, rec domain.SessionRecord) (cleanupResult, error) {
 	var res cleanupResult
+	var runtimeUnresolved bool
 
 	m.stopPreviewBestEffort(ctx, rec.ID)
 	m.destroyBrowserBestEffort(ctx, rec.ID)
@@ -76,13 +78,16 @@ func (m *Manager) releaseTerminalResources(ctx context.Context, rec domain.Sessi
 			return res, fmt.Errorf("runtime: %w", err)
 		}
 		res.runtimeReleased = true
+	} else {
+		// handle.ID == "": an unrouted / legacy-backlog row. Destroy returns nil
+		// for an empty handle too, so treating that as proof of release would
+		// silently leave a live-but-unrouted runtime leaked (#1458). Reconstructing
+		// the adapter's deterministic session name to probe such a runtime is a
+		// cross-adapter seam left as follow-up; until then, fail closed instead of
+		// false-succeeding — checked below, once we know there is a workspace to
+		// protect (a workspace-less terminal session has nothing to leak into).
+		runtimeUnresolved = true
 	}
-	// handle.ID == "": an unrouted / legacy-backlog row. Destroy returns nil for
-	// an empty handle too, so treating that as proof of release would silently
-	// leave a live-but-unrouted runtime leaked. We do NOT claim release
-	// (runtimeReleased stays false) and still proceed to workspace cleanup;
-	// actively reconstructing the adapter's deterministic session name to probe
-	// such a runtime is a cross-adapter seam left as follow-up (ties to #1458).
 
 	if err := m.terminateReviewer(ctx, rec.ID, "cancelled by worker session termination"); err != nil {
 		res.failureCode = failReviewerTerminator
@@ -110,6 +115,15 @@ func (m *Manager) releaseTerminalResources(ctx context.Context, rec domain.Sessi
 		return res, nil
 	}
 
+	// A resolvable-but-unconfirmed runtime must not let the workspace go: an
+	// unrouted runtime could still be live, and deleting its cwd out from under
+	// it can't be undone. Fail closed here (pending/retryable) rather than
+	// proceeding on the unproven assumption that "no handle" means "no process".
+	if runtimeUnresolved {
+		res.failureCode = failRuntimeUnresolved
+		return res, fmt.Errorf("runtime handle unresolved for %s; refusing to release its workspace", rec.ID)
+	}
+
 	// Gate shut any shell terminal scoped to this session BEFORE the worktree
 	// goes away: an open shell whose cwd is that directory can otherwise survive
 	// the removal (and on Windows can even block it — an open handle on a
@@ -132,10 +146,13 @@ func (m *Manager) releaseTerminalResources(ctx context.Context, rec domain.Sessi
 
 	if workspaceProject {
 		out := m.releaseWorkspaceProjectRows(ctx, rows)
-		if out.dirty == 0 && out.firstErr != nil {
-			// Purely non-dirty failure(s): surface so Kill fails closed and the
-			// finalizer/Cleanup schedule a retry. The failed rows are already
-			// marked retry_remove.
+		if out.firstErr != nil {
+			// A failed non-dirty child must stay retryable even alongside a dirty
+			// sibling: surfacing the error (rather than rolling straight to the
+			// terminal preserved_dirty disposition) is what lets the caller
+			// schedule a retry. The failed row is already marked retry_remove and
+			// the dirty row is left untouched either way, so a later retry that
+			// only needs to revisit the failed child converges correctly.
 			res.failureCode = workspaceFailureCode(out.firstErr)
 			return res, fmt.Errorf("workspace: %w", out.firstErr)
 		}

--- a/backend/internal/session_manager/finalize_test.go
+++ b/backend/internal/session_manager/finalize_test.go
@@ -113,6 +113,34 @@ func TestFinalize_RuntimeFailLeavesWorkspaceAndSchedulesRetry(t *testing.T) {
 	}
 }
 
+// TestFinalize_UnresolvedRuntimeHandleFailsClosed pins review gap #1 on #2931:
+// a terminal session with an empty/unrouted RuntimeHandleID (a legacy/backlog
+// row, e.g. #1458) must not let releaseTerminalResources proceed to destroy
+// its workspace — an unrouted runtime could still be live, and deleting its
+// cwd out from under it can't be undone. The release must fail closed
+// (pending/retryable) instead of false-succeeding.
+func TestFinalize_UnresolvedRuntimeHandleFailsClosed(t *testing.T) {
+	m, st, _, ws := finalizeManager(nil)
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1"}) // no RuntimeHandleID
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize should not surface a terminated session's teardown error: %v", err)
+	}
+	if ws.destroyed != 0 {
+		t.Fatal("an unresolved runtime handle must block workspace release, not just skip the runtime step")
+	}
+	facts := st.cleanup["mer-1"]
+	if facts.WorkspaceDisposition != domain.DispositionPending {
+		t.Fatalf("disposition = %q, want pending (retry scheduled)", facts.WorkspaceDisposition)
+	}
+	if facts.FailureCode != failRuntimeUnresolved {
+		t.Fatalf("failure code = %q, want %q", facts.FailureCode, failRuntimeUnresolved)
+	}
+	if !facts.RuntimeReleasedAt.IsZero() {
+		t.Fatal("runtime must NOT be recorded released when its handle was never resolved")
+	}
+}
+
 func TestFinalize_RetryExhaustionMarksFailed(t *testing.T) {
 	m, st, rt, _ := finalizeManager(nil)
 	rt.destroyErr = errors.New("permanently wedged")
@@ -294,6 +322,57 @@ func TestFinalize_WorkspaceProjectMixedCleanDirty(t *testing.T) {
 	}
 	if st.cleanup["mer-1"].WorkspaceDisposition != domain.DispositionPreservedDirty {
 		t.Fatalf("rollup = %q, want preserved_dirty", st.cleanup["mer-1"].WorkspaceDisposition)
+	}
+}
+
+// TestFinalize_WorkspaceProjectDirtyPlusFailedSiblingStaysRetryable pins review
+// gap #2 on #2931: when one child is dirty (preserved) and another, non-dirty
+// child's teardown *fails*, the session must not roll up to the terminal
+// preserved_dirty disposition — that would silently swallow the failed
+// child's error and stop it from ever being retried. The failed child's
+// retry_remove marker must get another attempt on a later sweep.
+func TestFinalize_WorkspaceProjectDirtyPlusFailedSiblingStaysRetryable(t *testing.T) {
+	m, st, _, ws := finalizeManager(nil)
+	ws.destroyErrByRepo = map[string]error{
+		"web":    fmt.Errorf("dirty: %w", ports.ErrWorkspaceDirty),
+		"broken": errors.New("locked"),
+	}
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{
+		{Name: "api", RelativePath: "api"},
+		{Name: "web", RelativePath: "web"},
+		{Name: "broken", RelativePath: "broken"},
+	}
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", RuntimeHandleID: "h1"})
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1", State: "active"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api", State: "active"},
+		{SessionID: "mer-1", RepoName: "web", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/web", State: "active"},
+		{SessionID: "mer-1", RepoName: "broken", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/broken", State: "active"},
+	}
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	states := map[string]string{}
+	for _, row := range st.worktrees["mer-1"] {
+		states[row.RepoName] = row.State
+	}
+	if states["api"] != "unavailable" || states[domain.RootWorkspaceRepoName] != "unavailable" {
+		t.Fatalf("clean children not reclaimed: states = %v", states)
+	}
+	if states["web"] != "active" {
+		t.Fatalf("dirty child web state = %q, want preserved (unchanged)", states["web"])
+	}
+	if states["broken"] != "retry_remove" {
+		t.Fatalf("failed child broken state = %q, want retry_remove", states["broken"])
+	}
+	facts := st.cleanup["mer-1"]
+	if facts.WorkspaceDisposition != domain.DispositionPending {
+		t.Fatalf("rollup = %q, want pending so the failed child is retried (a dirty sibling must not mask it as terminal preserved_dirty)", facts.WorkspaceDisposition)
+	}
+	if facts.NextAttemptAt.IsZero() {
+		t.Fatal("a pending mixed dirty+failed rollup must schedule a retry")
 	}
 }
 

--- a/backend/internal/session_manager/finalize_test.go
+++ b/backend/internal/session_manager/finalize_test.go
@@ -506,6 +506,47 @@ func TestCleanupSession_RetriesTerminalDisposition(t *testing.T) {
 	}
 }
 
+// TestCleanupSession_PersistFailurePropagatesError pins the correctness fix: a
+// storage failure while persisting cleanup facts must surface as an error
+// (the service maps it to a 500) rather than a synthesized-success record —
+// the caller asked for refreshed, durable facts and got neither.
+func TestCleanupSession_PersistFailurePropagatesError(t *testing.T) {
+	m, st, _, ws := finalizeManager(nil)
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+	boom := errors.New("db locked")
+	st.upsertCleanupErr = boom
+
+	facts, err := m.CleanupSession(ctx, "mer-1")
+	if err == nil {
+		t.Fatalf("cleanup: want error on persist failure, got facts %+v", facts)
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want wrapping %v", err, boom)
+	}
+	// The release itself must still have run (teardown is not gated on storage).
+	if ws.destroyed != 1 {
+		t.Fatalf("workspace destroyed = %d, want 1", ws.destroyed)
+	}
+}
+
+// TestCleanupSession_ReloadFailurePropagatesError: same contract for the
+// post-persist re-read — a storage error there must not be swallowed into a
+// synthesized record either.
+func TestCleanupSession_ReloadFailurePropagatesError(t *testing.T) {
+	m, st, _, _ := finalizeManager(nil)
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+	boom := errors.New("db unreachable")
+	st.getCleanupErr = boom
+
+	_, err := m.CleanupSession(ctx, "mer-1")
+	if err == nil {
+		t.Fatal("cleanup: want error on re-read failure")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want wrapping %v", err, boom)
+	}
+}
+
 // TestKill_WritesCleanupFacts pins critique #18: every terminal path (here Kill)
 // persists a facts row so the sessions-driven boot scan doesn't re-enqueue it
 // forever.

--- a/backend/internal/session_manager/finalize_test.go
+++ b/backend/internal/session_manager/finalize_test.go
@@ -450,6 +450,62 @@ func TestKill_SerializedWithFinalize(t *testing.T) {
 	}
 }
 
+// --- CleanupSession (per-session cleanup API primitive, PR 3) ---
+
+func TestCleanupSession_UnknownSessionIsNotFound(t *testing.T) {
+	m, _, _, _ := finalizeManager(nil)
+	if _, err := m.CleanupSession(ctx, "nope"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCleanupSession_LiveSessionIsNotTerminal(t *testing.T) {
+	m, st, rt, ws := finalizeManager(nil)
+	st.sessions["mer-1"] = mkLive("mer-1")
+	_, err := m.CleanupSession(ctx, "mer-1")
+	if !errors.Is(err, ErrNotTerminal) {
+		t.Fatalf("err = %v, want ErrNotTerminal", err)
+	}
+	if rt.destroyed != 0 || ws.destroyed != 0 {
+		t.Fatal("a live session must not be torn down by cleanup")
+	}
+}
+
+func TestCleanupSession_TerminalReleasesAndReturnsFacts(t *testing.T) {
+	m, st, _, ws := finalizeManager(nil)
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+	facts, err := m.CleanupSession(ctx, "mer-1")
+	if err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if ws.destroyed != 1 {
+		t.Fatalf("workspace destroyed = %d, want 1", ws.destroyed)
+	}
+	if facts.WorkspaceDisposition != domain.DispositionRemoved {
+		t.Fatalf("disposition = %q, want removed", facts.WorkspaceDisposition)
+	}
+}
+
+// TestCleanupSession_RetriesTerminalDisposition pins the user-retry contract: a
+// session already recorded failed (or preserved_dirty) is re-attempted, NOT
+// idempotent-skipped like the bulk/reconciler path. Here the retry now succeeds
+// (workspace clean) so the disposition flips to removed.
+func TestCleanupSession_RetriesTerminalDisposition(t *testing.T) {
+	m, st, _, _ := finalizeManager(nil)
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+	st.cleanup["mer-1"] = domain.SessionCleanupRecord{
+		SessionID: "mer-1", SessionGeneration: 0,
+		WorkspaceDisposition: domain.DispositionFailed, AttemptCount: maxCleanupAttempts, FailureCode: failWorkspaceDestroy,
+	}
+	facts, err := m.CleanupSession(ctx, "mer-1")
+	if err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if facts.WorkspaceDisposition != domain.DispositionRemoved {
+		t.Fatalf("disposition = %q, want removed (retry must not idempotent-skip a failed session)", facts.WorkspaceDisposition)
+	}
+}
+
 // TestKill_WritesCleanupFacts pins critique #18: every terminal path (here Kill)
 // persists a facts row so the sessions-driven boot scan doesn't re-enqueue it
 // forever.

--- a/backend/internal/session_manager/finalize_test.go
+++ b/backend/internal/session_manager/finalize_test.go
@@ -1,0 +1,388 @@
+package sessionmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// fakeReviewer stands in for the review service's ReviewerTerminator seam.
+type fakeReviewer struct {
+	terminateCalls int
+	terminateErr   error
+}
+
+func (f *fakeReviewer) TerminateReviewer(context.Context, domain.SessionID, string) error {
+	f.terminateCalls++
+	return f.terminateErr
+}
+func (f *fakeReviewer) TeardownReviewerTerminal(context.Context, domain.SessionID) error {
+	return nil
+}
+func (f *fakeReviewer) RestoreReviewer(context.Context, domain.SessionID) error { return nil }
+
+// finalizeManager builds a Manager wired for finalizer tests, with a fixed clock
+// (so backoff/next_attempt_at are deterministic) and an optional reviewer.
+func finalizeManager(rv ReviewerTerminator) (*Manager, *fakeStore, *fakeRuntime, *fakeWorkspace) {
+	st := newFakeStore()
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{}
+	m := New(Deps{
+		Runtime:   rt,
+		Agents:    fakeAgents{},
+		Workspace: ws,
+		Store:     st,
+		Messenger: &fakeMessenger{},
+		Lifecycle: &fakeLCM{store: st},
+		Clock:     func() time.Time { return time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC) },
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+	m.SetReviewerTerminator(rv)
+	return m, st, rt, ws
+}
+
+func TestFinalize_CleanTeardownReleasesRuntimeAndWorkspace(t *testing.T) {
+	m, st, rt, ws := finalizeManager(nil)
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if rt.destroyed != 1 || ws.destroyed != 1 {
+		t.Fatalf("runtime destroyed=%d workspace destroyed=%d, want 1/1", rt.destroyed, ws.destroyed)
+	}
+	facts, ok := st.cleanup["mer-1"]
+	if !ok {
+		t.Fatal("no cleanup facts written")
+	}
+	if facts.WorkspaceDisposition != domain.DispositionRemoved {
+		t.Fatalf("disposition = %q, want removed", facts.WorkspaceDisposition)
+	}
+	if facts.RuntimeReleasedAt.IsZero() {
+		t.Fatal("runtime_released_at should be stamped on a genuine release")
+	}
+}
+
+func TestFinalize_DirtyWorkspaceIsPreservedDirty(t *testing.T) {
+	m, st, _, ws := finalizeManager(nil)
+	ws.destroyErr = fmt.Errorf("gitworktree: refusing to remove: %w", ports.ErrWorkspaceDirty)
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	facts := st.cleanup["mer-1"]
+	if facts.WorkspaceDisposition != domain.DispositionPreservedDirty {
+		t.Fatalf("disposition = %q, want preserved_dirty", facts.WorkspaceDisposition)
+	}
+	// A preserved-dirty session is terminal for auto-retry: no next_attempt_at.
+	if !facts.NextAttemptAt.IsZero() {
+		t.Fatalf("next_attempt_at = %v, want none for preserved_dirty", facts.NextAttemptAt)
+	}
+}
+
+func TestFinalize_RuntimeFailLeavesWorkspaceAndSchedulesRetry(t *testing.T) {
+	m, st, rt, ws := finalizeManager(nil)
+	rt.destroyErr = errors.New("tmux transient")
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize should not surface a terminated session's teardown error: %v", err)
+	}
+	if ws.destroyed != 0 {
+		t.Fatal("runtime-first: workspace must be left untouched when runtime destroy fails")
+	}
+	facts := st.cleanup["mer-1"]
+	if facts.WorkspaceDisposition != domain.DispositionPending {
+		t.Fatalf("disposition = %q, want pending (retry scheduled)", facts.WorkspaceDisposition)
+	}
+	if facts.AttemptCount != 1 || facts.NextAttemptAt.IsZero() {
+		t.Fatalf("attempt=%d next=%v, want attempt 1 with a scheduled retry", facts.AttemptCount, facts.NextAttemptAt)
+	}
+	if facts.FailureCode != failRuntimeDestroy {
+		t.Fatalf("failure code = %q, want %q", facts.FailureCode, failRuntimeDestroy)
+	}
+	if !facts.RuntimeReleasedAt.IsZero() {
+		t.Fatal("runtime must NOT be recorded released when its destroy failed")
+	}
+}
+
+func TestFinalize_RetryExhaustionMarksFailed(t *testing.T) {
+	m, st, rt, _ := finalizeManager(nil)
+	rt.destroyErr = errors.New("permanently wedged")
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+
+	// Each attempt fails transiently and increments the count; the cap flips it to
+	// a terminal `failed` disposition that stops auto-retry.
+	for i := 0; i < maxCleanupAttempts; i++ {
+		if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+			t.Fatalf("finalize attempt %d: %v", i, err)
+		}
+	}
+	facts := st.cleanup["mer-1"]
+	if facts.WorkspaceDisposition != domain.DispositionFailed {
+		t.Fatalf("disposition = %q, want failed after %d attempts", facts.WorkspaceDisposition, maxCleanupAttempts)
+	}
+	if facts.AttemptCount != int64(maxCleanupAttempts) {
+		t.Fatalf("attempt count = %d, want %d", facts.AttemptCount, maxCleanupAttempts)
+	}
+	if !facts.NextAttemptAt.IsZero() {
+		t.Fatal("a failed (exhausted) cleanup must not schedule further auto-retry")
+	}
+}
+
+func TestFinalize_IdempotentReRunAfterRemoved(t *testing.T) {
+	m, st, rt, ws := finalizeManager(nil)
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize 1: %v", err)
+	}
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize 2: %v", err)
+	}
+	// Second run is a no-op: facts already record `removed` for this generation.
+	if rt.destroyed != 1 || ws.destroyed != 1 {
+		t.Fatalf("re-run should be a no-op: runtime=%d workspace=%d, want 1/1", rt.destroyed, ws.destroyed)
+	}
+}
+
+func TestFinalize_NotTerminalIsNoop(t *testing.T) {
+	m, st, rt, ws := finalizeManager(nil)
+	st.sessions["mer-1"] = mkLive("mer-1") // not terminated
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if rt.destroyed != 0 || ws.destroyed != 0 || len(st.cleanup) != 0 {
+		t.Fatal("finalize must not touch a live (non-terminal) session")
+	}
+}
+
+func TestFinalize_RestorePendingSessionIsSkipped(t *testing.T) {
+	m, st, rt, ws := finalizeManager(nil)
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+	// A "removed"-state row is a shutdown-restore marker: RestoreAll owns it.
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, State: "removed", WorktreePath: "/ws/mer-1"},
+	}
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if rt.destroyed != 0 || ws.destroyed != 0 || len(st.cleanup) != 0 {
+		t.Fatal("finalize must never release a restore-pending session")
+	}
+}
+
+func TestFinalize_NoWorkspaceIsNotApplicable(t *testing.T) {
+	m, st, _, _ := finalizeManager(nil)
+	// Terminal session with no workspace and no handle (spawn-failed / orchestrator).
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", IsTerminated: true}
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	facts, ok := st.cleanup["mer-1"]
+	if !ok || facts.WorkspaceDisposition != domain.DispositionNotApplicable {
+		t.Fatalf("facts = %+v, want a not_applicable row so the boot scan won't re-enqueue it forever", facts)
+	}
+}
+
+// TestFinalize_GenerationGuardDropsStaleResult pins critique #17: a finalize
+// begun under generation N must not persist after a Restore→Terminate cycle has
+// advanced the counter to N+1.
+func TestFinalize_GenerationGuardDropsStaleResult(t *testing.T) {
+	m, st, rt, _ := finalizeManager(nil)
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID: "mer-1", ProjectID: "mer", IsTerminated: true, CleanupGeneration: 1,
+		Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"},
+	}
+	// Simulate a Restore→Terminate cycle advancing the generation while the
+	// release core runs (during runtime Destroy).
+	rt.destroyHook = func() {
+		rec := st.sessions["mer-1"]
+		rec.CleanupGeneration = 2
+		st.sessions["mer-1"] = rec
+	}
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if _, ok := st.cleanup["mer-1"]; ok {
+		t.Fatal("a stale-generation finalize result must not be persisted")
+	}
+}
+
+// TestFinalize_ReviewerTerminateFailsDefersRemoval pins critique #24 / M1: a
+// worktree whose reviewer pane cannot be confirmed torn down is never removed;
+// the workspace becomes retryable.
+func TestFinalize_ReviewerTerminateFailsDefersRemoval(t *testing.T) {
+	rv := &fakeReviewer{terminateErr: errors.New("reviewer pane still live")}
+	m, st, _, ws := finalizeManager(rv)
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if rv.terminateCalls != 1 {
+		t.Fatalf("reviewer terminate calls = %d, want 1", rv.terminateCalls)
+	}
+	if ws.destroyed != 0 {
+		t.Fatal("worktree must not be removed while the reviewer pane can't be confirmed torn down")
+	}
+	facts := st.cleanup["mer-1"]
+	if facts.WorkspaceDisposition != domain.DispositionPending || facts.FailureCode != failReviewerTerminator {
+		t.Fatalf("facts = %+v, want pending/reviewer_terminator so it retries", facts)
+	}
+}
+
+func TestFinalize_ReviewerTerminatedThenWorktreeRemoved(t *testing.T) {
+	rv := &fakeReviewer{} // TerminateReviewer succeeds: pane confirmed gone
+	m, st, _, ws := finalizeManager(rv)
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if rv.terminateCalls != 1 || ws.destroyed != 1 {
+		t.Fatalf("terminate=%d workspace destroyed=%d, want 1/1", rv.terminateCalls, ws.destroyed)
+	}
+	if st.cleanup["mer-1"].WorkspaceDisposition != domain.DispositionRemoved {
+		t.Fatalf("disposition = %q, want removed", st.cleanup["mer-1"].WorkspaceDisposition)
+	}
+}
+
+// TestFinalize_WorkspaceProjectMixedCleanDirty pins critique #16 / M2: a dirty
+// child no longer strands its clean siblings — clean children are removed, the
+// dirty one is preserved, and the session rolls up to preserved_dirty.
+func TestFinalize_WorkspaceProjectMixedCleanDirty(t *testing.T) {
+	m, st, _, ws := finalizeManager(nil)
+	ws.destroyErrByRepo = map[string]error{
+		"web": fmt.Errorf("dirty: %w", ports.ErrWorkspaceDirty),
+	}
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
+	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{
+		{Name: "api", RelativePath: "api"},
+		{Name: "web", RelativePath: "web"},
+	}
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", RuntimeHandleID: "h1"})
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1", State: "active"},
+		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api", State: "active"},
+		{SessionID: "mer-1", RepoName: "web", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/web", State: "active"},
+	}
+
+	if err := m.FinalizeTerminalSession(ctx, "mer-1"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	states := map[string]string{}
+	for _, row := range st.worktrees["mer-1"] {
+		states[row.RepoName] = row.State
+	}
+	if states["api"] != "unavailable" || states[domain.RootWorkspaceRepoName] != "unavailable" {
+		t.Fatalf("clean children not reclaimed: states = %v", states)
+	}
+	if states["web"] != "active" {
+		t.Fatalf("dirty child web state = %q, want preserved (unchanged)", states["web"])
+	}
+	if st.cleanup["mer-1"].WorkspaceDisposition != domain.DispositionPreservedDirty {
+		t.Fatalf("rollup = %q, want preserved_dirty", st.cleanup["mer-1"].WorkspaceDisposition)
+	}
+}
+
+// overlapDetector returns an opHook that flags if two disk-touching workspace
+// ops are ever in flight at once for the same session, plus a reader for the flag.
+func overlapDetector() (hook func(string), overlapped func() bool) {
+	var mu sync.Mutex
+	inCS := 0
+	over := false
+	hook = func(string) {
+		mu.Lock()
+		inCS++
+		if inCS > 1 {
+			over = true
+		}
+		mu.Unlock()
+		time.Sleep(10 * time.Millisecond) // widen the window so a missing lock overlaps
+		mu.Lock()
+		inCS--
+		mu.Unlock()
+	}
+	overlapped = func() bool { mu.Lock(); defer mu.Unlock(); return over }
+	return hook, overlapped
+}
+
+// TestFinalize_SerializedWithRestore pins the gating review item: the per-session
+// lock must make a reconciler finalize and a concurrent RestoreWithMode mutually
+// exclusive, so a finalize can't remove the worktree of a session being
+// relaunched. Without the lock in RestoreWithMode, the workspace Destroy and
+// Restore overlap; -race would also flag the resulting store races.
+func TestFinalize_SerializedWithRestore(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		m, st, _, ws := finalizeManager(nil)
+		st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Config: testRoleAgents()}
+		st.sessions["mer-1"] = domain.SessionRecord{
+			ID: "mer-1", ProjectID: "mer", IsTerminated: true, CleanupGeneration: 1,
+			Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", RuntimeHandleID: "h1"},
+		}
+		hook, overlapped := overlapDetector()
+		ws.opHook = hook
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); _ = m.FinalizeTerminalSession(ctx, "mer-1") }()
+		go func() { defer wg.Done(); _, _ = m.RestoreWithMode(ctx, "mer-1") }()
+		wg.Wait()
+
+		if overlapped() {
+			t.Fatalf("iteration %d: finalize and restore overlapped — per-session lock not serializing them", i)
+		}
+	}
+}
+
+// TestKill_SerializedWithFinalize pins that a user Kill and a reconciler finalize
+// over the same session never tear down its workspace concurrently.
+func TestKill_SerializedWithFinalize(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		m, st, _, ws := finalizeManager(nil)
+		st.sessions["mer-1"] = domain.SessionRecord{
+			ID: "mer-1", ProjectID: "mer", IsTerminated: true, CleanupGeneration: 1,
+			Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", RuntimeHandleID: "h1"},
+		}
+		hook, overlapped := overlapDetector()
+		ws.opHook = hook
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); _, _ = m.Kill(ctx, "mer-1") }()
+		go func() { defer wg.Done(); _ = m.FinalizeTerminalSession(ctx, "mer-1") }()
+		wg.Wait()
+
+		if overlapped() {
+			t.Fatalf("iteration %d: kill and finalize overlapped — per-session lock not serializing them", i)
+		}
+	}
+}
+
+// TestKill_WritesCleanupFacts pins critique #18: every terminal path (here Kill)
+// persists a facts row so the sessions-driven boot scan doesn't re-enqueue it
+// forever.
+func TestKill_WritesCleanupFacts(t *testing.T) {
+	m, st, _, _ := finalizeManager(nil)
+	st.sessions["mer-1"] = mkLive("mer-1")
+
+	if _, err := m.Kill(ctx, "mer-1"); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	facts, ok := st.cleanup["mer-1"]
+	if !ok || facts.WorkspaceDisposition != domain.DispositionRemoved {
+		t.Fatalf("kill facts = %+v (ok=%v), want a removed row", facts, ok)
+	}
+}

--- a/backend/internal/session_manager/locks.go
+++ b/backend/internal/session_manager/locks.go
@@ -1,0 +1,53 @@
+package sessionmanager
+
+import (
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// keyedMutex serialises operations per session id. It mirrors the house idiom
+// (review.go:lockWorker / service.go:lockOrchestratorProject: an outer mutex
+// guarding a map of per-key mutexes) but adds refcounted eviction: the finalizer
+// runs for every terminated session, so a map that never deletes entries would
+// grow unbounded by total sessions ever seen. Each entry is dropped when its
+// last holder unlocks.
+type keyedMutex struct {
+	mu    sync.Mutex
+	locks map[domain.SessionID]*refLock
+}
+
+type refLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func newKeyedMutex() *keyedMutex {
+	return &keyedMutex{locks: map[domain.SessionID]*refLock{}}
+}
+
+// lock acquires the per-id mutex and returns an unlock func. The mutex is
+// non-reentrant, so a holder must never call lock for the same id again before
+// unlocking (the finalizer must therefore never run synchronously inside the CDC
+// callback, which is why the reconciler enqueues-and-returns instead).
+func (k *keyedMutex) lock(id domain.SessionID) func() {
+	k.mu.Lock()
+	rl, ok := k.locks[id]
+	if !ok {
+		rl = &refLock{}
+		k.locks[id] = rl
+	}
+	rl.refs++
+	k.mu.Unlock()
+
+	rl.mu.Lock()
+	return func() {
+		rl.mu.Unlock()
+		k.mu.Lock()
+		rl.refs--
+		if rl.refs == 0 {
+			delete(k.locks, id)
+		}
+		k.mu.Unlock()
+	}
+}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -1866,6 +1866,30 @@ func (m *Manager) restoreSavedSession(ctx context.Context, rec domain.SessionRec
 		return
 	}
 
+	// Release any runtime that survived a prior shutdown before relaunching.
+	// SaveAndTeardownAll's own runtime.Destroy is best-effort (a failure there
+	// only logs a warning); if it didn't actually land, or the daemon crashed
+	// before running it, the old deterministic pane can still be alive here,
+	// and Step 3 creating a new one under the same name would collide with it.
+	// Probe first (rather than an unconditional Destroy) so a handle that is
+	// already gone — the common case, and also true of a session captured and
+	// relaunched within this same boot pass — is left alone rather than
+	// recorded as an extra teardown. reconcileReap used to cover this as a
+	// pre-restore pass; it was removed once the finalizer subsumed runtime
+	// reclaim for every OTHER terminal path, but restore-pending rows are the
+	// one class the finalizer deliberately skips — RestoreAll owns those.
+	if handle := runtimeHandle(rec.Metadata); handle.ID != "" {
+		if alive, err := m.runtime.IsAlive(ctx, handle); err != nil {
+			if !errors.Is(err, ports.ErrRuntimeUnavailable) {
+				m.logger.Warn("restore-all: pre-restore runtime probe failed", "sessionID", rec.ID, "error", err)
+			}
+		} else if alive {
+			if err := m.runtime.Destroy(ctx, handle); err != nil {
+				m.logger.Warn("restore-all: pre-restore runtime release failed", "sessionID", rec.ID, "error", err)
+			}
+		}
+	}
+
 	// Step 1: ensure the worktree exists. workspace.Restore re-creates it
 	// if it was removed by SaveAndTeardownAll.
 	project, err := m.loadProject(ctx, rec.ProjectID)
@@ -2510,6 +2534,24 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 func (m *Manager) finalizeOne(ctx context.Context, rec domain.SessionRecord) domain.SessionCleanupRecord {
 	unlock := m.sessionLocks.lock(rec.ID)
 	defer unlock()
+
+	// Re-read under the lock: cleanupRecords took its snapshot before any lock
+	// was held, so a concurrent Restore can finish between that read and this
+	// lock acquisition. Without this, Cleanup would release the runtime/workspace
+	// of a session that has already been relaunched, using the stale terminated
+	// record instead of the current live one.
+	if cur, ok, err := m.store.GetSession(ctx, rec.ID); err != nil {
+		m.logger.Warn("cleanup: re-read session failed; proceeding on stale record", "sessionID", rec.ID, "error", err)
+	} else if !ok || !cur.IsTerminated {
+		// Gone, or restored since the caller's snapshot: nothing to clean now.
+		return domain.SessionCleanupRecord{
+			SessionID:            rec.ID,
+			SessionGeneration:    rec.CleanupGeneration,
+			WorkspaceDisposition: domain.DispositionNotApplicable,
+		}
+	} else {
+		rec = cur
+	}
 
 	generation := rec.CleanupGeneration
 	if facts, ok, err := m.store.GetSessionCleanupFacts(ctx, rec.ID); err == nil && ok &&

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -221,6 +221,13 @@ type Store interface {
 	// Kill and successful RestoreAll must remove these rows to prevent
 	// resurrecting sessions the user intentionally terminated.
 	DeleteSessionWorktrees(ctx context.Context, id domain.SessionID) error
+	// UpsertSessionCleanupFacts records the durable runtime/workspace teardown
+	// facts for a terminated session (disposition rollup + retry bookkeeping).
+	// The reconciler and the per-session cleanup API render from these.
+	UpsertSessionCleanupFacts(ctx context.Context, rec domain.SessionCleanupRecord) error
+	// GetSessionCleanupFacts returns a session's cleanup facts, ok=false when it
+	// has none yet.
+	GetSessionCleanupFacts(ctx context.Context, id domain.SessionID) (domain.SessionCleanupRecord, bool, error)
 }
 
 // Manager coordinates internal session spawn, restore, kill, and cleanup over
@@ -248,8 +255,17 @@ type Manager struct {
 	preview             PreviewLifecycle
 	browser             BrowserLifecycle
 	browserCapabilities BrowserCapabilityIssuer
-	dataDir             string
-	clock               func() time.Time
+	// sessionLocks serialises every disk-touching lifecycle op for a session —
+	// Spawn, RestoreWithMode, RestoreAll (per session), Kill, bulk Cleanup, and
+	// FinalizeTerminalSession — so a reconciler finalize can't git-worktree-remove
+	// out from under a concurrent Kill or Restore over the same runtime/workspace.
+	// The mutex is non-reentrant: the finalizer must never run synchronously inside
+	// the CDC callback (the reconciler enqueues-and-returns), and locked ops must
+	// not call each other (Spawn's rollback helpers never re-enter; RollbackSpawn→
+	// Kill is a separate top-level call). Refcounted so entries don't accumulate.
+	sessionLocks *keyedMutex
+	dataDir      string
+	clock        func() time.Time
 	// lookPath is exec.LookPath in production; tests substitute a stub so
 	// they don't need real binaries on PATH. Returns ports.ErrAgentBinaryNotFound
 	// when the binary is missing so the sentinel propagates through toAPIError.
@@ -487,6 +503,7 @@ func New(d Deps) *Manager {
 		preview:                d.Preview,
 		browser:                d.Browser,
 		browserCapabilities:    d.BrowserCapabilities,
+		sessionLocks:           newKeyedMutex(),
 		dataDir:                d.DataDir,
 		clock:                  d.Clock,
 		lookPath:               d.LookPath,
@@ -594,6 +611,14 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn: create: %w", err)
 	}
 	id := rec.ID
+	// Serialise this session's disk-touching lifecycle against a concurrent Kill
+	// or reconciler finalize (shared per-session lock). A brand-new id is never
+	// terminal so nothing targets it yet, but holding the lock keeps the
+	// one-writer-per-session invariant uniform across Spawn/Restore/Kill/finalize.
+	// Deadlock-safe: Spawn's rollback helpers never re-enter the lock (the public
+	// RollbackSpawn→Kill path is a separate top-level call).
+	unlock := m.sessionLocks.lock(id)
+	defer unlock()
 	systemPromptFile, err := m.prepareSystemPromptFile(id, cfg.Harness, systemPrompt)
 	if err != nil {
 		m.rollbackSpawnSeedRow(ctx, id)
@@ -1100,6 +1125,9 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	} else if active {
 		return false, fmt.Errorf("kill %s: %w", id, ErrSwitchInProgress)
 	}
+	unlock := m.sessionLocks.lock(id)
+	defer unlock()
+
 	rec, ok, err := m.store.GetSession(ctx, id)
 	if err != nil {
 		return false, fmt.Errorf("kill %s: %w", id, err)
@@ -1107,107 +1135,30 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 	if !ok {
 		return false, nil // already gone: benign race
 	}
-	m.stopPreviewBestEffort(ctx, id)
-	m.destroyBrowserBestEffort(ctx, id)
-	handle := runtimeHandle(rec.Metadata)
-	ws := workspaceInfo(rec)
+	generation := rec.CleanupGeneration
 
-	var workspaceProjectRows []ports.WorkspaceRepoInfo
-	workspaceProject := false
-	if rows, ok, rowErr := m.workspaceProjectRows(ctx, rec); rowErr != nil {
-		return false, fmt.Errorf("kill %s: workspace rows: %w", id, rowErr)
-	} else if ok {
-		workspaceProjectRows = rows
-		workspaceProject = true
+	res, releaseErr := m.releaseTerminalResources(ctx, rec)
+	if releaseErr != nil {
+		// Fail closed: a runtime or non-dirty workspace teardown failure leaves the
+		// session live (never marked terminated) so the user can retry — the same
+		// contract Kill has always had. A dirty worktree is NOT an error: the core
+		// reports it as preserved_dirty below.
+		return false, fmt.Errorf("kill %s: %w", id, releaseErr)
 	}
 
-	// Exactly one controller exists, so exactly one gets torn down. A chat
-	// session has no runtime handle; its controller owns an app-server child
-	// process, and closing it also settles any turn left in flight so a later
-	// read does not show work that is no longer running.
-	if domain.NormalizeSessionMode(rec.Mode) == domain.SessionModeChat {
-		m.stopChatBestEffort(ctx, id)
-	} else if handle.ID != "" {
-		if err := m.runtime.Destroy(ctx, handle); err != nil {
-			return false, fmt.Errorf("kill %s: runtime: %w", id, err)
-		}
-	}
-	if err := m.terminateReviewer(ctx, id, "cancelled by worker session termination"); err != nil {
-		return false, fmt.Errorf("kill %s: reviewer: %w", id, err)
-	}
-	// Gate shut any shell terminal scoped to this session BEFORE the worktree
-	// goes away: an open shell whose cwd is that directory can otherwise
-	// survive the removal (and on Windows can even block it — an open handle
-	// on a directory refuses deletion), or a concurrent Open could land a new
-	// one in the same race window. A runtime that cannot be confirmed dead
-	// stops Kill here — same shape as a dirty-workspace refusal — rather than
-	// letting the worktree disappear out from under it.
-	if ws.Path != "" {
-		release, err := m.beginShellTerminalTeardown(ctx, id)
-		if err != nil {
-			// Same shape as the dirty-workspace refusal below: the worktree is
-			// left alone, but the restore marker still must not survive a user
-			// kill, or the next boot's RestoreAll could resurrect a session the
-			// user explicitly terminated (#2319).
-			if err := m.store.DeleteSessionWorktrees(ctx, id); err != nil {
-				m.logger.Warn("kill: delete restore marker failed", "sessionID", id, "error", err)
-			}
-			if err := m.lcm.MarkTerminated(ctx, id); err != nil {
-				return false, fmt.Errorf("kill %s: %w", id, err)
-			}
-			m.cleanupSystemPromptDir(id)
-			return false, nil
-		}
-		if release != nil {
-			defer release()
-		}
-	}
-	freed := false
-	if workspaceProject {
-		cleaned, err := m.destroyWorkspaceProjectRows(ctx, workspaceProjectRows)
-		if err != nil {
-			if errors.Is(err, ports.ErrWorkspaceDirty) {
-				if err := m.lcm.MarkTerminated(ctx, id); err != nil {
-					return false, fmt.Errorf("kill %s: %w", id, err)
-				}
-				m.cleanupSystemPromptDir(id)
-				return false, nil
-			}
-			return false, fmt.Errorf("kill %s: workspace: %w", id, err)
-		}
-		freed = cleaned
-		if cleaned {
-			m.cleanupAgentWorkspace(ctx, rec, ws.Path)
-		}
-	} else if ws.Path != "" {
-		if err := m.workspace.Destroy(ctx, ws); err != nil {
-			if errors.Is(err, ports.ErrWorkspaceDirty) {
-				if err := m.store.DeleteSessionWorktrees(ctx, id); err != nil {
-					m.logger.Warn("kill: delete restore marker failed", "sessionID", id, "error", err)
-				}
-				if err := m.lcm.MarkTerminated(ctx, id); err != nil {
-					return false, fmt.Errorf("kill %s: %w", id, err)
-				}
-				m.cleanupSystemPromptDir(id)
-				return false, nil
-			}
-			return false, fmt.Errorf("kill %s: workspace: %w", id, err)
-		}
-		freed = true
-		m.cleanupAgentWorkspace(ctx, rec, ws.Path)
-	}
-	// Clear the restore marker so the next boot's RestoreAll cannot resurrect a
-	// killed session (#2319). For workspace projects this must happen after
-	// teardown reads the rows; dirty-preserved rows return above and are left as
-	// non-restorable inventory.
-	if err := m.store.DeleteSessionWorktrees(ctx, id); err != nil {
-		m.logger.Warn("kill: delete restore marker failed", "sessionID", id, "error", err)
-	}
 	if err := m.lcm.MarkTerminated(ctx, id); err != nil {
 		return false, fmt.Errorf("kill %s: %w", id, err)
 	}
-	m.cleanupSystemPromptDir(id)
-	return freed, nil
+	// Persist facts so a user-Kill exits the reconciler's boot scan and the UI can
+	// render its disposition. Best-effort: a facts-write hiccup must not fail the
+	// Kill (the session is already torn down and terminated).
+	if err := m.persistCleanupFacts(ctx, rec, generation, res); err != nil {
+		m.logger.Warn("kill: persist cleanup facts failed", "sessionID", id, "error", err)
+	}
+	// freed reports that the workspace was actually released. A preserved-dirty or
+	// not_applicable outcome frees nothing (any preserved/failed child on a
+	// workspace project → not freed).
+	return res.disposition == domain.DispositionRemoved, nil
 }
 
 // RetireForReplacement terminates a live orchestrator and releases its branch
@@ -1358,6 +1309,14 @@ func (m *Manager) RestoreWithMode(ctx context.Context, id domain.SessionID) (Res
 	} else if active {
 		return RestoreResult{}, fmt.Errorf("restore %s: %w", id, ErrSwitchInProgress)
 	}
+	// Held across the re-read, workspace.Restore, runtime.Create and the
+	// un-terminate/generation-bump so a concurrent reconciler finalize can't
+	// git-worktree-remove out from under the session being relaunched. The
+	// finalizer re-checks cleanup_generation under this same lock and aborts once
+	// the un-terminate has advanced it.
+	unlock := m.sessionLocks.lock(id)
+	defer unlock()
+
 	rec, ok, err := m.store.GetSession(ctx, id)
 	if err != nil {
 		return RestoreResult{}, fmt.Errorf("restore %s: %w", id, err)
@@ -1816,41 +1775,18 @@ func (m *Manager) reconcileLive(ctx context.Context, rec domain.SessionRecord) e
 	return nil
 }
 
-// reconcileReap kills the leaked tmux session of a session the DB already marks
-// terminated. This covers the teardown that marked the row terminated but failed
-// to kill the runtime (e.g. ForceDestroy/Destroy errored after MarkTerminated).
-// Destroy is idempotent, so an already-gone session is a no-op.
-func (m *Manager) reconcileReap(ctx context.Context, rec domain.SessionRecord) error {
-	handle := runtimeHandle(rec.Metadata)
-	if handle.ID == "" {
-		return nil
-	}
-	alive, err := m.runtime.IsAlive(ctx, handle)
-	if err != nil {
-		if errors.Is(err, ports.ErrRuntimeUnavailable) {
-			return nil // no server means no leaked session to reap
-		}
-		return fmt.Errorf("reconcile reap %s: probe: %w", rec.ID, err)
-	}
-	if !alive {
-		return nil
-	}
-	if err := m.runtime.Destroy(ctx, handle); err != nil {
-		return fmt.Errorf("reconcile reap %s: destroy: %w", rec.ID, err)
-	}
-	return nil
-}
-
 // Reconcile is the boot-time consistency pass. It replaces the bare RestoreAll
 // call so that however the previous daemon died (clean shutdown, SIGKILL, or
 // crash), live reality matches the DB:
 //
 //  1. Live pass: for each non-terminated session, adopt it if its runtime
 //     survived, else capture work and mark terminated (reconcileLive).
-//  2. Reap pass: for each terminated session whose runtime leaked, kill it
-//     (reconcileReap). Runs before restore so a restored session does not
-//     collide with a leaked tmux of the same name.
-//  3. Restore pass: relaunch shutdown-saved sessions (existing RestoreAll).
+//  2. Restore pass: relaunch shutdown-saved sessions (existing RestoreAll).
+//
+// The old reap pass (runtime-Destroy every terminated-but-alive session) is
+// gone: it is a strict subset of the terminal-resource reconciler's runtime-first
+// release, which now owns reclaiming leaked runtimes for every terminal session
+// via its boot scan. Keeping both would double-destroy and drift.
 //
 // Best-effort throughout: a per-session failure is logged and never aborts the
 // pass or blocks boot.
@@ -1870,14 +1806,6 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 		}
 		if err := m.reconcileLive(ctx, rec); err != nil {
 			m.logger.Error("reconcile: live pass failed, skipping", "sessionID", rec.ID, "error", err)
-		}
-	}
-	for _, rec := range recs {
-		if !rec.IsTerminated {
-			continue
-		}
-		if err := m.reconcileReap(ctx, rec); err != nil {
-			m.logger.Error("reconcile: reap pass failed, skipping", "sessionID", rec.ID, "error", err)
 		}
 	}
 	if err := m.RestoreAll(ctx); err != nil {
@@ -1911,123 +1839,133 @@ func (m *Manager) RestoreAll(ctx context.Context) error {
 		if !rec.IsTerminated {
 			continue
 		}
-		// Check the shutdown-saved marker: is there a session_worktrees row?
-		rows, err := m.store.ListSessionWorktrees(ctx, rec.ID)
-		if err != nil {
-			m.logger.Error("restore-all: list worktrees failed", "sessionID", rec.ID, "error", err)
-			continue
-		}
-		if len(rows) == 0 {
-			// No marker: this session was killed by the user before shutdown.
-			continue
-		}
-		rows = restorableWorktreeRows(rows)
-		if len(rows) == 0 {
-			continue
-		}
+		m.restoreSavedSession(ctx, rec)
+	}
+	return nil
+}
 
-		// Step 1: ensure the worktree exists. workspace.Restore re-creates it
-		// if it was removed by SaveAndTeardownAll.
-		project, err := m.loadProject(ctx, rec.ProjectID)
-		if err != nil {
-			m.logger.Error("restore-all: load project failed", "sessionID", rec.ID, "error", err)
-			continue
-		}
-		var ws ports.WorkspaceInfo
-		restoredWorkspaceProject := project.Kind.WithDefault() == domain.ProjectKindWorkspace
-		var projectRows []ports.WorkspaceRepoInfo
-		if restoredWorkspaceProject {
-			var rowErr error
-			projectRows, rowErr = m.workspaceProjectRestoreRowsFromMarkers(ctx, project, rec, rows)
-			if rowErr != nil {
-				m.logger.Error("restore-all: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
-				continue
-			}
-			root, restoreErr := m.restoreWorkspaceProjectRows(ctx, projectRows)
-			if restoreErr != nil {
-				m.logger.Error("restore-all: workspace project restore failed", "sessionID", rec.ID, "error", restoreErr)
-				continue
-			}
-			ws = workspaceInfoFromRepoInfo(root)
-		} else {
-			var restoreErr error
-			ws, restoreErr = m.workspace.Restore(ctx, ports.WorkspaceConfig{
-				ProjectID:     rec.ProjectID,
-				SessionID:     rec.ID,
-				Kind:          rec.Kind,
-				SessionPrefix: sessionPrefix(project),
-				Branch:        rec.Metadata.Branch,
-				Path:          rec.Metadata.WorkspacePath,
-			})
-			if restoreErr != nil {
-				m.logger.Error("restore-all: workspace restore failed", "sessionID", rec.ID, "error", restoreErr)
-				continue
-			}
-		}
-		if ws.Path == "" {
-			m.logger.Error("restore-all: workspace restore failed", "sessionID", rec.ID, "error", "empty restored root path")
-			continue
-		}
+// restoreSavedSession relaunches one shutdown-saved terminated session under the
+// shared per-session lock, so a concurrent reconciler finalize can't remove the
+// worktree it is restoring. Per-session failures are logged, never fatal.
+func (m *Manager) restoreSavedSession(ctx context.Context, rec domain.SessionRecord) {
+	unlock := m.sessionLocks.lock(rec.ID)
+	defer unlock()
 
-		// Step 2: replay preserve ref when one was recorded.
-		if restoredWorkspaceProject {
-			m.applyWorkspaceProjectPreserved(ctx, projectRows)
-		} else {
-			var preserveRef string
-			for _, r := range rows {
-				if r.PreservedRef != "" {
-					preserveRef = r.PreservedRef
-					break
+	// Check the shutdown-saved marker: is there a session_worktrees row?
+	rows, err := m.store.ListSessionWorktrees(ctx, rec.ID)
+	if err != nil {
+		m.logger.Error("restore-all: list worktrees failed", "sessionID", rec.ID, "error", err)
+		return
+	}
+	if len(rows) == 0 {
+		// No marker: this session was killed by the user before shutdown.
+		return
+	}
+	rows = restorableWorktreeRows(rows)
+	if len(rows) == 0 {
+		return
+	}
+
+	// Step 1: ensure the worktree exists. workspace.Restore re-creates it
+	// if it was removed by SaveAndTeardownAll.
+	project, err := m.loadProject(ctx, rec.ProjectID)
+	if err != nil {
+		m.logger.Error("restore-all: load project failed", "sessionID", rec.ID, "error", err)
+		return
+	}
+	var ws ports.WorkspaceInfo
+	restoredWorkspaceProject := project.Kind.WithDefault() == domain.ProjectKindWorkspace
+	var projectRows []ports.WorkspaceRepoInfo
+	if restoredWorkspaceProject {
+		var rowErr error
+		projectRows, rowErr = m.workspaceProjectRestoreRowsFromMarkers(ctx, project, rec, rows)
+		if rowErr != nil {
+			m.logger.Error("restore-all: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
+			return
+		}
+		root, restoreErr := m.restoreWorkspaceProjectRows(ctx, projectRows)
+		if restoreErr != nil {
+			m.logger.Error("restore-all: workspace project restore failed", "sessionID", rec.ID, "error", restoreErr)
+			return
+		}
+		ws = workspaceInfoFromRepoInfo(root)
+	} else {
+		var restoreErr error
+		ws, restoreErr = m.workspace.Restore(ctx, ports.WorkspaceConfig{
+			ProjectID:     rec.ProjectID,
+			SessionID:     rec.ID,
+			Kind:          rec.Kind,
+			SessionPrefix: sessionPrefix(project),
+			Branch:        rec.Metadata.Branch,
+			Path:          rec.Metadata.WorkspacePath,
+		})
+		if restoreErr != nil {
+			m.logger.Error("restore-all: workspace restore failed", "sessionID", rec.ID, "error", restoreErr)
+			return
+		}
+	}
+	if ws.Path == "" {
+		m.logger.Error("restore-all: workspace restore failed", "sessionID", rec.ID, "error", "empty restored root path")
+		return
+	}
+
+	// Step 2: replay preserve ref when one was recorded.
+	if restoredWorkspaceProject {
+		m.applyWorkspaceProjectPreserved(ctx, projectRows)
+	} else {
+		var preserveRef string
+		for _, r := range rows {
+			if r.PreservedRef != "" {
+				preserveRef = r.PreservedRef
+				break
+			}
+		}
+		if preserveRef != "" {
+			if applyErr := m.workspace.ApplyPreserved(ctx, ws, preserveRef); applyErr != nil {
+				if errors.Is(applyErr, ports.ErrPreservedConflict) {
+					m.logger.Warn("restore-all: apply preserved produced conflicts; agent relaunched with conflict markers in place",
+						"sessionID", rec.ID, "ref", preserveRef, "error", applyErr)
+				} else {
+					m.logger.Error("restore-all: apply preserved failed", "sessionID", rec.ID, "error", applyErr)
 				}
-			}
-			if preserveRef != "" {
-				if applyErr := m.workspace.ApplyPreserved(ctx, ws, preserveRef); applyErr != nil {
-					if errors.Is(applyErr, ports.ErrPreservedConflict) {
-						m.logger.Warn("restore-all: apply preserved produced conflicts; agent relaunched with conflict markers in place",
-							"sessionID", rec.ID, "ref", preserveRef, "error", applyErr)
-					} else {
-						m.logger.Error("restore-all: apply preserved failed", "sessionID", rec.ID, "error", applyErr)
-					}
-					// Continue: always relaunch even on conflict (never delete the ref here).
-				}
-			}
-		}
-
-		// Step 3: relaunch the agent in the restored workspace.
-		if _, err := m.relaunchRestoredSession(ctx, rec, project, ws); err != nil {
-			switch {
-			case errors.Is(err, ErrNotResumable):
-				// A promptless, unresumable worker is intentionally left terminated:
-				// expected, not an operational failure, so log it quietly.
-				m.logger.Warn("restore-all: session left terminated (nothing to resume)", "sessionID", rec.ID)
-			case errors.Is(err, ErrNotFound):
-				// The row was reaped between listing and relaunch (a stale id during
-				// reconciliation): skip it and keep restoring the rest.
-				m.logger.Warn("restore-all: session vanished before relaunch, skipping", "sessionID", rec.ID)
-			default:
-				m.logger.Error("restore-all: relaunch failed", "sessionID", rec.ID, "error", err)
-			}
-			continue
-		}
-
-		// One-shot: drop the consumed marker so it never outlives one restart
-		// (#2319). A still-live session re-acquires it at the next quit.
-		if restoredWorkspaceProject {
-			for _, row := range projectRows {
-				if err := m.upsertWorkspaceProjectRowState(ctx, row, "active"); err != nil {
-					m.logger.Warn("restore-all: marking workspace repo active failed", "sessionID", rec.ID, "repo", row.RepoName, "error", err)
-				}
-			}
-		} else {
-			if err := m.markSessionWorktreesActive(ctx, rows); err != nil {
-				m.logger.Warn("restore-all: marking worktrees active failed", "sessionID", rec.ID, "error", err)
-			}
-			if err := m.store.DeleteSessionWorktrees(ctx, rec.ID); err != nil {
-				m.logger.Warn("restore-all: delete restore marker failed", "sessionID", rec.ID, "error", err)
+				// Continue: always relaunch even on conflict (never delete the ref here).
 			}
 		}
 	}
-	return nil
+
+	// Step 3: relaunch the agent in the restored workspace.
+	if _, err := m.relaunchRestoredSession(ctx, rec, project, ws); err != nil {
+		switch {
+		case errors.Is(err, ErrNotResumable):
+			// A promptless, unresumable worker is intentionally left terminated:
+			// expected, not an operational failure, so log it quietly.
+			m.logger.Warn("restore-all: session left terminated (nothing to resume)", "sessionID", rec.ID)
+		case errors.Is(err, ErrNotFound):
+			// The row was reaped between listing and relaunch (a stale id during
+			// reconciliation): skip it and keep restoring the rest.
+			m.logger.Warn("restore-all: session vanished before relaunch, skipping", "sessionID", rec.ID)
+		default:
+			m.logger.Error("restore-all: relaunch failed", "sessionID", rec.ID, "error", err)
+		}
+		return
+	}
+
+	// One-shot: drop the consumed marker so it never outlives one restart
+	// (#2319). A still-live session re-acquires it at the next quit.
+	if restoredWorkspaceProject {
+		for _, row := range projectRows {
+			if err := m.upsertWorkspaceProjectRowState(ctx, row, "active"); err != nil {
+				m.logger.Warn("restore-all: marking workspace repo active failed", "sessionID", rec.ID, "repo", row.RepoName, "error", err)
+			}
+		}
+	} else {
+		if err := m.markSessionWorktreesActive(ctx, rows); err != nil {
+			m.logger.Warn("restore-all: marking worktrees active failed", "sessionID", rec.ID, "error", err)
+		}
+		if err := m.store.DeleteSessionWorktrees(ctx, rec.ID); err != nil {
+			m.logger.Warn("restore-all: delete restore marker failed", "sessionID", rec.ID, "error", err)
+		}
+	}
 }
 
 func restorableWorktreeRows(rows []domain.SessionWorktreeRecord) []domain.SessionWorktreeRecord {
@@ -2225,34 +2163,6 @@ func (m *Manager) saveAndTeardownWorkspaceProject(ctx context.Context, rec domai
 		m.cleanupAgentWorkspace(ctx, rec, rec.Metadata.WorkspacePath)
 	}
 	return nil
-}
-
-func (m *Manager) destroyWorkspaceProjectRows(ctx context.Context, rows []ports.WorkspaceRepoInfo) (bool, error) {
-	cleaned := false
-	var firstErr error
-	for i := len(rows) - 1; i >= 0; i-- {
-		if rows[i].Path == "" {
-			continue
-		}
-		info := workspaceInfoFromRepoInfo(rows[i])
-		if err := m.workspace.Destroy(ctx, info); err != nil {
-			if errors.Is(err, ports.ErrWorkspaceDirty) {
-				return cleaned, err
-			}
-			if stateErr := m.upsertWorkspaceProjectRowState(ctx, rows[i], "retry_remove"); stateErr != nil && firstErr == nil {
-				firstErr = stateErr
-			}
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-		if err := m.upsertWorkspaceProjectRowState(ctx, rows[i], "unavailable"); err != nil && firstErr == nil {
-			firstErr = err
-		}
-		cleaned = true
-	}
-	return cleaned, firstErr
 }
 
 func (m *Manager) upsertWorkspaceProjectRowState(ctx context.Context, row ports.WorkspaceRepoInfo, state string) error {
@@ -2576,76 +2486,69 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 		if !rec.IsTerminated {
 			continue
 		}
-		ws := workspaceInfo(rec)
-		if ws.Path == "" {
-			m.cleanupSystemPromptDir(rec.ID)
-			continue
+		facts := m.finalizeOne(ctx, rec)
+		switch facts.WorkspaceDisposition {
+		case domain.DispositionRemoved:
+			result.Cleaned = append(result.Cleaned, rec.ID)
+		case domain.DispositionNotApplicable:
+			// Nothing to reclaim (no workspace): neither cleaned nor skipped,
+			// matching the historical silent-skip for handle-less sessions.
+		default:
+			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(facts)})
 		}
-		if h := runtimeHandle(rec.Metadata); h.ID != "" {
-			_ = m.runtime.Destroy(ctx, h) // best effort; usually already gone
-		}
-		if reason := m.cleanupOne(ctx, rec, ws); reason != "" {
-			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: reason})
-			continue
-		}
-		m.cleanupSystemPromptDir(rec.ID)
-		result.Cleaned = append(result.Cleaned, rec.ID)
 	}
 	return result, nil
 }
 
-// cleanupOne reclaims one terminated session's workspace, gating shut any
-// shell terminal scoped to it first (same ordering as Kill). Split out of
-// Cleanup's loop so the release function's defer is scoped to one session's
-// call, not deferred across every iteration until Cleanup itself returns.
-// Returns "" when the workspace was reclaimed; a non-empty reason means it was
-// left alone this run (Cleanup records it in Skipped and can retry on a later
-// call) — most commonly because a scoped shell terminal could not be
-// confirmed closed, so reclaiming would pull the ground out from under it.
-func (m *Manager) cleanupOne(ctx context.Context, rec domain.SessionRecord, ws ports.WorkspaceInfo) (skipReason string) {
-	release, closeErr := m.beginShellTerminalTeardown(ctx, rec.ID)
-	if closeErr != nil {
-		m.logger.Warn("cleanup: shell terminal still open", "sessionID", rec.ID, "error", closeErr)
-		return "shell terminal still open"
-	}
-	if release != nil {
-		defer release()
+// finalizeOne runs the shared release core for one already-terminated session
+// under the per-session lock and returns the resulting disposition. Bulk Cleanup
+// uses it rather than FinalizeTerminalSession because Cleanup is an explicit user
+// request to reclaim — it deliberately does NOT skip restore-pending sessions
+// (an unresumable shutdown-saved leftover should still be cleanable). It shares
+// the same idempotent-skip guard (isTerminalDisposition) so an already-finalized
+// session isn't needlessly re-released.
+func (m *Manager) finalizeOne(ctx context.Context, rec domain.SessionRecord) domain.SessionCleanupRecord {
+	unlock := m.sessionLocks.lock(rec.ID)
+	defer unlock()
+
+	generation := rec.CleanupGeneration
+	if facts, ok, err := m.store.GetSessionCleanupFacts(ctx, rec.ID); err == nil && ok &&
+		facts.SessionGeneration == generation && isTerminalDisposition(facts.WorkspaceDisposition) {
+		return facts
 	}
 
-	if rows, ok, rowErr := m.workspaceProjectRows(ctx, rec); rowErr != nil {
-		m.logger.Warn("cleanup: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
-		return "workspace teardown failed"
-	} else if ok {
-		if _, err := m.destroyWorkspaceProjectRows(ctx, rows); err != nil {
-			if !errors.Is(err, ports.ErrWorkspaceDirty) {
-				m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
-			}
-			return cleanupSkipReason(err)
+	res, releaseErr := m.releaseTerminalResources(ctx, rec)
+	if releaseErr != nil {
+		res.disposition = domain.DispositionPending
+		if res.failureCode == "" {
+			res.failureCode = failTeardown
 		}
-		m.cleanupAgentWorkspace(ctx, rec, ws.Path)
-		return ""
 	}
-	if err := m.workspace.Destroy(ctx, ws); err != nil {
-		if !errors.Is(err, ports.ErrWorkspaceDirty) {
-			// The public reason stays a fixed string (the raw error carries
-			// internal filesystem paths); the full cause lands here.
-			m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
-		}
-		return cleanupSkipReason(err)
+	if err := m.persistCleanupFacts(ctx, rec, generation, res); err != nil {
+		m.logger.Warn("cleanup: persist facts failed", "sessionID", rec.ID, "error", err)
 	}
-	m.cleanupAgentWorkspace(ctx, rec, ws.Path)
-	return ""
+	// Re-read so a transient failure that just exhausted its attempt cap reports
+	// its terminal `failed` disposition rather than the in-memory `pending`.
+	if stored, ok, err := m.store.GetSessionCleanupFacts(ctx, rec.ID); err == nil && ok && stored.SessionGeneration == generation {
+		return stored
+	}
+	return domain.SessionCleanupRecord{
+		SessionID:            rec.ID,
+		SessionGeneration:    generation,
+		WorkspaceDisposition: res.disposition,
+		FailureCode:          res.failureCode,
+	}
 }
 
-// cleanupSkipReason renders a workspace teardown refusal as a short
-// user-facing reason for the cleanup report. Deliberately not the raw error:
-// it flows to the API response and CLI output, and teardown errors embed
-// internal filesystem paths.
-func cleanupSkipReason(err error) string {
-	if errors.Is(err, ports.ErrWorkspaceDirty) {
+// cleanupSkipReason renders a non-removed disposition as a short user-facing
+// reason for the cleanup report. Deliberately not the raw error: it flows to the
+// API response and CLI output, and teardown errors embed internal filesystem
+// paths.
+func cleanupSkipReason(facts domain.SessionCleanupRecord) string {
+	if facts.WorkspaceDisposition == domain.DispositionPreservedDirty {
 		return "workspace has uncommitted changes"
 	}
-	if errors.Is(err, ErrProjectNotResolvable) {
+	if facts.FailureCode == failProjectUnresolvable {
 		return "project is archived or unregistered — remove worktree manually"
 	}
 	return "workspace teardown failed"

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -35,6 +35,10 @@ var (
 	ErrAgentExited      = errors.New("session: agent exited")
 	ErrAgentNotExited   = errors.New("session: agent has not exited")
 	ErrIncompleteHandle = errors.New("session: incomplete teardown handle")
+	// ErrNotTerminal means a per-session cleanup was requested for a session that
+	// is still live. Only a terminated session's resources may be reclaimed; the
+	// API maps this to a 409.
+	ErrNotTerminal = errors.New("session: not terminal")
 	// ErrProjectNotResolvable means the spawn's project has no usable repo
 	// (unregistered, archived, or missing a path). The API maps it to a 400.
 	ErrProjectNotResolvable = errors.New("session: project repo not resolvable")
@@ -2553,12 +2557,42 @@ func (m *Manager) finalizeOne(ctx context.Context, rec domain.SessionRecord) dom
 		rec = cur
 	}
 
-	generation := rec.CleanupGeneration
 	if facts, ok, err := m.store.GetSessionCleanupFacts(ctx, rec.ID); err == nil && ok &&
-		facts.SessionGeneration == generation && isTerminalDisposition(facts.WorkspaceDisposition) {
+		facts.SessionGeneration == rec.CleanupGeneration && isTerminalDisposition(facts.WorkspaceDisposition) {
 		return facts
 	}
+	return m.releaseAndPersistLocked(ctx, rec)
+}
 
+// CleanupSession is the per-session cleanup API primitive (PR 3). Unlike the
+// reconciler's FinalizeTerminalSession it surfaces typed errors to the caller
+// (ErrNotFound / ErrNotTerminal) and, unlike finalizeOne, it does NOT
+// idempotent-skip a session already in a terminal disposition — a user
+// triggering cleanup on a preserved_dirty or failed session is explicitly asking
+// to re-attempt the release. It never marks a session terminated.
+func (m *Manager) CleanupSession(ctx context.Context, id domain.SessionID) (domain.SessionCleanupRecord, error) {
+	unlock := m.sessionLocks.lock(id)
+	defer unlock()
+
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return domain.SessionCleanupRecord{}, fmt.Errorf("cleanup %s: %w", id, err)
+	}
+	if !ok {
+		return domain.SessionCleanupRecord{}, ErrNotFound
+	}
+	if !rec.IsTerminated {
+		return domain.SessionCleanupRecord{}, ErrNotTerminal
+	}
+	return m.releaseAndPersistLocked(ctx, rec), nil
+}
+
+// releaseAndPersistLocked runs the shared release core for a terminal session
+// and persists the resulting facts, returning the stored record. The caller must
+// hold the per-session lock. A transient failure is recorded as a pending retry
+// (or exhausted `failed`) rather than surfaced.
+func (m *Manager) releaseAndPersistLocked(ctx context.Context, rec domain.SessionRecord) domain.SessionCleanupRecord {
+	generation := rec.CleanupGeneration
 	res, releaseErr := m.releaseTerminalResources(ctx, rec)
 	if releaseErr != nil {
 		res.disposition = domain.DispositionPending

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -2561,7 +2561,20 @@ func (m *Manager) finalizeOne(ctx context.Context, rec domain.SessionRecord) dom
 		facts.SessionGeneration == rec.CleanupGeneration && isTerminalDisposition(facts.WorkspaceDisposition) {
 		return facts
 	}
-	return m.releaseAndPersistLocked(ctx, rec)
+	facts, err := m.releaseAndPersistLocked(ctx, rec)
+	if err != nil {
+		// Bulk Cleanup has no per-session error channel (CleanupResult is
+		// Cleaned/Skipped only); a storage hiccup here becomes a pending retry the
+		// periodic sweep re-attempts, same as a release failure.
+		m.logger.Warn("cleanup: releaseAndPersistLocked failed", "sessionID", rec.ID, "error", err)
+		return domain.SessionCleanupRecord{
+			SessionID:            rec.ID,
+			SessionGeneration:    rec.CleanupGeneration,
+			WorkspaceDisposition: domain.DispositionPending,
+			FailureCode:          failTeardown,
+		}
+	}
+	return facts
 }
 
 // CleanupSession is the per-session cleanup API primitive (PR 3). Unlike the
@@ -2584,14 +2597,22 @@ func (m *Manager) CleanupSession(ctx context.Context, id domain.SessionID) (doma
 	if !rec.IsTerminated {
 		return domain.SessionCleanupRecord{}, ErrNotTerminal
 	}
-	return m.releaseAndPersistLocked(ctx, rec), nil
+	facts, err := m.releaseAndPersistLocked(ctx, rec)
+	if err != nil {
+		return domain.SessionCleanupRecord{}, fmt.Errorf("cleanup %s: %w", id, err)
+	}
+	return facts, nil
 }
 
 // releaseAndPersistLocked runs the shared release core for a terminal session
 // and persists the resulting facts, returning the stored record. The caller must
-// hold the per-session lock. A transient failure is recorded as a pending retry
-// (or exhausted `failed`) rather than surfaced.
-func (m *Manager) releaseAndPersistLocked(ctx context.Context, rec domain.SessionRecord) domain.SessionCleanupRecord {
+// hold the per-session lock. A *release* failure (runtime/workspace teardown) is
+// recorded as a pending retry (or exhausted `failed`) rather than surfaced — that
+// is expected, retryable steady-state. A *storage* failure (persisting or
+// re-reading the facts) is returned as an error instead: the caller asked for
+// refreshed facts and none were durably recorded, so reporting synthesized
+// success would be a lie.
+func (m *Manager) releaseAndPersistLocked(ctx context.Context, rec domain.SessionRecord) (domain.SessionCleanupRecord, error) {
 	generation := rec.CleanupGeneration
 	res, releaseErr := m.releaseTerminalResources(ctx, rec)
 	if releaseErr != nil {
@@ -2601,19 +2622,23 @@ func (m *Manager) releaseAndPersistLocked(ctx context.Context, rec domain.Sessio
 		}
 	}
 	if err := m.persistCleanupFacts(ctx, rec, generation, res); err != nil {
-		m.logger.Warn("cleanup: persist facts failed", "sessionID", rec.ID, "error", err)
+		return domain.SessionCleanupRecord{}, fmt.Errorf("persist cleanup facts %s: %w", rec.ID, err)
 	}
 	// Re-read so a transient failure that just exhausted its attempt cap reports
 	// its terminal `failed` disposition rather than the in-memory `pending`.
-	if stored, ok, err := m.store.GetSessionCleanupFacts(ctx, rec.ID); err == nil && ok && stored.SessionGeneration == generation {
-		return stored
+	stored, ok, err := m.store.GetSessionCleanupFacts(ctx, rec.ID)
+	if err != nil {
+		return domain.SessionCleanupRecord{}, fmt.Errorf("reload cleanup facts %s: %w", rec.ID, err)
+	}
+	if ok && stored.SessionGeneration == generation {
+		return stored, nil
 	}
 	return domain.SessionCleanupRecord{
 		SessionID:            rec.ID,
 		SessionGeneration:    generation,
 		WorkspaceDisposition: res.disposition,
 		FailureCode:          res.failureCode,
-	}
+	}, nil
 }
 
 // cleanupSkipReason renders a non-removed disposition as a short user-facing

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -23,13 +23,15 @@ import (
 var ctx = context.Background()
 
 type fakeStore struct {
-	sessions      map[domain.SessionID]domain.SessionRecord
-	pr            map[domain.SessionID]domain.PRFacts
-	projects      map[string]domain.ProjectRecord
-	workspaceRepo map[string][]domain.WorkspaceRepoRecord
-	num           int
-	deleteErr     error
-	upsertWTErr   error
+	sessions         map[domain.SessionID]domain.SessionRecord
+	pr               map[domain.SessionID]domain.PRFacts
+	projects         map[string]domain.ProjectRecord
+	workspaceRepo    map[string][]domain.WorkspaceRepoRecord
+	num              int
+	deleteErr        error
+	upsertWTErr      error
+	upsertCleanupErr error
+	getCleanupErr    error
 	// worktrees maps session ID to its saved worktree rows (shutdown-saved marker).
 	worktrees map[domain.SessionID][]domain.SessionWorktreeRecord
 	// cleanup maps session ID to its persisted terminal-resource cleanup facts.
@@ -136,6 +138,9 @@ func (f *fakeStore) DeleteSessionWorktrees(_ context.Context, id domain.SessionI
 	return nil
 }
 func (f *fakeStore) UpsertSessionCleanupFacts(_ context.Context, rec domain.SessionCleanupRecord) error {
+	if f.upsertCleanupErr != nil {
+		return f.upsertCleanupErr
+	}
 	if f.cleanup == nil {
 		f.cleanup = map[domain.SessionID]domain.SessionCleanupRecord{}
 	}
@@ -143,6 +148,9 @@ func (f *fakeStore) UpsertSessionCleanupFacts(_ context.Context, rec domain.Sess
 	return nil
 }
 func (f *fakeStore) GetSessionCleanupFacts(_ context.Context, id domain.SessionID) (domain.SessionCleanupRecord, bool, error) {
+	if f.getCleanupErr != nil {
+		return domain.SessionCleanupRecord{}, false, f.getCleanupErr
+	}
 	rec, ok := f.cleanup[id]
 	return rec, ok, nil
 }

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -2483,7 +2483,7 @@ func TestRestore_RefusesLiveSession(t *testing.T) {
 }
 func TestCleanup_ReclaimsTerminalWorkspaces(t *testing.T) {
 	m, st, _, ws := newManager()
-	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1"})
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
 	st.sessions["mer-2"] = mkLive("mer-2")
 	res, err := m.Cleanup(ctx, "mer")
 	if err != nil {
@@ -2500,6 +2500,37 @@ func TestCleanup_ReclaimsTerminalWorkspaces(t *testing.T) {
 	}
 }
 
+// TestCleanup_FinalizeOneReReadsUnderLock pins review gap #3 on #2931:
+// cleanupRecords takes its snapshot before finalizeOne acquires the
+// per-session lock, so a concurrent Restore can finish in that window.
+// finalizeOne must re-read the session under the lock rather than trust the
+// caller's stale terminated snapshot, or it would destroy the runtime/
+// workspace of a session that has already been relaunched.
+func TestCleanup_FinalizeOneReReadsUnderLock(t *testing.T) {
+	m, st, rt, ws := newManager()
+	// The store's CURRENT state: mer-1 was restored (live again) after
+	// cleanupRecords took its snapshot below.
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID: "mer-1", ProjectID: "mer", IsTerminated: false,
+		Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"},
+	}
+	// The stale pre-lock snapshot finalizeOne is called with, as cleanupRecords
+	// would have read it before the restore completed.
+	staleRec := domain.SessionRecord{
+		ID: "mer-1", ProjectID: "mer", IsTerminated: true,
+		Metadata: domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"},
+	}
+
+	facts := m.finalizeOne(ctx, staleRec)
+
+	if rt.destroyed != 0 || ws.destroyed != 0 {
+		t.Fatalf("finalizeOne must not release a session the fresh read shows is live: runtime destroyed=%d workspace destroyed=%d", rt.destroyed, ws.destroyed)
+	}
+	if facts.WorkspaceDisposition != domain.DispositionNotApplicable {
+		t.Fatalf("disposition = %q, want not_applicable (nothing to clean under the fresh live state)", facts.WorkspaceDisposition)
+	}
+}
+
 // TestCleanup_ClosesScopedShellTerminalsBeforeWorkspaceTeardown mirrors the
 // Kill regression: Cleanup must also gate shut a session's scoped shell
 // terminals before reclaiming its worktree, and release the gate afterward.
@@ -2509,7 +2540,7 @@ func TestCleanup_ClosesScopedShellTerminalsBeforeWorkspaceTeardown(t *testing.T)
 	ws.sharedLog = &calls
 	closer := &fakeShellTerminalCloser{sharedLog: &calls}
 	m.SetShellTerminalCloser(closer)
-	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", WorkspaceRepoPath: "/ws/mer-1"})
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", WorkspaceRepoPath: "/ws/mer-1", RuntimeHandleID: "h1"})
 
 	if _, err := m.Cleanup(ctx, "mer"); err != nil {
 		t.Fatal(err)
@@ -2574,7 +2605,7 @@ func TestCleanup_ReportsSkippedWorkspaces(t *testing.T) {
 	// session is now correctly an idempotent no-op, so each reason needs its own.)
 	{
 		m, st, _, ws := newManager()
-		seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1"})
+		seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
 		ws.destroyErr = fmt.Errorf("gitworktree: refusing to remove: %w", ports.ErrWorkspaceDirty)
 		res, err := m.Cleanup(ctx, "mer")
 		if err != nil {
@@ -2596,7 +2627,7 @@ func TestCleanup_ReportsSkippedWorkspaces(t *testing.T) {
 	// the server log, not the API response.
 	{
 		m, st, _, ws := newManager()
-		seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1"})
+		seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
 		ws.destroyErr = errors.New("disk on fire")
 		res, err := m.Cleanup(ctx, "mer")
 		if err != nil {
@@ -2615,7 +2646,7 @@ func TestCleanup_ReportsSkippedWorkspaces(t *testing.T) {
 	// distinct reason telling the user the worktree must be removed by hand.
 	{
 		m, st, _, ws := newManager()
-		seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1"})
+		seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", RuntimeHandleID: "h1"})
 		ws.destroyErr = fmt.Errorf("resolve project repo: %w", ErrProjectNotResolvable)
 		res, err := m.Cleanup(ctx, "mer")
 		if err != nil {
@@ -2690,7 +2721,7 @@ func TestCleanup_WorkspaceProjectDestroysChildrenBeforeRoot(t *testing.T) {
 	m, st, _, ws := newManager()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
 	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
-	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1"})
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", RuntimeHandleID: "h1"})
 	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
 		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1"},
 		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api"},
@@ -2714,7 +2745,7 @@ func TestCleanup_WorkspaceProjectMarksRetryRemoveAfterTeardownFailure(t *testing
 	ws.destroyErr = errors.New("locked")
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Path: "/repo/mer", Kind: domain.ProjectKindWorkspace, Config: testRoleAgents()}
 	st.workspaceRepo["mer"] = []domain.WorkspaceRepoRecord{{Name: "api", RelativePath: "api"}}
-	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1"})
+	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1", RuntimeHandleID: "h1"})
 	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
 		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, Branch: "ao/mer-1", WorktreePath: "/ws/mer-1"},
 		{SessionID: "mer-1", RepoName: "api", Branch: "ao/mer-1", WorktreePath: "/ws/mer-1/api"},
@@ -5637,6 +5668,47 @@ func TestRestoreAll_RestoresLegacyShutdownMarkerWithoutState(t *testing.T) {
 	}
 	if rows := st.worktrees["mer-1"]; len(rows) != 0 {
 		t.Fatalf("consumed restore marker = %+v, want deleted", rows)
+	}
+}
+
+// TestRestoreAll_ReleasesSurvivingRuntimeBeforeRelaunch pins review gap #4 on
+// #2931: reconcileReap used to kill a leaked-but-alive runtime for a
+// terminated, restore-marked session before RestoreAll ran. Since it was
+// removed (subsumed by the finalizer for every OTHER terminal path, but the
+// finalizer deliberately skips restore-pending rows), restoreSavedSession must
+// do this release itself — otherwise relaunching collides with the old
+// deterministic pane that survived a prior shutdown whose own best-effort
+// runtime.Destroy failed (or never ran, e.g. a crash).
+func TestRestoreAll_ReleasesSurvivingRuntimeBeforeRelaunch(t *testing.T) {
+	m, st, rt, _ := newLifecycleManager()
+	rt.aliveByHandle = map[string]bool{"mer-1": true}
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:           "mer-1",
+		ProjectID:    "mer",
+		Kind:         domain.KindWorker,
+		Harness:      domain.HarnessClaudeCode,
+		IsTerminated: true,
+		Metadata: domain.SessionMetadata{
+			WorkspacePath: "/ws/mer-1", Branch: "ao/mer-1/root", AgentSessionID: "agent-w",
+			RuntimeHandleID: "mer-1", // the old, still-alive pane from before shutdown
+		},
+		Activity: domain.Activity{State: domain.ActivityExited},
+	}
+	st.worktrees["mer-1"] = []domain.SessionWorktreeRecord{
+		{SessionID: "mer-1", RepoName: domain.RootWorkspaceRepoName, WorktreePath: "/ws/mer-1"},
+	}
+
+	if err := m.RestoreAll(ctx); err != nil {
+		t.Fatalf("RestoreAll err = %v", err)
+	}
+	if len(rt.destroyedIDs) != 1 || rt.destroyedIDs[0] != "mer-1" {
+		t.Fatalf("destroyedIDs = %v, want the surviving old handle released before relaunch", rt.destroyedIDs)
+	}
+	if rt.created != 1 {
+		t.Fatalf("RestoreAll must still relaunch after releasing the old runtime, runtime.Create called %d times", rt.created)
+	}
+	if st.sessions["mer-1"].IsTerminated {
+		t.Fatal("session must be live after RestoreAll releases the stale runtime and relaunches")
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -32,6 +32,8 @@ type fakeStore struct {
 	upsertWTErr   error
 	// worktrees maps session ID to its saved worktree rows (shutdown-saved marker).
 	worktrees map[domain.SessionID][]domain.SessionWorktreeRecord
+	// cleanup maps session ID to its persisted terminal-resource cleanup facts.
+	cleanup map[domain.SessionID]domain.SessionCleanupRecord
 	// sharedLog, when non-nil, receives an ordered call entry for each
 	// UpsertSessionWorktree invocation so ordering tests can compare across fakes.
 	sharedLog *[]string
@@ -44,6 +46,7 @@ func newFakeStore() *fakeStore {
 		projects:      map[string]domain.ProjectRecord{},
 		workspaceRepo: map[string][]domain.WorkspaceRepoRecord{},
 		worktrees:     map[domain.SessionID][]domain.SessionWorktreeRecord{},
+		cleanup:       map[domain.SessionID]domain.SessionCleanupRecord{},
 	}
 }
 func (f *fakeStore) GetProject(_ context.Context, id string) (domain.ProjectRecord, bool, error) {
@@ -132,6 +135,17 @@ func (f *fakeStore) DeleteSessionWorktrees(_ context.Context, id domain.SessionI
 	delete(f.worktrees, id)
 	return nil
 }
+func (f *fakeStore) UpsertSessionCleanupFacts(_ context.Context, rec domain.SessionCleanupRecord) error {
+	if f.cleanup == nil {
+		f.cleanup = map[domain.SessionID]domain.SessionCleanupRecord{}
+	}
+	f.cleanup[rec.SessionID] = rec
+	return nil
+}
+func (f *fakeStore) GetSessionCleanupFacts(_ context.Context, id domain.SessionID) (domain.SessionCleanupRecord, bool, error) {
+	rec, ok := f.cleanup[id]
+	return rec, ok, nil
+}
 
 type fakeLCM struct {
 	store     *fakeStore
@@ -205,6 +219,10 @@ type fakeRuntime struct {
 	aliveByHandle map[string]bool
 	aliveErr      error
 	destroyedIDs  []string
+	// destroyHook, when set, runs at the start of Destroy. Tests use it to
+	// simulate a concurrent mutation (e.g. a Restore→Terminate cycle advancing
+	// cleanup_generation) racing an in-flight finalize.
+	destroyHook func()
 }
 
 type fakePreviewLifecycle struct {
@@ -270,6 +288,9 @@ func (r *fakeRuntime) Create(_ context.Context, cfg ports.RuntimeConfig) (ports.
 	return ports.RuntimeHandle{ID: "h1"}, nil
 }
 func (r *fakeRuntime) Destroy(_ context.Context, handle ports.RuntimeHandle) error {
+	if r.destroyHook != nil {
+		r.destroyHook()
+	}
 	r.destroyed++
 	r.destroyedIDs = append(r.destroyedIDs, handle.ID)
 	return r.destroyErr
@@ -537,7 +558,11 @@ func (missingAgents) Agent(domain.AgentHarness) (ports.Agent, bool) { return nil
 type fakeWorkspace struct {
 	createErr  error
 	destroyErr error
-	destroyed  int
+	// destroyErrByRepo overrides destroyErr for a specific repo name (keyed by
+	// fakeWorkspaceRepoName), so a mixed clean+dirty workspace-project teardown is
+	// representable — the single destroyErr applies one error to every Destroy.
+	destroyErrByRepo map[string]error
+	destroyed        int
 	// createRepoPath, when set, is returned as the RepoPath of a single-repo
 	// Create so tests can assert it survives the spawn->teardown metadata round
 	// trip (production Create resolves this path; the zero default keeps every
@@ -565,6 +590,10 @@ type fakeWorkspace struct {
 	// set, is returned so best-effort handling can be exercised.
 	excludePatterns []string
 	addExcludeErr   error
+	// opHook, when set, runs at the start of Destroy and Restore with the op name.
+	// Serialization tests use it to detect whether two disk-touching ops overlap
+	// for the same session (they must not, under the per-session lock).
+	opHook func(op string)
 	// calls records the sequence of workspace method calls for ordering assertions.
 	calls []string
 	// sharedLog, when non-nil, receives entries alongside calls so ordering
@@ -625,6 +654,9 @@ func (w *fakeWorkspace) CreateWorkspaceProject(_ context.Context, cfg ports.Work
 }
 func (w *fakeWorkspace) Destroy(_ context.Context, info ports.WorkspaceInfo) error {
 	w.lastDestroyInfo = info
+	if w.opHook != nil {
+		w.opHook("Destroy")
+	}
 	if info.RepoPath != "" {
 		entry := "Destroy:" + fakeWorkspaceRepoName(info)
 		w.calls = append(w.calls, entry)
@@ -633,6 +665,11 @@ func (w *fakeWorkspace) Destroy(_ context.Context, info ports.WorkspaceInfo) err
 		}
 	}
 	w.destroyed++
+	if w.destroyErrByRepo != nil {
+		if err, ok := w.destroyErrByRepo[fakeWorkspaceRepoName(info)]; ok {
+			return err
+		}
+	}
 	return w.destroyErr
 }
 func (w *fakeWorkspace) DestroyWorkspaceProject(context.Context, ports.WorkspaceProjectInfo) error {
@@ -640,6 +677,9 @@ func (w *fakeWorkspace) DestroyWorkspaceProject(context.Context, ports.Workspace
 	return w.destroyErr
 }
 func (w *fakeWorkspace) Restore(ctx context.Context, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
+	if w.opHook != nil {
+		w.opHook("Restore")
+	}
 	if cfg.RepoPath != "" {
 		entry := "Restore:" + fakeWorkspaceRepoName(ports.WorkspaceInfo{
 			Path:      cfg.Path,
@@ -2226,7 +2266,11 @@ func TestKill_WorkspaceProjectDirtyRowRefusesRemoval(t *testing.T) {
 	if err != nil || freed {
 		t.Fatalf("freed=%v err=%v, want dirty row to preserve workspace", freed, err)
 	}
-	want := []string{"Destroy:api"}
+	// Continue-past-dirty (#16): a dirty child no longer aborts teardown of its
+	// siblings — every child is attempted child-first. Here both children are
+	// dirty (the fake applies one dirty error to every Destroy), so both are
+	// attempted and both preserved; the session is still terminated, freed=false.
+	want := []string{"Destroy:api", "Destroy:__root__"}
 	if got := ws.calls; strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("calls = %v, want %v", got, want)
 	}
@@ -2525,51 +2569,64 @@ func TestCleanup_SkipsWorkspaceReleaseWhenShellTerminalsWontClose(t *testing.T) 
 // the result with a reason — a silent skip leaves users staring at
 // "Would clean N … 0 sessions cleaned" with no explanation.
 func TestCleanup_ReportsSkippedWorkspaces(t *testing.T) {
-	m, st, _, ws := newManager()
-	seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1"})
-	ws.destroyErr = fmt.Errorf("gitworktree: refusing to remove: %w", ports.ErrWorkspaceDirty)
-	res, err := m.Cleanup(ctx, "mer")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(res.Cleaned) != 0 {
-		t.Fatalf("cleaned = %v, want none", res.Cleaned)
-	}
-	if len(res.Skipped) != 1 || res.Skipped[0].SessionID != "mer-1" {
-		t.Fatalf("skipped = %v, want mer-1", res.Skipped)
-	}
-	if res.Skipped[0].Reason != "workspace has uncommitted changes" {
-		t.Fatalf("reason = %q", res.Skipped[0].Reason)
+	// A dirty worktree is preserved and reported with the uncommitted-changes reason.
+	// (Independent setups per case: re-running Cleanup on the same already-finalized
+	// session is now correctly an idempotent no-op, so each reason needs its own.)
+	{
+		m, st, _, ws := newManager()
+		seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1"})
+		ws.destroyErr = fmt.Errorf("gitworktree: refusing to remove: %w", ports.ErrWorkspaceDirty)
+		res, err := m.Cleanup(ctx, "mer")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(res.Cleaned) != 0 {
+			t.Fatalf("cleaned = %v, want none", res.Cleaned)
+		}
+		if len(res.Skipped) != 1 || res.Skipped[0].SessionID != "mer-1" {
+			t.Fatalf("skipped = %v, want mer-1", res.Skipped)
+		}
+		if res.Skipped[0].Reason != "workspace has uncommitted changes" {
+			t.Fatalf("reason = %q", res.Skipped[0].Reason)
+		}
 	}
 
 	// A non-dirty teardown failure is reported too — but with a fixed public
 	// reason: the raw cause carries internal filesystem paths and belongs in
 	// the server log, not the API response.
-	ws.destroyErr = errors.New("disk on fire")
-	res, err = m.Cleanup(ctx, "mer")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(res.Skipped) != 1 || res.Skipped[0].Reason != "workspace teardown failed" {
-		t.Fatalf("skipped = %v, want fixed teardown-failed reason", res.Skipped)
-	}
-	if strings.Contains(res.Skipped[0].Reason, "disk on fire") {
-		t.Fatalf("raw internal error leaked into public reason: %q", res.Skipped[0].Reason)
+	{
+		m, st, _, ws := newManager()
+		seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1"})
+		ws.destroyErr = errors.New("disk on fire")
+		res, err := m.Cleanup(ctx, "mer")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(res.Skipped) != 1 || res.Skipped[0].Reason != "workspace teardown failed" {
+			t.Fatalf("skipped = %v, want fixed teardown-failed reason", res.Skipped)
+		}
+		if strings.Contains(res.Skipped[0].Reason, "disk on fire") {
+			t.Fatalf("raw internal error leaked into public reason: %q", res.Skipped[0].Reason)
+		}
 	}
 
 	// A teardown that fails because the session's project is archived or
 	// unregistered (its repo can no longer be resolved) is reported with a
 	// distinct reason telling the user the worktree must be removed by hand.
-	ws.destroyErr = fmt.Errorf("resolve project repo: %w", ErrProjectNotResolvable)
-	res, err = m.Cleanup(ctx, "mer")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(res.Skipped) != 1 || res.Skipped[0].SessionID != "mer-1" {
-		t.Fatalf("skipped = %v, want mer-1", res.Skipped)
-	}
-	if res.Skipped[0].Reason != "project is archived or unregistered — remove worktree manually" {
-		t.Fatalf("reason = %q, want archived-project reason", res.Skipped[0].Reason)
+	{
+		m, st, _, ws := newManager()
+		seedTerminal(st, "mer-1", domain.SessionMetadata{WorkspacePath: "/ws/mer-1"})
+		ws.destroyErr = fmt.Errorf("resolve project repo: %w", ErrProjectNotResolvable)
+		res, err := m.Cleanup(ctx, "mer")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(res.Skipped) != 1 || res.Skipped[0].SessionID != "mer-1" {
+			t.Fatalf("skipped = %v, want mer-1", res.Skipped)
+		}
+		if res.Skipped[0].Reason != "project is archived or unregistered — remove worktree manually" {
+			t.Fatalf("reason = %q, want archived-project reason", res.Skipped[0].Reason)
+		}
 	}
 }
 
@@ -6184,46 +6241,11 @@ func TestReconcile_AdoptAcrossDaemonRestart(t *testing.T) {
 	}
 }
 
-func TestReconcileReap_TerminatedButAliveTmuxDestroyed(t *testing.T) {
-	st := newFakeStore()
-	rt := &fakeRuntime{aliveByHandle: map[string]bool{"t1": true}}
-	ws := &fakeWorkspace{}
-	lcm := &fakeLCM{store: st}
-	lookPath := func(string) (string, error) { return "/bin/true", nil }
-	m := New(Deps{Runtime: rt, Agents: fakeAgents{}, Workspace: ws, Store: st, Messenger: &fakeMessenger{}, Lifecycle: lcm, LookPath: lookPath})
-
-	rec := domain.SessionRecord{
-		ID: "t1", ProjectID: "p1", IsTerminated: true,
-		Metadata: domain.SessionMetadata{RuntimeHandleID: "t1"},
-	}
-
-	if err := m.reconcileReap(context.Background(), rec); err != nil {
-		t.Fatalf("reconcileReap: %v", err)
-	}
-	if len(rt.destroyedIDs) != 1 || rt.destroyedIDs[0] != "t1" {
-		t.Fatalf("destroyedIDs = %v, want [t1]", rt.destroyedIDs)
-	}
-}
-
-func TestReconcileReap_TerminatedAndDeadTmuxLeftAlone(t *testing.T) {
-	st := newFakeStore()
-	rt := &fakeRuntime{aliveByHandle: map[string]bool{}} // t2 not alive
-	ws := &fakeWorkspace{}
-	lcm := &fakeLCM{store: st}
-	lookPath := func(string) (string, error) { return "/bin/true", nil }
-	m := New(Deps{Runtime: rt, Agents: fakeAgents{}, Workspace: ws, Store: st, Messenger: &fakeMessenger{}, Lifecycle: lcm, LookPath: lookPath})
-
-	rec := domain.SessionRecord{
-		ID: "t2", ProjectID: "p1", IsTerminated: true,
-		Metadata: domain.SessionMetadata{RuntimeHandleID: "t2"},
-	}
-	if err := m.reconcileReap(context.Background(), rec); err != nil {
-		t.Fatalf("reconcileReap: %v", err)
-	}
-	if rt.destroyed != 0 {
-		t.Fatalf("Destroy calls = %d, want 0", rt.destroyed)
-	}
-}
+// The former TestReconcileReap_* tests were removed with reconcileReap: the
+// boot reap pass (runtime-Destroy every terminated-but-alive session) is now a
+// strict subset of FinalizeTerminalSession's runtime-first release, which the
+// terminal-resource reconciler owns. Runtime reclaim of a terminated session is
+// covered by TestFinalize_* below.
 
 // --- Send activity-confirmation tests (issue #2342) ---
 

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -589,6 +589,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sessions/{sessionId}/cleanup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reclaim a single terminated session's runtime + workspace resources */
+        post: operations["cleanupSession"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/sessions/{sessionId}/conversation": {
         parameters: {
             query?: never;
@@ -1475,6 +1492,12 @@ export interface components {
             sessionId: string;
             takenOverFrom: string[];
         };
+        CleanupSessionResponse: {
+            cleanup?: components["schemas"]["SessionCleanupView"];
+            isTerminated: boolean;
+            ok: boolean;
+            sessionId: string;
+        };
         CleanupSessionsResponse: {
             cleaned: string[];
             ok: boolean;
@@ -1502,6 +1525,7 @@ export interface components {
         ControllersSessionView: {
             activity: components["schemas"]["DomainActivity"];
             branch?: string;
+            cleanup?: components["schemas"]["SessionCleanupView"];
             /** Format: date-time */
             createdAt: string;
             displayName?: string;
@@ -2158,6 +2182,16 @@ export interface components {
             message: string;
             ok: boolean;
             sessionId: string;
+        };
+        SessionCleanupView: {
+            /** Format: int64 */
+            attemptCount?: number;
+            failureCode?: string;
+            /** Format: date-time */
+            nextAttemptAt?: null | string;
+            /** Format: date-time */
+            runtimeReleasedAt?: null | string;
+            workspaceDisposition: string;
         };
         SessionInterfaceTransition: {
             /** Format: date-time */
@@ -4659,6 +4693,56 @@ export interface operations {
             };
             /** @description Not Implemented */
             501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    cleanupSession: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Session identifier, e.g. project-1. */
+                sessionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CleanupSessionResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -2191,7 +2191,8 @@ export interface components {
             nextAttemptAt?: null | string;
             /** Format: date-time */
             runtimeReleasedAt?: null | string;
-            workspaceDisposition: string;
+            /** @enum {string} */
+            workspaceDisposition: "pending" | "removed" | "preserved_dirty" | "failed" | "not_applicable";
         };
         SessionInterfaceTransition: {
             /** Format: date-time */

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -1288,6 +1288,23 @@ describe("SessionsBoard", () => {
 		expect(screen.queryByRole("button", { name: /cleanup/i })).not.toBeInTheDocument();
 	});
 
+	// A terminated session with no cleanup facts row at all (the reconciler
+	// hasn't attempted or persisted anything for it yet — the boot/newly-terminal
+	// case) must render the same pending indicator as an explicit "pending"
+	// disposition, not disappear entirely.
+	it("shows cleaning-up progress for a terminated session with no cleanup facts yet", async () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [workspaceWithSessions([terminatedSession()])],
+			isError: false,
+			isSuccess: true,
+		});
+		renderBoard("p1");
+
+		await userEvent.click(screen.getByRole("button", { name: /archive/i }));
+		expect(screen.getByText("Cleaning up…")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /cleanup/i })).not.toBeInTheDocument();
+	});
+
 	it("surfaces the cleanup affordance for a MERGED (but terminated) session", async () => {
 		// The gate is the raw isTerminated fact, not status === "terminated": a
 		// merged session is terminated and must still offer cleanup recovery.

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -1240,6 +1240,97 @@ describe("SessionsBoard", () => {
 		expect(await screen.findByRole("alert")).toHaveTextContent("Failed to terminate session (500)");
 		expect(screen.getByRole("button", { name: "Terminate merged worker" })).toBeEnabled();
 	});
+
+	it("retries cleanup for a preserved-dirty session and refreshes workspace data", async () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [workspaceWithSessions([terminatedSession({ cleanup: { disposition: "preserved_dirty" } })])],
+			isError: false,
+			isSuccess: true,
+		});
+		const queryClient = renderBoard("p1");
+		const invalidate = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+
+		await userEvent.click(screen.getByRole("button", { name: /archive/i }));
+		expect(screen.getByText("Worktree kept — uncommitted changes")).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: "Try cleanup again for dead worker" }));
+
+		await waitFor(() =>
+			expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/cleanup", {
+				params: { path: { sessionId: "s-dead" } },
+			}),
+		);
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: ["workspaces"] });
+	});
+
+	it("offers Retry cleanup for a failed (exhausted) session", async () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [workspaceWithSessions([terminatedSession({ cleanup: { disposition: "failed" } })])],
+			isError: false,
+			isSuccess: true,
+		});
+		renderBoard("p1");
+
+		await userEvent.click(screen.getByRole("button", { name: /archive/i }));
+		expect(screen.getByText("Cleanup failed")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Retry cleanup for dead worker" })).toBeInTheDocument();
+	});
+
+	it("shows cleaning-up progress with no retry action while cleanup is pending", async () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [workspaceWithSessions([terminatedSession({ cleanup: { disposition: "pending" } })])],
+			isError: false,
+			isSuccess: true,
+		});
+		renderBoard("p1");
+
+		await userEvent.click(screen.getByRole("button", { name: /archive/i }));
+		expect(screen.getByText("Cleaning up…")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /cleanup/i })).not.toBeInTheDocument();
+	});
+
+	it("surfaces the cleanup affordance for a MERGED (but terminated) session", async () => {
+		// The gate is the raw isTerminated fact, not status === "terminated": a
+		// merged session is terminated and must still offer cleanup recovery.
+		workspaceQueryMock.mockReturnValue({
+			data: [
+				workspaceWithSessions([
+					terminatedSession({
+						id: "s-merged",
+						title: "merged worker",
+						status: "merged",
+						cleanup: { disposition: "preserved_dirty" },
+					}),
+				]),
+			],
+			isError: false,
+			isSuccess: true,
+		});
+		renderBoard("p1");
+
+		await userEvent.click(screen.getByRole("button", { name: /archive/i }));
+		// The archive row offers both actions for a merged session: restore (unrelated
+		// to cleanup) and the cleanup recovery this test targets.
+		expect(screen.getByRole("button", { name: "Restore merged worker" })).toBeInTheDocument();
+		await userEvent.click(screen.getByRole("button", { name: "Try cleanup again for merged worker" }));
+		await waitFor(() =>
+			expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/cleanup", {
+				params: { path: { sessionId: "s-merged" } },
+			}),
+		);
+	});
+
+	it("shows no cleanup row for a removed (fully-reclaimed) session", async () => {
+		workspaceQueryMock.mockReturnValue({
+			data: [workspaceWithSessions([terminatedSession({ cleanup: { disposition: "removed" } })])],
+			isError: false,
+			isSuccess: true,
+		});
+		renderBoard("p1");
+
+		await userEvent.click(screen.getByRole("button", { name: /archive/i }));
+		expect(screen.queryByRole("button", { name: /cleanup/i })).not.toBeInTheDocument();
+		expect(screen.queryByText(/Cleaning up|Worktree kept|Cleanup failed/)).not.toBeInTheDocument();
+	});
 });
 
 function workspaceWithSessions(sessions: WorkspaceSession[]): WorkspaceSummary {

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -856,23 +856,17 @@ function SecondaryLaneSection({
 	);
 }
 
-// cleanupRetryable reports whether a terminated session's cleanup can be
-// user-retried: a preserved-dirty worktree or an exhausted failure. Gated on the
-// raw isTerminated fact, so a merged (but terminated) session qualifies too.
-function cleanupRetryable(session: WorkspaceSession): boolean {
-	if (!session.isTerminated) return false;
-	const d = session.cleanup?.disposition;
-	return d === "preserved_dirty" || d === "failed";
-}
-
 type CleanupCardView = { label: string; tone: string; retryLabel?: string };
 
 // cleanupCardView renders a terminated session's cleanup state into a compact
-// board label, or null when there is nothing to surface (never terminal, no
-// facts, or an already-clean removed/not_applicable outcome).
+// board label, or null when there is nothing to surface (never terminal, or an
+// already-clean removed/not_applicable outcome). A terminated session with no
+// facts row yet is the boot/newly-terminal case the reconciler has not attempted
+// or persisted — treated the same as an explicit `pending` disposition rather
+// than surfacing nothing.
 function cleanupCardView(session: WorkspaceSession): CleanupCardView | null {
-	if (!session.isTerminated || !session.cleanup) return null;
-	switch (session.cleanup.disposition) {
+	if (!session.isTerminated) return null;
+	switch (session.cleanup?.disposition ?? "pending") {
 		case "pending":
 			return { label: "Cleaning up…", tone: "text-passive" };
 		case "preserved_dirty":
@@ -882,6 +876,13 @@ function cleanupCardView(session: WorkspaceSession): CleanupCardView | null {
 		default:
 			return null; // removed / not_applicable — nothing to act on
 	}
+}
+
+// cleanupRetryable reports whether a terminated session's cleanup can be
+// user-retried. Derived from cleanupCardView so the retry rule can't drift from
+// the label-rendering rule as dispositions evolve.
+function cleanupRetryable(session: WorkspaceSession): boolean {
+	return cleanupCardView(session)?.retryLabel !== undefined;
 }
 
 function SessionCard({

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -37,6 +37,7 @@ import {
 	useSessionUsageSummaries,
 	type SessionUsageSummary,
 } from "../hooks/useSessionUsageSummaries";
+import { useCleanupSession } from "../hooks/useCleanupSession";
 import { useRestoreSession } from "../hooks/useRestoreSession";
 import {
 	clearTerminateSessionState,
@@ -91,6 +92,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const queryClient = useQueryClient();
 	const COLUMNS: Column[] = boardAttentionZoneOrder.map((zone) => getAttentionZoneViewForZone(zone, t));
 	const restoreSessionById = useRestoreSession();
+	const cleanupSessionById = useCleanupSession();
 	const workspaceQuery = useWorkspaceQuery();
 	const shell = useShellMaybe();
 	const usageBySession = useSessionUsageSummaries(projectId).data ?? emptyUsageBySession;
@@ -168,12 +170,16 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 	const [restoreErrors, setRestoreErrors] = useState<Record<string, string>>({});
 	const [restoreUnavailableSession, setRestoreUnavailableSession] = useState<WorkspaceSession | undefined>();
 	const terminateSession = useTerminateSession();
+	const [cleaningUpSessionId, setCleaningUpSessionId] = useState<string | undefined>();
+	const [cleanupErrors, setCleanupErrors] = useState<Record<string, string>>({});
 	const activeProjectIdRef = useRef(projectId);
 	activeProjectIdRef.current = projectId;
 	useEffect(() => {
 		setRestoringSessionId(undefined);
 		setRestoreErrors({});
 		setRestoreUnavailableSession(undefined);
+		setCleaningUpSessionId(undefined);
+		setCleanupErrors({});
 	}, [projectId]);
 
 	const openSession = (session: WorkspaceSession) =>
@@ -211,6 +217,33 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 		} finally {
 			if (isStillActiveProject()) {
 				setRestoringSessionId(undefined);
+			}
+		}
+	};
+
+	// cleanupDoneSession retries the terminal-resource cleanup for a preserved-dirty
+	// or failed session. Unlike restore it stays on the board — the refreshed
+	// cleanup facts (via the hook's query invalidation) re-render in place.
+	const cleanupDoneSession = async (event: MouseEvent<HTMLButtonElement>, session: WorkspaceSession) => {
+		event.stopPropagation();
+		if (cleaningUpSessionId) return;
+		const cleanupProjectId = projectId;
+		const isStillActiveProject = () => !cleanupProjectId || activeProjectIdRef.current === cleanupProjectId;
+		setCleaningUpSessionId(session.id);
+		setCleanupErrors((current) => {
+			const next = { ...current };
+			delete next[session.id];
+			return next;
+		});
+		try {
+			const result = await cleanupSessionById(session.id);
+			if (!isStillActiveProject()) return;
+			if (result.status === "error") {
+				setCleanupErrors((current) => ({ ...current, [session.id]: result.message }));
+			}
+		} finally {
+			if (isStillActiveProject()) {
+				setCleaningUpSessionId(undefined);
 			}
 		}
 	};
@@ -431,6 +464,9 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 									isRestoring={restoringSessionId === s.id}
 									isRestoreDisabled={restoringSessionId !== undefined}
 									usage={usageBySession.get(s.id)}
+									cleanupAction={cleanupRetryable(s) ? (event) => void cleanupDoneSession(event, s) : undefined}
+									cleanupError={cleanupErrors[s.id]}
+									isCleaningUp={cleaningUpSessionId === s.id}
 								/>
 							))}
 						</div>
@@ -820,6 +856,34 @@ function SecondaryLaneSection({
 	);
 }
 
+// cleanupRetryable reports whether a terminated session's cleanup can be
+// user-retried: a preserved-dirty worktree or an exhausted failure. Gated on the
+// raw isTerminated fact, so a merged (but terminated) session qualifies too.
+function cleanupRetryable(session: WorkspaceSession): boolean {
+	if (!session.isTerminated) return false;
+	const d = session.cleanup?.disposition;
+	return d === "preserved_dirty" || d === "failed";
+}
+
+type CleanupCardView = { label: string; tone: string; retryLabel?: string };
+
+// cleanupCardView renders a terminated session's cleanup state into a compact
+// board label, or null when there is nothing to surface (never terminal, no
+// facts, or an already-clean removed/not_applicable outcome).
+function cleanupCardView(session: WorkspaceSession): CleanupCardView | null {
+	if (!session.isTerminated || !session.cleanup) return null;
+	switch (session.cleanup.disposition) {
+		case "pending":
+			return { label: "Cleaning up…", tone: "text-passive" };
+		case "preserved_dirty":
+			return { label: "Worktree kept — uncommitted changes", tone: "text-foreground", retryLabel: "Try cleanup again" };
+		case "failed":
+			return { label: "Cleanup failed", tone: "text-destructive", retryLabel: "Retry cleanup" };
+		default:
+			return null; // removed / not_applicable — nothing to act on
+	}
+}
+
 function SessionCard({
 	session,
 	onOpen,
@@ -996,6 +1060,9 @@ function ArchiveSessionItem({
 	isRestoring,
 	isRestoreDisabled,
 	usage,
+	cleanupAction,
+	cleanupError,
+	isCleaningUp = false,
 }: {
 	session: WorkspaceSession;
 	restoreAction: (event: MouseEvent<HTMLButtonElement>) => void;
@@ -1003,7 +1070,11 @@ function ArchiveSessionItem({
 	isRestoring: boolean;
 	isRestoreDisabled: boolean;
 	usage?: SessionUsageSummary;
+	cleanupAction?: (event: MouseEvent<HTMLButtonElement>) => void;
+	cleanupError?: string;
+	isCleaningUp?: boolean;
 }) {
+	const cleanup = cleanupCardView(session);
 	const branch = session.branch || "";
 	const restoreButton = (
 		<ArchiveRestoreButton
@@ -1018,7 +1089,18 @@ function ArchiveSessionItem({
 		<SessionCard
 			action={restoreButton}
 			branchAction={branch ? <CopyActionButton label={`branch ${branch}`} value={branch} /> : undefined}
-			footer={<ArchiveRestoreError message={restoreError} />}
+			footer={
+				<>
+					<ArchiveRestoreError message={restoreError} />
+					<ArchiveCleanupRow
+						cleanup={cleanup}
+						cleanupAction={cleanupAction}
+						cleanupError={cleanupError}
+						isCleaningUp={isCleaningUp}
+						title={session.title}
+					/>
+				</>
+			}
 			interactive={false}
 			session={session}
 			usage={usage}
@@ -1083,6 +1165,55 @@ function ArchiveRestoreError({ message }: { message?: string }) {
 			{message}
 		</div>
 	) : null;
+}
+
+// ArchiveCleanupRow renders a terminated session's terminal-resource cleanup
+// state (and retry action) beneath its archive-list row, plus the last cleanup
+// error if one occurred. Absent entirely when there is nothing to surface
+// (cleanupCardView returns null for a never-terminal or already-clean session).
+function ArchiveCleanupRow({
+	cleanup,
+	cleanupAction,
+	cleanupError,
+	isCleaningUp,
+	title,
+}: {
+	cleanup: CleanupCardView | null;
+	cleanupAction?: (event: MouseEvent<HTMLButtonElement>) => void;
+	cleanupError?: string;
+	isCleaningUp: boolean;
+	title: string;
+}) {
+	return (
+		<>
+			{cleanup && (
+				<div
+					className="flex items-center gap-2 border-t border-border px-2 py-1.5 text-2xs"
+					onClick={(event) => event.stopPropagation()}
+				>
+					<span className={cn("truncate", cleanup.tone)} title={cleanup.label}>
+						{cleanup.label}
+					</span>
+					{cleanup.retryLabel && cleanupAction && (
+						<button
+							aria-label={`${cleanup.retryLabel} for ${title}`}
+							className="ml-auto inline-flex h-control-xs shrink-0 items-center justify-center rounded-sm border border-border px-2 text-2xs font-semibold text-foreground transition-colors hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-60"
+							disabled={isCleaningUp}
+							onClick={cleanupAction}
+							type="button"
+						>
+							{isCleaningUp ? "Cleaning up" : cleanup.retryLabel}
+						</button>
+					)}
+				</div>
+			)}
+			{cleanupError && (
+				<div className="border-t border-border px-2 py-1.5 text-2xs text-destructive" role="alert">
+					{cleanupError}
+				</div>
+			)}
+		</>
+	);
 }
 
 type BoardPRLifecycleStatus = { label: "closed" | "open" | "draft" | "merged"; className: string };

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -1185,6 +1185,7 @@ function ArchiveCleanupRow({
 	isCleaningUp: boolean;
 	title: string;
 }) {
+	const retryAriaLabel = cleanup?.retryLabel ? `${cleanup.retryLabel} for ${title}` : undefined;
 	return (
 		<>
 			{cleanup && (
@@ -1197,7 +1198,7 @@ function ArchiveCleanupRow({
 					</span>
 					{cleanup.retryLabel && cleanupAction && (
 						<button
-							aria-label={`${cleanup.retryLabel} for ${title}`}
+							aria-label={retryAriaLabel}
 							className="ml-auto inline-flex h-control-xs shrink-0 items-center justify-center rounded-sm border border-border px-2 text-2xs font-semibold text-foreground transition-colors hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-60"
 							disabled={isCleaningUp}
 							onClick={cleanupAction}

--- a/frontend/src/renderer/hooks/useCleanupSession.ts
+++ b/frontend/src/renderer/hooks/useCleanupSession.ts
@@ -1,0 +1,36 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
+import { workspaceQueryKey } from "./useWorkspaceQuery";
+
+export type CleanupSessionResult = { status: "success" } | { status: "error"; message: string };
+
+// useCleanupSession triggers the per-session terminal-resource cleanup
+// (POST /sessions/{id}/cleanup) and refreshes the workspace query so the updated
+// cleanup facts re-render. Mirrors useRestoreSession: a useCallback returning a
+// typed result union rather than throwing. Used to retry a preserved-dirty or
+// failed cleanup from the UI.
+export function useCleanupSession(): (sessionId: string) => Promise<CleanupSessionResult> {
+	const queryClient = useQueryClient();
+
+	return useCallback(
+		async (sessionId: string) => {
+			try {
+				const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/cleanup", {
+					params: { path: { sessionId } },
+				});
+				if (error) {
+					return { status: "error", message: apiErrorMessage(error, "Unable to clean up session") };
+				}
+				await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+				return { status: "success" };
+			} catch (err) {
+				return {
+					status: "error",
+					message: err instanceof Error ? err.message : "Unable to clean up session",
+				};
+			}
+		},
+		[queryClient],
+	);
+}

--- a/frontend/src/renderer/hooks/useWorkspaceQuery.ts
+++ b/frontend/src/renderer/hooks/useWorkspaceQuery.ts
@@ -11,6 +11,7 @@ import {
 	toAgentProvider,
 	toProjectKind,
 	toSessionActivity,
+	toSessionCleanup,
 	toSessionStatus,
 	type WorkspaceSummary,
 } from "../types/workspace";
@@ -100,6 +101,7 @@ async function fetchWorkspaces(): Promise<WorkspaceSummary[]> {
 						scmStatus,
 						isTerminated: session.isTerminated,
 						terminateOnPrMerge: session.terminateOnPrMerge ?? false,
+						cleanup: toSessionCleanup(session.cleanup),
 						createdAt: session.createdAt,
 						updatedAt: session.updatedAt,
 						activity,

--- a/frontend/src/renderer/lib/api-client.ts
+++ b/frontend/src/renderer/lib/api-client.ts
@@ -80,6 +80,7 @@ const ROUTE_TEMPLATES = [
 	"/api/v1/sessions",
 	"/api/v1/sessions/{sessionId}",
 	"/api/v1/sessions/{sessionId}/activity",
+	"/api/v1/sessions/{sessionId}/cleanup",
 	"/api/v1/sessions/{sessionId}/interface-transition",
 	"/api/v1/sessions/{sessionId}/kill",
 	"/api/v1/sessions/{sessionId}/pr",

--- a/frontend/src/renderer/types/workspace.test.ts
+++ b/frontend/src/renderer/types/workspace.test.ts
@@ -9,6 +9,7 @@ import {
 	sessionNeedsAttention,
 	toAgentProvider,
 	toSessionActivity,
+	toSessionCleanup,
 	toSessionStatus,
 	openPRs,
 	mergedPRCount,
@@ -91,6 +92,25 @@ describe("toSessionActivity", () => {
 	it("returns undefined for a missing activity", () => {
 		expect(toSessionActivity(undefined)).toBeUndefined();
 		expect(toSessionActivity(null)).toBeUndefined();
+	});
+});
+
+describe("toSessionCleanup", () => {
+	it.each(["pending", "removed", "preserved_dirty", "failed", "not_applicable"] as const)(
+		"passes through the known disposition %s",
+		(workspaceDisposition) => {
+			expect(toSessionCleanup({ workspaceDisposition })?.disposition).toBe(workspaceDisposition);
+		},
+	);
+
+	it("falls back to pending for an unrecognized disposition", () => {
+		// @ts-expect-error exercising a wire value outside the generated union (a
+		// stale client talking to a newer daemon)
+		expect(toSessionCleanup({ workspaceDisposition: "bogus" })?.disposition).toBe("pending");
+	});
+
+	it("returns undefined for a missing cleanup", () => {
+		expect(toSessionCleanup(undefined)).toBeUndefined();
 	});
 });
 

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -1,3 +1,4 @@
+import type { components } from "../../api/schema";
 import { attentionZone as presentationAttentionZone } from "../lib/session-presentation";
 
 import type { ReviewerHarnessId } from "../lib/reviewer-harnesses";
@@ -45,6 +46,14 @@ export function toSessionStatus(status?: string, isTerminated = false): SessionS
 // runtime + workspace release, mirroring the backend's workspace_disposition.
 export type CleanupDisposition = "pending" | "removed" | "preserved_dirty" | "failed" | "not_applicable";
 
+const cleanupDispositions = new Set<CleanupDisposition>([
+	"pending",
+	"removed",
+	"preserved_dirty",
+	"failed",
+	"not_applicable",
+]);
+
 // SessionCleanup is the client view of a terminated session's terminal-resource
 // cleanup facts. Present only for a terminated session that has a facts row.
 export type SessionCleanup = {
@@ -56,17 +65,22 @@ export type SessionCleanup = {
 };
 
 // toSessionCleanup maps the API cleanup facts onto the client shape, or undefined
-// when the session has none (a live or not-yet-finalized session).
-export function toSessionCleanup(cleanup?: {
-	workspaceDisposition: string;
-	runtimeReleasedAt?: string | null;
-	attemptCount?: number;
-	nextAttemptAt?: string | null;
-	failureCode?: string;
-}): SessionCleanup | undefined {
+// when the session has none (a live or not-yet-finalized session). Validates
+// workspaceDisposition against the closed value set rather than trusting the
+// wire string outright — the generated type already narrows it, but a stale
+// client talking to a newer daemon could still see an unrecognized value cross
+// the network boundary. An unrecognized value falls back to "pending" (the
+// safe "reconciler hasn't converged yet, no action" reading) rather than
+// forwarding a disposition the renderer's switch statements don't handle.
+export function toSessionCleanup(
+	cleanup?: components["schemas"]["SessionCleanupView"],
+): SessionCleanup | undefined {
 	if (!cleanup) return undefined;
+	const disposition = cleanupDispositions.has(cleanup.workspaceDisposition as CleanupDisposition)
+		? (cleanup.workspaceDisposition as CleanupDisposition)
+		: "pending";
 	return {
-		disposition: cleanup.workspaceDisposition as CleanupDisposition,
+		disposition,
 		runtimeReleasedAt: cleanup.runtimeReleasedAt ?? undefined,
 		attemptCount: cleanup.attemptCount,
 		nextAttemptAt: cleanup.nextAttemptAt ?? undefined,

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -41,6 +41,39 @@ export function toSessionStatus(status?: string, isTerminated = false): SessionS
 	return isTerminated ? "terminated" : "unknown";
 }
 
+// CleanupDisposition is the session-level rollup of a terminated session's
+// runtime + workspace release, mirroring the backend's workspace_disposition.
+export type CleanupDisposition = "pending" | "removed" | "preserved_dirty" | "failed" | "not_applicable";
+
+// SessionCleanup is the client view of a terminated session's terminal-resource
+// cleanup facts. Present only for a terminated session that has a facts row.
+export type SessionCleanup = {
+	disposition: CleanupDisposition;
+	runtimeReleasedAt?: string;
+	attemptCount?: number;
+	nextAttemptAt?: string;
+	failureCode?: string;
+};
+
+// toSessionCleanup maps the API cleanup facts onto the client shape, or undefined
+// when the session has none (a live or not-yet-finalized session).
+export function toSessionCleanup(cleanup?: {
+	workspaceDisposition: string;
+	runtimeReleasedAt?: string | null;
+	attemptCount?: number;
+	nextAttemptAt?: string | null;
+	failureCode?: string;
+}): SessionCleanup | undefined {
+	if (!cleanup) return undefined;
+	return {
+		disposition: cleanup.workspaceDisposition as CleanupDisposition,
+		runtimeReleasedAt: cleanup.runtimeReleasedAt ?? undefined,
+		attemptCount: cleanup.attemptCount,
+		nextAttemptAt: cleanup.nextAttemptAt ?? undefined,
+		failureCode: cleanup.failureCode,
+	};
+}
+
 export type SessionActivityState = "active" | "idle" | "waiting_input" | "blocked" | "exited" | "unknown";
 
 const sessionActivityStates = new Set<SessionActivityState>(["active", "idle", "waiting_input", "blocked", "exited"]);
@@ -145,10 +178,17 @@ export type WorkspaceSession = {
 	status: SessionStatus;
 	/** Stack-aware PR context derived by the daemon independently of runtime activity. */
 	scmStatus?: SessionStatus;
-	/** Durable runtime fact from the daemon; independent of the derived SCM-aware status. */
+	/**
+	 * Raw terminal fact from the daemon, independent of the derived status: a
+	 * merged session is terminated but has status "merged", so cleanup affordances
+	 * gate on this rather than status === "terminated". Optional only so existing
+	 * fixtures need not set it; the daemon mapping always populates it.
+	 */
 	isTerminated?: boolean;
 	/** User preference to tear down this session when its PR set completes through a merge. */
 	terminateOnPrMerge?: boolean;
+	/** Terminal-resource cleanup state; present only for a terminated session with a facts row. */
+	cleanup?: SessionCleanup;
 	/** ISO timestamp from the daemon — used for relative time in the inspector. */
 	createdAt?: string;
 	/** ISO timestamp from the daemon. */

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -72,9 +72,7 @@ export type SessionCleanup = {
 // the network boundary. An unrecognized value falls back to "pending" (the
 // safe "reconciler hasn't converged yet, no action" reading) rather than
 // forwarding a disposition the renderer's switch statements don't handle.
-export function toSessionCleanup(
-	cleanup?: components["schemas"]["SessionCleanupView"],
-): SessionCleanup | undefined {
+export function toSessionCleanup(cleanup?: components["schemas"]["SessionCleanupView"]): SessionCleanup | undefined {
 	if (!cleanup) return undefined;
 	const disposition = cleanupDispositions.has(cleanup.workspaceDisposition as CleanupDisposition)
 		? (cleanup.workspaceDisposition as CleanupDisposition)


### PR DESCRIPTION
Part 4 (final) of the terminal-resource reconciler redesign for #2811: frontend recoverability — render a terminated session's cleanup state and let the user retry a stuck cleanup.

- Plumb the raw `isTerminated` fact and the `cleanup` facts onto `WorkspaceSession` (they were dropped in the `useWorkspaceQuery` mapping — `isTerminated` only fed the derived status).
- **Gate the cleanup affordance on raw `isTerminated`, not `status === "terminated"`** — a merged session is terminated but has status `"merged"`, so it was invisible to the status check. Merged and terminated sessions in the Done column now both offer cleanup recovery.
- Render each `workspaceDisposition` distinctly on the Done card: `pending` → "Cleaning up…" (no action); `preserved_dirty` → "Worktree kept — uncommitted changes" + "Try cleanup again"; `failed` → "Cleanup failed" + "Retry cleanup"; `removed` / `not_applicable` → nothing. Merged/Terminated label unchanged.
- `useCleanupSession` hook (mirrors `useRestoreSession`); `ROUTE_TEMPLATES` entry for the per-session route.

The "Exited" vs "Done" activity-pill inconsistency is a pre-existing, build-specific presentation bug independent of cleanup state — left as a separate follow-up.

### Stacked PR
Depends on #3's API + read-model facts (and #2931, #2854). Reviews best after those land; rebases to stand alone.

### Tests
Each disposition renders its distinct state and the retry action fires — for a merged as well as a terminated session; a merged session surfaces the affordance (the raw-`isTerminated` gate); pending shows progress with no action; removed shows no cleanup row. Frontend typecheck + full vitest (982) green.
