### PR TITLE
fix: polish Connect Mobile get-app and shared settings chrome

### DIFF
--- a/frontend/src/renderer/components/ConnectMobileModal.tsx
+++ b/frontend/src/renderer/components/ConnectMobileModal.tsx
@@ -275,7 +275,7 @@ export function ConnectMobileModal({ open, onOpenChange }: ConnectMobileModalPro
 											}}
 											disabled={busy || !enabled}
 											tabIndex={enabled ? 0 : -1}
-											className="settings-footer-button mt-5 w-(--size-settings-mobile-regen-width) border-[var(--color-border-settings-input)] bg-[var(--color-bg-settings-input)] text-settings-label transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+											className="settings-footer-button mt-5 w-(--size-settings-mobile-regen-width) disabled:cursor-not-allowed disabled:opacity-50"
 										>
 											{regenerate.isPending && <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />}
 											Regenerate password

--- a/frontend/src/renderer/components/settings/ConnectMobileGetApp.test.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileGetApp.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, expect, test, vi } from "vitest";
-import { ConnectMobileGetApp, TESTFLIGHT_URL } from "./ConnectMobileGetApp";
+import { ANDROID_SIGNUP_URL, ConnectMobileGetApp, TESTFLIGHT_URL } from "./ConnectMobileGetApp";
 
 const { openExternal } = vi.hoisted(() => ({ openExternal: vi.fn() }));
 
@@ -21,10 +21,12 @@ test("TestFlight button opens the join link through the app bridge", async () =>
 	expect(TESTFLIGHT_URL).toBe("https://testflight.apple.com/join/t4U3fu2H");
 });
 
-test("Android is listed as not yet available", () => {
+test("Android signup button opens the internal-testing form", async () => {
 	render(<ConnectMobileGetApp />);
 	expect(screen.getByText("Android")).toBeInTheDocument();
-	expect(screen.getByText("Coming soon")).toBeInTheDocument();
+	await userEvent.click(screen.getByRole("button", { name: "Sign up for Android internal testing" }));
+	expect(openExternal).toHaveBeenCalledWith("https://forms.gle/pWLWoxTPXySAN4Ws8");
+	expect(ANDROID_SIGNUP_URL).toBe("https://forms.gle/pWLWoxTPXySAN4Ws8");
 });
 
 // The join link is useless without Apple's TestFlight app, and "TestFlight beta"

--- a/frontend/src/renderer/components/settings/ConnectMobileGetApp.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileGetApp.tsx
@@ -7,6 +7,9 @@ import { cn } from "../../lib/utils";
 /** TestFlight beta for the Agent Orchestrator iOS app. */
 export const TESTFLIGHT_URL = "https://testflight.apple.com/join/t4U3fu2H";
 
+/** Android internal-testing signup form. */
+export const ANDROID_SIGNUP_URL = "https://forms.gle/pWLWoxTPXySAN4Ws8";
+
 /** Deliberately smaller than the pairing QR so it never competes with it. */
 const TESTFLIGHT_QR_SIZE = 140;
 
@@ -19,11 +22,11 @@ export function ConnectMobileGetApp() {
 	const [showQR, setShowQR] = useState(false);
 
 	return (
-		<div className="mt-6 flex flex-col rounded-(--radius-settings-dialog-lg) border border-[var(--color-border-settings-input)] bg-[var(--color-bg-settings-input)] px-3.5 py-3">
+		<div className="mt-6 flex flex-col rounded-(--radius-settings-dialog-lg) border border-[var(--color-border-settings-input)] bg-[var(--color-bg-settings-dialog)] px-3.5 py-3">
 			<span className="text-subtitle leading-(--leading-settings-mobile-title) text-settings-label">Get the app</span>
 
 			{/* iOS — items-center so the action cluster sits on the row's optical centre. */}
-			<div className="mt-2.5 flex items-center justify-between gap-3">
+			<div className="mt-3 flex items-center justify-between gap-3 border-t border-[var(--color-border-settings-input)] pt-3">
 				<div className="flex min-w-0 flex-col">
 					<span className="text-sm leading-5 text-settings-label">iOS</span>
 					<span className="text-caption leading-(--leading-settings-mobile-hint) text-settings-muted">
@@ -35,7 +38,7 @@ export function ConnectMobileGetApp() {
 						type="button"
 						aria-label="Join the TestFlight beta"
 						onClick={() => void aoBridge.app.openExternal(TESTFLIGHT_URL)}
-						className="inline-flex h-7 shrink-0 items-center justify-center rounded-lg border border-[var(--color-border-settings-input)] bg-settings-row px-3 text-caption text-settings-label transition-opacity hover:opacity-90"
+						className="settings-footer-button"
 					>
 						Join beta
 					</button>
@@ -45,8 +48,8 @@ export function ConnectMobileGetApp() {
 						aria-expanded={showQR}
 						onClick={() => setShowQR((v) => !v)}
 						className={cn(
-							"inline-flex size-7 items-center justify-center rounded-lg transition-colors hover:bg-settings-row",
-							showQR ? "bg-settings-row text-settings-title" : "text-settings-muted",
+							"inline-flex size-(--size-settings-action-height) items-center justify-center rounded-(--radius-settings-action) transition-colors hover:bg-[var(--color-bg-settings-input)]",
+							showQR ? "bg-[var(--color-bg-settings-input)] text-settings-title" : "text-settings-muted",
 						)}
 					>
 						<QrCode className="size-4" aria-hidden="true" />
@@ -77,17 +80,22 @@ export function ConnectMobileGetApp() {
 				</div>
 			</div>
 
-			{/* Android — no build to hand out yet, so this row is informational only. */}
+			{/* Android — internal testing signup until a Play Store beta is live. */}
 			<div className="mt-3 flex items-center justify-between gap-3 border-t border-[var(--color-border-settings-input)] pt-3">
 				<div className="flex min-w-0 flex-col">
 					<span className="text-sm leading-5 text-settings-label">Android</span>
 					<span className="text-caption leading-(--leading-settings-mobile-hint) text-settings-muted">
-						Play Store beta
+						Join the internal testing program
 					</span>
 				</div>
-				<span className="inline-flex h-7 shrink-0 items-center rounded-lg bg-settings-row px-3 text-caption text-settings-muted">
-					Coming soon
-				</span>
+				<button
+					type="button"
+					aria-label="Sign up for Android internal testing"
+					onClick={() => void aoBridge.app.openExternal(ANDROID_SIGNUP_URL)}
+					className="settings-footer-button"
+				>
+					Join waitlist
+				</button>
 			</div>
 		</div>
 	);

--- a/frontend/src/renderer/components/settings/ConnectMobileSetup.test.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileSetup.test.tsx
@@ -9,16 +9,16 @@ test("LAN steps show by default", () => {
 	expect(screen.queryByText(/tailscale ip -4/i)).not.toBeInTheDocument();
 });
 
-test("Tailscale tab explains manual entry and echoes the live port", async () => {
+test("Tailscale mode explains manual entry and echoes the live port", async () => {
 	render(<ConnectMobileSetup port={3011} enabled={true} />);
-	await userEvent.click(screen.getByRole("tab", { name: "Tailscale" }));
+	await userEvent.click(screen.getByRole("radio", { name: "Tailscale" }));
 	expect(screen.getByText(/tailscale ip -4/i)).toBeInTheDocument();
 	expect(
 		screen.getByText((_, el) => el?.textContent?.includes("port 3011") ?? false, { selector: "li" }),
 	).toBeInTheDocument();
 });
 
-test("tabs leave the tab order while the bridge is disabled", () => {
+test("segments leave the tab order while the bridge is disabled", () => {
 	render(<ConnectMobileSetup port={3011} enabled={false} />);
-	expect(screen.getByRole("tab", { name: "LAN" })).toHaveAttribute("tabindex", "-1");
+	expect(screen.getByRole("radio", { name: "LAN" })).toHaveAttribute("tabindex", "-1");
 });

--- a/frontend/src/renderer/components/settings/ConnectMobileSetup.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileSetup.tsx
@@ -1,56 +1,65 @@
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+import { useState } from "react";
+import { RadioGroup } from "radix-ui";
 
 interface ConnectMobileSetupProps {
 	/** Live bridge port, echoed in the Tailscale manual-entry step. */
 	port: number;
 	/**
 	 * False while the bridge is off; the steps are then collapsed, so their
-	 * tabs must leave the tab order (same pattern as the pairing block).
+	 * controls must leave the tab order (same pattern as the pairing block).
 	 */
 	enabled: boolean;
 }
 
-const stepListClass =
-	"list-decimal space-y-1.5 pl-4 text-caption leading-(--leading-settings-mobile-hint) text-settings-muted";
-
-const triggerClass = "text-settings-muted data-[state=active]:bg-settings-row data-[state=active]:text-settings-title";
+type SetupMode = "lan" | "tailscale";
 
 // ConnectMobileSetup tells the user what to do with the pairing QR above it.
-// The LAN tab is the happy path (scan and go). The Tailscale tab is manual
+// The LAN mode is the happy path (scan and go). The Tailscale mode is manual
 // entry on purpose: the pairing QR can only ever carry the LAN address,
 // because AutopickLANIP skips utun* interfaces and rejects Tailscale's
 // 100.64.0.0/10 CGNAT range as non-private (backend/internal/mobilebridge/netiface.go).
 export function ConnectMobileSetup({ port, enabled }: ConnectMobileSetupProps) {
+	const [mode, setMode] = useState<SetupMode>("lan");
+
 	// Margin-free on purpose: the modal owns the spacing around this block.
 	return (
-		<Tabs defaultValue="lan" className="flex w-full flex-col items-center">
-			<TabsList className="bg-[var(--color-bg-settings-input)]">
-				<TabsTrigger value="lan" tabIndex={enabled ? 0 : -1} className={triggerClass}>
+		<div className="flex w-full flex-col items-center">
+			<RadioGroup.Root
+				value={mode}
+				onValueChange={(value) => setMode(value as SetupMode)}
+				aria-label="Connection method"
+				className="settings-segment"
+			>
+				<RadioGroup.Item value="lan" tabIndex={enabled ? 0 : -1} className="settings-segment-item">
 					LAN
-				</TabsTrigger>
-				<TabsTrigger value="tailscale" tabIndex={enabled ? 0 : -1} className={triggerClass}>
+				</RadioGroup.Item>
+				<RadioGroup.Item value="tailscale" tabIndex={enabled ? 0 : -1} className="settings-segment-item">
 					Tailscale
-				</TabsTrigger>
-			</TabsList>
+				</RadioGroup.Item>
+			</RadioGroup.Root>
 
-			<TabsContent value="lan" className="mt-3 w-full px-(--size-settings-mobile-details-pad-x)">
-				<ol className={stepListClass}>
-					<li>Put your phone on the same Wi-Fi as this computer.</li>
-					<li>Open Agent Orchestrator on your phone and tap Scan.</li>
-					<li>Scan the code below — address and password fill in automatically.</li>
-				</ol>
-			</TabsContent>
-
-			<TabsContent value="tailscale" className="mt-3 w-full px-(--size-settings-mobile-details-pad-x)">
-				<ol className={stepListClass}>
-					<li>Install Tailscale here and on your phone, signed into the same account.</li>
-					<li>
-						Run <span className="tracking-settings-mono text-settings-label">tailscale ip -4</span> here to get your
-						100.x address.
-					</li>
-					<li>In the app's Settings, enter that address, port {port}, and the password below. Leave Use TLS off.</li>
-				</ol>
-			</TabsContent>
-		</Tabs>
+			{mode === "lan" ? (
+				<div className="mt-3 w-full px-(--size-settings-mobile-details-pad-x)">
+					<ol className="settings-mobile-steps">
+						<li>Put your phone on the same Wi-Fi as this computer.</li>
+						<li>Open Agent Orchestrator on your phone and tap Scan.</li>
+						<li>Scan the code below — address and password fill in automatically.</li>
+					</ol>
+				</div>
+			) : (
+				<div className="mt-3 w-full px-(--size-settings-mobile-details-pad-x)">
+					<ol className="settings-mobile-steps">
+						<li>Install Tailscale here and on your phone, signed into the same account.</li>
+						<li>
+							Run <span className="tracking-settings-mono text-settings-label">tailscale ip -4</span> here to get
+							your 100.x address.
+						</li>
+						<li>
+							In the app's Settings, enter that address, port {port}, and the password below. Leave Use TLS off.
+						</li>
+					</ol>
+				</div>
+			)}
+		</div>
 	);
 }

--- a/frontend/src/renderer/components/settings/ConnectMobileSetup.tsx
+++ b/frontend/src/renderer/components/settings/ConnectMobileSetup.tsx
@@ -51,12 +51,10 @@ export function ConnectMobileSetup({ port, enabled }: ConnectMobileSetupProps) {
 					<ol className="settings-mobile-steps">
 						<li>Install Tailscale here and on your phone, signed into the same account.</li>
 						<li>
-							Run <span className="tracking-settings-mono text-settings-label">tailscale ip -4</span> here to get
-							your 100.x address.
+							Run <span className="tracking-settings-mono text-settings-label">tailscale ip -4</span> here to get your
+							100.x address.
 						</li>
-						<li>
-							In the app's Settings, enter that address, port {port}, and the password below. Leave Use TLS off.
-						</li>
+						<li>In the app's Settings, enter that address, port {port}, and the password below. Leave Use TLS off.</li>
 					</ol>
 				</div>
 			)}

--- a/frontend/src/renderer/components/settings/ReportProblemDialog.tsx
+++ b/frontend/src/renderer/components/settings/ReportProblemDialog.tsx
@@ -202,14 +202,10 @@ export function ReportProblemDialog({ open, onOpenChange }: ReportProblemDialogP
 							clearStatus();
 						}}
 						aria-label="Report destination"
-						className="inline-flex items-center gap-0.5 self-start rounded-(--radius-settings-action) border border-[var(--color-border-settings-input)] bg-[var(--color-bg-settings-input)] p-0.5"
+						className="settings-segment self-start"
 					>
 						{DESTINATIONS.map((option) => (
-							<RadioGroup.Item
-								key={option.value}
-								value={option.value}
-								className="inline-flex h-8 cursor-default items-center gap-1.5 rounded-lg px-3 text-control leading-none text-settings-muted outline-none transition-colors duration-150 hover:text-settings-title focus-visible:ring-2 focus-visible:ring-accent-weak data-[state=checked]:bg-[var(--color-bg-settings-menu-selected)] data-[state=checked]:text-settings-title"
-							>
+							<RadioGroup.Item key={option.value} value={option.value} className="settings-segment-item">
 								<option.icon className="size-icon-sm" aria-hidden="true" />
 								{option.label}
 							</RadioGroup.Item>
@@ -228,16 +224,13 @@ export function ReportProblemDialog({ open, onOpenChange }: ReportProblemDialogP
 
 				<div className="flex shrink-0 flex-wrap items-center justify-end gap-3 border-t border-[var(--color-border-settings-dialog-header)] px-6 py-3.5">
 					<DialogClose asChild>
-						<button
-							type="button"
-							className="settings-footer-button border-[var(--color-border-settings-input)] bg-[var(--color-bg-settings-input)] text-settings-label transition-opacity hover:opacity-90"
-						>
+						<button type="button" className="settings-footer-button">
 							Cancel
 						</button>
 					</DialogClose>
 					<button
 						type="button"
-						className="settings-footer-button border-transparent bg-settings-accent text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+						className="settings-footer-button border-transparent bg-settings-accent text-white disabled:cursor-not-allowed disabled:opacity-50"
 						disabled={!canCopy}
 						onClick={() => void copyDraft()}
 					>

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -450,17 +450,74 @@ button.settings-row-bar {
 	gap: calc(var(--spacing) * 2);
 	white-space: nowrap;
 	border-radius: var(--radius-settings-action);
-	border-width: 1px;
-	border-style: solid;
+	border: 1px solid var(--color-border-settings-input);
+	background-color: var(--color-bg-settings-input);
 	padding-inline: var(--space-3);
 	font-size: var(--font-size-md);
 	line-height: 1.25rem;
+	color: var(--color-text-settings-row);
 	outline: none;
 	transition-property: color, background-color, border-color, opacity, box-shadow;
 	transition-duration: var(--duration-normal);
 
+	&:hover {
+		opacity: 0.9;
+	}
+
 	&:focus-visible {
 		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+	}
+}
+
+/* Segmented control — ReportProblem destination picker, ConnectMobile LAN/Tailscale. */
+@utility settings-segment {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-0_5);
+	border-radius: var(--radius-settings-action);
+	border: 1px solid var(--color-border-settings-input);
+	background-color: var(--color-bg-settings-input);
+	padding: var(--space-0_5);
+}
+
+@utility settings-segment-item {
+	display: inline-flex;
+	height: var(--size-control-form);
+	cursor: default;
+	align-items: center;
+	gap: calc(var(--spacing) * 1.5);
+	border-radius: var(--radius-lg);
+	padding-inline: var(--space-3);
+	font-size: var(--font-size-base);
+	line-height: 1;
+	color: var(--color-text-settings-muted);
+	outline: none;
+	transition-property: color, background-color;
+	transition-duration: var(--duration-normal);
+
+	&:hover {
+		color: var(--color-text-settings-title);
+	}
+
+	&:focus-visible {
+		box-shadow: 0 0 0 2px var(--bridge-accent-weak);
+	}
+
+	&[data-state="checked"] {
+		background-color: var(--color-bg-settings-menu-selected);
+		color: var(--color-text-settings-title);
+	}
+}
+
+@utility settings-mobile-steps {
+	list-style-type: decimal;
+	padding-left: var(--space-4);
+	font-size: var(--font-size-caption);
+	line-height: var(--leading-settings-mobile-hint);
+	color: var(--color-text-settings-muted);
+
+	& > li + li {
+		margin-top: calc(var(--spacing) * 1.5);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace Android "Coming soon" with a waitlist CTA that opens the internal-testing Google Form
- Add a divider between "Get the app" and the iOS row; align get-app actions with shared `settings-footer-button` chrome
- Extract shared `settings-segment` / `settings-mobile-steps` utilities and use them for Connect Mobile LAN/Tailscale and Report Problem destination picker

## Test plan
- [ ] Open Connect Mobile → "Get the app" shows divider under the title; iOS "Join beta" still opens TestFlight
- [ ] Android "Join waitlist" opens the Google Form; QR disclosure still expands/collapses
- [ ] LAN / Tailscale segment switches steps; controls are not tabbable while the bridge is disabled
- [ ] Report Problem destination segment and Cancel footer button still look/behave correctly
- [ ] `cd frontend && npm test -- ConnectMobileGetApp ConnectMobileSetup`

## Before
<img width="776" height="717" alt="image" src="https://github.com/user-attachments/assets/a10f9fcf-ed49-4609-ae10-6d7439a57bf1" />
<img width="639" height="851" alt="image" src="https://github.com/user-attachments/assets/6810c389-94d1-404c-8869-5efc0f77a2c1" />

## After
<img width="733" height="593" alt="image" src="https://github.com/user-attachments/assets/2c1c1b39-2cec-4799-b09b-df27b344cc6f" />
<img width="720" height="862" alt="image" src="https://github.com/user-attachments/assets/d75a4eea-8d14-4403-9012-98afa6fce566" />
<img width="662" height="862" alt="image" src="https://github.com/user-attachments/assets/59cd0285-3637-475c-9dbc-878689df548f" />
