### PR TITLE
fix: tuck TitlebarNav under traffic lights only when windowed

### DIFF
--- a/frontend/e2e/support/fake-bridge.ts
+++ b/frontend/e2e/support/fake-bridge.ts
@@ -72,7 +72,11 @@ export async function installFakeBridge(page: Page, opts: FakeBridgeOptions = {}
 					onFocusTerminalShortcut: unsubscribe,
 				},
 				terminal: { saveDroppedFile: async () => "" },
-				window: { setOverlay: async () => undefined },
+				window: {
+					setOverlay: async () => undefined,
+					isFullScreen: async () => false,
+					onFullScreen: () => () => undefined,
+				},
 				theme: { set: async () => undefined },
 				menu: { action: async () => undefined, notifyShellFocus: () => undefined },
 				clipboard: {
@@ -426,7 +430,11 @@ export async function installFakeAgent(page: Page, opts: FakeAgentOptions = {}):
 					onFocusTerminalShortcut: unsubscribe,
 				},
 				terminal: { saveDroppedFile: async () => "" },
-				window: { setOverlay: async () => undefined },
+				window: {
+					setOverlay: async () => undefined,
+					isFullScreen: async () => false,
+					onFullScreen: () => () => undefined,
+				},
 				theme: { set: async () => undefined },
 				menu: { action: async () => undefined, notifyShellFocus: () => undefined },
 				clipboard: { writeText: async () => undefined, readText: async () => "" },

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -372,6 +372,16 @@ function createWindow(): void {
 		});
 	}
 
+	// macOS: traffic lights vanish in native fullscreen, so the renderer drops
+	// the clearance pad above TitlebarNav. Push state so the sidebar can react
+	// without polling isFullScreen().
+	const pushFullScreen = () => {
+		if (!mainWindow) return;
+		mainWindow.webContents.send("window:fullscreen", mainWindow.isFullScreen());
+	};
+	mainWindow.on("enter-full-screen", pushFullScreen);
+	mainWindow.on("leave-full-screen", pushFullScreen);
+
 	mainWindow.on("closed", () => {
 		browserViewHost?.dispose();
 		browserViewHost = null;
@@ -1105,6 +1115,8 @@ ipcMain.handle("window:setOverlay", (_event, overlay: { color: string; symbolCol
 		// Window has no overlay on this platform; ignore.
 	}
 });
+
+ipcMain.handle("window:isFullScreen", () => mainWindow?.isFullScreen() ?? false);
 
 // Drive Electron's nativeTheme from the app's theme preference so embedded
 // preview WebContentsViews (which follow prefers-color-scheme) flip in step with

--- a/frontend/src/preload.ts
+++ b/frontend/src/preload.ts
@@ -112,6 +112,14 @@ const api = {
 	window: {
 		setOverlay: (overlay: { color: string; symbolColor: string }) =>
 			ipcRenderer.invoke("window:setOverlay", overlay) as Promise<void>,
+		isFullScreen: () => ipcRenderer.invoke("window:isFullScreen") as Promise<boolean>,
+		onFullScreen: (listener: (fullScreen: boolean) => void) => {
+			const wrapped = (_event: Electron.IpcRendererEvent, fullScreen: boolean) => listener(fullScreen);
+			ipcRenderer.on("window:fullscreen", wrapped);
+			return () => {
+				ipcRenderer.off("window:fullscreen", wrapped);
+			};
+		},
 	},
 	theme: {
 		// Propagate the app's theme preference to Electron's nativeTheme so embedded

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -55,6 +55,8 @@ import { isMacPlatform, isWindowsPlatform } from "../lib/platform";
 
 // On macOS the sidebar is full-height: traffic lights sit over its top chrome,
 // and TitlebarNav (toggle + history) stacks in this header directly below them.
+// In native fullscreen the lights are gone, so the clearance pad drops and
+// TitlebarNav sits near the top edge instead.
 // Win/Linux still hang the sidebar under their shell titlebar/toolbar.
 const isMac = isMacPlatform();
 const isWindows = isWindowsPlatform();
@@ -82,6 +84,8 @@ type SidebarProps = {
 	topbarOffset?: "toolbar" | "titlebar";
 	/** Lock back/forward in TitlebarNav (empty welcome board). */
 	historyLocked?: boolean;
+	/** macOS: drop traffic-light clearance when the BrowserWindow is fullscreen. */
+	isFullScreen?: boolean;
 	workspaceError?: string;
 	workspaces: WorkspaceSummary[];
 	onCreateProject: (input: CreateProjectInput) => Promise<void>;
@@ -124,6 +128,7 @@ export function Sidebar({
 	underTopbar = true,
 	topbarOffset = "toolbar",
 	historyLocked = false,
+	isFullScreen = false,
 	workspaceError,
 	workspaces,
 	onCreateProject,
@@ -214,13 +219,20 @@ export function Sidebar({
 			)}
 		>
 			{/* macOS: pt clears the traffic lights + drag strip (shared
-			    --size-traffic-light-clearance); header padding stays constant
-			    across expand/collapse so the pinned toggle/logo column does
-			    not shift. */}
+			    --size-traffic-light-clearance) while windowed; in fullscreen the
+			    lights are gone so TitlebarNav moves up. Padding eases so the
+			    cluster slides under the lights on leave-fullscreen. Otherwise
+			    stays constant across expand/collapse so the pinned toggle/logo
+			    column does not shift. */}
 			<SidebarHeader
 				className={cn(
 					"gap-0 p-0",
-					isMac ? "pt-traffic-light-clearance" : "pt-2.5 pl-2.5 pr-1.75",
+					isMac
+						? cn(
+								"transition-[padding-top] duration-200 ease-out motion-reduce:transition-none",
+								isFullScreen ? "pt-traffic-light-clearance-fullscreen" : "pt-traffic-light-clearance",
+							)
+						: "pt-2.5 pl-2.5 pr-1.75",
 					!isMac && "group-data-[collapsible=icon]:px-1.5 group-data-[collapsible=icon]:pt-2",
 				)}
 			>

--- a/frontend/src/renderer/components/TitlebarNav.tsx
+++ b/frontend/src/renderer/components/TitlebarNav.tsx
@@ -8,9 +8,11 @@ const isMac = isMacPlatform();
 const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
 
 // macOS-only sidebar chrome cluster (sidebar toggle + history arrows). Lives
-// in the Sidebar header below the traffic lights. The toggle is pinned in the
-// icon-rail column so it never moves during expand/collapse; history arrows
-// sit absolutely to its right and only fade in when expanded.
+// in the Sidebar header below the traffic lights while windowed; in native
+// fullscreen the clearance pad drops so this cluster sits near the top edge.
+// The toggle is pinned in the icon-rail column so it never moves during
+// expand/collapse; history arrows sit absolutely to its right and only fade
+// in when expanded.
 // The installed router has no useCanGoForward, and deriving one as
 // `__TSR_index < history.length - 1` (the upstream hook's approach) is wrong
 // here: window.history.length also counts entries the router never created —

--- a/frontend/src/renderer/hooks/useWindowFullScreen.test.tsx
+++ b/frontend/src/renderer/hooks/useWindowFullScreen.test.tsx
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const isFullScreenMock = vi.fn();
+const onFullScreenMock = vi.fn();
+const isMacPlatformMock = vi.fn(() => true);
+
+vi.mock("../lib/bridge", () => ({
+	aoBridge: {
+		window: {
+			isFullScreen: () => isFullScreenMock(),
+			onFullScreen: (listener: (value: boolean) => void) => onFullScreenMock(listener),
+		},
+	},
+}));
+
+vi.mock("../lib/platform", () => ({
+	isMacPlatform: () => isMacPlatformMock(),
+}));
+
+import { useWindowFullScreen } from "./useWindowFullScreen";
+
+beforeEach(() => {
+	isMacPlatformMock.mockReturnValue(true);
+	isFullScreenMock.mockReset().mockResolvedValue(false);
+	onFullScreenMock.mockReset().mockReturnValue(() => undefined);
+});
+
+describe("useWindowFullScreen", () => {
+	it("no-ops off macOS", () => {
+		isMacPlatformMock.mockReturnValue(false);
+		const { result } = renderHook(() => useWindowFullScreen());
+		expect(result.current).toBe(false);
+		expect(isFullScreenMock).not.toHaveBeenCalled();
+		expect(onFullScreenMock).not.toHaveBeenCalled();
+	});
+
+	it("seeds from isFullScreen and follows push events", async () => {
+		isFullScreenMock.mockResolvedValue(true);
+		let push: ((value: boolean) => void) | undefined;
+		onFullScreenMock.mockImplementation((listener: (value: boolean) => void) => {
+			push = listener;
+			return () => undefined;
+		});
+
+		const { result } = renderHook(() => useWindowFullScreen());
+		await waitFor(() => expect(result.current).toBe(true));
+
+		act(() => push?.(false));
+		expect(result.current).toBe(false);
+	});
+
+	it("ignores a stale seed that resolves after a push event", async () => {
+		let resolveSeed!: (value: boolean) => void;
+		isFullScreenMock.mockReturnValue(
+			new Promise<boolean>((resolve) => {
+				resolveSeed = resolve;
+			}),
+		);
+		let push: ((value: boolean) => void) | undefined;
+		onFullScreenMock.mockImplementation((listener: (value: boolean) => void) => {
+			push = listener;
+			return () => undefined;
+		});
+
+		const { result } = renderHook(() => useWindowFullScreen());
+		expect(result.current).toBe(false);
+
+		act(() => push?.(true));
+		expect(result.current).toBe(true);
+
+		await act(async () => {
+			resolveSeed(false);
+			await Promise.resolve();
+		});
+		expect(result.current).toBe(true);
+	});
+});

--- a/frontend/src/renderer/hooks/useWindowFullScreen.ts
+++ b/frontend/src/renderer/hooks/useWindowFullScreen.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { aoBridge } from "../lib/bridge";
+import { isMacPlatform } from "../lib/platform";
+
+/**
+ * Whether the Electron BrowserWindow is in native fullscreen. macOS-only: used
+ * to drop the traffic-light clearance above TitlebarNav when the lights are gone.
+ * No-ops on Win/Linux (TitlebarNav / drag strip are not mounted there).
+ */
+export function useWindowFullScreen(): boolean {
+	const [fullScreen, setFullScreen] = useState(false);
+	useEffect(() => {
+		if (!isMacPlatform()) return;
+
+		let live = true;
+		// Push events bump the version so a late isFullScreen() seed cannot
+		// overwrite a newer enter/leave-full-screen notification.
+		let version = 0;
+
+		const off = aoBridge.window.onFullScreen((value) => {
+			version += 1;
+			setFullScreen(value);
+		});
+
+		const seedVersion = version;
+		void aoBridge.window.isFullScreen().then((value) => {
+			if (live && seedVersion === version) setFullScreen(value);
+		});
+
+		return () => {
+			live = false;
+			off?.();
+		};
+	}, []);
+	return fullScreen;
+}

--- a/frontend/src/renderer/lib/bridge.ts
+++ b/frontend/src/renderer/lib/bridge.ts
@@ -24,6 +24,8 @@ export const aoBridge: AoBridge =
 		},
 		window: {
 			setOverlay: async () => undefined,
+			isFullScreen: async () => false,
+			onFullScreen: () => () => undefined,
 		},
 		theme: {
 			set: async () => undefined,

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -536,11 +536,7 @@ function ShellLayout() {
 								"fixed top-0 left-0 z-chrome w-(--ao-sidebar-w,var(--size-sidebar-default)) transition-[height] duration-200 ease-out motion-reduce:transition-none",
 								isFullScreen ? "pointer-events-none h-0" : "h-traffic-light-clearance",
 							)}
-							style={
-								trafficLightDragActive
-									? ({ WebkitAppRegion: "drag" } as CSSProperties)
-									: undefined
-							}
+							style={trafficLightDragActive ? ({ WebkitAppRegion: "drag" } as CSSProperties) : undefined}
 						/>
 					) : null}
 				</SidebarProvider>

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -15,6 +15,7 @@ import { WindowTitlebar } from "../components/WindowTitlebar";
 import { agentsQueryKey, agentsQueryOptions, refreshAgents } from "../hooks/useAgentsQuery";
 import { useDaemonStatus } from "../hooks/useDaemonStatus";
 import { useOpenShellTerminal } from "../hooks/useShellTerminals";
+import { useWindowFullScreen } from "../hooks/useWindowFullScreen";
 import { useWorkspaceQuery, workspaceQueryKey, workspaceQueryOptions } from "../hooks/useWorkspaceQuery";
 import { apiClient, apiErrorCode, apiErrorMessage } from "../lib/api-client";
 import { refreshDaemonStatus } from "../lib/daemon-status";
@@ -24,6 +25,7 @@ import { restartProjectOrchestrator } from "../lib/restart-orchestrator";
 import { captureOrchestratorReplacementFailure } from "../lib/orchestrator-replacement-telemetry";
 import { applyDocumentTheme } from "../lib/theme";
 import { aoBridge } from "../lib/bridge";
+import { cn } from "../lib/utils";
 import {
 	isLinuxPlatform,
 	isMacPlatform,
@@ -90,6 +92,32 @@ function ShellLayout() {
 	const newShellTerminalNonce = useUiStore((state) => state.newShellTerminalNonce);
 	const setActiveShellTerminal = useUiStore((state) => state.setActiveShellTerminal);
 	const openShellTerminal = useOpenShellTerminal();
+	// Single subscription for sidebar clearance + drag strip (macOS no-ops inside the hook).
+	const isFullScreen = useWindowFullScreen();
+	// Drag is on immediately for a normal windowed launch. After leaving fullscreen,
+	// wait for the pad/height transition so the growing strip cannot steal clicks.
+	const [trafficLightDragActive, setTrafficLightDragActive] = useState(isMac);
+	const leftFullScreenRef = useRef(false);
+	useEffect(() => {
+		if (!isMac) return;
+		if (isFullScreen) {
+			leftFullScreenRef.current = true;
+			setTrafficLightDragActive(false);
+			return;
+		}
+		if (!leftFullScreenRef.current) {
+			setTrafficLightDragActive(true);
+			return;
+		}
+		const reducedMotion =
+			typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+		if (reducedMotion) {
+			setTrafficLightDragActive(true);
+			return;
+		}
+		const timer = window.setTimeout(() => setTrafficLightDragActive(true), 200);
+		return () => window.clearTimeout(timer);
+	}, [isFullScreen]);
 	// Seeded to the current value so a mount never opens a terminal unasked.
 	const handledShellNonceRef = useRef(newShellTerminalNonce);
 	const [isKeyboardShortcutsOpen, setIsKeyboardShortcutsOpen] = useState(false);
@@ -459,6 +487,7 @@ function ShellLayout() {
 					<Sidebar
 						hideEdgeBorder={isWelcomeBoard}
 						historyLocked={isWelcomeBoard}
+						isFullScreen={isFullScreen}
 						underTopbar={isWindows || (!framedAppTopbar && !hideShellTopbar && (isLinux ? isSessionRoute : true))}
 						topbarOffset={isWindows ? "titlebar" : "toolbar"}
 						onCreateProject={createProject}
@@ -498,12 +527,20 @@ function ShellLayout() {
               the traffic-light band only (same --size-traffic-light-clearance
               as the Sidebar header pad). TitlebarNav sits in the sidebar below
               that band, so a taller strip would cover the toggle/arrows and
-              swallow clicks. Width matches the sidebar. */}
+              swallow clicks. Height eases with the header pad on fullscreen
+              toggle. Width matches the sidebar. */}
 					{hideShellTopbar && isMac ? (
 						<div
 							aria-hidden="true"
-							className="fixed top-0 left-0 z-chrome h-traffic-light-clearance w-(--ao-sidebar-w,var(--size-sidebar-default))"
-							style={{ WebkitAppRegion: "drag" } as CSSProperties}
+							className={cn(
+								"fixed top-0 left-0 z-chrome w-(--ao-sidebar-w,var(--size-sidebar-default)) transition-[height] duration-200 ease-out motion-reduce:transition-none",
+								isFullScreen ? "pointer-events-none h-0" : "h-traffic-light-clearance",
+							)}
+							style={
+								trafficLightDragActive
+									? ({ WebkitAppRegion: "drag" } as CSSProperties)
+									: undefined
+							}
 						/>
 					) : null}
 				</SidebarProvider>

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -163,6 +163,7 @@
 	/* Layout — toolbar offset for fixed sidebar below topbar */
 	--spacing-toolbar: var(--size-toolbar);
 	--spacing-traffic-light-clearance: var(--size-traffic-light-clearance);
+	--spacing-traffic-light-clearance-fullscreen: var(--size-traffic-light-clearance-fullscreen);
 	--spacing-control-xs: var(--size-control-xs);
 	--spacing-control-sm: var(--size-control-sm);
 	--spacing-control-form: var(--size-control-form);
@@ -1010,10 +1011,11 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 }
 
 /* ── macOS titlebar cluster (TitlebarNav) ─────────────────────────────────
- * In-flow inside the Sidebar header, below the traffic lights. The toggle is
- * pinned in a --size-sidebar-icon column so its screen position never changes
- * during the width animation; history arrows are absolute to the right and
- * fade with .sidebar-expanded-chrome. */
+ * In-flow inside the Sidebar header, below the traffic lights while windowed.
+ * In native fullscreen the header drops the clearance pad so this cluster
+ * moves up. The toggle is pinned in a --size-sidebar-icon column so its screen
+ * position never changes during the width animation; history arrows are
+ * absolute to the right and fade with .sidebar-expanded-chrome. */
 .titlebar-nav {
 	position: relative;
 	display: flex;

--- a/frontend/src/renderer/test/setup.ts
+++ b/frontend/src/renderer/test/setup.ts
@@ -73,6 +73,8 @@ if (typeof window !== "undefined") {
 		},
 		window: {
 			setOverlay: async () => undefined,
+			isFullScreen: async () => false,
+			onFullScreen: () => () => undefined,
 		},
 		theme: {
 			set: async () => undefined,

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -205,8 +205,10 @@
 	--size-sidebar-default: 240px;
 	--size-sidebar-mobile: 288px;
 	/* Clears macOS traffic lights (y:20 discs) before in-sidebar TitlebarNav;
-	   keep Sidebar header padding and the shell drag strip on this same token. */
+	   keep Sidebar header padding and the shell drag strip on this same token.
+	   Fullscreen drops the lights, so TitlebarNav uses the tighter inset. */
 	--size-traffic-light-clearance: 36px;
+	--size-traffic-light-clearance-fullscreen: var(--space-2);
 	--size-resize-handle: 7px;
 	--size-resize-handle-offset: 3px;
 	--size-kanban-glow: 130px;


### PR DESCRIPTION
## Summary
- On macOS native fullscreen, drop the traffic-light clearance above TitlebarNav so the sidebar toggle / back / forward sit near the top instead of leaving an empty band.
- Keep the existing clearance (and drag strip) when the traffic lights are visible in windowed mode.
- Animate the pad/strip transition on leave-fullscreen; seed + push fullscreen state once from the shell via a small Electron IPC bridge.

## Test plan
- [ ] macOS windowed: TitlebarNav stays below the traffic lights; brand row does not overlap
- [ ] Enter fullscreen: clearance collapses; toggle/arrows move to the top; no empty gap
- [ ] Leave fullscreen: cluster eases back under the lights; drag strip becomes active after the transition
- [ ] Maximize (not fullscreen): clearance stays (lights still present)
- [ ] Click toggle / back / forward during and after the transition (no dead clicks from the drag strip)
- [ ] `npx vitest run src/renderer/hooks/useWindowFullScreen.test.tsx`
- [ ] `npm run frontend:typecheck`

## Before 
<img width="325" height="867" alt="image" src="https://github.com/user-attachments/assets/ac7e5c0b-8dcf-4c3e-8eef-bcf1af6ac1f6" />
<img width="334" height="623" alt="image" src="https://github.com/user-attachments/assets/902d1fc8-26e1-45ad-99ee-110db09fe445" />

## After
<img width="328" height="911" alt="image" src="https://github.com/user-attachments/assets/7536b3c3-bbc8-4d81-afc9-62ff6459559a" />
<img width="318" height="549" alt="image" src="https://github.com/user-attachments/assets/115d1b3c-4723-41e7-b902-2362f6091bd2" />
