### PR TITLE
fix(landing): prevent navbar content overlap

### DIFF
--- a/frontend/src/landing/components/LandingNav.tsx
+++ b/frontend/src/landing/components/LandingNav.tsx
@@ -151,7 +151,7 @@ export function LandingNav() {
 					</span>
 				</Link>
 
-				<nav className="absolute left-1/2 hidden -translate-x-1/2 items-center gap-7 md:flex" aria-label="Primary">
+				<nav className="hidden flex-1 items-center justify-center gap-5 md:flex" aria-label="Primary">
 					{navLinks.map((item) =>
 						item.href.startsWith("/") ? (
 							<Link


### PR DESCRIPTION
## Summary

- move the primary landing-page links into the navbar flex flow so they reserve horizontal space
- tighten the link spacing so the full row remains inside the floating pill at the `md` breakpoint
- preserve the existing branding, typography, controls, and mobile menu behavior

## Verification

- `npx --yes prettier@3 --check frontend/src/landing/components/LandingNav.tsx`
- `npm run build` in `frontend/src/landing`
- `npx --yes react-doctor@latest . --verbose` (completed with warnings and no errors)
- measured at 375, 768, 800, 900, 1023, 1024, and 1280px in normal and compact navbar states; no element overlap or container overflow

Fixes #3057