### PR TITLE
fix(landing): align design partners navigation

### DIFF
--- a/frontend/src/landing/app/design-partners/page.tsx
+++ b/frontend/src/landing/app/design-partners/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
-import Image from "next/image";
-import Link from "next/link";
 import { LandingFooter } from "../../components/LandingFooter";
+import { LandingNav } from "../../components/LandingNav";
 import { ScrollRevealProvider } from "../../components/ScrollRevealProvider";
 
 export const metadata: Metadata = {
@@ -287,51 +286,11 @@ function ChevronIcon({ className = "" }: IconProps) {
 	);
 }
 
-function PartnersNav() {
-	return (
-		<header className="border-b border-[color:var(--border)]">
-			<div className="container-page flex h-16 items-center justify-between">
-				<Link href="/" className="inline-flex items-center gap-3">
-					<Image
-						src="/ao-logo-transparent.png"
-						alt="Agent Orchestrator"
-						width={32}
-						height={32}
-						className="h-8 w-8 object-contain"
-					/>
-					<span className="text-[15px] font-semibold text-[color:var(--fg)]">Agent Orchestrator</span>
-				</Link>
-				<nav className="flex items-center gap-5">
-					<Link href="/" className="landing-nav-link hidden text-[13px] font-medium sm:inline-block">
-						Home
-					</Link>
-					<a
-						href="https://github.com/AgentWrapper/agent-orchestrator"
-						target="_blank"
-						rel="noreferrer"
-						className="landing-nav-link hidden text-[13px] font-medium sm:inline-block"
-					>
-						GitHub
-					</a>
-					<a
-						href={CAL_URL}
-						target="_blank"
-						rel="noreferrer"
-						className="hero-pressable btn-primary inline-flex h-9 items-center justify-center rounded-[6px] px-4 text-[13px] font-semibold"
-					>
-						Book a discovery call
-					</a>
-				</nav>
-			</div>
-		</header>
-	);
-}
-
 export default function DesignPartnersPage() {
 	return (
 		<ScrollRevealProvider>
 			<div className="landing-page relative z-10 min-h-dvh">
-				<PartnersNav />
+				<LandingNav sectionHrefPrefix="/" />
 
 				{/* Hero */}
 				<section className="relative overflow-hidden pt-[clamp(80px,10vw,140px)] pb-[clamp(64px,8vw,100px)]">

--- a/frontend/src/landing/components/LandingNav.tsx
+++ b/frontend/src/landing/components/LandingNav.tsx
@@ -84,13 +84,21 @@ const navLinks = [
 	{ label: "Docs", href: "/docs/" },
 ];
 
-export function LandingNav() {
+type LandingNavProps = {
+	sectionHrefPrefix?: string;
+};
+
+export function LandingNav({ sectionHrefPrefix = "" }: LandingNavProps = {}) {
 	const [open, setOpen] = useState(false);
 	const navRef = useRef<HTMLDivElement>(null);
 	const innerRef = useRef<HTMLDivElement>(null);
 	const { stars } = useGitHubRepoFacts();
 	const downloadTarget = useDownloadTarget();
 	const downloadHref = downloadTarget?.href ?? RELEASE_URL;
+	const resolvedNavLinks = navLinks.map((item) => ({
+		...item,
+		href: item.href.startsWith("#") ? `${sectionHrefPrefix}${item.href}` : item.href,
+	}));
 
 	useGSAP(() => {
 		// Shrink + hide-on-scroll only on desktop (>=768px). On mobile/tablet the
@@ -152,7 +160,7 @@ export function LandingNav() {
 				</Link>
 
 				<nav className="absolute left-1/2 hidden -translate-x-1/2 items-center gap-7 md:flex" aria-label="Primary">
-					{navLinks.map((item) =>
+					{resolvedNavLinks.map((item) =>
 						item.href.startsWith("/") ? (
 							<Link
 								key={item.label}
@@ -229,7 +237,7 @@ export function LandingNav() {
 					id="mobile-navigation-menu"
 					className="absolute inset-x-0 top-full mt-4 flex flex-col gap-1 rounded-2xl border border-[color:var(--border)] bg-[color:var(--bg)]/95 p-4 mx-4 backdrop-blur-xl shadow-2xl md:hidden"
 				>
-					{navLinks.map((item) =>
+					{resolvedNavLinks.map((item) =>
 						item.href.startsWith("/") ? (
 							<Link
 								key={item.label}


### PR DESCRIPTION
## What changed

- Replaced the Design Partners page's one-off header with the shared `LandingNav` component.
- Added an optional section-link prefix so `Demo` and `Features` return to the corresponding homepage sections from subpages.
- Preserved the landing page's existing same-page anchor behavior.

## Why

The Design Partners page defined a separate `PartnersNav`, so its navigation structure, styling, responsive behavior, and calls to action had drifted from the main landing page.

## Impact

The Design Partners page now uses the same desktop and mobile navigation as the homepage. Its homepage section links resolve to `/#see-it` and `/#features` instead of dead local anchors.

## Validation

- `npm run build` in `frontend/src/landing`
- Prettier check on both changed files
- Desktop and mobile browser verification on the local Design Partners page
- Browser console error check
