### PR TITLE
[feat]: Add command palette PR review actions

### DIFF
--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -8,6 +8,9 @@ import { useUiStore } from "../stores/ui-store";
 const navigateMock = vi.hoisted(() => vi.fn());
 const spawnMock = vi.hoisted(() => vi.fn());
 const choosePathMock = vi.hoisted(() => vi.fn());
+const openExternalMock = vi.hoisted(() => vi.fn());
+const clipboardWriteTextMock = vi.hoisted(() => vi.fn());
+const postMock = vi.hoisted(() => vi.fn());
 
 const ctx = vi.hoisted(() => {
 	const workspaces: WorkspaceSummary[] = [
@@ -52,6 +55,29 @@ const ctx = vi.hoisted(() => {
 					status: "terminated",
 					updatedAt: "2026-06-10T00:00:00Z",
 					prs: [],
+				},
+				{
+					id: "w-pr",
+					workspaceId: "proj-1",
+					workspaceName: "app",
+					title: "add cache",
+					provider: "codex",
+					kind: "worker",
+					branch: "feature/cache",
+					status: "pr_open",
+					updatedAt: "2026-06-10T00:00:00Z",
+					prs: [
+						{
+							url: "https://github.com/o/r/pull/42",
+							number: 42,
+							state: "open",
+							ci: "passing",
+							review: "pending",
+							mergeability: "clean",
+							reviewComments: false,
+							updatedAt: "2026-06-10T00:00:00Z",
+						},
+					],
 				},
 				{
 					id: "orch",
@@ -103,6 +129,24 @@ vi.mock("../lib/shell-context", () => ({
 
 vi.mock("../lib/spawn-orchestrator", () => ({ spawnOrchestrator: spawnMock }));
 
+vi.mock("../lib/bridge", () => ({
+	aoBridge: {
+		app: {
+			openExternal: (...args: unknown[]) => openExternalMock(...args),
+		},
+		clipboard: {
+			writeText: (...args: unknown[]) => clipboardWriteTextMock(...args),
+		},
+	},
+}));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: {
+		POST: (...args: unknown[]) => postMock(...args),
+	},
+	apiErrorMessage: (_error: unknown, fallback: string) => fallback,
+}));
+
 vi.mock("./NewTaskDialog", () => ({
 	NewTaskDialog: ({ open, projectId }: { open: boolean; projectId?: string }) =>
 		open ? <div data-testid="new-task-dialog">new task {projectId}</div> : null,
@@ -150,6 +194,9 @@ beforeEach(() => {
 	navigateMock.mockReset();
 	spawnMock.mockReset();
 	choosePathMock.mockReset();
+	openExternalMock.mockReset().mockResolvedValue(undefined);
+	clipboardWriteTextMock.mockReset().mockResolvedValue(undefined);
+	postMock.mockReset().mockResolvedValue({ data: {} });
 	act(() => {
 		useUiStore.setState({
 			isCommandPaletteOpen: false,
@@ -377,6 +424,50 @@ describe("CommandPalette actions", () => {
 		expect(await screen.findByRole("alert")).toHaveTextContent("daemon down");
 		expect(spawnMock).toHaveBeenCalledWith("proj-2", "command_palette");
 		expect(useUiStore.getState().isCommandPaletteOpen).toBe(true);
+	});
+
+	it("opens PRs externally from the palette", async () => {
+		ctx.params = {};
+		renderPalette();
+		act(() => useUiStore.getState().setCommandPaletteOpen(true));
+		const input = await screen.findByPlaceholderText(/search projects/i);
+		fireEvent.change(input, { target: { value: "open pr 42" } });
+
+		await waitFor(() => expect(screen.getByText("Open PR #42")).toBeInTheDocument());
+		fireEvent.click(screen.getByText("Open PR #42"));
+
+		expect(openExternalMock).toHaveBeenCalledWith("https://github.com/o/r/pull/42");
+		await waitFor(() => expect(paletteInput()).toBeNull());
+	});
+
+	it("copies PR URLs from the palette", async () => {
+		ctx.params = {};
+		renderPalette();
+		act(() => useUiStore.getState().setCommandPaletteOpen(true));
+		const input = await screen.findByPlaceholderText(/search projects/i);
+		fireEvent.change(input, { target: { value: "copy pr 42" } });
+
+		await waitFor(() => expect(screen.getByText("Copy PR #42 URL")).toBeInTheDocument());
+		fireEvent.click(screen.getByText("Copy PR #42 URL"));
+
+		expect(clipboardWriteTextMock).toHaveBeenCalledWith("https://github.com/o/r/pull/42");
+		await waitFor(() => expect(paletteInput()).toBeNull());
+	});
+
+	it("triggers review for the current session from the palette", async () => {
+		ctx.params = { projectId: "proj-1", sessionId: "w-pr" };
+		renderPalette();
+		act(() => useUiStore.getState().setCommandPaletteOpen(true));
+		await screen.findByPlaceholderText(/search projects/i);
+
+		fireEvent.click(screen.getByText("Trigger review"));
+
+		await waitFor(() =>
+			expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/reviews/trigger", {
+				params: { path: { sessionId: "w-pr" } },
+			}),
+		);
+		await waitFor(() => expect(paletteInput()).toBeNull());
 	});
 
 	it("toggles the theme and closes", async () => {

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObjec
 import { useCommandPaletteEnabled } from "../hooks/useCommandPaletteEnabled";
 import { useWorkspaceQuery, workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { aoBridge } from "../lib/bridge";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
 import {
 	buildCommands,
 	displayGroups,
@@ -132,6 +133,18 @@ export function CommandPalette() {
 		[workspaces, navigateToTarget, queryClient, closePalette, blockedByRestart],
 	);
 
+	const triggerReview = useCallback(
+		async (sessionId: string) => {
+			const { error } = await apiClient.POST("/api/v1/sessions/{sessionId}/reviews/trigger", {
+				params: { path: { sessionId } },
+			});
+			if (error) throw new Error(apiErrorMessage(error, "Unable to start review"));
+			await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+			closePalette();
+		},
+		[queryClient, closePalette],
+	);
+
 	const runAction = useCallback(
 		async (item: CommandItemModel) => {
 			const action = item.action;
@@ -152,6 +165,17 @@ export function CommandPalette() {
 					case "copy-branch":
 						await aoBridge.clipboard.writeText(action.branch);
 						closePalette();
+						break;
+					case "open-pr":
+						await aoBridge.app.openExternal(action.url);
+						closePalette();
+						break;
+					case "copy-pr-url":
+						await aoBridge.clipboard.writeText(action.url);
+						closePalette();
+						break;
+					case "trigger-review":
+						await triggerReview(action.sessionId);
 						break;
 					case "open-new-task":
 						if (blockedByRestart(action.projectId)) break;
@@ -174,7 +198,7 @@ export function CommandPalette() {
 				setPendingId(null);
 			}
 		},
-		[navigateToTarget, closePalette, toggleTheme, openOrchestrator, blockedByRestart],
+		[navigateToTarget, closePalette, toggleTheme, openOrchestrator, blockedByRestart, triggerReview],
 	);
 
 	const onSelectItem = useCallback(

--- a/frontend/src/renderer/lib/command-palette.test.ts
+++ b/frontend/src/renderer/lib/command-palette.test.ts
@@ -66,6 +66,8 @@ describe("buildCommands grouping", () => {
 		expect(map.get("current-project-settings")?.group).toBe("current");
 		expect(map.get("current-copy-branch")?.group).toBe("current");
 		expect(map.get("current-copy-branch")?.action).toEqual({ kind: "copy-branch", branch: "feature/w-pr" });
+		expect(map.get("current-trigger-review")?.group).toBe("current");
+		expect(map.get("current-trigger-review")?.action).toEqual({ kind: "trigger-review", sessionId: "w-pr" });
 	});
 
 	it("disables New task with a reason when the route project is absent from workspaces", () => {
@@ -133,17 +135,30 @@ describe("buildCommands sessions", () => {
 });
 
 describe("buildCommands pull requests", () => {
-	it("creates a per-PR item searchable by number, #number, url, branch and project", () => {
+	it("creates per-PR open/copy items searchable by number, url, branch and project", () => {
 		const items = buildCommands({ workspaces: workspaces() });
 		const prItem = byId(items).get("pr:w-pr:42");
+		const copyItem = byId(items).get("pr-copy:w-pr:42");
 		expect(prItem?.group).toBe("prs");
-		expect(prItem?.title).toBe("#42");
+		expect(prItem?.title).toBe("Open PR #42");
+		expect(prItem?.action).toEqual({ kind: "open-pr", url: "https://github.com/o/r/pull/42" });
+		expect(copyItem?.group).toBe("prs");
+		expect(copyItem?.title).toBe("Copy PR #42 URL");
+		expect(copyItem?.action).toEqual({ kind: "copy-pr-url", url: "https://github.com/o/r/pull/42" });
 		const keywords = prItem?.keywords ?? [];
 		expect(keywords).toContain("#42");
 		expect(keywords).toContain("42");
 		expect(keywords).toContain("https://github.com/o/r/pull/42");
 		expect(keywords).toContain("feature/w-pr");
 		expect(keywords).toContain("app");
+	});
+
+	it("creates review actions for sessions with open PRs", () => {
+		const items = buildCommands({ workspaces: workspaces() });
+		const reviewItem = byId(items).get("review:w-pr");
+		expect(reviewItem?.group).toBe("prs");
+		expect(reviewItem?.title).toBe("Trigger review");
+		expect(reviewItem?.action).toEqual({ kind: "trigger-review", sessionId: "w-pr" });
 	});
 
 	it("excludes merged and closed PRs (open/draft only)", () => {
@@ -160,6 +175,7 @@ describe("buildCommands pull requests", () => {
 		];
 		const ids = new Set(buildCommands({ workspaces: ws }).map((item) => item.id));
 		expect(ids.has("pr:w-mix:9")).toBe(true);
+		expect(ids.has("pr-copy:w-mix:9")).toBe(true);
 		expect(ids.has("pr:w-mix:7")).toBe(false);
 		expect(ids.has("pr:w-mix:8")).toBe(false);
 	});

--- a/frontend/src/renderer/lib/command-palette.ts
+++ b/frontend/src/renderer/lib/command-palette.ts
@@ -5,6 +5,7 @@ import {
 	sessionIsActive,
 	sessionNeedsAttention,
 	workerSessions,
+	type PullRequestFacts,
 	type WorkspaceSession,
 	type WorkspaceSummary,
 } from "../types/workspace";
@@ -23,6 +24,9 @@ export type CommandAction =
 	| { kind: "open-new-project" }
 	| { kind: "open-orchestrator"; projectId: string }
 	| { kind: "copy-branch"; branch: string }
+	| { kind: "open-pr"; url: string }
+	| { kind: "copy-pr-url"; url: string }
+	| { kind: "trigger-review"; sessionId: string }
 	| { kind: "toggle-theme" };
 
 export type CommandItem = {
@@ -59,6 +63,45 @@ function isSyntheticBranch(session: WorkspaceSession): boolean {
 	return session.branch === `session/${session.id}`;
 }
 
+function copyableBranch(session: WorkspaceSession): string | undefined {
+	if (session.kind === "orchestrator") return undefined;
+	if (!session.branch || isSyntheticBranch(session)) return undefined;
+	return session.branch;
+}
+
+function compactKeywords(...values: Array<string | undefined | null>): string[] {
+	return values.filter((value): value is string => Boolean(value));
+}
+
+function prKeywords(
+	workspace: WorkspaceSummary,
+	session: WorkspaceSession,
+	pr: PullRequestFacts,
+	...extra: string[]
+): string[] {
+	return compactKeywords(
+		`#${pr.number}`,
+		String(pr.number),
+		pr.url,
+		session.title,
+		session.branch,
+		workspace.name,
+		pr.state,
+		...extra,
+	);
+}
+
+function reviewCommandTitle(session: WorkspaceSession): string {
+	if (
+		session.status === "changes_requested" ||
+		session.status === "approved" ||
+		openPRs(session).some((pr) => pr.review !== "none" && pr.review !== "pending")
+	) {
+		return "Re-run review";
+	}
+	return "Trigger review";
+}
+
 type SessionCommandGroup = Extract<CommandGroupId, "attention" | "sessions">;
 
 const SESSION_ID_PREFIX: Record<SessionCommandGroup, string> = { attention: "attention", sessions: "session" };
@@ -73,7 +116,7 @@ function sessionCommand(
 		group,
 		title: session.title,
 		subtitle: workspace.name,
-		keywords: [workspace.name, session.branch, session.issueId ?? ""],
+		keywords: compactKeywords(workspace.name, session.branch, session.issueId),
 		action: {
 			kind: "navigate",
 			target: {
@@ -141,14 +184,26 @@ export function buildCommands(ctx: CommandPaletteContext): CommandItem[] {
 		});
 	}
 
-	if (currentSession && currentSession.kind !== "orchestrator" && !isSyntheticBranch(currentSession)) {
+	const currentBranch = currentSession ? copyableBranch(currentSession) : undefined;
+	if (currentSession && currentBranch) {
 		items.push({
 			id: "current-copy-branch",
 			group: "current",
 			title: "Copy branch name",
-			subtitle: currentSession.branch,
-			keywords: ["branch", "git", currentSession.branch, currentSession.title],
-			action: { kind: "copy-branch", branch: currentSession.branch },
+			subtitle: currentBranch,
+			keywords: compactKeywords("branch", "git", "copy", currentBranch, currentSession.title),
+			action: { kind: "copy-branch", branch: currentBranch },
+		});
+	}
+
+	if (currentSession && currentSession.kind !== "orchestrator" && openPRs(currentSession).length > 0) {
+		items.push({
+			id: "current-trigger-review",
+			group: "current",
+			title: reviewCommandTitle(currentSession),
+			subtitle: currentSession.title,
+			keywords: compactKeywords("review", "trigger", "run", "rerun", currentSession.title, currentSession.branch),
+			action: { kind: "trigger-review", sessionId: currentSession.id },
 		});
 	}
 
@@ -174,7 +229,7 @@ export function buildCommands(ctx: CommandPaletteContext): CommandItem[] {
 			id: `project:${workspace.id}`,
 			group: "projects",
 			title: workspace.name,
-			keywords: [workspace.path],
+			keywords: compactKeywords(workspace.path),
 			action: { kind: "navigate", target: { to: "/projects/$projectId", params: { projectId: workspace.id } } },
 		});
 	}
@@ -189,28 +244,33 @@ export function buildCommands(ctx: CommandPaletteContext): CommandItem[] {
 
 	for (const workspace of workspaces) {
 		for (const session of workerSessions(workspace.sessions)) {
-			for (const pr of openPRs(session)) {
+			const prs = openPRs(session);
+			if (prs.length > 0 && session.id !== currentSessionId) {
+				items.push({
+					id: `review:${session.id}`,
+					group: "prs",
+					title: reviewCommandTitle(session),
+					subtitle: `${session.title} - ${workspace.name}`,
+					keywords: compactKeywords("review", "trigger", "run", "rerun", session.title, session.branch, workspace.name),
+					action: { kind: "trigger-review", sessionId: session.id },
+				});
+			}
+			for (const pr of prs) {
 				items.push({
 					id: `pr:${session.id}:${pr.number}`,
 					group: "prs",
-					title: `#${pr.number}`,
+					title: `Open PR #${pr.number}`,
 					subtitle: `${session.title} · ${workspace.name}`,
-					keywords: [
-						`#${pr.number}`,
-						String(pr.number),
-						pr.url,
-						session.title,
-						session.branch,
-						workspace.name,
-						pr.state,
-					],
-					action: {
-						kind: "navigate",
-						target: {
-							to: "/projects/$projectId/sessions/$sessionId",
-							params: { projectId: workspace.id, sessionId: session.id },
-						},
-					},
+					keywords: prKeywords(workspace, session, pr, "open", "pull request"),
+					action: { kind: "open-pr", url: pr.url },
+				});
+				items.push({
+					id: `pr-copy:${session.id}:${pr.number}`,
+					group: "prs",
+					title: `Copy PR #${pr.number} URL`,
+					subtitle: `${session.title} - ${workspace.name}`,
+					keywords: prKeywords(workspace, session, pr, "copy", "url", "pull request"),
+					action: { kind: "copy-pr-url", url: pr.url },
 				});
 			}
 		}


### PR DESCRIPTION
## Summary

- add command palette actions to open PRs externally and copy PR URLs
- add current/session PR review commands for trigger and re-run review flows
- cover command generation and action execution with focused tests

## Screenshots

Attach these local screenshots:

- `C:/Agent Os/ao-command-palette-pr-actions.png`
- `C:/Agent Os/ao-command-palette-review-actions.png`

## Validation

- `npm.cmd run test -- src/renderer/lib/command-palette.test.ts src/renderer/components/CommandPalette.test.tsx`
- `npm.cmd run typecheck`