### PR TITLE
fix(continue): forward role-specific model config to launch and restore

### DIFF
--- a/backend/internal/adapters/agent/continueagent/continueagent.go
+++ b/backend/internal/adapters/agent/continueagent/continueagent.go
@@ -78,6 +78,22 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Continue understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `cn --model`.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the Continue CLI argv for a fresh launch.
 //
 // AO sessions are long-lived terminal sessions, so prompted and promptless
@@ -92,6 +108,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 
 	cmd = []string{binary}
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 	appendSystemPromptRule(&cmd, cfg.SystemPrompt, cfg.SystemPromptFile)
 
 	if cfg.Prompt != "" {
@@ -149,9 +166,10 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 		return nil, false, err
 	}
 
-	cmd = make([]string, 0, 5)
+	cmd = make([]string, 0, 7)
 	cmd = append(cmd, binary)
 	appendApprovalFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 	appendSystemPromptRule(&cmd, cfg.SystemPrompt, cfg.SystemPromptFile)
 	cmd = append(cmd, "--fork", agentSessionID)
 	return cmd, true, nil
@@ -216,5 +234,11 @@ func appendSystemPromptRule(cmd *[]string, inline, file string) {
 	}
 	if file != "" {
 		*cmd = append(*cmd, "--rule", file)
+	}
+}
+
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
 	}
 }

--- a/backend/internal/adapters/agent/continueagent/continueagent_test.go
+++ b/backend/internal/adapters/agent/continueagent/continueagent_test.go
@@ -36,13 +36,155 @@ func TestDoesNotImplementAuthChecker(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecEmpty(t *testing.T) {
+func TestGetConfigSpec(t *testing.T) {
 	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	if len(spec.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(spec.Fields))
+	}
+	f := spec.Fields[0]
+	if f.Key != "model" {
+		t.Errorf("expected field Key='model', got %q", f.Key)
+	}
+	if f.Type != ports.ConfigFieldString {
+		t.Errorf("expected field Type=ConfigFieldString, got %v", f.Type)
+	}
+}
+
+func TestGetLaunchCommandWithModel(t *testing.T) {
+	tests := []struct {
+		name      string
+		model     string
+		wantModel []string
+	}{
+		{
+			name:      "model present",
+			model:     "gpt-4o",
+			wantModel: []string{"--model", "gpt-4o"},
+		},
+		{
+			name:      "whitespace trimmed",
+			model:     "   claude-3-5-sonnet   ",
+			wantModel: []string{"--model", "claude-3-5-sonnet"},
+		},
+		{
+			name:      "empty model ignored",
+			model:     "",
+			wantModel: nil,
+		},
+		{
+			name:      "whitespace only ignored",
+			model:     "   ",
+			wantModel: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{resolvedBinary: "cn"}
+			cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+				Config: ports.AgentConfig{
+					Model: tt.model,
+				},
+				Prompt: "hello",
+			})
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			// Verify model arguments are either present or absent in the expected location
+			if len(tt.wantModel) > 0 {
+				found := false
+				for i := 0; i < len(cmd)-1; i++ {
+					if cmd[i] == tt.wantModel[0] && cmd[i+1] == tt.wantModel[1] {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected command %v to contain %v", cmd, tt.wantModel)
+				}
+			} else {
+				for _, arg := range cmd {
+					if arg == "--model" {
+						t.Errorf("expected command %v NOT to contain --model", cmd)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetRestoreCommandWithModel(t *testing.T) {
+	tests := []struct {
+		name      string
+		model     string
+		wantModel []string
+	}{
+		{
+			name:      "model present",
+			model:     "gpt-4o",
+			wantModel: []string{"--model", "gpt-4o"},
+		},
+		{
+			name:      "whitespace trimmed",
+			model:     "   claude-3-5-sonnet   ",
+			wantModel: []string{"--model", "claude-3-5-sonnet"},
+		},
+		{
+			name:      "empty model ignored",
+			model:     "",
+			wantModel: nil,
+		},
+		{
+			name:      "whitespace only ignored",
+			model:     "   ",
+			wantModel: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{resolvedBinary: "cn"}
+			cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+				Config: ports.AgentConfig{
+					Model: tt.model,
+				},
+				Session: ports.SessionRef{
+					Metadata: map[string]string{
+						ports.MetadataKeyAgentSessionID: "sess-123",
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if !ok {
+				t.Fatal("expected ok=true")
+			}
+
+			// Verify model arguments are either present or absent in the expected location
+			if len(tt.wantModel) > 0 {
+				found := false
+				for i := 0; i < len(cmd)-1; i++ {
+					if cmd[i] == tt.wantModel[0] && cmd[i+1] == tt.wantModel[1] {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected command %v to contain %v", cmd, tt.wantModel)
+				}
+			} else {
+				for _, arg := range cmd {
+					if arg == "--model" {
+						t.Errorf("expected command %v NOT to contain --model", cmd)
+					}
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

Update the Continue adapter to honor role-specific model configuration during both launch and restore.

This adds support for advertising the `model` configuration field, forwards the configured model to the Continue CLI, and adds unit tests covering the new behavior.

## Why

Fixes #2899

The Session Manager already resolves the effective `AgentConfig` (including role overrides) and passes it to adapters through `LaunchConfig.Config`, but the Continue adapter never translated `Config.Model` into Continue CLI arguments. As a result, role-specific model overrides were ignored for Continue sessions.

## How

- Implement `GetConfigSpec()` to advertise support for the `model` configuration field.
- Add `appendModelFlag()` to translate `AgentConfig.Model` into Continue CLI arguments, trimming whitespace and ignoring empty values.
- Apply model forwarding consistently in both `GetLaunchCommand()` and `GetRestoreCommand()`.
- Add focused unit tests covering:
  - launch-time model forwarding
  - restore-time model forwarding
  - whitespace trimming
  - empty/whitespace-only model values

The change is intentionally isolated to the Continue adapter. No changes were required to the Session Manager, domain model, or ports, as the configuration pipeline was already correctly propagating the resolved model.

## Testing

```bash
go test -v ./internal/adapters/agent/continueagent/...
```

Validated:

- Model is forwarded during launch.
- Model is forwarded during restore.
- Whitespace is trimmed before forwarding.
- Empty and whitespace-only model values are ignored.
- Existing Continue adapter tests continue to pass.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)