### PR TITLE
fix(opencode): honor configured model on launch and restore

### DIFF
--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -88,6 +88,22 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys opencode understands.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override passed to `opencode --model`, in provider/model form.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start a new interactive opencode session.
 // Shape:
 //
@@ -111,6 +127,7 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	cmd = envPrefix
 	cmd = append(cmd, binary)
 	appendPermissionFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 	if agentName != "" {
 		cmd = append(cmd, "--agent", agentName)
 	}
@@ -147,6 +164,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	cmd = envPrefix
 	cmd = append(cmd, binary)
 	appendPermissionFlags(&cmd, cfg.Permissions)
+	appendModelFlag(&cmd, cfg.Config)
 	if agentName != "" {
 		cmd = append(cmd, "--agent", agentName)
 	}
@@ -355,6 +373,12 @@ func opencodeDBCount(ctx context.Context, db *sql.DB, query string) (int, error)
 func appendPermissionFlags(cmd *[]string, permissions ports.PermissionMode) {
 	if ports.NormalizePermissionMode(permissions) == ports.PermissionModeBypassPermissions {
 		*cmd = append(*cmd, "--dangerously-skip-permissions")
+	}
+}
+
+func appendModelFlag(cmd *[]string, cfg ports.AgentConfig) {
+	if model := strings.TrimSpace(cfg.Model); model != "" {
+		*cmd = append(*cmd, "--model", model)
 	}
 }
 

--- a/backend/internal/adapters/agent/opencode/opencode_test.go
+++ b/backend/internal/adapters/agent/opencode/opencode_test.go
@@ -459,15 +459,76 @@ func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	plugin := &Plugin{}
 
 	spec, err := plugin.GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("unexpected config fields: %#v", spec.Fields)
+	want := []ports.ConfigField{
+		{
+			Key:         "model",
+			Type:        ports.ConfigFieldString,
+			Description: "Model override passed to `opencode --model`, in provider/model form.",
+		},
+	}
+	if !reflect.DeepEqual(spec.Fields, want) {
+		t.Fatalf("config fields\nwant: %#v\n got: %#v", want, spec.Fields)
+	}
+}
+
+func TestGetLaunchCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "opencode"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: "  anthropic/claude-4.5-sonnet  "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"opencode", "--model", "anthropic/claude-4.5-sonnet"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("launch cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandOmitsBlankConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "opencode"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Config: ports.AgentConfig{Model: " \t "},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(cmd, "--model") {
+		t.Fatalf("command %#v contains --model for a blank model", cmd)
+	}
+}
+
+func TestGetRestoreCommandAppendsConfiguredModel(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "opencode"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Config: ports.AgentConfig{Model: "anthropic/claude-4.5-sonnet"},
+		Session: ports.SessionRef{
+			Metadata: map[string]string{opencodeAgentSessionIDMetadataKey: "ses_abc123"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	want := []string{
+		"opencode",
+		"--model", "anthropic/claude-4.5-sonnet",
+		"--session", "ses_abc123",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
 	}
 }
 

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -164,7 +164,7 @@ describe("ProjectSettingsForm", () => {
 		expect(await screen.findByText("git@github.com:acme/project-one.git")).toBeInTheDocument();
 		expect(screen.getByLabelText("Default branch")).toHaveValue("develop");
 		expect(screen.getByLabelText("Session prefix")).toHaveValue("po");
-		expect(screen.getByLabelText("Model override")).toHaveValue("claude-opus-4-5");
+		expect(screen.queryByLabelText("Model override")).not.toBeInTheDocument();
 
 		const workerAgent = screen.getByRole("combobox", { name: "Default worker agent" });
 		const orchestratorAgent = screen.getByRole("combobox", { name: "Default orchestrator agent" });
@@ -179,8 +179,6 @@ describe("ProjectSettingsForm", () => {
 		await userEvent.type(screen.getByLabelText("Default branch"), "release");
 		await userEvent.clear(screen.getByLabelText("Session prefix"));
 		await userEvent.type(screen.getByLabelText("Session prefix"), "rel");
-		await userEvent.clear(screen.getByLabelText("Model override"));
-		await userEvent.type(screen.getByLabelText("Model override"), "gpt-5-codex");
 		await chooseOption(workerAgent, "OpenCode");
 		await chooseOption(orchestratorAgent, "Goose");
 		await chooseOption(permissionMode, "Bypass permissions");
@@ -204,7 +202,7 @@ describe("ProjectSettingsForm", () => {
 					},
 					orchestrator: { agent: "goose" },
 					agentConfig: {
-						model: "gpt-5-codex",
+						model: "claude-opus-4-5",
 						permissions: "bypass-permissions",
 					},
 					reviewers: [{ harness: "claude-code" }],

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -84,7 +84,6 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 		sessionPrefix: config.sessionPrefix ?? "",
 		workerAgent: config.worker?.agent ?? "",
 		orchestratorAgent: config.orchestrator?.agent ?? "",
-		model: config.agentConfig?.model ?? "",
 		permissions: config.agentConfig?.permissions ?? "",
 		reviewerHarness: config.reviewers?.[0]?.harness ?? "",
 		intakeEnabled: intake.enabled ?? false,
@@ -134,7 +133,6 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 						orchestrator: { ...config.orchestrator, agent: form.orchestratorAgent },
 						agentConfig: blankToUndefined({
 							...config.agentConfig,
-							model: form.model || undefined,
 							permissions: form.permissions || undefined,
 						}),
 					}
@@ -146,7 +144,6 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 						orchestrator: { ...config.orchestrator, agent: form.orchestratorAgent },
 						agentConfig: blankToUndefined({
 							...config.agentConfig,
-							model: form.model || undefined,
 							permissions: form.permissions || undefined,
 						}),
 						reviewers: form.reviewerHarness ? [{ harness: form.reviewerHarness }] : undefined,
@@ -331,15 +328,6 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 					{missingRequiredAgent && (
 						<p className="text-xs leading-row text-error">Worker and orchestrator agents are required.</p>
 					)}
-					<Field label="Model override" htmlFor="model">
-						<input
-							id="model"
-							className="h-control-form w-full rounded-md border border-input bg-transparent px-2.5 text-control text-foreground placeholder:text-passive focus-visible:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-weak"
-							value={form.model}
-							onChange={(e) => setForm((f) => ({ ...f, model: e.target.value }))}
-							placeholder="(agent default)"
-						/>
-					</Field>
 					<Field label="Permission mode" htmlFor="permissionMode">
 						<PermissionModeSelect
 							id="permissionMode"


### PR DESCRIPTION
## Summary

- forward the resolved project model to `opencode --model` for new and restored sessions
- advertise OpenCode's `model` configuration field, matching Codex and Claude Code
- keep model configuration CLI-only by removing the Project Settings input while preserving models configured through `ao project set-config --model`

Closes #2891

## Testing

- `go test ./internal/adapters/agent/opencode -run 'TestGetConfigSpecReportsModelField|TestGetLaunchCommand(AppendsConfiguredModel|OmitsBlankConfiguredModel)|TestGetRestoreCommandAppendsConfiguredModel' -count=1`
- `npm test -- src/renderer/components/ProjectSettingsForm.test.tsx` (12 tests passed)
- `npm run typecheck`