### PR TITLE
`fix(vibe): route keychain auth probe through aoprocess and guard on OS`

### DIFF
--- a/backend/internal/adapters/agent/authprobe/authprobe.go
+++ b/backend/internal/adapters/agent/authprobe/authprobe.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // DefaultCommands are cheap local auth/status probes common across agent CLIs.

--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -32,8 +32,8 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 const (

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -20,8 +20,8 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // Plugin is the Codex agent adapter. It is safe for concurrent use; the binary

--- a/backend/internal/adapters/agent/copilot/auth.go
+++ b/backend/internal/adapters/agent/copilot/auth.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)

--- a/backend/internal/adapters/agent/kilocode/auth.go
+++ b/backend/internal/adapters/agent/kilocode/auth.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 
 	_ "modernc.org/sqlite" // register sqlite driver for KiloCode auth database probes
 )

--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -35,8 +35,8 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 
 	_ "modernc.org/sqlite" // register sqlite driver for opencode session metadata probes
 )

--- a/backend/internal/adapters/agent/vibe/auth.go
+++ b/backend/internal/adapters/agent/vibe/auth.go
@@ -3,13 +3,14 @@ package vibe
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
@@ -121,6 +122,9 @@ func vibeEnvFileAuthStatus(path, envVar string) (ports.AgentAuthStatus, bool, er
 }
 
 func vibeKeychainAuthStatus(ctx context.Context, envVar string) (ports.AgentAuthStatus, bool, error) {
+	if runtime.GOOS != "darwin" {
+		return ports.AgentAuthStatusUnknown, false, nil
+	}
 	if strings.TrimSpace(envVar) == "" {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}
@@ -128,7 +132,7 @@ func vibeKeychainAuthStatus(ctx context.Context, envVar string) (ports.AgentAuth
 	defer cancel()
 
 	//nolint:gosec // invokes macOS security with fixed command and validated account/service arguments
-	out, err := exec.CommandContext(probeCtx, "security", "find-generic-password", "-s", vibeKeychainService, "-a", envVar, "-w").CombinedOutput()
+	out, err := aoprocess.CommandContext(probeCtx, "security", "find-generic-password", "-s", vibeKeychainService, "-a", envVar, "-w").CombinedOutput()
 	if probeCtx.Err() != nil {
 		return ports.AgentAuthStatusUnknown, false, nil
 	}

--- a/backend/internal/adapters/agent/vibe/auth.go
+++ b/backend/internal/adapters/agent/vibe/auth.go
@@ -131,7 +131,6 @@ func vibeKeychainAuthStatus(ctx context.Context, envVar string) (ports.AgentAuth
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	//nolint:gosec // invokes macOS security with fixed command and validated account/service arguments
 	out, err := aoprocess.CommandContext(probeCtx, "security", "find-generic-password", "-s", vibeKeychainService, "-a", envVar, "-w").CombinedOutput()
 	if probeCtx.Err() != nil {
 		return ports.AgentAuthStatusUnknown, false, nil

--- a/backend/internal/adapters/agent/vibe/vibe_test.go
+++ b/backend/internal/adapters/agent/vibe/vibe_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -126,6 +127,25 @@ func TestVibeSessionLogAuthStatusAuthorizedWithAssistantMessage(t *testing.T) {
 	}
 	if !ok || status != ports.AgentAuthStatusAuthorized {
 		t.Fatalf("status = (%q, %v), want (%q, true)", status, ok, ports.AgentAuthStatusAuthorized)
+	}
+}
+
+func TestVibeKeychainAuthStatus(t *testing.T) {
+	status, ok, err := vibeKeychainAuthStatus(context.Background(), "test-env-var")
+	if runtime.GOOS != "darwin" {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ok {
+			t.Fatalf("expected ok = false on non-darwin, got true")
+		}
+		if status != ports.AgentAuthStatusUnknown {
+			t.Fatalf("expected status %q, got %q", ports.AgentAuthStatusUnknown, status)
+		}
+	} else {
+		if err != nil {
+			t.Fatalf("unexpected error on darwin: %v", err)
+		}
 	}
 }
 

--- a/backend/internal/adapters/agent/vibe/vibe_test.go
+++ b/backend/internal/adapters/agent/vibe/vibe_test.go
@@ -3,6 +3,7 @@ package vibe
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -131,21 +132,59 @@ func TestVibeSessionLogAuthStatusAuthorizedWithAssistantMessage(t *testing.T) {
 }
 
 func TestVibeKeychainAuthStatus(t *testing.T) {
-	status, ok, err := vibeKeychainAuthStatus(context.Background(), "test-env-var")
-	if runtime.GOOS != "darwin" {
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if ok {
-			t.Fatalf("expected ok = false on non-darwin, got true")
-		}
-		if status != ports.AgentAuthStatusUnknown {
-			t.Fatalf("expected status %q, got %q", ports.AgentAuthStatusUnknown, status)
-		}
+	if runtime.GOOS == "darwin" {
+		t.Skip("This test only runs on non-Darwin platforms")
+	}
+
+	// 1. Create a temp directory for the fake security binary
+	tmpDir := t.TempDir()
+
+	// 2. Write a fake `security` script/binary that creates a sentinel file
+	//    when invoked — proving it was called
+	sentinelFile := filepath.Join(tmpDir, "security_was_called")
+
+	var fakeSecurityScript string
+	var scriptContent string
+	if runtime.GOOS == "windows" {
+		fakeSecurityScript = filepath.Join(tmpDir, "security.bat")
+		scriptContent = fmt.Sprintf("echo called > %s\r\n", sentinelFile)
 	} else {
-		if err != nil {
-			t.Fatalf("unexpected error on darwin: %v", err)
-		}
+		fakeSecurityScript = filepath.Join(tmpDir, "security")
+		scriptContent = fmt.Sprintf("#!/bin/sh\ntouch %s\n", sentinelFile)
+	}
+
+	err := os.WriteFile(fakeSecurityScript, []byte(scriptContent), 0o755)
+	if err != nil {
+		t.Fatalf("failed to write fake security executable: %v", err)
+	}
+
+	// 3. Prepend our fake binary dir to PATH
+	originalPath := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", originalPath) })
+	os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+originalPath)
+
+	// 4. Call the function
+	status, ok, err := vibeKeychainAuthStatus(
+		context.Background(),
+		"test-env-var",
+	)
+
+	// 5. Assert return values
+	if status != ports.AgentAuthStatusUnknown {
+		t.Errorf("status = %q, want %q", status, ports.AgentAuthStatusUnknown)
+	}
+	if ok {
+		t.Errorf("ok = true, want false")
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+
+	// 6. CRITICAL: Assert sentinel was NOT created
+	//    This proves security was never invoked
+	_, statErr := os.Stat(sentinelFile)
+	if !os.IsNotExist(statErr) {
+		t.Errorf("security binary was invoked but should have been skipped on non-Darwin")
 	}
 }
 


### PR DESCRIPTION
# PR Description

## Summary
This PR addresses feedback from the previous background probe fixes by updating the last remaining raw `exec.CommandContext` call site in the codebase: the Vibe agent keychain check in `vibeKeychainAuthStatus`.

## Changes
1. **OS Guard (`runtime.GOOS != "darwin"`)**: Added an early exit check in `vibeKeychainAuthStatus` to prevent attempting to locate and spawn the macOS-only `security` binary on non-macOS systems (Windows and Linux).
2. **Process Consistency**: Swapped raw `exec.CommandContext` with `aoprocess.CommandContext` to prevent console window flashing and align with the rest of the project's background probe pattern.

## Why
- The macOS `security` command does not exist on Linux and Windows. Running it unconditionally wastes CPU cycles resolving the non-existent binary path and handling process failures.
- Routing all background auth probes through `aoprocess` guarantees that there is no console window flash on Windows platforms, keeping behavior consistent across the workspace.

---
## OUTPUT VERIFICATION:
<img width="1032" height="177" alt="image" src="https://github.com/user-attachments/assets/a59ef0bb-415c-4b14-aa65-e2d612923921" />



