### PR TITLE
feat(terminals): scope shell tabs to the session and allow renaming them

### DIFF
--- a/backend/internal/adapters/agent/authprobe/authprobe.go
+++ b/backend/internal/adapters/agent/authprobe/authprobe.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // DefaultCommands are cheap local auth/status probes common across agent CLIs.

--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -32,8 +32,8 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 const (

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -20,8 +20,8 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 // Plugin is the Codex agent adapter. It is safe for concurrent use; the binary

--- a/backend/internal/adapters/agent/copilot/auth.go
+++ b/backend/internal/adapters/agent/copilot/auth.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/authprobe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 )
 
 var _ ports.AgentAuthChecker = (*Plugin)(nil)

--- a/backend/internal/adapters/agent/kilocode/auth.go
+++ b/backend/internal/adapters/agent/kilocode/auth.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 
 	_ "modernc.org/sqlite" // register sqlite driver for KiloCode auth database probes
 )

--- a/backend/internal/adapters/agent/opencode/opencode.go
+++ b/backend/internal/adapters/agent/opencode/opencode.go
@@ -35,8 +35,8 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agentbase"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/binaryutil"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/hookutil"
-	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	aoprocess "github.com/aoagents/agent-orchestrator/backend/internal/process"
 
 	_ "modernc.org/sqlite" // register sqlite driver for opencode session metadata probes
 )

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2830,6 +2830,10 @@ components:
           description: Project whose root the shell starts in. Omitted opens the shell
             in the daemon data dir.
           type: string
+        sessionId:
+          description: Agent session the shell is scoped to, so it appears only in
+            that session's tab strip. Omitted makes it a standalone shell.
+          type: string
       type: object
     OrchestratorResponse:
       properties:
@@ -3627,6 +3631,8 @@ components:
         handleId:
           type: string
         projectId:
+          type: string
+        sessionId:
           type: string
         title:
           type: string

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -2158,6 +2158,56 @@ paths:
       summary: Close a standalone shell terminal and destroy its PTY
       tags:
       - shellTerminals
+    patch:
+      operationId: renameShellTerminal
+      parameters:
+      - description: Shell terminal runtime handle identifier.
+        in: path
+        name: handleId
+        required: true
+        schema:
+          description: Shell terminal runtime handle identifier.
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateShellTerminalRequest'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ShellTerminalEnvelope'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Bad Request
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Internal Server Error
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+          description: Not Implemented
+      summary: Rename a standalone shell terminal tab
+      tags:
+      - shellTerminals
 components:
   schemas:
     APIError:
@@ -3759,6 +3809,14 @@ components:
       required:
       - displayName
       - config
+      type: object
+    UpdateShellTerminalRequest:
+      properties:
+        title:
+          description: New tab title for the shell terminal. Trimmed; must be non-empty.
+          type: string
+      required:
+      - title
       type: object
     WorkspaceFileResponse:
       properties:

--- a/backend/internal/httpd/apispec/specgen/build.go
+++ b/backend/internal/httpd/apispec/specgen/build.go
@@ -203,6 +203,7 @@ var schemaNames = map[string]string{
 	// httpd/controllers — standalone shell terminal wire envelopes
 	"ControllersShellTerminalHandleIDParam": "ShellTerminalHandleIDParam",
 	"ControllersOpenShellTerminalRequest":   "OpenShellTerminalRequest",
+	"ControllersUpdateShellTerminalRequest": "UpdateShellTerminalRequest",
 	"ControllersShellTerminalResponse":      "ShellTerminalResponse",
 	"ControllersListShellTerminalsResponse": "ListShellTerminalsResponse",
 	"ControllersShellTerminalEnvelope":      "ShellTerminalEnvelope",
@@ -357,6 +358,19 @@ func shellTerminalOperations() []operation {
 			reqBody: controllers.OpenShellTerminalRequest{},
 			resps: []respUnit{
 				{http.StatusCreated, controllers.ShellTerminalEnvelope{}},
+				{http.StatusBadRequest, envelope.APIError{}},
+				{http.StatusNotFound, envelope.APIError{}},
+				{http.StatusInternalServerError, envelope.APIError{}},
+				{http.StatusNotImplemented, envelope.APIError{}},
+			},
+		},
+		{
+			method: http.MethodPatch, path: "/api/v1/shell-terminals/{handleId}", id: "renameShellTerminal", tag: "shellTerminals",
+			summary:    "Rename a standalone shell terminal tab",
+			pathParams: []any{controllers.ShellTerminalHandleIDParam{}},
+			reqBody:    controllers.UpdateShellTerminalRequest{},
+			resps: []respUnit{
+				{http.StatusOK, controllers.ShellTerminalEnvelope{}},
 				{http.StatusBadRequest, envelope.APIError{}},
 				{http.StatusNotFound, envelope.APIError{}},
 				{http.StatusInternalServerError, envelope.APIError{}},

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -650,6 +650,11 @@ type OpenShellTerminalRequest struct {
 	ProjectID string `json:"projectId,omitempty" description:"Project whose root the shell starts in. Omitted opens the shell in the daemon data dir."`
 }
 
+// UpdateShellTerminalRequest is the body of PATCH /api/v1/shell-terminals/{handleId}.
+type UpdateShellTerminalRequest struct {
+	Title string `json:"title" description:"New tab title for the shell terminal. Trimmed; must be non-empty."`
+}
+
 // ShellTerminalResponse is one standalone shell terminal. HandleID is what the
 // client opens on the terminal mux, exactly as it would a session's pane.
 type ShellTerminalResponse struct {

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -648,6 +648,7 @@ type ShellTerminalHandleIDParam struct {
 // OpenShellTerminalRequest is the body of POST /api/v1/shell-terminals.
 type OpenShellTerminalRequest struct {
 	ProjectID string `json:"projectId,omitempty" description:"Project whose root the shell starts in. Omitted opens the shell in the daemon data dir."`
+	SessionID string `json:"sessionId,omitempty" description:"Agent session the shell is scoped to, so it appears only in that session's tab strip. Omitted makes it a standalone shell."`
 }
 
 // UpdateShellTerminalRequest is the body of PATCH /api/v1/shell-terminals/{handleId}.
@@ -660,6 +661,7 @@ type UpdateShellTerminalRequest struct {
 type ShellTerminalResponse struct {
 	HandleID   string    `json:"handleId"`
 	ProjectID  string    `json:"projectId,omitempty"`
+	SessionID  string    `json:"sessionId,omitempty"`
 	WorkingDir string    `json:"workingDir"`
 	Title      string    `json:"title"`
 	CreatedAt  time.Time `json:"createdAt"`

--- a/backend/internal/httpd/controllers/shell_terminals.go
+++ b/backend/internal/httpd/controllers/shell_terminals.go
@@ -20,6 +20,7 @@ import (
 type ShellTerminalService interface {
 	OpenShellTerminal(ctx context.Context, in shelltermsvc.OpenShellTerminalInput) (shelltermsvc.ShellTerminal, error)
 	ListShellTerminalsForCurrentAppRun(ctx context.Context) ([]shelltermsvc.ShellTerminal, error)
+	RenameShellTerminal(ctx context.Context, handleID, title string) (shelltermsvc.ShellTerminal, error)
 	CloseShellTerminal(ctx context.Context, handleID string) error
 }
 
@@ -33,6 +34,7 @@ type ShellTerminalsController struct {
 func (c *ShellTerminalsController) Register(r chi.Router) {
 	r.Get("/shell-terminals", c.list)
 	r.Post("/shell-terminals", c.open)
+	r.Patch("/shell-terminals/{handleId}", c.rename)
 	r.Delete("/shell-terminals/{handleId}", c.close)
 }
 
@@ -71,6 +73,26 @@ func (c *ShellTerminalsController) open(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	envelope.WriteJSON(w, http.StatusCreated, ShellTerminalEnvelope{
+		ShellTerminal: shellTerminalResponse(terminal),
+	})
+}
+
+func (c *ShellTerminalsController) rename(w http.ResponseWriter, r *http.Request) {
+	if c.Svc == nil {
+		apispec.NotImplemented(w, r, "PATCH", "/api/v1/shell-terminals/{handleId}")
+		return
+	}
+	var req UpdateShellTerminalRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+		return
+	}
+	terminal, err := c.Svc.RenameShellTerminal(r.Context(), chi.URLParam(r, "handleId"), req.Title)
+	if err != nil {
+		envelope.WriteError(w, r, err)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, ShellTerminalEnvelope{
 		ShellTerminal: shellTerminalResponse(terminal),
 	})
 }

--- a/backend/internal/httpd/controllers/shell_terminals.go
+++ b/backend/internal/httpd/controllers/shell_terminals.go
@@ -67,6 +67,7 @@ func (c *ShellTerminalsController) open(w http.ResponseWriter, r *http.Request) 
 	}
 	terminal, err := c.Svc.OpenShellTerminal(r.Context(), shelltermsvc.OpenShellTerminalInput{
 		ProjectID: domain.ProjectID(req.ProjectID),
+		SessionID: domain.SessionID(req.SessionID),
 	})
 	if err != nil {
 		envelope.WriteError(w, r, err)
@@ -121,6 +122,7 @@ func shellTerminalResponse(t shelltermsvc.ShellTerminal) ShellTerminalResponse {
 	return ShellTerminalResponse{
 		HandleID:   t.HandleID,
 		ProjectID:  string(t.ProjectID),
+		SessionID:  string(t.SessionID),
 		WorkingDir: t.WorkingDir,
 		Title:      t.Title,
 		CreatedAt:  t.CreatedAt,

--- a/backend/internal/httpd/controllers/shell_terminals_test.go
+++ b/backend/internal/httpd/controllers/shell_terminals_test.go
@@ -17,11 +17,14 @@ import (
 )
 
 type fakeShellTerminalService struct {
-	gotOpenInput shelltermsvc.OpenShellTerminalInput
-	gotCloseID   string
-	opened       shelltermsvc.ShellTerminal
-	listed       []shelltermsvc.ShellTerminal
-	err          error
+	gotOpenInput   shelltermsvc.OpenShellTerminalInput
+	gotCloseID     string
+	gotRenameID    string
+	gotRenameTitle string
+	opened         shelltermsvc.ShellTerminal
+	renamed        shelltermsvc.ShellTerminal
+	listed         []shelltermsvc.ShellTerminal
+	err            error
 }
 
 func (f *fakeShellTerminalService) OpenShellTerminal(_ context.Context, in shelltermsvc.OpenShellTerminalInput) (shelltermsvc.ShellTerminal, error) {
@@ -31,6 +34,12 @@ func (f *fakeShellTerminalService) OpenShellTerminal(_ context.Context, in shell
 
 func (f *fakeShellTerminalService) ListShellTerminalsForCurrentAppRun(context.Context) ([]shelltermsvc.ShellTerminal, error) {
 	return f.listed, f.err
+}
+
+func (f *fakeShellTerminalService) RenameShellTerminal(_ context.Context, handleID, title string) (shelltermsvc.ShellTerminal, error) {
+	f.gotRenameID = handleID
+	f.gotRenameTitle = title
+	return f.renamed, f.err
 }
 
 func (f *fakeShellTerminalService) CloseShellTerminal(_ context.Context, handleID string) error {
@@ -149,6 +158,39 @@ func TestShellTerminalsAPI_CloseUnknownHandleReturnsNotFoundEnvelope(t *testing.
 	}
 }
 
+func TestShellTerminalsAPI_RenameReturnsUpdatedTerminal(t *testing.T) {
+	renamed := sampleShellTerminal()
+	renamed.Title = "deploy"
+	svc := &fakeShellTerminalService{renamed: renamed}
+	srv := newShellTerminalTestServer(t, svc)
+
+	body, status, _ := doRequest(t, srv, "PATCH", "/api/v1/shell-terminals/shellterm-abc123", `{"title":"deploy"}`)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", status, body)
+	}
+	if svc.gotRenameID != "shellterm-abc123" || svc.gotRenameTitle != "deploy" {
+		t.Errorf("rename args = (%q, %q)", svc.gotRenameID, svc.gotRenameTitle)
+	}
+	var resp struct {
+		ShellTerminal struct {
+			Title string `json:"title"`
+		} `json:"shellTerminal"`
+	}
+	mustJSON(t, body, &resp)
+	if resp.ShellTerminal.Title != "deploy" {
+		t.Errorf("response title = %q, want deploy", resp.ShellTerminal.Title)
+	}
+}
+
+func TestShellTerminalsAPI_RenameRejectsMalformedBody(t *testing.T) {
+	srv := newShellTerminalTestServer(t, &fakeShellTerminalService{})
+
+	body, status, _ := doRequest(t, srv, "PATCH", "/api/v1/shell-terminals/shellterm-abc123", "{not json")
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", status, body)
+	}
+}
+
 // A daemon built without the service must answer the locked 501 envelope, not
 // panic on a nil interface.
 func TestShellTerminalsAPI_NotImplementedWithoutService(t *testing.T) {
@@ -157,6 +199,7 @@ func TestShellTerminalsAPI_NotImplementedWithoutService(t *testing.T) {
 	for _, tc := range []struct{ method, path string }{
 		{"GET", "/api/v1/shell-terminals"},
 		{"POST", "/api/v1/shell-terminals"},
+		{"PATCH", "/api/v1/shell-terminals/shellterm-abc123"},
 		{"DELETE", "/api/v1/shell-terminals/shellterm-abc123"},
 	} {
 		body, status, _ := doRequest(t, srv, tc.method, tc.path, "")

--- a/backend/internal/service/shellterm/service.go
+++ b/backend/internal/service/shellterm/service.go
@@ -106,6 +106,7 @@ func (s *Service) OpenShellTerminal(ctx context.Context, in OpenShellTerminalInp
 	rec := ShellTerminalRecord{
 		HandleID:   handle.ID,
 		ProjectID:  in.ProjectID,
+		SessionID:  in.SessionID,
 		WorkingDir: workingDir,
 		Title:      shellTerminalTitle(workingDir),
 		AppRunID:   s.appRunID,
@@ -281,6 +282,7 @@ func shellTerminalFromRecord(rec ShellTerminalRecord) ShellTerminal {
 	return ShellTerminal{
 		HandleID:   rec.HandleID,
 		ProjectID:  rec.ProjectID,
+		SessionID:  rec.SessionID,
 		WorkingDir: rec.WorkingDir,
 		Title:      rec.Title,
 		CreatedAt:  rec.CreatedAt,

--- a/backend/internal/service/shellterm/service.go
+++ b/backend/internal/service/shellterm/service.go
@@ -6,7 +6,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apierr"
@@ -120,6 +122,35 @@ func (s *Service) OpenShellTerminal(ctx context.Context, in OpenShellTerminalInp
 	}
 
 	s.log.Info("shell terminal opened", "handleId", handle.ID, "workingDir", workingDir)
+	return shellTerminalFromRecord(rec), nil
+}
+
+// maxShellTerminalTitleLen bounds a user-supplied tab name. Tabs are truncated
+// in the UI anyway; this only stops an unbounded string reaching the DB.
+const maxShellTerminalTitleLen = 80
+
+// RenameShellTerminal sets a shell terminal's tab title. The title is trimmed
+// and must be non-empty and within the length bound; an unknown handle is a 404.
+func (s *Service) RenameShellTerminal(ctx context.Context, handleID, title string) (ShellTerminal, error) {
+	if handleID == "" {
+		return ShellTerminal{}, apierr.Invalid("SHELL_TERMINAL_ID_REQUIRED", "A shell terminal id is required", nil)
+	}
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return ShellTerminal{}, apierr.Invalid("SHELL_TERMINAL_TITLE_REQUIRED", "A shell terminal title is required", nil)
+	}
+	if utf8.RuneCountInString(title) > maxShellTerminalTitleLen {
+		return ShellTerminal{}, apierr.Invalid("SHELL_TERMINAL_TITLE_TOO_LONG",
+			fmt.Sprintf("A shell terminal title must be at most %d characters", maxShellTerminalTitleLen), nil)
+	}
+	rec, found, err := s.store.UpdateShellTerminalTitle(ctx, handleID, title)
+	if err != nil {
+		return ShellTerminal{}, fmt.Errorf("rename shell terminal %s: %w", handleID, err)
+	}
+	if !found {
+		return ShellTerminal{}, apierr.NotFound("SHELL_TERMINAL_NOT_FOUND", "No such shell terminal: "+handleID)
+	}
+	s.log.Info("shell terminal renamed", "handleId", handleID)
 	return shellTerminalFromRecord(rec), nil
 }
 

--- a/backend/internal/service/shellterm/service_test.go
+++ b/backend/internal/service/shellterm/service_test.go
@@ -213,6 +213,24 @@ func TestOpenShellTerminalReturnsNotFoundForUnknownProject(t *testing.T) {
 	}
 }
 
+func TestOpenShellTerminalScopesToSession(t *testing.T) {
+	rt := newFakeShellRuntime()
+	st := &fakeShellTerminalStore{}
+	projects := &fakeProjectRootLocator{roots: map[domain.ProjectID]string{"portfolio": "/repos/portfolio"}}
+	svc := newTestService(rt, st, projects)
+
+	term, err := svc.OpenShellTerminal(context.Background(), OpenShellTerminalInput{ProjectID: "portfolio", SessionID: "portfolio-3"})
+	if err != nil {
+		t.Fatalf("OpenShellTerminal: %v", err)
+	}
+	if term.SessionID != "portfolio-3" {
+		t.Errorf("returned session id = %q, want portfolio-3", term.SessionID)
+	}
+	if len(st.records) != 1 || st.records[0].SessionID != "portfolio-3" {
+		t.Fatalf("session id not persisted on the record: %+v", st.records)
+	}
+}
+
 func TestRenameShellTerminalUpdatesTitle(t *testing.T) {
 	st := &fakeShellTerminalStore{records: []ShellTerminalRecord{
 		{HandleID: "shellterm-1", Title: "portfolio", AppRunID: testAppRunID},

--- a/backend/internal/service/shellterm/service_test.go
+++ b/backend/internal/service/shellterm/service_test.go
@@ -72,6 +72,16 @@ func (f *fakeShellTerminalStore) InsertShellTerminal(_ context.Context, rec Shel
 	return nil
 }
 
+func (f *fakeShellTerminalStore) UpdateShellTerminalTitle(_ context.Context, handleID, title string) (ShellTerminalRecord, bool, error) {
+	for i, rec := range f.records {
+		if rec.HandleID == handleID {
+			f.records[i].Title = title
+			return f.records[i], true, nil
+		}
+	}
+	return ShellTerminalRecord{}, false, nil
+}
+
 func (f *fakeShellTerminalStore) SelectShellTerminalsByAppRunID(_ context.Context, appRunID string) ([]ShellTerminalRecord, error) {
 	var out []ShellTerminalRecord
 	for _, rec := range f.records {
@@ -200,6 +210,50 @@ func TestOpenShellTerminalReturnsNotFoundForUnknownProject(t *testing.T) {
 	}
 	if len(rt.created) != 0 {
 		t.Error("a runtime was spawned for an unknown project")
+	}
+}
+
+func TestRenameShellTerminalUpdatesTitle(t *testing.T) {
+	st := &fakeShellTerminalStore{records: []ShellTerminalRecord{
+		{HandleID: "shellterm-1", Title: "portfolio", AppRunID: testAppRunID},
+	}}
+	svc := newTestService(newFakeShellRuntime(), st, &fakeProjectRootLocator{})
+
+	term, err := svc.RenameShellTerminal(context.Background(), "shellterm-1", "  deploy logs  ")
+	if err != nil {
+		t.Fatalf("RenameShellTerminal: %v", err)
+	}
+	if term.Title != "deploy logs" {
+		t.Errorf("returned title = %q, want the trimmed new title", term.Title)
+	}
+	if st.records[0].Title != "deploy logs" {
+		t.Errorf("stored title = %q, want the trimmed new title", st.records[0].Title)
+	}
+}
+
+func TestRenameShellTerminalRejectsEmptyTitle(t *testing.T) {
+	st := &fakeShellTerminalStore{records: []ShellTerminalRecord{{HandleID: "shellterm-1", Title: "portfolio"}}}
+	svc := newTestService(newFakeShellRuntime(), st, &fakeProjectRootLocator{})
+
+	_, err := svc.RenameShellTerminal(context.Background(), "shellterm-1", "   ")
+
+	var apiErr *apierr.Error
+	if !errors.As(err, &apiErr) || apiErr.Kind != apierr.KindInvalid {
+		t.Fatalf("error = %v, want an invalid apierr", err)
+	}
+	if st.records[0].Title != "portfolio" {
+		t.Errorf("title changed to %q on a rejected rename", st.records[0].Title)
+	}
+}
+
+func TestRenameShellTerminalReturnsNotFoundForUnknownHandle(t *testing.T) {
+	svc := newTestService(newFakeShellRuntime(), &fakeShellTerminalStore{}, &fakeProjectRootLocator{})
+
+	_, err := svc.RenameShellTerminal(context.Background(), "shellterm-ghost", "whatever")
+
+	var apiErr *apierr.Error
+	if !errors.As(err, &apiErr) || apiErr.Kind != apierr.KindNotFound {
+		t.Fatalf("error = %v, want a not-found apierr", err)
 	}
 }
 

--- a/backend/internal/service/shellterm/store.go
+++ b/backend/internal/service/shellterm/store.go
@@ -13,6 +13,7 @@ import (
 type ShellTerminalRecord struct {
 	HandleID   string
 	ProjectID  domain.ProjectID
+	SessionID  domain.SessionID
 	WorkingDir string
 	Title      string
 	AppRunID   string

--- a/backend/internal/service/shellterm/store.go
+++ b/backend/internal/service/shellterm/store.go
@@ -24,6 +24,7 @@ type ShellTerminalRecord struct {
 // does not depend on storage internals.
 type Store interface {
 	InsertShellTerminal(ctx context.Context, rec ShellTerminalRecord) error
+	UpdateShellTerminalTitle(ctx context.Context, handleID, title string) (ShellTerminalRecord, bool, error)
 	SelectShellTerminalsByAppRunID(ctx context.Context, appRunID string) ([]ShellTerminalRecord, error)
 	SelectShellTerminalsFromPreviousAppRuns(ctx context.Context, appRunID string) ([]ShellTerminalRecord, error)
 	DeleteShellTerminalByHandleID(ctx context.Context, handleID string) (bool, error)

--- a/backend/internal/service/shellterm/types.go
+++ b/backend/internal/service/shellterm/types.go
@@ -27,6 +27,7 @@ import (
 type ShellTerminal struct {
 	HandleID   string           `json:"handleId"`
 	ProjectID  domain.ProjectID `json:"projectId,omitempty"`
+	SessionID  domain.SessionID `json:"sessionId,omitempty"`
 	WorkingDir string           `json:"workingDir"`
 	Title      string           `json:"title"`
 	CreatedAt  time.Time        `json:"createdAt"`
@@ -34,9 +35,12 @@ type ShellTerminal struct {
 
 // OpenShellTerminalInput is the request to open a new shell pane. An empty
 // ProjectID opens the shell in the daemon's data dir instead of a project root,
-// which is what the topbar action does when no project is selected.
+// which is what the topbar action does when no project is selected. SessionID
+// scopes the shell to an agent session so it appears only in that session's tab
+// strip; an empty SessionID makes it a standalone shell on the /terminals screen.
 type OpenShellTerminalInput struct {
 	ProjectID domain.ProjectID `json:"projectId,omitempty"`
+	SessionID domain.SessionID `json:"sessionId,omitempty"`
 }
 
 // shellTerminalTitle labels a tab by the directory the shell started in, which

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -217,6 +217,7 @@ type ShellTerminal struct {
 	Title      string
 	AppRunID   string
 	CreatedAt  time.Time
+	SessionID  sql.NullString
 }
 
 type TelemetryEvent struct {

--- a/backend/internal/storage/sqlite/gen/shell_terminals.sql.go
+++ b/backend/internal/storage/sqlite/gen/shell_terminals.sql.go
@@ -7,6 +7,7 @@ package gen
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -40,14 +41,15 @@ func (q *Queries) DeleteShellTerminalsFromPreviousAppRuns(ctx context.Context, a
 
 const insertShellTerminal = `-- name: InsertShellTerminal :one
 INSERT INTO shell_terminals (
-    handle_id, project_id, working_dir, title, app_run_id, created_at
-) VALUES (?, ?, ?, ?, ?, ?)
-RETURNING handle_id, project_id, working_dir, title, app_run_id, created_at
+    handle_id, project_id, session_id, working_dir, title, app_run_id, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?)
+RETURNING handle_id, project_id, working_dir, title, app_run_id, created_at, session_id
 `
 
 type InsertShellTerminalParams struct {
 	HandleID   string
 	ProjectID  *domain.ProjectID
+	SessionID  sql.NullString
 	WorkingDir string
 	Title      string
 	AppRunID   string
@@ -58,6 +60,7 @@ func (q *Queries) InsertShellTerminal(ctx context.Context, arg InsertShellTermin
 	row := q.db.QueryRowContext(ctx, insertShellTerminal,
 		arg.HandleID,
 		arg.ProjectID,
+		arg.SessionID,
 		arg.WorkingDir,
 		arg.Title,
 		arg.AppRunID,
@@ -71,12 +74,13 @@ func (q *Queries) InsertShellTerminal(ctx context.Context, arg InsertShellTermin
 		&i.Title,
 		&i.AppRunID,
 		&i.CreatedAt,
+		&i.SessionID,
 	)
 	return i, err
 }
 
 const selectShellTerminalByHandleID = `-- name: SelectShellTerminalByHandleID :one
-SELECT handle_id, project_id, working_dir, title, app_run_id, created_at
+SELECT handle_id, project_id, working_dir, title, app_run_id, created_at, session_id
 FROM shell_terminals
 WHERE handle_id = ?
 `
@@ -91,12 +95,13 @@ func (q *Queries) SelectShellTerminalByHandleID(ctx context.Context, handleID st
 		&i.Title,
 		&i.AppRunID,
 		&i.CreatedAt,
+		&i.SessionID,
 	)
 	return i, err
 }
 
 const selectShellTerminalsByAppRunID = `-- name: SelectShellTerminalsByAppRunID :many
-SELECT handle_id, project_id, working_dir, title, app_run_id, created_at
+SELECT handle_id, project_id, working_dir, title, app_run_id, created_at, session_id
 FROM shell_terminals
 WHERE app_run_id = ?
 ORDER BY created_at
@@ -118,6 +123,7 @@ func (q *Queries) SelectShellTerminalsByAppRunID(ctx context.Context, appRunID s
 			&i.Title,
 			&i.AppRunID,
 			&i.CreatedAt,
+			&i.SessionID,
 		); err != nil {
 			return nil, err
 		}
@@ -133,7 +139,7 @@ func (q *Queries) SelectShellTerminalsByAppRunID(ctx context.Context, appRunID s
 }
 
 const selectShellTerminalsFromPreviousAppRuns = `-- name: SelectShellTerminalsFromPreviousAppRuns :many
-SELECT handle_id, project_id, working_dir, title, app_run_id, created_at
+SELECT handle_id, project_id, working_dir, title, app_run_id, created_at, session_id
 FROM shell_terminals
 WHERE app_run_id <> ?
 ORDER BY created_at
@@ -155,6 +161,7 @@ func (q *Queries) SelectShellTerminalsFromPreviousAppRuns(ctx context.Context, a
 			&i.Title,
 			&i.AppRunID,
 			&i.CreatedAt,
+			&i.SessionID,
 		); err != nil {
 			return nil, err
 		}
@@ -173,7 +180,7 @@ const updateShellTerminalTitle = `-- name: UpdateShellTerminalTitle :one
 UPDATE shell_terminals
 SET title = ?
 WHERE handle_id = ?
-RETURNING handle_id, project_id, working_dir, title, app_run_id, created_at
+RETURNING handle_id, project_id, working_dir, title, app_run_id, created_at, session_id
 `
 
 type UpdateShellTerminalTitleParams struct {
@@ -191,6 +198,7 @@ func (q *Queries) UpdateShellTerminalTitle(ctx context.Context, arg UpdateShellT
 		&i.Title,
 		&i.AppRunID,
 		&i.CreatedAt,
+		&i.SessionID,
 	)
 	return i, err
 }

--- a/backend/internal/storage/sqlite/gen/shell_terminals.sql.go
+++ b/backend/internal/storage/sqlite/gen/shell_terminals.sql.go
@@ -168,3 +168,29 @@ func (q *Queries) SelectShellTerminalsFromPreviousAppRuns(ctx context.Context, a
 	}
 	return items, nil
 }
+
+const updateShellTerminalTitle = `-- name: UpdateShellTerminalTitle :one
+UPDATE shell_terminals
+SET title = ?
+WHERE handle_id = ?
+RETURNING handle_id, project_id, working_dir, title, app_run_id, created_at
+`
+
+type UpdateShellTerminalTitleParams struct {
+	Title    string
+	HandleID string
+}
+
+func (q *Queries) UpdateShellTerminalTitle(ctx context.Context, arg UpdateShellTerminalTitleParams) (ShellTerminal, error) {
+	row := q.db.QueryRowContext(ctx, updateShellTerminalTitle, arg.Title, arg.HandleID)
+	var i ShellTerminal
+	err := row.Scan(
+		&i.HandleID,
+		&i.ProjectID,
+		&i.WorkingDir,
+		&i.Title,
+		&i.AppRunID,
+		&i.CreatedAt,
+	)
+	return i, err
+}

--- a/backend/internal/storage/sqlite/migrations/0036_add_shell_terminal_session_id.sql
+++ b/backend/internal/storage/sqlite/migrations/0036_add_shell_terminal_session_id.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- +goose StatementBegin
+-- session_id scopes a shell terminal to the agent session it was opened from,
+-- so a session's shells appear only in that session's tab strip rather than
+-- being shared across every session in the project. It is nullable on purpose:
+-- a shell opened outside any session (from the board or the standalone
+-- /terminals screen) has no session and lives only on that screen.
+--
+-- ON DELETE CASCADE ties a session's shells to its lifetime: deleting the
+-- session forgets its shell rows too, mirroring the project_id behaviour.
+ALTER TABLE shell_terminals
+    ADD COLUMN session_id TEXT REFERENCES sessions(id) ON DELETE CASCADE;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE shell_terminals DROP COLUMN session_id;
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/queries/shell_terminals.sql
+++ b/backend/internal/storage/sqlite/queries/shell_terminals.sql
@@ -21,6 +21,12 @@ FROM shell_terminals
 WHERE app_run_id <> ?
 ORDER BY created_at;
 
+-- name: UpdateShellTerminalTitle :one
+UPDATE shell_terminals
+SET title = ?
+WHERE handle_id = ?
+RETURNING *;
+
 -- name: DeleteShellTerminalByHandleID :execrows
 DELETE FROM shell_terminals
 WHERE handle_id = ?;

--- a/backend/internal/storage/sqlite/queries/shell_terminals.sql
+++ b/backend/internal/storage/sqlite/queries/shell_terminals.sql
@@ -1,7 +1,7 @@
 -- name: InsertShellTerminal :one
 INSERT INTO shell_terminals (
-    handle_id, project_id, working_dir, title, app_run_id, created_at
-) VALUES (?, ?, ?, ?, ?, ?)
+    handle_id, project_id, session_id, working_dir, title, app_run_id, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: SelectShellTerminalByHandleID :one

--- a/backend/internal/storage/sqlite/store/shell_terminal_store.go
+++ b/backend/internal/storage/sqlite/store/shell_terminal_store.go
@@ -20,6 +20,7 @@ func (s *Store) InsertShellTerminal(ctx context.Context, rec shelltermsvc.ShellT
 	_, err := s.qw.InsertShellTerminal(ctx, gen.InsertShellTerminalParams{
 		HandleID:   rec.HandleID,
 		ProjectID:  optionalProjectID(rec.ProjectID),
+		SessionID:  optionalSessionID(rec.SessionID),
 		WorkingDir: rec.WorkingDir,
 		Title:      rec.Title,
 		AppRunID:   rec.AppRunID,
@@ -101,6 +102,16 @@ func optionalProjectID(id domain.ProjectID) *domain.ProjectID {
 	return &id
 }
 
+// optionalSessionID maps the service's "no session" empty string onto the
+// nullable column, so a session-less shell stores NULL rather than an empty
+// string that would violate the sessions FK.
+func optionalSessionID(id domain.SessionID) sql.NullString {
+	if id == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: string(id), Valid: true}
+}
+
 func shellTerminalFromGen(row gen.ShellTerminal) shelltermsvc.ShellTerminalRecord {
 	rec := shelltermsvc.ShellTerminalRecord{
 		HandleID:   row.HandleID,
@@ -111,6 +122,9 @@ func shellTerminalFromGen(row gen.ShellTerminal) shelltermsvc.ShellTerminalRecor
 	}
 	if row.ProjectID != nil {
 		rec.ProjectID = *row.ProjectID
+	}
+	if row.SessionID.Valid {
+		rec.SessionID = domain.SessionID(row.SessionID.String)
 	}
 	return rec
 }

--- a/backend/internal/storage/sqlite/store/shell_terminal_store.go
+++ b/backend/internal/storage/sqlite/store/shell_terminal_store.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -48,6 +50,21 @@ func (s *Store) SelectShellTerminalsFromPreviousAppRuns(ctx context.Context, app
 		return nil, fmt.Errorf("select orphaned shell terminals: %w", err)
 	}
 	return shellTerminalsFromGen(rows), nil
+}
+
+// UpdateShellTerminalTitle renames one shell terminal, returning the updated row
+// and whether a row existed so the caller can answer 404 for an unknown handle.
+func (s *Store) UpdateShellTerminalTitle(ctx context.Context, handleID, title string) (shelltermsvc.ShellTerminalRecord, bool, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	row, err := s.qw.UpdateShellTerminalTitle(ctx, gen.UpdateShellTerminalTitleParams{Title: title, HandleID: handleID})
+	if errors.Is(err, sql.ErrNoRows) {
+		return shelltermsvc.ShellTerminalRecord{}, false, nil
+	}
+	if err != nil {
+		return shelltermsvc.ShellTerminalRecord{}, false, fmt.Errorf("rename shell terminal %s: %w", handleID, err)
+	}
+	return shellTerminalFromGen(row), true, nil
 }
 
 // DeleteShellTerminalByHandleID forgets one shell terminal, reporting whether a

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -1036,6 +1036,8 @@ export interface components {
         OpenShellTerminalRequest: {
             /** @description Project whose root the shell starts in. Omitted opens the shell in the daemon data dir. */
             projectId?: string;
+            /** @description Agent session the shell is scoped to, so it appears only in that session's tab strip. Omitted makes it a standalone shell. */
+            sessionId?: string;
         };
         OrchestratorResponse: {
             id: string;
@@ -1352,6 +1354,7 @@ export interface components {
             createdAt: string;
             handleId: string;
             projectId?: string;
+            sessionId?: string;
             title: string;
             workingDir: string;
         };

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -793,7 +793,8 @@ export interface paths {
         delete: operations["closeShellTerminal"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** Rename a standalone shell terminal tab */
+        patch: operations["renameShellTerminal"];
         trace?: never;
     };
 }
@@ -1420,6 +1421,10 @@ export interface components {
         UpdateProjectSettingsInput: {
             config: components["schemas"]["ProjectConfig"];
             displayName: string;
+        };
+        UpdateShellTerminalRequest: {
+            /** @description New tab title for the shell terminal. Trimmed; must be non-empty. */
+            title: string;
         };
         WorkspaceFileResponse: {
             additions: number;
@@ -4208,6 +4213,69 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["APIError"];
+                };
+            };
+        };
+    };
+    renameShellTerminal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Shell terminal runtime handle identifier. */
+                handleId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateShellTerminalRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShellTerminalEnvelope"];
+                };
             };
             /** @description Bad Request */
             400: {

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -57,7 +57,7 @@ describe("CenterPane toolbar session label", () => {
 
 		const scrollRegion = document.querySelector(".overflow-x-auto");
 		expect(scrollRegion).toHaveClass("scrollbar-none", "min-w-flex-min", "flex-1");
-		for (const tab of screen.getAllByTitle("/tmp/ws")) {
+		for (const tab of screen.getAllByTitle(/^\/tmp\/ws/)) {
 			expect(tab.parentElement).toHaveClass("min-w-shell-tab-min");
 			expect(tab.parentElement).not.toHaveClass("min-w-16", "shrink-0");
 			expect(tab).toHaveClass("min-w-flex-min");

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, Maximize2, Minimize2, Plus, Shield, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Maximize2, Minimize2, Plus, Shield } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type WheelEvent } from "react";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
 import { useTruncatedText } from "../hooks/useTruncatedText";
@@ -8,6 +8,7 @@ import { cn } from "../lib/utils";
 import type { Theme } from "../stores/ui-store";
 import type { TerminalTarget } from "../types/terminal";
 import { isOrchestratorSession, type WorkspaceSession } from "../types/workspace";
+import { ShellTerminalTab } from "./ShellTerminalTab";
 import { TerminalPane } from "./TerminalPane";
 
 type CenterPaneProps = {
@@ -21,6 +22,7 @@ type CenterPaneProps = {
 	onSelectSessionTerminal?: () => void;
 	onSelectShellTerminal?: (handleId: string) => void;
 	onCloseShellTerminal?: (handleId: string) => void;
+	onRenameShellTerminal?: (handleId: string, title: string) => void;
 	/** Opens a new standalone shell tab (Superset-style "+" at the end of the tab bar). */
 	onNewShellTerminal?: () => void;
 };
@@ -51,6 +53,7 @@ export function CenterPane({
 	onSelectSessionTerminal,
 	onSelectShellTerminal,
 	onCloseShellTerminal,
+	onRenameShellTerminal,
 	onNewShellTerminal,
 }: CenterPaneProps) {
 	const paneRef = useRef<HTMLDivElement | null>(null);
@@ -155,6 +158,7 @@ export function CenterPane({
 								key={shell.handleId}
 								isActive={target.kind === "shell" && target.handleId === shell.handleId}
 								onClose={() => onCloseShellTerminal?.(shell.handleId)}
+								onRename={onRenameShellTerminal ? (title) => onRenameShellTerminal(shell.handleId, title) : undefined}
 								onSelect={() => onSelectShellTerminal?.(shell.handleId)}
 								shell={shell}
 							/>
@@ -291,52 +295,6 @@ function SessionPaneTab({ label, isActive, onSelect }: SessionPaneTabProps) {
 				type="button"
 			>
 				{label}
-			</button>
-		</span>
-	);
-}
-
-type ShellTerminalTabProps = {
-	shell: ShellTerminal;
-	isActive: boolean;
-	onSelect: () => void;
-	onClose: () => void;
-};
-
-// The close control is a sibling button, not nested inside the tab button —
-// nesting interactive elements is invalid HTML and breaks keyboard traversal.
-// It stays hidden until the tab is hovered or focused (group-focus-within
-// keeps it reachable from the keyboard).
-function ShellTerminalTab({ shell, isActive, onSelect, onClose }: ShellTerminalTabProps) {
-	const { ref, isTruncated } = useTruncatedText<HTMLButtonElement>(shell.title);
-	return (
-		<span
-			className={cn(
-				"group inline-flex min-w-shell-tab-min items-center gap-1 rounded-md px-2 py-1 transition-colors",
-				isActive ? "bg-interactive-active" : "hover:bg-interactive-hover/60",
-			)}
-		>
-			<button
-				ref={ref}
-				aria-current={isActive}
-				className={cn(
-					"min-w-flex-min max-w-shell-tab-max truncate font-mono text-control font-semibold transition-colors",
-					isActive ? "text-foreground" : "text-passive hover:text-foreground",
-				)}
-				onClick={onSelect}
-				title={isTruncated ? shell.title : shell.workingDir}
-				type="button"
-			>
-				{shell.title}
-			</button>
-			<button
-				aria-label={`Close terminal ${shell.title}`}
-				className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-passive opacity-0 transition-[background,color,opacity] group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
-				onClick={onClose}
-				title="Close terminal"
-				type="button"
-			>
-				<X aria-hidden="true" className="size-icon-sm" />
 			</button>
 		</span>
 	);

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -51,7 +51,14 @@ const { workspaces, workspaceQueryState, panels, shellTerminalsState } = vi.hois
 		isLoading: false,
 	};
 	const shellTerminalsState: {
-		data: Array<{ handleId: string; projectId?: string; title: string; workingDir: string; createdAt: string }>;
+		data: Array<{
+			handleId: string;
+			projectId?: string;
+			sessionId?: string;
+			title: string;
+			workingDir: string;
+			createdAt: string;
+		}>;
 	} = {
 		data: [],
 	};
@@ -278,23 +285,23 @@ describe("SessionView", () => {
 		shellTerminalsState.data = [];
 	});
 
-	// Regression: shell terminals are an app-wide list, so without a per-project
-	// filter a shell opened in another project would show up as a tab in this
-	// session's strip. Only this project's shells (and no project-less ones)
-	// should reach the terminal pane.
-	it("shows only the current project's shell terminals as tabs", () => {
+	// Regression: shell terminals are an app-wide list, so without a per-session
+	// filter a shell opened in another session would show up as a tab in this
+	// session's strip. Only this session's shells (not another session's, and no
+	// session-less ones) should reach the terminal pane.
+	it("shows only the current session's shell terminals as tabs", () => {
 		shellTerminalsState.data = [
 			{
 				handleId: "sh-a",
-				projectId: "proj-1",
-				title: "proj-1-shell",
+				sessionId: "sess-1",
+				title: "sess-1-shell",
 				workingDir: "/p",
 				createdAt: "2026-07-24T00:00:00Z",
 			},
 			{
 				handleId: "sh-b",
-				projectId: "proj-2",
-				title: "proj-2-shell",
+				sessionId: "sess-2",
+				title: "sess-2-shell",
 				workingDir: "/q",
 				createdAt: "2026-07-24T00:00:00Z",
 			},
@@ -302,8 +309,8 @@ describe("SessionView", () => {
 		];
 		render(<SessionView sessionId="sess-1" />);
 		const tabs = screen.getByTestId("shell-tabs");
-		expect(tabs).toHaveTextContent("proj-1-shell");
-		expect(tabs).not.toHaveTextContent("proj-2-shell");
+		expect(tabs).toHaveTextContent("sess-1-shell");
+		expect(tabs).not.toHaveTextContent("sess-2-shell");
 		expect(tabs).not.toHaveTextContent("loose-shell");
 	});
 

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -18,7 +18,7 @@ type PanelEntry = {
 	onResize?: (size: { asPercentage: number; inPixels: number }) => void;
 };
 
-const { workspaces, workspaceQueryState, panels } = vi.hoisted(() => {
+const { workspaces, workspaceQueryState, panels, shellTerminalsState } = vi.hoisted(() => {
 	const worker = {
 		id: "sess-1",
 		workspaceId: "proj-1",
@@ -50,14 +50,26 @@ const { workspaces, workspaceQueryState, panels } = vi.hoisted(() => {
 		data: workspaces,
 		isLoading: false,
 	};
-	return { workspaces, workspaceQueryState, panels: new Map<string, PanelEntry>() };
+	const shellTerminalsState: {
+		data: Array<{ handleId: string; projectId?: string; title: string; workingDir: string; createdAt: string }>;
+	} = {
+		data: [],
+	};
+	return { workspaces, workspaceQueryState, panels: new Map<string, PanelEntry>(), shellTerminalsState };
 });
 
 // The terminal and inspector body pull in xterm/SSE machinery irrelevant to
 // the split under test. (ShellTopbar is shell-owned on Win/Linux; when the
 // platform hides the shell topbar, SessionView mounts it in-panel.)
 vi.mock("./ShellTopbar", () => ({ ShellTopbar: () => null }));
-vi.mock("./CenterPane", () => ({ CenterPane: () => <div>terminal center</div> }));
+vi.mock("./CenterPane", () => ({
+	CenterPane: ({ shellTerminals = [] }: { shellTerminals?: Array<{ handleId: string; title: string }> }) => (
+		<div>
+			terminal center
+			<div data-testid="shell-tabs">{shellTerminals.map((s) => s.title).join(",")}</div>
+		</div>
+	),
+}));
 vi.mock("./BrowserPanel", () => ({
 	BrowserPanelView: ({
 		poppedOut,
@@ -156,9 +168,10 @@ vi.mock("../hooks/useWorkspaceQuery", () => ({
 // Standalone shell terminals are orthogonal to the split under test, and their
 // real hooks would need a QueryClientProvider this suite deliberately omits.
 vi.mock("../hooks/useShellTerminals", () => ({
-	useShellTerminals: () => ({ data: [], isLoading: false }),
+	useShellTerminals: () => ({ data: shellTerminalsState.data, isLoading: false }),
 	useOpenShellTerminal: () => ({ mutate: vi.fn() }),
 	useCloseShellTerminal: () => ({ mutate: vi.fn() }),
+	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
 }));
 
 // jsdom has no layout engine, so the real react-resizable-panels would never
@@ -262,6 +275,36 @@ describe("SessionView", () => {
 		panels.clear();
 		browserDestroy.mockReset();
 		browserViewOptions.current = undefined;
+		shellTerminalsState.data = [];
+	});
+
+	// Regression: shell terminals are an app-wide list, so without a per-project
+	// filter a shell opened in another project would show up as a tab in this
+	// session's strip. Only this project's shells (and no project-less ones)
+	// should reach the terminal pane.
+	it("shows only the current project's shell terminals as tabs", () => {
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				projectId: "proj-1",
+				title: "proj-1-shell",
+				workingDir: "/p",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+			{
+				handleId: "sh-b",
+				projectId: "proj-2",
+				title: "proj-2-shell",
+				workingDir: "/q",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+			{ handleId: "sh-c", title: "loose-shell", workingDir: "/r", createdAt: "2026-07-24T00:00:00Z" },
+		];
+		render(<SessionView sessionId="sess-1" />);
+		const tabs = screen.getByTestId("shell-tabs");
+		expect(tabs).toHaveTextContent("proj-1-shell");
+		expect(tabs).not.toHaveTextContent("proj-2-shell");
+		expect(tabs).not.toHaveTextContent("loose-shell");
 	});
 
 	// Regression: react-resizable-panels v4 treats bare numeric sizes as PIXELS

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
 import { BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
@@ -10,7 +10,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "./ui/resiz
 import { useResolvedTheme, useUiStore, type InspectorView } from "../stores/ui-store";
 import { useShell } from "../lib/shell-context";
 import { useBrowserView } from "../hooks/useBrowserView";
-import { useCloseShellTerminal, useShellTerminals } from "../hooks/useShellTerminals";
+import { useCloseShellTerminal, useRenameShellTerminal, useShellTerminals } from "../hooks/useShellTerminals";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { hidesShellTopbar } from "../lib/platform";
 import { isOrchestratorSession, sessionIsActive } from "../types/workspace";
@@ -69,15 +69,32 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const [filesPoppedOut, setFilesPoppedOut] = useState(false);
 
 	const session = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
+	// The project owning this session: shell terminals are scoped to it below.
+	const currentProjectId = workspaces.find((workspace) => workspace.sessions.some((s) => s.id === sessionId))?.id;
 
 	// Standalone shell terminals live beside the session's pane as extra tabs.
 	// They belong to the app, not this session, so they persist across session
 	// navigation; only which one is *selected* is local state.
-	const shellTerminals = useShellTerminals().data ?? [];
+	//
+	// Scope them to THIS project: the daemon list is app-wide, so without the
+	// filter a shell opened in one project would show up as a tab in every other
+	// project's session view. A shell's projectId is the project it was opened
+	// in; project-less shells (opened from the board) live only on /terminals.
+	const allShellTerminals = useShellTerminals().data ?? [];
+	const shellTerminals = useMemo(
+		() => (currentProjectId ? allShellTerminals.filter((s) => s.projectId === currentProjectId) : []),
+		[allShellTerminals, currentProjectId],
+	);
 	const closeShellTerminal = useCloseShellTerminal();
+	const renameShellTerminal = useRenameShellTerminal();
 	const activeShellTerminalHandleId = useUiStore((state) => state.activeShellTerminalHandleId);
 	const setActiveShellTerminal = useUiStore((state) => state.setActiveShellTerminal);
 	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);
+
+	const renameShellTerminalByHandle = useCallback(
+		(handleId: string, title: string) => renameShellTerminal.mutate({ handleId, title }),
+		[renameShellTerminal],
+	);
 
 	const selectShellTerminal = useCallback(
 		(handleId: string) => {
@@ -123,6 +140,18 @@ export function SessionView({ sessionId }: SessionViewProps) {
 				: { kind: "shell", handleId: shell.handleId, title: shell.title },
 		);
 	}, [activeShellTerminalHandleId, shellTerminals]);
+
+	// If the pane is pointed at a shell that is not in THIS project's strip — e.g.
+	// after navigating to a different project whose globally-active shell belongs
+	// elsewhere — fall back to the session's own pane rather than render a tab
+	// that isn't shown here.
+	useEffect(() => {
+		setTerminalTarget((current) =>
+			current.kind === "shell" && !shellTerminals.some((s) => s.handleId === current.handleId)
+				? { kind: "worker" }
+				: current,
+		);
+	}, [shellTerminals]);
 	const isOrchestrator = session ? isOrchestratorSession(session) : false;
 	// Orchestrator sessions are terminal-only; only worker sessions have the rail.
 	const hasInspector = Boolean(session && !isOrchestrator);
@@ -310,6 +339,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 						daemonReady={daemonStatus.state === "ready"}
 						onCloseShellTerminal={closeShellTerminalByHandle}
 						onNewShellTerminal={requestNewShellTerminal}
+						onRenameShellTerminal={renameShellTerminalByHandle}
 						onSelectSessionTerminal={selectSessionTerminal}
 						onSelectShellTerminal={selectShellTerminal}
 						onSelectWorkerTerminal={selectSessionTerminal}

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -69,21 +69,18 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const [filesPoppedOut, setFilesPoppedOut] = useState(false);
 
 	const session = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
-	// The project owning this session: shell terminals are scoped to it below.
-	const currentProjectId = workspaces.find((workspace) => workspace.sessions.some((s) => s.id === sessionId))?.id;
 
-	// Standalone shell terminals live beside the session's pane as extra tabs.
-	// They belong to the app, not this session, so they persist across session
-	// navigation; only which one is *selected* is local state.
+	// Shell terminals opened inside a session live beside its pane as extra tabs.
 	//
-	// Scope them to THIS project: the daemon list is app-wide, so without the
-	// filter a shell opened in one project would show up as a tab in every other
-	// project's session view. A shell's projectId is the project it was opened
-	// in; project-less shells (opened from the board) live only on /terminals.
+	// Scope them to THIS session: the daemon list is app-wide, so without the
+	// filter a shell opened in one session would show up in every other session's
+	// strip (even across projects). A shell's sessionId is the session it was
+	// opened from; session-less shells (opened from the board) live only on the
+	// standalone /terminals screen.
 	const allShellTerminals = useShellTerminals().data ?? [];
 	const shellTerminals = useMemo(
-		() => (currentProjectId ? allShellTerminals.filter((s) => s.projectId === currentProjectId) : []),
-		[allShellTerminals, currentProjectId],
+		() => allShellTerminals.filter((s) => s.sessionId === sessionId),
+		[allShellTerminals, sessionId],
 	);
 	const closeShellTerminal = useCloseShellTerminal();
 	const renameShellTerminal = useRenameShellTerminal();
@@ -141,8 +138,8 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		);
 	}, [activeShellTerminalHandleId, shellTerminals]);
 
-	// If the pane is pointed at a shell that is not in THIS project's strip — e.g.
-	// after navigating to a different project whose globally-active shell belongs
+	// If the pane is pointed at a shell that is not in THIS session's strip — e.g.
+	// after navigating to a different session whose globally-active shell belongs
 	// elsewhere — fall back to the session's own pane rather than render a tab
 	// that isn't shown here.
 	useEffect(() => {

--- a/frontend/src/renderer/components/ShellTerminalTab.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ShellTerminal } from "../hooks/useShellTerminals";
+import { ShellTerminalTab } from "./ShellTerminalTab";
+
+const shell: ShellTerminal = {
+	handleId: "shellterm-1",
+	projectId: "ao",
+	workingDir: "/repos/ao",
+	title: "ao",
+	createdAt: "2026-07-24T10:00:00Z",
+};
+
+function renderTab(overrides: Partial<Parameters<typeof ShellTerminalTab>[0]> = {}) {
+	const onSelect = vi.fn();
+	const onClose = vi.fn();
+	const onRename = vi.fn();
+	render(
+		<ShellTerminalTab
+			isActive={false}
+			onClose={onClose}
+			onRename={onRename}
+			onSelect={onSelect}
+			shell={shell}
+			{...overrides}
+		/>,
+	);
+	return { onSelect, onClose, onRename };
+}
+
+describe("ShellTerminalTab rename", () => {
+	it("commits a new title on Enter", () => {
+		const { onRename } = renderTab();
+		fireEvent.doubleClick(screen.getByRole("button", { name: "ao" }));
+		const input = screen.getByRole("textbox", { name: /rename terminal/i });
+		fireEvent.change(input, { target: { value: "deploy" } });
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onRename).toHaveBeenCalledWith("deploy");
+	});
+
+	it("commits on blur", () => {
+		const { onRename } = renderTab();
+		fireEvent.doubleClick(screen.getByRole("button", { name: "ao" }));
+		const input = screen.getByRole("textbox", { name: /rename terminal/i });
+		fireEvent.change(input, { target: { value: "logs" } });
+		fireEvent.blur(input);
+		expect(onRename).toHaveBeenCalledWith("logs");
+	});
+
+	it("discards on Escape and leaves the title unchanged", () => {
+		const { onRename } = renderTab();
+		fireEvent.doubleClick(screen.getByRole("button", { name: "ao" }));
+		const input = screen.getByRole("textbox", { name: /rename terminal/i });
+		fireEvent.change(input, { target: { value: "throwaway" } });
+		fireEvent.keyDown(input, { key: "Escape" });
+		expect(onRename).not.toHaveBeenCalled();
+		expect(screen.getByRole("button", { name: "ao" })).toBeInTheDocument();
+	});
+
+	it("discards an empty or unchanged title", () => {
+		const { onRename } = renderTab();
+		fireEvent.doubleClick(screen.getByRole("button", { name: "ao" }));
+		const input = screen.getByRole("textbox", { name: /rename terminal/i });
+		fireEvent.change(input, { target: { value: "   " } });
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onRename).not.toHaveBeenCalled();
+	});
+
+	it("does not enter edit mode when rename is not wired", () => {
+		renderTab({ onRename: undefined });
+		fireEvent.doubleClick(screen.getByRole("button", { name: "ao" }));
+		expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+	});
+
+	it("selects the tab on single click", () => {
+		const { onSelect } = renderTab();
+		fireEvent.click(screen.getByRole("button", { name: "ao" }));
+		expect(onSelect).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/renderer/components/ShellTerminalTab.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.test.tsx
@@ -1,7 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ShellTerminal } from "../hooks/useShellTerminals";
 import { ShellTerminalTab } from "./ShellTerminalTab";
+
+const { isWindowsPlatform } = vi.hoisted(() => ({ isWindowsPlatform: vi.fn(() => false) }));
+vi.mock("../lib/platform", () => ({ isWindowsPlatform }));
+
+afterEach(() => isWindowsPlatform.mockReturnValue(false));
 
 const shell: ShellTerminal = {
 	handleId: "shellterm-1",
@@ -76,5 +81,26 @@ describe("ShellTerminalTab rename", () => {
 		const { onSelect } = renderTab();
 		fireEvent.click(screen.getByRole("button", { name: "ao" }));
 		expect(onSelect).toHaveBeenCalled();
+	});
+});
+
+describe("ShellTerminalTab rename gesture per platform", () => {
+	it("macOS/Linux: double-click enters edit, right-click does not", () => {
+		renderTab(); // isWindowsPlatform() defaults to false
+		const tab = screen.getByRole("button", { name: "ao" });
+		fireEvent.contextMenu(tab);
+		expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+		fireEvent.doubleClick(tab);
+		expect(screen.getByRole("textbox", { name: /rename terminal/i })).toBeInTheDocument();
+	});
+
+	it("Windows: right-click enters edit, double-click does not", () => {
+		isWindowsPlatform.mockReturnValue(true);
+		renderTab();
+		const tab = screen.getByRole("button", { name: "ao" });
+		fireEvent.doubleClick(tab);
+		expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+		fireEvent.contextMenu(tab);
+		expect(screen.getByRole("textbox", { name: /rename terminal/i })).toBeInTheDocument();
 	});
 });

--- a/frontend/src/renderer/components/ShellTerminalTab.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.test.tsx
@@ -94,6 +94,17 @@ describe("ShellTerminalTab rename gesture per platform", () => {
 		expect(screen.getByRole("textbox", { name: /rename terminal/i })).toBeInTheDocument();
 	});
 
+	it("macOS/Linux: two quick clicks enter edit even without a native dblclick (trackpad)", () => {
+		renderTab();
+		const tab = screen.getByRole("button", { name: "ao" });
+		// Two plain clicks, no dblclick event — mimics a trackpad double-tap that
+		// the OS delivers as separate clicks.
+		fireEvent.click(tab);
+		expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+		fireEvent.click(tab);
+		expect(screen.getByRole("textbox", { name: /rename terminal/i })).toBeInTheDocument();
+	});
+
 	it("Windows: right-click enters edit, double-click does not", () => {
 		isWindowsPlatform.mockReturnValue(true);
 		renderTab();

--- a/frontend/src/renderer/components/ShellTerminalTab.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.tsx
@@ -1,0 +1,109 @@
+import { X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useTruncatedText } from "../hooks/useTruncatedText";
+import type { ShellTerminal } from "../hooks/useShellTerminals";
+import { cn } from "../lib/utils";
+
+type ShellTerminalTabProps = {
+	shell: ShellTerminal;
+	isActive: boolean;
+	onSelect: () => void;
+	onClose: () => void;
+	/** Commit a new tab title. Omitted where rename is not wired. */
+	onRename?: (title: string) => void;
+};
+
+// One standalone-shell tab, shared by the session pane's tab strip (CenterPane)
+// and the standalone /terminals screen (ShellTerminalsView) so the two never
+// drift. The open tab gets the rounded background highlight used by the
+// inspector rail tabs; the full title only becomes the hover tooltip when the
+// strip truncates it; the close control appears on hover/focus.
+//
+// Double-clicking the label renames the tab inline: Enter or blur commits,
+// Escape cancels, and an empty or unchanged name is discarded. The close
+// control is a sibling button, not nested inside the tab button - nesting
+// interactive elements is invalid HTML and breaks keyboard traversal.
+export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename }: ShellTerminalTabProps) {
+	const { ref, isTruncated } = useTruncatedText<HTMLButtonElement>(shell.title);
+	const [isEditing, setIsEditing] = useState(false);
+	const [draft, setDraft] = useState(shell.title);
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	useEffect(() => {
+		if (isEditing) {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		}
+	}, [isEditing]);
+
+	const beginEdit = () => {
+		if (!onRename) return;
+		setDraft(shell.title);
+		setIsEditing(true);
+	};
+
+	const commit = () => {
+		if (!isEditing) return;
+		setIsEditing(false);
+		const next = draft.trim();
+		if (next && next !== shell.title) onRename?.(next);
+	};
+
+	const cancel = () => {
+		setIsEditing(false);
+		setDraft(shell.title);
+	};
+
+	return (
+		<span
+			className={cn(
+				"group inline-flex min-w-shell-tab-min items-center gap-1 rounded-md px-2 py-1 transition-colors",
+				isActive ? "bg-interactive-active" : "hover:bg-interactive-hover/60",
+			)}
+		>
+			{isEditing ? (
+				<input
+					aria-label={`Rename terminal ${shell.title}`}
+					className="min-w-flex-min max-w-shell-tab-max bg-transparent font-mono text-control font-semibold text-foreground outline-none"
+					onBlur={commit}
+					onChange={(event) => setDraft(event.target.value)}
+					onKeyDown={(event) => {
+						if (event.key === "Enter") {
+							event.preventDefault();
+							commit();
+						} else if (event.key === "Escape") {
+							event.preventDefault();
+							cancel();
+						}
+					}}
+					ref={inputRef}
+					value={draft}
+				/>
+			) : (
+				<button
+					ref={ref}
+					aria-current={isActive}
+					className={cn(
+						"min-w-flex-min max-w-shell-tab-max truncate font-mono text-control font-semibold transition-colors",
+						isActive ? "text-foreground" : "text-passive hover:text-foreground",
+					)}
+					onClick={onSelect}
+					onDoubleClick={beginEdit}
+					title={isTruncated ? shell.title : shell.workingDir}
+					type="button"
+				>
+					{shell.title}
+				</button>
+			)}
+			<button
+				aria-label={`Close terminal ${shell.title}`}
+				className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-passive opacity-0 transition-[background,color,opacity] group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
+				onClick={onClose}
+				title="Close terminal"
+				type="button"
+			>
+				<X aria-hidden="true" className="size-icon-sm" />
+			</button>
+		</span>
+	);
+}

--- a/frontend/src/renderer/components/ShellTerminalTab.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.tsx
@@ -64,7 +64,7 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 			{isEditing ? (
 				<input
 					aria-label={`Rename terminal ${shell.title}`}
-					className="min-w-flex-min max-w-shell-tab-max bg-transparent font-mono text-control font-semibold text-foreground outline-none"
+					className="min-w-flex-min max-w-shell-tab-max rounded-sm border border-accent bg-background px-1 font-mono text-control font-semibold text-foreground shadow-sm outline-none ring-1 ring-accent"
 					onBlur={commit}
 					onChange={(event) => setDraft(event.target.value)}
 					onKeyDown={(event) => {
@@ -84,7 +84,7 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 					ref={ref}
 					aria-current={isActive}
 					className={cn(
-						"min-w-flex-min max-w-shell-tab-max truncate font-mono text-control font-semibold transition-colors",
+						"min-w-flex-min max-w-shell-tab-max select-none truncate font-mono text-control font-semibold transition-colors",
 						isActive ? "text-foreground" : "text-passive hover:text-foreground",
 					)}
 					onClick={onSelect}

--- a/frontend/src/renderer/components/ShellTerminalTab.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.tsx
@@ -1,5 +1,5 @@
 import { X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { type MouseEvent, useEffect, useRef, useState } from "react";
 import { useTruncatedText } from "../hooks/useTruncatedText";
 import type { ShellTerminal } from "../hooks/useShellTerminals";
 import { isWindowsPlatform } from "../lib/platform";
@@ -42,10 +42,23 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 	}, [isEditing]);
 
 	const beginEdit = () => {
-		if (!onRename) return;
+		if (!onRename || isEditing) return;
 		setDraft(shell.title);
 		setIsEditing(true);
 	};
+
+	// The rename gesture lives on the whole tab so a double-click (or right-click
+	// on Windows) anywhere on the tab works, not just precisely on the label.
+	const containerRenameHandlers = isEditing
+		? {}
+		: renameViaRightClick
+			? {
+					onContextMenu: (event: MouseEvent) => {
+						event.preventDefault();
+						beginEdit();
+					},
+				}
+			: { onDoubleClick: beginEdit };
 
 	const commit = () => {
 		if (!isEditing) return;
@@ -65,6 +78,7 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 				"group inline-flex min-w-shell-tab-min items-center gap-1 rounded-md px-2 py-1 transition-colors",
 				isActive ? "bg-interactive-active" : "hover:bg-interactive-hover/60",
 			)}
+			{...containerRenameHandlers}
 		>
 			{isEditing ? (
 				<input
@@ -93,15 +107,6 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 						isActive ? "text-foreground" : "text-passive hover:text-foreground",
 					)}
 					onClick={onSelect}
-					onDoubleClick={renameViaRightClick ? undefined : beginEdit}
-					onContextMenu={
-						renameViaRightClick
-							? (event) => {
-									event.preventDefault();
-									beginEdit();
-								}
-							: undefined
-					}
 					title={
 						isTruncated
 							? shell.title
@@ -116,6 +121,8 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 				aria-label={`Close terminal ${shell.title}`}
 				className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-passive opacity-0 transition-[background,color,opacity] group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
 				onClick={onClose}
+				onDoubleClick={(event) => event.stopPropagation()}
+				onContextMenu={(event) => event.stopPropagation()}
 				title="Close terminal"
 				type="button"
 			>

--- a/frontend/src/renderer/components/ShellTerminalTab.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.tsx
@@ -2,6 +2,7 @@ import { X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTruncatedText } from "../hooks/useTruncatedText";
 import type { ShellTerminal } from "../hooks/useShellTerminals";
+import { isWindowsPlatform } from "../lib/platform";
 import { cn } from "../lib/utils";
 
 type ShellTerminalTabProps = {
@@ -19,15 +20,19 @@ type ShellTerminalTabProps = {
 // inspector rail tabs; the full title only becomes the hover tooltip when the
 // strip truncates it; the close control appears on hover/focus.
 //
-// Double-clicking the label renames the tab inline: Enter or blur commits,
-// Escape cancels, and an empty or unchanged name is discarded. The close
-// control is a sibling button, not nested inside the tab button - nesting
-// interactive elements is invalid HTML and breaks keyboard traversal.
+// Renaming happens inline with the platform's native gesture: double-click on
+// macOS/Linux, right-click on Windows. Enter or blur commits, Escape cancels,
+// and an empty or unchanged name is discarded. The close control is a sibling
+// button, not nested inside the tab button - nesting interactive elements is
+// invalid HTML and breaks keyboard traversal.
 export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename }: ShellTerminalTabProps) {
 	const { ref, isTruncated } = useTruncatedText<HTMLButtonElement>(shell.title);
 	const [isEditing, setIsEditing] = useState(false);
 	const [draft, setDraft] = useState(shell.title);
 	const inputRef = useRef<HTMLInputElement | null>(null);
+	// Rename gesture per platform: Windows uses right-click (its convention for
+	// tab/file renames); macOS and Linux use double-click.
+	const renameViaRightClick = isWindowsPlatform();
 
 	useEffect(() => {
 		if (isEditing) {
@@ -88,8 +93,20 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 						isActive ? "text-foreground" : "text-passive hover:text-foreground",
 					)}
 					onClick={onSelect}
-					onDoubleClick={beginEdit}
-					title={isTruncated ? shell.title : shell.workingDir}
+					onDoubleClick={renameViaRightClick ? undefined : beginEdit}
+					onContextMenu={
+						renameViaRightClick
+							? (event) => {
+									event.preventDefault();
+									beginEdit();
+								}
+							: undefined
+					}
+					title={
+						isTruncated
+							? shell.title
+							: `${shell.workingDir} (${renameViaRightClick ? "right-click" : "double-click"} to rename)`
+					}
 					type="button"
 				>
 					{shell.title}

--- a/frontend/src/renderer/components/ShellTerminalTab.tsx
+++ b/frontend/src/renderer/components/ShellTerminalTab.tsx
@@ -30,6 +30,7 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 	const [isEditing, setIsEditing] = useState(false);
 	const [draft, setDraft] = useState(shell.title);
 	const inputRef = useRef<HTMLInputElement | null>(null);
+	const lastClickAtRef = useRef(0);
 	// Rename gesture per platform: Windows uses right-click (its convention for
 	// tab/file renames); macOS and Linux use double-click.
 	const renameViaRightClick = isWindowsPlatform();
@@ -47,8 +48,20 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 		setIsEditing(true);
 	};
 
-	// The rename gesture lives on the whole tab so a double-click (or right-click
-	// on Windows) anywhere on the tab works, not just precisely on the label.
+	// Detect a double-click ourselves from two quick clicks rather than relying on
+	// the native dblclick event: some trackpad configurations deliver two taps as
+	// two separate clicks that never synthesize a dblclick, so onDoubleClick would
+	// never fire. Two clicks within 500ms anywhere on the tab start the rename.
+	const handleClick = () => {
+		const now = Date.now();
+		const isDoubleClick = now - lastClickAtRef.current < 500;
+		lastClickAtRef.current = isDoubleClick ? 0 : now;
+		if (isDoubleClick) beginEdit();
+	};
+
+	// The rename gesture lives on the whole tab so it works anywhere on the tab,
+	// not just precisely on the label. Windows uses right-click; macOS/Linux use
+	// the click-timing double-click detector above.
 	const containerRenameHandlers = isEditing
 		? {}
 		: renameViaRightClick
@@ -58,7 +71,7 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 						beginEdit();
 					},
 				}
-			: { onDoubleClick: beginEdit };
+			: { onClick: handleClick, onDoubleClick: beginEdit };
 
 	const commit = () => {
 		if (!isEditing) return;
@@ -120,7 +133,10 @@ export function ShellTerminalTab({ shell, isActive, onSelect, onClose, onRename 
 			<button
 				aria-label={`Close terminal ${shell.title}`}
 				className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-passive opacity-0 transition-[background,color,opacity] group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
-				onClick={onClose}
+				onClick={(event) => {
+					event.stopPropagation();
+					onClose();
+				}}
 				onDoubleClick={(event) => event.stopPropagation()}
 				onContextMenu={(event) => event.stopPropagation()}
 				title="Close terminal"

--- a/frontend/src/renderer/components/ShellTerminalsView.test.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.test.tsx
@@ -4,6 +4,7 @@ import { ShellTerminalsView } from "./ShellTerminalsView";
 
 vi.mock("../hooks/useShellTerminals", () => ({
 	useCloseShellTerminal: () => ({ mutate: vi.fn() }),
+	useRenameShellTerminal: () => ({ mutate: vi.fn() }),
 	useShellTerminals: () => ({ data: [] }),
 }));
 

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -1,11 +1,11 @@
-import { ChevronLeft, ChevronRight, Plus, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
 import { useEffect } from "react";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
-import { useTruncatedText } from "../hooks/useTruncatedText";
-import { useCloseShellTerminal, useShellTerminals, type ShellTerminal } from "../hooks/useShellTerminals";
+import { useCloseShellTerminal, useRenameShellTerminal, useShellTerminals } from "../hooks/useShellTerminals";
 import { useShell } from "../lib/shell-context";
 import { cn } from "../lib/utils";
 import { useResolvedTheme, useUiStore } from "../stores/ui-store";
+import { ShellTerminalTab } from "./ShellTerminalTab";
 import { TerminalPane } from "./TerminalPane";
 
 // The standalone terminals screen: shells with no agent session behind them,
@@ -20,6 +20,7 @@ export function ShellTerminalsView() {
 	const theme = useResolvedTheme();
 	const shellTerminals = useShellTerminals().data ?? [];
 	const closeShellTerminal = useCloseShellTerminal();
+	const renameShellTerminal = useRenameShellTerminal();
 	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);
 	const activeHandleId = useUiStore((state) => state.activeShellTerminalHandleId);
 	const setActiveShellTerminal = useUiStore((state) => state.setActiveShellTerminal);
@@ -65,10 +66,11 @@ export function ShellTerminalsView() {
 					{shellTerminals.map((shell) => {
 						const isActive = shell.handleId === active?.handleId;
 						return (
-							<ShellTab
+							<ShellTerminalTab
 								key={shell.handleId}
 								isActive={isActive}
 								onClose={() => closeShellTerminal.mutate(shell.handleId)}
+								onRename={(title) => renameShellTerminal.mutate({ handleId: shell.handleId, title })}
 								onSelect={() => setActiveShellTerminal(shell.handleId)}
 								shell={shell}
 							/>
@@ -118,55 +120,5 @@ export function ShellTerminalsView() {
 				)}
 			</div>
 		</div>
-	);
-}
-
-// Same tab chrome as the session view's strip: the open tab gets the rounded
-// background highlight used by the inspector rail tabs, the full title only
-// becomes the hover tooltip when the strip truncates it, and the close
-// control appears on hover/focus (kept a sibling button - nesting interactive
-// elements is invalid HTML).
-function ShellTab({
-	shell,
-	isActive,
-	onSelect,
-	onClose,
-}: {
-	shell: ShellTerminal;
-	isActive: boolean;
-	onSelect: () => void;
-	onClose: () => void;
-}) {
-	const { ref, isTruncated } = useTruncatedText<HTMLButtonElement>(shell.title);
-	return (
-		<span
-			className={cn(
-				"group inline-flex min-w-shell-tab-min items-center gap-1 rounded-md px-2 py-1 transition-colors",
-				isActive ? "bg-interactive-active" : "hover:bg-interactive-hover/60",
-			)}
-		>
-			<button
-				ref={ref}
-				aria-current={isActive}
-				className={cn(
-					"min-w-flex-min max-w-shell-tab-max truncate font-mono text-control font-semibold transition-colors",
-					isActive ? "text-foreground" : "text-passive hover:text-foreground",
-				)}
-				onClick={onSelect}
-				title={isTruncated ? shell.title : shell.workingDir}
-				type="button"
-			>
-				{shell.title}
-			</button>
-			<button
-				aria-label={`Close terminal ${shell.title}`}
-				className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-passive opacity-0 transition-[background,color,opacity] group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
-				onClick={onClose}
-				title="Close terminal"
-				type="button"
-			>
-				<X aria-hidden="true" className="size-icon-sm" />
-			</button>
-		</span>
 	);
 }

--- a/frontend/src/renderer/components/ShellTerminalsView.tsx
+++ b/frontend/src/renderer/components/ShellTerminalsView.tsx
@@ -18,7 +18,9 @@ import { TerminalPane } from "./TerminalPane";
 export function ShellTerminalsView() {
 	const { daemonStatus } = useShell();
 	const theme = useResolvedTheme();
-	const shellTerminals = useShellTerminals().data ?? [];
+	// The standalone screen shows only session-less shells; a session's own
+	// shells belong to that session's tab strip, not this global list.
+	const shellTerminals = (useShellTerminals().data ?? []).filter((s) => !s.sessionId);
 	const closeShellTerminal = useCloseShellTerminal();
 	const renameShellTerminal = useRenameShellTerminal();
 	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -113,3 +113,30 @@ export function useCloseShellTerminal() {
 		},
 	});
 }
+
+export type RenameShellTerminalInput = { handleId: string; title: string };
+
+/** Renames a shell terminal's tab. The new title persists on the daemon. */
+export function useRenameShellTerminal() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async ({ handleId, title }: RenameShellTerminalInput): Promise<ShellTerminal> => {
+			if (usePreviewData) {
+				previewShellTerminals = previewShellTerminals.map((s) => (s.handleId === handleId ? { ...s, title } : s));
+				const shell = previewShellTerminals.find((s) => s.handleId === handleId);
+				if (!shell) throw new Error("No such shell terminal");
+				return shell;
+			}
+			const { data, error } = await apiClient.PATCH("/api/v1/shell-terminals/{handleId}", {
+				params: { path: { handleId } },
+				body: { title },
+			});
+			if (error) throw error;
+			if (!data) throw new Error("Daemon returned no shell terminal");
+			return toShellTerminal(data.shellTerminal);
+		},
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: shellTerminalsQueryKey });
+		},
+	});
+}

--- a/frontend/src/renderer/hooks/useShellTerminals.ts
+++ b/frontend/src/renderer/hooks/useShellTerminals.ts
@@ -12,6 +12,8 @@ export type ShellTerminal = {
 	/** Runtime handle the terminal mux attaches to, exactly like a session pane's. */
 	handleId: string;
 	projectId?: string;
+	/** Agent session this shell is scoped to; absent for standalone shells. */
+	sessionId?: string;
 	workingDir: string;
 	title: string;
 	createdAt: string;
@@ -24,6 +26,7 @@ function toShellTerminal(t: components["schemas"]["ShellTerminalResponse"]): She
 	return {
 		handleId: t.handleId,
 		projectId: t.projectId,
+		sessionId: t.sessionId,
 		workingDir: t.workingDir,
 		title: t.title,
 		createdAt: t.createdAt,
@@ -62,16 +65,23 @@ export function useShellTerminals() {
 	return useQuery(shellTerminalsQueryOptions);
 }
 
-/** Opens a shell in the given project's root, or the daemon data dir when omitted. */
+export type OpenShellTerminalInput = { projectId?: string; sessionId?: string };
+
+/**
+ * Opens a shell in the given project's root (or the daemon data dir when
+ * omitted). When sessionId is set the shell is scoped to that session and only
+ * appears in its tab strip; otherwise it is a standalone shell on /terminals.
+ */
 export function useOpenShellTerminal() {
 	const queryClient = useQueryClient();
 	return useMutation({
-		mutationFn: async (projectId?: string): Promise<ShellTerminal> => {
+		mutationFn: async ({ projectId, sessionId }: OpenShellTerminalInput = {}): Promise<ShellTerminal> => {
 			if (usePreviewData) {
 				previewShellSeq += 1;
 				const shell: ShellTerminal = {
 					handleId: `shellterm-preview-${previewShellSeq}`,
 					projectId,
+					sessionId,
 					workingDir: `/Users/demo/Projects/${projectId ?? "ao"}`,
 					title: projectId ?? "shell",
 					createdAt: new Date().toISOString(),
@@ -79,9 +89,10 @@ export function useOpenShellTerminal() {
 				previewShellTerminals = [...previewShellTerminals, shell];
 				return shell;
 			}
-			const { data, error } = await apiClient.POST("/api/v1/shell-terminals", {
-				body: projectId ? { projectId } : {},
-			});
+			const body: OpenShellTerminalInput = {};
+			if (projectId) body.projectId = projectId;
+			if (sessionId) body.sessionId = sessionId;
+			const { data, error } = await apiClient.POST("/api/v1/shell-terminals", { body });
 			if (error) throw error;
 			if (!data) throw new Error("Daemon returned no shell terminal");
 			return toShellTerminal(data.shellTerminal);

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -479,14 +479,17 @@ function ShellLayout() {
 	useEffect(() => {
 		if (handledShellNonceRef.current === newShellTerminalNonce) return;
 		handledShellNonceRef.current = newShellTerminalNonce;
-		openShellTerminal.mutate(scopedProjectId, {
-			onSuccess: (shell) => {
-				setActiveShellTerminal(shell.handleId);
-				if (!routeParams.sessionId) {
-					void navigate({ to: "/terminals" });
-				}
+		openShellTerminal.mutate(
+			{ projectId: scopedProjectId, sessionId: routeParams.sessionId },
+			{
+				onSuccess: (shell) => {
+					setActiveShellTerminal(shell.handleId);
+					if (!routeParams.sessionId) {
+						void navigate({ to: "/terminals" });
+					}
+				},
 			},
-		});
+		);
 	}, [
 		newShellTerminalNonce,
 		openShellTerminal,

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -313,7 +313,10 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 
 		pressNewShellTerminal();
 
-		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith("proj-1", expect.anything());
+		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith(
+			expect.objectContaining({ projectId: "proj-1" }),
+			expect.anything(),
+		);
 	});
 
 	it("re-fires on a repeat press so a second terminal can be opened", async () => {


### PR DESCRIPTION
## Problem

Two issues with the standalone shell terminal tabs:

1. **Tabs collide across sessions.** Shell terminals are stored as a single app-wide daemon list and carried only a `projectId`, so a shell opened in one session showed up in every session's tab strip (even in a different session of the same project). See the two screenshots in the discussion: sessions `ao-7` ("review") and `ao-13` ("work") both showed the same "AO" shell.
2. **Tabs can't be renamed.** A shell's title was fixed at creation (the working dir's base name) with no way to change it.

## Fix

**Per-session isolation**
- Shell terminals gain a nullable `session_id` (migration `0036`, FK to `sessions` ON DELETE CASCADE), threaded through query → store → service → DTO → generated TS.
- The shell layout tags a new shell with the current route's `sessionId` when one is open. `SessionView` filters its strip to `sessionId === current session`. Shells opened outside any session (from the board) have no session and live only on the standalone `/terminals` screen, which now shows only session-less shells.
- When the globally-active shell belongs to another session, the pane falls back to the session's own tab instead of rendering a shell that isn't in the strip.

**Rename**
- New `PATCH /api/v1/shell-terminals/{handleId}` with `{ "title": "..." }`, backed by `UpdateShellTerminalTitle`. Title is trimmed, must be non-empty and ≤ 80 chars; unknown handle is a 404. The title persists on the daemon and survives reload.
- Double-click a shell tab to rename inline: Enter/blur commits, Escape cancels, empty/unchanged is discarded.
- The two near-identical tab components (`CenterPane`, `ShellTerminalsView`) are unified into one shared `ShellTerminalTab`.

OpenAPI spec and generated `schema.ts` regenerated from the code-first source.

## Also included

Merged latest `main` and reformatted six agent-adapter files with go.mod's canonical Go 1.25.7 `gofmt` (import order: `ports` before `process`). PR #3006 had committed them with a newer gofmt, turning `main`'s build-test/lint red; this un-breaks CI for the branch.

## Testing

- Backend: `go build ./...`, `go vet`, golangci-lint clean, and `go test ./internal/service/shellterm/... ./internal/httpd/... ./internal/storage/sqlite/...` pass. New tests: `sessionId` round-trips through open; rename success / empty-title rejection / unknown-handle 404; controller PATCH returns the updated terminal, malformed body 400, 501-without-service.
- Frontend: `tsc --noEmit` clean; full renderer suite (1045 tests) passes. New `ShellTerminalTab` rename tests + a `SessionView` regression test asserting only the current session's shells reach the strip.
- Verified live in the dev app: shells opened in different sessions no longer share a strip; rename persists across reload.