### PR TITLE
feat(frontend): compact board and review spacing

### DIFF
--- a/frontend/src/renderer/components/SessionFilesView.test.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.test.tsx
@@ -273,6 +273,9 @@ describe("SessionFilesView", () => {
 		expect(row).not.toHaveClass("border");
 		expect(row).not.toHaveClass("bg-surface");
 		expect(row).not.toHaveClass("shadow-sm");
+		expect(activeRowButton.parentElement).toHaveClass("min-h-10");
+		expect(activeRowButton).toHaveClass("gap-2", "px-3", "py-1.5");
+		expect(screen.getByLabelText("Session files").querySelector("header")).toHaveClass("h-11", "px-1.5");
 	});
 
 	it("lets the caller toggle between rail and maximized layouts", async () => {

--- a/frontend/src/renderer/components/SessionFilesView.tsx
+++ b/frontend/src/renderer/components/SessionFilesView.tsx
@@ -155,7 +155,7 @@ export function SessionFilesView({
 			className="flex h-full min-h-0 flex-col bg-background text-foreground"
 			aria-label="Session files"
 		>
-			<header className="flex h-13 shrink-0 items-center gap-0.5 border-b border-border bg-surface px-2">
+			<header className="flex h-11 shrink-0 items-center gap-0.5 border-b border-border bg-surface px-1.5">
 				{searchOpen ? (
 					<label className="relative mr-auto min-w-0 flex-1 max-w-[280px]">
 						<Search className="pointer-events-none absolute left-2.5 top-1/2 size-icon-sm -translate-y-1/2 text-passive" />
@@ -254,7 +254,7 @@ export function SessionFilesView({
 			</header>
 
 			<div className="min-h-0 flex-1 overflow-auto bg-background">
-				<div className="mx-auto flex w-full max-w-[1200px] flex-col px-0 py-2">
+				<div className="mx-auto flex w-full max-w-[1200px] flex-col px-0 py-1">
 					<ReviewFileList
 						error={filesQuery.error}
 						expandedPaths={expandedPaths}
@@ -348,7 +348,7 @@ function ReviewFileCard({
 		<article className="session-files-review-row overflow-hidden bg-transparent">
 			<div
 				className={cn(
-					"group/row flex min-h-11 items-center transition-colors",
+					"group/row flex min-h-10 items-center transition-colors",
 					expanded ? "bg-interactive-active/45" : "hover:bg-interactive-hover/50",
 				)}
 			>
@@ -356,7 +356,7 @@ function ReviewFileCard({
 					aria-controls={`workspace-diff-${file.path}`}
 					aria-expanded={expanded}
 					aria-label={`${expanded ? "Collapse" : "Expand"} ${file.path}`}
-					className="flex min-w-0 flex-1 items-center gap-3 px-4 py-2 text-left"
+					className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left"
 					data-file-toggle=""
 					onClick={onToggle}
 					type="button"
@@ -394,7 +394,7 @@ function CopyPathButton({ path }: { path: string }) {
 	return (
 		<Button
 			aria-label={copied ? "Path copied" : `Copy path for ${path}`}
-			className="mr-2 shrink-0 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/row:opacity-100"
+			className="mr-1.5 shrink-0 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/row:opacity-100"
 			onClick={() => {
 				void navigator.clipboard?.writeText(path);
 				setCopied(true);
@@ -621,9 +621,9 @@ function DiffView({
 	wrap: boolean;
 }) {
 	return (
-		<div className="flex min-h-[220px] max-h-[min(620px,calc(100vh-18rem))] flex-col">
+		<div className="flex min-h-[180px] max-h-[min(620px,calc(100vh-18rem))] flex-col">
 			{truncated ? (
-				<div className="shrink-0 border-b border-border bg-warning/10 px-4 py-2 text-xs text-warning">
+				<div className="shrink-0 border-b border-border bg-warning/10 px-3 py-1.5 text-xs text-warning">
 					Diff preview truncated.
 				</div>
 			) : null}
@@ -649,7 +649,7 @@ function DiffView({
 									>
 										{diffMarkerGlyph[row.kind]}
 									</span>
-									<span className={cn("pr-4", wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre")}>
+									<span className={cn("pr-3", wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre")}>
 										{row.segments ? (
 											<DiffLineSegments add={row.kind === "add"} segments={row.segments} />
 										) : (
@@ -668,7 +668,7 @@ function DiffView({
 
 function HunkBand({ row }: { row: DiffRow }) {
 	return (
-		<div className="flex select-none items-baseline gap-3 bg-surface-faint px-3 py-1 text-passive">
+		<div className="flex select-none items-baseline gap-2 bg-surface-faint px-2.5 py-0.75 text-passive">
 			<span className="shrink-0 text-passive/70">{row.text}</span>
 			{row.section ? <span className="min-w-0 truncate text-passive/90">{row.section}</span> : null}
 		</div>
@@ -733,7 +733,7 @@ function SplitSide({ row, side }: { row: DiffRow | null; side: "old" | "new" }) 
 			<span className="w-9 shrink-0 select-none border-r border-border/50 bg-terminal px-1.5 text-right text-passive/70 tabular-nums">
 				{lineNo ?? ""}
 			</span>
-			<span className="min-w-0 whitespace-pre-wrap break-all px-2">
+			<span className="min-w-0 whitespace-pre-wrap break-all px-1.5">
 				{row.segments ? <DiffLineSegments add={row.kind === "add"} segments={row.segments} /> : row.text || " "}
 			</span>
 		</div>

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -177,6 +177,9 @@ describe("SessionInspector tabs", () => {
 		const summaryTab = screen.getByRole("tab", { name: "Summary" });
 
 		expect(summaryTab).not.toHaveClass("flex-1");
+		expect(summaryTab).toHaveClass("h-control-md", "px-1.5");
+		expect(summaryTab).toHaveAttribute("title", "Summary");
+		expect(within(summaryTab).getByText("Summary")).toHaveClass("@max-[350px]/inspector:hidden");
 	});
 
 	it("renders the supplied files view when the Files tab opens", async () => {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -83,7 +83,7 @@ const prStateTone: Record<SessionPRSummary["state"], string> = {
 
 const inspectorShellClass = "@container/inspector flex h-full min-h-0 flex-col overflow-hidden";
 
-const inspectorBodyClass = "min-h-0 flex-1 overflow-y-auto p-4 pb-6 @max-[300px]/inspector:px-3";
+const inspectorBodyClass = "min-h-0 flex-1 overflow-y-auto p-3 pb-4 @max-[300px]/inspector:px-2.5";
 
 const inspectorEmptyClass = "text-xs text-muted-foreground leading-normal";
 
@@ -166,21 +166,23 @@ export function SessionInspector({
 
 	return (
 		<aside className={inspectorShellClass} aria-label="Session inspector">
-			<div className="flex h-inspector-tabs shrink-0 items-center gap-1 border-b border-border px-3" role="tablist">
+			<div className="flex h-inspector-tabs shrink-0 items-center gap-1 border-b border-border px-2.5" role="tablist">
 				{VIEWS.map((entry) => (
 					<button
+						aria-label={entry.label}
 						key={entry.id}
 						type="button"
 						role="tab"
 						aria-selected={view === entry.id}
 						className={cn(
-							"inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md p-1.5 text-sm-md font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
+							"inline-flex h-control-md shrink-0 items-center justify-center gap-1.5 rounded-md px-1.5 text-sm-md font-semibold text-passive transition-[background,color] duration-fast hover:bg-interactive-hover hover:text-foreground",
 							view === entry.id && "bg-interactive-active text-foreground",
 						)}
 						onClick={() => setView(entry.id)}
+						title={entry.label}
 					>
 						<span className="inline-flex shrink-0 [&_svg]:size-icon-md">{entry.icon}</span>
-						<span className="truncate">{entry.label}</span>
+						<span className="truncate @max-[350px]/inspector:hidden">{entry.label}</span>
 					</button>
 				))}
 			</div>
@@ -227,8 +229,8 @@ function Section({
 	title: string;
 }) {
 	return (
-		<section className={cn("mb-5 last:mb-0", className)} data-testid="inspector-section">
-			<div className="mb-2 flex items-center justify-between text-2xs font-semibold uppercase tracking-wide-lg text-passive">
+		<section className={cn("mb-4 last:mb-0", className)} data-testid="inspector-section">
+			<div className="mb-1.5 flex items-center justify-between text-2xs font-semibold uppercase tracking-wide-lg text-passive">
 				<span>{title}</span>
 				{action ?? null}
 			</div>
@@ -249,7 +251,7 @@ function SummaryView({ session }: { session: WorkspaceSession }) {
 				{prSummaries.length === 0 ? (
 					<p className={inspectorEmptyClass}>No pull request opened yet.</p>
 				) : (
-					<div className="flex flex-col gap-2">
+					<div className="flex flex-col gap-1.5">
 						{prSummaries.map((pr) => (
 							<PRSummaryCard key={pr.number} pr={pr} />
 						))}
@@ -264,7 +266,7 @@ function SummaryView({ session }: { session: WorkspaceSession }) {
 				<ResumeAgentControl session={session} />
 			</Section>
 
-			<Section className="border-t border-border pt-4" title="Overview">
+			<Section className="border-t border-border pt-3" title="Overview">
 				<dl className="flex flex-col gap-1">
 					<Row k="Agent" v={session.provider} mono />
 					{issueId && <Row k="Issue" v={issueId} mono />}
@@ -436,7 +438,7 @@ function updateSessionMergePolicy(
 
 function PRSummaryCard({ pr }: { pr: SessionPRSummary }) {
 	return (
-		<div className="rounded-md border border-border bg-surface px-3 py-2">
+		<div className="rounded-md border border-border bg-surface px-2.5 py-1.5">
 			<div className="flex items-center gap-2">
 				<GitPullRequest className="size-icon-md shrink-0 text-passive" aria-hidden="true" />
 				<span className="text-md-sm font-medium text-foreground">PR #{pr.number}</span>
@@ -456,9 +458,9 @@ function PRSummaryCard({ pr }: { pr: SessionPRSummary }) {
 					<ArrowUpRight aria-hidden="true" className="size-icon-2xs" strokeWidth={2} />
 				</a>
 			</div>
-			{pr.title ? <div className="mt-2 text-xs font-medium leading-snug text-foreground">{pr.title}</div> : null}
-			<PRSummaryMeta className="mt-1.5" pr={pr} />
-			<PRSummaryParts className="mt-2" pr={pr} variant="stacked" />
+			{pr.title ? <div className="mt-1.5 text-xs font-medium leading-snug text-foreground">{pr.title}</div> : null}
+			<PRSummaryMeta className="mt-1" pr={pr} />
+			<PRSummaryParts className="mt-1.5" pr={pr} variant="stacked" />
 		</div>
 	);
 }
@@ -877,7 +879,7 @@ function ReviewPanel({
 		openReviewStates.every((reviewState) => reviewState.status === "ineligible");
 
 	return (
-		<div className="flex flex-col gap-4">
+		<div className="flex flex-col gap-3">
 			{error ? (
 				<p className="m-0 rounded-md border border-error/28 bg-error/8 px-2.5 py-2 text-sm-md leading-normal text-error">
 					{apiErrorMessage(error, "Review request failed")}
@@ -888,13 +890,13 @@ function ReviewPanel({
 					{notice}
 				</p>
 			) : null}
-			<div className="inline-flex min-w-0 items-center gap-2 font-mono text-control font-semibold text-foreground">
+			<div className="inline-flex min-w-0 items-center gap-1.5 font-mono text-control font-semibold text-foreground">
 				<Shield aria-hidden="true" className="size-icon-lg shrink-0 text-passive" />
 				<span className="min-w-0 truncate">{harness}</span>
 				<span className="font-sans text-sm-md font-medium text-passive">reviewer</span>
 			</div>
-			<div className="flex flex-col gap-3 overflow-hidden rounded-lg border border-border bg-surface p-3 @max-[300px]/inspector:overflow-hidden">
-				<div className="flex min-w-0 items-center justify-between gap-2.5 @max-[300px]/inspector:flex-col @max-[300px]/inspector:items-start">
+			<div className="flex flex-col gap-2 overflow-hidden rounded-lg border border-border bg-surface p-2.5 @max-[300px]/inspector:overflow-hidden">
+				<div className="flex min-w-0 items-center justify-between gap-2 @max-[300px]/inspector:flex-col @max-[300px]/inspector:items-start">
 					<span className="min-w-0 truncate text-xs font-semibold text-muted-foreground">Pull requests</span>
 					<span
 						className={cn(
@@ -913,7 +915,7 @@ function ReviewPanel({
 						<ReviewStateRow key={`${reviewState.prUrl}:${reviewState.targetSha}`} reviewState={reviewState} />
 					))}
 				</div>
-				<div className="grid grid-cols-2 gap-2.5 pt-1 has-[:only-child]:grid-cols-1 @max-[300px]/inspector:grid-cols-1">
+				<div className="grid grid-cols-2 gap-2 has-[:only-child]:grid-cols-1 @max-[300px]/inspector:grid-cols-1">
 					<button
 						className={cn(
 							"inline-flex h-control-xl min-w-0 items-center justify-center gap-2 overflow-hidden truncate rounded-md border px-2.5 text-xs font-semibold transition-[background,border-color,color] duration-fast hover:bg-interactive-hover hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45 [&_svg]:size-icon-md [&_svg]:shrink-0",
@@ -950,7 +952,7 @@ function ReviewStateRow({ reviewState }: { reviewState: PRReviewState }) {
 	return (
 		<div
 			className={cn(
-				"grid min-h-row-md grid-cols-[minmax(0,1fr)_auto] items-center gap-2.5 border-0 border-b border-border bg-transparent p-3 last:border-b-0",
+				"grid min-h-row-md grid-cols-[minmax(0,1fr)_auto] items-center gap-2 border-0 border-b border-border bg-transparent p-2 last:border-b-0",
 				reviewState.status === "ineligible" && "opacity-70",
 			)}
 		>

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -179,6 +179,9 @@ describe("SessionsBoard", () => {
 		const terminateButton = within(idleCard).getByRole("button", { name: "Terminate brand-font-pipeline" });
 		expect(terminateButton).toHaveClass("opacity-0", "group-hover:opacity-100", "group-focus-within:opacity-100");
 		expect(terminateButton.querySelector("svg")).toHaveClass("lucide-trash-2");
+		expect(within(idleCard).getByText("Idle").parentElement).toHaveClass("pb-1.5", "pt-2");
+		expect(within(idleCard).getByText("brand-font-pipeline")).toHaveClass("pb-1");
+		expect(within(idleCard).getByText("no PR yet")).toHaveClass("py-1.25");
 	});
 
 	it("copies visible branch names and PR URLs without opening the session", async () => {
@@ -314,7 +317,7 @@ describe("SessionsBoard", () => {
 		renderBoard("p1");
 
 		const needsYouColumn = screen.getByText("Needs you").closest("section") as HTMLElement;
-		expect(needsYouColumn.firstElementChild).toHaveClass("pb-2.5");
+		expect(needsYouColumn.firstElementChild).toHaveClass("py-2");
 		expect(within(needsYouColumn).getByText("agent-exited-task")).toBeInTheDocument();
 		expect(within(needsYouColumn).getByText("Exited").closest("span")).toHaveClass("text-status-exited");
 	});

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -467,7 +467,7 @@ function ZoneColumn({
 				background: `linear-gradient(180deg, ${col.glow}, transparent var(--size-kanban-glow)), var(--color-overlay-subtle)`,
 			}}
 		>
-			<div className="flex shrink-0 items-center gap-2 px-3 pb-2.5 pt-2.5">
+			<div className="flex shrink-0 items-center gap-2 px-3 py-2">
 				<span
 					className="size-dot-sm rounded-full"
 					style={{
@@ -810,7 +810,7 @@ function SessionCard({
 				</button>
 			) : null}
 			<div {...cardBodyProps}>
-				<div className="flex items-center gap-2 px-3 pb-2 pt-2.5">
+				<div className="flex items-center gap-2 px-3 pb-1.5 pt-2">
 					<span className={cn("inline-flex items-center gap-1.5 text-caption font-medium", badge.className)}>
 						<span className={cn("size-dot-sm rounded-full bg-current")} />
 						{badge.label}
@@ -832,7 +832,7 @@ function SessionCard({
 				<div
 					className={cn(
 						"px-3 text-control font-medium leading-snug tracking-tight text-foreground",
-						showBranch ? "pb-1.5" : "pb-2.5",
+						showBranch ? "pb-1" : "pb-2",
 						"line-clamp-2 overflow-hidden",
 					)}
 				>
@@ -841,7 +841,7 @@ function SessionCard({
 			</div>
 			{showBranch && (
 				<div
-					className="flex min-w-0 items-center gap-1 px-3 pb-2 font-mono text-2xs text-passive"
+					className="flex min-w-0 items-center gap-1 px-3 pb-1.5 font-mono text-2xs text-passive"
 					onClick={interactive ? onOpen : undefined}
 				>
 					<span className="truncate">{branch}</span>
@@ -849,7 +849,7 @@ function SessionCard({
 				</div>
 			)}
 			<div aria-hidden="true" className="mx-3 my-px h-px bg-border" />
-			<div className="px-3 py-1.5 font-mono text-2xs text-passive">
+			<div className="px-3 py-1.25 font-mono text-2xs text-passive">
 				{prSummaries.length === 0 ? (
 					"no PR yet"
 				) : (

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -210,7 +210,7 @@
 	--size-control-board: 36px;
 	--size-table-head: var(--space-10);
 	--size-toolbar: 56px;
-	--size-inspector-tabs: 47px;
+	--size-inspector-tabs: 42px;
 	--size-row-md: 52px;
 	--size-browser-url: 29px;
 	--size-browser-min: 320px;


### PR DESCRIPTION
Closes #2882

Hey @Pulkit7070 and @codebanditssss, this tightens up the spacing across the board and review surfaces without changing their behavior.

What changed:
- made board headers and session cards more compact
- reduced spacing in the Summary and Reviews panels
- tightened the files toolbar, file rows, and diff container
- switched inspector tabs to accessible icon-only controls on narrow rails so they do not overflow
- added focused spacing assertions to the existing component tests

Checked with:
- `npm run typecheck`
- `npm run typecheck:e2e`
- `npx vitest run` — 1,038 tests passed
- `CI=true npm run test:e2e:renderer` — 20 tests passed
- Prettier and `git diff --check`
- visual checks at normal and narrow desktop widths
- Electron desktop launch
