### PR TITLE
fix(conpty): correctly implement pidAlive using processalive on Windows

### DIFF
--- a/backend/internal/adapters/runtime/conpty/pidalive_windows.go
+++ b/backend/internal/adapters/runtime/conpty/pidalive_windows.go
@@ -6,18 +6,12 @@ import (
 	"fmt"
 	"os"
 
-	"golang.org/x/sys/windows"
+	"github.com/aoagents/agent-orchestrator/backend/internal/processalive"
 )
 
-// pidAlive probes PID liveness on Windows by opening the process handle with
-// SYNCHRONIZE (minimal permission). Failure means the process is gone.
+// pidAlive probes PID liveness on Windows.
 func pidAlive(pid int) bool {
-	h, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
-	if err != nil {
-		return false
-	}
-	_ = windows.CloseHandle(h)
-	return true
+	return processalive.Alive(pid)
 }
 
 // defaultOSProcessFinder wraps os.FindProcess for Windows.


### PR DESCRIPTION
## What

Updates the `pidAlive` function in `backend/internal/adapters/runtime/conpty/pidalive_windows.go` to delegate to `processalive.Alive`.

## Why

Fixes #3079.

On Windows, the ConPTY runtime adapter's `pidAlive` implementation opened a handle to the process with `SYNCHRONIZE` access but never actually waited on it using `WaitForSingleObject`. Because Windows keeps process kernel objects alive until all handles are closed, `OpenProcess` succeeded for recently-terminated processes, incorrectly returning `true`. This broke the early-exit optimization during session teardown, causing the loop to always hang for the full 500ms deadline.

## How

- Replaced the flawed `OpenProcess` logic in `pidAlive` by directly calling `processalive.Alive(pid)`. 
- `processalive.Alive` is already implemented and proven elsewhere in the codebase, and correctly uses `WaitForSingleObject(handle, 0)` to check for `WAIT_TIMEOUT`.
- Replaced the `"golang.org/x/sys/windows"` import with `"github.com/aoagents/agent-orchestrator/backend/internal/processalive"`.

## Testing

- Confirmed that this effectively stops returning false positives for terminated processes.
- Checked that tests pass: `cd backend && go build ./... && go test ./...`

## Checklist

- [✓] Branched from `main` 
- [✓] One focused change; links the related issue when applicable
- [✓] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense *(Note: No new tests added as this delegates to the already-tested `processalive` package).*
- [✓] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
