### PR TITLE
fix: isolate session kill state across worker switches

### DIFF
--- a/docs/superpowers/plans/2026-07-25-kill-state-isolation.md
+++ b/docs/superpowers/plans/2026-07-25-kill-state-isolation.md
@@ -20,10 +20,12 @@
 ### Task 1: Isolate topbar kill state by session
 
 **Files:**
+
 - Modify: `frontend/src/renderer/components/ShellTopbar.tsx:225`
 - Test: `frontend/src/renderer/components/ShellTopbar.test.tsx:253`
 
 **Interfaces:**
+
 - Consumes: `WorkspaceSession.id`, the existing `renderTopbarSessions` test helper, and the existing `TopbarKillButton` mutation flow.
 - Produces: A `TopbarKillButton` instance whose React identity is the selected session ID.
 

--- a/docs/superpowers/plans/2026-07-25-kill-state-isolation.md
+++ b/docs/superpowers/plans/2026-07-25-kill-state-isolation.md
@@ -1,0 +1,128 @@
+# Session Kill State Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent one worker session's kill confirmation, pending state, or error from appearing after the user switches to another worker.
+
+**Architecture:** Give `TopbarKillButton` a React identity derived from `session.id`. When the selected session changes, React unmounts the old stateful control and mounts a clean control for the new worker while the original daemon request may continue independently.
+
+**Tech Stack:** React 19, TypeScript, TanStack Query, Vitest, Testing Library
+
+## Global Constraints
+
+- Keep the fix limited to frontend component identity and its regression test.
+- Do not change daemon, storage, or API contracts.
+- A pending kill request for worker A may continue after the UI switches to worker B.
+- Worker B must not display worker A's confirmation, pending state, or error.
+
+---
+
+### Task 1: Isolate topbar kill state by session
+
+**Files:**
+- Modify: `frontend/src/renderer/components/ShellTopbar.tsx:225`
+- Test: `frontend/src/renderer/components/ShellTopbar.test.tsx:253`
+
+**Interfaces:**
+- Consumes: `WorkspaceSession.id`, the existing `renderTopbarSessions` test helper, and the existing `TopbarKillButton` mutation flow.
+- Produces: A `TopbarKillButton` instance whose React identity is the selected session ID.
+
+- [x] **Step 1: Write the failing session-switch regression test**
+
+Add this test inside the existing `describe("TopbarKillButton", ...)` block:
+
+```tsx
+it("does not leak pending kill state when switching worker sessions", async () => {
+	postMock.mockReturnValue(new Promise(() => {}));
+	const view = renderTopbarSessions([worker, secondWorker], "sess-1");
+
+	await userEvent.click(screen.getByRole("button", { name: "Kill session" }));
+	await clickKillDialogConfirm();
+	expect(await screen.findByRole("button", { name: "Killing..." })).toBeDisabled();
+
+	paramsMock.sessionId = "sess-2";
+	view.rerenderTopbar();
+
+	expect(screen.queryByRole("dialog", { name: "Kill session?" })).not.toBeInTheDocument();
+	expect(screen.getByRole("button", { name: "Kill session" })).toBeEnabled();
+});
+```
+
+- [x] **Step 2: Run the focused test to verify RED**
+
+Run:
+
+```powershell
+cd frontend
+npm.cmd test -- ShellTopbar.test.tsx
+```
+
+Expected: FAIL in `does not leak pending kill state when switching worker sessions` because the dialog remains open with its `Killing...` button after the route changes to `sess-2`.
+
+- [x] **Step 3: Add the session identity key**
+
+Update the existing render site:
+
+```tsx
+<TopbarKillButton
+	key={session.id}
+	session={session}
+	orchestratorId={orchestrator?.id}
+	onKilled={(workspaceId, orchestratorId) => {
+		if (orchestratorId) {
+			void navigate({
+				to: "/projects/$projectId/sessions/$sessionId",
+				params: { projectId: workspaceId, sessionId: orchestratorId },
+			});
+			return;
+		}
+		void navigate({ to: "/projects/$projectId", params: { projectId: workspaceId } });
+	}}
+/>
+```
+
+The only production behavior change is the new `key={session.id}` prop.
+
+- [x] **Step 4: Run the focused test to verify GREEN**
+
+Run:
+
+```powershell
+cd frontend
+npm.cmd test -- ShellTopbar.test.tsx
+```
+
+Expected: all tests in `ShellTopbar.test.tsx` pass, including the new regression test.
+
+- [x] **Step 5: Run frontend verification**
+
+Run:
+
+```powershell
+cd frontend
+npm.cmd run typecheck
+npm.cmd run package
+```
+
+Expected: both commands exit successfully with no TypeScript or Electron
+packaging errors. The current frontend package has no standalone `build` script;
+`package` is its defined production-build path.
+
+- [x] **Step 6: Verify scope and commit**
+
+Run:
+
+```powershell
+git diff --check
+git diff -- frontend/src/renderer/components/ShellTopbar.tsx frontend/src/renderer/components/ShellTopbar.test.tsx
+git status --short
+```
+
+Expected: the production diff contains only `key={session.id}`, the test diff contains only the regression test, and there are no unrelated changes.
+
+Commit:
+
+```powershell
+git add -- frontend/src/renderer/components/ShellTopbar.tsx frontend/src/renderer/components/ShellTopbar.test.tsx docs/superpowers/plans/2026-07-25-kill-state-isolation.md
+git commit -m "fix: isolate session kill state"
+```

--- a/docs/superpowers/specs/2026-07-25-kill-state-isolation-design.md
+++ b/docs/superpowers/specs/2026-07-25-kill-state-isolation-design.md
@@ -1,0 +1,42 @@
+# Session Kill State Isolation
+
+## Problem
+
+`ShellTopbar` persists while the selected session route changes. Its
+`TopbarKillButton` child currently has no session-specific React key, so React
+reuses the component when the user switches workers. Confirmation, pending
+mutation, and error state from worker A can therefore appear while worker B is
+selected.
+
+## Intended Behavior
+
+Killing a worker affects only that worker's controls. If the user switches from
+worker A to worker B while A's kill request is pending, worker B shows its normal
+Kill button and does not expose A's confirmation, progress, or error state. The
+request to kill A may continue in the background.
+
+## Design
+
+Render `TopbarKillButton` with `key={session.id}`. A session change then unmounts
+the old button instance and mounts a new instance with clean local and mutation
+state. This establishes the session ID as the component identity without adding
+state synchronization or changing the daemon API.
+
+Alternatives considered:
+
+- Reset local and mutation state in an effect when `session.id` changes. This is
+  more complex and can briefly render stale state before the effect runs.
+- Store kill state in a parent map keyed by session ID. This is unnecessary
+  because the UI only presents controls for the selected session.
+
+## Testing
+
+Add a `ShellTopbar` regression test that:
+
+1. Renders worker A and starts a kill request that remains pending.
+2. Switches the route parameter to worker B and rerenders the persistent topbar.
+3. Verifies worker A's dialog and pending state are gone and worker B has a clean
+   Kill button.
+
+The focused `ShellTopbar` tests and frontend typecheck must pass. No backend,
+storage, or API contract changes are required.

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -324,4 +324,19 @@ describe("TopbarKillButton", () => {
 			expect(onKilledMock).toHaveBeenCalledWith("proj-1", undefined);
 		});
 	});
+
+	it("does not leak pending kill state when switching worker sessions", async () => {
+		postMock.mockReturnValue(new Promise(() => {}));
+		const view = renderTopbarSessions([worker, secondWorker], "sess-1");
+
+		await userEvent.click(screen.getByRole("button", { name: "Kill session" }));
+		await clickKillDialogConfirm();
+		expect(await screen.findByRole("button", { name: "Killing..." })).toBeDisabled();
+
+		paramsMock.sessionId = "sess-2";
+		view.rerenderTopbar();
+
+		expect(screen.queryByRole("dialog", { name: "Kill session?" })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Kill session" })).toBeEnabled();
+	});
 });

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -114,7 +114,7 @@ function renderTopbarSessions(sessions: WorkspaceSession[], sessionId: string) {
 		</QueryClientProvider>
 	);
 	const result = render(topbar());
-	return { ...result, rerenderTopbar: () => result.rerender(topbar()) };
+	return { ...result, queryClient, rerenderTopbar: () => result.rerender(topbar()) };
 }
 
 function renderKill(session: WorkspaceSession = worker, orchestratorId?: string) {
@@ -325,8 +325,13 @@ describe("TopbarKillButton", () => {
 		});
 	});
 
-	it("does not leak pending kill state when switching worker sessions", async () => {
-		postMock.mockReturnValue(new Promise(() => {}));
+	it("isolates an in-flight kill when switching worker sessions", async () => {
+		let resolveKill!: (value: { data: { ok: boolean; sessionId: string }; error: undefined }) => void;
+		postMock.mockReturnValue(
+			new Promise((resolve) => {
+				resolveKill = resolve;
+			}),
+		);
 		const view = renderTopbarSessions([worker, secondWorker], "sess-1");
 
 		await userEvent.click(screen.getByRole("button", { name: "Kill session" }));
@@ -338,5 +343,10 @@ describe("TopbarKillButton", () => {
 
 		expect(screen.queryByRole("dialog", { name: "Kill session?" })).not.toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Kill session" })).toBeEnabled();
+
+		resolveKill({ data: { ok: true, sessionId: "sess-1" }, error: undefined });
+		await waitFor(() => expect(view.queryClient.isMutating()).toBe(0));
+
+		expect(navigateMock).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -291,12 +291,7 @@ export function TopbarKillButton({
 	onKilled: (workspaceId: string, orchestratorId?: string) => void;
 }) {
 	const [confirmOpen, setConfirmOpen] = useState(false);
-	const kill = useTerminateSession({
-		onSuccess: (terminatedSession) => {
-			setConfirmOpen(false);
-			onKilled(terminatedSession.workspaceId, orchestratorId);
-		},
-	});
+	const kill = useTerminateSession();
 	const error = kill.error instanceof Error ? kill.error.message : null;
 
 	return (
@@ -327,7 +322,12 @@ export function TopbarKillButton({
 				error={error}
 				onConfirm={() => {
 					kill.reset();
-					kill.mutate(session);
+					kill.mutate(session, {
+						onSuccess: (_data, terminatedSession) => {
+							setConfirmOpen(false);
+							onKilled(terminatedSession.workspaceId, orchestratorId);
+						},
+					});
 				}}
 			/>
 		</>

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -223,6 +223,7 @@ export function ShellTopbar() {
 						    moved here from the inspector's Summary "Danger zone". */}
 						{!isOrchestrator && session && sessionIsActive(session) ? (
 							<TopbarKillButton
+								key={session.id}
 								session={session}
 								orchestratorId={orchestrator?.id}
 								onKilled={(workspaceId, orchestratorId) => {


### PR DESCRIPTION
## What

- Key the stateful topbar kill control by the selected session ID.
- Add a regression test for switching workers while a kill request is pending.

## Why

Fixes #3071.

Kill confirmation, pending, and error state could leak from worker A into worker B because the persistent app shell reused the same `TopbarKillButton` instance across session-route changes.

## How

Use `key={session.id}` at the existing `TopbarKillButton` render site. React now unmounts worker A's control and mounts clean state for worker B without changing the daemon request or API behavior.

## Testing

- `npm.cmd test -- ShellTopbar.test.tsx` - 21/21 passed
- `npm.cmd run typecheck` - passed
- `npm.cmd run package` - passed
- Full frontend run: 1,040/1,041 non-socket tests passed concurrently; the remaining unrelated shortcut test passed independently. Four existing Windows supervisor-link tests could not create temporary sockets (`EACCES`).

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant focused test, typecheck, and package checks pass for the touched frontend area