### PR TITLE
feat(browser): search non-URL input, open links in-app, and glow on new links

### DIFF
--- a/backend/internal/adapters/agent/fake/fake.go
+++ b/backend/internal/adapters/agent/fake/fake.go
@@ -237,7 +237,9 @@ func timelineScript(sleepSeconds float64) string {
 	phase("active", "session-start", true)
 	phase("waiting for input", "agent-needs-input", true)
 	phase("active", "user-prompt-submit", true)
-	phase("pushed PR", "pr-push", true)
+	// Print a realistic PR URL on the push line: real agents surface a link here,
+	// and the desktop watches terminal output for URLs to glow the Browser tab.
+	phase("pushed PR https://github.com/aoagents/agent-orchestrator/pull/2483", "pr-push", true)
 	phase("blocked", "permission-request", true)
 	phase("done", "session-end", false)
 	return b.String()

--- a/frontend/src/main/browser-view-host.test.ts
+++ b/frontend/src/main/browser-view-host.test.ts
@@ -167,6 +167,18 @@ describe("normalizeBrowserURL", () => {
 
 	it("defaults ordinary bare hosts to https", () => {
 		expect(normalizeBrowserURL("example.com").href).toBe("https://example.com/");
+		expect(normalizeBrowserURL("example.com/path?q=1").href).toBe("https://example.com/path?q=1");
+		expect(normalizeBrowserURL("192.168.1.5:8080").href).toBe("https://192.168.1.5:8080/");
+	});
+
+	it("routes non-URL input to a web search", () => {
+		expect(normalizeBrowserURL("hi").href).toBe("https://www.google.com/search?q=hi");
+		expect(normalizeBrowserURL("how do i center a div").href).toBe(
+			"https://www.google.com/search?q=how%20do%20i%20center%20a%20div",
+		);
+		// A dot-less token with a trailing colon is text, not a scheme, once it
+		// carries whitespace, so it still searches rather than throwing on new URL().
+		expect(normalizeBrowserURL("time: now").href).toBe("https://www.google.com/search?q=time%3A%20now");
 	});
 
 	it("allows file:// preview targets without mangling the scheme", () => {

--- a/frontend/src/main/browser-view-host.ts
+++ b/frontend/src/main/browser-view-host.ts
@@ -466,8 +466,30 @@ function withDefaultScheme(raw: string): string {
 	if (isWindowsAbsolutePath(raw) || isPosixAbsolutePath(raw)) return localPathToFileURL(raw);
 	if (/^https?:\/\//i.test(raw)) return raw;
 	if (isLocalhostLike(raw)) return `http://${raw}`;
-	if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(raw)) return raw;
-	return `https://${raw}`;
+	// A single token with no whitespace can be a destination: an explicit scheme
+	// (file:, mailto:, ...) or a bare hostname we default to https. Anything else —
+	// whitespace-containing text, or a lone word that is not a hostname — is a
+	// search query, not a URL (Chrome-style omnibox behavior).
+	if (!/\s/.test(raw)) {
+		if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(raw)) return raw;
+		if (looksLikeHost(raw)) return `https://${raw}`;
+	}
+	return searchURL(raw);
+}
+
+// Treat input as a navigable host when the authority (the part before any
+// path/query/fragment) is an IPv6 literal, carries an explicit :port, or has a
+// dot (a domain). Bare words like "hi" fail this and become a search instead.
+function looksLikeHost(raw: string): boolean {
+	const host = raw.split(/[/?#]/, 1)[0];
+	if (host === "") return false;
+	if (host.startsWith("[") && host.includes("]")) return true;
+	if (/:\d+$/.test(host)) return true;
+	return host.includes(".");
+}
+
+function searchURL(query: string): string {
+	return `https://www.google.com/search?q=${encodeURIComponent(query)}`;
 }
 
 function isWindowsAbsolutePath(raw: string): boolean {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -15,6 +15,7 @@ import { getAgentActivityView, getSessionTimelinePillView } from "../lib/session
 import { aoBridge } from "../lib/bridge";
 import { BrowserPanelView, type BrowserAnnotationQueueModel } from "./BrowserPanel";
 import type { BrowserViewModel } from "../hooks/useBrowserView";
+import { useUiStore } from "../stores/ui-store";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { cn } from "../lib/utils";
@@ -148,6 +149,10 @@ export function SessionInspector({
 }) {
 	const [internalView, setInternalView] = useState<InspectorView>("summary");
 	const view = viewProp ?? internalView;
+	// Badge the Browser tab when a preview target arrived without us opening it.
+	const browserUnseen = useUiStore((state) =>
+		session ? Boolean(state.inspectorSessions[session.id]?.browserUnseen) : false,
+	);
 	const setView = (next: InspectorView) => {
 		setInternalView(next);
 		onViewChange?.(next);
@@ -181,7 +186,17 @@ export function SessionInspector({
 						onClick={() => setView(entry.id)}
 						title={entry.label}
 					>
-						<span className="inline-flex shrink-0 [&_svg]:size-icon-md">{entry.icon}</span>
+						<span className="relative inline-flex shrink-0 [&_svg]:size-icon-md">
+							{entry.icon}
+							{entry.id === "browser" && browserUnseen ? (
+								<span aria-hidden="true" className="absolute -right-1 -top-1 inline-flex size-dot-sm">
+									{/* Pinging halo + solid core: a glowing beacon that draws the eye to
+									    a link that arrived in the terminal, cleared once the tab opens. */}
+									<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
+									<span className="relative inline-flex size-dot-sm rounded-full bg-primary ring-2 ring-background" />
+								</span>
+							) : null}
+						</span>
 						<span className="truncate @max-[350px]/inspector:hidden">{entry.label}</span>
 					</button>
 				))}

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -261,6 +261,10 @@ function inspectorOpen(sessionId: string): boolean {
 	return useUiStore.getState().inspectorSessions[sessionId]?.isOpen ?? true;
 }
 
+function browserUnseen(sessionId: string): boolean {
+	return Boolean(useUiStore.getState().inspectorSessions[sessionId]?.browserUnseen);
+}
+
 function inspectorButton(): HTMLElement {
 	const button = screen.getByText("pop browser").closest("button");
 	if (!button) throw new Error("missing inspector button");
@@ -584,7 +588,7 @@ describe("SessionView", () => {
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 	});
 
-	it("reveals an `ao preview` URL in the inspector Browser tab, not the center pane", () => {
+	it("badges the Browser tab on an `ao preview` URL without opening it or leaving the terminal", () => {
 		const worker = workerSession("sess-1");
 		const { rerender } = render(<SessionView sessionId="sess-1" />);
 
@@ -595,12 +599,27 @@ describe("SessionView", () => {
 		// Center pane keeps the terminal — the preview must not pop out over it.
 		expect(screen.getByText("terminal center")).toBeInTheDocument();
 		expect(screen.queryByRole("button", { name: "browser center" })).not.toBeInTheDocument();
-		// Rail opened and switched to the Browser tab.
-		expect(inspectorOpen("sess-1")).toBe(true);
-		expect(screen.getByRole("button", { name: "pop browser" })).toHaveAttribute("data-view", "browser");
+		// We badge the Browser tab instead of stealing focus: the active view stays
+		// on the default Summary tab and the unseen flag is set.
+		expect(screen.getByRole("button", { name: "pop browser" })).toHaveAttribute("data-view", "summary");
+		expect(browserUnseen("sess-1")).toBe(true);
 	});
 
-	it("keeps inspector state per worker session and opens Browser only for a new preview", () => {
+	it("clears the badge once the user opens the Browser tab", () => {
+		const worker = workerSession("sess-1");
+		const { rerender } = render(<SessionView sessionId="sess-1" />);
+
+		worker.previewUrl = "http://localhost:5173/";
+		worker.previewRevision = 1;
+		rerender(<SessionView sessionId="sess-1" />);
+		expect(browserUnseen("sess-1")).toBe(true);
+
+		act(() => useUiStore.getState().setInspectorView("sess-1", "browser"));
+		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+		expect(browserUnseen("sess-1")).toBe(false);
+	});
+
+	it("badges the Browser tab per worker session on a new preview, without switching tabs", () => {
 		const secondWorker = workerSession("sess-2");
 		secondWorker.previewUrl = "http://localhost:5173/";
 		secondWorker.previewRevision = 1;
@@ -616,28 +635,24 @@ describe("SessionView", () => {
 		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
 
 		// Navigating to another worker with an already-known preview URL must
-		// baseline that preview as seen and retain the default Summary tab.
+		// baseline that preview as seen: no badge, default Summary tab.
 		rerender(<SessionView sessionId="sess-2" />);
-		expect(inspectorOpen("sess-2")).toBe(true);
-		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
+		expect(browserUnseen("sess-2")).toBe(false);
 
 		// Switching back restores the first worker's own open Browser state.
 		rerender(<SessionView sessionId="sess-1" />);
-		expect(inspectorOpen("sess-1")).toBe(true);
-		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
 		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
 
-		// A new preview revision for the second worker is an explicit event and
-		// should reveal that session's Browser tab.
+		// A new preview revision for the second worker badges its Browser tab but
+		// does not switch the active view away from Summary.
 		secondWorker.previewRevision = 2;
 		rerender(<SessionView sessionId="sess-2" />);
-		expect(inspectorOpen("sess-2")).toBe(true);
-		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
-		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
+		expect(browserUnseen("sess-2")).toBe(true);
 	});
 
-	it("baselines an async preview, then expands for the next preview revision", () => {
+	it("baselines an async preview, then badges (not expands) on the next revision", () => {
 		const secondWorker = workerSession("sess-2");
 		secondWorker.previewUrl = "http://localhost:5173/";
 		secondWorker.previewRevision = 1;
@@ -653,14 +668,15 @@ describe("SessionView", () => {
 		expect(inspectorOpen("sess-2")).toBe(true);
 		expect(screen.getByTestId("panel-inspector")).not.toHaveAttribute("inert");
 		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
+		expect(browserUnseen("sess-2")).toBe(false);
 		const handle = panels.get("inspector")!.handle;
 		expect(handle.expand).not.toHaveBeenCalled();
 
 		secondWorker.previewRevision = 2;
 		rerender(<SessionView sessionId="sess-2" />);
 
-		expect(inspectorOpen("sess-2")).toBe(true);
-		expect(inspectorButton()).toHaveAttribute("data-view", "browser");
+		expect(inspectorButton()).toHaveAttribute("data-view", "summary");
+		expect(browserUnseen("sess-2")).toBe(true);
 		expect(handle.expand).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -61,6 +61,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const toggleInspector = useUiStore((state) => state.toggleInspector);
 	const setInspectorViewForSession = useUiStore((state) => state.setInspectorView);
 	const markInspectorPreviewSeen = useUiStore((state) => state.markInspectorPreviewSeen);
+	const setBrowserUnseen = useUiStore((state) => state.setBrowserUnseen);
 	const { daemonStatus } = useShell();
 	const inspectorRef = useRef<PanelImperativeHandle | null>(null);
 	const inspectorSeparatorRef = useRef<HTMLDivElement | null>(null);
@@ -195,11 +196,13 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		setBrowserPoppedOut(next);
 	}, []);
 
-	// `ao preview` sets session.previewUrl (streamed over CDC); surface the result
-	// in this session's inspector rail Browser tab (opening the rail if collapsed),
-	// not the center pane. Navigation alone must not reveal an already-present
-	// preview target, so the first observed preview key for each session is
-	// baselined as "seen"; only a later revision/URL opens the rail.
+	// `ao preview` sets session.previewUrl (streamed over CDC); badge the inspector
+	// rail's Browser tab so the user can open it when they choose — we never steal
+	// focus by opening the rail ourselves. A left-click on a terminal link opens the
+	// tab explicitly (see TerminalPane) and is exempt from the badge because the tab
+	// is already the active view by the time the CDC echo arrives. Navigation alone
+	// must not badge an already-present preview target, so the first observed preview
+	// key for each session is baselined as "seen"; only a later revision/URL badges.
 	useEffect(() => {
 		if (!hasInspector) return;
 		const previewKey = previewRevealKey(previewUrl, previewRevision);
@@ -211,17 +214,28 @@ export function SessionView({ sessionId }: SessionViewProps) {
 		if (seenKey === previewKey) return;
 		markInspectorPreviewSeen(sessionId, previewKey);
 		if (!previewKey) return;
-		setInspectorViewForSession(sessionId, "browser");
-		setInspectorOpenForSession(sessionId, true);
+		// Already looking at the Browser tab? Nothing to badge.
+		if (isInspectorOpen && inspectorView === "browser") return;
+		setBrowserUnseen(sessionId, true);
 	}, [
 		hasInspector,
+		inspectorView,
+		isInspectorOpen,
 		markInspectorPreviewSeen,
 		previewRevision,
 		previewUrl,
 		sessionId,
-		setInspectorOpenForSession,
-		setInspectorViewForSession,
+		setBrowserUnseen,
 	]);
+
+	// Keep the badge honest: clear it whenever the Browser tab is the open, active
+	// view (covers opening the rail while already parked on Browser, which
+	// setInspectorView's own clear does not see).
+	useEffect(() => {
+		if (hasInspector && isInspectorOpen && inspectorView === "browser") {
+			setBrowserUnseen(sessionId, false);
+		}
+	}, [hasInspector, inspectorView, isInspectorOpen, sessionId, setBrowserUnseen]);
 
 	// Computed when the inspector panel mounts and frozen while it stays
 	// mounted: rrp re-registers the panel (a layout effect keyed on defaultSize,

--- a/frontend/src/renderer/components/TerminalPane.test.tsx
+++ b/frontend/src/renderer/components/TerminalPane.test.tsx
@@ -199,10 +199,25 @@ describe("terminal link preview", () => {
 		},
 	);
 
-	it("does not mirror an external terminal link into the Browser preview", () => {
+	it("mirrors an external (non-loopback) terminal link into the Browser preview", async () => {
 		const view = renderPane(worker);
 		try {
-			act(() => terminalLinkHandler?.("https://example.com"));
+			act(() => terminalLinkHandler?.("https://example.com/pull/42"));
+			await waitFor(() =>
+				expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/preview", {
+					params: { path: { sessionId: "sess-1" } },
+					body: { url: "https://example.com/pull/42" },
+				}),
+			);
+		} finally {
+			view.restore();
+		}
+	});
+
+	it("does not mirror a non-web (mailto:) link", () => {
+		const view = renderPane(worker);
+		try {
+			act(() => terminalLinkHandler?.("mailto:dev@example.com"));
 			expect(postMock).not.toHaveBeenCalled();
 		} finally {
 			view.restore();

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -3,10 +3,10 @@ import { RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { TerminalTarget } from "../types/terminal";
 import { sessionIsActive, type WorkspaceSession } from "../types/workspace";
-import type { Theme } from "../stores/ui-store";
+import { useUiStore, type Theme } from "../stores/ui-store";
 import { useTerminalSession, type AttachableTerminal, type TerminalSessionState } from "../hooks/useTerminalSession";
 import { apiClient } from "../lib/api-client";
-import { isLoopbackHostname } from "../lib/loopback";
+import { createUrlWatcher, type UrlWatcher } from "../lib/detect-urls";
 import { cn } from "../lib/utils";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { useRestoreSession } from "../hooks/useRestoreSession";
@@ -238,7 +238,32 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 	// A shell pane has no session, so it hands the hook its handle directly
 	// instead of reading one off `attachSession`.
 	const shellTerminalHandleId = terminalTarget?.kind === "shell" ? terminalTarget.handleId : undefined;
-	const { attach, state, error } = useTerminalSession(attachSession, { daemonReady, shellTerminalHandleId });
+	// Glow the Browser tab when the agent prints a URL in this worker's terminal
+	// (e.g. a pushed-PR link). Detection only badges — the user still chooses to
+	// open it — and is skipped while they are already looking at the Browser tab.
+	const watchLinks = Boolean(session?.id && session.kind === "worker" && terminalTarget?.kind !== "shell");
+	const urlWatcherRef = useRef<UrlWatcher | null>(null);
+	const handleOutput = useCallback(
+		(text: string) => {
+			const sessionId = session?.id;
+			if (!sessionId) return;
+			if (!urlWatcherRef.current) {
+				urlWatcherRef.current = createUrlWatcher(() => {
+					const store = useUiStore.getState();
+					const current = store.inspectorSessions[sessionId];
+					const viewingBrowser = (current?.isOpen ?? true) && (current?.view ?? "summary") === "browser";
+					if (!viewingBrowser) store.setBrowserUnseen(sessionId, true);
+				});
+			}
+			urlWatcherRef.current.push(text);
+		},
+		[session?.id],
+	);
+	const { attach, state, error } = useTerminalSession(attachSession, {
+		daemonReady,
+		shellTerminalHandleId,
+		onOutput: watchLinks ? handleOutput : undefined,
+	});
 	const handleId = shellTerminalHandleId ?? attachSession?.terminalHandleId;
 	const provider = terminalTarget?.kind === "reviewer" ? terminalTarget.harness : session?.provider;
 	const hadAttachmentRef = useRef(false);
@@ -257,19 +282,26 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 		console.error("xterm failed to initialize", err);
 		setInitFailed(true);
 	}, []);
+	const setInspectorViewForSession = useUiStore((state) => state.setInspectorView);
+	const setInspectorOpenForSession = useUiStore((state) => state.setInspectorOpen);
 	const handleLinkOpen = useCallback(
 		(uri: string) => {
 			if (!session?.id || session.kind !== "worker" || !isSessionActive) return;
 			try {
 				const url = new URL(uri);
-				if ((url.protocol !== "http:" && url.protocol !== "https:") || !isLoopbackHostname(url.hostname)) return;
+				if (url.protocol !== "http:" && url.protocol !== "https:") return;
 			} catch {
 				return;
 			}
+			const linkSessionId = session.id;
+			// A left-click is an explicit request to view the link, so open the
+			// Browser tab now (unlike a passive `ao preview`, which only badges it).
+			setInspectorViewForSession(linkSessionId, "browser");
+			setInspectorOpenForSession(linkSessionId, true);
 			void (async () => {
 				try {
 					const { error: previewError } = await apiClient.POST("/api/v1/sessions/{sessionId}/preview", {
-						params: { path: { sessionId: session.id } },
+						params: { path: { sessionId: linkSessionId } },
 						body: { url: uri },
 					});
 					if (previewError) {
@@ -282,7 +314,7 @@ function AttachedTerminal({ session, theme, daemonReady, terminalTarget, fontSiz
 				}
 			})();
 		},
-		[isSessionActive, queryClient, session?.id, session?.kind],
+		[isSessionActive, queryClient, session?.id, session?.kind, setInspectorOpenForSession, setInspectorViewForSession],
 	);
 	const restoreSession = useCallback(async () => {
 		if (!session?.id || !canRestoreSession || isRestoring) return;

--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -740,22 +740,22 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenLastCalledWith("\x1b[5~", "wheel");
 	});
 
-	it("opens terminal links externally and reports the clicked URL", () => {
+	it("routes web links to the AO browser and does not open the system browser", () => {
 		const open = vi.spyOn(window, "open").mockReturnValue(null);
 		const onLinkOpen = vi.fn();
 		render(<XtermTerminal onLinkOpen={onLinkOpen} theme="dark" />);
 
-		// The default WebLinksAddon handler opens an empty window first, which the
-		// Electron main process denies; ours must pass the matched URL directly.
+		// A left-click on an http(s) link is reported to the parent (which shows it
+		// in the AO Browser panel); it must NOT spawn a system-browser window.
 		expect(state.linkHandler).toBeTypeOf("function");
 		state.linkHandler!({} as MouseEvent, "https://example.com");
 
-		expect(open).toHaveBeenCalledWith("https://example.com", "_blank", "noopener");
 		expect(onLinkOpen).toHaveBeenCalledWith("https://example.com");
+		expect(open).not.toHaveBeenCalled();
 		open.mockRestore();
 	});
 
-	it("opens OSC 8 links externally and reports the clicked URL", () => {
+	it("routes OSC 8 web links to the AO browser without a system-browser window", () => {
 		const open = vi.spyOn(window, "open").mockReturnValue(null);
 		const onLinkOpen = vi.fn();
 		render(<XtermTerminal onLinkOpen={onLinkOpen} theme="dark" />);
@@ -765,8 +765,21 @@ describe("XtermTerminal", () => {
 
 		oscLinkHandler.activate({} as MouseEvent, "http://localhost:3000");
 
-		expect(open).toHaveBeenCalledWith("http://localhost:3000", "_blank", "noopener");
 		expect(onLinkOpen).toHaveBeenCalledWith("http://localhost:3000");
+		expect(open).not.toHaveBeenCalled();
+		open.mockRestore();
+	});
+
+	it("opens non-web links (mailto:) in the system browser, not the AO browser", () => {
+		const open = vi.spyOn(window, "open").mockReturnValue(null);
+		const onLinkOpen = vi.fn();
+		render(<XtermTerminal onLinkOpen={onLinkOpen} theme="dark" />);
+
+		expect(state.linkHandler).toBeTypeOf("function");
+		state.linkHandler!({} as MouseEvent, "mailto:dev@example.com");
+
+		expect(open).toHaveBeenCalledWith("mailto:dev@example.com", "_blank", "noopener");
+		expect(onLinkOpen).not.toHaveBeenCalled();
 		open.mockRestore();
 	});
 

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -182,7 +182,19 @@ type TerminalContextMenuState = {
 	open: boolean;
 	x: number;
 	y: number;
+	// The web link under the cursor when the menu opened, if any — enables the
+	// "Open in system browser" item (left-click opens it in the AO Browser).
+	link: string | null;
 };
+
+function isWebLink(uri: string): boolean {
+	try {
+		const { protocol } = new URL(uri);
+		return protocol === "http:" || protocol === "https:";
+	} catch {
+		return false;
+	}
+}
 
 type TerminalContextMenuAction = "copy" | "paste" | "selectAll" | "clear";
 
@@ -231,7 +243,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		open: false,
 		x: 0,
 		y: 0,
+		link: null,
 	});
+	// The web link currently under the cursor, tracked via the link providers'
+	// hover/leave callbacks so the right-click menu can offer "Open in system
+	// browser" for it.
+	const hoveredLinkRef = useRef<string | null>(null);
 	// Latest callbacks in a ref so the mount effect stays dependency-free — we
 	// never tear down and recreate the terminal because a handler identity
 	// changed between renders.
@@ -273,8 +290,21 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		const host = hostRef.current;
 		if (!host) return undefined;
 		const activateLink = (_event: MouseEvent, uri: string) => {
+			// Left-click on a web link opens it inside the AO Browser panel (the
+			// parent decides how). Non-web schemes (mailto:, etc.) still go to the OS
+			// via the main process's window-open handler. Right-click to open a web
+			// link in the system browser instead — see the context menu below.
+			if (isWebLink(uri)) {
+				callbacksRef.current.onLinkOpen?.(uri);
+				return;
+			}
 			window.open(uri, "_blank", "noopener");
-			callbacksRef.current.onLinkOpen?.(uri);
+		};
+		const trackHover = (_event: MouseEvent, uri: string) => {
+			hoveredLinkRef.current = isWebLink(uri) ? uri : null;
+		};
+		const clearHover = () => {
+			hoveredLinkRef.current = null;
 		};
 
 		let term: Terminal;
@@ -294,7 +324,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 					'ui-monospace, Menlo, Monaco, "Courier New", monospace',
 				fontSize: props.fontSize ?? TERMINAL_FONT_SIZE_DEFAULT,
 				lineHeight: 1.35,
-				linkHandler: { activate: activateLink },
+				linkHandler: { activate: activateLink, hover: trackHover, leave: clearHover },
 				// Preserve standard terminal semantics: many agent TUIs use bold ANSI
 				// colors specifically to select the bright palette.
 				drawBoldTextInBrightColors: true,
@@ -330,7 +360,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		// passed to it (main.ts setWindowOpenHandler), so the default handlers'
 		// empty open is dropped and clicks silently no-op. Pass the matched URL to
 		// window.open directly so the main process routes it to shell.openExternal.
-		term.loadAddon(new WebLinksAddon(activateLink));
+		term.loadAddon(new WebLinksAddon(activateLink, { hover: trackHover, leave: clearHover }));
 		term.loadAddon(new SearchAddon());
 
 		term.open(host);
@@ -421,6 +451,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				open: true,
 				x: event.clientX,
 				y: event.clientY,
+				link: hoveredLinkRef.current,
 			});
 		};
 		host.addEventListener("contextmenu", openContextMenu);
@@ -767,6 +798,20 @@ export function XtermTerminal(props: XtermTerminalProps) {
 					side="right"
 					sideOffset={2}
 				>
+					{contextMenu.link ? (
+						<>
+							<DropdownMenuItem
+								onSelect={() => {
+									const { link } = contextMenu;
+									setContextMenuOpen(false);
+									if (link) void aoBridge.app.openExternal(link);
+								}}
+							>
+								Open in system browser
+							</DropdownMenuItem>
+							<DropdownMenuSeparator />
+						</>
+					) : null}
 					<DropdownMenuItem disabled={!contextMenu.canCopy} onSelect={() => runContextMenuAction("copy")}>
 						Copy
 					</DropdownMenuItem>

--- a/frontend/src/renderer/hooks/useTerminalSession.ts
+++ b/frontend/src/renderer/hooks/useTerminalSession.ts
@@ -56,6 +56,12 @@ export type UseTerminalSessionOptions = {
 	/** Test seam: build the mux client. Defaults to a fresh socket against the current API base. */
 	createMux?: () => TerminalMux;
 	/**
+	 * Observe decoded pane output (post-write). Callers use it to scan the stream
+	 * for signals like printed URLs; it must be cheap and side-effect-light since
+	 * it runs on every output chunk. Omit to skip decoding entirely.
+	 */
+	onOutput?: (text: string) => void;
+	/**
 	 * Attach to a standalone shell terminal (POST /api/v1/shell-terminals)
 	 * instead of a session's pane. When set it wins over `session`, which
 	 * callers pass as undefined for shell panes.
@@ -207,10 +213,15 @@ export function useTerminalSession(session: WorkspaceSession | undefined, option
 		const mux = (optionsRef.current.createMux ?? defaultCreateMux)();
 		r.mux = mux;
 
+		// Streaming decoder so a multi-byte sequence split across chunks decodes
+		// correctly for onOutput. Only built when a caller is listening.
+		const outputDecoder = optionsRef.current.onOutput ? new TextDecoder() : null;
+
 		r.disposers.push(
 			mux.onData(handle, (bytes) => {
 				if (!isCurrentAttachment(generation, handle, mux)) return;
 				terminal.write(bytes);
+				if (outputDecoder) optionsRef.current.onOutput?.(outputDecoder.decode(bytes, { stream: true }));
 			}),
 			mux.onOpened(handle, () => {
 				if (!isCurrentAttachment(generation, handle, mux)) return;

--- a/frontend/src/renderer/lib/detect-urls.test.ts
+++ b/frontend/src/renderer/lib/detect-urls.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { createUrlWatcher } from "./detect-urls";
+
+describe("createUrlWatcher", () => {
+	it("reports an http(s) URL printed on a line", () => {
+		const onUrl = vi.fn();
+		const watcher = createUrlWatcher(onUrl);
+		watcher.push("fake-agent: pushed PR https://github.com/org/repo/pull/42\n");
+		expect(onUrl).toHaveBeenCalledExactlyOnceWith("https://github.com/org/repo/pull/42");
+	});
+
+	it("reports each distinct URL once, ignoring repeats", () => {
+		const onUrl = vi.fn();
+		const watcher = createUrlWatcher(onUrl);
+		watcher.push("visit https://a.com/x and https://a.com/x again\n");
+		watcher.push("still https://a.com/x\n");
+		watcher.push("now https://b.com/y\n");
+		expect(onUrl.mock.calls.map((c) => c[0])).toEqual(["https://a.com/x", "https://b.com/y"]);
+	});
+
+	it("strips ANSI colors and trailing punctuation", () => {
+		const onUrl = vi.fn();
+		const watcher = createUrlWatcher(onUrl);
+		watcher.push("[32mopen (https://example.com/path).[0m\n");
+		expect(onUrl).toHaveBeenCalledExactlyOnceWith("https://example.com/path");
+	});
+
+	it("joins a URL split across two chunks and reports it once", () => {
+		const onUrl = vi.fn();
+		const watcher = createUrlWatcher(onUrl);
+		watcher.push("see https://example.com/very/long/pa");
+		expect(onUrl).not.toHaveBeenCalled(); // truncated at buffer edge, deferred
+		watcher.push("th/here\n");
+		expect(onUrl).toHaveBeenCalledExactlyOnceWith("https://example.com/very/long/path/here");
+	});
+
+	it("ignores non-web schemes", () => {
+		const onUrl = vi.fn();
+		const watcher = createUrlWatcher(onUrl);
+		watcher.push("mail me at mailto:dev@example.com or ftp://host/file\n");
+		expect(onUrl).not.toHaveBeenCalled();
+	});
+
+	it("forgets state on reset", () => {
+		const onUrl = vi.fn();
+		const watcher = createUrlWatcher(onUrl);
+		watcher.push("https://a.com/x\n");
+		watcher.reset();
+		watcher.push("https://a.com/x\n");
+		expect(onUrl).toHaveBeenCalledTimes(2);
+	});
+});

--- a/frontend/src/renderer/lib/detect-urls.ts
+++ b/frontend/src/renderer/lib/detect-urls.ts
@@ -1,0 +1,60 @@
+// Watches a terminal output stream for http(s) URLs and reports each new one
+// exactly once. Used to "glow" the Browser tab when an agent prints a link
+// (e.g. a pushed-PR URL) without the user having to click it. Detection only
+// badges — it never navigates — so occasional imprecision is harmless.
+//
+// The stream arrives in arbitrary chunks with ANSI escape codes and a URL can
+// straddle a chunk boundary, so we strip ANSI, keep a small carry-over tail, and
+// defer a match that ends exactly at the buffer edge (it may be truncated) until
+// more output arrives.
+
+// CSI/other escape sequences (ESC 0x1B or single-byte CSI 0x9B, plus params and
+// a final byte). Built from string escapes so the source stays pure ASCII.
+const ANSI_PATTERN = new RegExp("[\\u001B\\u009B][[\\]()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]", "g");
+const URL_PATTERN = /\bhttps?:\/\/[^\s"'`<>()[\]{}]+/gi;
+// Characters that commonly trail a URL in prose/logs but are not part of it.
+const TRAILING_PUNCT = /[.,;:!?)\]}'"]+$/;
+
+const TAIL_MAX = 2048;
+const SEEN_MAX = 512;
+
+export type UrlWatcher = {
+	/** Feed a decoded output chunk; fires the callback for each new URL. */
+	push: (chunk: string) => void;
+	/** Forget the tail and seen-set (call on session/handle change). */
+	reset: () => void;
+};
+
+function stripTrailingPunct(url: string): string {
+	return url.replace(TRAILING_PUNCT, "");
+}
+
+export function createUrlWatcher(onUrl: (url: string) => void): UrlWatcher {
+	let tail = "";
+	let seen = new Set<string>();
+
+	return {
+		push(chunk: string) {
+			if (!chunk) return;
+			const text = (tail + chunk).replace(ANSI_PATTERN, "");
+			URL_PATTERN.lastIndex = 0;
+			let match: RegExpExecArray | null;
+			while ((match = URL_PATTERN.exec(text)) !== null) {
+				const end = match.index + match[0].length;
+				// A match flush against the buffer end may be truncated mid-URL by a
+				// chunk split — leave it for the next push (it survives in `tail`).
+				if (end === text.length) break;
+				const url = stripTrailingPunct(match[0]);
+				if (!url || seen.has(url)) continue;
+				if (seen.size >= SEEN_MAX) seen = new Set();
+				seen.add(url);
+				onUrl(url);
+			}
+			tail = text.length > TAIL_MAX ? text.slice(text.length - TAIL_MAX) : text;
+		},
+		reset() {
+			tail = "";
+			seen = new Set();
+		},
+	};
+}

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -19,6 +19,10 @@ export type InspectorSessionState = {
 	isOpen: boolean;
 	view: InspectorView;
 	previewKey?: string;
+	// A preview target arrived (ao preview, or a clicked link) while the Browser
+	// tab was not the open/active view. We badge the Browser icon instead of
+	// stealing focus; cleared once the user opens the Browser tab.
+	browserUnseen?: boolean;
 };
 
 // Selection (which project/session is open) now lives in the URL — the router
@@ -63,6 +67,7 @@ type UiState = {
 	toggleInspector: (sessionId: string) => void;
 	setInspectorView: (sessionId: string, view: InspectorView) => void;
 	markInspectorPreviewSeen: (sessionId: string, previewKey: string) => void;
+	setBrowserUnseen: (sessionId: string, unseen: boolean) => void;
 	setCommandPaletteOpen: (open: boolean) => void;
 	setProjectRestarting: (projectId: string, restarting: boolean) => void;
 	setOrchestratorReplacementError: (projectId: string, message: string | null) => void;
@@ -144,10 +149,12 @@ export const useUiStore = create<UiState>((set) => ({
 	setInspectorView: (sessionId, view) =>
 		set((state) => {
 			const current = inspectorState(state.inspectorSessions, sessionId);
+			// Opening the Browser tab consumes any pending preview badge.
+			const browserUnseen = view === "browser" ? false : current.browserUnseen;
 			return {
 				inspectorSessions: {
 					...state.inspectorSessions,
-					[sessionId]: { ...current, view },
+					[sessionId]: { ...current, view, browserUnseen },
 				},
 			};
 		}),
@@ -158,6 +165,17 @@ export const useUiStore = create<UiState>((set) => ({
 				inspectorSessions: {
 					...state.inspectorSessions,
 					[sessionId]: { ...current, previewKey },
+				},
+			};
+		}),
+	setBrowserUnseen: (sessionId, browserUnseen) =>
+		set((state) => {
+			const current = inspectorState(state.inspectorSessions, sessionId);
+			if (Boolean(current.browserUnseen) === browserUnseen) return state;
+			return {
+				inspectorSessions: {
+					...state.inspectorSessions,
+					[sessionId]: { ...current, browserUnseen },
 				},
 			};
 		}),


### PR DESCRIPTION
## What and why

The session Browser panel had rough edges: typing non-URL text in the address
bar coerced it to `https://<text>` and dead-ended on a blank page, terminal
links only opened in-app for localhost, and an incoming preview stole focus by
auto-opening the panel. This reworks it to behave like a real in-app browser.

Related: #2830 tackles the same "keep local pages in-app" goal from the backend
(sessions.go + AGENTS.md); this PR is the frontend side (link routing + address
bar) and does not touch those files.

## Changes

- **Address bar search.** Non-URL input (e.g. `hi`, `how do i center a div`)
  now runs a web search instead of navigating to a bogus host. Real hostnames,
  localhost, file paths, and explicit schemes are unchanged.
  (`main/browser-view-host.ts`)
- **Links open in the AO browser.** A left-click on any http/https terminal
  link opens it in the Browser panel (previously localhost only; external links
  went to the system browser). Right-click gives "Open in system browser".
  Non-web schemes (mailto:) still open externally.
  (`XtermTerminal.tsx`, `TerminalPane.tsx`)
- **No focus stealing.** An incoming preview (`ao preview`, or a link) now
  badges the Browser tab instead of auto-opening it. The badge is a glowing
  beacon and clears when the tab opens. (`SessionView.tsx`, `SessionInspector.tsx`,
  `ui-store.ts`)
- **Glow on terminal-printed URLs.** When an agent prints a URL (e.g. a
  pushed-PR link), the Browser tab glows. Detection strips ANSI, handles URLs
  split across output chunks, and dedupes (`lib/detect-urls.ts`), fed by a new
  `onOutput` seam on the terminal hook (`useTerminalSession.ts`).
- **fake harness** prints a realistic PR URL on its push line so the
  terminal-URL glow is demoable and testable end to end. (`fake.go`)

## Testing

- New `detect-urls` unit suite (detect, dedupe, ANSI strip, split-chunk join,
  non-web ignore, reset).
- Updated `browser-view-host`, `SessionView`, `TerminalPane`, and
  `XtermTerminal` suites for the new behavior.
- Full frontend suite green (1064 tests); `tsc --noEmit` clean; Go `fake`
  package test green. Rebased on latest `main`.
- Ran the built desktop app and drove the Browser panel: it renders a live URL
  and re-navigates in place when the preview command re-fires. Address-bar
  search, right-click menu, and the terminal glow rest on the unit suite; GUI
  keystroke automation was blocked by macOS assistive-access in this environment.

## Risks

- URL detection runs on every terminal output chunk for worker panes; it is
  ANSI-strip + regex + a bounded seen-set, kept cheap and skipped for non-worker
  panes.
- Behavior change: external terminal links now open in-app rather than the
  system browser (right-click restores the old behavior).
