### PR TITLE
fix(storage): apply missing out-of-order migrations

### DIFF
--- a/backend/internal/storage/sqlite/db.go
+++ b/backend/internal/storage/sqlite/db.go
@@ -130,7 +130,11 @@ func migrate(db *sql.DB) error {
 	if err := goose.SetDialect("sqlite3"); err != nil {
 		return fmt.Errorf("set goose dialect: %w", err)
 	}
-	if err := goose.Up(db, "migrations"); err != nil {
+	// Builds can advance a database past a migration that is added or
+	// renumbered later (notably across fast-moving Nightly releases). Apply
+	// those embedded migrations instead of permanently wedging daemon startup
+	// on goose's out-of-order-history guard.
+	if err := goose.Up(db, "migrations", goose.WithAllowMissing()); err != nil {
 		return fmt.Errorf("run migrations: %w", err)
 	}
 	return nil

--- a/backend/internal/storage/sqlite/migrate_missing_test.go
+++ b/backend/internal/storage/sqlite/migrate_missing_test.go
@@ -1,0 +1,73 @@
+package sqlite
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// TestMigrateAppliesMissingMigrationsBeforeCurrentVersion covers databases
+// created by builds whose migration history advanced past migrations that were
+// later added or renumbered. Goose rejects that history by default, which
+// prevents the daemon from starting even though the missing migrations can be
+// applied normally.
+func TestMigrateAppliesMissingMigrationsBeforeCurrentVersion(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(t.TempDir(), "ao.db")+pragmas)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	upTo(t, db, 27)
+	if _, err := db.Exec(`
+INSERT INTO projects (
+	id, path, repo_origin_url, display_name, registered_at, config, kind
+) VALUES (?, ?, ?, ?, ?, ?, ?)
+`,
+		"project-1",
+		`C:\src\project-1`,
+		"https://example.com/project-1.git",
+		"Project One",
+		"2026-07-25T00:00:00Z",
+		`{"worker":{"agent":"codex"}}`,
+		"single_repo",
+	); err != nil {
+		t.Fatalf("seed project: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO goose_db_version (version_id, is_applied) VALUES (46, 1)`,
+	); err != nil {
+		t.Fatalf("seed later migration version: %v", err)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate database with missing earlier versions: %v", err)
+	}
+
+	var applied int
+	if err := db.QueryRow(`
+SELECT COUNT(DISTINCT version_id)
+FROM goose_db_version
+WHERE is_applied = 1 AND version_id IN (28, 29, 30, 31)
+`).Scan(&applied); err != nil {
+		t.Fatalf("query applied migrations: %v", err)
+	}
+	if applied != 4 {
+		t.Fatalf("applied migrations 28-31 = %d, want 4", applied)
+	}
+
+	var path, displayName string
+	if err := db.QueryRow(
+		`SELECT path, display_name FROM projects WHERE id = ?`,
+		"project-1",
+	).Scan(&path, &displayName); err != nil {
+		t.Fatalf("query preserved project: %v", err)
+	}
+	if path != `C:\src\project-1` || displayName != "Project One" {
+		t.Fatalf("preserved project = (%q, %q), want Windows path and display name unchanged", path, displayName)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("repeat migrate: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- allow Goose to apply embedded migrations that are missing below the database's recorded maximum version
- add a regression for a version-46 database missing migrations 28–31
- verify Windows-style project paths and existing project data survive the repair
- keep migration startup idempotent without modifying any shipped migration files

## Root cause

Goose's default `Up` behavior rejects any embedded migration whose version is absent from the database history but lower than the database's maximum recorded version. A database produced by builds with later or renumbered migrations can therefore reach version 46 without versions 28–31 and permanently wedge daemon startup before the HTTP server is available.

Using Goose's supported `WithAllowMissing` option applies those authoritative embedded migrations in order instead of rejecting the history.

## User impact

Affected Windows users can relaunch AO without moving, deleting, or resetting `~/.ao/data/ao.db`. Existing project records are preserved.

Fixes #3091.

## Validation

- `go test ./internal/storage/sqlite/... -count=1`
- `go test -race ./internal/storage/sqlite/... -count=1`
- `go vet ./internal/storage/sqlite/...`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./...`
- regression confirmed failing before the fix and passing afterward

The full `go test ./... -count=1` run reached two unrelated wall-clock-sensitive agent test failures under package-parallel load; both pass when rerun in isolation, and the SQLite packages remain green.
