### PR TITLE
fix: keep the notification bell at the right end of the topbar on all platforms

### DIFF
--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import {
 	Bell,
+	BellRing,
 	Check,
 	CheckCheck,
 	CircleAlert,
@@ -170,7 +171,11 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 					style={style}
 					variant="icon"
 				>
-					<Bell className={cn("size-icon-lg", unreadCount > 0 && "fill-current text-foreground")} aria-hidden="true" />
+					{unreadCount > 0 ? (
+						<BellRing className="size-icon-lg fill-current text-foreground" aria-hidden="true" />
+					) : (
+						<Bell className="size-icon-lg" aria-hidden="true" />
+					)}
 					{unreadCount > 0 ? (
 						<span className="pointer-events-none absolute -right-0.5 -top-0.5 grid min-w-4 place-items-center rounded-full bg-foreground px-1 font-mono text-[9px] font-semibold leading-4 text-background shadow-sm">
 							{unreadCount > 99 ? "99+" : unreadCount}

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -228,7 +228,6 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 
 	const actions = projectId ? (
 		<>
-			{boardOwnsNotificationCenter ? <NotificationCenter /> : null}
 			{visibleSpawnError && !showProjectEmpty && (
 				<TopbarKillError className="max-w-content-max truncate" title={visibleSpawnError}>
 					{visibleSpawnError}
@@ -258,6 +257,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 							? "Orchestrator"
 							: "Spawn Orchestrator"}
 			</TopbarButton>
+			{boardOwnsNotificationCenter ? <NotificationCenter /> : null}
 		</>
 	) : boardOwnsNotificationCenter ? (
 		<NotificationCenter />

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -17,13 +17,11 @@ import { addRendererExceptionStep, captureRendererEvent, captureRendererExceptio
 import { useUiStore } from "../stores/ui-store";
 import { OrchestratorIcon } from "./icons";
 import { getAgentActivityView } from "../lib/session-presentation";
-import { isLinuxPlatform, isMacPlatform, isWindowsPlatform, usesBoardActionsInPanel } from "../lib/platform";
+import { isMacPlatform, usesBoardActionsInPanel } from "../lib/platform";
 import { StatusPill } from "./StatusPill";
 import { TopbarButton, TopbarKillError, topbarHeaderClass, topbarProjectLabelClass } from "./TopbarButton";
 
 const isMac = isMacPlatform();
-const isLinux = isLinuxPlatform();
-const isWindows = isWindowsPlatform();
 const boardActionsInPanel = usesBoardActionsInPanel();
 const dragStyle = isMac ? ({ WebkitAppRegion: "drag" } as React.CSSProperties) : undefined;
 const noDragStyle = isMac ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined;
@@ -162,8 +160,6 @@ export function ShellTopbar() {
 			<div className="min-w-0 flex-1" />
 
 			<div className="flex shrink-0 items-center gap-1.5">
-				{/* Native-titlebar platforms keep the bell leading the actions row; the custom titlebar pins it to the far edge. */}
-				{boardActionsInPanel && !isLinux && !isWindows ? <NotificationCenter style={noDragStyle} /> : null}
 				{!boardActionsInPanel && isProjectBoardRoute ? (
 					<>
 						{boardSpawnError ? (
@@ -268,8 +264,8 @@ export function ShellTopbar() {
 						)}
 					</>
 				) : null}
-				{/* Custom-titlebar platforms pin the bell to the far right. */}
-				{!boardActionsInPanel ? <NotificationCenter style={noDragStyle} /> : null}
+				{/* The bell always trails the actions row, on every platform. */}
+				<NotificationCenter style={noDragStyle} />
 			</div>
 		</header>
 	);


### PR DESCRIPTION
## Problem

The notification bell's position was platform-dependent:

- On **Windows/Linux** it rendered as the last item of the topbar actions row (far right).
- On **macOS** a dedicated branch in `ShellTopbar` rendered it *leading* the actions row — before Kill / Orchestrator — and in the `SessionsBoard` in-panel action row it also sat *before* the New task / Orchestrator buttons.

So the same button moved around depending on which machine you opened the app on.

## Changes

- **`ShellTopbar.tsx`** — remove the macOS-only leading render (`boardActionsInPanel && !isLinux && !isWindows`) and always render the bell as the trailing item of the actions row, on every platform. (Also drops the now-unused `isLinux`/`isWindows` locals.)
- **`SessionsBoard.tsx`** — in the macOS in-panel board action row, move the bell after the New task / Orchestrator buttons so it trails there too.
- **`NotificationCenter.tsx`** — small UX polish while touching the bell: the unread state now swaps the plain `Bell` for lucide's `BellRing` (with the existing fill + count badge), so unread notifications are distinguishable at a glance instead of only by fill color.

After this, wherever the bell exists it is always the right-most element of the top action row — session routes, board routes, on Windows, Linux, and macOS alike. Screens without shell chrome (settings, first-launch welcome board) intentionally have no bell on any platform, unchanged.


<img width="516" height="112" alt="Screenshot 2026-07-25 170039" src="https://github.com/user-attachments/assets/09e017fd-a2c1-4f46-8b26-953e958fcdb4" />


## Testing

- `npm run typecheck` — clean
- `vitest`: `ShellTopbar.test.tsx`, `SessionsBoard.test.tsx`, `NotificationCenter.test.tsx`, `Sidebar.test.tsx` — 92 tests passing
- Verified live in the dev app on Windows: bell stays at the far right of the topbar on board and session routes; unread simulation (row inserted into the dev DB, cleaned up afterwards) shows the BellRing + badge state