### PR TITLE
feat(desktop): add platform-native terminal line-boundary shortcuts

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -511,6 +511,115 @@ describe("XtermTerminal", () => {
 		expect(onInput).toHaveBeenCalledWith(expected, "shortcut");
 	});
 
+	it.each([
+		["Cmd+Left (macOS) → line start", "ArrowLeft", "\x01"],
+		["Cmd+Right (macOS) → line end", "ArrowRight", "\x05"],
+	])("normalizes %s into terminal input on macOS", (_name, key, expected) => {
+		setNavigatorPlatform("macOS");
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		const event = {
+			key,
+			metaKey: true,
+			ctrlKey: false,
+			shiftKey: false,
+			altKey: false,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		} as unknown as KeyboardEvent;
+		const allowed = state.lastTerminal!.keyHandler!(event);
+
+		expect(allowed).toBe(false);
+		expect(event.preventDefault).toHaveBeenCalled();
+		expect(event.stopPropagation).toHaveBeenCalled();
+		expect(onInput).toHaveBeenCalledWith(expected, "shortcut");
+	});
+
+	it.each([
+		["Home → line start", "Home", "\x01"],
+		["End → line end", "End", "\x05"],
+	])("normalizes %s into terminal input on Windows", (_name, key, expected) => {
+		setNavigatorPlatform("Win32");
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		const event = {
+			key,
+			metaKey: false,
+			ctrlKey: false,
+			shiftKey: false,
+			altKey: false,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		} as unknown as KeyboardEvent;
+		const allowed = state.lastTerminal!.keyHandler!(event);
+
+		expect(allowed).toBe(false);
+		expect(event.preventDefault).toHaveBeenCalled();
+		expect(event.stopPropagation).toHaveBeenCalled();
+		expect(onInput).toHaveBeenCalledWith(expected, "shortcut");
+	});
+
+	it("does not treat Cmd+Left/Right as line-boundary on Windows (Windows key is not macOS Cmd)", () => {
+		setNavigatorPlatform("Win32");
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		for (const key of ["ArrowLeft", "ArrowRight"]) {
+			const event = {
+				key,
+				metaKey: true,
+				ctrlKey: false,
+				shiftKey: false,
+				altKey: false,
+				preventDefault: vi.fn(),
+				stopPropagation: vi.fn(),
+			} as unknown as KeyboardEvent;
+			expect(state.lastTerminal!.keyHandler!(event)).toBe(true);
+			expect(event.preventDefault).not.toHaveBeenCalled();
+		}
+		expect(onInput).not.toHaveBeenCalled();
+	});
+
+	it("keeps Ctrl+Left/Right as word-navigation shortcuts on Windows (not repurposed as line-boundary)", () => {
+		setNavigatorPlatform("Win32");
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		const base = { metaKey: false, ctrlKey: true, shiftKey: false, altKey: false, preventDefault: vi.fn(), stopPropagation: vi.fn() };
+
+		state.lastTerminal!.keyHandler!({ ...base, key: "ArrowLeft" } as unknown as KeyboardEvent);
+		expect(onInput).toHaveBeenCalledWith("\x1b[1;5D", "shortcut");
+
+		onInput.mockClear();
+		state.lastTerminal!.keyHandler!({ ...base, key: "ArrowRight" } as unknown as KeyboardEvent);
+		expect(onInput).toHaveBeenCalledWith("\x1b[1;5C", "shortcut");
+	});
+
+	it("does not re-fire Cmd+Left line-start on the keyup that follows its keydown (macOS)", () => {
+		setNavigatorPlatform("macOS");
+		const onInput = vi.fn();
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		const keyDown = {
+			type: "keydown",
+			key: "ArrowLeft",
+			metaKey: true,
+			ctrlKey: false,
+			shiftKey: false,
+			altKey: false,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		} as unknown as KeyboardEvent;
+		expect(state.lastTerminal!.keyHandler!(keyDown)).toBe(false);
+		expect(onInput).toHaveBeenCalledTimes(1);
+
+		const keyUp = { ...keyDown, type: "keyup" } as unknown as KeyboardEvent;
+		expect(state.lastTerminal!.keyHandler!(keyUp)).toBe(true);
+		expect(onInput).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not re-fire a shortcut on the keyup that follows its keydown", () => {
 		// xterm.js invokes attachCustomKeyEventHandler on keydown, keyup, AND
 		// keypress for the same physical key press. Without gating on event.type,

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -30,6 +30,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import type { AttachableTerminal, TerminalUserInputSource } from "../hooks/useTerminalSession";
 import { aoBridge } from "../lib/bridge";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../lib/design-tokens";
+import { isMacPlatform, isWindowsPlatform } from "../lib/platform";
 import { buildTerminalThemes } from "../lib/terminal-themes";
 import type { Theme } from "../stores/ui-store";
 import {
@@ -107,12 +108,6 @@ function isTerminalCopyShortcut(event: KeyboardEvent): boolean {
 	return isWindowsPlatform() && event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey;
 }
 
-function isWindowsPlatform(): boolean {
-	const platform =
-		(navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform ?? navigator.platform;
-	return platform.toLowerCase().startsWith("win");
-}
-
 function isTerminalPasteShortcut(event: KeyboardEvent): boolean {
 	if (event.key === "Insert") return event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey;
 	if (event.key.toLowerCase() !== "v") return false;
@@ -127,7 +122,23 @@ function consumeTerminalShortcut(event: KeyboardEvent): void {
 }
 
 function normalizedTerminalShortcut(event: KeyboardEvent): string | null {
-	if (event.metaKey || event.shiftKey) return null;
+	if (event.shiftKey) return null;
+
+	// Guard with isMacPlatform() so the Windows key (metaKey on Windows) is not
+	// mistakenly treated as the macOS Command modifier.
+	if (event.metaKey && !event.ctrlKey && !event.altKey && isMacPlatform()) {
+		switch (event.key) {
+			case "ArrowLeft":
+				return "\x01";
+			case "ArrowRight":
+				return "\x05";
+			default:
+				return null;
+		}
+	}
+
+	// Non-macOS metaKey: do not handle.
+	if (event.metaKey) return null;
 
 	if (event.altKey && !event.ctrlKey) {
 		switch (event.key) {
@@ -154,6 +165,18 @@ function normalizedTerminalShortcut(event: KeyboardEvent): string | null {
 				return "\x1b\x7f";
 			case "Delete":
 				return "\x1bd";
+			default:
+				return null;
+		}
+	}
+
+	// Windows: Home/End for line start/end (platform-native convention).
+	if (isWindowsPlatform()) {
+		switch (event.key) {
+			case "Home":
+				return "\x01";
+			case "End":
+				return "\x05";
 			default:
 				return null;
 		}


### PR DESCRIPTION
## What

Add platform-native line-boundary shortcuts to the terminal input handler. Cmd+Left/Cmd+Right on macOS and Home/End on Windows now move the cursor to the start/end of the current input line.

## Why

Fixes #3093. These chords are standard text-editing gestures on their respective platforms but were silently ignored -normalizedTerminalShortcut returned null for any metaKey event, and Home/End had no handler.

## How

- isMacPlatform and isWindowsPlatform imported from the existing ../lib/platform module,  no new helpers added.
- Cmd+Left/Right handled only when isMacPlatform() is true, so the Windows key (metaKey on Windows) is not mistakenly treated as Command.
- Both shortcuts emit readline control bytes: \x01 (Ctrl+A, line start) and \x05 (Ctrl+E, line end).
- Ctrl+Left/Right word-navigation and Option+Left/Right word-navigation are untouched.

## Testing

- npx vitest run src/renderer/components/XtermTerminal.test.tsx — 50/50 pass.

- Six new unit tests cover: macOS Cmd+Arrow emits correct sequences, Windows Home/End emits correct sequences, Windows metaKey falls through, Ctrl+Arrow on Windows still word-navigates, keyup after Cmd+Left does not re-fire.

- Manual: open a shell terminal in AO, type a long command and tried with these shortcuts.

## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)
