### PR TITLE
fix: polish windows shell controls

### DIFF
--- a/frontend/src/renderer/components/NotificationCenter.tsx
+++ b/frontend/src/renderer/components/NotificationCenter.tsx
@@ -172,9 +172,9 @@ export function NotificationCenter({ style }: NotificationCenterProps) {
 					variant="icon"
 				>
 					{unreadCount > 0 ? (
-						<BellRing className="size-icon-lg fill-current text-foreground" aria-hidden="true" />
+						<BellRing className="size-5 fill-current text-foreground" aria-hidden="true" />
 					) : (
-						<Bell className="size-icon-lg" aria-hidden="true" />
+						<Bell className="size-5" aria-hidden="true" />
 					)}
 					{unreadCount > 0 ? (
 						<span className="pointer-events-none absolute -right-0.5 -top-0.5 grid min-w-4 place-items-center rounded-full bg-foreground px-1 font-mono text-[9px] font-semibold leading-4 text-background shadow-sm">

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -142,8 +142,8 @@ export function ShellTopbar() {
 				) : isSessionRoute ? (
 					<div className="flex min-w-0 items-center gap-3">
 						{session?.branch ? (
-							<div className="inline-flex min-w-0 items-center gap-1 font-mono text-2xs leading-none text-passive">
-								<GitBranch className="size-icon-2xs shrink-0" aria-hidden="true" />
+							<div className="inline-flex min-w-0 items-center gap-1.5 font-mono text-brand leading-none text-foreground">
+								<GitBranch className="size-4 shrink-0" aria-hidden="true" />
 								<span className="truncate">{session.branch}</span>
 							</div>
 						) : null}
@@ -174,7 +174,7 @@ export function ShellTopbar() {
 							style={noDragStyle}
 							variant="accent"
 						>
-							<Plus className="size-icon-md" aria-hidden="true" />
+							<Plus className="size-icon-lg" aria-hidden="true" />
 							New task
 						</TopbarButton>
 						<TopbarButton
@@ -184,7 +184,7 @@ export function ShellTopbar() {
 							style={noDragStyle}
 							variant="primary"
 						>
-							<OrchestratorIcon className="size-icon-md" aria-hidden="true" />
+							<OrchestratorIcon className="size-icon-lg" aria-hidden="true" />
 							{isProjectRestarting
 								? "Restarting…"
 								: isSpawning
@@ -206,11 +206,11 @@ export function ShellTopbar() {
 									style={noDragStyle}
 									variant="accent"
 								>
-									<Plus className="size-icon-md" aria-hidden="true" />
+									<Plus className="size-icon-lg" aria-hidden="true" />
 									New task
 								</TopbarButton>
 								<TopbarButton aria-label="Open Kanban" onClick={openBoard} style={noDragStyle} variant="primary">
-									<LayoutDashboard className="size-icon-md" aria-hidden="true" />
+									<LayoutDashboard className="size-icon-lg" aria-hidden="true" />
 									Kanban
 								</TopbarButton>
 							</>
@@ -241,7 +241,7 @@ export function ShellTopbar() {
 								style={noDragStyle}
 								variant="primary"
 							>
-								<OrchestratorIcon className="size-icon-md" aria-hidden="true" />
+								<OrchestratorIcon className="size-icon-lg" aria-hidden="true" />
 								{isProjectRestarting ? "Restarting…" : isSpawning ? "Spawning…" : "Orchestrator"}
 							</TopbarButton>
 						)}
@@ -256,9 +256,9 @@ export function ShellTopbar() {
 								variant="icon"
 							>
 								{isInspectorOpen ? (
-									<PanelRightClose className="size-icon-lg" aria-hidden="true" />
+									<PanelRightClose className="size-5" aria-hidden="true" />
 								) : (
-									<PanelRightOpen className="size-icon-lg" aria-hidden="true" />
+									<PanelRightOpen className="size-5" aria-hidden="true" />
 								)}
 							</TopbarButton>
 						)}
@@ -306,7 +306,7 @@ export function TopbarKillButton({
 				title="Kill session"
 				variant="kill"
 			>
-				<Trash2 className="size-icon-sm" aria-hidden="true" />
+				<Trash2 className="size-icon-lg" aria-hidden="true" />
 				Kill
 			</TopbarButton>
 			<ConfirmDialog
@@ -330,5 +330,7 @@ export function TopbarKillButton({
 }
 function SessionStatusPill({ session }: { session: WorkspaceSession }) {
 	const { label, tone, breathe } = getAgentActivityView(session.activity);
-	return <StatusPill label={label} tone={tone} breathe={breathe} leading="none" />;
+	return (
+		<StatusPill label={label} tone={tone} breathe={breathe} leading="none" className="px-3.5 py-2 text-sm" />
+	);
 }

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -329,7 +329,7 @@ export function Sidebar({
 					<RestartToUpdateRow status={updateStatus} />
 					<button
 						aria-label="Settings"
-						className="flex w-full items-center justify-center gap-2.5 rounded-settings-row bg-interactive-hover px-2.5 py-2.5 text-control font-medium text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground [&_svg]:size-icon-lg [&_svg]:shrink-0 [&_svg]:text-muted-foreground"
+						className="flex w-full items-center justify-center gap-2.5 rounded-settings-row bg-interactive-hover px-2.5 py-2.5 text-control font-medium text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground [&_svg]:size-icon-lg [&_svg]:shrink-0"
 						onClick={() => selection.goGlobalSettings()}
 						type="button"
 					>

--- a/frontend/src/renderer/components/TopbarButton.tsx
+++ b/frontend/src/renderer/components/TopbarButton.tsx
@@ -7,11 +7,11 @@ const topbarButtonVariants = cva(
 		variants: {
 			variant: {
 				primary:
-					"h-control-md gap-1.5 rounded-md bg-accent-strong px-3 text-xs font-semibold leading-none text-accent-foreground hover:brightness-110 active:brightness-95",
+					"h-control-lg gap-1.5 rounded-md bg-accent-strong px-3.5 text-sm font-semibold leading-none text-accent-foreground hover:brightness-110 active:brightness-95",
 				accent:
-					"h-control-md gap-1.5 rounded-md border border-border px-3 text-xs font-semibold leading-none bg-raised text-muted-foreground hover:bg-surface hover:text-foreground",
-				icon: "grid size-control-md place-items-center rounded-md text-muted-foreground hover:bg-interactive-hover hover:text-foreground",
-				kill: "h-control-md gap-1.5 rounded-md border border-border bg-transparent px-3 text-xs font-semibold leading-none text-error/80 hover:border-error/50 hover:bg-error/10 hover:text-error",
+					"h-control-lg gap-1.5 rounded-md border border-border px-3.5 text-sm font-semibold leading-none bg-raised text-muted-foreground hover:bg-surface hover:text-foreground",
+				icon: "grid size-control-lg place-items-center rounded-md text-muted-foreground hover:bg-interactive-hover hover:text-foreground",
+				kill: "h-control-lg gap-1.5 rounded-md border border-border bg-transparent px-3.5 text-sm font-semibold leading-none text-error/80 hover:border-error/50 hover:bg-error/10 hover:text-error",
 				killConfirm:
 					"h-control-lg gap-1.5 rounded-md border border-error/40 bg-error/10 px-3 text-control font-semibold leading-none text-error hover:bg-error/16",
 				killCancel:

--- a/frontend/src/renderer/components/ui/switch.tsx
+++ b/frontend/src/renderer/components/ui/switch.tsx
@@ -10,7 +10,7 @@ function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimi
 		<SwitchPrimitive.Root
 			data-slot="switch"
 			className={cn(
-				"peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-border",
+				"peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-border-strong",
 				className,
 			)}
 			{...props}
@@ -18,7 +18,7 @@ function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimi
 			<SwitchPrimitive.Thumb
 				data-slot="switch-thumb"
 				className={cn(
-					"pointer-events-none block h-4 w-4 rounded-full bg-foreground shadow ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0.5",
+					"pointer-events-none block h-4 w-4 rounded-full bg-primary-foreground shadow ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0.5",
 				)}
 			/>
 		</SwitchPrimitive.Root>

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -459,7 +459,7 @@
 	--color-bg-tertiary: #ededee;
 	--color-bg-elevated: #e4e4e6;
 	--color-bg-sidebar: #fcfcfc;
-	--color-bg-terminal: #fafafa;
+	--color-bg-terminal: #f5f5f4;
 
 	--color-text-primary: #1a1a1a;
 	--color-text-muted: #666666;
@@ -545,19 +545,19 @@
 	--color-settings-switch-on: #3b82f6;
 
 	--color-term-black: #24292f;
-	--color-term-red: #cf222e;
-	--color-term-green: #1a7f37;
-	--color-term-yellow: #9a6700;
-	--color-term-blue: #0969da;
-	--color-term-magenta: #8250df;
-	--color-term-cyan: #0a7f89;
-	--color-term-white: #6e7781;
-	--color-term-bright-black: #57606a;
-	--color-term-bright-red: #a40e26;
-	--color-term-bright-green: #116329;
-	--color-term-bright-yellow: #7d4e00;
-	--color-term-bright-blue: #0550ae;
-	--color-term-bright-magenta: #6639ba;
-	--color-term-bright-cyan: #096b73;
+	--color-term-red: #a13c37;
+	--color-term-green: #2e6b3e;
+	--color-term-yellow: #87660f;
+	--color-term-blue: #3b5aa6;
+	--color-term-magenta: #7b5799;
+	--color-term-cyan: #3d7a7a;
+	--color-term-white: #666d75;
+	--color-term-bright-black: #4c535b;
+	--color-term-bright-red: #7e3330;
+	--color-term-bright-green: #265231;
+	--color-term-bright-yellow: #6b5108;
+	--color-term-bright-blue: #31487f;
+	--color-term-bright-magenta: #5f4476;
+	--color-term-bright-cyan: #316061;
 	--color-term-bright-white: #24292f;
 }


### PR DESCRIPTION
## What

Polishes the Windows shell UI controls in a small frontend-only PR.

This specifically fixes and tightens:

- Topbar action buttons: increases shared `TopbarButton` height, padding, and label size so primary/accent/kill actions read consistently.
- Topbar icons: updates New task, Orchestrator, Kanban, Kill, inspector, and notification icons to match the larger control scale.
- Notification bell: keeps the bell at the far right of the topbar and resolves the upstream/local conflict without moving it back into the old layout.
- Session branch/status area: makes the branch label more readable and gives the status pill a little more breathing room.
- Toggle/switch styling: improves unchecked switch contrast with `border-strong` and uses the proper foreground token for the thumb.
- Sidebar settings row: lets the settings icon inherit the correct hover/text color instead of forcing muted color.
- Light terminal palette: softens the light terminal background and ANSI colors so terminal content is less harsh.

## Why

The previous shell controls were a little too small/inconsistent after the topbar notification placement change on `main`. This keeps the PR restrictive: it only touches presentation details in the renderer and design tokens, without changing app behavior, daemon APIs, storage, generated files, or backend logic.

## How

- Updated the shared `TopbarButton` variants instead of restyling each button independently.
- Matched individual topbar icon sizes to the new shared button scale.
- Resolved `NotificationCenter.tsx` by preserving upstream's trailing notification placement and keeping the intended local icon sizing.
- Updated switch and sidebar classes to use existing theme/token utilities.
- Adjusted only light-mode terminal color tokens in `frontend/src/styles/tokens.css`.

## Screenshots

TODO: add screenshots before merge.

Suggested screenshots:

- Board/topbar showing New task, Orchestrator, and notification bell.
- Notification popover opened from the bell.
- Session inspector or settings screen showing the toggle/switch styling.

## Testing

- `npm run frontend:typecheck`
- `npm --prefix frontend run test -- src/renderer/components/NotificationCenter.test.tsx src/renderer/components/Sidebar.test.tsx src/renderer/components/ShellTopbar.test.tsx`
- `git diff --cached --check`
- Independent read-only code review: no blocking findings.
- CI on PR passed: `Frontend / test`, `Frontend / renderer-smoke`, and `gitleaks / scan`.

Note: full local `npm --prefix frontend run test` was attempted, but four unrelated `src/main/supervisor-link.test.ts` tests failed locally because Windows socket binding returned `EACCES`. The rest of that run passed: 85/86 test files and 1075/1079 tests.


## Before
<img width="1646" height="1020" alt="Screenshot 2026-07-25 205957" src="https://github.com/user-attachments/assets/59fa0a9f-a0cd-4923-bb0a-291962be86ea" />
<img width="132" height="132" alt="Screenshot 2026-07-25 182246" src="https://github.com/user-attachments/assets/ea039bb1-b49c-4b3c-b373-5e4568da20d8" />
<img width="86" height="86" alt="Screenshot 2026-07-25 182259" src="https://github.com/user-attachments/assets/2414d313-3eef-4715-a549-0c402653ccb2" />


## After
<img width="1652" height="1020" alt="image" src="https://github.com/user-attachments/assets/71224a19-fcb3-45f5-bdfc-160e7860b827" />

<img width="187" height="142" alt="Screenshot 2026-07-25 183145" src="https://github.com/user-attachments/assets/17999958-8361-4130-83d7-5b3d7fb957ef" />


## Checklist

- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)