### PR TITLE
fix: align settings center panel with board frame insets

### DIFF
--- a/frontend/src/renderer/components/CenterPanelShell.tsx
+++ b/frontend/src/renderer/components/CenterPanelShell.tsx
@@ -13,7 +13,7 @@ const isMac = isMacPlatform();
  * `center-panel-surface`).
  *
  * `titlebarAlign` (default true) pulls Board/Terminal titles into the macOS
- * traffic-light band. Settings opts out so it keeps the large centered layout.
+ * traffic-light band.
  */
 export function CenterPanelShell({
 	className,

--- a/frontend/src/renderer/components/settings/SettingsPageShell.tsx
+++ b/frontend/src/renderer/components/settings/SettingsPageShell.tsx
@@ -1,9 +1,7 @@
 import type { ReactNode } from "react";
 import { CenterPanelShell } from "../CenterPanelShell";
 
-/** Outer settings frame — sidebar chrome with the settings inset panel. */
+/** Outer settings frame — same center-panel insets as board/session. */
 export function SettingsPageShell({ children }: { children: ReactNode }) {
-	// Settings keeps its own large centered layout; do not pull the heading into
-	// the macOS titlebar band or flush fullscreen margins.
-	return <CenterPanelShell titlebarAlign={false}>{children}</CenterPanelShell>;
+	return <CenterPanelShell>{children}</CenterPanelShell>;
 }


### PR DESCRIPTION
## Summary
- Settings page shell now uses the default `CenterPanelShell` insets (same as board/session) instead of opting out via `titlebarAlign={false}`.
- Leaves the centered settings content column (max-width, padding, rows) unchanged.

## Test plan
- [ ] Open Settings on macOS and confirm the rounded center panel sits flush like the Board panel (same outer frame gap).
- [ ] Confirm Settings inner content is still a centered ~768px column with original padding and row layout.
- [ ] Toggle fullscreen and collapsed sidebar; Settings frame should still match Board.
- [ ] Spot-check Win/Linux if available: Settings still renders in the shared center panel shell.

## Before
<img width="1469" height="953" alt="image" src="https://github.com/user-attachments/assets/a149ef82-6848-46de-adda-ec6a3943c6c7" />

## After
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/d1afba4d-5e7f-499a-94e2-9020735cb8ea" />
