### PR TITLE
fix(codex): recover sessions stuck in active state

### DIFF
--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -64,6 +64,7 @@ var _ adapters.Adapter = (*Plugin)(nil)
 var _ ports.Agent = (*Plugin)(nil)
 var _ ports.ActiveTurnSteerer = (*Plugin)(nil)
 var _ ports.AgentAuthChecker = (*Plugin)(nil)
+var _ ports.TerminalActivityDetector = (*Plugin)(nil)
 
 // Manifest returns the adapter's static self-description.
 func (p *Plugin) Manifest() adapters.Manifest {

--- a/backend/internal/adapters/agent/codex/terminal_activity.go
+++ b/backend/internal/adapters/agent/codex/terminal_activity.go
@@ -1,0 +1,49 @@
+package codex
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+var codexTerminalEscape = regexp.MustCompile(`\x1b(?:\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]|\][^\x07]*(?:\x07|\x1b\\))`)
+
+// DetectTerminalActivity reports idle only when Codex's composer and footer are visible.
+func (p *Plugin) DetectTerminalActivity(output string) (domain.ActivityState, bool) {
+	lines := terminalLines(output)
+	if len(lines) < 2 {
+		return "", false
+	}
+	start := len(lines) - 12
+	if start < 0 {
+		start = 0
+	}
+	for _, line := range lines[start:] {
+		if strings.Contains(strings.ToLower(line), "esc to interrupt") {
+			return "", false
+		}
+	}
+	for i := len(lines) - 2; i >= start; i-- {
+		if !strings.HasPrefix(strings.TrimSpace(lines[i]), "›") {
+			continue
+		}
+		if strings.Contains(lines[i+1], " · ") {
+			return domain.ActivityIdle, true
+		}
+	}
+	return "", false
+}
+
+func terminalLines(output string) []string {
+	plain := codexTerminalEscape.ReplaceAllString(strings.ReplaceAll(output, "\r", "\n"), "")
+	raw := strings.Split(plain, "\n")
+	lines := raw[:0]
+	for _, line := range raw {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/backend/internal/adapters/agent/codex/terminal_activity_test.go
+++ b/backend/internal/adapters/agent/codex/terminal_activity_test.go
@@ -1,0 +1,43 @@
+package codex
+
+import (
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestDetectTerminalActivity(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   domain.ActivityState
+		ok     bool
+	}{
+		{
+			name:   "idle composer",
+			output: "\x1b[1m›\x1b[0m \x1b[2mWrite tests for @filename\x1b[0m\n\ngpt-5.6-sol low · ~/project\n",
+			want:   domain.ActivityIdle,
+			ok:     true,
+		},
+		{
+			name:   "working composer",
+			output: "• Working (2m 10s • esc to interrupt)\n› Add tests\n\ngpt-5.6-sol low · ~/project\n",
+		},
+		{
+			name:   "approval picker",
+			output: "› 1. Approve once\n  2. Deny\nPress enter to confirm or esc to go back\n",
+		},
+		{
+			name:   "assistant text",
+			output: "The symbol is:\n›\nnot a composer footer\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := (&Plugin{}).DetectTerminalActivity(tt.output)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("DetectTerminalActivity() = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
+	activityobserver "github.com/aoagents/agent-orchestrator/backend/internal/observe/activity"
 	"github.com/aoagents/agent-orchestrator/backend/internal/observe/reaper"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 	reviewcore "github.com/aoagents/agent-orchestrator/backend/internal/review"
@@ -40,6 +41,7 @@ type lifecycleStack struct {
 	LCM           *lifecycle.Manager
 	runtimeReaper *reaper.Reaper
 	reaperDone    <-chan struct{}
+	activityDone  <-chan struct{}
 	scmDone       <-chan struct{}
 	trackerDone   <-chan struct{}
 	sweepDone     <-chan struct{}
@@ -60,10 +62,12 @@ func startLifecycle(ctx context.Context, store *sqlite.Store, runtime ports.Runt
 		lifecycle.WithActiveSteering(activeTurnSteering(agents)),
 	)
 	rp := reaper.New(lcm, store, runtime, reaper.Config{Logger: logger})
+	activityPoller := activityobserver.New(store, lcm, runtime, agents, activityobserver.Config{Logger: logger})
 	return &lifecycleStack{
 		LCM:           lcm,
 		runtimeReaper: rp,
 		reaperDone:    rp.Start(ctx),
+		activityDone:  activityPoller.Start(ctx),
 		sweepDone:     startWorkerIdleSweep(ctx, lcm),
 	}
 }
@@ -118,6 +122,9 @@ func startWorkerIdleSweep(ctx context.Context, lcm *lifecycle.Manager) <-chan st
 // passed to startLifecycle before calling Stop.
 func (l *lifecycleStack) Stop() {
 	<-l.reaperDone
+	if l.activityDone != nil {
+		<-l.activityDone
+	}
 	if l.sweepDone != nil {
 		<-l.sweepDone
 	}

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -294,6 +294,11 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 		m.mu.Unlock()
 		return nil
 	}
+	if !s.ExpectedUpdatedAt.IsZero() &&
+		(rec.Activity.State != domain.ActivityActive || !rec.UpdatedAt.Equal(s.ExpectedUpdatedAt)) {
+		m.mu.Unlock()
+		return nil
+	}
 	// An explicit prompt submission is proof that an agent was relaunched in the
 	// preserved shell. Other same-generation callbacks may have been delayed
 	// behind the process-exit report and cannot resurrect an exited workload.
@@ -337,7 +342,7 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	// first to ARRIVE may match the seeded state — e.g. a turn's "active"
 	// POST is lost and its Stop hook lands idle on the idle-seeded row.
 	if sameState && !rec.FirstSignalAt.IsZero() {
-		if metadataChanged {
+		if metadataChanged || s.Event == "user-prompt-submit" {
 			rec.UpdatedAt = now
 			err := m.store.UpdateSession(ctx, rec)
 			m.mu.Unlock()

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -305,6 +305,77 @@ func TestActivity_SameStateSignalStillStoresAgentSessionID(t *testing.T) {
 	}
 }
 
+func TestActivity_ReconciledIdleRequiresUnchangedActiveSnapshot(t *testing.T) {
+	m, st, _ := newManager()
+	updatedAt := time.Unix(100, 0).UTC()
+	rec := working("mer-1")
+	rec.Kind = domain.KindWorker
+	rec.FirstSignalAt = updatedAt
+	rec.UpdatedAt = updatedAt
+	st.sessions[rec.ID] = rec
+
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		Valid:             true,
+		State:             domain.ActivityIdle,
+		Event:             "terminal-idle",
+		ExpectedUpdatedAt: updatedAt.Add(-time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions[rec.ID].Activity.State; got != domain.ActivityActive {
+		t.Fatalf("stale reconciliation changed activity to %q", got)
+	}
+
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		Valid:             true,
+		State:             domain.ActivityIdle,
+		Event:             "terminal-idle",
+		ExpectedUpdatedAt: updatedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions[rec.ID].Activity.State; got != domain.ActivityIdle {
+		t.Fatalf("current reconciliation left activity %q", got)
+	}
+	if len(st.idleEvents) != 1 {
+		t.Fatalf("worker idle events = %d, want 1", len(st.idleEvents))
+	}
+}
+
+func TestActivity_RepeatedUserPromptFencesTerminalReconciliation(t *testing.T) {
+	m, st, _ := newManager()
+	before := time.Unix(100, 0).UTC()
+	after := time.Unix(200, 0).UTC()
+	m.clock = func() time.Time { return after }
+	rec := working("mer-1")
+	rec.FirstSignalAt = before
+	rec.UpdatedAt = before
+	st.sessions[rec.ID] = rec
+
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		Valid: true,
+		State: domain.ActivityActive,
+		Event: "user-prompt-submit",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions[rec.ID].UpdatedAt; !got.Equal(after) {
+		t.Fatalf("updated at = %v, want %v", got, after)
+	}
+
+	if err := m.ApplyActivitySignal(ctx, rec.ID, ports.ActivitySignal{
+		Valid:             true,
+		State:             domain.ActivityIdle,
+		Event:             "terminal-idle",
+		ExpectedUpdatedAt: before,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.sessions[rec.ID].Activity.State; got != domain.ActivityActive {
+		t.Fatalf("fresh prompt was overwritten with %q", got)
+	}
+}
+
 func TestActivity_BlankAgentSessionIDDoesNotOverwriteMetadata(t *testing.T) {
 	m, st, _ := newManager()
 	rec := working("mer-1")

--- a/backend/internal/observe/activity/observer.go
+++ b/backend/internal/observe/activity/observer.go
@@ -1,0 +1,137 @@
+package activity
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/observe"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Default activity observation settings.
+const (
+	DefaultTickInterval = 30 * time.Second
+	DefaultStaleAfter   = 2 * time.Minute
+	DefaultOutputLines  = 40
+)
+
+// Config controls activity reconciliation polling.
+type Config struct {
+	Tick        time.Duration
+	StaleAfter  time.Duration
+	OutputLines int
+	Clock       func() time.Time
+	Logger      *slog.Logger
+}
+
+type sessionSource interface {
+	ListAllSessions(ctx context.Context) ([]domain.SessionRecord, error)
+}
+
+type activitySink interface {
+	ApplyActivitySignal(ctx context.Context, id domain.SessionID, signal ports.ActivitySignal) error
+}
+
+type outputReader interface {
+	GetOutput(ctx context.Context, handle ports.RuntimeHandle, lines int) (string, error)
+}
+
+// Observer reconciles stale hook activity from adapter-owned terminal markers.
+type Observer struct {
+	sessions    sessionSource
+	sink        activitySink
+	runtime     outputReader
+	agents      ports.AgentResolver
+	tick        time.Duration
+	staleAfter  time.Duration
+	outputLines int
+	clock       func() time.Time
+	logger      *slog.Logger
+}
+
+// New builds an activity observer.
+func New(sessions sessionSource, sink activitySink, runtime outputReader, agents ports.AgentResolver, cfg Config) *Observer {
+	o := &Observer{
+		sessions:    sessions,
+		sink:        sink,
+		runtime:     runtime,
+		agents:      agents,
+		tick:        cfg.Tick,
+		staleAfter:  cfg.StaleAfter,
+		outputLines: cfg.OutputLines,
+		clock:       cfg.Clock,
+		logger:      cfg.Logger,
+	}
+	if o.tick <= 0 {
+		o.tick = DefaultTickInterval
+	}
+	if o.staleAfter <= 0 {
+		o.staleAfter = DefaultStaleAfter
+	}
+	if o.outputLines <= 0 {
+		o.outputLines = DefaultOutputLines
+	}
+	if o.clock == nil {
+		o.clock = time.Now
+	}
+	if o.logger == nil {
+		o.logger = slog.Default()
+	}
+	return o
+}
+
+// Start runs polling until the context is canceled.
+func (o *Observer) Start(ctx context.Context) <-chan struct{} {
+	return observe.StartPollLoop(ctx, o.tick, o.Poll, o.logger, "activity observer")
+}
+
+// Poll performs one activity reconciliation pass.
+func (o *Observer) Poll(ctx context.Context) error {
+	sessions, err := o.sessions.ListAllSessions(ctx)
+	if err != nil {
+		return err
+	}
+	now := o.clock()
+	for _, session := range sessions {
+		o.reconcile(ctx, session, now)
+	}
+	return nil
+}
+
+func (o *Observer) reconcile(ctx context.Context, session domain.SessionRecord, now time.Time) {
+	if session.IsTerminated || session.Activity.State != domain.ActivityActive ||
+		session.Activity.LastActivityAt.IsZero() || now.Sub(session.Activity.LastActivityAt) < o.staleAfter ||
+		session.Metadata.RuntimeHandleID == "" || o.agents == nil {
+		return
+	}
+	agent, ok := o.agents.Agent(session.Harness)
+	if !ok {
+		return
+	}
+	detector, ok := agent.(ports.TerminalActivityDetector)
+	if !ok {
+		return
+	}
+	output, err := o.runtime.GetOutput(ctx, ports.RuntimeHandle{ID: session.Metadata.RuntimeHandleID}, o.outputLines)
+	if err != nil {
+		o.logger.Debug("activity observer: terminal output unavailable", "session", session.ID, "err", err)
+		return
+	}
+	state, ok := detector.DetectTerminalActivity(output)
+	if !ok || state != domain.ActivityIdle {
+		return
+	}
+	err = o.sink.ApplyActivitySignal(ctx, session.ID, ports.ActivitySignal{
+		Valid:             true,
+		State:             state,
+		Timestamp:         now,
+		ExpectedUpdatedAt: session.UpdatedAt,
+		Event:             "terminal-idle",
+		LaunchID:          session.Metadata.RuntimeLaunchID,
+	})
+	if err != nil {
+		o.logger.Error("activity observer: reconciliation failed", "session", session.ID, "err", err)
+	}
+}

--- a/backend/internal/observe/activity/observer_integration_test.go
+++ b/backend/internal/observe/activity/observer_integration_test.go
@@ -1,0 +1,149 @@
+package activity
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/tmux"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+func TestObserverIntegrationReconcilesRealTmuxOutputIntoSQLite(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux unavailable")
+	}
+
+	tests := []struct {
+		name       string
+		output     string
+		wantState  domain.ActivityState
+		wantEvents int
+	}{
+		{
+			name:       "idle composer repairs missed stop",
+			output:     "\n› Write tests for @filename\n\ngpt-5.6-sol low · ~/project\n",
+			wantState:  domain.ActivityIdle,
+			wantEvents: 1,
+		},
+		{
+			name:       "working marker prevents demotion",
+			output:     "\n• Working (3m 10s • esc to interrupt)\n› Add tests\n\ngpt-5.6-sol low · ~/project\n",
+			wantState:  domain.ActivityActive,
+			wantEvents: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, err := sqlite.Open(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = store.Close() })
+
+			workspace := t.TempDir()
+			now := time.Now().UTC()
+			staleAt := now.Add(-3 * time.Minute)
+			projectID := domain.ProjectID("ao3115e2e")
+			if err := store.UpsertProject(ctx, domain.ProjectRecord{
+				ID:           string(projectID),
+				Path:         workspace,
+				RegisteredAt: staleAt,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			session, err := store.CreateSession(ctx, domain.SessionRecord{
+				ProjectID:     projectID,
+				Kind:          domain.KindWorker,
+				Harness:       domain.HarnessCodex,
+				Activity:      domain.Activity{State: domain.ActivityActive, LastActivityAt: staleAt},
+				FirstSignalAt: staleAt,
+				CreatedAt:     staleAt,
+				UpdatedAt:     staleAt,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			runtime := tmux.New(tmux.Options{Timeout: 5 * time.Second, ReapGrace: 100 * time.Millisecond})
+			handle, err := runtime.Create(ctx, ports.RuntimeConfig{
+				SessionID:     session.ID,
+				WorkspacePath: workspace,
+				Argv:          []string{"sh", "-c", "printf '%s' " + shellQuote(tt.output) + "; sleep 30"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = runtime.Destroy(context.Background(), handle) })
+
+			waitForTerminalOutput(t, runtime, handle, "gpt-5.6-sol low · ~/project")
+			session.Metadata.RuntimeHandleID = handle.ID
+			session.Metadata.RuntimeLaunchID = "launch-1"
+			if err := store.UpdateSession(ctx, session); err != nil {
+				t.Fatal(err)
+			}
+
+			manager := lifecycle.New(store, nil)
+			observer := New(
+				store,
+				manager,
+				runtime,
+				fakeAgents{domain.HarnessCodex: codex.New()},
+				Config{
+					StaleAfter: time.Minute,
+					Clock:      func() time.Time { return now },
+					Logger:     testLogger(),
+				},
+			)
+			if err := observer.Poll(ctx); err != nil {
+				t.Fatal(err)
+			}
+
+			got, ok, err := store.GetSession(ctx, session.ID)
+			if err != nil || !ok {
+				t.Fatalf("GetSession: ok=%v err=%v", ok, err)
+			}
+			if got.Activity.State != tt.wantState {
+				t.Fatalf("activity state = %q, want %q", got.Activity.State, tt.wantState)
+			}
+			events, err := store.ListPendingWorkerIdleEvents(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(events) != tt.wantEvents {
+				t.Fatalf("pending worker idle events = %d, want %d", len(events), tt.wantEvents)
+			}
+			if tt.wantEvents == 1 && events[0].WorkerID != session.ID {
+				t.Fatalf("worker idle event worker = %q, want %q", events[0].WorkerID, session.ID)
+			}
+		})
+	}
+}
+
+func waitForTerminalOutput(t *testing.T, runtime *tmux.Runtime, handle ports.RuntimeHandle, want string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		output, err := runtime.GetOutput(context.Background(), handle, 40)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(output, want) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("terminal output never contained %q", want)
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/backend/internal/observe/activity/observer_test.go
+++ b/backend/internal/observe/activity/observer_test.go
@@ -1,0 +1,172 @@
+package activity
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type fakeSessions struct {
+	rows []domain.SessionRecord
+	err  error
+}
+
+func (f fakeSessions) ListAllSessions(context.Context) ([]domain.SessionRecord, error) {
+	return f.rows, f.err
+}
+
+type fakeSink struct {
+	id      domain.SessionID
+	signals []ports.ActivitySignal
+}
+
+func (f *fakeSink) ApplyActivitySignal(_ context.Context, id domain.SessionID, signal ports.ActivitySignal) error {
+	f.id = id
+	f.signals = append(f.signals, signal)
+	return nil
+}
+
+type fakeRuntime struct {
+	output string
+	err    error
+	calls  int
+}
+
+func (f *fakeRuntime) GetOutput(context.Context, ports.RuntimeHandle, int) (string, error) {
+	f.calls++
+	return f.output, f.err
+}
+
+type fakeAgents map[domain.AgentHarness]ports.Agent
+
+func (f fakeAgents) Agent(harness domain.AgentHarness) (ports.Agent, bool) {
+	agent, ok := f[harness]
+	return agent, ok
+}
+
+func activeSession(now time.Time, harness domain.AgentHarness) domain.SessionRecord {
+	return domain.SessionRecord{
+		ID:        "ao-1",
+		Harness:   harness,
+		Activity:  domain.Activity{State: domain.ActivityActive, LastActivityAt: now.Add(-3 * time.Minute)},
+		UpdatedAt: now.Add(-3 * time.Minute),
+		Metadata: domain.SessionMetadata{
+			RuntimeHandleID: "ao-1",
+			RuntimeLaunchID: "launch-1",
+		},
+	}
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestPollReconcilesStaleCodexAtComposer(t *testing.T) {
+	now := time.Unix(500, 0).UTC()
+	session := activeSession(now, domain.HarnessCodex)
+	sink := &fakeSink{}
+	runtime := &fakeRuntime{output: "› Write tests for @filename\n\ngpt-5.6-sol low · ~/project\n"}
+	observer := New(
+		fakeSessions{rows: []domain.SessionRecord{session}},
+		sink,
+		runtime,
+		fakeAgents{domain.HarnessCodex: codex.New()},
+		Config{Clock: func() time.Time { return now }, Logger: testLogger()},
+	)
+
+	if err := observer.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.signals) != 1 {
+		t.Fatalf("signals = %d, want 1", len(sink.signals))
+	}
+	signal := sink.signals[0]
+	if sink.id != session.ID || signal.State != domain.ActivityIdle || signal.Event != "terminal-idle" {
+		t.Fatalf("unexpected reconciliation: id=%q signal=%+v", sink.id, signal)
+	}
+	if !signal.ExpectedUpdatedAt.Equal(session.UpdatedAt) || signal.LaunchID != "launch-1" {
+		t.Fatalf("reconciliation fence = %+v, want updatedAt=%v launch=launch-1", signal, session.UpdatedAt)
+	}
+}
+
+func TestPollKeepsGenuineLongCodexTurnActive(t *testing.T) {
+	now := time.Unix(500, 0).UTC()
+	sink := &fakeSink{}
+	runtime := &fakeRuntime{output: "• Working (3m 10s • esc to interrupt)\n› Add tests\n\ngpt-5.6-sol low · ~/project\n"}
+	observer := New(
+		fakeSessions{rows: []domain.SessionRecord{activeSession(now, domain.HarnessCodex)}},
+		sink,
+		runtime,
+		fakeAgents{domain.HarnessCodex: codex.New()},
+		Config{Clock: func() time.Time { return now }, Logger: testLogger()},
+	)
+
+	if err := observer.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.signals) != 0 {
+		t.Fatalf("long active turn emitted reconciliation: %+v", sink.signals)
+	}
+}
+
+func TestPollLeavesOtherHarnessesUntouched(t *testing.T) {
+	now := time.Unix(500, 0).UTC()
+	sink := &fakeSink{}
+	runtime := &fakeRuntime{output: "› prompt\nmodel · ~/project\n"}
+	observer := New(
+		fakeSessions{rows: []domain.SessionRecord{activeSession(now, domain.HarnessClaudeCode)}},
+		sink,
+		runtime,
+		fakeAgents{domain.HarnessClaudeCode: claudecode.New()},
+		Config{Clock: func() time.Time { return now }, Logger: testLogger()},
+	)
+
+	if err := observer.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.calls != 0 || len(sink.signals) != 0 {
+		t.Fatalf("unaffected harness: output calls=%d signals=%+v", runtime.calls, sink.signals)
+	}
+}
+
+func TestPollSkipsFreshActiveAndOutputFailures(t *testing.T) {
+	now := time.Unix(500, 0).UTC()
+	fresh := activeSession(now, domain.HarnessCodex)
+	fresh.Activity.LastActivityAt = now.Add(-time.Minute)
+	runtime := &fakeRuntime{err: errors.New("capture failed")}
+	observer := New(
+		fakeSessions{rows: []domain.SessionRecord{fresh}},
+		&fakeSink{},
+		runtime,
+		fakeAgents{domain.HarnessCodex: codex.New()},
+		Config{Clock: func() time.Time { return now }, Logger: testLogger()},
+	)
+	if err := observer.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.calls != 0 {
+		t.Fatalf("fresh session output calls = %d, want 0", runtime.calls)
+	}
+
+	stale := activeSession(now, domain.HarnessCodex)
+	observer.sessions = fakeSessions{rows: []domain.SessionRecord{stale}}
+	if err := observer.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPollReturnsSessionListFailure(t *testing.T) {
+	want := errors.New("list failed")
+	observer := New(fakeSessions{err: want}, &fakeSink{}, &fakeRuntime{}, nil, Config{Logger: testLogger()})
+	if err := observer.Poll(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+}

--- a/backend/internal/ports/agent.go
+++ b/backend/internal/ports/agent.go
@@ -94,6 +94,11 @@ type AgentPromptReadinessProvider interface {
 	PromptReadinessHints(ctx context.Context, cfg LaunchConfig) (PromptReadinessHints, error)
 }
 
+// TerminalActivityDetector derives activity only from authoritative terminal UI markers.
+type TerminalActivityDetector interface {
+	DetectTerminalActivity(output string) (domain.ActivityState, bool)
+}
+
 // PromptReadinessHints describes when an after-start prompt should be sent.
 // Empty hints mean "send immediately" to preserve existing adapter behavior.
 type PromptReadinessHints struct {

--- a/backend/internal/ports/runtime_observations.go
+++ b/backend/internal/ports/runtime_observations.go
@@ -39,13 +39,14 @@ type RuntimeFacts struct {
 // (old CLIs, adapters with no tool identity) keeps plain last-writer-wins
 // state semantics.
 type ActivitySignal struct {
-	Valid          bool
-	State          domain.ActivityState
-	Timestamp      time.Time
-	Event          string
-	ToolName       string
-	ToolUseID      string
-	AgentSessionID string
+	Valid             bool
+	State             domain.ActivityState
+	Timestamp         time.Time
+	ExpectedUpdatedAt time.Time
+	Event             string
+	ToolName          string
+	ToolUseID         string
+	AgentSessionID    string
 	// LaunchID is set by AO's process supervisor. Lifecycle rejects a signal
 	// from an older process generation of the same session.
 	LaunchID string


### PR DESCRIPTION
Fixes #3115.

## What changed

Codex can occasionally miss its final `stop` hook, which leaves AO showing a session as working even after Codex has returned to the composer.

This adds a small activity observer that:

- checks only stale active sessions whose adapter supports terminal activity detection;
- recognizes Codex's idle composer and footer markers;
- keeps sessions active while the `esc to interrupt` working marker is visible;
- fences terminal observations with the runtime launch and session update timestamp so stale output cannot overwrite a newer prompt;
- uses the normal lifecycle transition, including the durable worker-idle event.

Other agent adapters are left unchanged.

## Verification

- `npm run lint`
- `cd backend && go test -race ./...`
- `cd backend && go vet ./...`
- `cd backend && go build ./...`
- frontend typecheck and E2E typecheck
- 1,084 frontend Vitest tests
- 20 renderer-smoke Playwright tests
- real tmux + SQLite regression test covering both idle recovery and a genuine long-running Codex turn
