### PR TITLE
ci: skip canonical-only workflows on forks

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -19,6 +19,9 @@ concurrency:
 
 jobs:
   build:
+    # Pages deploy is canonical-repo only. Forks copy this workflow but cannot
+    # create/enable GitHub Pages with GITHUB_TOKEN, which otherwise fails red.
+    if: github.repository == 'AgentWrapper/agent-orchestrator'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +46,7 @@ jobs:
           path: frontend/src/landing/out
 
   deploy:
+    if: github.repository == 'AgentWrapper/agent-orchestrator'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/release-latest-guard.yml
+++ b/.github/workflows/release-latest-guard.yml
@@ -11,6 +11,10 @@ on:
 
 jobs:
   latest-release:
+    # Stable /releases/latest only exists on the canonical repo. Forks copy
+    # this workflow (including the hourly schedule) but have no desktop
+    # release, so the check fails red every hour.
+    if: github.repository == 'AgentWrapper/agent-orchestrator'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Gate `Deploy landing to GitHub Pages` build/deploy jobs to `AgentWrapper/agent-orchestrator` so forks skip instead of failing on Pages enablement.
- Gate `Release latest guard` the same way so the hourly schedule does not fail on forks that have no stable desktop release.
- Fixes [#3119](https://github.com/AgentWrapper/agent-orchestrator/issues/3119).

## Test plan
- [ ] On a fork, confirm landing deploy jobs are skipped (not failed) when the workflow runs.
- [ ] On a fork, confirm the next scheduled `Release latest guard` run skips (not `release not found`).
- [ ] On `AgentWrapper/agent-orchestrator`, confirm landing deploy still runs when landing paths change (or via `workflow_dispatch`).
- [ ] On `AgentWrapper/agent-orchestrator`, confirm release-latest guard still runs on schedule/release events.