### PR TITLE
fix(sidebar): Linux collapse to icon rail + align rail tiles

### DIFF
--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -866,7 +866,7 @@ function CreateProjectButton({
 						<button
 							aria-label="New project"
 							className={cn(
-								"grid size-control-board place-items-center rounded-lg text-passive transition-colors hover:bg-interactive-hover hover:text-muted-foreground",
+								"grid size-icon-xl place-items-center rounded-sm text-passive transition-colors hover:bg-interactive-hover hover:text-muted-foreground",
 								hideTrigger && "hidden",
 							)}
 							disabled={disabled}

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -203,7 +203,11 @@ export function Sidebar({
 		// full-height surface behind the titlebar while their content keeps the
 		// same chrome clearance, leaving the titlebar controls unobstructed.
 		<SidebarRoot
-			collapsible="offcanvas"
+			// mac/Windows re-expand a collapsed sidebar from the titlebar toggle, so
+			// they can slide it fully off-canvas. Linux has no titlebar chrome — its
+			// only expand control lives in the sidebar itself, so it must collapse to
+			// the icon rail (keeping that control visible) rather than vanish.
+			collapsible={isMac || isWindows ? "offcanvas" : "icon"}
 			data-expanded-chrome={expandedChromeVisible ? "visible" : "hidden"}
 			onPointerLeave={onPreviewLeave}
 			overlay={isOverlay}

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -825,7 +825,7 @@ function SidebarSearchButton({ onOpen }: { onOpen: () => void }) {
 					"h-control-form gap-2 rounded-settings-row bg-interactive-hover px-3 py-0 text-control font-medium text-muted-foreground",
 					"hover:bg-interactive-hover hover:text-foreground active:bg-interactive-hover active:text-foreground",
 					"[&>svg]:size-icon-md!",
-					"group-data-[collapsible=icon]:size-control-form! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:rounded-lg group-data-[collapsible=icon]:bg-transparent group-data-[collapsible=icon]:p-0!",
+					"group-data-[collapsible=icon]:size-control-board! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:rounded-lg group-data-[collapsible=icon]:bg-transparent group-data-[collapsible=icon]:p-0!",
 				)}
 			>
 				<Search strokeWidth={1.75} aria-hidden="true" />
@@ -866,7 +866,7 @@ function CreateProjectButton({
 						<button
 							aria-label="New project"
 							className={cn(
-								"grid size-icon-xl place-items-center rounded-sm text-passive transition-colors hover:bg-interactive-hover hover:text-muted-foreground",
+								"grid size-control-board place-items-center rounded-lg text-passive transition-colors hover:bg-interactive-hover hover:text-muted-foreground",
 								hideTrigger && "hidden",
 							)}
 							disabled={disabled}


### PR DESCRIPTION
## Problems

1. On Linux, collapsing the sidebar made it disappear entirely — including the expand button — with no way to bring it back.
2. In the collapsed icon rail, the tiles didn't line up (search and the new-project button were smaller than the rest).

## Causes

1. `SidebarRoot` used `collapsible="offcanvas"` on every platform, which slides the whole sidebar off-canvas (`w-0`) when collapsed. mac/Windows re-expand from a titlebar toggle (`TitlebarNav` / `WindowTitlebar`), but Linux has no custom titlebar — its only expand control lives inside the sidebar header, so offcanvas hid it.
2. Rail tiles had mismatched box sizes: brand / toggle / project / settings were `size-control-board` (36px), but search was `size-control-form` (32px) and the new-project button was `size-icon-xl` (18px), so their edges never aligned.

## Fixes

1. Linux now uses `collapsible="icon"`, collapsing to the 48px icon rail (the `--size-sidebar-icon` rail the existing `group-data-[collapsible=icon]` styling was already built for), keeping the expand trigger visible. mac/Windows unchanged.
2. Every interactive rail tile is now `size-control-board` (36px), so they share one centered box.

Verified: `tsc` clean, Sidebar suite (38 tests) passes.