### PR TITLE
fix(desktop): recover when orchestrator agent is missing

### DIFF
--- a/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
+++ b/frontend/src/renderer/__tests__/integration/board-empty-states.test.tsx
@@ -36,7 +36,7 @@ import { SessionsBoard } from "../../components/SessionsBoard";
 import { ShellProvider, type ShellContextValue } from "../../lib/shell-context";
 import { useUiStore } from "../../stores/ui-store";
 
-type Project = { id: string; name: string; path: string };
+type Project = { id: string; name: string; path: string; orchestratorAgent?: string };
 type Session = Record<string, unknown>;
 
 function respondWith(projects: Project[], sessions: Session[]) {
@@ -47,7 +47,12 @@ function respondWith(projects: Project[], sessions: Session[]) {
 	});
 }
 
-const project: Project = { id: "proj-1", name: "my-app", path: "/repo/my-app" };
+const project: Project = {
+	id: "proj-1",
+	name: "my-app",
+	path: "/repo/my-app",
+	orchestratorAgent: "claude-code",
+};
 
 const workerSession: Session = {
 	id: "sess-1",
@@ -186,6 +191,22 @@ describe("project board with no sessions", () => {
 		await userEvent.click(spawnButton);
 
 		expect(await screen.findByText(/branch is already checked out/)).toBeInTheDocument();
+	});
+
+	it("opens project settings instead of spawning when no orchestrator agent is configured", async () => {
+		const unconfiguredProject = { ...project, orchestratorAgent: undefined };
+		respondWith([unconfiguredProject], []);
+		renderBoard(<SessionsBoard projectId="proj-1" />);
+
+		await screen.findByText("No worker sessions yet");
+		const [spawnButton] = screen.getAllByRole("button", { name: "Spawn Orchestrator" });
+		await userEvent.click(spawnButton);
+
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/settings",
+			params: { projectId: "proj-1" },
+		});
+		expect(spawnOrchestratorMock).not.toHaveBeenCalled();
 	});
 
 	it("shows the project creation startup error after navigating to the project board", async () => {

--- a/frontend/src/renderer/components/CommandPalette.test.tsx
+++ b/frontend/src/renderer/components/CommandPalette.test.tsx
@@ -16,6 +16,7 @@ const ctx = vi.hoisted(() => {
 			name: "app",
 			path: "/repos/app",
 			type: "main",
+			orchestratorAgent: "codex",
 			sessions: [
 				{
 					id: "w-merge",
@@ -72,6 +73,7 @@ const ctx = vi.hoisted(() => {
 			name: "lib",
 			path: "/repos/lib",
 			type: "main",
+			orchestratorAgent: "codex",
 			sessions: [],
 		},
 	];
@@ -147,6 +149,8 @@ const paletteInput = () => screen.queryByPlaceholderText(/search projects/i);
 beforeEach(() => {
 	ctx.params = {};
 	ctx.enabled = true;
+	ctx.workspaces[0].orchestratorAgent = "codex";
+	ctx.workspaces[1].orchestratorAgent = "codex";
 	navigateMock.mockReset();
 	spawnMock.mockReset();
 	choosePathMock.mockReset();
@@ -344,6 +348,22 @@ describe("CommandPalette actions", () => {
 		fireEvent.click(screen.getByText("Open orchestrator"));
 		expect(spawnMock).not.toHaveBeenCalled();
 		expect(navigateMock).not.toHaveBeenCalled();
+	});
+
+	it("opens project settings instead of spawning when no orchestrator agent is configured", async () => {
+		ctx.params = { projectId: "proj-2" };
+		ctx.workspaces[1].orchestratorAgent = undefined;
+		renderPalette();
+		act(() => useUiStore.getState().setCommandPaletteOpen(true));
+		await screen.findByPlaceholderText(/search projects/i);
+		fireEvent.click(screen.getByText("Open orchestrator"));
+
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/settings",
+			params: { projectId: "proj-2" },
+		});
+		expect(spawnMock).not.toHaveBeenCalled();
+		await waitFor(() => expect(paletteInput()).toBeNull());
 	});
 
 	it("navigates and closes when selecting a project", async () => {

--- a/frontend/src/renderer/components/CommandPalette.tsx
+++ b/frontend/src/renderer/components/CommandPalette.tsx
@@ -15,7 +15,7 @@ import { iconForCommand } from "../lib/command-palette-icons";
 import { isDialogOrMenuOpen } from "../lib/dom-selectors";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { useShell } from "../lib/shell-context";
-import { findProjectOrchestrator } from "../types/workspace";
+import { findProjectOrchestrator, hasConfiguredOrchestratorAgent } from "../types/workspace";
 import { useUiStore } from "../stores/ui-store";
 import { CreateProjectFlow } from "./CreateProjectFlow";
 import { NewTaskDialog } from "./NewTaskDialog";
@@ -123,6 +123,14 @@ export function CommandPalette() {
 					params: { projectId, sessionId: orchestrator.id },
 				});
 				closePalette();
+				return;
+			}
+			const workspace = workspaces.find((candidate) => candidate.id === projectId);
+			if (!hasConfiguredOrchestratorAgent(workspace)) {
+				if (workspace) {
+					navigateToTarget({ to: "/projects/$projectId/settings", params: { projectId } });
+					closePalette();
+				}
 				return;
 			}
 			const sessionId = await spawnOrchestrator(projectId, "command_palette");

--- a/frontend/src/renderer/components/RestoreUnavailableDialog.test.tsx
+++ b/frontend/src/renderer/components/RestoreUnavailableDialog.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
+import { RestoreUnavailableDialog } from "./RestoreUnavailableDialog";
+
+const { navigateMock, spawnMock, workspaceQueryMock } = vi.hoisted(() => ({
+	navigateMock: vi.fn(),
+	spawnMock: vi.fn(),
+	workspaceQueryMock: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+	useNavigate: () => navigateMock,
+}));
+
+vi.mock("../hooks/useWorkspaceQuery", () => ({
+	useWorkspaceQuery: () => workspaceQueryMock(),
+}));
+
+vi.mock("../lib/spawn-orchestrator", () => ({
+	spawnOrchestrator: spawnMock,
+}));
+
+const session: WorkspaceSession = {
+	id: "orch-old",
+	workspaceId: "proj-1",
+	workspaceName: "Project One",
+	title: "orchestrator",
+	provider: "codex",
+	kind: "orchestrator",
+	status: "terminated",
+	updatedAt: "2026-07-26T00:00:00Z",
+	prs: [],
+};
+
+const workspace: WorkspaceSummary = {
+	id: "proj-1",
+	name: "Project One",
+	path: "/repo/project-one",
+	orchestratorAgent: "codex",
+	sessions: [session],
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	workspaceQueryMock.mockReturnValue({ data: [workspace], isLoading: false });
+});
+
+describe("RestoreUnavailableDialog", () => {
+	it("opens project settings instead of recreating when no orchestrator agent is configured", async () => {
+		const onOpenChange = vi.fn();
+		const onRecreated = vi.fn();
+		workspaceQueryMock.mockReturnValue({
+			data: [{ ...workspace, orchestratorAgent: undefined }],
+			isLoading: false,
+		});
+		render(
+			<RestoreUnavailableDialog
+				open
+				session={session}
+				onOpenChange={onOpenChange}
+				onRecreated={onRecreated}
+			/>,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Configure orchestrator agent" }));
+
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/settings",
+			params: { projectId: "proj-1" },
+		});
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(onRecreated).not.toHaveBeenCalled();
+	});
+
+	it("preserves clean recreation when an orchestrator agent is configured", async () => {
+		const onOpenChange = vi.fn();
+		const onRecreated = vi.fn();
+		spawnMock.mockResolvedValue("orch-new");
+		render(
+			<RestoreUnavailableDialog
+				open
+				session={session}
+				onOpenChange={onOpenChange}
+				onRecreated={onRecreated}
+			/>,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Create new orchestrator" }));
+
+		await waitFor(() => expect(onRecreated).toHaveBeenCalledWith("orch-new"));
+		expect(spawnMock).toHaveBeenCalledWith("proj-1", "restore_dialog", true);
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+});

--- a/frontend/src/renderer/components/RestoreUnavailableDialog.tsx
+++ b/frontend/src/renderer/components/RestoreUnavailableDialog.tsx
@@ -1,9 +1,11 @@
 import * as Dialog from "@radix-ui/react-dialog";
+import { useNavigate } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "./ui/button";
+import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
-import { isOrchestratorSession } from "../types/workspace";
+import { hasConfiguredOrchestratorAgent, isOrchestratorSession } from "../types/workspace";
 import type { WorkspaceSession } from "../types/workspace";
 
 type RestoreUnavailableDialogProps = {
@@ -14,11 +16,25 @@ type RestoreUnavailableDialogProps = {
 };
 
 export function RestoreUnavailableDialog({ open, session, onOpenChange, onRecreated }: RestoreUnavailableDialogProps) {
+	const navigate = useNavigate();
+	const workspaceQuery = useWorkspaceQuery();
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState<string | undefined>();
 	const orchestrator = isOrchestratorSession(session);
+	const workspace = workspaceQuery.data?.find((candidate) => candidate.id === session.workspaceId);
+	const hasOrchestratorAgent = hasConfiguredOrchestratorAgent(workspace);
+	const checkingProject = workspaceQuery.isLoading && workspaceQuery.data === undefined;
 
 	const recreate = async () => {
+		if (checkingProject) return;
+		if (!hasOrchestratorAgent) {
+			onOpenChange(false);
+			void navigate({
+				to: "/projects/$projectId/settings",
+				params: { projectId: session.workspaceId },
+			});
+			return;
+		}
 		setBusy(true);
 		setError(undefined);
 		try {
@@ -49,9 +65,13 @@ export function RestoreUnavailableDialog({ open, session, onOpenChange, onRecrea
 							{orchestrator ? "Cancel" : "Close"}
 						</Button>
 						{orchestrator && (
-							<Button onClick={recreate} disabled={busy}>
+							<Button onClick={recreate} disabled={busy || checkingProject}>
 								{busy && <Loader2 className="mr-2 size-icon-base animate-spin" />}
-								Create new orchestrator
+								{checkingProject
+									? "Checking project…"
+									: hasOrchestratorAgent
+										? "Create new orchestrator"
+										: "Configure orchestrator agent"}
 							</Button>
 						)}
 					</div>

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -16,6 +16,7 @@ import {
 import {
 	type WorkspaceSession,
 	canonicalTrackerIssueId,
+	hasConfiguredOrchestratorAgent,
 	newestActiveOrchestrator,
 	orchestratorHealth,
 	workerSessions,
@@ -204,6 +205,12 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 				to: "/projects/$projectId/sessions/$sessionId",
 				params: { projectId, sessionId: orchestrator.id },
 			});
+			return;
+		}
+		if (!hasConfiguredOrchestratorAgent(workspace)) {
+			if (workspace) {
+				void navigate({ to: "/projects/$projectId/settings", params: { projectId } });
+			}
 			return;
 		}
 		setSpawnError(null);

--- a/frontend/src/renderer/components/ShellTopbar.test.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.test.tsx
@@ -6,11 +6,12 @@ import { useUiStore } from "../stores/ui-store";
 import type { SessionActivityState, WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { ShellTopbar, TopbarKillButton } from "./ShellTopbar";
 
-const { navigateMock, onKilledMock, paramsMock, postMock, useWorkspaceQueryMock } = vi.hoisted(() => ({
+const { navigateMock, onKilledMock, paramsMock, postMock, spawnMock, useWorkspaceQueryMock } = vi.hoisted(() => ({
 	navigateMock: vi.fn(),
 	onKilledMock: vi.fn(),
 	paramsMock: { projectId: undefined as string | undefined, sessionId: undefined as string | undefined },
 	postMock: vi.fn(),
+	spawnMock: vi.fn(),
 	useWorkspaceQueryMock: vi.fn(),
 }));
 
@@ -41,7 +42,7 @@ vi.mock("../lib/api-client", () => ({
 	},
 }));
 
-vi.mock("../lib/spawn-orchestrator", () => ({ spawnOrchestrator: vi.fn() }));
+vi.mock("../lib/spawn-orchestrator", () => ({ spawnOrchestrator: spawnMock }));
 vi.mock("../lib/telemetry", () => ({
 	addRendererExceptionStep: vi.fn(),
 	captureRendererEvent: vi.fn(),
@@ -101,6 +102,7 @@ function renderTopbarSessions(sessions: WorkspaceSession[], sessionId: string) {
 			id: sessions[0].workspaceId,
 			name: sessions[0].workspaceName,
 			path: "/repo/my-app",
+			orchestratorAgent: "claude-code",
 			sessions,
 		},
 	];
@@ -202,6 +204,36 @@ describe("ShellTopbar orchestrator actions", () => {
 		expect(screen.getByRole("button", { name: "Open Kanban" })).toHaveClass("bg-accent-strong");
 		expect(screen.getByRole("button", { name: "New task" })).toHaveClass("bg-raised");
 		expect(screen.getByRole("button", { name: "New task" })).not.toHaveClass("bg-accent-strong");
+	});
+
+	it("opens project settings instead of spawning when no orchestrator agent is configured", async () => {
+		useWorkspaceQueryMock.mockReturnValue({
+			data: [
+				{
+					id: "proj-1",
+					name: "my-app",
+					path: "/repo/my-app",
+					sessions: [worker],
+				},
+			],
+			isError: false,
+			isLoading: false,
+		});
+		paramsMock.projectId = "proj-1";
+		paramsMock.sessionId = "sess-1";
+		render(
+			<QueryClientProvider client={new QueryClient()}>
+				<ShellTopbar />
+			</QueryClientProvider>,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Open orchestrator" }));
+
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/settings",
+			params: { projectId: "proj-1" },
+		});
+		expect(spawnMock).not.toHaveBeenCalled();
 	});
 });
 

--- a/frontend/src/renderer/components/ShellTopbar.tsx
+++ b/frontend/src/renderer/components/ShellTopbar.tsx
@@ -6,6 +6,7 @@ import { ConfirmDialog } from "./ConfirmDialog";
 import { NotificationCenter } from "./NotificationCenter";
 import {
 	findProjectOrchestrator,
+	hasConfiguredOrchestratorAgent,
 	isOrchestratorSession,
 	sessionIsActive,
 	type WorkspaceSession,
@@ -99,6 +100,12 @@ export function ShellTopbar() {
 				to: "/projects/$projectId/sessions/$sessionId",
 				params: { projectId, sessionId: orchestrator.id },
 			});
+			return;
+		}
+		if (!hasConfiguredOrchestratorAgent(project)) {
+			if (project) {
+				void navigate({ to: "/projects/$projectId/settings", params: { projectId } });
+			}
 			return;
 		}
 		setIsSpawning(true);

--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -8,18 +8,20 @@ import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 import { agentsQueryKey } from "../hooks/useAgentsQuery";
 import { useUiStore } from "../stores/ui-store";
 
-const { getMock, navigateMock, mockParams, renameSessionMock, updateStatusMock, commandPaletteEnabled } = vi.hoisted(
+const { getMock, navigateMock, mockParams, renameSessionMock, spawnMock, updateStatusMock, commandPaletteEnabled } = vi.hoisted(
 	() => ({
 		getMock: vi.fn(),
 		navigateMock: vi.fn(),
 		mockParams: { projectId: undefined as string | undefined },
 		renameSessionMock: vi.fn().mockResolvedValue(undefined),
+		spawnMock: vi.fn(),
 		updateStatusMock: vi.fn(),
 		commandPaletteEnabled: { current: true },
 	}),
 );
 
 vi.mock("../lib/rename-session", () => ({ renameSession: renameSessionMock }));
+vi.mock("../lib/spawn-orchestrator", () => ({ spawnOrchestrator: spawnMock }));
 
 vi.mock("../hooks/useCommandPaletteEnabled", () => ({
 	useCommandPaletteEnabled: () => commandPaletteEnabled.current,
@@ -61,6 +63,7 @@ const workspace: WorkspaceSummary = {
 	id: "proj-1",
 	name: "Project One",
 	path: "/repo/project-one",
+	orchestratorAgent: "claude-code",
 	sessions: [],
 };
 
@@ -217,6 +220,7 @@ beforeEach(() => {
 	});
 	navigateMock.mockReset();
 	renameSessionMock.mockReset().mockResolvedValue(undefined);
+	spawnMock.mockReset();
 	updateStatusMock.mockReset().mockResolvedValue({ state: "idle" });
 	mockParams.projectId = undefined;
 });
@@ -233,6 +237,19 @@ describe("Sidebar", () => {
 		expect(content).toHaveClass("overflow-y-auto");
 		expect(content).toHaveClass("scrollbar-none");
 		expect(content).not.toContainElement(screen.getByText("Projects"));
+	});
+
+	it("opens project settings instead of spawning when no orchestrator agent is configured", async () => {
+		const user = userEvent.setup();
+		renderSidebar({ workspaces: [{ ...workspace, orchestratorAgent: undefined }] });
+
+		await user.click(screen.getByRole("button", { name: "Spawn Project One orchestrator" }));
+
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/settings",
+			params: { projectId: "proj-1" },
+		});
+		expect(spawnMock).not.toHaveBeenCalled();
 	});
 
 	it("shows a ConfirmDialog and calls onRemoveProject when confirmed", async () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import type { UpdateStatus } from "../../main/update-settings";
 import { APP_SHORTCUTS, shortcutKeys } from "../../shared/shortcuts";
 import {
+	hasConfiguredOrchestratorAgent,
 	newestActiveOrchestrator,
 	type WorkspaceSession,
 	type WorkspaceSummary,
@@ -436,6 +437,10 @@ function ProjectItem({
 		if (isProjectRestarting) return;
 		if (orchestrator) {
 			selection.goSession(workspace.id, orchestrator.id);
+			return;
+		}
+		if (!hasConfiguredOrchestratorAgent(workspace)) {
+			selection.goSettings(workspace.id);
 			return;
 		}
 		setIsSpawning(true);

--- a/frontend/src/renderer/types/workspace.ts
+++ b/frontend/src/renderer/types/workspace.ts
@@ -291,6 +291,12 @@ export type WorkspaceSummary = {
 	sessions: WorkspaceSession[];
 };
 
+export function hasConfiguredOrchestratorAgent(
+	workspace: Pick<WorkspaceSummary, "orchestratorAgent"> | undefined,
+): boolean {
+	return Boolean(workspace?.orchestratorAgent);
+}
+
 export function orchestratorNeedsRestart(workspace: WorkspaceSummary, orchestrator?: WorkspaceSession): boolean {
 	if (!orchestrator || !workspace.orchestratorAgent) return false;
 	return orchestrator.provider !== workspace.orchestratorAgent;


### PR DESCRIPTION
## What changed

- redirect unconfigured projects to Project Settings before spawning an orchestrator
- cover the board, top bar, sidebar, and command palette launchers
- keep the existing one-click flow unchanged when an agent is configured or an orchestrator is already running
- add regression coverage for every affected launcher

## Why

Projects added through the CLI can exist without an orchestrator agent. The desktop still showed an enabled spawn action and sent a request that could only fail with `AGENT_REQUIRED`. This gives the user a recovery path instead.

## Checks

- frontend typecheck
- E2E typecheck
- full Vitest suite: 1,081 passed
- renderer smoke: 20 passed
- `git diff --check`

Closes #3125
