### PR TITLE
fix(board): make the kanban grid shrink to fit (no horizontal scroll)

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -328,8 +328,11 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 						spawnError={visibleSpawnError}
 					/>
 				) : (
-					<div className="h-full overflow-x-auto overflow-y-hidden">
-						<div className="grid h-full min-w-[64rem] grid-cols-4 gap-2 xl:min-w-0">
+					<div className="h-full overflow-hidden">
+						{/* The 4 zone columns share the width and shrink to fit — no
+						    horizontal scroll on a narrow window (each column is min-w-0,
+						    cards truncate/wrap). */}
+						<div className="grid h-full grid-cols-4 gap-2">
 							{COLUMNS.map((col) => (
 								<BoardColumn
 									key={`${projectId ?? "all"}:${col.zone}`}


### PR DESCRIPTION
minimizing / narrowing the window showed a horizontal scrollbar on the kanban board (see the scroll rail under the columns). the 4-column grid carried a fixed `min-w-[64rem]` (1024px), so any pane narrower than that overflowed and scrolled.

## change
- drop `min-w-[64rem]` and the now-dead `xl:min-w-0` from the grid, and switch the wrapper from `overflow-x-auto` to `overflow-hidden`
- the columns are already `min-w-0` and cards truncate/wrap, so the grid just shares the available width — responsive at any window size, no horizontal scroll

single file: `SessionsBoard.tsx`. also removes a hardcoded arbitrary width value.

## verification
- `tsc` clean, board suite green (28 tests)
- rendered the board at 780px under the fake bridge: measured `scrollWidth <= clientWidth` (no h-scroll) and confirmed the 4 columns fit and shrink cleanly

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/708bdb5f-18b5-4ebc-ab1f-799986d508d1" />
