### PR TITLE
fix(board): show agent brand logo on archive cards (was text label)

### DIFF
--- a/frontend/src/renderer/components/AgentAvatar.tsx
+++ b/frontend/src/renderer/components/AgentAvatar.tsx
@@ -58,6 +58,10 @@ type AgentAvatarProps = {
  * no tile, border, or background — so each brand's own shape shows (codex,
  * claude, cursor, … carry their own rounded backgrounds). Agents without an
  * asset fall back to a bare initial. Kept small so the title stays the hero.
+ *
+ * The provider is exposed as the accessible name (alt / aria-label), not just a
+ * hover title, so surfaces that show the logo in place of visible agent text —
+ * e.g. the archive cards — still name the agent for screen readers.
  */
 export function AgentAvatar({ provider, className }: AgentAvatarProps) {
 	const logo = LOGOS[provider];
@@ -65,7 +69,7 @@ export function AgentAvatar({ provider, className }: AgentAvatarProps) {
 		return (
 			<img
 				src={logo}
-				alt=""
+				alt={provider}
 				className={cn("size-icon-xl shrink-0 object-contain", className)}
 				draggable={false}
 				title={provider}
@@ -74,6 +78,8 @@ export function AgentAvatar({ provider, className }: AgentAvatarProps) {
 	}
 	return (
 		<span
+			role="img"
+			aria-label={provider}
 			className={cn(
 				"inline-flex size-icon-xl shrink-0 items-center justify-center text-caption font-bold uppercase leading-none text-muted-foreground",
 				className,

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -504,8 +504,8 @@ describe("SessionsBoard", () => {
 		expect(terminatedCard).not.toBeNull();
 		expect(within(terminatedCard!).queryByRole("button", { name: "Open dead worker" })).not.toBeInTheDocument();
 		expect(within(terminatedCard!).getByText("Terminated")).toBeInTheDocument();
-		// Agent shown as its brand logo (title = provider), not a text label.
-		expect(within(terminatedCard!).getByTitle("claude-code")).toBeInTheDocument();
+		// Agent shown as its brand logo with an accessible name (not a text label).
+		expect(within(terminatedCard!).getByRole("img", { name: "claude-code" })).toBeInTheDocument();
 		expect(screen.getByText("ao/dead-worker")).toBeInTheDocument();
 		expect(screen.getByText("github:INT-17")).toBeInTheDocument();
 		const prStatus = screen.getByLabelText("#42 merged");
@@ -517,6 +517,14 @@ describe("SessionsBoard", () => {
 			screen.getByText("ao/dead-worker").compareDocumentPosition(divider!) & Node.DOCUMENT_POSITION_FOLLOWING,
 		).not.toBe(0);
 		expect(screen.getByRole("button", { name: "Restore dead worker" })).toBeInTheDocument();
+
+		// The row layout renders the same accessible logo (both archive layouts changed).
+		await userEvent.click(screen.getByRole("button", { name: "Rows" }));
+		const rowCard = within(screen.getByRole("list", { name: "Archived sessions" }))
+			.getByText("dead worker")
+			.closest<HTMLElement>("[role='listitem']");
+		expect(rowCard).not.toBeNull();
+		expect(within(rowCard!).getByRole("img", { name: "claude-code" })).toBeInTheDocument();
 	});
 
 	it("switches between rows and columns and remembers the archive layout", async () => {

--- a/frontend/src/renderer/components/SessionsBoard.test.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.test.tsx
@@ -504,7 +504,8 @@ describe("SessionsBoard", () => {
 		expect(terminatedCard).not.toBeNull();
 		expect(within(terminatedCard!).queryByRole("button", { name: "Open dead worker" })).not.toBeInTheDocument();
 		expect(within(terminatedCard!).getByText("Terminated")).toBeInTheDocument();
-		expect(screen.getByText("Claude")).toBeInTheDocument();
+		// Agent shown as its brand logo (title = provider), not a text label.
+		expect(within(terminatedCard!).getByTitle("claude-code")).toBeInTheDocument();
 		expect(screen.getByText("ao/dead-worker")).toBeInTheDocument();
 		expect(screen.getByText("github:INT-17")).toBeInTheDocument();
 		const prStatus = screen.getByLabelText("#42 merged");

--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -937,7 +937,7 @@ function ArchiveSessionItem({
 				<div className="min-h-0 flex-1 px-3 pb-2 pt-1.5 text-left">
 					<div className="line-clamp-2 text-control font-medium leading-snug text-foreground">{session.title}</div>
 					<div className="mt-1 flex min-w-0 items-center gap-2">
-						<span className="shrink-0 font-mono text-2xs text-passive">{agentLabel(session.provider)}</span>
+						<AgentAvatar provider={session.provider} />
 						{issueId && (
 							<span className="max-w-branch-chip truncate rounded-sm bg-accent/12 px-1.5 py-0.5 font-mono text-micro text-accent">
 								{issueId}
@@ -970,8 +970,8 @@ function ArchiveSessionItem({
 								{issueId}
 							</span>
 						)}
-						<span className="ml-auto hidden shrink-0 font-mono text-2xs text-passive md:inline">
-							{agentLabel(session.provider)}
+						<span className="ml-auto hidden shrink-0 md:inline-flex">
+							<AgentAvatar provider={session.provider} />
 						</span>
 						<span className="w-15 shrink-0 text-right font-mono text-2xs text-passive">
 							{formatTimeCompact(session.updatedAt)}
@@ -1173,15 +1173,4 @@ function sameLabel(a: string, b: string): boolean {
 			.replace(/^(feat|fix|chore|refactor|session)\//, "")
 			.replace(/[^a-z0-9]+/g, "");
 	return normalize(a) === normalize(b);
-}
-
-function agentLabel(provider: WorkspaceSession["provider"]): string {
-	switch (provider) {
-		case "claude-code":
-			return "Claude";
-		case "opencode":
-			return "OpenCode";
-		default:
-			return provider;
-	}
 }


### PR DESCRIPTION
the ARCHIVE cards under the board printed the agent as a plain text label ("Claude", "OpenCode", …), while the live task cards now show the agent's brand logo. this makes the archive match.

## change
- both archive layouts (grid + rows) render the same bare `AgentAvatar` brand logo the kanban task cards use, in place of the `agentLabel(...)` text
- removed the now-unused `agentLabel` helper
- updated the archive-card test to assert the logo (by `title=provider`) instead of the "Claude" text

single component: `SessionsBoard.tsx` (+ its test).

## verification
- `tsc` clean, board suite green (28 tests)
- rendered the expanded archive under the fake bridge: grid cards show the bare logo (claude-code mascot, codex, cursor, …) where the text used to be, matching the task cards

before 
<img width="1920" height="218" alt="image" src="https://github.com/user-attachments/assets/3bfe1d16-8a76-4041-b89d-cf4e08e7b440" />

after 
<img width="1920" height="218" alt="image" src="https://github.com/user-attachments/assets/33e24aeb-5d07-413e-bc75-178ab1f5e87c" />
