### PR TITLE
fix(desktop): guard app.dock for Electron 39 types

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -235,7 +235,9 @@ function applyRuntimeAppIcon(): void {
 	if (!iconPath) return;
 	const icon = nativeImage.createFromPath(iconPath);
 	if (!icon.isEmpty()) {
-		app.dock.setIcon(icon);
+		// app.dock is macOS-only, so it is always set under the darwin guard above;
+		// the optional call is for the type, which TypeScript cannot narrow from it.
+		app.dock?.setIcon(icon);
 	}
 }
 


### PR DESCRIPTION
## Problem

Dependabot's electron 33 to 39 bump (#3123) fails its `test` job on a single typecheck error:

```
src/main.ts(238,3): error TS18048: 'app.dock' is possibly 'undefined'.
```

Electron 39 types `app.dock` as possibly `undefined` because the Dock API is macOS-only. `applyRuntimeAppIcon` already returns early on non-darwin platforms, so the value is always set at that call site, but TypeScript cannot narrow through a `process.platform` check.

## Change

Optional-call the setter, with a comment explaining that the guard is for the type rather than the runtime. No behavior change on any platform.

Landing this separately from #3123 keeps the dependency bump to lockfiles and manifests only, and lets that PR go green on a rebase.

## Verification

Controlled both directions, running the real `npm run typecheck` against each Electron version:

| Config | Result |
| --- | --- |
| This fix + electron 39.8.5 | clean |
| Without this fix + electron 39.8.5 | `TS18048` reproduces at the same line |
| This fix + electron 33.4.11 (current main) | clean, no regression |

Electron 39 was installed with `--no-save` for the check, so no manifest or lockfile is touched by this PR.

## Follow-up

#3123 still deserves a manual smoke test of the Electron surface before merging. Six majors is a wide jump and typecheck only proves compilation, not runtime behavior. This PR only clears the compile blocker.

Refs #3123
