### PR TITLE
fix: preserve failed scratch workspaces for retries

### DIFF
--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -350,8 +350,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	// Per-project workspace provisioning: symlink shared files, then run any
 	// post-create commands (e.g. `pnpm install`) before the agent launches.
 	if err := m.provisionWorkspace(ctx, project, ws.Path); err != nil {
-		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, false)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: provision: %w", id, err)
 	}
 
@@ -363,8 +362,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	if len(cfg.Attachments) > 0 {
 		refs, err := writeSpawnAttachments(ws.Path, cfg.Attachments)
 		if err != nil {
-			_ = m.workspace.Destroy(ctx, ws)
-			m.rollbackSpawnSeedRow(ctx, id)
+			m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, false)
 			return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: attachments: %w", id, err)
 		}
 		// Keep the attachments dir out of git status. Best-effort: the images are
@@ -377,16 +375,14 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 
 	agent, ok := m.agents.Agent(cfg.Harness)
 	if !ok {
-		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, false)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: no agent adapter for harness %q", id, cfg.Harness)
 	}
 	agentConfig := effectiveAgentConfig(cfg.Kind, project.Config)
 	env := m.runtimeEnv(id, cfg.ProjectID, cfg.IssueID, project.Config.Env)
 	m.augmentAgentRuntimeEnv(agent, env)
 	if err := m.prepareWorkspace(ctx, agent, id, ws.Path, systemPrompt, systemPromptFile, agentConfig, env); err != nil {
-		m.destroySpawnWorkspace(ctx, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, false)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: %w", id, err)
 	}
 	launchCfg := ports.LaunchConfig{
@@ -403,8 +399,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	}
 	delivery, err := agent.GetPromptDeliveryStrategy(ctx, launchCfg)
 	if err != nil {
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: prompt delivery: %w", id, err)
 	}
 	if delivery == ports.PromptDeliveryAfterStart {
@@ -412,8 +407,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	}
 	argv, err := agent.GetLaunchCommand(ctx, launchCfg)
 	if err != nil {
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: launch command: %w", id, err)
 	}
 	// Pre-flight: confirm argv[0] actually exists on PATH (or as an absolute
@@ -421,20 +415,17 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	// tmux happily creates a session+pane around a missing command, so an
 	// unresolved binary would leak through as a "live" session that never ran.
 	if err := m.validateAgentBinary(argv); err != nil {
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: %w", id, err)
 	}
 	m.augmentRuntimePATHForLaunchBinary(ctx, env, argv)
 	argv, launchID, err := m.superviseAgentProcess(agent, id, env, argv)
 	if err != nil {
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: supervisor: %w", id, err)
 	}
 	if err := m.lcm.PrepareLaunch(id, launchID); err != nil {
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: prepare launch: %w", id, err)
 	}
 	defer m.lcm.CancelLaunch(id, launchID)
@@ -445,8 +436,7 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		Env:           env,
 	})
 	if err != nil {
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-		m.rollbackSpawnSeedRow(ctx, id)
+		m.rollbackSeedSpawnWorkspace(ctx, rec, ws, workspaceProject, true)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: runtime: %w", id, err)
 	}
 
@@ -573,6 +563,34 @@ func (m *Manager) destroySpawnWorkspace(ctx context.Context, ws ports.WorkspaceI
 func (m *Manager) rollbackPreparedSpawnWorkspace(ctx context.Context, rec domain.SessionRecord, ws ports.WorkspaceInfo, workspaceProject *ports.WorkspaceProjectInfo) {
 	if m.destroySpawnWorkspace(ctx, ws, workspaceProject) {
 		m.cleanupAgentWorkspace(ctx, rec, ws.Path)
+	}
+}
+
+func (m *Manager) rollbackSeedSpawnWorkspace(ctx context.Context, rec domain.SessionRecord, ws ports.WorkspaceInfo, workspaceProject *ports.WorkspaceProjectInfo, prepared bool) {
+	if m.destroySpawnWorkspace(ctx, ws, workspaceProject) {
+		if prepared {
+			m.cleanupAgentWorkspace(ctx, rec, ws.Path)
+		}
+		m.rollbackSpawnSeedRow(ctx, rec.ID)
+		return
+	}
+	m.preserveFailedSpawnWorkspace(ctx, rec.ID, ws)
+	m.markSpawnFailedTerminated(ctx, rec.ID)
+}
+
+func (m *Manager) preserveFailedSpawnWorkspace(ctx context.Context, id domain.SessionID, ws ports.WorkspaceInfo) {
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil || !ok {
+		m.logger.Warn("spawn rollback: preserved workspace could not be recorded", "sessionID", id, "workspacePath", ws.Path, "error", err)
+		return
+	}
+	rec.Metadata.Branch = ws.Branch
+	rec.Metadata.WorkspacePath = ws.Path
+	rec.Metadata.WorkspaceRepoPath = ws.RepoPath
+	rec.Metadata.RuntimeHandleID = ""
+	rec.Metadata.RuntimeLaunchID = ""
+	if err := m.store.UpdateSession(ctx, rec); err != nil {
+		m.logger.Warn("spawn rollback: preserved workspace could not be recorded", "sessionID", id, "workspacePath", ws.Path, "error", err)
 	}
 }
 

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -449,16 +449,20 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		Prompt:            prompt,
 	}
 	if err := m.lcm.MarkSpawned(ctx, id, metadata); err != nil {
-		_ = m.runtime.Destroy(ctx, handle)
-		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
+		runtimeDestroyed := m.runtime.Destroy(ctx, handle) == nil
+		m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject, runtimeDestroyed)
 		m.markSpawnFailedTerminated(ctx, id)
 		return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: completed: %w", id, err)
 	}
 	if delivery == ports.PromptDeliveryAfterStart && prompt != "" {
 		if err := m.deliverAfterStartPrompt(ctx, agent, launchCfg, handle, id, prompt); err != nil {
-			_ = m.runtime.Destroy(ctx, handle)
-			m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject)
-			m.markSpawnFailedTerminatedWithoutWorkspace(ctx, id)
+			runtimeDestroyed := m.runtime.Destroy(ctx, handle) == nil
+			workspaceDestroyed := m.rollbackPreparedSpawnWorkspace(ctx, rec, ws, workspaceProject, runtimeDestroyed)
+			if runtimeDestroyed && workspaceDestroyed {
+				m.markSpawnFailedTerminatedWithoutWorkspace(ctx, id)
+			} else {
+				m.markSpawnFailedTerminated(ctx, id)
+			}
 			return domain.SessionRecord{}, 0, 0, fmt.Errorf("spawn %s: deliver prompt: %w", id, err)
 		}
 	}
@@ -560,10 +564,13 @@ func (m *Manager) destroySpawnWorkspace(ctx context.Context, ws ports.WorkspaceI
 	return err == nil
 }
 
-func (m *Manager) rollbackPreparedSpawnWorkspace(ctx context.Context, rec domain.SessionRecord, ws ports.WorkspaceInfo, workspaceProject *ports.WorkspaceProjectInfo) {
+func (m *Manager) rollbackPreparedSpawnWorkspace(ctx context.Context, rec domain.SessionRecord, ws ports.WorkspaceInfo, workspaceProject *ports.WorkspaceProjectInfo, runtimeDestroyed bool) bool {
 	if m.destroySpawnWorkspace(ctx, ws, workspaceProject) {
 		m.cleanupAgentWorkspace(ctx, rec, ws.Path)
+		return true
 	}
+	m.preserveFailedSpawnWorkspace(ctx, rec.ID, ws, runtimeDestroyed)
+	return false
 }
 
 func (m *Manager) rollbackSeedSpawnWorkspace(ctx context.Context, rec domain.SessionRecord, ws ports.WorkspaceInfo, workspaceProject *ports.WorkspaceProjectInfo, prepared bool) {
@@ -574,23 +581,29 @@ func (m *Manager) rollbackSeedSpawnWorkspace(ctx context.Context, rec domain.Ses
 		m.rollbackSpawnSeedRow(ctx, rec.ID)
 		return
 	}
-	m.preserveFailedSpawnWorkspace(ctx, rec.ID, ws)
+	m.preserveFailedSpawnWorkspace(ctx, rec.ID, ws, true)
 	m.markSpawnFailedTerminated(ctx, rec.ID)
 }
 
-func (m *Manager) preserveFailedSpawnWorkspace(ctx context.Context, id domain.SessionID, ws ports.WorkspaceInfo) {
+func (m *Manager) preserveFailedSpawnWorkspace(ctx context.Context, id domain.SessionID, ws ports.WorkspaceInfo, runtimeDestroyed bool) {
 	rec, ok, err := m.store.GetSession(ctx, id)
-	if err != nil || !ok {
-		m.logger.Warn("spawn rollback: preserved workspace could not be recorded", "sessionID", id, "workspacePath", ws.Path, "error", err)
+	if err != nil {
+		m.logger.Warn("spawn rollback: failed to load session for preserved workspace", "sessionID", id, "workspacePath", ws.Path, "error", err)
+		return
+	}
+	if !ok {
+		m.logger.Warn("spawn rollback: session missing for preserved workspace", "sessionID", id, "workspacePath", ws.Path)
 		return
 	}
 	rec.Metadata.Branch = ws.Branch
 	rec.Metadata.WorkspacePath = ws.Path
 	rec.Metadata.WorkspaceRepoPath = ws.RepoPath
-	rec.Metadata.RuntimeHandleID = ""
-	rec.Metadata.RuntimeLaunchID = ""
+	if runtimeDestroyed {
+		rec.Metadata.RuntimeHandleID = ""
+		rec.Metadata.RuntimeLaunchID = ""
+	}
 	if err := m.store.UpdateSession(ctx, rec); err != nil {
-		m.logger.Warn("spawn rollback: preserved workspace could not be recorded", "sessionID", id, "workspacePath", ws.Path, "error", err)
+		m.logger.Warn("spawn rollback: failed to record preserved workspace", "sessionID", id, "workspacePath", ws.Path, "error", err)
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -374,6 +374,33 @@ func (a *scratchHookAgent) GetLaunchCommand(context.Context, ports.LaunchConfig)
 	return []string{"missing-agent"}, nil
 }
 
+type scratchHookAfterStartAgent struct {
+	scratchHookAgent
+}
+
+func (a *scratchHookAfterStartAgent) GetLaunchCommand(context.Context, ports.LaunchConfig) ([]string, error) {
+	return []string{"agent"}, nil
+}
+
+func (a *scratchHookAfterStartAgent) GetPromptDeliveryStrategy(context.Context, ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	return ports.PromptDeliveryAfterStart, nil
+}
+
+type nonEmptyWorkspace struct {
+	ports.Workspace
+}
+
+func (w *nonEmptyWorkspace) Create(ctx context.Context, cfg ports.WorkspaceConfig) (ports.WorkspaceInfo, error) {
+	info, err := w.Workspace.Create(ctx, cfg)
+	if err != nil {
+		return ports.WorkspaceInfo{}, err
+	}
+	if err := os.WriteFile(filepath.Join(info.Path, "provisioned.txt"), []byte("preserve"), 0o600); err != nil {
+		return ports.WorkspaceInfo{}, err
+	}
+	return info, nil
+}
+
 type maxSessionNumStore struct {
 	*fakeStore
 }
@@ -3466,6 +3493,103 @@ func TestSpawn_MissingBinaryPreservesNonEmptyScratchWorkspaceForRetry(t *testing
 	}
 	if _, ok := st.sessions["scratch-2"]; !ok {
 		t.Fatal("retry did not allocate a fresh scratch session")
+	}
+}
+
+func TestSpawn_EarlyFailurePreservesNonEmptyScratchWorkspace(t *testing.T) {
+	st := newFakeStore()
+	config := testRoleAgents()
+	config.Symlinks = []string{"../invalid"}
+	st.projects["scratch"] = domain.ProjectRecord{
+		ID:     "scratch",
+		Kind:   domain.ProjectKindScratch,
+		Config: config,
+	}
+	store := &maxSessionNumStore{fakeStore: st}
+	baseWorkspace, err := scratch.New(scratch.Options{ManagedRoot: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := &nonEmptyWorkspace{Workspace: baseWorkspace}
+	m := New(Deps{
+		Runtime:   &fakeRuntime{},
+		Agents:    fakeAgents{},
+		Workspace: workspace,
+		Store:     store,
+		Messenger: &fakeMessenger{},
+		Lifecycle: &fakeLCM{store: st},
+		DataDir:   t.TempDir(),
+	})
+
+	_, _, _, err = m.Spawn(ctx, ports.SpawnConfig{ProjectID: "scratch", Kind: domain.KindOrchestrator})
+	if err == nil || !strings.Contains(err.Error(), "provision") {
+		t.Fatalf("Spawn err = %v, want provisioning failure", err)
+	}
+	failed, ok := st.sessions["scratch-1"]
+	if !ok {
+		t.Fatal("failed early scratch spawn row was deleted")
+	}
+	if !failed.IsTerminated {
+		t.Fatal("failed early scratch spawn row must be terminated")
+	}
+	if failed.Metadata.WorkspacePath == "" {
+		t.Fatal("failed early scratch spawn must retain its preserved workspace path")
+	}
+	if _, err := os.Stat(filepath.Join(failed.Metadata.WorkspacePath, "provisioned.txt")); err != nil {
+		t.Fatalf("preserved workspace file: %v", err)
+	}
+}
+
+func TestSpawn_AfterStartFailurePreservesNonEmptyScratchWorkspace(t *testing.T) {
+	st := newFakeStore()
+	st.projects["scratch"] = domain.ProjectRecord{
+		ID:     "scratch",
+		Kind:   domain.ProjectKindScratch,
+		Config: testRoleAgents(),
+	}
+	store := &maxSessionNumStore{fakeStore: st}
+	workspace, err := scratch.New(scratch.Options{ManagedRoot: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := &fakeRuntime{}
+	m := New(Deps{
+		Runtime:   runtime,
+		Agents:    singleAgent{agent: &scratchHookAfterStartAgent{}},
+		Workspace: workspace,
+		Store:     store,
+		Messenger: &fakeMessenger{err: errors.New("pane unavailable")},
+		Lifecycle: &fakeLCM{store: st},
+		DataDir:   t.TempDir(),
+		LookPath:  func(string) (string, error) { return "/bin/true", nil },
+	})
+
+	_, _, _, err = m.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "scratch",
+		Kind:      domain.KindOrchestrator,
+		Prompt:    "continue",
+	})
+	if err == nil || !strings.Contains(err.Error(), "deliver prompt") {
+		t.Fatalf("Spawn err = %v, want prompt delivery failure", err)
+	}
+	failed, ok := st.sessions["scratch-1"]
+	if !ok {
+		t.Fatal("failed after-start scratch spawn row was deleted")
+	}
+	if !failed.IsTerminated {
+		t.Fatal("failed after-start scratch spawn row must be terminated")
+	}
+	if failed.Metadata.WorkspacePath == "" {
+		t.Fatal("failed after-start scratch spawn must retain its preserved workspace path")
+	}
+	if failed.Metadata.RuntimeHandleID != "" || failed.Metadata.RuntimeLaunchID != "" {
+		t.Fatalf("destroyed runtime metadata was retained: %#v", failed.Metadata)
+	}
+	if runtime.created != 1 || runtime.destroyed != 1 {
+		t.Fatalf("runtime created=%d destroyed=%d, want 1/1", runtime.created, runtime.destroyed)
+	}
+	if _, err := os.Stat(filepath.Join(failed.Metadata.WorkspacePath, ".claude", "settings.local.json")); err != nil {
+		t.Fatalf("preserved hook file: %v", err)
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/scratch"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -356,6 +357,44 @@ func (a promptStrategyErrorAgent) GetPromptDeliveryStrategy(context.Context, por
 type singleAgent struct{ agent ports.Agent }
 
 func (s singleAgent) Agent(domain.AgentHarness) (ports.Agent, bool) { return s.agent, true }
+
+type scratchHookAgent struct {
+	fakeAgent
+}
+
+func (a *scratchHookAgent) GetAgentHooks(_ context.Context, cfg ports.WorkspaceHookConfig) error {
+	dir := filepath.Join(cfg.WorkspacePath, ".claude")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "settings.local.json"), []byte("{}"), 0o600)
+}
+
+func (a *scratchHookAgent) GetLaunchCommand(context.Context, ports.LaunchConfig) ([]string, error) {
+	return []string{"missing-agent"}, nil
+}
+
+type maxSessionNumStore struct {
+	*fakeStore
+}
+
+func (s *maxSessionNumStore) CreateSession(_ context.Context, rec domain.SessionRecord) (domain.SessionRecord, error) {
+	next := 1
+	prefix := string(rec.ProjectID) + "-"
+	for id := range s.sessions {
+		if !strings.HasPrefix(string(id), prefix) {
+			continue
+		}
+		raw := strings.TrimPrefix(string(id), prefix)
+		var num int
+		if _, err := fmt.Sscanf(raw, "%d", &num); err == nil && num >= next {
+			next = num + 1
+		}
+	}
+	rec.ID = domain.SessionID(fmt.Sprintf("%s-%d", rec.ProjectID, next))
+	s.sessions[rec.ID] = rec
+	return rec, nil
+}
 
 type cleaningAgent struct {
 	fakeAgent
@@ -3369,6 +3408,65 @@ func TestSpawn_RejectsMissingAgentBinary(t *testing.T) {
 		t.Fatalf("seed row must be deleted before a runtime handle is live, got %+v", rec)
 	}
 	requireNoPromptDir(t, dataDir, "mer-1")
+}
+
+func TestSpawn_MissingBinaryPreservesNonEmptyScratchWorkspaceForRetry(t *testing.T) {
+	st := newFakeStore()
+	st.projects["scratch"] = domain.ProjectRecord{
+		ID:     "scratch",
+		Kind:   domain.ProjectKindScratch,
+		Config: testRoleAgents(),
+	}
+	store := &maxSessionNumStore{fakeStore: st}
+	workspace, err := scratch.New(scratch.Options{ManagedRoot: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	notFound := func(name string) (string, error) {
+		if name == "tmux" {
+			return "/bin/tmux", nil
+		}
+		return "", fmt.Errorf("exec: %q: not found", name)
+	}
+	m := New(Deps{
+		Runtime:   &fakeRuntime{},
+		Agents:    singleAgent{agent: &scratchHookAgent{}},
+		Workspace: workspace,
+		Store:     store,
+		Messenger: &fakeMessenger{},
+		Lifecycle: &fakeLCM{store: st},
+		DataDir:   t.TempDir(),
+		LookPath:  notFound,
+	})
+
+	_, _, _, err = m.Spawn(ctx, ports.SpawnConfig{ProjectID: "scratch", Kind: domain.KindOrchestrator})
+	if !errors.Is(err, ports.ErrAgentBinaryNotFound) {
+		t.Fatalf("first spawn err = %v, want ErrAgentBinaryNotFound", err)
+	}
+	failed, ok := st.sessions["scratch-1"]
+	if !ok {
+		t.Fatal("failed scratch spawn row was deleted")
+	}
+	if !failed.IsTerminated {
+		t.Fatal("failed scratch spawn row must be terminated")
+	}
+	if failed.Metadata.WorkspacePath == "" {
+		t.Fatal("failed scratch spawn must retain its preserved workspace path")
+	}
+	if _, err := os.Stat(filepath.Join(failed.Metadata.WorkspacePath, ".claude", "settings.local.json")); err != nil {
+		t.Fatalf("preserved hook file: %v", err)
+	}
+
+	_, _, _, err = m.Spawn(ctx, ports.SpawnConfig{ProjectID: "scratch", Kind: domain.KindOrchestrator})
+	if !errors.Is(err, ports.ErrAgentBinaryNotFound) {
+		t.Fatalf("retry err = %v, want ErrAgentBinaryNotFound", err)
+	}
+	if errors.Is(err, ports.ErrWorkspaceDirty) {
+		t.Fatalf("retry reused preserved workspace: %v", err)
+	}
+	if _, ok := st.sessions["scratch-2"]; !ok {
+		t.Fatal("retry did not allocate a fresh scratch session")
+	}
 }
 
 func TestSpawn_ValidatesBinaryAfterEnvPrefix(t *testing.T) {


### PR DESCRIPTION
## What

Fixes #3135 by keeping a failed scratch session when its non-empty workspace can't be removed, so retries get a fresh session number instead of colliding with the old path.

## Why

Scratch workspaces intentionally refuse to delete non-empty directories. The old rollback still deleted the seed session row, which made the next spawn reuse `scratch-1` and fail with a dirty-workspace error.

## How

- record the preserved workspace path when rollback cannot remove it
- mark that failed session as terminated
- keep the existing delete-and-cleanup behavior when workspace removal succeeds
- verify the next spawn allocates `scratch-2`

No force deletion or fallback cleanup was added, so user files remain protected.

## Testing

- `npm run lint`
- `go test -race ./internal/session_manager -count=1`
- `go build ./...`
- `go vet ./...`

## Checklist

- [x] Branched from `main`
- [x] One focused change linked to #3135
- [x] Follows `AGENTS.md` conventions
- [x] Regression coverage added
- [x] Relevant backend checks pass