### PR TITLE
Feat/project session tabs

### DIFF
--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -18,6 +18,12 @@ const worker = {
 	updatedAt: "2026-06-10T00:00:00Z",
 	prs: [],
 } satisfies WorkspaceSession;
+const secondWorker = {
+	...worker,
+	id: "sess-2",
+	title: "review the change",
+	branch: "ao/sess-2",
+} satisfies WorkspaceSession;
 
 describe("CenterPane toolbar session label", () => {
 	const makeShells = (count: number) =>
@@ -32,6 +38,81 @@ describe("CenterPane toolbar session label", () => {
 		render(<CenterPane session={worker} theme="dark" daemonReady />);
 		expect(screen.getByText("do the thing")).toBeInTheDocument();
 		expect(screen.queryByText("sess-1")).not.toBeInTheDocument();
+	});
+
+	it("renders project sessions as tabs and opens a sibling session", () => {
+		const onSelectProjectSession = vi.fn();
+		render(
+			<CenterPane
+				session={worker}
+				projectSessions={[worker, secondWorker]}
+				onSelectProjectSession={onSelectProjectSession}
+				theme="dark"
+				daemonReady
+			/>,
+		);
+
+		expect(screen.getByRole("button", { name: "do the thing" })).toHaveAttribute("aria-current", "true");
+		fireEvent.click(screen.getByRole("button", { name: "review the change" }));
+		expect(onSelectProjectSession).toHaveBeenCalledWith(secondWorker);
+	});
+
+	it("adds workers and terminals only through the tab launcher", () => {
+		const onAddProjectSession = vi.fn();
+		const onNewShellTerminal = vi.fn();
+		render(
+			<CenterPane
+				session={worker}
+				projectSessions={[worker]}
+				availableProjectSessions={[secondWorker]}
+				onAddProjectSession={onAddProjectSession}
+				onNewShellTerminal={onNewShellTerminal}
+				theme="dark"
+				daemonReady
+			/>,
+		);
+
+		expect(screen.queryByRole("button", { name: "review the change" })).not.toBeInTheDocument();
+		fireEvent.pointerDown(screen.getByRole("button", { name: "Add tab" }), { button: 0, ctrlKey: false });
+		fireEvent.click(screen.getByRole("menuitem", { name: /review the change/ }));
+		expect(onAddProjectSession).toHaveBeenCalledWith(secondWorker);
+
+		fireEvent.pointerDown(screen.getByRole("button", { name: "Add tab" }), { button: 0, ctrlKey: false });
+		fireEvent.click(screen.getByRole("menuitem", { name: "Terminal" }));
+		expect(onNewShellTerminal).toHaveBeenCalledOnce();
+	});
+
+	it("limits a large session list, then expands it into a searchable scroll area", () => {
+		const sessions = Array.from({ length: 7 }, (_, index) => ({
+			...secondWorker,
+			id: `sess-${index + 2}`,
+			title: `Worker ${index + 1}`,
+		}));
+		render(
+			<CenterPane
+				session={worker}
+				projectSessions={[worker]}
+				availableProjectSessions={sessions}
+				theme="dark"
+				daemonReady
+			/>,
+		);
+
+		fireEvent.pointerDown(screen.getByRole("button", { name: "Add tab" }), { button: 0, ctrlKey: false });
+		expect(screen.getByRole("textbox", { name: "Search sessions" })).toBeInTheDocument();
+		expect(screen.getByRole("menuitem", { name: /Worker 5/ })).toBeInTheDocument();
+		expect(screen.queryByRole("menuitem", { name: /Worker 6/ })).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("menuitem", { name: "Show all sessions" }));
+		const lastSession = screen.getByRole("menuitem", { name: /Worker 7/ });
+		expect(lastSession).toBeInTheDocument();
+		expect(lastSession.parentElement).toHaveClass("h-52", "overflow-y-auto");
+
+		fireEvent.change(screen.getByRole("textbox", { name: "Search sessions" }), {
+			target: { value: "Worker 7" },
+		});
+		expect(screen.getByRole("menuitem", { name: /Worker 7/ })).toBeInTheDocument();
+		expect(screen.queryByRole("menuitem", { name: /Worker 1/ })).not.toBeInTheDocument();
 	});
 
 	it("shows 'Orchestrator' for an orchestrator session", () => {

--- a/frontend/src/renderer/components/CenterPane.test.tsx
+++ b/frontend/src/renderer/components/CenterPane.test.tsx
@@ -99,7 +99,9 @@ describe("CenterPane toolbar session label", () => {
 		);
 
 		fireEvent.pointerDown(screen.getByRole("button", { name: "Add tab" }), { button: 0, ctrlKey: false });
-		expect(screen.getByRole("textbox", { name: "Search sessions" })).toBeInTheDocument();
+		const search = screen.getByRole("textbox", { name: "Search sessions" });
+		const terminal = screen.getByRole("menuitem", { name: "Terminal" });
+		expect(terminal.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 		expect(screen.getByRole("menuitem", { name: /Worker 5/ })).toBeInTheDocument();
 		expect(screen.queryByRole("menuitem", { name: /Worker 6/ })).not.toBeInTheDocument();
 

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -1,5 +1,4 @@
 import {
-	ChevronDown,
 	ChevronLeft,
 	ChevronRight,
 	Maximize2,
@@ -26,7 +25,6 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
-	DropdownMenuLabel,
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
@@ -265,10 +263,14 @@ export function CenterPane({
 								type="button"
 							>
 								<Plus aria-hidden="true" className="size-icon-md" />
-								<ChevronDown aria-hidden="true" className="size-icon-2xs" />
 							</button>
 						</DropdownMenuTrigger>
 						<DropdownMenuContent align="start" className="w-72">
+							<DropdownMenuItem onSelect={onNewShellTerminal}>
+								<TerminalIcon aria-hidden="true" />
+								Terminal
+							</DropdownMenuItem>
+							<DropdownMenuSeparator />
 							{hasMoreSessions ? (
 								<div className="relative px-1 pb-1">
 									<Search
@@ -285,12 +287,6 @@ export function CenterPane({
 									/>
 								</div>
 							) : null}
-							<DropdownMenuItem onSelect={onNewShellTerminal}>
-								<TerminalIcon aria-hidden="true" />
-								Terminal
-							</DropdownMenuItem>
-							<DropdownMenuSeparator />
-							<DropdownMenuLabel className="font-sans normal-case tracking-normal">Sessions</DropdownMenuLabel>
 							<div className={cn(expandedSessionList && "h-52 overflow-y-auto overscroll-contain")}>
 								{visibleSessions.length > 0 ? (
 									visibleSessions.map((candidate) => {

--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -1,4 +1,15 @@
-import { ChevronLeft, ChevronRight, Maximize2, Minimize2, Plus, Shield } from "lucide-react";
+import {
+	ChevronDown,
+	ChevronLeft,
+	ChevronRight,
+	Maximize2,
+	Minimize2,
+	Plus,
+	Search,
+	Shield,
+	Terminal as TerminalIcon,
+	X,
+} from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type WheelEvent } from "react";
 import { useOverflowScroll } from "../hooks/useOverflowScroll";
 import { useTruncatedText } from "../hooks/useTruncatedText";
@@ -10,9 +21,25 @@ import type { TerminalTarget } from "../types/terminal";
 import { isOrchestratorSession, type WorkspaceSession } from "../types/workspace";
 import { ShellTerminalTab } from "./ShellTerminalTab";
 import { TerminalPane } from "./TerminalPane";
+import { Input } from "./ui/input";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
 
 type CenterPaneProps = {
 	session?: WorkspaceSession;
+	/** Tabs pinned to the originating session's private layout. */
+	projectSessions?: WorkspaceSession[];
+	availableProjectSessions?: WorkspaceSession[];
+	tabOwnerSessionId?: string;
+	onAddProjectSession?: (session: WorkspaceSession) => void;
+	onCloseProjectSession?: (session: WorkspaceSession) => void;
+	onSelectProjectSession?: (session: WorkspaceSession) => void;
 	theme: Theme;
 	daemonReady: boolean;
 	terminalTarget?: TerminalTarget;
@@ -30,6 +57,7 @@ type CenterPaneProps = {
 const terminalFontSizeStorageKey = "ao.terminal.fontSize";
 const WHEEL_ZOOM_THRESHOLD = 80;
 const WHEEL_ZOOM_RESET_MS = 250;
+const COMPACT_SESSION_LIMIT = 5;
 
 function clampTerminalFontSize(size: number): number {
 	return Math.min(TERMINAL_FONT_SIZE_MAX, Math.max(TERMINAL_FONT_SIZE_MIN, size));
@@ -45,6 +73,12 @@ function initialTerminalFontSize(): number {
 
 export function CenterPane({
 	session,
+	projectSessions,
+	availableProjectSessions = [],
+	tabOwnerSessionId,
+	onAddProjectSession,
+	onCloseProjectSession,
+	onSelectProjectSession,
 	theme,
 	daemonReady,
 	terminalTarget,
@@ -61,7 +95,25 @@ export function CenterPane({
 	const lastWheelZoomAtRef = useRef(0);
 	const [fontSize, setFontSize] = useState(initialTerminalFontSize);
 	const [isFullscreen, setIsFullscreen] = useState(false);
-	const tabOverflowWatch = `session|${shellTerminals.map((t) => t.handleId).join("|")}`;
+	const [isTabLauncherOpen, setIsTabLauncherOpen] = useState(false);
+	const [showAllSessions, setShowAllSessions] = useState(false);
+	const [sessionSearch, setSessionSearch] = useState("");
+	const sessionTabs = projectSessions?.length ? projectSessions : session ? [session] : [];
+	const effectiveTabOwnerSessionId = tabOwnerSessionId ?? session?.id;
+	const hasMoreSessions = availableProjectSessions.length > COMPACT_SESSION_LIMIT;
+	const normalizedSessionSearch = sessionSearch.trim().toLowerCase();
+	const filteredSessions = normalizedSessionSearch
+		? availableProjectSessions.filter((candidate) =>
+				`${candidate.title} ${candidate.workspaceName}`.toLowerCase().includes(normalizedSessionSearch),
+			)
+		: availableProjectSessions;
+	const expandedSessionList = showAllSessions || normalizedSessionSearch.length > 0;
+	const visibleSessions = expandedSessionList
+		? filteredSessions
+		: filteredSessions.slice(0, COMPACT_SESSION_LIMIT);
+	const tabOverflowWatch = `${sessionTabs.map((item) => item.id).join("|")}|${shellTerminals
+		.map((terminal) => terminal.handleId)
+		.join("|")}`;
 	const tabsOverflow = useOverflowScroll<HTMLDivElement>(tabOverflowWatch);
 	const target = terminalTarget ?? { kind: "worker" };
 
@@ -139,20 +191,38 @@ export function CenterPane({
 					>
 						<ChevronLeft aria-hidden="true" className="size-icon-md" />
 					</button>
-					{/* The session's own pane is always the first tab; standalone shells
-					    follow it in the order they were opened. With no shells open this
-					    renders as the plain session label it has always been. Tabs shrink
-					    and truncate like browser tabs down to a minimum width; beyond
-					    that the strip scrolls and edge chevrons reveal the overflow. */}
+					{/* Each originating session owns a private set of pinned worker and
+					    shell tabs. The + menu is the only way to add to that layout. */}
 					<div
 						ref={tabsOverflow.ref}
 						className="scrollbar-none flex min-w-flex-min flex-1 items-center gap-3 overflow-x-auto"
 					>
-						<SessionPaneTab
-							isActive={target.kind !== "shell"}
-							label={!session ? "No session" : isOrchestratorSession(session) ? "Orchestrator" : session.title}
-							onSelect={onSelectSessionTerminal}
-						/>
+						{sessionTabs.length > 0 ? (
+							sessionTabs.map((projectSession) => {
+								const isCurrent = projectSession.id === session?.id;
+								return (
+									<SessionPaneTab
+										key={projectSession.id}
+										isActive={isCurrent && target.kind !== "shell"}
+										label={
+											isOrchestratorSession(projectSession) ? "Orchestrator" : projectSession.title
+										}
+										onSelect={
+											isCurrent
+												? onSelectSessionTerminal
+												: () => onSelectProjectSession?.(projectSession)
+										}
+										onClose={
+											projectSession.id !== effectiveTabOwnerSessionId
+												? () => onCloseProjectSession?.(projectSession)
+												: undefined
+										}
+									/>
+								);
+							})
+						) : (
+							<SessionPaneTab isActive={target.kind !== "shell"} label="No session" />
+						)}
 						{shellTerminals.map((shell) => (
 							<ShellTerminalTab
 								key={shell.handleId}
@@ -177,19 +247,88 @@ export function CenterPane({
 					>
 						<ChevronRight aria-hidden="true" className="size-icon-md" />
 					</button>
-					{/* New shell tab at the end of the strip — the same action Ctrl+Shift+`
-					    fires, routed through the store so the two cannot drift. */}
-					{onNewShellTerminal && (
-						<button
-							aria-label="New terminal"
-							className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
-							onClick={onNewShellTerminal}
-							title="New terminal (Ctrl+Shift+`)"
-							type="button"
-						>
-							<Plus aria-hidden="true" className="size-icon-md" />
-						</button>
-					)}
+					<DropdownMenu
+						open={isTabLauncherOpen}
+						onOpenChange={(open) => {
+							setIsTabLauncherOpen(open);
+							if (!open) {
+								setShowAllSessions(false);
+								setSessionSearch("");
+							}
+						}}
+					>
+						<DropdownMenuTrigger asChild>
+							<button
+								aria-label="Add tab"
+								className="inline-flex h-control-sm shrink-0 items-center gap-px rounded-sm px-1 text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
+								title="Add tab"
+								type="button"
+							>
+								<Plus aria-hidden="true" className="size-icon-md" />
+								<ChevronDown aria-hidden="true" className="size-icon-2xs" />
+							</button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="start" className="w-72">
+							{hasMoreSessions ? (
+								<div className="relative px-1 pb-1">
+									<Search
+										aria-hidden="true"
+										className="pointer-events-none absolute top-1/2 left-3 size-icon-md -translate-y-[calc(50%+2px)] text-passive"
+									/>
+									<Input
+										aria-label="Search sessions"
+										className="h-control-board pl-8"
+										onChange={(event) => setSessionSearch(event.target.value)}
+										onKeyDown={(event) => event.stopPropagation()}
+										placeholder="Search sessions"
+										value={sessionSearch}
+									/>
+								</div>
+							) : null}
+							<DropdownMenuItem onSelect={onNewShellTerminal}>
+								<TerminalIcon aria-hidden="true" />
+								Terminal
+							</DropdownMenuItem>
+							<DropdownMenuSeparator />
+							<DropdownMenuLabel className="font-sans normal-case tracking-normal">Sessions</DropdownMenuLabel>
+							<div className={cn(expandedSessionList && "h-52 overflow-y-auto overscroll-contain")}>
+								{visibleSessions.length > 0 ? (
+									visibleSessions.map((candidate) => {
+										const isOpen = sessionTabs.some((tab) => tab.id === candidate.id);
+										return (
+											<DropdownMenuItem
+												key={candidate.id}
+												disabled={isOpen}
+												onSelect={() => onAddProjectSession?.(candidate)}
+											>
+												<span className="size-2 shrink-0 rounded-full bg-passive" aria-hidden="true" />
+												<span className="min-w-0 flex-1 truncate">{candidate.title}</span>
+												<span className="max-w-20 truncate text-micro text-passive">
+													{isOpen ? "Open" : candidate.workspaceName}
+												</span>
+											</DropdownMenuItem>
+										);
+									})
+								) : (
+									<DropdownMenuItem disabled>No sessions found</DropdownMenuItem>
+								)}
+							</div>
+							{hasMoreSessions && !expandedSessionList ? (
+								<>
+									<DropdownMenuSeparator />
+									<DropdownMenuItem
+										className="justify-center text-foreground"
+										onSelect={(event) => {
+											event.preventDefault();
+											setShowAllSessions(true);
+										}}
+									>
+										Show all sessions
+									</DropdownMenuItem>
+								</>
+							) : null}
+						</DropdownMenuContent>
+					</DropdownMenu>
 				</div>
 			</div>
 			{target.kind === "reviewer" ? (
@@ -268,18 +407,19 @@ type SessionPaneTabProps = {
 	label: string;
 	isActive: boolean;
 	onSelect?: () => void;
+	onClose?: () => void;
 };
 
 // Shared tab chrome: the open tab is highlighted with the same rounded
 // background as the inspector rail tabs (Summary · Reviews · Browser), and
 // the full label only becomes the hover tooltip when the tab strip is
 // crowded enough to truncate it.
-function SessionPaneTab({ label, isActive, onSelect }: SessionPaneTabProps) {
+function SessionPaneTab({ label, isActive, onSelect, onClose }: SessionPaneTabProps) {
 	const { ref, isTruncated } = useTruncatedText<HTMLButtonElement>(label);
 	return (
 		<span
 			className={cn(
-				"inline-flex min-w-shell-tab-min items-center rounded-md px-2 py-1 transition-colors",
+				"group inline-flex min-w-shell-tab-min items-center gap-1 rounded-md px-2 py-1 transition-colors",
 				isActive ? "bg-interactive-active" : "hover:bg-interactive-hover/60",
 			)}
 		>
@@ -296,6 +436,19 @@ function SessionPaneTab({ label, isActive, onSelect }: SessionPaneTabProps) {
 			>
 				{label}
 			</button>
+			{onClose ? (
+				<button
+					aria-label={`Close session tab ${label}`}
+					className="inline-flex size-control-sm shrink-0 items-center justify-center rounded-sm text-passive opacity-0 transition-[background,color,opacity] group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-interactive-hover hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent/50"
+					onClick={(event) => {
+						event.stopPropagation();
+						onClose();
+					}}
+					type="button"
+				>
+					<X aria-hidden="true" className="size-icon-sm" />
+				</button>
+			) : null}
 		</span>
 	);
 }

--- a/frontend/src/renderer/components/SessionView.test.tsx
+++ b/frontend/src/renderer/components/SessionView.test.tsx
@@ -5,6 +5,12 @@ import { SessionView } from "./SessionView";
 import { useUiStore } from "../stores/ui-store";
 import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 
+const navigateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/react-router", () => ({
+	useNavigate: () => navigateMock,
+}));
+
 type FakePanelHandle = {
 	collapse: Mock;
 	expand: Mock;
@@ -43,8 +49,17 @@ const { workspaces, workspaceQueryState, panels, shellTerminalsState } = vi.hois
 		kind: "orchestrator",
 		title: "orchestrate",
 	} satisfies WorkspaceSession;
+	const crossProjectWorker = {
+		...worker,
+		id: "sess-cross-project",
+		workspaceId: "proj-2",
+		workspaceName: "other-app",
+		title: "cross-project task",
+		branch: "ao/cross-project",
+	} satisfies WorkspaceSession;
 	const workspaces: WorkspaceSummary[] = [
 		{ id: "proj-1", name: "my-app", path: "/p", type: "main", sessions: [worker, secondWorker, orchestrator] },
+		{ id: "proj-2", name: "other-app", path: "/q", type: "main", sessions: [crossProjectWorker] },
 	];
 	const workspaceQueryState: { data: WorkspaceSummary[] | undefined; isLoading: boolean } = {
 		data: workspaces,
@@ -70,10 +85,43 @@ const { workspaces, workspaceQueryState, panels, shellTerminalsState } = vi.hois
 // platform hides the shell topbar, SessionView mounts it in-panel.)
 vi.mock("./ShellTopbar", () => ({ ShellTopbar: () => null }));
 vi.mock("./CenterPane", () => ({
-	CenterPane: ({ shellTerminals = [] }: { shellTerminals?: Array<{ handleId: string; title: string }> }) => (
+	CenterPane: ({
+		shellTerminals = [],
+		projectSessions = [],
+		availableProjectSessions = [],
+		onAddProjectSession,
+		onCloseProjectSession,
+		onSelectProjectSession,
+	}: {
+		shellTerminals?: Array<{ handleId: string; title: string }>;
+		projectSessions?: WorkspaceSession[];
+		availableProjectSessions?: WorkspaceSession[];
+		onAddProjectSession?: (session: WorkspaceSession) => void;
+		onCloseProjectSession?: (session: WorkspaceSession) => void;
+		onSelectProjectSession?: (session: WorkspaceSession) => void;
+	}) => (
 		<div>
 			terminal center
 			<div data-testid="shell-tabs">{shellTerminals.map((s) => s.title).join(",")}</div>
+			<div data-testid="project-tabs">
+				{projectSessions.map((session) => (
+					<button key={session.id} type="button" onClick={() => onSelectProjectSession?.(session)}>
+						{session.title}
+					</button>
+				))}
+			</div>
+			<div data-testid="available-project-tabs">
+				{availableProjectSessions.map((session) => (
+					<button key={session.id} type="button" onClick={() => onAddProjectSession?.(session)}>
+						Add {session.title}
+					</button>
+				))}
+			</div>
+			{projectSessions.slice(1).map((session) => (
+				<button key={session.id} type="button" onClick={() => onCloseProjectSession?.(session)}>
+					Close {session.title}
+				</button>
+			))}
 		</div>
 	),
 }));
@@ -274,7 +322,7 @@ function inspectorButton(): HTMLElement {
 describe("SessionView", () => {
 	beforeEach(() => {
 		window.localStorage.clear();
-		for (const session of workspaces[0].sessions) {
+		for (const session of workspaces.flatMap((workspace) => workspace.sessions)) {
 			delete session.previewUrl;
 			delete session.previewRevision;
 			delete session.isTerminated;
@@ -282,11 +330,12 @@ describe("SessionView", () => {
 		}
 		workspaceQueryState.data = workspaces;
 		workspaceQueryState.isLoading = false;
-		useUiStore.setState({ inspectorSessions: {} });
+		useUiStore.setState({ inspectorSessions: {}, sessionTabsByOwner: {} });
 		panels.clear();
 		browserDestroy.mockReset();
 		browserViewOptions.current = undefined;
 		shellTerminalsState.data = [];
+		navigateMock.mockReset();
 	});
 
 	// Regression: shell terminals are an app-wide list, so without a per-session
@@ -316,6 +365,66 @@ describe("SessionView", () => {
 		expect(tabs).toHaveTextContent("sess-1-shell");
 		expect(tabs).not.toHaveTextContent("sess-2-shell");
 		expect(tabs).not.toHaveTextContent("loose-shell");
+	});
+
+	it("starts with only the owner tab and pins another worker through the add menu", () => {
+		render(<SessionView sessionId="sess-1" />);
+
+		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the thing");
+		expect(screen.getByTestId("project-tabs")).not.toHaveTextContent("do the other thing");
+		expect(screen.getByTestId("available-project-tabs")).toHaveTextContent("Add do the other thing");
+
+		fireEvent.click(screen.getByRole("button", { name: "Add do the other thing" }));
+		expect(useUiStore.getState().sessionTabsByOwner["sess-1"]).toEqual(["sess-2"]);
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/sessions/$sessionId",
+			params: { projectId: "proj-1", sessionId: "sess-2" },
+			search: { tabOwner: "sess-1" },
+		});
+	});
+
+	it("offers and pins live worker sessions from other projects", () => {
+		render(<SessionView sessionId="sess-1" />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Add cross-project task" }));
+		expect(useUiStore.getState().sessionTabsByOwner["sess-1"]).toEqual(["sess-cross-project"]);
+		expect(navigateMock).toHaveBeenCalledWith({
+			to: "/projects/$projectId/sessions/$sessionId",
+			params: { projectId: "proj-2", sessionId: "sess-cross-project" },
+			search: { tabOwner: "sess-1" },
+		});
+	});
+
+	it("keeps pinned worker and shell tabs private to their owner session", () => {
+		useUiStore.getState().addSessionTab("sess-1", "sess-2");
+		shellTerminalsState.data = [
+			{
+				handleId: "sh-a",
+				sessionId: "sess-1",
+				title: "owner-shell",
+				workingDir: "/p",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+			{
+				handleId: "sh-b",
+				sessionId: "sess-2",
+				title: "worker-shell",
+				workingDir: "/q",
+				createdAt: "2026-07-24T00:00:00Z",
+			},
+		];
+		const { rerender } = render(<SessionView sessionId="sess-2" tabOwnerSessionId="sess-1" />);
+
+		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the thing");
+		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the other thing");
+		expect(screen.getByTestId("shell-tabs")).toHaveTextContent("owner-shell");
+		expect(screen.getByTestId("shell-tabs")).not.toHaveTextContent("worker-shell");
+
+		rerender(<SessionView sessionId="sess-2" />);
+		expect(screen.getByTestId("project-tabs")).not.toHaveTextContent("do the thing");
+		expect(screen.getByTestId("project-tabs")).toHaveTextContent("do the other thing");
+		expect(screen.getByTestId("shell-tabs")).not.toHaveTextContent("owner-shell");
+		expect(screen.getByTestId("shell-tabs")).toHaveTextContent("worker-shell");
 	});
 
 	// Regression: react-resizable-panels v4 treats bare numeric sizes as PIXELS

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useNavigate } from "@tanstack/react-router";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
 import { BrowserPanelView, useBrowserAnnotationQueue } from "./BrowserPanel";
 import { CenterPane } from "./CenterPane";
@@ -10,16 +11,22 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "./ui/resiz
 import { useResolvedTheme, useUiStore, type InspectorView } from "../stores/ui-store";
 import { useShell } from "../lib/shell-context";
 import { useBrowserView } from "../hooks/useBrowserView";
-import { useCloseShellTerminal, useRenameShellTerminal, useShellTerminals } from "../hooks/useShellTerminals";
+import {
+	useCloseShellTerminal,
+	useOpenShellTerminal,
+	useRenameShellTerminal,
+	useShellTerminals,
+} from "../hooks/useShellTerminals";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { hidesShellTopbar } from "../lib/platform";
-import { isOrchestratorSession, sessionIsActive } from "../types/workspace";
+import { isOrchestratorSession, sessionIsActive, workerSessions, type WorkspaceSession } from "../types/workspace";
 import type { TerminalTarget } from "../types/terminal";
 
 const INSPECTOR_MIN_PERCENT = 22;
 const INSPECTOR_MAX_PERCENT = 45;
 const inspectorSplitStorageKey = "ao.inspector.split";
 const shellTopbarHiddenByPlatform = hidesShellTopbar();
+const emptySessionTabIds: string[] = [];
 
 function initialSplitPercent(): number {
 	const raw = typeof window === "undefined" ? null : window.localStorage?.getItem(inspectorSplitStorageKey);
@@ -37,6 +44,7 @@ function previewRevealKey(previewUrl?: string, previewRevision?: number): string
 
 type SessionViewProps = {
 	sessionId: string;
+	tabOwnerSessionId?: string;
 };
 
 // The session detail screen: terminal + git rail. On Win/Linux the shell owns
@@ -51,7 +59,8 @@ type SessionViewProps = {
 // imperative API from the ui-store (topbar button / ⌘⇧B), animated by the
 // flex-grow transition in styles.css. Content keeps a stable min-width inside
 // the clipped panel so nothing reflows mid-animation; split width persists.
-export function SessionView({ sessionId }: SessionViewProps) {
+export function SessionView({ sessionId, tabOwnerSessionId }: SessionViewProps) {
+	const navigate = useNavigate();
 	const workspaceQuery = useWorkspaceQuery();
 	const workspaces = workspaceQuery.data ?? [];
 	const theme = useResolvedTheme();
@@ -70,29 +79,86 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const [filesPoppedOut, setFilesPoppedOut] = useState(false);
 
 	const session = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
+	const allSessions = workspaces.flatMap((workspace) => workspace.sessions);
+	const tabOwnerSession = allSessions.find((candidate) => candidate.id === tabOwnerSessionId) ?? session;
+	const ownerSessionId = tabOwnerSession?.id ?? sessionId;
+	const storedSessionTabIds = useUiStore((state) => state.sessionTabsByOwner[ownerSessionId] ?? emptySessionTabIds);
+	const addSessionTab = useUiStore((state) => state.addSessionTab);
+	const removeSessionTab = useUiStore((state) => state.removeSessionTab);
+	const availableSessions = workspaces.flatMap((workspace) =>
+		workerSessions(workspace.sessions).filter((candidate) => candidate.isTerminated !== true),
+	);
+	const projectSessions = tabOwnerSession
+		? [
+				tabOwnerSession,
+				...storedSessionTabIds
+					.map((tabId) => allSessions.find((candidate) => candidate.id === tabId))
+					.filter(
+						(projectSession): projectSession is WorkspaceSession =>
+							Boolean(projectSession && projectSession.isTerminated !== true && projectSession.id !== tabOwnerSession.id),
+					),
+			]
+		: [];
+	if (session && !projectSessions.some((projectSession) => projectSession.id === session.id)) {
+		projectSessions.push(session);
+	}
+	const selectProjectSession = useCallback(
+		(projectSession: WorkspaceSession) => {
+			void navigate({
+				to: "/projects/$projectId/sessions/$sessionId",
+				params: { projectId: projectSession.workspaceId, sessionId: projectSession.id },
+				search: projectSession.id === ownerSessionId ? {} : { tabOwner: ownerSessionId },
+			});
+		},
+		[navigate, ownerSessionId],
+	);
+	const addProjectSession = useCallback(
+		(projectSession: WorkspaceSession) => {
+			addSessionTab(ownerSessionId, projectSession.id);
+			selectProjectSession(projectSession);
+		},
+		[addSessionTab, ownerSessionId, selectProjectSession],
+	);
+	const closeProjectSession = useCallback(
+		(projectSession: WorkspaceSession) => {
+			removeSessionTab(ownerSessionId, projectSession.id);
+			if (projectSession.id === sessionId && tabOwnerSession) selectProjectSession(tabOwnerSession);
+		},
+		[ownerSessionId, removeSessionTab, selectProjectSession, sessionId, tabOwnerSession],
+	);
 
 	// Shell terminals opened inside a session live beside its pane as extra tabs.
 	//
-	// Scope them to THIS session: the daemon list is app-wide, so without the
-	// filter a shell opened in one session would show up in every other session's
-	// strip (even across projects). A shell's sessionId is the session it was
-	// opened from; session-less shells (opened from the board) live only on the
-	// standalone /terminals screen.
+	// Scope shells to the tab layout's originating session. Navigating to a
+	// pinned worker keeps the owner's shell tabs; opening that worker directly
+	// from the sidebar uses its own separate shell set.
 	const allShellTerminals = useShellTerminals().data ?? [];
 	const shellTerminals = useMemo(
-		() => allShellTerminals.filter((s) => s.sessionId === sessionId),
-		[allShellTerminals, sessionId],
+		() => allShellTerminals.filter((shell) => shell.sessionId === ownerSessionId),
+		[allShellTerminals, ownerSessionId],
 	);
+	const openShellTerminal = useOpenShellTerminal();
 	const closeShellTerminal = useCloseShellTerminal();
 	const renameShellTerminal = useRenameShellTerminal();
 	const activeShellTerminalHandleId = useUiStore((state) => state.activeShellTerminalHandleId);
 	const setActiveShellTerminal = useUiStore((state) => state.setActiveShellTerminal);
-	const requestNewShellTerminal = useUiStore((state) => state.requestNewShellTerminal);
 
 	const renameShellTerminalByHandle = useCallback(
 		(handleId: string, title: string) => renameShellTerminal.mutate({ handleId, title }),
 		[renameShellTerminal],
 	);
+
+	const addShellTerminal = useCallback(() => {
+		openShellTerminal.mutate(
+			{ projectId: tabOwnerSession?.workspaceId, sessionId: ownerSessionId },
+			{
+				onSuccess: (shell) => {
+					setActiveShellTerminal(shell.handleId);
+					setTerminalTarget({ kind: "shell", handleId: shell.handleId, title: shell.title });
+				},
+			},
+		);
+	}, [openShellTerminal, ownerSessionId, setActiveShellTerminal, tabOwnerSession?.workspaceId]);
 
 	const selectShellTerminal = useCallback(
 		(handleId: string) => {
@@ -347,15 +413,23 @@ export function SessionView({ sessionId }: SessionViewProps) {
             be strings. Numeric sizes here once clamped the inspector to 45px. */}
 				<ResizablePanel defaultSize="72%" id="terminal" minSize="45%">
 					<CenterPane
+						availableProjectSessions={availableSessions.filter(
+							(candidate) => candidate.id !== tabOwnerSession?.id,
+						)}
 						daemonReady={daemonStatus.state === "ready"}
+						onAddProjectSession={addProjectSession}
+						onCloseProjectSession={closeProjectSession}
 						onCloseShellTerminal={closeShellTerminalByHandle}
-						onNewShellTerminal={requestNewShellTerminal}
+						onNewShellTerminal={addShellTerminal}
 						onRenameShellTerminal={renameShellTerminalByHandle}
+						onSelectProjectSession={selectProjectSession}
 						onSelectSessionTerminal={selectSessionTerminal}
 						onSelectShellTerminal={selectShellTerminal}
 						onSelectWorkerTerminal={selectSessionTerminal}
 						session={session}
+						projectSessions={projectSessions}
 						shellTerminals={shellTerminals}
+						tabOwnerSessionId={ownerSessionId}
 						terminalTarget={terminalTarget}
 						theme={theme}
 					/>

--- a/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.projects.$projectId_.sessions.$sessionId.tsx
@@ -1,11 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SessionView } from "../components/SessionView";
 
+type SessionSearch = { tabOwner?: string };
+
 export const Route = createFileRoute("/_shell/projects/$projectId_/sessions/$sessionId")({
+	validateSearch: (search: Record<string, unknown>): SessionSearch =>
+		typeof search.tabOwner === "string" ? { tabOwner: search.tabOwner } : {},
 	component: ProjectSessionRoute,
 });
 
 function ProjectSessionRoute() {
 	const { sessionId } = Route.useParams();
-	return <SessionView sessionId={sessionId} />;
+	const { tabOwner } = Route.useSearch();
+	return <SessionView sessionId={sessionId} tabOwnerSessionId={tabOwner} />;
 }

--- a/frontend/src/renderer/routes/_shell.sessions.$sessionId.tsx
+++ b/frontend/src/renderer/routes/_shell.sessions.$sessionId.tsx
@@ -1,11 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SessionView } from "../components/SessionView";
 
+type SessionSearch = { tabOwner?: string };
+
 export const Route = createFileRoute("/_shell/sessions/$sessionId")({
+	validateSearch: (search: Record<string, unknown>): SessionSearch =>
+		typeof search.tabOwner === "string" ? { tabOwner: search.tabOwner } : {},
 	component: SessionRoute,
 });
 
 function SessionRoute() {
 	const { sessionId } = Route.useParams();
-	return <SessionView sessionId={sessionId} />;
+	const { tabOwner } = Route.useSearch();
+	return <SessionView sessionId={sessionId} tabOwnerSessionId={tabOwner} />;
 }

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useMatchRoute, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { CommandPalette } from "../components/CommandPalette";
@@ -125,6 +125,11 @@ function ShellLayout() {
 	const [isSidebarPeekOpen, setIsSidebarPeekOpen] = useState(false);
 	const sidebarPeekCloseTimerRef = useRef<number | undefined>(undefined);
 	const routeParams = useParams({ strict: false }) as { projectId?: string; sessionId?: string };
+	const routeSearch = useSearch({ strict: false }) as { tabOwner?: string };
+	const tabOwnerSession = routeSearch.tabOwner
+		? workspaces.flatMap((workspace) => workspace.sessions).find((session) => session.id === routeSearch.tabOwner)
+		: undefined;
+	const tabOwnerSessionId = tabOwnerSession?.id;
 	// Project in scope for a new-session shortcut: the route's project, or the
 	// workspace owning the open session (so the shortcut works from a worker's
 	// detail view, where the URL carries only a sessionId).
@@ -476,7 +481,10 @@ function ShellLayout() {
 		if (handledShellNonceRef.current === newShellTerminalNonce) return;
 		handledShellNonceRef.current = newShellTerminalNonce;
 		openShellTerminal.mutate(
-			{ projectId: scopedProjectId, sessionId: routeParams.sessionId },
+			{
+				projectId: tabOwnerSession?.workspaceId ?? scopedProjectId,
+				sessionId: tabOwnerSessionId ?? routeParams.sessionId,
+			},
 			{
 				onSuccess: (shell) => {
 					setActiveShellTerminal(shell.handleId);
@@ -491,6 +499,8 @@ function ShellLayout() {
 		openShellTerminal,
 		scopedProjectId,
 		routeParams.sessionId,
+		tabOwnerSession?.workspaceId,
+		tabOwnerSessionId,
 		navigate,
 		setActiveShellTerminal,
 	]);

--- a/frontend/src/renderer/stores/ui-store.test.ts
+++ b/frontend/src/renderer/stores/ui-store.test.ts
@@ -35,3 +35,38 @@ describe("ui-store developerMode persistence", () => {
 		expect(window.localStorage.getItem("ao.developerMode")).toBe("false");
 	});
 });
+
+describe("ui-store session tab persistence", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+		vi.resetModules();
+	});
+
+	it("keeps added tabs isolated by owner session and restores them", async () => {
+		let store = (await import("./ui-store")).useUiStore;
+		store.getState().addSessionTab("session-a", "session-c");
+		store.getState().addSessionTab("session-a", "session-d");
+		store.getState().addSessionTab("session-b", "session-c");
+
+		expect(store.getState().sessionTabsByOwner).toEqual({
+			"session-a": ["session-c", "session-d"],
+			"session-b": ["session-c"],
+		});
+
+		vi.resetModules();
+		store = (await import("./ui-store")).useUiStore;
+		expect(store.getState().sessionTabsByOwner["session-a"]).toEqual(["session-c", "session-d"]);
+	});
+
+	it("deduplicates additions and removes only the requested owner's tab", async () => {
+		const { useUiStore: store } = await import("./ui-store");
+		store.getState().addSessionTab("session-a", "session-c");
+		store.getState().addSessionTab("session-a", "session-c");
+		store.getState().addSessionTab("session-b", "session-c");
+		store.getState().removeSessionTab("session-a", "session-c");
+
+		expect(store.getState().sessionTabsByOwner).toEqual({
+			"session-b": ["session-c"],
+		});
+	});
+});

--- a/frontend/src/renderer/stores/ui-store.ts
+++ b/frontend/src/renderer/stores/ui-store.ts
@@ -33,6 +33,8 @@ type UiState = {
 	workbenchTab: WorkbenchTab;
 	isSidebarOpen: boolean;
 	inspectorSessions: Record<string, InspectorSessionState>;
+	/** Extra worker tabs pinned to each originating session's terminal strip. */
+	sessionTabsByOwner: Record<string, string[]>;
 	isCommandPaletteOpen: boolean;
 	themePreference: ThemePreference;
 	/** Resolved light/dark for React consumers; may track OS while preference is system. */
@@ -69,6 +71,8 @@ type UiState = {
 	setInspectorOpen: (sessionId: string, isOpen: boolean) => void;
 	toggleInspector: (sessionId: string) => void;
 	setInspectorView: (sessionId: string, view: InspectorView) => void;
+	addSessionTab: (ownerSessionId: string, sessionId: string) => void;
+	removeSessionTab: (ownerSessionId: string, sessionId: string) => void;
 	markInspectorPreviewSeen: (sessionId: string, previewKey: string) => void;
 	setBrowserUnseen: (sessionId: string, unseen: boolean) => void;
 	setCommandPaletteOpen: (open: boolean) => void;
@@ -83,6 +87,7 @@ type UiState = {
 
 const sidebarStorageKey = "ao.sidebar.open";
 const developerModeStorageKey = "ao.developerMode";
+const sessionTabsStorageKey = "ao.sessionTabs";
 
 function getLocalStorage() {
 	if (typeof window === "undefined" || !window.localStorage) return null;
@@ -97,6 +102,28 @@ function initialDeveloperMode() {
 	return getLocalStorage()?.getItem(developerModeStorageKey) === "true";
 }
 
+function initialSessionTabs(): Record<string, string[]> {
+	const raw = getLocalStorage()?.getItem(sessionTabsStorageKey);
+	if (!raw) return {};
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+		return Object.fromEntries(
+			Object.entries(parsed).flatMap(([ownerSessionId, sessionIds]) =>
+				Array.isArray(sessionIds) && sessionIds.every((sessionId) => typeof sessionId === "string")
+					? [[ownerSessionId, sessionIds]]
+					: [],
+			),
+		);
+	} catch {
+		return {};
+	}
+}
+
+function storeSessionTabs(sessionTabsByOwner: Record<string, string[]>) {
+	getLocalStorage()?.setItem(sessionTabsStorageKey, JSON.stringify(sessionTabsByOwner));
+}
+
 function inspectorState(sessions: Record<string, InspectorSessionState>, sessionId: string): InspectorSessionState {
 	return sessions[sessionId] ?? { isOpen: true, view: "summary" };
 }
@@ -107,6 +134,7 @@ export const useUiStore = create<UiState>((set) => ({
 	workbenchTab: "changes",
 	isSidebarOpen: initialSidebarOpen(),
 	inspectorSessions: {},
+	sessionTabsByOwner: initialSessionTabs(),
 	isCommandPaletteOpen: false,
 	themePreference: initialThemePreference,
 	resolvedTheme: resolveTheme(initialThemePreference),
@@ -170,6 +198,28 @@ export const useUiStore = create<UiState>((set) => ({
 					[sessionId]: { ...current, view, browserUnseen },
 				},
 			};
+		}),
+	addSessionTab: (ownerSessionId, sessionId) =>
+		set((state) => {
+			const current = state.sessionTabsByOwner[ownerSessionId] ?? [];
+			if (ownerSessionId === sessionId || current.includes(sessionId)) return state;
+			const sessionTabsByOwner = {
+				...state.sessionTabsByOwner,
+				[ownerSessionId]: [...current, sessionId],
+			};
+			storeSessionTabs(sessionTabsByOwner);
+			return { sessionTabsByOwner };
+		}),
+	removeSessionTab: (ownerSessionId, sessionId) =>
+		set((state) => {
+			const current = state.sessionTabsByOwner[ownerSessionId] ?? [];
+			if (!current.includes(sessionId)) return state;
+			const remaining = current.filter((id) => id !== sessionId);
+			const sessionTabsByOwner = { ...state.sessionTabsByOwner };
+			if (remaining.length > 0) sessionTabsByOwner[ownerSessionId] = remaining;
+			else delete sessionTabsByOwner[ownerSessionId];
+			storeSessionTabs(sessionTabsByOwner);
+			return { sessionTabsByOwner };
 		}),
 	markInspectorPreviewSeen: (sessionId, previewKey) =>
 		set((state) => {

--- a/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
+++ b/frontend/src/renderer/test/shell-new-session-shortcut.test.tsx
@@ -14,6 +14,7 @@ const shellMocks = vi.hoisted(() => {
 		nextSessionListener: undefined as (() => void) | undefined,
 		focusTerminalListener: undefined as (() => void) | undefined,
 		routeParams: {} as { projectId?: string; sessionId?: string },
+		routeSearch: {} as { tabOwner?: string },
 		workspaces: [] as WorkspaceSummary[],
 	};
 	return {
@@ -68,6 +69,7 @@ vi.mock("@tanstack/react-router", async (importOriginal) => ({
 	useMatchRoute: () => () => false,
 	useNavigate: () => shellMocks.navigate,
 	useParams: () => shellMocks.state.routeParams,
+	useSearch: () => shellMocks.state.routeSearch,
 }));
 
 vi.mock("../lib/bridge", () => ({
@@ -175,11 +177,17 @@ const workspaces = [
 		name: "Project One",
 		path: "/one",
 		sessions: [
-			{ id: "sess-1", status: "working" },
-			{ id: "sess-2", status: "terminated" },
-			{ id: "sess-merged-terminated", status: "merged", isTerminated: true },
-			{ id: "sess-3", status: "idle" },
+			{ id: "sess-1", workspaceId: "proj-1", status: "working" },
+			{ id: "sess-2", workspaceId: "proj-1", status: "terminated" },
+			{ id: "sess-merged-terminated", workspaceId: "proj-1", status: "merged", isTerminated: true },
+			{ id: "sess-3", workspaceId: "proj-1", status: "idle" },
 		],
+	},
+	{
+		id: "proj-2",
+		name: "Project Two",
+		path: "/two",
+		sessions: [{ id: "sess-cross", workspaceId: "proj-2", status: "working" }],
 	},
 ] as unknown as WorkspaceSummary[];
 
@@ -225,6 +233,7 @@ beforeEach(() => {
 	shellMocks.state.nextSessionListener = undefined;
 	shellMocks.state.focusTerminalListener = undefined;
 	shellMocks.state.routeParams = {};
+	shellMocks.state.routeSearch = {};
 	shellMocks.state.workspaces = workspaces;
 	useUiStore.setState({
 		createProjectNonce: 0,
@@ -297,6 +306,19 @@ describe("shell new-shell-terminal shortcut subscription", () => {
 
 		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith(
 			expect.objectContaining({ projectId: "proj-1" }),
+			expect.anything(),
+		);
+	});
+
+	it("scopes the terminal to the originating session while viewing one of its pinned tabs", async () => {
+		shellMocks.state.routeParams = { projectId: "proj-2", sessionId: "sess-cross" };
+		shellMocks.state.routeSearch = { tabOwner: "sess-1" };
+		await renderShell();
+
+		pressNewShellTerminal();
+
+		expect(shellMocks.openShellTerminal).toHaveBeenCalledWith(
+			expect.objectContaining({ projectId: "proj-1", sessionId: "sess-1" }),
 			expect.anything(),
 		);
 	});


### PR DESCRIPTION
#3113  
tldr: 
• Persistent, isolated tab layouts per session. 
• Add terminals or live sessions across projects. 
• Compact 5-session launcher with search and scrollable “Show all”. 
• Closing/switching tabs preserves the originating session context.