### PR TITLE
feat(landing): add 0.11.0 changelog entry + restore the detail route

### DIFF
--- a/frontend/src/landing/content/changelog/agent-orchestrator-0-11-0.mdx
+++ b/frontend/src/landing/content/changelog/agent-orchestrator-0-11-0.mdx
@@ -1,0 +1,97 @@
+---
+title: "Agent Orchestrator 0.11.0 — The Floor"
+description: "271 commits and 270 merged PRs later, from 49 authors. The difference isn't a rewrite stacked on a rewrite — it's that the foundation finally holds weight, and the app grew outward on top of it."
+date: "2026-07-26"
+---
+
+> Covers everything since **v0.10.0**. If you are on 0.10.3, you already have part of this.
+
+v0.10.0 was the first release after a ground-up rewrite — Go daemon, tmux session layer, Electron shell. It worked, mostly. But a rewrite's first release is a promise, not a product.
+
+0.11.0 is 271 commits and 270 merged PRs later, from 49 authors. The difference isn't a rewrite stacked on a rewrite. It's that the foundation finally holds weight — and the app grew outward on top of it.
+
+---
+
+## Highlights
+
+### Your phone is a real control surface
+
+The mobile companion app went from a port to a shipping surface. Pair a phone to your daemon over LAN with a password via **Connect Mobile**, co-view terminals with pinch zoom and pan, and get **push notifications on iOS and Android** when a session needs you. Settings walks you through LAN or Tailscale pairing and links straight to the app. (#2522, #2533, #2569, #2654, #2851, #2881, #2918, #2933)
+
+### Agents can drive a browser
+
+Agents render Markdown and drive an embedded browser preview. Annotate directly inside it to point an agent at a specific UI element, and localhost links clicked in a terminal open there instead of bouncing you out of the app. (#2455, #2548, #2610, #3085)
+
+### Feature Releases — install any open PR
+
+Every PR can now produce its own installable prerelease build, so testing an in-flight change means installing a real app rather than doing a checkout. Gated behind a new **Developer Mode** toggle so the channel picker stays out of the way for everyone else. (#2459, #3039)
+
+### GitHub issue intake
+
+Projects can auto-start a worker session per assigned GitHub issue — polling, dedupe, pagination and per-project backoff — configured under **Tracker Intake** in project settings and the create-project flow. (#2325)
+
+### Workspace files, and a diff viewer that parses
+
+A new inspector panel browses a session's workspace files. The Changes view now renders a parsed diff with gutters, hunk headers, +/- markers and an adds/dels summary, instead of dumping raw `git diff` text with broken line numbers. (#2772, #3013)
+
+### Standalone shell terminals
+
+Open a plain terminal not bound to any agent session — scoped per session, renameable, with a right-click context menu, drag-a-file-to-insert-path, and sane tab overflow. (#2828, #2861, #2948, #2644, #3019, #3077)
+
+### Keyboard-first navigation
+
+Experimental Cmd/Ctrl+K command palette wired into sidebar search, a spawn shortcut, settings and session-navigation and terminal-focus shortcuts, an in-app shortcuts reference, and Enter-to-send / Shift+Enter-for-newline in the New Task brief to match Claude and Codex. (#2687, #2695, #2795, #2954, #2955)
+
+### Also new
+
+- Paste, drag-drop or attach **images** directly into a task brief (#2722, #2907)
+- **Restart-to-update** row with per-channel escalation, a revamped Updates screen, and a fix so the desktop app performs background update checks at all (#2381, #2709, #2939)
+- **CLI**: `ao agent ls` with install and auth status, `ao spawn` resolving project context instead of demanding `--project`, `--kind worker|orchestrator`, `ao review stop|restart`, `ao pr` (#2371, #2416, #2669, #2673, #3043)
+- **Settings and first run** rebuilt — redesigned settings with the PR board folded into the per-session inspector, onboarding replacing four empty kanban columns, and a first-run scratch project so there's somewhere to try AO immediately (#2432, #2797, #2952, #2348)
+- Renderer moved to a **token-based design system** (~1.4k lines of legacy CSS removed), followed by a unified framed desktop shell across macOS, Windows and Linux (#2535, #2937, #2997)
+
+---
+
+## Reliability
+
+This is where most of the cycle went.
+
+**Sessions survive restarts.** Sessions now resume the agent's own native transcript rather than restarting cold, with a toast when AO has to fall back to replaying the saved prompt. Per-harness restore landed for OpenCode, Copilot, Agy, Kimi, Grok, Qwen, Goose and Vibe, backed by a test proving sessions survive daemon restart *and* upgrade. (#2350, #2744, #2765, #2790, #2796, #2856, #2857, #2858)
+
+**Model config actually reaches the agent.** The model you picked in settings was silently dropped for most agents. Closed across Codex, Cline, Goose, Auggie, Pi, Vibe, Autohand, Kimi, Kilocode, Qwen and Copilot, with Kiro now advertising its options at all. (#2869, #2932, #2953, #2956, #2961, #2969, #2971, #2975, #2985, #2989, #2993, #3044)
+
+**Lifecycle and coordination.** Killed sessions stay dead. Worker-idle completions reach a busy orchestrator through a durable outbox instead of being dropped. Orchestrator replacement goes through a safe canonical branch handoff with stale worktree recovery. AO no longer nudges a session that is genuinely paused on a permission dialog. (#2319, #2320, #2357, #2431, #2530, #2600, #2794, #2798, #2799, #2836, #3072)
+
+**Daemon failures explain themselves.** Start failures surface the real error with recovery instructions and copyable output, as a floating toast rather than a banner that shoves the board around. `ao spawn --issue` without a GitHub token no longer panics the daemon. (#2690, #2871, #2972, #3017)
+
+**tmux and terminal.** Fail fast with a clear message when tmux is missing, correct `TERM` on attach, forced UTF-8 client mode so non-ASCII stops garbling, pane descendants reaped on destroy so no zombie processes leak, no more double-firing Ctrl+Arrow / Ctrl+Backspace / Ctrl+V, wheel scroll in Codex and OpenCode transcripts, and a startup state instead of a blank pane while launching. (#2259, #2312, #2466, #2499, #2512, #2586, #2602, #2650)
+
+**Upgrade safety.** Two duplicate migration-version collisions resolved, and out-of-order migrations are now applied instead of silently skipped. (#2294, #3035, #3092)
+
+**Windows.** NSIS installer shortcut points at the real binary, `.ico` taskbar icon, ConPTY `ProgramFiles(x86)` fix, Codex preferring the npm binary over the WindowsApps stub, npm-installed agent binaries found when launched from the GUI, native notifications, a custom titlebar, and background auth checks routed through `aoprocess` so console windows stop flashing. (#2404, #2481, #2566, #2583, #2666, #2691, #2838, #3006)
+
+**PR review.** Reviewer enforced read-only via a tool allowlist, binary preflighted with unavailable options disabled before a run is created, pane respawned when the harness changes instead of reusing a stale process, cross-fork PR detection across all remotes, forced re-fetch past max age so the list stops going stale, and the previous-head verdict shown as context while a new review runs. (#2193, #2194, #2368, #2506, #2678, #2750, #2767, #2800, #3008, #3009, #3049)
+
+---
+
+## Under the hood
+
+The agent adapter layer was consolidated, cutting ~3,100 lines of duplication into shared `agentbase` and `activitystate` packages. The release pipeline gained channel awareness, retried macOS sign/notary flakes, a guard on the `latest` desktop release, an advisory e2e gate against real installed builds before a stable cut, and a dispatchable unsigned build-artifacts workflow that emits the Linux `.deb`. On quality: a T0/P0 renderer smoke suite with `data-testid` instrumentation, a deterministic no-LLM fake harness for e2e, and TypeScript typechecking in frontend CI. Telemetry was capped in volume, switched to anonymous IDs, and no longer leaks raw CLI args into error events. (#2266, #2415, #2489, #2683, #2692, #2696, #2697, #2829, #2864, #2978, #2986)
+
+Docs and the landing site now deploy to [aoagents.dev](https://aoagents.dev) via GitHub Pages, with a privacy policy, a PR-wise changelog, platform-detecting download links, and a contributing guide. (#2308, #2385, #2605, #2757, #2826, #2837, #2846, #2913)
+
+---
+
+## Upgrading
+
+GitHub Releases and Homebrew are the supported install paths; the npm package is frozen. Existing installs should update in place — the migration ordering fixes in this release specifically target the "it broke after updating" class of failure.
+
+---
+
+## Contributors
+
+49 distinct authors landed work in this range, and 30 of them landed four commits or fewer. That shape is the point: a first PR to AO is a realistic weekend.
+
+Special thanks to Harshit Singh Bhandari, Nikhil Achale, Just_Anniee, Apoorv Singh, Khushi Diwan, Vaibhaav Tiwari and Pulkit Saraf, and to everyone else who filed an issue, tested a nightly, or sent a patch.
+
+**Full changelog:** https://github.com/AgentWrapper/agent-orchestrator/compare/v0.10.0...v0.11.0

--- a/frontend/src/landing/package-lock.json
+++ b/frontend/src/landing/package-lock.json
@@ -33,6 +33,7 @@
         "react-dom": "19.2.3",
         "react-fast-marquee": "1.6.5",
         "react-icons": "5.6.0",
+        "react-markdown": "^10.1.0",
         "remark-gfm": "4.0.1",
         "shiki": "^3.23.0",
         "simplex-noise": "^4.0.3",
@@ -484,9 +485,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -502,9 +500,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -522,9 +517,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -540,9 +532,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -560,9 +549,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -578,9 +564,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -598,9 +581,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -617,9 +597,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -635,9 +612,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -661,9 +635,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -685,9 +656,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -711,9 +679,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -735,9 +700,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -761,9 +723,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -786,9 +745,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -810,9 +766,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1060,9 +1013,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1078,9 +1028,6 @@
       "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1098,9 +1045,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1116,9 +1060,6 @@
       "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1903,9 +1844,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1918,9 +1856,6 @@
       "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1935,9 +1870,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1950,9 +1882,6 @@
       "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1967,9 +1896,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1982,9 +1908,6 @@
       "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1999,9 +1922,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2014,9 +1934,6 @@
       "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2031,9 +1948,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2046,9 +1960,6 @@
       "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2063,9 +1974,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2079,9 +1987,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2094,9 +1999,6 @@
       "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2979,9 +2881,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2999,9 +2898,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3019,9 +2915,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3039,9 +2932,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4519,6 +4409,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -4856,9 +4756,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4880,9 +4777,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4904,9 +4798,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4928,9 +4819,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6752,6 +6640,33 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
       }
     },
     "node_modules/recma-build-jsx": {

--- a/frontend/src/landing/package.json
+++ b/frontend/src/landing/package.json
@@ -34,6 +34,7 @@
     "react-dom": "19.2.3",
     "react-fast-marquee": "1.6.5",
     "react-icons": "5.6.0",
+    "react-markdown": "^10.1.0",
     "remark-gfm": "4.0.1",
     "shiki": "^3.23.0",
     "simplex-noise": "^4.0.3",

--- a/frontend/src/landing/src/app/changelog.xml/route.ts
+++ b/frontend/src/landing/src/app/changelog.xml/route.ts
@@ -5,7 +5,7 @@ import { getChangelogEntries } from "@/lib/changelog";
 export const dynamic = "force-static";
 
 export async function GET() {
-	const entries = getChangelogEntries();
+	const entries = await getChangelogEntries();
 	const baseUrl = COMPANY.MARKETING_URL;
 
 	const escapeXml = (str: string) =>

--- a/frontend/src/landing/src/app/changelog/[slug]/page.tsx
+++ b/frontend/src/landing/src/app/changelog/[slug]/page.tsx
@@ -7,8 +7,8 @@ import { getAllChangelogSlugs, getChangelogEntry } from "@/lib/changelog";
 import { ChangelogEntry } from "../components/ChangelogEntry";
 
 // Static export needs every entry enumerated at build time.
-export function generateStaticParams() {
-  return getAllChangelogSlugs().map((slug) => ({ slug }));
+export async function generateStaticParams() {
+  return (await getAllChangelogSlugs()).map((slug) => ({ slug }));
 }
 
 export async function generateMetadata({
@@ -17,7 +17,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const entry = getChangelogEntry(slug);
+  const entry = await getChangelogEntry(slug);
   if (!entry) {
     return { title: "Changelog" };
   }
@@ -46,7 +46,7 @@ export default async function ChangelogEntryPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const entry = getChangelogEntry(slug);
+  const entry = await getChangelogEntry(slug);
   if (!entry) {
     notFound();
   }

--- a/frontend/src/landing/src/app/changelog/[slug]/page.tsx
+++ b/frontend/src/landing/src/app/changelog/[slug]/page.tsx
@@ -1,0 +1,88 @@
+import { ArrowLeft } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { GridCross } from "@/app/blog/components/GridCross";
+import { getAllChangelogSlugs, getChangelogEntry } from "@/lib/changelog";
+import { ChangelogEntry } from "../components/ChangelogEntry";
+
+// Static export needs every entry enumerated at build time.
+export function generateStaticParams() {
+  return getAllChangelogSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = getChangelogEntry(slug);
+  if (!entry) {
+    return { title: "Changelog" };
+  }
+  return {
+    title: entry.title,
+    description: entry.description,
+    alternates: { canonical: entry.url },
+    openGraph: {
+      title: `${entry.title} | Agent Orchestrator`,
+      description: entry.description,
+      url: entry.url,
+      images: ["/opengraph-image"],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${entry.title} | Agent Orchestrator`,
+      description: entry.description,
+      images: ["/opengraph-image"],
+    },
+  };
+}
+
+export default async function ChangelogEntryPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const entry = getChangelogEntry(slug);
+  if (!entry) {
+    notFound();
+  }
+
+  return (
+    <main className="relative min-h-screen">
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          backgroundImage: `
+            linear-gradient(to right, transparent 0%, transparent calc(50% - 384px), rgba(255,255,255,0.06) calc(50% - 384px), rgba(255,255,255,0.06) calc(50% - 383px), transparent calc(50% - 383px), transparent calc(50% + 383px), rgba(255,255,255,0.06) calc(50% + 383px), rgba(255,255,255,0.06) calc(50% + 384px), transparent calc(50% + 384px))
+          `,
+        }}
+      />
+
+      <header className="relative border-b border-border">
+        <div className="max-w-3xl mx-auto px-6 pt-16 pb-10 md:pt-20 md:pb-12 relative">
+          <GridCross className="top-0 left-0" />
+          <GridCross className="top-0 right-0" />
+
+          <Link
+            href="/changelog"
+            className="inline-flex items-center gap-1.5 text-sm font-mono text-muted-foreground hover:text-foreground transition-colors tracking-[0.5px]"
+          >
+            <ArrowLeft className="size-4" />
+            Changelog
+          </Link>
+
+          <GridCross className="bottom-0 left-0" />
+          <GridCross className="bottom-0 right-0" />
+        </div>
+      </header>
+
+      <div className="relative max-w-3xl mx-auto px-6 py-16">
+        <ChangelogEntry entry={entry} />
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/landing/src/app/changelog/components/ChangelogEntry/ChangelogEntry.tsx
+++ b/frontend/src/landing/src/app/changelog/components/ChangelogEntry/ChangelogEntry.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { MDXRemote } from "next-mdx-remote/rsc";
+import remarkGfm from "remark-gfm";
 import {
 	type ChangelogEntry as ChangelogEntryType,
 	formatChangelogDate,
@@ -63,7 +64,11 @@ export async function ChangelogEntry({ entry }: ChangelogEntryProps) {
 
 			{/* Full MDX content */}
 			<div className="prose prose-invert max-w-none prose-headings:font-medium prose-headings:tracking-[-0.5px] prose-h2:text-xl prose-h2:mt-8 prose-h2:mb-4 prose-h3:text-lg prose-h3:mt-6 prose-h3:mb-3 prose-p:text-muted-foreground prose-p:leading-relaxed prose-li:text-muted-foreground prose-strong:text-foreground prose-a:text-foreground prose-a:underline prose-a:underline-offset-4 hover:prose-a:text-muted-foreground prose-hr:border-border prose-hr:my-8">
-				<MDXRemote source={entry.content} components={changelogMdxComponents} />
+				<MDXRemote
+					source={entry.content}
+					components={changelogMdxComponents}
+					options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
+				/>
 			</div>
 		</article>
 	);

--- a/frontend/src/landing/src/app/changelog/components/ChangelogEntry/ChangelogEntry.tsx
+++ b/frontend/src/landing/src/app/changelog/components/ChangelogEntry/ChangelogEntry.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { MDXRemote } from "next-mdx-remote/rsc";
+import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
 	type ChangelogEntry as ChangelogEntryType,
@@ -62,13 +63,19 @@ export async function ChangelogEntry({ entry }: ChangelogEntryProps) {
 				</p>
 			)}
 
-			{/* Full MDX content */}
+			{/* Body. Curated entries compile as MDX (custom components); GitHub
+			    release bodies are plain Markdown, rendered without the MDX compiler
+			    so arbitrary text can never be parsed as MDX. */}
 			<div className="prose prose-invert max-w-none prose-headings:font-medium prose-headings:tracking-[-0.5px] prose-h2:text-xl prose-h2:mt-8 prose-h2:mb-4 prose-h3:text-lg prose-h3:mt-6 prose-h3:mb-3 prose-p:text-muted-foreground prose-p:leading-relaxed prose-li:text-muted-foreground prose-strong:text-foreground prose-a:text-foreground prose-a:underline prose-a:underline-offset-4 hover:prose-a:text-muted-foreground prose-hr:border-border prose-hr:my-8">
-				<MDXRemote
-					source={entry.content}
-					components={changelogMdxComponents}
-					options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
-				/>
+				{entry.source === "release" ? (
+					<ReactMarkdown remarkPlugins={[remarkGfm]}>{entry.content}</ReactMarkdown>
+				) : (
+					<MDXRemote
+						source={entry.content}
+						components={changelogMdxComponents}
+						options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
+					/>
+				)}
 			</div>
 		</article>
 	);

--- a/frontend/src/landing/src/app/changelog/page.tsx
+++ b/frontend/src/landing/src/app/changelog/page.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
 };
 
 export default async function ChangelogPage() {
-  const entries = getChangelogEntries();
+  const entries = await getChangelogEntries();
 
   return (
     <main className="relative min-h-screen">

--- a/frontend/src/landing/src/app/sitemap.ts
+++ b/frontend/src/landing/src/app/sitemap.ts
@@ -9,7 +9,7 @@ import { getAllPeople } from "@/lib/people";
 
 export const dynamic = "force-static";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const baseUrl = COMPANY.MARKETING_URL;
 
 	const staticPages: MetadataRoute.Sitemap = [
@@ -113,7 +113,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 		priority: 0.8,
 	}));
 
-	const changelogEntries = getChangelogEntries();
+	const changelogEntries = await getChangelogEntries();
 	const changelogPages: MetadataRoute.Sitemap = changelogEntries.map(
 		(entry) => ({
 			url: `${baseUrl}/changelog/${entry.slug}`,

--- a/frontend/src/landing/src/lib/changelog-utils.ts
+++ b/frontend/src/landing/src/lib/changelog-utils.ts
@@ -13,6 +13,12 @@ export interface ChangelogEntry {
 	date: string;
 	image?: string;
 	content: string;
+	/**
+	 * Where the body came from. "mdx" (curated content/docs) is compiled as MDX;
+	 * "release" (a GitHub release body) is plain Markdown and rendered through a
+	 * Markdown-only path so arbitrary text can never be parsed as MDX.
+	 */
+	source?: "mdx" | "release";
 	/** Draft entries (frontmatter `draft: true`) never render on the site. */
 	draft?: boolean;
 }

--- a/frontend/src/landing/src/lib/changelog.ts
+++ b/frontend/src/landing/src/lib/changelog.ts
@@ -12,9 +12,9 @@ export {
 
 const CHANGELOG_DIR = path.join(process.cwd(), "content/changelog");
 
-// Releases are pulled from GitHub so the changelog updates itself on each build
-// (the landing redeploys on push to main + a daily schedule). Curated MDX
-// entries in content/changelog still take precedence for the same version.
+// Releases are pulled from GitHub at build time, so the changelog refreshes
+// whenever the landing is redeployed (a push to main, or a manual deploy).
+// Curated MDX entries in content/changelog take precedence for the same version.
 const RELEASES_REPO = "AgentWrapper/agent-orchestrator";
 // Only stable vMAJOR.MINOR.PATCH tags — skips nightlies, per-PR prereleases,
 // and package tags like @composio/ao@x.
@@ -45,6 +45,7 @@ function parseFrontmatter(filePath: string): ChangelogEntry | null {
 			date: dateValue,
 			image: data.image,
 			content,
+			source: "mdx",
 			draft: data.draft === true,
 		};
 	} catch {
@@ -63,15 +64,24 @@ function getMdxEntries(): ChangelogEntry[] {
 		.map((file) => parseFrontmatter(path.join(CHANGELOG_DIR, file)))
 		.filter((entry): entry is ChangelogEntry => entry !== null && !entry.draft);
 }
+function isStableReleaseWithBody(r: GithubRelease): boolean {
+	return !r.draft && !r.prerelease && STABLE_TAG.test(r.tag_name) && (r.body ?? "").trim().length > 0;
+}
 
-// Release bodies are plain GitHub markdown, not MDX. Escape the constructs MDX
-// would otherwise try to evaluate (JSX tags, {expressions}) everywhere except
-// code spans, so an arbitrary release body can never break the build.
-function sanitizeMdx(markdown: string): string {
-	return markdown
-		.split(/(```[\s\S]*?```|`[^`\n]*`)/g)
-		.map((segment, i) => (i % 2 === 1 ? segment : segment.replace(/[<{}]/g, (c) => `\\${c}`)))
-		.join("");
+// A release body is plain GitHub Markdown, kept verbatim and rendered through a
+// Markdown-only path (source: "release") — it never touches the MDX compiler,
+// so arbitrary text (import/export lines, JSX, {expressions}) can't break it.
+function releaseToEntry(r: GithubRelease): ChangelogEntry {
+	const slug = slugify(r.tag_name);
+	return {
+		slug,
+		url: `/changelog/${slug}`,
+		title: r.name?.trim() || r.tag_name,
+		date: normalizeContentDate(r.published_at) as string,
+		content: r.body ?? "",
+		source: "release",
+		draft: false,
+	};
 }
 
 async function getReleaseEntries(): Promise<ChangelogEntry[]> {
@@ -90,21 +100,12 @@ async function getReleaseEntries(): Promise<ChangelogEntry[]> {
 			return [];
 		}
 		const releases = (await res.json()) as GithubRelease[];
-		return releases
-			.filter(
-				(r) => !r.draft && !r.prerelease && STABLE_TAG.test(r.tag_name) && (r.body ?? "").trim().length > 0,
-			)
-			.map((r) => {
-				const slug = slugify(r.tag_name);
-				return {
-					slug,
-					url: `/changelog/${slug}`,
-					title: r.name?.trim() || r.tag_name,
-					date: normalizeContentDate(r.published_at) as string,
-					content: sanitizeMdx(r.body ?? ""),
-					draft: false,
-				} satisfies ChangelogEntry;
-			});
+		// Single pass: filter + map together (no double iteration).
+		const entries: ChangelogEntry[] = [];
+		for (const r of releases) {
+			if (isStableReleaseWithBody(r)) entries.push(releaseToEntry(r));
+		}
+		return entries;
 	} catch {
 		return [];
 	}

--- a/frontend/src/landing/src/lib/changelog.ts
+++ b/frontend/src/landing/src/lib/changelog.ts
@@ -12,6 +12,23 @@ export {
 
 const CHANGELOG_DIR = path.join(process.cwd(), "content/changelog");
 
+// Releases are pulled from GitHub so the changelog updates itself on each build
+// (the landing redeploys on push to main + a daily schedule). Curated MDX
+// entries in content/changelog still take precedence for the same version.
+const RELEASES_REPO = "AgentWrapper/agent-orchestrator";
+// Only stable vMAJOR.MINOR.PATCH tags — skips nightlies, per-PR prereleases,
+// and package tags like @composio/ao@x.
+const STABLE_TAG = /^v\d+\.\d+\.\d+$/;
+
+interface GithubRelease {
+	tag_name: string;
+	name: string | null;
+	body: string | null;
+	published_at: string;
+	draft: boolean;
+	prerelease: boolean;
+}
+
 function parseFrontmatter(filePath: string): ChangelogEntry | null {
 	try {
 		const fileContent = fs.readFileSync(filePath, "utf-8");
@@ -35,38 +52,95 @@ function parseFrontmatter(filePath: string): ChangelogEntry | null {
 	}
 }
 
-export function getChangelogEntries(): ChangelogEntry[] {
+function getMdxEntries(): ChangelogEntry[] {
 	if (!fs.existsSync(CHANGELOG_DIR)) {
 		return [];
 	}
 
 	const files = fs.readdirSync(CHANGELOG_DIR).filter((f) => f.endsWith(".mdx"));
 
-	const entries = files
+	return files
 		.map((file) => parseFrontmatter(path.join(CHANGELOG_DIR, file)))
 		.filter((entry): entry is ChangelogEntry => entry !== null && !entry.draft);
-
-	return entries.sort((a, b) => {
-		const dateA = new Date(a.date);
-		const dateB = new Date(b.date);
-		return dateB.getTime() - dateA.getTime();
-	});
 }
 
-export function getChangelogEntry(slug: string): ChangelogEntry | undefined {
-	const filePath = path.join(CHANGELOG_DIR, `${slug}.mdx`);
+// Release bodies are plain GitHub markdown, not MDX. Escape the constructs MDX
+// would otherwise try to evaluate (JSX tags, {expressions}) everywhere except
+// code spans, so an arbitrary release body can never break the build.
+function sanitizeMdx(markdown: string): string {
+	return markdown
+		.split(/(```[\s\S]*?```|`[^`\n]*`)/g)
+		.map((segment, i) => (i % 2 === 1 ? segment : segment.replace(/[<{}]/g, (c) => `\\${c}`)))
+		.join("");
+}
 
-	if (!fs.existsSync(filePath)) {
-		return undefined;
+async function getReleaseEntries(): Promise<ChangelogEntry[]> {
+	try {
+		const token = process.env.GITHUB_TOKEN;
+		const res = await fetch(`https://api.github.com/repos/${RELEASES_REPO}/releases?per_page=100`, {
+			headers: {
+				Accept: "application/vnd.github+json",
+				"X-GitHub-Api-Version": "2022-11-28",
+				...(token ? { Authorization: `Bearer ${token}` } : {}),
+			},
+			// Baked in at build for the static export; the redeploy is the refresh.
+			next: { revalidate: 3600 },
+		});
+		if (!res.ok) {
+			return [];
+		}
+		const releases = (await res.json()) as GithubRelease[];
+		return releases
+			.filter(
+				(r) => !r.draft && !r.prerelease && STABLE_TAG.test(r.tag_name) && (r.body ?? "").trim().length > 0,
+			)
+			.map((r) => {
+				const slug = slugify(r.tag_name);
+				return {
+					slug,
+					url: `/changelog/${slug}`,
+					title: r.name?.trim() || r.tag_name,
+					date: normalizeContentDate(r.published_at) as string,
+					content: sanitizeMdx(r.body ?? ""),
+					draft: false,
+				} satisfies ChangelogEntry;
+			});
+	} catch {
+		return [];
 	}
-
-	const entry = parseFrontmatter(filePath) ?? undefined;
-	return entry?.draft ? undefined : entry;
 }
 
-export function getAllChangelogSlugs(): string[] {
-	// Drafts are excluded so they're never statically generated.
-	return getChangelogEntries().map((entry) => entry.slug);
+// The X.Y.Z inside a title/slug, used to dedupe a curated entry against its
+// eventual GitHub release.
+function versionKey(entry: ChangelogEntry): string | null {
+	const match = `${entry.title} ${entry.slug}`.match(/(\d+)\.(\d+)\.(\d+)/);
+	return match ? `${match[1]}.${match[2]}.${match[3]}` : null;
+}
+
+export async function getChangelogEntries(): Promise<ChangelogEntry[]> {
+	const mdx = getMdxEntries();
+	const releases = await getReleaseEntries();
+	const curatedVersions = new Set(mdx.map(versionKey).filter((v): v is string => v !== null));
+
+	const merged = [
+		...mdx,
+		...releases.filter((r) => {
+			const v = versionKey(r);
+			return v === null || !curatedVersions.has(v);
+		}),
+	];
+
+	return merged.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
+
+export async function getChangelogEntry(slug: string): Promise<ChangelogEntry | undefined> {
+	const entries = await getChangelogEntries();
+	return entries.find((entry) => entry.slug === slug);
+}
+
+export async function getAllChangelogSlugs(): Promise<string[]> {
+	const entries = await getChangelogEntries();
+	return entries.map((entry) => entry.slug);
 }
 
 export function extractToc(


### PR DESCRIPTION
the changelog page showed **"No updates yet."** the site's changelog now builds itself from GitHub Releases, with the curated 0.11.0 entry on top.

## what
- `getChangelogEntries` fetches stable `vX.Y.Z` releases from the GitHub API at build time and merges them with any curated `content/changelog` MDX (curated wins for the same version, so 0.11.0 "The Floor" stays until v0.11.0 is tagged)
- filters out nightlies, per-PR prereleases, package tags, and empty-body releases
- **release bodies render as plain Markdown** (`react-markdown` + `remark-gfm`), never through the MDX compiler — so arbitrary release text (`import`/`export` lines, JSX, `{expressions}`) can't break the static build. curated entries still compile as MDX; a `source` field picks the renderer
- restored the missing `/changelog/[slug]` detail route (`generateStaticParams`); the data fns went async (list page, `[slug]`, sitemap, `changelog.xml` updated)

## refresh mechanism
the changelog is baked in at build, so it updates whenever the landing is **redeployed** (a push to `main`, or a manual dispatch). making a newly published release appear automatically needs a `release: [published]` + `schedule` trigger on `deploy-landing.yml` — that workflow edit can't be pushed from this PR's token (no `workflow` scope), so it's a small follow-up a maintainer applies alongside.

## verification
- `next build` (`output: export`) generates `/changelog` + a detail page per entry (0.11.0 + v0.10.3 → v0.2.0)
- reproduced the reviewer's failing case (`export const metadata = {…}` in a body) through react-markdown: renders clean, text kept literal, no throw