### PR TITLE
fix: close session lifecycle gaps

### DIFF
--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -275,7 +275,13 @@ func (r *Runtime) Restart(ctx context.Context, handle ports.RuntimeHandle, cfg p
 	}
 	alive, err := r.IsAlive(ctx, handle)
 	if err != nil {
-		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: verify restarted session %s: %w", id, err)
+		// respawn-pane -k has already killed the old workload and launched the
+		// replacement. Preserve ownership of that applied side effect so the
+		// session manager can durably adopt the new generation even when this
+		// separate probe fails transiently (including caller cancellation).
+		return handle, &ports.RestartAppliedUnverifiedError{
+			Cause: fmt.Errorf("tmux runtime: verify restarted session %s: %w", id, err),
+		}
 	}
 	if !alive {
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: session %s exited during restart", id)

--- a/backend/internal/adapters/runtime/tmux/tmux.go
+++ b/backend/internal/adapters/runtime/tmux/tmux.go
@@ -201,8 +201,27 @@ func (r *Runtime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.Ru
 
 	launchCmd := buildLaunchCommand(cfg)
 	args := newSessionArgs(id, cfg.WorkspacePath, r.shell, launchCmd)
-	if _, err := r.run(ctx, args...); err != nil {
+	// new-session is the creation ownership boundary. Honor cancellation before
+	// dispatch, then let the local tmux client finish on its bounded detached
+	// context. If that client times out after dispatch, destroy the exact session
+	// name before returning so a possibly-created process cannot run without a
+	// durable owner.
+	if err := ctx.Err(); err != nil {
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: create session %s: %w", id, err)
+	}
+	if outcomeUncertain, err := r.runCommitted(ctx, args...); err != nil {
+		cause := fmt.Errorf("tmux runtime: create session %s: %w", id, err)
+		if !outcomeUncertain {
+			return ports.RuntimeHandle{}, cause
+		}
+		handle := ports.RuntimeHandle{ID: id}
+		if destroyErr := r.Destroy(context.WithoutCancel(ctx), handle); destroyErr != nil {
+			return ports.RuntimeHandle{}, errors.Join(
+				cause,
+				fmt.Errorf("tmux runtime: compensate outcome-uncertain create session %s: %w", id, destroyErr),
+			)
+		}
+		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: compensated outcome-uncertain create session %s: %w", id, err)
 	}
 	if err := r.verifyPaneWorkingDirectory(ctx, id, cfg.WorkspacePath); err != nil {
 		_ = r.Destroy(context.Background(), ports.RuntimeHandle{ID: id})
@@ -270,15 +289,35 @@ func (r *Runtime) Restart(ctx context.Context, handle ports.RuntimeHandle, cfg p
 	}
 
 	launchCmd := buildLaunchCommand(cfg)
-	if _, err := r.run(ctx, respawnPaneArgs(id, cfg.WorkspacePath, r.shell, launchCmd)...); err != nil {
+	// respawn-pane -k is destructive: once tmux begins it, cancelling the
+	// client can leave us unable to tell whether the server killed the old
+	// workload and launched the replacement. Define the cancellation boundary
+	// immediately before that command and let an accepted operation finish on
+	// its own bounded context. Verification is likewise detached and bounded so
+	// caller cancellation cannot discard a useful definitive result after the
+	// destructive boundary.
+	if err := ctx.Err(); err != nil {
 		return ports.RuntimeHandle{}, fmt.Errorf("tmux runtime: restart session %s: %w", id, err)
 	}
-	alive, err := r.IsAlive(ctx, handle)
+	if outcomeUncertain, err := r.runCommitted(ctx, respawnPaneArgs(id, cfg.WorkspacePath, r.shell, launchCmd)...); err != nil {
+		cause := fmt.Errorf("tmux runtime: restart session %s: %w", id, err)
+		if outcomeUncertain {
+			// The tmux client timed out after dispatch. The server may already
+			// have applied respawn-pane, so conservatively preserve ownership
+			// and require the session manager to compensate it rather than
+			// adopting a generation that may never have started.
+			return handle, &ports.RestartOutcomeUncertainError{Cause: cause}
+		}
+		return ports.RuntimeHandle{}, cause
+	}
+	verifyCtx, cancelVerify := context.WithTimeout(context.WithoutCancel(ctx), r.timeout)
+	defer cancelVerify()
+	alive, err := r.IsAlive(verifyCtx, handle)
 	if err != nil {
 		// respawn-pane -k has already killed the old workload and launched the
 		// replacement. Preserve ownership of that applied side effect so the
 		// session manager can durably adopt the new generation even when this
-		// separate probe fails transiently (including caller cancellation).
+		// separate probe fails transiently.
 		return handle, &ports.RestartAppliedUnverifiedError{
 			Cause: fmt.Errorf("tmux runtime: verify restarted session %s: %w", id, err),
 		}
@@ -549,6 +588,29 @@ func attachEnv(base []string) []string {
 // run wraps runner.Run with a per-call timeout context.
 func (r *Runtime) run(ctx context.Context, args ...string) ([]byte, error) {
 	return r.runCommand(ctx, r.binary, args...)
+}
+
+// runCommitted runs a destructive tmux command after its caller has accepted
+// the cancellation boundary. The command is isolated from caller cancellation
+// but remains bounded by the runtime timeout. A nil runner error wins a
+// simultaneous timeout race because it is definitive evidence that the tmux
+// client completed successfully.
+//
+// A runner error at the internal timeout remains inherently ambiguous: the
+// local tmux client may have timed out before or after the server applied the
+// command. outcomeUncertain tells the caller to retain ownership until it can
+// compensate the possible side effect.
+func (r *Runtime) runCommitted(ctx context.Context, args ...string) (outcomeUncertain bool, err error) {
+	cmdCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), r.timeout)
+	defer cancel()
+	out, err := r.runner.Run(cmdCtx, nil, r.binary, args...)
+	if err == nil {
+		return false, nil
+	}
+	if cmdCtx.Err() != nil {
+		return true, cmdCtx.Err()
+	}
+	return false, commandError{err: err, output: strings.TrimSpace(string(out))}
 }
 
 func (r *Runtime) runCommand(ctx context.Context, name string, args ...string) ([]byte, error) {

--- a/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
@@ -2,10 +2,13 @@ package tmux
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,13 +16,22 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
+func integrationSessionID(t *testing.T) string {
+	t.Helper()
+	var entropy [8]byte
+	if _, err := rand.Read(entropy[:]); err != nil {
+		t.Fatalf("generate tmux integration session id: %v", err)
+	}
+	return "ao-test-" + hex.EncodeToString(entropy[:])
+}
+
 func TestRuntimeIntegration(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux unavailable")
 	}
 
 	ctx := context.Background()
-	id := strings.ReplaceAll(t.Name(), "/", "_")
+	id := integrationSessionID(t)
 	r := New(Options{Timeout: 5 * time.Second})
 
 	// Ensure clean slate: ignore errors (session may not exist).
@@ -88,7 +100,7 @@ func TestRuntimeIntegrationExactSessionParsing(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	base := strings.ReplaceAll(t.Name(), "/", "_")
+	base := integrationSessionID(t)
 	longID := base + "_long"
 	prefixID := base
 
@@ -127,21 +139,110 @@ func TestRuntimeIntegrationExactSessionParsing(t *testing.T) {
 
 type failPostRespawnProbeRunner struct {
 	delegate      runner
-	probeArmed    bool
+	mu            sync.Mutex
+	probeTargets  map[string]int
 	probeFailures int
 }
 
 func (r *failPostRespawnProbeRunner) Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
-	if r.probeArmed && len(args) > 0 && args[0] == "has-session" {
-		r.probeArmed = false
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	target := commandTarget(args)
+	if len(args) > 0 && args[0] == "has-session" && r.probeTargets[target] > 0 {
+		r.probeTargets[target]--
+		if r.probeTargets[target] == 0 {
+			delete(r.probeTargets, target)
+		}
 		r.probeFailures++
 		return nil, errors.New("injected post-respawn probe failure")
 	}
 	out, err := r.delegate.Run(ctx, env, name, args...)
 	if err == nil && len(args) > 0 && args[0] == "respawn-pane" {
-		r.probeArmed = true
+		paneTarget := commandTarget(args)
+		if sessionTarget := strings.TrimSuffix(paneTarget, ":0.0"); sessionTarget != paneTarget {
+			if r.probeTargets == nil {
+				r.probeTargets = make(map[string]int)
+			}
+			r.probeTargets[exactSessionTarget(sessionTarget)]++
+		}
 	}
 	return out, err
+}
+
+func (r *failPostRespawnProbeRunner) ProbeFailures() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.probeFailures
+}
+
+func commandTarget(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-t" {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func TestFailPostRespawnProbeRunnerIsConcurrentAndTargetSpecific(t *testing.T) {
+	probeRunner := &failPostRespawnProbeRunner{
+		delegate: runnerFunc(func(_ context.Context, _ []string, _ string, _ ...string) ([]byte, error) {
+			return nil, nil
+		}),
+	}
+	if _, err := probeRunner.Run(context.Background(), nil, "tmux", respawnPaneArgs("target", "/tmp/ws", "/bin/sh", "true")...); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := probeRunner.Run(context.Background(), nil, "tmux", hasSessionArgs("other")...); err != nil {
+		t.Fatalf("unrelated probe consumed injected failure: %v", err)
+	}
+
+	const probes = 32
+	results := make(chan error, probes)
+	for i := 0; i < probes; i++ {
+		go func() {
+			_, err := probeRunner.Run(context.Background(), nil, "tmux", hasSessionArgs("target")...)
+			results <- err
+		}()
+	}
+	failures := 0
+	for i := 0; i < probes; i++ {
+		if err := <-results; err != nil {
+			if !strings.Contains(err.Error(), "injected post-respawn probe failure") {
+				t.Fatalf("unexpected probe error: %v", err)
+			}
+			failures++
+		}
+	}
+	if failures != 1 {
+		t.Fatalf("concurrent injected failures = %d, want 1", failures)
+	}
+	if got := probeRunner.ProbeFailures(); got != 1 {
+		t.Fatalf("recorded probe failures = %d, want 1", got)
+	}
+}
+
+func TestFailPostRespawnProbeRunnerTracksInterleavedTargets(t *testing.T) {
+	probeRunner := &failPostRespawnProbeRunner{
+		delegate: runnerFunc(func(_ context.Context, _ []string, _ string, _ ...string) ([]byte, error) {
+			return nil, nil
+		}),
+	}
+	for _, target := range []string{"target-a", "target-b"} {
+		if _, err := probeRunner.Run(context.Background(), nil, "tmux", respawnPaneArgs(target, "/tmp/ws", "/bin/sh", "true")...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, target := range []string{"target-a", "target-b"} {
+		if _, err := probeRunner.Run(context.Background(), nil, "tmux", hasSessionArgs(target)...); err == nil ||
+			!strings.Contains(err.Error(), "injected post-respawn probe failure") {
+			t.Fatalf("target %s probe error = %v, want its own injected failure", target, err)
+		}
+	}
+	if got := probeRunner.ProbeFailures(); got != 2 {
+		t.Fatalf("recorded interleaved probe failures = %d, want 2", got)
+	}
 }
 
 func TestRuntimeIntegrationRestartPreservesAppliedHandleWhenProbeFails(t *testing.T) {
@@ -150,7 +251,7 @@ func TestRuntimeIntegrationRestartPreservesAppliedHandleWhenProbeFails(t *testin
 	}
 
 	ctx := context.Background()
-	id := strings.ReplaceAll(t.Name(), "/", "_")
+	id := integrationSessionID(t)
 	r := New(Options{Timeout: 5 * time.Second})
 	probeRunner := &failPostRespawnProbeRunner{delegate: r.runner}
 	r.runner = probeRunner
@@ -181,8 +282,8 @@ func TestRuntimeIntegrationRestartPreservesAppliedHandleWhenProbeFails(t *testin
 	if !errors.As(err, &applied) {
 		t.Fatalf("Restart error = %v, want RestartAppliedUnverifiedError", err)
 	}
-	if probeRunner.probeFailures != 1 {
-		t.Fatalf("injected probe failures = %d, want 1", probeRunner.probeFailures)
+	if got := probeRunner.ProbeFailures(); got != 1 {
+		t.Fatalf("injected probe failures = %d, want 1", got)
 	}
 
 	alive, probeErr := r.IsAlive(ctx, restarted)
@@ -201,7 +302,7 @@ func TestRuntimeIntegrationSupervisedExitKeepsInteractiveShell(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	id := strings.ReplaceAll(t.Name(), "/", "_")
+	id := integrationSessionID(t)
 	const launchID = "launch-1"
 	r := New(Options{Timeout: 5 * time.Second})
 	tmuxID := SessionName(id)
@@ -311,5 +412,6 @@ func waitForOutput(t *testing.T, r *Runtime, h ports.RuntimeHandle, want string,
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+	t.Fatalf("timed out waiting for %q in tmux output: %q", want, out)
 	return out
 }

--- a/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_integration_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"strings"
@@ -121,6 +122,76 @@ func TestRuntimeIntegrationExactSessionParsing(t *testing.T) {
 	if prefixAlive {
 		_ = r.Destroy(ctx, h)
 		t.Fatal("prefix handle reported alive; tmux session matching is not exact")
+	}
+}
+
+type failPostRespawnProbeRunner struct {
+	delegate      runner
+	probeArmed    bool
+	probeFailures int
+}
+
+func (r *failPostRespawnProbeRunner) Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
+	if r.probeArmed && len(args) > 0 && args[0] == "has-session" {
+		r.probeArmed = false
+		r.probeFailures++
+		return nil, errors.New("injected post-respawn probe failure")
+	}
+	out, err := r.delegate.Run(ctx, env, name, args...)
+	if err == nil && len(args) > 0 && args[0] == "respawn-pane" {
+		r.probeArmed = true
+	}
+	return out, err
+}
+
+func TestRuntimeIntegrationRestartPreservesAppliedHandleWhenProbeFails(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux unavailable")
+	}
+
+	ctx := context.Background()
+	id := strings.ReplaceAll(t.Name(), "/", "_")
+	r := New(Options{Timeout: 5 * time.Second})
+	probeRunner := &failPostRespawnProbeRunner{delegate: r.runner}
+	r.runner = probeRunner
+	tmuxID := SessionName(id)
+	workspace := t.TempDir()
+	_ = r.Destroy(ctx, ports.RuntimeHandle{ID: tmuxID})
+	t.Cleanup(func() { _ = r.Destroy(context.Background(), ports.RuntimeHandle{ID: tmuxID}) })
+
+	h, err := r.Create(ctx, ports.RuntimeConfig{
+		SessionID:     domain.SessionID(id),
+		WorkspacePath: workspace,
+		Argv:          []string{"sh", "-c", "echo real-generation-one"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	waitForOutput(t, r, h, "real-generation-one", 5*time.Second)
+
+	restarted, err := r.Restart(ctx, h, ports.RuntimeConfig{
+		SessionID:     domain.SessionID(id),
+		WorkspacePath: workspace,
+		Argv:          []string{"sh", "-c", "echo real-generation-two"},
+	})
+	if restarted != h {
+		t.Fatalf("restart handle = %+v, want owned handle %+v", restarted, h)
+	}
+	var applied *ports.RestartAppliedUnverifiedError
+	if !errors.As(err, &applied) {
+		t.Fatalf("Restart error = %v, want RestartAppliedUnverifiedError", err)
+	}
+	if probeRunner.probeFailures != 1 {
+		t.Fatalf("injected probe failures = %d, want 1", probeRunner.probeFailures)
+	}
+
+	alive, probeErr := r.IsAlive(ctx, restarted)
+	if probeErr != nil || !alive {
+		t.Fatalf("real restarted tmux session = (%v, %v), want (true, nil)", alive, probeErr)
+	}
+	out := waitForOutput(t, r, restarted, "real-generation-two", 5*time.Second)
+	if !strings.Contains(out, "real-generation-two") {
+		t.Fatalf("restarted output = %q, want real-generation-two", out)
 	}
 }
 

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -28,6 +28,12 @@ type runnerCall struct {
 	args []string
 }
 
+type runnerFunc func(ctx context.Context, env []string, name string, args ...string) ([]byte, error)
+
+func (f runnerFunc) Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
+	return f(ctx, env, name, args...)
+}
+
 func (f *fakeRunner) Run(_ context.Context, env []string, name string, args ...string) ([]byte, error) {
 	f.calls = append(f.calls, runnerCall{env: append([]string(nil), env...), name: name, args: append([]string(nil), args...)})
 	var out []byte
@@ -422,6 +428,35 @@ func TestCreateDestroysAndReturnsErrorWhenNotAlive(t *testing.T) {
 	}
 }
 
+func TestCreateCompensatesOutcomeUncertainNewSession(t *testing.T) {
+	r, _ := newTestRuntime(0)
+	r.timeout = 10 * time.Millisecond
+	var calls []string
+	r.runner = runnerFunc(func(runCtx context.Context, _ []string, _ string, args ...string) ([]byte, error) {
+		calls = append(calls, args[0])
+		if args[0] == "new-session" {
+			<-runCtx.Done()
+			return nil, runCtx.Err()
+		}
+		return nil, nil
+	})
+
+	got, err := r.Create(context.Background(), ports.RuntimeConfig{
+		SessionID:     "sess-1",
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"codex"},
+	})
+	if got.ID != "" {
+		t.Fatalf("Create handle = %+v, want compensated empty handle", got)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Create error = %v, want context.DeadlineExceeded", err)
+	}
+	if want := []string{"new-session", "list-panes", "kill-session"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %#v, want uncertain create followed by exact cleanup %#v", calls, want)
+	}
+}
+
 // fakeRunnerSelectiveErr returns an exec.ExitError (carrying errOutput) for the
 // call whose tmux subcommand is exitErrOn, and succeeds for every other call.
 // Matching on the subcommand rather than a call index is deliberate: Create's
@@ -495,6 +530,164 @@ func TestRestartReturnsOwnedHandleWhenPostRespawnProbeIsInconclusive(t *testing.
 	}
 	if len(fr.calls) != 2 || fr.calls[0].args[0] != "respawn-pane" || fr.calls[1].args[0] != "has-session" {
 		t.Fatalf("calls = %#v, want respawn followed by probe", fr.calls)
+	}
+}
+
+func TestRestartDefinitiveRespawnErrorDoesNotClaimOwnership(t *testing.T) {
+	r := New(Options{Binary: "tmux-test", Timeout: time.Second, Shell: "/bin/sh"})
+	r.reapSessions = (&recordingReaper{}).reap
+	respawnErr := errors.New("tmux rejected respawn")
+	r.runner = runnerFunc(func(_ context.Context, _ []string, _ string, args ...string) ([]byte, error) {
+		if args[0] != "respawn-pane" {
+			t.Fatalf("unexpected command after definitive respawn failure: %v", args)
+		}
+		return []byte("bad target"), respawnErr
+	})
+
+	got, err := r.Restart(context.Background(), ports.RuntimeHandle{ID: "sess-1"}, ports.RuntimeConfig{
+		SessionID:     "sess-1",
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"codex"},
+	})
+	if got.ID != "" {
+		t.Fatalf("Restart handle = %+v, want no claimed ownership", got)
+	}
+	if !errors.Is(err, respawnErr) || !strings.Contains(err.Error(), "bad target") {
+		t.Fatalf("Restart error = %v, want definitive command error and output", err)
+	}
+	var applied *ports.RestartAppliedUnverifiedError
+	var uncertain *ports.RestartOutcomeUncertainError
+	if errors.As(err, &applied) || errors.As(err, &uncertain) {
+		t.Fatalf("definitive respawn error was classified as partial ownership: %v", err)
+	}
+}
+
+func TestRestartRejectsCancellationBeforeDestructiveBoundary(t *testing.T) {
+	r, _ := newTestRuntime(0)
+	called := false
+	r.runner = runnerFunc(func(_ context.Context, _ []string, _ string, _ ...string) ([]byte, error) {
+		called = true
+		return nil, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := r.Restart(ctx, ports.RuntimeHandle{ID: "sess-1"}, ports.RuntimeConfig{
+		SessionID:     "sess-1",
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"codex", "resume", "native-1"},
+	})
+	if got.ID != "" {
+		t.Fatalf("Restart handle = %+v, want no applied handle", got)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Restart error = %v, want context.Canceled", err)
+	}
+	if called {
+		t.Fatal("runner called after cancellation before destructive boundary")
+	}
+}
+
+func TestRestartCallerCancellationDoesNotInterruptAcceptedTransition(t *testing.T) {
+	r, _ := newTestRuntime(0)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var calls []string
+	var respawnContextErr error
+	var probeContextErr error
+	r.runner = runnerFunc(func(runCtx context.Context, _ []string, _ string, args ...string) ([]byte, error) {
+		calls = append(calls, args[0])
+		switch args[0] {
+		case "respawn-pane":
+			cancel()
+			respawnContextErr = runCtx.Err()
+			return nil, nil
+		case "has-session":
+			probeContextErr = runCtx.Err()
+			return nil, nil
+		default:
+			return nil, nil
+		}
+	})
+	handle := ports.RuntimeHandle{ID: "sess-1"}
+
+	got, err := r.Restart(ctx, handle, ports.RuntimeConfig{
+		SessionID:     "sess-1",
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"codex", "resume", "native-1"},
+	})
+	if got != handle {
+		t.Fatalf("Restart handle = %+v, want owned handle %+v", got, handle)
+	}
+	if err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	if respawnContextErr != nil {
+		t.Fatalf("respawn context was cancelled by caller: %v", respawnContextErr)
+	}
+	if probeContextErr != nil {
+		t.Fatalf("verification context was cancelled by caller: %v", probeContextErr)
+	}
+	if want := []string{"respawn-pane", "has-session"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestRestartSuccessfulRespawnWinsInternalDeadlineRace(t *testing.T) {
+	r, _ := newTestRuntime(0)
+	r.timeout = 10 * time.Millisecond
+	r.runner = runnerFunc(func(runCtx context.Context, _ []string, _ string, args ...string) ([]byte, error) {
+		if args[0] == "respawn-pane" {
+			<-runCtx.Done()
+			// A successful runner result is definitive even if the deadline
+			// became observable at the same instant.
+			return nil, nil
+		}
+		return nil, nil
+	})
+	handle := ports.RuntimeHandle{ID: "sess-1"}
+
+	got, err := r.Restart(context.Background(), handle, ports.RuntimeConfig{
+		SessionID:     "sess-1",
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"codex", "resume", "native-1"},
+	})
+	if err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	if got != handle {
+		t.Fatalf("Restart handle = %+v, want %+v", got, handle)
+	}
+}
+
+func TestRestartInternalTimeoutPreservesOutcomeUncertainOwnership(t *testing.T) {
+	r, _ := newTestRuntime(0)
+	r.timeout = 10 * time.Millisecond
+	calls := 0
+	r.runner = runnerFunc(func(runCtx context.Context, _ []string, _ string, _ ...string) ([]byte, error) {
+		calls++
+		<-runCtx.Done()
+		return nil, runCtx.Err()
+	})
+
+	got, err := r.Restart(context.Background(), ports.RuntimeHandle{ID: "sess-1"}, ports.RuntimeConfig{
+		SessionID:     "sess-1",
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"codex", "resume", "native-1"},
+	})
+	wantHandle := ports.RuntimeHandle{ID: "sess-1"}
+	if got != wantHandle {
+		t.Fatalf("Restart handle = %+v, want conservatively owned handle %+v", got, wantHandle)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Restart error = %v, want context.DeadlineExceeded", err)
+	}
+	var uncertain *ports.RestartOutcomeUncertainError
+	if !errors.As(err, &uncertain) {
+		t.Fatalf("ambiguous timeout error = %v, want RestartOutcomeUncertainError", err)
+	}
+	if calls != 1 {
+		t.Fatalf("runner calls = %d, want only the respawn attempt", calls)
 	}
 }
 

--- a/backend/internal/adapters/runtime/tmux/tmux_test.go
+++ b/backend/internal/adapters/runtime/tmux/tmux_test.go
@@ -18,6 +18,7 @@ import (
 type fakeRunner struct {
 	calls   []runnerCall
 	outputs [][]byte
+	errs    []error
 	err     error
 }
 
@@ -33,6 +34,13 @@ func (f *fakeRunner) Run(_ context.Context, env []string, name string, args ...s
 	if len(f.outputs) > 0 {
 		out = f.outputs[0]
 		f.outputs = f.outputs[1:]
+	}
+	if len(f.errs) > 0 {
+		err := f.errs[0]
+		f.errs = f.errs[1:]
+		if err != nil {
+			return out, err
+		}
 	}
 	if f.err != nil {
 		return out, f.err
@@ -461,6 +469,54 @@ func TestRestartRespawnsExistingPaneAndPreservesHandle(t *testing.T) {
 	}
 	if args := fr.calls[1].args; !reflect.DeepEqual(args, hasSessionArgs("sess-1")) {
 		t.Fatalf("liveness args = %#v, want %#v", args, hasSessionArgs("sess-1"))
+	}
+}
+
+func TestRestartReturnsOwnedHandleWhenPostRespawnProbeIsInconclusive(t *testing.T) {
+	r, fr := newTestRuntime(0)
+	handle := ports.RuntimeHandle{ID: "sess-1"}
+	probeErr := errors.New("tmux temporarily unavailable")
+	fr.errs = []error{nil, probeErr}
+
+	got, err := r.Restart(context.Background(), handle, ports.RuntimeConfig{
+		SessionID:     "sess-1",
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"codex", "resume", "native-1"},
+	})
+	if got != handle {
+		t.Fatalf("Restart handle = %+v, want owned handle %+v", got, handle)
+	}
+	var applied *ports.RestartAppliedUnverifiedError
+	if !errors.As(err, &applied) {
+		t.Fatalf("Restart error = %v, want RestartAppliedUnverifiedError", err)
+	}
+	if !errors.Is(err, probeErr) {
+		t.Fatalf("Restart error = %v, want wrapped probe error", err)
+	}
+	if len(fr.calls) != 2 || fr.calls[0].args[0] != "respawn-pane" || fr.calls[1].args[0] != "has-session" {
+		t.Fatalf("calls = %#v, want respawn followed by probe", fr.calls)
+	}
+}
+
+func TestRestartTreatsDefinitivelyMissingPostRespawnSessionAsFailure(t *testing.T) {
+	r, fr := newTestRuntime(0)
+	fr.outputs = [][]byte{nil, []byte("can't find session: sess-1")}
+	fr.errs = []error{nil, &exec.ExitError{}}
+
+	got, err := r.Restart(context.Background(), ports.RuntimeHandle{ID: "sess-1"}, ports.RuntimeConfig{
+		SessionID:     "sess-1",
+		WorkspacePath: "/tmp/ws",
+		Argv:          []string{"codex", "resume", "native-1"},
+	})
+	if got.ID != "" {
+		t.Fatalf("Restart handle = %+v, want no owned live handle", got)
+	}
+	if err == nil || !strings.Contains(err.Error(), "exited during restart") {
+		t.Fatalf("Restart error = %v, want definitive missing failure", err)
+	}
+	var applied *ports.RestartAppliedUnverifiedError
+	if errors.As(err, &applied) {
+		t.Fatalf("definitive missing error must not be applied-unverified: %v", err)
 	}
 }
 

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -816,6 +816,41 @@ func (m *Manager) MarkSpawned(ctx context.Context, id domain.SessionID, metadata
 	return m.store.UpdateSession(ctx, rec)
 }
 
+// MarkResumed conditionally commits a replacement agent generation inside an
+// existing live runtime. Unlike MarkSpawned, it never clears termination: the
+// record must still describe the exact live/exited generation that Resume
+// validated before it crossed the runtime side-effect boundary. A false result
+// means another lifecycle action won that race and the caller must not publish
+// this generation as authoritative.
+func (m *Manager) MarkResumed(ctx context.Context, id domain.SessionID, expectedRuntimeLaunchID string, metadata domain.SessionMetadata) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	defer m.finishLaunchLocked(id, strings.TrimSpace(metadata.RuntimeLaunchID))
+
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, fmt.Errorf("lifecycle: MarkResumed for unknown session %q", id)
+	}
+	if rec.IsTerminated ||
+		rec.Activity.State != domain.ActivityExited ||
+		rec.Metadata.RuntimeLaunchID != expectedRuntimeLaunchID {
+		return false, nil
+	}
+
+	now := m.clock()
+	rec.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: now}
+	rec.FirstSignalAt = time.Time{}
+	rec.Metadata = mergeMetadata(rec.Metadata, metadata)
+	rec.UpdatedAt = now
+	if err := m.store.UpdateSession(ctx, rec); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // MarkTerminated marks a session terminated without tearing down external resources.
 func (m *Manager) MarkTerminated(ctx context.Context, id domain.SessionID) error {
 	return m.mutate(ctx, id, func(cur domain.SessionRecord, now time.Time) (domain.SessionRecord, bool) {

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -617,6 +617,134 @@ func TestMarkSpawnedStoresRuntimeMetadata(t *testing.T) {
 	}
 }
 
+func TestMarkResumedCommitsOnlyExpectedLiveExitedGeneration(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*domain.SessionRecord)
+	}{
+		{
+			name: "terminated",
+			mutate: func(rec *domain.SessionRecord) {
+				rec.IsTerminated = true
+			},
+		},
+		{
+			name: "agent no longer exited",
+			mutate: func(rec *domain.SessionRecord) {
+				rec.Activity.State = domain.ActivityIdle
+			},
+		},
+		{
+			name: "generation changed",
+			mutate: func(rec *domain.SessionRecord) {
+				rec.Metadata.RuntimeLaunchID = "launch-other"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, st, _ := newManager()
+			rec := domain.SessionRecord{
+				ID:        "mer-1",
+				ProjectID: "mer",
+				Activity:  domain.Activity{State: domain.ActivityExited},
+				Metadata: domain.SessionMetadata{
+					RuntimeHandleID: "h1",
+					RuntimeLaunchID: "launch-old",
+				},
+			}
+			tt.mutate(&rec)
+			st.sessions[rec.ID] = rec
+
+			committed, err := m.MarkResumed(ctx, rec.ID, "launch-old", domain.SessionMetadata{
+				RuntimeHandleID: "h1",
+				RuntimeLaunchID: "launch-new",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if committed {
+				t.Fatal("MarkResumed committed after its expected state changed")
+			}
+			if got := st.sessions[rec.ID]; got != rec {
+				t.Fatalf("rejected resume mutated record:\n got %+v\nwant %+v", got, rec)
+			}
+		})
+	}
+}
+
+func TestMarkResumedCommitsExpectedGenerationAndReleasesLaunchFence(t *testing.T) {
+	m, st, _ := newManager()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Activity:  domain.Activity{State: domain.ActivityExited},
+		Metadata: domain.SessionMetadata{
+			RuntimeHandleID: "h1",
+			RuntimeLaunchID: "launch-old",
+		},
+	}
+	if err := m.PrepareLaunch("mer-1", "launch-new"); err != nil {
+		t.Fatal(err)
+	}
+
+	committed, err := m.MarkResumed(ctx, "mer-1", "launch-old", domain.SessionMetadata{
+		RuntimeHandleID: "h1",
+		RuntimeLaunchID: "launch-new",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !committed {
+		t.Fatal("MarkResumed rejected unchanged live/exited generation")
+	}
+	got := st.sessions["mer-1"]
+	if got.IsTerminated || got.Activity.State != domain.ActivityIdle || got.Metadata.RuntimeLaunchID != "launch-new" {
+		t.Fatalf("resumed record = %+v", got)
+	}
+	if _, pending := m.pendingLaunches["mer-1"]; pending {
+		t.Fatal("committed resume left launch fence pending")
+	}
+}
+
+func TestMarkResumedRejectsAcceptedTerminalIntentAndReleasesLaunchFence(t *testing.T) {
+	m, st, _ := newManager()
+	st.sessions["mer-1"] = domain.SessionRecord{
+		ID:        "mer-1",
+		ProjectID: "mer",
+		Activity:  domain.Activity{State: domain.ActivityExited},
+		Metadata: domain.SessionMetadata{
+			RuntimeHandleID: "h1",
+			RuntimeLaunchID: "launch-old",
+		},
+	}
+	if err := m.PrepareLaunch("mer-1", "launch-new"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.MarkTerminated(ctx, "mer-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	committed, err := m.MarkResumed(ctx, "mer-1", "launch-old", domain.SessionMetadata{
+		RuntimeHandleID: "h1",
+		RuntimeLaunchID: "launch-new",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if committed {
+		t.Fatal("MarkResumed cleared accepted terminal intent")
+	}
+	got := st.sessions["mer-1"]
+	if !got.IsTerminated || got.Activity.State != domain.ActivityExited || got.Metadata.RuntimeLaunchID != "launch-old" {
+		t.Fatalf("terminal record changed by rejected resume: %+v", got)
+	}
+	if _, pending := m.pendingLaunches["mer-1"]; pending {
+		t.Fatal("rejected resume left launch fence pending")
+	}
+}
+
 // TestMarkSpawned_StampsUTCActivity locks the lifecycle clock to UTC so
 // activity-driven timestamps match the session manager's spawn timestamps. A
 // local clock here left `ao session get` showing created in UTC but updated in

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -92,10 +92,12 @@ type Runtime interface {
 //
 // A restart can cross an ownership boundary before every verification step has
 // completed. Once the replacement command has been applied, an implementation
-// must return the owned handle even if a later probe fails. It reports that
-// partial-success state with RestartAppliedUnverifiedError so callers can
-// durably adopt or explicitly compensate the replacement instead of treating
-// it as though no side effect occurred.
+// must return the owned handle even if a later probe fails, using
+// RestartAppliedUnverifiedError so the caller can durably adopt or compensate
+// it. If a timeout after dispatch makes the destructive command's outcome
+// uncertain, the implementation must instead return the owned handle with
+// RestartOutcomeUncertainError so the caller can compensate it without falsely
+// adopting an unproven generation.
 type RuntimeRestarter interface {
 	Restart(ctx context.Context, handle RuntimeHandle, cfg RuntimeConfig) (RuntimeHandle, error)
 }
@@ -117,6 +119,29 @@ func (e *RestartAppliedUnverifiedError) Error() string {
 }
 
 func (e *RestartAppliedUnverifiedError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// RestartOutcomeUncertainError means the destructive restart command was
+// dispatched, but its client timed out before learning whether the runtime
+// applied it. The RuntimeRestarter must return the possibly affected handle
+// alongside this error. Callers must compensate that handle and must not adopt
+// the unproven generation as durable state.
+type RestartOutcomeUncertainError struct {
+	Cause error
+}
+
+func (e *RestartOutcomeUncertainError) Error() string {
+	if e == nil || e.Cause == nil {
+		return "runtime restart outcome uncertain after dispatch"
+	}
+	return fmt.Sprintf("runtime restart outcome uncertain after dispatch: %v", e.Cause)
+}
+
+func (e *RestartOutcomeUncertainError) Unwrap() error {
 	if e == nil {
 		return nil
 	}

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -89,8 +89,38 @@ type Runtime interface {
 // RuntimeRestarter is an optional runtime capability for replacing the process
 // inside an existing terminal session. Implementations should preserve the
 // handle when possible so attached clients do not need a new terminal identity.
+//
+// A restart can cross an ownership boundary before every verification step has
+// completed. Once the replacement command has been applied, an implementation
+// must return the owned handle even if a later probe fails. It reports that
+// partial-success state with RestartAppliedUnverifiedError so callers can
+// durably adopt or explicitly compensate the replacement instead of treating
+// it as though no side effect occurred.
 type RuntimeRestarter interface {
 	Restart(ctx context.Context, handle RuntimeHandle, cfg RuntimeConfig) (RuntimeHandle, error)
+}
+
+// RestartAppliedUnverifiedError means a runtime restart's destructive launch
+// step succeeded, but a later verification probe failed inconclusively. The
+// RuntimeRestarter must return the handle it still owns alongside this error.
+// A definitive observation that the restarted runtime is missing must use an
+// ordinary error instead.
+type RestartAppliedUnverifiedError struct {
+	Cause error
+}
+
+func (e *RestartAppliedUnverifiedError) Error() string {
+	if e == nil || e.Cause == nil {
+		return "runtime restart applied but could not be verified"
+	}
+	return fmt.Sprintf("runtime restart applied but could not be verified: %v", e.Cause)
+}
+
+func (e *RestartAppliedUnverifiedError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
 }
 
 // RuntimeConfig is the spec for launching a session's process in a Runtime.

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -221,6 +221,10 @@ const (
 	sendConfirmPollInterval    = 300 * time.Millisecond
 	sendConfirmAttemptDeadline = 2 * time.Second
 	sendConfirmMaxAttempts     = 3
+	// runtimeReplacementTimeout bounds the full fallback Destroy/Create
+	// transition for runtimes without an atomic Restart capability. It is
+	// intentionally separate from the subsequent durable-finalization budget.
+	runtimeReplacementTimeout = 30 * time.Second
 	// launchFinalizeTimeout bounds the cancellation-detached phase after a
 	// runtime Create/Restart has crossed its external side-effect boundary.
 	// Durable generation adoption (or compensation) must finish even when the
@@ -1206,6 +1210,22 @@ func (m *Manager) restartRuntime(ctx context.Context, handle ports.RuntimeHandle
 			if restartErr == nil {
 				return restarted, nil
 			}
+			var uncertain *ports.RestartOutcomeUncertainError
+			if errors.As(restartErr, &uncertain) {
+				if restarted.ID == "" {
+					return ports.RuntimeHandle{}, fmt.Errorf("restart reported uncertain outcome without an owned handle: %w", restartErr)
+				}
+				compensateCtx, cancelCompensate := context.WithTimeout(context.WithoutCancel(ctx), launchFinalizeTimeout)
+				destroyErr := m.runtime.Destroy(compensateCtx, restarted)
+				cancelCompensate()
+				if destroyErr != nil {
+					return ports.RuntimeHandle{}, errors.Join(
+						restartErr,
+						fmt.Errorf("compensate outcome-uncertain restart for handle %s: %w", restarted.ID, destroyErr),
+					)
+				}
+				return ports.RuntimeHandle{}, fmt.Errorf("compensated outcome-uncertain restart for handle %s: %w", restarted.ID, restartErr)
+			}
 			var applied *ports.RestartAppliedUnverifiedError
 			if !errors.As(restartErr, &applied) {
 				return ports.RuntimeHandle{}, restartErr
@@ -1217,9 +1237,30 @@ func (m *Manager) restartRuntime(ctx context.Context, handle ports.RuntimeHandle
 				"sessionID", cfg.SessionID, "handle", restarted.ID, "error", applied)
 			return restarted, nil
 		}
-		if err := m.runtime.Destroy(ctx, handle); err != nil {
+		// The fallback is necessarily a destructive two-step transition. Honor
+		// cancellation before crossing that boundary, then detach and bound the
+		// whole Destroy/Create sequence so caller cancellation cannot strand the
+		// durable row between the two operations. The legacy Runtime interface
+		// cannot distinguish a Destroy error returned after an applied side
+		// effect; adapters that can do an atomic replacement should implement
+		// RuntimeRestarter instead.
+		if err := ctx.Err(); err != nil {
+			return ports.RuntimeHandle{}, err
+		}
+		replaceCtx, cancelReplace := context.WithTimeout(context.WithoutCancel(ctx), runtimeReplacementTimeout)
+		defer cancelReplace()
+		if err := m.runtime.Destroy(replaceCtx, handle); err != nil {
 			return ports.RuntimeHandle{}, fmt.Errorf("destroy existing runtime: %w", err)
 		}
+		replacement, createErr := m.runtime.Create(replaceCtx, cfg)
+		if createErr != nil {
+			// Keep the exited generation and its stable handle in the durable
+			// row. The next Resume will probe that handle as dead and can retry
+			// Create; marking it terminated here would invent user intent and
+			// move a transient launch failure into Archive.
+			return ports.RuntimeHandle{}, fmt.Errorf("create replacement runtime after destroying existing runtime: %w", createErr)
+		}
+		return replacement, nil
 	}
 	return m.runtime.Create(ctx, cfg)
 }
@@ -2077,46 +2118,70 @@ func (m *Manager) Cleanup(ctx context.Context, project domain.ProjectID) (Cleanu
 		return CleanupResult{}, fmt.Errorf("cleanup %s: %w", project, err)
 	}
 	result := CleanupResult{Cleaned: make([]domain.SessionID, 0, len(recs)), Skipped: []CleanupSkip{}}
-	for _, rec := range recs {
-		if !rec.IsTerminated {
+	for _, candidate := range recs {
+		if !candidate.IsTerminated {
 			continue
 		}
-		ws := workspaceInfo(rec)
-		if ws.Path == "" {
-			m.cleanupSystemPromptDir(rec.ID)
-			continue
+		cleaned, skipped, cleanupErr := m.cleanupTerminalSession(ctx, project, candidate.ID)
+		if cleanupErr != nil {
+			return result, fmt.Errorf("cleanup %s session %s: %w", project, candidate.ID, cleanupErr)
 		}
-		if h := runtimeHandle(rec.Metadata); h.ID != "" {
-			_ = m.runtime.Destroy(ctx, h) // best effort; usually already gone
+		if skipped != nil {
+			result.Skipped = append(result.Skipped, *skipped)
 		}
-		if rows, ok, rowErr := m.workspaceProjectRows(ctx, rec); rowErr != nil {
-			m.logger.Warn("cleanup: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
-			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: "workspace teardown failed"})
-			continue
-		} else if ok {
-			if _, err := m.destroyWorkspaceProjectRows(ctx, rows); err != nil {
-				if !errors.Is(err, ports.ErrWorkspaceDirty) {
-					m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
-				}
-				result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(err)})
-				continue
-			}
-			m.cleanupAgentWorkspace(ctx, rec, ws.Path)
-		} else if err := m.workspace.Destroy(ctx, ws); err != nil {
-			if !errors.Is(err, ports.ErrWorkspaceDirty) {
-				// The public reason stays a fixed string (the raw error carries
-				// internal filesystem paths); the full cause lands here.
-				m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
-			}
-			result.Skipped = append(result.Skipped, CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(err)})
-			continue
-		} else {
-			m.cleanupAgentWorkspace(ctx, rec, ws.Path)
+		if cleaned {
+			result.Cleaned = append(result.Cleaned, candidate.ID)
 		}
-		m.cleanupSystemPromptDir(rec.ID)
-		result.Cleaned = append(result.Cleaned, rec.ID)
 	}
 	return result, nil
+}
+
+// cleanupTerminalSession joins the same per-session operation boundary as
+// Restore/Kill/Resume, then re-reads the candidate selected by Cleanup's
+// snapshot. A restore that wins the lock can therefore make the row live before
+// cleanup touches either its newly restored runtime or workspace.
+func (m *Manager) cleanupTerminalSession(ctx context.Context, project domain.ProjectID, id domain.SessionID) (bool, *CleanupSkip, error) {
+	unlock := m.lockSessionOperation(id)
+	defer unlock()
+
+	rec, ok, err := m.store.GetSession(ctx, id)
+	if err != nil {
+		return false, nil, err
+	}
+	if !ok || !rec.IsTerminated || (project != "" && rec.ProjectID != project) {
+		return false, nil, nil
+	}
+	ws := workspaceInfo(rec)
+	if ws.Path == "" {
+		m.cleanupSystemPromptDir(rec.ID)
+		return false, nil, nil
+	}
+	if h := runtimeHandle(rec.Metadata); h.ID != "" {
+		_ = m.runtime.Destroy(ctx, h) // best effort; usually already gone
+	}
+	if rows, workspaceProject, rowErr := m.workspaceProjectRows(ctx, rec); rowErr != nil {
+		m.logger.Warn("cleanup: workspace rows failed", "sessionID", rec.ID, "error", rowErr)
+		return false, &CleanupSkip{SessionID: rec.ID, Reason: "workspace teardown failed"}, nil
+	} else if workspaceProject {
+		if _, err := m.destroyWorkspaceProjectRows(ctx, rows); err != nil {
+			if !errors.Is(err, ports.ErrWorkspaceDirty) {
+				m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
+			}
+			return false, &CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(err)}, nil
+		}
+		m.cleanupAgentWorkspace(ctx, rec, ws.Path)
+	} else if err := m.workspace.Destroy(ctx, ws); err != nil {
+		if !errors.Is(err, ports.ErrWorkspaceDirty) {
+			// The public reason stays a fixed string (the raw error carries
+			// internal filesystem paths); the full cause lands here.
+			m.logger.Warn("cleanup: workspace teardown failed", "sessionID", rec.ID, "path", ws.Path, "error", err)
+		}
+		return false, &CleanupSkip{SessionID: rec.ID, Reason: cleanupSkipReason(err)}, nil
+	} else {
+		m.cleanupAgentWorkspace(ctx, rec, ws.Path)
+	}
+	m.cleanupSystemPromptDir(rec.ID)
+	return true, nil, nil
 }
 
 // cleanupSkipReason renders a workspace teardown refusal as a short

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -90,6 +90,7 @@ type lifecycleRecorder interface {
 	PrepareLaunch(id domain.SessionID, launchID string) error
 	CancelLaunch(id domain.SessionID, launchID string)
 	MarkSpawned(ctx context.Context, id domain.SessionID, metadata domain.SessionMetadata) error
+	MarkResumed(ctx context.Context, id domain.SessionID, expectedRuntimeLaunchID string, metadata domain.SessionMetadata) (bool, error)
 	MarkTerminated(ctx context.Context, id domain.SessionID) error
 }
 
@@ -180,6 +181,11 @@ type Manager struct {
 	newLaunchID func() string
 	resumeMu    sync.Mutex
 	resuming    map[domain.SessionID]struct{}
+	// operationLocks serialize resource/lifecycle transitions for one session.
+	// Resume keeps the separate resuming reservation above so a duplicate Resume
+	// can still fail immediately instead of waiting behind the first request.
+	operationMu    sync.Mutex
+	operationLocks map[domain.SessionID]*sessionOperationLock
 	// sendConfirm bounds the best-effort post-send confirmation that the session
 	// actually became active (the agent accepted the prompt). New fills in the
 	// sendConfirm* defaults; tests in this package shrink the timings directly.
@@ -204,12 +210,22 @@ type sendConfirmConfig struct {
 	maxAttempts int
 }
 
+type sessionOperationLock struct {
+	locker sync.Locker
+	users  int
+}
+
 // Production sendConfirm bounds: 3 Enters total (1 from Send + 2 re-sends),
 // each given 2s to flip the session active, polled every 300ms.
 const (
 	sendConfirmPollInterval    = 300 * time.Millisecond
 	sendConfirmAttemptDeadline = 2 * time.Second
 	sendConfirmMaxAttempts     = 3
+	// launchFinalizeTimeout bounds the cancellation-detached phase after a
+	// runtime Create/Restart has crossed its external side-effect boundary.
+	// Durable generation adoption (or compensation) must finish even when the
+	// initiating HTTP request has already gone away.
+	launchFinalizeTimeout = 15 * time.Second
 )
 
 // Deps are the collaborators a Session Manager needs; New wires them together.
@@ -243,17 +259,18 @@ type Deps struct {
 // time.Now when Deps.Clock is nil.
 func New(d Deps) *Manager {
 	m := &Manager{
-		runtime:     d.Runtime,
-		agents:      d.Agents,
-		workspace:   d.Workspace,
-		store:       d.Store,
-		lcm:         d.Lifecycle,
-		dataDir:     d.DataDir,
-		clock:       d.Clock,
-		lookPath:    d.LookPath,
-		executable:  d.Executable,
-		newLaunchID: d.NewLaunchID,
-		resuming:    make(map[domain.SessionID]struct{}),
+		runtime:        d.Runtime,
+		agents:         d.Agents,
+		workspace:      d.Workspace,
+		store:          d.Store,
+		lcm:            d.Lifecycle,
+		dataDir:        d.DataDir,
+		clock:          d.Clock,
+		lookPath:       d.LookPath,
+		executable:     d.Executable,
+		newLaunchID:    d.NewLaunchID,
+		resuming:       make(map[domain.SessionID]struct{}),
+		operationLocks: make(map[domain.SessionID]*sessionOperationLock),
 		sendConfirm: sendConfirmConfig{
 			pollInterval:    sendConfirmPollInterval,
 			attemptDeadline: sendConfirmAttemptDeadline,
@@ -731,6 +748,32 @@ func (m *Manager) RollbackSpawn(ctx context.Context, id domain.SessionID) (delet
 	return m.rollbackSpawn(ctx, id)
 }
 
+func (m *Manager) lockSessionOperation(id domain.SessionID) func() {
+	m.operationMu.Lock()
+	if m.operationLocks == nil {
+		m.operationLocks = make(map[domain.SessionID]*sessionOperationLock)
+	}
+	entry := m.operationLocks[id]
+	if entry == nil {
+		entry = &sessionOperationLock{locker: &sync.Mutex{}}
+		m.operationLocks[id] = entry
+	}
+	entry.users++
+	m.operationMu.Unlock()
+
+	entry.locker.Lock()
+	return func() {
+		entry.locker.Unlock()
+
+		m.operationMu.Lock()
+		defer m.operationMu.Unlock()
+		entry.users--
+		if entry.users == 0 && m.operationLocks[id] == entry {
+			delete(m.operationLocks, id)
+		}
+	}
+}
+
 // Kill tears down the runtime and workspace, then records terminal intent with
 // the LCM. A workspace teardown refused by the worktree-remove safety
 // (uncommitted work) is never forced: Kill succeeds with freed=false,
@@ -742,6 +785,9 @@ func (m *Manager) RollbackSpawn(ctx context.Context, id domain.SessionID) (delet
 // available destroy steps are skipped so it can be cleaned up from the
 // dashboard.
 func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
+	unlock := m.lockSessionOperation(id)
+	defer unlock()
+
 	rec, ok, err := m.store.GetSession(ctx, id)
 	if err != nil {
 		return false, fmt.Errorf("kill %s: %w", id, err)
@@ -822,6 +868,9 @@ func (m *Manager) Kill(ctx context.Context, id domain.SessionID) (bool, error) {
 // This deliberately does not write a session_worktrees row: those rows are
 // boot-restore markers, and a replaced orchestrator must stay terminated.
 func (m *Manager) RetireForReplacement(ctx context.Context, id domain.SessionID) error {
+	unlock := m.lockSessionOperation(id)
+	defer unlock()
+
 	rec, ok, err := m.store.GetSession(ctx, id)
 	if err != nil {
 		return fmt.Errorf("retire replacement %s: %w", id, err)
@@ -921,6 +970,9 @@ func (m *Manager) retireWorkspaceProjectForReplacement(ctx context.Context, rec 
 // runs before any durable session write, so a failure never resurrects the row
 // or destroys the worktree (it may hold the agent's prior work).
 func (m *Manager) RestoreWithMode(ctx context.Context, id domain.SessionID) (RestoreResult, error) {
+	unlock := m.lockSessionOperation(id)
+	defer unlock()
+
 	rec, ok, err := m.store.GetSession(ctx, id)
 	if err != nil {
 		return RestoreResult{}, fmt.Errorf("restore %s: %w", id, err)
@@ -970,6 +1022,9 @@ func (m *Manager) ResumeAgentWithMode(ctx context.Context, id domain.SessionID) 
 	}
 	defer m.endAgentResume(id)
 
+	unlock := m.lockSessionOperation(id)
+	defer unlock()
+
 	rec, ok, err := m.store.GetSession(ctx, id)
 	if err != nil {
 		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, err)
@@ -983,14 +1038,15 @@ func (m *Manager) ResumeAgentWithMode(ctx context.Context, id domain.SessionID) 
 	if rec.Activity.State != domain.ActivityExited {
 		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrAgentNotExited)
 	}
-	meta := rec.Metadata
-	if meta.WorkspacePath == "" || meta.Branch == "" || meta.RuntimeHandleID == "" {
-		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrIncompleteHandle)
-	}
-
 	project, err := m.loadProject(ctx, rec.ProjectID)
 	if err != nil {
 		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, err)
+	}
+	meta := rec.Metadata
+	if meta.WorkspacePath == "" ||
+		meta.RuntimeHandleID == "" ||
+		(meta.Branch == "" && project.Kind.WithDefault() != domain.ProjectKindScratch) {
+		return RestoreResult{}, fmt.Errorf("resume agent %s: %w", id, ErrIncompleteHandle)
 	}
 	ws := ports.WorkspaceInfo{
 		Path:      meta.WorkspacePath,
@@ -1079,6 +1135,9 @@ func (m *Manager) relaunchSession(ctx context.Context, operation string, rec dom
 		m.cleanupSystemPromptDir(rec.ID)
 		return RestoreResult{}, fmt.Errorf("%s %s: runtime: %w", operation, rec.ID, err)
 	}
+	finalizeCtx, cancelFinalize := context.WithTimeout(context.WithoutCancel(ctx), launchFinalizeTimeout)
+	defer cancelFinalize()
+
 	metadata := domain.SessionMetadata{
 		Branch:            ws.Branch,
 		WorkspacePath:     ws.Path,
@@ -1088,8 +1147,23 @@ func (m *Manager) relaunchSession(ctx context.Context, operation string, rec dom
 		AgentSessionID:    rec.Metadata.AgentSessionID,
 		Prompt:            rec.Metadata.Prompt,
 	}
-	if err := m.lcm.MarkSpawned(ctx, rec.ID, metadata); err != nil {
-		_ = m.runtime.Destroy(ctx, handle)
+	if restartHandle == nil {
+		err = m.lcm.MarkSpawned(finalizeCtx, rec.ID, metadata)
+	} else {
+		var committed bool
+		committed, err = m.lcm.MarkResumed(finalizeCtx, rec.ID, rec.Metadata.RuntimeLaunchID, metadata)
+		if err == nil && !committed {
+			err = errors.New("session changed while resume was starting")
+		}
+	}
+	if err != nil {
+		compensateCtx, cancelCompensate := context.WithTimeout(context.WithoutCancel(ctx), launchFinalizeTimeout)
+		destroyErr := m.runtime.Destroy(compensateCtx, handle)
+		cancelCompensate()
+		if destroyErr != nil {
+			m.logger.Warn("relaunch: compensate runtime after durable commit failure",
+				"operation", operation, "sessionID", rec.ID, "handle", handle.ID, "error", destroyErr)
+		}
 		m.cleanupSystemPromptDir(rec.ID)
 		return RestoreResult{}, fmt.Errorf("%s %s: completed: %w", operation, rec.ID, err)
 	}
@@ -1105,14 +1179,16 @@ func (m *Manager) relaunchSession(ctx context.Context, operation string, rec dom
 			Config:           agentConfig,
 			Permissions:      agentConfig.Permissions,
 		}
-		if err := m.deliverAfterStartPrompt(ctx, agent, launchCfg, handle, rec.ID, rec.Metadata.Prompt); err != nil {
-			_ = m.runtime.Destroy(ctx, handle)
-			_ = m.lcm.MarkTerminated(ctx, rec.ID)
+		if err := m.deliverAfterStartPrompt(finalizeCtx, agent, launchCfg, handle, rec.ID, rec.Metadata.Prompt); err != nil {
+			compensateCtx, cancelCompensate := context.WithTimeout(context.WithoutCancel(ctx), launchFinalizeTimeout)
+			_ = m.runtime.Destroy(compensateCtx, handle)
+			_ = m.lcm.MarkTerminated(compensateCtx, rec.ID)
+			cancelCompensate()
 			m.cleanupSystemPromptDir(rec.ID)
 			return RestoreResult{}, fmt.Errorf("%s %s: deliver prompt: %w", operation, rec.ID, err)
 		}
 	}
-	updated, err := m.getRecord(ctx, rec.ID)
+	updated, err := m.getRecord(finalizeCtx, rec.ID)
 	if err != nil {
 		return RestoreResult{}, err
 	}
@@ -1126,7 +1202,20 @@ func (m *Manager) restartRuntime(ctx context.Context, handle ports.RuntimeHandle
 	}
 	if alive {
 		if restarter, ok := m.runtime.(ports.RuntimeRestarter); ok {
-			return restarter.Restart(ctx, handle, cfg)
+			restarted, restartErr := restarter.Restart(ctx, handle, cfg)
+			if restartErr == nil {
+				return restarted, nil
+			}
+			var applied *ports.RestartAppliedUnverifiedError
+			if !errors.As(restartErr, &applied) {
+				return ports.RuntimeHandle{}, restartErr
+			}
+			if restarted.ID == "" {
+				return ports.RuntimeHandle{}, fmt.Errorf("restart reported applied without an owned handle: %w", restartErr)
+			}
+			m.logger.Warn("resume: runtime restart applied but verification was inconclusive",
+				"sessionID", cfg.SessionID, "handle", restarted.ID, "error", applied)
+			return restarted, nil
 		}
 		if err := m.runtime.Destroy(ctx, handle); err != nil {
 			return ports.RuntimeHandle{}, fmt.Errorf("destroy existing runtime: %w", err)

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -252,6 +252,54 @@ func (r *blockingDestroyRestartRuntime) Destroy(ctx context.Context, handle port
 	return r.fakeRuntime.Destroy(ctx, handle)
 }
 
+type blockingCreateRuntime struct {
+	*fakeRuntime
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (r *blockingCreateRuntime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
+	close(r.entered)
+	select {
+	case <-r.release:
+	case <-ctx.Done():
+		return ports.RuntimeHandle{}, ctx.Err()
+	}
+	return r.fakeRuntime.Create(ctx, cfg)
+}
+
+type cancelAfterDestroyRuntime struct {
+	*fakeRuntime
+	cancel       context.CancelFunc
+	createCtxErr error
+}
+
+func (r *cancelAfterDestroyRuntime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error {
+	if err := r.fakeRuntime.Destroy(ctx, handle); err != nil {
+		return err
+	}
+	r.cancel()
+	return nil
+}
+
+func (r *cancelAfterDestroyRuntime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
+	r.createCtxErr = ctx.Err()
+	return r.fakeRuntime.Create(ctx, cfg)
+}
+
+type callbackCreateRuntime struct {
+	*fakeRuntime
+	onCreate func(ports.RuntimeHandle)
+}
+
+func (r *callbackCreateRuntime) Create(ctx context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
+	handle, err := r.fakeRuntime.Create(ctx, cfg)
+	if err == nil && r.onCreate != nil {
+		r.onCreate(handle)
+	}
+	return handle, err
+}
+
 type observedLocker struct {
 	mu        sync.Mutex
 	attempted chan struct{}
@@ -1116,6 +1164,45 @@ func TestResumeAgent_CompensatesAppliedRestartWhenDurableAdoptionIsRejected(t *t
 	}
 }
 
+func TestResumeAgent_CompensatesOutcomeUncertainRestartWithoutAdoptingGeneration(t *testing.T) {
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	runtime := &fakeRestartRuntime{
+		fakeRuntime:   baseRuntime,
+		restartErr:    &ports.RestartOutcomeUncertainError{Cause: context.DeadlineExceeded},
+		handleOnError: true,
+	}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	runtime.onRestart = cancelRequest
+
+	if _, err := m.ResumeAgentWithMode(requestCtx, "mer-1"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Resume error = %v, want outcome-uncertain deadline", err)
+	}
+	if requestCtx.Err() != context.Canceled {
+		t.Fatalf("request context error = %v, want canceled", requestCtx.Err())
+	}
+	if baseRuntime.destroyed != 1 || !reflect.DeepEqual(baseRuntime.destroyedIDs, []string{"tmux-mer-1"}) {
+		t.Fatalf("uncertain restart compensation = %d ids=%v, want owned handle once",
+			baseRuntime.destroyed, baseRuntime.destroyedIDs)
+	}
+	if baseRuntime.destroyCtxErr != nil {
+		t.Fatalf("uncertain restart compensation inherited caller cancellation: %v", baseRuntime.destroyCtxErr)
+	}
+	got := st.sessions["mer-1"]
+	if got.IsTerminated || got.Activity.State != domain.ActivityExited ||
+		got.Metadata.RuntimeHandleID != "tmux-mer-1" || got.Metadata.RuntimeLaunchID != "launch-old" {
+		t.Fatalf("uncertain restart changed durable generation: %+v", got)
+	}
+	lcm := m.lcm.(*fakeLCM)
+	if lcm.completed != 0 {
+		t.Fatalf("uncertain restart completed durable generation: %d", lcm.completed)
+	}
+	if !reflect.DeepEqual(lcm.cancelled, []string{"mer-1:launch-new"}) {
+		t.Fatalf("uncertain restart launch cleanup = %v, want pending generation released", lcm.cancelled)
+	}
+}
+
 func TestResumeAgent_FallsBackToRuntimeRecreateWithoutRestartCapability(t *testing.T) {
 	runtime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
 	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
@@ -1129,6 +1216,106 @@ func TestResumeAgent_FallsBackToRuntimeRecreateWithoutRestartCapability(t *testi
 	}
 	if got := st.sessions["mer-1"].Metadata.RuntimeHandleID; got != "h1" {
 		t.Fatalf("fallback runtime handle = %q, want h1", got)
+	}
+}
+
+func TestResumeAgent_FallbackReplacementSurvivesCallerCancellationAfterDestroy(t *testing.T) {
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	runtime := &cancelAfterDestroyRuntime{fakeRuntime: baseRuntime, cancel: cancelRequest}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+
+	result, err := m.ResumeAgentWithMode(requestCtx, "mer-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requestCtx.Err() != context.Canceled {
+		t.Fatalf("request context error = %v, want canceled", requestCtx.Err())
+	}
+	if runtime.createCtxErr != nil {
+		t.Fatalf("replacement Create inherited caller cancellation: %v", runtime.createCtxErr)
+	}
+	if baseRuntime.destroyed != 1 || baseRuntime.created != 1 {
+		t.Fatalf("fallback runtime lifecycle: created=%d destroyed=%d, want one each",
+			baseRuntime.created, baseRuntime.destroyed)
+	}
+	got := st.sessions["mer-1"]
+	if got.IsTerminated || got.Activity.State != domain.ActivityIdle ||
+		got.Metadata.RuntimeHandleID != "h1" || got.Metadata.RuntimeLaunchID != "launch-new" {
+		t.Fatalf("cancellation-safe fallback resume = %+v", got)
+	}
+	if result.Session.Metadata.RuntimeHandleID != "h1" {
+		t.Fatalf("returned replacement handle = %q, want h1", result.Session.Metadata.RuntimeHandleID)
+	}
+}
+
+func TestResumeAgent_FallbackCreateFailureRemainsExitedAndRetryable(t *testing.T) {
+	createFailure := errors.New("replacement unavailable")
+	runtime := &fakeRuntime{
+		aliveByHandle: map[string]bool{"tmux-mer-1": true},
+		createErr:     createFailure,
+	}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+	lcm := m.lcm.(*fakeLCM)
+
+	if _, err := m.ResumeAgentWithMode(ctx, "mer-1"); !errors.Is(err, createFailure) {
+		t.Fatalf("Resume error = %v, want replacement Create failure", err)
+	}
+	got := st.sessions["mer-1"]
+	if got.IsTerminated || got.Activity.State != domain.ActivityExited ||
+		got.Metadata.RuntimeHandleID != "tmux-mer-1" || got.Metadata.RuntimeLaunchID != "launch-old" {
+		t.Fatalf("failed fallback changed retryable exited generation: %+v", got)
+	}
+	if runtime.destroyed != 1 || runtime.created != 0 {
+		t.Fatalf("failed fallback runtime lifecycle: created=%d destroyed=%d", runtime.created, runtime.destroyed)
+	}
+	if !reflect.DeepEqual(lcm.cancelled, []string{"mer-1:launch-new"}) {
+		t.Fatalf("failed fallback launch cleanup = %v, want pending generation released", lcm.cancelled)
+	}
+
+	// ConPTY removes the destroyed handle from its registry, so the next Resume
+	// observes it as dead and can retry Create without another Destroy.
+	runtime.aliveByHandle["tmux-mer-1"] = false
+	runtime.createErr = nil
+	if _, err := m.ResumeAgentWithMode(ctx, "mer-1"); err != nil {
+		t.Fatalf("retry Resume: %v", err)
+	}
+	got = st.sessions["mer-1"]
+	if got.IsTerminated || got.Activity.State != domain.ActivityIdle ||
+		got.Metadata.RuntimeHandleID != "h1" || got.Metadata.RuntimeLaunchID != "launch-new" {
+		t.Fatalf("retried fallback resume = %+v", got)
+	}
+	if runtime.destroyed != 1 || runtime.created != 1 {
+		t.Fatalf("retry runtime lifecycle: created=%d destroyed=%d, want create without second destroy",
+			runtime.created, runtime.destroyed)
+	}
+}
+
+func TestResumeAgent_FallbackReplacementIsCompensatedWhenCommitIsRejected(t *testing.T) {
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	runtime := &callbackCreateRuntime{fakeRuntime: baseRuntime}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+	runtime.onCreate = func(ports.RuntimeHandle) {
+		rec := st.sessions["mer-1"]
+		rec.IsTerminated = true
+		st.sessions["mer-1"] = rec
+	}
+
+	if _, err := m.ResumeAgentWithMode(ctx, "mer-1"); err == nil || !strings.Contains(err.Error(), "session changed") {
+		t.Fatalf("Resume error = %v, want rejected durable adoption", err)
+	}
+	if baseRuntime.created != 1 || baseRuntime.destroyed != 2 ||
+		!reflect.DeepEqual(baseRuntime.destroyedIDs, []string{"tmux-mer-1", "h1"}) {
+		t.Fatalf("fallback compensation: created=%d destroyed=%d ids=%v",
+			baseRuntime.created, baseRuntime.destroyed, baseRuntime.destroyedIDs)
+	}
+	got := st.sessions["mer-1"]
+	if !got.IsTerminated || got.Activity.State != domain.ActivityExited ||
+		got.Metadata.RuntimeHandleID != "tmux-mer-1" || got.Metadata.RuntimeLaunchID != "launch-old" {
+		t.Fatalf("rejected fallback adoption changed terminal record: %+v", got)
 	}
 }
 
@@ -1196,6 +1383,25 @@ func TestResumeAgent_RejectsConcurrentRequest(t *testing.T) {
 	close(runtime.release)
 	if err := <-firstDone; err != nil {
 		t.Fatalf("first resume: %v", err)
+	}
+}
+
+func TestSessionOperationLock_DifferentSessionsProceedIndependently(t *testing.T) {
+	m, _, _, _ := newManager()
+	unlockFirst := m.lockSessionOperation("mer-1")
+	defer unlockFirst()
+
+	secondDone := make(chan struct{})
+	go func() {
+		unlockSecond := m.lockSessionOperation("mer-2")
+		unlockSecond()
+		close(secondDone)
+	}()
+
+	select {
+	case <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatal("operation on mer-2 blocked behind unrelated mer-1 operation")
 	}
 }
 
@@ -2323,6 +2529,148 @@ func TestCleanup_ReclaimsTerminalWorkspaces(t *testing.T) {
 	}
 	if ws.destroyed != 1 {
 		t.Fatal("live workspace must not be destroyed")
+	}
+}
+
+func TestCleanupRestoreRace_RestoreWinsAndCleanupSkipsFreshLiveResources(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	seedTerminal(st, "mer-1", domain.SessionMetadata{
+		WorkspacePath:   "/ws/mer-1",
+		Branch:          "ao/mer-1",
+		RuntimeHandleID: "old-handle",
+		AgentSessionID:  "agent-x",
+		RuntimeLaunchID: "launch-old",
+	})
+	baseRuntime := &fakeRuntime{}
+	runtime := &blockingCreateRuntime{
+		fakeRuntime: baseRuntime,
+		entered:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	ws := &fakeWorkspace{}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m := New(Deps{
+		Runtime: runtime, Agents: singleAgent{agent: agent}, Workspace: ws, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+		LookPath:    func(string) (string, error) { return "/bin/true", nil },
+		Executable:  func() (string, error) { return "/opt/ao", nil },
+		NewLaunchID: func() string { return "launch-new" },
+	})
+	operationLock := &observedLocker{attempted: make(chan struct{}, 2)}
+	m.operationLocks["mer-1"] = &sessionOperationLock{locker: operationLock}
+
+	restoreDone := make(chan error, 1)
+	go func() {
+		_, err := m.RestoreWithMode(ctx, "mer-1")
+		restoreDone <- err
+	}()
+	<-operationLock.attempted
+	<-runtime.entered
+
+	type cleanupCall struct {
+		result CleanupResult
+		err    error
+	}
+	cleanupDone := make(chan cleanupCall, 1)
+	go func() {
+		result, err := m.Cleanup(ctx, "mer")
+		cleanupDone <- cleanupCall{result: result, err: err}
+	}()
+	// Cleanup took its terminal-session snapshot and reached the shared lock
+	// while Restore still owns it and has not committed the live generation.
+	<-operationLock.attempted
+
+	close(runtime.release)
+	if err := <-restoreDone; err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	cleanup := <-cleanupDone
+	if cleanup.err != nil {
+		t.Fatalf("Cleanup: %v", cleanup.err)
+	}
+	if len(cleanup.result.Cleaned) != 0 || len(cleanup.result.Skipped) != 0 {
+		t.Fatalf("Cleanup result = %+v, want restored session skipped", cleanup.result)
+	}
+	if baseRuntime.destroyed != 0 || ws.destroyed != 0 {
+		t.Fatalf("Cleanup destroyed restored resources: runtime=%d workspace=%d",
+			baseRuntime.destroyed, ws.destroyed)
+	}
+	got := st.sessions["mer-1"]
+	if got.IsTerminated || got.Activity.State != domain.ActivityIdle ||
+		got.Metadata.RuntimeHandleID != "h1" || got.Metadata.RuntimeLaunchID != "launch-new" {
+		t.Fatalf("restored session after overlapping Cleanup = %+v", got)
+	}
+}
+
+func TestCleanupRestoreRace_CleanupWinsBeforeRestoreRecreatesResources(t *testing.T) {
+	st := newFakeStore()
+	st.projects["mer"] = domain.ProjectRecord{ID: "mer", Config: testRoleAgents()}
+	seedTerminal(st, "mer-1", domain.SessionMetadata{
+		WorkspacePath:   "/ws/mer-1",
+		Branch:          "ao/mer-1",
+		RuntimeHandleID: "old-handle",
+		AgentSessionID:  "agent-x",
+		RuntimeLaunchID: "launch-old",
+	})
+	baseRuntime := &fakeRuntime{}
+	runtime := &blockingDestroyRestartRuntime{
+		fakeRestartRuntime: &fakeRestartRuntime{fakeRuntime: baseRuntime},
+		entered:            make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+	ws := &fakeWorkspace{}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m := New(Deps{
+		Runtime: runtime, Agents: singleAgent{agent: agent}, Workspace: ws, Store: st,
+		Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st},
+		LookPath:    func(string) (string, error) { return "/bin/true", nil },
+		Executable:  func() (string, error) { return "/opt/ao", nil },
+		NewLaunchID: func() string { return "launch-new" },
+	})
+	operationLock := &observedLocker{attempted: make(chan struct{}, 2)}
+	m.operationLocks["mer-1"] = &sessionOperationLock{locker: operationLock}
+
+	type cleanupCall struct {
+		result CleanupResult
+		err    error
+	}
+	cleanupDone := make(chan cleanupCall, 1)
+	go func() {
+		result, err := m.Cleanup(ctx, "mer")
+		cleanupDone <- cleanupCall{result: result, err: err}
+	}()
+	<-operationLock.attempted
+	<-runtime.entered
+
+	restoreDone := make(chan error, 1)
+	go func() {
+		_, err := m.RestoreWithMode(ctx, "mer-1")
+		restoreDone <- err
+	}()
+	// Restore is queued while Cleanup still owns the operation boundary.
+	<-operationLock.attempted
+
+	close(runtime.release)
+	cleanup := <-cleanupDone
+	if cleanup.err != nil {
+		t.Fatalf("Cleanup: %v", cleanup.err)
+	}
+	if !reflect.DeepEqual(cleanup.result.Cleaned, []domain.SessionID{"mer-1"}) ||
+		len(cleanup.result.Skipped) != 0 {
+		t.Fatalf("Cleanup result = %+v, want mer-1 cleaned", cleanup.result)
+	}
+	if err := <-restoreDone; err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if baseRuntime.destroyed != 1 || baseRuntime.created != 1 || ws.destroyed != 1 {
+		t.Fatalf("serialized resource lifecycle: runtime created=%d destroyed=%d workspace destroyed=%d",
+			baseRuntime.created, baseRuntime.destroyed, ws.destroyed)
+	}
+	got := st.sessions["mer-1"]
+	if got.IsTerminated || got.Activity.State != domain.ActivityIdle ||
+		got.Metadata.RuntimeHandleID != "h1" || got.Metadata.RuntimeLaunchID != "launch-new" {
+		t.Fatalf("session after Cleanup then Restore = %+v", got)
 	}
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -158,6 +159,22 @@ func (l *fakeLCM) MarkSpawned(_ context.Context, id domain.SessionID, metadata d
 	l.store.sessions[id] = rec
 	return nil
 }
+func (l *fakeLCM) MarkResumed(ctx context.Context, id domain.SessionID, expectedRuntimeLaunchID string, metadata domain.SessionMetadata) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	rec := l.store.sessions[id]
+	if rec.IsTerminated ||
+		rec.Activity.State != domain.ActivityExited ||
+		rec.Metadata.RuntimeLaunchID != expectedRuntimeLaunchID {
+		return false, nil
+	}
+	l.completed++
+	rec.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: time.Now()}
+	rec.Metadata = metadata
+	l.store.sessions[id] = rec
+	return true, nil
+}
 func (l *fakeLCM) MarkTerminated(_ context.Context, id domain.SessionID) error {
 	if l.terminated == nil {
 		l.terminated = map[domain.SessionID]int{}
@@ -182,6 +199,7 @@ type fakeRuntime struct {
 	aliveByHandle map[string]bool
 	aliveErr      error
 	destroyedIDs  []string
+	destroyCtxErr error
 }
 
 type fakeRestartRuntime struct {
@@ -189,6 +207,7 @@ type fakeRestartRuntime struct {
 	restarted     int
 	restartHandle ports.RuntimeHandle
 	restartErr    error
+	handleOnError bool
 	onRestart     func()
 }
 
@@ -200,6 +219,9 @@ func (r *fakeRestartRuntime) Restart(_ context.Context, handle ports.RuntimeHand
 	r.restartHandle = handle
 	r.lastCfg = cfg
 	if r.restartErr != nil {
+		if r.handleOnError {
+			return handle, r.restartErr
+		}
 		return ports.RuntimeHandle{}, r.restartErr
 	}
 	return handle, nil
@@ -218,6 +240,32 @@ func (r *blockingRestartRuntime) Restart(_ context.Context, handle ports.Runtime
 	return handle, nil
 }
 
+type blockingDestroyRestartRuntime struct {
+	*fakeRestartRuntime
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (r *blockingDestroyRestartRuntime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error {
+	r.entered <- struct{}{}
+	<-r.release
+	return r.fakeRuntime.Destroy(ctx, handle)
+}
+
+type observedLocker struct {
+	mu        sync.Mutex
+	attempted chan struct{}
+}
+
+func (l *observedLocker) Lock() {
+	l.attempted <- struct{}{}
+	l.mu.Lock()
+}
+
+func (l *observedLocker) Unlock() {
+	l.mu.Unlock()
+}
+
 func (r *fakeRuntime) Create(_ context.Context, cfg ports.RuntimeConfig) (ports.RuntimeHandle, error) {
 	if r.createErr != nil {
 		return ports.RuntimeHandle{}, r.createErr
@@ -226,9 +274,10 @@ func (r *fakeRuntime) Create(_ context.Context, cfg ports.RuntimeConfig) (ports.
 	r.created++
 	return ports.RuntimeHandle{ID: "h1"}, nil
 }
-func (r *fakeRuntime) Destroy(_ context.Context, handle ports.RuntimeHandle) error {
+func (r *fakeRuntime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error {
 	r.destroyed++
 	r.destroyedIDs = append(r.destroyedIDs, handle.ID)
+	r.destroyCtxErr = ctx.Err()
 	return r.destroyErr
 }
 func (r *fakeRuntime) IsAlive(_ context.Context, handle ports.RuntimeHandle) (bool, error) {
@@ -955,6 +1004,118 @@ func TestResumeAgent_RestartsRuntimeWithManagedGeneration(t *testing.T) {
 	}
 }
 
+func TestResumeAgent_AllowsBranchlessScratchSession(t *testing.T) {
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	runtime := &fakeRestartRuntime{fakeRuntime: baseRuntime}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+	project := st.projects["mer"]
+	project.Kind = domain.ProjectKindScratch
+	st.projects["mer"] = project
+	rec := st.sessions["mer-1"]
+	rec.Metadata.Branch = ""
+	st.sessions["mer-1"] = rec
+
+	result, err := m.ResumeAgentWithMode(ctx, "mer-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.restarted != 1 {
+		t.Fatalf("runtime restarts = %d, want 1", runtime.restarted)
+	}
+	if got := st.sessions["mer-1"]; got.IsTerminated ||
+		got.Activity.State != domain.ActivityIdle ||
+		got.Metadata.Branch != "" ||
+		got.Metadata.RuntimeLaunchID != "launch-new" {
+		t.Fatalf("branchless scratch resume = %+v", got)
+	}
+	if result.Mode != RestoreModeNative {
+		t.Fatalf("resume mode = %q, want native", result.Mode)
+	}
+}
+
+func TestResumeAgent_RequiresBranchForNonScratchSession(t *testing.T) {
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	runtime := &fakeRestartRuntime{fakeRuntime: baseRuntime}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+	rec := st.sessions["mer-1"]
+	rec.Metadata.Branch = ""
+	st.sessions["mer-1"] = rec
+
+	if _, err := m.ResumeAgentWithMode(ctx, "mer-1"); !errors.Is(err, ErrIncompleteHandle) {
+		t.Fatalf("Resume error = %v, want ErrIncompleteHandle", err)
+	}
+	if runtime.restarted != 0 || baseRuntime.created != 0 || baseRuntime.destroyed != 0 {
+		t.Fatalf("invalid non-scratch resume touched runtime: restarted=%d created=%d destroyed=%d",
+			runtime.restarted, baseRuntime.created, baseRuntime.destroyed)
+	}
+}
+
+func TestResumeAgent_AdoptsAppliedRestartAfterProbeFailureAndCallerCancel(t *testing.T) {
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	runtime := &fakeRestartRuntime{
+		fakeRuntime:   baseRuntime,
+		restartErr:    &ports.RestartAppliedUnverifiedError{Cause: context.Canceled},
+		handleOnError: true,
+	}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	runtime.onRestart = cancelRequest
+
+	result, err := m.ResumeAgentWithMode(requestCtx, "mer-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requestCtx.Err() != context.Canceled {
+		t.Fatalf("request context error = %v, want canceled", requestCtx.Err())
+	}
+	got := st.sessions["mer-1"]
+	if got.IsTerminated || got.Activity.State != domain.ActivityIdle || got.Metadata.RuntimeLaunchID != "launch-new" {
+		t.Fatalf("applied restart was not durably adopted: %+v", got)
+	}
+	if baseRuntime.destroyed != 0 {
+		t.Fatalf("adopted applied restart was compensated: destroyed=%d", baseRuntime.destroyed)
+	}
+	if result.Session.Metadata.RuntimeLaunchID != "launch-new" {
+		t.Fatalf("returned launch ID = %q, want launch-new", result.Session.Metadata.RuntimeLaunchID)
+	}
+}
+
+func TestResumeAgent_CompensatesAppliedRestartWhenDurableAdoptionIsRejected(t *testing.T) {
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	runtime := &fakeRestartRuntime{
+		fakeRuntime:   baseRuntime,
+		restartErr:    &ports.RestartAppliedUnverifiedError{Cause: errors.New("probe timed out")},
+		handleOnError: true,
+	}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	runtime.onRestart = func() {
+		rec := st.sessions["mer-1"]
+		rec.IsTerminated = true
+		st.sessions["mer-1"] = rec
+		cancelRequest()
+	}
+
+	if _, err := m.ResumeAgentWithMode(requestCtx, "mer-1"); err == nil || !strings.Contains(err.Error(), "session changed") {
+		t.Fatalf("Resume error = %v, want rejected durable adoption", err)
+	}
+	if baseRuntime.destroyed != 1 || !reflect.DeepEqual(baseRuntime.destroyedIDs, []string{"tmux-mer-1"}) {
+		t.Fatalf("compensating destroys = %d ids=%v, want restarted handle once",
+			baseRuntime.destroyed, baseRuntime.destroyedIDs)
+	}
+	if baseRuntime.destroyCtxErr != nil {
+		t.Fatalf("compensating destroy inherited canceled request context: %v", baseRuntime.destroyCtxErr)
+	}
+	got := st.sessions["mer-1"]
+	if !got.IsTerminated || got.Activity.State != domain.ActivityExited || got.Metadata.RuntimeLaunchID != "launch-old" {
+		t.Fatalf("rejected adoption changed terminal record: %+v", got)
+	}
+}
+
 func TestResumeAgent_FallsBackToRuntimeRecreateWithoutRestartCapability(t *testing.T) {
 	runtime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
 	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
@@ -1035,6 +1196,104 @@ func TestResumeAgent_RejectsConcurrentRequest(t *testing.T) {
 	close(runtime.release)
 	if err := <-firstDone; err != nil {
 		t.Fatalf("first resume: %v", err)
+	}
+}
+
+func TestResumeKillRace_ResumeStartsFirstThenKillWinsTerminalState(t *testing.T) {
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	runtime := &blockingRestartRuntime{
+		fakeRuntime: baseRuntime,
+		entered:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, runtime, agent)
+	operationLock := &observedLocker{attempted: make(chan struct{}, 2)}
+	m.operationLocks["mer-1"] = &sessionOperationLock{locker: operationLock}
+
+	resumeDone := make(chan error, 1)
+	go func() {
+		_, err := m.ResumeAgentWithMode(ctx, "mer-1")
+		resumeDone <- err
+	}()
+	<-operationLock.attempted
+	<-runtime.entered
+
+	killDone := make(chan error, 1)
+	go func() {
+		_, err := m.Kill(ctx, "mer-1")
+		killDone <- err
+	}()
+	// The second lock attempt proves Kill reached the shared operation boundary
+	// while Resume still owns it inside the blocked runtime restart.
+	<-operationLock.attempted
+
+	close(runtime.release)
+	if err := <-resumeDone; err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if err := <-killDone; err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	got := st.sessions["mer-1"]
+	if !got.IsTerminated || got.Activity.State != domain.ActivityExited {
+		t.Fatalf("Kill did not remain authoritative after overlapping Resume: %+v", got)
+	}
+	if baseRuntime.destroyed != 1 {
+		t.Fatalf("runtime destroys = %d, want Kill to destroy resumed runtime once", baseRuntime.destroyed)
+	}
+	m.operationMu.Lock()
+	remainingLocks := len(m.operationLocks)
+	m.operationMu.Unlock()
+	if remainingLocks != 0 {
+		t.Fatalf("idle session operation locks = %d, want 0", remainingLocks)
+	}
+}
+
+func TestResumeKillRace_KillStartsFirstPreventsRuntimeRecreation(t *testing.T) {
+	baseRuntime := &fakeRuntime{aliveByHandle: map[string]bool{"tmux-mer-1": true}}
+	restartRuntime := &fakeRestartRuntime{fakeRuntime: baseRuntime}
+	blockingRuntime := &blockingDestroyRestartRuntime{
+		fakeRestartRuntime: restartRuntime,
+		entered:            make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+	agent := supervisedLaunchAgent{launchArgvAgent{argv: []string{"codex", "resume", "agent-x"}}}
+	m, st, _ := newExitedResumeManager(t, blockingRuntime, agent)
+	operationLock := &observedLocker{attempted: make(chan struct{}, 2)}
+	m.operationLocks["mer-1"] = &sessionOperationLock{locker: operationLock}
+
+	killDone := make(chan error, 1)
+	go func() {
+		_, err := m.Kill(ctx, "mer-1")
+		killDone <- err
+	}()
+	<-operationLock.attempted
+	<-blockingRuntime.entered
+
+	resumeDone := make(chan error, 1)
+	go func() {
+		_, err := m.ResumeAgentWithMode(ctx, "mer-1")
+		resumeDone <- err
+	}()
+	// Resume reserves itself before attempting this lock, so observing the
+	// second attempt proves it is queued behind Kill without timing or sleeps.
+	<-operationLock.attempted
+
+	close(blockingRuntime.release)
+	if err := <-killDone; err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if err := <-resumeDone; !errors.Is(err, ErrTerminated) {
+		t.Fatalf("Resume error = %v, want ErrTerminated", err)
+	}
+	got := st.sessions["mer-1"]
+	if !got.IsTerminated || got.Activity.State != domain.ActivityExited {
+		t.Fatalf("Resume cleared Kill terminal intent: %+v", got)
+	}
+	if restartRuntime.restarted != 0 || baseRuntime.created != 0 {
+		t.Fatalf("Resume recreated runtime after Kill: restarted=%d created=%d",
+			restartRuntime.restarted, baseRuntime.created)
 	}
 }
 

--- a/backend/internal/storage/sqlite/gen/sessions.sql.go
+++ b/backend/internal/storage/sqlite/gen/sessions.sql.go
@@ -337,33 +337,32 @@ UPDATE sessions SET
     activity_state = ?, activity_last_at = ?, first_signal_at = ?, is_terminated = ?,
     branch = ?, workspace_path = ?, workspace_repo_path = ?, runtime_handle_id = ?,
     runtime_launch_id = ?, agent_session_id = ?, prompt = ?,
-    preview_url = ?, preview_revision = ?, terminate_on_pr_merge = ?,
-    cleanup_generation = ?, updated_at = ?
+    preview_url = ?, preview_revision = ?, cleanup_generation = ?,
+    updated_at = ?
 WHERE id = ?
 `
 
 type UpdateSessionParams struct {
-	IssueID            domain.IssueID
-	Kind               domain.SessionKind
-	Harness            domain.AgentHarness
-	DisplayName        string
-	ActivityState      domain.ActivityState
-	ActivityLastAt     time.Time
-	FirstSignalAt      sql.NullTime
-	IsTerminated       bool
-	Branch             string
-	WorkspacePath      string
-	WorkspaceRepoPath  string
-	RuntimeHandleID    string
-	RuntimeLaunchID    string
-	AgentSessionID     string
-	Prompt             string
-	PreviewURL         string
-	PreviewRevision    int64
-	TerminateOnPRMerge bool
-	CleanupGeneration  int64
-	UpdatedAt          time.Time
-	ID                 domain.SessionID
+	IssueID           domain.IssueID
+	Kind              domain.SessionKind
+	Harness           domain.AgentHarness
+	DisplayName       string
+	ActivityState     domain.ActivityState
+	ActivityLastAt    time.Time
+	FirstSignalAt     sql.NullTime
+	IsTerminated      bool
+	Branch            string
+	WorkspacePath     string
+	WorkspaceRepoPath string
+	RuntimeHandleID   string
+	RuntimeLaunchID   string
+	AgentSessionID    string
+	Prompt            string
+	PreviewURL        string
+	PreviewRevision   int64
+	CleanupGeneration int64
+	UpdatedAt         time.Time
+	ID                domain.SessionID
 }
 
 func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) error {
@@ -385,7 +384,6 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) er
 		arg.Prompt,
 		arg.PreviewURL,
 		arg.PreviewRevision,
-		arg.TerminateOnPRMerge,
 		arg.CleanupGeneration,
 		arg.UpdatedAt,
 		arg.ID,

--- a/backend/internal/storage/sqlite/queries/sessions.sql
+++ b/backend/internal/storage/sqlite/queries/sessions.sql
@@ -17,8 +17,8 @@ UPDATE sessions SET
     activity_state = ?, activity_last_at = ?, first_signal_at = ?, is_terminated = ?,
     branch = ?, workspace_path = ?, workspace_repo_path = ?, runtime_handle_id = ?,
     runtime_launch_id = ?, agent_session_id = ?, prompt = ?,
-    preview_url = ?, preview_revision = ?, terminate_on_pr_merge = ?,
-    cleanup_generation = ?, updated_at = ?
+    preview_url = ?, preview_revision = ?, cleanup_generation = ?,
+    updated_at = ?
 WHERE id = ?;
 
 -- name: GetSession :one

--- a/backend/internal/storage/sqlite/store/session_store.go
+++ b/backend/internal/storage/sqlite/store/session_store.go
@@ -32,8 +32,10 @@ func (s *Store) CreateSession(ctx context.Context, rec domain.SessionRecord) (do
 	return rec, nil
 }
 
-// UpdateSession writes the full mutable state of an existing session. The
-// id/project/num/created_at are immutable and not touched here.
+// UpdateSession writes mutable state for an existing session. The independently
+// owned terminate_on_pr_merge policy is intentionally not touched so a stale
+// full record cannot overwrite a newer user choice. The id/project/num/
+// created_at fields are immutable too.
 func (s *Store) UpdateSession(ctx context.Context, rec domain.SessionRecord) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
@@ -269,27 +271,26 @@ func recordToInsert(rec domain.SessionRecord, num int64) gen.InsertSessionParams
 func recordToUpdate(rec domain.SessionRecord) gen.UpdateSessionParams {
 	activity := normalActivity(rec.Activity, rec.UpdatedAt)
 	return gen.UpdateSessionParams{
-		ID:                 rec.ID,
-		IssueID:            rec.IssueID,
-		Kind:               rec.Kind,
-		Harness:            rec.Harness,
-		DisplayName:        rec.DisplayName,
-		ActivityState:      activity.State,
-		ActivityLastAt:     activity.LastActivityAt,
-		FirstSignalAt:      timeToNullTime(rec.FirstSignalAt),
-		IsTerminated:       rec.IsTerminated,
-		Branch:             rec.Metadata.Branch,
-		WorkspacePath:      rec.Metadata.WorkspacePath,
-		WorkspaceRepoPath:  rec.Metadata.WorkspaceRepoPath,
-		RuntimeHandleID:    rec.Metadata.RuntimeHandleID,
-		RuntimeLaunchID:    rec.Metadata.RuntimeLaunchID,
-		AgentSessionID:     rec.Metadata.AgentSessionID,
-		Prompt:             rec.Metadata.Prompt,
-		PreviewURL:         rec.Metadata.PreviewURL,
-		PreviewRevision:    rec.Metadata.PreviewRevision,
-		TerminateOnPRMerge: rec.TerminateOnPRMerge,
-		CleanupGeneration:  rec.CleanupGeneration,
-		UpdatedAt:          rec.UpdatedAt,
+		ID:                rec.ID,
+		IssueID:           rec.IssueID,
+		Kind:              rec.Kind,
+		Harness:           rec.Harness,
+		DisplayName:       rec.DisplayName,
+		ActivityState:     activity.State,
+		ActivityLastAt:    activity.LastActivityAt,
+		FirstSignalAt:     timeToNullTime(rec.FirstSignalAt),
+		IsTerminated:      rec.IsTerminated,
+		Branch:            rec.Metadata.Branch,
+		WorkspacePath:     rec.Metadata.WorkspacePath,
+		WorkspaceRepoPath: rec.Metadata.WorkspaceRepoPath,
+		RuntimeHandleID:   rec.Metadata.RuntimeHandleID,
+		RuntimeLaunchID:   rec.Metadata.RuntimeLaunchID,
+		AgentSessionID:    rec.Metadata.AgentSessionID,
+		Prompt:            rec.Metadata.Prompt,
+		PreviewURL:        rec.Metadata.PreviewURL,
+		PreviewRevision:   rec.Metadata.PreviewRevision,
+		CleanupGeneration: rec.CleanupGeneration,
+		UpdatedAt:         rec.UpdatedAt,
 	}
 }
 

--- a/backend/internal/storage/sqlite/store/store_test.go
+++ b/backend/internal/storage/sqlite/store/store_test.go
@@ -380,6 +380,82 @@ func TestSessionTerminateOnPRMergePolicyRoundTripAndCDC(t *testing.T) {
 	}
 }
 
+func TestSessionLifecycleWritesPreserveTerminateOnPRMergePolicy(t *testing.T) {
+	writers := []struct {
+		name  string
+		write func(context.Context, *sqlite.Store, domain.SessionRecord) error
+	}{
+		{
+			name: "UpdateSession",
+			write: func(ctx context.Context, s *sqlite.Store, stale domain.SessionRecord) error {
+				return s.UpdateSession(ctx, stale)
+			},
+		},
+		{
+			name: "RecordWorkerIdle",
+			write: func(ctx context.Context, s *sqlite.Store, stale domain.SessionRecord) error {
+				return s.RecordWorkerIdle(ctx, stale, domain.WorkerIdleEvent{
+					ID:           "wie_stale",
+					ProjectID:    stale.ProjectID,
+					WorkerID:     stale.ID,
+					TransitionAt: stale.UpdatedAt,
+					CreatedAt:    stale.UpdatedAt,
+				})
+			},
+		},
+	}
+	directions := []struct {
+		name        string
+		stalePolicy bool
+		newPolicy   bool
+	}{
+		{name: "false_to_true", stalePolicy: false, newPolicy: true},
+		{name: "true_to_false", stalePolicy: true, newPolicy: false},
+	}
+
+	for _, writer := range writers {
+		for _, direction := range directions {
+			t.Run(writer.name+"/"+direction.name, func(t *testing.T) {
+				s := newTestStore(t)
+				ctx := context.Background()
+				seedProject(t, s, "mer")
+				rec := sampleRecord("mer")
+				rec.TerminateOnPRMerge = direction.stalePolicy
+				stale, err := s.CreateSession(ctx, rec)
+				if err != nil {
+					t.Fatalf("create session: %v", err)
+				}
+
+				policyAt := stale.UpdatedAt.Add(time.Minute)
+				ok, err := s.SetSessionTerminateOnPRMerge(ctx, stale.ID, direction.newPolicy, policyAt)
+				if err != nil || !ok {
+					t.Fatalf("set policy to %v: ok=%v err=%v", direction.newPolicy, ok, err)
+				}
+
+				// This record was read before the narrow policy update, but its
+				// lifecycle change finishes afterward. Persisting the stale copy
+				// must land the activity change without reverting the user policy.
+				stale.Activity = domain.Activity{State: domain.ActivityIdle, LastActivityAt: policyAt.Add(time.Minute)}
+				stale.UpdatedAt = policyAt.Add(time.Minute)
+				if err := writer.write(ctx, s, stale); err != nil {
+					t.Fatalf("%s stale write: %v", writer.name, err)
+				}
+
+				got, found, err := s.GetSession(ctx, stale.ID)
+				if err != nil || !found {
+					t.Fatalf("get session: found=%v err=%v", found, err)
+				}
+				if got.TerminateOnPRMerge != direction.newPolicy {
+					t.Fatalf("policy = %v after stale %s, want %v", got.TerminateOnPRMerge, writer.name, direction.newPolicy)
+				}
+				if got.Activity.State != domain.ActivityIdle {
+					t.Fatalf("activity = %q after stale %s, want idle", got.Activity.State, writer.name)
+				}
+			})
+		}
+	}
+}
+
 func TestSessionRuntimeLaunchIDRoundTrip(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -304,11 +304,12 @@ describe("SessionInspector Activity section", () => {
 	const activitySection = () =>
 		within(screen.getByText("Activity").closest("[data-testid='inspector-section']") as HTMLElement);
 
-	it("offers a managed resume only for an exited, nonterminated agent", async () => {
+	it("offers managed resume for an exited, nonterminated branchless agent", async () => {
 		renderWithQuery(
 			<SessionInspector
 				session={session([], {
 					status: "exited",
+					branch: undefined,
 					activity: { state: "exited", lastActivityAt: "2026-06-15T10:00:00Z" },
 				})}
 			/>,
@@ -595,34 +596,70 @@ describe("SessionInspector Activity section", () => {
 		expect(within(doneRow).getByText("30m ago")).toBeInTheDocument();
 	});
 
-	it("renders the current state before reverse-chronological historical milestones", () => {
-		vi.useFakeTimers();
-		vi.setSystemTime(new Date("2026-06-15T12:00:00Z"));
+	it("sorts valid history by time with deterministic equal, missing, and invalid fallbacks", async () => {
+		const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60 * 1000).toISOString();
+		const summaries = [
+			prSummary(42, "draft", {
+				createdAt: minutesAgo(10),
+				stateChangedAt: minutesAgo(10),
+			}),
+			prSummary(41, "open", {
+				createdAt: minutesAgo(30),
+			}),
+			prSummary(43, "open", {
+				createdAt: "not-a-timestamp",
+			}),
+			prSummary(44, "open"),
+			prSummary(40, "merged", {
+				createdAt: minutesAgo(180),
+				stateChangedAt: minutesAgo(20),
+			}),
+		];
+		getMock.mockImplementation(async (path: string) => {
+			if (path === "/api/v1/sessions/{sessionId}/pr") {
+				return { data: { sessionId: "sess-1", prs: summaries }, error: undefined };
+			}
+			return { data: { reviewerHandleId: "", reviews: [] }, error: undefined };
+		});
 
 		renderWithQuery(
 			<SessionInspector
-				session={session([pr(42, "draft"), pr(41, "open"), pr(40, "merged")], {
+				session={session([pr(42, "draft"), pr(41, "open"), pr(43, "open"), pr(44, "open"), pr(40, "merged")], {
 					status: "merged",
-					createdAt: "2026-06-15T09:00:00Z",
-					updatedAt: "2026-06-15T11:55:00Z",
-					activity: { state: "idle", lastActivityAt: "2026-06-15T10:00:00Z" },
+					createdAt: minutesAgo(300),
+					updatedAt: minutesAgo(5),
+					activity: { state: "idle", lastActivityAt: minutesAgo(120) },
 				})}
 			/>,
 		);
 
 		const section = screen.getByText("Activity").closest("[data-testid='inspector-section']") as HTMLElement;
-		const rows = Array.from(section.querySelectorAll("[data-testid='inspector-timeline-event']"), (row) =>
-			row.textContent?.replace(/\s+/g, " ").trim(),
-		);
-		expect(rows).toEqual([
+		const timelineRows = () =>
+			Array.from(section.querySelectorAll("[data-testid='inspector-timeline-event']"), (row) => {
+				const link = row.querySelector("a[aria-label]");
+				if (link) return link.getAttribute("aria-label");
+				if (row.textContent?.includes("Idle")) return "Idle";
+				if (row.textContent?.includes("Done")) return "Done";
+				if (row.textContent?.includes("Created workspace")) return "Created workspace";
+				return row.textContent?.replace(/\s+/g, " ").trim();
+			});
+		const expectedRows = [
 			"Idle",
+			"Draft PR #42",
 			"Done",
 			"Merged PR #40",
-			"Opened PR #40",
 			"Opened PR #41",
-			"Draft PR #42",
-			"Created workspace3h ago",
-		]);
+			"Opened PR #40",
+			"Created workspace",
+			"Opened PR #44",
+			"Opened PR #43",
+		];
+		await waitFor(() => expect(timelineRows()).toEqual(expectedRows));
+
+		const invalidTimestampRow = screen
+			.getByRole("link", { name: "Opened PR #43" })
+			.closest("[data-testid='inspector-timeline-event']") as HTMLElement;
+		expect(within(invalidTimestampRow).queryByText("just now")).not.toBeInTheDocument();
 
 		const eventRows = section.querySelectorAll("[data-testid='inspector-timeline-event']");
 		expect(section.querySelectorAll("[data-testid='inspector-timeline-connector']")).toHaveLength(eventRows.length - 1);

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -510,6 +510,13 @@ function PRSummaryCard({ pr }: { pr: SessionPRSummary }) {
 
 type TimelineTone = "now" | "good" | "warn" | "neutral";
 
+type HistoricalTimelineEvent = {
+	tone: TimelineTone;
+	node: ReactNode;
+	timestamp: string | null;
+	order: number;
+};
+
 const timelineNodeTone: Record<TimelineTone, string> = {
 	neutral: "bg-passive shadow-timeline-dot",
 	now: "bg-working shadow-timeline-dot-now",
@@ -518,43 +525,46 @@ const timelineNodeTone: Record<TimelineTone, string> = {
 };
 
 function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: WorkspaceSession }) {
-	const history: { tone: TimelineTone; node: ReactNode; ts: string | null }[] = [];
+	const history: HistoricalTimelineEvent[] = [];
+	const addHistoricalEvent = (event: Omit<HistoricalTimelineEvent, "order">) => {
+		history.push({ ...event, order: history.length });
+	};
 
-	history.push({
+	addHistoricalEvent({
 		tone: "neutral",
 		node: <>Created workspace</>,
-		ts: formatTimeCompact(session.createdAt ?? session.updatedAt),
+		timestamp: session.createdAt ?? session.updatedAt,
 	});
 
 	for (const pr of prs.filter((pr) => pr.state === "draft")) {
-		history.push({
+		addHistoricalEvent({
 			tone: "neutral",
 			node: <PRTimelineLink pr={pr} verb="Draft" />,
-			ts: prStateTime(pr),
+			timestamp: pr.stateChangedAt ?? null,
 		});
 	}
 
 	for (const pr of prs.filter((pr) => pr.state !== "draft")) {
-		history.push({
+		addHistoricalEvent({
 			tone: "neutral",
 			node: <PRTimelineLink pr={pr} verb="Opened" />,
-			ts: prCreatedTime(pr),
+			timestamp: pr.createdAt ?? null,
 		});
 	}
 
 	for (const pr of prs.filter((pr) => pr.state === "merged")) {
-		history.push({
+		addHistoricalEvent({
 			tone: "good",
 			node: <PRTimelineLink pr={pr} verb="Merged" />,
-			ts: prStateTime(pr),
+			timestamp: pr.stateChangedAt ?? null,
 		});
 	}
 
 	if (session.status === "merged") {
-		history.push({
+		addHistoricalEvent({
 			tone: "good",
 			node: <>Done</>,
-			ts: latestMergedTime(prs),
+			timestamp: latestMergedTimestamp(prs),
 		});
 	}
 
@@ -580,9 +590,9 @@ function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: 
 				))}
 			</span>
 		),
-		ts: null,
-	} satisfies { tone: TimelineTone; node: ReactNode; ts: null };
-	const events = [current, ...history.reverse()];
+		timestamp: null,
+	} satisfies { tone: TimelineTone; node: ReactNode; timestamp: null };
+	const events = [current, ...history.sort(compareHistoricalTimelineEvents)];
 
 	return (
 		<div className="relative pl-5">
@@ -609,7 +619,9 @@ function ActivityTimeline({ prs, session }: { prs: SessionPRSummary[]; session: 
 						/>
 						<div className="text-xs leading-normal text-foreground [&_b]:font-semibold">{event.node}</div>
 					</div>
-					{event.ts ? <div className="mt-1 font-mono text-2xs text-passive">{event.ts}</div> : null}
+					{event.timestamp && timelineTimestamp(event.timestamp) !== null ? (
+						<div className="mt-1 font-mono text-2xs text-passive">{formatTimeCompact(event.timestamp)}</div>
+					) : null}
 				</div>
 			))}
 		</div>
@@ -632,15 +644,25 @@ function PRTimelineLink({ pr, verb }: { pr: SessionPRSummary; verb: "Draft" | "O
 	);
 }
 
-function prStateTime(pr: SessionPRSummary): string | null {
-	return pr.stateChangedAt ? formatTimeCompact(pr.stateChangedAt) : null;
+function compareHistoricalTimelineEvents(a: HistoricalTimelineEvent, b: HistoricalTimelineEvent): number {
+	const aTime = timelineTimestamp(a.timestamp);
+	const bTime = timelineTimestamp(b.timestamp);
+	if (aTime !== null && bTime !== null && aTime !== bTime) return bTime - aTime;
+	if (aTime !== null && bTime === null) return -1;
+	if (aTime === null && bTime !== null) return 1;
+	// Later construction order preserves the established semantic precedence
+	// for equal times (for example, Done before its matching Merged milestone)
+	// and gives missing or invalid timestamps a deterministic fallback.
+	return b.order - a.order;
 }
 
-function prCreatedTime(pr: SessionPRSummary): string | null {
-	return pr.createdAt ? formatTimeCompact(pr.createdAt) : null;
+function timelineTimestamp(timestamp: string | null): number | null {
+	if (!timestamp) return null;
+	const milliseconds = Date.parse(timestamp);
+	return Number.isFinite(milliseconds) ? milliseconds : null;
 }
 
-function latestMergedTime(prs: SessionPRSummary[]): string | null {
+function latestMergedTimestamp(prs: SessionPRSummary[]): string | null {
 	let latest: { timestamp: string; milliseconds: number } | undefined;
 	for (const pr of prs) {
 		if (pr.state !== "merged" || !pr.stateChangedAt) continue;
@@ -650,7 +672,7 @@ function latestMergedTime(prs: SessionPRSummary[]): string | null {
 			latest = { timestamp: pr.stateChangedAt, milliseconds };
 		}
 	}
-	return latest ? formatTimeCompact(latest.timestamp) : null;
+	return latest?.timestamp ?? null;
 }
 
 type ScmTimelineState = "ci_failed" | "changes_requested" | "conflict";

--- a/frontend/src/renderer/lib/command-palette.test.ts
+++ b/frontend/src/renderer/lib/command-palette.test.ts
@@ -176,24 +176,36 @@ describe("buildCommands finished sessions", () => {
 				sessions: [
 					session({ id: "w-live", title: "live one", status: "working" }),
 					session({ id: "w-done", title: "archived cleanup", status: "terminated" }),
-					session({ id: "w-merged", title: "old merge", status: "merged" }),
+					session({ id: "w-merged-live", title: "live merge", status: "merged", isTerminated: false }),
+					session({ id: "w-merged-done", title: "archived merge", status: "merged", isTerminated: true }),
 				],
 			},
 		];
 	}
 
-	it("indexes merged/terminated sessions as search-only (hidden until typed, then findable)", () => {
+	it("keeps a live merged session in Needs attention", () => {
+		const items = buildCommands({ workspaces: withFinished() });
+		expect(byId(items).has("attention:w-merged-live")).toBe(true);
+		expect(byId(items).has("session:w-merged-live")).toBe(false);
+	});
+
+	it("indexes terminated and terminated-merged sessions as search-only", () => {
 		const items = buildCommands({ workspaces: withFinished() });
 		const done = byId(items).get("session:w-done");
+		const mergedDone = byId(items).get("session:w-merged-done");
 		expect(done?.searchOnly).toBe(true);
+		expect(mergedDone?.searchOnly).toBe(true);
 		expect(byId(items).get("session:w-live")?.searchOnly).toBeFalsy();
+		expect(byId(items).has("attention:w-merged-done")).toBe(false);
 
 		const suggested = filterCommands(items, "");
 		expect(suggested.some((item) => item.id === "session:w-done")).toBe(false);
+		expect(suggested.some((item) => item.id === "session:w-merged-done")).toBe(false);
 		expect(suggested.some((item) => item.id === "session:w-live")).toBe(true);
 
 		const searched = filterCommands(items, "archived");
 		expect(searched.some((item) => item.id === "session:w-done")).toBe(true);
+		expect(searched.some((item) => item.id === "session:w-merged-done")).toBe(true);
 	});
 });
 

--- a/frontend/src/renderer/lib/command-palette.ts
+++ b/frontend/src/renderer/lib/command-palette.ts
@@ -157,7 +157,9 @@ export function buildCommands(ctx: CommandPaletteContext): CommandItem[] {
 		.flatMap((workspace) => workerSessions(workspace.sessions).map((session) => ({ workspace, session })))
 		.filter(
 			({ session }) =>
-				session.id !== currentSessionId && (attentionZone(session) === "merge" || sessionNeedsAttention(session)),
+				session.id !== currentSessionId &&
+				sessionIsActive(session) &&
+				(attentionZone(session) === "merge" || sessionNeedsAttention(session)),
 		)
 		.sort(
 			(a, b) =>


### PR DESCRIPTION
## Summary

- make agent Resume project-aware so branchless Scratch sessions can resume while repository-backed sessions still require a branch
- serialize Resume, Kill, Restore, replacement retirement, and terminal Cleanup per session, with a re-read before Cleanup destroys resources
- fence the durable Resume commit against concurrent terminal intent and launch-generation changes
- make tmux create/restart transitions cancellation-safe: proven post-respawn probe failures retain ownership, while dispatch-timeout uncertainty is separately typed and compensated instead of being falsely adopted
- keep non-atomic runtime replacement (used by Windows ConPTY) inside one bounded, cancellation-detached Destroy/Create transition, while leaving genuine Create failures exited and retryable
- keep `terminate_on_pr_merge` under its dedicated setter so stale generic lifecycle writes cannot revert user policy
- sort activity history by raw timestamps with deterministic invalid/missing fallbacks
- keep terminated sessions out of command-palette attention actions while retaining them in search

## Root cause

Several lifecycle boundaries treated validation, runtime mutation, and persistence as independent operations. Scratch Resume inherited repository-only branch validation; Resume and Kill could cross each other; a successful tmux respawn followed by a transient probe error was reported as total failure; cancellation could split a destructive runtime command from durable adoption or compensation; Cleanup could act on a stale terminated snapshot after Restore had recreated resources; and generic session updates could overwrite independently owned policy state. The renderer also derived timeline ordering and attention actions from presentation-oriented state instead of the underlying lifecycle facts.

## Concurrency and ownership guarantees

- operations for the same session share one ref-counted lock; different session IDs remain independent
- both Resume-first/Kill-second and Kill-first/Resume-second orderings preserve monotonic terminal intent
- Cleanup re-reads the session under that lock, so it cannot destroy a runtime/workspace recreated by a winning Restore
- caller cancellation is honored before a destructive runtime boundary; after dispatch, bounded detached work reaches a coherent adoption or compensation result
- a confirmed tmux respawn plus failed verification is adoptable, but a dispatch-timeout outcome is never treated as proven success and is compensated using the owned handle
- the test-only post-respawn probe runner is mutex-protected, exact-target-specific, and supports interleaved targets without one probe stealing another target's injected failure

## Impact

Scratch sessions can resume reliably, concurrent lifecycle operations preserve terminal monotonicity, Cleanup cannot tear down freshly restored resources, and cancellation or transient tmux failures cannot silently leave an authoritative generation disagreed with runtime reality. Merge policy and renderer state remain consistent across asynchronous updates.

## Validation

- `GOFLAGS=-p=4 npm run lint` — all backend tests and golangci-lint, 0 issues
- `GOFLAGS=-p=4 go test -race ./... -timeout=10m`
- focused concurrency/cancellation suites under `-race -count=50` for Resume/Kill, Cleanup/Restore, fallback Destroy/Create, tmux Create/Restart, compensation, retry, and target-specific probe injection
- real isolated tmux daemon: race-enabled post-respawn failure integration test passed three consecutive runs
- full frontend Vitest suite: 87 files / 1,086 tests
- `npm --prefix frontend run typecheck`
- packaged Electron → real daemon/SQLite → real agent process/hooks → real isolated tmux Resume E2E, passed twice
- `git diff --check`

Fixes #3087
