### PR TITLE
fix(landing): recenter hero preview after resize

### DIFF
--- a/frontend/src/landing/src/app/components/HeroSection/components/AppMockup/AppMockup.tsx
+++ b/frontend/src/landing/src/app/components/HeroSection/components/AppMockup/AppMockup.tsx
@@ -683,6 +683,10 @@ function useFloatingWindow(
 	outerRef: React.RefObject<HTMLElement | null>,
 ) {
 	const stateRef = useRef<WindowState | null>(null);
+	// The geometry the user asked for, kept unclamped by container size. Narrow
+	// containers squash the rendered state into the corner; replaying from this
+	// instead lets a return to a wide viewport restore the original placement.
+	const desiredStateRef = useRef<WindowState | null>(null);
 	const containerSizeRef = useRef({ width: 0, height: 0 });
 	const interactionRef = useRef<{
 		type: "drag" | "resize";
@@ -709,15 +713,16 @@ function useFloatingWindow(
 		if (!parent) return;
 		const rect = parent.getBoundingClientRect();
 		containerSizeRef.current = { width: rect.width, height: rect.height };
-		if (stateRef.current) {
-			stateRef.current = clampWindowState(
-				stateRef.current,
-				rect.width,
-				rect.height,
-			);
-		} else {
-			stateRef.current = createInitialWindowState(rect.width, rect.height);
-		}
+		// Until the user drags or resizes, the window is laid out by the container,
+		// so re-derive it on every container change instead of clamping the last
+		// render. Clamping alone pins x/y to the margin at narrow widths and never
+		// recovers the centered position when the container grows back.
+		stateRef.current = clampWindowState(
+			desiredStateRef.current ??
+				createInitialWindowState(rect.width, rect.height),
+			rect.width,
+			rect.height,
+		);
 		applyState();
 	}, [applyState, outerRef]);
 
@@ -798,6 +803,7 @@ function useFloatingWindow(
 			}
 
 			next = clampWindowState(next, containerWidth, containerHeight);
+			desiredStateRef.current = next;
 			stateRef.current = next;
 			applyState();
 		};


### PR DESCRIPTION
## Summary

- Re-derive the untouched hero preview window layout when its container resizes.
- Preserve user-requested drag and resize geometry across responsive viewport changes.
- Port the fix from ronishrohan/aoagents#2 to the moved landing-page source.

## Root cause

The resize observer clamped the last rendered state on every container change. A narrow viewport pinned the preview to the window margin, and returning to desktop grew it from that corner instead of restoring its centered layout.

## Impact

The landing-page hero preview now recenters after a desktop-to-mobile-to-desktop round trip while retaining intentional user positioning after a drag or resize.

## Validation

- `npm run build` in `frontend/src/landing`
- `npx tsc --noEmit` in `frontend/src/landing`
- `npm run frontend:typecheck`
- `git diff --check`
