### PR TITLE
fix(frontend): remove hidden sidebar controls from tab order

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -230,6 +230,41 @@ afterEach(() => {
 });
 
 describe("Sidebar", () => {
+	it("keeps only the expanded Settings control keyboard-accessible while expanded", () => {
+		renderSidebar();
+
+		const settingsButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('button[aria-label="Settings"]'));
+		const expandedButton = settingsButtons.find((button) => button.textContent?.includes("Settings"));
+		const collapsedButton = settingsButtons.find((button) => !button.textContent?.includes("Settings"));
+
+		expect(settingsButtons).toHaveLength(2);
+		expect(expandedButton).toHaveAttribute("tabindex", "0");
+		expect(expandedButton?.parentElement).not.toHaveAttribute("aria-hidden");
+		expect(collapsedButton).toHaveAttribute("tabindex", "-1");
+		expect(collapsedButton?.closest('[aria-hidden="true"]')).toBeInTheDocument();
+	});
+
+	it("keeps only the collapsed Settings control keyboard-accessible while collapsed", async () => {
+		renderSidebar();
+
+		fireEvent.pointerDown(screen.getByTestId("resize-handle"), { clientX: 240 });
+		fireEvent.pointerMove(window, { clientX: 120 });
+
+		await waitFor(() => {
+			expect(document.querySelector('[data-slot="sidebar"][data-state="collapsed"]')).toBeInTheDocument();
+		});
+
+		const settingsButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('button[aria-label="Settings"]'));
+		const expandedButton = settingsButtons.find((button) => button.textContent?.includes("Settings"));
+		const collapsedButton = settingsButtons.find((button) => !button.textContent?.includes("Settings"));
+
+		expect(settingsButtons).toHaveLength(2);
+		expect(expandedButton).toHaveAttribute("tabindex", "-1");
+		expect(expandedButton?.closest('[aria-hidden="true"]')).toBeInTheDocument();
+		expect(collapsedButton).toHaveAttribute("tabindex", "0");
+		expect(collapsedButton?.closest('[aria-hidden="true"]')).toBeNull();
+	});
+
 	it("keeps sidebar scrolling functional while hiding the visible scrollbar", () => {
 		renderSidebar();
 

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -334,26 +334,34 @@ export function Sidebar({
 						daemon {daemonStatus.state}
 					</span>
 				)}
-				<div className="sidebar-expanded-chrome relative flex w-full min-w-46.5 flex-col gap-1 transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0">
-					<RestartToUpdateRow status={updateStatus} />
+				<div
+					aria-hidden={isCollapsed || undefined}
+					className="sidebar-expanded-chrome relative flex w-full min-w-46.5 flex-col gap-1 transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0"
+				>
+					<RestartToUpdateRow status={updateStatus} tabIndex={isCollapsed ? -1 : 0} />
 					<button
 						aria-label="Settings"
 						className="flex w-full items-center justify-center gap-2.5 rounded-settings-row bg-interactive-hover px-2.5 py-2.5 text-control font-medium text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground [&_svg]:size-icon-lg [&_svg]:shrink-0"
 						onClick={() => selection.goGlobalSettings()}
+						tabIndex={isCollapsed ? -1 : 0}
 						type="button"
 					>
 						<Settings aria-hidden="true" />
 						<span className="tracking-tight">Settings</span>
 					</button>
 				</div>
-				<div className="pointer-events-none absolute inset-x-1.5 bottom-0 top-auto flex min-h-row-md flex-col items-center justify-end gap-1 opacity-0 transition-opacity duration-150 ease-out group-data-[collapsible=icon]:pointer-events-auto group-data-[collapsible=icon]:opacity-100">
-					<RestartToUpdateRailButton status={updateStatus} />
+				<div
+					aria-hidden={!isCollapsed || undefined}
+					className="pointer-events-none absolute inset-x-1.5 bottom-0 top-auto flex min-h-row-md flex-col items-center justify-end gap-1 opacity-0 transition-opacity duration-150 ease-out group-data-[collapsible=icon]:pointer-events-auto group-data-[collapsible=icon]:opacity-100"
+				>
+					<RestartToUpdateRailButton status={updateStatus} tabIndex={isCollapsed ? 0 : -1} />
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<button
 								aria-label="Settings"
 								className="grid size-control-board place-items-center rounded-settings-row bg-interactive-hover text-muted-foreground transition-colors hover:bg-interactive-hover hover:text-foreground [&_svg]:size-icon-base"
 								onClick={() => selection.goGlobalSettings()}
+								tabIndex={isCollapsed ? 0 : -1}
 								type="button"
 							>
 								<Settings aria-hidden="true" />
@@ -722,7 +730,7 @@ function SessionRow({ session, active, onOpen }: { session: WorkspaceSession; ac
 // the main-process evaluator flags it escalated. Clicking installs immediately;
 // the row itself is the prompt, so no confirmation dialog. Renders nothing in
 // every other update state.
-function RestartToUpdateRow({ status }: { status: UpdateStatus }) {
+function RestartToUpdateRow({ status, tabIndex }: { status: UpdateStatus; tabIndex: number }) {
 	if (status.state !== "downloaded") return null;
 	const escalated = status.escalated === true;
 	return (
@@ -735,6 +743,7 @@ function RestartToUpdateRow({ status }: { status: UpdateStatus }) {
 					: "text-passive hover:bg-interactive-hover hover:text-foreground [&_svg]:text-passive",
 			)}
 			onClick={() => void aoBridge.updates.install()}
+			tabIndex={tabIndex}
 			type="button"
 		>
 			<RefreshCw aria-hidden="true" className="size-icon-lg shrink-0" />
@@ -756,7 +765,7 @@ function RestartToUpdateRow({ status }: { status: UpdateStatus }) {
 
 // Icon-rail variant of RestartToUpdateRow for the collapsed sidebar: icon-only
 // with the two-line copy in the tooltip.
-function RestartToUpdateRailButton({ status }: { status: UpdateStatus }) {
+function RestartToUpdateRailButton({ status, tabIndex }: { status: UpdateStatus; tabIndex: number }) {
 	if (status.state !== "downloaded") return null;
 	const escalated = status.escalated === true;
 	return (
@@ -771,6 +780,7 @@ function RestartToUpdateRailButton({ status }: { status: UpdateStatus }) {
 							: "text-passive hover:bg-interactive-hover hover:text-foreground",
 					)}
 					onClick={() => void aoBridge.updates.install()}
+					tabIndex={tabIndex}
 					type="button"
 				>
 					<RefreshCw aria-hidden="true" />


### PR DESCRIPTION
## What changed

- remove inactive sidebar footer controls from keyboard navigation
- hide the inactive expanded/collapsed footer variant from assistive technologies
- apply the same handling to the restart-to-update controls
- add regression coverage for both sidebar states

## Why

When the sidebar was expanded, pressing Tab from the visible Settings row focused the hidden collapsed-rail Settings button. The inactive control stayed at `tabIndex=0` even though it had `pointer-events: none`.

## Verification

- native Electron keyboard verification: Tab skips the hidden Settings control
- `npm run typecheck`
- `npm run typecheck:e2e`
- full frontend suite: 1,087 tests passed
- renderer smoke: 20 tests passed
- focused Sidebar suite: 41 tests passed

Closes #3147
