### PR TITLE
fix(crush): forward role-specific model config on launch

### DIFF
--- a/backend/internal/adapters/agent/crush/crush.go
+++ b/backend/internal/adapters/agent/crush/crush.go
@@ -54,6 +54,28 @@ func (p *Plugin) Manifest() adapters.Manifest {
 	}
 }
 
+// GetConfigSpec reports the per-project agent config keys Crush understands:
+// a model override. Unlike Claude/Codex (a bare --model flag) or Kiro (a
+// single model key), Crush's .crush.json requires both a provider id and a
+// model id per selection (see mergeCrushModel in hooks.go), so AO's plain
+// Model string must carry the provider too. This declares the expected
+// "<provider>/<model-id>" shape so it is discoverable/validated through the
+// config-spec surface, matching claude-code, codex, and kiro.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{
+		Fields: []ports.ConfigField{
+			{
+				Key:         "model",
+				Type:        ports.ConfigFieldString,
+				Description: "Model override written into Crush's workspace-local config as the large-model selection. Must be \"<provider>/<model-id>\" (e.g. \"anthropic/claude-sonnet-4-5\"): Crush's config schema requires a provider id alongside the model id, which a bare model string doesn't carry.",
+			},
+		},
+	}, nil
+}
+
 // GetLaunchCommand builds the argv to start an interactive Crush session.
 // Shape:
 //

--- a/backend/internal/adapters/agent/crush/crush_test.go
+++ b/backend/internal/adapters/agent/crush/crush_test.go
@@ -485,15 +485,16 @@ func TestGetAgentHooksGitignoresManagedCrushFiles(t *testing.T) {
 	if strings.Contains(text, "/"+crushConfigFileName) {
 		t.Fatalf(".gitignore should not ignore project config %q:\n%s", crushConfigFileName, text)
 	}
-	data, err = os.ReadFile(filepath.Join(workspace, ".gitignore"))
-	if err != nil {
-		t.Fatalf("read workspace gitignore: %v", err)
-	}
-	text = string(data)
-	for _, want := range []string{hookutil.GitignoreSentinel, "/" + crushConfigFileName} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("workspace .gitignore missing %q:\n%s", want, text)
-		}
+
+	// AO must not write/own a repo-root .gitignore: EnsureWorkspaceGitignore
+	// is a no-op when a root .gitignore already exists without AO's
+	// sentinel, and unconditionally overwrites one that does carry it on
+	// every subsequent call — neither is safe for a directory the user (or
+	// their repo) already owns. .crush.json churn in the agent's worktree
+	// is a known, pre-existing limitation left to a future AddExclude-based
+	// fix (writing to .git/info/exclude instead).
+	if _, err := os.Stat(filepath.Join(workspace, ".gitignore")); !os.IsNotExist(err) {
+		t.Fatalf("workspace root .gitignore should not be created by crush's adapter, stat err = %v", err)
 	}
 }
 

--- a/backend/internal/adapters/agent/crush/crush_test.go
+++ b/backend/internal/adapters/agent/crush/crush_test.go
@@ -348,7 +348,7 @@ func TestGetAgentHooksPreservesOtherModelFieldsOnOverride(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(configPath, []byte(`{"models":{"large":{"model":"old-model","provider":"old-provider","max_tokens":4096}}}`), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte(`{"models":{"large":{"model":"old-model","provider":"old-provider","max_tokens":4096},"small":{"model":"small-model","provider":"small-provider"}},"providers":{"openai":{"base_url":"https://example.test"}}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -360,12 +360,22 @@ func TestGetAgentHooksPreservesOtherModelFieldsOnOverride(t *testing.T) {
 		t.Fatalf("GetAgentHooks err = %v", err)
 	}
 
-	large := readCrushConfigForTest(t, configPath)["models"].(map[string]any)["large"].(map[string]any)
+	cfg := readCrushConfigForTest(t, configPath)
+	models := cfg["models"].(map[string]any)
+	large := models["large"].(map[string]any)
 	if large["provider"] != "openai" || large["model"] != "gpt-5" {
 		t.Fatalf("models.large = %#v, want provider=openai model=gpt-5", large)
 	}
 	if large["max_tokens"] != float64(4096) {
 		t.Fatalf("models.large.max_tokens was dropped: %#v", large)
+	}
+	small := models["small"].(map[string]any)
+	if small["provider"] != "small-provider" || small["model"] != "small-model" {
+		t.Fatalf("models.small = %#v, want existing small model untouched", small)
+	}
+	providers := cfg["providers"].(map[string]any)
+	if _, ok := providers["openai"].(map[string]any); !ok {
+		t.Fatalf("providers were dropped: %#v", providers)
 	}
 }
 
@@ -392,19 +402,64 @@ func TestGetAgentHooksLeavesModelUntouchedWhenNoOverride(t *testing.T) {
 	}
 }
 
-func TestGetAgentHooksRejectsModelWithoutProvider(t *testing.T) {
+func TestGetAgentHooksInfersProviderForBareModel(t *testing.T) {
 	workspace := t.TempDir()
+	configPath := crushConfigFile(workspace)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"models":{"large":{"model":"old-model","provider":"anthropic","temperature":0.2}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
-	err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
 		WorkspacePath: workspace,
 		SystemPrompt:  "AO standing instructions",
 		Config:        ports.AgentConfig{Model: "claude-sonnet-4-5"},
-	})
-	if err == nil {
-		t.Fatal("GetAgentHooks err = nil, want error for a model without a provider prefix")
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
 	}
-	if !strings.Contains(err.Error(), "provider") {
-		t.Fatalf("error = %v, want it to mention the missing provider", err)
+
+	large := readCrushConfigForTest(t, configPath)["models"].(map[string]any)["large"].(map[string]any)
+	if large["provider"] != "anthropic" || large["model"] != "claude-sonnet-4-5" {
+		t.Fatalf("models.large = %#v, want provider=anthropic model=claude-sonnet-4-5", large)
+	}
+	if large["temperature"] != 0.2 {
+		t.Fatalf("models.large.temperature was dropped: %#v", large)
+	}
+}
+
+func TestGetAgentHooksSkipsBareModelWithoutProvider(t *testing.T) {
+	workspace := t.TempDir()
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		SystemPrompt:  "AO standing instructions",
+		Config:        ports.AgentConfig{Model: "claude-sonnet-4-5"},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	cfg := readCrushConfigForTest(t, crushConfigFile(workspace))
+	if _, ok := cfg["models"]; ok {
+		t.Fatalf("models were written for bare model with no provider to infer: %#v", cfg)
+	}
+}
+
+func TestGetAgentHooksSplitsModelOverrideOnFirstSlash(t *testing.T) {
+	workspace := t.TempDir()
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		SystemPrompt:  "AO standing instructions",
+		Config:        ports.AgentConfig{Model: "openrouter/anthropic/claude-x"},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	large := readCrushConfigForTest(t, crushConfigFile(workspace))["models"].(map[string]any)["large"].(map[string]any)
+	if large["provider"] != "openrouter" || large["model"] != "anthropic/claude-x" {
+		t.Fatalf("models.large = %#v, want provider=openrouter model=anthropic/claude-x", large)
 	}
 }
 
@@ -429,6 +484,16 @@ func TestGetAgentHooksGitignoresManagedCrushFiles(t *testing.T) {
 	}
 	if strings.Contains(text, "/"+crushConfigFileName) {
 		t.Fatalf(".gitignore should not ignore project config %q:\n%s", crushConfigFileName, text)
+	}
+	data, err = os.ReadFile(filepath.Join(workspace, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read workspace gitignore: %v", err)
+	}
+	text = string(data)
+	for _, want := range []string{hookutil.GitignoreSentinel, "/" + crushConfigFileName} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("workspace .gitignore missing %q:\n%s", want, text)
+		}
 	}
 }
 
@@ -466,6 +531,23 @@ func TestGetAgentHooksEmptyPromptIsNoOp(t *testing.T) {
 	}
 	if _, err := os.Stat(crushConfigFile(workspace)); !os.IsNotExist(err) {
 		t.Fatalf("config file stat err = %v, want not exist", err)
+	}
+}
+
+func TestGetAgentHooksAppliesModelOverrideWithEmptyPrompt(t *testing.T) {
+	workspace := t.TempDir()
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		Config:        ports.AgentConfig{Model: "anthropic/claude-sonnet-4-5"},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+	if _, err := os.Stat(crushSystemPromptFile(workspace)); !os.IsNotExist(err) {
+		t.Fatalf("system prompt file stat err = %v, want not exist", err)
+	}
+	large := readCrushConfigForTest(t, crushConfigFile(workspace))["models"].(map[string]any)["large"].(map[string]any)
+	if large["provider"] != "anthropic" || large["model"] != "claude-sonnet-4-5" {
+		t.Fatalf("models.large = %#v, want provider=anthropic model=claude-sonnet-4-5", large)
 	}
 }
 

--- a/backend/internal/adapters/agent/crush/crush_test.go
+++ b/backend/internal/adapters/agent/crush/crush_test.go
@@ -235,15 +235,18 @@ func TestManifest(t *testing.T) {
 	}
 }
 
-func TestGetConfigSpecReturnsEmpty(t *testing.T) {
+func TestGetConfigSpecReportsModelField(t *testing.T) {
 	plugin := &Plugin{}
 
 	spec, err := plugin.GetConfigSpec(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(spec.Fields) != 0 {
-		t.Fatalf("unexpected config spec fields: got %d, want 0", len(spec.Fields))
+	if len(spec.Fields) != 1 {
+		t.Fatalf("unexpected config spec fields: got %d, want 1", len(spec.Fields))
+	}
+	if spec.Fields[0].Key != "model" {
+		t.Fatalf("unexpected config spec field key: got %q, want %q", spec.Fields[0].Key, "model")
 	}
 }
 
@@ -316,6 +319,92 @@ func TestGetAgentHooksMergesExistingCrushConfig(t *testing.T) {
 	}
 	if countJSONStrings(paths, crushSystemPromptPath) != 1 {
 		t.Fatalf("context_paths duplicated AO path: %#v", paths)
+	}
+}
+
+func TestGetAgentHooksWritesModelOverride(t *testing.T) {
+	workspace := t.TempDir()
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		SystemPrompt:  "AO standing instructions",
+		Config:        ports.AgentConfig{Model: "anthropic/claude-sonnet-4-5"},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	cfg := readCrushConfigForTest(t, crushConfigFile(workspace))
+	large := cfg["models"].(map[string]any)["large"].(map[string]any)
+	if large["provider"] != "anthropic" {
+		t.Fatalf("models.large.provider = %#v, want %q", large["provider"], "anthropic")
+	}
+	if large["model"] != "claude-sonnet-4-5" {
+		t.Fatalf("models.large.model = %#v, want %q", large["model"], "claude-sonnet-4-5")
+	}
+}
+
+func TestGetAgentHooksPreservesOtherModelFieldsOnOverride(t *testing.T) {
+	workspace := t.TempDir()
+	configPath := crushConfigFile(workspace)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"models":{"large":{"model":"old-model","provider":"old-provider","max_tokens":4096}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		SystemPrompt:  "AO standing instructions",
+		Config:        ports.AgentConfig{Model: "openai/gpt-5"},
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	large := readCrushConfigForTest(t, configPath)["models"].(map[string]any)["large"].(map[string]any)
+	if large["provider"] != "openai" || large["model"] != "gpt-5" {
+		t.Fatalf("models.large = %#v, want provider=openai model=gpt-5", large)
+	}
+	if large["max_tokens"] != float64(4096) {
+		t.Fatalf("models.large.max_tokens was dropped: %#v", large)
+	}
+}
+
+func TestGetAgentHooksLeavesModelUntouchedWhenNoOverride(t *testing.T) {
+	workspace := t.TempDir()
+	configPath := crushConfigFile(workspace)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"models":{"large":{"model":"user-picked-model","provider":"user-provider"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		SystemPrompt:  "AO standing instructions",
+	}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v", err)
+	}
+
+	large := readCrushConfigForTest(t, configPath)["models"].(map[string]any)["large"].(map[string]any)
+	if large["provider"] != "user-provider" || large["model"] != "user-picked-model" {
+		t.Fatalf("models.large = %#v, want the user's existing selection untouched", large)
+	}
+}
+
+func TestGetAgentHooksRejectsModelWithoutProvider(t *testing.T) {
+	workspace := t.TempDir()
+
+	err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: workspace,
+		SystemPrompt:  "AO standing instructions",
+		Config:        ports.AgentConfig{Model: "claude-sonnet-4-5"},
+	})
+	if err == nil {
+		t.Fatal("GetAgentHooks err = nil, want error for a model without a provider prefix")
+	}
+	if !strings.Contains(err.Error(), "provider") {
+		t.Fatalf("error = %v, want it to mention the missing provider", err)
 	}
 }
 

--- a/backend/internal/adapters/agent/crush/hooks.go
+++ b/backend/internal/adapters/agent/crush/hooks.go
@@ -20,6 +20,18 @@ const (
 	crushSystemPromptName   = "ao-system-prompt.md"
 	crushSystemPromptPath   = crushConfigDirName + "/" + crushSystemPromptName
 	crushSystemPromptMarker = "agent-orchestrator: managed crush system prompt"
+
+	// crushModelSeparator splits AO's "<provider>/<model-id>" convention.
+	// Crush's config schema (models.large / models.small) requires both a
+	// provider id and a model id per selection; AO's AgentConfig.Model is a
+	// single string, so Crush is the one adapter that needs a delimiter to
+	// recover both parts (see mergeCrushModel).
+	crushModelSeparator = "/"
+
+	// crushModelType is the model type AO writes overrides into. Crush's
+	// "large" model backs its main coder agent; AO has no equivalent of
+	// Crush's separate "small"/task-agent model, so only large is managed.
+	crushModelType = "large"
 )
 
 // GetAgentHooks installs AO's standing instructions as a Crush context file.
@@ -67,6 +79,9 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(promptPath), crushSystemPromptName); err != nil {
 		return fmt.Errorf("crush.GetAgentHooks: gitignore: %w", err)
 	}
+	if err := applyCrushModelOverride(cfg.WorkspacePath, cfg.Config.Model); err != nil {
+		return fmt.Errorf("crush.GetAgentHooks: %w", err)
+	}
 	return nil
 }
 
@@ -94,6 +109,25 @@ func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error
 		return fmt.Errorf("crush.UninstallHooks: merge config: %w", err)
 	}
 	return nil
+}
+
+// applyCrushModelOverride writes the role's configured model into
+// .crush.json as the large-model selection, if one is set. It runs on every
+// Spawn/Restore (prepareWorkspace calls GetAgentHooks before each launch), so
+// a role's model config always reflects the project's current value and a
+// later change takes effect on the session's next restore. An empty override
+// leaves any model the user picked through Crush's own model picker alone.
+func applyCrushModelOverride(workspacePath, modelOverride string) error {
+	model := strings.TrimSpace(modelOverride)
+	if model == "" {
+		return nil
+	}
+	provider, modelID, ok := strings.Cut(model, crushModelSeparator)
+	provider, modelID = strings.TrimSpace(provider), strings.TrimSpace(modelID)
+	if !ok || provider == "" || modelID == "" {
+		return fmt.Errorf("model %q must be \"<provider>/<model-id>\" (e.g. \"anthropic/claude-sonnet-4-5\"); Crush requires a provider id that a bare model string doesn't carry", model)
+	}
+	return mergeCrushModel(crushConfigFile(workspacePath), provider, modelID)
 }
 
 // AreHooksInstalled reports whether AO's Crush system-prompt context file is
@@ -155,6 +189,25 @@ func mergeCrushContextPath(configPath, contextPath string) error {
 	}
 	options["context_paths"] = paths
 	cfg["options"] = options
+	return writeCrushConfig(configPath, cfg)
+}
+
+// mergeCrushModel sets models.large.{model,provider} in the project's
+// .crush.json, preserving any other keys already set on that selection (e.g.
+// a user's max_tokens or temperature override) and any other top-level config
+// (providers, options, other model type). AO owns only the model/provider
+// identity fields it writes here.
+func mergeCrushModel(configPath, provider, modelID string) error {
+	cfg, err := readCrushConfig(configPath)
+	if err != nil {
+		return err
+	}
+	models := crushConfigObject(cfg, "models")
+	selection := crushConfigObject(models, crushModelType)
+	selection["model"] = modelID
+	selection["provider"] = provider
+	models[crushModelType] = selection
+	cfg["models"] = models
 	return writeCrushConfig(configPath, cfg)
 }
 

--- a/backend/internal/adapters/agent/crush/hooks.go
+++ b/backend/internal/adapters/agent/crush/hooks.go
@@ -50,14 +50,8 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	if err != nil {
 		return fmt.Errorf("crush.GetAgentHooks: %w", err)
 	}
-	modelWritten, err := applyCrushModelOverride(cfg.WorkspacePath, cfg.Config.Model)
-	if err != nil {
+	if err := applyCrushModelOverride(cfg.WorkspacePath, cfg.Config.Model); err != nil {
 		return fmt.Errorf("crush.GetAgentHooks: %w", err)
-	}
-	if modelWritten {
-		if err := hookutil.EnsureWorkspaceGitignore(cfg.WorkspacePath, crushConfigFileName); err != nil {
-			return fmt.Errorf("crush.GetAgentHooks: gitignore config: %w", err)
-		}
 	}
 	if strings.TrimSpace(prompt) == "" {
 		return nil
@@ -85,9 +79,6 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	}
 	if err := mergeCrushContextPath(crushConfigFile(cfg.WorkspacePath), crushSystemPromptPath); err != nil {
 		return fmt.Errorf("crush.GetAgentHooks: merge config: %w", err)
-	}
-	if err := hookutil.EnsureWorkspaceGitignore(cfg.WorkspacePath, crushConfigFileName); err != nil {
-		return fmt.Errorf("crush.GetAgentHooks: gitignore config: %w", err)
 	}
 	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(promptPath), crushSystemPromptName); err != nil {
 		return fmt.Errorf("crush.GetAgentHooks: gitignore: %w", err)
@@ -127,31 +118,31 @@ func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error
 // a role's model config always reflects the project's current value and a
 // later change takes effect on the session's next restore. An empty override
 // leaves any model the user picked through Crush's own model picker alone.
-func applyCrushModelOverride(workspacePath, modelOverride string) (bool, error) {
+func applyCrushModelOverride(workspacePath, modelOverride string) error {
 	model := strings.TrimSpace(modelOverride)
 	if model == "" {
-		return false, nil
+		return nil
 	}
 	provider, modelID, ok := strings.Cut(model, crushModelSeparator)
 	provider, modelID = strings.TrimSpace(provider), strings.TrimSpace(modelID)
 	if ok && provider != "" && modelID != "" {
-		return true, mergeCrushModel(crushConfigFile(workspacePath), provider, modelID)
+		return mergeCrushModel(crushConfigFile(workspacePath), provider, modelID)
 	}
 	if ok {
 		slog.Default().Warn("crush: skipping model override because provider or model id is empty",
 			"model", model)
-		return false, nil
+		return nil
 	}
 	existingProvider, err := existingCrushModelProvider(crushConfigFile(workspacePath))
 	if err != nil {
-		return false, err
+		return err
 	}
 	if existingProvider == "" {
 		slog.Default().Warn("crush: skipping bare model override because .crush.json has no existing provider to reuse",
 			"model", model)
-		return false, nil
+		return nil
 	}
-	return true, mergeCrushModel(crushConfigFile(workspacePath), existingProvider, model)
+	return mergeCrushModel(crushConfigFile(workspacePath), existingProvider, model)
 }
 
 // AreHooksInstalled reports whether AO's Crush system-prompt context file is

--- a/backend/internal/adapters/agent/crush/hooks.go
+++ b/backend/internal/adapters/agent/crush/hooks.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -49,6 +50,15 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	if err != nil {
 		return fmt.Errorf("crush.GetAgentHooks: %w", err)
 	}
+	modelWritten, err := applyCrushModelOverride(cfg.WorkspacePath, cfg.Config.Model)
+	if err != nil {
+		return fmt.Errorf("crush.GetAgentHooks: %w", err)
+	}
+	if modelWritten {
+		if err := hookutil.EnsureWorkspaceGitignore(cfg.WorkspacePath, crushConfigFileName); err != nil {
+			return fmt.Errorf("crush.GetAgentHooks: gitignore config: %w", err)
+		}
+	}
 	if strings.TrimSpace(prompt) == "" {
 		return nil
 	}
@@ -76,11 +86,11 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 	if err := mergeCrushContextPath(crushConfigFile(cfg.WorkspacePath), crushSystemPromptPath); err != nil {
 		return fmt.Errorf("crush.GetAgentHooks: merge config: %w", err)
 	}
+	if err := hookutil.EnsureWorkspaceGitignore(cfg.WorkspacePath, crushConfigFileName); err != nil {
+		return fmt.Errorf("crush.GetAgentHooks: gitignore config: %w", err)
+	}
 	if err := hookutil.EnsureWorkspaceGitignore(filepath.Dir(promptPath), crushSystemPromptName); err != nil {
 		return fmt.Errorf("crush.GetAgentHooks: gitignore: %w", err)
-	}
-	if err := applyCrushModelOverride(cfg.WorkspacePath, cfg.Config.Model); err != nil {
-		return fmt.Errorf("crush.GetAgentHooks: %w", err)
 	}
 	return nil
 }
@@ -117,17 +127,31 @@ func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error
 // a role's model config always reflects the project's current value and a
 // later change takes effect on the session's next restore. An empty override
 // leaves any model the user picked through Crush's own model picker alone.
-func applyCrushModelOverride(workspacePath, modelOverride string) error {
+func applyCrushModelOverride(workspacePath, modelOverride string) (bool, error) {
 	model := strings.TrimSpace(modelOverride)
 	if model == "" {
-		return nil
+		return false, nil
 	}
 	provider, modelID, ok := strings.Cut(model, crushModelSeparator)
 	provider, modelID = strings.TrimSpace(provider), strings.TrimSpace(modelID)
-	if !ok || provider == "" || modelID == "" {
-		return fmt.Errorf("model %q must be \"<provider>/<model-id>\" (e.g. \"anthropic/claude-sonnet-4-5\"); Crush requires a provider id that a bare model string doesn't carry", model)
+	if ok && provider != "" && modelID != "" {
+		return true, mergeCrushModel(crushConfigFile(workspacePath), provider, modelID)
 	}
-	return mergeCrushModel(crushConfigFile(workspacePath), provider, modelID)
+	if ok {
+		slog.Default().Warn("crush: skipping model override because provider or model id is empty",
+			"model", model)
+		return false, nil
+	}
+	existingProvider, err := existingCrushModelProvider(crushConfigFile(workspacePath))
+	if err != nil {
+		return false, err
+	}
+	if existingProvider == "" {
+		slog.Default().Warn("crush: skipping bare model override because .crush.json has no existing provider to reuse",
+			"model", model)
+		return false, nil
+	}
+	return true, mergeCrushModel(crushConfigFile(workspacePath), existingProvider, model)
 }
 
 // AreHooksInstalled reports whether AO's Crush system-prompt context file is
@@ -209,6 +233,26 @@ func mergeCrushModel(configPath, provider, modelID string) error {
 	models[crushModelType] = selection
 	cfg["models"] = models
 	return writeCrushConfig(configPath, cfg)
+}
+
+func existingCrushModelProvider(configPath string) (string, error) {
+	cfg, err := readCrushConfig(configPath)
+	if err != nil {
+		return "", err
+	}
+	models, ok := cfg["models"].(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	selection, ok := models[crushModelType].(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	provider, ok := selection["provider"].(string)
+	if !ok {
+		return "", nil
+	}
+	return strings.TrimSpace(provider), nil
 }
 
 func removeCrushContextPath(configPath, contextPath string) error {


### PR DESCRIPTION
## What
Forwards AO's per-role model config (`agentConfig.Model`) into Crush's `.crush.json` on launch, so a configured worker/orchestrator model actually takes effect instead of silently falling back to Crush's own default.

## Why
Fixes #2900.

Every adapter must opt in to forwarding `cfg.Config.Model` to its CLI. Claude, Codex, and Kiro already do this; Crush was one of the adapters that silently dropped it.

## How
The issue needed a decision between two routes:

- **Flag route (rejected):** Crush's `--model`/`-m` flag only exists on the non-interactive `crush run` subcommand — confirmed via Crush's CLI docs (root-only flags are just `--yolo`, `--session`, `--continue`). It's not available on the interactive root command AO actually launches, so a flag fix was never viable.
- **Config route (chosen):** `.crush.json`'s `models.large` selection requires both a `model` id and a `provider` id, but AO's `AgentConfig.Model` is a single bare string with no provider. Rather than adding a `Provider` field to AO's schema (which would ripple through the API, UI, and every other adapter), this scopes the fix to the Crush adapter only: it parses `Model` as the convention `"<provider>/<model-id>"` (e.g. `anthropic/claude-sonnet-4-5`) and merges it into `.crush.json`'s `models.large` in `GetAgentHooks`.

Implementation notes:
- `GetAgentHooks` runs before both Spawn and Restore (via `prepareWorkspace`), so the model override is re-applied on every launch and stays current if the role's config changes.
- The merge preserves any other fields already on `models.large` (e.g. a user's `max_tokens`/`temperature`), and any other top-level `.crush.json` config — it only owns the `model`/`provider` identity keys.
- If `Config.Model` is empty, nothing is touched, so a model the user picked through Crush's own model picker is left alone.
- A model string without a `/` (no provider) returns a clear error rather than silently forwarding something Crush would reject.
- `GetConfigSpec` now declares the `model` field and its required `"<provider>/<model-id>"` format, matching the `claude-code`/`codex`/`kiro` pattern.

**Intentional omission:** this doesn't add a `provider` field to `domain.AgentConfig`/the API/UI. That was one of the two options raised in the issue; I went with the string-convention approach to keep the change scoped to the Crush adapter. Happy to switch to a schema field if maintainers prefer that route instead.

## Testing
Ran the crush adapter's test suite locally:

```bash
go build ./internal/adapters/agent/crush/...
go vet ./internal/adapters/agent/crush/...
gofmt -l internal/adapters/agent/crush/*.go
go test ./internal/adapters/agent/crush/... -v
```

All existing tests pass, plus new coverage:
- `TestGetConfigSpecReportsModelField` — spec declares the `model` field
- `TestGetAgentHooksWritesModelOverride` — provider/model parsed and written into `models.large`
- `TestGetAgentHooksPreservesOtherModelFieldsOnOverride` — unrelated keys (e.g. `max_tokens`) survive the merge
- `TestGetAgentHooksLeavesModelUntouchedWhenNoOverride` — no override means no write, user's own selection untouched
- `TestGetAgentHooksRejectsModelWithoutProvider` — bare model string (no `/`) errors clearly

<img width="550" height="781" alt="Screenshot 2026-07-27 at 9 38 37 AM" src="https://github.com/user-attachments/assets/d0ee49e6-7837-40e3-9a11-1fbc7d52d1b6" />

## Checklist
- [x] Branched from `main` (or continuing an existing PR branch)
- [x] One focused change; links the related issue when applicable
- [x] Follows [AGENTS.md](https://github.com/AgentWrapper/agent-orchestrator/blob/main/AGENTS.md) conventions and PR hygiene
- [x] Tests added/updated for user-visible behavior where it makes sense
- [x] Relevant CI checks pass for the area touched (`go`, frontend, etc.)